### PR TITLE
Fix `typeof` example in @GlobalScope docs

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1428,7 +1428,7 @@
 				var json = JSON.new()
 				json.parse('["a", "b", "c"]')
 				var result = json.get_data()
-				if result is Array:
+				if typeof(result) == TYPE_ARRAY:
 					print(result[0]) # Prints "a"
 				else:
 					print("Unexpected result!")


### PR DESCRIPTION
I added a (hopefully) more relevant example to the typeof() method in the @GlobalScope documentation, as per this issue: https://github.com/godotengine/godot-docs/issues/10957

*bugsquad edit:*
Closes https://github.com/godotengine/godot-docs/issues/10957.

