### PR TITLE
Add `insert_item` method to ItemList

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -179,6 +179,18 @@
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>
+		<method name="insert_item">
+			<return type="void" />
+			<param index="0" name="idx" type="int" />
+			<param index="1" name="text" type="String" />
+			<param index="2" name="icon" type="Texture2D" default="null" />
+			<param index="3" name="selectable" type="bool" default="true" />
+			<description>
+				Inserts an item at the specified index in the item list with the specified text.
+				Specify an [param icon], or use [code]null[/code] as the [param icon] for a list item with no icon.
+				If [param selectable] is [code]true[/code], the list item will be selectable.
+			</description>
+		</method>
 		<method name="is_anything_selected">
 			<return type="bool" />
 			<description>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -186,7 +186,7 @@
 			<param index="2" name="icon" type="Texture2D" default="null" />
 			<param index="3" name="selectable" type="bool" default="true" />
 			<description>
-				Inserts an item at the specified index in the item list with the specified text.
+				Inserts an item with the specified text at the specified index in the item list.
 				Specify an [param icon], or use [code]null[/code] as the [param icon] for a list item with no icon.
 				If [param selectable] is [code]true[/code], the list item will be selectable.
 			</description>

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -71,6 +71,24 @@ int ItemList::add_item(const String &p_item, const Ref<Texture2D> &p_texture, bo
 	return item_id;
 }
 
+void ItemList::insert_item(int p_idx, const String &p_item, const Ref<Texture2D> &p_texture, bool p_selectable) {
+	ERR_FAIL_INDEX(p_idx, items.size() + 1);
+
+	Item item;
+	item.icon = p_texture;
+	item.text = p_item;
+	item.selectable = p_selectable;
+	items.insert(p_idx, item);
+
+	items.write[p_idx].xl_text = _atr(p_idx, p_item);
+	_shape_text(p_idx);
+
+	queue_accessibility_update();
+	queue_redraw();
+	shape_changed = true;
+	notify_property_list_changed();
+}
+
 int ItemList::add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable) {
 	Item item;
 	item.icon = p_item;
@@ -2207,6 +2225,8 @@ bool ItemList::_set(const StringName &p_name, const Variant &p_value) {
 void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_item", "text", "icon", "selectable"), &ItemList::add_item, DEFVAL(Variant()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("add_icon_item", "icon", "selectable"), &ItemList::add_icon_item, DEFVAL(true));
+
+	ClassDB::bind_method(D_METHOD("insert_item", "idx", "text", "icon", "selectable"), &ItemList::insert_item, DEFVAL(Variant()), DEFVAL(true));
 
 	ClassDB::bind_method(D_METHOD("set_item_text", "idx", "text"), &ItemList::set_item_text);
 	ClassDB::bind_method(D_METHOD("get_item_text", "idx"), &ItemList::get_item_text);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -204,6 +204,8 @@ public:
 	int add_item(const String &p_item, const Ref<Texture2D> &p_texture = Ref<Texture2D>(), bool p_selectable = true);
 	int add_icon_item(const Ref<Texture2D> &p_item, bool p_selectable = true);
 
+	void insert_item(int p_idx, const String &p_item, const Ref<Texture2D> &p_texture = Ref<Texture2D>(), bool p_selectable = true);
+
 	void set_item_text(int p_idx, const String &p_text);
 	String get_item_text(int p_idx) const;
 


### PR DESCRIPTION
Hello, first-time PR here.

With this addition, you can insert an item into an `ItemList` at any index, such as 0 for the top, even including the new index at the bottom that will exist when an item is added. This is a pretty familiar idea for people coming from other GUI frameworks.

Hopefully I've done a decent enough job to consider adding this to the main codebase because I'd love to use this contribution myself. It does compile and work for me on Windows, VS2022, built with scons platform=windows dev_build=yes. I do need some help with the unit testing aspect of this because I don't quite understand how to write an appropriate test for this yet.

Rationale: While working with ItemList, I wanted a method to add/insert an item at any arbitrary index in the list, particularly at the top (index 0), so I created it. It's more efficient (in terms of CPU cycles and lines-of-code) than calling `add_item`, storing its return value, then calling `move_item`.

Code notes: This is short and simple, inspired by `add_item` and `move_item`. I thought about overloading `add_item` for this but landed on creating a separate `insert_item` method instead. Generally the index parameter is first in most languages' insert functions, so that's what I did here - and overloading `add_item` this way didn't feel good. The method doesn't return a value because you either know the index already or will be receiving an error, and as far as I can see, something like `ERR_FAIL_INDEX` isn't available for methods returning a value anyway.

edit: Following a code review, I reworded position to index, since position is commonly used for 2D coordinates. I also removed everything related to an unnecessary insert-at-end modality.

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/12482