### PR TITLE
Renderer: Eliminate `String` allocations for all labels in the renderer

### DIFF
--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -56,6 +56,8 @@ class PixelFormats;
 class MDResourceCache;
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) RenderingContextDriverMetal : public RenderingContextDriver {
+	bool capture_available = false;
+
 protected:
 #ifdef __OBJC__
 	id<MTLDevice> metal_device = nullptr;
@@ -80,7 +82,7 @@ public:
 	void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) final override;
 	bool surface_get_needs_resize(SurfaceID p_surface) const final override;
 	void surface_destroy(SurfaceID p_surface) final override;
-	bool is_debug_utils_enabled() const final override { return true; }
+	bool is_debug_utils_enabled() const final override { return capture_available; }
 
 #pragma mark - Metal-specific methods
 

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -45,6 +45,10 @@ RenderingContextDriverMetal::~RenderingContextDriverMetal() {
 }
 
 Error RenderingContextDriverMetal::initialize() {
+	if (OS::get_singleton()->get_environment(U"METAL_DEVICE_WRAPPER_TYPE") == "1") {
+		capture_available = true;
+	}
+
 	metal_device = MTLCreateSystemDefaultDevice();
 #if TARGET_OS_OSX
 	if (@available(macOS 13.3, *)) {

--- a/servers/rendering/renderer_rd/effects/fsr.h
+++ b/servers/rendering/renderer_rd/effects/fsr.h
@@ -38,13 +38,11 @@
 namespace RendererRD {
 
 class FSR : public SpatialUpscaler {
-	String name = "FSR 1.0 Upscale";
-
 public:
 	FSR();
 	~FSR();
 
-	virtual String get_label() const final { return name; }
+	virtual const Span<char> get_label() const final { return "FSR 1.0 Upscale"; }
 	virtual void ensure_context(Ref<RenderSceneBuffersRD> p_render_buffers) final {}
 	virtual void process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_source_rd_texture, RID p_destination_texture) final;
 

--- a/servers/rendering/renderer_rd/effects/metal_fx.h
+++ b/servers/rendering/renderer_rd/effects/metal_fx.h
@@ -76,10 +76,9 @@ class MFXSpatialEffect : public SpatialUpscaler {
 
 	PagedAllocator<CallbackArgs, true, 16> args_allocator;
 	static void callback(RDD *p_driver, RDD::CommandBufferID p_command_buffer, CallbackArgs *p_userdata);
-	String name = "MetalFX Spatial Upscale";
 
 public:
-	virtual String get_label() const final { return name; }
+	virtual const Span<char> get_label() const final { return "MetalFX Spatial Upscale"; }
 	virtual void ensure_context(Ref<RenderSceneBuffersRD> p_render_buffers) final;
 	virtual void process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_src, RID p_dst) final;
 

--- a/servers/rendering/renderer_rd/effects/spatial_upscaler.h
+++ b/servers/rendering/renderer_rd/effects/spatial_upscaler.h
@@ -36,7 +36,7 @@ class RenderSceneBuffersRD;
 
 class SpatialUpscaler {
 public:
-	virtual String get_label() const = 0;
+	virtual const Span<char> get_label() const = 0;
 	virtual void ensure_context(Ref<RenderSceneBuffersRD> p_render_buffers) = 0;
 	virtual void process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_source_rd_texture, RID p_destination_texture) = 0;
 

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -985,7 +985,7 @@ void SSEffects::gather_ssao(RD::ComputeListID p_compute_list, const RID *p_ao_sl
 			continue;
 		}
 
-		RD::Uniform u_ao_slice(RD::UNIFORM_TYPE_IMAGE, 0, Vector<RID>({ p_ao_slices[i] }));
+		RD::Uniform u_ao_slice(RD::UNIFORM_TYPE_IMAGE, 0, p_ao_slices[i]);
 
 		ssao.gather_push_constant.pass_coord_offset[0] = i % 2;
 		ssao.gather_push_constant.pass_coord_offset[1] = i / 2;
@@ -1419,7 +1419,11 @@ void SSEffects::screen_space_reflection(Ref<RenderSceneBuffersRD> p_render_buffe
 			blur_radius[1] = p_render_buffers->get_texture_slice(RB_SCOPE_SSR, RB_BLUR_RADIUS, 1, 0);
 		}
 
-		RD::get_singleton()->draw_command_begin_label(String("SSR View ") + itos(v));
+		{
+			char label[16];
+			int len = snprintf(label, sizeof(label), "SSR View %d", v);
+			RD::get_singleton()->draw_command_begin_label(Span<char>(label, len));
+		}
 
 		{ //scale color and depth to half
 			RD::get_singleton()->draw_command_begin_label("SSR Scale");

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6200,7 +6200,11 @@ void RenderingDevice::set_resource_name(RID p_id, const String &p_name) {
 #endif
 }
 
-void RenderingDevice::draw_command_begin_label(String p_label_name, const Color &p_color) {
+void RenderingDevice::_draw_command_begin_label(String p_label_name, const Color &p_color) {
+	draw_command_begin_label(p_label_name.utf8().span(), p_color);
+}
+
+void RenderingDevice::draw_command_begin_label(const Span<char> p_label_name, const Color &p_color) {
 	ERR_RENDER_THREAD_GUARD();
 
 	if (!context->is_debug_utils_enabled()) {
@@ -7450,7 +7454,7 @@ void RenderingDevice::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_resource_name", "id", "name"), &RenderingDevice::set_resource_name);
 
-	ClassDB::bind_method(D_METHOD("draw_command_begin_label", "name", "color"), &RenderingDevice::draw_command_begin_label);
+	ClassDB::bind_method(D_METHOD("draw_command_begin_label", "name", "color"), &RenderingDevice::_draw_command_begin_label);
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("draw_command_insert_label", "name", "color"), &RenderingDevice::draw_command_insert_label);
 #endif

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1643,7 +1643,8 @@ public:
 
 	void set_resource_name(RID p_id, const String &p_name);
 
-	void draw_command_begin_label(String p_label_name, const Color &p_color = Color(1, 1, 1, 1));
+	void _draw_command_begin_label(String p_label_name, const Color &p_color = Color(1, 1, 1, 1));
+	void draw_command_begin_label(const Span<char> p_label_name, const Color &p_color = Color(1, 1, 1, 1));
 	void draw_command_end_label();
 
 	String get_device_vendor_name() const;

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -2218,13 +2218,12 @@ void RenderingDeviceGraph::add_synchronization() {
 	}
 }
 
-void RenderingDeviceGraph::begin_label(const String &p_label_name, const Color &p_color) {
+void RenderingDeviceGraph::begin_label(const Span<char> &p_label_name, const Color &p_color) {
 	uint32_t command_label_offset = command_label_chars.size();
-	PackedByteArray command_label_utf8 = p_label_name.to_utf8_buffer();
-	int command_label_utf8_size = command_label_utf8.size();
-	command_label_chars.resize(command_label_offset + command_label_utf8_size + 1);
-	memcpy(&command_label_chars[command_label_offset], command_label_utf8.ptr(), command_label_utf8.size());
-	command_label_chars[command_label_offset + command_label_utf8_size] = '\0';
+	int command_label_size = p_label_name.size();
+	command_label_chars.resize(command_label_offset + command_label_size + 1);
+	memcpy(&command_label_chars[command_label_offset], p_label_name.ptr(), command_label_size);
+	command_label_chars[command_label_offset + command_label_size] = '\0';
 	command_label_colors.push_back(p_color);
 	command_label_offsets.push_back(command_label_offset);
 	command_label_index = command_label_count;

--- a/servers/rendering/rendering_device_graph.h
+++ b/servers/rendering/rendering_device_graph.h
@@ -816,7 +816,7 @@ public:
 	void add_texture_update(RDD::TextureID p_dst, ResourceTracker *p_dst_tracker, VectorView<RecordedBufferToTextureCopy> p_buffer_copies, VectorView<ResourceTracker *> p_buffer_trackers = VectorView<ResourceTracker *>());
 	void add_capture_timestamp(RDD::QueryPoolID p_query_pool, uint32_t p_index);
 	void add_synchronization();
-	void begin_label(const String &p_label_name, const Color &p_color);
+	void begin_label(const Span<char> &p_label_name, const Color &p_color);
 	void end_label();
 	void end(bool p_reorder_commands, bool p_full_barriers, RDD::CommandBufferID &r_command_buffer, CommandBufferPool &r_command_buffer_pool);
 	static ResourceTracker *resource_tracker_create();


### PR DESCRIPTION
All calls to `draw_command_begin_label` within the rendering servers no longer allocate a `String` each time it is called **when capture tools are disabled**. This would be the expected case for production. The `String` API is still available for `GDScript` and GDExtensions.

> [!NOTE]
>
> Metal was worse that Windows or Linux, as it always returned `true` that debug capture was enabled

- [x] Add allocation profiles demonstrating the before, after and when capture is disabled.

> [!NOTE]
>
> Tested with the Bistro demo, running for 500 frames to be consistent across runs.

| When | Capture Enabled? | Total Allocations | Instruments Preview |
| :---- | :---- | :---- | :---- |
| Before (Metal) | N | 33,978 | <img src="https://github.com/user-attachments/assets/ea8b1b04-2481-4968-adb9-2365e58fbe9c" width="200px" /> |
| Before (Win / Linux) | N | 16,941 | <img src="https://github.com/user-attachments/assets/d12b1d1a-6a2f-4584-8a57-b3fb841e8c26" width="200px" /> |
| After (all) | N | 0 | <img src="https://github.com/user-attachments/assets/54e05be9-0072-420c-8a26-335b3f5cb369" width="200px" /> |
| After (all) | Y | 28 | <img src="https://github.com/user-attachments/assets/f3f59aa5-1646-4e7a-84f4-470c1358ae00" width="200px" /> |