### PR TITLE
Add "Distraction Free Mode" button to `EditorBottomPanel` when bottom panel is expanded

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -679,7 +679,7 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 		editor_main_screen->add_theme_style_override(SceneStringName(panel), theme->get_stylebox(SNAME("Content"), EditorStringName(EditorStyles)));
 		bottom_panel->_theme_changed();
 		distraction_free->set_button_icon(theme->get_icon(SNAME("DistractionFree"), EditorStringName(EditorIcons)));
-		distraction_free->add_theme_style_override(SceneStringName(pressed), theme->get_stylebox(CoreStringName(normal), "FlatMenuButton"));
+		update_distraction_free_button_theme();
 
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_SEARCH), _get_editor_theme_native_menu_icon(SNAME("HelpSearch"), global_menu, dark_mode));
 		help_menu->set_item_icon(help_menu->get_item_index(HELP_COPY_SYSTEM_INFO), _get_editor_theme_native_menu_icon(SNAME("ActionCopy"), global_menu, dark_mode));
@@ -6536,6 +6536,16 @@ void EditorNode::set_distraction_free_mode(bool p_enter) {
 
 bool EditorNode::is_distraction_free_mode_enabled() const {
 	return distraction_free->is_pressed();
+}
+
+void EditorNode::update_distraction_free_button_theme() {
+	if (distraction_free->get_meta("_scene_tabs_owned", true)) {
+		distraction_free->set_theme_type_variation("FlatMenuButton");
+		distraction_free->add_theme_style_override(SceneStringName(pressed), theme->get_stylebox(CoreStringName(normal), "FlatMenuButton"));
+	} else {
+		distraction_free->set_theme_type_variation("BottomPanelButton");
+		distraction_free->remove_theme_style_override(SceneStringName(pressed));
+	}
 }
 
 void EditorNode::set_center_split_offset(int p_offset) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -752,6 +752,8 @@ public:
 	static EditorBottomPanel *get_bottom_panel() { return singleton->bottom_panel; }
 	static EditorMainScreen *get_editor_main_screen() { return singleton->editor_main_screen; }
 
+	static Button *get_distraction_free_button() { return singleton->distraction_free; }
+
 	static String adjust_scene_name_casing(const String &p_root_name);
 	static String adjust_script_name_casing(const String &p_file_name, ScriptLanguage::ScriptNameCasing p_auto_casing);
 
@@ -802,6 +804,7 @@ public:
 	void update_distraction_free_mode();
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
+	void update_distraction_free_button_theme();
 
 	void set_center_split_offset(int p_offset);
 

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/gui/editor_version_button.h"
+#include "editor/scene/editor_scene_tabs.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
@@ -186,6 +187,18 @@ void EditorBottomPanel::set_expanded(bool p_expanded) {
 
 void EditorBottomPanel::_expand_button_toggled(bool p_pressed) {
 	EditorNode::get_top_split()->set_visible(!p_pressed);
+
+	Button *distraction_free = EditorNode::get_singleton()->get_distraction_free_button();
+	distraction_free->set_meta("_scene_tabs_owned", !p_pressed);
+	EditorNode::get_singleton()->update_distraction_free_button_theme();
+	if (p_pressed) {
+		distraction_free->reparent(bottom_hbox);
+		bottom_hbox->move_child(distraction_free, -2);
+	} else {
+		distraction_free->get_parent()->remove_child(distraction_free);
+		EditorSceneTabs::get_singleton()->add_extra_button(distraction_free);
+	}
+	_theme_changed();
 }
 
 void EditorBottomPanel::_update_center_split_offset() {


### PR DESCRIPTION
Attempt to resolve https://github.com/godotengine/godot-proposals/issues/12052


https://github.com/user-attachments/assets/4754d35b-7d32-4b9f-84a9-5fe686e07303

