### PR TITLE
Support CameraFeed format on macOS

### DIFF
--- a/modules/camera/camera_apple.mm
+++ b/modules/camera/camera_apple.mm
@@ -47,6 +47,7 @@
 	Ref<CameraFeed> feed;
 	size_t width[2];
 	size_t height[2];
+	size_t channel[2];
 	Vector<uint8_t> img_data[2];
 
 	AVCaptureDeviceInput *input;
@@ -63,8 +64,10 @@
 		feed = p_feed;
 		width[0] = 0;
 		height[0] = 0;
+		channel[0] = 0;
 		width[1] = 0;
 		height[1] = 0;
+		channel[1] = 0;
 
 #ifdef IOS_ENABLED
 		if ([p_device lockForConfiguration:&error]) {
@@ -120,8 +123,8 @@
 			return nil;
 		}
 
-		NSDictionary *settings = @{ (NSString *)kCVPixelBufferPixelFormatTypeKey : @(kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) };
-		output.videoSettings = settings;
+		// set videoSettings to empty dictionary to receive device native formats.
+		output.videoSettings = @{};
 
 		// discard if the data output queue is blocked (as we process the still image)
 		[output setAlwaysDiscardsLateVideoFrames:YES];
@@ -174,97 +177,106 @@
 		return;
 	}
 
+	CMFormatDescriptionRef format = CMSampleBufferGetFormatDescription(sampleBuffer);
+	FourCharCode fourcc = CMFormatDescriptionGetMediaSubType(format);
+
 	// It says that we need to lock this on the documentation pages but it's not in the samples
 	// need to lock our base address so we can access our pixel buffers, better safe then sorry?
 	CVPixelBufferLockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
 
-	// Check if we have the expected number of planes (Y and CbCr).
-	size_t planeCount = CVPixelBufferGetPlaneCount(pixelBuffer);
-	if (planeCount < 2) {
-		static bool plane_count_error_logged = false;
-		if (!plane_count_error_logged) {
-			ERR_PRINT("Unexpected plane count in pixel buffer (expected 2, got " + itos(planeCount) + ")");
-			plane_count_error_logged = true;
-		}
-		CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-		return;
-	}
-
-	// get our buffers
-	unsigned char *dataY = (unsigned char *)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 0);
-	unsigned char *dataCbCr = (unsigned char *)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, 1);
-	if (dataY == nullptr || dataCbCr == nullptr) {
-		static bool buffer_access_error_logged = false;
-		if (!buffer_access_error_logged) {
-			ERR_PRINT("Couldn't access pixel buffer plane data");
-			buffer_access_error_logged = true;
-		}
-		CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
-		return;
-	}
-
 	Ref<Image> img[2];
 
-	{
-		// do Y
-		size_t new_width = CVPixelBufferGetWidthOfPlane(pixelBuffer, 0);
-		size_t new_height = CVPixelBufferGetHeightOfPlane(pixelBuffer, 0);
-		size_t row_stride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 0);
-
-		if ((width[0] != new_width) || (height[0] != new_height)) {
-			width[0] = new_width;
-			height[0] = new_height;
-			img_data[0].resize(new_width * new_height);
+	if (fourcc == kCVPixelFormatType_24RGB) {
+		img[0] = [self createImage:pixelBuffer plane:0 channels:3];
+		if (img[0].is_valid()) {
+			feed->set_rgb_image(img[0]);
 		}
-
-		uint8_t *w = img_data[0].ptrw();
-		if (new_width == row_stride) {
-			memcpy(w, dataY, new_width * new_height);
-		} else {
-			for (size_t i = 0; i < new_height; i++) {
-				memcpy(w, dataY, new_width);
-				w += new_width;
-				dataY += row_stride;
-			}
+	} else if (fourcc == kCVPixelFormatType_32RGBA) {
+		img[0] = [self createImage:pixelBuffer plane:0 channels:4];
+		if (img[0].is_valid()) {
+			feed->set_rgb_image(img[0]);
 		}
-
-		img[0].instantiate();
-		img[0]->set_data(new_width, new_height, 0, Image::FORMAT_R8, img_data[0]);
+	} else if (fourcc == kCVPixelFormatType_422YpCbCr8_yuvs) {
+		img[0] = [self createImage:pixelBuffer plane:0 channels:2];
+		if (img[0].is_valid()) {
+			feed->set_ycbcr_image(img[0]);
+		}
+	} else if (fourcc == kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange || fourcc == kCVPixelFormatType_420YpCbCr8BiPlanarFullRange) {
+		img[0] = [self createImage:pixelBuffer plane:0 channels:1];
+		img[1] = [self createImage:pixelBuffer plane:1 channels:2];
+		if (img[0].is_valid() && img[1].is_valid()) {
+			feed->set_ycbcr_images(img[0], img[1]);
+		}
+	} else {
+		ERR_PRINT_ONCE(vformat("Unexpected pixel format: %x", fourcc));
 	}
-
-	{
-		// do CbCr
-		size_t new_width = CVPixelBufferGetWidthOfPlane(pixelBuffer, 1);
-		size_t new_height = CVPixelBufferGetHeightOfPlane(pixelBuffer, 1);
-		size_t row_stride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, 1);
-
-		if ((width[1] != new_width) || (height[1] != new_height)) {
-			width[1] = new_width;
-			height[1] = new_height;
-			img_data[1].resize(2 * new_width * new_height);
-		}
-
-		uint8_t *w = img_data[1].ptrw();
-		if (new_width * 2 == row_stride) {
-			memcpy(w, dataCbCr, 2 * new_width * new_height);
-		} else {
-			for (size_t i = 0; i < new_height; i++) {
-				memcpy(w, dataCbCr, new_width * 2);
-				w += new_width * 2;
-				dataCbCr += row_stride;
-			}
-		}
-
-		///TODO OpenGL doesn't support FORMAT_RG8, need to do some form of conversion
-		img[1].instantiate();
-		img[1]->set_data(new_width, new_height, 0, Image::FORMAT_RG8, img_data[1]);
-	}
-
-	// set our texture...
-	feed->set_ycbcr_images(img[0], img[1]);
 
 	// and unlock
 	CVPixelBufferUnlockBaseAddress(pixelBuffer, kCVPixelBufferLock_ReadOnly);
+}
+
+- (Ref<Image>)createImage:(CVImageBufferRef)pixelBuffer plane:(uint32_t)plane channels:(uint32_t)channels {
+	uint8_t *data;
+	size_t new_width;
+	size_t new_height;
+	size_t row_stride;
+	Image::Format image_format;
+	Ref<Image> img;
+
+	if (channels == 1) {
+		image_format = Image::FORMAT_R8;
+	} else if (channels == 2) {
+		image_format = Image::FORMAT_RG8;
+	} else if (channels == 3) {
+		image_format = Image::FORMAT_RGB8;
+	} else if (channels == 4) {
+		image_format = Image::FORMAT_RGBA8;
+	} else {
+		ERR_PRINT_ONCE("Unexpected channel count.");
+		return img;
+	}
+
+	size_t planeCount = CVPixelBufferGetPlaneCount(pixelBuffer);
+	if (planeCount > 0) { // planar format
+		ERR_FAIL_INDEX_V(plane, planeCount, img);
+		data = (uint8_t *)CVPixelBufferGetBaseAddressOfPlane(pixelBuffer, plane);
+		new_width = CVPixelBufferGetWidthOfPlane(pixelBuffer, plane);
+		new_height = CVPixelBufferGetHeightOfPlane(pixelBuffer, plane);
+		row_stride = CVPixelBufferGetBytesPerRowOfPlane(pixelBuffer, plane);
+	} else { // packed format
+		plane = 0;
+		data = (uint8_t *)CVPixelBufferGetBaseAddress(pixelBuffer);
+		new_width = CVPixelBufferGetWidth(pixelBuffer);
+		new_height = CVPixelBufferGetHeight(pixelBuffer);
+		row_stride = CVPixelBufferGetBytesPerRow(pixelBuffer);
+	}
+
+	if (data == nullptr) {
+		ERR_PRINT_ONCE("Couldn't access pixel buffer data");
+		return img;
+	}
+
+	if ((width[plane] != new_width) || (height[plane] != new_height) || (channel[plane] != channels)) {
+		width[plane] = new_width;
+		height[plane] = new_height;
+		channel[plane] = channels;
+		img_data[plane].resize(channels * new_width * new_height);
+	}
+
+	uint8_t *w = img_data[plane].ptrw();
+	if (channels * new_width == row_stride) {
+		memcpy(w, data, channels * new_width * new_height);
+	} else {
+		for (size_t i = 0; i < new_height; i++) {
+			memcpy(w, data, channels * new_width);
+			w += channels * new_width;
+			data += row_stride;
+		}
+	}
+
+	img.instantiate();
+	img->set_data(new_width, new_height, false, image_format, img_data[plane]);
+	return img;
 }
 
 @end
@@ -276,12 +288,20 @@ class CameraFeedApple : public CameraFeed {
 	GDSOFTCLASS(CameraFeedApple, CameraFeed);
 
 private:
+	struct FeedFormat {
+		AVCaptureDeviceFormat *format = nullptr;
+		AVFrameRateRange *range = nullptr;
+	};
+
 	AVCaptureDevice *device;
 	MyCaptureSession *capture_session;
+	Vector<FeedFormat> feed_formats;
 	bool device_locked;
 	bool was_active_before_pause = false;
 
 public:
+	static String get_format_name(const FourCharCode &p_fourcc);
+
 	AVCaptureDevice *get_device() const;
 
 	CameraFeedApple();
@@ -295,6 +315,9 @@ public:
 
 	bool activate_feed() override;
 	void deactivate_feed() override;
+
+	bool set_format(int p_index, const Dictionary &p_parameters) override;
+	Array get_formats() const override;
 };
 
 AVCaptureDevice *CameraFeedApple::get_device() const {
@@ -326,6 +349,26 @@ void CameraFeedApple::set_device(AVCaptureDevice *p_device) {
 	} else if ([p_device position] == AVCaptureDevicePositionFront) {
 		position = CameraFeed::FEED_FRONT;
 	};
+	for (AVCaptureDeviceFormat *format in p_device.formats) {
+		CMFormatDescriptionRef formatDescription = format.formatDescription;
+		FourCharCode fourcc = CMFormatDescriptionGetMediaSubType(formatDescription);
+		switch (fourcc) {
+			case kCVPixelFormatType_24RGB:
+			case kCVPixelFormatType_32RGBA:
+			case kCVPixelFormatType_422YpCbCr8_yuvs:
+			case kCVPixelFormatType_420YpCbCr8BiPlanarVideoRange:
+			case kCVPixelFormatType_420YpCbCr8BiPlanarFullRange:
+				break;
+			default:
+				continue;
+		}
+		for (AVFrameRateRange *range in format.videoSupportedFrameRateRanges) {
+			FeedFormat feed_format = {};
+			feed_format.format = format;
+			feed_format.range = range;
+			feed_formats.append(feed_format);
+		}
+	}
 }
 
 void CameraFeedApple::handle_rotation_change(int p_orientation) {
@@ -384,6 +427,19 @@ bool CameraFeedApple::activate_feed() {
 		return true;
 	}
 
+	// Configure device format if specified.
+	if (selected_format != -1) {
+		NSError *error;
+		if (!device_locked) {
+			device_locked = [device lockForConfiguration:&error];
+			ERR_FAIL_COND_V_MSG(!device_locked, false, error.localizedFailureReason.UTF8String);
+		}
+		const FeedFormat &feed_format = feed_formats[selected_format];
+		[device setActiveFormat:feed_format.format];
+		[device setActiveVideoMinFrameDuration:feed_format.range.minFrameDuration];
+		[device setActiveVideoMaxFrameDuration:feed_format.range.maxFrameDuration];
+	}
+
 	// Start camera capture, check permission.
 	AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeVideo];
 	if (status == AVAuthorizationStatusAuthorized) {
@@ -417,6 +473,68 @@ void CameraFeedApple::deactivate_feed() {
 	if (device_locked) {
 		[device unlockForConfiguration];
 		device_locked = false;
+	}
+}
+
+bool CameraFeedApple::set_format(int p_index, const Dictionary &p_parameters) {
+	if (p_index == -1) {
+		selected_format = p_index;
+		if (capture_session) {
+			[capture_session beginConfiguration];
+		}
+		if (device_locked) {
+			[device unlockForConfiguration];
+			device_locked = false;
+		}
+		if (capture_session) {
+			[capture_session commitConfiguration];
+		}
+		return true;
+	}
+	ERR_FAIL_INDEX_V((unsigned int)p_index, feed_formats.size(), false);
+	if (capture_session) {
+		if (!device_locked) {
+			NSError *error;
+			device_locked = [device lockForConfiguration:&error];
+			ERR_FAIL_COND_V_MSG(!device_locked, false, error.localizedFailureReason.UTF8String);
+		}
+		[capture_session beginConfiguration];
+		const FeedFormat &feed_format = feed_formats[p_index];
+		[device setActiveFormat:feed_format.format];
+		[device setActiveVideoMinFrameDuration:feed_format.range.minFrameDuration];
+		[device setActiveVideoMaxFrameDuration:feed_format.range.maxFrameDuration];
+		[capture_session commitConfiguration];
+	}
+	selected_format = p_index;
+	return true;
+}
+
+Array CameraFeedApple::get_formats() const {
+	Array result;
+	for (const FeedFormat &feed_format : feed_formats) {
+		Dictionary dictionary;
+		CMFormatDescriptionRef formatDescription = feed_format.format.formatDescription;
+		CMVideoDimensions dimension = CMVideoFormatDescriptionGetDimensions(formatDescription);
+		FourCharCode fourcc = CMFormatDescriptionGetMediaSubType(formatDescription);
+		dictionary["width"] = dimension.width;
+		dictionary["height"] = dimension.height;
+		dictionary["format"] = get_format_name(fourcc);
+		dictionary["frame_numerator"] = feed_format.range.minFrameDuration.value;
+		dictionary["frame_denominator"] = feed_format.range.minFrameDuration.timescale;
+		result.push_back(dictionary);
+	}
+	return result;
+}
+
+String CameraFeedApple::get_format_name(const FourCharCode &p_fourcc) {
+	switch (p_fourcc) {
+		case kCVPixelFormatType_24RGB:
+			return "RGB8";
+		default:
+			return String::chr((char)(p_fourcc >> 24) & 0xFF) +
+					String::chr((char)(p_fourcc >> 16) & 0xFF) +
+					String::chr((char)(p_fourcc >> 8) & 0xFF) +
+					String::chr((char)(p_fourcc >> 0) & 0xFF);
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Implement `CameraFeedMacOS::set_format` and `CameraFeedMacOS::get_formats`.

When activating the feed, if `selected_format` is specified, try locking the device to set its active format and framerate range, and unlocking the device upon deactivation.

Supported formats:

- FEED_RGB (RGB, RGBA)
- FEED_YCBCR (yuvs)
- FEED_YCBCR_SEP (420v, 420f)