### PR TITLE
Change `JoltShapeInstance3D` to use move semantics

### DIFF
--- a/modules/jolt_physics/shapes/jolt_shape_instance_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_shape_instance_3d.cpp
@@ -42,12 +42,11 @@ JoltShapeInstance3D::ShapeReference::ShapeReference(JoltShapedObject3D *p_parent
 	}
 }
 
-JoltShapeInstance3D::ShapeReference::ShapeReference(const ShapeReference &p_other) :
+JoltShapeInstance3D::ShapeReference::ShapeReference(ShapeReference &&p_other) :
 		parent(p_other.parent),
 		shape(p_other.shape) {
-	if (shape != nullptr) {
-		shape->add_owner(parent);
-	}
+	p_other.parent = nullptr;
+	p_other.shape = nullptr;
 }
 
 JoltShapeInstance3D::ShapeReference::~ShapeReference() {
@@ -56,16 +55,10 @@ JoltShapeInstance3D::ShapeReference::~ShapeReference() {
 	}
 }
 
-JoltShapeInstance3D::ShapeReference &JoltShapeInstance3D::ShapeReference::operator=(const ShapeReference &p_other) {
-	if (shape != nullptr) {
-		shape->remove_owner(parent);
-	}
-
-	parent = p_other.parent;
-	shape = p_other.shape;
-
-	if (shape != nullptr) {
-		shape->add_owner(parent);
+JoltShapeInstance3D::ShapeReference &JoltShapeInstance3D::ShapeReference::operator=(ShapeReference &&p_other) {
+	if (this != &p_other) {
+		SWAP(parent, p_other.parent);
+		SWAP(shape, p_other.shape);
 	}
 
 	return *this;

--- a/modules/jolt_physics/shapes/jolt_shape_instance_3d.h
+++ b/modules/jolt_physics/shapes/jolt_shape_instance_3d.h
@@ -40,20 +40,19 @@ class JoltShapedObject3D;
 class JoltShape3D;
 
 class JoltShapeInstance3D {
-	// This RAII helper exists solely to avoid needing to maintain copy construction/assignment in the shape instance.
-	// Ideally this would be move-only instead, but Godot's containers don't support that at the moment.
+	// This RAII helper exists solely to avoid needing to maintain move construction/assignment in `JoltShapeInstance3D`.
 	struct ShapeReference {
 		JoltShapedObject3D *parent = nullptr;
 		JoltShape3D *shape = nullptr;
 
 		ShapeReference() = default;
 		ShapeReference(JoltShapedObject3D *p_parent, JoltShape3D *p_shape);
-		ShapeReference(const ShapeReference &p_other);
-		ShapeReference(ShapeReference &&p_other) = delete;
+		ShapeReference(const ShapeReference &p_other) = delete;
+		ShapeReference(ShapeReference &&p_other);
 		~ShapeReference();
 
-		ShapeReference &operator=(const ShapeReference &p_other);
-		ShapeReference &operator=(ShapeReference &&p_other) = delete;
+		ShapeReference &operator=(const ShapeReference &p_other) = delete;
+		ShapeReference &operator=(ShapeReference &&p_other);
 
 		JoltShape3D *operator*() const { return shape; }
 		JoltShape3D *operator->() const { return shape; }


### PR DESCRIPTION
Now that `LocalVector` uses move semantics internally (#100477, #104693) it can also be used to hold move-only types.

`JoltShapeInstance3D` (through its `ShapeReference` RAII helper) is a good candidate for utilizing this, as it has no reason to ever be copied, and the copies that are currently happening as part of (for example) resizing `JoltObject3D::shapes`[^1] are quite wasteful, as each copy is forced to register and unregister the `JoltObject3D` with the `JoltShape3D`.

So this PR simply swaps out its current copy constructor/assignment with a move constructor/assignment instead.

(There's no real reason to actually `delete` the copy constructor/assignment, but again, there's also no reason for this class to ever be copied, so I'd prefer to just delete them entirely.)

[^1]: Which I'm realizing now should really live in `JoltShapedObject3D`. I have no idea how that got left behind.