### PR TITLE
Change editor debugger error list jump action to double-click to avoid accidental trigger

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -106,8 +106,8 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	node->connect("stop_requested", callable_mp(this, &EditorDebuggerNode::_debugger_wants_stop).bind(id));
 	node->connect("stopped", callable_mp(this, &EditorDebuggerNode::_debugger_stopped).bind(id));
 	node->connect("stack_frame_selected", callable_mp(this, &EditorDebuggerNode::_stack_frame_selected).bind(id));
-	node->connect("error_selected", callable_mp(this, &EditorDebuggerNode::_error_selected).bind(id));
-	node->connect("breakpoint_selected", callable_mp(this, &EditorDebuggerNode::_error_selected).bind(id));
+	node->connect("view_error", callable_mp(this, &EditorDebuggerNode::_view_error).bind(id));
+	node->connect("breakpoint_selected", callable_mp(this, &EditorDebuggerNode::_view_error).bind(id));
 	node->connect("clear_execution", callable_mp(this, &EditorDebuggerNode::_clear_execution));
 	node->connect("breaked", callable_mp(this, &EditorDebuggerNode::_breaked).bind(id));
 	node->connect("debug_data", callable_mp(this, &EditorDebuggerNode::_debug_data).bind(id));
@@ -152,7 +152,7 @@ void EditorDebuggerNode::_stack_frame_selected(int p_debugger) {
 	_text_editor_stack_goto(dbg);
 }
 
-void EditorDebuggerNode::_error_selected(const String &p_file, int p_line, int p_debugger) {
+void EditorDebuggerNode::_view_error(const String &p_file, int p_line, int p_debugger) {
 	Ref<Script> s = ResourceLoader::load(p_file);
 	emit_signal(SNAME("goto_script_line"), s, p_line - 1);
 }

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -153,7 +153,7 @@ protected:
 	void _text_editor_stack_goto(const ScriptEditorDebugger *p_debugger);
 	void _text_editor_stack_clear(const ScriptEditorDebugger *p_debugger);
 	void _stack_frame_selected(int p_debugger);
-	void _error_selected(const String &p_file, int p_line, int p_debugger);
+	void _view_error(const String &p_file, int p_line, int p_debugger);
 	void _breaked(bool p_breaked, bool p_can_debug, const String &p_message, bool p_has_stackdump, int p_debugger);
 	void _paused();
 	void _break_state_changed();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1006,7 +1006,6 @@ void ScriptEditorDebugger::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			le_set->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_set));
 			le_clear->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_live_edit_clear));
-			error_tree->connect(SceneStringName(item_selected), callable_mp(this, &ScriptEditorDebugger::_error_selected));
 			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 			breakpoints_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_breakpoint_tree_clicked));
 			connect("started", callable_mp(expression_evaluator, &EditorExpressionEvaluator::on_start));
@@ -1674,25 +1673,12 @@ void ScriptEditorDebugger::_error_activated() {
 		return;
 	}
 
-	TreeItem *ci = selected->get_first_child();
-	if (ci) {
-		selected->set_collapsed(!selected->is_collapsed());
-	}
-}
-
-void ScriptEditorDebugger::_error_selected() {
-	TreeItem *selected = error_tree->get_selected();
-
-	if (!selected) {
-		return;
-	}
-
 	Array meta = selected->get_metadata(0);
 	if (meta.is_empty()) {
 		return;
 	}
 
-	emit_signal(SNAME("error_selected"), String(meta[0]), int(meta[1]));
+	emit_signal(SNAME("view_error"), String(meta[0]), int(meta[1]));
 }
 
 void ScriptEditorDebugger::_expand_errors_list() {
@@ -1896,7 +1882,7 @@ void ScriptEditorDebugger::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("stopped"));
 	ADD_SIGNAL(MethodInfo("stop_requested"));
 	ADD_SIGNAL(MethodInfo("stack_frame_selected", PropertyInfo(Variant::INT, "frame")));
-	ADD_SIGNAL(MethodInfo("error_selected", PropertyInfo(Variant::INT, "error")));
+	ADD_SIGNAL(MethodInfo("view_error", PropertyInfo(Variant::INT, "error")));
 	ADD_SIGNAL(MethodInfo("breakpoint_selected", PropertyInfo("script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("set_execution", PropertyInfo("script"), PropertyInfo(Variant::INT, "line")));
 	ADD_SIGNAL(MethodInfo("clear_execution", PropertyInfo("script")));

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -252,7 +252,6 @@ private:
 	void _property_changed(Object *p_base, const StringName &p_property, const Variant &p_value);
 
 	void _error_activated();
-	void _error_selected();
 
 	void _expand_errors_list();
 	void _collapse_errors_list();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Currently, the behavior of jumping to the error location is bind to the `Tree::item_selected` signal, which results in jumping to the error location in the editor with only one click on the error item. It is easy to accidental trigger (e.g. when you try to click the expand button to the left of the error item). And right-clicking can also trigger this signal, making it impossible to access the right-click menu without jumping to the error location. These issues are especially noticeable when using external text editors and harm the user experience
This pr binds the behavior of jumping to the error location to the `Tree::item_activate` signal, so that only double-clicking on the error item or pressing enter after selecting it will jump to the error location

https://github.com/user-attachments/assets/789f820d-bb74-487d-971a-d2b37e198509
