### PR TITLE
Fix light range in VoxelGI

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2943,6 +2943,10 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 		}
 	}
 
+	// probe size relative to 1 unit in world space
+	Vector3 ps = gi->voxel_gi_get_octree_size(probe) / gi->voxel_gi_get_bounds(probe).size;
+	float cell_size = (1.0 / MAX(MAX(ps.x, ps.y), ps.z));
+
 	if (has_dynamic_object_data || p_update_light_instances || p_dynamic_objects.size()) {
 		// PROCESS MIPMAPS
 		if (mipmaps.size()) {
@@ -2961,6 +2965,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 			push_constant.dynamic_range = gi->voxel_gi_get_dynamic_range(probe);
 			push_constant.light_count = light_count;
 			push_constant.aniso_strength = 0;
+			push_constant.cell_size = cell_size;
 
 			/*		print_line("probe update to version " + itos(last_probe_version));
 			print_line("propagation " + rtos(push_constant.propagation));
@@ -3161,9 +3166,9 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 				push_constant.prev_rect_size[1] = 0;
 				push_constant.on_mipmap = false;
 				push_constant.propagation = gi->voxel_gi_get_propagation(probe);
+				push_constant.cell_size = cell_size;
 				push_constant.pad[0] = 0;
 				push_constant.pad[1] = 0;
-				push_constant.pad[2] = 0;
 
 				//process lighting
 				RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -188,7 +188,7 @@ private:
 		uint32_t cell_offset;
 		uint32_t cell_count;
 		float aniso_strength;
-		uint32_t pad;
+		float cell_size;
 	};
 
 	struct VoxelGIDynamicPushConstant {
@@ -209,7 +209,8 @@ private:
 		float dynamic_range;
 		uint32_t on_mipmap;
 		float propagation;
-		float pad[3];
+		float cell_size;
+		float pad[2];
 	};
 
 	VoxelGILight *voxel_gi_lights = nullptr;

--- a/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/voxel_gi.glsl
@@ -86,7 +86,7 @@ layout(push_constant, std430) uniform Params {
 	uint cell_offset;
 	uint cell_count;
 	float aniso_strength;
-	uint pad;
+	float cell_size;
 }
 params;
 
@@ -126,7 +126,8 @@ layout(push_constant, std430) uniform Params {
 	float dynamic_range;
 	bool on_mipmap;
 	float propagation;
-	float pad[3];
+	float cell_size;
+	float pad[2];
 }
 params;
 
@@ -209,7 +210,10 @@ bool compute_light_vector(uint light, vec3 pos, out float attenuation, out vec3 
 			return false;
 		}
 
-		attenuation = get_omni_attenuation(distance, 1.0 / lights.data[light].radius, lights.data[light].attenuation);
+		attenuation = get_omni_attenuation(
+				distance * params.cell_size,
+				1.0 / (lights.data[light].radius * params.cell_size),
+				lights.data[light].attenuation);
 
 		if (lights.data[light].type == LIGHT_TYPE_SPOT) {
 			vec3 rel = normalize(pos - light_pos);


### PR DESCRIPTION
I don't know what I'm doing here, I'd appreciate if someone more familiar with the code base could help me if there's a better way to do this.

fixes https://github.com/godotengine/godot/issues/80101
thanks to @juniez3d in that thread for their comment that led me the right direction

this PR fixes a bug where voxel GI has the wrong radius for lights, because I think it internally uses voxels as units instead of godot units, and they aren't getting converted. this leads to bugs like changing the voxel resolution affecting light brightness, cartoony looking lights with a harsh edge because the radius that clips the light is properly calculated but not the attenuation, and incorrect light attenuation because attenuation works in world space (though that honestly seems like it's own bug...).

this might improve https://github.com/godotengine/godot/issues/55639 but probably isn't a fix since that scene uses a directional light which isn't helped by this PR.

![pr](https://github.com/user-attachments/assets/45844a8c-9ffe-4bfa-b261-d415bb146dc1)
top is 1.0 attenuation, bottom is ~8.0 attenuation, right 4 images are voxel debug view

_bugsquad edit: fixes https://github.com/godotengine/godot/issues/107118_