### PR TITLE
Editor: Add highlight around docks when dragging

### DIFF
--- a/editor/editor_dock_manager.h
+++ b/editor/editor_dock_manager.h
@@ -37,9 +37,11 @@ class Button;
 class ConfigFile;
 class Control;
 class PopupMenu;
+class TabBar;
 class TabContainer;
 class VBoxContainer;
 class WindowWrapper;
+class StyleBoxFlat;
 
 class DockSplitContainer : public SplitContainer {
 	GDCLASS(DockSplitContainer, SplitContainer);
@@ -58,6 +60,7 @@ public:
 };
 
 class DockContextPopup;
+class EditorDockDragHint;
 
 class EditorDockManager : public Object {
 	GDCLASS(EditorDockManager, Object);
@@ -78,6 +81,7 @@ public:
 
 private:
 	friend class DockContextPopup;
+	friend class EditorDockDragHint;
 
 	struct DockInfo {
 		String title;
@@ -101,7 +105,9 @@ private:
 
 	Vector<WindowWrapper *> dock_windows;
 	TabContainer *dock_slot[DOCK_SLOT_MAX];
+	EditorDockDragHint *dock_drag_rects[DOCK_SLOT_MAX];
 	HashMap<Control *, DockInfo> all_docks;
+	Control *dock_tab_dragged = nullptr;
 	bool docks_visible = true;
 
 	DockContextPopup *dock_context_popup = nullptr;
@@ -109,6 +115,8 @@ private:
 	Vector<Control *> docks_menu_docks;
 	Control *closed_dock_parent = nullptr;
 
+	Control *_get_dock_tab_dragged();
+	void _dock_drag_stopped();
 	void _dock_split_dragged(int p_offset);
 	void _dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container);
 	void _bottom_dock_button_gui_input(const Ref<InputEvent> &p_input, Control *p_dock, Button *p_bottom_button);
@@ -167,9 +175,40 @@ public:
 	EditorDockManager();
 };
 
+class EditorDockDragHint : public Control {
+	GDCLASS(EditorDockDragHint, Control);
+
+private:
+	EditorDockManager *dock_manager = nullptr;
+	EditorDockManager::DockSlot occupied_slot = EditorDockManager::DOCK_SLOT_MAX;
+	TabBar *drop_tabbar = nullptr;
+
+	Color valid_drop_color;
+	Ref<StyleBoxFlat> dock_drop_highlight;
+	bool can_drop_dock = false;
+	bool mouse_inside = false;
+	bool mouse_inside_tabbar = false;
+
+	void _drag_move_tab(int p_from_index, int p_to_index);
+	void _drag_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
+
+protected:
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+	void _notification(int p_what);
+	bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
+	void drop_data(const Point2 &p_point, const Variant &p_data) override;
+
+public:
+	void set_slot(EditorDockManager::DockSlot p_slot);
+
+	EditorDockDragHint();
+};
+
 class DockContextPopup : public PopupPanel {
 	GDCLASS(DockContextPopup, PopupPanel);
 
+private:
 	VBoxContainer *dock_select_popup_vb = nullptr;
 
 	Button *make_float_button = nullptr;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -572,46 +572,52 @@ void TabBar::_notification(int p_what) {
 			}
 
 			if (dragging_valid_tab) {
-				int x;
-
-				int closest_tab = get_closest_tab_idx_to_point(get_local_mouse_position());
-				if (closest_tab != -1) {
-					Rect2 tab_rect = get_tab_rect(closest_tab);
-					x = tab_rect.position.x;
-
-					// Only add the tab_separation if closest tab is not on the edge.
-					bool not_leftmost_tab = -1 != (rtl ? get_next_available(closest_tab) : get_previous_available(closest_tab));
-					bool not_rightmost_tab = -1 != (rtl ? get_previous_available(closest_tab) : get_next_available(closest_tab));
-
-					// Calculate midpoint between tabs.
-					if (get_local_mouse_position().x > tab_rect.get_center().x) {
-						x += tab_rect.size.x;
-						if (not_rightmost_tab) {
-							x += Math::ceil(0.5f * theme_cache.tab_separation);
-						}
-					} else if (not_leftmost_tab) {
-						x -= Math::floor(0.5f * theme_cache.tab_separation);
-					}
-				} else {
-					if (rtl ^ (get_local_mouse_position().x < get_tab_rect(0).position.x)) {
-						x = get_tab_rect(0).position.x;
-						if (rtl) {
-							x += get_tab_rect(0).size.width;
-						}
-					} else {
-						Rect2 tab_rect = get_tab_rect(get_tab_count() - 1);
-
-						x = tab_rect.position.x;
-						if (!rtl) {
-							x += tab_rect.size.width;
-						}
-					}
-				}
-
-				theme_cache.drop_mark_icon->draw(get_canvas_item(), Point2(x - theme_cache.drop_mark_icon->get_width() / 2, (size.height - theme_cache.drop_mark_icon->get_height()) / 2), theme_cache.drop_mark_color);
+				_draw_tab_drop(get_canvas_item());
 			}
 		} break;
 	}
+}
+
+void TabBar::_draw_tab_drop(RID p_canvas_item) {
+	Vector2 size = get_size();
+	int x;
+	bool rtl = is_layout_rtl();
+
+	int closest_tab = get_closest_tab_idx_to_point(get_local_mouse_position());
+	if (closest_tab != -1) {
+		Rect2 tab_rect = get_tab_rect(closest_tab);
+		x = tab_rect.position.x;
+
+		// Only add the tab_separation if closest tab is not on the edge.
+		bool not_leftmost_tab = -1 != (rtl ? get_next_available(closest_tab) : get_previous_available(closest_tab));
+		bool not_rightmost_tab = -1 != (rtl ? get_previous_available(closest_tab) : get_next_available(closest_tab));
+
+		// Calculate midpoint between tabs.
+		if (get_local_mouse_position().x > tab_rect.get_center().x) {
+			x += tab_rect.size.x;
+			if (not_rightmost_tab) {
+				x += Math::ceil(0.5f * theme_cache.tab_separation);
+			}
+		} else if (not_leftmost_tab) {
+			x -= Math::floor(0.5f * theme_cache.tab_separation);
+		}
+	} else {
+		if (rtl ^ (get_local_mouse_position().x < get_tab_rect(0).position.x)) {
+			x = get_tab_rect(0).position.x;
+			if (rtl) {
+				x += get_tab_rect(0).size.width;
+			}
+		} else {
+			Rect2 tab_rect = get_tab_rect(get_tab_count() - 1);
+
+			x = tab_rect.position.x;
+			if (!rtl) {
+				x += tab_rect.size.width;
+			}
+		}
+	}
+
+	theme_cache.drop_mark_icon->draw(p_canvas_item, Point2(x - theme_cache.drop_mark_icon->get_width() / 2, (size.height - theme_cache.drop_mark_icon->get_height()) / 2), theme_cache.drop_mark_color);
 }
 
 void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_index, float p_x, bool p_focus) {

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -201,6 +201,7 @@ public:
 	Variant _handle_get_drag_data(const String &p_type, const Point2 &p_point);
 	bool _handle_can_drop_data(const String &p_type, const Point2 &p_point, const Variant &p_data) const;
 	void _handle_drop_data(const String &p_type, const Point2 &p_point, const Variant &p_data, const Callable &p_move_tab_callback, const Callable &p_move_tab_from_other_callback);
+	void _draw_tab_drop(RID p_canvas_item);
 
 	void add_tab(const String &p_str = "", const Ref<Texture2D> &p_icon = Ref<Texture2D>());
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12489

Adds a highlight around docks when dragging that tells you whether you can drop a dock. Also increases the area to drop docks to the entire TabContainer. 

https://github.com/user-attachments/assets/074e7e41-32e1-4b0b-baa2-35c233f834e3

This PR also creates the EditorDockDragHint node to contain the logic.