### PR TITLE
Fix error when closing all scene tabs on the last tab

### DIFF
--- a/editor/gui/editor_scene_tabs.h
+++ b/editor/gui/editor_scene_tabs.h
@@ -47,7 +47,7 @@ class EditorSceneTabs : public MarginContainer {
 
 public:
 	enum {
-		SCENE_SHOW_IN_FILESYSTEM = 3000, // Prevents conflicts with EditorNode options.
+		SCENE_SHOW_IN_FILESYSTEM = 1000, // Prevents conflicts with EditorNode options.
 		SCENE_RUN,
 		SCENE_CLOSE_OTHERS,
 		SCENE_CLOSE_RIGHT,


### PR DESCRIPTION
To reproduce the error, open two scenes and right click on the last scene tab, choose "Close All Tabs".

The scenes will close successfully, but an error will be printed:

```
ERROR: Index p_idx = 1 is out of bounds (edited_scene.size() = 1).
   at: get_scene_path (editor/editor_data.cpp:893)
```

This is because this context menu has two `id_pressed` handlers, one forwarding to `EditorNode`'s scene menu, the other is for custom menu items added by plugins:

https://github.com/godotengine/godot/blob/be3ecaeb3c51433058ad4e96ec892d18f4291efd/editor/gui/editor_scene_tabs.cpp#L434-L435

The error is caused by the menu item IDs in this context menu starting from 3000.

- A very large number was picked so they don't clash with `EditorNode`'s scene menu item IDs.
- However, IDs starting from 2000 are considered custom menu items added by plugins.

https://github.com/godotengine/godot/blob/be3ecaeb3c51433058ad4e96ec892d18f4291efd/editor/gui/editor_scene_tabs.h#L49-L55

https://github.com/godotengine/godot/blob/be3ecaeb3c51433058ad4e96ec892d18f4291efd/editor/plugins/editor_context_menu_plugin.h#L58

https://github.com/godotengine/godot/blob/be3ecaeb3c51433058ad4e96ec892d18f4291efd/editor/gui/editor_scene_tabs.cpp#L223-L227

In addition to being mistakened as a custom menu item, if the built-in menu item causes the current tab to be closed before the second handler `EditorSceneTabs::_custom_menu_option` is called, this error will occur.

This PR changes the starting item ID to 1000 so only one of the two handlers will be called.