### PR TITLE
Ignore destination alpha when blitting to window in compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -437,6 +437,9 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, rt->color);
+	glEnable(GL_BLEND);
+	glBlendFunc(GL_ONE, GL_ZERO);
+
 	if (rt->view_count > 1) {
 		copy_effects->copy_to_rect_3d(screenrect, p_layer, GLES3::Texture::TYPE_LAYERED);
 	} else {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/106727

On Macos the default color of the system framebuffer appears to be transparent black. When blending to that using the mix blend mode it remained transparent. 

This PR resolves the issue by using a blend mode that ignores the destination color and alpha when blitting. 