### PR TITLE
Add `ORIENTATION` built-in to sky shaders

### DIFF
--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -97,8 +97,7 @@ layout(std140) uniform MaterialUniforms{ //ubo:3
 #define AT_QUARTER_RES_PASS false
 #endif
 
-// mat4 is a waste of space, but we don't have an easy way to set a mat3 uniform for now
-uniform mat4 orientation;
+uniform mat3 orientation;
 uniform vec4 projection;
 uniform vec3 position;
 uniform float time;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1476,6 +1476,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["COLOR"] = "color";
 		actions.renames["ALPHA"] = "alpha";
 		actions.renames["EYEDIR"] = "cube_normal";
+		actions.renames["ORIENTATION"] = "orientation";
 		actions.renames["POSITION"] = "position";
 		actions.renames["SKY_COORDS"] = "panorama_coords";
 		actions.renames["SCREEN_UV"] = "uv";

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -407,6 +407,24 @@ public:
 		glUniformMatrix4fv(uniform_location, 1, false, matrix);
 	}}
 
+	_FORCE_INLINE_ void version_set_uniform(Uniforms p_uniform, const Basis &p_basis, RID p_version, ShaderVariant p_variant{defvariant}, uint64_t p_specialization = {defspec}) {{
+		TRY_GET_UNIFORM(uniform_location);
+
+		GLfloat matrix[9] = {{ /* build a 3x3 matrix */
+			(GLfloat)p_basis.rows[0][0],
+			(GLfloat)p_basis.rows[1][0],
+			(GLfloat)p_basis.rows[2][0],
+			(GLfloat)p_basis.rows[0][1],
+			(GLfloat)p_basis.rows[1][1],
+			(GLfloat)p_basis.rows[2][1],
+			(GLfloat)p_basis.rows[0][2],
+			(GLfloat)p_basis.rows[1][2],
+			(GLfloat)p_basis.rows[2][2],
+		}};
+
+		glUniformMatrix3fv(uniform_location, 1, false, matrix);
+	}}
+
 #undef TRY_GET_UNIFORM
 
 """)

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -772,6 +772,7 @@ void SkyRD::init() {
 		actions.renames["COLOR"] = "color";
 		actions.renames["ALPHA"] = "alpha";
 		actions.renames["EYEDIR"] = "cube_normal";
+		actions.renames["ORIENTATION"] = "params.orientation";
 		actions.renames["POSITION"] = "params.position";
 		actions.renames["SKY_COORDS"] = "panorama_coords";
 		actions.renames["SCREEN_UV"] = "uv";

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -446,6 +446,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SKY].functions["constants"].built_ins["PI"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_SKY].functions["constants"].built_ins["TAU"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_SKY].functions["constants"].built_ins["E"] = constt(ShaderLanguage::TYPE_FLOAT);
+	shader_modes[RS::SHADER_SKY].functions["global"].built_ins["ORIENTATION"] = constt(ShaderLanguage::TYPE_MAT3);
 	shader_modes[RS::SHADER_SKY].functions["global"].built_ins["POSITION"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SKY].functions["global"].built_ins["RADIANCE"] = constt(ShaderLanguage::TYPE_SAMPLERCUBE);
 	shader_modes[RS::SHADER_SKY].functions["global"].built_ins["AT_HALF_RES_PASS"] = constt(ShaderLanguage::TYPE_BOOL);


### PR DESCRIPTION
Alternative/addition to https://github.com/godotengine/godot-proposals/issues/12442. 

Also adds wrapper for sending Basis to a shader as mat3, I haven't tested if this affects anything elsewhere. Any advice for supporting visual shaders is appreciated.