### PR TITLE
Relax the requirements for making `EditorImportPlugin`

### DIFF
--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -160,7 +160,7 @@
 			<param index="1" name="option_name" type="StringName" />
 			<param index="2" name="options" type="Dictionary" />
 			<description>
-				This method can be overridden to hide specific import options if conditions are met. This is mainly useful for hiding options that depend on others if one of them is disabled.
+				Gets whether the import option specified by [param option_name] should be visible in the Import dock. The default implementation always returns [code]true[/code], making all options visible. This is mainly useful for hiding options that depend on others if one of them is disabled.
 				[codeblocks]
 				[gdscript]
 				func _get_option_visibility(option, options):
@@ -183,7 +183,6 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				Returns [code]true[/code] to make all options always visible.
 			</description>
 		</method>
 		<method name="_get_preset_count" qualifiers="virtual const">

--- a/editor/import/editor_import_plugin.cpp
+++ b/editor/import/editor_import_plugin.cpp
@@ -66,7 +66,7 @@ String EditorImportPlugin::get_preset_name(int p_idx) const {
 	if (GDVIRTUAL_CALL(_get_preset_name, p_idx, ret)) {
 		return ret;
 	}
-	ERR_FAIL_V_MSG(String(), "Unimplemented _get_preset_name in add-on.");
+	ERR_FAIL_V_MSG(itos(p_idx), "Unimplemented _get_preset_name in add-on.");
 }
 
 int EditorImportPlugin::get_preset_count() const {
@@ -74,7 +74,7 @@ int EditorImportPlugin::get_preset_count() const {
 	if (GDVIRTUAL_CALL(_get_preset_count, ret)) {
 		return ret;
 	}
-	ERR_FAIL_V_MSG(-1, "Unimplemented _get_preset_count in add-on.");
+	return 0;
 }
 
 String EditorImportPlugin::get_save_extension() const {
@@ -98,7 +98,7 @@ float EditorImportPlugin::get_priority() const {
 	if (GDVIRTUAL_CALL(_get_priority, ret)) {
 		return ret;
 	}
-	ERR_FAIL_V_MSG(-1, "Unimplemented _get_priority in add-on.");
+	return 1.0;
 }
 
 int EditorImportPlugin::get_import_order() const {
@@ -106,7 +106,7 @@ int EditorImportPlugin::get_import_order() const {
 	if (GDVIRTUAL_CALL(_get_import_order, ret)) {
 		return ret;
 	}
-	ERR_FAIL_V_MSG(-1, "Unimplemented _get_import_order in add-on.");
+	return IMPORT_ORDER_DEFAULT;
 }
 
 int EditorImportPlugin::get_format_version() const {
@@ -162,8 +162,7 @@ bool EditorImportPlugin::get_option_visibility(const String &p_path, const Strin
 	if (GDVIRTUAL_CALL(_get_option_visibility, p_path, p_option, d, visible)) {
 		return visible;
 	}
-
-	ERR_FAIL_V_MSG(false, "Unimplemented _get_option_visibility in add-on.");
+	return true;
 }
 
 Error EditorImportPlugin::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -379,7 +379,7 @@ void ImportDock::_update_preset_menu() {
 	}
 	preset->show();
 
-	if (params->importer->get_preset_count() == 0) {
+	if (params->importer->get_preset_count() <= 0) {
 		preset->get_popup()->add_item(TTRC("Default"));
 	} else {
 		for (int i = 0; i < params->importer->get_preset_count(); i++) {


### PR DESCRIPTION
The example `EditorImportPlugin` code in the class reference does not work because it didn't override methods like `_get_priority()`, `_get_import_order()`, and `_get_option_visibility()`.

- `_get_priority()` and `_get_import_order()`: These two methods have documented default value. This PR allows not overridding these two methods. Default values mentioned in the documentation will be used in this case.
- `_get_option_visibility()`: This method is for advanced usage and should provide a default implementation that always returns true, making all options visible.

Other changes:

- `_get_preset_count()`: Defaults to zero when not overridden.
- `_get_preset_name()`: When not overridden and the preset count is positive, the editor errors and uses an empty string as the preset name, making the dropdown menu look broken. This PR makes it return the preset index as the error return value.
- Fixed broken preset menu when `_get_preset_count()` mistakenly returns a negative value. 