### PR TITLE
Core: Implement `RequiredObj<T>`, utilizing C++20 features

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -16,8 +16,7 @@ env:
 
 jobs:
   build-linux:
-    # Stay one LTS before latest to increase portability of Linux artifacts.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:

--- a/SConstruct
+++ b/SConstruct
@@ -663,16 +663,16 @@ cc_version_metadata1 = cc_version["metadata1"]
 
 if cc_version_major == -1:
     print_warning(
-        "Couldn't detect compiler version, skipping version checks. "
-        "Build may fail if the compiler doesn't support C++17 fully."
+        "Couldn't detect compiler version, skipping version checks. Build may "
+        "fail if the compiler doesn't support C++20 fully."
     )
 elif methods.using_gcc(env):
-    if cc_version_major < 9:
+    if cc_version_major < 11:
         print_error(
-            "Detected GCC version older than 9, which does not fully support "
-            "C++17, or has bugs when compiling Godot. Supported versions are 9 "
-            "and later. Use a newer GCC version, or Clang 6 or later by passing "
-            '"use_llvm=yes" to the SCons command line.'
+            "Detected GCC version older than 11, which does not fully support "
+            "C++20. Supported versions are GCC 11 and later. Use a newer GCC "
+            'version, or Clang 10 or later by passing "use_llvm=yes" to the '
+            "SCons command line."
         )
         Exit(255)
     elif cc_version_metadata1 == "win32":
@@ -687,47 +687,33 @@ elif methods.using_clang(env):
     # Apple LLVM versions differ from upstream LLVM version \o/, compare
     # in https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
     if methods.is_apple_clang(env):
+        if cc_version_major < 14:
+            print_error(
+                "Detected Apple Clang version older than 14, which does not fully "
+                "support C++20. Supported versions are Apple Clang 14 and later."
+            )
+            Exit(255)
+    else:
         if cc_version_major < 10:
             print_error(
-                "Detected Apple Clang version older than 10, which does not fully "
-                "support C++17. Supported versions are Apple Clang 10 and later."
+                "Detected Clang version older than 10, which does not fully support "
+                "C++20. Supported versions are Clang 10 and later."
             )
             Exit(255)
-        elif env["debug_paths_relative"] and cc_version_major < 12:
-            print_warning(
-                "Apple Clang < 12 doesn't support -ffile-prefix-map, disabling `debug_paths_relative` option."
-            )
-            env["debug_paths_relative"] = False
-    else:
-        if cc_version_major < 6:
-            print_error(
-                "Detected Clang version older than 6, which does not fully support "
-                "C++17. Supported versions are Clang 6 and later."
-            )
-            Exit(255)
-        elif env["debug_paths_relative"] and cc_version_major < 10:
-            print_warning("Clang < 10 doesn't support -ffile-prefix-map, disabling `debug_paths_relative` option.")
-            env["debug_paths_relative"] = False
 
 elif env.msvc:
     # Ensure latest minor builds of Visual Studio 2017/2019.
     # https://github.com/godotengine/godot/pull/94995#issuecomment-2336464574
-    if cc_version_major == 16 and cc_version_minor < 11:
+    if cc_version_major < 16:
+        print_error(
+            "Detected Visual Studio version older than 2019, which does not fully "
+            "support C++20. Supported versions are Visual Studio 2019 and later."
+        )
+        Exit(255)
+    elif cc_version_major == 16 and cc_version_minor < 11:
         print_error(
             "Detected Visual Studio 2019 version older than 16.11, which has bugs "
             "when compiling Godot. Use a newer VS2019 version, or VS2022."
-        )
-        Exit(255)
-    if cc_version_major == 15 and cc_version_minor < 9:
-        print_error(
-            "Detected Visual Studio 2017 version older than 15.9, which has bugs "
-            "when compiling Godot. Use a newer VS2017 version, or VS2019/VS2022."
-        )
-        Exit(255)
-    if cc_version_major < 15:
-        print_error(
-            "Detected Visual Studio 2015 or earlier, which is unsupported in Godot. "
-            "Supported versions are Visual Studio 2017 and later."
         )
         Exit(255)
 
@@ -824,22 +810,17 @@ if env["lto"] != "none":
     print("Using LTO: " + env["lto"])
 
 # Set our C and C++ standard requirements.
-# C++17 is required as we need guaranteed copy elision as per GH-36436.
-# Prepending to make it possible to override.
 # This needs to come after `configure`, otherwise we don't have env.msvc.
 if not env.msvc:
     # Specifying GNU extensions support explicitly, which are supported by
-    # both GCC and Clang. Both currently default to gnu17 and gnu++17.
+    # both GCC and Clang. Both currently default to gnu17 and gnu++20.
     env.Prepend(CFLAGS=["-std=gnu17"])
-    env.Prepend(CXXFLAGS=["-std=gnu++17"])
+    env.Prepend(CXXFLAGS=["-std=gnu++20"])
 else:
     # MSVC started offering C standard support with Visual Studio 2019 16.8, which covers all
-    # of our supported VS2019 & VS2022 versions; VS2017 will only pass the C++ standard.
-    env.Prepend(CXXFLAGS=["/std:c++17"])
-    if cc_version_major < 16:
-        print_warning("Visual Studio 2017 cannot specify a C-Standard.")
-    else:
-        env.Prepend(CFLAGS=["/std:c17"])
+    # of our supported VS2019 & VS2022 versions.
+    env.Prepend(CFLAGS=["/std:c17"])
+    env.Prepend(CXXFLAGS=["/std:c++20"])
     # MSVC is non-conforming with the C++ standard by default, so we enable more conformance.
     # Note that this is still not complete conformance, as certain Windows-related headers
     # don't compile under complete conformance.
@@ -897,22 +878,15 @@ if env.msvc and not methods.using_clang(env):  # MSVC
 else:  # GCC, Clang
     common_warnings = []
     if methods.using_gcc(env):
-        common_warnings += ["-Wshadow", "-Wno-misleading-indentation"]
-        if cc_version_major < 11:
-            # Regression in GCC 9/10, spams so much in our variadic templates
-            # that we need to outright disable it.
-            common_warnings += ["-Wno-type-limits"]
+        common_warnings += ["-Wshadow", "-Wno-misleading-indentation", "-Wenum-conversion"]
         if cc_version_major == 12:
             # Regression in GCC 12, false positives in our error macros, see GH-58747.
             common_warnings += ["-Wno-return-type"]
-        if cc_version_major >= 11:
-            common_warnings += ["-Wenum-conversion"]
     elif methods.using_clang(env) or methods.using_emcc(env):
-        common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local"]
+        common_warnings += ["-Wshadow-field-in-constructor", "-Wshadow-uncaptured-local", "-Wenum-conversion"]
         # We often implement `operator<` for structs of pointers as a requirement
         # for putting them in `Set` or `Map`. We don't mind about unreliable ordering.
         common_warnings += ["-Wno-ordered-compare-function-pointers"]
-        common_warnings += ["-Wenum-conversion"]
 
     # clang-cl will interpret `-Wall` as `-Weverything`, workaround with compatibility cast.
     env["WARNLEVEL"] = "-Wall" if not env.msvc else "-W3"
@@ -924,19 +898,14 @@ else:  # GCC, Clang
             env.AppendUnique(
                 CCFLAGS=[
                     "-Walloc-zero",
+                    "-Wattribute-alias=2",
                     "-Wduplicated-branches",
                     "-Wduplicated-cond",
+                    "-Wlogical-op",
                     "-Wstringop-overflow=4",
                 ]
             )
             env.AppendUnique(CXXFLAGS=["-Wplacement-new=1", "-Wvirtual-inheritance"])
-            # Need to fix a warning with AudioServer lambdas before enabling.
-            # if cc_version_major != 9:  # GCC 9 had a regression (GH-36325).
-            #    env.Append(CXXFLAGS=["-Wnoexcept"])
-            if cc_version_major >= 9:
-                env.AppendUnique(CCFLAGS=["-Wattribute-alias=2"])
-            if cc_version_major >= 11:  # Broke on MethodBind templates before GCC 11.
-                env.AppendUnique(CCFLAGS=["-Wlogical-op"])
         elif methods.using_clang(env) or methods.using_emcc(env):
             env.AppendUnique(CCFLAGS=["-Wimplicit-fallthrough"])
     elif env["warnings"] == "all":

--- a/SConstruct
+++ b/SConstruct
@@ -671,7 +671,7 @@ elif methods.using_gcc(env):
         print_error(
             "Detected GCC version older than 11, which does not fully support "
             "C++20. Supported versions are GCC 11 and later. Use a newer GCC "
-            'version, or Clang 10 or later by passing "use_llvm=yes" to the '
+            'version, or Clang 16 or later by passing "use_llvm=yes" to the '
             "SCons command line."
         )
         Exit(255)
@@ -687,17 +687,17 @@ elif methods.using_clang(env):
     # Apple LLVM versions differ from upstream LLVM version \o/, compare
     # in https://en.wikipedia.org/wiki/Xcode#Toolchain_versions
     if methods.is_apple_clang(env):
-        if cc_version_major < 14:
+        if cc_version_major < 15:
             print_error(
-                "Detected Apple Clang version older than 14, which does not fully "
-                "support C++20. Supported versions are Apple Clang 14 and later."
+                "Detected Apple Clang version older than 15, which does not fully "
+                "support C++20. Supported versions are Apple Clang 15 and later."
             )
             Exit(255)
     else:
-        if cc_version_major < 10:
+        if cc_version_major < 16:
             print_error(
-                "Detected Clang version older than 10, which does not fully support "
-                "C++20. Supported versions are Clang 10 and later."
+                "Detected Clang version older than 16, which does not fully support "
+                "C++20. Supported versions are Clang 16 and later."
             )
             Exit(255)
 

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -161,7 +161,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_INDEX_V(m_index, m_size, m_retval)                                                             \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                     \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		GODOT_DEPRECATED_BEGIN                                                                                  \
 		return m_retval;                                                                                        \
+		GODOT_DEPRECATED_END                                                                                    \
 	} else                                                                                                      \
 		((void)0)
 
@@ -172,7 +174,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                         \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                            \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+		GODOT_DEPRECATED_BEGIN                                                                                         \
 		return m_retval;                                                                                               \
+		GODOT_DEPRECATED_END                                                                                           \
 	} else                                                                                                             \
 		((void)0)
 
@@ -182,7 +186,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                             \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+		GODOT_DEPRECATED_BEGIN                                                                                               \
 		return m_retval;                                                                                                     \
+		GODOT_DEPRECATED_END                                                                                                 \
 	} else                                                                                                                   \
 		((void)0)
 
@@ -264,7 +270,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_UNSIGNED_INDEX_V(m_index, m_size, m_retval)                                                    \
 	if (unlikely((m_index) >= (m_size))) {                                                                      \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size)); \
+		GODOT_DEPRECATED_BEGIN                                                                                  \
 		return m_retval;                                                                                        \
+		GODOT_DEPRECATED_END                                                                                    \
 	} else                                                                                                      \
 		((void)0)
 
@@ -275,7 +283,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_UNSIGNED_INDEX_V_MSG(m_index, m_size, m_retval, m_msg)                                                \
 	if (unlikely((m_index) >= (m_size))) {                                                                             \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg); \
+		GODOT_DEPRECATED_BEGIN                                                                                         \
 		return m_retval;                                                                                               \
+		GODOT_DEPRECATED_END                                                                                           \
 	} else                                                                                                             \
 		((void)0)
 
@@ -285,7 +295,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_UNSIGNED_INDEX_V_EDMSG(m_index, m_size, m_retval, m_msg)                                                    \
 	if (unlikely((m_index) >= (m_size))) {                                                                                   \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+		GODOT_DEPRECATED_BEGIN                                                                                               \
 		return m_retval;                                                                                                     \
+		GODOT_DEPRECATED_END                                                                                                 \
 	} else                                                                                                                   \
 		((void)0)
 
@@ -367,7 +379,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_NULL_V(m_param, m_retval)                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                 \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null."); \
+		GODOT_DEPRECATED_BEGIN                                                                          \
 		return m_retval;                                                                                \
+		GODOT_DEPRECATED_END                                                                            \
 	} else                                                                                              \
 		((void)0)
 
@@ -378,7 +392,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_NULL_V_MSG(m_param, m_retval, m_msg)                                                          \
 	if (unlikely(m_param == nullptr)) {                                                                        \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg); \
+		GODOT_DEPRECATED_BEGIN                                                                                 \
 		return m_retval;                                                                                       \
+		GODOT_DEPRECATED_END                                                                                   \
 	} else                                                                                                     \
 		((void)0)
 
@@ -388,7 +404,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_NULL_V_EDMSG(m_param, m_retval, m_msg)                                                              \
 	if (unlikely(m_param == nullptr)) {                                                                              \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Parameter \"" _STR(m_param) "\" is null.", m_msg, true); \
+		GODOT_DEPRECATED_BEGIN                                                                                       \
 		return m_retval;                                                                                             \
+		GODOT_DEPRECATED_END                                                                                         \
 	} else                                                                                                           \
 		((void)0)
 
@@ -444,7 +462,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_COND_V(m_cond, m_retval)                                                                                         \
 	if (unlikely(m_cond)) {                                                                                                       \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval)); \
+		GODOT_DEPRECATED_BEGIN                                                                                                    \
 		return m_retval;                                                                                                          \
+		GODOT_DEPRECATED_END                                                                                                      \
 	} else                                                                                                                        \
 		((void)0)
 
@@ -458,7 +478,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_COND_V_MSG(m_cond, m_retval, m_msg)                                                                                     \
 	if (unlikely(m_cond)) {                                                                                                              \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg); \
+		GODOT_DEPRECATED_BEGIN                                                                                                           \
 		return m_retval;                                                                                                                 \
+		GODOT_DEPRECATED_END                                                                                                             \
 	} else                                                                                                                               \
 		((void)0)
 
@@ -468,7 +490,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_COND_V_EDMSG(m_cond, m_retval, m_msg)                                                                                         \
 	if (unlikely(m_cond)) {                                                                                                                    \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Condition \"" _STR(m_cond) "\" is true. Returning: " _STR(m_retval), m_msg, true); \
+		GODOT_DEPRECATED_BEGIN                                                                                                                 \
 		return m_retval;                                                                                                                       \
+		GODOT_DEPRECATED_END                                                                                                                   \
 	} else                                                                                                                                     \
 		((void)0)
 
@@ -622,7 +646,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_V(m_retval)                                                                                      \
 	if (true) {                                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval)); \
+		GODOT_DEPRECATED_BEGIN                                                                                    \
 		return m_retval;                                                                                          \
+		GODOT_DEPRECATED_END                                                                                      \
 	} else                                                                                                        \
 		((void)0)
 
@@ -635,7 +661,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_V_MSG(m_retval, m_msg)                                                                                  \
 	if (true) {                                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg); \
+		GODOT_DEPRECATED_BEGIN                                                                                           \
 		return m_retval;                                                                                                 \
+		GODOT_DEPRECATED_END                                                                                             \
 	} else                                                                                                               \
 		((void)0)
 
@@ -645,7 +673,9 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 #define ERR_FAIL_V_EDMSG(m_retval, m_msg)                                                                                      \
 	if (true) {                                                                                                                \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Method/function failed. Returning: " _STR(m_retval), m_msg, true); \
+		GODOT_DEPRECATED_BEGIN                                                                                                 \
 		return m_retval;                                                                                                       \
+		GODOT_DEPRECATED_END                                                                                                   \
 	} else                                                                                                                     \
 		((void)0)
 

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -88,7 +88,7 @@ static String get_property_info_type_name(const PropertyInfo &p_info) {
 }
 
 static String get_type_meta_name(const GodotTypeInfo::Metadata metadata) {
-	static const char *argmeta[13] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double", "char16", "char32" };
+	static const char *argmeta[14] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double", "char16", "char32", "required" };
 	return argmeta[metadata];
 }
 

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -63,21 +63,7 @@ public:
 		}
 		return true;
 	}
-
-	bool operator!=(const IPAddress &p_ip) const {
-		if (p_ip.valid != valid) {
-			return true;
-		}
-		if (!valid) {
-			return true;
-		}
-		for (int i = 0; i < 4; i++) {
-			if (field32[i] != p_ip.field32[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
+	bool operator==(const String &p_ip) const { return operator==(IPAddress(p_ip)); }
 
 	void clear();
 	bool is_wildcard() const { return wildcard; }

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -61,9 +61,6 @@ struct [[nodiscard]] AABB {
 	constexpr bool operator==(const AABB &p_rval) const {
 		return position == p_rval.position && size == p_rval.size;
 	}
-	constexpr bool operator!=(const AABB &p_rval) const {
-		return position != p_rval.position || size != p_rval.size;
-	}
 
 	bool is_equal_approx(const AABB &p_aabb) const;
 	bool is_same(const AABB &p_aabb) const;

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -124,7 +124,6 @@ struct [[nodiscard]] Basis {
 	bool is_finite() const;
 
 	constexpr bool operator==(const Basis &p_matrix) const;
-	constexpr bool operator!=(const Basis &p_matrix) const;
 
 	_FORCE_INLINE_ Vector3 xform(const Vector3 &p_vector) const;
 	_FORCE_INLINE_ Vector3 xform_inv(const Vector3 &p_vector) const;
@@ -257,10 +256,6 @@ constexpr bool Basis::operator==(const Basis &p_matrix) const {
 	}
 
 	return true;
-}
-
-constexpr bool Basis::operator!=(const Basis &p_matrix) const {
-	return (!(*this == p_matrix));
 }
 
 _FORCE_INLINE_ void Basis::operator*=(const Basis &p_matrix) {

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -59,7 +59,6 @@ struct BVH_ABB {
 	POINT neg_max;
 
 	bool operator==(const BVH_ABB &o) const { return (min == o.min) && (neg_max == o.neg_max); }
-	bool operator!=(const BVH_ABB &o) const { return (*this == o) == false; }
 
 	void set(const POINT &_min, const POINT &_max) {
 		min = _min;

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -101,7 +101,6 @@ struct BVHHandle {
 	void set_id(uint32_t p_id) { _data = p_id; }
 
 	bool operator==(const BVHHandle &p_h) const { return _data == p_h._data; }
-	bool operator!=(const BVHHandle &p_h) const { return (*this == p_h) == false; }
 };
 
 // helper class to make iterative versions of recursive functions

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -73,9 +73,6 @@ struct [[nodiscard]] Color {
 	constexpr bool operator==(const Color &p_color) const {
 		return (r == p_color.r && g == p_color.g && b == p_color.b && a == p_color.a);
 	}
-	constexpr bool operator!=(const Color &p_color) const {
-		return (r != p_color.r || g != p_color.g || b != p_color.b || a != p_color.a);
-	}
 
 	constexpr Color operator+(const Color &p_color) const;
 	constexpr void operator+=(const Color &p_color);

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -136,10 +136,6 @@ public:
 			return (x == b.x) && (y == b.y) && (z == b.z);
 		}
 
-		bool operator!=(const Point32 &b) const {
-			return (x != b.x) || (y != b.y) || (z != b.z);
-		}
-
 		bool is_zero() {
 			return (x == 0) && (y == 0) && (z == 0);
 		}

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -77,7 +77,6 @@ struct [[nodiscard]] Plane {
 	bool is_finite() const;
 
 	constexpr bool operator==(const Plane &p_plane) const;
-	constexpr bool operator!=(const Plane &p_plane) const;
 	operator String() const;
 
 	Plane() = default;
@@ -127,10 +126,6 @@ Plane::Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_
 
 constexpr bool Plane::operator==(const Plane &p_plane) const {
 	return normal == p_plane.normal && d == p_plane.d;
-}
-
-constexpr bool Plane::operator!=(const Plane &p_plane) const {
-	return normal != p_plane.normal || d != p_plane.d;
 }
 
 template <>

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -150,10 +150,6 @@ struct [[nodiscard]] Projection {
 		return true;
 	}
 
-	constexpr bool operator!=(const Projection &p_cam) const {
-		return !(*this == p_cam);
-	}
-
 	real_t get_lod_multiplier() const;
 
 	Projection() = default;

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -113,7 +113,6 @@ struct [[nodiscard]] Quaternion {
 	constexpr Quaternion operator/(real_t p_s) const;
 
 	constexpr bool operator==(const Quaternion &p_quaternion) const;
-	constexpr bool operator!=(const Quaternion &p_quaternion) const;
 
 	operator String() const;
 
@@ -228,10 +227,6 @@ constexpr Quaternion Quaternion::operator/(real_t p_s) const {
 
 constexpr bool Quaternion::operator==(const Quaternion &p_quaternion) const {
 	return x == p_quaternion.x && y == p_quaternion.y && z == p_quaternion.z && w == p_quaternion.w;
-}
-
-constexpr bool Quaternion::operator!=(const Quaternion &p_quaternion) const {
-	return x != p_quaternion.x || y != p_quaternion.y || z != p_quaternion.z || w != p_quaternion.w;
 }
 
 constexpr void Quaternion::operator*=(const Quaternion &p_q) {

--- a/core/math/rect2.cpp
+++ b/core/math/rect2.cpp
@@ -293,3 +293,7 @@ Rect2::operator String() const {
 Rect2::operator Rect2i() const {
 	return Rect2i(position, size);
 }
+
+bool Rect2::operator==(const Rect2i &p_recti) const {
+	return operator==(Rect2(p_recti));
+}

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -206,7 +206,7 @@ struct [[nodiscard]] Rect2 {
 	bool is_finite() const;
 
 	constexpr bool operator==(const Rect2 &p_rect) const { return position == p_rect.position && size == p_rect.size; }
-	constexpr bool operator!=(const Rect2 &p_rect) const { return position != p_rect.position || size != p_rect.size; }
+	bool operator==(const Rect2i &p_recti) const;
 
 	inline Rect2 grow(real_t p_amount) const {
 		Rect2 g = *this;

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -144,7 +144,6 @@ struct [[nodiscard]] Rect2i {
 	}
 
 	constexpr bool operator==(const Rect2i &p_rect) const { return position == p_rect.position && size == p_rect.size; }
-	constexpr bool operator!=(const Rect2i &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
 	Rect2i grow(int p_amount) const {
 		Rect2i g = *this;

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -110,7 +110,6 @@ struct [[nodiscard]] Transform2D {
 	Transform2D looking_at(const Vector2 &p_target) const;
 
 	constexpr bool operator==(const Transform2D &p_transform) const;
-	constexpr bool operator!=(const Transform2D &p_transform) const;
 
 	void operator*=(const Transform2D &p_transform);
 	Transform2D operator*(const Transform2D &p_transform) const;
@@ -157,16 +156,6 @@ constexpr bool Transform2D::operator==(const Transform2D &p_transform) const {
 	}
 
 	return true;
-}
-
-constexpr bool Transform2D::operator!=(const Transform2D &p_transform) const {
-	for (int i = 0; i < 3; i++) {
-		if (columns[i] != p_transform.columns[i]) {
-			return true;
-		}
-	}
-
-	return false;
 }
 
 constexpr void Transform2D::operator*=(real_t p_val) {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -78,7 +78,6 @@ struct [[nodiscard]] Transform3D {
 	bool is_finite() const;
 
 	constexpr bool operator==(const Transform3D &p_transform) const;
-	constexpr bool operator!=(const Transform3D &p_transform) const;
 
 	_FORCE_INLINE_ Vector3 xform(const Vector3 &p_vector) const;
 	_FORCE_INLINE_ AABB xform(const AABB &p_aabb) const;
@@ -138,10 +137,6 @@ struct [[nodiscard]] Transform3D {
 
 constexpr bool Transform3D::operator==(const Transform3D &p_transform) const {
 	return (basis == p_transform.basis && origin == p_transform.origin);
-}
-
-constexpr bool Transform3D::operator!=(const Transform3D &p_transform) const {
-	return (basis != p_transform.basis || origin != p_transform.origin);
 }
 
 constexpr void Transform3D::operator*=(real_t p_val) {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -213,3 +213,7 @@ Vector2::operator String() const {
 Vector2::operator Vector2i() const {
 	return Vector2i(x, y);
 }
+
+bool Vector2::operator==(const Vector2i &p_vector2i) const {
+	return operator==(Vector2(p_vector2i));
+}

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -153,12 +153,11 @@ struct [[nodiscard]] Vector2 {
 	constexpr Vector2 operator-() const;
 
 	constexpr bool operator==(const Vector2 &p_vec2) const;
-	constexpr bool operator!=(const Vector2 &p_vec2) const;
-
 	constexpr bool operator<(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y < p_vec2.y) : (x < p_vec2.x); }
 	constexpr bool operator>(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y > p_vec2.y) : (x > p_vec2.x); }
 	constexpr bool operator<=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y <= p_vec2.y) : (x < p_vec2.x); }
 	constexpr bool operator>=(const Vector2 &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
+	bool operator==(const Vector2i &p_vector2i) const;
 
 	real_t angle() const;
 	static Vector2 from_angle(real_t p_angle);
@@ -247,10 +246,6 @@ constexpr Vector2 Vector2::operator-() const {
 
 constexpr bool Vector2::operator==(const Vector2 &p_vec2) const {
 	return x == p_vec2.x && y == p_vec2.y;
-}
-
-constexpr bool Vector2::operator!=(const Vector2 &p_vec2) const {
-	return x != p_vec2.x || y != p_vec2.y;
 }
 
 Vector2 Vector2::lerp(const Vector2 &p_to, real_t p_weight) const {

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -126,7 +126,6 @@ struct [[nodiscard]] Vector2i {
 	constexpr bool operator>=(const Vector2i &p_vec2) const { return x == p_vec2.x ? (y >= p_vec2.y) : (x > p_vec2.x); }
 
 	constexpr bool operator==(const Vector2i &p_vec2) const;
-	constexpr bool operator!=(const Vector2i &p_vec2) const;
 
 	int64_t length_squared() const;
 	double length() const;
@@ -213,10 +212,6 @@ constexpr Vector2i Vector2i::operator-() const {
 
 constexpr bool Vector2i::operator==(const Vector2i &p_vec2) const {
 	return x == p_vec2.x && y == p_vec2.y;
-}
-
-constexpr bool Vector2i::operator!=(const Vector2i &p_vec2) const {
-	return x != p_vec2.x || y != p_vec2.y;
 }
 
 // Multiplication operators required to workaround issues with LLVM using implicit conversion.

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -175,3 +175,7 @@ Vector3::operator String() const {
 Vector3::operator Vector3i() const {
 	return Vector3i(x, y, z);
 }
+
+bool Vector3::operator==(const Vector3i &p_Vector3i) const {
+	return operator==(Vector3(p_Vector3i));
+}

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -180,11 +180,11 @@ struct [[nodiscard]] Vector3 {
 	constexpr Vector3 operator-() const;
 
 	constexpr bool operator==(const Vector3 &p_v) const;
-	constexpr bool operator!=(const Vector3 &p_v) const;
 	constexpr bool operator<(const Vector3 &p_v) const;
 	constexpr bool operator<=(const Vector3 &p_v) const;
 	constexpr bool operator>(const Vector3 &p_v) const;
 	constexpr bool operator>=(const Vector3 &p_v) const;
+	bool operator==(const Vector3i &p_vector3i) const;
 
 	operator String() const;
 	operator Vector3i() const;
@@ -430,10 +430,6 @@ constexpr Vector3 Vector3::operator-() const {
 
 constexpr bool Vector3::operator==(const Vector3 &p_v) const {
 	return x == p_v.x && y == p_v.y && z == p_v.z;
-}
-
-constexpr bool Vector3::operator!=(const Vector3 &p_v) const {
-	return x != p_v.x || y != p_v.y || z != p_v.z;
 }
 
 constexpr bool Vector3::operator<(const Vector3 &p_v) const {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -124,7 +124,6 @@ struct [[nodiscard]] Vector3i {
 	constexpr Vector3i operator-() const;
 
 	constexpr bool operator==(const Vector3i &p_v) const;
-	constexpr bool operator!=(const Vector3i &p_v) const;
 	constexpr bool operator<(const Vector3i &p_v) const;
 	constexpr bool operator<=(const Vector3i &p_v) const;
 	constexpr bool operator>(const Vector3i &p_v) const;
@@ -277,10 +276,6 @@ constexpr Vector3i Vector3i::operator-() const {
 
 constexpr bool Vector3i::operator==(const Vector3i &p_v) const {
 	return (x == p_v.x && y == p_v.y && z == p_v.z);
-}
-
-constexpr bool Vector3i::operator!=(const Vector3i &p_v) const {
-	return (x != p_v.x || y != p_v.y || z != p_v.z);
 }
 
 constexpr bool Vector3i::operator<(const Vector3i &p_v) const {

--- a/core/math/vector4.cpp
+++ b/core/math/vector4.cpp
@@ -225,3 +225,7 @@ static_assert(sizeof(Vector4) == 4 * sizeof(real_t));
 Vector4::operator Vector4i() const {
 	return Vector4i(x, y, z, w);
 }
+
+bool Vector4::operator==(const Vector4i &p_vector4i) const {
+	return operator==(Vector4(p_vector4i));
+}

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -137,11 +137,11 @@ struct [[nodiscard]] Vector4 {
 	constexpr Vector4 operator/(real_t p_s) const;
 
 	constexpr bool operator==(const Vector4 &p_vec4) const;
-	constexpr bool operator!=(const Vector4 &p_vec4) const;
 	constexpr bool operator>(const Vector4 &p_vec4) const;
 	constexpr bool operator<(const Vector4 &p_vec4) const;
 	constexpr bool operator>=(const Vector4 &p_vec4) const;
 	constexpr bool operator<=(const Vector4 &p_vec4) const;
+	bool operator==(const Vector4i &p_vector4i) const;
 
 	operator String() const;
 	operator Vector4i() const;
@@ -228,10 +228,6 @@ constexpr Vector4 Vector4::operator/(real_t p_s) const {
 
 constexpr bool Vector4::operator==(const Vector4 &p_vec4) const {
 	return x == p_vec4.x && y == p_vec4.y && z == p_vec4.z && w == p_vec4.w;
-}
-
-constexpr bool Vector4::operator!=(const Vector4 &p_vec4) const {
-	return x != p_vec4.x || y != p_vec4.y || z != p_vec4.z || w != p_vec4.w;
 }
 
 constexpr bool Vector4::operator<(const Vector4 &p_v) const {

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -126,7 +126,6 @@ struct [[nodiscard]] Vector4i {
 	constexpr Vector4i operator-() const;
 
 	constexpr bool operator==(const Vector4i &p_v) const;
-	constexpr bool operator!=(const Vector4i &p_v) const;
 	constexpr bool operator<(const Vector4i &p_v) const;
 	constexpr bool operator<=(const Vector4i &p_v) const;
 	constexpr bool operator>(const Vector4i &p_v) const;
@@ -288,10 +287,6 @@ constexpr Vector4i Vector4i::operator-() const {
 
 constexpr bool Vector4i::operator==(const Vector4i &p_v) const {
 	return (x == p_v.x && y == p_v.y && z == p_v.z && w == p_v.w);
-}
-
-constexpr bool Vector4i::operator!=(const Vector4i &p_v) const {
-	return (x != p_v.x || y != p_v.y || z != p_v.z || w != p_v.w);
 }
 
 constexpr bool Vector4i::operator<(const Vector4i &p_v) const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -50,6 +50,9 @@ class TypedArray;
 template <typename T>
 class Ref;
 
+template <typename T>
+class RequiredObj;
+
 enum PropertyHint {
 	PROPERTY_HINT_NONE, ///< no hint provided.
 	PROPERTY_HINT_RANGE, ///< hint_text = "min,max[,step][,or_greater][,or_less][,hide_slider][,radians_as_degrees][,degrees][,exp][,suffix:<keyword>] range.

--- a/core/object/object_id.h
+++ b/core/object/object_id.h
@@ -48,7 +48,6 @@ public:
 	_ALWAYS_INLINE_ operator int64_t() const { return (int64_t)id; }
 
 	_ALWAYS_INLINE_ bool operator==(const ObjectID &p_id) const { return id == p_id.id; }
-	_ALWAYS_INLINE_ bool operator!=(const ObjectID &p_id) const { return id != p_id.id; }
 	_ALWAYS_INLINE_ bool operator<(const ObjectID &p_id) const { return id < p_id.id; }
 
 	_ALWAYS_INLINE_ void operator=(int64_t p_int64) { id = p_int64; }

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -92,13 +92,10 @@ public:
 	_FORCE_INLINE_ bool operator==(const T *p_ptr) const {
 		return reference == p_ptr;
 	}
-	_FORCE_INLINE_ bool operator!=(const T *p_ptr) const {
-		return reference != p_ptr;
-	}
+
 #ifdef STRICT_CHECKS
 	// Delete these to prevent raw comparisons with `nullptr`.
 	bool operator==(std::nullptr_t) const = delete;
-	bool operator!=(std::nullptr_t) const = delete;
 #endif // STRICT_CHECKS
 
 	_FORCE_INLINE_ bool operator<(const Ref<T> &p_r) const {
@@ -107,8 +104,9 @@ public:
 	_FORCE_INLINE_ bool operator==(const Ref<T> &p_r) const {
 		return reference == p_r.reference;
 	}
-	_FORCE_INLINE_ bool operator!=(const Ref<T> &p_r) const {
-		return reference != p_r.reference;
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	_FORCE_INLINE_ bool operator==(const Ref<T_Other> &p_r) const {
+		return reference == p_r.ptr();
 	}
 
 	_FORCE_INLINE_ T *operator*() const {

--- a/core/object/required_obj.h
+++ b/core/object/required_obj.h
@@ -1,0 +1,190 @@
+/**************************************************************************/
+/*  required_obj.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+#include "core/templates/simple_type.h"
+
+#include <compare>
+#include <source_location>
+
+namespace Internal {
+
+template <typename T, typename = void>
+struct GetElementType;
+
+template <typename T>
+struct GetElementType<T, std::enable_if_t<!std::is_same_v<T, GetSimpleTypeT<T>>>> : GetElementType<GetSimpleTypeT<T>> {};
+
+template <typename T>
+struct GetElementType<T *> {
+	using element_type = GetSimpleTypeT<T>;
+};
+
+template <typename T>
+struct GetElementType<Ref<T>> {
+	using element_type = T;
+};
+
+} // namespace Internal
+
+template <typename T>
+class RequiredObj {
+	static_assert(!std::is_scalar_v<T>, "T may not be a scalar type");
+	static_assert(!std::is_reference_v<T>, "T may not be a reference type");
+	static_assert(!std::is_const_v<T> && !std::is_volatile_v<T>, "T may not be cv-qualified");
+
+	T *_value = nullptr;
+
+	_ALWAYS_INLINE_ void _null_validate(const std::source_location p_source) {
+		if (_value == nullptr) [[unlikely]] {
+			_err_print_error(p_source.function_name(), p_source.file_name(), p_source.line(), "Null value was passed to a required object. This is an issue in the engine, and should be reported.");
+		}
+	}
+
+	constexpr RequiredObj() = default;
+
+public:
+	using element_type = T;
+
+	// RequiredObj variables assumed to already have validated contents; no check required.
+	constexpr RequiredObj(const RequiredObj &p_other) = default;
+	constexpr RequiredObj(RequiredObj &&p_other) = default;
+	constexpr RequiredObj &operator=(const RequiredObj &p_other) = default;
+	constexpr RequiredObj &operator=(RequiredObj &&p_other) = default;
+
+	// RequiredObj of different type also validated, albeit with a derived-type constraint.
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	constexpr RequiredObj(const RequiredObj<T_Other> &p_other) :
+			_value(const_cast<T_Other *>(p_other.ptr())) {}
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	constexpr RequiredObj &operator=(const RequiredObj<T_Other> &p_other) {
+		_value = const_cast<T_Other *>(p_other.ptr());
+		return *this;
+	}
+
+	// Non-validated types pass along source location metadata.
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ RequiredObj(const T_Other *p_ptr, const std::source_location p_source = std::source_location::current()) :
+			_value(const_cast<std::remove_const_t<T_Other> *>(p_ptr)) {
+		_null_validate(p_source);
+	}
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	_ALWAYS_INLINE_ RequiredObj(const Ref<T_Other> &p_ref, const std::source_location p_source = std::source_location::current()) :
+			_value(p_ref.ptr()) {
+		_null_validate(p_source);
+	}
+
+	// Assignment operators excluded for non-validated types, as they cannot be passed location
+	//  metadata. This has the benefit of requiring assignments to be explicit.
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	RequiredObj &operator=(const T_Other *) = delete;
+	template <typename T_Other, std::enable_if_t<std::is_base_of_v<T, T_Other>, int> = 0>
+	RequiredObj &operator=(const Ref<T_Other> &) = delete;
+
+	// Prevent erroneously assigning null values by explicitly removing nullptr constructor/assignment.
+	RequiredObj(std::nullptr_t) = delete;
+	RequiredObj &operator=(std::nullptr_t) = delete;
+
+	// As an alternative to non-validated constructors, RequiredObj supports construction directly.
+	//  This doesn't need a validation step, as there's guaranteed to be *something* after `memnew`.
+	template <typename... VarArgs>
+	static constexpr RequiredObj construct(VarArgs... p_params) {
+		RequiredObj tmp = RequiredObj();
+		tmp._value = memnew(T(p_params...));
+		return tmp;
+	}
+
+	// We will occasionally need to return an empty RequiredObj when the function itself encounters
+	//  an error. However, we don't want to use the default construction methods, as that would note
+	//  that this intended fallback is an engine bug. Instead, this function silently returns null,
+	//  but within a deprecated wrapper, so that it cannot be used directly within the codebase.
+	//  Deprecation-suppression macros surround the return value of error macros, meaning this should
+	//  only be possible to call in that specific context.
+	[[nodiscard, deprecated("Should not be called directly; must be used as return argument in error macro.")]]
+	static constexpr RequiredObj silent_null() { return RequiredObj<T>(); }
+
+	[[nodiscard]] constexpr T *operator->() { return _value; }
+	[[nodiscard]] constexpr const T *operator->() const { return _value; }
+	[[nodiscard]] constexpr T *ptr() { return _value; }
+	[[nodiscard]] constexpr const T *ptr() const { return _value; }
+
+	[[nodiscard]] constexpr bool is_null() const { return _value == nullptr; }
+	[[nodiscard]] constexpr bool is_valid() const { return _value != nullptr; }
+
+	// Comparison operators.
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const RequiredObj &p_other) const = default;
+	[[nodiscard]] constexpr bool operator==(const RequiredObj &p_other) const = default;
+
+	template <typename T_Other>
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const RequiredObj<T_Other> &p_other) const { return ptr() <=> p_other.ptr(); }
+	template <typename T_Other>
+	[[nodiscard]] constexpr bool operator==(const RequiredObj<T_Other> &p_other) const { return operator<=>(p_other) == 0; }
+
+	template <typename T_Other>
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const T_Other *p_ptr) const { return ptr() <=> p_ptr; }
+	template <typename T_Other>
+	[[nodiscard]] constexpr bool operator==(const T_Other *p_ptr) const { return operator<=>(p_ptr) == 0; }
+
+	template <typename T_Other>
+	[[nodiscard]] constexpr std::strong_ordering operator<=>(const Ref<T_Other> &p_ref) const { return ptr() <=> p_ref.ptr(); }
+	template <typename T_Other>
+	[[nodiscard]] constexpr bool operator==(const Ref<T_Other> &p_ref) const { return operator<=>(p_ref) == 0; }
+
+	// Operators we never want.
+	bool operator==(std::nullptr_t) const = delete;
+	RequiredObj &operator++() = delete;
+	RequiredObj &operator--() = delete;
+	RequiredObj operator++(int) = delete;
+	RequiredObj operator--(int) = delete;
+	RequiredObj operator+(size_t) const = delete;
+	RequiredObj &operator+=(size_t) = delete;
+	RequiredObj operator-(size_t) const = delete;
+	RequiredObj &operator-=(size_t) = delete;
+	RequiredObj operator+(std::ptrdiff_t) const = delete;
+	RequiredObj &operator+=(std::ptrdiff_t) = delete;
+	RequiredObj operator-(std::ptrdiff_t) const = delete;
+	RequiredObj &operator-=(std::ptrdiff_t) = delete;
+	void operator[](std::ptrdiff_t) const = delete;
+	template <typename T_Other>
+	std::ptrdiff_t operator+(const RequiredObj<T_Other> &) const = delete;
+	template <typename T_Other>
+	std::ptrdiff_t operator-(const RequiredObj<T_Other> &) const = delete;
+};
+
+template <typename T>
+RequiredObj(const T *) -> RequiredObj<T>;
+template <typename T>
+RequiredObj(const Ref<T> &) -> RequiredObj<T>;
+
+// Technically zero-constructible, but not recommended.
+template <typename T>
+struct is_zero_constructible<RequiredObj<T>> : std::true_type {};

--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -93,7 +93,7 @@ static_assert(std::atomic_bool::is_always_lock_free);
 
 class SpinLock {
 	union {
-		mutable std::atomic<bool> locked = ATOMIC_VAR_INIT(false);
+		mutable std::atomic<bool> locked = false;
 		char aligner[Thread::CACHE_LINE_BYTES];
 	};
 

--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -153,10 +153,6 @@ bool NodePath::operator==(const NodePath &p_path) const {
 	return true;
 }
 
-bool NodePath::operator!=(const NodePath &p_path) const {
-	return (!(*this == p_path));
-}
-
 void NodePath::operator=(const NodePath &p_path) {
 	if (this == &p_path) {
 		return;

--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -82,8 +82,9 @@ public:
 	bool is_empty() const;
 
 	bool operator==(const NodePath &p_path) const;
-	bool operator!=(const NodePath &p_path) const;
 	void operator=(const NodePath &p_path);
+
+	bool operator==(const String &p_path) const { return operator==(NodePath(p_path)); }
 
 	void simplify();
 	NodePath simplified() const;

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -152,14 +152,6 @@ bool StringName::operator==(const char *p_name) const {
 	return p_name[0] == 0;
 }
 
-bool StringName::operator!=(const String &p_name) const {
-	return !(operator==(p_name));
-}
-
-bool StringName::operator!=(const char *p_name) const {
-	return !(operator==(p_name));
-}
-
 char32_t StringName::operator[](int p_index) const {
 	if (_data) {
 		return _data->name[p_index];
@@ -405,18 +397,4 @@ StringName StringName::search(const String &p_name) {
 	}
 
 	return StringName(); //does not exist
-}
-
-bool operator==(const String &p_name, const StringName &p_string_name) {
-	return p_string_name.operator==(p_name);
-}
-bool operator!=(const String &p_name, const StringName &p_string_name) {
-	return p_string_name.operator!=(p_name);
-}
-
-bool operator==(const char *p_name, const StringName &p_string_name) {
-	return p_string_name.operator==(p_name);
-}
-bool operator!=(const char *p_name, const StringName &p_string_name) {
-	return p_string_name.operator!=(p_name);
 }

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -81,8 +81,6 @@ public:
 
 	bool operator==(const String &p_name) const;
 	bool operator==(const char *p_name) const;
-	bool operator!=(const String &p_name) const;
-	bool operator!=(const char *p_name) const;
 
 	const char32_t *get_data() const { return _data ? _data->name.ptr() : U""; }
 	char32_t operator[](int p_index) const;
@@ -111,9 +109,6 @@ public:
 		// The real magic of all this mess happens here.
 		// This is why path comparisons are very fast.
 		return _data == p_name._data;
-	}
-	_FORCE_INLINE_ bool operator!=(const StringName &p_name) const {
-		return _data != p_name._data;
 	}
 	_FORCE_INLINE_ uint32_t hash() const {
 		if (_data) {
@@ -196,11 +191,6 @@ public:
 // Zero-constructing StringName initializes _data to nullptr (and thus empty).
 template <>
 struct is_zero_constructible<StringName> : std::true_type {};
-
-bool operator==(const String &p_name, const StringName &p_string_name);
-bool operator!=(const String &p_name, const StringName &p_string_name);
-bool operator==(const char *p_name, const StringName &p_string_name);
-bool operator!=(const char *p_name, const StringName &p_string_name);
 
 /*
  * The SNAME macro is used to speed up StringName creation, as it allows caching it after the first usage in a very efficient way.

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -388,50 +388,6 @@ bool String::operator==(const Span<char32_t> &p_str_range) const {
 	return memcmp(ptr(), p_str_range.ptr(), len * sizeof(char32_t)) == 0;
 }
 
-bool operator==(const char *p_chr, const String &p_str) {
-	return p_str == p_chr;
-}
-
-bool operator==(const wchar_t *p_chr, const String &p_str) {
-#ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit
-	return p_str == String::utf16((const char16_t *)p_chr);
-#else
-	// wchar_t is 32-bi
-	return p_str == String((const char32_t *)p_chr);
-#endif
-}
-
-bool operator!=(const char *p_chr, const String &p_str) {
-	return !(p_str == p_chr);
-}
-
-bool operator!=(const wchar_t *p_chr, const String &p_str) {
-#ifdef WINDOWS_ENABLED
-	// wchar_t is 16-bit
-	return !(p_str == String::utf16((const char16_t *)p_chr));
-#else
-	// wchar_t is 32-bi
-	return !(p_str == String((const char32_t *)p_chr));
-#endif
-}
-
-bool String::operator!=(const char *p_str) const {
-	return (!(*this == p_str));
-}
-
-bool String::operator!=(const wchar_t *p_str) const {
-	return (!(*this == p_str));
-}
-
-bool String::operator!=(const char32_t *p_str) const {
-	return (!(*this == p_str));
-}
-
-bool String::operator!=(const String &p_str) const {
-	return !((*this == p_str));
-}
-
 bool String::operator<=(const String &p_str) const {
 	return !(p_str < *this);
 }

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -208,7 +208,6 @@ public:
 		}
 		return memcmp(ptr(), p_other.ptr(), length() * sizeof(T)) == 0;
 	}
-	_FORCE_INLINE_ bool operator!=(const CharStringT<T> &p_other) const { return !(*this == p_other); }
 	_FORCE_INLINE_ bool operator<(const CharStringT<T> &p_other) const {
 		if (length() == 0) {
 			return p_other.length() != 0;
@@ -338,7 +337,6 @@ public:
 	/* Compatibility Operators */
 
 	bool operator==(const String &p_str) const;
-	bool operator!=(const String &p_str) const;
 	String operator+(const String &p_str) const;
 	String operator+(const char *p_char) const;
 	String operator+(const wchar_t *p_char) const;
@@ -355,10 +353,6 @@ public:
 	bool operator==(const wchar_t *p_str) const;
 	bool operator==(const char32_t *p_str) const;
 	bool operator==(const Span<char32_t> &p_str_range) const;
-
-	bool operator!=(const char *p_str) const;
-	bool operator!=(const wchar_t *p_str) const;
-	bool operator!=(const char32_t *p_str) const;
 
 	bool operator<(const char32_t *p_str) const;
 	bool operator<(const char *p_str) const;
@@ -687,11 +681,6 @@ public:
 // Zero-constructing String initializes _cowdata.ptr() to nullptr and thus empty.
 template <>
 struct is_zero_constructible<String> : std::true_type {};
-
-bool operator==(const char *p_chr, const String &p_str);
-bool operator==(const wchar_t *p_chr, const String &p_str);
-bool operator!=(const char *p_chr, const String &p_str);
-bool operator!=(const wchar_t *p_chr, const String &p_str);
 
 String operator+(const char *p_chr, const String &p_str);
 String operator+(const wchar_t *p_chr, const String &p_str);

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -445,7 +445,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return pair == b.pair; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return pair != b.pair; }
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return pair != end;
@@ -494,7 +493,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return pair == b.pair; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return pair != b.pair; }
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return pair != end;

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -455,7 +455,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return E != nullptr;
@@ -491,7 +490,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return E != nullptr;

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -336,7 +336,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return keys == b.keys && index == b.index; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return keys != b.keys || index != b.index; }
 
 		_FORCE_INLINE_ explicit operator bool() const {
 			return keys != nullptr;

--- a/core/templates/interpolated_property.h
+++ b/core/templates/interpolated_property.h
@@ -82,10 +82,6 @@ public:
 		return p_o == curr;
 	}
 
-	bool operator!=(const T &p_o) const {
-		return p_o != curr;
-	}
-
 	InterpolatedProperty &operator=(T p_val) {
 		curr = p_val;
 		_interpolated = p_val;

--- a/core/templates/list.h
+++ b/core/templates/list.h
@@ -155,7 +155,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
 
 		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ ConstIterator() {}
@@ -180,7 +179,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
 
 		Iterator(Element *p_E) { E = p_E; }
 		Iterator() {}

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -198,7 +198,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
 
 		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
 		Iterator() {}
@@ -223,7 +222,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
 
 		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
 		ConstIterator() {}

--- a/core/templates/pair.h
+++ b/core/templates/pair.h
@@ -42,7 +42,6 @@ struct Pair {
 			first(p_first), second(p_second) {}
 
 	constexpr bool operator==(const Pair &p_other) const { return first == p_other.first && second == p_other.second; }
-	constexpr bool operator!=(const Pair &p_other) const { return first != p_other.first || second != p_other.second; }
 	constexpr bool operator<(const Pair &p_other) const { return first == p_other.first ? (second < p_other.second) : (first < p_other.first); }
 	constexpr bool operator<=(const Pair &p_other) const { return first == p_other.first ? (second <= p_other.second) : (first < p_other.first); }
 	constexpr bool operator>(const Pair &p_other) const { return first == p_other.first ? (second > p_other.second) : (first > p_other.first); }
@@ -76,7 +75,6 @@ struct KeyValue {
 			key(p_pair.first), value(p_pair.second) {}
 
 	constexpr bool operator==(const KeyValue &p_other) const { return key == p_other.key && value == p_other.value; }
-	constexpr bool operator!=(const KeyValue &p_other) const { return key != p_other.key || value != p_other.value; }
 	constexpr bool operator<(const KeyValue &p_other) const { return key == p_other.key ? (value < p_other.value) : (key < p_other.key); }
 	constexpr bool operator<=(const KeyValue &p_other) const { return key == p_other.key ? (value <= p_other.value) : (key < p_other.key); }
 	constexpr bool operator>(const KeyValue &p_other) const { return key == p_other.key ? (value > p_other.value) : (key > p_other.key); }

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -113,7 +113,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &p_it) const { return E == p_it.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &p_it) const { return E != p_it.E; }
 		explicit operator bool() const {
 			return E != nullptr;
 		}
@@ -145,7 +144,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_it) const { return E == p_it.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_it) const { return E != p_it.E; }
 		explicit operator bool() const {
 			return E != nullptr;
 		}

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -98,7 +98,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return E != b.E; }
 
 		explicit operator bool() const { return E != nullptr; }
 		Iterator(Element *p_E) { E = p_E; }
@@ -124,7 +123,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return E == b.E; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return E != b.E; }
 
 		_FORCE_INLINE_ ConstIterator(const Element *p_E) { E = p_E; }
 		_FORCE_INLINE_ ConstIterator() {}

--- a/core/templates/rid.h
+++ b/core/templates/rid.h
@@ -54,9 +54,6 @@ public:
 	_ALWAYS_INLINE_ bool operator>=(const RID &p_rid) const {
 		return _id >= p_rid._id;
 	}
-	_ALWAYS_INLINE_ bool operator!=(const RID &p_rid) const {
-		return _id != p_rid._id;
-	}
 	_ALWAYS_INLINE_ bool is_valid() const { return _id != 0; }
 	_ALWAYS_INLINE_ bool is_null() const { return _id == 0; }
 

--- a/core/templates/safe_list.h
+++ b/core/templates/safe_list.h
@@ -105,17 +105,9 @@ public:
 			return cursor == p_other;
 		}
 
-		bool operator!=(const void *p_other) const {
-			return cursor != p_other;
-		}
-
 		// These two allow easy range-based for loops.
 		bool operator==(const Iterator &p_other) const {
 			return cursor == p_other.cursor;
-		}
-
-		bool operator!=(const Iterator &p_other) const {
-			return cursor != p_other.cursor;
 		}
 	};
 

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -225,19 +225,6 @@ public:
 		return true;
 	}
 
-	bool operator!=(const Vector<T> &p_arr) const {
-		Size s = size();
-		if (s != p_arr.size()) {
-			return true;
-		}
-		for (Size i = 0; i < s; i++) {
-			if (operator[](i) != p_arr[i]) {
-				return true;
-			}
-		}
-		return false;
-	}
-
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {
 			return *elem_ptr;
@@ -253,7 +240,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return elem_ptr != b.elem_ptr; }
 
 		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
 		Iterator() {}
@@ -278,7 +264,6 @@ public:
 		}
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &b) const { return elem_ptr == b.elem_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &b) const { return elem_ptr != b.elem_ptr; }
 
 		ConstIterator(const T *p_ptr) { elem_ptr = p_ptr; }
 		ConstIterator() {}

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -36,9 +36,9 @@
 
 // IWYU pragma: always_keep
 
-// Ensure that C++ standard is at least C++17.
+// Ensure that C++ standard is at least C++20.
 // If on MSVC, also ensures that the `Zc:__cplusplus` flag is present.
-static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
+static_assert(__cplusplus >= 202002L, "Minimum of C++20 required.");
 
 // IWYU pragma: begin_exports
 

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -384,3 +384,12 @@ inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 #define GODOT_MSVC_WARNING_POP
 #define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
 #endif
+
+#define GODOT_DEPRECATED_BEGIN                                       \
+	GODOT_CLANG_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations") \
+	GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdeprecated-declarations")   \
+	GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4996)
+#define GODOT_DEPRECATED_END \
+	GODOT_CLANG_WARNING_POP  \
+	GODOT_GCC_WARNING_POP    \
+	GODOT_MSVC_WARNING_POP

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -127,10 +127,6 @@ bool Array::operator==(const Array &p_array) const {
 	return recursive_equal(p_array, 0);
 }
 
-bool Array::operator!=(const Array &p_array) const {
-	return !recursive_equal(p_array, 0);
-}
-
 bool Array::recursive_equal(const Array &p_array, int recursion_count) const {
 	// Cheap checks
 	if (_p == p_array._p) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -56,7 +56,6 @@ public:
 		_FORCE_INLINE_ ConstIterator &operator--();
 
 		_FORCE_INLINE_ bool operator==(const ConstIterator &p_other) const { return element_ptr == p_other.element_ptr; }
-		_FORCE_INLINE_ bool operator!=(const ConstIterator &p_other) const { return element_ptr != p_other.element_ptr; }
 
 		_FORCE_INLINE_ ConstIterator(const Variant *p_element_ptr) :
 				element_ptr(p_element_ptr) {}
@@ -81,7 +80,6 @@ public:
 		_FORCE_INLINE_ Iterator &operator--();
 
 		_FORCE_INLINE_ bool operator==(const Iterator &p_other) const { return element_ptr == p_other.element_ptr; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &p_other) const { return element_ptr != p_other.element_ptr; }
 
 		_FORCE_INLINE_ Iterator(Variant *p_element_ptr, Variant *p_read_only = nullptr) :
 				element_ptr(p_element_ptr), read_only(p_read_only) {}
@@ -121,7 +119,6 @@ public:
 	void clear();
 
 	bool operator==(const Array &p_array) const;
-	bool operator!=(const Array &p_array) const;
 	bool recursive_equal(const Array &p_array, int recursion_count) const;
 
 	uint32_t hash() const;

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -32,6 +32,7 @@
 
 #include "core/input/input_enums.h"
 #include "core/object/object.h"
+#include "core/object/required_obj.h"
 #include "core/os/keyboard.h"
 #include "core/templates/simple_type.h"
 #include "core/typedefs.h"

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -286,10 +286,6 @@ bool Callable::operator==(const Callable &p_callable) const {
 	}
 }
 
-bool Callable::operator!=(const Callable &p_callable) const {
-	return !(*this == p_callable);
-}
-
 bool Callable::operator<(const Callable &p_callable) const {
 	bool custom_a = is_custom();
 	bool custom_b = p_callable.is_custom();
@@ -502,10 +498,6 @@ StringName Signal::get_name() const {
 
 bool Signal::operator==(const Signal &p_signal) const {
 	return object == p_signal.object && name == p_signal.name;
-}
-
-bool Signal::operator!=(const Signal &p_signal) const {
-	return object != p_signal.object || name != p_signal.name;
 }
 
 bool Signal::operator<(const Signal &p_signal) const {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -118,7 +118,6 @@ public:
 	const Callable *get_base_comparator() const; //used for bind/unbind to do less precise comparisons (ignoring binds) in signal connect/disconnect
 
 	bool operator==(const Callable &p_callable) const;
-	bool operator!=(const Callable &p_callable) const;
 	bool operator<(const Callable &p_callable) const;
 
 	void operator=(const Callable &p_callable);
@@ -187,7 +186,6 @@ public:
 	StringName get_name() const;
 
 	bool operator==(const Signal &p_signal) const;
-	bool operator!=(const Signal &p_signal) const;
 	bool operator<(const Signal &p_signal) const;
 
 	operator String() const;

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -74,9 +74,6 @@ struct ContainerTypeValidate {
 	_FORCE_INLINE_ bool operator==(const ContainerTypeValidate &p_type) const {
 		return type == p_type.type && class_name == p_type.class_name && script == p_type.script;
 	}
-	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
-		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
-	}
 
 	// Coerces String and StringName into each other and int into float when needed.
 	_FORCE_INLINE_ bool validate(Variant &inout_variant, const char *p_operation = "use") const {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -254,10 +254,6 @@ bool Dictionary::operator==(const Dictionary &p_dictionary) const {
 	return recursive_equal(p_dictionary, 0);
 }
 
-bool Dictionary::operator!=(const Dictionary &p_dictionary) const {
-	return !recursive_equal(p_dictionary, 0);
-}
-
 bool Dictionary::recursive_equal(const Dictionary &p_dictionary, int recursion_count) const {
 	// Cheap checks
 	if (_p == p_dictionary._p) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -84,7 +84,6 @@ public:
 	bool erase(const Variant &p_key);
 
 	bool operator==(const Dictionary &p_dictionary) const;
-	bool operator!=(const Dictionary &p_dictionary) const;
 	bool recursive_equal(const Dictionary &p_dictionary, int recursion_count) const;
 
 	uint32_t hash() const;

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -167,6 +167,19 @@ struct PtrToArg<const T *> {
 	}
 };
 
+// This is for RequiredPtr.
+
+template <typename T>
+struct PtrToArg<RequiredObj<T>> {
+	_FORCE_INLINE_ static RequiredObj<T> convert(const void *p_ptr) {
+		return RequiredObj<T>(*reinterpret_cast<T *const *>(p_ptr));
+	}
+	typedef RequiredObj<T> EncodeT;
+	_FORCE_INLINE_ static void encode(RequiredObj<T> p_val, const void *p_ptr) {
+		*(const_cast<RequiredObj<T> *>(reinterpret_cast<const RequiredObj<T> *>(p_ptr))) = p_val;
+	}
+};
+
 // This is for ObjectID.
 
 template <>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -50,6 +50,7 @@ enum Metadata {
 	METADATA_REAL_IS_DOUBLE,
 	METADATA_INT_IS_CHAR16,
 	METADATA_INT_IS_CHAR32,
+	METADATA_OBJECT_IS_REQUIRED,
 };
 }
 
@@ -175,6 +176,15 @@ template <typename T>
 struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(StringName(T::get_class_static()));
+	}
+};
+
+template <typename T>
+struct GetTypeInfo<RequiredObj<T>> {
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -865,17 +865,6 @@ bool Variant::operator==(const Variant &p_variant) const {
 	return hash_compare(p_variant);
 }
 
-bool Variant::operator!=(const Variant &p_variant) const {
-	// Don't use `!hash_compare(p_variant)` given it makes use of OP_EQUAL
-	if (type != p_variant.type) { //evaluation of operator== needs to be more strict
-		return true;
-	}
-	bool v;
-	Variant r;
-	evaluate(OP_NOT_EQUAL, *this, p_variant, r, v);
-	return r;
-}
-
 bool Variant::operator<(const Variant &p_variant) const {
 	if (type != p_variant.type) { //if types differ, then order by type first
 		return type < p_variant.type;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -814,8 +814,71 @@ public:
 	//argsVariant call()
 
 	bool operator==(const Variant &p_variant) const;
-	bool operator!=(const Variant &p_variant) const;
 	bool operator<(const Variant &p_variant) const;
+
+	// FIXME: Starting with C++20, the above equality operator is no longer sufficient for comparison
+	//  with non-Variant types. While this should eventually get a pass to make those ambiguous situations
+	//  use explicit calls, these additional operators serve as a temporary workaround to restore the
+	//  previous behavior.
+	_FORCE_INLINE_ bool operator==(bool p_bool) const { return operator==(Variant(p_bool)); }
+	_FORCE_INLINE_ bool operator==(int64_t p_int64) const { return operator==(Variant(p_int64)); }
+	_FORCE_INLINE_ bool operator==(int32_t p_int32) const { return operator==(Variant(p_int32)); }
+	_FORCE_INLINE_ bool operator==(int16_t p_int16) const { return operator==(Variant(p_int16)); }
+	_FORCE_INLINE_ bool operator==(int8_t p_int8) const { return operator==(Variant(p_int8)); }
+	_FORCE_INLINE_ bool operator==(uint64_t p_uint64) const { return operator==(Variant(p_uint64)); }
+	_FORCE_INLINE_ bool operator==(uint32_t p_uint32) const { return operator==(Variant(p_uint32)); }
+	_FORCE_INLINE_ bool operator==(uint16_t p_uint16) const { return operator==(Variant(p_uint16)); }
+	_FORCE_INLINE_ bool operator==(uint8_t p_uint8) const { return operator==(Variant(p_uint8)); }
+	_FORCE_INLINE_ bool operator==(double p_double) const { return operator==(Variant(p_double)); }
+	_FORCE_INLINE_ bool operator==(float p_float) const { return operator==(Variant(p_float)); }
+	_FORCE_INLINE_ bool operator==(const String &p_string) const { return operator==(Variant(p_string)); }
+	_FORCE_INLINE_ bool operator==(const char *p_cstring) const { return operator==(Variant(p_cstring)); }
+	_FORCE_INLINE_ bool operator==(char32_t p_char32) const { return operator==(Variant(p_char32)); }
+	_FORCE_INLINE_ bool operator==(const Vector2 &p_vector2) const { return operator==(Variant(p_vector2)); }
+	_FORCE_INLINE_ bool operator==(const Vector2i &p_vector2i) const { return operator==(Variant(p_vector2i)); }
+	_FORCE_INLINE_ bool operator==(const Rect2 &p_rect2) const { return operator==(Variant(p_rect2)); }
+	_FORCE_INLINE_ bool operator==(const Rect2i &p_rect2i) const { return operator==(Variant(p_rect2i)); }
+	_FORCE_INLINE_ bool operator==(const Vector3 &p_vector3) const { return operator==(Variant(p_vector3)); }
+	_FORCE_INLINE_ bool operator==(const Vector3i &p_vector3i) const { return operator==(Variant(p_vector3i)); }
+	_FORCE_INLINE_ bool operator==(const Transform2D &p_transform_2d) const { return operator==(Variant(p_transform_2d)); }
+	_FORCE_INLINE_ bool operator==(const Vector4 &p_vector4) const { return operator==(Variant(p_vector4)); }
+	_FORCE_INLINE_ bool operator==(const Vector4i &p_vector4i) const { return operator==(Variant(p_vector4i)); }
+	_FORCE_INLINE_ bool operator==(const Plane &p_plane) const { return operator==(Variant(p_plane)); }
+	_FORCE_INLINE_ bool operator==(const Quaternion &p_quaternion) const { return operator==(Variant(p_quaternion)); }
+	_FORCE_INLINE_ bool operator==(const ::AABB &p_aabb) const { return operator==(Variant(p_aabb)); }
+	_FORCE_INLINE_ bool operator==(const Basis &p_basis) const { return operator==(Variant(p_basis)); }
+	_FORCE_INLINE_ bool operator==(const Transform3D &p_transform_3d) const { return operator==(Variant(p_transform_3d)); }
+	_FORCE_INLINE_ bool operator==(const Projection &p_projection) const { return operator==(Variant(p_projection)); }
+	_FORCE_INLINE_ bool operator==(const Color &p_color) const { return operator==(Variant(p_color)); }
+	_FORCE_INLINE_ bool operator==(const StringName &p_string_name) const { return operator==(Variant(p_string_name)); }
+	_FORCE_INLINE_ bool operator==(const NodePath &p_node_path) const { return operator==(Variant(p_node_path)); }
+	_FORCE_INLINE_ bool operator==(const ::RID &p_rid) const { return operator==(Variant(p_rid)); }
+	template <typename T, std::enable_if_t<std::is_base_of_v<Object, T>, int> = 0>
+	_FORCE_INLINE_ bool operator==(const T *p_object) const { return operator==(Variant(p_object)); }
+	template <typename T, std::enable_if_t<std::is_base_of_v<Object, T>, int> = 0>
+	_FORCE_INLINE_ bool operator==(const Ref<T> &p_ref) const { return operator==(Variant(p_ref)); }
+	_FORCE_INLINE_ bool operator==(const ObjectID &p_object_id) const { return operator==(Variant(p_object_id)); }
+	_FORCE_INLINE_ bool operator==(const Callable &p_callable) const { return operator==(Variant(p_callable)); }
+	_FORCE_INLINE_ bool operator==(const Signal &p_signal) const { return operator==(Variant(p_signal)); }
+	_FORCE_INLINE_ bool operator==(const Dictionary &p_dictionary) const { return operator==(Variant(p_dictionary)); }
+	_FORCE_INLINE_ bool operator==(const Array &p_array) const { return operator==(Variant(p_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedByteArray &p_packed_byte_array) const { return operator==(Variant(p_packed_byte_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedInt32Array &p_packed_int32_array) const { return operator==(Variant(p_packed_int32_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedInt64Array &p_packed_int64_array) const { return operator==(Variant(p_packed_int64_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedFloat32Array &p_packed_float32_array) const { return operator==(Variant(p_packed_float32_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedFloat64Array &p_packed_float64_array) const { return operator==(Variant(p_packed_float64_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedStringArray &p_packed_string_array) const { return operator==(Variant(p_packed_string_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedVector2Array &p_packed_vector2_array) const { return operator==(Variant(p_packed_vector2_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedVector3Array &p_packed_vector3_array) const { return operator==(Variant(p_packed_vector3_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedColorArray &p_packed_color_array) const { return operator==(Variant(p_packed_color_array)); }
+	_FORCE_INLINE_ bool operator==(const PackedVector4Array &p_packed_vector4_array) const { return operator==(Variant(p_packed_vector4_array)); }
+	_FORCE_INLINE_ bool operator==(const Vector<::RID> &p_vector_rid) const { return operator==(Variant(p_vector_rid)); }
+	_FORCE_INLINE_ bool operator==(const Vector<Plane> &p_vector_plane) const { return operator==(Variant(p_vector_plane)); }
+	_FORCE_INLINE_ bool operator==(const Vector<Face3> &p_vector_face) const { return operator==(Variant(p_vector_face)); }
+	_FORCE_INLINE_ bool operator==(const Vector<Variant> &p_vector_variant) const { return operator==(Variant(p_vector_variant)); }
+	_FORCE_INLINE_ bool operator==(const Vector<StringName> &p_vector_string_name) const { return operator==(Variant(p_vector_string_name)); }
+	_FORCE_INLINE_ bool operator==(const IPAddress &p_ip_address) const { return operator==(Variant(p_ip_address)); }
+
 	uint32_t hash() const;
 	uint32_t recursive_hash(int recursion_count) const;
 

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1045,6 +1045,14 @@ struct VariantInternalAccessor<Object *> {
 	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { VariantInternal::object_assign(v, p_value); }
 };
 
+template <typename T>
+struct VariantInternalAccessor<RequiredObj<T>> {
+	static _FORCE_INLINE_ RequiredObj<T> get(const Variant *v) { return RequiredObj<T>(*VariantInternal::get_object(v)); }
+	static _FORCE_INLINE_ void set(Variant *v, const RequiredObj<T> &p_required) {
+		VariantInternal::object_assign(v, p_required.ptr());
+	}
+};
+
 template <>
 struct VariantInternalAccessor<Variant> {
 	static _FORCE_INLINE_ Variant &get(Variant *v) { return *v; }

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -34,11 +34,6 @@ env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 env_metal.drivers_sources += thirdparty_obj
 
-# Enable C++20 for the Objective-C++ Metal code, which uses C++20 concepts.
-if "-std=gnu++17" in env_metal["CXXFLAGS"]:
-    env_metal["CXXFLAGS"].remove("-std=gnu++17")
-env_metal.Append(CXXFLAGS=["-std=c++20"])
-
 # Enable module support
 env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
 

--- a/drivers/metal/inflection_map.h
+++ b/drivers/metal/inflection_map.h
@@ -70,7 +70,6 @@ public:
 		operator ValueType *() { return &map->_values[index]; }
 
 		bool operator==(const Iterator &p_it) const { return map == p_it.map && index == p_it.index; }
-		bool operator!=(const Iterator &p_it) const { return map != p_it.map || index != p_it.index; }
 
 		Iterator &operator++() {
 			index++;

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -45,10 +45,6 @@ bool AbstractPolygon2DEditor::Vertex::operator==(const AbstractPolygon2DEditor::
 	return polygon == p_vertex.polygon && vertex == p_vertex.vertex;
 }
 
-bool AbstractPolygon2DEditor::Vertex::operator!=(const AbstractPolygon2DEditor::Vertex &p_vertex) const {
-	return !(*this == p_vertex);
-}
-
 bool AbstractPolygon2DEditor::Vertex::valid() const {
 	return vertex >= 0;
 }

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -54,7 +54,6 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 				vertex(p_vertex) {}
 
 		bool operator==(const Vertex &p_vertex) const;
-		bool operator!=(const Vertex &p_vertex) const;
 
 		bool valid() const;
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -226,10 +226,6 @@ public:
 			return false;
 		}
 
-		bool operator!=(const DataType &p_other) const {
-			return !(*this == p_other);
-		}
-
 		void operator=(const DataType &p_other) {
 			kind = p_other.kind;
 			type_source = p_other.type_source;

--- a/modules/mono/editor/semver.h
+++ b/modules/mono/editor/semver.h
@@ -61,10 +61,6 @@ public:
 		return cmp(*this, b) == 0;
 	}
 
-	bool operator!=(const SemVer &b) const {
-		return !operator==(b);
-	}
-
 	bool operator<(const SemVer &b) const {
 		return cmp(*this, b) < 0;
 	}

--- a/modules/mono/mono_gc_handle.h
+++ b/modules/mono/mono_gc_handle.h
@@ -46,9 +46,12 @@ struct GCHandleIntPtr {
 	void *value;
 
 	_FORCE_INLINE_ bool operator==(const GCHandleIntPtr &p_other) { return value == p_other.value; }
-	_FORCE_INLINE_ bool operator!=(const GCHandleIntPtr &p_other) { return value != p_other.value; }
 
+	// FIXME: C++20 doesn't allow aggregate initializers to bypass deleted constructors.
+	// http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2018/p1008r1.pdf
+#if 0
 	GCHandleIntPtr() = delete;
+#endif
 };
 }
 

--- a/modules/navigation_2d/nav_utils_2d.h
+++ b/modules/navigation_2d/nav_utils_2d.h
@@ -135,10 +135,6 @@ struct NavigationPoly {
 		return poly == p_other.poly;
 	}
 
-	bool operator!=(const NavigationPoly &p_other) const {
-		return !(*this == p_other);
-	}
-
 	void reset() {
 		poly = nullptr;
 		traversable_poly_index = UINT32_MAX;

--- a/modules/navigation_3d/nav_utils_3d.h
+++ b/modules/navigation_3d/nav_utils_3d.h
@@ -136,10 +136,6 @@ struct NavigationPoly {
 		return poly == p_other.poly;
 	}
 
-	bool operator!=(const NavigationPoly &p_other) const {
-		return !(*this == p_other);
-	}
-
 	void reset() {
 		poly = nullptr;
 		traversable_poly_index = UINT32_MAX;

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -257,9 +257,6 @@ public:
 			return physics_layer < p_other.physics_layer;
 		}
 
-		bool operator!=(const PhysicsBodyKey &p_other) const {
-			return !this->operator==(p_other);
-		}
 		bool operator==(const PhysicsBodyKey &p_other) const {
 			return physics_layer == p_other.physics_layer &&
 					linear_velocity == p_other.linear_velocity &&

--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -102,9 +102,6 @@ union TileMapCell {
 		}
 	}
 
-	bool operator!=(const TileMapCell &p_other) const {
-		return !(source_id == p_other.source_id && coord_x == p_other.coord_x && coord_y == p_other.coord_y && alternative_tile == p_other.alternative_tile);
-	}
 	bool operator==(const TileMapCell &p_other) const {
 		return source_id == p_other.source_id && coord_x == p_other.coord_x && coord_y == p_other.coord_y && alternative_tile == p_other.alternative_tile;
 	}
@@ -281,9 +278,6 @@ public:
 
 		bool operator<(const TerrainsPattern &p_terrains_pattern) const;
 		bool operator==(const TerrainsPattern &p_terrains_pattern) const;
-		bool operator!=(const TerrainsPattern &p_terrains_pattern) const {
-			return !operator==(p_terrains_pattern);
-		}
 
 		void set_terrain(int p_terrain);
 		int get_terrain() const;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -430,10 +430,6 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 			return (texture == p_val.texture) && (other == p_val.other);
 		}
 
-		_ALWAYS_INLINE_ bool operator!=(const TextureState &p_val) const {
-			return (texture != p_val.texture) || (other != p_val.other);
-		}
-
 		_ALWAYS_INLINE_ bool is_valid() const { return texture.is_valid(); }
 		_ALWAYS_INLINE_ bool is_null() const { return texture.is_null(); }
 
@@ -469,10 +465,6 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 
 		_ALWAYS_INLINE_ bool operator==(const RIDSetKey &p_val) const {
 			return state == p_val.state && instance_data == p_val.instance_data;
-		}
-
-		_ALWAYS_INLINE_ bool operator!=(const RIDSetKey &p_val) const {
-			return !(*this == p_val);
 		}
 
 		_ALWAYS_INLINE_ uint32_t hash() const {

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -965,10 +965,6 @@ public:
 		BitField<ShaderStage> stages = {};
 		uint32_t length = 0; // Size of arrays (in total elements), or ubos (in bytes * total elements).
 
-		bool operator!=(const ShaderUniform &p_other) const {
-			return binding != p_other.binding || type != p_other.type || writable != p_other.writable || stages != p_other.stages || length != p_other.length;
-		}
-
 		bool operator<(const ShaderUniform &p_other) const {
 			if (binding != p_other.binding) {
 				return binding < p_other.binding;

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -139,9 +139,6 @@ public:
 		_ALWAYS_INLINE_ bool operator==(const m_name##ID &p_other) const {        \
 			return id == p_other.id;                                              \
 		}                                                                         \
-		_ALWAYS_INLINE_ bool operator!=(const m_name##ID &p_other) const {        \
-			return id != p_other.id;                                              \
-		}                                                                         \
 		_ALWAYS_INLINE_ m_name##ID(const m_name##ID &p_other) : ID(p_other.id) {} \
 		_ALWAYS_INLINE_ explicit m_name##ID(uint64_t p_int) : ID(p_int) {}        \
 		_ALWAYS_INLINE_ explicit m_name##ID(void *p_ptr) : ID((uint64_t)p_ptr) {} \

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -155,10 +155,6 @@ bool Glyph::operator==(const Glyph &p_a) const {
 	return (p_a.index == index) && (p_a.font_rid == font_rid) && (p_a.font_size == font_size) && (p_a.start == start);
 }
 
-bool Glyph::operator!=(const Glyph &p_a) const {
-	return (p_a.index != index) || (p_a.font_rid != font_rid) || (p_a.font_size != font_size) || (p_a.start != start);
-}
-
 bool Glyph::operator<(const Glyph &p_a) const {
 	if (p_a.start == start) {
 		if (p_a.count == count) {

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -634,7 +634,6 @@ struct Glyph {
 	int span_index = -1;
 
 	bool operator==(const Glyph &p_a) const;
-	bool operator!=(const Glyph &p_a) const;
 
 	bool operator<(const Glyph &p_a) const;
 	bool operator>(const Glyph &p_a) const;

--- a/tests/core/object/test_required_obj.h
+++ b/tests/core/object/test_required_obj.h
@@ -1,0 +1,117 @@
+/**************************************************************************/
+/*  test_required_obj.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "core/object/required_obj.h"
+#include "tests/test_macros.h"
+
+namespace TestRequiredObj {
+
+TEST_CASE("[RequiredObj] Constructor assertions") {
+	static_assert(!std::is_constructible_v<RequiredObj<Object>>, "RequiredObj shouldn't allow empty construction.");
+	static_assert(!std::is_constructible_v<RequiredObj<Object>, std::nullptr_t>, "RequiredObj shouldn't allow nullptr construction.");
+	static_assert(!std::is_constructible_v<RequiredObj<Object>, Variant>, "RequiredObj shouldn't allow Variant construction.");
+
+	static_assert(std::is_constructible_v<RequiredObj<Object>, RequiredObj<Object>>, "RequiredObj should allow same-type RequiredObj construction.");
+	static_assert(std::is_constructible_v<RequiredObj<Object>, RequiredObj<RefCounted>>, "RequiredObj should allow derived-type RequiredObj construction.");
+	static_assert(!std::is_constructible_v<RequiredObj<RefCounted>, RequiredObj<Object>>, "RequiredObj shouldn't allow upcast RequiredObj construction.");
+
+	static_assert(std::is_constructible_v<RequiredObj<Object>, Object *>, "RequiredObj should allow same-type pointer construction.");
+	static_assert(std::is_constructible_v<RequiredObj<Object>, RefCounted *>, "RequiredObj should allow derived-type pointer construction.");
+	static_assert(!std::is_constructible_v<RequiredObj<RefCounted>, Object *>, "RequiredObj shouldn't allow upcast pointer construction.");
+
+	static_assert(std::is_constructible_v<RequiredObj<RefCounted>, Ref<RefCounted>>, "RequiredObj should allow same-type Ref construction.");
+	static_assert(std::is_constructible_v<RequiredObj<RefCounted>, Ref<WeakRef>>, "RequiredObj should allow derived-type Ref construction.");
+	static_assert(!std::is_constructible_v<RequiredObj<WeakRef>, Ref<RefCounted>>, "RequiredObj shouldn't allow upcast Ref construction.");
+}
+
+TEST_CASE("[RequiredObj] Static construction") {
+	RequiredObj<Object> required = RequiredObj<Object>::construct();
+	CHECK(required.is_valid());
+	memdelete(required.ptr());
+
+	// FIXME: const object pointers don't play nice with `memdelete`
+	// const RequiredObj<Object> required_const = RequiredObj<Object>::construct();
+	// CHECK(required_const.is_valid());
+	// memdelete(required_const.ptr());
+}
+
+TEST_CASE("[RequiredObj] Conversion operations") {
+	Object *object = memnew(Object);
+	RequiredObj<Object> required = RequiredObj(object);
+	CHECK(required.is_valid());
+	CHECK_EQ(object, required.operator->());
+	CHECK_EQ(object, required.ptr());
+	memdelete(object);
+}
+
+TEST_CASE("[RequiredObj] Const-awareness") {
+	static_assert(!std::is_same_v<Object *, const Object *>, "Sanity check.");
+
+	GODOT_DEPRECATED_BEGIN
+	RequiredObj<Object> dummy = RequiredObj<Object>::silent_null();
+	const RequiredObj<Object> const_dummy = RequiredObj<Object>::silent_null();
+	constexpr RequiredObj<Object> constexpr_dummy = RequiredObj<Object>::silent_null();
+	GODOT_DEPRECATED_END
+
+	static_assert(std::is_same_v<decltype(dummy.ptr()), Object *>, "A non-const RequiredObj should return non-const pointers.");
+	static_assert(std::is_same_v<decltype(const_dummy.ptr()), const Object *>, "A const RequiredObj should return const pointers.");
+	static_assert(std::is_same_v<decltype(constexpr_dummy.ptr()), const Object *>, "A constexpr RequiredObj should return const pointers.");
+}
+
+template <typename T>
+RequiredObj<T> failed_function() {
+	ERR_FAIL_V_MSG(RequiredObj<T>::silent_null(), "Should not trigger deprecated warning.");
+}
+
+TEST_CASE("[RequiredObj] Allow null as failed return type") {
+	ERR_PRINT_OFF
+	RequiredObj<Object> required_object = failed_function<Object>();
+	ERR_PRINT_ON
+	CHECK_MESSAGE(required_object.is_null(), "RequiredObj should allow for null from a failed function.");
+}
+
+TEST_CASE("[RequiredObj] Ill-formed behavior") {
+	constexpr Object *empty_object = nullptr;
+	ERR_PRINT_OFF
+	RequiredObj<Object> required_object = RequiredObj(empty_object);
+	ERR_PRINT_ON
+	CHECK(required_object.is_null());
+
+	Ref<WeakRef> empty_reference = Ref<WeakRef>();
+	ERR_PRINT_OFF
+	RequiredObj<RefCounted> required_reference = RequiredObj(empty_reference);
+	ERR_PRINT_ON
+	CHECK(required_reference.is_null());
+}
+
+} // namespace TestRequiredObj

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -88,6 +88,7 @@
 #include "tests/core/object/test_class_db.h"
 #include "tests/core/object/test_method_bind.h"
 #include "tests/core/object/test_object.h"
+#include "tests/core/object/test_required_obj.h"
 #include "tests/core/object/test_undo_redo.h"
 #include "tests/core/os/test_os.h"
 #include "tests/core/string/test_fuzzy_search.h"

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -982,6 +982,7 @@ Patches:
 
 - `0001-revert-tvglines-bezier-precision.patch` (GH-96658)
 - `0002-png-explicit-variable-scope.patch` (GH-105093)
+- `0003-cpp20-explicit-namespace.patch` (GH-100749)
 
 
 ## tinyexr

--- a/thirdparty/thorvg/patches/0003-cpp20-explicit-namespace.patch
+++ b/thirdparty/thorvg/patches/0003-cpp20-explicit-namespace.patch
@@ -1,0 +1,24 @@
+diff --git a/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp b/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
+index 175739250a..5c2b36d394 100644
+--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
++++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
+@@ -218 +218 @@ static bool _appendClipUseNode(SvgLoaderData& loaderData, SvgNode* node, Shape*
+-    return _appendClipShape(loaderData, child, shape, vBox, svgPath, identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
++    return _appendClipShape(loaderData, child, shape, vBox, svgPath, tvg::identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
+diff --git a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp
+index e012465b70..380e547dcf 100644
+--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp
++++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp
+@@ -231 +231 @@ bool _prepareLinear(SwFill* fill, const LinearGradient* linear, const Matrix& tr
+-    bool isTransformation = !identity((const Matrix*)(&gradTransform));
++    bool isTransformation = !tvg::identity((const Matrix*)(&gradTransform));
+@@ -298 +298 @@ bool _prepareRadial(SwFill* fill, const RadialGradient* radial, const Matrix& tr
+-    bool isTransformation = !identity((const Matrix*)(&gradTransform));
++    bool isTransformation = !tvg::identity((const Matrix*)(&gradTransform));
+diff --git a/thirdparty/thorvg/src/renderer/tvgPaint.cpp b/thirdparty/thorvg/src/renderer/tvgPaint.cpp
+index e00c2c1954..873e65527b 100644
+--- a/thirdparty/thorvg/src/renderer/tvgPaint.cpp
++++ b/thirdparty/thorvg/src/renderer/tvgPaint.cpp
+@@ -316 +316 @@ bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transforme
+-    if (!transformed || identity(&m)) {
++    if (!transformed || tvg::identity(&m)) {

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgSceneBuilder.cpp
@@ -215,7 +215,7 @@ static bool _appendClipUseNode(SvgLoaderData& loaderData, SvgNode* node, Shape* 
     }
     if (child->transform) finalTransform *= *child->transform;
 
-    return _appendClipShape(loaderData, child, shape, vBox, svgPath, identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
+    return _appendClipShape(loaderData, child, shape, vBox, svgPath, tvg::identity((const Matrix*)(&finalTransform)) ? nullptr : &finalTransform);
 }
 
 

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp
@@ -228,7 +228,7 @@ bool _prepareLinear(SwFill* fill, const LinearGradient* linear, const Matrix& tr
     fill->linear.offset = -fill->linear.dx * x1 - fill->linear.dy * y1;
 
     auto gradTransform = linear->transform();
-    bool isTransformation = !identity((const Matrix*)(&gradTransform));
+    bool isTransformation = !tvg::identity((const Matrix*)(&gradTransform));
 
     if (isTransformation) {
         gradTransform = transform * gradTransform;
@@ -295,7 +295,7 @@ bool _prepareRadial(SwFill* fill, const RadialGradient* radial, const Matrix& tr
     if (fill->radial.a > 0) fill->radial.invA = 1.0f / fill->radial.a;
 
     auto gradTransform = radial->transform();
-    bool isTransformation = !identity((const Matrix*)(&gradTransform));
+    bool isTransformation = !tvg::identity((const Matrix*)(&gradTransform));
 
     if (isTransformation) gradTransform = transform * gradTransform;
     else {

--- a/thirdparty/thorvg/src/renderer/tvgPaint.cpp
+++ b/thirdparty/thorvg/src/renderer/tvgPaint.cpp
@@ -313,7 +313,7 @@ bool Paint::Impl::bounds(float* x, float* y, float* w, float* h, bool transforme
     const auto& m = this->transform(origin);
 
     //Case: No transformed, quick return!
-    if (!transformed || identity(&m)) {
+    if (!transformed || tvg::identity(&m)) {
         PAINT_METHOD(ret, bounds(x, y, w, h, stroking));
         return ret;
     }


### PR DESCRIPTION
- Implements godotengine/godot-proposals#2241
- Requires #100749
- Supersedes #90767
- Supersedes #105962
- Supersedes #106075
- Related #86079

Finally have the groundwork for handling non-nullable objects that I'm satisfied with! This uses David's PR as a base, but integrates my suggestions by taking advantage of C++20 features. The paradigm this is hoping to achieve is similar to that of clang's `_Nonnull`, where the concept of something being null is invalid, but not undefined. That is: error checks will still need to be taken under certain circumstances, but the class is setup to track/relay that information & utilize builtin guards to make it as difficult as possible to erroneously assign `nullptr`.

## Featureset (WIP):
- **Metadata on construction**. By taking advantage of C++20's `std::source_location`, this class's constructors are able to relay *where* an invalid assignment takes place. This means that, instead of relying strictly on a usual error macro to tell us that a null value was passed, it will print an error on invalid assignment that relays *where* said assignment occurred.
> [!NOTE]
> This necessitated bumping Clang to 16 for full `std::source_location` support, so the Linux GHA now uses Ubuntu 24.04
- **No empty/`nullptr` construction**. These constructors/assignments are outright removed. Comparison with `nullptr` is similarly removed, instead utilizing `is_valid()`/`is_null()` like `Ref`.
- **No `Variant` conversion**. This class explicitly prevent conversion to/from `Variant` directly. There's already too many implicit operators setup in that class, and it would risk circumventing the checks put in place for null values. Bindings still exist internally for the sake of GDExtension, but the majority of the time will require first converting `Variant` to a pointer.
- **Static constructor.** No validation is necessary if you're outright creating the object, so this class offers the ability to call the static function `RequiredObj<T>::construct(...)` as if you were constructing from `memnew(T(...))`. This will allow MUCH easier integration in the codebase, as many instances of objects that're guaranteed to be non-null can just use this as a one-liner replacement

Will add more to this featureset/PR soon, but I wanted to get this up now for early feedback/discussion