### PR TITLE
[Web] Fix `LineEdit` `text_submitted` signal not triggering when using a virtual keyboard

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -789,6 +789,35 @@ void DisplayServerWeb::_vk_input_text_callback(const String &p_text, int p_curso
 	}
 }
 
+void DisplayServerWeb::vk_submit_text_callback() {
+#ifdef PROXY_TO_PTHREAD_ENABLED
+	if (!Thread::is_main_thread()) {
+		callable_mp_static(DisplayServerWeb::_vk_submit_text_callback).call_deferred();
+		return;
+	}
+#endif
+
+	_vk_submit_text_callback();
+}
+
+void DisplayServerWeb::_vk_submit_text_callback() {
+	DisplayServerWeb *ds = DisplayServerWeb::get_singleton();
+	if (!ds || !ds->input_event_callback.is_valid()) {
+		return;
+	}
+	Ref<InputEventKey> k;
+	k.instantiate();
+	k->set_pressed(true);
+	k->set_echo(false);
+	k->set_keycode(Key::ENTER);
+	ds->input_event_callback.call(k);
+	k.instantiate();
+	k->set_pressed(false);
+	k->set_echo(false);
+	k->set_keycode(Key::ENTER);
+	ds->input_event_callback.call(k);
+}
+
 void DisplayServerWeb::virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect, VirtualKeyboardType p_type, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
 	godot_js_display_vk_show(p_existing_text.utf8().get_data(), p_type, p_cursor_start, p_cursor_end);
 }
@@ -1145,7 +1174,7 @@ DisplayServerWeb::DisplayServerWeb(const String &p_rendering_driver, WindowMode 
 			WINDOW_EVENT_MOUSE_EXIT,
 			WINDOW_EVENT_FOCUS_IN,
 			WINDOW_EVENT_FOCUS_OUT);
-	godot_js_display_vk_cb(&DisplayServerWeb::vk_input_text_callback);
+	godot_js_display_vk_cb(&DisplayServerWeb::vk_input_text_callback, &DisplayServerWeb::vk_submit_text_callback);
 
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_event);
 }

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -130,6 +130,8 @@ private:
 	static void _key_callback(const String &p_key_event_code, const String &p_key_event_key, int p_pressed, int p_repeat, int p_modifiers);
 	WASM_EXPORT static void vk_input_text_callback(const char *p_text, int p_cursor);
 	static void _vk_input_text_callback(const String &p_text, int p_cursor);
+	WASM_EXPORT static void vk_submit_text_callback();
+	static void _vk_submit_text_callback();
 	WASM_EXPORT static void gamepad_callback(int p_index, int p_connected, const char *p_id, const char *p_guid);
 	static void _gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid);
 	WASM_EXPORT static void js_utterance_callback(int p_event, int p_id, int p_pos);

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -127,7 +127,7 @@ extern void godot_js_display_notification_cb(void (*p_callback)(int p_notificati
 // Display Virtual Keyboard
 extern int godot_js_display_vk_available();
 extern int godot_js_display_tts_available();
-extern void godot_js_display_vk_cb(void (*p_input)(const char *p_text, int p_cursor));
+extern void godot_js_display_vk_cb(void (*p_input)(const char *p_text, int p_cursor), void (*p_callback)());
 extern void godot_js_display_vk_show(const char *p_text, int p_type, int p_start, int p_end);
 extern void godot_js_display_vk_hide();
 

--- a/platform/web/js/libs/library_godot_display.js
+++ b/platform/web/js/libs/library_godot_display.js
@@ -40,7 +40,7 @@ const GodotDisplayVK = {
 			return GodotConfig.virtual_keyboard && 'ontouchstart' in window;
 		},
 
-		init: function (input_cb) {
+		init: function (input_cb, submit_cb) {
 			function create(what) {
 				const elem = document.createElement(what);
 				elem.style.display = 'none';
@@ -66,7 +66,18 @@ const GodotDisplayVK = {
 					elem.readonly = true;
 					elem.disabled = true;
 				}, false);
-				GodotConfig.canvas.insertAdjacentElement('beforebegin', elem);
+				const form = document.createElement('form');
+				form.method = 'POST'; // avoids having `?` added to the URL
+				form.appendChild(elem);
+				const submit = document.createElement('input');
+				submit.type = 'submit';
+				submit.style.overflow = 'hidden';
+				form.appendChild(submit);
+				GodotEventListeners.add(form, 'submit', function (evt) {
+					evt.preventDefault();
+					submit_cb();
+				}, false);
+				GodotConfig.canvas.insertAdjacentElement('beforebegin', form);
 				return elem;
 			}
 			GodotDisplayVK.textinput = create('input');
@@ -789,10 +800,11 @@ const GodotDisplay = {
 
 	godot_js_display_vk_cb__proxy: 'sync',
 	godot_js_display_vk_cb__sig: 'vi',
-	godot_js_display_vk_cb: function (p_input_cb) {
+	godot_js_display_vk_cb: function (p_input_cb, p_submit_cb) {
 		const input_cb = GodotRuntime.get_func(p_input_cb);
+		const submit_cb = GodotRuntime.get_func(p_submit_cb);
 		if (GodotDisplayVK.available()) {
-			GodotDisplayVK.init(input_cb);
+			GodotDisplayVK.init(input_cb, submit_cb);
 		}
 	},
 };


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103771 (see also https://github.com/godotengine/godot/pull/106540)
Fixes (partially) https://github.com/godotengine/godot/issues/76215

The way this works is by wrapping the HTML input in a submit form and listening for the submit event. 

### Minimal reproduction project (MRP)
[line_edit_vk_submit_2025-05-22_21-29-35.zip](https://github.com/user-attachments/files/20399409/line_edit_vk_submit_2025-05-22_21-29-35.zip)


