### PR TITLE
Show `Curve3D` point tilt in degrees in inspector

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -2458,7 +2458,7 @@ void Curve3D::_get_property_list(List<PropertyInfo> *p_list) const {
 			p_list->push_back(pi);
 		}
 
-		pi = PropertyInfo(Variant::FLOAT, vformat("point_%d/tilt", i));
+		pi = PropertyInfo(Variant::FLOAT, vformat("point_%d/tilt", i), PROPERTY_HINT_RANGE, "-360,360,0.1,or_less,or_greater,radians_as_degrees");
 		pi.usage &= ~PROPERTY_USAGE_STORAGE;
 		p_list->push_back(pi);
 	}


### PR DESCRIPTION
Resolves #106601.

Copy-pasted the hint string from `Node2D.rotation`.

Before|After
-|-
![Godot_v4 4 1-stable_win64_uGgpKNBK6W](https://github.com/user-attachments/assets/bcc1832e-4410-4433-9633-2d5470000589)|![godot windows editor dev x86_64_Nel8Vbh4u6](https://github.com/user-attachments/assets/8b0856b3-0f05-4001-b3ba-412dc6287d27)


Note that Curve3D's point tilt has no description in the tooltip, so currently there's no note mentioning it's in degrees only in the inspector like for `Node2D.rotation` or `Node2D.skew`:

![godot windows editor dev x86_64_UZqPCnwhMV](https://github.com/user-attachments/assets/f7b7c5fc-a178-45f9-bf4d-766032741bcf)|![godot windows editor dev x86_64_rIPV10VGG7](https://github.com/user-attachments/assets/8fcb5478-4828-46c2-8dc9-77175a351b54)|![godot windows editor dev x86_64_XvoHniLHpV](https://github.com/user-attachments/assets/835239aa-fc9b-4eca-a62e-fd98b2674415)
-|-|-
