### PR TITLE
Fix `get_rpc_config()` missing return configurations

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -540,8 +540,10 @@
 		</method>
 		<method name="get_rpc_config" qualifiers="const">
 			<return type="Variant" />
+			<param index="0" name="script_rpc_get" type="bool" default="true" />
 			<description>
 				Returns a [Dictionary] mapping method names to their RPC configuration defined for this node using [method rpc_config].
+				If [param script_rpc_get] is [code]true[/code], return [Dictionary] will also contain functions RPC configuration of attached GDScript.
 			</description>
 		</method>
 		<method name="get_scene_instance_load_placeholder" qualifiers="const">

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -784,7 +784,7 @@ public:
 	bool is_multiplayer_authority() const;
 
 	void rpc_config(const StringName &p_method, const Variant &p_config); // config a local method for RPC
-	Variant get_rpc_config() const;
+	Variant get_rpc_config(bool script_rpc_get = false) const;
 
 	template <typename... VarArgs>
 	Error rpc(const StringName &p_method, VarArgs... p_args);


### PR DESCRIPTION
Fixes bug https://github.com/godotengine/godot/issues/105675#issuecomment-2899207447 introduced by https://github.com/godotengine/godot/pull/96024

GDScript RPC configurations (set by **@rpc** annotations) are now returned by `get_rpc_config()` call.

Internal interface is kept stable by adding an optional parameter defaulting to `false`.
Exposed GDScript `get_rpc_config()` defaults to `true`, so default behaviour is changed to return attached GDScript configs too.