### PR TITLE
Fix finished signal on GPU particles

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -81,6 +81,9 @@ void GPUParticles2D::set_lifetime(double p_lifetime) {
 }
 
 void GPUParticles2D::set_one_shot(bool p_enable) {
+	if (one_shot == p_enable) {
+		return;
+	}
 	one_shot = p_enable;
 	RS::get_singleton()->particles_set_one_shot(particles, one_shot);
 
@@ -90,8 +93,11 @@ void GPUParticles2D::set_one_shot(bool p_enable) {
 			RenderingServer::get_singleton()->particles_restart(particles);
 		}
 	}
-
-	if (!one_shot) {
+	if (one_shot) {
+		active = true;
+		emission_time = lifetime;
+		active_time = lifetime * (2 - explosiveness_ratio);
+	} else {
 		set_process_internal(false);
 	}
 }

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -89,6 +89,9 @@ void GPUParticles3D::set_interp_to_end(float p_interp) {
 }
 
 void GPUParticles3D::set_one_shot(bool p_one_shot) {
+	if (one_shot == p_one_shot) {
+		return;
+	}
 	one_shot = p_one_shot;
 	RS::get_singleton()->particles_set_one_shot(particles, one_shot);
 
@@ -96,6 +99,11 @@ void GPUParticles3D::set_one_shot(bool p_one_shot) {
 		if (!one_shot) {
 			RenderingServer::get_singleton()->particles_restart(particles);
 		}
+	}
+	if (one_shot) {
+		active = true;
+		emission_time = lifetime;
+		active_time = lifetime * (2 - explosiveness_ratio);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/93991

Fixes two issues:
1. `finished` signal is now emitted when continuously emitting `GPUParticles2D` (or 3D) is stopped by setting `one_shot` to true. 
    - Previously `finished` signal was not emitted and it was extremely difficult to work with particles. I have a lot of use cases where I need to do something when the particles are stopped.
    - There was a workaround which at least sometimes worked. Calling `gpu_particles_2d.restart()` in `_ready()` function allowed `finished` signal to emit.

So this kind of code works now:
```gdscript
func _on_button_pressed() -> void:
	gpu_particles_2d.one_shot = true
	gpu_particles_2d.finished.connect(func(): prints("FINISHED!!!!!"))
```

2. Setting `one_shot` to `false` when it already is `false` no longer resets the particle system. 

I tested master's CPUParticles2D and that doesn't have same problem.