### PR TITLE
Fix use-after-free error in profiling-related code in GDScriptFunction::call

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1916,7 +1916,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #ifdef DEBUG_ENABLED
 
-				if (GDScriptLanguage::get_singleton()->profiling) {
+				bool was_base_object_freed = false;
+				base_obj = base->get_validated_object_with_check(was_base_object_freed);
+				if (GDScriptLanguage::get_singleton()->profiling && !was_base_object_freed) {
 					uint64_t t_taken = OS::get_singleton()->get_ticks_usec() - call_time;
 					if (GDScriptLanguage::get_singleton()->profile_native_calls && _profile_count_as_native(base_obj, *methodname)) {
 						_profile_native_call(t_taken, *methodname, base_class);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #106680 by adding a freed check before entering profiling related code in `GDScriptFunction::call`.
