### PR TITLE
SPIR-V Reflection Bindings

### DIFF
--- a/doc/classes/RDPipelineSpecializationConstant.xml
+++ b/doc/classes/RDPipelineSpecializationConstant.xml
@@ -13,6 +13,9 @@
 		<member name="constant_id" type="int" setter="set_constant_id" getter="get_constant_id" default="0">
 			The identifier of the specialization constant. This is a value starting from [code]0[/code] and that increments for every different specialization constant for a given shader.
 		</member>
+		<member name="type" type="int" getter="get_type" enum="RenderingDevice.PipelineSpecializationConstantType" default="0">
+			The specialization constant's type. Corresponds to either [bool], [int] or [float].
+		</member>
 		<member name="value" type="Variant" setter="set_value" getter="get_value">
 			The specialization constant's value. Only [bool], [int] and [float] types are valid for specialization constants.
 		</member>

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -240,6 +240,9 @@ void register_server_types() {
 	GDREGISTER_CLASS(RDShaderFile);
 	GDREGISTER_CLASS(RDPipelineSpecializationConstant);
 
+	GDREGISTER_ABSTRACT_CLASS(RDUniformDescription);
+	GDREGISTER_ABSTRACT_CLASS(RDShaderDescription);
+
 	GDREGISTER_ABSTRACT_CLASS(RenderData);
 	GDREGISTER_CLASS(RenderDataExtension);
 	GDREGISTER_CLASS(RenderDataRD);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3479,6 +3479,25 @@ RID RenderingDevice::shader_create_placeholder() {
 	return shader_owner.make_rid(shader);
 }
 
+void RenderingDevice::shader_get_description(RID p_shader, RenderingDeviceCommons::ShaderDescription &shader_desc) {
+	_THREAD_SAFE_METHOD_
+
+	const Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_NULL(shader);
+
+	shader_desc.vertex_input_mask = shader->vertex_input_mask;
+	shader_desc.fragment_output_mask = shader->fragment_output_mask;
+	shader_desc.is_compute = shader->is_compute;
+
+	shader_desc.compute_local_size[0] = shader->compute_local_size[0];
+	shader_desc.compute_local_size[1] = shader->compute_local_size[1];
+	shader_desc.compute_local_size[2] = shader->compute_local_size[2];
+
+	shader_desc.push_constant_size = shader->push_constant_size;
+	shader_desc.uniform_sets = shader->uniform_sets;
+	shader_desc.stages = shader->stages;
+}
+
 uint64_t RenderingDevice::shader_get_vertex_input_attribute_mask(RID p_shader) {
 	_THREAD_SAFE_METHOD_
 
@@ -7364,6 +7383,8 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_create_from_bytecode", "binary_data", "placeholder_rid"), &RenderingDevice::shader_create_from_bytecode, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("shader_create_placeholder"), &RenderingDevice::shader_create_placeholder);
 
+	ClassDB::bind_method(D_METHOD("shader_get_description", "shader"), &RenderingDevice::_shader_get_description);
+
 	ClassDB::bind_method(D_METHOD("shader_get_vertex_input_attribute_mask", "shader"), &RenderingDevice::shader_get_vertex_input_attribute_mask);
 
 	ClassDB::bind_method(D_METHOD("uniform_buffer_create", "size_bytes", "data", "creation_bits"), &RenderingDevice::uniform_buffer_create, DEFVAL(Vector<uint8_t>()), DEFVAL(0));
@@ -8258,6 +8279,16 @@ RID RenderingDevice::_shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv
 	return shader_create_from_spirv(stage_data);
 }
 
+Ref<RDShaderDescription> RenderingDevice::_shader_get_description(RID p_shader) {
+	_THREAD_SAFE_METHOD_
+
+	Ref<RDShaderDescription> rd_shader_desc;
+	rd_shader_desc.instantiate();
+	shader_get_description(p_shader, rd_shader_desc->base);
+
+	return rd_shader_desc;
+}
+
 RID RenderingDevice::_uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set) {
 	LocalVector<Uniform> uniforms;
 	uniforms.resize(p_uniforms.size());
@@ -8273,32 +8304,13 @@ Error RenderingDevice::_buffer_update_bind(RID p_buffer, uint32_t p_offset, uint
 	return buffer_update(p_buffer, p_offset, p_size, p_data.ptr());
 }
 
-static Vector<RenderingDevice::PipelineSpecializationConstant> _get_spec_constants(const TypedArray<RDPipelineSpecializationConstant> &p_constants) {
+Vector<RenderingDevice::PipelineSpecializationConstant> RenderingDevice::_get_spec_constants(const TypedArray<RDPipelineSpecializationConstant> &p_constants) {
 	Vector<RenderingDevice::PipelineSpecializationConstant> ret;
 	ret.resize(p_constants.size());
 	for (int i = 0; i < p_constants.size(); i++) {
-		Ref<RDPipelineSpecializationConstant> c = p_constants[i];
-		ERR_CONTINUE(c.is_null());
-		RenderingDevice::PipelineSpecializationConstant &sc = ret.write[i];
-		Variant value = c->get_value();
-		switch (value.get_type()) {
-			case Variant::BOOL: {
-				sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;
-				sc.bool_value = value;
-			} break;
-			case Variant::INT: {
-				sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT;
-				sc.int_value = value;
-			} break;
-			case Variant::FLOAT: {
-				sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_FLOAT;
-				sc.float_value = value;
-			} break;
-			default: {
-			}
-		}
-
-		sc.constant_id = c->get_constant_id();
+		Ref<RDPipelineSpecializationConstant> spec_const = p_constants[i];
+		ERR_CONTINUE(spec_const.is_null());
+		ret.write[i] = spec_const->base;
 	}
 	return ret;
 }

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -55,6 +55,7 @@ class RDPipelineDepthStencilState;
 class RDPipelineColorBlendState;
 class RDFramebufferPass;
 class RDPipelineSpecializationConstant;
+class RDShaderDescription;
 
 class RenderingDevice : public RenderingDeviceCommons {
 	GDCLASS(RenderingDevice, Object)
@@ -977,6 +978,8 @@ public:
 	RID shader_create_placeholder();
 	void shader_destroy_modules(RID p_shader);
 
+	void shader_get_description(RID p_shader, RenderingDeviceCommons::ShaderDescription &shader_desc);
+
 	uint64_t shader_get_vertex_input_attribute_mask(RID p_shader);
 
 	/******************/
@@ -1166,6 +1169,8 @@ private:
 	Vector<uint8_t> _load_pipeline_cache();
 	void _update_pipeline_cache(bool p_closing = false);
 	static void _save_pipeline_cache(void *p_data);
+
+	static Vector<PipelineSpecializationConstant> _get_spec_constants(const TypedArray<RDPipelineSpecializationConstant> &p_constants);
 
 	struct ComputePipeline {
 		RID shader;
@@ -1702,6 +1707,8 @@ private:
 	Ref<RDShaderSPIRV> _shader_compile_spirv_from_source(const Ref<RDShaderSource> &p_source, bool p_allow_cache = true);
 	Vector<uint8_t> _shader_compile_binary_from_spirv(const Ref<RDShaderSPIRV> &p_bytecode, const String &p_shader_name = "");
 	RID _shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv, const String &p_shader_name = "");
+
+	Ref<RDShaderDescription> _shader_get_description(RID p_shader);
 
 	RID _uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set);
 

--- a/servers/rendering/rendering_device_binds.h
+++ b/servers/rendering/rendering_device_binds.h
@@ -32,13 +32,20 @@
 
 #include "servers/rendering/rendering_device.h"
 
+#define RD_GET(m_type, m_member)    \
+	m_type get_##m_member() const { \
+		return base.m_member;       \
+	}
+
 #define RD_SETGET(m_type, m_member)            \
 	void set_##m_member(m_type p_##m_member) { \
 		base.m_member = p_##m_member;          \
 	}                                          \
-	m_type get_##m_member() const {            \
-		return base.m_member;                  \
-	}
+	RD_GET(m_type, m_member)
+
+#define RD_BIND_GET(m_variant_type, m_class, m_member)                                 \
+	ClassDB::bind_method(D_METHOD("get_" _MKSTR(m_member)), &m_class::get_##m_member); \
+	ADD_PROPERTY(PropertyInfo(m_variant_type, #m_member), "", "get_" _MKSTR(m_member))
 
 #define RD_BIND(m_variant_type, m_class, m_member)                                                          \
 	ClassDB::bind_method(D_METHOD("set_" _MKSTR(m_member), "p_" _MKSTR(member)), &m_class::set_##m_member); \
@@ -494,26 +501,56 @@ protected:
 class RDPipelineSpecializationConstant : public RefCounted {
 	GDCLASS(RDPipelineSpecializationConstant, RefCounted)
 	friend class RenderingDevice;
+	friend class RDShaderDescription;
 
-	Variant value = false;
-	uint32_t constant_id = 0;
+	RD::PipelineSpecializationConstant base;
 
 public:
-	void set_value(const Variant &p_value) {
-		ERR_FAIL_COND(p_value.get_type() != Variant::BOOL && p_value.get_type() != Variant::INT && p_value.get_type() != Variant::FLOAT);
-		value = p_value;
-	}
-	Variant get_value() const { return value; }
+	RD_GET(RenderingDeviceCommons::PipelineSpecializationConstantType, type)
 
-	void set_constant_id(uint32_t p_id) {
-		constant_id = p_id;
+	void set_value(const Variant &p_value) {
+		switch (p_value.get_type()) {
+			case Variant::BOOL: {
+				base.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;
+				base.bool_value = p_value;
+			} break;
+			case Variant::INT: {
+				base.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT;
+				base.int_value = p_value;
+			} break;
+			case Variant::FLOAT: {
+				base.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_FLOAT;
+				base.float_value = p_value;
+			} break;
+			default: {
+				ERR_FAIL_MSG("Specialization constant value has to be a boolean, integer or float.");
+			}
+		}
 	}
-	uint32_t get_constant_id() const {
-		return constant_id;
+
+	Variant get_value() const {
+		switch (base.type) {
+			case RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL: {
+				return base.bool_value;
+			} break;
+			case RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_INT: {
+				return base.int_value;
+			} break;
+			case RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_FLOAT: {
+				return base.float_value;
+			} break;
+			default: {
+				ERR_FAIL_V(0);
+			}
+		}
 	}
+
+	RD_SETGET(uint32_t, constant_id)
 
 protected:
 	static void _bind_methods() {
+		RD_BIND_GET(Variant::INT, RDPipelineSpecializationConstant, type);
+
 		ClassDB::bind_method(D_METHOD("set_value", "value"), &RDPipelineSpecializationConstant::set_value);
 		ClassDB::bind_method(D_METHOD("get_value"), &RDPipelineSpecializationConstant::get_value);
 
@@ -522,6 +559,117 @@ protected:
 
 		ADD_PROPERTY(PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), "set_value", "get_value");
 		ADD_PROPERTY(PropertyInfo(Variant::INT, "constant_id", PROPERTY_HINT_RANGE, "0,65535,0"), "set_constant_id", "get_constant_id");
+	}
+};
+
+class RDUniformDescription : public RefCounted {
+	GDCLASS(RDUniformDescription, RefCounted)
+	friend class RDShaderDescription;
+
+	uint32_t set; // TODO: Move to RD::ShaderUniform?
+	RD::ShaderUniform base;
+
+public:
+	RD_GET(RD::UniformType, type)
+	RD_GET(bool, writable)
+
+	uint32_t get_set() const {
+		return set;
+	}
+
+	RD_GET(uint32_t, binding)
+	RD_GET(uint64_t, stages) // TODO: Refactor RD::ShaderStage into two and turn this into a bitfield?
+	RD_GET(uint32_t, length)
+
+protected:
+	static void _bind_methods() {
+		RD_BIND_GET(Variant::INT, RDUniformDescription, type);
+		RD_BIND_GET(Variant::BOOL, RDUniformDescription, writable);
+		RD_BIND_GET(Variant::INT, RDUniformDescription, set);
+		RD_BIND_GET(Variant::INT, RDUniformDescription, binding);
+		RD_BIND_GET(Variant::INT, RDUniformDescription, stages);
+		RD_BIND_GET(Variant::INT, RDUniformDescription, length);
+	}
+};
+
+class RDShaderDescription : public RefCounted {
+	GDCLASS(RDShaderDescription, RefCounted)
+	friend class RenderingDevice;
+
+	RD::ShaderDescription base;
+
+public:
+	RD_GET(uint64_t, vertex_input_mask)
+	RD_GET(uint32_t, fragment_output_mask)
+	RD_GET(bool, is_compute)
+
+	Vector3i get_compute_local_size() const {
+		return Vector3i(
+				base.compute_local_size[0],
+				base.compute_local_size[1],
+				base.compute_local_size[2]);
+	}
+
+	RD_GET(uint32_t, push_constant_size)
+
+	uint32_t get_uniform_sets() const {
+		return base.uniform_sets.size();
+	}
+
+	TypedArray<RDUniformDescription> find_uniforms_by_set(uint32_t p_set) const {
+		ERR_FAIL_COND_V(p_set > base.uniform_sets.size() - 1, {});
+		TypedArray<RDUniformDescription> uniforms = {};
+		for (uint32_t b = 0; b < base.uniform_sets[p_set].size(); b++) {
+			Ref<RDUniformDescription> uniform;
+			uniform.instantiate();
+			uniform->set = p_set;
+			uniform->base = base.uniform_sets[p_set][b];
+			uniforms.append(uniform);
+		}
+		return uniforms;
+	}
+
+	TypedArray<RDUniformDescription> get_uniforms() const {
+		TypedArray<RDUniformDescription> uniforms = {};
+		for (uint32_t s = 0; s < base.uniform_sets.size(); s++) {
+			uniforms.append_array(find_uniforms_by_set(s));
+		}
+		return uniforms;
+	}
+
+	TypedArray<RDPipelineSpecializationConstant> get_specialization_constants() const {
+		TypedArray<RDPipelineSpecializationConstant> spec_constants = {};
+		for (uint32_t i = 0; i < base.specialization_constants.size(); i++) {
+			Ref<RDPipelineSpecializationConstant> spec_const;
+			spec_const.instantiate();
+			spec_const->base = base.specialization_constants[i];
+			spec_constants.append(spec_const);
+		}
+		return spec_constants;
+	}
+
+	// TODO: Refactor RD::ShaderStage into two and turn this into a bitfield?
+	uint64_t get_stages() const {
+		uint64_t stages = 0;
+		for (uint32_t i = 0; i < base.stages.size(); i++) {
+			stages |= (((uint64_t)1) << base.stages[i]);
+		}
+		return stages;
+	}
+
+protected:
+	static void _bind_methods() {
+		RD_BIND_GET(Variant::INT, RDShaderDescription, vertex_input_mask);
+		RD_BIND_GET(Variant::INT, RDShaderDescription, fragment_output_mask);
+		RD_BIND_GET(Variant::BOOL, RDShaderDescription, is_compute);
+		RD_BIND_GET(Variant::VECTOR3I, RDShaderDescription, compute_local_size);
+		RD_BIND_GET(Variant::INT, RDShaderDescription, push_constant_size);
+		RD_BIND_GET(Variant::INT, RDShaderDescription, uniform_sets);
+		RD_BIND_GET(Variant::ARRAY, RDShaderDescription, uniforms);
+		RD_BIND_GET(Variant::ARRAY, RDShaderDescription, specialization_constants);
+		RD_BIND_GET(Variant::INT, RDShaderDescription, stages);
+
+		ClassDB::bind_method(D_METHOD("find_uniforms_by_set", "set"), &RDShaderDescription::find_uniforms_by_set);
 	}
 };
 


### PR DESCRIPTION
Closes [#10740 ](https://github.com/godotengine/godot-proposals/issues/10740)

This is the first iteration of bindings to be used to reflect on the structure of the SPIR-V intermediary shader format.

For now it only exposes the reflection data already available in the `RenderingDeviceCommons::ShaderDescription` struct. However this is insufficient as it does not contain all the necessary information, in particular the names and layouts of uniforms, push constants and pipeline specialization constants used in the shader. This information can theoretically be added to the `ShaderDescription` object, but afaik this would have to be done for each `RenderingDeviceDriver` individually. And since #102552 includes a major refactor of the internal shader reflection routines that make them driver-independent and easier to access, it seems reasonable to wait until that PR is merged (hopefully soon). Until then the purpose of this draft PR is to reflect (pun intended) on the changes so far, and discuss how the finalized (low level) API should look.

The main object of this PR is the `RDShaderDescription` object, which can be retrieved using `RenderingDevice.shader_get_description(shader: RID)`. From it one can then retrieve the aforementioned  `ShaderDescription` contents. In particular, one can query `RDUniformDescription`s , another new object which contains all the information that `RenderingDeviceCommons::ShaderUniform` does. One can also retrieve all the shader's `RDPipelineSpecializationConstant`s, which have been modified to also expose their (hitherto unused) `RenderingDeviceCommons::PipelineSpecializationConstantType`.

A rough checklist of things still to be done is as follows:

- [ ] Adopt changes provided by the merging of #102552.
- [ ] Expose field names for uniforms, push constants and pipeline specialization constants.
- [ ] Expose push constants layout.
- [ ] Expose uniform buffer layout.
- [ ] Add `RenderingDevice` functions to retrieve reflection data directly from `RDShaderSPIRV` byte code.
- [ ] Add documentation.
- [ ] (Optional) Split up `RenderingDeviceCommons::ShaderStage` into `ShaderStage`  (same as before) and `ShaderStageBits` (only containing the bit flags) so the latter can be used as a `BitField`. A future PR can then deprecate the bit flags in the former.
- [ ]  (Optional) Add high-level shader dispatch API based on reflection bindings.
- [ ] ...