### PR TITLE
Remove force enter/exit logic from `JoltArea3D`

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -133,11 +133,7 @@ private:
 	void _notify_body_entered(const JPH::BodyID &p_body_id);
 	void _notify_body_exited(const JPH::BodyID &p_body_id);
 
-	void _force_bodies_entered();
-	void _force_bodies_exited(bool p_remove);
-
-	void _force_areas_entered();
-	void _force_areas_exited(bool p_remove);
+	void _remove_all_overlaps();
 
 	void _update_sleeping();
 	void _update_group_filter();


### PR DESCRIPTION
Prior to merging #106490 we were unable to rely on Jolt's contact listener to emit the relevant events whenever an overlapping body/area would enter/exit as a result of disabling the `Area3D.monitoring` property, since it had no actual impact on the underlying collision detection. This led to having a bunch of messy bookkeeping code in `JoltArea3D` that would essentially just simulate those events as you toggled said property.

Now with #106490 merged we can finally remove all that, in favor of just relying on Jolt's contact listener events, greatly simplifying things.

There was also a minor related bug lurking in `JoltArea3D::_space_changing`, from #100983, which is that we were queueing up a bunch of exit events (one per shape pair) as part of force-exiting all the overlapping bodies/areas, as the `Area3D` was leaving/changing the physics space. Then we would immediately remove that same `Area3D` from the list of areas that were meant to flush their events next tick, since its corresponding scene node would be gone by then anyway. This meant that if you never actually freed that area (e.g. when just pulling it out of the scene tree temporarily) you would be sitting on some amount of allocated memory (i.e. the pending events) for no reason whatsoever.

Now instead we just clear the entire `bodies_by_id` and `areas_by_id` maps, which hold all the overlaps and any pending events they might have, as we leave/change the physics space.