### PR TITLE
Implement window names for session restoration

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1721,6 +1721,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen,Exclusive Fullscreen"), 0);
 
 	// Keep the enum values in sync with the `Window::WINDOW_INITIAL_POSITION_` enum.
+	GLOBAL_DEF_BASIC("display/window/size/restore_window_properties", true);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/initial_position_type", PROPERTY_HINT_ENUM, "Absolute:0,Center of Primary Screen:1,Center of Other Screen:3,Center of Screen With Mouse Pointer:4,Center of Screen With Keyboard Focus:5"), 1);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::VECTOR2I, "display/window/size/initial_position"), Vector2i());
 	// Keep the enum values in sync with the `DisplayServer::SCREEN_` enum.

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2580,7 +2580,7 @@
 			<param index="0" name="session_id" type="String" />
 			<param index="1" name="window_id" type="int" default="0" />
 			<description>
-				Set the key this window will use when restoring its properties after opening and closing this window.
+				Sets the key this window will use when restoring its properties after opening and closing this window.
 				This key must be a string that is [b]unique[/b] across the project and [b]consistent[/b] across restarts.
 			</description>
 		</method>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2575,6 +2575,15 @@
 				[b]Warning:[/b] Advanced users only! Adding such a callback to a [Window] node will override its default implementation, which can introduce bugs.
 			</description>
 		</method>
+		<method name="window_set_session_id">
+			<return type="void" />
+			<param index="0" name="session_id" type="String" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Set the key this window will use when restoring its properties after opening and closing this window.
+				This key must be a string that is [b]unique[/b] across the project and [b]consistent[/b] across restarts.
+			</description>
+		</method>
 		<method name="window_set_size">
 			<return type="void" />
 			<param index="0" name="size" type="Vector2i" />

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1049,6 +1049,10 @@
 			[b]Note:[/b] Certain window managers can be configured to ignore the non-resizable status of a window. Do not rely on this setting as a guarantee that the window will [i]never[/i] be resizable.
 			[b]Note:[/b] This setting is ignored on iOS.
 		</member>
+		<member name="display/window/size/restore_window_properties" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], when a window with a [code]session_id[/code] is presented, its size and position from when it was last closed will be restored.
+			[b]Note:[/b] The main window is considered to have a [code]session_id[/code] of "MainWindow".
+		</member>
 		<member name="display/window/size/sharp_corners" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the main window uses sharp corners by default.
 			[b]Note:[/b] This property is implemented only on Windows (11).

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -761,9 +761,9 @@
 			[b]Note:[/b] This property only works if [member initial_position] is set to [constant WINDOW_INITIAL_POSITION_ABSOLUTE].
 		</member>
 		<member name="session_id" type="String" setter="set_session_id" getter="get_session_id" default="&quot;&quot;">
-			The unique id that will be used to restore the properties of the window on restart.
+			The unique ID that will be used to restore the properties of the window on restart.
 			For this property to function it must be set before the window enters the scene tree.
-			If it has been set in time, the position, size, screen and mode will be restored.
+			If it has been set in time, the position, size, screen, and mode will be restored.
 			[b]Note:[/b] This must be [b]unique[/b] across all windows in the app and [b]consistent[/b] across restarts.
 		</member>
 		<member name="sharp_corners" type="bool" setter="set_flag" getter="get_flag" default="false">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -760,6 +760,12 @@
 			If [member ProjectSettings.display/window/subwindows/embed_subwindows] is [code]false[/code], the position is in absolute screen coordinates. This typically applies to editor plugins. If the setting is [code]true[/code], the window's position is in the coordinates of its parent [Viewport].
 			[b]Note:[/b] This property only works if [member initial_position] is set to [constant WINDOW_INITIAL_POSITION_ABSOLUTE].
 		</member>
+		<member name="session_id" type="String" setter="set_session_id" getter="get_session_id" default="&quot;&quot;">
+			The unique id that will be used to restore the properties of the window on restart.
+			For this property to function it must be set before the window enters the scene tree.
+			If it has been set in time, the position, size, screen and mode will be restored.
+			[b]Note:[/b] This must be [b]unique[/b] across all windows in the app and [b]consistent[/b] across restarts.
+		</member>
 		<member name="sharp_corners" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the [Window] will override the OS window style to display sharp corners.
 			[b]Note:[/b] This property is implemented only on Windows (11).

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6202,7 +6202,6 @@ void EditorNode::_save_editor_layout() {
 	editor_dock_manager->save_docks_to_config(config, "docks");
 	_save_open_scenes_to_config(config);
 	_save_central_editor_layout_to_config(config);
-	_save_window_settings_to_config(config, "EditorWindow");
 	editor_data.get_plugin_window_layout(config);
 
 	config->save(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
@@ -6300,38 +6299,6 @@ void EditorNode::_load_central_editor_layout_from_config(Ref<ConfigFile> p_confi
 	// Main editor (plugin).
 
 	editor_main_screen->load_layout_from_config(p_config_file, EDITOR_NODE_CONFIG_SECTION);
-}
-
-void EditorNode::_save_window_settings_to_config(Ref<ConfigFile> p_layout, const String &p_section) {
-	Window *w = get_window();
-	if (w) {
-		p_layout->set_value(p_section, "screen", w->get_current_screen());
-
-		Window::Mode mode = w->get_mode();
-		switch (mode) {
-			case Window::MODE_WINDOWED:
-				p_layout->set_value(p_section, "mode", "windowed");
-				p_layout->set_value(p_section, "size", w->get_size());
-				break;
-			case Window::MODE_FULLSCREEN:
-			case Window::MODE_EXCLUSIVE_FULLSCREEN:
-				p_layout->set_value(p_section, "mode", "fullscreen");
-				break;
-			case Window::MODE_MINIMIZED:
-				if (was_window_windowed_last) {
-					p_layout->set_value(p_section, "mode", "windowed");
-					p_layout->set_value(p_section, "size", w->get_size());
-				} else {
-					p_layout->set_value(p_section, "mode", "maximized");
-				}
-				break;
-			default:
-				p_layout->set_value(p_section, "mode", "maximized");
-				break;
-		}
-
-		p_layout->set_value(p_section, "position", w->get_position());
-	}
 }
 
 void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
@@ -9430,6 +9397,7 @@ EditorNode::EditorNode() {
 	gui_base->add_child(open_imported);
 
 	quick_open_dialog = memnew(EditorQuickOpenDialog);
+	quick_open_dialog->set_session_id("QuickOpen");
 	gui_base->add_child(quick_open_dialog);
 
 	quick_open_color_palette = memnew(EditorQuickOpenDialog);

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -303,6 +303,7 @@ void QuickSettingsDialog::_bind_methods() {
 
 QuickSettingsDialog::QuickSettingsDialog() {
 	set_title(TTRC("Quick Settings"));
+	set_session_id("QuickSettings");
 	set_ok_button_text(TTRC("Close"));
 
 	VBoxContainer *main_vbox = memnew(VBoxContainer);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -224,7 +224,6 @@ static bool recovery_mode = false;
 static bool auto_build_solutions = false;
 static String debug_server_uri;
 static bool wait_for_import = false;
-static bool restore_editor_window_layout = true;
 #ifndef DISABLE_DEPRECATED
 static int converter_max_kb_file = 4 * 1024; // 4MB
 static int converter_max_line_length = 100000;
@@ -242,6 +241,9 @@ static DisplayServerEnums::VSyncMode window_vsync_mode = DisplayServerEnums::VSY
 static uint32_t window_flags = 0;
 static Size2i window_size = Size2i(1152, 648);
 
+static String session_path;
+
+static bool init_restore_window = false;
 static int init_screen = DisplayServerEnums::SCREEN_PRIMARY;
 static bool init_fullscreen = false;
 static bool init_maximized = false;
@@ -2674,7 +2676,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 		window_mode = (DisplayServerEnums::WindowMode)(GLOBAL_GET("display/window/size/mode").operator int());
 		int initial_position_type = GLOBAL_GET("display/window/size/initial_position_type").operator int();
-		if (initial_position_type == Window::WINDOW_INITIAL_POSITION_ABSOLUTE) { // Absolute.
+		if (GLOBAL_GET("display/window/size/restore_window_properties")) {
+			if (!init_use_custom_pos) {
+				init_restore_window = true;
+			}
+		} else if (initial_position_type == Window::WINDOW_INITIAL_POSITION_ABSOLUTE) { // Absolute.
 			if (!init_use_custom_pos) {
 				init_custom_pos = GLOBAL_GET("display/window/size/initial_position").operator Vector2i();
 				init_use_custom_pos = true;
@@ -3056,7 +3062,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 								screen_found = true;
 
 								if (editor) {
-									restore_editor_window_layout = value.operator int() == EditorSettings::InitialScreen::INITIAL_SCREEN_AUTO;
+									init_restore_window = value.operator int() == EditorSettings::InitialScreen::INITIAL_SCREEN_AUTO;
 								}
 							}
 							if (!ac_found && assign == "interface/accessibility/accessibility_support") {
@@ -3105,16 +3111,30 @@ Error Main::setup2(bool p_show_boot_logo) {
 			}
 		}
 
+#ifdef TOOLS_ENABLED
+		if (project_manager) {
+			session_path = EditorPaths::get_singleton()->get_data_dir() + "/window_state.cfg";
+		} else if (editor) {
+			session_path = EditorPaths::get_singleton()->get_project_data_dir() + "/window_state.cfg";
+		} else {
+			session_path = "user://godot_window_state.cfg";
+		}
+#else
+		session_path = "user://godot_window_state.cfg";
+#endif
+
+		DisplayServer::set_session_path(session_path);
+
 		bool has_command_line_window_override = init_use_custom_pos || init_use_custom_screen || init_windowed;
-		if (editor && !has_command_line_window_override && restore_editor_window_layout) {
+		if (!has_command_line_window_override && init_restore_window) {
 			Ref<ConfigFile> config;
 			config.instantiate();
 			// Load and amend existing config if it exists.
-			Error err = config->load(EditorPaths::get_singleton()->get_project_settings_dir().path_join("editor_layout.cfg"));
+			Error err = config->load(session_path);
 			if (err == OK) {
-				init_screen = config->get_value("EditorWindow", "screen", init_screen);
-				String mode = config->get_value("EditorWindow", "mode", "maximized");
-				window_size = config->get_value("EditorWindow", "size", window_size);
+				init_screen = config->get_value("MainWindow", "screen", init_screen);
+				String mode = config->get_value("MainWindow", "mode", "maximized");
+				window_size = config->get_value("MainWindow", "size", window_size);
 				if (mode == "windowed") {
 					window_mode = DisplayServerEnums::WINDOW_MODE_WINDOWED;
 					init_windowed = true;
@@ -3128,7 +3148,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 				if (init_windowed) {
 					init_use_custom_pos = true;
-					init_custom_pos = config->get_value("EditorWindow", "position", Vector2i(0, 0));
+					init_custom_pos = config->get_value("MainWindow", "position", Vector2i(0, 0));
 				}
 			}
 		}
@@ -4642,7 +4662,7 @@ int Main::start() {
 			if (editor_embed_subwindows) {
 				sml->get_root()->set_embedding_subwindows(true);
 			}
-			restore_editor_window_layout = EDITOR_GET("interface/editor/appearance/editor_screen").operator int() == EditorSettings::InitialScreen::INITIAL_SCREEN_AUTO;
+			init_restore_window = EDITOR_GET("interface/editor/appearance/editor_screen").operator int() == EditorSettings::InitialScreen::INITIAL_SCREEN_AUTO;
 		}
 #endif
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -36,7 +36,6 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"
-#include "core/io/config_file.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -723,41 +722,13 @@ void Window::_make_window() {
 	}
 
 	DisplayServerEnums::VSyncMode vsync_mode = DisplayServer::get_singleton()->window_get_vsync_mode(DisplayServerEnums::MAIN_WINDOW_ID);
-	bool restored_window = false;
 	Rect2i window_rect;
-	if (GLOBAL_GET("display/window/size/restore_window_properties") && !session_id.is_empty()) {
-		String path = DisplayServer::get_session_path();
-		Ref<ConfigFile> window_state;
-		window_state.instantiate();
-		window_state->load(path);
-
-		if (window_state->has_section(session_id)) {
-			position = window_state->get_value(session_id, "position");
-
-			String mode_str = window_state->get_value(session_id, "mode", "windowed");
-			if (mode_str == "windowed") {
-				mode = Mode::MODE_WINDOWED;
-				size = window_state->get_value(session_id, "size");
-			} else if (mode_str == "minimized") {
-				// TODO: is this correct?
-				mode = Mode::MODE_MINIMIZED;
-				size = window_state->get_value(session_id, "size");
-			} else if (mode_str == "maximized") {
-				// TODO: is this correct?
-				mode = Mode::MODE_MAXIMIZED;
-			} else if (mode_str == "fullscreen") {
-				// TODO: is this correct?
-				mode = Mode::MODE_FULLSCREEN;
-			} else {
-				mode = Mode::MODE_WINDOWED;
-			}
-
-			restored_window = true;
-			window_rect = Rect2i(position, size);
-		}
-	}
-
-	if (!restored_window) {
+	if (_should_restore_window()) {
+		mode = DisplayServer::get_singleton()->get_window_metadata(session_id, "mode", DisplayServerEnums::WINDOW_MODE_WINDOWED);
+		position = DisplayServer::get_singleton()->get_window_metadata(session_id, "position", position);
+		size = DisplayServer::get_singleton()->get_window_metadata(session_id, "size", size);
+		window_rect = Rect2i(position, size);
+	} else {
 		if (initial_position == WINDOW_INITIAL_POSITION_ABSOLUTE) {
 			window_rect = Rect2i(position, size);
 		} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN) {
@@ -833,7 +804,6 @@ void Window::_clear_window() {
 	}
 
 	_update_from_window();
-	_save_window();
 
 	DisplayServer::get_singleton()->delete_sub_window(window_id);
 	window_id = DisplayServerEnums::INVALID_WINDOW_ID;
@@ -851,39 +821,16 @@ void Window::_clear_window() {
 	}
 }
 
-void Window::_save_window() {
+bool Window::_should_restore_window() const {
 	if (session_id.is_empty()) {
-		return;
+		return false;
 	}
 
-	String path = DisplayServer::get_session_path();
-	Ref<ConfigFile> state;
-	state.instantiate();
-	state->load(path);
-
-	state->set_value(session_id, "screen", get_current_screen());
-
-	Mode new_mode = get_mode();
-	switch (new_mode) {
-		case Window::MODE_WINDOWED:
-			state->set_value(session_id, "mode", "windowed");
-			state->set_value(session_id, "size", get_size());
-			break;
-		case Window::MODE_FULLSCREEN:
-		case Window::MODE_EXCLUSIVE_FULLSCREEN:
-			state->set_value(session_id, "mode", "fullscreen");
-			break;
-		case Window::MODE_MINIMIZED:
-			// ?????
-			break;
-		default:
-			state->set_value(session_id, "mode", "maximized");
-			break;
+	if (!GLOBAL_GET("display/window/size/restore_window_properties")) {
+		return false;
 	}
 
-	state->set_value(session_id, "position", get_position());
-
-	state->save(path);
+	return DisplayServer::get_singleton()->get_window_metadata(session_id, "tracked", false);
 }
 
 void Window::_rect_changed_callback(const Rect2i &p_callback) {
@@ -891,8 +838,6 @@ void Window::_rect_changed_callback(const Rect2i &p_callback) {
 	if (size == p_callback.size && position == p_callback.position) {
 		return;
 	}
-
-	_save_window();
 
 	if (position != p_callback.position) {
 		position = p_callback.position;
@@ -1119,27 +1064,16 @@ void Window::set_visible(bool p_visible) {
 		if (visible) {
 			embedder = embedder_vp;
 
-			bool restored_window = false;
-			if (GLOBAL_GET("display/window/size/restore_window_properties") && !session_id.is_empty()) {
-				String path = DisplayServer::get_session_path();
-				Ref<ConfigFile> window_state;
-				window_state.instantiate();
-				window_state->load(path);
-
-				if (window_state->has_section(session_id)) {
-					position = window_state->get_value(session_id, "position");
-					restored_window = true;
-				}
-			}
-
-			if (!restored_window) {
-				if (initial_position != WINDOW_INITIAL_POSITION_ABSOLUTE) {
-					if (is_in_edited_scene_root()) {
-						Size2 screen_size = Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_width"), GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_height"));
-						position = (screen_size - size) / 2;
-					} else {
-						position = (embedder->get_visible_rect().size - size) / 2;
-					}
+			if (_should_restore_window()) {
+				// Don't restore mode because when embedded, only Windowed makes sense.
+				position = DisplayServer::get_singleton()->get_window_metadata(session_id, "position", position);
+				size = DisplayServer::get_singleton()->get_window_metadata(session_id, "size", size);
+			} else if (initial_position != WINDOW_INITIAL_POSITION_ABSOLUTE) {
+				if (is_in_edited_scene_root()) {
+					Size2 screen_size = Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_width"), GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_height"));
+					position = (screen_size - size) / 2;
+				} else {
+					position = (embedder->get_visible_rect().size - size) / 2;
 				}
 			}
 
@@ -1153,7 +1087,6 @@ void Window::set_visible(bool p_visible) {
 				_update_viewport_for_hdr_output();
 			}
 		} else {
-			_save_window();
 			embedder->_sub_window_remove(this);
 			embedder = nullptr;
 			RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RSE::VIEWPORT_UPDATE_DISABLED);
@@ -1170,6 +1103,13 @@ void Window::set_visible(bool p_visible) {
 			}
 		}
 	} else {
+		if (!session_id.is_empty()) {
+			DisplayServer::get_singleton()->set_window_metadata(session_id, "tracked", true);
+			DisplayServer::get_singleton()->set_window_metadata(session_id, "mode", mode);
+			DisplayServer::get_singleton()->set_window_metadata(session_id, "position", position);
+			DisplayServer::get_singleton()->set_window_metadata(session_id, "size", size);
+		}
+
 		if (get_tree() && get_tree()->is_accessibility_supported()) {
 			_accessibility_notify_exit(this);
 			if (!embedder_vp) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -36,6 +36,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/input/input.h"
+#include "core/io/config_file.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -328,6 +329,20 @@ String Window::get_title() const {
 String Window::get_displayed_title() const {
 	ERR_READ_THREAD_GUARD_V(String());
 	return displayed_title;
+}
+
+void Window::set_session_id(const String &p_name) {
+	ERR_MAIN_THREAD_GUARD;
+	session_id = p_name;
+
+	if (window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_session_id(p_name, window_id);
+	}
+}
+
+String Window::get_session_id() const {
+	ERR_READ_THREAD_GUARD_V(String());
+	return session_id;
 }
 
 void Window::_settings_changed() {
@@ -708,23 +723,59 @@ void Window::_make_window() {
 	}
 
 	DisplayServerEnums::VSyncMode vsync_mode = DisplayServer::get_singleton()->window_get_vsync_mode(DisplayServerEnums::MAIN_WINDOW_ID);
+	bool restored_window = false;
 	Rect2i window_rect;
-	if (initial_position == WINDOW_INITIAL_POSITION_ABSOLUTE) {
-		window_rect = Rect2i(position, size);
-	} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN) {
-		window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_PRIMARY) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_PRIMARY) - size) / 2, size);
-	} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_MAIN_WINDOW_SCREEN) {
-		window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) - size) / 2, size);
-	} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_OTHER_SCREEN) {
-		window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(current_screen) + (DisplayServer::get_singleton()->screen_get_size(current_screen) - size) / 2, size);
-	} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_MOUSE_FOCUS) {
-		window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_WITH_MOUSE_FOCUS) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_WITH_MOUSE_FOCUS) - size) / 2, size);
-	} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_KEYBOARD_FOCUS) {
-		window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_WITH_KEYBOARD_FOCUS) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_WITH_KEYBOARD_FOCUS) - size) / 2, size);
+	if (GLOBAL_GET("display/window/size/restore_window_properties") && !session_id.is_empty()) {
+		String path = DisplayServer::get_session_path();
+		Ref<ConfigFile> window_state;
+		window_state.instantiate();
+		window_state->load(path);
+
+		if (window_state->has_section(session_id)) {
+			position = window_state->get_value(session_id, "position");
+
+			String mode_str = window_state->get_value(session_id, "mode", "windowed");
+			if (mode_str == "windowed") {
+				mode = Mode::MODE_WINDOWED;
+				size = window_state->get_value(session_id, "size");
+			} else if (mode_str == "minimized") {
+				// TODO: is this correct?
+				mode = Mode::MODE_MINIMIZED;
+				size = window_state->get_value(session_id, "size");
+			} else if (mode_str == "maximized") {
+				// TODO: is this correct?
+				mode = Mode::MODE_MAXIMIZED;
+			} else if (mode_str == "fullscreen") {
+				// TODO: is this correct?
+				mode = Mode::MODE_FULLSCREEN;
+			} else {
+				mode = Mode::MODE_WINDOWED;
+			}
+
+			restored_window = true;
+			window_rect = Rect2i(position, size);
+		}
+	}
+
+	if (!restored_window) {
+		if (initial_position == WINDOW_INITIAL_POSITION_ABSOLUTE) {
+			window_rect = Rect2i(position, size);
+		} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_PRIMARY_SCREEN) {
+			window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_PRIMARY) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_PRIMARY) - size) / 2, size);
+		} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_MAIN_WINDOW_SCREEN) {
+			window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) - size) / 2, size);
+		} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_OTHER_SCREEN) {
+			window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(current_screen) + (DisplayServer::get_singleton()->screen_get_size(current_screen) - size) / 2, size);
+		} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_MOUSE_FOCUS) {
+			window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_WITH_MOUSE_FOCUS) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_WITH_MOUSE_FOCUS) - size) / 2, size);
+		} else if (initial_position == WINDOW_INITIAL_POSITION_CENTER_SCREEN_WITH_KEYBOARD_FOCUS) {
+			window_rect = Rect2i(DisplayServer::get_singleton()->screen_get_position(DisplayServerEnums::SCREEN_WITH_KEYBOARD_FOCUS) + (DisplayServer::get_singleton()->screen_get_size(DisplayServerEnums::SCREEN_WITH_KEYBOARD_FOCUS) - size) / 2, size);
+		}
 	}
 
 	window_id = DisplayServer::get_singleton()->create_sub_window(DisplayServerEnums::WindowMode(mode), vsync_mode, f, window_rect, is_in_edited_scene_root() ? false : exclusive, transient_parent ? transient_parent->window_id : DisplayServerEnums::INVALID_WINDOW_ID);
 	ERR_FAIL_COND(window_id == DisplayServerEnums::INVALID_WINDOW_ID);
+	DisplayServer::get_singleton()->window_set_session_id(session_id, window_id);
 	DisplayServer::get_singleton()->window_set_max_size(Size2i(), window_id);
 	DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
 	DisplayServer::get_singleton()->window_set_mouse_passthrough(mpath, window_id);
@@ -782,6 +833,7 @@ void Window::_clear_window() {
 	}
 
 	_update_from_window();
+	_save_window();
 
 	DisplayServer::get_singleton()->delete_sub_window(window_id);
 	window_id = DisplayServerEnums::INVALID_WINDOW_ID;
@@ -799,11 +851,48 @@ void Window::_clear_window() {
 	}
 }
 
+void Window::_save_window() {
+	if (session_id.is_empty()) {
+		return;
+	}
+
+	String path = DisplayServer::get_session_path();
+	Ref<ConfigFile> state;
+	state.instantiate();
+	state->load(path);
+
+	state->set_value(session_id, "screen", get_current_screen());
+
+	Mode new_mode = get_mode();
+	switch (new_mode) {
+		case Window::MODE_WINDOWED:
+			state->set_value(session_id, "mode", "windowed");
+			state->set_value(session_id, "size", get_size());
+			break;
+		case Window::MODE_FULLSCREEN:
+		case Window::MODE_EXCLUSIVE_FULLSCREEN:
+			state->set_value(session_id, "mode", "fullscreen");
+			break;
+		case Window::MODE_MINIMIZED:
+			// ?????
+			break;
+		default:
+			state->set_value(session_id, "mode", "maximized");
+			break;
+	}
+
+	state->set_value(session_id, "position", get_position());
+
+	state->save(path);
+}
+
 void Window::_rect_changed_callback(const Rect2i &p_callback) {
 	//we must always accept this as the truth
 	if (size == p_callback.size && position == p_callback.position) {
 		return;
 	}
+
+	_save_window();
 
 	if (position != p_callback.position) {
 		position = p_callback.position;
@@ -1029,14 +1118,31 @@ void Window::set_visible(bool p_visible) {
 	} else {
 		if (visible) {
 			embedder = embedder_vp;
-			if (initial_position != WINDOW_INITIAL_POSITION_ABSOLUTE) {
-				if (is_in_edited_scene_root()) {
-					Size2 screen_size = Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_width"), GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_height"));
-					position = (screen_size - size) / 2;
-				} else {
-					position = (embedder->get_visible_rect().size - size) / 2;
+
+			bool restored_window = false;
+			if (GLOBAL_GET("display/window/size/restore_window_properties") && !session_id.is_empty()) {
+				String path = DisplayServer::get_session_path();
+				Ref<ConfigFile> window_state;
+				window_state.instantiate();
+				window_state->load(path);
+
+				if (window_state->has_section(session_id)) {
+					position = window_state->get_value(session_id, "position");
+					restored_window = true;
 				}
 			}
+
+			if (!restored_window) {
+				if (initial_position != WINDOW_INITIAL_POSITION_ABSOLUTE) {
+					if (is_in_edited_scene_root()) {
+						Size2 screen_size = Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_width"), GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_height"));
+						position = (screen_size - size) / 2;
+					} else {
+						position = (embedder->get_visible_rect().size - size) / 2;
+					}
+				}
+			}
+
 			embedder->_sub_window_register(this);
 			RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RSE::VIEWPORT_UPDATE_WHEN_PARENT_VISIBLE);
 
@@ -1047,6 +1153,7 @@ void Window::set_visible(bool p_visible) {
 				_update_viewport_for_hdr_output();
 			}
 		} else {
+			_save_window();
 			embedder->_sub_window_remove(this);
 			embedder = nullptr;
 			RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RSE::VIEWPORT_UPDATE_DISABLED);
@@ -1643,6 +1750,7 @@ void Window::_notification(int p_what) {
 					// It's the root window!
 					visible = true; // Always visible.
 					window_id = DisplayServerEnums::MAIN_WINDOW_ID;
+					session_id = "MainWindow";
 					focused_window = this;
 					DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 					AccessibilityServer::get_singleton()->set_window_callbacks(window_id, callable_mp(this, &Window::_accessibility_activate), callable_mp(this, &Window::_accessibility_deactivate));
@@ -3326,6 +3434,9 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &Window::set_title);
 	ClassDB::bind_method(D_METHOD("get_title"), &Window::get_title);
 
+	ClassDB::bind_method(D_METHOD("set_session_id", "session_id"), &Window::set_session_id);
+	ClassDB::bind_method(D_METHOD("get_session_id"), &Window::get_session_id);
+
 	ClassDB::bind_method(D_METHOD("set_initial_position", "initial_position"), &Window::set_initial_position);
 	ClassDB::bind_method(D_METHOD("get_initial_position"), &Window::get_initial_position);
 
@@ -3516,6 +3627,8 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Windowed,Minimized,Maximized,Fullscreen,Exclusive Fullscreen"), "set_mode", "get_mode");
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "title"), "set_title", "get_title");
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "session_id"), "set_session_id", "get_session_id");
 
 	// Keep the enum values in sync with the `WindowInitialPosition` enum.
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "initial_position", PROPERTY_HINT_ENUM, "Absolute,Center of Primary Screen,Center of Main Window Screen,Center of Other Screen,Center of Screen With Mouse Pointer,Center of Screen With Keyboard Focus"), "set_initial_position", "get_initial_position");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -120,6 +120,8 @@ private:
 
 	String title;
 	String displayed_title;
+	String session_id;
+
 	mutable int current_screen = 0;
 	mutable Point2i position;
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
@@ -167,6 +169,7 @@ private:
 	void _make_window();
 	void _clear_window();
 	void _update_from_window();
+	void _save_window();
 	void _accessibility_notify_enter(Node *p_node);
 	void _accessibility_notify_exit(Node *p_node);
 
@@ -306,6 +309,9 @@ public:
 	void set_title(const String &p_title);
 	String get_title() const;
 	String get_displayed_title() const;
+
+	void set_session_id(const String &p_name);
+	String get_session_id() const;
 
 	void set_initial_position(WindowInitialPosition p_initial_position);
 	WindowInitialPosition get_initial_position() const;

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -169,7 +169,7 @@ private:
 	void _make_window();
 	void _clear_window();
 	void _update_from_window();
-	void _save_window();
+	bool _should_restore_window() const;
 	void _accessibility_notify_enter(Node *p_node);
 	void _accessibility_notify_exit(Node *p_node);
 

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -60,10 +60,13 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #endif
 
 DisplayServer *DisplayServer::singleton = nullptr;
-String DisplayServer::session_path = "";
 
 bool DisplayServer::window_early_clear_override_enabled = false;
 Color DisplayServer::window_early_clear_override_color = Color(0, 0, 0, 0);
+
+String DisplayServer::session_path = "";
+Ref<ConfigFile> DisplayServer::window_metadata = Ref<ConfigFile>();
+bool DisplayServer::window_metadata_dirty = false;
 
 DisplayServer::DisplayServerCreate DisplayServer::server_create_functions[DisplayServer::MAX_SERVERS] = {
 	{ "headless", &DisplayServerHeadless::create_func, &DisplayServerHeadless::get_rendering_drivers_func }
@@ -510,8 +513,41 @@ void DisplayServer::set_session_path(const String &p_path) {
 	session_path = p_path;
 }
 
-String DisplayServer::get_session_path() {
-	return session_path;
+void DisplayServer::set_window_metadata(const String &p_section, const String &p_key, const Variant &p_data) {
+	if (window_metadata.is_null()) {
+		window_metadata.instantiate();
+
+		Error err = window_metadata->load(session_path);
+		if (err != OK && err != ERR_FILE_NOT_FOUND) {
+			ERR_PRINT("Cannot load window metadata from file '" + session_path + "'.");
+		}
+	}
+
+	window_metadata->set_value(p_section, p_key, p_data);
+	window_metadata_dirty = true;
+}
+
+Variant DisplayServer::get_window_metadata(const String &p_section, const String &p_key, const Variant &p_default) const {
+	if (window_metadata.is_null()) {
+		window_metadata.instantiate();
+
+		Error err = window_metadata->load(session_path);
+		if (err != OK && err != ERR_FILE_NOT_FOUND) {
+			ERR_PRINT("Cannot load window metadata from file '" + session_path + "'.");
+		}
+	}
+
+	return window_metadata->get_value(p_section, p_key, p_default);
+}
+
+void DisplayServer::save_window_metadata() {
+	if (!window_metadata_dirty) {
+		return;
+	}
+
+	Error err = window_metadata->save(session_path);
+	ERR_FAIL_COND_MSG(err != OK, "Cannot save project metadata to file '" + session_path + "'.");
+	window_metadata_dirty = false;
 }
 
 void DisplayServer::mouse_set_mode(DisplayServerEnums::MouseMode p_mode) {
@@ -2279,5 +2315,7 @@ DisplayServer::DisplayServer() {
 }
 
 DisplayServer::~DisplayServer() {
+	// TODO: find better locations
+	singleton->save_window_metadata();
 	singleton = nullptr;
 }

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -60,6 +60,7 @@ STATIC_ASSERT_INCOMPLETE_TYPE(class, RenderingServer);
 #endif
 
 DisplayServer *DisplayServer::singleton = nullptr;
+String DisplayServer::session_path = "";
 
 bool DisplayServer::window_early_clear_override_enabled = false;
 Color DisplayServer::window_early_clear_override_color = Color(0, 0, 0, 0);
@@ -505,6 +506,14 @@ void DisplayServer::set_early_window_clear_color_override(bool p_enabled, Color 
 	window_early_clear_override_color = p_color;
 }
 
+void DisplayServer::set_session_path(const String &p_path) {
+	session_path = p_path;
+}
+
+String DisplayServer::get_session_path() {
+	return session_path;
+}
+
 void DisplayServer::mouse_set_mode(DisplayServerEnums::MouseMode p_mode) {
 	WARN_PRINT("Mouse is not supported by this display server.");
 }
@@ -623,6 +632,10 @@ void DisplayServer::delete_sub_window(DisplayServerEnums::WindowID p_id) {
 
 void DisplayServer::window_set_exclusive(DisplayServerEnums::WindowID p_window, bool p_exclusive) {
 	// Do nothing, if not supported.
+}
+
+void DisplayServer::window_set_session_id(const String &p_session_id, DisplayServerEnums::WindowID p_window) {
+	// Do nothing, if the DisplayServer does not use this
 }
 
 void DisplayServer::window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window) {
@@ -1497,6 +1510,8 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("window_set_title", "title", "window_id"), &DisplayServer::window_set_title, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_title_size", "title", "window_id"), &DisplayServer::window_get_title_size, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_session_id", "session_id", "window_id"), &DisplayServer::window_set_session_id, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
+
 	ClassDB::bind_method(D_METHOD("window_set_mouse_passthrough", "region", "window_id"), &DisplayServer::window_set_mouse_passthrough, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_get_current_screen", "window_id"), &DisplayServer::window_get_current_screen, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/input/input_enums.h"
+#include "core/io/config_file.h"
 #include "core/io/image.h"
 #include "core/io/resource.h"
 #include "core/object/object.h"
@@ -63,7 +64,6 @@ class DisplayServer : public Object {
 	GDCLASS(DisplayServer, Object)
 
 	static DisplayServer *singleton;
-	static String session_path;
 
 public:
 	_FORCE_INLINE_ static DisplayServer *get_singleton() {
@@ -366,13 +366,20 @@ private:
 	static bool window_early_clear_override_enabled;
 	static Color window_early_clear_override_color;
 
+	static String session_path;
+	static Ref<ConfigFile> window_metadata;
+	static bool window_metadata_dirty;
+
 protected:
 	static bool _get_window_early_clear_override(Color &r_color);
 
 public:
 	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
 	static void set_session_path(const String &p_path);
-	static String get_session_path();
+
+	void set_window_metadata(const String &p_section, const String &p_key, const Variant &p_data);
+	Variant get_window_metadata(const String &p_section, const String &p_key, const Variant &p_default) const;
+	void save_window_metadata();
 
 	virtual Vector<DisplayServerEnums::WindowID> get_window_list() const = 0;
 

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -63,6 +63,7 @@ class DisplayServer : public Object {
 	GDCLASS(DisplayServer, Object)
 
 	static DisplayServer *singleton;
+	static String session_path;
 
 public:
 	_FORCE_INLINE_ static DisplayServer *get_singleton() {
@@ -370,6 +371,8 @@ protected:
 
 public:
 	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
+	static void set_session_path(const String &p_path);
+	static String get_session_path();
 
 	virtual Vector<DisplayServerEnums::WindowID> get_window_list() const = 0;
 
@@ -398,6 +401,7 @@ public:
 
 	virtual void window_set_title(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) = 0;
 	virtual Size2i window_get_title_size(const String &p_title, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID) const { return Size2i(); }
+	virtual void window_set_session_id(const String &p_session_id, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID);
 
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServerEnums::WindowID p_window = DisplayServerEnums::MAIN_WINDOW_ID);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/5005

This introduces a new window property the "window name" (term very much up for discussion) which is used to index a ConfigFile for window properties like https://github.com/godotengine/godot/pull/76085 did but with an actual API instead of hardcoded names. Since setting the name is enough for restoration this can be exposed to user scripting/gdextension to give games access to easy window restoration.

[Screencast_20250520_195106.webm](https://github.com/user-attachments/assets/45ebd92a-a71d-478f-9ece-25df4901ccbd)

TODOs I can think of as of now
* ~~Better name for this property~~
* Think of the timeline of window creation, currentlty for the name to work it must be set before `enter_child` is called
* ~~This uses an `"editor/"` include in scene which isn't good. There should likely be multiple files anyway based on context but for now it's hardcoded to the project's `.godot`~~
* Opening and closing the file is done quite frequently, maybe there's a better callback to set these window values?
* On Wayland, this does not fully work (we cannot know or set many of these values), however the `xx-session-management` protocol would allow us to do precisely this if we pass the name to the DisplayServer.