### PR TITLE
Add support for static members from basic types to `Expression`

### DIFF
--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -117,7 +117,10 @@ private:
 			TYPE_DICTIONARY,
 			TYPE_CONSTRUCTOR,
 			TYPE_BUILTIN_FUNC,
-			TYPE_CALL
+			TYPE_CALL,
+			TYPE_BASIC_TYPE_FUNC,
+			TYPE_BASIC_TYPE_CONSTANT,
+			TYPE_BASIC_TYPE_ENUM
 		};
 
 		ENode *next = nullptr;
@@ -227,6 +230,32 @@ private:
 		Vector<ENode *> arguments;
 		BuiltinFuncNode() {
 			type = TYPE_BUILTIN_FUNC;
+		}
+	};
+
+	struct BasicTypeFuncNode : public ENode {
+		Variant::Type data_type = Variant::Type::NIL;
+		StringName func;
+		Vector<ENode *> arguments;
+		BasicTypeFuncNode() {
+			type = TYPE_BASIC_TYPE_FUNC;
+		}
+	};
+
+	struct BasicTypeConstNode : public ENode {
+		Variant::Type data_type = Variant::Type::NIL;
+		StringName name;
+		BasicTypeConstNode() {
+			type = TYPE_BASIC_TYPE_CONSTANT;
+		}
+	};
+
+	struct BasicTypeEnumNode : public ENode {
+		Variant::Type data_type = Variant::Type::NIL;
+		StringName enum_name;
+		StringName enumeration;
+		BasicTypeEnumNode() {
+			type = TYPE_BASIC_TYPE_ENUM;
 		}
 	};
 


### PR DESCRIPTION
- Fixes: #106542

Basic types (`Vector2`, `Basis`, etc) can be used in an `Expression` out-of-the-box, but it only parses constructors. This PR adds support for their constants, static functions, and enums too.

```gdscript
@tool
extends Node


@export_tool_button("parse") var eval = _ready


func _ready() -> void:
	# None should fail
	assert(evaluate("Vector2.AXIS_Y") == Vector2.AXIS_Y)
	assert(evaluate("Vector2.Axis.AXIS_Y") == Vector2.Axis.AXIS_Y)
	assert(evaluate("Vector3(Vector2.Axis.AXIS_Y, 0, 5) * 2") == Vector3(Vector2.Axis.AXIS_Y, 0, 5) * 2)
	assert(evaluate('Vector2.UP') == Vector2(0, -1))
	assert(evaluate('Vector2.from_angle(2).is_equal_approx(Vector2(-0.416147, 0.909297))') == true)
	assert(evaluate('String.chr(65)') == 'A')


func evaluate(expr:String):
	var expression = Expression.new()
	var error = expression.parse(expr)

	if error != OK:
		print("Parse failed: %s" % expression.get_error_text())
		return null

	var result = expression.execute()
	if not expression.has_execute_failed():
		print("Execute succeeded: \"%s\": %s" % [expr, result])
	else:
		print("Execute failed: \"%s\"" % expr)

	return result

```