### PR TITLE
Introduce BBCodeParser class

### DIFF
--- a/core/io/bbcode.cpp
+++ b/core/io/bbcode.cpp
@@ -40,7 +40,7 @@ void BBCodeToken::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // TODO: bind enum
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "value"), "set_value", "get_value");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "parameters"), "set_parameters", "get_parameters");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "parameters", PROPERTY_HINT_DICTIONARY_TYPE, "String;Variant"), "set_parameters", "get_parameters");
 }
 
 Dictionary BBCodeParser::validate_tag(const String &p_tag, const Dictionary &p_parameters) {
@@ -351,10 +351,6 @@ void BBCodeParser::_bind_methods() {
 
 	GDVIRTUAL_BIND(_validate_tag, "tag", "parameters")
 	GDVIRTUAL_BIND(_validate_text, "text")
-}
-
-BBCodeParser::BBCodeParser() {
-	set_local_to_scene(true);
 }
 
 BBCodeParser::~BBCodeParser() {

--- a/core/io/bbcode.cpp
+++ b/core/io/bbcode.cpp
@@ -1,0 +1,362 @@
+/**************************************************************************/
+/*  bbcode.cpp                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "bbcode.h"
+
+void BBCodeToken::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_type"), &BBCodeToken::get_type);
+	ClassDB::bind_method(D_METHOD("set_type", "type"), &BBCodeToken::set_type);
+	ClassDB::bind_method(D_METHOD("get_value"), &BBCodeToken::get_value);
+	ClassDB::bind_method(D_METHOD("set_value", "value"), &BBCodeToken::set_value);
+	ClassDB::bind_method(D_METHOD("get_parameters"), &BBCodeToken::get_parameters);
+	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &BBCodeToken::set_parameters);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // TODO: bind enum
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "value"), "set_value", "get_value");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "parameters"), "set_parameters", "get_parameters");
+}
+
+Dictionary BBCodeParser::validate_tag(const String &p_tag, const Dictionary &p_parameters) {
+	Dictionary result;
+	if (!GDVIRTUAL_CALL(_validate_tag, p_tag, p_parameters, result)) {
+		result = _validate_tag(p_tag, p_parameters);
+	}
+	return result;
+}
+
+Error BBCodeParser::validate_text(const String &p_text) {
+	Error result;
+	if (!GDVIRTUAL_CALL(_validate_text, p_text, result)) {
+		result = _validate_text(p_text);
+	}
+	return result;
+}
+
+void BBCodeParser::_parse_tag(const String &p_bbcode, const int p_start, String &r_tag, Dictionary &r_parameters, int &r_end) {
+	enum State {
+		TAG_NAME,
+		PARAM_NAME,
+		PARAM_VALUE,
+	};
+	// TODO: allow escaping quotes with backslash?
+	// TODO: how should a string like abc"def"ghi be handled?
+	enum Escape {
+		NONE,
+		SINGLE_QUOTE,
+		DOUBLE_QUOTE,
+	};
+
+	String buffer;
+	String parameter;
+	State state = State::TAG_NAME;
+	Escape escaping = Escape::NONE;
+
+	int pos;
+	for (pos = p_start; pos < p_bbcode.length(); pos++) {
+		const char32_t cchar = p_bbcode[pos];
+
+		switch (state) {
+			case State::TAG_NAME:
+				switch (cchar) {
+					case ' ':
+						if (buffer.is_empty()) {
+							continue;
+						}
+						if (buffer[0] == '/') {
+							// Closing tag can't have parameters.
+							_update_error(ERR_PARSE_ERROR);
+							goto END;
+						}
+						r_tag = buffer.strip_edges();
+						buffer.clear();
+						state = State::PARAM_NAME;
+						break;
+					case '=':
+						if (buffer.is_empty()) {
+							continue;
+						}
+						if (buffer[0] == '/') {
+							// Closing tag can't have parameters.
+							_update_error(ERR_PARSE_ERROR);
+							goto END;
+						}
+						r_tag = buffer.strip_edges();
+						buffer.clear();
+						state = State::PARAM_NAME;
+						break;
+					case ']':
+						r_tag = buffer.strip_edges();
+						goto END;
+					default:
+						buffer += cchar;
+						break;
+				}
+				break;
+			case State::PARAM_NAME:
+				switch (cchar) {
+					case ' ':
+						if (buffer.is_empty()) {
+							continue;
+						}
+						r_parameters.set(buffer.strip_edges(), Variant());
+						buffer.clear();
+						break;
+					case '=':
+						if (buffer.is_empty()) {
+							continue;
+						}
+						parameter = buffer.strip_edges();
+						buffer.clear();
+						state = State::PARAM_VALUE;
+						break;
+					case ']':
+						if (!buffer.is_empty()) {
+							r_parameters.set(buffer.strip_edges(), Variant());
+						}
+						goto END;
+					default:
+						buffer += cchar;
+						break;
+				}
+				break;
+			case State::PARAM_VALUE:
+				switch (escaping) {
+					case Escape::NONE:
+						switch (cchar) {
+							case ' ':
+								if (buffer.is_empty()) {
+									continue;
+								}
+								r_parameters.set(parameter, buffer.strip_edges());
+								parameter.clear();
+								buffer.clear();
+								state = State::PARAM_NAME;
+								break;
+							case '\'':
+								escaping = Escape::SINGLE_QUOTE;
+								break;
+							case '"':
+								escaping = Escape::DOUBLE_QUOTE;
+								break;
+							case ']':
+								if (!buffer.is_empty()) {
+									r_parameters.set(parameter, buffer.strip_edges());
+								}
+								goto END;
+							default:
+								buffer += cchar;
+								break;
+						}
+						break;
+					case Escape::SINGLE_QUOTE:
+						switch (cchar) {
+							case '\'':
+								// When using quotes, do not strip spaces and allow an empty string value.
+								escaping = Escape::NONE;
+								r_parameters.set(parameter, buffer);
+								parameter.clear();
+								buffer.clear();
+								state = State::PARAM_NAME;
+								break;
+							default:
+								buffer += cchar;
+								break;
+						}
+						break;
+					case Escape::DOUBLE_QUOTE:
+						switch (cchar) {
+							case '"':
+								// When using quotes, do not strip spaces and allow an empty string value.
+								escaping = Escape::NONE;
+								r_parameters.set(parameter, buffer);
+								parameter.clear();
+								buffer.clear();
+								state = State::PARAM_NAME;
+								break;
+							default:
+								buffer += cchar;
+								break;
+						}
+						break;
+				}
+				break;
+		}
+	}
+
+	// Missing closing bracket.
+	_update_error(ERR_PARSE_ERROR);
+
+END:
+	r_end = pos;
+}
+
+TypedArray<BBCodeToken> BBCodeParser::get_items() const {
+	TypedArray<BBCodeToken> arr;
+	int size = tokens.size();
+	arr.resize(size);
+	for (int i = 0; i < size; i++) {
+		arr[i] = tokens[i];
+	}
+	return arr;
+}
+
+void BBCodeParser::clear() {
+	for (BBCodeToken *token : tokens) {
+		memdelete(token);
+	}
+	tokens.clear();
+}
+
+void BBCodeParser::push_bbcode(const String &p_bbcode) {
+	int pos = 0;
+	while (pos <= p_bbcode.length()) {
+		int brk_pos = p_bbcode.find_char('[', pos);
+
+		if (brk_pos < 0) {
+			brk_pos = p_bbcode.length();
+		}
+
+		String txt = brk_pos > pos ? p_bbcode.substr(pos, brk_pos - pos) : "";
+
+		if (!txt.is_empty()) {
+			push_text(txt);
+		}
+
+		if (brk_pos == p_bbcode.length()) {
+			break; // Nothing else to add.
+		}
+
+		String tag;
+		Dictionary parameters;
+		_parse_tag(p_bbcode, brk_pos + 1, tag, parameters, pos);
+		// Move after the closing brace.
+		pos++;
+
+		bool is_closing_tag = !tag.is_empty() && tag[0] == '/';
+		tag = is_closing_tag ? tag.substr(1) : tag;
+
+		// TODO: this unnecessarily splits escaped tags into their own text tokens
+		if (escape_contents) {
+			DEV_ASSERT(!tag_stack.is_empty());
+
+			// Wait for closing tag to stop escaping.
+			if (tag_stack[tag_stack.size() - 1] == tag) {
+				escape_contents = false;
+			} else {
+				push_text(p_bbcode.substr(brk_pos, pos - brk_pos));
+				continue;
+			}
+		}
+
+		if (is_closing_tag) {
+			push_close_tag(tag);
+		} else {
+			push_open_tag(tag, parameters);
+		}
+	}
+}
+
+void BBCodeParser::push_text(const String &p_text) {
+	_update_error(validate_text(p_text));
+	if (error == OK) {
+		BBCodeToken *token = memnew(BBCodeToken);
+		token->set_type(BBCodeToken::Type::TEXT);
+		token->set_value(p_text);
+		tokens.append(token);
+	}
+}
+
+void BBCodeParser::push_open_tag(const String &p_tag, const Dictionary &p_parameters) {
+	Dictionary result = validate_tag(p_tag, p_parameters);
+
+	Variant error_var = result.get("error", OK);
+	ERR_FAIL_COND(error_var.get_type() != Variant::Type::INT);
+	_update_error(static_cast<Error>(error_var));
+
+	if (error == OK) {
+		BBCodeToken *token = memnew(BBCodeToken);
+		token->set_type(BBCodeToken::Type::OPEN_TAG);
+		token->set_value(p_tag);
+		token->set_parameters(p_parameters);
+		tokens.append(token);
+
+		Variant self_closing_var = result.get("self_closing", false);
+		ERR_FAIL_COND(self_closing_var.get_type() != Variant::Type::BOOL);
+		if (!static_cast<bool>(self_closing_var)) {
+			tag_stack.append(p_tag);
+		}
+
+		Variant escape_var = result.get("escape_contents", false);
+		ERR_FAIL_COND(escape_var.get_type() != Variant::Type::BOOL);
+		escape_contents = static_cast<bool>(escape_var);
+	}
+}
+
+void BBCodeParser::push_close_tag(const String &p_tag) {
+	if (!tag_stack.is_empty()) {
+		const String &top_tag = tag_stack[tag_stack.size() - 1];
+		if (top_tag != p_tag) {
+			// Mismatching top tag.
+			_update_error(Error::ERR_INVALID_DATA);
+			return;
+		}
+		tag_stack.remove_at(tag_stack.size() - 1);
+	}
+
+	BBCodeToken *token = memnew(BBCodeToken);
+	token->set_type(BBCodeToken::Type::CLOSE_TAG);
+	token->set_value(p_tag);
+	tokens.append(token);
+}
+
+void BBCodeParser::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("validate_tag", "tag", "parameters"), &BBCodeParser::validate_tag);
+	ClassDB::bind_method(D_METHOD("validate_text", "text"), &BBCodeParser::validate_text);
+
+	ClassDB::bind_method(D_METHOD("get_error"), &BBCodeParser::get_error);
+	ClassDB::bind_method(D_METHOD("get_items"), &BBCodeParser::get_items);
+
+	ClassDB::bind_method(D_METHOD("clear"), &BBCodeParser::clear);
+	ClassDB::bind_method(D_METHOD("push_bbcode", "bbcode"), &BBCodeParser::push_bbcode);
+	ClassDB::bind_method(D_METHOD("push_text", "text"), &BBCodeParser::push_text);
+	ClassDB::bind_method(D_METHOD("push_open_tag", "tag", "parameters"), &BBCodeParser::push_open_tag);
+	ClassDB::bind_method(D_METHOD("push_close_tag", "tag"), &BBCodeParser::push_close_tag);
+
+	GDVIRTUAL_BIND(_validate_tag, "tag", "parameters")
+	GDVIRTUAL_BIND(_validate_text, "text")
+}
+
+BBCodeParser::BBCodeParser() {
+	set_local_to_scene(true);
+}
+
+BBCodeParser::~BBCodeParser() {
+	clear();
+}

--- a/core/io/bbcode.cpp
+++ b/core/io/bbcode.cpp
@@ -31,14 +31,14 @@
 #include "bbcode.h"
 
 void BBCodeToken::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_type"), &BBCodeToken::get_type);
-	ClassDB::bind_method(D_METHOD("set_type", "type"), &BBCodeToken::set_type);
+	ClassDB::bind_method(D_METHOD("get_token_type"), &BBCodeToken::get_type);
+	ClassDB::bind_method(D_METHOD("set_token_type", "type"), &BBCodeToken::set_type);
 	ClassDB::bind_method(D_METHOD("get_value"), &BBCodeToken::get_value);
 	ClassDB::bind_method(D_METHOD("set_value", "value"), &BBCodeToken::set_value);
 	ClassDB::bind_method(D_METHOD("get_parameters"), &BBCodeToken::get_parameters);
 	ClassDB::bind_method(D_METHOD("set_parameters", "parameters"), &BBCodeToken::set_parameters);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_type", "get_type"); // TODO: bind enum
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "type"), "set_token_type", "get_token_type"); // TODO: bind enum
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "value"), "set_value", "get_value");
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "parameters", PROPERTY_HINT_DICTIONARY_TYPE, "String;Variant"), "set_parameters", "get_parameters");
 }

--- a/core/io/bbcode.cpp
+++ b/core/io/bbcode.cpp
@@ -355,9 +355,9 @@ void BBCodeParser::push_bbcode(const String &p_bbcode) {
 		}
 
 		if (is_closing_tag) {
-			push_close_tag(tag);
+			pop_tag(tag);
 		} else {
-			push_open_tag(tag, parameters);
+			push_tag(tag, parameters);
 		}
 	}
 }
@@ -372,7 +372,7 @@ void BBCodeParser::push_text(const String &p_text) {
 	}
 }
 
-void BBCodeParser::push_open_tag(const String &p_tag, const Dictionary &p_parameters) {
+void BBCodeParser::push_tag(const String &p_tag, const Dictionary &p_parameters) {
 	Dictionary result = validate_tag(p_tag, p_parameters);
 
 	Variant error_var = result.get("error", OK);
@@ -398,7 +398,7 @@ void BBCodeParser::push_open_tag(const String &p_tag, const Dictionary &p_parame
 	}
 }
 
-void BBCodeParser::push_close_tag(const String &p_tag) {
+void BBCodeParser::pop_tag(const String &p_tag) {
 	if (!tag_stack.is_empty()) {
 		const String &top_tag = tag_stack[tag_stack.size() - 1];
 		if (top_tag != p_tag) {
@@ -430,8 +430,8 @@ void BBCodeParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &BBCodeParser::clear);
 	ClassDB::bind_method(D_METHOD("push_bbcode", "bbcode"), &BBCodeParser::push_bbcode);
 	ClassDB::bind_method(D_METHOD("push_text", "text"), &BBCodeParser::push_text);
-	ClassDB::bind_method(D_METHOD("push_open_tag", "tag", "parameters"), &BBCodeParser::push_open_tag);
-	ClassDB::bind_method(D_METHOD("push_close_tag", "tag"), &BBCodeParser::push_close_tag);
+	ClassDB::bind_method(D_METHOD("push_tag", "tag", "parameters"), &BBCodeParser::push_tag);
+	ClassDB::bind_method(D_METHOD("pop_tag", "tag"), &BBCodeParser::pop_tag);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "escape_brackets", PROPERTY_HINT_FLAGS, "Double Brackets,Wrapped Brackets,Backslash,Abbreviation"), "set_escape_brackets", "get_escape_brackets");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "backslash_escape_quotes"), "set_backslash_escape_quotes", "get_backslash_escape_quotes");

--- a/core/io/bbcode.h
+++ b/core/io/bbcode.h
@@ -97,6 +97,5 @@ public:
 	void push_open_tag(const String &p_tag, const Dictionary &p_parameters);
 	void push_close_tag(const String &p_tag);
 
-	BBCodeParser();
 	~BBCodeParser();
 };

--- a/core/io/bbcode.h
+++ b/core/io/bbcode.h
@@ -37,14 +37,14 @@ class BBCodeToken : public Object {
 	GDCLASS(BBCodeToken, Object);
 
 public:
-	enum Type {
-		TEXT,
-		OPEN_TAG,
-		CLOSE_TAG,
+	enum TokenType {
+		TOKEN_TYPE_TEXT,
+		TOKEN_TYPE_OPEN_TAG,
+		TOKEN_TYPE_CLOSE_TAG,
 	};
 
 private:
-	int type;
+	TokenType type = TokenType::TOKEN_TYPE_TEXT;
 	String value;
 	Dictionary parameters;
 
@@ -52,8 +52,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	int get_type() const { return type; }
-	void set_type(int p_type) { type = p_type; }
+	TokenType get_type() const { return type; }
+	void set_type(TokenType p_type) { type = p_type; }
 	String get_value() const { return value; }
 	void set_value(String p_value) { value = p_value; }
 	Dictionary get_parameters() const { return parameters; }
@@ -63,13 +63,23 @@ public:
 class BBCodeParser : public Resource {
 	GDCLASS(BBCodeParser, Resource);
 
+public:
+	enum EscapeBrackets {
+		ESCAPE_BRACKETS_NONE = 0,
+		ESCAPE_BRACKETS_WRAPPED = (1 << 0),
+		ESCAPE_BRACKETS_BACKSLASH = (1 << 1),
+		ESCAPE_BRACKETS_ABBREVIATION = (1 << 2),
+	};
+
 protected:
 	static void _bind_methods();
 
 	GDVIRTUAL2RC(Dictionary, _validate_tag, String, Dictionary)
 	GDVIRTUAL1RC(Error, _validate_text, String)
 
+	bool backslash_escape_quotes = true;
 	bool escape_contents = false;
+	BitField<EscapeBrackets> escape_brackets = ESCAPE_BRACKETS_NONE;
 	Error error = OK;
 	Vector<BBCodeToken *> tokens;
 	Vector<String> tag_stack;
@@ -91,6 +101,12 @@ public:
 	Error get_error() const { return error; }
 	TypedArray<BBCodeToken> get_items() const;
 
+	EscapeBrackets get_escape_brackets() const { return escape_brackets; }
+	void set_escape_brackets(const EscapeBrackets p_value) { escape_brackets = p_value; }
+
+	bool get_backslash_escape_quotes() const { return backslash_escape_quotes; }
+	void set_backslash_escape_quotes(const bool p_value) { backslash_escape_quotes = p_value; }
+
 	void clear();
 	void push_bbcode(const String &p_bbcode);
 	void push_text(const String &p_text);
@@ -99,3 +115,6 @@ public:
 
 	~BBCodeParser();
 };
+
+VARIANT_ENUM_CAST(BBCodeToken::TokenType);
+VARIANT_BITFIELD_CAST(BBCodeParser::EscapeBrackets);

--- a/core/io/bbcode.h
+++ b/core/io/bbcode.h
@@ -110,8 +110,8 @@ public:
 	void clear();
 	void push_bbcode(const String &p_bbcode);
 	void push_text(const String &p_text);
-	void push_open_tag(const String &p_tag, const Dictionary &p_parameters);
-	void push_close_tag(const String &p_tag);
+	void push_tag(const String &p_tag, const Dictionary &p_parameters);
+	void pop_tag(const String &p_tag);
 
 	~BBCodeParser();
 };

--- a/core/io/bbcode.h
+++ b/core/io/bbcode.h
@@ -44,6 +44,8 @@ public:
 	};
 
 private:
+	int position_start = 0;
+	String parsed_bbcode;
 	TokenType type = TokenType::TOKEN_TYPE_TEXT;
 	String value;
 	Dictionary parameters;
@@ -52,12 +54,18 @@ protected:
 	static void _bind_methods();
 
 public:
+	String get_normalized_bbcode() const;
+	String get_parsed_bbcode() const { return parsed_bbcode; }
+	void set_parsed_bbcode(const String &p_parsed_bbcode) { parsed_bbcode = p_parsed_bbcode; }
 	TokenType get_type() const { return type; }
 	void set_type(TokenType p_type) { type = p_type; }
 	String get_value() const { return value; }
-	void set_value(String p_value) { value = p_value; }
+	void set_value(const String &p_value) { value = p_value; }
 	Dictionary get_parameters() const { return parameters; }
-	void set_parameters(Dictionary p_parameters) { parameters = p_parameters; }
+	void set_parameters(const Dictionary &p_parameters) { parameters = p_parameters; }
+	int get_position_start() const { return position_start; }
+	void set_position_start(int p_position_start) { position_start = p_position_start; }
+	int get_position_end() const { return position_start + parsed_bbcode.length(); }
 };
 
 class BBCodeParser : public Resource {
@@ -77,6 +85,7 @@ protected:
 	GDVIRTUAL2RC(Dictionary, _validate_tag, String, Dictionary)
 	GDVIRTUAL1RC(Error, _validate_text, String)
 
+	int position = 0;
 	bool backslash_escape_quotes = true;
 	bool escape_contents = false;
 	BitField<EscapeBrackets> escape_brackets = ESCAPE_BRACKETS_NONE;
@@ -90,6 +99,10 @@ protected:
 			error = p_error;
 		}
 	}
+	void _parsed_push_text(const String &p_parsed_bbcode, const String &p_text);
+	void _parsed_push_tag(const String &p_parsed_bbcode, const String &p_tag, const Dictionary &p_parameters);
+	void _parsed_pop_tag(const String &p_parsed_bbcode, const String &p_tag);
+	void _push_token(const String &p_parsed_bbcode, BBCodeToken *p_token);
 
 public:
 	// Returns { error: Error = OK, escape_contents: boolean = false, self_closing: boolean = false }

--- a/core/io/bbcode.h
+++ b/core/io/bbcode.h
@@ -79,6 +79,12 @@ public:
 		ESCAPE_BRACKETS_ABBREVIATION = (1 << 2),
 	};
 
+	enum ErrorHandling {
+		ERROR_HANDLING_REMOVE = 0,
+		ERROR_HANDLING_PARSE_AS_TEXT = 1,
+		ERROR_HANDLING_KEEP = 2,
+	};
+
 protected:
 	static void _bind_methods();
 
@@ -88,8 +94,9 @@ protected:
 	int position = 0;
 	bool backslash_escape_quotes = true;
 	bool escape_contents = false;
-	BitField<EscapeBrackets> escape_brackets = ESCAPE_BRACKETS_NONE;
+	BitField<EscapeBrackets> escape_brackets = ESCAPE_BRACKETS_BACKSLASH;
 	Error error = OK;
+	ErrorHandling error_handling = ERROR_HANDLING_REMOVE;
 	Vector<BBCodeToken *> tokens;
 	Vector<String> tag_stack;
 
@@ -103,6 +110,8 @@ protected:
 	void _parsed_push_tag(const String &p_parsed_bbcode, const String &p_tag, const Dictionary &p_parameters);
 	void _parsed_pop_tag(const String &p_parsed_bbcode, const String &p_tag);
 	void _push_token(const String &p_parsed_bbcode, BBCodeToken *p_token);
+
+	bool _is_ok() const { return error == OK || error_handling == ERROR_HANDLING_KEEP; }
 
 public:
 	// Returns { error: Error = OK, escape_contents: boolean = false, self_closing: boolean = false }
@@ -120,6 +129,9 @@ public:
 	bool get_backslash_escape_quotes() const { return backslash_escape_quotes; }
 	void set_backslash_escape_quotes(const bool p_value) { backslash_escape_quotes = p_value; }
 
+	ErrorHandling get_error_handling() const { return error_handling; }
+	void set_error_handling(ErrorHandling p_error_handling) { error_handling = p_error_handling; }
+
 	void clear();
 	void push_bbcode(const String &p_bbcode);
 	void push_text(const String &p_text);
@@ -130,4 +142,5 @@ public:
 };
 
 VARIANT_ENUM_CAST(BBCodeToken::TokenType);
+VARIANT_ENUM_CAST(BBCodeParser::ErrorHandling);
 VARIANT_BITFIELD_CAST(BBCodeParser::EscapeBrackets);

--- a/core/io/bbcode.h
+++ b/core/io/bbcode.h
@@ -1,0 +1,102 @@
+/**************************************************************************/
+/*  bbcode.h                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource.h"
+#include "core/variant/typed_array.h"
+
+class BBCodeToken : public Object {
+	GDCLASS(BBCodeToken, Object);
+
+public:
+	enum Type {
+		TEXT,
+		OPEN_TAG,
+		CLOSE_TAG,
+	};
+
+private:
+	int type;
+	String value;
+	Dictionary parameters;
+
+protected:
+	static void _bind_methods();
+
+public:
+	int get_type() const { return type; }
+	void set_type(int p_type) { type = p_type; }
+	String get_value() const { return value; }
+	void set_value(String p_value) { value = p_value; }
+	Dictionary get_parameters() const { return parameters; }
+	void set_parameters(Dictionary p_parameters) { parameters = p_parameters; }
+};
+
+class BBCodeParser : public Resource {
+	GDCLASS(BBCodeParser, Resource);
+
+protected:
+	static void _bind_methods();
+
+	GDVIRTUAL2RC(Dictionary, _validate_tag, String, Dictionary)
+	GDVIRTUAL1RC(Error, _validate_text, String)
+
+	bool escape_contents = false;
+	Error error = OK;
+	Vector<BBCodeToken *> tokens;
+	Vector<String> tag_stack;
+
+	void _parse_tag(const String &p_bbcode, const int p_start, String &r_tag, Dictionary &r_parameters, int &r_end);
+	void _update_error(Error p_error) {
+		if (error == OK) {
+			error = p_error;
+		}
+	}
+
+public:
+	// Returns { error: Error = OK, escape_contents: boolean = false, self_closing: boolean = false }
+	virtual Dictionary _validate_tag(const String &p_tag, const Dictionary &p_parameters) const { return Dictionary(); }
+	Dictionary validate_tag(const String &p_tag, const Dictionary &p_parameters);
+	virtual Error _validate_text(const String &p_text) const { return OK; }
+	Error validate_text(const String &p_text);
+
+	Error get_error() const { return error; }
+	TypedArray<BBCodeToken> get_items() const;
+
+	void clear();
+	void push_bbcode(const String &p_bbcode);
+	void push_text(const String &p_text);
+	void push_open_tag(const String &p_tag, const Dictionary &p_parameters);
+	void push_close_tag(const String &p_tag);
+
+	BBCodeParser();
+	~BBCodeParser();
+};

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -42,6 +42,7 @@
 #include "core/input/input.h"
 #include "core/input/input_map.h"
 #include "core/input/shortcut.h"
+#include "core/io/bbcode.h"
 #include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/dtls_server.h"
@@ -275,6 +276,9 @@ void register_core_types() {
 	GDREGISTER_CLASS(PackedDataContainer);
 	GDREGISTER_ABSTRACT_CLASS(PackedDataContainerRef);
 #endif
+
+	GDREGISTER_CLASS(BBCodeToken);
+	GDREGISTER_CLASS(BBCodeParser);
 
 	GDREGISTER_ABSTRACT_CLASS(ImageFormatLoader);
 	GDREGISTER_CLASS(ImageFormatLoaderExtension);

--- a/doc/classes/BBCodeParser.xml
+++ b/doc/classes/BBCodeParser.xml
@@ -94,4 +94,30 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="backslash_escape_quotes" type="bool" setter="set_backslash_escape_quotes" getter="get_backslash_escape_quotes" default="true">
+			Allow single and double quotes used inside of opening BBCode tags to be escaped by prefixing them with a backslash.
+			Quotes used in plain-text are always treated as literals and do not need to be escaped.
+			In order to write a literal backslash inside of opening BBCode tags after enabling this escaping syntax, use [code]\\[/code].
+		</member>
+		<member name="escape_brackets" type="int" setter="set_escape_brackets" getter="get_escape_brackets" enum="BBCodeParser.EscapeBrackets" is_bitfield="true" default="0">
+			Configure which syntax is supported for escaping brackets. Instead of parsing these brackets as part of tags, they are instead treated as text that contains literal brackets.
+			[b]Note:[/b] When specifying a parameter value in BBCode surrounded with quotes, the contents are handled verbatim, including brackets. Every escape mode except for [constant ESCAPE_BRACKETS_BACKSLASH] is not respected and will be left unchanged.
+		</member>
+	</members>
+	<constants>
+		<constant name="ESCAPE_BRACKETS_NONE" value="0" enum="EscapeBrackets" is_bitfield="true">
+			Brackets can not be escaped.
+		</constant>
+		<constant name="ESCAPE_BRACKETS_WRAPPED" value="1" enum="EscapeBrackets" is_bitfield="true">
+			Brackets are escaped by wrapping the literal bracket into a tag: [code][[][/code] and [code][]][/code].
+		</constant>
+		<constant name="ESCAPE_BRACKETS_BACKSLASH" value="2" enum="EscapeBrackets" is_bitfield="true">
+			Brackets are escaped by prefixing the bracket with a backslash: [code]\[[/code] and [code]\][/code].
+			In order to write a literal backslash after enabling this escape syntax, use [code]\\[/code].
+		</constant>
+		<constant name="ESCAPE_BRACKETS_ABBREVIATION" value="4" enum="EscapeBrackets" is_bitfield="true">
+			Brackets are escaped by using special abbreviated tags: [code][lb][/code] for opening bracket and [code][rb][/code] for closing bracket.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/BBCodeParser.xml
+++ b/doc/classes/BBCodeParser.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="BBCodeParser" inherits="Resource" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Parser for BBCode.
+	</brief_description>
+	<description>
+		Configurable parser for BBCode strings, converting them to a list of tokens.
+		Validate methods can be overridden to create parser errors for determining invalid tag names or parameters.
+		Push methods can be called multiple times, keeping the current stack of tags and previously parsed tokens in memory.
+		[b]Note:[/b] When the parser is cleared or freed, all of its tokens are also freed. Do not hold on to references of tokens for longer than necessary.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_validate_tag" qualifiers="virtual const">
+			<return type="Dictionary" />
+			<param index="0" name="tag" type="String" />
+			<param index="1" name="parameters" type="Dictionary" />
+			<description>
+				Check whether the specified [param tag] with [param parameters] is valid. This gets called while parsing BBCode tags to decide whether parsing should be successful.
+			</description>
+		</method>
+		<method name="_validate_text" qualifiers="virtual const">
+			<return type="int" enum="Error" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Check whether the specified [param text] is valid. This gets called while parsing plain-text to decide whether parsing should be successful.
+			</description>
+		</method>
+		<method name="clear">
+			<return type="void" />
+			<description>
+				Clear the list of previously parsed tokens stored in this parser.
+				[b]Note:[/b] Upon calling this method, all of the tokens are also freed. Do not hold on to references of tokens for longer than necessary.
+			</description>
+		</method>
+		<method name="get_error" qualifiers="const">
+			<return type="int" enum="Error" />
+			<description>
+				Returns the last error encountered during parsing of BBCode.
+				This includes syntax errors, as well as validation errors triggered by the various validate methods.
+			</description>
+		</method>
+		<method name="get_items" qualifiers="const">
+			<return type="BBCodeToken[]" />
+			<description>
+				Returns the list of tokens parsed by this parser.
+			</description>
+		</method>
+		<method name="push_bbcode">
+			<return type="void" />
+			<param index="0" name="bbcode" type="String" />
+			<description>
+				Append a string containing BBCode.
+			</description>
+		</method>
+		<method name="push_close_tag">
+			<return type="void" />
+			<param index="0" name="tag" type="String" />
+			<description>
+				Append a closing BBCode tag.
+			</description>
+		</method>
+		<method name="push_open_tag">
+			<return type="void" />
+			<param index="0" name="tag" type="String" />
+			<param index="1" name="parameters" type="Dictionary" />
+			<description>
+				Append an opening BBCode tag.
+			</description>
+		</method>
+		<method name="push_text">
+			<return type="void" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Append plain-text string. Brackets are automatically escaped and treated literally.
+			</description>
+		</method>
+		<method name="validate_tag">
+			<return type="Dictionary" />
+			<param index="0" name="tag" type="String" />
+			<param index="1" name="parameters" type="Dictionary" />
+			<description>
+				Check whether the specified [param tag] with [param parameters] is valid. This gets called while parsing BBCode tags to decide whether parsing should be successful.
+				For the default [BBCodeParser], every tag is considered valid. However, sub-classes can override [method _validate_tag] to configure this behavior.
+			</description>
+		</method>
+		<method name="validate_text">
+			<return type="int" enum="Error" />
+			<param index="0" name="text" type="String" />
+			<description>
+				Check whether the specified [param text] is valid. This gets called while parsing plain-text to decide whether parsing should be successful.
+				For the default [BBCodeParser], all text is considered valid. However, sub-classes can override [method _validate_text] to configure this behavior.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/BBCodeParser.xml
+++ b/doc/classes/BBCodeParser.xml
@@ -100,7 +100,10 @@
 			Quotes used in plain-text are always treated as literals and do not need to be escaped.
 			In order to write a literal backslash inside of opening BBCode tags after enabling this escaping syntax, use [code]\\[/code].
 		</member>
-		<member name="escape_brackets" type="int" setter="set_escape_brackets" getter="get_escape_brackets" enum="BBCodeParser.EscapeBrackets" is_bitfield="true" default="0">
+		<member name="error_handling" type="int" setter="set_error_handling" getter="get_error_handling" enum="BBCodeParser.ErrorHandling" default="0">
+			How syntax or validation errors in the BBCode should be handled.
+		</member>
+		<member name="escape_brackets" type="int" setter="set_escape_brackets" getter="get_escape_brackets" enum="BBCodeParser.EscapeBrackets" is_bitfield="true" default="2">
 			Configure which syntax is supported for escaping brackets. Instead of parsing these brackets as part of tags, they are instead treated as text that contains literal brackets.
 			[b]Note:[/b] When specifying a parameter value in BBCode surrounded with quotes, the contents are handled verbatim, including brackets. Every escape mode except for [constant ESCAPE_BRACKETS_BACKSLASH] is not respected and will be left unchanged.
 		</member>
@@ -118,6 +121,15 @@
 		</constant>
 		<constant name="ESCAPE_BRACKETS_ABBREVIATION" value="4" enum="EscapeBrackets" is_bitfield="true">
 			Brackets are escaped by using special abbreviated tags: [code][lb][/code] for opening bracket and [code][rb][/code] for closing bracket.
+		</constant>
+		<constant name="ERROR_HANDLING_REMOVE" value="0" enum="ErrorHandling">
+			Erroneous data is not included in the output.
+		</constant>
+		<constant name="ERROR_HANDLING_PARSE_AS_TEXT" value="1" enum="ErrorHandling">
+			Erroneous data is included as plain-text instead.
+		</constant>
+		<constant name="ERROR_HANDLING_KEEP" value="2" enum="ErrorHandling">
+			Errors are ignored - all data is included in the output.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/BBCodeParser.xml
+++ b/doc/classes/BBCodeParser.xml
@@ -47,6 +47,13 @@
 				Returns the list of tokens parsed by this parser.
 			</description>
 		</method>
+		<method name="pop_tag">
+			<return type="void" />
+			<param index="0" name="tag" type="String" />
+			<description>
+				Append a closing BBCode tag. Errors if the specified tag name does not match the last opened tag on the stack.
+			</description>
+		</method>
 		<method name="push_bbcode">
 			<return type="void" />
 			<param index="0" name="bbcode" type="String" />
@@ -54,26 +61,19 @@
 				Append a string containing BBCode.
 			</description>
 		</method>
-		<method name="push_close_tag">
-			<return type="void" />
-			<param index="0" name="tag" type="String" />
-			<description>
-				Append a closing BBCode tag.
-			</description>
-		</method>
-		<method name="push_open_tag">
+		<method name="push_tag">
 			<return type="void" />
 			<param index="0" name="tag" type="String" />
 			<param index="1" name="parameters" type="Dictionary" />
 			<description>
-				Append an opening BBCode tag.
+				Append an opening BBCode tag. Queries [method validate_tag] to determine if the specified tag is valid, auto-escaping or self-closing.
 			</description>
 		</method>
 		<method name="push_text">
 			<return type="void" />
 			<param index="0" name="text" type="String" />
 			<description>
-				Append plain-text string. Brackets are automatically escaped and treated literally.
+				Append plain-text string. The string is pushed verbatim, no escaping is supported. Queries [method validate_text] to determine if the specified text is valid.
 			</description>
 		</method>
 		<method name="validate_tag">

--- a/doc/classes/BBCodeToken.xml
+++ b/doc/classes/BBCodeToken.xml
@@ -13,11 +13,22 @@
 		<member name="parameters" type="Dictionary" setter="set_parameters" getter="get_parameters" default="{}">
 			For opening tags, this contains the names and values of all parameters. Values are strings, except for parameters without an explicit value, as they have [code]null[/code] as their value instead.
 		</member>
-		<member name="type" type="int" setter="set_token_type" getter="get_token_type" default="0">
+		<member name="type" type="int" setter="set_token_type" getter="get_token_type" enum="BBCodeToken.TokenType" default="0">
 			Type of BBCode token.
 		</member>
 		<member name="value" type="String" setter="set_value" getter="get_value" default="&quot;&quot;">
 			For text tokens, this is the text itself. For tags, it is the name of the tag.
 		</member>
 	</members>
+	<constants>
+		<constant name="TOKEN_TYPE_TEXT" value="0" enum="TokenType">
+			Literal text. [member value] contains the text.
+		</constant>
+		<constant name="TOKEN_TYPE_OPEN_TAG" value="1" enum="TokenType">
+			Opening tag. [member value] contains the tag name and [member parameters] is filled.
+		</constant>
+		<constant name="TOKEN_TYPE_CLOSE_TAG" value="2" enum="TokenType">
+			Closing tag. [member value] contains the tag name.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/BBCodeToken.xml
+++ b/doc/classes/BBCodeToken.xml
@@ -9,26 +9,59 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<members>
-		<member name="parameters" type="Dictionary" setter="set_parameters" getter="get_parameters" default="{}">
-			For opening tags, this contains the names and values of all parameters. Values are strings, except for parameters without an explicit value, as they have [code]null[/code] as their value instead.
-		</member>
-		<member name="type" type="int" setter="set_token_type" getter="get_token_type" enum="BBCodeToken.TokenType" default="0">
-			Type of BBCode token.
-		</member>
-		<member name="value" type="String" setter="set_value" getter="get_value" default="&quot;&quot;">
-			For text tokens, this is the text itself. For tags, it is the name of the tag.
-		</member>
-	</members>
+	<methods>
+		<method name="get_normalized_bbcode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns a normalized BBCode string of this token. This will reconstruct the token as a string from the ground up.
+			</description>
+		</method>
+		<method name="get_parameters" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				For opening tags, this returns the names and values of all parameters. Dictionary keys and values are strings, except for parameters without an explicit value, as they have [code]null[/code] as their value instead.
+			</description>
+		</method>
+		<method name="get_parsed_bbcode" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the BBCode string as it was parsed via [method BBCodeParser.push_bbcode]. If another method was used to generate this token, the value of this will be computed via [method get_normalized_bbcode].
+			</description>
+		</method>
+		<method name="get_position_end" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns this token's last character position in the full BBCode string. If the token was generated without parsing a BBCode string, the token's size is computed via [method get_normalized_bbcode].
+			</description>
+		</method>
+		<method name="get_position_start" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns this token's first character position in the full BBCode string.
+			</description>
+		</method>
+		<method name="get_token_type" qualifiers="const">
+			<return type="int" enum="BBCodeToken.TokenType" />
+			<description>
+				Returns the type of BBCode token.
+			</description>
+		</method>
+		<method name="get_value" qualifiers="const">
+			<return type="String" />
+			<description>
+				For text tokens, this returns the text itself. For tags, it returns the name of the tag.
+			</description>
+		</method>
+	</methods>
 	<constants>
 		<constant name="TOKEN_TYPE_TEXT" value="0" enum="TokenType">
-			Literal text. [member value] contains the text.
+			Literal text. [method get_value] contains the text.
 		</constant>
 		<constant name="TOKEN_TYPE_OPEN_TAG" value="1" enum="TokenType">
-			Opening tag. [member value] contains the tag name and [member parameters] is filled.
+			Opening tag. [method get_value] contains the tag name and [method get_parameters] is filled.
 		</constant>
 		<constant name="TOKEN_TYPE_CLOSE_TAG" value="2" enum="TokenType">
-			Closing tag. [member value] contains the tag name.
+			Closing tag. [method get_value] contains the tag name.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/BBCodeToken.xml
+++ b/doc/classes/BBCodeToken.xml
@@ -13,7 +13,7 @@
 		<member name="parameters" type="Dictionary" setter="set_parameters" getter="get_parameters" default="{}">
 			For opening tags, this contains the names and values of all parameters. Values are strings, except for parameters without an explicit value, as they have [code]null[/code] as their value instead.
 		</member>
-		<member name="type" type="int" setter="set_type" getter="get_type" default="0">
+		<member name="type" type="int" setter="set_token_type" getter="get_token_type" default="0">
 			Type of BBCode token.
 		</member>
 		<member name="value" type="String" setter="set_value" getter="get_value" default="&quot;&quot;">

--- a/doc/classes/BBCodeToken.xml
+++ b/doc/classes/BBCodeToken.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="BBCodeToken" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		BBCode tokens of a [BBCodeParser].
+	</brief_description>
+	<description>
+		BBCode tokens generated from calls to [method BBCodeParser.get_items].
+		[b]Note:[/b] When the parser is cleared or freed, all of its tokens are also freed. Do not hold on to references of tokens for longer than necessary.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="parameters" type="Dictionary" setter="set_parameters" getter="get_parameters" default="{}">
+			For opening tags, this contains the names and values of all parameters. Values are strings, except for parameters without an explicit value, as they have [code]null[/code] as their value instead.
+		</member>
+		<member name="type" type="int" setter="set_type" getter="get_type" default="0">
+			Type of BBCode token.
+		</member>
+		<member name="value" type="String" setter="set_value" getter="get_value" default="&quot;&quot;">
+			For text tokens, this is the text itself. For tags, it is the name of the tag.
+		</member>
+	</members>
+</class>

--- a/doc/classes/RichTextLabelBBCodeParser.xml
+++ b/doc/classes/RichTextLabelBBCodeParser.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="RichTextLabelBBCodeParser" inherits="BBCodeParser" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A [BBCodeParser] compatible with [RichTextLabel] syntax.
+	</brief_description>
+	<description>
+		The [BBCodeParser] type that is used by [RichTextLabel].
+	</description>
+	<tutorials>
+		<link title="BBCode in RichTextLabel">$DOCS_URL/tutorials/ui/bbcode_in_richtextlabel.html</link>
+	</tutorials>
+	<methods>
+		<method name="add_custom_effect">
+			<return type="void" />
+			<param index="0" name="effect" type="RichTextEffect" />
+			<description>
+				Add a custom effect to the list of known effects. Custom effects decide their own BBCode tag, but can not validate their parameters.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="backslash_escape_quotes" type="bool" setter="set_backslash_escape_quotes" getter="get_backslash_escape_quotes" overrides="BBCodeParser" default="false" />
+		<member name="custom_effects" type="RichTextEffect[]" setter="set_custom_effects" getter="get_custom_effects" default="[]">
+			List of custom [RichTextEffect] resources known to this parser. A custom effect decides its own BBCode tag, but can not validate its parameters.
+		</member>
+		<member name="escape_brackets" type="int" setter="set_escape_brackets" getter="get_escape_brackets" overrides="BBCodeParser" enum="BBCodeParser.EscapeBrackets" is_bitfield="true" default="4" />
+	</members>
+</class>

--- a/doc/classes/RichTextLabelBBCodeParser.xml
+++ b/doc/classes/RichTextLabelBBCodeParser.xml
@@ -23,6 +23,7 @@
 		<member name="custom_effects" type="RichTextEffect[]" setter="set_custom_effects" getter="get_custom_effects" default="[]">
 			List of custom [RichTextEffect] resources known to this parser. A custom effect decides its own BBCode tag, but can not validate its parameters.
 		</member>
+		<member name="error_handling" type="int" setter="set_error_handling" getter="get_error_handling" overrides="BBCodeParser" enum="BBCodeParser.ErrorHandling" default="1" />
 		<member name="escape_brackets" type="int" setter="set_escape_brackets" getter="get_escape_brackets" overrides="BBCodeParser" enum="BBCodeParser.EscapeBrackets" is_bitfield="true" default="4" />
 	</members>
 </class>

--- a/scene/gui/rich_text_label_parser.cpp
+++ b/scene/gui/rich_text_label_parser.cpp
@@ -1,0 +1,192 @@
+/**************************************************************************/
+/*  rich_text_label_parser.cpp                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rich_text_label_parser.h"
+
+#include "scene/gui/rich_text_effect.h"
+
+const Vector<String> parameterless_tags = {
+	"b",
+	"i",
+	"u",
+	"s",
+	"code",
+	"center",
+	"left",
+	"right",
+	"fill",
+	"indent",
+};
+
+const Vector<String> self_closing_tags = {
+	"br",
+	"lb",
+	"rb",
+	"lrm",
+	"rlm",
+	"rle",
+	"lro",
+	"rlo",
+	"pdf",
+	"alm",
+	"lri",
+	"rli",
+	"fsi",
+	"pdi",
+	"zwj",
+	"zwnj",
+	"wj",
+	"shy",
+};
+
+const Vector<String> main_parameter_tags = {
+	"char",
+	"color",
+	"url",
+	"hint",
+	"font_size",
+	"opentype_features",
+	"lang",
+	"bgcolor",
+	"fgcolor",
+	"outline_size",
+	"outline_color",
+	"table",
+};
+
+const Vector<String> complex_tags = {
+	"p",
+	"img",
+	"font",
+	"dropcap",
+	"cell",
+	"ul",
+	"ol",
+	"pulse",
+	"fade",
+	"shake",
+	"wave",
+	"tornado",
+	"rainbow",
+};
+
+static Vector<String> make_all_known_tags() {
+	Vector<String> tags;
+	tags.append_array(parameterless_tags);
+	tags.append_array(self_closing_tags);
+	tags.append_array(main_parameter_tags);
+	tags.append_array(complex_tags);
+	return tags;
+}
+
+const Vector<String> all_known_tags = make_all_known_tags();
+
+Dictionary RichTextLabelBBCodeParser::_validate_tag(const String &p_tag, const Dictionary &p_parameters) const {
+	Dictionary result;
+	Error err = OK;
+
+	if (parameterless_tags.has(p_tag)) {
+		if (!p_parameters.is_empty()) {
+			err = ERR_INVALID_PARAMETER;
+		}
+	} else if (self_closing_tags.has(p_tag)) {
+		if (!p_parameters.is_empty()) {
+			err = ERR_INVALID_PARAMETER;
+		}
+		result["self_closing"] = true;
+	} else if (main_parameter_tags.has(p_tag)) {
+		// Main parameter is required for every tag except URL.
+		if (p_parameters.is_empty() && p_tag != "url") {
+			err = ERR_INVALID_PARAMETER;
+		}
+		// Too many parameters.
+		if (p_parameters.size() > 1) {
+			err = ERR_INVALID_PARAMETER;
+		}
+		if (!p_parameters.is_empty()) {
+			// Parameter may not be name=value syntax.
+			const String &key = p_parameters.get_key_at_index(0);
+			const Variant &value = p_parameters[key];
+			if (!value.is_null()) {
+				err = ERR_INVALID_PARAMETER;
+			}
+		}
+		// TODO: data validation, e.g. check for valid (fg|bg|outline)color, font_size being a number, etc.
+	} else if (complex_tags.has(p_tag)) {
+		// TODO: parameter syntax & data validation
+	} else {
+		bool valid = false;
+		for (int i = 0; i < custom_effects.size(); i++) {
+			Ref<RichTextEffect> effect = custom_effects[i];
+			if (effect.is_null()) {
+				continue;
+			}
+
+			if (effect->get_bbcode() == p_tag) {
+				valid = true;
+				break;
+			}
+		}
+
+		if (!valid) {
+			// Unknown tag.
+			err = ERR_DOES_NOT_EXIST;
+		}
+	}
+
+	result.set("error", err);
+	return result;
+}
+
+void RichTextLabelBBCodeParser::add_custom_effect(const Ref<RichTextEffect> &p_effect) {
+	ERR_FAIL_COND_MSG(p_effect.is_null(), "Invalid RichTextEffect resource.");
+	custom_effects.append(p_effect);
+}
+
+TypedArray<RichTextEffect> RichTextLabelBBCodeParser::get_custom_effects() {
+	return custom_effects;
+}
+
+void RichTextLabelBBCodeParser::set_custom_effects(const TypedArray<RichTextEffect> &p_effects) {
+	custom_effects = p_effects;
+}
+
+void RichTextLabelBBCodeParser::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_custom_effect", "effect"), &RichTextLabelBBCodeParser::add_custom_effect);
+	ClassDB::bind_method(D_METHOD("get_custom_effects"), &RichTextLabelBBCodeParser::get_custom_effects);
+	ClassDB::bind_method(D_METHOD("set_custom_effects", "effects"), &RichTextLabelBBCodeParser::set_custom_effects);
+
+	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "custom_effects", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("RichTextEffect")), "set_custom_effects", "get_custom_effects");
+}
+
+RichTextLabelBBCodeParser::RichTextLabelBBCodeParser() {
+	set_backslash_escape_quotes(false); // For backwards-compatibility.
+	set_escape_brackets(ESCAPE_BRACKETS_ABBREVIATION);
+}

--- a/scene/gui/rich_text_label_parser.cpp
+++ b/scene/gui/rich_text_label_parser.cpp
@@ -187,6 +187,9 @@ void RichTextLabelBBCodeParser::_bind_methods() {
 }
 
 RichTextLabelBBCodeParser::RichTextLabelBBCodeParser() {
-	set_backslash_escape_quotes(false); // For backwards-compatibility.
 	set_escape_brackets(ESCAPE_BRACKETS_ABBREVIATION);
+
+	// For backwards-compatibility:
+	set_backslash_escape_quotes(false);
+	set_error_handling(ERROR_HANDLING_PARSE_AS_TEXT);
 }

--- a/scene/gui/rich_text_label_parser.h
+++ b/scene/gui/rich_text_label_parser.h
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  rich_text_label_parser.h                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/bbcode.h"
+
+class RichTextEffect;
+
+class RichTextLabelBBCodeParser : public BBCodeParser {
+	GDCLASS(RichTextLabelBBCodeParser, BBCodeParser);
+
+protected:
+	static void _bind_methods();
+
+	TypedArray<RichTextEffect> custom_effects;
+
+public:
+	virtual Dictionary _validate_tag(const String &p_tag, const Dictionary &p_parameters) const override;
+
+	void add_custom_effect(const Ref<RichTextEffect> &p_effect);
+	TypedArray<RichTextEffect> get_custom_effects();
+	void set_custom_effects(const TypedArray<RichTextEffect> &p_effects);
+
+	RichTextLabelBBCodeParser();
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -78,6 +78,7 @@
 #include "scene/gui/reference_rect.h"
 #include "scene/gui/rich_text_effect.h"
 #include "scene/gui/rich_text_label.h"
+#include "scene/gui/rich_text_label_parser.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/separator.h"
@@ -510,6 +511,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SpinBox);
 	GDREGISTER_CLASS(ColorPicker);
 	GDREGISTER_CLASS(ColorPickerButton);
+	GDREGISTER_CLASS(RichTextLabelBBCodeParser);
 	GDREGISTER_CLASS(RichTextLabel);
 	GDREGISTER_CLASS(RichTextEffect);
 	GDREGISTER_CLASS(CharFXTransform);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/10339

- [ ] Allow disambiguation between `[a b]` and `[a=b]` style parameters
  - Contrived example: `[color=red inverted]` would currently parse as `{ "red": null, "inverted": null }` so the user would have to use the order of dictionary keys to find out which of the parameters is the "main" parameter.
- [ ] Resolve code TODOs
- [x] Resolve open discussion points in the proposal
- [ ] Finish API and functionality
  - [ ] Tree-style API (might leave it out if RTL can be ported without it)
  - [x] Introduce configuration for how brackets and quotes can be escaped
  - [x] Add `pop` method to remove the topmost tag from the stack
  - [x] Find out what other info the Token class should expose and store (e.g. start/end char index?)
  - [ ] Should closing tags also be validated? It makes little sense to e.g. filter out unknown opening tags, if their closing tags still exist in the data.
  - [ ] Decide how to do error handling
    - [x] Allow user to configure whether error should remove data (current PR implementation), to convert invalid tags to plaintext (how RichTextLabel currently works), or to keep erroneous data as-is (so insert an OPEN_TAG token even if it has an error)
    - [ ] Should error codes perhaps be replaced with error strings? Or a custom BBCodeParser-specific error enum to draw from?
- [ ] Do another pass over the docs
- [ ] Tests

In order to ensure that this parser can later be used for RichTextLabel, EditorHelp etc., I may push some WIP parser code in here.
However these changes will likely be split into separate PRs before landing.

## Example

```gdscript
extends Node

func _ready() -> void:
	var bb = MyBBCodeParser.new()
	bb.push_bbcode("hello [world foo='bar' neat]testing[i]")
	bb.push_bbcode("split up[/world] [br] [tag=me weird=' one ']")
	bb.push_text("literal [ stuff")
	bb.pop_tag("tag")
	print(error_string(bb.get_error()))
	print("\n".join(bb.get_items().map(func(t): return token_to_str(t))))

func token_to_str(token: BBCodeToken):
	var ty = ["TEXT", "OPEN_TAG", "CLOSE_TAG"][token.get_type()]
	var par = token.get_parameters() if token.get_type() == BBCodeToken.TOKEN_TYPE_OPEN_TAG else ""
	return "%s \"%s\" %s" % [ty, token.get_value(), par]

class MyBBCodeParser extends BBCodeParser:
	func _validate_tag(tag: String, parameters: Dictionary) -> Dictionary:
		if tag == "br":
			return { "self_closing": true }
		if tag == "world":
			return { "escape_contents": true }
		if tag == "img" and parameters.is_empty():
			return { "error": ERR_INVALID_PARAMETER }
		return {}

	func _validate_text(text: String) -> Error:
		if "fire" in text:
			return ERR_PRINTER_ON_FIRE
		return OK
```

Prints the following:

```
OK
TEXT "hello " 
OPEN_TAG "world" { "foo": "bar", "neat": <null> }
TEXT "testing" 
TEXT "[i]"
TEXT "split up" 
CLOSE_TAG "world" 
TEXT " " 
OPEN_TAG "br" {  }
TEXT " " 
OPEN_TAG "tag" { "me": <null>, "weird": " one " }
TEXT "literal [ stuff" 
CLOSE_TAG "tag" 
```