### PR TITLE
Fix `execute_with_pipe` / `create_process` exit code.

### DIFF
--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -71,7 +71,7 @@ class OS_Unix : public OS {
 	void _load_iconv();
 #endif
 
-	static int _wait_for_pid_completion(const pid_t p_pid, int *r_status, int p_options);
+	static int _wait_for_pid_completion(const pid_t p_pid, int *r_status, int p_options, pid_t *r_pid = nullptr);
 	bool _check_pid_is_running(const pid_t p_pid, int *r_status) const;
 
 protected:


### PR DESCRIPTION
When `WNOHANG` is set, `waitpid` set correct status only when call returns the same `pid` as requested, subsequent calls return `-1` and always set state to `0`.

Fixes https://github.com/godotengine/godot/issues/106644