### PR TITLE
Explicitly mention Directional classes in their variants

### DIFF
--- a/doc/classes/HBoxContainer.xml
+++ b/doc/classes/HBoxContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A variant of [BoxContainer] that can only arrange its child controls horizontally. Child controls are rearranged automatically when their minimum size changes.
+		This class inherits its properties, methods, and signals from [BoxContainer].
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>

--- a/doc/classes/HFlowContainer.xml
+++ b/doc/classes/HFlowContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A variant of [FlowContainer] that can only arrange its child controls horizontally, wrapping them around at the borders. This is similar to how text in a book wraps around when no more words can fit on a line.
+		This class inherits its properties, methods, and signals from [FlowContainer].
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>

--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A horizontal scrollbar, typically used to navigate through content that extends beyond the visible width of a control. It is a [Range]-based control and goes from left (min) to right (max).
+		This class inherits its properties, methods, and signals from [ScrollBar].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HSeparator.xml
+++ b/doc/classes/HSeparator.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A horizontal separator used for separating other controls that are arranged [b]vertically[/b]. [HSeparator] is purely visual and normally drawn as a [StyleBoxLine].
+		This class inherits its properties, methods, and signals from [Separator].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HSlider.xml
+++ b/doc/classes/HSlider.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A horizontal slider, used to adjust a value by moving a grabber along a horizontal axis. It is a [Range]-based control and goes from left (min) to right (max).
+		This class inherits its properties, methods, and signals from [Slider].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A container that accepts only two child controls, then arranges them horizontally and creates a divisor between them. The divisor can be dragged around to change the size relation between the child controls.
+		This class inherits its properties, methods, and signals from [SplitContainer].
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>

--- a/doc/classes/VBoxContainer.xml
+++ b/doc/classes/VBoxContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A variant of [BoxContainer] that can only arrange its child controls vertically. Child controls are rearranged automatically when their minimum size changes.
+		This class inherits its properties, methods, and signals from [BoxContainer].
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>

--- a/doc/classes/VFlowContainer.xml
+++ b/doc/classes/VFlowContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A variant of [FlowContainer] that can only arrange its child controls vertically, wrapping them around at the borders. This is similar to how text in a book wraps around when no more words can fit on a line, except vertically.
+		This class inherits its properties, methods, and signals from [FlowContainer].
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A vertical scrollbar, typically used to navigate through content that extends beyond the visible height of a control. It is a [Range]-based control and goes from top (min) to bottom (max). Note that this direction is the opposite of [VSlider]'s.
+		This class inherits its properties, methods, and signals from [ScrollBar].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VSeparator.xml
+++ b/doc/classes/VSeparator.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A vertical separator used for separating other controls that are arranged [b]horizontally[/b]. [VSeparator] is purely visual and normally drawn as a [StyleBoxLine].
+		This class inherits its properties, methods, and signals from [Separator].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A vertical slider, used to adjust a value by moving a grabber along a vertical axis. It is a [Range]-based control and goes from bottom (min) to top (max). Note that this direction is the opposite of [VScrollBar]'s.
+		This class inherits its properties, methods, and signals from [Slider].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		A container that accepts only two child controls, then arranges them vertically and creates a divisor between them. The divisor can be dragged around to change the size relation between the child controls.
+		This class inherits its properties, methods, and signals from [SplitContainer].
 	</description>
 	<tutorials>
 		<link title="Using Containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>


### PR DESCRIPTION
Currently the docs for classes like `HSplitContainer` and `VSplitContainer` do not mention the `SplitContainer` class directly, only notes that it inherits from it. Therefore anyone looking for the variables and functions used by these variants will have to know to visit `SplitContainer` instead for this information. This PR changes the docs in these two classes in order to mention `SplitContainer` explicitly, aiding navigation.

This mimics how `HFlowContainer` is written in the docs.

This PR also does this for `ScrollBar`, `Separator`, and `Slider` classes.