### PR TITLE
Fix for implicit conversion from `char16_t` to `char32_t` in `TextServerAdvanced`

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -6289,7 +6289,7 @@ bool TextServerAdvanced::_shaped_text_update_justification_ops(const RID &p_shap
 			// No data - use fallback.
 			int limit = 0;
 			for (int i = 0; i < sd->text.length(); i++) {
-				if (is_whitespace(data[i])) {
+				if (is_whitespace(sd->text[i])) {
 					int ks = _generate_kashida_justification_opportunities(sd->text, limit, i) + sd->start;
 					if (ks != -1) {
 						sd->jstops[ks] = true;


### PR DESCRIPTION
Fix for `clang 21` warning (error with `dev_mode=yes`):

> modules/text_server_adv/text_server_adv.cpp:6292:23: error: implicit conversion from 'const UChar' (aka 'const char16_t') to 'char32_t' 
> may change the meaning of the represented code unit [-Werror,-Wcharacter-conversion]
