### PR TITLE
[Wayland] Implement the xx-session-management-v1 protocol

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8438,6 +8438,7 @@ EditorNode::EditorNode() {
 	gui_base->add_child(open_imported);
 
 	quick_open_dialog = memnew(EditorQuickOpenDialog);
+	quick_open_dialog->set_session_id("QuickOpen");
 	gui_base->add_child(quick_open_dialog);
 
 	quick_open_color_palette = memnew(EditorQuickOpenDialog);

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -261,6 +261,7 @@ void QuickSettingsDialog::_bind_methods() {
 
 QuickSettingsDialog::QuickSettingsDialog() {
 	set_title(TTRC("Quick Settings"));
+	set_session_id("QuickSettings");
 	set_ok_button_text(TTRC("Close"));
 
 	VBoxContainer *main_vbox = memnew(VBoxContainer);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3204,6 +3204,16 @@ Error Main::setup2(bool p_show_boot_logo) {
 		}
 
 #ifdef TOOLS_ENABLED
+		if (project_manager) {
+			String path = EditorPaths::get_singleton()->get_data_dir() + "/window_state.cfg";
+			DisplayServer::get_singleton()->set_session_path(path);
+		} else if (editor) {
+			String path = EditorPaths::get_singleton()->get_project_data_dir() + "/editor_layout.cfg";
+			DisplayServer::get_singleton()->set_session_path(path);
+		} else {
+			DisplayServer::get_singleton()->set_session_path("user://godot_window_state.cfg");
+		}
+
 		if (project_manager && init_display_scale_found) {
 			float ui_scale = init_custom_scale;
 			switch (init_display_scale) {

--- a/platform/linuxbsd/wayland/SCsub
+++ b/platform/linuxbsd/wayland/SCsub
@@ -160,6 +160,14 @@ env.NoCache(
         "protocol/xdg_system_bell.gen.c",
         "#thirdparty/wayland-protocols/staging/xdg-system-bell/xdg-system-bell-v1.xml",
     ),
+    env.WAYLAND_API_HEADER(
+        "protocol/xx_session_management.gen.h",
+        "#thirdparty/wayland-protocols/experimental/xx-session-management/xx-session-management-v1.xml",
+    ),
+    env.WAYLAND_API_CODE(
+        "protocol/xx_session_management.gen.c",
+        "#thirdparty/wayland-protocols/experimental/xx-session-management/xx-session-management-v1.xml",
+    ),
 )
 
 
@@ -175,6 +183,7 @@ source_files = [
     "protocol/xdg_decoration.gen.c",
     "protocol/xdg_activation.gen.c",
     "protocol/relative_pointer.gen.c",
+    "protocol/xx_session_management.gen.c",
     "protocol/pointer_constraints.gen.c",
     "protocol/pointer_gestures.gen.c",
     "protocol/primary_selection.gen.c",

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -223,6 +223,22 @@ String DisplayServerWayland::get_name() const {
 	return "Wayland";
 }
 
+void DisplayServerWayland::set_session(const String &p_name) {
+	DisplayServer::set_session(p_name);
+
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	wayland_thread.set_session_path(get_session_path());
+}
+
+void DisplayServerWayland::set_session_path(const String &p_path) {
+	DisplayServer::set_session_path(p_path);
+
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	wayland_thread.set_session_path(get_session_path());
+}
+
 #ifdef SPEECHD_ENABLED
 
 void DisplayServerWayland::initialize_tts() const {
@@ -994,6 +1010,26 @@ void DisplayServerWayland::window_set_title(const String &p_title, DisplayServer
 	if (wd.visible) {
 		wayland_thread.window_set_title(p_window_id, wd.title);
 	}
+}
+
+void DisplayServerWayland::window_set_session_id(const String &p_id, DisplayServer::WindowID p_window_id) {
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	ERR_FAIL_COND(!windows.has(p_window_id));
+
+	WindowData &wd = windows[p_window_id];
+
+	wd.session_id = p_id;
+
+	wayland_thread.window_set_session_id(p_window_id, p_id);
+}
+
+String DisplayServerWayland::window_get_session_id(DisplayServer::WindowID p_window_id) const {
+	MutexLock mutex_lock(wayland_thread.mutex);
+
+	ERR_FAIL_COND_V(!windows.has(p_window_id), String());
+
+	return windows[p_window_id].session_id;
 }
 
 void DisplayServerWayland::window_set_mouse_passthrough(const Vector<Vector2> &p_region, DisplayServer::WindowID p_window_id) {

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -108,6 +108,7 @@ class DisplayServerWayland : public DisplayServer {
 		Callable input_text_callback;
 
 		String title;
+		String session_id;
 		ObjectID instance_id;
 	};
 
@@ -192,6 +193,9 @@ public:
 
 	virtual String get_name() const override;
 
+	virtual void set_session(const String &p_name) override;
+	virtual void set_session_path(const String &p_path) override;
+
 #ifdef SPEECHD_ENABLED
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
@@ -262,6 +266,8 @@ public:
 	virtual ObjectID window_get_attached_instance_id(WindowID p_window_id = MAIN_WINDOW_ID) const override;
 
 	virtual void window_set_title(const String &p_title, WindowID p_window_id = MAIN_WINDOW_ID) override;
+	virtual void window_set_session_id(const String &p_session_id, WindowID p_window_id = MAIN_WINDOW_ID) override;
+	virtual String window_get_session_id(WindowID p_window_id = MAIN_WINDOW_ID) const override;
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window_id = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_rect_changed_callback(const Callable &p_callable, WindowID p_window_id = MAIN_WINDOW_ID) override;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -30,6 +30,8 @@
 
 #include "wayland_thread.h"
 
+#include "core/io/config_file.h"
+
 #ifdef WAYLAND_ENABLED
 
 #ifdef __FreeBSD__
@@ -651,6 +653,11 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 		return;
 	}
 
+	if (strcmp(interface, xx_session_manager_v1_interface.name) == 0) {
+		registry->xx_session_manager = (struct xx_session_manager_v1 *)wl_registry_bind(wl_registry, name, &xx_session_manager_v1_interface, 1);
+		registry->xx_session_manager_name = name;
+	}
+
 	if (strcmp(interface, FIFO_INTERFACE_NAME) == 0) {
 		registry->wp_fifo_manager_name = name;
 	}
@@ -1060,6 +1067,20 @@ void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry
 
 			it = it->next();
 		}
+	}
+
+	if (name == registry->xx_session_manager_name) {
+		if (registry->xx_session) {
+			xx_session_v1_destroy(registry->xx_session);
+			registry->xx_session = nullptr;
+		}
+
+		if (registry->xx_session_manager) {
+			xx_session_manager_v1_destroy(registry->xx_session_manager);
+			registry->xx_session_manager = nullptr;
+		}
+
+		registry->xx_session_manager_name = 0;
 	}
 
 	if (name == registry->wp_fifo_manager_name) {
@@ -2977,6 +2998,24 @@ void WaylandThread::_xdg_activation_token_on_done(void *data, struct xdg_activat
 	DEBUG_LOG_WAYLAND_THREAD(vformat("Received activation token and requested window activation."));
 }
 
+void WaylandThread::_xx_session_on_created(void *data, struct xx_session_v1 *xx_session, const char *id) {
+	RegistryState *registry = (RegistryState *)data;
+
+	Ref<ConfigFile> file;
+	file.instantiate();
+	file->load(registry->session_path);
+
+	file->set_value("meta", "wayland_session_id", id);
+
+	file->save(registry->session_path);
+}
+
+void WaylandThread::_xx_session_on_restored(void *data, struct xx_session_v1 *xx_session) {
+}
+
+void WaylandThread::_xx_session_on_replaced(void *data, struct xx_session_v1 *xx_session) {
+}
+
 // NOTE: This must be started after a valid wl_display is loaded.
 void WaylandThread::_poll_events_thread(void *p_data) {
 	ThreadData *data = (ThreadData *)p_data;
@@ -3455,6 +3494,23 @@ void WaylandThread::seat_state_echo_keys(SeatState *p_ss) {
 	}
 }
 
+void WaylandThread::set_session_path(const String &p_path) {
+	registry.session_path = p_path;
+
+	Ref<ConfigFile> file;
+	file.instantiate();
+	file->load(p_path);
+
+	String session = file->get_value("meta", "wayland_session_id", "");
+	if (session.is_empty()) {
+		registry.xx_session = xx_session_manager_v1_get_session(registry.xx_session_manager, xx_session_manager_v1_reason::XX_SESSION_MANAGER_V1_REASON_LAUNCH, nullptr);
+		xx_session_v1_add_listener(registry.xx_session, &xx_session_listener, &registry);
+	} else {
+		registry.xx_session = xx_session_manager_v1_get_session(registry.xx_session_manager, xx_session_manager_v1_reason::XX_SESSION_MANAGER_V1_REASON_LAUNCH, session.utf8().get_data());
+		xx_session_v1_add_listener(registry.xx_session, &xx_session_listener, &registry);
+	}
+}
+
 void WaylandThread::push_message(Ref<Message> message) {
 	messages.push_back(message);
 }
@@ -3529,6 +3585,24 @@ void WaylandThread::window_create(DisplayServer::WindowID p_window_id, int p_wid
 
 			decorated = true;
 		}
+	}
+
+	if (registry.xx_session && !ws.session_id.is_empty()) {
+		Ref<ConfigFile> window_state;
+		window_state.instantiate();
+		window_state->load(registry.session_path);
+
+		if (window_state->get_value(ws.session_id, "wayland_tracked", false)) {
+			//TODO: are these useful for us?
+			struct xx_toplevel_session_v1 *toplevel_session = xx_session_v1_restore_toplevel(registry.xx_session, ws.xdg_toplevel, ws.session_id.utf8().get_data());
+			xx_toplevel_session_v1_destroy(toplevel_session);
+			window_state->set_value(ws.session_id, "wayland_tracked", true);
+		} else {
+			struct xx_toplevel_session_v1 *toplevel_session = xx_session_v1_add_toplevel(registry.xx_session, ws.xdg_toplevel, ws.session_id.utf8().get_data());
+			xx_toplevel_session_v1_destroy(toplevel_session);
+		}
+
+		window_state->save(registry.session_path);
 	}
 
 	ws.frame_callback = wl_surface_frame(ws.wl_surface);
@@ -4079,6 +4153,13 @@ void WaylandThread::window_set_app_id(DisplayServer::WindowID p_window_id, const
 		xdg_toplevel_set_app_id(ws.xdg_toplevel, p_app_id.utf8().get_data());
 		return;
 	}
+}
+
+void WaylandThread::window_set_session_id(DisplayServer::WindowID p_window_id, const String &p_session_id) {
+	ERR_FAIL_COND(!windows.has(p_window_id));
+	WindowState &ws = windows[p_window_id];
+
+	ws.session_id = p_session_id;
 }
 
 DisplayServer::WindowMode WaylandThread::window_get_mode(DisplayServer::WindowID p_window_id) const {
@@ -5027,6 +5108,15 @@ void WaylandThread::destroy() {
 	if (registry.xdg_exporter_v2) {
 		zxdg_exporter_v2_destroy(registry.xdg_exporter_v2);
 	}
+
+	if (registry.xx_session_manager) {
+		xx_session_manager_v1_destroy(registry.xx_session_manager);
+	}
+
+	if (registry.xx_session) {
+		xx_session_v1_destroy(registry.xx_session);
+	}
+
 	if (registry.wl_shm) {
 		wl_shm_destroy(registry.wl_shm);
 	}

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -70,6 +70,7 @@
 #include "wayland/protocol/xdg_foreign_v2.gen.h"
 #include "wayland/protocol/xdg_shell.gen.h"
 #include "wayland/protocol/xdg_system_bell.gen.h"
+#include "wayland/protocol/xx_session_management.gen.h"
 
 // NOTE: Deprecated.
 #include "wayland/protocol/xdg_foreign_v1.gen.h"
@@ -221,6 +222,11 @@ public:
 		struct zwp_text_input_manager_v3 *wp_text_input_manager = nullptr;
 		uint32_t wp_text_input_manager_name = 0;
 
+		struct xx_session_manager_v1 *xx_session_manager = nullptr;
+		struct xx_session_v1 *xx_session = nullptr;
+		String session_path;
+		uint32_t xx_session_manager_name = 0;
+
 		// We're really not meant to use this one directly but we still need to know
 		// whether it's available.
 		uint32_t wp_fifo_manager_name = 0;
@@ -293,6 +299,8 @@ public:
 		struct zxdg_toplevel_decoration_v1 *xdg_toplevel_decoration = nullptr;
 
 		struct zwp_idle_inhibitor_v1 *wp_idle_inhibitor = nullptr;
+
+		String session_id = "";
 
 #ifdef LIBDECOR_ENABLED
 		// If this is null the xdg_* variables must be set and vice-versa. This way we
@@ -735,6 +743,10 @@ private:
 
 	static void _xdg_activation_token_on_done(void *data, struct xdg_activation_token_v1 *xdg_activation_token, const char *token);
 
+	static void _xx_session_on_created(void *data, struct xx_session_v1 *xx_session, const char *id);
+	static void _xx_session_on_restored(void *data, struct xx_session_v1 *xx_session);
+	static void _xx_session_on_replaced(void *data, struct xx_session_v1 *xx_session);
+
 	// Core Wayland event listeners.
 	static constexpr struct wl_registry_listener wl_registry_listener = {
 		.global = _wl_registry_on_global,
@@ -922,6 +934,12 @@ private:
 		.done = _xdg_activation_token_on_done,
 	};
 
+	static constexpr struct xx_session_v1_listener xx_session_listener = {
+		.created = _xx_session_on_created,
+		.restored = _xx_session_on_restored,
+		.replaced = _xx_session_on_replaced
+	};
+
 #ifdef LIBDECOR_ENABLED
 	// libdecor event handlers.
 	static void libdecor_on_error(struct libdecor *context, enum libdecor_error error, const char *message);
@@ -1017,6 +1035,8 @@ public:
 
 	static Vector2i scale_vector2i(const Vector2i &p_vector, double p_amount);
 
+	void set_session_path(const String &p_path);
+
 	void push_message(Ref<Message> message);
 	bool has_message();
 	Ref<Message> pop_message();
@@ -1044,6 +1064,7 @@ public:
 	void window_set_borderless(DisplayServer::WindowID p_window_id, bool p_borderless);
 	void window_set_title(DisplayServer::WindowID p_window_id, const String &p_title);
 	void window_set_app_id(DisplayServer::WindowID p_window_id, const String &p_app_id);
+	void window_set_session_id(DisplayServer::WindowID p_window_id, const String &p_session_id);
 
 	bool window_is_focused(DisplayServer::WindowID p_window_id);
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -121,6 +121,7 @@ private:
 
 	String title;
 	String tr_title;
+	String session_id;
 	mutable int current_screen = 0;
 	mutable Point2i position;
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
@@ -294,6 +295,9 @@ public:
 	void set_title(const String &p_title);
 	String get_title() const;
 	String get_translated_title() const;
+
+	void set_session_id(const String &p_name);
+	String get_session_id() const;
 
 	void set_initial_position(WindowInitialPosition p_initial_position);
 	WindowInitialPosition get_initial_position() const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -52,6 +52,8 @@ DisplayServer::AccessibilityMode DisplayServer::accessibility_mode = DisplayServ
 
 bool DisplayServer::hidpi_allowed = false;
 
+String DisplayServer::session_path = "user://godot_window_state.cfg";
+
 bool DisplayServer::window_early_clear_override_enabled = false;
 Color DisplayServer::window_early_clear_override_color = Color(0, 0, 0, 0);
 
@@ -411,6 +413,18 @@ Dictionary DisplayServer::global_menu_get_system_menu_roots() const {
 
 #endif
 
+void DisplayServer::set_session(const String &p_name) {
+	session_path = "user://" + p_name + ".cfg";
+}
+
+void DisplayServer::set_session_path(const String &p_path) {
+	session_path = p_path;
+}
+
+String DisplayServer::get_session_path() {
+	return session_path;
+}
+
 bool DisplayServer::tts_is_speaking() const {
 	WARN_PRINT("TTS is not supported by this display server.");
 	return false;
@@ -614,6 +628,14 @@ void DisplayServer::delete_sub_window(WindowID p_id) {
 
 void DisplayServer::window_set_exclusive(WindowID p_window, bool p_exclusive) {
 	// Do nothing, if not supported.
+}
+
+void DisplayServer::window_set_session_id(const String &p_session_id, WindowID p_window) {
+	// Do nothing, if the DisplayServer does not use this
+}
+
+String DisplayServer::window_get_session_id(WindowID p_window) const {
+	return String();
 }
 
 void DisplayServer::window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window) {

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -46,6 +46,7 @@ class DisplayServer : public Object {
 
 	static DisplayServer *singleton;
 	static bool hidpi_allowed;
+	static String session_path;
 
 #ifndef DISABLE_DEPRECATED
 	mutable HashMap<String, RID> menu_names;
@@ -234,6 +235,10 @@ public:
 
 	virtual Dictionary global_menu_get_system_menu_roots() const;
 #endif
+
+	virtual void set_session(const String &p_name);
+	virtual void set_session_path(const String &p_path);
+	virtual String get_session_path();
 
 	struct TTSUtterance {
 		String text;
@@ -469,6 +474,9 @@ public:
 
 	virtual void window_set_title(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual Size2i window_get_title_size(const String &p_title, WindowID p_window = MAIN_WINDOW_ID) const { return Size2i(); }
+
+	virtual void window_set_session_id(const String &p_session_id, WindowID p_window = MAIN_WINDOW_ID);
+	virtual String window_get_session_id(WindowID p_window = MAIN_WINDOW_ID) const;
 
 	virtual void window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window = MAIN_WINDOW_ID);
 

--- a/thirdparty/wayland-protocols/experimental/xx-session-management/README
+++ b/thirdparty/wayland-protocols/experimental/xx-session-management/README
@@ -1,0 +1,4 @@
+Session management protocol
+
+Maintainers:
+Carlos Garnacho <carlosg@gnome.org>

--- a/thirdparty/wayland-protocols/experimental/xx-session-management/xx-session-management-v1.xml
+++ b/thirdparty/wayland-protocols/experimental/xx-session-management/xx-session-management-v1.xml
@@ -1,0 +1,264 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="xx_session_management_v1">
+  <copyright>
+    Copyright 2018 Mike Blumenkrantz
+    Copyright 2018 Samsung Electronics Co., Ltd
+    Copyright 2018 Red Hat Inc.
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="Protocol for managing application sessions">
+    This description provides a high-level overview of the interplay between
+    the interfaces defined this protocol. For details, see the protocol
+    specification.
+
+    The xx_session_manager protocol declares interfaces necessary to
+    allow clients to restore toplevel state from previous executions. The
+    xx_session_manager_v1.get_session request can be used to obtain a
+    xx_session_v1 resource representing the state of a set of toplevels.
+
+    Clients may obtain the session string to use in future calls through
+    the xx_session_v1.created event. Compositors will use this string
+    as an identifiable token for future runs, possibly storing data about
+    the related toplevels in persistent storage.
+
+    Toplevels are managed through the xx_session_v1.add_toplevel and
+    xx_session_toplevel_v1.remove pair of requests. Clients will explicitly
+    request a toplevel to be restored according to prior state through the
+    xx_session_v1.restore_toplevel request before the toplevel is mapped.
+
+    Warning! The protocol described in this file is currently in the
+    experimental phase. Backwards incompatible major versions of the
+    protocol are to be expected. Exposing this protocol without an opt-in
+    mechanism is discouraged.
+  </description>
+
+  <interface name="xx_session_manager_v1" version="1">
+    <description summary="manage sessions for applications">
+      The xx_session_manager interface defines base requests for creating and
+      managing a session for an application. Sessions persist across application
+      and compositor restarts unless explicitly destroyed. A session is created
+      for the purpose of maintaining an application's xdg_toplevel surfaces
+      across compositor or application restarts. The compositor should remember
+      as many states as possible for surfaces in a given session, but there is
+      no requirement for which states must be remembered.
+    </description>
+
+    <enum name="error">
+      <entry name="in_use" summary="a requested session is already in use"
+             value="1"/>
+    </enum>
+
+    <enum name="reason">
+      <description summary="reason for getting a session">
+        The reason may determine in what way a session restores the window
+        management state of associated toplevels.
+
+        For example newly launched applications might be launched on the active
+        workspace with restored size and position, while a recovered
+        applications might restore additional state such as active workspace and
+        stacking order.
+      </description>
+      <entry name="launch" value="1">
+        <description summary="an app is newly launched">
+          A new app instance is launched, for example from an app launcher.
+        </description>
+      </entry>
+      <entry name="recover" value="2">
+        <description summary="an app recovered">
+          A app instance is recovering from for example a compositor or app crash.
+        </description>
+      </entry>
+      <entry name="session_restore" value="3">
+        <description summary="an app restored">
+          A app instance is restored, for example part of a restored session, or
+          restored from having been temporarily terminated due to resource
+          constraints.
+        </description>
+      </entry>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy this object">
+        This has no effect other than to destroy the xx_session_manager object.
+      </description>
+    </request>
+
+    <request name="get_session">
+      <description summary="create or restore a session">
+        Create a session object corresponding to either an existing session
+        identified by the given session identifier string or a new session.
+        While the session object exists, the session is considered to be "in
+        use".
+
+        If a identifier string represents a session that is currently actively
+        in use by the the same client, an 'in_use' error is raised. If some
+        other client is currently using the same session, the new session will
+        replace managing the associated state.
+
+        NULL is passed to initiate a new session. If an id is passed which does
+        not represent a valid session, the compositor treats it as if NULL had
+        been passed.
+
+        A client is allowed to have any number of in use sessions at the same
+        time.
+      </description>
+      <arg name="id" type="new_id" interface="xx_session_v1"/>
+      <arg name="reason" type="uint" enum="reason"
+           summary="reason for session"/>
+      <arg name="session" type="string"
+           summary="the session to restore"
+           allow-null="true"/>
+    </request>
+  </interface>
+
+  <interface name="xx_session_v1" version="1">
+    <description summary="A session for an application">
+      A xx_session_v1 object represents a session for an application. While the
+      object exists, all surfaces which have been added to the session will
+      have states stored by the compositor which can be reapplied at a later
+      time. Two sessions cannot exist for the same identifier string.
+
+      States for surfaces added to a session are automatically updated by the
+      compositor when they are changed.
+
+      Surfaces which have been added to a session are automatically removed from
+      the session if xdg_toplevel.destroy is called for the surface.
+    </description>
+
+    <enum name="error">
+      <entry name="invalid_restore"
+             summary="restore cannot be performed after initial toplevel commit"
+             value="1"/>
+      <entry name="name_in_use"
+             summary="toplevel name is already in used"
+             value="2"/>
+      <entry name="already_mapped"
+             summary="toplevel was already mapped when restored"
+             value="3"/>
+    </enum>
+
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the session">
+        Destroy a session object, preserving the current state but not continuing
+        to make further updates if state changes occur. This makes the associated
+        xx_toplevel_session_v1 objects inert.
+      </description>
+    </request>
+
+    <request name="remove" type="destructor">
+      <description summary="Remove the session">
+        Remove the session, making it no longer available for restoration. A
+        compositor should in response to this request remove the data related to
+        this session from its storage.
+      </description>
+    </request>
+
+    <request name="add_toplevel">
+      <description summary="add a new surface to the session">
+        Attempt to add a given surface to the session. The passed name is used
+        to identify what window is being restored, and may be used store window
+        specific state within the session.
+
+        Calling this with a toplevel that is already managed by the session with
+        the same associated will raise an in_use error.
+      </description>
+      <arg name="id" type="new_id" interface="xx_toplevel_session_v1"/>
+      <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+      <arg name="name" type="string"/>
+    </request>
+
+    <request name="restore_toplevel">
+      <description summary="restore a surface state">
+        Inform the compositor that the toplevel associated with the passed name
+        should have its window management state restored.
+
+        Calling this with a toplevel that is already managed by the session with
+        the same associated will raise an in_use error.
+
+        This request must be called prior to the first commit on the associated
+        wl_surface, otherwise an already_mapped error is raised.
+
+        As part of the initial configure sequence, if the toplevel was
+        successfully restored, a xx_toplevel_session_v1.restored event is
+        emitted. See the xx_toplevel_session_v1.restored event for further
+        details.
+      </description>
+      <arg name="id" type="new_id" interface="xx_toplevel_session_v1"/>
+      <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+      <arg name="name" type="string"/>
+    </request>
+
+    <event name="created">
+      <description summary="newly-created session id">
+        Emitted at most once some time after getting a new session object. It
+        means that no previous state was restored, and a new session was created.
+        The passed id can be used to restore previous sessions.
+      </description>
+      <arg name="id" type="string"/>
+    </event>
+
+    <event name="restored">
+      <description summary="the session has been restored">
+        Emitted at most once some time after getting a new session object. It
+        means that previous state was at least partially restored. The same id
+        can again be used to restore previous sessions.
+      </description>
+    </event>
+
+    <event name="replaced">
+      <description summary="the session has been restored">
+        Emitted at most once, if the session was taken over by some other
+        client. When this happens, the session and all its toplevel session
+        objects become inert, and should be destroyed.
+      </description>
+    </event>
+  </interface>
+
+  <interface name="xx_toplevel_session_v1" version="1">
+    <request name="destroy" type="destructor">
+      <description summary="Destroy the object">
+        Destroy the object. This has no effect window management of the
+        associated toplevel.
+      </description>
+    </request>
+
+    <request name="remove" type="destructor">
+      <description summary="remove a surface from the session">
+        Remove a specified surface from the session and render any corresponding
+        xx_toplevel_session_v1 object inert. The compositor should remove any
+        data related to the toplevel in the corresponding session from its internal
+        storage.
+      </description>
+    </request>
+
+    <event name="restored">
+      <description summary="a toplevel's session has been restored">
+        The "restored" event is emitted prior to the first
+        xdg_toplevel.configure for the toplevel. It will only be emitted after
+        xx_session_v1.restore_toplevel, and the initial empty surface state has
+        been applied, and it indicates that the surface's session is being
+        restored with this configure event.
+      </description>
+      <arg name="surface" type="object" interface="xdg_toplevel"/>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
Based on https://github.com/godotengine/godot/pull/106648.
Wayland does not allow us to restore the session ourselves,
instead we must make use of this protocol to allow the compositor to do it.

This is the main reason #106648 has DisplayServer APIs.
It is also a large factor for the lifetime of session management
since for us to make use of this protocol we must have a session
and a session id before any native windows are created.

Reasons this is a draft:
* The upstream PR is also a draft so it'd be quite strange for this not to be
* The protocol is experimental which means it is not even installed by default, despite that I believe it is quite unlikely this is likely to break in ways that are so significant major rewrites are needed.
* I don't have a kwin version that can test this yet

And Riteo if you see this, feel free to take a while to review. Window embedding is more important and relevant seeing as that can actually be done now while this uses an experimental protocol which most compositors don't even have enabled and is based on a draft pr.