### PR TITLE
Allow customizing FileDialog's features

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -96,6 +96,21 @@
 				[b]Note:[/b] This method does nothing on native file dialogs.
 			</description>
 		</method>
+		<method name="is_customization_flag_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="flag" type="int" enum="FileDialog.Customization" />
+			<description>
+				Returns [code]true[/code] if the provided [param flag] is enabled.
+			</description>
+		</method>
+		<method name="set_customization_flag_enabled">
+			<return type="void" />
+			<param index="0" name="flag" type="int" enum="FileDialog.Customization" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				Toggles the specified customization [param flag], allowing to customize features available in this [FileDialog]. See [enum Customization] for options.
+			</description>
+		</method>
 		<method name="set_option_default">
 			<return type="void" />
 			<param index="0" name="option" type="int" />
@@ -140,8 +155,17 @@
 		<member name="display_mode" type="int" setter="set_display_mode" getter="get_display_mode" enum="FileDialog.DisplayMode" default="0">
 			Display mode of the dialog's file list.
 		</member>
+		<member name="favorites_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the toggle favorite button and favorite list on the left side of the dialog.
+		</member>
+		<member name="file_filter_toggle_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the toggle file filter button.
+		</member>
 		<member name="file_mode" type="int" setter="set_file_mode" getter="get_file_mode" enum="FileDialog.FileMode" default="4">
 			The dialog's open or save mode, which affects the selection behavior.
+		</member>
+		<member name="file_sort_options_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the file sorting options button.
 		</member>
 		<member name="filename_filter" type="String" setter="set_filename_filter" getter="get_filename_filter" default="&quot;&quot;">
 			The filter for file names (case-insensitive). When set to a non-empty string, only files that contains the substring will be shown. [member filename_filter] can be edited by the user with the filter button at the top of the file dialog.
@@ -151,11 +175,23 @@
 			The available file type filters. Each filter string in the array should be formatted like this: [code]*.png,*.jpg,*.jpeg;Image Files;image/png,image/jpeg[/code]. The description text of the filter is optional and can be omitted. Both file extensions and MIME type should be always set.
 			[b]Note:[/b] Embedded file dialog and Windows file dialog support only file extensions, while Android, Linux, and macOS file dialogs also support MIME types.
 		</member>
+		<member name="folder_creation_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the button for creating new directories (when using [constant FILE_MODE_OPEN_DIR], [constant FILE_MODE_OPEN_ANY], or [constant FILE_MODE_SAVE_FILE]).
+		</member>
+		<member name="hidden_files_toggle_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the toggle hidden files button.
+		</member>
+		<member name="layout_toggle_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the layout switch buttons (list/thumbnails).
+		</member>
 		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title" default="true">
 			If [code]true[/code], changing the [member file_mode] property will set the window title accordingly (e.g. setting [member file_mode] to [constant FILE_MODE_OPEN_FILE] will change the window title to "Open a File").
 		</member>
 		<member name="option_count" type="int" setter="set_option_count" getter="get_option_count" default="0">
 			The number of additional [OptionButton]s and [CheckBox]es in the dialog.
+		</member>
+		<member name="recent_list_enabled" type="bool" setter="set_customization_flag_enabled" getter="is_customization_flag_enabled" default="true">
+			If [code]true[/code], shows the recent directories list on the left side of the dialog.
 		</member>
 		<member name="root_subfolder" type="String" setter="set_root_subfolder" getter="get_root_subfolder" default="&quot;&quot;">
 			If non-empty, the given sub-folder will be "root" of this [FileDialog], i.e. user won't be able to go to its parent directory.
@@ -231,6 +267,34 @@
 		</constant>
 		<constant name="DISPLAY_LIST" value="1" enum="DisplayMode">
 			The dialog displays files as a list of filenames.
+		</constant>
+		<constant name="CUSTOMIZATION_HIDDEN_FILES" value="0" enum="Customization">
+			Toggles visibility of the favorite button, and the favorite list on the left side of the dialog.
+			Equivalent to [member hidden_files_toggle_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_CREATE_FOLDER" value="1" enum="Customization">
+			If enabled, shows the button for creating new directories (when using [constant FILE_MODE_OPEN_DIR], [constant FILE_MODE_OPEN_ANY], or [constant FILE_MODE_SAVE_FILE]).
+			Equivalent to [member folder_creation_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_FILE_FILTER" value="2" enum="Customization">
+			If enabled, shows the toggle file filter button.
+			Equivalent to [member file_filter_toggle_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_FILE_SORT" value="3" enum="Customization">
+			If enabled, shows the file sorting options button.
+			Equivalent to [member file_sort_options_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_FAVORITES" value="4" enum="Customization">
+			If enabled, shows the toggle favorite button and favorite list on the left side of the dialog.
+			Equivalent to [member favorites_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_RECENT" value="5" enum="Customization">
+			If enabled, shows the recent directories list on the left side of the dialog.
+			Equivalent to [member recent_list_enabled].
+		</constant>
+		<constant name="CUSTOMIZATION_LAYOUT" value="6" enum="Customization">
+			If enabled, shows the layout switch buttons (list/thumbnails).
+			Equivalent to [member layout_toggle_enabled].
 		</constant>
 	</constants>
 	<theme_items>

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -43,6 +43,7 @@ class MenuButton;
 class OptionButton;
 class PopupMenu;
 class VBoxContainer;
+class VSeparator;
 
 class FileDialog : public ConfirmationDialog {
 	GDCLASS(FileDialog, ConfirmationDialog);
@@ -134,6 +135,17 @@ public:
 		ITEM_MENU_SHOW_BUNDLE_CONTENT,
 	};
 
+	enum Customization {
+		CUSTOMIZATION_HIDDEN_FILES,
+		CUSTOMIZATION_CREATE_FOLDER,
+		CUSTOMIZATION_FILE_FILTER,
+		CUSTOMIZATION_FILE_SORT,
+		CUSTOMIZATION_FAVORITES,
+		CUSTOMIZATION_RECENT,
+		CUSTOMIZATION_LAYOUT,
+		CUSTOMIZATION_MAX
+	};
+
 	typedef Ref<Texture2D> (*GetIconFunc)(const String &);
 	typedef void (*RegisterFunc)(FileDialog *);
 
@@ -148,6 +160,7 @@ private:
 	inline static bool default_show_hidden_files = false;
 	bool show_hidden_files = false;
 	bool use_native_dialog = false;
+	bool customization_flags[CUSTOMIZATION_MAX]; // Initialized to true in the constructor.
 
 	inline static LocalVector<String> global_favorites;
 	inline static LocalVector<String> global_recents;
@@ -191,16 +204,23 @@ private:
 
 	Button *refresh_button = nullptr;
 	Button *favorite_button = nullptr;
+	HBoxContainer *make_dir_container = nullptr;
 	Button *make_dir_button = nullptr;
+
 	Button *show_hidden = nullptr;
+	VSeparator *show_hidden_separator = nullptr;
+	HBoxContainer *layout_container = nullptr;
+	VSeparator *layout_separator = nullptr;
 	Button *thumbnail_mode_button = nullptr;
 	Button *list_mode_button = nullptr;
 	Button *show_filename_filter_button = nullptr;
 	MenuButton *file_sort_button = nullptr;
 
+	VBoxContainer *favorite_vbox = nullptr;
 	Button *fav_up_button = nullptr;
 	Button *fav_down_button = nullptr;
 	ItemList *favorite_list = nullptr;
+	VBoxContainer *recent_vbox = nullptr;
 	ItemList *recent_list = nullptr;
 
 	ItemList *file_list = nullptr;
@@ -260,6 +280,7 @@ private:
 	void update_filename_filter();
 	void update_filename_filter_gui();
 	void update_filters();
+	void update_customization();
 
 	void _item_menu_id_pressed(int p_option);
 	void _empty_clicked(const Vector2 &p_pos, MouseButton p_button);
@@ -307,6 +328,7 @@ private:
 
 	void _invalidate();
 	void _setup_button(Button *p_button, const Ref<Texture2D> &p_icon);
+	void _update_make_dir_visible();
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
 
@@ -386,6 +408,9 @@ public:
 	void set_display_mode(DisplayMode p_mode);
 	DisplayMode get_display_mode() const;
 
+	void set_customization_flag_enabled(Customization p_flag, bool p_enabled);
+	bool is_customization_flag_enabled(Customization p_flag) const;
+
 	VBoxContainer *get_vbox() { return main_vbox; }
 	LineEdit *get_line_edit() { return filename_edit; }
 
@@ -410,3 +435,4 @@ public:
 VARIANT_ENUM_CAST(FileDialog::FileMode);
 VARIANT_ENUM_CAST(FileDialog::Access);
 VARIANT_ENUM_CAST(FileDialog::DisplayMode);
+VARIANT_ENUM_CAST(FileDialog::Customization);


### PR DESCRIPTION
Basically #67741 for FileDialog. As new features are added to the dialog (as part of https://github.com/godotengine/godot-proposals/issues/6831), disabling some of them might be useful.

https://github.com/user-attachments/assets/686484ab-70a4-4e7c-ba8d-272e1db66aa5

