### PR TITLE
Lazy create menu and slider nodes in `Tree`

### DIFF
--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -33,6 +33,7 @@
 #include "scene/gui/control.h"
 #include "scene/resources/text_paragraph.h"
 
+class VBoxContainer;
 class HScrollBar;
 class HSlider;
 class LineEdit;
@@ -529,6 +530,7 @@ private:
 	bool popup_edit_committed = true;
 	RID accessibility_scroll_element;
 
+	VBoxContainer *popup_editor_vb = nullptr;
 	Popup *popup_editor = nullptr;
 	LineEdit *line_editor = nullptr;
 	TextEdit *text_editor = nullptr;
@@ -559,6 +561,8 @@ private:
 	void _text_editor_popup_modal_close();
 	void _text_editor_gui_input(const Ref<InputEvent> &p_event);
 	void value_editor_changed(double p_value);
+	void _update_popup_menu(const TreeItem::Cell &p_cell);
+	void _update_value_editor(const TreeItem::Cell &p_cell);
 
 	void popup_select(int p_option);
 


### PR DESCRIPTION
`Tree` has a slider and a popup menu for cells using `CELL_MODE_RANGE`.

This mode is rarely used. Even in the editor, there are only a few instances where it is used, and the popup menu is only used in the replication editor.

This PR makes these two controls lazy created.