### PR TITLE
Expose Camera2D current rotation

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -7,7 +7,7 @@
 		Camera node for 2D scenes. It forces the screen (current layer) to scroll following this node. This makes it easier (and faster) to program scrollable scenes than manually changing the position of [CanvasItem]-based nodes.
 		Cameras register themselves in the nearest [Viewport] node (when ascending the tree). Only one camera can be active per viewport. If no viewport is available ascending the tree, the camera will register in the global viewport.
 		This node is intended to be a simple helper to get things going quickly, but more functionality may be desired to change how the camera works. To make your own custom camera node, inherit it from [Node2D] and change the transform of the canvas by setting [member Viewport.canvas_transform] in [Viewport] (you can obtain the current [Viewport] by using [method Node.get_viewport]).
-		Note that the [Camera2D] node's [code]position[/code] doesn't represent the actual position of the screen, which may differ due to applied smoothing or limits. You can use [method get_screen_center_position] to get the real position.
+		Note that the [Camera2D] node's [member Node2D.global_position] doesn't represent the actual position of the screen, which may differ due to applied smoothing or limits. You can use [method get_screen_center_position] to get the real position. Same for the node's [member Node2D.global_rotation] which may be different due to applied rotation smoothing. You can use [method get_screen_rotation] to get the current rotation of the screen.
 	</description>
 	<tutorials>
 		<link title="2D Platformer Demo">https://godotengine.org/asset-library/asset/2727</link>
@@ -45,6 +45,13 @@
 			<description>
 				Returns the center of the screen from this camera's point of view, in global coordinates.
 				[b]Note:[/b] The exact targeted position of the camera may be different. See [method get_target_position].
+			</description>
+		</method>
+		<method name="get_screen_rotation" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the current screen rotation from this camera's point of view.
+				[b]Note:[/b] The screen rotation can be different from [member Node2D.global_rotation] if the camera is rotating smoothly due to [member rotation_smoothing_enabled].
 			</description>
 		</method>
 		<method name="get_target_position" qualifiers="const">

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -800,6 +800,10 @@ Point2 Camera2D::get_camera_screen_center() const {
 	return camera_screen_center;
 }
 
+real_t Camera2D::get_screen_rotation() const {
+	return camera_angle;
+}
+
 Size2 Camera2D::_get_camera_screen_size() const {
 	if (is_part_of_edited_scene()) {
 		return Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_width"), GLOBAL_GET_CACHED(real_t, "display/window/size/viewport_height"));
@@ -996,6 +1000,7 @@ void Camera2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_target_position"), &Camera2D::get_camera_position);
 	ClassDB::bind_method(D_METHOD("get_screen_center_position"), &Camera2D::get_camera_screen_center);
+	ClassDB::bind_method(D_METHOD("get_screen_rotation"), &Camera2D::get_screen_rotation);
 
 	ClassDB::bind_method(D_METHOD("set_zoom", "zoom"), &Camera2D::set_zoom);
 	ClassDB::bind_method(D_METHOD("get_zoom"), &Camera2D::get_zoom);

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -202,6 +202,7 @@ public:
 	Vector2 get_zoom() const;
 
 	Point2 get_camera_screen_center() const;
+	real_t get_screen_rotation() const;
 
 	void set_custom_viewport(Node *p_viewport);
 	Node *get_custom_viewport() const;


### PR DESCRIPTION
Add `get_screen_rotation()` to `Camera2D` which exposes current rotation of camera instead of target rotation. These values can differ in case of applied rotation smoothing.
