### PR TITLE
Expose helper methods for converting UIDs

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -364,6 +364,10 @@ void ResourceUID::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_id_path", "id"), &ResourceUID::get_id_path);
 	ClassDB::bind_method(D_METHOD("remove_id", "id"), &ResourceUID::remove_id);
 
+	ClassDB::bind_static_method("ResourceUID", D_METHOD("uid_to_path", "uid"), &ResourceUID::uid_to_path);
+	ClassDB::bind_static_method("ResourceUID", D_METHOD("path_to_uid", "path"), &ResourceUID::path_to_uid);
+	ClassDB::bind_static_method("ResourceUID", D_METHOD("ensure_path", "path_or_uid"), &ResourceUID::ensure_path);
+
 	BIND_CONSTANT(INVALID_ID)
 }
 ResourceUID *ResourceUID::singleton = nullptr;

--- a/doc/classes/ResourceUID.xml
+++ b/doc/classes/ResourceUID.xml
@@ -33,6 +33,13 @@
 				Like [method create_id], but the UID is seeded with the provided [param path] and project name. UIDs generated for that path will be always the same within the current project.
 			</description>
 		</method>
+		<method name="ensure_path" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="path_or_uid" type="String" />
+			<description>
+				Returns a path, converting [param path_or_uid] if necessary. Prints an error if provided an invalid UID.
+			</description>
+		</method>
 		<method name="get_id_path" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="id" type="int" />
@@ -53,6 +60,13 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Converts the given UID to a [code]uid://[/code] string value.
+			</description>
+		</method>
+		<method name="path_to_uid" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Converts the provided resource [param path] to a UID. Returns the unchanged path if it has no associated UID.
 			</description>
 		</method>
 		<method name="remove_id">
@@ -77,6 +91,13 @@
 			<param index="0" name="text_id" type="String" />
 			<description>
 				Extracts the UID value from the given [code]uid://[/code] string.
+			</description>
+		</method>
+		<method name="uid_to_path" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="uid" type="String" />
+			<description>
+				Converts the provided [param uid] to a path. Prints an error if the UID is invalid.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Related https://github.com/godotengine/godot/pull/105414#issuecomment-2899185397

Exposes the static methods for converting between paths and UIDs. They are widely used in the engine and didn't change since they were added, so there is no reason to keep them unexposed. They make working with UIDs more convenient.