### PR TITLE
Simplify `Memory::memnew_arr_placement` to always initialize memory

### DIFF
--- a/core/os/memory.h
+++ b/core/os/memory.h
@@ -196,19 +196,15 @@ T *memnew_arr_template(size_t p_elements) {
 }
 
 // Fast alternative to a loop constructor pattern.
-template <bool p_ensure_zero = false, typename T>
+template <typename T>
 _FORCE_INLINE_ void memnew_arr_placement(T *p_start, size_t p_num) {
-	if constexpr (std::is_trivially_constructible_v<T> && !p_ensure_zero) {
-		// Don't need to do anything :)
-		(void)p_start;
-		(void)p_num;
-	} else if constexpr (is_zero_constructible_v<T>) {
+	if constexpr (is_zero_constructible_v<T>) {
 		// Can optimize with memset.
 		memset(static_cast<void *>(p_start), 0, p_num * sizeof(T));
 	} else {
 		// Need to use a for loop.
 		for (size_t i = 0; i < p_num; i++) {
-			memnew_placement(p_start + i, T);
+			memnew_placement(p_start + i, T());
 		}
 	}
 }

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -182,7 +182,7 @@ public:
 	_FORCE_INLINE_ operator Span<T>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<T> span() const { return Span(ptr(), length()); }
 
-	_FORCE_INLINE_ Error resize(int p_size) { return _cowdata.resize(p_size); }
+	_FORCE_INLINE_ Error resize(int p_size) { return _cowdata.template resize<false>(p_size); }
 
 	_FORCE_INLINE_ T get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
@@ -324,7 +324,7 @@ public:
 
 	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }
-	Error resize(int p_size) { return _cowdata.resize(p_size); }
+	Error resize(int p_size) { return _cowdata.resize<false>(p_size); }
 
 	_FORCE_INLINE_ const char32_t &operator[](int p_index) const {
 		if (unlikely(p_index == _cowdata.size())) {

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -208,7 +208,7 @@ public:
 		return _ptr[p_index];
 	}
 
-	template <bool p_ensure_zero = false>
+	template <bool p_initialize = true>
 	Error resize(Size p_size);
 
 	_FORCE_INLINE_ void remove_at(Size p_index) {
@@ -366,7 +366,7 @@ Error CowData<T>::_fork_allocate(USize p_size) {
 }
 
 template <typename T>
-template <bool p_ensure_zero>
+template <bool p_initialize>
 Error CowData<T>::resize(Size p_size) {
 	ERR_FAIL_COND_V(p_size < 0, ERR_INVALID_PARAMETER);
 
@@ -380,8 +380,12 @@ Error CowData<T>::resize(Size p_size) {
 		return error;
 	}
 
-	if (p_size > prev_size) {
-		memnew_arr_placement<p_ensure_zero>(_ptr + prev_size, p_size - prev_size);
+	if constexpr (p_initialize) {
+		if (p_size > prev_size) {
+			memnew_arr_placement(_ptr + prev_size, p_size - prev_size);
+		}
+	} else {
+		static_assert(std::is_trivially_destructible_v<T>);
 	}
 
 	return OK;

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -107,7 +107,7 @@ public:
 	constexpr Error resize_initialized(uint32_t p_size) {
 		if (p_size > _size) {
 			ERR_FAIL_COND_V(p_size > CAPACITY, ERR_OUT_OF_MEMORY);
-			memnew_arr_placement<true>(ptr() + _size, p_size - _size);
+			memnew_arr_placement(ptr() + _size, p_size - _size);
 		} else if (p_size < _size) {
 			if constexpr (!std::is_trivially_destructible_v<T>) {
 				for (uint32_t i = p_size; i < _size; i++) {

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -93,13 +93,13 @@ public:
 	_FORCE_INLINE_ operator Span<T>() const { return _cowdata.span(); }
 	_FORCE_INLINE_ Span<T> span() const { return _cowdata.span(); }
 
-	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ void clear() { _cowdata.clear(); }
 	_FORCE_INLINE_ bool is_empty() const { return _cowdata.is_empty(); }
 
 	_FORCE_INLINE_ T get(Size p_index) { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ const T &get(Size p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(Size p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
-	Error resize(Size p_size) { return _cowdata.resize(p_size); }
+	Error resize(Size p_size) { return _cowdata.template resize<!std::is_trivially_constructible_v<T>>(p_size); }
 	Error resize_zeroed(Size p_size) { return _cowdata.template resize<true>(p_size); }
 	_FORCE_INLINE_ const T &operator[](Size p_index) const { return _cowdata.get(p_index); }
 	// Must take a copy instead of a reference (see GH-31736).


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/105505

The parameter `ensure_zero` has always been somewhat of an oddball: If you don't want to ensure zero, why call the function at all?

I think it makes sense to make it simpler, and just make the function _always_ initialize elements. The various logics to avoid initialization (e.g. for 'trivial' types) is a decision that is better made explicitly by callers.
The decision is further bubbled up from `CowData`, such that it is made by `Vector`, and it can be seen at a glance that elements are not initialized when they are trivially constructible.