### PR TITLE
Adjust SVG in OT scaling and baseline.

### DIFF
--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -226,27 +226,31 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 
 		float svg_width, svg_height;
 		picture->size(&svg_width, &svg_height);
-		double aspect = svg_width / svg_height;
+		double aspect_x = (svg_width > svg_height) ? svg_width / svg_height : 1.0;
+		double aspect_y = (svg_width < svg_height) ? svg_height / svg_width : 1.0;
 
-		result = picture->size(embox_x * aspect, embox_y);
+		result = picture->size(embox_x * aspect_x, embox_y * aspect_y);
 		if (result != tvg::Result::Success) {
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to resize SVG document.");
 		}
 
-		double x_svg_to_out = (double)metrics.x_ppem / embox_x;
-		double y_svg_to_out = (double)metrics.y_ppem / embox_y;
+		double scale = double(embox_x * aspect_x) / double(svg_width);
+		double yoff = double(document->metrics.ascender + document->metrics.descender) / double(document->metrics.ascender);
+
+		double x_svg_to_out = (double)metrics.x_ppem / embox_x / scale;
+		double y_svg_to_out = (double)metrics.y_ppem / embox_y / scale;
 
 		gl_state.m.e11 = (double)document->transform.xx / (1 << 16);
 		gl_state.m.e12 = -(double)document->transform.xy / (1 << 16);
 		gl_state.m.e21 = -(double)document->transform.yx / (1 << 16);
 		gl_state.m.e22 = (double)document->transform.yy / (1 << 16);
-		gl_state.m.e13 = (double)document->delta.x / 64 * embox_x / metrics.x_ppem;
-		gl_state.m.e23 = -(double)document->delta.y / 64 * embox_y / metrics.y_ppem;
+		gl_state.m.e13 = (double)document->delta.x / 64 * embox_x / metrics.x_ppem * scale;
+		gl_state.m.e23 = -(double)document->delta.y / 64 * embox_y / metrics.y_ppem * scale;
 		gl_state.m.e31 = 0;
 		gl_state.m.e32 = 0;
 		gl_state.m.e33 = 1;
 
-		result = picture->size(embox_x * aspect * x_svg_to_out, embox_y * y_svg_to_out);
+		result = picture->size(embox_x * aspect_x * x_svg_to_out, embox_y * aspect_y * y_svg_to_out);
 		if (result != tvg::Result::Success) {
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to resize SVG document.");
 		}
@@ -257,8 +261,9 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 		}
 
 		picture->size(&gl_state.w, &gl_state.h);
-		gl_state.x = (gl_state.h - gl_state.w) / 2.0;
-		gl_state.y = -gl_state.h;
+
+		gl_state.x = (double(p_slot->metrics.horiAdvance) / 64.0 - gl_state.w) / 2.0;
+		gl_state.y = -Math::ceil(gl_state.h * yoff);
 
 		gl_state.ready = true;
 	}

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -226,27 +226,31 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 
 		float svg_width, svg_height;
 		picture->size(&svg_width, &svg_height);
-		double aspect = svg_width / svg_height;
+		double aspect_x = (svg_width > svg_height) ? svg_width / svg_height : 1.0;
+		double aspect_y = (svg_width < svg_height) ? svg_height / svg_width : 1.0;
 
-		result = picture->size(embox_x * aspect, embox_y);
+		result = picture->size(embox_x * aspect_x, embox_y * aspect_y);
 		if (result != tvg::Result::Success) {
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to resize SVG document.");
 		}
 
-		double x_svg_to_out = (double)metrics.x_ppem / embox_x;
-		double y_svg_to_out = (double)metrics.y_ppem / embox_y;
+		double scale = double(embox_x * aspect_x) / double(svg_width);
+		double yoff = double(document->metrics.ascender + document->metrics.descender) / double(document->metrics.ascender);
+
+		double x_svg_to_out = (double)metrics.x_ppem / embox_x / scale;
+		double y_svg_to_out = (double)metrics.y_ppem / embox_y / scale;
 
 		gl_state.m.e11 = (double)document->transform.xx / (1 << 16);
 		gl_state.m.e12 = -(double)document->transform.xy / (1 << 16);
 		gl_state.m.e21 = -(double)document->transform.yx / (1 << 16);
 		gl_state.m.e22 = (double)document->transform.yy / (1 << 16);
-		gl_state.m.e13 = (double)document->delta.x / 64 * embox_x / metrics.x_ppem;
-		gl_state.m.e23 = -(double)document->delta.y / 64 * embox_y / metrics.y_ppem;
+		gl_state.m.e13 = (double)document->delta.x / 64 * embox_x / metrics.x_ppem * scale;
+		gl_state.m.e23 = -(double)document->delta.y / 64 * embox_y / metrics.y_ppem * scale;
 		gl_state.m.e31 = 0;
 		gl_state.m.e32 = 0;
 		gl_state.m.e33 = 1;
 
-		result = picture->size(embox_x * aspect * x_svg_to_out, embox_y * y_svg_to_out);
+		result = picture->size(embox_x * aspect_x * x_svg_to_out, embox_y * aspect_y * y_svg_to_out);
 		if (result != tvg::Result::Success) {
 			ERR_FAIL_V_MSG(FT_Err_Invalid_SVG_Document, "Failed to resize SVG document.");
 		}
@@ -257,8 +261,9 @@ FT_Error tvg_svg_in_ot_preset_slot(FT_GlyphSlot p_slot, FT_Bool p_cache, FT_Poin
 		}
 
 		picture->size(&gl_state.w, &gl_state.h);
-		gl_state.x = (gl_state.h - gl_state.w) / 2.0;
-		gl_state.y = -gl_state.h;
+
+		gl_state.x = (double(p_slot->metrics.horiAdvance) / 64.0 - gl_state.w) / 2.0;
+		gl_state.y = -Math::ceil(gl_state.h * yoff);
 
 		gl_state.ready = true;
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106429
Fixes https://github.com/godotengine/godot/issues/80766
Fixes https://github.com/godotengine/godot/issues/98211

Before:
<img width="1179" alt="Screenshot 2025-05-19 at 09 29 45" src="https://github.com/user-attachments/assets/9885b20c-0bd1-46ce-81c6-5c6f7bb1e3c4" />

After:
<img width="1179" alt="Screenshot 2025-05-19 at 09 29 26" src="https://github.com/user-attachments/assets/a963bf1d-e1f9-4ba0-ad79-68f7cb417c34" />
