### PR TITLE
[.Net] Implement `AddRange(ROS)` for `Godot.Collections.Array(<T>)`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Array.cs
@@ -610,6 +610,41 @@ namespace Godot.Collections
         }
 
         /// <summary>
+        /// Adds the elements of the specified array to the end of this <see cref="Array"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The array is read-only.
+        /// </exception>
+        /// <param name="array">The array of <see cref="Variant"/> items to add.</param>
+        public void AddRange<[MustBeVariant] T>(T[] array)
+        {
+            AddRange<T>(array.AsSpan());
+        }
+
+        /// <summary>
+        /// Adds the elements of the specified collection to the end of this <see cref="Array"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The array is read-only.
+        /// </exception>
+        /// <param name="span">The span of <see cref="Variant"/> items to add.</param>
+        public void AddRange<[MustBeVariant] T>(ReadOnlySpan<T> span)
+        {
+            ThrowIfReadOnly();
+            if (span.Length == 0)
+            {
+                return;
+            }
+
+            int oldCount = Count;
+            Resize(Count + span.Length);
+            foreach (ref readonly T item in span)
+            {
+                this[oldCount++] = Variant.From(item);
+            }
+        }
+
+        /// <summary>
         /// Finds the index of an existing value using binary search.
         /// If the value is not present in the array, it returns the bitwise
         /// complement of the insertion index that maintains sorting order.
@@ -1678,6 +1713,46 @@ namespace Godot.Collections
             foreach (var item in collection)
             {
                 Add(item);
+            }
+        }
+
+        /// <summary>
+        /// Adds the elements of the specified array to the end of this <see cref="Array{T}"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The array is read-only.
+        /// </exception>
+        /// <exception cref="ArgumentNullException">
+        /// The <paramref name="array"/> is <see langword="null"/>.
+        /// </exception>
+        /// <param name="array">The array of <see cref="Variant"/> items to add.</param>
+        public void AddRange(T[] array)
+        {
+            AddRange(array.AsSpan());
+        }
+
+        /// <summary>
+        /// Adds the elements of the specified span to the end of this <see cref="Array{T}"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">
+        /// The array is read-only.
+        /// </exception>
+        /// <param name="span">The span of <see cref="Variant"/> items to add.</param>
+        public void AddRange(ReadOnlySpan<T> span)
+        {
+            ThrowIfReadOnly();
+
+            if (span.Length == 0)
+            {
+                return;
+            }
+
+            int oldCount = Count;
+            Resize(Count + span.Length);
+
+            foreach (ref readonly T item in span)
+            {
+                this[oldCount++] = item;
             }
         }
 


### PR DESCRIPTION
As the Godot Arrays (script-language-wise) are effectively C# Lists, this PR implements `AddRange(ReadOnlySpan)` overloads to the corresponding C# wrapper type to match the same implementation in [CollectionExtensions.cs](https://github.com/dotnet/runtime/blob/87b35f477c09f146107a6c11627317f6b15e9d3e/src/libraries/System.Private.CoreLib/src/System/Collections/Generic/CollectionExtensions.cs#L96).

This also benefits existing codes, as all AddRange calls with collection expressions and arrays automatically bind to the new ROS overload (after recompilation). This removes GC-tracked objects (for collection expressions) or fewer virtual calls (for arrays).