### PR TITLE
Fix accidental mutations in `Dictionary` (and possibly `Array` and `NodePath`).

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -101,13 +101,6 @@ int NodePath::get_total_name_count() const {
 	return data->path.size() + data->subpath.size();
 }
 
-void NodePath::unref() {
-	if (data && data->refcount.unref()) {
-		memdelete(data);
-	}
-	data = nullptr;
-}
-
 bool NodePath::operator==(const NodePath &p_path) const {
 	if (data == p_path.data) {
 		return true;
@@ -159,15 +152,7 @@ bool NodePath::operator!=(const NodePath &p_path) const {
 }
 
 void NodePath::operator=(const NodePath &p_path) {
-	if (this == &p_path) {
-		return;
-	}
-
-	unref();
-
-	if (p_path.data && p_path.data->refcount.ref()) {
-		data = p_path.data;
-	}
+	data = p_path.data;
 }
 
 NodePath::operator String() const {
@@ -368,8 +353,7 @@ NodePath::NodePath(const Vector<StringName> &p_path, bool p_absolute) {
 		return;
 	}
 
-	data = memnew(Data);
-	data->refcount.init();
+	data = SharedPtr<Data>::make();
 	data->absolute = p_absolute;
 	data->path = p_path;
 	data->hash_cache_valid = false;
@@ -380,19 +364,15 @@ NodePath::NodePath(const Vector<StringName> &p_path, const Vector<StringName> &p
 		return;
 	}
 
-	data = memnew(Data);
-	data->refcount.init();
+	data = SharedPtr<Data>::make();
 	data->absolute = p_absolute;
 	data->path = p_path;
 	data->subpath = p_subpath;
 	data->hash_cache_valid = false;
 }
 
-NodePath::NodePath(const NodePath &p_path) {
-	if (p_path.data && p_path.data->refcount.ref()) {
-		data = p_path.data;
-	}
-}
+NodePath::NodePath(const NodePath &p_path) :
+		data(p_path.data) {}
 
 NodePath::NodePath(const String &p_path) {
 	if (p_path.length() == 0) {
@@ -445,8 +425,7 @@ NodePath::NodePath(const String &p_path) {
 		return;
 	}
 
-	data = memnew(Data);
-	data->refcount.init();
+	data = SharedPtr<Data>::make();
 	data->absolute = absolute;
 	data->subpath = subpath;
 	data->hash_cache_valid = false;
@@ -474,6 +453,4 @@ NodePath::NodePath(const String &p_path) {
 	}
 }
 
-NodePath::~NodePath() {
-	unref();
-}
+NodePath::~NodePath() {}

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -32,23 +32,22 @@
 
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
+#include "core/templates/shared_ptr.h"
 
 #include <climits>
 
 class [[nodiscard]] NodePath {
 	struct Data {
-		SafeRefCount refcount;
 		Vector<StringName> path;
 		Vector<StringName> subpath;
-		StringName concatenated_path;
-		StringName concatenated_subpath;
+		mutable StringName concatenated_path;
+		mutable StringName concatenated_subpath;
 		bool absolute;
 		mutable bool hash_cache_valid;
 		mutable uint32_t hash_cache;
 	};
 
-	mutable Data *data = nullptr;
-	void unref();
+	SharedPtr<Data> data;
 
 	void _update_hash_cache() const;
 

--- a/core/templates/shared_ptr.h
+++ b/core/templates/shared_ptr.h
@@ -1,0 +1,163 @@
+/**************************************************************************/
+/*  shared_ptr.h                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/os/memory.h"
+#include "core/templates/safe_refcount.h"
+
+#include <memory>
+
+/**
+ * A smart pointer with shared ownership, similar to std::shared_ptr.
+ * Uses SafeRefCount to handle reference counters.
+ * When the last reference to the pointee destructs, the pointee is destructed.
+ */
+template <typename T>
+class SharedPtr {
+	struct Data {
+		SafeRefCount refcount;
+		T t;
+	};
+
+	Data *_ptr = nullptr;
+
+	explicit SharedPtr(Data *p_data) :
+			_ptr(p_data) {}
+
+	void _ref(const SharedPtr &p_ptr) {
+		if (_ptr == p_ptr._ptr) {
+			return;
+		}
+		if (p_ptr._ptr && !p_ptr._ptr->refcount.ref()) {
+			return; // Failed to reference.
+		}
+
+		_unref();
+		_ptr = p_ptr._ptr;
+	}
+
+	void _unref() {
+		if (_ptr && _ptr->refcount.unref()) {
+			_ptr->~Data();
+			std::allocator<Data> allocator;
+			allocator.deallocate(_ptr, 1);
+		}
+		_ptr = nullptr;
+	}
+
+public:
+	// Allows access to the pointee type statically.
+	// Matches the same declaration from std smart pointers (std::shared_ptr etc.).
+	using element_type = T;
+
+	_FORCE_INLINE_ SafeRefCount &refcount() { return _ptr->refcount; }
+	_FORCE_INLINE_ const SafeRefCount &refcount() const { return _ptr->refcount; }
+
+	_FORCE_INLINE_ void *ptr() { return _ptr; }
+	_FORCE_INLINE_ const void *ptr() const { return _ptr; }
+
+	_FORCE_INLINE_ operator T *() { return _ptr ? &_ptr->t : nullptr; }
+	_FORCE_INLINE_ operator const T *() const { return _ptr ? &_ptr->t : nullptr; }
+
+	_FORCE_INLINE_ T &operator*() { return _ptr->t; }
+	_FORCE_INLINE_ const T &operator*() const { return _ptr->t; }
+
+	_FORCE_INLINE_ T *operator->() { return _ptr ? &_ptr->t : nullptr; }
+	_FORCE_INLINE_ const T *operator->() const { return _ptr ? &_ptr->t : nullptr; }
+
+	_FORCE_INLINE_ operator bool() const { return _ptr; }
+
+	_FORCE_INLINE_ SharedPtr &operator=(const SharedPtr &p_ptr) {
+		_ref(p_ptr);
+		return *this;
+	}
+	_FORCE_INLINE_ SharedPtr &operator=(SharedPtr &&p_ptr) {
+		if (_ptr == p_ptr._ptr) {
+			return *this;
+		}
+		_unref();
+		_ptr = p_ptr._ptr;
+		p_ptr._ptr = nullptr;
+		return *this;
+	}
+
+	_FORCE_INLINE_ void reset() { _unref(); }
+
+	template <typename... Args>
+	static SharedPtr make(Args... args) {
+		std::allocator<Data> allocator;
+		Data *data = allocator.allocate(1);
+		memnew_placement(&data->refcount, SafeRefCount);
+		data->refcount.init();
+		memnew_placement(&data->t, T(std::forward<Args>(args)...));
+		return SharedPtr(data);
+	}
+
+	SharedPtr() = default;
+	SharedPtr(std::nullptr_t) :
+			_ptr(nullptr) {}
+	SharedPtr(const SharedPtr &p_ptr) {
+		if (!p_ptr._ptr || !p_ptr._ptr->refcount.ref()) {
+			return;
+		}
+		_ptr = p_ptr._ptr;
+	}
+	SharedPtr(SharedPtr &&p_ptr) {
+		_ptr = p_ptr._ptr;
+		p_ptr._ptr = nullptr;
+	}
+	~SharedPtr() { _unref(); }
+};
+
+template <typename TL, typename TR>
+bool operator==(SharedPtr<TL> p_lhs, SharedPtr<TR> p_rhs) {
+	return p_lhs.ptr() == p_rhs.ptr();
+}
+
+template <typename TL, typename TR>
+bool operator==(SharedPtr<TL> p_lhs, const TR *p_rhs) {
+	return p_lhs.ptr() == p_rhs;
+}
+
+template <typename TL, typename TR>
+bool operator==(const TL *p_lhs, const SharedPtr<TR> p_rhs) {
+	return p_lhs == p_rhs.ptr();
+}
+
+template <typename TL>
+bool operator==(SharedPtr<TL> p_lhs, std::nullptr_t p_rhs) {
+	return p_lhs.ptr() == p_rhs;
+}
+
+template <typename TR>
+bool operator==(std::nullptr_t p_lhs, SharedPtr<TR> p_rhs) {
+	return p_lhs == p_rhs.ptr();
+}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -180,7 +180,7 @@ public:
 	}
 
 	template <typename Comparator, typename Value, typename... Args>
-	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
+	Size bsearch_custom(const Value &p_value, bool p_before, Args &&...args) const {
 		return span().bisect(p_value, p_before, Comparator{ args... });
 	}
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -43,47 +43,17 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
 #include "core/variant/dictionary.h"
 
 struct ArrayPrivate {
-	SafeRefCount refcount;
 	Vector<Variant> array;
 	Variant *read_only = nullptr; // If enabled, a pointer is used to a temporary value that is used to return read-only values.
-	ContainerTypeValidate typed;
+	mutable ContainerTypeValidate typed;
 
 	ArrayPrivate() {}
 	ArrayPrivate(std::initializer_list<Variant> p_init) :
 			array(p_init) {}
+	~ArrayPrivate() {
+		memdelete_notnull(read_only);
+	}
 };
-
-void Array::_ref(const Array &p_from) const {
-	ArrayPrivate *_fp = p_from._p;
-
-	ERR_FAIL_NULL(_fp); // Should NOT happen.
-
-	if (_fp == _p) {
-		return; // whatever it is, nothing to do here move along
-	}
-
-	bool success = _fp->refcount.ref();
-
-	ERR_FAIL_COND(!success); // should really not happen either
-
-	_unref();
-
-	_p = _fp;
-}
-
-void Array::_unref() const {
-	if (!_p) {
-		return;
-	}
-
-	if (_p->refcount.unref()) {
-		if (_p->read_only) {
-			memdelete(_p->read_only);
-		}
-		memdelete(_p);
-	}
-	_p = nullptr;
-}
 
 Array::Iterator Array::begin() {
 	return Iterator(_p->array.ptrw(), _p->read_only);
@@ -208,10 +178,7 @@ uint32_t Array::recursive_hash(int recursion_count) const {
 }
 
 void Array::operator=(const Array &p_array) {
-	if (this == &p_array) {
-		return;
-	}
-	_ref(p_array);
+	_p = p_array._p;
 }
 
 void Array::assign(const Array &p_array) {
@@ -872,8 +839,7 @@ const void *Array::id() const {
 }
 
 Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
-	_p = memnew(ArrayPrivate);
-	_p->refcount.init();
+	_p = SharedPtr<ArrayPrivate>::make();
 	set_typed(p_type, p_class_name, p_script);
 	assign(p_from);
 }
@@ -885,7 +851,7 @@ void Array::set_typed(const ContainerType &p_element_type) {
 void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
-	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
+	ERR_FAIL_COND_MSG(_p.refcount().get() > 1, "Type can only be set when array has no more than one user.");
 	ERR_FAIL_COND_MSG(_p->typed.type != Variant::NIL, "Type can only be set once.");
 	ERR_FAIL_COND_MSG(p_class_name != StringName() && p_type != Variant::OBJECT, "Class names can only be set for type OBJECT");
 	Ref<Script> script = p_script;
@@ -949,22 +915,15 @@ Span<Variant> Array::span() const {
 	return _p->array.span();
 }
 
-Array::Array(const Array &p_from) {
-	_p = nullptr;
-	_ref(p_from);
-}
+Array::Array(const Array &p_from) :
+		_p(p_from._p) {}
 
 Array::Array(std::initializer_list<Variant> p_init) {
-	_p = memnew(ArrayPrivate);
-	_p->refcount.init();
-	_p->array = Vector<Variant>(p_init);
+	_p = SharedPtr<ArrayPrivate>::make(p_init);
 }
 
 Array::Array() {
-	_p = memnew(ArrayPrivate);
-	_p->refcount.init();
+	_p = SharedPtr<ArrayPrivate>::make();
 }
 
-Array::~Array() {
-	_unref();
-}
+Array::~Array() {}

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/shared_ptr.h"
 #include "core/templates/span.h"
 #include "core/typedefs.h"
 #include "core/variant/variant_deep_duplicate.h"
@@ -45,9 +46,7 @@ struct ArrayPrivate;
 struct ContainerType;
 
 class Array {
-	mutable ArrayPrivate *_p;
-	void _ref(const Array &p_from) const;
-	void _unref() const;
+	SharedPtr<ArrayPrivate> _p;
 
 public:
 	struct ConstIterator {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -33,6 +33,7 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pair.h"
+#include "core/templates/shared_ptr.h"
 #include "core/variant/variant_deep_duplicate.h"
 
 class Array;
@@ -44,10 +45,7 @@ struct DictionaryPrivate;
 struct StringLikeVariantComparator;
 
 class Dictionary {
-	mutable DictionaryPrivate *_p;
-
-	void _ref(const Dictionary &p_from) const;
-	void _unref() const;
+	SharedPtr<DictionaryPrivate> _p;
 
 public:
 	using ConstIterator = HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::ConstIterator;


### PR DESCRIPTION
`Dictionary` currently has a design flaw where it is possible for C++ code to mutate the underlying data even if it is supposed to be `const`. This PR fixes this problem by introducing `SharedPtr`.

In particular, it was previously possible to accidentally add key-values to `const Dictionary` through `operator[]`. This bug was triggered at least in `AudioStreamWAV::load_from_buffer`.

This PR is likely to cause regressions, because it exposes incorrect code. I recommend merging it soon to have time to test it before the 4.5 release.

## Explanation

Some of our data structures use shared reference semantics. They currently use a pattern where the data type is merely a pointer to some shared data, and the data has a `SafeRefCount` to keep track of reference counts:

https://github.com/godotengine/godot/blob/a2aefab4c78273c8a2006daf28b700d427e1feeb/core/variant/dictionary.h#L46-L47

https://github.com/godotengine/godot/blob/a2aefab4c78273c8a2006daf28b700d427e1feeb/core/variant/dictionary.cpp#L43-L44

Unfortunately, this implementation creates a problem: `const`-ness of `Dictionary` is not transferred over to the `DictionaryPrivate` pointee of `_p`. That means _all_ functions of `Dictionary` actually have full write access into the dictionary, even `const` ones:

```c++
const Variant &Dictionary::dummy_get(const Variant &p_variant) const {
    _p->variant_map.insert(p_variant, 2); // This, unexpectedly, does not statically fail.
}
```

To address this problem, `DictionaryPrivate *` needs to be wrapped in a smart pointer.
I decided to use this opportunity to simplify and unify implementations, and go straight for an owned smart pointer, called `SharedPtr`. This pointer works similarly to `std::shared_ptr`, i.e. all references have read-write access to it. The `refcount` and `T` contents are placed next to each other in memory, which perfectly mimicks the way it was previously set up. The new class could be used for `Dictionary`, `Array` and `NodePath`, alleviating house-keeping duties from them.

## Affected Code

This change exposed a few minor bugs in the codebase:
- `Dictionary::operator[]` accidentally inserts an empty value when the key is not found, even on `const` access.
    - This also made it possible for typed dictionaries to contain untyped values, possibly introducing obscure bugs.
    - `AudioStreamWAV::load_from_buffer` is one affected caller, unknowingly modified the `Dictionary` parameter, even though it was `const`.
    - The function is supposed to crash when unknown keys are used. Instead, I made it gracefully fail. This mitigates the regressions this PR causes, and gives us time to find and regressions.
- `bsearch_custom` was non-const, although it could have been `const`.
- Functions in `dictionary.cpp`, `array.cpp` and `node_path.cpp` unknowingly called non-const versions of functions on data, possibly leading to worse performance (or even bugs).
