### PR TITLE
Add support for bilinear downscaling using FSR2 or MetalFX Temporal Native

### DIFF
--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -181,17 +181,21 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 			bool scaling_3d_is_not_bilinear = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF && scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
 			bool use_taa = p_viewport->use_taa;
 
-			if (scaling_3d_is_not_bilinear && (scaling_3d_scale >= (1.0 + EPSILON))) {
-				// FSR and MetalFX is not designed for downsampling.
+			if (scaling_3d_is_not_bilinear && scaling_type != RS::VIEWPORT_SCALING_3D_TYPE_TEMPORAL && scaling_3d_scale >= 1.0 + EPSILON) {
+				// FSR1 and MetalFX Spatial are not designed for downsampling.
 				// Fall back to bilinear scaling.
-				WARN_PRINT_ONCE("FSR 3D resolution scaling is not designed for downsampling. Falling back to bilinear 3D resolution scaling.");
+				//
+				// FSR2 and MetalFX temporal are not designed for downsampling either,
+				// but we can render at the specified render scale and downscale bilinearly
+				// to achieve the same effect.
+				WARN_PRINT_ONCE("FSR1 or MetalFX Spatial 3D resolution scaling is not designed for downsampling. Falling back to bilinear 3D resolution scaling.");
 				scaling_3d_mode = RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
 			}
 
 			if (scaling_3d_is_not_bilinear && !upscaler_available) {
 				// FSR is not actually available.
 				// Fall back to bilinear scaling.
-				WARN_PRINT_ONCE("FSR 3D resolution scaling is not available. Falling back to bilinear 3D resolution scaling.");
+				WARN_PRINT_ONCE("FSR or MetalFX 3D resolution scaling is not available. Falling back to bilinear 3D resolution scaling.");
 				scaling_3d_mode = RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
 			}
 
@@ -216,14 +220,29 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 					render_width = CLAMP(target_width * scaling_3d_scale, 1, 16384);
 					render_height = CLAMP(target_height * scaling_3d_scale, 1, 16384);
 					break;
-				case RS::VIEWPORT_SCALING_3D_MODE_METALFX_SPATIAL:
-				case RS::VIEWPORT_SCALING_3D_MODE_METALFX_TEMPORAL:
 				case RS::VIEWPORT_SCALING_3D_MODE_FSR:
-				case RS::VIEWPORT_SCALING_3D_MODE_FSR2:
+				case RS::VIEWPORT_SCALING_3D_MODE_METALFX_SPATIAL:
 					target_width = p_viewport->size.width;
 					target_height = p_viewport->size.height;
 					render_width = MAX(target_width * scaling_3d_scale, 1.0); // target_width / (target_width * scaling)
 					render_height = MAX(target_height * scaling_3d_scale, 1.0);
+					break;
+				case RS::VIEWPORT_SCALING_3D_MODE_FSR2:
+				case RS::VIEWPORT_SCALING_3D_MODE_METALFX_TEMPORAL:
+					if (scaling_3d_scale > 1.0 + EPSILON) {
+						// Downsampling is not supported by FSR2 or MetalFX Temporal.
+						// Instead, we render at native resolution at the specified resolution scale
+						// and downscale bilinearly.
+						target_width = p_viewport->size.width * scaling_3d_scale;
+						target_height = p_viewport->size.height * scaling_3d_scale;
+						render_width = target_width;
+						render_height = target_height;
+					} else {
+						target_width = p_viewport->size.width;
+						target_height = p_viewport->size.height;
+						render_width = MAX(target_width * scaling_3d_scale, 1.0); // target_width / (target_width * scaling)
+						render_height = MAX(target_height * scaling_3d_scale, 1.0);
+					}
 					break;
 				case RS::VIEWPORT_SCALING_3D_MODE_OFF:
 					target_width = p_viewport->size.width;


### PR DESCRIPTION
FSR2 and MetalFX Temporal don't natively support downscaling, so we make them render at native resolution at the specified 3D render scale, then downscale the result bilinearly. This is a similar outcome to standard bilinear downscaling when TAA is enabled, but overall quality is slightly higher (at the cost of higher GPU utilization).

PS: This same approach could also be used to make FSR2/MetalFX Temporal upscale to a lower-than-native resolution, then have the engine upscale bilinearly to the window size. This is worth considering for low-end GPUs where upscaling to native resolution can require a lot of resources for little visual gain (e.g. it might be better to upscale from 720p to 1440p than 720p to 4K with FSR2/MetalFX Temporal).

- This supersedes https://github.com/godotengine/godot/pull/83268. cc @Jamsers

## Preview

Using Movie Maker mode on https://github.com/Calinou/godot-reflection with this command line:

```
--write-movie /tmp/out.png --quit-after 50 --time-scale 16 -- --benchmark
```

We retain the last rendered frame (numbered `49` as it counts from `0`). This simulates very fast motion by increasing the time scale. FSR sharpness was set to `2.0` to disable it (higher values result in lower sharpness).

<details>

### TAA at 2.0 render scale

![taa](https://github.com/user-attachments/assets/7e17e068-da28-46a0-bdfa-a2db865b8ed8)

### FSR2 at 2.0 render scale

*Notice the different handling of ghosting on the left. This is normally not noticeable in real world scenarios, but with very fast motion like in this example, a difference can be seen.*

![fsr2](https://github.com/user-attachments/assets/1484ec1c-9ddb-449c-9a48-f49ce52bed77)

### "Ground truth" (downscaled from 8K in an image editor)

![ground_truth](https://github.com/user-attachments/assets/6a209c59-1cfa-4fd5-931b-1cc4981ce8bd)
</details>

## 4× zoom

<details>

### TAA at 2.0 render scale

![taa_zoom](https://github.com/user-attachments/assets/2b3bd158-fb9b-4222-b741-79bc15c1503b)

### FSR2 at 2.0 render scale

![fsr2_zoom](https://github.com/user-attachments/assets/9673c57b-344b-49ee-867b-8e88c6a037da)

### "Ground truth" (downscaled from 8K in an image editor)

![ground_truth_zoom](https://github.com/user-attachments/assets/8162d234-133c-45b1-b9ee-197f1bc20713)
</details>