### PR TITLE
Fix shader compiler crash when parsing case labels with non-existent vars.

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8532,7 +8532,11 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 					DataType data_type;
 					bool is_const;
 
-					_find_identifier(p_block, false, p_function_info, tk.text, &data_type, nullptr, &is_const);
+					bool found = _find_identifier(p_block, false, p_function_info, tk.text, &data_type, nullptr, &is_const);
+					if (!found) {
+						_set_error(vformat(RTR("Undefined identifier '%s' in a case label."), String(tk.text)));
+						return ERR_PARSE_ERROR;
+					}
 					if (is_const && data_type == p_block->expected_type) {
 						correct_constant_expression = true;
 					}


### PR DESCRIPTION
Fixes a crash in the shader compiler when parsing case labels with non-existent vars.

## Bug repro

Compile the following shader:
```
shader_type canvas_item;

const int FOO = 42;

void fragment() {
	int x = 13;
	switch (x) {
		case FOO:
			COLOR.r = 1.0;
		case BAR:
			COLOR.g = 1.0;
	}
}
```

## Behavior on master

Crash

## Behavior with this fix

Error message: `error(1): Undefined identifier BAR in case label.`.