### PR TITLE
Fix heap-use-after-free when closing a scene with 2D particle nodes selected

### DIFF
--- a/editor/plugins/particles_editor_plugin.cpp
+++ b/editor/plugins/particles_editor_plugin.cpp
@@ -293,30 +293,55 @@ Particles2DEditorPlugin::Particles2DEditorPlugin() {
 	emission_mask->connect(SceneStringName(confirmed), callable_mp(this, &Particles2DEditorPlugin::_generate_emission_mask));
 }
 
+void Particles2DEditorPlugin::_set_show_gizmos(Node *p_node, bool p_show) {
+	GPUParticles2D *gpu_particles = Object::cast_to<GPUParticles2D>(p_node);
+	if (gpu_particles) {
+		gpu_particles->set_show_gizmos(p_show);
+	}
+	CPUParticles2D *cpu_particles = Object::cast_to<CPUParticles2D>(p_node);
+	if (cpu_particles) {
+		cpu_particles->set_show_gizmos(p_show);
+	}
+
+	// The `selection_changed` signal is deferred. A node could be deleted before the signal is emitted.
+	if (p_show) {
+		p_node->connect(SceneStringName(tree_exiting), callable_mp(this, &Particles2DEditorPlugin::_node_removed).bind(p_node));
+	} else {
+		p_node->disconnect(SceneStringName(tree_exiting), callable_mp(this, &Particles2DEditorPlugin::_node_removed));
+	}
+}
+
 void Particles2DEditorPlugin::_selection_changed() {
-	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
-	if (selected_particles.is_empty() && selected_nodes.is_empty()) {
+	List<Node *> current_selection = EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list();
+	if (selected_particles.is_empty() && current_selection.is_empty()) {
 		return;
 	}
 
-	for (Node *particles : selected_particles) {
-		if (GPUParticles2D *gpu_particles = Object::cast_to<GPUParticles2D>(particles)) {
-			gpu_particles->set_show_gizmos(false);
-		} else if (CPUParticles2D *cpu_particles = Object::cast_to<CPUParticles2D>(particles)) {
-			cpu_particles->set_show_gizmos(false);
+	// Turn gizmos off for nodes that are no longer selected.
+	for (List<Node *>::Element *E = selected_particles.front(); E;) {
+		Node *node = E->get();
+		List<Node *>::Element *N = E->next();
+		if (current_selection.find(node) == nullptr) {
+			_set_show_gizmos(node, false);
+			selected_particles.erase(E);
 		}
+		E = N;
 	}
 
-	selected_particles.clear();
-
-	for (Node *node : selected_nodes) {
-		if (GPUParticles2D *selected_gpu_particle = Object::cast_to<GPUParticles2D>(node)) {
-			selected_gpu_particle->set_show_gizmos(true);
-			selected_particles.push_back(selected_gpu_particle);
-		} else if (CPUParticles2D *selected_cpu_particle = Object::cast_to<CPUParticles2D>(node)) {
-			selected_cpu_particle->set_show_gizmos(true);
-			selected_particles.push_back(selected_cpu_particle);
+	// Turn gizmos on for nodes that are newly selected.
+	for (Node *node : current_selection) {
+		if (selected_particles.find(node) == nullptr) {
+			_set_show_gizmos(node, true);
+			selected_particles.push_back(node);
 		}
+	}
+}
+
+void Particles2DEditorPlugin::_node_removed(Node *p_node) {
+	List<Node *>::Element *E = selected_particles.find(p_node);
+	if (E) {
+		_set_show_gizmos(E->get(), false);
+		selected_particles.erase(E);
 	}
 }
 

--- a/editor/plugins/particles_editor_plugin.h
+++ b/editor/plugins/particles_editor_plugin.h
@@ -109,7 +109,9 @@ protected:
 	void _get_base_emission_mask(PackedVector2Array &r_valid_positions, PackedVector2Array &r_valid_normals, PackedByteArray &r_valid_colors, Vector2i &r_image_size);
 	virtual void _generate_emission_mask() = 0;
 	void _notification(int p_what);
+	void _set_show_gizmos(Node *p_node, bool p_show);
 	void _selection_changed();
+	void _node_removed(Node *p_node);
 
 public:
 	Particles2DEditorPlugin();


### PR DESCRIPTION
Fixes #104994
Supersedes #105057
Follow-up to #102249

The `selection_changed` signal is deferred. A node could be deleted before the signal is emitted, making its pointer dangling. This PR makes the plugin handle the `tree_exiting` signal for all the particles nodes it tracks.

<details><summary>asan output</summary>

```
=================================================================
==285941==ERROR: AddressSanitizer: heap-use-after-free on address 0x78ac2d1bd390 at pc 0x5cdef36915a3 bp 0x7ffe8bbaf280 sp 0x7ffe8bbaf270
READ of size 8 at 0x78ac2d1bd390 thread T0
    #0 0x5cdef36915a2 in GPUParticles2D* Object::cast_to<GPUParticles2D>(Object*) core/object/object.h:796
    #1 0x5cdef4abaf87 in Particles2DEditorPlugin::_selection_changed() editor/plugins/particles_editor_plugin.cpp:303
    #2 0x5cdef4ad8b2d in void call_with_variant_args_helper<Particles2DEditorPlugin>(Particles2DEditorPlugin*, void (Particles2DEditorPlugin::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:223
    #3 0x5cdef4ad80e6 in void call_with_variant_args<Particles2DEditorPlugin>(Particles2DEditorPlugin*, void (Particles2DEditorPlugin::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:337
    #4 0x5cdef4ad5f4e in CallableCustomMethodPointer<Particles2DEditorPlugin, void>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:103
    #5 0x5cdefa7716d6 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #6 0x5cdefaf9e7ce in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1287
    #7 0x5cdeeed38a4b in Error Object::emit_signal<>(StringName const&) core/object/object.h:930
    #8 0x5cdef31bdf08 in EditorSelection::_emit_change() editor/editor_data.cpp:1312
    #9 0x5cdef31e255f in void call_with_variant_args_helper<EditorSelection>(EditorSelection*, void (EditorSelection::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:223
    #10 0x5cdef31e18ed in void call_with_variant_args<EditorSelection>(EditorSelection*, void (EditorSelection::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:337
    #11 0x5cdef31dfb84 in CallableCustomMethodPointer<EditorSelection, void>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:103
    #12 0x5cdefa7716d6 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #13 0x5cdefaf86c53 in CallQueue::_call_function(Callable const&, Variant const*, int, bool) core/object/message_queue.cpp:220
    #14 0x5cdefaf874b7 in CallQueue::flush() core/object/message_queue.cpp:268
    #15 0x5cdef57d2a34 in SceneTree::process(double) scene/main/scene_tree.cpp:698
    #16 0x5cdeee653304 in Main::iteration() main/main.cpp:4749
    #17 0x5cdeee418485 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:979
    #18 0x5cdeee4058bf in main platform/linuxbsd/godot_linuxbsd.cpp:85
    #19 0x7afc2df3f6b4  (/usr/lib/libc.so.6+0x276b4) (BuildId: 468e3585c794491a48ea75fceb9e4d6b1464fc35)
    #20 0x7afc2df3f768 in __libc_start_main (/usr/lib/libc.so.6+0x27768) (BuildId: 468e3585c794491a48ea75fceb9e4d6b1464fc35)
    #21 0x5cdeee4054a4 in _start (/home/timothy/repos/godot-master/bin/godot.linuxbsd.editor.dev.x86_64.san+0xa2524a4) (BuildId: 7fdeb6392c21601066d73f3456f9503ade33d8fb)

0x78ac2d1bd390 is located 16 bytes inside of 1488-byte region [0x78ac2d1bd380,0x78ac2d1bd950)
freed by thread T0 here:
    #0 0x7afc2e31f8fd in free /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:51
    #1 0x5cdefa174e7a in Memory::free_static(void*, bool) core/os/memory.cpp:201
    #2 0x5cdeeecc1aa1 in void memdelete<Node>(Node*) core/os/memory.h:142
    #3 0x5cdef570ace5 in Node::_notification(int) scene/main/node.cpp:345
    #4 0x5cdeeea08da8 in Node::_notification_backwardv(int) scene/main/node.h:48
    #5 0x5cdeeed4fe63 in CanvasItem::_notification_backwardv(int) scene/main/canvas_item.h:43
    #6 0x5cdef6ba01e3 in Node2D::_notification_backwardv(int) scene/2d/node_2d.h:36
    #7 0x5cdefaf9a050 in Object::_notification_backward(int) core/object/object.cpp:965
    #8 0x5cdeee407a0c in Object::notification(int, bool) core/object/object.h:877
    #9 0x5cdefaf9314b in Object::_predelete() core/object/object.cpp:256
    #10 0x5cdefafaf376 in predelete_handler(Object*) core/object/object.cpp:2328
    #11 0x5cdeeecc1a2f in void memdelete<Node>(Node*) core/os/memory.h:135
    #12 0x5cdef31b2dff in EditorData::remove_scene(int) editor/editor_data.cpp:646
    #13 0x5cdef3554c12 in EditorNode::_remove_edited_scene(bool) editor/editor_node.cpp:3965
    #14 0x5cdef3554caf in EditorNode::_remove_scene(int, bool) editor/editor_node.cpp:3977
    #15 0x5cdef354f2e4 in EditorNode::_discard_changes(String const&) editor/editor_node.cpp:3620
    #16 0x5cdef3574397 in EditorNode::_scene_tab_closed(int) editor/editor_node.cpp:5973
    #17 0x5cdef3617ab6 in void call_with_variant_args_helper<EditorNode, int, 0ul>(EditorNode*, void (EditorNode::*)(int), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:223
    #18 0x5cdef3615848 in void call_with_variant_args<EditorNode, int>(EditorNode*, void (EditorNode::*)(int), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:337
    #19 0x5cdef360c2a0 in CallableCustomMethodPointer<EditorNode, void, int>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:103
    #20 0x5cdefa7716d6 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #21 0x5cdefaf9e7ce in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1287
    #22 0x5cdef574a2a3 in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:4291
    #23 0x5cdeef83b075 in Error Object::emit_signal<int>(StringName const&, int) core/object/object.h:930
    #24 0x5cdef408f759 in EditorSceneTabs::_scene_tab_closed(int) editor/gui/editor_scene_tabs.cpp:92
    #25 0x5cdef409fdd7 in void call_with_variant_args_helper<EditorSceneTabs, int, 0ul>(EditorSceneTabs*, void (EditorSceneTabs::*)(int), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:223
    #26 0x5cdef409f6a6 in void call_with_variant_args<EditorSceneTabs, int>(EditorSceneTabs*, void (EditorSceneTabs::*)(int), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:337
    #27 0x5cdef409e218 in CallableCustomMethodPointer<EditorSceneTabs, void, int>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:103
    #28 0x5cdefa7716d6 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #29 0x5cdefaf9e7ce in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1287

previously allocated by thread T0 here:
    #0 0x7afc2e320e15 in malloc /usr/src/debug/gcc/gcc/libsanitizer/asan/asan_malloc_linux.cpp:67
    #1 0x5cdefa17593f in void* Memory::alloc_static<false>(unsigned long, bool) core/os/memory.cpp:108
    #2 0x5cdefa1744a0 in operator new(unsigned long, char const*) core/os/memory.cpp:38
    #3 0x5cdef55becd4 in Object* ClassDB::creator<GPUParticles2D>(bool) core/object/class_db.h:149
    #4 0x5cdefaf456c7 in ClassDB::_instantiate_internal(StringName const&, bool, bool, bool) core/object/class_db.cpp:598
    #5 0x5cdefaf459b2 in ClassDB::instantiate(StringName const&) core/object/class_db.cpp:632
    #6 0x5cdef773a561 in SceneState::instantiate(SceneState::GenEditState) const scene/resources/packed_scene.cpp:260
    #7 0x5cdef775686b in PackedScene::instantiate(PackedScene::GenEditState) const scene/resources/packed_scene.cpp:2178
    #8 0x5cdef3559120 in EditorNode::load_scene(String const&, bool, bool, bool, bool) editor/editor_node.cpp:4281
    #9 0x5cdef35296da in EditorNode::load_scene_or_resource(String const&, bool, bool) editor/editor_node.cpp:1454
    #10 0x5cdef38f3781 in FileSystemDock::_select_file(String const&, bool, bool) editor/filesystem_dock.cpp:1271
    #11 0x5cdef38f3f44 in FileSystemDock::_tree_activate_file() editor/filesystem_dock.cpp:1312
    #12 0x5cdef3965161 in void call_with_variant_args_helper<FileSystemDock>(FileSystemDock*, void (FileSystemDock::*)(), Variant const**, Callable::CallError&, IndexSequence<>) core/variant/binder_common.h:223
    #13 0x5cdef39603b3 in void call_with_variant_args<FileSystemDock>(FileSystemDock*, void (FileSystemDock::*)(), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:337
    #14 0x5cdef395929e in CallableCustomMethodPointer<FileSystemDock, void>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:103
    #15 0x5cdefa7716d6 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #16 0x5cdefaf9e7ce in Object::emit_signalp(StringName const&, Variant const**, int) core/object/object.cpp:1287
    #17 0x5cdef574a2a3 in Node::emit_signalp(StringName const&, Variant const**, int) scene/main/node.cpp:4291
    #18 0x5cdeeed38a4b in Error Object::emit_signal<>(StringName const&) core/object/object.h:930
    #19 0x5cdef63a34fd in Tree::gui_input(Ref<InputEvent> const&) scene/gui/tree.cpp:4171
    #20 0x5cdef5bb1d7b in Control::_call_gui_input(Ref<InputEvent> const&) scene/gui/control.cpp:1865
    #21 0x5cdef5859064 in Viewport::_gui_call_input(Control*, Ref<InputEvent> const&) scene/main/viewport.cpp:1725
    #22 0x5cdef585cb18 in Viewport::_gui_input_event(Ref<InputEvent>) scene/main/viewport.cpp:1959
    #23 0x5cdef586fd84 in Viewport::push_input(Ref<InputEvent> const&, bool) scene/main/viewport.cpp:3426
    #24 0x5cdef59434dd in Window::_window_input(Ref<InputEvent> const&) scene/main/window.cpp:1837
    #25 0x5cdef59da249 in void call_with_variant_args_helper<Window, Ref<InputEvent> const&, 0ul>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, Callable::CallError&, IndexSequence<0ul>) core/variant/binder_common.h:223
    #26 0x5cdef59cdf06 in void call_with_variant_args<Window, Ref<InputEvent> const&>(Window*, void (Window::*)(Ref<InputEvent> const&), Variant const**, int, Callable::CallError&) core/variant/binder_common.h:337
    #27 0x5cdef59b8732 in CallableCustomMethodPointer<Window, void, Ref<InputEvent> const&>::call(Variant const**, int, Variant&, Callable::CallError&) const core/object/callable_method_pointer.h:103
    #28 0x5cdefa7716d6 in Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const core/variant/callable.cpp:57
    #29 0x5cdeee4c9671 in Variant Callable::call<Ref<InputEvent> >(Ref<InputEvent>) const core/variant/variant.h:950

SUMMARY: AddressSanitizer: heap-use-after-free core/object/object.h:796 in GPUParticles2D* Object::cast_to<GPUParticles2D>(Object*)
Shadow bytes around the buggy address:
  0x78ac2d1bd100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd180: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd200: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd280: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x78ac2d1bd300: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x78ac2d1bd380: fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd400: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd480: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd500: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd580: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x78ac2d1bd600: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==285941==ABORTING
```

</details>