### PR TITLE
Use `LocalVector` for `RingBuffer`

### DIFF
--- a/core/templates/ring_buffer.h
+++ b/core/templates/ring_buffer.h
@@ -30,11 +30,11 @@
 
 #pragma once
 
-#include "core/templates/vector.h"
+#include "core/templates/local_vector.h"
 
 template <typename T>
 class RingBuffer {
-	Vector<T> data;
+	LocalVector<T> data;
 	int read_pos = 0;
 	int write_pos = 0;
 	int size_mask;
@@ -142,7 +142,7 @@ public:
 
 	Error write(const T &p_v) {
 		ERR_FAIL_COND_V(space_left() < 1, FAILED);
-		data.write[inc(write_pos, 1)] = p_v;
+		data[inc(write_pos, 1)] = p_v;
 		return OK;
 	}
 
@@ -159,7 +159,7 @@ public:
 			int total = end - pos;
 
 			for (int i = 0; i < total; i++) {
-				data.write[pos + i] = p_buf[src++];
+				data[pos + i] = p_buf[src++];
 			}
 			to_write -= total;
 			pos = 0;
@@ -199,7 +199,7 @@ public:
 		data.resize(int64_t(1) << int64_t(p_power));
 		if (old_size < new_size && read_pos > write_pos) {
 			for (int i = 0; i < write_pos; i++) {
-				data.write[(old_size + i) & mask] = data[i];
+				data[(old_size + i) & mask] = data[i];
 			}
 			write_pos = (old_size + write_pos) & mask;
 		} else {


### PR DESCRIPTION
Updated `RingBuffer` to use `LocalVector` instead of `Vector`, to avoid `_copy_on_write` overhead when writing to the buffer.

This makes `StreamPeerGZIP` decompression around 2x faster, measured with gdscript below:

```gdscript
func _ready() -> void:
	var compressed_bytes := get_compressed_bytes()
	var start := Time.get_ticks_msec()
	for i in 10:
		var decompress := StreamPeerGZIP.new()
		decompress.start_decompression()
		var result := process_byte_array(compressed_bytes, decompress, false)
	var end := Time.get_ticks_msec()
	print("%dms" % [end - start])

func get_compressed_bytes() -> PackedByteArray:
	var str := "test string".repeat(1000000)
	var str_bytes = str.to_ascii_buffer()
	var compress := StreamPeerGZIP.new()
	compress.start_compression()
	return process_byte_array(str_bytes, compress, true)

func process_byte_array(input: PackedByteArray, stream_peer: StreamPeerGZIP, compress: bool) -> PackedByteArray:
	var remaining := input
	var result: PackedByteArray = []
	while remaining.size() > 0:
		var sent_bytes = stream_peer.put_partial_data(remaining)[1]
		remaining = remaining.slice(sent_bytes)
		result.append_array(stream_peer.get_data(stream_peer.get_available_bytes())[1])
	if compress:
		stream_peer.finish()
		result.append_array(stream_peer.get_data(stream_peer.get_available_bytes())[1])
	return result
```

Results:
```
old: 557ms
new: 241ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- *Production edit: See https://github.com/godotengine/godot/issues/106632.*
