### PR TITLE
Fix print/error ordering issue in editor Output

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7014,7 +7014,11 @@ static Node *_resource_get_edited_scene() {
 }
 
 void EditorNode::_print_handler(void *p_this, const String &p_string, bool p_error, bool p_rich) {
-	callable_mp_static(&EditorNode::_print_handler_impl).call_deferred(p_string, p_error, p_rich);
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(&EditorNode::_print_handler_impl).call_deferred(p_string, p_error, p_rich);
+	} else {
+		_print_handler_impl(p_string, p_error, p_rich);
+	}
 }
 
 void EditorNode::_print_handler_impl(const String &p_string, bool p_error, bool p_rich) {


### PR DESCRIPTION
Fixes #84481.

This fixes the issue of regular `print` calls and things like `ERR_PRINT` ending up out-of-order in the editor's Output panel, when done from something like a tool script, and potentially other contexts as well.

The issue seems to have been a regression from #77251, which changed `EditorNode::_print_handler` (and `EditorNode::_file_access_close_error_notify`) to be thread-safe, by deferring every such call, leading to `print` messages being deferred, when error messages are not.

The adding of error messages is thread-safe as well, but rightfully checks whether we're on the main thread first, and only defers it if we're not, as seen here:

https://github.com/godotengine/godot/blob/25a3c27c41ac32f65d8efb8a54b08ad88211a700/editor/editor_log.cpp#L56-L60

This PR fixes this issue by doing exactly that for `EditorNode::_print_handler` as well and only deferring the call if we're not on the main thread.

I've left `EditorNode::_file_access_close_error_notify` as-is, but there might be some argument for changing that as well. Let me know if I should throw that in here.