### PR TITLE
Move some accessibility properties from Node to Control

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -85,6 +85,13 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="_get_accessibility_container_name" qualifiers="virtual const">
+			<return type="String" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Override this method to return a human-readable description of the position of the child [param node] in the custom container, added to the [member accessibility_name].
+			</description>
+		</method>
 		<method name="_get_drag_data" qualifiers="virtual">
 			<return type="Variant" />
 			<param index="0" name="at_position" type="Vector2" />
@@ -962,6 +969,27 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_controls_nodes" type="NodePath[]" setter="set_accessibility_controls_nodes" getter="get_accessibility_controls_nodes" default="[]">
+			The paths to the nodes which are controlled by this node.
+		</member>
+		<member name="accessibility_described_by_nodes" type="NodePath[]" setter="set_accessibility_described_by_nodes" getter="get_accessibility_described_by_nodes" default="[]">
+			The paths to the nodes which are describing this node.
+		</member>
+		<member name="accessibility_description" type="String" setter="set_accessibility_description" getter="get_accessibility_description" default="&quot;&quot;">
+			The human-readable node description that is reported to assistive apps.
+		</member>
+		<member name="accessibility_flow_to_nodes" type="NodePath[]" setter="set_accessibility_flow_to_nodes" getter="get_accessibility_flow_to_nodes" default="[]">
+			The paths to the nodes which this node flows into.
+		</member>
+		<member name="accessibility_labeled_by_nodes" type="NodePath[]" setter="set_accessibility_labeled_by_nodes" getter="get_accessibility_labeled_by_nodes" default="[]">
+			The paths to the nodes which label this node.
+		</member>
+		<member name="accessibility_live" type="int" setter="set_accessibility_live" getter="get_accessibility_live" enum="DisplayServer.AccessibilityLiveMode" default="0">
+			The mode with which a live region updates. A live region is a [Node] that is updated as a result of an external event when the user's focus may be elsewhere.
+		</member>
+		<member name="accessibility_name" type="String" setter="set_accessibility_name" getter="get_accessibility_name" default="&quot;&quot;">
+			The human-readable node name that is reported to assistive apps.
+		</member>
 		<member name="anchor_bottom" type="float" setter="_set_anchor" getter="get_anchor" default="0.0">
 			Anchors the bottom edge of the node to the origin, the center, or the end of its parent control. It changes how the bottom offset updates when the node moves or changes size. You can use one of the [enum Anchor] constants for convenience.
 		</member>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -43,13 +43,6 @@
 				Returning an empty array produces no warnings.
 			</description>
 		</method>
-		<method name="_get_accessibility_container_name" qualifiers="virtual const">
-			<return type="String" />
-			<param index="0" name="node" type="Node" />
-			<description>
-				Return a human-readable description of the position of [param node] child in the custom container, added to the node name.
-			</description>
-		</method>
 		<method name="_get_configuration_warnings" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<description>
@@ -1035,27 +1028,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="accessibility_controls_nodes" type="NodePath[]" setter="set_accessibility_controls_nodes" getter="get_accessibility_controls_nodes" default="[]">
-			The list of nodes which are controlled by this node.
-		</member>
-		<member name="accessibility_described_by_nodes" type="NodePath[]" setter="set_accessibility_described_by_nodes" getter="get_accessibility_described_by_nodes" default="[]">
-			The list of nodes which are describing this node.
-		</member>
-		<member name="accessibility_description" type="String" setter="set_accessibility_description" getter="get_accessibility_description" default="&quot;&quot;">
-			The human-readable node description that is reported to assistive apps.
-		</member>
-		<member name="accessibility_flow_to_nodes" type="NodePath[]" setter="set_accessibility_flow_to_nodes" getter="get_accessibility_flow_to_nodes" default="[]">
-			The list of nodes which this node flows into.
-		</member>
-		<member name="accessibility_labeled_by_nodes" type="NodePath[]" setter="set_accessibility_labeled_by_nodes" getter="get_accessibility_labeled_by_nodes" default="[]">
-			The list of nodes which label this node.
-		</member>
-		<member name="accessibility_live" type="int" setter="set_accessibility_live" getter="get_accessibility_live" enum="DisplayServer.AccessibilityLiveMode" default="0">
-			Live region update mode, a live region is [Node] that is updated as a result of an external event when user focus may be elsewhere.
-		</member>
-		<member name="accessibility_name" type="String" setter="set_accessibility_name" getter="get_accessibility_name" default="&quot;&quot;">
-			The human-readable node name that is reported to assistive apps.
-		</member>
 		<member name="auto_translate_mode" type="int" setter="set_auto_translate_mode" getter="get_auto_translate_mode" enum="Node.AutoTranslateMode" default="0">
 			Defines if any text should automatically change to its translated version depending on the current locale (for nodes such as [Label], [RichTextLabel], [Window], etc.). Also decides if the node's strings should be parsed for POT generation.
 			[b]Note:[/b] For the root node, auto translate mode can also be set via [member ProjectSettings.internationalization/rendering/root_node_auto_translate].

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -578,6 +578,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_description" type="String" setter="set_accessibility_description" getter="get_accessibility_description" default="&quot;&quot;">
+			The human-readable node description that is reported to assistive apps.
+		</member>
+		<member name="accessibility_name" type="String" setter="set_accessibility_name" getter="get_accessibility_name" default="&quot;&quot;">
+			The human-readable node name that is reported to assistive apps.
+		</member>
 		<member name="always_on_top" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the window will be on top of all other windows. Does not work if [member transient] is enabled.
 		</member>

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -250,6 +250,17 @@ private:
 
 		ObjectID shortcut_context;
 
+		// Accessibility.
+
+		String accessibility_name;
+		String accessibility_description;
+		DisplayServer::AccessibilityLiveMode accessibility_live = DisplayServer::AccessibilityLiveMode::LIVE_OFF;
+
+		TypedArray<NodePath> accessibility_controls_nodes;
+		TypedArray<NodePath> accessibility_described_by_nodes;
+		TypedArray<NodePath> accessibility_labeled_by_nodes;
+		TypedArray<NodePath> accessibility_flow_to_nodes;
+
 		// Theming.
 
 		ThemeOwner *theme_owner = nullptr;
@@ -396,6 +407,7 @@ protected:
 	GDVIRTUAL1RC(Object *, _make_custom_tooltip, String)
 
 	GDVIRTUAL0RC(String, _accessibility_get_contextual_info);
+	GDVIRTUAL1RC(String, _get_accessibility_container_name, const Node *)
 
 	GDVIRTUAL1(_gui_input, Ref<InputEvent>)
 
@@ -596,6 +608,31 @@ public:
 	NodePath get_focus_next() const;
 	void set_focus_previous(const NodePath &p_prev);
 	NodePath get_focus_previous() const;
+
+	// Accessibility.
+
+	virtual String get_accessibility_container_name(const Node *p_node) const;
+
+	void set_accessibility_name(const String &p_name);
+	String get_accessibility_name() const;
+
+	void set_accessibility_description(const String &p_description);
+	String get_accessibility_description() const;
+
+	void set_accessibility_live(DisplayServer::AccessibilityLiveMode p_mode);
+	DisplayServer::AccessibilityLiveMode get_accessibility_live() const;
+
+	void set_accessibility_controls_nodes(const TypedArray<NodePath> &p_node_path);
+	TypedArray<NodePath> get_accessibility_controls_nodes() const;
+
+	void set_accessibility_described_by_nodes(const TypedArray<NodePath> &p_node_path);
+	TypedArray<NodePath> get_accessibility_described_by_nodes() const;
+
+	void set_accessibility_labeled_by_nodes(const TypedArray<NodePath> &p_node_path);
+	TypedArray<NodePath> get_accessibility_labeled_by_nodes() const;
+
+	void set_accessibility_flow_to_nodes(const TypedArray<NodePath> &p_node_path);
+	TypedArray<NodePath> get_accessibility_flow_to_nodes() const;
 
 	// Rendering.
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -61,53 +61,7 @@ void Node::_notification(int p_notification) {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
-			// Base info.
-			if (data.parent) {
-				String container_info = data.parent->get_accessibility_container_name(this);
-				DisplayServer::get_singleton()->accessibility_update_set_name(ae, container_info.is_empty() ? get_accessibility_name() : get_accessibility_name() + " " + container_info);
-			} else {
-				DisplayServer::get_singleton()->accessibility_update_set_name(ae, get_accessibility_name());
-			}
-			DisplayServer::get_singleton()->accessibility_update_set_description(ae, get_accessibility_description());
-			DisplayServer::get_singleton()->accessibility_update_set_live(ae, get_accessibility_live());
-
-			// Related nodes.
-			for (int i = 0; i < data.accessibility_controls_nodes.size(); i++) {
-				const NodePath &np = data.accessibility_controls_nodes[i];
-				if (!np.is_empty()) {
-					Node *n = get_node(np);
-					if (n && !n->is_part_of_edited_scene()) {
-						DisplayServer::get_singleton()->accessibility_update_add_related_controls(ae, n->get_accessibility_element());
-					}
-				}
-			}
-			for (int i = 0; i < data.accessibility_described_by_nodes.size(); i++) {
-				const NodePath &np = data.accessibility_described_by_nodes[i];
-				if (!np.is_empty()) {
-					Node *n = get_node(np);
-					if (n && !n->is_part_of_edited_scene()) {
-						DisplayServer::get_singleton()->accessibility_update_add_related_described_by(ae, n->get_accessibility_element());
-					}
-				}
-			}
-			for (int i = 0; i < data.accessibility_labeled_by_nodes.size(); i++) {
-				const NodePath &np = data.accessibility_labeled_by_nodes[i];
-				if (!np.is_empty()) {
-					Node *n = get_node(np);
-					if (n && !n->is_part_of_edited_scene()) {
-						DisplayServer::get_singleton()->accessibility_update_add_related_labeled_by(ae, n->get_accessibility_element());
-					}
-				}
-			}
-			for (int i = 0; i < data.accessibility_flow_to_nodes.size(); i++) {
-				const NodePath &np = data.accessibility_flow_to_nodes[i];
-				if (!np.is_empty()) {
-					Node *n = get_node(np);
-					if (n && !n->is_part_of_edited_scene()) {
-						DisplayServer::get_singleton()->accessibility_update_add_related_flow_to(ae, n->get_accessibility_element());
-					}
-				}
-			}
+			DisplayServer::get_singleton()->accessibility_update_set_name(ae, get_name());
 
 			// Node children.
 			if (!accessibility_override_tree_hierarchy()) {
@@ -1450,91 +1404,6 @@ void Node::_propagate_translation_domain_dirty() {
 	if (is_inside_tree() && data.auto_translate_mode != AUTO_TRANSLATE_MODE_DISABLED) {
 		notification(NOTIFICATION_TRANSLATION_CHANGED);
 	}
-}
-
-void Node::set_accessibility_name(const String &p_name) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_name != p_name) {
-		data.accessibility_name = p_name;
-		queue_accessibility_update();
-		update_configuration_warnings();
-	}
-}
-
-String Node::get_accessibility_name() const {
-	return tr(data.accessibility_name);
-}
-
-void Node::set_accessibility_description(const String &p_description) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_description != p_description) {
-		data.accessibility_description = p_description;
-		queue_accessibility_update();
-	}
-}
-
-String Node::get_accessibility_description() const {
-	return tr(data.accessibility_description);
-}
-
-void Node::set_accessibility_live(DisplayServer::AccessibilityLiveMode p_mode) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_live != p_mode) {
-		data.accessibility_live = p_mode;
-		queue_accessibility_update();
-	}
-}
-
-DisplayServer::AccessibilityLiveMode Node::get_accessibility_live() const {
-	return data.accessibility_live;
-}
-
-void Node::set_accessibility_controls_nodes(const TypedArray<NodePath> &p_node_path) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_controls_nodes != p_node_path) {
-		data.accessibility_controls_nodes = p_node_path;
-		queue_accessibility_update();
-	}
-}
-
-TypedArray<NodePath> Node::get_accessibility_controls_nodes() const {
-	return data.accessibility_controls_nodes;
-}
-
-void Node::set_accessibility_described_by_nodes(const TypedArray<NodePath> &p_node_path) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_described_by_nodes != p_node_path) {
-		data.accessibility_described_by_nodes = p_node_path;
-		queue_accessibility_update();
-	}
-}
-
-TypedArray<NodePath> Node::get_accessibility_described_by_nodes() const {
-	return data.accessibility_described_by_nodes;
-}
-
-void Node::set_accessibility_labeled_by_nodes(const TypedArray<NodePath> &p_node_path) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_labeled_by_nodes != p_node_path) {
-		data.accessibility_labeled_by_nodes = p_node_path;
-		queue_accessibility_update();
-	}
-}
-
-TypedArray<NodePath> Node::get_accessibility_labeled_by_nodes() const {
-	return data.accessibility_labeled_by_nodes;
-}
-
-void Node::set_accessibility_flow_to_nodes(const TypedArray<NodePath> &p_node_path) {
-	ERR_THREAD_GUARD
-	if (data.accessibility_flow_to_nodes != p_node_path) {
-		data.accessibility_flow_to_nodes = p_node_path;
-		queue_accessibility_update();
-	}
-}
-
-TypedArray<NodePath> Node::get_accessibility_flow_to_nodes() const {
-	return data.accessibility_flow_to_nodes;
 }
 
 StringName Node::get_name() const {
@@ -3806,15 +3675,6 @@ RID Node::get_focused_accessibility_element() const {
 	}
 }
 
-String Node::get_accessibility_container_name(const Node *p_node) const {
-	String ret;
-	if (GDVIRTUAL_CALL(_get_accessibility_container_name, p_node, ret)) {
-	} else if (data.parent) {
-		ret = data.parent->get_accessibility_container_name(this);
-	}
-	return ret;
-}
-
 void Node::queue_accessibility_update() {
 	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		data.tree->_accessibility_notify_change(this);
@@ -3911,21 +3771,6 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_process_thread_group_order", "order"), &Node::set_process_thread_group_order);
 	ClassDB::bind_method(D_METHOD("get_process_thread_group_order"), &Node::get_process_thread_group_order);
-
-	ClassDB::bind_method(D_METHOD("set_accessibility_name", "name"), &Node::set_accessibility_name);
-	ClassDB::bind_method(D_METHOD("get_accessibility_name"), &Node::get_accessibility_name);
-	ClassDB::bind_method(D_METHOD("set_accessibility_description", "description"), &Node::set_accessibility_description);
-	ClassDB::bind_method(D_METHOD("get_accessibility_description"), &Node::get_accessibility_description);
-	ClassDB::bind_method(D_METHOD("set_accessibility_live", "mode"), &Node::set_accessibility_live);
-	ClassDB::bind_method(D_METHOD("get_accessibility_live"), &Node::get_accessibility_live);
-	ClassDB::bind_method(D_METHOD("set_accessibility_controls_nodes", "node_path"), &Node::set_accessibility_controls_nodes);
-	ClassDB::bind_method(D_METHOD("get_accessibility_controls_nodes"), &Node::get_accessibility_controls_nodes);
-	ClassDB::bind_method(D_METHOD("set_accessibility_described_by_nodes", "node_path"), &Node::set_accessibility_described_by_nodes);
-	ClassDB::bind_method(D_METHOD("get_accessibility_described_by_nodes"), &Node::get_accessibility_described_by_nodes);
-	ClassDB::bind_method(D_METHOD("set_accessibility_labeled_by_nodes", "node_path"), &Node::set_accessibility_labeled_by_nodes);
-	ClassDB::bind_method(D_METHOD("get_accessibility_labeled_by_nodes"), &Node::get_accessibility_labeled_by_nodes);
-	ClassDB::bind_method(D_METHOD("set_accessibility_flow_to_nodes", "node_path"), &Node::set_accessibility_flow_to_nodes);
-	ClassDB::bind_method(D_METHOD("get_accessibility_flow_to_nodes"), &Node::get_accessibility_flow_to_nodes);
 
 	ClassDB::bind_method(D_METHOD("queue_accessibility_update"), &Node::queue_accessibility_update);
 	ClassDB::bind_method(D_METHOD("get_accessibility_element"), &Node::get_accessibility_element);
@@ -4156,15 +4001,6 @@ void Node::_bind_methods() {
 	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");
 
-	ADD_GROUP("Accessibility", "accessibility_");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "accessibility_name"), "set_accessibility_name", "get_accessibility_name");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "accessibility_description"), "set_accessibility_description", "get_accessibility_description");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "accessibility_live", PROPERTY_HINT_ENUM, "Off,Polite,Assertive"), "set_accessibility_live", "get_accessibility_live");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "accessibility_controls_nodes", PROPERTY_HINT_ARRAY_TYPE, "NodePath"), "set_accessibility_controls_nodes", "get_accessibility_controls_nodes");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "accessibility_described_by_nodes", PROPERTY_HINT_ARRAY_TYPE, "NodePath"), "set_accessibility_described_by_nodes", "get_accessibility_described_by_nodes");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "accessibility_labeled_by_nodes", PROPERTY_HINT_ARRAY_TYPE, "NodePath"), "set_accessibility_labeled_by_nodes", "get_accessibility_labeled_by_nodes");
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "accessibility_flow_to_nodes", PROPERTY_HINT_ARRAY_TYPE, "NodePath"), "set_accessibility_flow_to_nodes", "get_accessibility_flow_to_nodes");
-
 	GDVIRTUAL_BIND(_process, "delta");
 	GDVIRTUAL_BIND(_physics_process, "delta");
 	GDVIRTUAL_BIND(_enter_tree);
@@ -4177,7 +4013,6 @@ void Node::_bind_methods() {
 	GDVIRTUAL_BIND(_unhandled_input, "event");
 	GDVIRTUAL_BIND(_unhandled_key_input, "event");
 	GDVIRTUAL_BIND(_get_focused_accessibility_element);
-	GDVIRTUAL_BIND(_get_accessibility_container_name, "node");
 }
 
 String Node::_get_name_num_separator() {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -190,14 +190,6 @@ private:
 
 		mutable RID accessibility_element;
 
-		String accessibility_name;
-		String accessibility_description;
-		DisplayServer::AccessibilityLiveMode accessibility_live = DisplayServer::AccessibilityLiveMode::LIVE_OFF;
-		TypedArray<NodePath> accessibility_controls_nodes;
-		TypedArray<NodePath> accessibility_described_by_nodes;
-		TypedArray<NodePath> accessibility_labeled_by_nodes;
-		TypedArray<NodePath> accessibility_flow_to_nodes;
-
 		HashMap<StringName, GroupData> grouped;
 		List<Node *>::Element *OW = nullptr; // Owned element.
 		List<Node *> owned;
@@ -414,7 +406,6 @@ protected:
 	GDVIRTUAL1(_unhandled_key_input, Ref<InputEvent>)
 
 	GDVIRTUAL0RC(RID, _get_focused_accessibility_element)
-	GDVIRTUAL1RC(String, _get_accessibility_container_name, const Node *)
 
 #ifndef DISABLE_DEPRECATED
 	void _set_name_bind_compat_76560(const String &p_name);
@@ -678,32 +669,10 @@ public:
 	void set_process_thread_messages(BitField<ProcessThreadMessages> p_flags);
 	BitField<ProcessThreadMessages> get_process_thread_messages() const;
 
-	void set_accessibility_name(const String &p_name);
-	String get_accessibility_name() const;
-
-	void set_accessibility_description(const String &p_description);
-	String get_accessibility_description() const;
-
-	void set_accessibility_live(DisplayServer::AccessibilityLiveMode p_mode);
-	DisplayServer::AccessibilityLiveMode get_accessibility_live() const;
-
-	void set_accessibility_controls_nodes(const TypedArray<NodePath> &p_node_path);
-	TypedArray<NodePath> get_accessibility_controls_nodes() const;
-
-	void set_accessibility_described_by_nodes(const TypedArray<NodePath> &p_node_path);
-	TypedArray<NodePath> get_accessibility_described_by_nodes() const;
-
-	void set_accessibility_labeled_by_nodes(const TypedArray<NodePath> &p_node_path);
-	TypedArray<NodePath> get_accessibility_labeled_by_nodes() const;
-
-	void set_accessibility_flow_to_nodes(const TypedArray<NodePath> &p_node_path);
-	TypedArray<NodePath> get_accessibility_flow_to_nodes() const;
-
 	void queue_accessibility_update();
 
 	virtual RID get_accessibility_element() const;
 	virtual RID get_focused_accessibility_element() const;
-	virtual String get_accessibility_container_name(const Node *p_node) const;
 	virtual bool accessibility_override_tree_hierarchy() const { return false; }
 
 	virtual PackedStringArray get_accessibility_configuration_warnings() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1430,7 +1430,12 @@ void Window::_notification(int p_what) {
 			ERR_FAIL_COND(ae.is_null());
 
 			DisplayServer::get_singleton()->accessibility_update_set_role(ae, DisplayServer::AccessibilityRole::ROLE_WINDOW);
-			DisplayServer::get_singleton()->accessibility_update_set_name(ae, tr_title);
+			if (accessibility_name.is_empty()) {
+				DisplayServer::get_singleton()->accessibility_update_set_name(ae, tr_title);
+			} else {
+				DisplayServer::get_singleton()->accessibility_update_set_name(ae, accessibility_name);
+			}
+			DisplayServer::get_singleton()->accessibility_update_set_description(ae, accessibility_description);
 			DisplayServer::get_singleton()->accessibility_update_set_flag(ae, DisplayServer::AccessibilityFlags::FLAG_MODAL, exclusive);
 			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_FOCUS, callable_mp(this, &Window::_accessibility_action_grab_focus));
 			DisplayServer::get_singleton()->accessibility_update_set_flag(ae, DisplayServer::AccessibilityFlags::FLAG_HIDDEN, !visible);
@@ -2212,7 +2217,33 @@ Rect2i Window::get_usable_parent_rect() const {
 	return parent_rect;
 }
 
+void Window::set_accessibility_name(const String &p_name) {
+	ERR_MAIN_THREAD_GUARD;
+	if (accessibility_name != p_name) {
+		accessibility_name = p_name;
+		queue_accessibility_update();
+		update_configuration_warnings();
+	}
+}
+
+String Window::get_accessibility_name() const {
+	return tr(accessibility_name);
+}
+
+void Window::set_accessibility_description(const String &p_description) {
+	ERR_MAIN_THREAD_GUARD;
+	if (accessibility_description != p_description) {
+		accessibility_description = p_description;
+		queue_accessibility_update();
+	}
+}
+
+String Window::get_accessibility_description() const {
+	return tr(accessibility_description);
+}
+
 void Window::accessibility_announcement(const String &p_announcement) {
+	ERR_MAIN_THREAD_GUARD;
 	announcement = p_announcement;
 	queue_accessibility_update();
 }
@@ -3198,6 +3229,11 @@ void Window::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_window_id"), &Window::get_window_id);
 
+	ClassDB::bind_method(D_METHOD("set_accessibility_name", "name"), &Window::set_accessibility_name);
+	ClassDB::bind_method(D_METHOD("get_accessibility_name"), &Window::get_accessibility_name);
+	ClassDB::bind_method(D_METHOD("set_accessibility_description", "description"), &Window::set_accessibility_description);
+	ClassDB::bind_method(D_METHOD("get_accessibility_description"), &Window::get_accessibility_description);
+
 	ClassDB::bind_static_method("Window", D_METHOD("get_focused_window"), &Window::get_focused_window);
 
 	ClassDB::bind_method(D_METHOD("set_layout_direction", "direction"), &Window::set_layout_direction);
@@ -3273,6 +3309,10 @@ void Window::_bind_methods() {
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_auto_translate", "is_auto_translating");
 #endif
+
+	ADD_GROUP("Accessibility", "accessibility_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "accessibility_name"), "set_accessibility_name", "get_accessibility_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "accessibility_description"), "set_accessibility_description", "get_accessibility_description");
 
 	ADD_GROUP("Theme", "theme_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -158,6 +158,8 @@ private:
 	RID accessibility_title_element;
 	RID accessibility_announcement_element;
 	String announcement;
+	String accessibility_name;
+	String accessibility_description;
 
 	void _make_window();
 	void _clear_window();
@@ -419,6 +421,12 @@ public:
 	void start_resize(DisplayServer::WindowResizeEdge p_edge);
 
 	Rect2i get_usable_parent_rect() const;
+
+	void set_accessibility_name(const String &p_name);
+	String get_accessibility_name() const;
+
+	void set_accessibility_description(const String &p_description);
+	String get_accessibility_description() const;
 
 	void accessibility_announcement(const String &p_announcement);
 


### PR DESCRIPTION
These properties are not useful for generic `Node` which can't have GUI focus and more suitable for `Control`. And it seems like a number of properties have some impact on performance, so there is no need to expose these for `Node`. It's still possible to set them using `DisaplyServer` API directly, if a specific non-`Control` node is customized to emulate GUI focus. Save 56-bytes per `Node`.