### PR TITLE
Fix Android AAB Export

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -90,7 +90,7 @@ android {
         jvmTarget = versions.javaVersion
     }
 
-    assetPacks = [":assetPacksInstallTime"]
+    assetPacks = [":assetPacks:installTime"]
 
     namespace = 'com.godot.game'
 

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -15,5 +15,5 @@ pluginManagement {
     }
 }
 
-include ':assetPacksInstallTime'
-project(':assetPacksInstallTime').projectDir = file("assetPacks/installTime")
+include ':assetPacks:installTime'
+project(':assetPacks:installTime').projectDir = file("assetPacks/installTime")

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -25,5 +25,5 @@ include ':lib'
 include ':nativeSrcsConfigs'
 include ':editor'
 
-include ':assetPacksInstallTime'
-project(':assetPacksInstallTime').projectDir = file("app/assetPacks/installTime")
+include ':assetPacks:installTime'
+project(':assetPacks:installTime').projectDir = file("app/assetPacks/installTime")


### PR DESCRIPTION
fix aab export by changing assetPacksInstallTime back to assetPacks:installTime

Fixes issue: https://github.com/godotengine/godot/issues/106582

Introduced by commit: https://github.com/godotengine/godot/commit/4b4144cc39ee307494c89c034ea5fd180f48db42

Copying in issue description for ease of reading:

> It appears the above commit changed how assetPacks/installTime is handled. Specifically, the variable was changed from:
> 
> ":assetPacks:installTime" to ":assetPacksInstallTime"
> 
> This breaks aab exports. The assetPacks/installTime is no longer included in the exported aab.
> 
> The apk builds do not seem to be affected by this change.
> 
> Reading here: https://stackoverflow.com/questions/52310921/setting-path-in-gradle-when-to-use-slash-and-when-colon
> 
> And here: https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:project_and_task_paths
> 
> It seems the : holds special meaning in gradle. The fix is to simply change the variable back to using the :