### PR TITLE
Update VARCALL_ARRAY_SETTER_GETTER to account for negative indices

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -659,10 +659,16 @@ static _FORCE_INLINE_ void vc_ptrcall(void (*method)(T *, P...), void *p_base, c
 
 #define VARCALL_ARRAY_GETTER_SETTER(m_packed_type, m_type)                                                      \
 	static m_type func_##m_packed_type##_get(m_packed_type *p_instance, int64_t p_index) {                      \
+		if (p_index < 0) {                                                                                      \
+			p_index += p_instance->size();                                                                      \
+		}                                                                                                       \
 		ERR_FAIL_INDEX_V(p_index, p_instance->size(), m_type());                                                \
 		return p_instance->get(p_index);                                                                        \
 	}                                                                                                           \
 	static void func_##m_packed_type##_set(m_packed_type *p_instance, int64_t p_index, const m_type &p_value) { \
+		if (p_index < 0) {                                                                                      \
+			p_index += p_instance->size();                                                                      \
+		}                                                                                                       \
 		ERR_FAIL_INDEX(p_index, p_instance->size());                                                            \
 		p_instance->set(p_index, p_value);                                                                      \
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This fixes https://github.com/godotengine/godot/issues/106628

Running the following code
![code](https://github.com/user-attachments/assets/3c7978cb-e8fb-40e5-8d3c-ce820cfab33d)


Produced this before the fix
![before](https://github.com/user-attachments/assets/5001cb4c-718d-4288-985d-de9e3b96ed1c)

And this after the fix
![after](https://github.com/user-attachments/assets/d0c12137-be9a-484a-a902-38d5f88cbeb4)



