### PR TITLE
OpenXR Futures: Add return value support

### DIFF
--- a/modules/openxr/doc_classes/OpenXRFutureResult.xml
+++ b/modules/openxr/doc_classes/OpenXRFutureResult.xml
@@ -21,10 +21,24 @@
 				Return the [code]XrFutureEXT[/code] value this result relates to.
 			</description>
 		</method>
+		<method name="get_result_value" qualifiers="const">
+			<return type="Variant" />
+			<description>
+				Returns the result value of our asynchronous function (if set by the extension). The type of this result value depends on the function being called. Consult the documentation of the relevant function.
+			</description>
+		</method>
 		<method name="get_status" qualifiers="const">
 			<return type="int" enum="OpenXRFutureResult.ResultStatus" />
 			<description>
 				Returns the status of this result.
+			</description>
+		</method>
+		<method name="set_result_value">
+			<return type="void" />
+			<param index="0" name="result_value" type="Variant" />
+			<description>
+				Stores the result value we expose to the user.
+				[b]Note:[/b] This method should only be called by an OpenXR extension that implements an asynchronous function.
 			</description>
 		</method>
 	</methods>

--- a/modules/openxr/extensions/openxr_future_extension.h
+++ b/modules/openxr/extensions/openxr_future_extension.h
@@ -74,6 +74,9 @@ public:
 	ResultStatus get_status() const;
 	XrFutureEXT get_future() const;
 
+	void set_result_value(const Variant &p_result_value);
+	Variant get_result_value() const;
+
 	void cancel_future();
 
 	OpenXRFutureResult(XrFutureEXT p_future, const Callable &p_on_success);
@@ -81,6 +84,7 @@ public:
 private:
 	ResultStatus status = RESULT_RUNNING;
 	XrFutureEXT future;
+	Variant result_value;
 	Callable on_success_callback;
 
 	uint64_t _get_future() const;


### PR DESCRIPTION
Now that I've implemented a few OpenXR asynchronous functions using the futures system I kept having to add a result value wrapper for those functions. It seemed that we could make this far more versatile by adding this into our futures result object.

This PR makes two changes:

- A minor breaking change in our callback logic where we pass our `OpenXRFutureResult` object instead of the OpenXR future id value. This allows our callback code to set the result value. Seeing all OpenXR APIs using futures are still closed we can reasonably assume nobody has used the futures system yet, and as we introduced future support in an earlier Godot 4.5 dev build this should be ok.
- We add our `set_result_value` and `get_result_value` methods. There is no property as we don't define a type but use a Variant. So far most functions I've made either set a `RID` or `BOOL` value but I figured we'd future proof this.

On the C++ side actual asynchronous functions follow this pattern:
```
void SomeOpenXRExtension::_bind_methods() {
	ClassDB::bind_method(D_METHOD("do_some_async_function", "some_value", "user_callback"), &SomeOpenXRExtension::do_some_async_function, DEFVAL(Callable()));
}

Ref<OpenXRFutureResult> SomeOpenXRExtension::do_some_async_function(int p_some_value, Callable p_user_callback) {
	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
	ERR_FAIL_NULL_V(openxr_api, nullptr);

	OpenXRFutureExtension *future_api = OpenXRFutureExtension::get_singleton();
	ERR_FAIL_NULL_V(future_api, nullptr);

	XrSomeFunctionInfo function_info = { ... };
	XrFutureEXT future = XR_NULL_HANDLE;
	XrResult result = xrDoSomeAsyncFunction(openxr_api->get_session(), &function_info , &future);
	ERR_FAIL_COND_V(XR_FAILED(result), nullptr);

	return future_api->register_future(future, callable_mp(this, &SomeOpenXRExtension::_on_function_ready).bind(p_user_callback));
}

void SomeOpenXRExtension::_on_function_ready(Ref<OpenXRFutureResult> p_future_result, Callable p_user_callback) {
	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
	ERR_FAIL_NULL(openxr_api);

	XrSomeFunctionCompletionResult completion = { .. };
	XrResult result = xrSomeFunctionComplete(openxr_api->get_session(), p_future_result->get_future(), &completion);
	ERR_FAIL_COND(XR_FAILED(result));
	ERR_FAIL_COND(XR_FAILED(completion.futureResult));

	p_future_result->set_result_value(completion.SomeResultValue);

	// And perform our callback if we have one.
	if (p_user_callback.is_valid()) {
		p_user_callback.call(completion.SomeResultValue);
	}
}
```
So we have a function that starts our asynchronous process, and an internal function that gets called once its completed and handles the result data. In the example above I'm assuming we can use the result data directly, however often extra functionality is require such as converting data to a string or capturing object data in a RID.
Finally we chain an optional user callback function, this is especially important when calling this function in C++ as we don't have the concept of `await` and using the signal for a callback looses scope.

With the callback optional this also means that this can be a fire and forget call where we don't care about the result. We just care about execution.

In GDScript using the callback will look something like:
```
func _ready():
    SomeOpenXRExtension.do_some_async_function(1234, _on_some_function_completed)

func _on_some_function_completed(future_result):
    var result_value = future_result.get_result_value()
    if result_value:
        # Successs!
        pass
    else:
        # Failure!
        pass
```

But in GDScript using our future result directly is better:
```
func _ready():
    var future_result = SomeOpenXRExtension.do_some_async_function(1234)

    await future_result.completed

    var result_value = future_result.get_result_value()
    if result_value:
        # Successs!
        pass
    else:
        # Failure!
        pass
```

*Contributed by Khronos Group through the Godot Integration Project*