### PR TITLE
Disable GPU threaded optimizations option (GL debug)

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -341,6 +341,10 @@ public:
 	virtual Vector<String> get_granted_permissions() const { return Vector<String>(); }
 	virtual void revoke_granted_permissions() {}
 
+	// Allow overrides "disable" and can be specified via the command line.
+	virtual bool _is_gdriver_threaded_optimization_allowed() const { return false; }
+	virtual void _set_gdriver_threaded_optimization_allowed(bool p_allow) {}
+
 	// For recording / measuring benchmark data. Only enabled with tools
 	void set_use_benchmark(bool p_use_benchmark);
 	bool is_use_benchmark_set();

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2883,6 +2883,11 @@
 		<member name="rendering/gl_compatibility/nvidia_disable_threaded_optimization" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], disables the threaded optimization feature from the NVIDIA drivers, which are known to cause stuttering in most OpenGL applications.
 			[b]Note:[/b] This setting only works on Windows, as threaded optimization is disabled by default on other platforms.
+			[b]Note:[/b] If [member rendering/gl_compatibility/tune_nvidia_driver] is set to [code]true[/code] the feature will be disabled directly in the driver; if set to [code]false[/code], Godot will attempt to disable the feature indirectly by enabling minimal OpenGL logging.
+		</member>
+		<member name="rendering/gl_compatibility/tune_nvidia_driver" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the NVIDIA drivers are tuned for G-Sync and to control threaded optimization (see [member rendering/gl_compatibility/nvidia_disable_threaded_optimization]).
+			[b]Note:[/b] This setting only works on Windows.
 		</member>
 		<member name="rendering/global_illumination/gi/use_half_resolution" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], renders [VoxelGI] and SDFGI ([member Environment.sdfgi_enabled]) buffers at halved resolution (e.g. 960×540 when the viewport size is 1920×1080). This improves performance significantly when VoxelGI or SDFGI is enabled, at the cost of artifacts that may be visible on polygon edges. The loss in quality becomes less noticeable as the viewport resolution increases. [LightmapGI] rendering is not affected by this setting.

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -139,6 +139,11 @@ void RasterizerGLES3::clear_depth(float p_depth) {
 }
 
 #ifdef CAN_DEBUG
+// We offer the option to disable GPU threaded optimizations indirectly by forcing debug output.
+// We aren't actually interested in the strings in this case so we try and make the call as cheap as possible.
+static void GLAPIENTRY _gl_debug_print_dummy(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
+}
+
 static void GLAPIENTRY _gl_debug_print(GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *message, const GLvoid *userParam) {
 	// These are ultimately annoying, so removing for now.
 	if (type == _EXT_DEBUG_TYPE_OTHER_ARB || type == _EXT_DEBUG_TYPE_PERFORMANCE_ARB || type == _EXT_DEBUG_TYPE_MARKER_ARB) {
@@ -240,6 +245,26 @@ void *_egl_load_function_wrapper(const char *p_name) {
 RasterizerGLES3::RasterizerGLES3() {
 	singleton = this;
 
+	// Use dummy OpenGL logging to indirectly disable threaded optimization if desired.
+	bool disable_threaded_optimization = false;
+
+	if (OS::get_singleton()->get_name() == "Windows") {
+		bool disable_requested = GLOBAL_GET("rendering/gl_compatibility/nvidia_disable_threaded_optimization");
+
+		// Don't disable when we are already using the Nvidia SDK technique.
+		bool tune_driver = GLOBAL_GET("rendering/gl_compatibility/tune_nvidia_driver");
+
+		disable_threaded_optimization = disable_requested && !tune_driver && !OS::get_singleton()->_is_gdriver_threaded_optimization_allowed();
+		if (disable_threaded_optimization) {
+			String video_adapter = RenderingServer::get_singleton()->get_video_adapter_name().to_lower();
+
+			// Only disable for nvidia currently.
+			if (video_adapter.find("nvidia") == -1) {
+				disable_threaded_optimization = false;
+			}
+		}
+	}
+
 #ifdef GLAD_ENABLED
 	bool glad_loaded = false;
 
@@ -289,6 +314,14 @@ RasterizerGLES3::RasterizerGLES3() {
 			} else {
 				print_line("OpenGL debugging not supported!");
 			}
+		} else if (disable_threaded_optimization) {
+			if (GLAD_GL_ARB_debug_output) {
+				glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+				glDebugMessageCallbackARB((GLDEBUGPROCARB)_gl_debug_print_dummy, nullptr);
+				glEnable(_EXT_DEBUG_OUTPUT);
+			} else {
+				print_line("Disabling GPU threaded optimization via OpenGL debugging not supported by this driver.");
+			}
 		}
 	}
 #endif // GLAD_ENABLED
@@ -304,6 +337,8 @@ RasterizerGLES3::RasterizerGLES3() {
 			glDebugMessageControlARB(_EXT_DEBUG_SOURCE_API_ARB, _EXT_DEBUG_TYPE_PORTABILITY_ARB, _EXT_DEBUG_SEVERITY_HIGH_ARB, 0, nullptr, GL_TRUE);
 			glDebugMessageControlARB(_EXT_DEBUG_SOURCE_API_ARB, _EXT_DEBUG_TYPE_PERFORMANCE_ARB, _EXT_DEBUG_SEVERITY_HIGH_ARB, 0, nullptr, GL_TRUE);
 			glDebugMessageControlARB(_EXT_DEBUG_SOURCE_API_ARB, _EXT_DEBUG_TYPE_OTHER_ARB, _EXT_DEBUG_SEVERITY_HIGH_ARB, 0, nullptr, GL_TRUE);
+		} else if (disable_threaded_optimization && GLAD_GL_ARB_debug_output) {
+			glDebugMessageControlARB(_EXT_DEBUG_SOURCE_API_ARB, _EXT_DEBUG_TYPE_ERROR_ARB, _EXT_DEBUG_SEVERITY_HIGH_ARB, 0, nullptr, GL_TRUE);
 		}
 	}
 #endif // GL_API_ENABLED
@@ -319,6 +354,18 @@ RasterizerGLES3::RasterizerGLES3() {
 				print_line("godot: ENABLING GL DEBUG");
 				glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
 				callback((DEBUGPROCARB)_gl_debug_print, nullptr);
+				glEnable(_EXT_DEBUG_OUTPUT);
+			}
+		} else if (disable_threaded_optimization) {
+			DebugMessageCallbackARB callback = (DebugMessageCallbackARB)eglGetProcAddress("glDebugMessageCallback");
+			if (!callback) {
+				callback = (DebugMessageCallbackARB)eglGetProcAddress("glDebugMessageCallbackKHR");
+			}
+
+			if (callback) {
+				print_line("godot: ENABLING GL DEBUG dummy output");
+				glEnable(_EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB);
+				callback((DEBUGPROCARB)_gl_debug_print_dummy, nullptr);
 				glEnable(_EXT_DEBUG_OUTPUT);
 			}
 		}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -656,6 +656,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--disable-crash-handler", "Disable crash handler when supported by the platform code.\n");
 	print_help_option("--fixed-fps <fps>", "Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
 	print_help_option("--delta-smoothing <enable>", "Enable or disable frame delta smoothing [\"enable\", \"disable\"].\n");
+	print_help_option("--allow-gpu-threaded-optimization", "Override the \"nvidia_disable_threaded_optimizations\" project setting.\n");
 	print_help_option("--print-fps", "Print the frames per second to the stdout.\n");
 #ifdef TOOLS_ENABLED
 	print_help_option("--editor-pseudolocalization", "Enable pseudolocalization for the editor and the project manager.\n", CLI_OPTION_AVAILABILITY_EDITOR);
@@ -1772,6 +1773,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
 				goto error;
 			}
+		} else if (arg == "--allow-gpu-threaded-optimization") {
+			OS::get_singleton()->_set_gdriver_threaded_optimization_allowed(true);
 		} else if (arg == "--disable-render-loop") {
 			disable_render_loop = true;
 		} else if (arg == "--fixed-fps") {
@@ -2209,6 +2212,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		GLOBAL_DEF_RST(PropertyInfo(Variant::STRING, "rendering/gl_compatibility/driver.macos", PROPERTY_HINT_ENUM, "opengl3,opengl3_angle"), "opengl3");
 
 		GLOBAL_DEF_RST("rendering/gl_compatibility/nvidia_disable_threaded_optimization", true);
+		GLOBAL_DEF_RST("rendering/gl_compatibility/tune_nvidia_driver", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_angle", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_native", true);
 		GLOBAL_DEF_RST("rendering/gl_compatibility/fallback_to_gles", true);

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -243,7 +243,7 @@ void GLManagerNative_Windows::_nvapi_setup_profile() {
 	ogl_thread_control_setting.settingId = OGL_THREAD_CONTROL_ID;
 	ogl_thread_control_setting.settingType = NVDRS_DWORD_TYPE;
 	int thread_control_val = OGL_THREAD_CONTROL_DISABLE;
-	if (!GLOBAL_GET("rendering/gl_compatibility/nvidia_disable_threaded_optimization")) {
+	if (!GLOBAL_GET("rendering/gl_compatibility/nvidia_disable_threaded_optimization") || OS::get_singleton()->_is_gdriver_threaded_optimization_allowed()) {
 		thread_control_val = OGL_THREAD_CONTROL_ENABLE;
 	}
 	ogl_thread_control_setting.u32CurrentValue = thread_control_val;
@@ -503,7 +503,9 @@ void GLManagerNative_Windows::swap_buffers() {
 }
 
 Error GLManagerNative_Windows::initialize() {
-	_nvapi_setup_profile();
+	if (GLOBAL_GET("rendering/gl_compatibility/tune_nvidia_driver")) {
+		_nvapi_setup_profile();
+	}
 	return OK;
 }
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -129,6 +129,8 @@ class OS_Windows : public OS {
 
 	HashMap<void *, String> temp_libraries;
 
+	bool _allow_gdriver_threaded_optimizations = false;
+
 	void _remove_temp_library(void *p_library_handle);
 	String _get_default_fontname(const String &p_font_name) const;
 	DWRITE_FONT_WEIGHT _weight_to_dw(int p_weight) const;
@@ -254,6 +256,9 @@ public:
 	virtual Error move_to_trash(const String &p_path) override;
 
 	virtual String get_system_ca_certificates() override;
+
+	virtual bool _is_gdriver_threaded_optimization_allowed() const override { return _allow_gdriver_threaded_optimizations; }
+	virtual void _set_gdriver_threaded_optimization_allowed(bool p_allow) override { _allow_gdriver_threaded_optimizations = p_allow; }
 
 	void set_main_window(HWND p_main_window) { main_window = p_main_window; }
 


### PR DESCRIPTION
We can disable indirectly by enabling verbose GL debug output.

Forward port of #106556

## Discussion
A long standing issue on Windows with Nvidia drivers has been the threaded optimization (T.O.) driver setting. This seems to cause significant stuttering for some users.

Godot 4 tries the approach of using the Nvidia SDK to turn off the optimization directly in the driver (#71472), however that has caused a number of regressions (e.g. #85111).

Instead users have reported that enabling OpenGL debug logging seems to fix the issue, believed to be by forcing the driver to disable the feature. This is not ideal for exports, because Godot does significant processing to print these debug logs.

Here we add a similar feature which turns on debug logging, but instead provides a pass through so that no processing takes place on Godot side, minimizing the cost of the technique.

## Switching on and interactions with Nvidia specific code
This will probably take some discussion and bikeshedding as there are a number of ways of doing this, but after some testing of alternatives I'm currently most in favour of this approach:

* Use the existing `nvidia_disable_threaded_optimization` as a master switch
* Add a new `tune_nvidia_driver` setting

This latter setting determines two things:
1) Whether the Nvidia driver is accessed _at all_ (to change gsync & T.O.)
2) Whether T.O. is disabled (using the driver directly, or indirectly via debug logging, determined by (1))

In the course of developing these PRs I also tried alternative approaches, like having an independent switch for nvidia disable and debug log disable. The problem here is that the nvidia code also controls gsync, and thus regressions with the driver occur if it is accessed _at all_ (as I understand it). So the obvious options are 3 settings (disable nvidia, gsync nvidia and disable logging, with descriptions of the combinations possible) or these two presented in this PR. So far these two *seem* like the best compromise (albeit being a little tricky to explain).

## Notes
* Only disables for video adapter with "nvidia" in the name, on windows only.
* Tested by @elvisish and confirmed to work (I can't fully test this, as I don't have windows or nvidia GPU).
* Added a command line switch `--allow-gdriver-to` to override the project setting just in case an end user wants to play a game with multithread optimizations enabled. This also works for the nvidia driver method.
* `verbose_logging` takes precedence, but by definition if that is on, it will also disable threaded optimization. So probably no need to mention it in the docs. 
* We might not need the full complement of debug logging in order to trick the driver into disabling T.O.. It might be possible to call a subset of the commands, or toggle the logging on then off. Unfortunately I can't test this as I don't have the required hardware but would welcome testing / modifications / follow up PRs if we can minimize the logging requirements further.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
