### PR TITLE
Android: Add export option for custom theme attributes

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -52,6 +52,12 @@
 		<member name="gradle_build/android_source_template" type="String" setter="" getter="">
 			Path to a ZIP file holding the source for the export template used in a Gradle build. If left empty, the default template is used.
 		</member>
+		<member name="gradle_build/custom_theme_attributes" type="Dictionary" setter="" getter="">
+			A dictionary of custom theme attributes to include in the exported Android project. Each entry defines a theme attribute name and its value, and will be added to the [b]GodotAppMainTheme[/b].
+			For example, the key [code]android:windowSwipeToDismiss[/code] with the value [code]false[/code] is resolved to [code]&lt;item name="android:windowSwipeToDismiss"&gt;false&lt;/item&gt;[/code].
+			[b]Note:[/b] To add a custom attribute to the [b]GodotAppSplashTheme[/b], prefix the attribute name with [code][splash][/code].
+			[b]Note:[/b] Reserved attributes configured via other export options or project settings cannot be overridden by [code]custom_theme_attributes[/code] and are skipped during export.
+		</member>
 		<member name="gradle_build/export_format" type="int" setter="" getter="">
 			Application export format (*.apk or *.aab).
 		</member>

--- a/platform/android/java/app/res/values/themes.xml
+++ b/platform/android/java/app/res/values/themes.xml
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
+	<!-- GodotAppMainTheme is auto-generated during export. Manual changes will be overwritten.
+		 To add custom attributes, use the "gradle_build/custom_theme_attributes" Android export option. -->
 	<style name="GodotAppMainTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar">
 		<item name="android:windowDrawsSystemBarBackgrounds">false</item>
 		<item name="android:windowSwipeToDismiss">false</item>
 	</style>
 
+	<!-- GodotAppSplashTheme is auto-generated during export. Manual changes will be overwritten.
+		 To add custom attributes, use the "gradle_build/custom_theme_attributes" Android export option. -->
 	<style name="GodotAppSplashTheme" parent="Theme.SplashScreen">
-		<!-- Set the splash screen background, animated icon, and animation
-   duration. -->
 		<item name="android:windowSplashScreenBackground">@mipmap/icon_background</item>
-
-		<!-- Use windowSplashScreenAnimatedIcon to add a drawable or an animated
-			 drawable. One of these is required. -->
 		<item name="windowSplashScreenAnimatedIcon">@mipmap/icon_foreground</item>
-
-		<!-- Set the theme of the Activity that directly follows your splash
-		screen. This is required. -->
 		<item name="postSplashScreenTheme">@style/GodotAppMainTheme</item>
 	</style>
 </resources>


### PR DESCRIPTION
- Regenerate the `GodotAppMainTheme` and `GodotAppSplashTheme` during Android export. Any manual changes to this style will be cleared and replaced with default theme attributes.

- Adds a new export option `gradle_build/custom_theme_attributes` for injecting custom theme attributes directly via the export window, avoiding the need to manually modify themes.xml.

It helps to avoid the issue I metioned in https://github.com/godotengine/godot/pull/106709#discussion_r2103088921.

![image](https://github.com/user-attachments/assets/9326e82d-3843-4a15-ab4e-5bc29a212f5f)
According to the attributes shown in the image:
- The first pair adds `<item name="android:windowIsTranslucent">true</item>` to the GodotAppMainTheme.
- In the second pair key is prefixed with `[splash]`, so it adds the attribute to the GodotAppSplashTheme.