### PR TITLE
Add per-instance 'Enabled' checkbox to 'Run Instances' dialog

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -157,13 +157,13 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	}
 
 	String exec = OS::get_singleton()->get_executable_path();
-	int instance_count = RunInstancesDialog::get_singleton()->get_instance_count();
-	for (int i = 0; i < instance_count; i++) {
+	LocalVector<int> enabled_instances = RunInstancesDialog::get_singleton()->get_enabled_instances_indices();
+	for (const int &instance_idx : enabled_instances) {
 		List<String> instance_args(args);
-		RunInstancesDialog::get_singleton()->get_argument_list_for_instance(i, instance_args);
-		RunInstancesDialog::get_singleton()->apply_custom_features(i);
+		RunInstancesDialog::get_singleton()->get_argument_list_for_instance(instance_idx, instance_args);
+		RunInstancesDialog::get_singleton()->apply_custom_features(instance_idx);
 		if (instance_starting_callback) {
-			instance_starting_callback(i, instance_args);
+			instance_starting_callback(instance_idx, instance_args);
 		}
 
 		if (OS::get_singleton()->is_stdout_verbose()) {

--- a/editor/run_instances_dialog.cpp
+++ b/editor/run_instances_dialog.cpp
@@ -80,6 +80,10 @@ void RunInstancesDialog::_create_instance(InstanceData &p_instance, const Dictio
 	TreeItem *instance_item = instance_tree->create_item();
 	p_instance.item = instance_item;
 
+	instance_item->set_cell_mode(COLUMN_ENABLED, TreeItem::CELL_MODE_CHECK);
+	instance_item->set_editable(COLUMN_ENABLED, true);
+	instance_item->set_checked(COLUMN_ENABLED, p_data.get("enabled", false));
+
 	instance_item->set_cell_mode(COLUMN_OVERRIDE_ARGS, TreeItem::CELL_MODE_CHECK);
 	instance_item->set_editable(COLUMN_OVERRIDE_ARGS, true);
 	instance_item->set_text(COLUMN_OVERRIDE_ARGS, TTR("Enabled"));
@@ -108,6 +112,7 @@ void RunInstancesDialog::_save_arguments() {
 	for (int i = 0; i < instances_data.size(); i++) {
 		const InstanceData &instance = instances_data[i];
 		Dictionary dict;
+		dict["enabled"] = instance.is_enabled();
 		dict["override_args"] = instance.overrides_run_args();
 		dict["arguments"] = instance.get_launch_arguments();
 		dict["override_features"] = instance.overrides_features();
@@ -197,12 +202,14 @@ void RunInstancesDialog::popup_dialog() {
 	popup_centered(Vector2(1200, 600) * EDSCALE);
 }
 
-int RunInstancesDialog::get_instance_count() const {
-	if (enable_multiple_instances_checkbox->is_pressed()) {
-		return instance_count->get_value();
-	} else {
-		return 1;
+LocalVector<int> RunInstancesDialog::get_enabled_instances_indices() const {
+	LocalVector<int> indices;
+	for (int i = 0; i < instances_data.size(); i++) {
+		if (instances_data[i].is_enabled()) {
+			indices.push_back(i);
+		}
 	}
+	return indices;
 }
 
 void RunInstancesDialog::get_argument_list_for_instance(int p_idx, List<String> &r_list) const {
@@ -375,8 +382,10 @@ RunInstancesDialog::RunInstancesDialog() {
 	instance_tree = memnew(Tree);
 	instance_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	instance_tree->set_h_scroll_enabled(false);
-	instance_tree->set_columns(4);
+	instance_tree->set_columns(5);
 	instance_tree->set_column_titles_visible(true);
+	instance_tree->set_column_title(COLUMN_ENABLED, TTR("Enabled"));
+	instance_tree->set_column_expand(COLUMN_ENABLED, false);
 	instance_tree->set_column_title(COLUMN_OVERRIDE_ARGS, TTR("Override Main Run Args"));
 	instance_tree->set_column_expand(COLUMN_OVERRIDE_ARGS, false);
 	instance_tree->set_column_title(COLUMN_LAUNCH_ARGUMENTS, TTR("Launch Arguments"));
@@ -396,6 +405,10 @@ RunInstancesDialog::RunInstancesDialog() {
 
 	_refresh_argument_count();
 	instance_tree->connect("item_edited", callable_mp(this, &RunInstancesDialog::_start_instance_timer));
+}
+
+bool RunInstancesDialog::InstanceData::is_enabled() const {
+	return item->is_checked(COLUMN_ENABLED);
 }
 
 bool RunInstancesDialog::InstanceData::overrides_run_args() const {

--- a/editor/run_instances_dialog.h
+++ b/editor/run_instances_dialog.h
@@ -44,6 +44,7 @@ class RunInstancesDialog : public AcceptDialog {
 	GDCLASS(RunInstancesDialog, AcceptDialog);
 
 	enum Columns {
+		COLUMN_ENABLED,
 		COLUMN_OVERRIDE_ARGS,
 		COLUMN_LAUNCH_ARGUMENTS,
 		COLUMN_OVERRIDE_FEATURES,
@@ -53,6 +54,7 @@ class RunInstancesDialog : public AcceptDialog {
 	struct InstanceData {
 		TreeItem *item = nullptr;
 
+		bool is_enabled() const;
 		bool overrides_run_args() const;
 		String get_launch_arguments() const;
 		bool overrides_features() const;
@@ -96,7 +98,7 @@ class RunInstancesDialog : public AcceptDialog {
 
 public:
 	void popup_dialog();
-	int get_instance_count() const;
+	LocalVector<int> get_enabled_instances_indices() const;
 	void get_argument_list_for_instance(int p_idx, List<String> &r_list) const;
 	void apply_custom_features(int p_instance_idx);
 


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/12468

I agree with the author of the proposal, lack of this checkbox seems like a huge oversight, and although personally I am not a fan of the entire design of this dialog, and would gladly see it reworked - just adding this checkbox already makes it infinitely more usable.

<img width="882" alt="image" src="https://github.com/user-attachments/assets/8dd69c52-97b2-4c65-88cd-bfa0973c4cab" />
