### PR TITLE
Deprecate `Control::accept_event`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -10,7 +10,7 @@
 		[b]User Interface nodes and input[/b]
 		Godot propagates input events via viewports. Each [Viewport] is responsible for propagating [InputEvent]s to their child nodes. As the [member SceneTree.root] is a [Window], this already happens automatically for all UI elements in your game.
 		Input events are propagated through the [SceneTree] from the root node to all child nodes by calling [method Node._input]. For UI elements specifically, it makes more sense to override the virtual method [method _gui_input], which filters out unrelated input events, such as by checking z-order, [member mouse_filter], focus, or if the event was inside of the control's bounding box.
-		Call [method accept_event] so no other node receives the event. Once you accept an input, it becomes handled so [method Node._unhandled_input] will not process it.
+		Call [method Viewport.set_input_as_handled] so no other node receives the event. Once you accept an input, it becomes handled so [method Node._unhandled_input] will not process it.
 		Only one [Control] node can be in focus. Only the node in focus will receive events. To get the focus, call [method grab_focus]. [Control] nodes lose focus when another node grabs it, or if you hide the node in focus.
 		Sets [member mouse_filter] to [constant MOUSE_FILTER_IGNORE] to tell a [Control] node to ignore mouse or touch events. You'll need it if you place an icon on top of a button.
 		[Theme] resources change the control's appearance. The [member theme] of a [Control] node affects all of its direct and indirect children (as long as a chain of controls is uninterrupted). To override some of the theme items, call one of the [code]add_theme_*_override[/code] methods, like [method add_theme_font_override]. You can also override theme items in the Inspector.
@@ -130,7 +130,7 @@
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Virtual method to be implemented by the user. Override this method to handle and accept inputs on UI elements. See also [method accept_event].
+				Virtual method to be implemented by the user. Override this method to handle and accept inputs on UI elements. See also [method Viewport.set_input_as_handled].
 				[b]Example:[/b] Click on the control to print a message:
 				[codeblocks]
 				[gdscript]
@@ -225,7 +225,7 @@
 				Returns an [Array] of [Vector3i] text ranges and text base directions, in the left-to-right order. Ranges should cover full source [param text] without overlaps. BiDi algorithm will be used on each range separately.
 			</description>
 		</method>
-		<method name="accept_event">
+		<method name="accept_event" deprecated="Use [method Viewport.set_input_as_handled] instead.">
 			<return type="void" />
 			<description>
 				Marks an input event as handled. Once you accept an input event, it stops propagating, even to nodes listening to [method Node._unhandled_input] or [method Node._unhandled_key_input].

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		The [Input] singleton handles key presses, mouse buttons and movement, gamepads, and input actions. Actions and their events can be set in the [b]Input Map[/b] tab in [b]Project &gt; Project Settings[/b], or with the [InputMap] class.
-		[b]Note:[/b] [Input]'s methods reflect the global input state and are not affected by [method Control.accept_event] or [method Viewport.set_input_as_handled], as those methods only deal with the way input is propagated in the [SceneTree].
+		[b]Note:[/b] [Input]'s methods reflect the global input state and are not affected by [method Viewport.set_input_as_handled], as that method only deals with the way input is propagated in the [SceneTree].
 	</description>
 	<tutorials>
 		<link title="Inputs documentation index">$DOCS_URL/tutorials/inputs/index.html</link>

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -971,7 +971,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (panner->gui_input(p_event)) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -980,31 +980,31 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (!read_only) {
 				duplicate_selected_keys(-1.0, false);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		if (ED_IS_SHORTCUT("animation_editor/cut_selected_keys", p_event)) {
 			if (!read_only) {
 				copy_selected_keys(true);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		if (ED_IS_SHORTCUT("animation_editor/copy_selected_keys", p_event)) {
 			if (!read_only) {
 				copy_selected_keys(false);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		if (ED_IS_SHORTCUT("animation_editor/paste_keys", p_event)) {
 			if (!read_only) {
 				paste_keys(-1.0, false);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		if (ED_IS_SHORTCUT("animation_editor/delete_selection", p_event)) {
 			if (!read_only) {
 				delete_selection();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 
@@ -1032,7 +1032,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 			if (focused_keys.is_empty()) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 
@@ -1075,7 +1075,7 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		} else if (ED_IS_SHORTCUT("animation_bezier_editor/select_all_keys", p_event)) {
 			for (int i = 0; i < edit_points.size(); ++i) {
@@ -1083,14 +1083,14 @@ void AnimationBezierTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		} else if (ED_IS_SHORTCUT("animation_bezier_editor/deselect_all_keys", p_event)) {
 			selection.clear();
 			emit_signal(SNAME("clear_selection"));
 
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1892,7 +1892,7 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (panner->gui_input(p_event, get_global_rect())) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -1902,14 +1902,14 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (track_edit) {
 			track_edit->get_editor()->goto_prev_step(true);
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && mb->is_alt_pressed() && mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 		if (track_edit) {
 			track_edit->get_editor()->goto_next_step(true);
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && hsize_rect.has_point(mb->get_position())) {
@@ -2976,33 +2976,33 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (!read_only) {
 				emit_signal(SNAME("duplicate_request"), -1.0, false);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		if (ED_IS_SHORTCUT("animation_editor/cut_selected_keys", p_event)) {
 			if (!read_only) {
 				emit_signal(SNAME("cut_request"));
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		if (ED_IS_SHORTCUT("animation_editor/copy_selected_keys", p_event)) {
 			if (!read_only) {
 				emit_signal(SNAME("copy_request"));
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (ED_IS_SHORTCUT("animation_editor/paste_keys", p_event)) {
 			if (!read_only) {
 				emit_signal(SNAME("paste_request"), -1.0, false);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (ED_IS_SHORTCUT("animation_editor/delete_selection", p_event)) {
 			if (!read_only) {
 				emit_signal(SNAME("delete_request"));
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 
@@ -3024,7 +3024,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				undo_redo->add_undo_method(animation.ptr(), "track_set_enabled", track, animation->track_is_enabled(track));
 				undo_redo->commit_action();
 				queue_redraw();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 
 			if (icon_rect.has_point(pos)) {
@@ -3039,7 +3039,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			// Don't overlap track keys if they start at 0.
 			if (path_rect.has_point(pos + Size2(type_icon->get_width(), 0))) {
 				clicking_on_name = true;
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 
 			if (update_mode_rect.has_point(pos)) {
@@ -3065,7 +3065,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				Vector2 popup_pos = get_screen_position() + update_mode_rect.position + Vector2(0, update_mode_rect.size.height);
 				menu->set_position(popup_pos);
 				menu->popup();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 
 			if (interp_mode_rect.has_point(pos)) {
@@ -3114,7 +3114,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				Vector2 popup_pos = get_screen_position() + interp_mode_rect.position + Vector2(0, interp_mode_rect.size.height);
 				menu->set_position(popup_pos);
 				menu->popup();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 
 			if (loop_wrap_rect.has_point(pos)) {
@@ -3134,18 +3134,18 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				Vector2 popup_pos = get_screen_position() + loop_wrap_rect.position + Vector2(0, loop_wrap_rect.size.height);
 				menu->set_position(popup_pos);
 				menu->popup();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 
 			if (remove_rect.has_point(pos)) {
 				emit_signal(SNAME("remove_request"), track);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
 
 		if (_try_select_at_ui_pos(pos, mb->is_command_or_control_pressed() || mb->is_shift_pressed(), true)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 
@@ -3192,7 +3192,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->popup();
 
 				insert_at_pos = offset + timeline->get_value();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 	}
@@ -6098,7 +6098,7 @@ void AnimationTrackEditor::_box_selection_draw() {
 void AnimationTrackEditor::_scroll_input(const Ref<InputEvent> &p_event) {
 	if (!box_selecting) {
 		if (panner->gui_input(p_event, scroll->get_global_rect())) {
-			scroll->accept_event();
+			scroll->get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
@@ -8681,7 +8681,7 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		Point2 pos = mb->get_position();
 		if (_try_select_at_ui_pos(pos, mb->is_command_or_control_pressed() || mb->is_shift_pressed(), true)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (!_is_ui_pos_in_current_section(pos)) {
 			_clear_selection_for_anim(animation);
 		}
@@ -8693,25 +8693,25 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 			if (moving_selection && moving_selection_effective) {
 				if (Math::abs(moving_selection_offset) > CMP_EPSILON) {
 					_move_selection_commit();
-					accept_event(); // So play position doesn't snap to the end of move selection.
+					get_viewport()->set_input_as_handled(); // So play position doesn't snap to the end of move selection.
 				}
 			} else if (select_single_attempt) {
 				call_deferred("_select_key", select_single_attempt, true);
 
 				// First select click should not affect play position.
 				if (!selection.has(select_single_attempt)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				} else {
 					// Second click and onwards should snap to marker time.
 					double ofs = animation->get_marker_time(select_single_attempt);
 					timeline->set_play_position(ofs);
 					timeline->emit_signal(SNAME("timeline_changed"), ofs, mb->is_alt_pressed());
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 			} else {
 				// First select click should not affect play position.
 				if (!selection.has(select_single_attempt)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 			}
 
@@ -8752,7 +8752,7 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->popup();
 
 				insert_at_pos = offset + timeline->get_value();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 	}

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1087,7 +1087,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -1102,7 +1102,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 		len_resizing_from_px = mb->get_position().x;
 		len_resizing_rel = 0;
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -1145,7 +1145,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 		len_resizing_index = -1;
 		len_resizing = false;
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -174,7 +174,7 @@ void FindReplaceBar::input(const Ref<InputEvent> &p_event) {
 
 		if (text_editor->has_focus() || (focus_owner && is_ancestor_of(focus_owner))) {
 			_hide_bar();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -882,12 +882,12 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 		if ((find_replace_bar != nullptr && find_replace_bar->is_visible()) && (find_replace_bar->has_focus() || (get_viewport()->gui_get_focus_owner() && find_replace_bar->is_ancestor_of(get_viewport()->gui_get_focus_owner())))) {
 			if (ED_IS_SHORTCUT("script_text_editor/find_next", key_event)) {
 				find_replace_bar->search_next();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (ED_IS_SHORTCUT("script_text_editor/find_previous", key_event)) {
 				find_replace_bar->search_prev();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
@@ -896,27 +896,27 @@ void CodeTextEditor::input(const Ref<InputEvent> &event) {
 
 	if (ED_IS_SHORTCUT("script_text_editor/move_up", key_event)) {
 		text_editor->move_lines_up();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/move_down", key_event)) {
 		text_editor->move_lines_down();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/delete_line", key_event)) {
 		text_editor->delete_lines();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/duplicate_selection", key_event)) {
 		text_editor->duplicate_selection();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (ED_IS_SHORTCUT("script_text_editor/duplicate_lines", key_event)) {
 		text_editor->duplicate_lines();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 }
@@ -928,12 +928,12 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 		if (mb->is_pressed() && mb->is_command_or_control_pressed()) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				_zoom_in();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 				_zoom_out();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
@@ -943,7 +943,7 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
 	if (magnify_gesture.is_valid()) {
 		_zoom_to(zoom_factor * std::pow(magnify_gesture->get_factor(), 0.25f));
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 #endif
@@ -954,17 +954,17 @@ void CodeTextEditor::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 		if (k->is_pressed()) {
 			if (ED_IS_SHORTCUT("script_editor/zoom_in", p_event)) {
 				_zoom_in();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (ED_IS_SHORTCUT("script_editor/zoom_out", p_event)) {
 				_zoom_out();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (ED_IS_SHORTCUT("script_editor/reset_zoom", p_event)) {
 				_zoom_to(1);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -640,7 +640,7 @@ void ConnectDialog::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			filter_nodes->grab_focus();
 			filter_nodes->select_all();
-			filter_nodes->accept_event();
+			filter_nodes->get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -1317,14 +1317,14 @@ void ConnectionsDock::_tree_gui_input(const Ref<InputEvent> &p_event) {
 				update_tree();
 
 				// Stop the Delete input from propagating elsewhere.
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		} else if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 			search_box->grab_focus();
 			search_box->select_all();
 
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
@@ -1363,7 +1363,7 @@ void ConnectionsDock::_tree_gui_input(const Ref<InputEvent> &p_event) {
 				class_menu->set_position(screen_position);
 				class_menu->reset_size();
 				class_menu->popup();
-				accept_event(); // Don't collapse item.
+				get_viewport()->set_input_as_handled(); // Don't collapse item.
 				break;
 			case TREE_ITEM_TYPE_SIGNAL:
 				signal_menu->set_position(screen_position);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -534,13 +534,13 @@ void CreateDialog::_sbox_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			search_options->gui_input(key);
-			search_box->accept_event();
+			search_box->get_viewport()->set_input_as_handled();
 		} else if (key->is_action_pressed("ui_select", true)) {
 			TreeItem *ti = search_options->get_selected();
 			if (ti) {
 				ti->set_collapsed(!ti->is_collapsed());
 			}
-			search_box->accept_event();
+			search_box->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -597,7 +597,7 @@ void EditorAudioBus::gui_input(const Ref<InputEvent> &p_event) {
 		bus_popup->reset_size();
 		bus_popup->popup();
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -607,7 +607,7 @@ void EditorAudioBus::_effects_gui_input(Ref<InputEvent> p_event) {
 		TreeItem *current_effect = effects->get_selected();
 		if (current_effect && current_effect->get_metadata(0).get_type() == Variant::INT) {
 			_delete_effect_pressed(0);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -190,7 +190,7 @@ void EditorCommandPalette::_sbox_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			search_options->gui_input(key);
-			command_search_box->accept_event();
+			command_search_box->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4935,7 +4935,7 @@ void FindBar::input(const Ref<InputEvent> &p_event) {
 
 		if (rich_text_label->has_focus() || (focus_owner && is_ancestor_of(focus_owner))) {
 			_hide_bar();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -175,7 +175,7 @@ void EditorHelpSearch::_search_box_gui_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			results_tree->gui_input(key);
-			search_box->accept_event();
+			search_box->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -996,7 +996,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 		select();
 
 		if (keying_rect.has_point(mpos)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			emit_signal(SNAME("property_keyed"), property, use_keying_next());
 
 			if (use_keying_next()) {
@@ -1019,12 +1019,12 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 		if (delete_rect.has_point(mpos)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			emit_signal(SNAME("property_deleted"), property);
 		}
 
 		if (revert_rect.has_point(mpos)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			get_viewport()->gui_release_focus();
 			bool is_valid_revert = false;
 			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property, &is_valid_revert);
@@ -1034,13 +1034,13 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (check_rect.has_point(mpos)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			checked = !checked;
 			queue_redraw();
 			emit_signal(SNAME("property_checked"), property, checked);
 		}
 	} else if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		_update_popup();
 		menu->set_position(get_screen_position() + get_local_mouse_position());
 		menu->reset_size();
@@ -1076,13 +1076,13 @@ void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event) {
 	if (k.is_valid() && k->is_pressed()) {
 		if (ED_IS_SHORTCUT("property_editor/copy_value", p_event)) {
 			menu_option(MENU_COPY_VALUE);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (!is_read_only() && ED_IS_SHORTCUT("property_editor/paste_value", p_event)) {
 			menu_option(MENU_PASTE_VALUE);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (!internal && ED_IS_SHORTCUT("property_editor/copy_property_path", p_event)) {
 			menu_option(MENU_COPY_PROPERTY_PATH);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -1305,11 +1305,11 @@ void EditorProperty::menu_option(int p_option) {
 			queue_redraw();
 		} break;
 		case MENU_DELETE: {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			emit_signal(SNAME("property_deleted"), property);
 		} break;
 		case MENU_REVERT_VALUE: {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			get_viewport()->gui_release_focus();
 			bool is_valid_revert = false;
 			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property, &is_valid_revert);
@@ -2085,7 +2085,7 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed()) {
 		if (foldable && has_children_to_show && k->is_action("ui_accept", true)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 
 			bool should_unfold = !object->editor_is_section_unfolded(section);
 			if (should_unfold) {
@@ -2106,7 +2106,7 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 
 		if (check_rect.has_point(mb->get_position())) {
 			checked = !checked;
@@ -2372,14 +2372,14 @@ void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index
 
 		if (array_elements[p_index].panel->has_focus() && key.is_pressed() && key.get_keycode() == Key::KEY_DELETE) {
 			_move_element(begin_array_index + p_index, -1);
-			array_elements[p_index].panel->accept_event();
+			array_elements[p_index].panel->get_viewport()->set_input_as_handled();
 		}
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
 		if (movable && mb->get_button_index() == MouseButton::RIGHT) {
-			array_elements[p_index].panel->accept_event();
+			array_elements[p_index].panel->get_viewport()->set_input_as_handled();
 			popup_array_index_pressed = begin_array_index + p_index;
 			rmb_popup->set_item_disabled(OPTION_MOVE_UP, popup_array_index_pressed == 0);
 			rmb_popup->set_item_disabled(OPTION_MOVE_DOWN, popup_array_index_pressed == count - 1);

--- a/editor/event_listener_line_edit.cpp
+++ b/editor/event_listener_line_edit.cpp
@@ -173,14 +173,14 @@ void EventListenerLineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			hold_next = OS::get_singleton()->get_ticks_msec();
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	} else if (p_event->is_action_released(SNAME("ui_cancel"), true)) {
 		accept_release = true;
 	}
 	hold_next = 0;
 
-	accept_event();
+	get_viewport()->set_input_as_handled();
 	if (!(p_event->is_pressed() || accept_release) || p_event->is_echo() || p_event->is_match(event) || !_is_event_allowed(p_event)) {
 		return;
 	}

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3711,7 +3711,7 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 			}
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -3775,7 +3775,7 @@ void FileSystemDock::_file_list_gui_input(Ref<InputEvent> p_event) {
 			}
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -804,7 +804,7 @@ void GroupsEditor::_groups_gui_input(Ref<InputEvent> p_event) {
 			return;
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -620,7 +620,7 @@ void QuickOpenResultContainer::handle_search_box_input(const Ref<InputEvent> &p_
 		if (move_selection) {
 			_move_selection_index(key_event->get_keycode());
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -139,7 +139,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 				_grab_end();
 				set_value(pre_grab_value);
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -187,11 +187,11 @@ void EditorSpinSlider::_grabber_gui_input(const Ref<InputEvent> &p_event) {
 			if (mb->get_button_index() == MouseButton::WHEEL_UP) {
 				set_value(get_value() + get_step());
 				mousewheel_over_grabber = true;
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			} else if (mb->get_button_index() == MouseButton::WHEEL_DOWN) {
 				set_value(get_value() - get_step());
 				mousewheel_over_grabber = true;
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 	}

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -2326,7 +2326,7 @@ void SceneTreeDialog::_on_filter_gui_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			tree->get_scene_tree()->gui_input(key);
-			filter->accept_event();
+			filter->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -701,7 +701,7 @@ void InspectorDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 		search->grab_focus();
 		search->select_all();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -64,7 +64,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			if (!read_only) {
 				_erase_selected();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -108,7 +108,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 			if (!read_only) {
 				_erase_selected();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1618,25 +1618,25 @@ void AnimationPlayerEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 	if (is_visible_in_tree() && k.is_valid() && k->is_pressed() && !k->is_echo()) {
 		if (ED_IS_SHORTCUT("animation_editor/stop_animation", p_ev)) {
 			_stop_pressed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (ED_IS_SHORTCUT("animation_editor/play_animation", p_ev)) {
 			_play_from_pressed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (ED_IS_SHORTCUT("animation_editor/play_animation_backwards", p_ev)) {
 			_play_bw_from_pressed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (ED_IS_SHORTCUT("animation_editor/play_animation_from_start", p_ev)) {
 			_play_pressed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (ED_IS_SHORTCUT("animation_editor/play_animation_from_end", p_ev)) {
 			_play_bw_pressed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (ED_IS_SHORTCUT("animation_editor/go_to_next_keyframe", p_ev)) {
 			_go_to_nearest_keyframe(false);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (ED_IS_SHORTCUT("animation_editor/go_to_previous_keyframe", p_ev)) {
 			_go_to_nearest_keyframe(true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -143,7 +143,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			if (!read_only) {
 				_erase_selected();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -737,7 +737,7 @@ void EditorAssetLibrary::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (key->is_match(InputEventKey::create_reference(KeyModifierMask::CMD_OR_CTRL | Key::F)) && is_visible_in_tree()) {
 			filter->grab_focus();
 			filter->select_all();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2783,7 +2783,7 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 	accepted = (_gui_input_zoom_or_pan(p_event, accepted) || accepted);
 
 	if (accepted) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	// Handles the mouse hovering

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -170,7 +170,7 @@ void CurveEdit::gui_input(const Ref<InputEvent> &p_event) {
 				hovered_index = -1;
 				hovered_tangent_index = TANGENT_NONE;
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (k->get_keycode() == Key::SHIFT || k->get_keycode() == Key::ALT) {

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -248,7 +248,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		grabbing = GRAB_NONE;
 		hovered_index = -1;
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
@@ -277,7 +277,7 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 				}
 			}
 			grabbing = GRAB_NONE;
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		// Select point.
@@ -289,12 +289,12 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 				if (!mb->is_double_click()) {
 					_show_color_picker();
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			} else if (mb->is_double_click()) {
 				set_selected_index(_get_point_at(adjusted_mb_x));
 				_show_color_picker();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2294,7 +2294,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			if (processed) {
 				// Ignore mouse inputs once we receive a numeric input.
 				set_process_input(false);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
@@ -2358,7 +2358,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 				} else {
 					update_transform(Input::get_singleton()->is_key_pressed(Key::SHIFT));
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
@@ -2519,7 +2519,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 	// freelook uses most of the useful shortcuts, like save, so its ok
 	// to consider freelook active as end of the line for future events.
 	if (freelook_active) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -446,7 +446,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 	}
 
 	if (panner->gui_input(p_input, canvas->get_global_rect())) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -344,7 +344,7 @@ void ScriptEditorQuickOpen::_sbox_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			search_options->gui_input(key);
-			search_box->accept_event();
+			search_box->get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -3342,7 +3342,7 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 			_go_to_tab(script_list->get_item_metadata(next_tab));
 			_update_script_names();
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 	if (ED_IS_SHORTCUT("script_editor/prev_script", p_event)) {
 		if (script_list->get_item_count() > 1) {
@@ -3351,15 +3351,15 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 			_go_to_tab(script_list->get_item_metadata(next_tab));
 			_update_script_names();
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 	if (ED_IS_SHORTCUT("script_editor/window_move_up", p_event)) {
 		_menu_option(FILE_MENU_MOVE_UP);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 	if (ED_IS_SHORTCUT("script_editor/window_move_down", p_event)) {
 		_menu_option(FILE_MENU_MOVE_DOWN);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, p_event);
@@ -3370,7 +3370,7 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 			resource = current->get_edited_resource();
 		}
 		EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, resource);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -451,7 +451,7 @@ void Sprite2DEditor::_add_as_sibling_or_child(Node *p_own_node, Node *p_new_node
 
 void Sprite2DEditor::_debug_uv_input(const Ref<InputEvent> &p_input) {
 	if (panner->gui_input(p_input, debug_uv->get_global_rect())) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -263,11 +263,11 @@ void SpriteFramesEditor::_sheet_scroll_input(const Ref<InputEvent> &p_event) {
 		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_pressed() && mb->is_ctrl_pressed()) {
 			_sheet_zoom_on_position(scale_ratio, mb->get_position());
 			// Don't scroll up after zooming in.
-			split_sheet_scroll->accept_event();
+			split_sheet_scroll->get_viewport()->set_input_as_handled();
 		} else if (mb->get_button_index() == MouseButton::WHEEL_DOWN && mb->is_pressed() && mb->is_ctrl_pressed()) {
 			_sheet_zoom_on_position(1 / scale_ratio, mb->get_position());
 			// Don't scroll down after zooming out.
-			split_sheet_scroll->accept_event();
+			split_sheet_scroll->get_viewport()->set_input_as_handled();
 		}
 	}
 
@@ -1318,11 +1318,11 @@ void SpriteFramesEditor::_frame_list_gui_input(const Ref<InputEvent> &p_event) {
 		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_pressed() && mb->is_ctrl_pressed()) {
 			_zoom_in();
 			// Don't scroll up after zooming in.
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (mb->get_button_index() == MouseButton::WHEEL_DOWN && mb->is_pressed() && mb->is_ctrl_pressed()) {
 			_zoom_out();
 			// Don't scroll down after zooming out.
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 			Point2 pos = mb->get_position();
 			right_clicked_frame = frame_list->get_item_at_position(pos, true);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2181,7 +2181,7 @@ void ThemeTypeDialog::_type_filter_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			add_type_options->gui_input(key);
-			add_type_filter->accept_event();
+			add_type_filter->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -37,10 +37,11 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/view_panner.h"
+#include "scene/main/viewport.h"
 
 void TileAtlasView::gui_input(const Ref<InputEvent> &p_event) {
 	if (panner->gui_input(p_event, get_global_rect())) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -530,14 +530,14 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 		panning += pan_gesture->get_delta() * 8;
 		drag_last_pos = Vector2();
 		button_center_view->set_disabled(panning.is_zero_approx());
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	Ref<InputEventMagnifyGesture> magnify_gesture = p_event;
 	if (magnify_gesture.is_valid()) {
 		editor_zoom_widget->set_zoom(editor_zoom_widget->get_zoom() * magnify_gesture->get_factor());
 		_zoom_changed();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -570,11 +570,11 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 		if (mb->get_button_index() == MouseButton::WHEEL_UP && mb->is_command_or_control_pressed()) {
 			editor_zoom_widget->set_zoom_by_increments(1);
 			_zoom_changed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (mb->get_button_index() == MouseButton::WHEEL_DOWN && mb->is_command_or_control_pressed()) {
 			editor_zoom_widget->set_zoom_by_increments(-1);
 			_zoom_changed();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (mb->get_button_index() == MouseButton::LEFT) {
 			if (mb->is_pressed()) {
 				if (tools_button_group->get_pressed_button() != button_create) {
@@ -2237,7 +2237,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 				}
 			}
 			drag_last_pos = mm->get_position();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_BITS) {
 			int terrain_set = Dictionary(drag_painted_value)["terrain_set"];
 			int terrain = Dictionary(drag_painted_value)["terrain"];
@@ -2287,7 +2287,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 				}
 			}
 			drag_last_pos = mm->get_position();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 
@@ -2322,7 +2322,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 						terrain_set_property_editor->update_property();
 						_update_terrain_selector();
 						picker_button->set_pressed(false);
-						accept_event();
+						get_viewport()->set_input_as_handled();
 					}
 				} else {
 					Vector2i coords = p_tile_atlas_view->get_atlas_tile_coords_at_pos(mb->get_position());
@@ -2373,7 +2373,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 							}
 							drag_last_pos = mb->get_position();
 						}
-						accept_event();
+						get_viewport()->set_input_as_handled();
 					} else if (tile_data->get_terrain_set() == terrain_set) {
 						// Paint terrain bits.
 						if (mb->get_button_index() == MouseButton::RIGHT) {
@@ -2435,7 +2435,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 							}
 							drag_last_pos = mb->get_position();
 						}
-						accept_event();
+						get_viewport()->set_input_as_handled();
 					}
 				}
 			} else {
@@ -2478,7 +2478,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 					}
 					undo_redo->commit_action(true);
 					drag_type = DRAG_TYPE_NONE;
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_SET) {
 					undo_redo->create_action(TTR("Painting Terrain Set"));
 					for (KeyValue<TileMapCell, Variant> &E : drag_modified) {
@@ -2499,7 +2499,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 					}
 					undo_redo->commit_action(false);
 					drag_type = DRAG_TYPE_NONE;
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_BITS) {
 					Dictionary painted = Dictionary(drag_painted_value);
 					int terrain_set = int(painted["terrain_set"]);
@@ -2523,7 +2523,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 					}
 					undo_redo->commit_action(false);
 					drag_type = DRAG_TYPE_NONE;
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_BITS_RECT) {
 					Dictionary painted = Dictionary(drag_painted_value);
 					int terrain_set = int(painted["terrain_set"]);
@@ -2592,7 +2592,7 @@ void TileDataTerrainsEditor::forward_painting_atlas_gui_input(TileAtlasView *p_t
 					}
 					undo_redo->commit_action(true);
 					drag_type = DRAG_TYPE_NONE;
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 			}
 		}
@@ -2629,7 +2629,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 			}
 
 			drag_last_pos = mm->get_position();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_BITS) {
 			Dictionary painted = Dictionary(drag_painted_value);
 			int terrain_set = int(painted["terrain_set"]);
@@ -2682,7 +2682,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 				}
 			}
 			drag_last_pos = mm->get_position();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 
@@ -2720,7 +2720,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 						terrain_set_property_editor->update_property();
 						_update_terrain_selector();
 						picker_button->set_pressed(false);
-						accept_event();
+						get_viewport()->set_input_as_handled();
 					}
 				} else {
 					int terrain_set = int(dummy_object->get("terrain_set"));
@@ -2755,7 +2755,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 								tile_data->set_terrain_set(drag_painted_value);
 							}
 							drag_last_pos = mb->get_position();
-							accept_event();
+							get_viewport()->set_input_as_handled();
 						} else if (tile_data->get_terrain_set() == terrain_set) {
 							// Paint terrain bits.
 							if (mb->get_button_index() == MouseButton::RIGHT) {
@@ -2806,7 +2806,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 								}
 							}
 							drag_last_pos = mb->get_position();
-							accept_event();
+							get_viewport()->set_input_as_handled();
 						}
 					}
 				}
@@ -2829,7 +2829,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 					}
 					undo_redo->commit_action(false);
 					drag_type = DRAG_TYPE_NONE;
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				} else if (drag_type == DRAG_TYPE_PAINT_TERRAIN_BITS) {
 					Dictionary painted = Dictionary(drag_painted_value);
 					int terrain_set = int(painted["terrain_set"]);
@@ -2853,7 +2853,7 @@ void TileDataTerrainsEditor::forward_painting_alternatives_gui_input(TileAtlasVi
 					}
 					undo_redo->commit_action(false);
 					drag_type = DRAG_TYPE_NONE;
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 			}
 		}

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -333,7 +333,7 @@ void TileMapLayerEditorTilesPlugin::_patterns_item_list_gui_input(const Ref<Inpu
 		undo_redo->add_do_method(*tile_set, "add_pattern", tile_map_clipboard, new_pattern_index);
 		undo_redo->add_undo_method(*tile_set, "remove_pattern", new_pattern_index);
 		undo_redo->commit_action();
-		patterns_item_list->accept_event();
+		patterns_item_list->get_viewport()->set_input_as_handled();
 	}
 
 	if (ED_IS_SHORTCUT("tiles_editor/delete", p_event) && p_event->is_pressed() && !p_event->is_echo()) {
@@ -346,7 +346,7 @@ void TileMapLayerEditorTilesPlugin::_patterns_item_list_gui_input(const Ref<Inpu
 			undo_redo->add_undo_method(*tile_set, "add_pattern", tile_set->get_pattern(pattern_index), pattern_index);
 		}
 		undo_redo->commit_action();
-		patterns_item_list->accept_event();
+		patterns_item_list->get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1703,7 +1703,7 @@ void TileSetAtlasSourceEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 	if (ED_IS_SHORTCUT("tiles_editor/delete", p_event)) {
 		if (tools_button_group->get_pressed_button() == tool_select_button && !selection.is_empty()) {
 			_menu_option(TILE_DELETE);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -421,7 +421,7 @@ void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event
 			undo_redo->add_undo_method(*tile_set, "add_pattern", tile_set->get_pattern(pattern_index), pattern_index);
 		}
 		undo_redo->commit_action();
-		patterns_item_list->accept_event();
+		patterns_item_list->get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -888,7 +888,7 @@ void VersionControlEditorPlugin::_commit_message_gui_input(const Ref<InputEvent>
 
 			_commit();
 
-			commit_message->accept_event();
+			commit_message->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5090,7 +5090,7 @@ void VisualShaderEditor::_sbox_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			members->gui_input(key);
-			node_filter->accept_event();
+			node_filter->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1196,7 +1196,7 @@ void ProjectManager::shortcut_input(const Ref<InputEvent> &p_ev) {
 		}
 
 		if (keycode_handled) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -46,7 +46,7 @@ void PropertySelector::_sbox_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			search_options->gui_input(key);
-			search_box->accept_event();
+			search_box->get_viewport()->set_input_as_handled();
 
 			TreeItem *root = search_options->get_root();
 			if (!root->get_first_child()) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -241,7 +241,7 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	// Tool selection was successful, accept the event to stop propagation.
-	accept_event();
+	get_viewport()->set_input_as_handled();
 }
 
 void SceneTreeDock::_scene_tree_gui_input(Ref<InputEvent> p_event) {
@@ -254,7 +254,7 @@ void SceneTreeDock::_scene_tree_gui_input(Ref<InputEvent> p_event) {
 	if (ED_IS_SHORTCUT("editor/open_search", p_event)) {
 		filter->grab_focus();
 		filter->select_all();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -4034,7 +4034,7 @@ void SceneTreeDock::_filter_gui_input(const Ref<InputEvent> &p_event) {
 		filter_quick_menu->reset_size();
 		filter_quick_menu->popup();
 		filter_quick_menu->grab_focus();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -453,7 +453,7 @@ void ScreenSelect::_handle_mouse_shortcut(const Ref<InputEvent> &p_event) {
 	if (mouse_button.is_valid()) {
 		if (mouse_button->is_pressed() && mouse_button->get_button_index() == MouseButton::LEFT) {
 			_emit_screen_signal(get_window()->get_current_screen());
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -651,7 +651,7 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 		if (mode_buttons_group->get_pressed_button() == transform_mode_button) {
 			if (transform_mode_button->get_shortcut().is_valid() && transform_mode_button->get_shortcut()->matches_event(p_event)) {
 				select_mode_button->set_pressed(true);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return EditorPlugin::AFTER_GUI_INPUT_STOP;
 			}
 			return EditorPlugin::AFTER_GUI_INPUT_PASS;
@@ -669,7 +669,7 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 					// Can't press a button without toggle mode, so just emit the signal directly.
 					b->emit_signal(SceneStringName(pressed));
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return EditorPlugin::AFTER_GUI_INPUT_STOP;
 			}
 		}
@@ -693,13 +693,13 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 		// Options menu shortcuts:
 		Ref<Shortcut> ed_shortcut = ED_GET_SHORTCUT("grid_map/previous_floor");
 		if (ed_shortcut.is_valid() && ed_shortcut->matches_event(p_event)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			_menu_option(MENU_OPTION_PREV_LEVEL);
 			return EditorPlugin::AFTER_GUI_INPUT_STOP;
 		}
 		ed_shortcut = ED_GET_SHORTCUT("grid_map/next_floor");
 		if (ed_shortcut.is_valid() && ed_shortcut->matches_event(p_event)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			_menu_option(MENU_OPTION_NEXT_LEVEL);
 			return EditorPlugin::AFTER_GUI_INPUT_STOP;
 		}
@@ -707,7 +707,7 @@ EditorPlugin::AfterGUIInput GridMapEditor::forward_spatial_input_event(Camera3D 
 			const Ref<Shortcut> &shortcut = options->get_popup()->get_item_shortcut(i);
 			if (shortcut.is_valid() && shortcut->matches_event(p_event)) {
 				// Consume input to avoid conflicts with other plugins.
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				_menu_option(options->get_popup()->get_item_id(i));
 				return EditorPlugin::AFTER_GUI_INPUT_STOP;
 			}
@@ -881,7 +881,7 @@ void GridMapEditor::_sbox_input(const Ref<InputEvent> &p_event) {
 	if (key.is_valid()) {
 		if (key->is_action("ui_up", true) || key->is_action("ui_down", true) || key->is_action("ui_page_up") || key->is_action("ui_page_down")) {
 			mesh_library_palette->gui_input(key);
-			search_box->accept_event();
+			search_box->get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -275,7 +275,7 @@ void LayerHost::gui_input(const Ref<InputEvent> &p_event) {
 				ds->mouse_set_mode(DisplayServer::MOUSE_MODE_VISIBLE);
 				script_debugger->send_message("embed:mouse_set_mode", { DisplayServer::MOUSE_MODE_VISIBLE });
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
@@ -283,7 +283,7 @@ void LayerHost::gui_input(const Ref<InputEvent> &p_event) {
 	PackedByteArray data;
 	if (encode_input_event(p_event, data)) {
 		script_debugger->send_message("embed:event", { data });
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -446,7 +446,7 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 			_pressed();
 		}
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 
 		if (shortcut_feedback && is_inside_tree()) {
 			if (shortcut_feedback_timer == nullptr) {

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -300,7 +300,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 			code_completion_pan_offset = 0;
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -314,21 +314,21 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		if (is_code_completion_scroll_pressed && mb->get_button_index() == MouseButton::LEFT) {
 			is_code_completion_scroll_pressed = false;
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			queue_redraw();
 			return;
 		}
 
 		if (is_code_completion_drag_started && !mb->is_pressed()) {
 			is_code_completion_drag_started = false;
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			queue_redraw();
 			return;
 		}
 
 		if (code_completion_active && code_completion_rect.has_point(mb->get_position())) {
 			if (!mb->is_pressed()) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			is_code_completion_drag_started = true;
@@ -366,11 +366,11 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					break;
 			}
 
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		} else if (code_completion_active && code_completion_scroll_rect.has_point(mb->get_position())) {
 			if (mb->get_button_index() != MouseButton::LEFT) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 
@@ -382,7 +382,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				queue_redraw();
 			}
 
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -461,26 +461,26 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		bool scroll_hovered = code_completion_scroll_rect.has_point(mpos);
 		if (is_code_completion_scroll_hovered != scroll_hovered) {
 			is_code_completion_scroll_hovered = scroll_hovered;
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			queue_redraw();
 		}
 
 		if (is_code_completion_scroll_pressed) {
 			_update_scroll_selected_line(mpos.y);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			queue_redraw();
 			return;
 		}
 
 		if (code_completion_active && code_completion_rect.has_point(mm->get_position())) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
 
 	Ref<InputEventKey> k = p_gui_input;
 	if (TextEdit::alt_input(p_gui_input)) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -522,7 +522,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	/* AUTO-COMPLETE */
 	if (code_completion_enabled && k->is_action("ui_text_completion_query", true)) {
 		request_code_completion(true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -536,7 +536,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			code_completion_force_item_center = -1;
 			code_completion_pan_offset = 0.0f;
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_down", true)) {
@@ -548,7 +548,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			code_completion_force_item_center = -1;
 			code_completion_pan_offset = 0.0f;
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_page_up", true)) {
@@ -556,7 +556,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			code_completion_force_item_center = -1;
 			code_completion_pan_offset = 0.0f;
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_page_down", true)) {
@@ -564,7 +564,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			code_completion_force_item_center = -1;
 			code_completion_pan_offset = 0.0f;
 			queue_redraw();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_line_end", true)) {
@@ -572,18 +572,18 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 		if (k->is_action("ui_text_completion_replace", true) || k->is_action("ui_text_completion_accept", true)) {
 			confirm_code_completion(k->is_action("ui_text_completion_replace", true));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_cancel", true)) {
 			cancel_code_completion();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_backspace", true)) {
 			backspace();
 			_filter_code_completion_candidates_impl();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -597,7 +597,7 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	/* MISC */
 	if (!code_hint.is_empty() && k->is_action("ui_cancel", true)) {
 		set_code_hint("");
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (allow_unicode_handling && k->get_unicode() == ')') {
@@ -607,30 +607,30 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	/* Indentation */
 	if (k->is_action("ui_text_indent", true)) {
 		do_indent();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
 	if (k->is_action("ui_text_dedent", true)) {
 		unindent_lines();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
 	// Override new line actions, for auto indent.
 	if (k->is_action("ui_text_newline_above", true)) {
 		_new_line(false, true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_newline_blank", true)) {
 		_new_line(false);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_newline", true)) {
 		_new_line();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -178,7 +178,7 @@ void ColorPicker::_notification(int p_what) {
 					if (current_shape == SHAPE_NONE) {
 						shapes[current_shape]->echo_multiplier = 1;
 					}
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					set_process_internal(false);
 					return;
 				}
@@ -196,7 +196,7 @@ void ColorPicker::_notification(int p_what) {
 							input->is_action_pressed("ui_down") - input->is_action_pressed("ui_up"));
 
 					shapes[current_shape]->update_cursor(color_change_vector, true);
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 				return;
 			}

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -191,13 +191,13 @@ void ColorPickerShape::handle_cursor_editing(const Ref<InputEvent> &p_event, Con
 	if (p_event->is_action_pressed("ui_accept", false, true)) {
 		cursor_editing = !cursor_editing;
 		p_control->queue_redraw();
-		color_picker->accept_event();
+		color_picker->get_viewport()->set_input_as_handled();
 	}
 
 	if (cursor_editing && p_event->is_action_pressed("ui_cancel", false, true)) {
 		cursor_editing = false;
 		p_control->queue_redraw();
-		color_picker->accept_event();
+		color_picker->get_viewport()->set_input_as_handled();
 	}
 
 	if (!cursor_editing) {
@@ -210,7 +210,7 @@ void ColorPickerShape::handle_cursor_editing(const Ref<InputEvent> &p_event, Con
 	if (p_event->is_action_pressed("ui_left", true) || p_event->is_action_pressed("ui_right", true) || p_event->is_action_pressed("ui_up", true) || p_event->is_action_pressed("ui_down", true)) {
 		if (is_joypad_event) {
 			if (color_picker->is_processing_internal()) {
-				color_picker->accept_event();
+				color_picker->get_viewport()->set_input_as_handled();
 				return;
 			}
 			color_picker->set_process_internal(true);
@@ -220,7 +220,7 @@ void ColorPickerShape::handle_cursor_editing(const Ref<InputEvent> &p_event, Con
 				input->is_action_pressed("ui_right") - input->is_action_pressed("ui_left"),
 				input->is_action_pressed("ui_down") - input->is_action_pressed("ui_up"));
 		update_cursor(color_change_vector, p_event->is_echo());
-		color_picker->accept_event();
+		color_picker->get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -387,12 +387,12 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 		if (!wheel_focused && p_event->is_action_pressed("ui_down", true)) {
 			wheel_focused = true;
 			wheel_uv->queue_redraw();
-			color_picker->accept_event();
+			color_picker->get_viewport()->set_input_as_handled();
 			return;
 		} else if (wheel_focused && p_event->is_action_pressed("ui_up", true)) {
 			wheel_focused = false;
 			wheel_uv->queue_redraw();
-			color_picker->accept_event();
+			color_picker->get_viewport()->set_input_as_handled();
 			return;
 		}
 	}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1868,12 +1868,14 @@ void Control::_call_gui_input(const Ref<InputEvent> &p_event) {
 void Control::gui_input(const Ref<InputEvent> &p_event) {
 }
 
+#ifndef DISABLE_DEPRECATED
 void Control::accept_event() {
-	ERR_MAIN_THREAD_GUARD;
-	if (is_inside_tree()) {
-		get_viewport()->_gui_accept_event();
+	Viewport *v = get_viewport();
+	if (v) {
+		v->set_input_as_handled();
 	}
 }
+#endif // DISABLE_DEPRECATED
 
 bool Control::has_point(const Point2 &p_point) const {
 	ERR_READ_THREAD_GUARD_V(false);
@@ -3814,7 +3816,9 @@ void Control::_notification(int p_notification) {
 }
 
 void Control::_bind_methods() {
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("accept_event"), &Control::accept_event);
+#endif // DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("get_minimum_size"), &Control::get_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_combined_minimum_size"), &Control::get_combined_minimum_size);
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -541,7 +541,9 @@ public:
 	// Input events.
 
 	virtual void gui_input(const Ref<InputEvent> &p_event);
+#ifndef DISABLE_DEPRECATED
 	void accept_event();
+#endif // DISABLE_DEPRECATED
 
 	virtual bool has_point(const Point2 &p_point) const;
 

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -30,6 +30,7 @@
 
 #include "foldable_container.h"
 
+#include "scene/main/viewport.h"
 #include "scene/resources/text_line.h"
 #include "scene/theme/theme_db.h"
 
@@ -235,7 +236,7 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	if (p_event->is_action_pressed(SNAME("ui_accept"), false, true)) {
 		set_folded(!folded);
 		emit_signal(SNAME("folding_changed"), folded);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -245,7 +246,7 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 		if (b->get_button_index() == MouseButton::LEFT && b->is_pressed() && title_rect.has_point(b->get_position())) {
 			set_folded(!folded);
 			emit_signal(SNAME("folding_changed"), folded);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -176,7 +176,7 @@ void GraphEditMinimap::gui_input(const Ref<InputEvent> &p_ev) {
 			is_pressing = false;
 			is_resizing = false;
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	} else if (mm.is_valid() && is_pressing) {
 		if (is_resizing) {
 			// Prevent setting minimap wider than GraphEdit.
@@ -189,7 +189,7 @@ void GraphEditMinimap::gui_input(const Ref<InputEvent> &p_ev) {
 			Vector2 click_position = _convert_to_graph_position(mm->get_position() - minimap_padding) - graph_padding;
 			_adjust_graph_scroll(click_position);
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -2270,16 +2270,16 @@ void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 	if (p_ev->is_pressed()) {
 		if (p_ev->is_action("ui_graph_duplicate", true)) {
 			emit_signal(SNAME("duplicate_nodes_request"));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_ev->is_action("ui_copy", true)) {
 			emit_signal(SNAME("copy_nodes_request"));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_ev->is_action("ui_cut", true)) {
 			emit_signal(SNAME("cut_nodes_request"));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_ev->is_action("ui_paste", true)) {
 			emit_signal(SNAME("paste_nodes_request"));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_ev->is_action("ui_graph_delete", true)) {
 			TypedArray<StringName> nodes;
 
@@ -2294,7 +2294,7 @@ void GraphEdit::key_input(const Ref<InputEvent> &p_ev) {
 			}
 
 			emit_signal(SNAME("delete_nodes_request"), nodes);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -31,6 +31,7 @@
 #include "graph_element.h"
 
 #include "scene/gui/graph_edit.h"
+#include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 
 #ifdef TOOLS_ENABLED
@@ -150,7 +151,7 @@ void GraphElement::gui_input(const Ref<InputEvent> &p_ev) {
 				resizing = true;
 				resizing_from = mpos;
 				resizing_from_size = get_size();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 

--- a/scene/gui/graph_frame.cpp
+++ b/scene/gui/graph_frame.cpp
@@ -32,6 +32,7 @@
 
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
+#include "scene/main/viewport.h"
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_texture.h"
 #include "scene/theme/theme_db.h"
@@ -52,7 +53,7 @@ void GraphFrame::gui_input(const Ref<InputEvent> &p_ev) {
 				resizing = true;
 				resizing_from = mpos;
 				resizing_from_size = get_size();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -33,6 +33,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/gui/label.h"
+#include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 
 bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
@@ -412,26 +413,26 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 			if (selected_slot < 0) {
 				selected_slot = -1;
 			} else {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_down", true)) {
 			selected_slot++;
 			if (selected_slot >= slot_count) {
 				selected_slot = -1;
 			} else {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_cancel", true)) {
 			GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
 			if (graph && graph->is_keyboard_connecting()) {
 				graph->force_connection_drag_end();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_graph_delete", true)) {
 			GraphEdit *graph = Object::cast_to<GraphEdit>(get_parent());
 			if (graph && graph->is_keyboard_connecting()) {
 				graph->end_keyboard_connecting(this, -1, -1);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_graph_follow_left", true)) {
 			if (slot_table.has(selected_slot)) {
@@ -444,7 +445,7 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 								GraphNode *target = graph->get_input_connection_target(get_name(), i);
 								if (target) {
 									target->grab_focus();
-									accept_event();
+									get_viewport()->set_input_as_handled();
 									break;
 								}
 							}
@@ -463,7 +464,7 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 								GraphNode *target = graph->get_output_connection_target(get_name(), i);
 								if (target) {
 									target->grab_focus();
-									accept_event();
+									get_viewport()->set_input_as_handled();
 									break;
 								}
 							}
@@ -484,7 +485,7 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 								} else {
 									graph->start_keyboard_connecting(this, i, -1);
 								}
-								accept_event();
+								get_viewport()->set_input_as_handled();
 								break;
 							}
 						}
@@ -504,7 +505,7 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 								} else {
 									graph->start_keyboard_connecting(this, -1, i);
 								}
-								accept_event();
+								get_viewport()->set_input_as_handled();
 								break;
 							}
 						}
@@ -526,7 +527,7 @@ void GraphNode::gui_input(const Ref<InputEvent> &p_event) {
 					}
 					idx++;
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 		queue_accessibility_update();

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
+#include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 
 void ItemList::_shape_text(int p_idx) {
@@ -908,7 +909,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 
 				emit_signal(SNAME("item_clicked"), i, get_item_rect(i).position, MouseButton::RIGHT);
 
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
@@ -916,7 +917,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		if (select_mode == SELECT_MULTI && p_event->is_action("ui_up", false) && ev_key.is_valid() && ev_key->is_shift_pressed()) {
 			int next = MAX(current - max_columns, 0);
 			_shift_range_select(current, next);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		else if (p_event->is_action("ui_up", true)) {
@@ -936,7 +937,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 							break;
 						}
 					}
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 			}
@@ -947,7 +948,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					next = next - current_columns;
 				}
 				if (next < 0) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 				set_current(next);
@@ -955,7 +956,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				if (select_mode == SELECT_SINGLE) {
 					emit_signal(SceneStringName(item_selected), current);
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 
@@ -963,7 +964,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		else if (select_mode == SELECT_MULTI && p_event->is_action("ui_down", false) && ev_key.is_valid() && ev_key->is_shift_pressed()) {
 			int next = MIN(current + max_columns, items.size() - 1);
 			_shift_range_select(current, next);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		else if (p_event->is_action("ui_down", true)) {
@@ -982,7 +983,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 							break;
 						}
 					}
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 			}
@@ -993,7 +994,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					next = next + current_columns;
 				}
 				if (next >= items.size()) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 				set_current(next);
@@ -1001,7 +1002,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				if (select_mode == SELECT_SINGLE) {
 					emit_signal(SceneStringName(item_selected), current);
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_page_up", true)) {
 			search_string = ""; //any mousepress cancels
@@ -1014,7 +1015,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					if (select_mode == SELECT_SINGLE) {
 						emit_signal(SceneStringName(item_selected), current);
 					}
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					break;
 				}
 			}
@@ -1029,7 +1030,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					if (select_mode == SELECT_SINGLE) {
 						emit_signal(SceneStringName(item_selected), current);
 					}
-					accept_event();
+					get_viewport()->set_input_as_handled();
 
 					break;
 				}
@@ -1040,7 +1041,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		else if (select_mode == SELECT_MULTI && p_event->is_action("ui_left", false) && ev_key.is_valid() && ev_key->is_shift_pressed()) {
 			int next = MAX(current - 1, 0);
 			_shift_range_select(current, next);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		else if (p_event->is_action("ui_left", true)) {
@@ -1053,7 +1054,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					next = next - 1;
 				}
 				if (next < 0 || !IS_SAME_ROW(next, current_row)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 				set_current(next);
@@ -1061,7 +1062,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				if (select_mode == SELECT_SINGLE) {
 					emit_signal(SceneStringName(item_selected), current);
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 
@@ -1069,7 +1070,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 		else if (select_mode == SELECT_MULTI && p_event->is_action("ui_right", false) && ev_key.is_valid() && ev_key->is_shift_pressed()) {
 			int next = MIN(current + 1, items.size() - 1);
 			_shift_range_select(current, next);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		else if (p_event->is_action("ui_right", true)) {
@@ -1082,7 +1083,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 					next = next + 1;
 				}
 				if (items.size() <= next || !IS_SAME_ROW(next, current_row)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 				set_current(next);
@@ -1090,7 +1091,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 				if (select_mode == SELECT_SINGLE) {
 					emit_signal(SceneStringName(item_selected), current);
 				}
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_cancel", true)) {
 			search_string = "";
@@ -1160,7 +1161,7 @@ void ItemList::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (scroll_value_modified && (scroll_bar_v->get_value() != prev_scroll_v || scroll_bar_h->get_value() != prev_scroll_h)) {
-		accept_event(); //accept event if scroll changed
+		get_viewport()->set_input_as_handled(); //accept event if scroll changed
 	}
 
 #undef CAN_SELECT

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -387,7 +387,7 @@ void LineEdit::unhandled_key_input(const Ref<InputEvent> &p_event) {
 			if (text.length() != prev_len) {
 				_text_changed();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -417,7 +417,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				emit_signal(SNAME("editing_toggled"), true);
 			}
 
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -444,7 +444,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 					text_changed_dirty = true;
 				}
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -459,7 +459,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (b->is_pressed()) {
 			apply_ime();
 
-			accept_event(); // Don't pass event further when clicked on text field.
+			get_viewport()->set_input_as_handled(); // Don't pass event further when clicked on text field.
 			if (editable && !text.is_empty() && _is_over_clear_button(b->get_position())) {
 				clear_button_status.press_attempt = true;
 				clear_button_status.pressing_inside = true;
@@ -631,7 +631,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (editable && !editing && k->is_action_pressed("ui_text_submit", false)) {
 		edit();
 		emit_signal(SNAME("editing_toggled"), true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -645,7 +645,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			menu->popup();
 			menu->grab_focus();
 
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
@@ -653,13 +653,13 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (is_shortcut_keys_enabled()) {
 		if (k->is_action("ui_copy", true)) {
 			copy_text();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		if (k->is_action("ui_text_select_all", true)) {
 			select();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -669,7 +669,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			} else {
 				copy_text();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
@@ -690,7 +690,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		ime_selection = Vector2i(0, -1);
 		_shape();
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -706,7 +706,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		ime_selection = Vector2i(0, -1);
 		_shape();
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -722,7 +722,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		ime_selection = Vector2i(0, -1);
 		_shape();
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -738,7 +738,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		ime_selection = Vector2i(0, -1);
 		_shape();
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -809,7 +809,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		ime_selection = Vector2i(0, -1);
 		_shape();
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -849,7 +849,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			_shape();
 		}
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -862,7 +862,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		ime_selection = Vector2i();
 		_shape();
 		queue_redraw();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -882,7 +882,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal(SNAME("editing_toggled"), false);
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -892,27 +892,27 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal(SNAME("editing_toggled"), false);
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
 	if (is_shortcut_keys_enabled()) {
 		if (k->is_action("ui_paste", true)) {
 			paste_text();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// Undo / Redo
 		if (k->is_action("ui_undo", true)) {
 			undo();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		if (k->is_action("ui_redo", true)) {
 			redo();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}
@@ -920,34 +920,34 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	// BACKSPACE
 	if (k->is_action("ui_text_backspace_all_to_left", true)) {
 		_backspace(false, true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_backspace_word", true)) {
 		_backspace(true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_backspace", true)) {
 		_backspace();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
 	// DELETE
 	if (k->is_action("ui_text_delete_all_to_right", true)) {
 		_delete(false, true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_delete_word", true)) {
 		_delete(true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_delete", true)) {
 		_delete();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -960,41 +960,41 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (k->is_action("ui_text_caret_word_left", true)) {
 		_move_caret_left(shift_pressed, true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_caret_left", true)) {
 		_move_caret_left(shift_pressed);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_caret_word_right", true)) {
 		_move_caret_right(shift_pressed, true);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_caret_right", true)) {
 		_move_caret_right(shift_pressed, false);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
 	// Up = Home, Down = End
 	if (k->is_action("ui_text_caret_up", true) || k->is_action("ui_text_caret_line_start", true) || k->is_action("ui_text_caret_page_up", true)) {
 		_move_caret_start(shift_pressed);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 	if (k->is_action("ui_text_caret_down", true) || k->is_action("ui_text_caret_line_end", true) || k->is_action("ui_text_caret_page_down", true)) {
 		_move_caret_end(shift_pressed);
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
 	// Misc
 	if (k->is_action("ui_swap_input_direction", true)) {
 		_swap_current_input_direction();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 
@@ -1018,7 +1018,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				text_changed_dirty = true;
 			}
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 }

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -173,7 +173,7 @@ void MenuBar::shortcut_input(const Ref<InputEvent> &p_event) {
 				continue;
 			}
 			if (popups[i]->activate_item_by_event(p_event, false)) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -40,7 +40,7 @@ void MenuButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_pressed() && !is_disabled() && is_visible_in_tree() && popup->activate_item_by_event(p_event, false)) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -42,7 +42,7 @@ void OptionButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_pressed() && !p_event->is_echo() && !is_disabled() && is_visible_in_tree() && popup->activate_item_by_event(p_event, false)) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 		return;
 	}
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2679,7 +2679,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (scroll_value_modified && vscroll->get_value() != prev_scroll) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -2840,7 +2840,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 			}
 
 			if (handled) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 	}

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -47,18 +47,18 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> b = p_event;
 
 	if (b.is_valid()) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 
 		if (b->get_button_index() == MouseButton::WHEEL_DOWN && b->is_pressed()) {
 			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
 			scroll(MAX(change, get_step()));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (b->get_button_index() == MouseButton::WHEEL_UP && b->is_pressed()) {
 			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
 			scroll(-MAX(change, get_step()));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (b->get_button_index() != MouseButton::LEFT) {
@@ -141,7 +141,7 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (m.is_valid()) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 
 		if (drag.active) {
 			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -168,7 +168,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 			}
 
 			if (scroll_value_modified && (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll)) {
-				accept_event(); // Accept event if scroll changed.
+				get_viewport()->set_input_as_handled(); // Accept event if scroll changed.
 				return;
 			}
 		}
@@ -242,7 +242,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
-			accept_event(); // Accept event if scroll changed.
+			get_viewport()->set_input_as_handled(); // Accept event if scroll changed.
 		}
 		return;
 	}
@@ -257,7 +257,7 @@ void ScrollContainer::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
-			accept_event(); // Accept event if scroll changed.
+			get_viewport()->set_input_as_handled(); // Accept event if scroll changed.
 		}
 		return;
 	}

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -30,6 +30,7 @@
 
 #include "slider.h"
 
+#include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
 
 Size2 Slider::get_minimum_size() const {
@@ -146,7 +147,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 			} else {
 				set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_event->is_action_pressed("ui_right", true)) {
 			if (orientation != HORIZONTAL) {
 				return;
@@ -162,7 +163,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 			} else {
 				set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_event->is_action_pressed("ui_up", true)) {
 			if (orientation != VERTICAL) {
 				return;
@@ -174,7 +175,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				set_process_internal(true);
 			}
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_event->is_action_pressed("ui_down", true)) {
 			if (orientation != VERTICAL) {
 				return;
@@ -186,13 +187,13 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				set_process_internal(true);
 			}
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_event->is_action("ui_home", true) && p_event->is_pressed()) {
 			set_value(get_min());
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		} else if (p_event->is_action("ui_end", true) && p_event->is_pressed()) {
 			set_value(get_max());
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -189,7 +189,7 @@ LineEdit *SpinBox::get_line_edit() {
 
 void SpinBox::_line_edit_input(const Ref<InputEvent> &p_event) {
 	if (drag.enabled) {
-		line_edit->accept_event();
+		line_edit->get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -293,14 +293,14 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 				if (line_edit->is_editing()) {
 					use_custom_arrow_step = false;
 					set_value(get_value() + step * mb->get_factor());
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 			} break;
 			case MouseButton::WHEEL_DOWN: {
 				if (line_edit->is_editing()) {
 					use_custom_arrow_step = false;
 					set_value(get_value() - step * mb->get_factor());
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 			} break;
 			default:

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -316,7 +316,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				set_process_internal(true);
 			}
 			if (is_layout_rtl() ? select_previous_available() : select_next_available()) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		} else if (p_event->is_action("ui_left", true)) {
 			if (is_joypad_event) {
@@ -326,7 +326,7 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				set_process_internal(true);
 			}
 			if (is_layout_rtl() ? select_next_available() : select_previous_available()) {
-				accept_event();
+				get_viewport()->set_input_as_handled();
 			}
 		}
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2029,7 +2029,7 @@ void TextEdit::unhandled_key_input(const Ref<InputEvent> &p_event) {
 		// Handle Unicode (with modifiers active, process after shortcuts).
 		if (has_focus() && editable && (k->get_unicode() >= 32)) {
 			handle_unicode_input(k->get_unicode());
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }
@@ -2485,7 +2485,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		}
 		h_scroll->set_value(h_scroll->get_value() + pan_gesture->get_delta().x * 100);
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
-			accept_event(); // Accept event if scroll changed.
+			get_viewport()->set_input_as_handled(); // Accept event if scroll changed.
 		}
 		queue_accessibility_update();
 
@@ -2557,14 +2557,14 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
-		accept_event(); // Accept event if scroll changed.
+		get_viewport()->set_input_as_handled(); // Accept event if scroll changed.
 	}
 
 	Ref<InputEventKey> k = p_gui_input;
 
 	if (k.is_valid()) {
 		if (alt_input(p_gui_input)) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (!k->is_pressed()) {
@@ -2589,61 +2589,61 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		// NEWLINES.
 		if (k->is_action("ui_text_newline_above", true)) {
 			_new_line(false, true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_newline_blank", true)) {
 			_new_line(false);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_newline", true)) {
 			_new_line();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// BACKSPACE AND DELETE.
 		if (k->is_action("ui_text_backspace_all_to_left", true)) {
 			_do_backspace(false, true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_backspace_word", true)) {
 			_do_backspace(true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_backspace", true)) {
 			_do_backspace();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_delete_all_to_right", true)) {
 			_delete(false, true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_delete_word", true)) {
 			_delete(true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_delete", true)) {
 			_delete();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// SCROLLING.
 		if (k->is_action("ui_text_scroll_up", true)) {
 			_scroll_lines_up();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_scroll_down", true)) {
 			_scroll_lines_down();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -2652,67 +2652,67 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			// CLEAR CARETS AND SELECTIONS, CUT, COPY, PASTE.
 			if (k->is_action("ui_text_select_all", true)) {
 				select_all();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_text_select_word_under_caret", true)) {
 				select_word_under_caret();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_text_add_selection_for_next_occurrence", true)) {
 				add_selection_for_next_occurrence();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_text_skip_selection_for_next_occurrence", true)) {
 				skip_selection_for_next_occurrence();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_text_clear_carets_and_selection", true)) {
 				// Since the default shortcut is ESC, accepts the event only if it's actually performed.
 				if (_clear_carets_and_selection()) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 					return;
 				}
 			}
 			if (k->is_action("ui_cut", true)) {
 				cut();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_copy", true)) {
 				copy();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_paste", true)) {
 				paste();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 
 			// UNDO/REDO.
 			if (k->is_action("ui_undo", true)) {
 				undo();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_redo", true)) {
 				redo();
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 
 			if (k->is_action("ui_text_caret_add_below", true)) {
 				add_caret_at_carets(true);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 			if (k->is_action("ui_text_caret_add_above", true)) {
 				add_caret_at_carets(false);
-				accept_event();
+				get_viewport()->set_input_as_handled();
 				return;
 			}
 		}
@@ -2728,17 +2728,17 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				menu->popup();
 				menu->grab_focus();
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_toggle_insert_mode", true)) {
 			set_overtype_mode_enabled(!overtype_mode);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_swap_input_direction", true)) {
 			_swap_current_input_direction();
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -2752,77 +2752,77 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		// CARET MOVEMENT - LEFT, RIGHT.
 		if (k->is_action("ui_text_caret_word_left", true)) {
 			_move_caret_left(shift_pressed, true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_left", true)) {
 			_move_caret_left(shift_pressed, false);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_word_right", true)) {
 			_move_caret_right(shift_pressed, true);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_right", true)) {
 			_move_caret_right(shift_pressed, false);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// CARET MOVEMENT - UP, DOWN.
 		if (k->is_action("ui_text_caret_up", true)) {
 			_move_caret_up(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_down", true)) {
 			_move_caret_down(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// CARET MOVEMENT - DOCUMENT START/END.
 		if (k->is_action("ui_text_caret_document_start", true)) { // && shift_pressed) {
 			_move_caret_document_start(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_document_end", true)) { // && shift_pressed) {
 			_move_caret_document_end(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// CARET MOVEMENT - LINE START/END.
 		if (k->is_action("ui_text_caret_line_start", true)) {
 			_move_caret_to_line_start(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_line_end", true)) {
 			_move_caret_to_line_end(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// CARET MOVEMENT - PAGE UP/DOWN.
 		if (k->is_action("ui_text_caret_page_up", true)) {
 			_move_caret_page_up(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 		if (k->is_action("ui_text_caret_page_down", true)) {
 			_move_caret_page_down(shift_pressed);
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// Toggle Tab mode.
 		if (k->is_action("ui_focus_mode", true)) {
 			tab_input_mode = !tab_input_mode;
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
@@ -2831,14 +2831,14 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 			if (editable) {
 				insert_text_at_caret("\t");
 			}
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 
 		// Handle Unicode (if no modifiers active).
 		if (allow_unicode_handling && editable && k->get_unicode() >= 32) {
 			handle_unicode_input(k->get_unicode());
-			accept_event();
+			get_viewport()->set_input_as_handled();
 			return;
 		}
 	}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3360,12 +3360,12 @@ void Tree::_text_editor_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (p_event->is_action_pressed("ui_text_newline_blank", true)) {
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	} else if (p_event->is_action_pressed("ui_text_newline")) {
 		popup_edit_committed = true; // End edit popup processing.
 		popup_editor->hide();
 		_apply_multiline_edit();
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 }
 
@@ -3526,7 +3526,7 @@ void Tree::_go_left() {
 	}
 	queue_accessibility_update();
 	queue_redraw();
-	accept_event();
+	get_viewport()->set_input_as_handled();
 	ensure_cursor_is_visible();
 }
 
@@ -3554,7 +3554,7 @@ void Tree::_go_right() {
 	queue_accessibility_update();
 	queue_redraw();
 	ensure_cursor_is_visible();
-	accept_event();
+	get_viewport()->set_input_as_handled();
 }
 
 void Tree::_go_up() {
@@ -3589,7 +3589,7 @@ void Tree::_go_up() {
 
 	queue_accessibility_update();
 	ensure_cursor_is_visible();
-	accept_event();
+	get_viewport()->set_input_as_handled();
 }
 
 void Tree::_shift_select_range(TreeItem *new_item) {
@@ -3630,7 +3630,7 @@ void Tree::_shift_select_range(TreeItem *new_item) {
 	selected_col = s_col;
 	ensure_cursor_is_visible();
 	queue_redraw();
-	accept_event();
+	get_viewport()->set_input_as_handled();
 }
 
 void Tree::_go_down() {
@@ -3665,7 +3665,7 @@ void Tree::_go_down() {
 
 	queue_accessibility_update();
 	ensure_cursor_is_visible();
-	accept_event();
+	get_viewport()->set_input_as_handled();
 }
 
 bool Tree::_scroll(bool p_horizontal, float p_pages) {
@@ -3729,7 +3729,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 	bool is_command = k.is_valid() && k->is_command_or_control_pressed();
 	if (p_event->is_action(cache.rtl ? "ui_left" : "ui_right") && p_event->is_pressed()) {
 		if (!cursor_can_exit_tree) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (!selected_item || selected_col > (columns.size() - 1)) {
@@ -3747,7 +3747,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 	} else if (p_event->is_action(cache.rtl ? "ui_right" : "ui_left") && p_event->is_pressed()) {
 		if (!cursor_can_exit_tree) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		if (!selected_item || selected_col < 0) {
@@ -3765,7 +3765,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 	} else if (p_event->is_action("ui_up") && p_event->is_pressed() && !is_command) {
 		if (!cursor_can_exit_tree) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		// Shift Up Selection.
 		if (k.is_valid() && k->is_shift_pressed() && selected_item && select_mode == SELECT_MULTI) {
@@ -3777,7 +3777,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 	} else if (p_event->is_action("ui_down") && p_event->is_pressed() && !is_command) {
 		if (!cursor_can_exit_tree) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 		// Shift Down Selection.
 		if (k.is_valid() && k->is_shift_pressed() && selected_item && select_mode == SELECT_MULTI) {
@@ -3791,10 +3791,10 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			emit_signal(SNAME("item_mouse_selected"), get_item_rect(selected_item).position, MouseButton::RIGHT);
 		}
 
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	} else if (p_event->is_action("ui_page_down") && p_event->is_pressed()) {
 		if (!cursor_can_exit_tree) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		TreeItem *next = nullptr;
@@ -3833,7 +3833,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		ensure_cursor_is_visible();
 	} else if (p_event->is_action("ui_page_up") && p_event->is_pressed()) {
 		if (!cursor_can_exit_tree) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 
 		TreeItem *prev = nullptr;
@@ -3888,7 +3888,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			const TreeItem::Cell &c = selected_item->cells[selected_col];
 			emit_signal("button_clicked", selected_item, selected_col, c.buttons[selected_button].id, MouseButton::LEFT);
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	} else if (p_event->is_action("ui_accept") && p_event->is_pressed()) {
 		if (selected_item) {
 			// Bring up editor if possible.
@@ -3900,7 +3900,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				incr_search.clear();
 			}
 		}
-		accept_event();
+		get_viewport()->set_input_as_handled();
 	}
 
 	if (allow_search && k.is_valid()) { // Incremental search.
@@ -3921,7 +3921,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (k->get_unicode() > 0) {
 			_do_incr_search(String::chr(k->get_unicode()));
-			accept_event();
+			get_viewport()->set_input_as_handled();
 
 			return;
 		} else {
@@ -4175,25 +4175,25 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 			} break;
 			case MouseButton::WHEEL_UP: {
 				if (_scroll(mb->is_shift_pressed(), -mb->get_factor() / 8)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 
 			} break;
 			case MouseButton::WHEEL_DOWN: {
 				if (_scroll(mb->is_shift_pressed(), mb->get_factor() / 8)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 
 			} break;
 			case MouseButton::WHEEL_LEFT: {
 				if (_scroll(!mb->is_shift_pressed(), -mb->get_factor() / 8)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 
 			} break;
 			case MouseButton::WHEEL_RIGHT: {
 				if (_scroll(!mb->is_shift_pressed(), mb->get_factor() / 8)) {
-					accept_event();
+					get_viewport()->set_input_as_handled();
 				}
 
 			} break;
@@ -4215,7 +4215,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (v_scroll->get_value() != prev_v || h_scroll->get_value() != prev_h) {
-			accept_event();
+			get_viewport()->set_input_as_handled();
 		}
 	}
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2661,12 +2661,6 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 	}
 }
 
-void Viewport::_gui_accept_event() {
-	if (is_inside_tree()) {
-		set_input_as_handled();
-	}
-}
-
 void Viewport::_drop_mouse_focus() {
 	Control *c = gui.mouse_focus;
 	BitField<MouseButtonMask> mask = gui.mouse_focus_mask;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -462,7 +462,6 @@ private:
 	void _gui_control_grab_focus(Control *p_control);
 	void _gui_grab_click_focus(Control *p_control);
 	void _post_gui_grab_click_focus();
-	void _gui_accept_event();
 
 	bool _gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_check);
 


### PR DESCRIPTION
`Control::accept_event` does `get_viewport()->_gui_accept_event()` only if the control is inside the tree. `Viewport::_gui_accept_event` does `set_input_as_handled()` only if the viewport is inside the tree. 

A strange method. Why would it be called outside the tree? Why make a private method in a separate class that only calls two public methods? Why the checks?

The viewport returned by `get_viewport()` in `accept_event` will always be in the tree, meaning `_gui_accept_event` has no purpose beyond calling the `set_input_as_handled`, which could have been in `accept_event` directly.

I also find the existence of `accept_event` itself unnecessary and misleading. It's just `get_viewport()->set_input_as_handled()` except instead of getting an error when it isn't in the tree (`get_viewport()` would be null), it just silently does nothing as if the user hadn't done anything wrong, when doing either outside of the tree should be a clear error on the user's part. 

The user should never call `accept_event()` where they would not call `get_viewport()->set_input_as_handled()`. That is, they should not be calling either outside of an input method. If they _are_ in an input method, there is an event to handle, therefore, there must be a viewport inside the tree that propagated the event, making the checks unnecessary. If the user _really_ wants to accept input events outside of an input method (if they even can), they are free to do their own check if they're in the tree. Otherwise, using `set_input_as_handled` is always the better option.

I have made a slight modification and deprecated `Control::accept_event` in favor of `Viewport::set_input_as_handled`. Since `accept_event` was the only user of the useless `Viewport::_gui_accept_event`, it has been removed.