### PR TITLE
Optimize property access for `Object` subtypes

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -117,6 +117,16 @@ public:
 		Variant::Type type;
 	};
 
+	struct PropertyVariant {
+		enum {
+			PROPERTY,
+			CONSTANT,
+			METHOD,
+			SIGNAL
+		} type;
+		void *ptr;
+	};
+
 	struct ClassInfo {
 		APIType api = API_NONE;
 		ClassInfo *inherits_ptr = nullptr;
@@ -126,14 +136,14 @@ public:
 
 		HashMap<StringName, MethodBind *> method_map;
 		HashMap<StringName, LocalVector<MethodBind *>> method_map_compatibility;
-		HashMap<StringName, int64_t> constant_map;
+		HashMap<StringName, int64_t *> constant_map;
 		struct EnumInfo {
 			List<StringName> constants;
 			bool is_bitfield = false;
 		};
 
 		HashMap<StringName, EnumInfo> enum_map;
-		HashMap<StringName, MethodInfo> signal_map;
+		HashMap<StringName, MethodInfo *> signal_map;
 		List<PropertyInfo> property_list;
 		HashMap<StringName, PropertyInfo> property_map;
 
@@ -151,7 +161,7 @@ public:
 		List<StringName> dependency_list;
 #endif
 
-		HashMap<StringName, PropertySetGet> property_setget;
+		HashMap<StringName, PropertySetGet *> property_setget;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
 		StringName inherits;
@@ -163,6 +173,8 @@ public:
 		bool is_runtime = false;
 		// The bool argument indicates the need to postinitialize.
 		Object *(*creation_func)(bool) = nullptr;
+
+		HashMap<StringName, PropertyVariant> property_cache;
 
 		ClassInfo() {}
 		~ClassInfo() {}
@@ -245,6 +257,8 @@ private:
 	static Object *_instantiate_internal(const StringName &p_class, bool p_require_real_class = false, bool p_notify_postinitialize = true, bool p_exposed_only = true);
 
 	static bool _can_instantiate(ClassInfo *p_class_info, bool p_exposed_only = true);
+
+	static void _insert_property_cache(ClassInfo *p_class_info, const StringName &p_property_name, const PropertyVariant &p_variant);
 
 public:
 	template <typename T>

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -124,7 +124,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, int64_t> &F : t->constant_map) {
+			for (const KeyValue<StringName, int64_t *> &F : t->constant_map) {
 				snames.push_back(F.key);
 			}
 
@@ -149,7 +149,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, MethodInfo> &F : t->signal_map) {
+			for (const KeyValue<StringName, MethodInfo *> &F : t->signal_map) {
 				snames.push_back(F.key);
 			}
 
@@ -161,12 +161,12 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary signal_dict;
 				signals.push_back(signal_dict);
 
-				MethodInfo &mi = t->signal_map[F];
+				MethodInfo *mi = t->signal_map[F];
 				signal_dict["name"] = F;
 
 				Array arguments;
 				signal_dict["arguments"] = arguments;
-				for (const PropertyInfo &pi : mi.arguments) {
+				for (const PropertyInfo &pi : mi->arguments) {
 					Dictionary argument_dict;
 					arguments.push_back(argument_dict);
 					argument_dict["type"] = pi.type;
@@ -182,7 +182,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, ClassDB::PropertySetGet> &F : t->property_setget) {
+			for (const KeyValue<StringName, ClassDB::PropertySetGet *> &F : t->property_setget) {
 				snames.push_back(F.key);
 			}
 
@@ -194,7 +194,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary property_dict;
 				properties.push_back(property_dict);
 
-				ClassDB::PropertySetGet *psg = t->property_setget.getptr(F);
+				ClassDB::PropertySetGet *psg = *t->property_setget.getptr(F);
 
 				property_dict["name"] = F;
 				property_dict["setter"] = psg->setter;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4245,12 +4245,12 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 		// Populate signals
 
-		const HashMap<StringName, MethodInfo> &signal_map = class_info->signal_map;
+		const HashMap<StringName, MethodInfo *> &signal_map = class_info->signal_map;
 
-		for (const KeyValue<StringName, MethodInfo> &E : signal_map) {
+		for (const KeyValue<StringName, MethodInfo *> &E : signal_map) {
 			SignalInterface isignal;
 
-			const MethodInfo &method_info = E.value;
+			const MethodInfo &method_info = *E.value;
 
 			isignal.name = method_info.name;
 			isignal.cname = method_info.name;
@@ -4352,11 +4352,11 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 			const List<StringName> &enum_constants = E.value.constants;
 			for (const StringName &constant_cname : enum_constants) {
 				String constant_name = constant_cname.operator String();
-				int64_t *value = class_info->constant_map.getptr(constant_cname);
+				int64_t **value = class_info->constant_map.getptr(constant_cname);
 				ERR_FAIL_NULL_V(value, false);
 				constants.erase(constant_name);
 
-				ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), *value);
+				ConstantInterface iconstant(constant_name, snake_to_pascal_case(constant_name, true), **value);
 
 				iconstant.const_doc = nullptr;
 				for (int i = 0; i < itype.class_doc->constants.size(); i++) {
@@ -4397,7 +4397,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		}
 
 		for (const String &constant_name : constants) {
-			int64_t *value = class_info->constant_map.getptr(StringName(constant_name));
+			int64_t **value = class_info->constant_map.getptr(StringName(constant_name));
 			ERR_FAIL_NULL_V(value, false);
 
 			String constant_proxy_name = snake_to_pascal_case(constant_name, true);
@@ -4408,7 +4408,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 				constant_proxy_name += "Constant";
 			}
 
-			ConstantInterface iconstant(constant_name, constant_proxy_name, *value);
+			ConstantInterface iconstant(constant_name, constant_proxy_name, **value);
 
 			iconstant.const_doc = nullptr;
 			for (int i = 0; i < itype.class_doc->constants.size(); i++) {

--- a/tests/core/object/test_class_db.h
+++ b/tests/core/object/test_class_db.h
@@ -718,12 +718,12 @@ void add_exposed_classes(Context &r_context) {
 
 		// Add signals
 
-		const HashMap<StringName, MethodInfo> &signal_map = class_info->signal_map;
+		const HashMap<StringName, MethodInfo *> &signal_map = class_info->signal_map;
 
-		for (const KeyValue<StringName, MethodInfo> &K : signal_map) {
+		for (const KeyValue<StringName, MethodInfo *> &K : signal_map) {
 			SignalData signal;
 
-			const MethodInfo &method_info = signal_map.get(K.key);
+			const MethodInfo &method_info = *signal_map.get(K.key);
 
 			signal.name = method_info.name;
 			TEST_FAIL_COND(!String(signal.name).is_valid_ascii_identifier(),
@@ -782,14 +782,14 @@ void add_exposed_classes(Context &r_context) {
 				TEST_FAIL_COND(String(constant_name).contains("::"),
 						"Enum constant contains '::', check bindings to remove the scope: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
-				int64_t *value = class_info->constant_map.getptr(constant_name);
+				int64_t **value = class_info->constant_map.getptr(constant_name);
 				TEST_FAIL_COND(!value, "Missing enum constant value: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
 				constants.erase(constant_name);
 
 				ConstantData constant;
 				constant.name = constant_name;
-				constant.value = *value;
+				constant.value = **value;
 
 				enum_.constants.push_back(constant);
 			}
@@ -804,12 +804,12 @@ void add_exposed_classes(Context &r_context) {
 			TEST_FAIL_COND(constant_name.contains("::"),
 					"Constant contains '::', check bindings to remove the scope: '",
 					String(class_name), ".", constant_name, "'.");
-			int64_t *value = class_info->constant_map.getptr(StringName(E));
+			int64_t **value = class_info->constant_map.getptr(StringName(E));
 			TEST_FAIL_COND(!value, "Missing constant value: '", String(class_name), ".", String(constant_name), "'.");
 
 			ConstantData constant;
 			constant.name = constant_name;
-			constant.value = *value;
+			constant.value = **value;
 
 			exposed_class.constants.push_back(constant);
 		}


### PR DESCRIPTION
I optimized property access (properties, methods, constants, signals) on `Object` subtypes.

Subtypes benefit especially, sometimes seeing a performance improvement of 1.6x from GDScript.
This should benefit most GDScript based projects.

Regressions in other areas are expected, but they can be addressed in future PRs as we improve the API further.

## Explanation

`ClassDB` is a major bottleneck in current GDScript. I've found that `BunnyMark` spent ~30% of CPU time just getting properties. Some of this is down to RAM not being in cache, but some is due to inefficient code paths.
I've proposed https://github.com/godotengine/godot-proposals/issues/12155 and https://github.com/godotengine/godot-proposals/issues/12323 to get to the root of this.

Still, even without major refactors, we can start improving our performance by starting to adopt a first-class `Type` mindset. One improvement is to cache property resolution, since types are not expected to change during the runtime of a Godot run.

For this, i introduce `property_cache` to `ClassInfo`. This attribute is constructed and updated when the type is being registered, and serves as a shortcut to resolving properties at runtime. It is somewhat analogous to the `__dict__` attribute in Python.

To make it work, `constant_map`, `signal_map` and `property_setget` have to be reformatted to accept object pointers instead of full objects. Otherwise, objects are relocated when the hashmaps are resized, which would invalidate the cache pointers. This makes regular access slightly slower, but regular access is not needed with caches in place.
This is not technically required, but the current setup of `ClassDB` makes it necessary as a stopgap (since `ClassInfo` aren't formally finalized). I think the values will move to other places in the future anyway as we modernize `ClassDB`.

Future implementations should reduce the amount of indirection by storing getters in known places (see https://github.com/godotengine/godot-proposals/issues/12155).

## Benchmark

I benchmarked a 1.6x improvement of property `get` and `set` on a 3-level deep `Object` subtype:

```gdscript
extends Camera3D

func _ready() -> void:
	var start := Time.get_ticks_usec()
	for i in range(5000000):
		editor_description = editor_description
		editor_description = editor_description
		editor_description = editor_description
		editor_description = editor_description
	var end := Time.get_ticks_usec()
	print((end - start) / 1000, "ms")
```

This printed:
- `1747ms` on `master`
- `1080ms` on this pr