### PR TITLE
[WIP Prototype] Add HDR support to tonemappers

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1602,6 +1602,13 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/size/minimize_disabled", false);
 	GLOBAL_DEF("display/window/size/maximize_disabled", false);
 
+	GLOBAL_DEF("display/window/hdr/enabled", false);
+	GLOBAL_DEF("display/window/hdr/prefer_high_precision", false);
+	GLOBAL_DEF("display/window/hdr/auto_adjust_reference_luminance", true);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "display/window/hdr/reference_luminance", PROPERTY_HINT_RANGE, "0,2000,1,or_greater"), 200.0f); // BT.2408 recommendation of 203 nits for HDR Reference White, rounded to 200 to be a more pleasant player-facing value.
+	GLOBAL_DEF("display/window/hdr/auto_adjust_max_luminance", true);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "display/window/hdr/max_luminance", PROPERTY_HINT_RANGE, "0,2000,1,or_greater"), 1000.0f);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_width_override", PROPERTY_HINT_RANGE, "0,7680,1,or_greater"), 0); // 8K resolution
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "display/window/size/window_height_override", PROPERTY_HINT_RANGE, "0,4320,1,or_greater"), 0); // 8K resolution
 

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1731,12 +1731,43 @@
 				[b]Note:[/b] On macOS, this method requires the "Screen Recording" permission. If permission is not granted, this method returns a screenshot that will not include other application windows or OS elements not related to the application.
 			</description>
 		</method>
+		<method name="screen_get_max_full_frame_luminance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns the maximum full screen luminance of [param screen] in nits (cd/m²).
+				Some displays support brighter luminance in small areas, but this is the maximum luminance that can be achieved across the entire screen.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] This method is intended to be informational and may not be implemented even if [constant FEATURE_HDR] is supported.
+				[b]Note:[/b] On Windows, this method is implemented only in builds with D3D12 enabled.
+			</description>
+		</method>
+		<method name="screen_get_max_luminance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns the maximum luminance of a pixel on [param screen] in nits (cd/m²).
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] This method is intended to be informational and may not be implemented even if [constant FEATURE_HDR] is supported.
+				[b]Note:[/b] On Windows, this method is implemented only in builds with D3D12 enabled.
+			</description>
+		</method>
 		<method name="screen_get_max_scale" qualifiers="const">
 			<return type="float" />
 			<description>
 				Returns the greatest scale factor of all screens.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] if there is at least one hiDPI (Retina) screen in the system, and [code]1.0[/code] in all other cases.
 				[b]Note:[/b] This method is implemented only on macOS.
+			</description>
+		</method>
+		<method name="screen_get_min_luminance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns the minimum luminance of a pixel on [param screen] in nits (cd/m²).
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] This method is intended to be informational and may not be implemented even if [constant FEATURE_HDR] is supported.
+				[b]Note:[/b] On Windows, this method is implemented only in builds with D3D12 enabled.
 			</description>
 		</method>
 		<method name="screen_get_orientation" qualifiers="const">
@@ -1800,6 +1831,16 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Web, macOS, and Linux (Wayland). On other platforms, this method always returns [code]1.0[/code].
 			</description>
 		</method>
+		<method name="screen_get_sdr_white_level" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns the standard dynamic range (SDR) white level of [param screen] in nits (cd/m²).
+				This is the maximum brightness SDR content (such as UI) should be rendered at to match other applications on the display.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] This method is intended to be informational and may not be implemented even if [constant FEATURE_HDR] is supported.
+			</description>
+		</method>
 		<method name="screen_get_size" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="screen" type="int" default="-1" />
@@ -1815,6 +1856,17 @@
 				Returns the portion of the screen that is not obstructed by a status bar in pixels. See also [method screen_get_size].
 				[b]Note:[/b] One of the following constants can be used as [param screen]: [constant SCREEN_OF_MAIN_WINDOW], [constant SCREEN_PRIMARY], [constant SCREEN_WITH_MOUSE_FOCUS], or [constant SCREEN_WITH_KEYBOARD_FOCUS].
 				[b]Note:[/b] This method is implemented on Linux/X11, macOS, and Windows. On other platforms, this method always returns [code]Rect2i(screen_get_position(screen), screen_get_size(screen))[/code].
+			</description>
+		</method>
+		<method name="screen_is_hdr_supported" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Returns [code]true[/code] if the [param screen] supports HDR.
+				Use [method window_is_hdr_output_supported] to check if a specific window can output HDR content.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] This method is intended to be informational and may not be implemented even if [constant FEATURE_HDR] is supported.
+				[b]Note:[/b] On Windows, this method is implemented only in builds with D3D12 enabled.
 			</description>
 		</method>
 		<method name="screen_is_kept_on" qualifiers="const">
@@ -2131,6 +2183,32 @@
 				Returns the current value of the given window's [param flag].
 			</description>
 		</method>
+		<method name="window_get_hdr_output_max_luminance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns the maximum luminance in nits (cd/m²) set for HDR content for the window specified by [param window_id].
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
+		<method name="window_get_hdr_output_max_value" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns the maximum value for color components that can be displayed in HDR mode for the window specified by [param window_id].
+				Use this to scale HDR content to max out the display's brightness, for example lasers or other bright effects.
+				Will return 1.0 if HDR is not enabled or not supported.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
+		<method name="window_get_hdr_output_reference_luminance" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns the SDR reference luminance in nits (cd/m²) set for HDR content for the window specified by [param window_id].
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
 		<method name="window_get_max_size" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="window_id" type="int" default="0" />
@@ -2226,6 +2304,45 @@
 				Returns [code]true[/code] if the window specified by [param window_id] is focused.
 			</description>
 		</method>
+		<method name="window_is_hdr_output_auto_adjusting_max_luminance" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns whether the window specified by [param window_id] automatically adjusts the maximum luminance for HDR output based on the display's capabilities.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
+		<method name="window_is_hdr_output_auto_adjusting_reference_luminance" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns whether the window specified by [param window_id] automatically adjusts the reference luminance for HDR output based on the display's capabilities.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
+		<method name="window_is_hdr_output_enabled" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns whether HDR output is requested for the window specified by [param window_id].
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
+		<method name="window_is_hdr_output_preferring_high_precision" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns whether the window specified by [param window_id] prefers a high precision (16-bit per color) HDR framebuffer.
+			</description>
+		</method>
+		<method name="window_is_hdr_output_supported" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="window_id" type="int" default="0" />
+			<description>
+				Returns whether the window specified by [param window_id] supports HDR output.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+			</description>
+		</method>
 		<method name="window_is_maximize_allowed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="window_id" type="int" default="0" />
@@ -2298,6 +2415,70 @@
 			<param index="2" name="window_id" type="int" default="0" />
 			<description>
 				Enables or disables the given window's given [param flag].
+			</description>
+		</method>
+		<method name="window_set_hdr_output_auto_adjust_max_luminance">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets whether the window specified by [param window_id] should automatically adjust the maximum luminance for HDR content based on the display's brightness.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] Requires support by the rendering device.
+			</description>
+		</method>
+		<method name="window_set_hdr_output_auto_adjust_reference_luminance">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets whether the window specified by [param window_id] should automatically adjust the SDR reference luminance for HDR content based on the display's brightness.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] Requires support by the rendering device.
+			</description>
+		</method>
+		<method name="window_set_hdr_output_enabled">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets whether HDR output should be enabled for the window specified by [param window_id], falling back to SDR if not supported.
+				Only available on platforms that support HDR output, have HDR enabled in the system settings, and have a compatible display connected.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] Requires support by the rendering device.
+			</description>
+		</method>
+		<method name="window_set_hdr_output_max_luminance">
+			<return type="void" />
+			<param index="0" name="max_luminance" type="float" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets the maximum luminance in nits (cd/m²) for HDR content for the window specified by [param window_id].
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] Requires support by the rendering device.
+				[b]Note:[/b] Will not immediately take effect while [method window_is_hdr_output_auto_adjusting_max_luminance] is [code]true[/code]. Any value set will take effect once auto-adjustment is disabled.
+			</description>
+		</method>
+		<method name="window_set_hdr_output_prefer_high_precision">
+			<return type="void" />
+			<param index="0" name="enabled" type="bool" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets whether the window specified by [param window_id] prefers a high precision (16-bit per color) framebuffer.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] Requires support by the rendering device.
+			</description>
+		</method>
+		<method name="window_set_hdr_output_reference_luminance">
+			<return type="void" />
+			<param index="0" name="reference_luminance" type="float" />
+			<param index="1" name="window_id" type="int" default="0" />
+			<description>
+				Sets the SDR reference luminance in nits (cd/m²) for HDR content for the window specified by [param window_id].
+				This controls the brightness of SDR content (such as UI) when HDR is enabled.
+				[b]Note:[/b] Requires support for [constant FEATURE_HDR].
+				[b]Note:[/b] Requires support by the rendering device.
+				[b]Note:[/b] Will not immediately take effect while [method window_is_hdr_output_auto_adjusting_reference_luminance] is [code]true[/code]. Any value set will take effect once auto-adjustment is disabled.
 			</description>
 		</method>
 		<method name="window_set_ime_active">
@@ -2611,6 +2792,9 @@
 		</constant>
 		<constant name="FEATURE_ACCESSIBILITY_SCREEN_READER" value="34" enum="Feature">
 			Display server supports interaction with screen reader or Braille display. [b]Linux (X11/Wayland), macOS, Windows[/b]
+		</constant>
+		<constant name="FEATURE_HDR" value="35" enum="Feature">
+			Display server supports HDR output. [b]Windows[/b]
 		</constant>
 		<constant name="ROLE_UNKNOWN" value="0" enum="AccessibilityRole">
 			Unknown or custom role.

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -313,6 +313,12 @@
 		<member name="ssr_max_steps" type="int" setter="set_ssr_max_steps" getter="get_ssr_max_steps" default="64">
 			The maximum number of steps for screen-space reflections. Higher values are slower.
 		</member>
+		<member name="tonemap_black" type="float" setter="set_tonemap_black" getter="get_tonemap_black" default="0.0">
+			Adjusts the range of input values to the tonemapper. Values provided to the tonemapper that are below [member tonemap_black] will be hard-clipped to 0.0. This parameter can be used to ensure that the viewer will never see certain dark features, regardless of the output dynamic range or viewing environment.
+		</member>
+		<member name="tonemap_contrast" type="float" setter="set_tonemap_contrast" getter="get_tonemap_contrast" default="1.25653">
+			Increasing [member tonemap_contrast] will make dark values darker and bright values brighter. Produces a higher quality result than [member adjustment_contrast] without any additional performance cost, but is only available when using the [constant TONE_MAPPER_AGX] or [constant TONE_MAPPER_ADJUSTABLE] tonemapper.
+		</member>
 		<member name="tonemap_exposure" type="float" setter="set_tonemap_exposure" getter="get_tonemap_exposure" default="1.0">
 			Adjusts the brightness of values before they are provided to the tonemapper. Higher [member tonemap_exposure] values result in a brighter image. See also [member tonemap_white].
 			[b]Note:[/b] Values provided to the tonemapper will also be multiplied by [code]2.0[/code] and [code]1.8[/code] for [constant TONE_MAPPER_FILMIC] and [constant TONE_MAPPER_ACES] respectively to produce a similar apparent brightness as [constant TONE_MAPPER_LINEAR].
@@ -321,8 +327,8 @@
 			The tonemapping mode to use. Tonemapping is the process that "converts" HDR values to be suitable for rendering on an LDR display. (Godot doesn't support rendering on HDR displays yet.)
 		</member>
 		<member name="tonemap_white" type="float" setter="set_tonemap_white" getter="get_tonemap_white" default="1.0">
-			The white reference value for tonemapping, which indicates where bright white is located in the scale of values provided to the tonemapper. For photorealistic lighting, recommended values are between [code]6.0[/code] and [code]8.0[/code]. Higher values result in less blown out highlights, but may make the scene appear lower contrast. See also [member tonemap_exposure].
-			[b]Note:[/b] [member tonemap_white] is ignored when using [constant TONE_MAPPER_LINEAR] or [constant TONE_MAPPER_AGX].
+			The white reference value for tonemapping, which indicates where bright white is located in the scale of values provided to the tonemapper. For photorealistic lighting, it is recommended to set [member tonemap_white] to at least [code]6.0[/code]. Higher values result in less blown out highlights, but may make the scene appear lower contrast. See also [member tonemap_exposure].
+			[b]Note:[/b] [member tonemap_white] must be set to [code]2.0[/code] or lower on the Mobile rendering method to produce bright images.
 		</member>
 		<member name="volumetric_fog_albedo" type="Color" setter="set_volumetric_fog_albedo" getter="get_volumetric_fog_albedo" default="Color(1, 1, 1, 1)">
 			The [Color] of the volumetric fog when interacting with lights. Mist and fog have an albedo close to [code]Color(1, 1, 1, 1)[/code] while smoke has a darker albedo.
@@ -422,15 +428,18 @@
 			[b]Note:[/b] When [member tonemap_white] is left at the default value of [code]1.0[/code], [constant TONE_MAPPER_REINHARDT] produces an identical image to [constant TONE_MAPPER_LINEAR].
 		</constant>
 		<constant name="TONE_MAPPER_FILMIC" value="2" enum="ToneMapper">
-			Uses a film-like tonemapping curve to prevent clipping of bright values and provide better contrast than [constant TONE_MAPPER_REINHARDT]. Slightly slower than [constant TONE_MAPPER_REINHARDT].
+			Uses a film-like tonemapping curve to prevent clipping of bright values and provide better contrast than [constant TONE_MAPPER_REINHARDT]. Slightly slower than [constant TONE_MAPPER_REINHARDT]. This tonemapper only supports Standard Dynamic Range (SDR) output.
 		</constant>
 		<constant name="TONE_MAPPER_ACES" value="3" enum="ToneMapper">
-			Uses a high-contrast film-like tonemapping curve and desaturates bright values for a more realistic appearance. Slightly slower than [constant TONE_MAPPER_FILMIC].
+			Uses a high-contrast film-like tonemapping curve and desaturates bright values for a more realistic appearance. Slightly slower than [constant TONE_MAPPER_FILMIC]. This tonemapper only supports Standard Dynamic Range (SDR) output.
 			[b]Note:[/b] This tonemapping operator is called "ACES Fitted" in Godot 3.x.
 		</constant>
 		<constant name="TONE_MAPPER_AGX" value="4" enum="ToneMapper">
-			Uses a film-like tonemapping curve and desaturates bright values for a more realistic appearance. Better than other tonemappers at maintaining the hue of colors as they become brighter. The slowest tonemapping option.
-			[b]Note:[/b] [member tonemap_white] is fixed at a value of [code]16.29[/code], which makes [constant TONE_MAPPER_AGX] unsuitable for use with the Mobile rendering method.
+			Uses an adjustable film-like tonemapping curve and desaturates bright values for a more realistic appearance. Better than other tonemappers at maintaining the hue of colors as they become brighter. The slowest tonemapping option.
+			[b]Note:[/b] When using [constant TONE_MAPPER_AGX], the minimum supported [member tonemap_white] is [code]2.0[/code] and a value of [code]16.0[/code] is recommended for use with the Compatibility and Forward+ rendering methods.
+		</constant>
+		<constant name="TONE_MAPPER_ADJUSTABLE" value="5" enum="ToneMapper">
+			Uses a film-like tonemapping curve with an adjustable contrast. Slightly slower than [constant TONE_MAPPER_ACES] (That's my goal, anyway!).
 		</constant>
 		<constant name="GLOW_BLEND_MODE_ADDITIVE" value="0" enum="GlowBlendMode">
 			Additive glow blending mode. Mostly used for particles, glows (bloom), lens flare, bright sources.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -946,6 +946,33 @@
 			The default screen orientation to use on mobile devices. See [enum DisplayServer.ScreenOrientation] for possible values.
 			[b]Note:[/b] When set to a portrait orientation, this project setting does not flip the project resolution's width and height automatically. Instead, you have to set [member display/window/size/viewport_width] and [member display/window/size/viewport_height] accordingly.
 		</member>
+		<member name="display/window/hdr/auto_adjust_max_luminance" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], automatically adjusts the maximum luminance of the main window based on the current system settings and connected display capabilities.
+			This is useful for ensuring that HDR content is displayed correctly on different displays without requiring manual configuration.
+			[b]Note:[/b] If information is missing for the display, the maximum luminance will be set to [member display/window/hdr/max_luminance].
+		</member>
+		<member name="display/window/hdr/auto_adjust_reference_luminance" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], automatically adjusts the SDR reference luminance of the main window based on the current system settings and connected display capabilities.
+			This is useful for ensuring that HDR content is displayed correctly on different displays without requiring manual configuration.
+			[b]Note:[/b] If information is missing for the display, the SDR reference luminance will be set to [member display/window/hdr/reference_luminance].
+		</member>
+		<member name="display/window/hdr/enabled" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], enables HDR output on supported platforms for the main window, falling back to SDR if not supported.
+			Only available on platforms that support HDR output, have HDR enabled in the system settings, and have a compatible display connected.
+		</member>
+		<member name="display/window/hdr/max_luminance" type="float" setter="" getter="" default="1000.0">
+			Sets the maximum luminance of the main window in nits (cd/m²) when HDR is enabled.
+		</member>
+		<member name="display/window/hdr/prefer_high_precision" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], uses 16 bit per color buffers for the frame buffer of the main window when HDR is enabled.
+			If [code]false[/code], uses 10 bit per color buffers, with 2 bits for alpha, for the frame buffer of the main window when HDR is enabled.
+			This may improve color precision and reduce banding in the final image, but will use more memory and may reduce performance.
+			If transparent backgrounds are enabled, you may want to enable this setting to enable smooth blending of HDR content.
+		</member>
+		<member name="display/window/hdr/reference_luminance" type="float" setter="" getter="" default="200.0">
+			Sets the SDR reference luminance of the main window in nits (cd/m²) when HDR is enabled.
+			This is used to scale the HDR effect to ensure sRGB content looks the same in both SDR and HDR.
+		</member>
 		<member name="display/window/ios/allow_high_refresh_rate" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], iOS devices that support high refresh rate/"ProMotion" will be allowed to render at up to 120 frames per second.
 		</member>
@@ -3377,6 +3404,9 @@
 			If [code]true[/code], enables [member Viewport.use_hdr_2d] on the root viewport. 2D rendering will use a high dynamic range (HDR) format framebuffer matching the bit depth of the 3D framebuffer. When using the Forward+ renderer this will be an [code]RGBA16[/code] framebuffer, while when using the Mobile renderer it will be an [code]RGB10_A2[/code] framebuffer. Additionally, 2D rendering will take place in linear color space and will be converted to sRGB space immediately before blitting to the screen. Practically speaking, this means that the end result of the Viewport will not be clamped into the [code]0-1[/code] range and can be used in 3D rendering without color space adjustments. This allows 2D rendering to take advantage of effects requiring high dynamic range (e.g. 2D glow) as well as substantially improves the appearance of effects requiring highly detailed gradients.
 			[b]Note:[/b] This setting will have no effect when using the Compatibility renderer, which always renders in low dynamic range for performance reasons.
 			[b]Note:[/b] This property is only read when the project starts. To toggle HDR 2D at runtime, set [member Viewport.use_hdr_2d] on the root [Viewport].
+		</member>
+		<member name="rendering/viewport/tonemap_to_window" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables [member Viewport.tonemap_to_window] on the root viewport.
 		</member>
 		<member name="rendering/viewport/transparent_background" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables [member Viewport.transparent_bg] on the root viewport. This allows per-pixel transparency to be effective after also enabling [member display/window/size/transparent] and [member display/window/per_pixel_transparency/allowed].

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -758,6 +758,22 @@
 				Returns [code]true[/code] if implementation supports using a texture of [param format] with the given [param sampler_filter].
 			</description>
 		</method>
+		<method name="screen_get_color_format" qualifiers="const">
+			<return type="int" enum="RenderingDevice.DataFormat" />
+			<param index="0" name="screen" type="int" default="0" />
+			<description>
+				Returns the color format of the given screen.
+				[b]Note:[/b] Only the main [RenderingDevice] returned by [method RenderingServer.get_rendering_device] has a format. If called on a local [RenderingDevice], this method prints an error and returns [constant DATA_FORMAT_MAX].
+			</description>
+		</method>
+		<method name="screen_get_color_space" qualifiers="const">
+			<return type="int" enum="RenderingDevice.ColorSpace" />
+			<param index="0" name="screen" type="int" default="0" />
+			<description>
+				Returns the color space of the given screen.
+				[b]Note:[/b] Only the main [RenderingDevice] returned by [method RenderingServer.get_rendering_device] has a format. If called on a local [RenderingDevice], this method prints an error and returns [constant COLOR_SPACE_MAX].
+			</description>
+		</method>
 		<method name="screen_get_framebuffer_format" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="screen" type="int" default="0" />
@@ -1904,6 +1920,18 @@
 		<constant name="DATA_FORMAT_MAX" value="232" enum="DataFormat">
 			Represents the size of the [enum DataFormat] enum.
 		</constant>
+		<constant name="COLOR_SPACE_REC709_LINEAR" value="0" enum="ColorSpace">
+			Color space using Rec 709 primaries and linear gamma.
+		</constant>
+		<constant name="COLOR_SPACE_REC709_SRGB" value="1" enum="ColorSpace">
+			Color space using Rec 709 primaries and non-linear sRGB gamma.
+		</constant>
+		<constant name="COLOR_SPACE_REC2020_ST2084" value="2" enum="ColorSpace">
+			Color space using Rec 2020 primaries and the ST 2084 transfer function.
+		</constant>
+		<constant name="COLOR_SPACE_MAX" value="3" enum="ColorSpace">
+			Represents the size of the [enum ColorSpace] enum.
+		</constant>
 		<constant name="BARRIER_MASK_VERTEX" value="1" enum="BarrierMask" is_bitfield="true">
 			Vertex shader barrier mask.
 		</constant>
@@ -2492,6 +2520,9 @@
 		</constant>
 		<constant name="SUPPORTS_IMAGE_ATOMIC_32_BIT" value="7" enum="Features">
 			Support for 32-bit image atomic operations.
+		</constant>
+		<constant name="SUPPORTS_HDR_OUTPUT" value="9" enum="Features">
+			Features support for high dynamic range (HDR) output.
 		</constant>
 		<constant name="LIMIT_MAX_BOUND_UNIFORM_SETS" value="0" enum="Limit">
 			Maximum number of uniform sets that can be bound at a given time.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1500,6 +1500,8 @@
 			<param index="1" name="tone_mapper" type="int" enum="RenderingServer.EnvironmentToneMapper" />
 			<param index="2" name="exposure" type="float" />
 			<param index="3" name="white" type="float" />
+			<param index="4" name="black" type="float" />
+			<param index="5" name="contrast" type="float" default="1.25" />
 			<description>
 				Sets the variables to be used with the "tonemap" post-process effect. See [Environment] for more details.
 			</description>
@@ -5458,15 +5460,18 @@
 			[b]Note:[/b] When [member Environment.tonemap_white] is left at the default value of [code]1.0[/code], [constant ENV_TONE_MAPPER_REINHARD] produces an identical image to [constant ENV_TONE_MAPPER_LINEAR].
 		</constant>
 		<constant name="ENV_TONE_MAPPER_FILMIC" value="2" enum="EnvironmentToneMapper">
-			Uses a film-like tonemapping curve to prevent clipping of bright values and provide better contrast than [constant ENV_TONE_MAPPER_REINHARD]. Slightly slower than [constant ENV_TONE_MAPPER_REINHARD].
+			Uses a film-like tonemapping curve to prevent clipping of bright values and provide better contrast than [constant ENV_TONE_MAPPER_REINHARD]. Slightly slower than [constant ENV_TONE_MAPPER_REINHARD]. This tonemapper only supports Standard Dynamic Range (SDR) output.
 		</constant>
 		<constant name="ENV_TONE_MAPPER_ACES" value="3" enum="EnvironmentToneMapper">
-			Uses a high-contrast film-like tonemapping curve and desaturates bright values for a more realistic appearance. Slightly slower than [constant ENV_TONE_MAPPER_FILMIC].
+			Uses a high-contrast film-like tonemapping curve and desaturates bright values for a more realistic appearance. Slightly slower than [constant ENV_TONE_MAPPER_FILMIC]. This tonemapper only supports Standard Dynamic Range (SDR) output.
 			[b]Note:[/b] This tonemapping operator is called "ACES Fitted" in Godot 3.x.
 		</constant>
 		<constant name="ENV_TONE_MAPPER_AGX" value="4" enum="EnvironmentToneMapper">
-			Uses a film-like tonemapping curve and desaturates bright values for a more realistic appearance. Better than other tonemappers at maintaining the hue of colors as they become brighter. The slowest tonemapping option.
-			[b]Note:[/b] [member Environment.tonemap_white] is fixed at a value of [code]16.29[/code], which makes [constant ENV_TONE_MAPPER_AGX] unsuitable for use with the Mobile rendering method.
+			Uses an adjustable film-like tonemapping curve and desaturates bright values for a more realistic appearance. Better than other tonemappers at maintaining the hue of colors as they become brighter. The slowest tonemapping option.
+			[b]Note:[/b] When using [constant ENV_TONE_MAPPER_AGX], the minimum supported [member Environment.tonemap_white] is [code]2.0[/code] and a value of [code]16.0[/code] is recommended for use with the Compatibility and Forward+ rendering methods.
+		</constant>
+		<constant name="ENV_TONE_MAPPER_ADJUSTABLE" value="5" enum="EnvironmentToneMapper">
+			Uses a film-like tonemapping curve with an adjustable contrast. Slightly slower than [constant ENV_TONE_MAPPER_ACES] (That's my goal, anyway!).
 		</constant>
 		<constant name="ENV_SSR_ROUGHNESS_QUALITY_DISABLED" value="0" enum="EnvironmentSSRRoughnessQuality">
 			Lowest quality of roughness filter for screen-space reflections. Rough materials will not have blurrier screen-space reflections compared to smooth (non-rough) materials. This is the fastest option.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4211,6 +4211,14 @@
 				[b]Note:[/b] When the 3D scaling mode is set to FSR 1.0, this value is used to adjust the automatic mipmap bias which is calculated internally based on the scale factor. The formula for this is [code]-log2(1.0 / scale) + mipmap_bias[/code].
 			</description>
 		</method>
+		<method name="viewport_set_tonemap_to_screen">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="enabled" type="bool" />
+			<description>
+				If [code]true[/code], the viewport will tonemap its content to the window's HDR output luminance range, if HDR output is enabled.
+			</description>
+		</method>
 		<method name="viewport_set_transparent_background">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -440,6 +440,10 @@
 			[b]Note:[/b] If [member scaling_3d_scale] is lower than [code]1.0[/code] (exclusive), [member texture_mipmap_bias] is used to adjust the automatic mipmap bias which is calculated internally based on the scale factor. The formula for this is [code]log2(scaling_3d_scale) + mipmap_bias[/code].
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/textures/default_filters/texture_mipmap_bias] project setting.
 		</member>
+		<member name="tonemap_to_window" type="bool" setter="set_tonemap_to_window" getter="is_tonemapping_to_window" default="false">
+			If [code]true[/code], the viewport will tonemap its content to the window's HDR output luminance range, if HDR output is enabled.
+			This is useful for viewports that are not the root of the window, but still need their content to adjust to the capabilities of the display.
+		</member>
 		<member name="transparent_bg" type="bool" setter="set_transparent_background" getter="has_transparent_background" default="false">
 			If [code]true[/code], the viewport should render its background as transparent.
 		</member>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -114,6 +114,14 @@
 				Returns the focused window.
 			</description>
 		</method>
+		<method name="get_hdr_output_max_value" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the maximum value for color components that can be displayed in HDR mode for this window.
+				Use this to scale HDR content to max out the display's brightness, for example lasers or other bright effects.
+				Will return 1.0 if HDR is not enabled or not supported.
+			</description>
+		</method>
 		<method name="get_layout_direction" qualifiers="const">
 			<return type="int" enum="Window.LayoutDirection" />
 			<description>
@@ -339,6 +347,12 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the window is currently embedded in another window.
+			</description>
+		</method>
+		<method name="is_hdr_output_supported" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the window supports HDR output.
 			</description>
 		</method>
 		<method name="is_layout_rtl" qualifiers="const">
@@ -628,6 +642,26 @@
 		<member name="force_native" type="bool" setter="set_force_native" getter="get_force_native" default="false">
 			If [code]true[/code], native window will be used regardless of parent viewport and project settings.
 		</member>
+		<member name="hdr_output_auto_adjust_max_luminance" type="bool" setter="set_hdr_output_auto_adjust_max_luminance" getter="is_hdr_output_auto_adjusting_max_luminance" default="false">
+			If [code]true[/code], the [Window] will automatically adjust the maximum luminance when HDR is enabled.
+		</member>
+		<member name="hdr_output_auto_adjust_reference_luminance" type="bool" setter="set_hdr_output_auto_adjust_reference_luminance" getter="is_hdr_output_auto_adjusting_reference_luminance" default="false">
+			If [code]true[/code], the [Window] will automatically adjust the SDR reference luminance when HDR is enabled.
+		</member>
+		<member name="hdr_output_enabled" type="bool" setter="set_hdr_output_enabled" getter="is_hdr_output_enabled" default="false">
+			If [code]true[/code], the [Window] will output in HDR.
+			Only available on platforms that support HDR output, have HDR enabled in the system settings, and have a compatible display connected.
+		</member>
+		<member name="hdr_output_max_luminance" type="float" setter="set_hdr_output_max_luminance" getter="get_hdr_output_max_luminance" default="1000.0">
+			The maximum luminance in nits (cd/m²) when HDR is enabled.
+		</member>
+		<member name="hdr_output_prefer_high_precision" type="bool" setter="set_hdr_output_prefer_high_precision" getter="is_hdr_output_preferring_high_precision" default="false">
+			If [code]true[/code], the [Window] will prefer high-precision (16-bit per color) framebuffer when available and HDR is enabled.
+		</member>
+		<member name="hdr_output_reference_luminance" type="float" setter="set_hdr_output_reference_luminance" getter="get_hdr_output_reference_luminance" default="200.0">
+			The SDR reference luminance in nits (cd/m²) when HDR is enabled.
+			This controls the brightness of SDR content (such as UI) when HDR is enabled.
+		</member>
 		<member name="initial_position" type="int" setter="set_initial_position" getter="get_initial_position" enum="Window.WindowInitialPosition" default="0">
 			Specifies the initial type of position for the [Window].
 		</member>
@@ -720,6 +754,7 @@
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
 			The window's title. If the [Window] is native, title styles set in [Theme] will have no effect.
 		</member>
+		<member name="tonemap_to_window" type="bool" setter="set_tonemap_to_window" getter="is_tonemapping_to_window" overrides="Viewport" default="true" />
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
 			If [code]true[/code], the [Window] is transient, i.e. it's considered a child of another [Window]. The transient window will be destroyed with its transient parent and will return focus to their parent when closed. The transient window is displayed on top of a non-exclusive full-screen parent window. Transient windows can't enter full-screen mode.
 			Note that behavior might be different depending on the platform.

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -268,6 +268,53 @@ DisplayServer::VSyncMode RenderingContextDriverD3D12::surface_get_vsync_mode(Sur
 	return surface->vsync_mode;
 }
 
+void RenderingContextDriverD3D12::surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_output = p_enabled;
+	surface->needs_resize = true;
+}
+
+bool RenderingContextDriverD3D12::surface_get_hdr_output_enabled(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_output;
+}
+
+void RenderingContextDriverD3D12::surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_prefer_high_precision = p_enabled;
+	surface->needs_resize = true;
+}
+
+bool RenderingContextDriverD3D12::surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_prefer_high_precision;
+}
+
+void RenderingContextDriverD3D12::surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_reference_luminance = p_reference_luminance;
+}
+
+float RenderingContextDriverD3D12::surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_reference_luminance;
+}
+
+void RenderingContextDriverD3D12::surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_max_luminance = p_max_luminance;
+}
+
+float RenderingContextDriverD3D12::surface_get_hdr_output_max_luminance(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_max_luminance;
+}
+
+float RenderingContextDriverD3D12::surface_get_hdr_output_max_value(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return MAX(surface->hdr_max_luminance / MAX(surface->hdr_reference_luminance, 1.0f), 1.0f);
+}
+
 uint32_t RenderingContextDriverD3D12::surface_get_width(SurfaceID p_surface) const {
 	Surface *surface = (Surface *)(p_surface);
 	return surface->width;

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -75,6 +75,15 @@ public:
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
 	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) override;
+	virtual bool surface_get_hdr_output_enabled(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) override;
+	virtual bool surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) override;
+	virtual float surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) override;
+	virtual float surface_get_hdr_output_max_luminance(SurfaceID p_surface) const override;
+	virtual float surface_get_hdr_output_max_value(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_width(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_height(SurfaceID p_surface) const override;
 	virtual void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) override;
@@ -94,6 +103,12 @@ public:
 		uint32_t height = 0;
 		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
 		bool needs_resize = false;
+
+		bool hdr_output = false;
+		bool hdr_prefer_high_precision = false;
+		float hdr_reference_luminance = 0.0f;
+		float hdr_max_luminance = 0.0f;
+
 #ifdef DCOMP_ENABLED
 		ComPtr<IDCompositionDevice> composition_device;
 		ComPtr<IDCompositionTarget> composition_target;

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -315,6 +315,12 @@ const RenderingDeviceDriverD3D12::D3D12Format RenderingDeviceDriverD3D12::RD_TO_
 	/* DATA_FORMAT_ASTC_12x12_SFLOAT_BLOCK */ {},
 };
 
+const DXGI_COLOR_SPACE_TYPE RenderingDeviceDriverD3D12::RD_TO_DXGI_COLOR_SPACE_TYPE[RDD::COLOR_SPACE_MAX]{
+	/* COLOR_SPACE_REC709_LINEAR */ DXGI_COLOR_SPACE_RGB_FULL_G10_NONE_P709,
+	/* COLOR_SPACE_REC709_SRGB */ DXGI_COLOR_SPACE_RGB_FULL_G22_NONE_P709,
+	/* COLOR_SPACE_REC2020_ST2084 */ DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020,
+};
+
 Error RenderingDeviceDriverD3D12::DescriptorsHeap::allocate(ID3D12Device *p_device, D3D12_DESCRIPTOR_HEAP_TYPE p_type, uint32_t p_descriptor_count, bool p_for_gpu) {
 	ERR_FAIL_COND_V(heap, ERR_ALREADY_EXISTS);
 	ERR_FAIL_COND_V(p_descriptor_count == 0, ERR_INVALID_PARAMETER);
@@ -2495,6 +2501,11 @@ void RenderingDeviceDriverD3D12::command_buffer_execute_secondary(CommandBufferI
 void RenderingDeviceDriverD3D12::_swap_chain_release(SwapChain *p_swap_chain) {
 	_swap_chain_release_buffers(p_swap_chain);
 
+	if (p_swap_chain->render_pass.id != 0) {
+		render_pass_free(p_swap_chain->render_pass);
+		p_swap_chain->render_pass = RenderPassID();
+	}
+
 	p_swap_chain->d3d_swap_chain.Reset();
 }
 
@@ -2513,10 +2524,10 @@ void RenderingDeviceDriverD3D12::_swap_chain_release_buffers(SwapChain *p_swap_c
 	p_swap_chain->framebuffers.clear();
 }
 
-RDD::SwapChainID RenderingDeviceDriverD3D12::swap_chain_create(RenderingContextDriver::SurfaceID p_surface) {
+RDD::RenderPassID RenderingDeviceDriverD3D12::_swap_chain_create_render_pass(RDD::DataFormat p_format) {
 	// Create the render pass that will be used to draw to the swap chain's framebuffers.
 	RDD::Attachment attachment;
-	attachment.format = DATA_FORMAT_R8G8B8A8_UNORM;
+	attachment.format = p_format;
 	attachment.samples = RDD::TEXTURE_SAMPLES_1;
 	attachment.load_op = RDD::ATTACHMENT_LOAD_OP_CLEAR;
 	attachment.store_op = RDD::ATTACHMENT_STORE_OP_STORE;
@@ -2527,14 +2538,35 @@ RDD::SwapChainID RenderingDeviceDriverD3D12::swap_chain_create(RenderingContextD
 	color_ref.aspect.set_flag(RDD::TEXTURE_ASPECT_COLOR_BIT);
 	subpass.color_references.push_back(color_ref);
 
-	RenderPassID render_pass = render_pass_create(attachment, subpass, {}, 1, AttachmentReference());
-	ERR_FAIL_COND_V(!render_pass, SwapChainID());
+	return render_pass_create(attachment, subpass, {}, 1, AttachmentReference());
+}
 
-	// Create the empty swap chain until it is resized.
+void RenderingDeviceDriverD3D12::_determine_swap_chain_format(SwapChain *p_swap_chain, DataFormat &r_format, ColorSpace &r_color_space) {
+	DEV_ASSERT(p_swap_chain);
+	DEV_ASSERT(p_swap_chain->surface != 0);
+
+	// Direct3D Hardware level 10 mandates support for all these formats.
+	// Godot requires at least Hardware level 11, so these formats are guaranteed to be supported.
+	if (context_driver->surface_get_hdr_output_enabled(p_swap_chain->surface)) {
+		if (context_driver->surface_get_hdr_output_prefer_high_precision(p_swap_chain->surface)) {
+			r_format = DATA_FORMAT_R16G16B16A16_SFLOAT;
+			r_color_space = COLOR_SPACE_REC709_LINEAR;
+		} else {
+			r_format = DATA_FORMAT_A2R10G10B10_UNORM_PACK32;
+			r_color_space = COLOR_SPACE_REC2020_ST2084;
+		}
+	} else {
+		r_format = DATA_FORMAT_R8G8B8A8_UNORM;
+		r_color_space = COLOR_SPACE_REC709_SRGB;
+	}
+}
+
+RDD::SwapChainID RenderingDeviceDriverD3D12::swap_chain_create(RenderingContextDriver::SurfaceID p_surface) {
+	DEV_ASSERT(p_surface != 0);
+
+	// Create an empty swap chain until it is resized.
 	SwapChain *swap_chain = memnew(SwapChain);
 	swap_chain->surface = p_surface;
-	swap_chain->data_format = attachment.format;
-	swap_chain->render_pass = render_pass;
 	return SwapChainID(swap_chain);
 }
 
@@ -2576,10 +2608,16 @@ Error RenderingDeviceDriverD3D12::swap_chain_resize(CommandQueueID p_cmd_queue, 
 			break;
 	}
 
-	if (swap_chain->d3d_swap_chain != nullptr && creation_flags != swap_chain->creation_flags) {
-		// The swap chain must be recreated if the creation flags are different.
+	RDD::DataFormat new_data_format;
+	RDD::ColorSpace new_color_space;
+	_determine_swap_chain_format(swap_chain, new_data_format, new_color_space);
+
+	if (swap_chain->d3d_swap_chain != nullptr && (creation_flags != swap_chain->creation_flags || new_data_format != swap_chain->data_format)) {
+		// The swap chain must be recreated if the creation flags or data format are different.
 		_swap_chain_release(swap_chain);
 	}
+
+	swap_chain->data_format = new_data_format;
 
 	DXGI_SWAP_CHAIN_DESC1 swap_chain_desc = {};
 	if (swap_chain->d3d_swap_chain != nullptr) {
@@ -2587,6 +2625,10 @@ Error RenderingDeviceDriverD3D12::swap_chain_resize(CommandQueueID p_cmd_queue, 
 		res = swap_chain->d3d_swap_chain->ResizeBuffers(p_desired_framebuffer_count, surface->width, surface->height, DXGI_FORMAT_UNKNOWN, creation_flags);
 		ERR_FAIL_COND_V(!SUCCEEDED(res), ERR_UNAVAILABLE);
 	} else {
+		DEV_ASSERT(swap_chain->render_pass.id == 0);
+		swap_chain->render_pass = _swap_chain_create_render_pass(new_data_format);
+		ERR_FAIL_COND_V(!swap_chain->render_pass, ERR_CANT_CREATE);
+
 		swap_chain_desc.BufferCount = p_desired_framebuffer_count;
 		swap_chain_desc.Format = RD_TO_D3D12_FORMAT[swap_chain->data_format].general_format;
 		swap_chain_desc.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
@@ -2622,6 +2664,13 @@ Error RenderingDeviceDriverD3D12::swap_chain_resize(CommandQueueID p_cmd_queue, 
 
 		res = context_driver->dxgi_factory_get()->MakeWindowAssociation(surface->hwnd, DXGI_MWA_NO_ALT_ENTER | DXGI_MWA_NO_WINDOW_CHANGES);
 		ERR_FAIL_COND_V(!SUCCEEDED(res), ERR_CANT_CREATE);
+	}
+
+	if (swap_chain->color_space != new_color_space) {
+		res = swap_chain->d3d_swap_chain->SetColorSpace1(RD_TO_DXGI_COLOR_SPACE_TYPE[new_color_space]);
+		ERR_FAIL_COND_V(!SUCCEEDED(res), ERR_CANT_CREATE);
+
+		swap_chain->color_space = new_color_space;
 	}
 
 #ifdef DCOMP_ENABLED
@@ -2735,10 +2784,14 @@ RDD::DataFormat RenderingDeviceDriverD3D12::swap_chain_get_format(SwapChainID p_
 	return swap_chain->data_format;
 }
 
+RDD::ColorSpace RenderingDeviceDriverD3D12::swap_chain_get_color_space(SwapChainID p_swap_chain) {
+	const SwapChain *swap_chain = (const SwapChain *)(p_swap_chain.id);
+	return swap_chain->color_space;
+}
+
 void RenderingDeviceDriverD3D12::swap_chain_free(SwapChainID p_swap_chain) {
 	SwapChain *swap_chain = (SwapChain *)(p_swap_chain.id);
 	_swap_chain_release(swap_chain);
-	render_pass_free(swap_chain->render_pass);
 	memdelete(swap_chain);
 }
 
@@ -5590,6 +5643,8 @@ bool RenderingDeviceDriverD3D12::has_feature(Features p_feature) {
 			return true;
 		case SUPPORTS_VULKAN_MEMORY_MODEL:
 			return false;
+		case SUPPORTS_HDR_OUTPUT:
+			return true;
 		default:
 			return false;
 	}

--- a/drivers/d3d12/rendering_device_driver_d3d12.h
+++ b/drivers/d3d12/rendering_device_driver_d3d12.h
@@ -76,6 +76,7 @@ class RenderingDeviceDriverD3D12 : public RenderingDeviceDriver {
 	};
 
 	static const D3D12Format RD_TO_D3D12_FORMAT[RDD::DATA_FORMAT_MAX];
+	static const DXGI_COLOR_SPACE_TYPE RD_TO_DXGI_COLOR_SPACE_TYPE[RDD::COLOR_SPACE_MAX];
 
 	struct DeviceLimits {
 		uint64_t max_srvs_per_shader_stage = 0;
@@ -477,10 +478,13 @@ private:
 		TightLocalVector<TextureInfo> render_targets_info;
 		TightLocalVector<FramebufferID> framebuffers;
 		RDD::DataFormat data_format = DATA_FORMAT_MAX;
+		RDD::ColorSpace color_space = COLOR_SPACE_MAX;
 	};
 
 	void _swap_chain_release(SwapChain *p_swap_chain);
 	void _swap_chain_release_buffers(SwapChain *p_swap_chain);
+	RenderPassID _swap_chain_create_render_pass(RDD::DataFormat p_format);
+	void _determine_swap_chain_format(SwapChain *p_swap_chain, DataFormat &r_format, ColorSpace &r_color_space);
 
 public:
 	virtual SwapChainID swap_chain_create(RenderingContextDriver::SurfaceID p_surface) override;
@@ -488,6 +492,7 @@ public:
 	virtual FramebufferID swap_chain_acquire_framebuffer(CommandQueueID p_cmd_queue, SwapChainID p_swap_chain, bool &r_resize_required) override;
 	virtual RenderPassID swap_chain_get_render_pass(SwapChainID p_swap_chain) override;
 	virtual DataFormat swap_chain_get_format(SwapChainID p_swap_chain) override;
+	virtual ColorSpace swap_chain_get_color_space(SwapChainID p_swap_chain) override;
 	virtual void swap_chain_free(SwapChainID p_swap_chain) override;
 
 	/*********************/

--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -77,6 +77,15 @@ public:
 	void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) final override;
 	void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) final override;
 	DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const final override;
+	virtual void surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) final override;
+	virtual bool surface_get_hdr_output_enabled(SurfaceID p_surface) const final override;
+	virtual void surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) override;
+	virtual bool surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) final override;
+	virtual float surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const final override;
+	virtual void surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) final override;
+	virtual float surface_get_hdr_output_max_luminance(SurfaceID p_surface) const final override;
+	virtual float surface_get_hdr_output_max_value(SurfaceID p_surface) const final override;
 	uint32_t surface_get_width(SurfaceID p_surface) const final override;
 	uint32_t surface_get_height(SurfaceID p_surface) const final override;
 	void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) final override;
@@ -109,6 +118,11 @@ public:
 		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
 		bool needs_resize = false;
 		double present_minimum_duration = 0.0;
+
+		bool hdr_output = false;
+		bool hdr_prefer_high_precision = false;
+		float hdr_reference_luminance = 0.0f;
+		float hdr_max_luminance = 0.0f;
 
 		Surface(
 #ifdef __OBJC__

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -215,6 +215,53 @@ DisplayServer::VSyncMode RenderingContextDriverMetal::surface_get_vsync_mode(Sur
 	return surface->vsync_mode;
 }
 
+void RenderingContextDriverMetal::surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_output = p_enabled;
+	surface->needs_resize = true;
+}
+
+bool RenderingContextDriverMetal::surface_get_hdr_output_enabled(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_output;
+}
+
+void RenderingContextDriverMetal::surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_prefer_high_precision = p_enabled;
+	surface->needs_resize = true;
+}
+
+bool RenderingContextDriverMetal::surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_prefer_high_precision;
+}
+
+void RenderingContextDriverMetal::surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_reference_luminance = p_reference_luminance;
+}
+
+float RenderingContextDriverMetal::surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_reference_luminance;
+}
+
+void RenderingContextDriverMetal::surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_max_luminance = p_max_luminance;
+}
+
+float RenderingContextDriverMetal::surface_get_hdr_output_max_luminance(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_max_luminance;
+}
+
+float RenderingContextDriverMetal::surface_get_hdr_output_max_value(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return MAX(surface->hdr_max_luminance / MAX(surface->hdr_reference_luminance, 1.0f), 1.0f);
+}
+
 uint32_t RenderingContextDriverMetal::surface_get_width(SurfaceID p_surface) const {
 	Surface *surface = (Surface *)(p_surface);
 	return surface->width;

--- a/drivers/metal/rendering_device_driver_metal.h
+++ b/drivers/metal/rendering_device_driver_metal.h
@@ -224,6 +224,7 @@ public:
 	virtual RenderPassID swap_chain_get_render_pass(SwapChainID p_swap_chain) override final;
 	virtual DataFormat swap_chain_get_format(SwapChainID p_swap_chain) override final;
 	virtual void swap_chain_set_max_fps(SwapChainID p_swap_chain, int p_max_fps) override final;
+	virtual ColorSpace swap_chain_get_color_space(SwapChainID p_swap_chain) override final;
 	virtual void swap_chain_free(SwapChainID p_swap_chain) override final;
 
 #pragma mark - Frame Buffer

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1056,6 +1056,10 @@ void RenderingDeviceDriverMetal::swap_chain_set_max_fps(SwapChainID p_swap_chain
 	metal_surface->set_max_fps(p_max_fps);
 }
 
+RDD::ColorSpace RenderingDeviceDriverMetal::swap_chain_get_color_space(SwapChainID p_swap_chain) {
+	return RDD::COLOR_SPACE_REC709_SRGB;
+}
+
 void RenderingDeviceDriverMetal::swap_chain_free(SwapChainID p_swap_chain) {
 	SwapChain *swap_chain = (SwapChain *)(p_swap_chain.id);
 	_swap_chain_release(swap_chain);

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -436,6 +436,9 @@ Error RenderingContextDriverVulkan::_initialize_instance_extensions() {
 	// This extension allows us to use the properties2 features to query additional device capabilities.
 	_register_requested_instance_extension(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME, false);
 
+	// This extension allows us to use colorspaces other than SRGB.
+	_register_requested_instance_extension(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME, false);
+
 #if defined(USE_VOLK) && (defined(MACOS_ENABLED) || defined(IOS_ENABLED))
 	_register_requested_instance_extension(VK_KHR_PORTABILITY_ENUMERATION_EXTENSION_NAME, true);
 #endif
@@ -991,6 +994,53 @@ DisplayServer::VSyncMode RenderingContextDriverVulkan::surface_get_vsync_mode(Su
 	return surface->vsync_mode;
 }
 
+void RenderingContextDriverVulkan::surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_output = p_enabled;
+	surface->needs_resize = true;
+}
+
+bool RenderingContextDriverVulkan::surface_get_hdr_output_enabled(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_output;
+}
+
+void RenderingContextDriverVulkan::surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_prefer_high_precision = p_enabled;
+	surface->needs_resize = true;
+}
+
+bool RenderingContextDriverVulkan::surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_prefer_high_precision;
+}
+
+void RenderingContextDriverVulkan::surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_reference_luminance = p_reference_luminance;
+}
+
+float RenderingContextDriverVulkan::surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_reference_luminance;
+}
+
+void RenderingContextDriverVulkan::surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) {
+	Surface *surface = (Surface *)(p_surface);
+	surface->hdr_max_luminance = p_max_luminance;
+}
+
+float RenderingContextDriverVulkan::surface_get_hdr_output_max_luminance(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return surface->hdr_max_luminance;
+}
+
+float RenderingContextDriverVulkan::surface_get_hdr_output_max_value(SurfaceID p_surface) const {
+	Surface *surface = (Surface *)(p_surface);
+	return MAX(surface->hdr_max_luminance / MAX(surface->hdr_reference_luminance, 1.0f), 1.0f);
+}
+
 uint32_t RenderingContextDriverVulkan::surface_get_width(SurfaceID p_surface) const {
 	Surface *surface = (Surface *)(p_surface);
 	return surface->width;
@@ -1019,6 +1069,10 @@ void RenderingContextDriverVulkan::surface_destroy(SurfaceID p_surface) {
 
 bool RenderingContextDriverVulkan::is_debug_utils_enabled() const {
 	return enabled_instance_extension_names.has(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+}
+
+bool RenderingContextDriverVulkan::is_colorspace_supported() const {
+	return enabled_instance_extension_names.has(VK_EXT_SWAPCHAIN_COLOR_SPACE_EXTENSION_NAME);
 }
 
 VkInstance RenderingContextDriverVulkan::instance_get() const {

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -138,12 +138,22 @@ public:
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
 	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) override;
+	virtual bool surface_get_hdr_output_enabled(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) override;
+	virtual bool surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) override;
+	virtual float surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const override;
+	virtual void surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) override;
+	virtual float surface_get_hdr_output_max_luminance(SurfaceID p_surface) const override;
+	virtual float surface_get_hdr_output_max_value(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_width(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_height(SurfaceID p_surface) const override;
 	virtual void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) override;
 	virtual bool surface_get_needs_resize(SurfaceID p_surface) const override;
 	virtual void surface_destroy(SurfaceID p_surface) override;
 	virtual bool is_debug_utils_enabled() const override;
+	bool is_colorspace_supported() const;
 
 	// Vulkan-only methods.
 	struct Surface {
@@ -152,6 +162,11 @@ public:
 		uint32_t height = 0;
 		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
 		bool needs_resize = false;
+
+		bool hdr_output = false;
+		bool hdr_prefer_high_precision = false;
+		float hdr_reference_luminance = 0.0f;
+		float hdr_max_luminance = 0.0f;
 	};
 
 	VkInstance instance_get() const;

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -2997,6 +2997,99 @@ void RenderingDeviceDriverVulkan::command_buffer_execute_secondary(CommandBuffer
 /**** SWAP CHAIN ****/
 /********************/
 
+struct FormatCandidate {
+	VkFormat format;
+	VkColorSpaceKHR colorspace;
+};
+
+bool RenderingDeviceDriverVulkan::_determine_swap_chain_format(RenderingContextDriver::SurfaceID p_surface, VkFormat &r_format, VkColorSpaceKHR &r_color_space) {
+	DEV_ASSERT(p_surface != 0);
+
+	RenderingContextDriverVulkan::Surface *surface = (RenderingContextDriverVulkan::Surface *)(p_surface);
+	const RenderingContextDriverVulkan::Functions &functions = context_driver->functions_get();
+
+	// Retrieve the formats supported by the surface.
+	uint32_t format_count = 0;
+	VkResult err = functions.GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface->vk_surface, &format_count, nullptr);
+	ERR_FAIL_COND_V(err != VK_SUCCESS, false);
+
+	TightLocalVector<VkSurfaceFormatKHR> formats;
+	formats.resize(format_count);
+	err = functions.GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface->vk_surface, &format_count, formats.ptr());
+	ERR_FAIL_COND_V(err != VK_SUCCESS, false);
+
+	// If the format list includes just one entry of VK_FORMAT_UNDEFINED, the surface has no preferred format.
+	if (format_count == 1 && formats[0].format == VK_FORMAT_UNDEFINED) {
+		r_format = VK_FORMAT_B8G8R8A8_UNORM;
+		r_color_space = formats[0].colorSpace;
+		return true;
+	}
+
+	bool colorspace_supported = context_driver->is_colorspace_supported();
+	bool hdr_output_requested = context_driver->surface_get_hdr_output_enabled(p_surface);
+	bool high_precision_requested = context_driver->surface_get_hdr_output_prefer_high_precision(p_surface);
+
+	// Determine which formats to prefer based on the requested capabilities.
+	LocalVector<FormatCandidate> preferred_formats = LocalVector<FormatCandidate>();
+	preferred_formats.reserve(5);
+
+	// If the surface requests HDR output, try to get an HDR format.
+	if (hdr_output_requested && colorspace_supported) {
+		if (high_precision_requested) {
+			// If high precision is requested, add the high precision format to the top.
+			preferred_formats.push_back({ VK_FORMAT_R16G16B16A16_SFLOAT, VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT });
+
+			// Followed by the HDR10 formats
+			preferred_formats.push_back({ VK_FORMAT_A2B10G10R10_UNORM_PACK32, VK_COLOR_SPACE_HDR10_ST2084_EXT });
+			preferred_formats.push_back({ VK_FORMAT_A2R10G10B10_UNORM_PACK32, VK_COLOR_SPACE_HDR10_ST2084_EXT });
+		} else {
+			// Otherwise add the HDR10 formats to the top.
+			preferred_formats.push_back({ VK_FORMAT_A2B10G10R10_UNORM_PACK32, VK_COLOR_SPACE_HDR10_ST2084_EXT });
+			preferred_formats.push_back({ VK_FORMAT_A2R10G10B10_UNORM_PACK32, VK_COLOR_SPACE_HDR10_ST2084_EXT });
+
+			// Followed by the high precision format for devices that don't support HDR 10.
+			preferred_formats.push_back({ VK_FORMAT_R16G16B16A16_SFLOAT, VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT });
+		}
+	}
+
+	// These formats are always considered for SDR.
+	preferred_formats.push_back({ VK_FORMAT_B8G8R8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR });
+	preferred_formats.push_back({ VK_FORMAT_R8G8B8A8_UNORM, VK_COLOR_SPACE_SRGB_NONLINEAR_KHR });
+
+	bool found = false;
+	for (const FormatCandidate &candidate : preferred_formats) {
+		for (uint32_t i = 0; i < format_count; i++) {
+			if (formats[i].format == candidate.format && formats[i].colorSpace == candidate.colorspace) {
+				r_format = formats[i].format;
+				r_color_space = formats[i].colorSpace;
+				found = true;
+				break;
+			}
+		}
+
+		if (found) {
+			break;
+		}
+	}
+
+	// Warnings for when HDR capabilities are requested but not found.
+	if (hdr_output_requested) {
+		if (!colorspace_supported) {
+			WARN_PRINT("HDR output requested but the vulkan driver does not support VK_EXT_swapchain_colorspace, falling back to SDR.");
+		}
+
+		if (high_precision_requested && r_format != VK_FORMAT_R16G16B16A16_SFLOAT) {
+			WARN_PRINT("HDR output requested with high precision but no high precision format was found.");
+		}
+
+		if (r_color_space == VK_COLOR_SPACE_SRGB_NONLINEAR_KHR) {
+			WARN_PRINT("HDR output requested but no HDR compatible format was found, falling back to SDR.");
+		}
+	}
+
+	return found;
+}
+
 void RenderingDeviceDriverVulkan::_swap_chain_release(SwapChain *swap_chain) {
 	// Destroy views and framebuffers associated to the swapchain's images.
 	for (FramebufferID framebuffer : swap_chain->framebuffers) {
@@ -3025,6 +3118,11 @@ void RenderingDeviceDriverVulkan::_swap_chain_release(SwapChain *swap_chain) {
 		swap_chain->vk_swapchain = VK_NULL_HANDLE;
 	}
 
+	if (swap_chain->render_pass.id != 0) {
+		render_pass_free(swap_chain->render_pass);
+		swap_chain->render_pass = RenderPassID();
+	}
+
 	for (uint32_t i = 0; i < swap_chain->command_queues_acquired.size(); i++) {
 		_recreate_image_semaphore(swap_chain->command_queues_acquired[i], swap_chain->command_queues_acquired_semaphores[i], false);
 	}
@@ -3042,84 +3140,9 @@ void RenderingDeviceDriverVulkan::_swap_chain_release(SwapChain *swap_chain) {
 RenderingDeviceDriver::SwapChainID RenderingDeviceDriverVulkan::swap_chain_create(RenderingContextDriver::SurfaceID p_surface) {
 	DEV_ASSERT(p_surface != 0);
 
-	RenderingContextDriverVulkan::Surface *surface = (RenderingContextDriverVulkan::Surface *)(p_surface);
-	const RenderingContextDriverVulkan::Functions &functions = context_driver->functions_get();
-
-	// Retrieve the formats supported by the surface.
-	uint32_t format_count = 0;
-	VkResult err = functions.GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface->vk_surface, &format_count, nullptr);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SwapChainID());
-
-	TightLocalVector<VkSurfaceFormatKHR> formats;
-	formats.resize(format_count);
-	err = functions.GetPhysicalDeviceSurfaceFormatsKHR(physical_device, surface->vk_surface, &format_count, formats.ptr());
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SwapChainID());
-
-	VkFormat format = VK_FORMAT_UNDEFINED;
-	VkColorSpaceKHR color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
-	if (format_count == 1 && formats[0].format == VK_FORMAT_UNDEFINED) {
-		// If the format list includes just one entry of VK_FORMAT_UNDEFINED, the surface has no preferred format.
-		format = VK_FORMAT_B8G8R8A8_UNORM;
-		color_space = formats[0].colorSpace;
-	} else if (format_count > 0) {
-		// Use one of the supported formats, prefer B8G8R8A8_UNORM.
-		const VkFormat preferred_format = VK_FORMAT_B8G8R8A8_UNORM;
-		const VkFormat second_format = VK_FORMAT_R8G8B8A8_UNORM;
-		for (uint32_t i = 0; i < format_count; i++) {
-			if (formats[i].format == preferred_format || formats[i].format == second_format) {
-				format = formats[i].format;
-				if (formats[i].format == preferred_format) {
-					// This is the preferred format, stop searching.
-					break;
-				}
-			}
-		}
-	}
-
-	// No formats are supported.
-	ERR_FAIL_COND_V_MSG(format == VK_FORMAT_UNDEFINED, SwapChainID(), "Surface did not return any valid formats.");
-
-	// Create the render pass for the chosen format.
-	VkAttachmentDescription2KHR attachment = {};
-	attachment.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2_KHR;
-	attachment.format = format;
-	attachment.samples = VK_SAMPLE_COUNT_1_BIT;
-	attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-	attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-	attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-	attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-	attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-	attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
-
-	VkAttachmentReference2KHR color_reference = {};
-	color_reference.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2_KHR;
-	color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
-
-	VkSubpassDescription2KHR subpass = {};
-	subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2_KHR;
-	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-	subpass.colorAttachmentCount = 1;
-	subpass.pColorAttachments = &color_reference;
-
-	VkRenderPassCreateInfo2KHR pass_info = {};
-	pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2_KHR;
-	pass_info.attachmentCount = 1;
-	pass_info.pAttachments = &attachment;
-	pass_info.subpassCount = 1;
-	pass_info.pSubpasses = &subpass;
-
-	VkRenderPass vk_render_pass = VK_NULL_HANDLE;
-	err = _create_render_pass(vk_device, &pass_info, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_RENDER_PASS), &vk_render_pass);
-	ERR_FAIL_COND_V(err != VK_SUCCESS, SwapChainID());
-
-	RenderPassInfo *render_pass_info = VersatileResource::allocate<RenderPassInfo>(resources_allocator);
-	render_pass_info->vk_render_pass = vk_render_pass;
-
+	// Create an empty swap chain until it is resized.
 	SwapChain *swap_chain = memnew(SwapChain);
 	swap_chain->surface = p_surface;
-	swap_chain->format = format;
-	swap_chain->color_space = color_space;
-	swap_chain->render_pass = RenderPassID(render_pass_info);
 	return SwapChainID(swap_chain);
 }
 
@@ -3253,6 +3276,16 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 		has_comp_alpha[(uint64_t)p_cmd_queue.id] = (composite_alpha != VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR);
 	}
 
+	// Determine the format and color space for the swap chain.
+	VkFormat format = VK_FORMAT_UNDEFINED;
+	VkColorSpaceKHR color_space = VK_COLOR_SPACE_SRGB_NONLINEAR_KHR;
+	if (!_determine_swap_chain_format(swap_chain->surface, format, color_space)) {
+		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Surface did not return any valid formats.");
+	} else {
+		swap_chain->format = format;
+		swap_chain->color_space = color_space;
+	}
+
 	VkSwapchainCreateInfoKHR swap_create_info = {};
 	swap_create_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
 	swap_create_info.surface = surface->vk_surface;
@@ -3351,10 +3384,48 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 
 	swap_chain->framebuffers.reserve(image_count);
 
-	const RenderPassInfo *render_pass = (const RenderPassInfo *)(swap_chain->render_pass.id);
+	// Create the render pass for the chosen format.
+	VkAttachmentDescription2KHR attachment = {};
+	attachment.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2_KHR;
+	attachment.format = format;
+	attachment.samples = VK_SAMPLE_COUNT_1_BIT;
+	attachment.loadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+	attachment.storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+	attachment.stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+	attachment.stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+	attachment.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+	attachment.finalLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
+
+	VkAttachmentReference2KHR color_reference = {};
+	color_reference.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2_KHR;
+	color_reference.layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+
+	VkSubpassDescription2KHR subpass = {};
+	subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2_KHR;
+	subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+	subpass.colorAttachmentCount = 1;
+	subpass.pColorAttachments = &color_reference;
+
+	VkRenderPassCreateInfo2KHR pass_info = {};
+	pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2_KHR;
+	pass_info.attachmentCount = 1;
+	pass_info.pAttachments = &attachment;
+	pass_info.subpassCount = 1;
+	pass_info.pSubpasses = &subpass;
+
+	VkRenderPass vk_render_pass = VK_NULL_HANDLE;
+	err = _create_render_pass(vk_device, &pass_info, VKC::get_allocation_callbacks(VK_OBJECT_TYPE_RENDER_PASS), &vk_render_pass);
+	ERR_FAIL_COND_V(err != VK_SUCCESS, ERR_CANT_CREATE);
+
+	RenderPassInfo *render_pass_info = VersatileResource::allocate<RenderPassInfo>(resources_allocator);
+	render_pass_info->vk_render_pass = vk_render_pass;
+
+	DEV_ASSERT(swap_chain->render_pass.id == 0);
+	swap_chain->render_pass = RenderPassID(render_pass_info);
+
 	VkFramebufferCreateInfo fb_create_info = {};
 	fb_create_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-	fb_create_info.renderPass = render_pass->vk_render_pass;
+	fb_create_info.renderPass = vk_render_pass;
 	fb_create_info.attachmentCount = 1;
 	fb_create_info.width = surface->width;
 	fb_create_info.height = surface->height;
@@ -3478,6 +3549,12 @@ RDD::DataFormat RenderingDeviceDriverVulkan::swap_chain_get_format(SwapChainID p
 			return DATA_FORMAT_B8G8R8A8_UNORM;
 		case VK_FORMAT_R8G8B8A8_UNORM:
 			return DATA_FORMAT_R8G8B8A8_UNORM;
+		case VK_FORMAT_A2B10G10R10_UNORM_PACK32:
+			return DATA_FORMAT_A2B10G10R10_UNORM_PACK32;
+		case VK_FORMAT_A2R10G10B10_UNORM_PACK32:
+			return DATA_FORMAT_A2R10G10B10_UNORM_PACK32;
+		case VK_FORMAT_R16G16B16A16_SFLOAT:
+			return DATA_FORMAT_R16G16B16A16_SFLOAT;
 		default:
 			DEV_ASSERT(false && "Unknown swap chain format.");
 			return DATA_FORMAT_MAX;
@@ -3500,15 +3577,28 @@ void RenderingDeviceDriverVulkan::swap_chain_set_max_fps(SwapChainID p_swap_chai
 #endif
 }
 
+RDD::ColorSpace RenderingDeviceDriverVulkan::swap_chain_get_color_space(SwapChainID p_swap_chain) {
+	DEV_ASSERT(p_swap_chain.id != 0);
+
+	SwapChain *swap_chain = (SwapChain *)(p_swap_chain.id);
+	switch (swap_chain->color_space) {
+		case VK_COLOR_SPACE_SRGB_NONLINEAR_KHR:
+			return COLOR_SPACE_REC709_SRGB;
+		case VK_COLOR_SPACE_HDR10_ST2084_EXT:
+			return COLOR_SPACE_REC2020_ST2084;
+		case VK_COLOR_SPACE_EXTENDED_SRGB_LINEAR_EXT:
+			return COLOR_SPACE_REC709_LINEAR;
+		default:
+			DEV_ASSERT(false && "Unknown swap chain color space.");
+			return COLOR_SPACE_MAX;
+	}
+}
+
 void RenderingDeviceDriverVulkan::swap_chain_free(SwapChainID p_swap_chain) {
 	DEV_ASSERT(p_swap_chain.id != 0);
 
 	SwapChain *swap_chain = (SwapChain *)(p_swap_chain.id);
 	_swap_chain_release(swap_chain);
-
-	if (swap_chain->render_pass) {
-		render_pass_free(swap_chain->render_pass);
-	}
 
 	memdelete(swap_chain);
 }
@@ -5927,6 +6017,8 @@ bool RenderingDeviceDriverVulkan::has_feature(Features p_feature) {
 #endif
 		case SUPPORTS_VULKAN_MEMORY_MODEL:
 			return vulkan_memory_model_support && vulkan_memory_model_device_scope_support;
+		case SUPPORTS_HDR_OUTPUT:
+			return context_driver->is_colorspace_supported();
 		default:
 			return false;
 	}

--- a/drivers/vulkan/rendering_device_driver_vulkan.h
+++ b/drivers/vulkan/rendering_device_driver_vulkan.h
@@ -375,6 +375,7 @@ private:
 #endif
 	};
 
+	bool _determine_swap_chain_format(RenderingContextDriver::SurfaceID p_surface, VkFormat &r_format, VkColorSpaceKHR &r_color_space);
 	void _swap_chain_release(SwapChain *p_swap_chain);
 
 public:
@@ -385,6 +386,7 @@ public:
 	virtual int swap_chain_get_pre_rotation_degrees(SwapChainID p_swap_chain) override final;
 	virtual DataFormat swap_chain_get_format(SwapChainID p_swap_chain) override final;
 	virtual void swap_chain_set_max_fps(SwapChainID p_swap_chain, int p_max_fps) override final;
+	virtual ColorSpace swap_chain_get_color_space(SwapChainID p_swap_chain) override final;
 	virtual void swap_chain_free(SwapChainID p_swap_chain) override final;
 
 private:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -456,6 +456,26 @@ void EditorNode::_update_from_settings() {
 		scene_root->propagate_notification(Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
 	}
 
+	// Enable HDR if requested and available.
+	bool force_hdr_2d = false;
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HDR) && RD::get_singleton() && RD::get_singleton()->has_feature(RD::Features::SUPPORTS_HDR_OUTPUT)) {
+		bool hdr_enabled = GLOBAL_GET("display/window/hdr/enabled");
+		bool prefer_high_precision = GLOBAL_GET("display/window/hdr/prefer_high_precision");
+		bool auto_adjust_reference_luminance = GLOBAL_GET("display/window/hdr/auto_adjust_reference_luminance");
+		float reference_luminance = GLOBAL_GET("display/window/hdr/reference_luminance");
+		bool auto_adjust_max_luminance = GLOBAL_GET("display/window/hdr/auto_adjust_max_luminance");
+		float max_luminance = GLOBAL_GET("display/window/hdr/max_luminance");
+
+		DisplayServer::get_singleton()->window_set_hdr_output_enabled(hdr_enabled);
+		DisplayServer::get_singleton()->window_set_hdr_output_prefer_high_precision(prefer_high_precision);
+		DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_reference_luminance(auto_adjust_reference_luminance);
+		DisplayServer::get_singleton()->window_set_hdr_output_reference_luminance(reference_luminance);
+		DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_max_luminance(auto_adjust_max_luminance);
+		DisplayServer::get_singleton()->window_set_hdr_output_max_luminance(max_luminance);
+
+		force_hdr_2d = hdr_enabled;
+	}
+
 	RS::DOFBokehShape dof_shape = RS::DOFBokehShape(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape")));
 	RS::get_singleton()->camera_attributes_set_dof_blur_bokeh_shape(dof_shape);
 	RS::DOFBlurQuality dof_quality = RS::DOFBlurQuality(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality")));
@@ -516,8 +536,12 @@ void EditorNode::_update_from_settings() {
 	get_viewport()->set_use_debanding(use_debanding);
 
 	bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	scene_root->set_use_hdr_2d(use_hdr_2d);
-	get_viewport()->set_use_hdr_2d(use_hdr_2d);
+	scene_root->set_use_hdr_2d(use_hdr_2d || force_hdr_2d);
+	get_viewport()->set_use_hdr_2d(use_hdr_2d || force_hdr_2d);
+
+	const bool tonemap_to_window = GLOBAL_GET("rendering/viewport/tonemap_to_window");
+	scene_root->set_tonemap_to_window(tonemap_to_window);
+	get_viewport()->set_tonemap_to_window(tonemap_to_window);
 
 	float mesh_lod_threshold = GLOBAL_GET("rendering/mesh_lod/lod_change/threshold_pixels");
 	scene_root->set_mesh_lod_threshold(mesh_lod_threshold);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2921,6 +2921,12 @@ void Node3DEditorViewport::_project_settings_changed() {
 
 	_update_shrink();
 
+	// Check if HDR is supported and enabled and force 2D HDR if so.
+	bool force_hdr_2d = false;
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HDR) && RD::get_singleton() && RD::get_singleton()->has_feature(RD::Features::SUPPORTS_HDR_OUTPUT)) {
+		force_hdr_2d = GLOBAL_GET("display/window/hdr/enabled");
+	}
+
 	// Update MSAA, screen-space AA and debanding if changed
 
 	const int msaa_mode = GLOBAL_GET("rendering/anti_aliasing/quality/msaa_3d");
@@ -2934,7 +2940,10 @@ void Node3DEditorViewport::_project_settings_changed() {
 	viewport->set_transparent_background(transparent_background);
 
 	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
-	viewport->set_use_hdr_2d(use_hdr_2d);
+	viewport->set_use_hdr_2d(use_hdr_2d || force_hdr_2d);
+
+	const bool tonemap_to_window = GLOBAL_GET("rendering/viewport/tonemap_to_window");
+	viewport->set_tonemap_to_window(tonemap_to_window);
 
 	const bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
 	viewport->set_use_debanding(use_debanding);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3449,6 +3449,23 @@ Error Main::setup2(bool p_show_boot_logo) {
 			}
 		}
 
+		// Enable HDR if requested and available.
+		if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HDR) && RD::get_singleton() && RD::get_singleton()->has_feature(RD::Features::SUPPORTS_HDR_OUTPUT)) {
+			bool hdr_enabled = GLOBAL_GET("display/window/hdr/enabled");
+			bool prefer_high_precision = GLOBAL_GET("display/window/hdr/prefer_high_precision");
+			bool auto_adjust_reference_luminance = GLOBAL_GET("display/window/hdr/auto_adjust_reference_luminance");
+			float reference_luminance = GLOBAL_GET("display/window/hdr/reference_luminance");
+			bool auto_adjust_max_luminance = GLOBAL_GET("display/window/hdr/auto_adjust_max_luminance");
+			float max_luminance = GLOBAL_GET("display/window/hdr/max_luminance");
+
+			DisplayServer::get_singleton()->window_set_hdr_output_enabled(hdr_enabled);
+			DisplayServer::get_singleton()->window_set_hdr_output_prefer_high_precision(prefer_high_precision);
+			DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_reference_luminance(auto_adjust_reference_luminance);
+			DisplayServer::get_singleton()->window_set_hdr_output_reference_luminance(reference_luminance);
+			DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_max_luminance(auto_adjust_max_luminance);
+			DisplayServer::get_singleton()->window_set_hdr_output_max_luminance(max_luminance);
+		}
+
 		Color clear = GLOBAL_DEF_BASIC("rendering/environment/defaults/default_clear_color", Color(0.3, 0.3, 0.3));
 		RenderingServer::get_singleton()->set_default_clear_color(clear);
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -150,6 +150,7 @@ bool DisplayServerWindows::has_feature(Feature p_feature) const {
 		case FEATURE_WINDOW_EMBEDDING:
 		case FEATURE_WINDOW_DRAG:
 		case FEATURE_SCREEN_EXCLUDE_FROM_CAPTURE:
+		case FEATURE_HDR:
 			return true;
 		case FEATURE_EMOJI_AND_SYMBOL_PICKER:
 			return (os_ver.dwBuildNumber >= 17134); // Windows 10 Redstone 4 (1803)+ only.
@@ -1146,6 +1147,24 @@ static BOOL CALLBACK _MonitorEnumProcCount(HMONITOR hMonitor, HDC hdcMonitor, LP
 	return TRUE;
 }
 
+static BOOL CALLBACK _MonitorEnumProcMonitor(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
+	EnumScreenData *data = (EnumScreenData *)dwData;
+
+	if (data->screen == data->count) {
+		data->monitor = hMonitor;
+		return FALSE;
+	}
+
+	data->count++;
+	return TRUE;
+}
+
+static HMONITOR _get_hmonitor_of_screen(int p_screen) {
+	EnumScreenData data = { 0, p_screen, nullptr };
+	EnumDisplayMonitors(nullptr, nullptr, _MonitorEnumProcMonitor, (LPARAM)&data);
+	return data.monitor;
+}
+
 int DisplayServerWindows::get_screen_count() const {
 	_THREAD_SAFE_METHOD_
 
@@ -1234,6 +1253,14 @@ typedef struct {
 	int screen;
 	float rate;
 } EnumRefreshRateData;
+
+typedef struct {
+	Vector<DISPLAYCONFIG_PATH_INFO> paths;
+	Vector<DISPLAYCONFIG_MODE_INFO> modes;
+	int count;
+	int screen;
+	float sdrWhiteLevelInNits;
+} EnumSdrWhiteLevelData;
 
 static BOOL CALLBACK _MonitorEnumProcSize(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
 	EnumSizeData *data = (EnumSizeData *)dwData;
@@ -1515,6 +1542,201 @@ Ref<Image> DisplayServerWindows::screen_get_image_rect(const Rect2i &p_rect) con
 	}
 
 	return img;
+}
+
+#ifdef D3D12_ENABLED
+static bool _get_monitor_desc(HMONITOR p_monitor, DXGI_OUTPUT_DESC1 &r_Desc) {
+	ComPtr<IDXGIFactory4> dxgi_factory;
+	r_Desc = {};
+
+	if (FAILED(CreateDXGIFactory2(0, IID_PPV_ARGS(&dxgi_factory)))) {
+		return false;
+	}
+
+	// Retrieve the current default adapter.
+	ComPtr<IDXGIAdapter1> dxgiAdapter;
+	if (FAILED(dxgi_factory->EnumAdapters1(0, &dxgiAdapter))) {
+		return false;
+	}
+
+	UINT i = 0;
+	ComPtr<IDXGIOutput> dxgiOutput;
+	DXGI_OUTPUT_DESC1 desc1;
+	while (dxgiAdapter->EnumOutputs(i, &dxgiOutput) != DXGI_ERROR_NOT_FOUND) {
+		ComPtr<IDXGIOutput6> output6;
+		if (FAILED(dxgiOutput.As(&output6))) {
+			continue;
+		}
+
+		if (FAILED(output6->GetDesc1(&desc1))) {
+			continue;
+		}
+
+		if (desc1.Monitor == p_monitor) {
+			r_Desc = desc1;
+			return true;
+		}
+
+		i++;
+	}
+
+	return false;
+}
+#endif // D3D12_ENABLED
+
+bool DisplayServerWindows::screen_is_hdr_supported(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	p_screen = _get_screen_index(p_screen);
+#ifdef D3D12_ENABLED
+	HMONITOR monitor = _get_hmonitor_of_screen(p_screen);
+	if (monitor == nullptr) {
+		return false;
+	}
+	DXGI_OUTPUT_DESC1 desc1;
+	if (!_get_monitor_desc(monitor, desc1)) {
+		return false;
+	}
+
+	return (desc1.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020);
+#else
+	return false;
+#endif // D3D12_ENABLED
+}
+
+float DisplayServerWindows::screen_get_min_luminance(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	const float default_return = 0.0f;
+	p_screen = _get_screen_index(p_screen);
+#ifdef D3D12_ENABLED
+	HMONITOR monitor = _get_hmonitor_of_screen(p_screen);
+	if (monitor == nullptr) {
+		return default_return;
+	}
+	DXGI_OUTPUT_DESC1 desc1;
+	if (!_get_monitor_desc(monitor, desc1)) {
+		return default_return;
+	}
+
+	return desc1.MinLuminance;
+#else
+	return default_return;
+#endif // D3D12_ENABLED
+}
+
+float DisplayServerWindows::screen_get_max_luminance(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	const float default_return = 0.0f;
+	p_screen = _get_screen_index(p_screen);
+#ifdef D3D12_ENABLED
+	HMONITOR monitor = _get_hmonitor_of_screen(p_screen);
+	DXGI_OUTPUT_DESC1 desc1;
+	if (!_get_monitor_desc(monitor, desc1)) {
+		return default_return;
+	}
+
+	return desc1.MaxLuminance;
+#else
+	return default_return;
+#endif // D3D12_ENABLED
+}
+
+float DisplayServerWindows::screen_get_max_full_frame_luminance(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	const float default_return = 0.0f;
+	p_screen = _get_screen_index(p_screen);
+#ifdef D3D12_ENABLED
+	HMONITOR monitor = _get_hmonitor_of_screen(p_screen);
+	DXGI_OUTPUT_DESC1 desc1;
+	if (!_get_monitor_desc(monitor, desc1)) {
+		return default_return;
+	}
+
+	return desc1.MaxFullFrameLuminance;
+#else
+	return default_return;
+#endif // D3D12_ENABLED
+}
+
+static BOOL CALLBACK _MonitorEnumProcSdrWhiteLevel(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
+	EnumSdrWhiteLevelData *data = (EnumSdrWhiteLevelData *)dwData;
+
+	// Only return TRUE to go to the next screen. Everything past this point should return FALSE.
+	if (data->count != data->screen) {
+		data->count++;
+		return TRUE;
+	}
+
+	MONITORINFOEXW minfo;
+	memset(&minfo, 0, sizeof(minfo));
+	minfo.cbSize = sizeof(minfo);
+	if (!GetMonitorInfoW(hMonitor, &minfo)) {
+		ERR_FAIL_V_MSG(FALSE, vformat("Failed to get monitor info for screen: %d", data->screen));
+	}
+
+	// Find this screen's path.
+	for (const DISPLAYCONFIG_PATH_INFO &path : data->paths) {
+		DISPLAYCONFIG_SOURCE_DEVICE_NAME source_name;
+		memset(&source_name, 0, sizeof(source_name));
+		source_name.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SOURCE_NAME;
+		source_name.header.size = sizeof(source_name);
+		source_name.header.adapterId = path.sourceInfo.adapterId;
+		source_name.header.id = path.sourceInfo.id;
+
+		if (DisplayConfigGetDeviceInfo(&source_name.header) != ERROR_SUCCESS) {
+			ERR_PRINT(vformat("Failed to get source name for screen: %d, adapterId: 0x%08X%08X, id: %d", data->screen, (uint32_t)path.sourceInfo.adapterId.HighPart, (uint32_t)path.sourceInfo.adapterId.LowPart, path.sourceInfo.id));
+			continue;
+		}
+
+		if (wcscmp(minfo.szDevice, source_name.viewGdiDeviceName) != 0) {
+			continue;
+		}
+
+		// Query the SDR white level.
+		DISPLAYCONFIG_SDR_WHITE_LEVEL sdr_white_level;
+		memset(&sdr_white_level, 0, sizeof(sdr_white_level));
+		sdr_white_level.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_SDR_WHITE_LEVEL;
+		sdr_white_level.header.size = sizeof(sdr_white_level);
+		sdr_white_level.header.adapterId = path.targetInfo.adapterId;
+		sdr_white_level.header.id = path.targetInfo.id;
+
+		if (DisplayConfigGetDeviceInfo(&sdr_white_level.header) != ERROR_SUCCESS) {
+			ERR_PRINT(vformat("Failed to get SDR white level for screen: %d, adapterId: 0x%08X%08X, id: %d", data->screen, (uint32_t)path.targetInfo.adapterId.HighPart, (uint32_t)path.targetInfo.adapterId.LowPart, path.targetInfo.id));
+			continue;
+		}
+
+		data->sdrWhiteLevelInNits = (float)sdr_white_level.SDRWhiteLevel / 1000.0f * 80.0f;
+	}
+
+	return FALSE;
+}
+
+float DisplayServerWindows::screen_get_sdr_white_level(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	const float default_return = 0.0f;
+	p_screen = _get_screen_index(p_screen);
+	EnumSdrWhiteLevelData data = { Vector<DISPLAYCONFIG_PATH_INFO>(), Vector<DISPLAYCONFIG_MODE_INFO>(), 0, p_screen, default_return };
+
+	uint32_t path_count = 0;
+	uint32_t mode_count = 0;
+
+	if (GetDisplayConfigBufferSizes(QDC_ONLY_ACTIVE_PATHS, &path_count, &mode_count) != ERROR_SUCCESS) {
+		ERR_FAIL_V_MSG(0.0f, "Failed to get display config buffer sizes.");
+	}
+
+	data.paths.resize(path_count);
+	data.modes.resize(mode_count);
+
+	if (QueryDisplayConfig(QDC_ONLY_ACTIVE_PATHS, &path_count, data.paths.ptrw(), &mode_count, data.modes.ptrw(), nullptr) != ERROR_SUCCESS) {
+		ERR_FAIL_V_MSG(0.0f, "Failed to query display config.");
+	}
+
+	EnumDisplayMonitors(nullptr, nullptr, _MonitorEnumProcSdrWhiteLevel, (LPARAM)&data);
+	return data.sdrWhiteLevelInNits;
 }
 
 float DisplayServerWindows::screen_get_refresh_rate(int p_screen) const {
@@ -3114,6 +3336,81 @@ HWND DisplayServerWindows::_find_window_from_process_id(OS::ProcessID p_pid, HWN
 	return NULL;
 }
 
+// Get screen HDR capabilities for internal use only.
+// Do not report values from this method to the user.
+DisplayServerWindows::ScreenHdrData DisplayServerWindows::_get_screen_hdr_data(int p_screen) const {
+	ScreenHdrData data;
+#ifdef D3D12_ENABLED
+	HMONITOR monitor = _get_hmonitor_of_screen(p_screen);
+	DXGI_OUTPUT_DESC1 desc;
+	if (_get_monitor_desc(monitor, desc)) {
+		data.hdr_supported = desc.ColorSpace == DXGI_COLOR_SPACE_RGB_FULL_G2084_NONE_P2020;
+		data.min_luminance = desc.MinLuminance;
+		data.max_luminance = desc.MaxLuminance;
+		data.max_average_luminance = desc.MaxFullFrameLuminance;
+	}
+#else
+	// If we don't have D3D12, assume HDR is supported to avoid blocking Vulkan only builds.
+	data.hdr_supported = true;
+	data.min_luminance = 0.0f;
+	data.max_luminance = 0.0f;
+	data.max_average_luminance = 0.0f;
+#endif // D3D12_ENABLED
+
+	data.sdr_white_level = screen_get_sdr_white_level(p_screen);
+	return data;
+}
+
+void DisplayServerWindows::_update_hdr_output_for_window(WindowID p_window, const WindowData &p_window_data, ScreenHdrData p_screen_data) {
+#ifdef RD_ENABLED
+	if (rendering_context) {
+		bool current_hdr_enabled = rendering_context->window_get_hdr_output_enabled(p_window);
+		bool desired_hdr_enabled = p_window_data.hdr_output_requested && p_screen_data.hdr_supported;
+
+		if (current_hdr_enabled != desired_hdr_enabled) {
+			rendering_context->window_set_hdr_output_enabled(p_window, desired_hdr_enabled);
+		}
+
+		if (p_window_data.hdr_output_auto_adjust_reference_luminance) {
+			if (p_screen_data.sdr_white_level > 0.0f) {
+				rendering_context->window_set_hdr_output_reference_luminance(p_window, p_screen_data.sdr_white_level);
+			} else {
+				// If we failed to get the SDR white level, fallback to the last set value.
+				rendering_context->window_set_hdr_output_reference_luminance(p_window, p_window_data.hdr_output_reference_luminance);
+			}
+		}
+
+		if (p_window_data.hdr_output_auto_adjust_max_luminance) {
+			if (p_screen_data.max_luminance > 0.0f) {
+				rendering_context->window_set_hdr_output_max_luminance(p_window, p_screen_data.max_luminance);
+			} else {
+				// If we failed to get the max luminance, fallback to the last set value.
+				rendering_context->window_set_hdr_output_max_luminance(p_window, p_window_data.hdr_output_max_luminance);
+			}
+		}
+	}
+#endif // RD_ENABLED
+}
+
+void DisplayServerWindows::_update_hdr_output_for_tracked_windows() {
+	HashMap<int, ScreenHdrData> outputs;
+	for (const KeyValue<WindowID, WindowData> &E : windows) {
+		if (E.value.hdr_output_requested) {
+			int screen = window_get_current_screen(E.key);
+
+			ScreenHdrData data;
+			if (!outputs.has(screen)) {
+				data = _get_screen_hdr_data(screen);
+				outputs.insert(screen, data);
+			} else {
+				data = outputs[screen];
+			}
+
+			_update_hdr_output_for_window(E.key, E.value, data);
+		}
+	}
+}
+
 Error DisplayServerWindows::embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) {
 	_THREAD_SAFE_METHOD_
 
@@ -4236,6 +4533,212 @@ DisplayServer::VSyncMode DisplayServerWindows::window_get_vsync_mode(WindowID p_
 	}
 #endif
 	return DisplayServer::VSYNC_ENABLED;
+}
+
+bool DisplayServerWindows::window_is_hdr_output_supported(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+#if defined(RD_ENABLED)
+	if (rendering_device && !rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) {
+		return false; // HDR output is not supported by the rendering device.
+	}
+#endif
+
+	// The window supports HDR if the screen it is on supports HDR.
+	int screen = window_get_current_screen(p_window);
+	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+	return data.hdr_supported;
+}
+
+void DisplayServerWindows::window_set_hdr_output_enabled(const bool p_enabled, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+#if defined(RD_ENABLED)
+	ERR_FAIL_COND_MSG(p_enabled && (rendering_device && rendering_device->has_feature(RenderingDevice::Features::SUPPORTS_HDR_OUTPUT)) == false, "HDR output is not supported by the rendering device.");
+#endif
+
+	WindowData &wd = windows[p_window];
+	wd.hdr_output_requested = p_enabled;
+
+	int screen = window_get_current_screen(p_window);
+	DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+	_update_hdr_output_for_window(p_window, wd, data);
+}
+
+bool DisplayServerWindows::window_is_hdr_output_enabled(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		return rendering_context->window_get_hdr_output_enabled(p_window);
+	}
+#endif
+
+	return false;
+}
+
+void DisplayServerWindows::window_set_hdr_output_prefer_high_precision(const bool p_enabled, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	WindowData &wd = windows[p_window];
+	if (wd.hdr_output_prefer_high_precision == p_enabled) {
+		return; // No change.
+	}
+
+	wd.hdr_output_prefer_high_precision = p_enabled;
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_hdr_output_prefer_high_precision(p_window, p_enabled);
+	}
+#endif
+}
+
+bool DisplayServerWindows::window_is_hdr_output_preferring_high_precision(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	const WindowData &wd = windows[p_window];
+	return wd.hdr_output_prefer_high_precision;
+}
+
+void DisplayServerWindows::window_set_hdr_output_auto_adjust_reference_luminance(const bool p_enabled, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	WindowData &wd = windows[p_window];
+	if (wd.hdr_output_auto_adjust_reference_luminance == p_enabled) {
+		return;
+	}
+
+	wd.hdr_output_auto_adjust_reference_luminance = p_enabled;
+
+	if (wd.hdr_output_auto_adjust_reference_luminance) {
+		int screen = window_get_current_screen(p_window);
+		DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+		_update_hdr_output_for_window(p_window, wd, data);
+	} else {
+		// Apply the previously set reference luminance.
+#if defined(RD_ENABLED)
+		if (rendering_context) {
+			rendering_context->window_set_hdr_output_reference_luminance(p_window, wd.hdr_output_reference_luminance);
+		}
+#endif
+	}
+}
+
+bool DisplayServerWindows::window_is_hdr_output_auto_adjusting_reference_luminance(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	const WindowData &wd = windows[p_window];
+	return wd.hdr_output_auto_adjust_reference_luminance;
+}
+
+void DisplayServerWindows::window_set_hdr_output_reference_luminance(const float p_reference_luminance, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_MSG(p_reference_luminance < 0.0f, "Reference luminance must be non-negative.");
+
+	WindowData &wd = windows[p_window];
+	wd.hdr_output_reference_luminance = p_reference_luminance;
+
+	// If the reference luminance is set to auto-adjust, don't apply it.
+	if (wd.hdr_output_auto_adjust_reference_luminance) {
+		return;
+	}
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_hdr_output_reference_luminance(p_window, p_reference_luminance);
+	}
+#endif
+}
+
+float DisplayServerWindows::window_get_hdr_output_reference_luminance(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		return rendering_context->window_get_hdr_output_reference_luminance(p_window);
+	}
+#endif
+
+	return 0.0f;
+}
+
+void DisplayServerWindows::window_set_hdr_output_auto_adjust_max_luminance(const bool p_enabled, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	WindowData &wd = windows[p_window];
+	if (wd.hdr_output_auto_adjust_max_luminance == p_enabled) {
+		return;
+	}
+
+	wd.hdr_output_auto_adjust_max_luminance = p_enabled;
+
+	if (wd.hdr_output_auto_adjust_max_luminance) {
+		int screen = window_get_current_screen(p_window);
+		DisplayServerWindows::ScreenHdrData data = _get_screen_hdr_data(screen);
+		_update_hdr_output_for_window(p_window, wd, data);
+	} else {
+		// Apply the previously set maximum luminance.
+#if defined(RD_ENABLED)
+		if (rendering_context) {
+			rendering_context->window_set_hdr_output_max_luminance(p_window, wd.hdr_output_max_luminance);
+		}
+#endif
+	}
+}
+
+bool DisplayServerWindows::window_is_hdr_output_auto_adjusting_max_luminance(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+	const WindowData &wd = windows[p_window];
+	return wd.hdr_output_auto_adjust_max_luminance;
+}
+
+void DisplayServerWindows::window_set_hdr_output_max_luminance(const float p_max_luminance, WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_MSG(p_max_luminance < 0.0f, "Maximum luminance must be non-negative.");
+
+	WindowData &wd = windows[p_window];
+	wd.hdr_output_max_luminance = p_max_luminance;
+
+	// If the maximum luminance is set to auto-adjust, don't apply it.
+	if (wd.hdr_output_auto_adjust_max_luminance) {
+		return;
+	}
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		rendering_context->window_set_hdr_output_max_luminance(p_window, p_max_luminance);
+	}
+#endif
+}
+
+float DisplayServerWindows::window_get_hdr_output_max_luminance(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		return rendering_context->window_get_hdr_output_max_luminance(p_window);
+	}
+#endif
+
+	return 0.0f;
+}
+
+float DisplayServerWindows::window_get_hdr_output_max_value(WindowID p_window) const {
+	_THREAD_SAFE_METHOD_
+
+#if defined(RD_ENABLED)
+	if (rendering_context) {
+		if (rendering_context->window_get_hdr_output_enabled(p_window)) {
+			return rendering_context->window_get_hdr_output_max_value(p_window);
+		}
+	}
+#endif
+
+	return 1.0f;
 }
 
 void DisplayServerWindows::window_start_drag(WindowID p_window) {
@@ -5687,6 +6190,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 		} break;
 
+		case WM_DISPLAYCHANGE: {
+			_update_hdr_output_for_tracked_windows();
+		} break;
+
 		case WM_WINDOWPOSCHANGED: {
 			WindowData &window = windows[window_id];
 
@@ -5779,6 +6286,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				if (window.rect_changed_callback.is_valid()) {
 					window.rect_changed_callback.call(Rect2i(window.last_pos.x, window.last_pos.y, window.width, window.height));
 				}
+
+				_update_hdr_output_for_tracked_windows();
 
 				// Update cursor clip region after window rect has changed.
 				if (mouse_mode == MOUSE_MODE_CAPTURED || mouse_mode == MOUSE_MODE_CONFINED || mouse_mode == MOUSE_MODE_CONFINED_HIDDEN) {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -371,6 +371,15 @@ class DisplayServerWindows : public DisplayServer {
 		bool is_popup = false;
 		Rect2i parent_safe_rect;
 
+		// HDR
+		bool hdr_output_requested = false;
+		bool hdr_output_enabled = false;
+		bool hdr_output_prefer_high_precision = false;
+		bool hdr_output_auto_adjust_reference_luminance = false;
+		float hdr_output_reference_luminance = 0.0f;
+		bool hdr_output_auto_adjust_max_luminance = false;
+		float hdr_output_max_luminance = 0.0f;
+
 		bool initialized = false;
 
 		HWND parent_hwnd = 0;
@@ -515,6 +524,17 @@ class DisplayServerWindows : public DisplayServer {
 
 	void initialize_tts() const;
 
+	struct ScreenHdrData {
+		bool hdr_supported = false;
+		float min_luminance = 0.0f;
+		float max_luminance = 0.0f;
+		float max_average_luminance = 0.0f;
+		float sdr_white_level = 0.0f;
+	};
+	ScreenHdrData _get_screen_hdr_data(int p_screen) const;
+	void _update_hdr_output_for_window(WindowID p_window, const WindowData &p_window_data, ScreenHdrData p_screen_data);
+	void _update_hdr_output_for_tracked_windows();
+
 public:
 	LRESULT WndProcFileDialog(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 	LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
@@ -574,6 +594,13 @@ public:
 	virtual Color screen_get_pixel(const Point2i &p_position) const override;
 	virtual Ref<Image> screen_get_image(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Ref<Image> screen_get_image_rect(const Rect2i &p_rect) const override;
+
+	// Display capabilities for HDR.
+	virtual bool screen_is_hdr_supported(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_min_luminance(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_max_luminance(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_max_full_frame_luminance(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_sdr_white_level(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	virtual void screen_set_keep_on(bool p_enable) override; //disable screensaver
 	virtual bool screen_is_kept_on() const override;
@@ -659,6 +686,24 @@ public:
 
 	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
+
+	virtual bool window_is_hdr_output_supported(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_hdr_output_enabled(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_is_hdr_output_enabled(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_hdr_output_prefer_high_precision(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_is_hdr_output_preferring_high_precision(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_hdr_output_auto_adjust_reference_luminance(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_is_hdr_output_auto_adjusting_reference_luminance(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_hdr_output_reference_luminance(const float p_reference_luminance, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual float window_get_hdr_output_reference_luminance(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual void window_set_hdr_output_auto_adjust_max_luminance(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual bool window_is_hdr_output_auto_adjusting_max_luminance(WindowID p_window = MAIN_WINDOW_ID) const override;
+	virtual void window_set_hdr_output_max_luminance(const float p_max_luminance, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual float window_get_hdr_output_max_luminance(WindowID p_window = MAIN_WINDOW_ID) const override;
+
+	virtual float window_get_hdr_output_max_value(WindowID p_window = MAIN_WINDOW_ID) const override;
 
 	virtual void window_start_drag(WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_start_resize(WindowResizeEdge p_edge, WindowID p_window = MAIN_WINDOW_ID) override;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2067,6 +2067,9 @@ SceneTree::SceneTree() {
 	const bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
 	root->set_use_hdr_2d(use_hdr_2d);
 
+	const bool tonemap_to_window = GLOBAL_DEF("rendering/viewport/tonemap_to_window", true);
+	root->set_tonemap_to_window(tonemap_to_window);
+
 	const int ssaa_mode = GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "rendering/anti_aliasing/quality/screen_space_aa", PROPERTY_HINT_ENUM, "Disabled (Fastest),FXAA (Fast),SMAA (Average)"), 0);
 	root->set_screen_space_aa(Viewport::ScreenSpaceAA(ssaa_mode));
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1287,6 +1287,17 @@ bool Viewport::is_using_hdr_2d() const {
 	return use_hdr_2d;
 }
 
+void Viewport::set_tonemap_to_window(bool p_enable) {
+	ERR_MAIN_THREAD_GUARD;
+	tonemap_to_window = p_enable;
+	RS::get_singleton()->viewport_set_tonemap_to_screen(viewport, p_enable);
+}
+
+bool Viewport::is_tonemapping_to_window() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return tonemap_to_window;
+}
+
 void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 	ERR_MAIN_THREAD_GUARD;
 	if (world_2d == p_world_2d) {
@@ -4947,6 +4958,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_hdr_2d", "enable"), &Viewport::set_use_hdr_2d);
 	ClassDB::bind_method(D_METHOD("is_using_hdr_2d"), &Viewport::is_using_hdr_2d);
 
+	ClassDB::bind_method(D_METHOD("set_tonemap_to_window", "enable"), &Viewport::set_tonemap_to_window);
+	ClassDB::bind_method(D_METHOD("is_tonemapping_to_window"), &Viewport::is_tonemapping_to_window);
+
 	ClassDB::bind_method(D_METHOD("set_msaa_2d", "msaa"), &Viewport::set_msaa_2d);
 	ClassDB::bind_method(D_METHOD("get_msaa_2d"), &Viewport::get_msaa_2d);
 
@@ -5139,6 +5153,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mesh_lod_threshold", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_mesh_lod_threshold", "get_mesh_lod_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_draw", PROPERTY_HINT_ENUM, "Disabled,Unshaded,Lighting,Overdraw,Wireframe,Normal Buffer,VoxelGI Albedo,VoxelGI Lighting,VoxelGI Emission,Shadow Atlas,Directional Shadow Map,Scene Luminance,SSAO,SSIL,Directional Shadow Splits,Decal Atlas,SDFGI Cascades,SDFGI Probes,VoxelGI/SDFGI Buffer,Disable Mesh LOD,OmniLight3D Cluster,SpotLight3D Cluster,Decal Cluster,ReflectionProbe Cluster,Occlusion Culling Buffer,Motion Vectors,Internal Buffer"), "set_debug_draw", "get_debug_draw");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hdr_2d"), "set_use_hdr_2d", "is_using_hdr_2d");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tonemap_to_window"), "set_tonemap_to_window", "is_tonemapping_to_window");
 
 #ifndef _3D_DISABLED
 	ADD_GROUP("Scaling 3D", "");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -268,6 +268,7 @@ private:
 	bool transparent_bg = false;
 	bool use_hdr_2d = false;
 	bool gen_mipmaps = false;
+	bool tonemap_to_window = false;
 
 	bool snap_controls_to_pixels = true;
 	bool snap_2d_transforms_to_pixel = false;
@@ -555,6 +556,9 @@ public:
 
 	void set_use_hdr_2d(bool p_enable);
 	bool is_using_hdr_2d() const;
+
+	void set_tonemap_to_window(bool p_enable);
+	bool is_tonemapping_to_window() const;
 
 	Ref<ViewportTexture> get_texture() const;
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -570,6 +570,148 @@ bool Window::get_flag(Flags p_flag) const {
 	return flags[p_flag];
 }
 
+bool Window::is_hdr_output_supported() const {
+	ERR_READ_THREAD_GUARD_V(false);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		return DisplayServer::get_singleton()->window_is_hdr_output_supported(window_id);
+	}
+
+	return false;
+}
+
+void Window::set_hdr_output_enabled(bool p_enabled) {
+	ERR_MAIN_THREAD_GUARD;
+
+	hdr_output_enabled = p_enabled;
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_hdr_output_enabled(hdr_output_enabled, window_id);
+	}
+
+	_update_viewport_for_hdr_output();
+}
+
+bool Window::is_hdr_output_enabled() const {
+	ERR_READ_THREAD_GUARD_V(false);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		hdr_output_enabled = DisplayServer::get_singleton()->window_is_hdr_output_enabled(window_id);
+	}
+
+	return hdr_output_enabled;
+}
+
+void Window::set_hdr_output_prefer_high_precision(bool p_enabled) {
+	ERR_MAIN_THREAD_GUARD;
+
+	hdr_output_prefer_high_precision = p_enabled;
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_hdr_output_prefer_high_precision(hdr_output_prefer_high_precision, window_id);
+	}
+}
+
+bool Window::is_hdr_output_preferring_high_precision() const {
+	ERR_READ_THREAD_GUARD_V(false);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		hdr_output_prefer_high_precision = DisplayServer::get_singleton()->window_is_hdr_output_preferring_high_precision(window_id);
+	}
+
+	return hdr_output_prefer_high_precision;
+}
+
+void Window::set_hdr_output_auto_adjust_reference_luminance(bool p_enabled) {
+	ERR_MAIN_THREAD_GUARD;
+
+	hdr_output_auto_adjust_reference_luminance = p_enabled;
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_reference_luminance(hdr_output_auto_adjust_reference_luminance, window_id);
+	}
+}
+
+bool Window::is_hdr_output_auto_adjusting_reference_luminance() const {
+	ERR_READ_THREAD_GUARD_V(false);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		hdr_output_auto_adjust_reference_luminance = DisplayServer::get_singleton()->window_is_hdr_output_auto_adjusting_reference_luminance(window_id);
+	}
+
+	return hdr_output_auto_adjust_reference_luminance;
+}
+
+void Window::set_hdr_output_reference_luminance(float p_reference_luminance) {
+	ERR_MAIN_THREAD_GUARD;
+
+	hdr_output_reference_luminance = p_reference_luminance;
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_hdr_output_reference_luminance(hdr_output_reference_luminance, window_id);
+	}
+}
+
+float Window::get_hdr_output_reference_luminance() const {
+	ERR_READ_THREAD_GUARD_V(0.0f);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		hdr_output_reference_luminance = DisplayServer::get_singleton()->window_get_hdr_output_reference_luminance(window_id);
+	}
+
+	return hdr_output_reference_luminance;
+}
+
+void Window::set_hdr_output_auto_adjust_max_luminance(bool p_enabled) {
+	ERR_MAIN_THREAD_GUARD;
+
+	hdr_output_auto_adjust_max_luminance = p_enabled;
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_max_luminance(hdr_output_auto_adjust_max_luminance, window_id);
+	}
+}
+
+bool Window::is_hdr_output_auto_adjusting_max_luminance() const {
+	ERR_READ_THREAD_GUARD_V(false);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		hdr_output_auto_adjust_max_luminance = DisplayServer::get_singleton()->window_is_hdr_output_auto_adjusting_max_luminance(window_id);
+	}
+
+	return hdr_output_auto_adjust_max_luminance;
+}
+
+void Window::set_hdr_output_max_luminance(float p_max_luminance) {
+	ERR_MAIN_THREAD_GUARD;
+
+	hdr_output_max_luminance = p_max_luminance;
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_hdr_output_max_luminance(hdr_output_max_luminance, window_id);
+	}
+}
+
+float Window::get_hdr_output_max_luminance() const {
+	ERR_READ_THREAD_GUARD_V(0.0f);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		hdr_output_max_luminance = DisplayServer::get_singleton()->window_get_hdr_output_max_luminance(window_id);
+	}
+
+	return hdr_output_max_luminance;
+}
+
+float Window::get_hdr_output_max_value() const {
+	ERR_READ_THREAD_GUARD_V(1.0f);
+
+	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		return DisplayServer::get_singleton()->window_get_hdr_output_max_value(window_id);
+	}
+
+	return 1.0f;
+}
+
 bool Window::is_maximize_allowed() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
@@ -669,6 +811,16 @@ void Window::_make_window() {
 	DisplayServer::get_singleton()->window_set_mouse_passthrough(mpath, window_id);
 	DisplayServer::get_singleton()->window_set_title(displayed_title, window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
+
+	// Set HDR output settings.
+	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_HDR) && RD::get_singleton() && RD::get_singleton()->has_feature(RD::Features::SUPPORTS_HDR_OUTPUT)) {
+		DisplayServer::get_singleton()->window_set_hdr_output_enabled(hdr_output_enabled, window_id);
+		DisplayServer::get_singleton()->window_set_hdr_output_prefer_high_precision(hdr_output_prefer_high_precision, window_id);
+		DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_reference_luminance(hdr_output_auto_adjust_reference_luminance, window_id);
+		DisplayServer::get_singleton()->window_set_hdr_output_reference_luminance(hdr_output_reference_luminance, window_id);
+		DisplayServer::get_singleton()->window_set_hdr_output_auto_adjust_max_luminance(hdr_output_auto_adjust_max_luminance, window_id);
+		DisplayServer::get_singleton()->window_set_hdr_output_max_luminance(hdr_output_max_luminance, window_id);
+	}
 
 	_update_window_size();
 
@@ -952,6 +1104,13 @@ void Window::set_visible(bool p_visible) {
 			embedder->_sub_window_register(this);
 			embedder->queue_accessibility_update();
 			RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_PARENT_VISIBLE);
+
+			// Make sure the sub-window shares the HDR output settings of the embedder.
+			Window *containing_window = embedder->get_window();
+			if (containing_window) {
+				hdr_output_enabled = containing_window->is_hdr_output_enabled();
+				_update_viewport_for_hdr_output();
+			}
 		} else {
 			embedder->_sub_window_remove(this);
 			embedder->queue_accessibility_update();
@@ -1517,6 +1676,17 @@ void Window::_notification(int p_what) {
 						size = DisplayServer::get_singleton()->window_get_size(window_id);
 						focused = DisplayServer::get_singleton()->window_is_focused(window_id);
 					}
+					// Update HDR settings to reflect the current state of the window.
+					{
+						hdr_output_enabled = DisplayServer::get_singleton()->window_is_hdr_output_enabled(window_id);
+						hdr_output_prefer_high_precision = DisplayServer::get_singleton()->window_is_hdr_output_preferring_high_precision(window_id);
+						hdr_output_auto_adjust_reference_luminance = DisplayServer::get_singleton()->window_is_hdr_output_auto_adjusting_reference_luminance(window_id);
+						hdr_output_reference_luminance = DisplayServer::get_singleton()->window_get_hdr_output_reference_luminance(window_id);
+						hdr_output_auto_adjust_max_luminance = DisplayServer::get_singleton()->window_is_hdr_output_auto_adjusting_max_luminance(window_id);
+						hdr_output_max_luminance = DisplayServer::get_singleton()->window_get_hdr_output_max_luminance(window_id);
+
+						_update_viewport_for_hdr_output();
+					}
 					_update_window_size(); // Inform DisplayServer of minimum and maximum size.
 					_update_viewport_size(); // Then feed back to the viewport.
 					_update_window_callbacks();
@@ -1760,6 +1930,16 @@ void Window::child_controls_changed() {
 
 	updating_child_controls = true;
 	callable_mp(this, &Window::_update_child_controls).call_deferred();
+}
+
+void Window::_update_viewport_for_hdr_output() {
+	// If HDR output is enabled, we need to enable HDR 2D rendering as well.
+	// This is required to get the correct dynamic range for the final output.
+	// We only need to do this if the viewport is not already set up for HDR 2D rendering.
+
+	if (!is_using_hdr_2d()) {
+		RS::get_singleton()->viewport_set_use_hdr_2d(viewport, hdr_output_enabled);
+	}
 }
 
 void Window::_update_child_controls() {
@@ -3129,6 +3309,28 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_flag", "flag", "enabled"), &Window::set_flag);
 	ClassDB::bind_method(D_METHOD("get_flag", "flag"), &Window::get_flag);
 
+	ClassDB::bind_method(D_METHOD("is_hdr_output_supported"), &Window::is_hdr_output_supported);
+
+	ClassDB::bind_method(D_METHOD("set_hdr_output_enabled", "enabled"), &Window::set_hdr_output_enabled);
+	ClassDB::bind_method(D_METHOD("is_hdr_output_enabled"), &Window::is_hdr_output_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_hdr_output_prefer_high_precision", "enabled"), &Window::set_hdr_output_prefer_high_precision);
+	ClassDB::bind_method(D_METHOD("is_hdr_output_preferring_high_precision"), &Window::is_hdr_output_preferring_high_precision);
+
+	ClassDB::bind_method(D_METHOD("set_hdr_output_auto_adjust_reference_luminance", "enabled"), &Window::set_hdr_output_auto_adjust_reference_luminance);
+	ClassDB::bind_method(D_METHOD("is_hdr_output_auto_adjusting_reference_luminance"), &Window::is_hdr_output_auto_adjusting_reference_luminance);
+
+	ClassDB::bind_method(D_METHOD("set_hdr_output_reference_luminance", "reference_luminance"), &Window::set_hdr_output_reference_luminance);
+	ClassDB::bind_method(D_METHOD("get_hdr_output_reference_luminance"), &Window::get_hdr_output_reference_luminance);
+
+	ClassDB::bind_method(D_METHOD("set_hdr_output_auto_adjust_max_luminance", "enabled"), &Window::set_hdr_output_auto_adjust_max_luminance);
+	ClassDB::bind_method(D_METHOD("is_hdr_output_auto_adjusting_max_luminance"), &Window::is_hdr_output_auto_adjusting_max_luminance);
+
+	ClassDB::bind_method(D_METHOD("set_hdr_output_max_luminance", "max_luminance"), &Window::set_hdr_output_max_luminance);
+	ClassDB::bind_method(D_METHOD("get_hdr_output_max_luminance"), &Window::get_hdr_output_max_luminance);
+
+	ClassDB::bind_method(D_METHOD("get_hdr_output_max_value"), &Window::get_hdr_output_max_value);
+
 	ClassDB::bind_method(D_METHOD("is_maximize_allowed"), &Window::is_maximize_allowed);
 
 	ClassDB::bind_method(D_METHOD("request_attention"), &Window::request_attention);
@@ -3323,6 +3525,14 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "content_scale_stretch", PROPERTY_HINT_ENUM, "Fractional,Integer"), "set_content_scale_stretch", "get_content_scale_stretch");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "content_scale_factor", PROPERTY_HINT_RANGE, "0.5,8.0,0.01"), "set_content_scale_factor", "get_content_scale_factor");
 
+	ADD_GROUP("HDR Output", "hdr_output_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr_output_enabled"), "set_hdr_output_enabled", "is_hdr_output_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr_output_prefer_high_precision"), "set_hdr_output_prefer_high_precision", "is_hdr_output_preferring_high_precision");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr_output_auto_adjust_reference_luminance"), "set_hdr_output_auto_adjust_reference_luminance", "is_hdr_output_auto_adjusting_reference_luminance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hdr_output_reference_luminance", PROPERTY_HINT_RANGE, "0,2000,1,or_greater"), "set_hdr_output_reference_luminance", "get_hdr_output_reference_luminance");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hdr_output_auto_adjust_max_luminance"), "set_hdr_output_auto_adjust_max_luminance", "is_hdr_output_auto_adjusting_max_luminance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "hdr_output_max_luminance", PROPERTY_HINT_RANGE, "0,2000,1,or_greater"), "set_hdr_output_max_luminance", "get_hdr_output_max_luminance");
+
 #ifndef DISABLE_DEPRECATED
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_auto_translate", "is_auto_translating");
 #endif
@@ -3433,6 +3643,10 @@ Window::Window() {
 
 	theme_owner = memnew(ThemeOwner(this));
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_DISABLED);
+
+	// Tonemap the root viewport of this window by default.
+	tonemap_to_window = true;
+	RS::get_singleton()->viewport_set_tonemap_to_screen(get_viewport_rid(), tonemap_to_window);
 }
 
 Window::~Window() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -134,6 +134,15 @@ private:
 	WindowInitialPosition initial_position = WINDOW_INITIAL_POSITION_ABSOLUTE;
 	bool force_native = false;
 
+	mutable bool hdr_output_enabled = false;
+	mutable bool hdr_output_prefer_high_precision = false;
+	mutable bool hdr_output_auto_adjust_reference_luminance = false;
+	mutable float hdr_output_reference_luminance = 200.0f; // BT.2408 recommendation of 203 nits for HDR Reference White, rounded to 200 to be a more pleasant player-facing value.
+	mutable bool hdr_output_auto_adjust_max_luminance = false;
+	mutable float hdr_output_max_luminance = 1000.0f;
+
+	void _update_viewport_for_hdr_output();
+
 	bool transient = false;
 	bool transient_to_focused = false;
 	bool exclusive = false;
@@ -331,6 +340,28 @@ public:
 
 	void set_flag(Flags p_flag, bool p_enabled);
 	bool get_flag(Flags p_flag) const;
+
+	bool is_hdr_output_supported() const;
+
+	void set_hdr_output_enabled(bool p_enabled);
+	bool is_hdr_output_enabled() const;
+
+	void set_hdr_output_prefer_high_precision(bool p_enabled);
+	bool is_hdr_output_preferring_high_precision() const;
+
+	void set_hdr_output_auto_adjust_reference_luminance(bool p_enabled);
+	bool is_hdr_output_auto_adjusting_reference_luminance() const;
+
+	void set_hdr_output_reference_luminance(float p_reference_luminance);
+	float get_hdr_output_reference_luminance() const;
+
+	void set_hdr_output_auto_adjust_max_luminance(bool p_enabled);
+	bool is_hdr_output_auto_adjusting_max_luminance() const;
+
+	void set_hdr_output_max_luminance(float p_max_luminance);
+	float get_hdr_output_max_luminance() const;
+
+	float get_hdr_output_max_value() const;
 
 	bool is_maximize_allowed() const;
 

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -227,12 +227,32 @@ float Environment::get_tonemap_white() const {
 	return tonemap_white;
 }
 
+void Environment::set_tonemap_black(float p_black) {
+	tonemap_black = p_black;
+	_update_tonemap();
+}
+
+float Environment::get_tonemap_black() const {
+	return tonemap_black;
+}
+
+void Environment::set_tonemap_contrast(float p_contrast) {
+	tonemap_contrast = p_contrast;
+	_update_tonemap();
+}
+
+float Environment::get_tonemap_contrast() const {
+	return tonemap_contrast;
+}
+
 void Environment::_update_tonemap() {
 	RS::get_singleton()->environment_set_tonemap(
 			environment,
 			RS::EnvironmentToneMapper(tone_mapper),
 			tonemap_exposure,
-			tonemap_white);
+			tonemap_white,
+			tonemap_black,
+			tonemap_contrast);
 }
 
 // SSR
@@ -1115,8 +1135,15 @@ void Environment::_validate_property(PropertyInfo &p_property) const {
 		}
 	}
 
-	if (p_property.name == "tonemap_white" && (tone_mapper == TONE_MAPPER_LINEAR || tone_mapper == TONE_MAPPER_AGX)) {
-		// Whitepoint adjustment is not available with AgX or linear as it's hardcoded there.
+	if (p_property.name == "tonemap_white" && tone_mapper == TONE_MAPPER_LINEAR) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	if (p_property.name == "tonemap_black" && (tone_mapper == TONE_MAPPER_LINEAR)) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+
+	if (p_property.name == "tonemap_contrast" && tone_mapper != TONE_MAPPER_AGX && tone_mapper != TONE_MAPPER_ADJUSTABLE) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
@@ -1243,11 +1270,17 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tonemap_exposure"), &Environment::get_tonemap_exposure);
 	ClassDB::bind_method(D_METHOD("set_tonemap_white", "white"), &Environment::set_tonemap_white);
 	ClassDB::bind_method(D_METHOD("get_tonemap_white"), &Environment::get_tonemap_white);
+	ClassDB::bind_method(D_METHOD("set_tonemap_black", "black"), &Environment::set_tonemap_black);
+	ClassDB::bind_method(D_METHOD("get_tonemap_black"), &Environment::get_tonemap_black);
+	ClassDB::bind_method(D_METHOD("set_tonemap_contrast", "contrast"), &Environment::set_tonemap_contrast);
+	ClassDB::bind_method(D_METHOD("get_tonemap_contrast"), &Environment::get_tonemap_contrast);
 
 	ADD_GROUP("Tonemap", "tonemap_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "tonemap_mode", PROPERTY_HINT_ENUM, "Linear,Reinhard,Filmic,ACES,AgX"), "set_tonemapper", "get_tonemapper");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "tonemap_mode", PROPERTY_HINT_ENUM, "Linear,Reinhard,Filmic,ACES,AgX,Adjustable"), "set_tonemapper", "get_tonemapper");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_exposure", "get_tonemap_exposure");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_white", "get_tonemap_white");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "0.01,16,0.01"), "set_tonemap_white", "get_tonemap_white");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_black", PROPERTY_HINT_RANGE, "0.0,0.15,0.001"), "set_tonemap_black", "get_tonemap_black");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_contrast", PROPERTY_HINT_RANGE, "1.0,5,0.01"), "set_tonemap_contrast", "get_tonemap_contrast");
 
 	// SSR
 
@@ -1551,6 +1584,7 @@ void Environment::_bind_methods() {
 	BIND_ENUM_CONSTANT(TONE_MAPPER_FILMIC);
 	BIND_ENUM_CONSTANT(TONE_MAPPER_ACES);
 	BIND_ENUM_CONSTANT(TONE_MAPPER_AGX);
+	BIND_ENUM_CONSTANT(TONE_MAPPER_ADJUSTABLE);
 
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_ADDITIVE);
 	BIND_ENUM_CONSTANT(GLOW_BLEND_MODE_SCREEN);

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -67,6 +67,7 @@ public:
 		TONE_MAPPER_FILMIC,
 		TONE_MAPPER_ACES,
 		TONE_MAPPER_AGX,
+		TONE_MAPPER_ADJUSTABLE,
 	};
 
 	enum SDFGIYScale {
@@ -114,7 +115,9 @@ private:
 	// Tonemap
 	ToneMapper tone_mapper = TONE_MAPPER_LINEAR;
 	float tonemap_exposure = 1.0;
+	float tonemap_black = 0.0;
 	float tonemap_white = 1.0;
+	float tonemap_contrast = 1.25; // Default to approximately Blender's AgX contrast
 	void _update_tonemap();
 
 	// SSR
@@ -271,6 +274,10 @@ public:
 	float get_tonemap_exposure() const;
 	void set_tonemap_white(float p_white);
 	float get_tonemap_white() const;
+	void set_tonemap_black(float p_black);
+	float get_tonemap_black() const;
+	void set_tonemap_contrast(float p_contrast);
+	float get_tonemap_contrast() const;
 
 	// SSR
 	void set_ssr_enabled(bool p_enabled);

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1267,6 +1267,62 @@ DisplayServer::VSyncMode DisplayServer::window_get_vsync_mode(WindowID p_window)
 	return VSyncMode::VSYNC_ENABLED;
 }
 
+bool DisplayServer::window_is_hdr_output_supported(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServer::window_set_hdr_output_enabled(const bool p_enabled, WindowID p_window) {
+	WARN_PRINT("HDR output is not supported by this display server.");
+}
+
+bool DisplayServer::window_is_hdr_output_enabled(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServer::window_set_hdr_output_prefer_high_precision(const bool p_enabled, WindowID p_window) {
+	WARN_PRINT("HDR output is not supported by this display server.");
+}
+
+bool DisplayServer::window_is_hdr_output_preferring_high_precision(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServer::window_set_hdr_output_auto_adjust_reference_luminance(const bool p_enabled, WindowID p_window) {
+	WARN_PRINT("HDR output is not supported by this display server.");
+}
+
+bool DisplayServer::window_is_hdr_output_auto_adjusting_reference_luminance(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServer::window_set_hdr_output_reference_luminance(const float p_reference_luminance, WindowID p_window) {
+	WARN_PRINT("HDR output is not supported by this display server.");
+}
+
+float DisplayServer::window_get_hdr_output_reference_luminance(WindowID p_window) const {
+	return 0.0f;
+}
+
+void DisplayServer::window_set_hdr_output_auto_adjust_max_luminance(const bool p_enabled, WindowID p_window) {
+	WARN_PRINT("HDR output is not supported by this display server.");
+}
+
+bool DisplayServer::window_is_hdr_output_auto_adjusting_max_luminance(WindowID p_window) const {
+	return false;
+}
+
+void DisplayServer::window_set_hdr_output_max_luminance(const float p_max_luminance, WindowID p_window) {
+	WARN_PRINT("HDR output is not supported by this display server.");
+}
+
+float DisplayServer::window_get_hdr_output_max_luminance(WindowID p_window) const {
+	return 0.0f;
+}
+
+float DisplayServer::window_get_hdr_output_max_value(WindowID p_window) const {
+	return 1.0f;
+}
+
 DisplayServer::WindowID DisplayServer::get_focused_window() const {
 	return MAIN_WINDOW_ID; // Proper value for single windows.
 }
@@ -1402,6 +1458,12 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("screen_get_image", "screen"), &DisplayServer::screen_get_image, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_image_rect", "rect"), &DisplayServer::screen_get_image_rect);
 
+	ClassDB::bind_method(D_METHOD("screen_is_hdr_supported", "screen"), &DisplayServer::screen_is_hdr_supported, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_min_luminance", "screen"), &DisplayServer::screen_get_min_luminance, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_max_luminance", "screen"), &DisplayServer::screen_get_max_luminance, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_max_full_frame_luminance", "screen"), &DisplayServer::screen_get_max_full_frame_luminance, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+	ClassDB::bind_method(D_METHOD("screen_get_sdr_white_level", "screen"), &DisplayServer::screen_get_sdr_white_level, DEFVAL(SCREEN_OF_MAIN_WINDOW));
+
 	ClassDB::bind_method(D_METHOD("screen_set_orientation", "orientation", "screen"), &DisplayServer::screen_set_orientation, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 	ClassDB::bind_method(D_METHOD("screen_get_orientation", "screen"), &DisplayServer::screen_get_orientation, DEFVAL(SCREEN_OF_MAIN_WINDOW));
 
@@ -1468,6 +1530,24 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("window_set_vsync_mode", "vsync_mode", "window_id"), &DisplayServer::window_set_vsync_mode, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_get_vsync_mode", "window_id"), &DisplayServer::window_get_vsync_mode, DEFVAL(MAIN_WINDOW_ID));
+
+	ClassDB::bind_method(D_METHOD("window_is_hdr_output_supported", "window_id"), &DisplayServer::window_is_hdr_output_supported, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_hdr_output_enabled", "enabled", "window_id"), &DisplayServer::window_set_hdr_output_enabled, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_is_hdr_output_enabled", "window_id"), &DisplayServer::window_is_hdr_output_enabled, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_hdr_output_prefer_high_precision", "enabled", "window_id"), &DisplayServer::window_set_hdr_output_prefer_high_precision, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_is_hdr_output_preferring_high_precision", "window_id"), &DisplayServer::window_is_hdr_output_preferring_high_precision, DEFVAL(MAIN_WINDOW_ID));
+
+	ClassDB::bind_method(D_METHOD("window_set_hdr_output_auto_adjust_reference_luminance", "enabled", "window_id"), &DisplayServer::window_set_hdr_output_auto_adjust_reference_luminance, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_is_hdr_output_auto_adjusting_reference_luminance", "window_id"), &DisplayServer::window_is_hdr_output_auto_adjusting_reference_luminance, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_hdr_output_reference_luminance", "reference_luminance", "window_id"), &DisplayServer::window_set_hdr_output_reference_luminance, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_get_hdr_output_reference_luminance", "window_id"), &DisplayServer::window_get_hdr_output_reference_luminance, DEFVAL(MAIN_WINDOW_ID));
+
+	ClassDB::bind_method(D_METHOD("window_set_hdr_output_auto_adjust_max_luminance", "enabled", "window_id"), &DisplayServer::window_set_hdr_output_auto_adjust_max_luminance, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_is_hdr_output_auto_adjusting_max_luminance", "window_id"), &DisplayServer::window_is_hdr_output_auto_adjusting_max_luminance, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_set_hdr_output_max_luminance", "max_luminance", "window_id"), &DisplayServer::window_set_hdr_output_max_luminance, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_get_hdr_output_max_luminance", "window_id"), &DisplayServer::window_get_hdr_output_max_luminance, DEFVAL(MAIN_WINDOW_ID));
+
+	ClassDB::bind_method(D_METHOD("window_get_hdr_output_max_value", "window_id"), &DisplayServer::window_get_hdr_output_max_value, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_is_maximize_allowed", "window_id"), &DisplayServer::window_is_maximize_allowed, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_maximize_on_title_dbl_click"), &DisplayServer::window_maximize_on_title_dbl_click);
@@ -1657,6 +1737,7 @@ void DisplayServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEATURE_NATIVE_COLOR_PICKER);
 	BIND_ENUM_CONSTANT(FEATURE_SELF_FITTING_WINDOWS);
 	BIND_ENUM_CONSTANT(FEATURE_ACCESSIBILITY_SCREEN_READER);
+	BIND_ENUM_CONSTANT(FEATURE_HDR);
 
 	BIND_ENUM_CONSTANT(ROLE_UNKNOWN);
 	BIND_ENUM_CONSTANT(ROLE_DEFAULT_BUTTON);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -169,6 +169,7 @@ public:
 		FEATURE_NATIVE_COLOR_PICKER,
 		FEATURE_SELF_FITTING_WINDOWS,
 		FEATURE_ACCESSIBILITY_SCREEN_READER,
+		FEATURE_HDR,
 	};
 
 	virtual bool has_feature(Feature p_feature) const = 0;
@@ -371,6 +372,13 @@ public:
 	virtual Ref<Image> screen_get_image_rect(const Rect2i &p_rect) const { return Ref<Image>(); }
 	virtual bool is_touchscreen_available() const;
 
+	// Display capabilities for HDR.
+	virtual bool screen_is_hdr_supported(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return false; }
+	virtual float screen_get_min_luminance(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return 0.0f; }
+	virtual float screen_get_max_luminance(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return 0.0f; }
+	virtual float screen_get_max_full_frame_luminance(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return 0.0f; }
+	virtual float screen_get_sdr_white_level(int p_screen = SCREEN_OF_MAIN_WINDOW) const { return 0.0f; }
+
 	// Keep the ScreenOrientation enum values in sync with the `display/window/handheld/orientation`
 	// project setting hint.
 	enum ScreenOrientation {
@@ -498,6 +506,24 @@ public:
 
 	virtual void window_set_vsync_mode(VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID);
 	virtual VSyncMode window_get_vsync_mode(WindowID p_window) const;
+
+	virtual bool window_is_hdr_output_supported(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_hdr_output_enabled(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID);
+	virtual bool window_is_hdr_output_enabled(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_hdr_output_prefer_high_precision(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID);
+	virtual bool window_is_hdr_output_preferring_high_precision(WindowID p_window = MAIN_WINDOW_ID) const;
+
+	virtual void window_set_hdr_output_auto_adjust_reference_luminance(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID);
+	virtual bool window_is_hdr_output_auto_adjusting_reference_luminance(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_hdr_output_reference_luminance(const float p_reference_luminance, WindowID p_window = MAIN_WINDOW_ID);
+	virtual float window_get_hdr_output_reference_luminance(WindowID p_window = MAIN_WINDOW_ID) const;
+
+	virtual void window_set_hdr_output_auto_adjust_max_luminance(const bool p_enabled, WindowID p_window = MAIN_WINDOW_ID);
+	virtual bool window_is_hdr_output_auto_adjusting_max_luminance(WindowID p_window = MAIN_WINDOW_ID) const;
+	virtual void window_set_hdr_output_max_luminance(const float p_max_luminance, WindowID p_window = MAIN_WINDOW_ID);
+	virtual float window_get_hdr_output_max_luminance(WindowID p_window = MAIN_WINDOW_ID) const;
+
+	virtual float window_get_hdr_output_max_value(WindowID p_window = MAIN_WINDOW_ID) const;
 
 	virtual bool window_is_maximize_allowed(WindowID p_window = MAIN_WINDOW_ID) const = 0;
 

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -119,6 +119,7 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	tonemap.push_constant.white = p_settings.white;
 	tonemap.push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
 	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
+	tonemap.push_constant.output_max_value = MAX(p_settings.max_value, 1.0f);
 
 	tonemap.push_constant.flags |= p_settings.use_color_correction ? TONEMAP_FLAG_USE_COLOR_CORRECTION : 0;
 
@@ -209,6 +210,7 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	tonemap.push_constant.exposure = p_settings.exposure;
 	tonemap.push_constant.white = p_settings.white;
 	tonemap.push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
+	tonemap.push_constant.output_max_value = MAX(p_settings.max_value, 1.0f);
 
 	tonemap.push_constant.flags |= p_settings.use_color_correction ? TONEMAP_FLAG_USE_COLOR_CORRECTION : 0;
 	if (p_settings.debanding_mode == TonemapSettings::DEBANDING_MODE_8_BIT) {

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -114,9 +114,16 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 	}
 
 	tonemap.push_constant.tonemapper = p_settings.tonemap_mode;
+	tonemap.push_constant.tonemap_black = p_settings.tonemap_black;
+	tonemap.push_constant.tonemap_a = p_settings.tonemap_a;
+	tonemap.push_constant.tonemap_b = p_settings.tonemap_b;
+	tonemap.push_constant.tonemap_c = p_settings.tonemap_c;
+	tonemap.push_constant.tonemap_d = p_settings.tonemap_d;
+	tonemap.push_constant.tonemap_e = p_settings.tonemap_e;
+	tonemap.push_constant.tonemap_f = p_settings.tonemap_f;
+	tonemap.push_constant.tonemap_g = p_settings.tonemap_g;
 	tonemap.push_constant.flags |= p_settings.use_auto_exposure ? TONEMAP_FLAG_USE_AUTO_EXPOSURE : 0;
 	tonemap.push_constant.exposure = p_settings.exposure;
-	tonemap.push_constant.white = p_settings.white;
 	tonemap.push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
 	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
 	tonemap.push_constant.output_max_value = MAX(p_settings.max_value, 1.0f);
@@ -206,9 +213,16 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	}
 
 	tonemap.push_constant.tonemapper = p_settings.tonemap_mode;
+	tonemap.push_constant.tonemap_black = p_settings.tonemap_black;
+	tonemap.push_constant.tonemap_a = p_settings.tonemap_a;
+	tonemap.push_constant.tonemap_b = p_settings.tonemap_b;
+	tonemap.push_constant.tonemap_c = p_settings.tonemap_c;
+	tonemap.push_constant.tonemap_d = p_settings.tonemap_d;
+	tonemap.push_constant.tonemap_e = p_settings.tonemap_e;
+	tonemap.push_constant.tonemap_f = p_settings.tonemap_f;
+	tonemap.push_constant.tonemap_g = p_settings.tonemap_g;
 	tonemap.push_constant.flags |= p_settings.use_auto_exposure ? TONEMAP_FLAG_USE_AUTO_EXPOSURE : 0;
 	tonemap.push_constant.exposure = p_settings.exposure;
-	tonemap.push_constant.white = p_settings.white;
 	tonemap.push_constant.auto_exposure_scale = p_settings.auto_exposure_scale;
 	tonemap.push_constant.output_max_value = MAX(p_settings.max_value, 1.0f);
 

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -70,26 +70,32 @@ private:
 
 	struct TonemapPushConstant {
 		float bcs[3]; // 12 - 12
-		uint32_t flags; // 4 - 16
+		uint32_t flags; //  4 - 16
 
-		float pixel_size[2]; // 8 - 24
-		uint32_t tonemapper; // 4 - 28
-		uint32_t pad1; // 4 - 32
+		float pixel_size[2]; //  8 - 24
+		uint32_t tonemapper; //  4 - 28
+		float tonemap_black; //  4 - 32
+		float tonemap_a; //  4 - 36
+		float tonemap_b; //  4 - 40
+		float tonemap_c; //  4 - 44
+		float tonemap_d; //  4 - 48
+		float tonemap_e; //  4 - 52
+		float tonemap_f; //  4 - 56
+		float tonemap_g; //  4 - 60
+		uint32_t pad; // 4 - 64
 
-		uint32_t glow_texture_size[2]; // 8 - 40
-		float glow_intensity; // 4 - 44
-		float glow_map_strength; // 4 - 48
+		uint32_t glow_texture_size[2]; //  8 - 72
+		float glow_intensity; //  4 - 76
+		float glow_map_strength; //  4 - 80
 
-		uint32_t glow_mode; // 4 - 52
-		float glow_levels[7]; // 28 - 80
+		uint32_t glow_mode; //  4 - 84
+		float glow_levels[7]; // 28 - 112
 
-		float exposure; // 4 - 84
-		float white; // 4 - 88
-		float auto_exposure_scale; // 4 - 92
-		float luminance_multiplier; // 4 - 96
+		float exposure; //  4 - 116
+		float auto_exposure_scale; //  4 - 120
+		float luminance_multiplier; //  4 - 124
 
-		float output_max_value; // 4 - 100
-		uint32_t pad2[3]; // 12 - 112
+		float output_max_value; //  4 - 128
 	};
 
 	/* tonemap actually writes to a framebuffer, which is
@@ -127,8 +133,15 @@ public:
 		RID glow_map;
 
 		RS::EnvironmentToneMapper tonemap_mode = RS::ENV_TONE_MAPPER_LINEAR;
+		float tonemap_black = 0.0;
+		float tonemap_a = 0.0;
+		float tonemap_b = 0.0;
+		float tonemap_c = 0.0;
+		float tonemap_d = 0.0;
+		float tonemap_e = 0.0;
+		float tonemap_f = 0.0;
+		float tonemap_g = 0.0;
 		float exposure = 1.0;
-		float white = 1.0;
 		float max_value = 1.0;
 
 		bool use_auto_exposure = false;

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -70,23 +70,26 @@ private:
 
 	struct TonemapPushConstant {
 		float bcs[3]; // 12 - 12
-		uint32_t flags; //  4 - 16
+		uint32_t flags; // 4 - 16
 
-		float pixel_size[2]; //  8 - 24
-		uint32_t tonemapper; //  4 - 28
-		uint32_t pad; //  4 - 32
+		float pixel_size[2]; // 8 - 24
+		uint32_t tonemapper; // 4 - 28
+		uint32_t pad1; // 4 - 32
 
-		uint32_t glow_texture_size[2]; //  8 - 40
-		float glow_intensity; //  4 - 44
-		float glow_map_strength; //  4 - 48
+		uint32_t glow_texture_size[2]; // 8 - 40
+		float glow_intensity; // 4 - 44
+		float glow_map_strength; // 4 - 48
 
-		uint32_t glow_mode; //  4 - 52
+		uint32_t glow_mode; // 4 - 52
 		float glow_levels[7]; // 28 - 80
 
-		float exposure; //  4 - 84
-		float white; //  4 - 88
-		float auto_exposure_scale; //  4 - 92
-		float luminance_multiplier; //  4 - 96
+		float exposure; // 4 - 84
+		float white; // 4 - 88
+		float auto_exposure_scale; // 4 - 92
+		float luminance_multiplier; // 4 - 96
+
+		float output_max_value; // 4 - 100
+		uint32_t pad2[3]; // 12 - 112
 	};
 
 	/* tonemap actually writes to a framebuffer, which is
@@ -126,6 +129,7 @@ public:
 		RS::EnvironmentToneMapper tonemap_mode = RS::ENV_TONE_MAPPER_LINEAR;
 		float exposure = 1.0;
 		float white = 1.0;
+		float max_value = 1.0;
 
 		bool use_auto_exposure = false;
 		float auto_exposure_scale = 0.5;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -43,8 +43,14 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		return;
 	}
 
+	BlitPipelines blit_pipelines = _get_blit_pipelines_for_format(RD::get_singleton()->screen_get_framebuffer_format(p_screen));
+
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin_for_screen(p_screen);
 	ERR_FAIL_COND(draw_list == RD::INVALID_ID);
+
+	const RD::ColorSpace color_space = RD::get_singleton()->screen_get_color_space(p_screen);
+	const float reference_luminance = RD::get_singleton()->get_context_driver()->window_get_hdr_output_reference_luminance(p_screen);
+	const float reference_multiplier = _compute_reference_multiplier(color_space, reference_luminance);
 
 	for (int i = 0; i < p_amount; i++) {
 		RID rd_texture = texture_storage->render_target_get_rd_texture(p_render_targets[i].render_target);
@@ -66,7 +72,8 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 
 		Size2 screen_size(RD::get_singleton()->screen_get_width(p_screen), RD::get_singleton()->screen_get_height(p_screen));
 		BlitMode mode = p_render_targets[i].lens_distortion.apply ? BLIT_MODE_LENS : (p_render_targets[i].multi_view.use_layer ? BLIT_MODE_USE_LAYER : BLIT_MODE_NORMAL);
-		RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blit.pipelines[mode]);
+
+		RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blit_pipelines.pipelines[mode]);
 		RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 		RD::get_singleton()->draw_list_bind_uniform_set(draw_list, it->value, 0);
 
@@ -95,8 +102,10 @@ void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID
 		blit.push_constant.k2 = p_render_targets[i].lens_distortion.k2;
 		blit.push_constant.upscale = p_render_targets[i].lens_distortion.upscale;
 		blit.push_constant.aspect_ratio = p_render_targets[i].lens_distortion.aspect_ratio;
-		blit.push_constant.convert_to_srgb = texture_storage->render_target_is_using_hdr(p_render_targets[i].render_target);
+		blit.push_constant.source_is_srgb = !texture_storage->render_target_is_using_hdr(p_render_targets[i].render_target);
 		blit.push_constant.use_debanding = texture_storage->render_target_is_using_debanding(p_render_targets[i].render_target);
+		blit.push_constant.target_color_space = color_space;
+		blit.push_constant.reference_multiplier = reference_multiplier;
 
 		RD::get_singleton()->draw_list_set_push_constant(draw_list, &blit.push_constant, sizeof(BlitPushConstant));
 		RD::get_singleton()->draw_list_draw(draw_list, true);
@@ -131,15 +140,7 @@ void RendererCompositorRD::initialize() {
 		blit_modes.push_back("\n");
 
 		blit.shader.initialize(blit_modes);
-
 		blit.shader_version = blit.shader.version_create();
-
-		for (int i = 0; i < BLIT_MODE_MAX; i++) {
-			blit.pipelines[i] = RD::get_singleton()->render_pipeline_create(blit.shader.version_get_shader(blit.shader_version, i), RD::get_singleton()->screen_get_framebuffer_format(DisplayServer::MAIN_WINDOW_ID), RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), i == BLIT_MODE_NORMAL_ALPHA ? RenderingDevice::PipelineColorBlendState::create_blend() : RenderingDevice::PipelineColorBlendState::create_disabled(), 0);
-
-			// Unload shader modules to save memory.
-			RD::get_singleton()->shader_destroy_modules(blit.shader.version_get_shader(blit.shader_version, i));
-		}
 
 		//create index array for copy shader
 		Vector<uint8_t> pv;
@@ -185,6 +186,38 @@ void RendererCompositorRD::finalize() {
 	RD::get_singleton()->free(blit.sampler);
 }
 
+RendererCompositorRD::BlitPipelines RendererCompositorRD::_get_blit_pipelines_for_format(RenderingDevice::FramebufferFormatID format) {
+	HashMap<RenderingDevice::FramebufferFormatID, BlitPipelines>::Iterator it = blit.pipelinesByFormat.find(format);
+	if (it != blit.pipelinesByFormat.end()) {
+		return it->value;
+	}
+
+	BlitPipelines pipelines;
+	for (int i = 0; i < BLIT_MODE_MAX; i++) {
+		pipelines.pipelines[i] = RD::get_singleton()->render_pipeline_create(blit.shader.version_get_shader(blit.shader_version, i), format, RD::INVALID_ID, RD::RENDER_PRIMITIVE_TRIANGLES, RD::PipelineRasterizationState(), RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), i == BLIT_MODE_NORMAL_ALPHA ? RenderingDevice::PipelineColorBlendState::create_blend() : RenderingDevice::PipelineColorBlendState::create_disabled(), 0);
+	}
+	blit.pipelinesByFormat.insert(format, pipelines);
+	return pipelines;
+}
+
+float RendererCompositorRD::_compute_reference_multiplier(RD::ColorSpace p_color_space, const float p_reference_luminance) {
+	switch (p_color_space) {
+		case RD::COLOR_SPACE_REC2020_ST2084:
+			// Max brightness of ST2084 is 10000 nits, we output from 0 to 1.
+			return p_reference_luminance / 10000.0f;
+		case RD::COLOR_SPACE_REC709_LINEAR:
+#ifdef WINDOWS_ENABLED
+			// Windows expects multiples of 80 nits.
+			return p_reference_luminance / 80.0f;
+#else
+			// Default to 100 nits.
+			return p_reference_luminance / 100.0f;
+#endif
+		default:
+			return 1.0f;
+	}
+}
+
 void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
 	if (p_image.is_null() || p_image->is_empty()) {
 		return;
@@ -195,6 +228,8 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 		// Window is minimized and does not have valid swapchain, skip drawing without printing errors.
 		return;
 	}
+
+	BlitPipelines blit_pipelines = _get_blit_pipelines_for_format(RD::get_singleton()->screen_get_framebuffer_format(DisplayServer::MAIN_WINDOW_ID));
 
 	RID texture = texture_storage->texture_allocate();
 	texture_storage->texture_2d_initialize(texture, p_image);
@@ -232,9 +267,13 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	screenrect.position /= window_size;
 	screenrect.size /= window_size;
 
+	const RD::ColorSpace color_space = RD::get_singleton()->screen_get_color_space(DisplayServer::MAIN_WINDOW_ID);
+	const float reference_luminance = RD::get_singleton()->get_context_driver()->window_get_hdr_output_reference_luminance(DisplayServer::MAIN_WINDOW_ID);
+	const float reference_multiplier = _compute_reference_multiplier(color_space, reference_luminance);
+
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin_for_screen(DisplayServer::MAIN_WINDOW_ID, p_color);
 
-	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blit.pipelines[BLIT_MODE_NORMAL_ALPHA]);
+	RD::get_singleton()->draw_list_bind_render_pipeline(draw_list, blit_pipelines.pipelines[BLIT_MODE_NORMAL_ALPHA]);
 	RD::get_singleton()->draw_list_bind_index_array(draw_list, blit.array);
 	RD::get_singleton()->draw_list_bind_uniform_set(draw_list, uset, 0);
 
@@ -257,8 +296,10 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	blit.push_constant.k2 = 0;
 	blit.push_constant.upscale = 1.0;
 	blit.push_constant.aspect_ratio = 1.0;
-	blit.push_constant.convert_to_srgb = false;
+	blit.push_constant.source_is_srgb = true;
 	blit.push_constant.use_debanding = false;
+	blit.push_constant.target_color_space = color_space;
+	blit.push_constant.reference_multiplier = reference_multiplier;
 
 	RD::get_singleton()->draw_list_set_push_constant(draw_list, &blit.push_constant, sizeof(BlitPushConstant));
 	RD::get_singleton()->draw_list_draw(draw_list, true);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -68,29 +68,36 @@ protected:
 	};
 
 	struct BlitPushConstant {
-		float src_rect[4];
-		float dst_rect[4];
+		float src_rect[4]; // 16 - 16
+		float dst_rect[4]; // 16 - 32
 
-		float rotation_sin;
-		float rotation_cos;
+		float rotation_sin; // 4 - 36
+		float rotation_cos; // 4 - 40
+		float eye_center[2]; // 8 - 48
 
-		float eye_center[2];
-		float k1;
-		float k2;
+		float k1; // 4 - 52
+		float k2; // 4 - 56
+		float upscale; // 4 - 60
+		float aspect_ratio; // 4 - 64
 
-		float upscale;
-		float aspect_ratio;
-		uint32_t layer;
-		uint32_t convert_to_srgb;
-		uint32_t use_debanding;
-		float pad;
+		uint32_t layer; // 4 - 68
+		uint32_t source_is_srgb; // 4 - 72
+		uint32_t use_debanding; // 4 - 76
+		uint32_t target_color_space; // 4 - 80
+
+		float reference_multiplier; // 4 - 84
+		uint32_t pad[3]; // 12 - 96 (padding to reach 16-byte boundary)
+	};
+
+	struct BlitPipelines {
+		RID pipelines[BLIT_MODE_MAX];
 	};
 
 	struct Blit {
 		BlitPushConstant push_constant;
 		BlitShaderRD shader;
 		RID shader_version;
-		RID pipelines[BLIT_MODE_MAX];
+		HashMap<RenderingDevice::FramebufferFormatID, BlitPipelines> pipelinesByFormat;
 		RID index_buffer;
 		RID array;
 		RID sampler;
@@ -103,6 +110,9 @@ protected:
 
 	static uint64_t frame;
 	static RendererCompositorRD *singleton;
+
+	BlitPipelines _get_blit_pipelines_for_format(RenderingDevice::FramebufferFormatID format);
+	float _compute_reference_multiplier(RD::ColorSpace p_color_space, const float p_reference_luminance);
 
 public:
 	RendererUtilities *get_utilities() { return utilities; }

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -659,7 +659,15 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 		if (p_render_data->environment.is_valid()) {
 			tonemap.tonemap_mode = environment_get_tone_mapper(p_render_data->environment);
-			tonemap.white = environment_get_white(p_render_data->environment);
+			RendererEnvironmentStorage::TonemapParameters params = environment_get_tonemap_parameters(p_render_data->environment);
+			tonemap.tonemap_black = params.tonemap_black;
+			tonemap.tonemap_a = params.tonemap_a;
+			tonemap.tonemap_b = params.tonemap_b;
+			tonemap.tonemap_c = params.tonemap_c;
+			tonemap.tonemap_d = params.tonemap_d;
+			tonemap.tonemap_e = params.tonemap_e;
+			tonemap.tonemap_f = params.tonemap_f;
+			tonemap.tonemap_g = params.tonemap_g;
 			tonemap.exposure = environment_get_exposure(p_render_data->environment);
 			tonemap.max_value = environment_get_max_value(p_render_data->environment);
 		}
@@ -820,8 +828,16 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 
 	if (p_render_data->environment.is_valid()) {
 		tonemap.tonemap_mode = environment_get_tone_mapper(p_render_data->environment);
+		RendererEnvironmentStorage::TonemapParameters params = environment_get_tonemap_parameters(p_render_data->environment);
+		tonemap.tonemap_black = params.tonemap_black;
+		tonemap.tonemap_a = params.tonemap_a;
+		tonemap.tonemap_b = params.tonemap_b;
+		tonemap.tonemap_c = params.tonemap_c;
+		tonemap.tonemap_d = params.tonemap_d;
+		tonemap.tonemap_e = params.tonemap_e;
+		tonemap.tonemap_f = params.tonemap_f;
+		tonemap.tonemap_g = params.tonemap_g;
 		tonemap.exposure = environment_get_exposure(p_render_data->environment);
-		tonemap.white = environment_get_white(p_render_data->environment);
 		tonemap.max_value = environment_get_max_value(p_render_data->environment);
 	}
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -661,6 +661,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			tonemap.tonemap_mode = environment_get_tone_mapper(p_render_data->environment);
 			tonemap.white = environment_get_white(p_render_data->environment);
 			tonemap.exposure = environment_get_exposure(p_render_data->environment);
+			tonemap.max_value = environment_get_max_value(p_render_data->environment);
 		}
 
 		tonemap.use_color_correction = false;
@@ -821,6 +822,7 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 		tonemap.tonemap_mode = environment_get_tone_mapper(p_render_data->environment);
 		tonemap.exposure = environment_get_exposure(p_render_data->environment);
 		tonemap.white = environment_get_white(p_render_data->environment);
+		tonemap.max_value = environment_get_max_value(p_render_data->environment);
 	}
 
 	// We don't support glow or auto exposure here, if they are needed, don't use subpasses!

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1240,9 +1240,11 @@ public:
 
 	// Tonemap
 	PASS4(environment_set_tonemap, RID, RS::EnvironmentToneMapper, float, float)
+	PASS2(environment_set_max_value, RID, float)
 	PASS1RC(RS::EnvironmentToneMapper, environment_get_tone_mapper, RID)
 	PASS1RC(float, environment_get_exposure, RID)
 	PASS1RC(float, environment_get_white, RID)
+	PASS1RC(float, environment_get_max_value, RID)
 
 	// Fog
 	PASS11(environment_set_fog, RID, bool, const Color &, float, float, float, float, float, float, float, RS::EnvironmentFogMode)

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1239,7 +1239,7 @@ public:
 	PASS1RC(RS::EnvironmentReflectionSource, environment_get_reflection_source, RID)
 
 	// Tonemap
-	PASS4(environment_set_tonemap, RID, RS::EnvironmentToneMapper, float, float)
+	PASS6(environment_set_tonemap, RID, RS::EnvironmentToneMapper, float, float, float, float)
 	PASS2(environment_set_max_value, RID, float)
 	PASS1RC(RS::EnvironmentToneMapper, environment_get_tone_mapper, RID)
 	PASS1RC(float, environment_get_exposure, RID)

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -365,6 +365,10 @@ void RendererSceneRender::environment_set_tonemap(RID p_env, RS::EnvironmentTone
 	environment_storage.environment_set_tonemap(p_env, p_tone_mapper, p_exposure, p_white);
 }
 
+void RendererSceneRender::environment_set_max_value(RID p_env, float p_max_value) {
+	environment_storage.environment_set_max_value(p_env, p_max_value);
+}
+
 RS::EnvironmentToneMapper RendererSceneRender::environment_get_tone_mapper(RID p_env) const {
 	return environment_storage.environment_get_tone_mapper(p_env);
 }
@@ -375,6 +379,10 @@ float RendererSceneRender::environment_get_exposure(RID p_env) const {
 
 float RendererSceneRender::environment_get_white(RID p_env) const {
 	return environment_storage.environment_get_white(p_env);
+}
+
+float RendererSceneRender::environment_get_max_value(RID p_env) const {
+	return environment_storage.environment_get_max_value(p_env);
 }
 
 // Fog

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -361,8 +361,8 @@ int RendererSceneRender::environment_get_camera_feed_id(RID p_env) const {
 
 // Tonemap
 
-void RendererSceneRender::environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white) {
-	environment_storage.environment_set_tonemap(p_env, p_tone_mapper, p_exposure, p_white);
+void RendererSceneRender::environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, float p_black, float p_contrast) {
+	environment_storage.environment_set_tonemap(p_env, p_tone_mapper, p_exposure, p_white, p_black, p_contrast);
 }
 
 void RendererSceneRender::environment_set_max_value(RID p_env, float p_max_value) {
@@ -381,8 +381,20 @@ float RendererSceneRender::environment_get_white(RID p_env) const {
 	return environment_storage.environment_get_white(p_env);
 }
 
+float RendererSceneRender::environment_get_black(RID p_env) const {
+	return environment_storage.environment_get_black(p_env);
+}
+
+float RendererSceneRender::environment_get_tonemap_contrast(RID p_env) const {
+	return environment_storage.environment_get_tonemap_contrast(p_env);
+}
+
 float RendererSceneRender::environment_get_max_value(RID p_env) const {
 	return environment_storage.environment_get_max_value(p_env);
+}
+
+RendererEnvironmentStorage::TonemapParameters RendererSceneRender::environment_get_tonemap_parameters(RID p_env) const {
+	return environment_storage.environment_get_tonemap_parameters(p_env);
 }
 
 // Fog

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -134,12 +134,15 @@ public:
 	int environment_get_camera_feed_id(RID p_env) const;
 
 	// Tonemap
-	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white);
+	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, float p_black, float p_contrast);
 	void environment_set_max_value(RID p_env, float p_max_value);
 	RS::EnvironmentToneMapper environment_get_tone_mapper(RID p_env) const;
 	float environment_get_exposure(RID p_env) const;
 	float environment_get_white(RID p_env) const;
+	float environment_get_black(RID p_env) const;
+	float environment_get_tonemap_contrast(RID p_env) const;
 	float environment_get_max_value(RID p_env) const;
+	RendererEnvironmentStorage::TonemapParameters environment_get_tonemap_parameters(RID p_env) const;
 
 	// Fog
 	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect, RS::EnvironmentFogMode p_mode);

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -135,9 +135,11 @@ public:
 
 	// Tonemap
 	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white);
+	void environment_set_max_value(RID p_env, float p_max_value);
 	RS::EnvironmentToneMapper environment_get_tone_mapper(RID p_env) const;
 	float environment_get_exposure(RID p_env) const;
 	float environment_get_white(RID p_env) const;
+	float environment_get_max_value(RID p_env) const;
 
 	// Fog
 	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect, RS::EnvironmentFogMode p_mode);

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -79,9 +79,10 @@ public:
 		bool use_occlusion_culling = false;
 		bool occlusion_buffer_dirty = false;
 
-		DisplayServer::WindowID viewport_to_screen;
+		DisplayServer::WindowID viewport_to_screen = DisplayServer::INVALID_WINDOW_ID;
 		Rect2 viewport_to_screen_rect;
-		bool viewport_render_direct_to_screen;
+		bool viewport_render_direct_to_screen = false;
+		bool tonemap_to_screen = false;
 
 		bool disable_2d = false;
 		RS::ViewportEnvironmentMode disable_environment = RS::VIEWPORT_ENVIRONMENT_INHERIT;
@@ -116,6 +117,7 @@ public:
 
 		bool transparent_bg = false;
 		bool use_hdr_2d = false;
+		bool hdr_output_with_no_hdr_2d_warning_issued = false;
 
 		uint32_t canvas_cull_mask = 0xffffffff;
 
@@ -158,6 +160,7 @@ public:
 			clear_mode = RS::VIEWPORT_CLEAR_ALWAYS;
 			transparent_bg = false;
 			use_hdr_2d = false;
+			hdr_output_with_no_hdr_2d_warning_issued = false;
 
 			viewport_to_screen = DisplayServer::INVALID_WINDOW_ID;
 			shadow_atlas_size = 0;
@@ -207,6 +210,7 @@ private:
 	void _configure_3d_render_buffers(Viewport *p_viewport);
 	void _draw_3d(Viewport *p_viewport);
 	void _draw_viewport(Viewport *p_viewport);
+	DisplayServer::WindowID _get_containing_window(Viewport *p_viewport);
 
 	int occlusion_rays_per_thread = 512;
 
@@ -222,6 +226,7 @@ public:
 
 	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
 	void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable);
+	void viewport_set_tonemap_to_screen(RID p_viewport, bool p_enable);
 
 	void viewport_set_active(RID p_viewport, bool p_active);
 	void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport);

--- a/servers/rendering/rendering_context_driver.cpp
+++ b/servers/rendering/rendering_context_driver.cpp
@@ -75,6 +75,79 @@ DisplayServer::VSyncMode RenderingContextDriver::window_get_vsync_mode(DisplaySe
 	}
 }
 
+void RenderingContextDriver::window_set_hdr_output_enabled(DisplayServer::WindowID p_window, bool p_enabled) {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		surface_set_hdr_output_enabled(surface, p_enabled);
+	}
+}
+
+bool RenderingContextDriver::window_get_hdr_output_enabled(DisplayServer::WindowID p_window) const {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		return surface_get_hdr_output_enabled(surface);
+	} else {
+		return false;
+	}
+}
+
+void RenderingContextDriver::window_set_hdr_output_prefer_high_precision(DisplayServer::WindowID p_window, bool p_enabled) {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		surface_set_hdr_output_prefer_high_precision(surface, p_enabled);
+	}
+}
+
+bool RenderingContextDriver::window_get_hdr_output_prefer_high_precision(DisplayServer::WindowID p_window) const {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		return surface_get_hdr_output_prefer_high_precision(surface);
+	} else {
+		return false;
+	}
+}
+
+void RenderingContextDriver::window_set_hdr_output_reference_luminance(DisplayServer::WindowID p_window, float p_reference_luminance) {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		surface_set_hdr_output_reference_luminance(surface, p_reference_luminance);
+	}
+}
+
+float RenderingContextDriver::window_get_hdr_output_reference_luminance(DisplayServer::WindowID p_window) const {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		return surface_get_hdr_output_reference_luminance(surface);
+	} else {
+		return 0.0f;
+	}
+}
+
+void RenderingContextDriver::window_set_hdr_output_max_luminance(DisplayServer::WindowID p_window, float p_max_luminance) {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		surface_set_hdr_output_max_luminance(surface, p_max_luminance);
+	}
+}
+
+float RenderingContextDriver::window_get_hdr_output_max_luminance(DisplayServer::WindowID p_window) const {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		return surface_get_hdr_output_max_luminance(surface);
+	} else {
+		return 0.0f;
+	}
+}
+
+float RenderingContextDriver::window_get_hdr_output_max_value(DisplayServer::WindowID p_window) const {
+	SurfaceID surface = surface_get_from_window(p_window);
+	if (surface) {
+		return surface_get_hdr_output_max_value(surface);
+	} else {
+		return 1.0f;
+	}
+}
+
 void RenderingContextDriver::window_destroy(DisplayServer::WindowID p_window) {
 	SurfaceID surface = surface_get_from_window(p_window);
 	if (surface) {

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -47,6 +47,15 @@ public:
 	void window_set_size(DisplayServer::WindowID p_window, uint32_t p_width, uint32_t p_height);
 	void window_set_vsync_mode(DisplayServer::WindowID p_window, DisplayServer::VSyncMode p_vsync_mode);
 	DisplayServer::VSyncMode window_get_vsync_mode(DisplayServer::WindowID p_window) const;
+	void window_set_hdr_output_enabled(DisplayServer::WindowID p_window, bool p_enabled);
+	bool window_get_hdr_output_enabled(DisplayServer::WindowID p_window) const;
+	void window_set_hdr_output_prefer_high_precision(DisplayServer::WindowID p_window, bool p_enabled);
+	bool window_get_hdr_output_prefer_high_precision(DisplayServer::WindowID p_window) const;
+	void window_set_hdr_output_reference_luminance(DisplayServer::WindowID p_window, float p_reference_luminance);
+	float window_get_hdr_output_reference_luminance(DisplayServer::WindowID p_window) const;
+	void window_set_hdr_output_max_luminance(DisplayServer::WindowID p_window, float p_max_luminance);
+	float window_get_hdr_output_max_luminance(DisplayServer::WindowID p_window) const;
+	float window_get_hdr_output_max_value(DisplayServer::WindowID p_window) const;
 	void window_destroy(DisplayServer::WindowID p_window);
 
 public:
@@ -97,6 +106,15 @@ public:
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) = 0;
 	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) = 0;
 	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const = 0;
+	virtual void surface_set_hdr_output_enabled(SurfaceID p_surface, bool p_enabled) = 0;
+	virtual bool surface_get_hdr_output_enabled(SurfaceID p_surface) const = 0;
+	virtual void surface_set_hdr_output_prefer_high_precision(SurfaceID p_surface, bool p_enabled) = 0;
+	virtual bool surface_get_hdr_output_prefer_high_precision(SurfaceID p_surface) const = 0;
+	virtual void surface_set_hdr_output_reference_luminance(SurfaceID p_surface, float p_reference_luminance) = 0;
+	virtual float surface_get_hdr_output_reference_luminance(SurfaceID p_surface) const = 0;
+	virtual void surface_set_hdr_output_max_luminance(SurfaceID p_surface, float p_max_luminance) = 0;
+	virtual float surface_get_hdr_output_max_luminance(SurfaceID p_surface) const = 0;
+	virtual float surface_get_hdr_output_max_value(SurfaceID p_surface) const = 0;
 	virtual uint32_t surface_get_width(SurfaceID p_surface) const = 0;
 	virtual uint32_t surface_get_height(SurfaceID p_surface) const = 0;
 	virtual void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) = 0;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -4345,6 +4345,28 @@ RenderingDevice::FramebufferFormatID RenderingDevice::screen_get_framebuffer_for
 	return const_cast<RenderingDevice *>(this)->framebuffer_format_create(screen_attachment);
 }
 
+RenderingDevice::DataFormat RenderingDevice::screen_get_color_format(DisplayServer::WindowID p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServer::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
+	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), DATA_FORMAT_MAX, "Screen was never prepared.");
+
+	DataFormat format = driver->swap_chain_get_format(it->value);
+	ERR_FAIL_COND_V_MSG(format == DATA_FORMAT_MAX, DATA_FORMAT_MAX, "Unknown format.");
+	return format;
+}
+
+RenderingDevice::ColorSpace RenderingDevice::screen_get_color_space(DisplayServer::WindowID p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	HashMap<DisplayServer::WindowID, RDD::SwapChainID>::ConstIterator it = screen_swap_chains.find(p_screen);
+	ERR_FAIL_COND_V_MSG(it == screen_swap_chains.end(), COLOR_SPACE_MAX, "Screen was never prepared.");
+
+	ColorSpace color_space = driver->swap_chain_get_color_space(it->value);
+	ERR_FAIL_COND_V_MSG(color_space == COLOR_SPACE_MAX, COLOR_SPACE_MAX, "Unknown color space.");
+	return color_space;
+}
+
 Error RenderingDevice::screen_free(DisplayServer::WindowID p_screen) {
 	_THREAD_SAFE_METHOD_
 
@@ -7415,6 +7437,8 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("screen_get_width", "screen"), &RenderingDevice::screen_get_width, DEFVAL(DisplayServer::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("screen_get_height", "screen"), &RenderingDevice::screen_get_height, DEFVAL(DisplayServer::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("screen_get_framebuffer_format", "screen"), &RenderingDevice::screen_get_framebuffer_format, DEFVAL(DisplayServer::MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("screen_get_color_format", "screen"), &RenderingDevice::screen_get_color_format, DEFVAL(DisplayServer::MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("screen_get_color_space", "screen"), &RenderingDevice::screen_get_color_space, DEFVAL(DisplayServer::MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("draw_list_begin_for_screen", "screen", "clear_color"), &RenderingDevice::draw_list_begin_for_screen, DEFVAL(DisplayServer::MAIN_WINDOW_ID), DEFVAL(Color()));
 
@@ -7774,6 +7798,11 @@ void RenderingDevice::_bind_methods() {
 	BIND_ENUM_CONSTANT(DATA_FORMAT_ASTC_12x12_SFLOAT_BLOCK);
 	BIND_ENUM_CONSTANT(DATA_FORMAT_MAX);
 
+	BIND_ENUM_CONSTANT(COLOR_SPACE_REC709_LINEAR);
+	BIND_ENUM_CONSTANT(COLOR_SPACE_REC709_SRGB);
+	BIND_ENUM_CONSTANT(COLOR_SPACE_REC2020_ST2084);
+	BIND_ENUM_CONSTANT(COLOR_SPACE_MAX);
+
 #ifndef DISABLE_DEPRECATED
 	BIND_BITFIELD_FLAG(BARRIER_MASK_VERTEX);
 	BIND_BITFIELD_FLAG(BARRIER_MASK_FRAGMENT);
@@ -8001,6 +8030,7 @@ void RenderingDevice::_bind_methods() {
 	BIND_ENUM_CONSTANT(SUPPORTS_METALFX_TEMPORAL);
 	BIND_ENUM_CONSTANT(SUPPORTS_BUFFER_DEVICE_ADDRESS);
 	BIND_ENUM_CONSTANT(SUPPORTS_IMAGE_ATOMIC_32_BIT);
+	BIND_ENUM_CONSTANT(SUPPORTS_HDR_OUTPUT);
 
 	BIND_ENUM_CONSTANT(LIMIT_MAX_BOUND_UNIFORM_SETS);
 	BIND_ENUM_CONSTANT(LIMIT_MAX_FRAMEBUFFER_COLOR_ATTACHMENTS);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1199,6 +1199,8 @@ public:
 	int screen_get_height(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	int screen_get_pre_rotation_degrees(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	FramebufferFormatID screen_get_framebuffer_format(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
+	DataFormat screen_get_color_format(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
+	ColorSpace screen_get_color_space(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
 	Error screen_free(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
 
 	/*************************/
@@ -1718,6 +1720,7 @@ VARIANT_ENUM_CAST(RenderingDevice::ShaderStage)
 VARIANT_ENUM_CAST(RenderingDevice::ShaderLanguage)
 VARIANT_ENUM_CAST(RenderingDevice::CompareOperator)
 VARIANT_ENUM_CAST(RenderingDevice::DataFormat)
+VARIANT_ENUM_CAST(RenderingDevice::ColorSpace)
 VARIANT_ENUM_CAST(RenderingDevice::TextureType)
 VARIANT_ENUM_CAST(RenderingDevice::TextureSamples)
 VARIANT_BITFIELD_CAST(RenderingDevice::TextureUsageBits)

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -317,6 +317,13 @@ public:
 		DATA_FORMAT_MAX,
 	};
 
+	enum ColorSpace {
+		COLOR_SPACE_REC709_LINEAR,
+		COLOR_SPACE_REC709_SRGB,
+		COLOR_SPACE_REC2020_ST2084,
+		COLOR_SPACE_MAX,
+	};
+
 	// Breadcrumb markers are useful for debugging GPU crashes (i.e. DEVICE_LOST). Internally
 	// they're just an uint32_t to "tag" a GPU command. These are only used for debugging and do not
 	// (or at least shouldn't) alter the execution behavior in any way.
@@ -954,6 +961,7 @@ public:
 		SUPPORTS_BUFFER_DEVICE_ADDRESS,
 		SUPPORTS_IMAGE_ATOMIC_32_BIT,
 		SUPPORTS_VULKAN_MEMORY_MODEL,
+		SUPPORTS_HDR_OUTPUT,
 	};
 
 	enum SubgroupOperations {

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -451,6 +451,9 @@ public:
 	// Android uses this with Swappy library. Some implementations or platforms may ignore this hint.
 	virtual void swap_chain_set_max_fps(SwapChainID p_swap_chain, int p_max_fps) {}
 
+	// Retrieve the color space used by the swap chain's framebuffers.
+	virtual ColorSpace swap_chain_get_color_space(SwapChainID p_swap_chain) = 0;
+
 	// Wait until all rendering associated to the swap chain is finished before deleting it.
 	virtual void swap_chain_free(SwapChainID p_swap_chain) = 0;
 

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -185,10 +185,12 @@ public:
 
 	// Tonemap
 	virtual void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white) = 0;
+	virtual void environment_set_max_value(RID p_env, float p_max_value) = 0;
 
 	virtual RS::EnvironmentToneMapper environment_get_tone_mapper(RID p_env) const = 0;
 	virtual float environment_get_exposure(RID p_env) const = 0;
 	virtual float environment_get_white(RID p_env) const = 0;
+	virtual float environment_get_max_value(RID p_env) const = 0;
 
 	// Fog
 	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect, RS::EnvironmentFogMode p_mode = RS::EnvironmentFogMode::ENV_FOG_MODE_EXPONENTIAL) = 0;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -184,7 +184,7 @@ public:
 	virtual RS::EnvironmentReflectionSource environment_get_reflection_source(RID p_env) const = 0;
 
 	// Tonemap
-	virtual void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white) = 0;
+	virtual void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, float p_black, float p_contrast) = 0;
 	virtual void environment_set_max_value(RID p_env, float p_max_value) = 0;
 
 	virtual RS::EnvironmentToneMapper environment_get_tone_mapper(RID p_env) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -700,6 +700,7 @@ public:
 
 	FUNC3(viewport_attach_to_screen, RID, const Rect2 &, int)
 	FUNC2(viewport_set_render_direct_to_screen, RID, bool)
+	FUNC2(viewport_set_tonemap_to_screen, RID, bool)
 
 	FUNC2(viewport_set_scaling_3d_mode, RID, ViewportScaling3DMode)
 	FUNC2(viewport_set_scaling_3d_scale, RID, float)
@@ -823,6 +824,7 @@ public:
 	FUNC1(environment_glow_set_use_bicubic_upscale, bool)
 
 	FUNC4(environment_set_tonemap, RID, EnvironmentToneMapper, float, float)
+	FUNC2(environment_set_max_value, RID, float)
 
 	FUNC7(environment_set_adjustment, RID, bool, float, float, float, bool, RID)
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -823,7 +823,7 @@ public:
 	FUNC13(environment_set_glow, RID, bool, Vector<float>, float, float, float, float, EnvironmentGlowBlendMode, float, float, float, float, RID)
 	FUNC1(environment_glow_set_use_bicubic_upscale, bool)
 
-	FUNC4(environment_set_tonemap, RID, EnvironmentToneMapper, float, float)
+	FUNC6(environment_set_tonemap, RID, EnvironmentToneMapper, float, float, float, float)
 	FUNC2(environment_set_max_value, RID, float)
 
 	FUNC7(environment_set_adjustment, RID, bool, float, float, float, bool, RID)

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -211,6 +211,12 @@ void RendererEnvironmentStorage::environment_set_tonemap(RID p_env, RS::Environm
 	env->white = p_white;
 }
 
+void RendererEnvironmentStorage::environment_set_max_value(RID p_env, float p_max_value) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_NULL(env);
+	env->max_value = p_max_value;
+}
+
 RS::EnvironmentToneMapper RendererEnvironmentStorage::environment_get_tone_mapper(RID p_env) const {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL_V(env, RS::ENV_TONE_MAPPER_LINEAR);
@@ -227,6 +233,12 @@ float RendererEnvironmentStorage::environment_get_white(RID p_env) const {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_NULL_V(env, 1.0);
 	return env->white;
+}
+
+float RendererEnvironmentStorage::environment_get_max_value(RID p_env) const {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_NULL_V(env, 1.0);
+	return env->max_value;
 }
 
 // Fog

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -62,6 +62,7 @@ private:
 		RS::EnvironmentToneMapper tone_mapper;
 		float exposure = 1.0;
 		float white = 1.0;
+		float max_value = 1.0;
 
 		// Fog
 		bool fog_enabled = false;
@@ -200,9 +201,11 @@ public:
 
 	// Tonemap
 	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white);
+	void environment_set_max_value(RID p_env, float p_max_value);
 	RS::EnvironmentToneMapper environment_get_tone_mapper(RID p_env) const;
 	float environment_get_exposure(RID p_env) const;
 	float environment_get_white(RID p_env) const;
+	float environment_get_max_value(RID p_env) const;
 
 	// Fog
 	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect, RS::EnvironmentFogMode p_mode);

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -61,7 +61,9 @@ private:
 		// Tonemap
 		RS::EnvironmentToneMapper tone_mapper;
 		float exposure = 1.0;
+		float black = 0.0;
 		float white = 1.0;
+		float tonemap_contrast = 1.25; // Default to approximately Blender's AgX contrast
 		float max_value = 1.0;
 
 		// Fog
@@ -159,6 +161,19 @@ private:
 	mutable RID_Owner<Environment, true> environment_owner;
 
 public:
+	struct TonemapParameters {
+		float tonemap_black = 0.0;
+		float tonemap_a = 0.0;
+		float tonemap_b = 0.0;
+		float tonemap_c = 0.0;
+		float tonemap_d = 0.0;
+		float tonemap_e = 0.0;
+		float tonemap_f = 0.0;
+		float tonemap_g = 0.0;
+		float exposure = 1.0;
+		float max_value = 1.0;
+	};
+
 	static RendererEnvironmentStorage *get_singleton() { return singleton; }
 
 	RendererEnvironmentStorage();
@@ -200,12 +215,15 @@ public:
 	RS::EnvironmentReflectionSource environment_get_reflection_source(RID p_env) const;
 
 	// Tonemap
-	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white);
+	void environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, float p_black, float p_contrast);
 	void environment_set_max_value(RID p_env, float p_max_value);
 	RS::EnvironmentToneMapper environment_get_tone_mapper(RID p_env) const;
 	float environment_get_exposure(RID p_env) const;
 	float environment_get_white(RID p_env) const;
+	float environment_get_black(RID p_env) const;
+	float environment_get_tonemap_contrast(RID p_env) const;
 	float environment_get_max_value(RID p_env) const;
+	TonemapParameters environment_get_tonemap_parameters(RID p_env) const;
 
 	// Fog
 	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect, RS::EnvironmentFogMode p_mode);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3040,7 +3040,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_canvas_max_layer", "env", "max_layer"), &RenderingServer::environment_set_canvas_max_layer);
 	ClassDB::bind_method(D_METHOD("environment_set_ambient_light", "env", "color", "ambient", "energy", "sky_contribution", "reflection_source"), &RenderingServer::environment_set_ambient_light, DEFVAL(RS::ENV_AMBIENT_SOURCE_BG), DEFVAL(1.0), DEFVAL(0.0), DEFVAL(RS::ENV_REFLECTION_SOURCE_BG));
 	ClassDB::bind_method(D_METHOD("environment_set_glow", "env", "enable", "levels", "intensity", "strength", "mix", "bloom_threshold", "blend_mode", "hdr_bleed_threshold", "hdr_bleed_scale", "hdr_luminance_cap", "glow_map_strength", "glow_map"), &RenderingServer::environment_set_glow);
-	ClassDB::bind_method(D_METHOD("environment_set_tonemap", "env", "tone_mapper", "exposure", "white"), &RenderingServer::environment_set_tonemap);
+	ClassDB::bind_method(D_METHOD("environment_set_tonemap", "env", "tone_mapper", "exposure", "white", "black", "contrast"), &RenderingServer::environment_set_tonemap, DEFVAL(1.25));
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "use_1d_color_correction", "color_correction"), &RenderingServer::environment_set_adjustment);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance"), &RenderingServer::environment_set_ssr);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "power", "detail", "horizon", "sharpness", "light_affect", "ao_channel_affect"), &RenderingServer::environment_set_ssao);
@@ -3096,6 +3096,7 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_FILMIC);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ACES);
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_AGX);
+	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ADJUSTABLE);
 
 	BIND_ENUM_CONSTANT(ENV_SSR_ROUGHNESS_QUALITY_DISABLED);
 	BIND_ENUM_CONSTANT(ENV_SSR_ROUGHNESS_QUALITY_LOW);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2827,6 +2827,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);
 	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &RenderingServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(DisplayServer::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("viewport_set_render_direct_to_screen", "viewport", "enabled"), &RenderingServer::viewport_set_render_direct_to_screen);
+	ClassDB::bind_method(D_METHOD("viewport_set_tonemap_to_screen", "viewport", "enabled"), &RenderingServer::viewport_set_tonemap_to_screen);
 	ClassDB::bind_method(D_METHOD("viewport_set_canvas_cull_mask", "viewport", "canvas_cull_mask"), &RenderingServer::viewport_set_canvas_cull_mask);
 
 	ClassDB::bind_method(D_METHOD("viewport_set_scaling_3d_mode", "viewport", "scaling_3d_mode"), &RenderingServer::viewport_set_scaling_3d_mode);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1276,9 +1276,10 @@ public:
 		ENV_TONE_MAPPER_FILMIC,
 		ENV_TONE_MAPPER_ACES,
 		ENV_TONE_MAPPER_AGX,
+		ENV_TONE_MAPPER_ADJUSTABLE,
 	};
 
-	virtual void environment_set_tonemap(RID p_env, EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white) = 0;
+	virtual void environment_set_tonemap(RID p_env, EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, float p_black, float p_contrast = 1.25) = 0;
 	virtual void environment_set_max_value(RID p_env, float p_max_value) = 0;
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, bool p_use_1d_color_correction, RID p_color_correction) = 0;
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -986,6 +986,7 @@ public:
 
 	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) = 0;
 	virtual void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) = 0;
+	virtual void viewport_set_tonemap_to_screen(RID p_viewport, bool p_enable) = 0;
 
 	virtual void viewport_set_scaling_3d_mode(RID p_viewport, ViewportScaling3DMode p_scaling_3d_mode) = 0;
 	virtual void viewport_set_scaling_3d_scale(RID p_viewport, float p_scaling_3d_scale) = 0;
@@ -1278,6 +1279,7 @@ public:
 	};
 
 	virtual void environment_set_tonemap(RID p_env, EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white) = 0;
+	virtual void environment_set_max_value(RID p_env, float p_max_value) = 0;
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, bool p_use_1d_color_correction, RID p_color_correction) = 0;
 
 	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance) = 0;


### PR DESCRIPTION
This prototype demonstrates how tonemappers could behave when HDR output is enabled. Please provide feedback in the comments! You can use Windows Game bar to take HDR screenshots OBS Studio has good support for HDR video recording as well (let me know if you want me to give you OBS configuration details).

This branch builds on top of #94496. Please share any feedback relating to HDR (not tonemappers) on that PR instead! Many of the changes from this PR should be merged in [a separate PR](https://github.com/godotengine/godot/pull/106940), as these changes include adding `white` parameter support to the AgX tonemapper, which is required independently of HDR output support.

This draft PR implements godotengine/godot-proposals#12317, including the addition of two new tonemaping user parameters: `black` and `contrast`, both of which I feel are required for flexible and stable HDR output behaviour. Please review this proposal for rationale.

Importantly, **Flimic and ACES tonemappers cannot support HDR output**. This is because the `white` parameter of these tonemappers was designed exclusively for SDR and this style of white parameter cannot work with HDR and variable Extended Dynamic Range (EDR). This PR demonstrates how they should behave in HDR mode: exactly the same as they behave in SDR mode, limited to [0.0, 1.0] range.

Because Filmic cannot support HDR mode, I have introduced a new tonemapper that is HDR-compatible to replace it: the **Adjustable** tonemapper. Unlike AgX, this tonemapper does not desaturate colours to white as they become very bright and applies the tone curve directly in the linear sRGB working colour space, just like Filmic does. It's configuration parameters match AgX and it can be configured to appear similar to Filmic in SDR.

[Check out videos of how this new "Adjustable" tonemapping curve works on my blog post.](https://allenwp.com/blog/2025/05/29/allenwp-tonemapping-curve/)

On a related note, the new configuration parameters of AgX (specifically `contrast`) can be used to make it appear similar to ACES, but with correct HDR output support.

## Usage

[Download windows-editor Artifact from the Checks page of my branch.](https://github.com/godotengine/godot/pull/106696/checks)

The basics of tonemapping in Godot is [covered in the docs](https://docs.godotengine.org/en/stable/tutorials/3d/environment_and_post_processing.html#tonemap). In this PR I've updated the in-engine docs to have some more detail.

HDR output is covered in detail in the original PR #94496, but here's a quick summary:

1. Enable 2D HDR: `rendering/viewport/hdr_2d`
2. Enable HDR output: `display/window/hdr/enabled`

### To control HDR brightness settings:

**Option 1:** Simply change the SDR content brightness in Windows (you might need to move or resize the Godot window to force it to refresh):
![image](https://github.com/user-attachments/assets/f44ce763-f53b-4a0e-8701-4f28accfaf71)

**Option 2:** Disable `display/window/hdr/use_screen_luminance` and manually set the Reference Luminance (this is equivalent to SDR content brightness) and Max Luminance.

**Note:** Reducing the max luminance with Option 2 may be necessary to circumvent the built-in tonemapping of your display.

## Performance

Performance of the AgX tonemapper is better than the current implementation in `master`. I wasn't able to get as good of performance as my best attempt using Timothy Lottes' curve in #102435, but the stability and predictability of the curve in this PR across all of variable EDR is a reasonable trade off that gives a significantly better user experience when targeting both SDR and HDR.

A number of additional parameters are now passed from the CPU to the GPU, increasing the number of bytes passed into the tonemapper. This has a minor impact on performance (barely measurable on my NVIDIA 980 Ti for a 4K window). Unfortunately, this affects all tonemappers... which leads me to my next point:

Adding another tonemapper to Godot, as it is currently implemented, causes a notable performance degradation to **all** tonemappers. This happened in Godot 4.4 when AgX was added to Godot, and it will happen again when the new Adjustable tonemapper is added. Work needs to be done to address this at a structural level.

The `black` parameter makes ALL tonemapping notably slower. I haven't looked into how this can be optimized yet; this PR simply demonstrates how it should look when it is correctly implemented.

## Limitations

- Windows only
- Currently only works with Mobile and Forward+ rendering methods.
- Optimization work is not complete: It's possible these changes cause a minor performance regression and performance of the new tonemappers is not representative of their final optimized form.

## Known Issues

- My intent is for Reinhard to behave differently than SDR when `white` is less than 1.0 and HDR has been enabled. The code currently checks to see if `max_value != 1.0` instead of checking if HDR is enabled, but this is incorrect because `max_value` can equal `1.0` when HDR is enabled and `reference_luminance == max_luminance`.