### PR TITLE
Add a Point Radius property to SoftBody3D

### DIFF
--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1150,6 +1150,14 @@
 				Returns the current position of the given soft body point in global coordinates.
 			</description>
 		</method>
+		<method name="soft_body_get_point_radius" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+				Returns the radius of all points of the given soft body.
+				[b]Note:[/b] This is only supported when using Jolt Physics (see [member ProjectSettings.physics/3d/physics_engine]).
+			</description>
+		</method>
 		<method name="soft_body_get_pressure_coefficient" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
@@ -1283,6 +1291,15 @@
 			<param index="1" name="mesh" type="RID" />
 			<description>
 				Sets the mesh of the given soft body.
+			</description>
+		</method>
+		<method name="soft_body_set_point_radius">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="radius" type="float" />
+			<description>
+				Sets the radius of all points of the given soft body. When using a thin mesh as a soft body (such as a [PlaneMesh] for cloth simulation), this can be increased to prevent the mesh from clipping through other objects. Setting this too high will make the soft body appear to float, can also make its simulation look more "rounded".
+				[b]Note:[/b] This is only supported when using Jolt Physics (see [member ProjectSettings.physics/3d/physics_engine]).
 			</description>
 		</method>
 		<method name="soft_body_set_pressure_coefficient">

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1073,6 +1073,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_soft_body_get_point_radius" qualifiers="virtual required const">
+			<return type="float" />
+			<param index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_soft_body_get_pressure_coefficient" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
@@ -1185,6 +1191,13 @@
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mesh" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_set_point_radius" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="body" type="RID" />
+			<param index="1" name="radius" type="float" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2679,9 +2679,6 @@
 		<member name="physics/jolt_physics_3d/simulation/sleep_velocity_threshold" type="float" setter="" getter="" default="0.03">
 			The linear velocity of specific points on the bounding box of a [RigidBody3D], below which it can be put to sleep, in meters per second. These points help capture both the linear and angular motion of a [RigidBody3D].
 		</member>
-		<member name="physics/jolt_physics_3d/simulation/soft_body_point_radius" type="float" setter="" getter="" default="0.01">
-			How big the points of a [SoftBody3D] are, in meters. A higher value can prevent behavior such as cloth laying perfectly flush against other surfaces and causing Z-fighting.
-		</member>
 		<member name="physics/jolt_physics_3d/simulation/speculative_contact_distance" type="float" setter="" getter="" default="0.02">
 			Radius around physics bodies, inside which speculative contact points will be detected, in meters. This is mainly used to prevent tunneling/penetration for [RigidBody3D] nodes during simulation.
 			[b]Note:[/b] Setting this too high may result in ghost collisions, as speculative contacts are based on the closest points during the collision detection step which may not be the actual closest points by the time the two bodies hit.

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -150,6 +150,10 @@
 		<member name="parent_collision_ignore" type="NodePath" setter="set_parent_collision_ignore" getter="get_parent_collision_ignore" default="NodePath(&quot;&quot;)">
 			[NodePath] to a [CollisionObject3D] this SoftBody3D should avoid clipping.
 		</member>
+		<member name="point_radius" type="float" setter="set_point_radius" getter="get_point_radius" default="0.01">
+			The radius of the soft body's points. When using a thin mesh as a soft body (such as a [PlaneMesh] for cloth simulation), this can be increased to prevent the mesh from clipping through other objects. Setting this too high will make the soft body appear to float, can also make its simulation look more "rounded".
+			[b]Note:[/b] This is only supported when using Jolt Physics (see [member ProjectSettings.physics/3d/physics_engine]).
+		</member>
 		<member name="pressure_coefficient" type="float" setter="set_pressure_coefficient" getter="get_pressure_coefficient" default="0.0">
 			The pressure coefficient of this soft body. Simulate pressure build-up from inside this body. Higher values increase the strength of this effect.
 		</member>

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1104,6 +1104,13 @@ int GodotPhysicsServer3D::soft_body_get_simulation_precision(RID p_body) const {
 	return soft_body->get_iteration_count();
 }
 
+void GodotPhysicsServer3D::soft_body_set_point_radius(RID p_body, real_t p_radius) {
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_point_radius(RID p_body) const {
+	return 0.01;
+}
+
 void GodotPhysicsServer3D::soft_body_set_total_mass(RID p_body, real_t p_total_mass) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -288,6 +288,9 @@ public:
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) override;
 	virtual int soft_body_get_simulation_precision(RID p_body) const override;
 
+	virtual void soft_body_set_point_radius(RID p_body, real_t p_radius) override;
+	virtual real_t soft_body_get_point_radius(RID p_body) const override;
+
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) override;
 	virtual real_t soft_body_get_total_mass(RID p_body) const override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1126,6 +1126,20 @@ int JoltPhysicsServer3D::soft_body_get_simulation_precision(RID p_body) const {
 	return body->get_simulation_precision();
 }
 
+void JoltPhysicsServer3D::soft_body_set_point_radius(RID p_body, real_t p_radius) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->set_point_radius((float)p_radius);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_point_radius(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 0.0);
+
+	return (real_t)body->get_point_radius();
+}
+
 void JoltPhysicsServer3D::soft_body_set_total_mass(RID p_body, real_t p_total_mass) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -330,6 +330,9 @@ public:
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_precision) override;
 	virtual int soft_body_get_simulation_precision(RID p_body) const override;
 
+	virtual void soft_body_set_point_radius(RID p_body, real_t p_radius) override;
+	virtual real_t soft_body_get_point_radius(RID p_body) const override;
+
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) override;
 	virtual real_t soft_body_get_total_mass(RID p_body) const override;
 

--- a/modules/jolt_physics/jolt_project_settings.cpp
+++ b/modules/jolt_physics/jolt_project_settings.cpp
@@ -40,7 +40,6 @@ void JoltProjectSettings::register_settings() {
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/penetration_slop", PROPERTY_HINT_RANGE, U"0,1,0.00001,or_greater,suffix:m"), 0.02f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/speculative_contact_distance", PROPERTY_HINT_RANGE, U"0,1,0.00001,or_greater,suffix:m"), 0.02f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/baumgarte_stabilization_factor", PROPERTY_HINT_RANGE, U"0,1,0.01"), 0.2f);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/soft_body_point_radius", PROPERTY_HINT_RANGE, U"0,1,0.001,or_greater,suffix:m"), 0.01f);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/bounce_velocity_threshold", PROPERTY_HINT_RANGE, U"0,1,0.001,or_greater,suffix:m/s"), 1.0f);
 	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "physics/jolt_physics_3d/simulation/allow_sleep"), true);
 	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "physics/jolt_physics_3d/simulation/sleep_velocity_threshold", PROPERTY_HINT_RANGE, U"0,1,0.001,or_greater,suffix:m/s"), 0.03f);
@@ -84,7 +83,6 @@ void JoltProjectSettings::read_settings() {
 	penetration_slop = GLOBAL_GET("physics/jolt_physics_3d/simulation/penetration_slop");
 	speculative_contact_distance = GLOBAL_GET("physics/jolt_physics_3d/simulation/speculative_contact_distance");
 	baumgarte_stabilization_factor = GLOBAL_GET("physics/jolt_physics_3d/simulation/baumgarte_stabilization_factor");
-	soft_body_point_radius = GLOBAL_GET("physics/jolt_physics_3d/simulation/soft_body_point_radius");
 	bounce_velocity_threshold = GLOBAL_GET("physics/jolt_physics_3d/simulation/bounce_velocity_threshold");
 	sleep_allowed = GLOBAL_GET("physics/jolt_physics_3d/simulation/allow_sleep");
 	sleep_velocity_threshold = GLOBAL_GET("physics/jolt_physics_3d/simulation/sleep_velocity_threshold");

--- a/modules/jolt_physics/jolt_project_settings.h
+++ b/modules/jolt_physics/jolt_project_settings.h
@@ -46,7 +46,6 @@ public:
 	inline static float penetration_slop;
 	inline static float speculative_contact_distance;
 	inline static float baumgarte_stabilization_factor;
-	inline static float soft_body_point_radius;
 	inline static float bounce_velocity_threshold;
 	inline static bool sleep_allowed;
 	inline static float sleep_velocity_threshold;

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -142,7 +142,7 @@ bool JoltSoftBody3D::_ref_shared_data() {
 		LocalVector<int> &mesh_to_physics = iter_shared_data->value.mesh_to_physics;
 
 		JPH::SoftBodySharedSettings &settings = *iter_shared_data->value.settings;
-		settings.mVertexRadius = JoltProjectSettings::soft_body_point_radius;
+		settings.mVertexRadius = point_radius;
 
 		JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings.mVertices;
 		JPH::Array<JPH::SoftBodySharedSettings::Face> &physics_faces = settings.mFaces;
@@ -297,6 +297,10 @@ void JoltSoftBody3D::_mesh_changed() {
 }
 
 void JoltSoftBody3D::_simulation_precision_changed() {
+	wake_up();
+}
+
+void JoltSoftBody3D::_point_radius_changed() {
 	wake_up();
 }
 
@@ -481,6 +485,16 @@ void JoltSoftBody3D::set_simulation_precision(int p_precision) {
 	simulation_precision = MAX(p_precision, 0);
 
 	_simulation_precision_changed();
+}
+
+void JoltSoftBody3D::set_point_radius(float p_radius) {
+	if (unlikely(point_radius == p_radius)) {
+		return;
+	}
+
+	point_radius = MAX(p_radius, 0.0f);
+
+	_point_radius_changed();
 }
 
 void JoltSoftBody3D::set_mass(float p_mass) {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -61,6 +61,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 
 	float mass = 0.0f;
+	float point_radius = 0.01f;
 	float pressure = 0.0f;
 	float linear_damping = 0.01f;
 	float stiffness_coefficient = 0.5f;
@@ -89,6 +90,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 
 	void _mesh_changed();
 	void _simulation_precision_changed();
+	void _point_radius_changed();
 	void _mass_changed();
 	void _pressure_changed();
 	void _damping_changed();
@@ -133,6 +135,9 @@ public:
 
 	int get_simulation_precision() const { return simulation_precision; }
 	void set_simulation_precision(int p_precision);
+
+	float get_point_radius() const { return point_radius; }
+	void set_point_radius(float p_radius);
 
 	float get_mass() const { return mass; }
 	void set_mass(float p_mass);

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -440,6 +440,9 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_simulation_precision", "simulation_precision"), &SoftBody3D::set_simulation_precision);
 	ClassDB::bind_method(D_METHOD("get_simulation_precision"), &SoftBody3D::get_simulation_precision);
 
+	ClassDB::bind_method(D_METHOD("set_point_radius", "radius"), &SoftBody3D::set_point_radius);
+	ClassDB::bind_method(D_METHOD("get_point_radius"), &SoftBody3D::get_point_radius);
+
 	ClassDB::bind_method(D_METHOD("set_total_mass", "mass"), &SoftBody3D::set_total_mass);
 	ClassDB::bind_method(D_METHOD("get_total_mass"), &SoftBody3D::get_total_mass);
 
@@ -477,6 +480,7 @@ void SoftBody3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "parent_collision_ignore", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "CollisionObject3D"), "set_parent_collision_ignore", "get_parent_collision_ignore");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "simulation_precision", PROPERTY_HINT_RANGE, "1,100,1"), "set_simulation_precision", "get_simulation_precision");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "point_radius", PROPERTY_HINT_RANGE, "0.0,1.0,0.0001,or_greater"), "set_point_radius", "get_point_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_mass", PROPERTY_HINT_RANGE, "0.01,10000,1"), "set_total_mass", "get_total_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_linear_stiffness", "get_linear_stiffness");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shrinking_factor", PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"), "set_shrinking_factor", "get_shrinking_factor");
@@ -742,6 +746,14 @@ int SoftBody3D::get_simulation_precision() {
 
 void SoftBody3D::set_simulation_precision(int p_simulation_precision) {
 	PhysicsServer3D::get_singleton()->soft_body_set_simulation_precision(physics_rid, p_simulation_precision);
+}
+
+real_t SoftBody3D::get_point_radius() {
+	return PhysicsServer3D::get_singleton()->soft_body_get_point_radius(physics_rid);
+}
+
+void SoftBody3D::set_point_radius(real_t p_radius) {
+	PhysicsServer3D::get_singleton()->soft_body_set_point_radius(physics_rid, p_radius);
 }
 
 real_t SoftBody3D::get_total_mass() {

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -170,6 +170,9 @@ public:
 	void set_simulation_precision(int p_simulation_precision);
 	int get_simulation_precision();
 
+	void set_point_radius(real_t p_radius);
+	real_t get_point_radius();
+
 	void set_total_mass(real_t p_total_mass);
 	real_t get_total_mass();
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -332,6 +332,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_set_simulation_precision, "body", "simulation_precision");
 	GDVIRTUAL_BIND(_soft_body_get_simulation_precision, "body");
 
+	GDVIRTUAL_BIND(_soft_body_set_point_radius, "body", "radius");
+	GDVIRTUAL_BIND(_soft_body_get_point_radius, "body");
+
 	GDVIRTUAL_BIND(_soft_body_set_total_mass, "body", "total_mass");
 	GDVIRTUAL_BIND(_soft_body_get_total_mass, "body");
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -439,6 +439,9 @@ public:
 	EXBIND2(soft_body_set_simulation_precision, RID, int)
 	EXBIND1RC(int, soft_body_get_simulation_precision, RID)
 
+	EXBIND2(soft_body_set_point_radius, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_point_radius, RID)
+
 	EXBIND2(soft_body_set_total_mass, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_total_mass, RID)
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -870,6 +870,9 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("soft_body_set_simulation_precision", "body", "simulation_precision"), &PhysicsServer3D::soft_body_set_simulation_precision);
 	ClassDB::bind_method(D_METHOD("soft_body_get_simulation_precision", "body"), &PhysicsServer3D::soft_body_get_simulation_precision);
 
+	ClassDB::bind_method(D_METHOD("soft_body_set_point_radius", "body", "radius"), &PhysicsServer3D::soft_body_set_point_radius);
+	ClassDB::bind_method(D_METHOD("soft_body_get_point_radius", "body"), &PhysicsServer3D::soft_body_get_point_radius);
+
 	ClassDB::bind_method(D_METHOD("soft_body_set_total_mass", "body", "total_mass"), &PhysicsServer3D::soft_body_set_total_mass);
 	ClassDB::bind_method(D_METHOD("soft_body_get_total_mass", "body"), &PhysicsServer3D::soft_body_get_total_mass);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -601,6 +601,9 @@ public:
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) = 0;
 	virtual int soft_body_get_simulation_precision(RID p_body) const = 0;
 
+	virtual void soft_body_set_point_radius(RID p_body, real_t p_radius) = 0;
+	virtual real_t soft_body_get_point_radius(RID p_body) const = 0;
+
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) = 0;
 	virtual real_t soft_body_get_total_mass(RID p_body) const = 0;
 

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -335,6 +335,9 @@ public:
 	virtual void soft_body_set_simulation_precision(RID p_body, int p_simulation_precision) override {}
 	virtual int soft_body_get_simulation_precision(RID p_body) const override { return 0; }
 
+	virtual void soft_body_set_point_radius(RID p_body, real_t p_radius) override {}
+	virtual real_t soft_body_get_point_radius(RID p_body) const override { return 0.01; }
+
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) override {}
 	virtual real_t soft_body_get_total_mass(RID p_body) const override { return 0; }
 

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -303,6 +303,9 @@ public:
 	FUNC2(soft_body_set_simulation_precision, RID, int);
 	FUNC1RC(int, soft_body_get_simulation_precision, RID);
 
+	FUNC2(soft_body_set_point_radius, RID, real_t);
+	FUNC1RC(real_t, soft_body_get_point_radius, RID);
+
 	FUNC2(soft_body_set_total_mass, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_total_mass, RID);
 


### PR DESCRIPTION
> [!NOTE]
>
> This PR is pending a slight change that needs https://github.com/jrouwe/JoltPhysics/pull/1649 to be merged in Godot first (by updating Jolt to the latest version).
>
> Quoting @jrouwe:
>
> > The `SoftBodySharedSettings` object is an object that is shared amonst all soft bodies using the same mesh (see `mesh_to_shared` above). This means that with this implementation you can get into a situation where modifying the point radius of one soft body accidentally may modify another. I should probably move `mVertexRadius` to `SoftBodyCreationSettings` instead.

This allows configuring the point radius on a per-body basis, as opposed to the previous project-wide setting. The project-wide setting was removed as it's no longer needed.

This is only supported when using Jolt Physics. It has no effect when using GodotPhysics3D.

- This closes https://github.com/godotengine/godot-proposals/issues/12445.

**Testing project:** [test_softbody_point_radius.zip](https://github.com/user-attachments/files/20377214/test_softbody_point_radius.zip)

## Preview

*From left to right: Point radius `0.04`, `0.01` (default), `0.0`.*

![image](https://github.com/user-attachments/assets/c803b29d-3aa5-4edf-a735-c7e8c4b07093)

## TODO

- [x] Figure out if the project setting is still needed. I left it in for now, but we may want to remove it if there are no good use cases for using a global multiplier on all soft bodies.
  - Removed the project setting.
- [ ] See if we can make overriding the new methods optional. I had to add dummy implementations to GodotPhysics3D to get it to compile, but logically, this shouldn't be required if we want to keep compatibility with existing physics engine modules/extensions.
