### PR TITLE
Fix crash on exit due to GDScriptLanguage::CallStack mismatched deallocation

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -448,7 +448,7 @@ class GDScriptLanguage : public ScriptLanguage {
 
 		void free() {
 			if (levels) {
-				memdelete(levels);
+				memdelete_arr(levels);
 				levels = nullptr;
 			}
 		}


### PR DESCRIPTION
I discovered this issue while working on integrating Godot 4.5 changes in [sentry-godot](https://github.com/getsentry/sentry-godot) extension. The demo project kept crashing in release exports with the call stack tracking enabled in the project settings. I'm not sure why this doesn't manifest in the editor, but I finally tracked it down to mismatched allocator/deallocator in `GDScriptLanguage::CallStack`.

Fixes #106667 