### PR TITLE
Add CameraFeed support for Web

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -26,7 +26,7 @@ clangd:
   - "!**/*-so_wrap.{h,c}"
   - "!drivers/{apple*,core*,d3d12,metal,wasapi,windows,winmidi,xaudio2}/**"
   - "!editor/shader/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.{h,cpp}"
-  - "!modules/camera/camera_{android,macos,win}.{h,cpp}"
+  - "!modules/camera/camera_{android,macos,web,win}.{h,cpp}"
   - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"
   - "!platform/{android,ios,macos,visionos,web,windows}/**"
   - "platform/{android,ios,macos,visionos,web,windows}/{api,export}/*.{h,hpp,hxx,hh,c,cpp,cxx,cc}"

--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -21,7 +21,7 @@ clangd:
   - "!**/*-so_wrap.{h,c}"
   - "!drivers/{apple*,core*,d3d12,metal,wasapi,windows,winmidi,xaudio2}/**"
   - "!editor/shader/shader_baker/shader_baker_export_plugin_platform_{d3d12,metal}.{h,cpp}"
-  - "!modules/camera/camera_{android,macos,win}.{h,cpp}"
+  - "!modules/camera/camera_{android,macos,web,win}.{h,cpp}"
   - "!modules/openxr/extensions/platform/openxr_{android,metal}_extension.{h,cpp}"
   - "!platform/{android,ios,macos,visionos,web,windows}/**"
   - "platform/{android,ios,macos,visionos,web,windows}/{api,export}/*.{h,hpp,hxx,hh,c,cpp,cxx,cc}"

--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -6,7 +6,7 @@
 	<description>
 		A camera feed gives you access to a single physical camera attached to your device. When enabled, Godot will start capturing frames from the camera which can then be used. See also [CameraServer].
 		[b]Note:[/b] Many cameras will return YCbCr images which are split into two textures and need to be combined in a shader. Godot does this automatically for you if you set the environment to show the camera image in the background.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, and iOS. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS and Web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -136,6 +136,18 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="activation_failed">
+			<param index="0" name="error" type="String" />
+			<description>
+				Emitted when asynchronous activation fails. The feed remains inactive.
+			</description>
+		</signal>
+		<signal name="activation_status_changed">
+			<param index="0" name="status" type="int" />
+			<description>
+				Emitted when the feed's activation status changes.
+			</description>
+		</signal>
 		<signal name="format_changed">
 			<description>
 				Emitted when the format has changed.
@@ -171,6 +183,15 @@
 		</constant>
 		<constant name="FEED_BACK" value="2" enum="FeedPosition">
 			Camera is mounted at the back of the device.
+		</constant>
+		<constant name="FEED_INACTIVE" value="0" enum="FeedActivationStatus">
+			The feed is inactive.
+		</constant>
+		<constant name="FEED_ACTIVATING" value="1" enum="FeedActivationStatus">
+			The feed is being activated asynchronously.
+		</constant>
+		<constant name="FEED_ACTIVE" value="2" enum="FeedActivationStatus">
+			The feed is active.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -6,7 +6,7 @@
 	<description>
 		A camera feed gives you access to a single physical camera attached to your device. When enabled, Godot will start capturing frames from the camera which can then be used. See also [CameraServer].
 		[b]Note:[/b] Many cameras will return YCbCr images which are split into two textures and need to be combined in a shader. Godot does this automatically for you if you set the environment to show the camera image in the background.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS and Web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS, and web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -6,7 +6,7 @@
 	<description>
 		The [CameraServer] keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
 		It is notably used to provide AR modules with a video feed from the camera.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, and iOS. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS and Web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -6,7 +6,7 @@
 	<description>
 		The [CameraServer] keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
 		It is notably used to provide AR modules with a video feed from the camera.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS and Web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS, and web. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -6,7 +6,7 @@ Import("env_modules")
 
 env_camera = env_modules.Clone()
 
-if env["platform"] in ["windows", "macos", "linuxbsd", "android", "ios", "visionos"]:
+if env["platform"] in ["windows", "macos", "linuxbsd", "android", "ios", "visionos", "web"]:
     env_camera.add_source_files(env.modules_sources, "register_types.cpp")
 
 if env["platform"] == "windows":
@@ -28,4 +28,8 @@ elif env["platform"] in ["ios", "visionos"]:
 elif env["platform"] == "linuxbsd":
     env_camera.add_source_files(env.modules_sources, "camera_linux.cpp")
     env_camera.add_source_files(env.modules_sources, "camera_feed_linux.cpp")
+    env_camera.add_source_files(env.modules_sources, "buffer_decoder.cpp")
+
+elif env["platform"] == "web":
+    env_camera.add_source_files(env.modules_sources, "camera_web.cpp")
     env_camera.add_source_files(env.modules_sources, "buffer_decoder.cpp")

--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -32,7 +32,9 @@
 
 #include "servers/camera/camera_feed.h"
 
+#ifdef LINUXBSD_ENABLED
 #include <linux/videodev2.h>
+#endif
 
 BufferDecoder::BufferDecoder(CameraFeed *p_camera_feed) {
 	camera_feed = p_camera_feed;
@@ -43,6 +45,7 @@ BufferDecoder::BufferDecoder(CameraFeed *p_camera_feed) {
 
 AbstractYuyvBufferDecoder::AbstractYuyvBufferDecoder(CameraFeed *p_camera_feed) :
 		BufferDecoder(p_camera_feed) {
+#ifdef LINUXBSD_ENABLED
 	switch (camera_feed->get_format().pixel_format) {
 		case V4L2_PIX_FMT_YYUV:
 			component_indexes = new int[4]{ 0, 1, 2, 3 };
@@ -59,6 +62,9 @@ AbstractYuyvBufferDecoder::AbstractYuyvBufferDecoder(CameraFeed *p_camera_feed) 
 		default:
 			component_indexes = new int[4]{ 0, 2, 1, 3 };
 	}
+#else
+	component_indexes = new int[4]{ 0, 2, 1, 3 };
+#endif
 }
 
 AbstractYuyvBufferDecoder::~AbstractYuyvBufferDecoder() {
@@ -73,7 +79,7 @@ SeparateYuyvBufferDecoder::SeparateYuyvBufferDecoder(CameraFeed *p_camera_feed) 
 	cbcr_image.instantiate();
 }
 
-void SeparateYuyvBufferDecoder::decode(StreamingBuffer p_buffer) {
+void SeparateYuyvBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	uint8_t *y_dst = (uint8_t *)y_image_data.ptrw();
 	uint8_t *uv_dst = (uint8_t *)cbcr_image_data.ptrw();
 	uint8_t *src = (uint8_t *)p_buffer.start;
@@ -97,12 +103,12 @@ void SeparateYuyvBufferDecoder::decode(StreamingBuffer p_buffer) {
 	if (y_image.is_valid()) {
 		y_image->set_data(width, height, false, Image::FORMAT_L8, y_image_data);
 	} else {
-		y_image.instantiate(width, height, false, Image::FORMAT_RGB8, y_image_data);
+		y_image.instantiate(width, height, false, Image::FORMAT_L8, y_image_data);
 	}
 	if (cbcr_image.is_valid()) {
-		cbcr_image->set_data(width, height, false, Image::FORMAT_L8, cbcr_image_data);
+		cbcr_image->set_data(width / 2, height, false, Image::FORMAT_RG8, cbcr_image_data);
 	} else {
-		cbcr_image.instantiate(width, height, false, Image::FORMAT_RGB8, cbcr_image_data);
+		cbcr_image.instantiate(width / 2, height, false, Image::FORMAT_RG8, cbcr_image_data);
 	}
 
 	camera_feed->set_ycbcr_images(y_image, cbcr_image);
@@ -113,7 +119,7 @@ YuyvToGrayscaleBufferDecoder::YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_
 	image_data.resize(width * height);
 }
 
-void YuyvToGrayscaleBufferDecoder::decode(StreamingBuffer p_buffer) {
+void YuyvToGrayscaleBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
 	uint8_t *src = (uint8_t *)p_buffer.start;
 	uint8_t *y0_src = src + component_indexes[0];
@@ -130,7 +136,7 @@ void YuyvToGrayscaleBufferDecoder::decode(StreamingBuffer p_buffer) {
 	if (image.is_valid()) {
 		image->set_data(width, height, false, Image::FORMAT_L8, image_data);
 	} else {
-		image.instantiate(width, height, false, Image::FORMAT_RGB8, image_data);
+		image.instantiate(width, height, false, Image::FORMAT_L8, image_data);
 	}
 
 	camera_feed->set_rgb_image(image);
@@ -141,7 +147,7 @@ YuyvToRgbBufferDecoder::YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed) :
 	image_data.resize(width * height * 3);
 }
 
-void YuyvToRgbBufferDecoder::decode(StreamingBuffer p_buffer) {
+void YuyvToRgbBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	uint8_t *src = (uint8_t *)p_buffer.start;
 	uint8_t *y0_src = src + component_indexes[0];
 	uint8_t *y1_src = src + component_indexes[1];
@@ -179,20 +185,51 @@ void YuyvToRgbBufferDecoder::decode(StreamingBuffer p_buffer) {
 	camera_feed->set_rgb_image(image);
 }
 
-CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba) :
+CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, CopyFormat p_format) :
 		BufferDecoder(p_camera_feed) {
-	rgba = p_rgba;
-	image_data.resize(width * height * (rgba ? 4 : 2));
+	format = p_format.format;
+	convert_bgr = p_format.convert_bgr;
+	image_data.resize(width * height * p_format.stride);
 }
 
-void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
+void CopyBufferDecoder::decode(const StreamingBuffer &p_buffer) {
+	uint8_t *scan_line0 = (uint8_t *)p_buffer.start;
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
-	memcpy(dst, p_buffer.start, p_buffer.length);
+	int32_t pitch = p_buffer.pitch;
+
+	// If pitch is not set, calculate from buffer length (assumes top-down, contiguous).
+	if (pitch == 0) {
+		pitch = p_buffer.length / height;
+	}
+
+	if (convert_bgr) {
+		// Windows RGB24 uses BGR byte order.
+		// See: https://learn.microsoft.com/en-us/windows/win32/directshow/uncompressed-rgb-video-subtypes
+		for (int y = 0; y < height; y++) {
+			uint8_t *row_src = scan_line0 + y * pitch;
+			for (int x = 0; x < width; x++) {
+				dst[0] = row_src[2];
+				dst[1] = row_src[1];
+				dst[2] = row_src[0];
+				dst += 3;
+				row_src += 3;
+			}
+		}
+	} else {
+		// Copy only the pixel data (width * bytes_per_pixel), not the full
+		// pitch which may include padding from stride alignment.
+		int row_bytes = image_data.size() / height;
+		for (int y = 0; y < height; y++) {
+			uint8_t *row_src = scan_line0 + y * pitch;
+			memcpy(dst, row_src, row_bytes);
+			dst += row_bytes;
+		}
+	}
 
 	if (image.is_valid()) {
-		image->set_data(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);
+		image->set_data(width, height, false, format, image_data);
 	} else {
-		image.instantiate(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);
+		image.instantiate(width, height, false, format, image_data);
 	}
 
 	camera_feed->set_rgb_image(image);
@@ -202,11 +239,118 @@ JpegBufferDecoder::JpegBufferDecoder(CameraFeed *p_camera_feed) :
 		BufferDecoder(p_camera_feed) {
 }
 
-void JpegBufferDecoder::decode(StreamingBuffer p_buffer) {
+void JpegBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	image_data.resize(p_buffer.length);
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
 	memcpy(dst, p_buffer.start, p_buffer.length);
 	if (image->load_jpg_from_buffer(image_data) == OK) {
 		camera_feed->set_rgb_image(image);
 	}
+}
+
+Nv12BufferDecoder::Nv12BufferDecoder(CameraFeed *p_camera_feed) :
+		BufferDecoder(p_camera_feed) {
+	// Round chroma dimensions up for odd sizes.
+	chroma_width = (width + 1) / 2;
+	chroma_height = (height + 1) / 2;
+	data_y.resize(width * height);
+	data_uv.resize(chroma_width * chroma_height * 2);
+}
+
+void Nv12BufferDecoder::decode(const StreamingBuffer &p_buffer) {
+	// NV12 format: Y plane followed by a single interleaved Cb/Cr plane.
+	// Create separate Y and UV images for YCbCr format.
+	uint8_t *y_dst = (uint8_t *)data_y.ptrw();
+	uint8_t *uv_dst = (uint8_t *)data_uv.ptrw();
+
+	uint8_t *src = (uint8_t *)p_buffer.start;
+	const int y_stride = p_buffer.pitch != 0 ? abs(p_buffer.pitch) : width;
+	const int uv_stride = chroma_width * 2;
+
+	// Copy Y plane row by row (stride may differ from width due to alignment).
+	for (int y = 0; y < height; y++) {
+		memcpy(y_dst + y * width, src + y * y_stride, width);
+	}
+
+	// Copy interleaved UV plane row by row (half height, rounded up).
+	uint8_t *uv_src = src + y_stride * height;
+	for (int y = 0; y < chroma_height; y++) {
+		memcpy(uv_dst + y * uv_stride, uv_src + y * uv_stride, uv_stride);
+	}
+
+	// Create Y image.
+	if (image_y.is_valid()) {
+		image_y->set_data(width, height, false, Image::FORMAT_L8, data_y);
+	} else {
+		image_y.instantiate(width, height, false, Image::FORMAT_L8, data_y);
+	}
+
+	// Create UV image (half resolution, rounded up).
+	if (image_uv.is_valid()) {
+		image_uv->set_data(chroma_width, chroma_height, false, Image::FORMAT_RG8, data_uv);
+	} else {
+		image_uv.instantiate(chroma_width, chroma_height, false, Image::FORMAT_RG8, data_uv);
+	}
+
+	// Set the YCbCr images.
+	camera_feed->set_ycbcr_images(image_y, image_uv);
+}
+
+I420BufferDecoder::I420BufferDecoder(CameraFeed *p_camera_feed) :
+		BufferDecoder(p_camera_feed) {
+	// Round chroma dimensions up for odd sizes.
+	chroma_width = (width + 1) / 2;
+	chroma_height = (height + 1) / 2;
+	data_y.resize(width * height);
+	data_uv.resize(chroma_width * chroma_height * 2);
+}
+
+void I420BufferDecoder::decode(const StreamingBuffer &p_buffer) {
+	// Interleave the separate U/V planes into one Cb/Cr image (reusing the
+	// NV12 YCbCr path). I420A's trailing alpha plane is ignored.
+	uint8_t *src = (uint8_t *)p_buffer.start;
+	const int y_stride = p_buffer.pitch != 0 ? abs(p_buffer.pitch) : width;
+
+	// Copy Y plane row by row (stride may differ from width due to alignment).
+	uint8_t *y_dst = (uint8_t *)data_y.ptrw();
+	for (int y = 0; y < height; y++) {
+		memcpy(y_dst + y * width, src + y * y_stride, width);
+	}
+
+	// Interleave the U and V planes into Cb/Cr (R = Cb/U, G = Cr/V).
+	const uint8_t *u_plane = src + y_stride * height;
+	const uint8_t *v_plane = u_plane + chroma_width * chroma_height;
+	uint8_t *uv_dst = (uint8_t *)data_uv.ptrw();
+	for (int y = 0; y < chroma_height; y++) {
+		const uint8_t *u_row = u_plane + y * chroma_width;
+		const uint8_t *v_row = v_plane + y * chroma_width;
+		for (int x = 0; x < chroma_width; x++) {
+			*uv_dst++ = u_row[x];
+			*uv_dst++ = v_row[x];
+		}
+	}
+
+	// Create Y image.
+	if (image_y.is_valid()) {
+		image_y->set_data(width, height, false, Image::FORMAT_L8, data_y);
+	} else {
+		image_y.instantiate(width, height, false, Image::FORMAT_L8, data_y);
+	}
+
+	// Create Cb/Cr image (half resolution, rounded up).
+	if (image_uv.is_valid()) {
+		image_uv->set_data(chroma_width, chroma_height, false, Image::FORMAT_RG8, data_uv);
+	} else {
+		image_uv.instantiate(chroma_width, chroma_height, false, Image::FORMAT_RG8, data_uv);
+	}
+
+	// Set the YCbCr images.
+	camera_feed->set_ycbcr_images(image_y, image_uv);
+}
+
+NullBufferDecoder::NullBufferDecoder(CameraFeed *p_camera_feed) :
+		BufferDecoder(p_camera_feed) {
+}
+
+void NullBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 }

--- a/modules/camera/buffer_decoder.h
+++ b/modules/camera/buffer_decoder.h
@@ -38,6 +38,7 @@ class CameraFeed;
 struct StreamingBuffer {
 	void *start = nullptr;
 	size_t length = 0;
+	int32_t pitch = 0; // Row stride in bytes (negative for bottom-up images).
 };
 
 class BufferDecoder {
@@ -48,7 +49,7 @@ protected:
 	int height = 0;
 
 public:
-	virtual void decode(StreamingBuffer p_buffer) = 0;
+	virtual void decode(const StreamingBuffer &p_buffer) = 0;
 
 	BufferDecoder(CameraFeed *p_camera_feed);
 	virtual ~BufferDecoder() {}
@@ -72,7 +73,7 @@ private:
 
 public:
 	SeparateYuyvBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class YuyvToGrayscaleBufferDecoder : public AbstractYuyvBufferDecoder {
@@ -81,7 +82,7 @@ private:
 
 public:
 	YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class YuyvToRgbBufferDecoder : public AbstractYuyvBufferDecoder {
@@ -90,17 +91,30 @@ private:
 
 public:
 	YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class CopyBufferDecoder : public BufferDecoder {
 private:
 	Vector<uint8_t> image_data;
-	bool rgba = false;
+	Image::Format format;
+	bool convert_bgr;
 
 public:
-	CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	struct CopyFormat {
+		int stride;
+		Image::Format format;
+		bool convert_bgr;
+	};
+	static inline constexpr const CopyFormat la = { 2, Image::FORMAT_LA8, false };
+	static inline constexpr const CopyFormat rgb = { 3, Image::FORMAT_RGB8, false };
+	static inline constexpr const CopyFormat rgba = { 4, Image::FORMAT_RGBA8, false };
+	// Windows RGB24 uses BGR byte order. See:
+	// https://learn.microsoft.com/en-us/windows/win32/directshow/uncompressed-rgb-video-subtypes
+	static inline constexpr const CopyFormat bgr = { 3, Image::FORMAT_RGB8, true };
+
+	CopyBufferDecoder(CameraFeed *p_camera_feed, CopyFormat p_format);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class JpegBufferDecoder : public BufferDecoder {
@@ -109,5 +123,40 @@ private:
 
 public:
 	JpegBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
+};
+
+class Nv12BufferDecoder : public BufferDecoder {
+private:
+	Ref<Image> image_y;
+	Ref<Image> image_uv;
+	Vector<uint8_t> data_y;
+	Vector<uint8_t> data_uv;
+	int chroma_width = 0;
+	int chroma_height = 0;
+
+public:
+	Nv12BufferDecoder(CameraFeed *p_camera_feed);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
+};
+
+// Decodes planar I420/I420A (alpha ignored), reusing the NV12 YCbCr path.
+class I420BufferDecoder : public BufferDecoder {
+private:
+	Ref<Image> image_y;
+	Ref<Image> image_uv;
+	Vector<uint8_t> data_y;
+	Vector<uint8_t> data_uv;
+	int chroma_width = 0;
+	int chroma_height = 0;
+
+public:
+	I420BufferDecoder(CameraFeed *p_camera_feed);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
+};
+
+class NullBufferDecoder : public BufferDecoder {
+public:
+	NullBufferDecoder(CameraFeed *p_camera_feed);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -258,12 +258,12 @@ BufferDecoder *CameraFeedLinux::_create_buffer_decoder() {
 				return memnew(YuyvToGrayscaleBufferDecoder(this));
 			}
 			if (output == "copy") {
-				return memnew(CopyBufferDecoder(this, false));
+				return memnew(CopyBufferDecoder(this, CopyBufferDecoder::la));
 			}
 			return memnew(YuyvToRgbBufferDecoder(this));
 		}
 		default:
-			return memnew(CopyBufferDecoder(this, true));
+			return memnew(CopyBufferDecoder(this, CopyBufferDecoder::rgba));
 	}
 }
 

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -75,8 +75,7 @@ BufferDecoder *CameraFeedWeb::_create_buffer_decoder(CameraFeedWeb *p_feed, int 
 			return memnew(CopyBufferDecoder(p_feed, CopyBufferDecoder::rgba));
 		default:
 			// Unknown format - drop frames to avoid mis-sizing the destination image.
-			ERR_PRINT(vformat("Camera feed error: Unknown pixel format code %d.", p_pixel_format));
-			return memnew(NullBufferDecoder(p_feed));
+			ERR_FAIL_V_MSG(memnew(NullBufferDecoder(p_feed)), vformat("Camera feed error: Unknown pixel format code %d.", p_pixel_format));
 	}
 }
 
@@ -113,16 +112,14 @@ void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, c
 			feed->set_active(false);
 		}
 		feed->call_deferred("emit_signal", SNAME("activation_failed"), error_str);
-		ERR_PRINT(vformat("Camera feed error from JS: %s", error_str));
-		return;
+		ERR_FAIL_MSG(vformat("Camera feed error from JS: %s.", error_str));
 	}
 
 	if (p_data == nullptr || p_length <= 0 || p_width <= 0 || p_height <= 0) {
 		if (feed->is_active()) {
 			feed->set_active(false);
 		}
-		ERR_PRINT("Camera feed error: Invalid pixel data received.");
-		return;
+		ERR_FAIL_MSG("Camera feed error: Invalid pixel data received.");
 	}
 	if (feed->get_activation_status() == CameraFeed::FEED_ACTIVATING) {
 		feed->_set_activation_status(CameraFeed::FEED_ACTIVE);
@@ -157,8 +154,8 @@ void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, c
 			feed->synthesized_format = true;
 			feed->call_deferred("emit_signal", SNAME("format_changed"));
 		} else {
-			for (int i = 0; i < feed->formats.size(); i++) {
-				feed->formats.write[i].format = feed->detected_format_name;
+			for (FeedFormat &feed_format : feed->formats) {
+				feed_format.format = feed->detected_format_name;
 			}
 		}
 
@@ -221,8 +218,7 @@ void CameraFeedWeb::_on_formats_callback(void *p_context, const char *p_result) 
 
 	Vector<FeedFormat> new_formats;
 	Array formats_array = v_formats;
-	for (int i = 0; i < formats_array.size(); i++) {
-		Variant format_variant = formats_array[i];
+	for (Variant format_variant : formats_array) {
 		if (format_variant.get_type() != Variant::DICTIONARY) {
 			continue;
 		}
@@ -319,8 +315,6 @@ void CameraFeedWeb::deactivate_feed() {
 }
 
 bool CameraFeedWeb::set_format(int p_index, const Dictionary &p_parameters) {
-	(void)p_parameters;
-
 	ERR_FAIL_COND_V_MSG(active, false, "Feed is active.");
 	ERR_FAIL_INDEX_V_MSG(p_index, formats.size(), false, "Invalid format index.");
 
@@ -384,8 +378,8 @@ void CameraWeb::_on_get_cameras_callback(void *p_context, const Vector<CameraInf
 
 	// Build a set of new device IDs for quick lookup.
 	HashSet<String> new_device_ids;
-	for (int i = 0; i < p_camera_info.size(); i++) {
-		new_device_ids.insert(p_camera_info[i].device_id);
+	for (const CameraInfo &camera_info : p_camera_info) {
+		new_device_ids.insert(camera_info.device_id);
 	}
 
 	// Remove feeds that are no longer present.
@@ -401,17 +395,16 @@ void CameraWeb::_on_get_cameras_callback(void *p_context, const Vector<CameraInf
 
 	// Build a set of existing device IDs.
 	HashSet<String> existing_device_ids;
-	for (int i = 0; i < server->feeds.size(); i++) {
-		Ref<CameraFeedWeb> feed = server->feeds[i];
+	for (Ref<CameraFeedWeb> feed : server->feeds) {
 		if (feed.is_valid()) {
 			existing_device_ids.insert(feed->get_device_id());
 		}
 	}
 
 	// Add new feeds that don't already exist.
-	for (int i = 0; i < p_camera_info.size(); i++) {
-		if (!existing_device_ids.has(p_camera_info[i].device_id)) {
-			Ref<CameraFeedWeb> feed = memnew(CameraFeedWeb(p_camera_info[i]));
+	for (const CameraInfo &camera_info : p_camera_info) {
+		if (!existing_device_ids.has(camera_info.device_id)) {
+			Ref<CameraFeedWeb> feed = memnew(CameraFeedWeb(camera_info));
 			server->add_feed(feed);
 		}
 	}

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -93,6 +93,14 @@ String CameraFeedWeb::_get_format_name(int p_pixel_format) {
 	}
 }
 
+Size2i CameraFeedWeb::_get_requested_size() const {
+	if (selected_format >= 0 && selected_format < formats.size()) {
+		const CameraFeed::FeedFormat &format = formats[selected_format];
+		return Size2i(format.width, format.height);
+	}
+	return Size2i();
+}
+
 void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_pixel_format, const int p_facing_mode, const char *p_error) {
 	// Validate context first to avoid dereferencing null on error paths.
 	ERR_FAIL_NULL_MSG(p_context, "Camera feed error: Null context received.");
@@ -100,10 +108,11 @@ void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, c
 	CameraFeedWeb *feed = reinterpret_cast<CameraFeedWeb *>(p_context);
 
 	if (p_error) {
+		String error_str = String::utf8(p_error);
 		if (feed->is_active()) {
 			feed->set_active(false);
 		}
-		String error_str = String::utf8(p_error);
+		feed->call_deferred("emit_signal", SNAME("activation_failed"), error_str);
 		ERR_PRINT(vformat("Camera feed error from JS: %s", error_str));
 		return;
 	}
@@ -114,6 +123,9 @@ void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, c
 		}
 		ERR_PRINT("Camera feed error: Invalid pixel data received.");
 		return;
+	}
+	if (feed->get_activation_status() == CameraFeed::FEED_ACTIVATING) {
+		feed->_set_activation_status(CameraFeed::FEED_ACTIVE);
 	}
 
 	// Update feed position based on facing mode.
@@ -281,24 +293,20 @@ bool CameraFeedWeb::activate_feed() {
 	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
 	ERR_FAIL_NULL_V_MSG(driver, false, "CameraDriverWeb singleton is not initialized.");
 
-	int width = 0;
-	int height = 0;
-	if (selected_format >= 0 && selected_format < formats.size()) {
-		CameraFeed::FeedFormat f = formats[selected_format];
-		width = f.width;
-		height = f.height;
-	}
+	const Size2i requested_size = _get_requested_size();
+	_set_activation_status(CameraFeed::FEED_ACTIVATING);
 
 	// 'this' is passed as a raw context pointer to JS. This is safe because
-	// Web builds are single-threaded - stop_stream() synchronously cancels all
-	// pending callbacks, so no callback can fire after deactivate_feed() returns.
-	driver->get_pixel_data(this, device_id, width, height, &_on_get_pixel_data, &_on_denied_callback, &_on_formats_callback);
+	// CameraWeb aborts pending operations before its feeds can be destroyed.
+	driver->get_pixel_data(this, device_id, requested_size.x, requested_size.y, &_on_get_pixel_data, &_on_denied_callback, &_on_formats_callback);
 	return true;
 }
 
 void CameraFeedWeb::deactivate_feed() {
 	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
 	ERR_FAIL_NULL_MSG(driver, "CameraDriverWeb singleton is not initialized.");
+	// Abort any in-flight open for this feed before stopping.
+	driver->abort_stream(this);
 	driver->stop_stream(device_id);
 
 	if (buffer_decoder) {
@@ -421,6 +429,13 @@ void CameraWeb::_update_feeds() {
 void CameraWeb::_cleanup() {
 	request_id++;
 	if (driver != nullptr) {
+		// Abort in-flight opens for each active feed before stopping all streams.
+		for (int i = 0; i < feeds.size(); i++) {
+			CameraFeedWeb *feed = Object::cast_to<CameraFeedWeb>(feeds[i].ptr());
+			if (feed) {
+				driver->abort_stream(feed);
+			}
+		}
 		driver->stop_stream();
 		memdelete(driver);
 		driver = nullptr;

--- a/modules/camera/camera_web.cpp
+++ b/modules/camera/camera_web.cpp
@@ -1,0 +1,449 @@
+/**************************************************************************/
+/*  camera_web.cpp                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "camera_web.h"
+
+#include "core/io/json.h"
+#include "core/templates/hash_set.h"
+
+#include "platform/web/camera_driver_web.h"
+
+namespace {
+// Pixel format codes - must match FORMAT_CODE_* in library_godot_camera.js.
+constexpr int FORMAT_CODE_RGBA = 0;
+constexpr int FORMAT_CODE_NV12 = 1;
+constexpr int FORMAT_CODE_I420 = 2;
+
+const String KEY_HEIGHT("height");
+const String KEY_FORMATS("formats");
+const String KEY_FRAME_RATE("frameRate");
+const String KEY_FACING_MODE("facingMode");
+const String KEY_CURRENT("current");
+const String KEY_WIDTH("width");
+const String FORMAT_BROWSER("Browser");
+
+struct CameraWebRequest {
+	ObjectID server_id;
+	uint64_t request_id = 0;
+};
+
+int get_int_value(const Variant &p_value) {
+	if (p_value.get_type() == Variant::INT) {
+		return p_value;
+	}
+	if (p_value.get_type() == Variant::FLOAT) {
+		return static_cast<int>(p_value.operator float());
+	}
+	return 0;
+}
+} // namespace
+
+BufferDecoder *CameraFeedWeb::_create_buffer_decoder(CameraFeedWeb *p_feed, int p_pixel_format) {
+	switch (p_pixel_format) {
+		case FORMAT_CODE_NV12:
+			return memnew(Nv12BufferDecoder(p_feed));
+		case FORMAT_CODE_I420:
+			return memnew(I420BufferDecoder(p_feed));
+		case FORMAT_CODE_RGBA:
+			return memnew(CopyBufferDecoder(p_feed, CopyBufferDecoder::rgba));
+		default:
+			// Unknown format - drop frames to avoid mis-sizing the destination image.
+			ERR_PRINT(vformat("Camera feed error: Unknown pixel format code %d.", p_pixel_format));
+			return memnew(NullBufferDecoder(p_feed));
+	}
+}
+
+String CameraFeedWeb::_get_format_name(int p_pixel_format) {
+	switch (p_pixel_format) {
+		case FORMAT_CODE_NV12:
+			return String("NV12");
+		case FORMAT_CODE_I420:
+			return String("I420");
+		case FORMAT_CODE_RGBA:
+			return String("RGBA");
+		default:
+			return String("Unknown");
+	}
+}
+
+void CameraFeedWeb::_on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_pixel_format, const int p_facing_mode, const char *p_error) {
+	// Validate context first to avoid dereferencing null on error paths.
+	ERR_FAIL_NULL_MSG(p_context, "Camera feed error: Null context received.");
+
+	CameraFeedWeb *feed = reinterpret_cast<CameraFeedWeb *>(p_context);
+
+	if (p_error) {
+		if (feed->is_active()) {
+			feed->set_active(false);
+		}
+		String error_str = String::utf8(p_error);
+		ERR_PRINT(vformat("Camera feed error from JS: %s", error_str));
+		return;
+	}
+
+	if (p_data == nullptr || p_length <= 0 || p_width <= 0 || p_height <= 0) {
+		if (feed->is_active()) {
+			feed->set_active(false);
+		}
+		ERR_PRINT("Camera feed error: Invalid pixel data received.");
+		return;
+	}
+
+	// Update feed position based on facing mode.
+	// p_facing_mode: 0=unknown, 1=user/front, 2=environment/back
+	if (p_facing_mode == 1) {
+		feed->position = CameraFeed::FEED_FRONT;
+	} else if (p_facing_mode == 2) {
+		feed->position = CameraFeed::FEED_BACK;
+	}
+
+	// (Re)create the decoder when the pixel format or actual frame size changes.
+	// Browser streams may not match the requested format exactly, so keep the
+	// delivered size separately from the stable list returned by get_formats().
+	const bool size_changed = feed->current_frame_width != p_width || feed->current_frame_height != p_height;
+	if (feed->buffer_decoder == nullptr || feed->current_pixel_format != p_pixel_format || size_changed) {
+		feed->detected_format_name = _get_format_name(p_pixel_format);
+		feed->current_frame_width = p_width;
+		feed->current_frame_height = p_height;
+
+		// The browser may deliver frames before it reports a format list.
+		// Synthesize one so the feed stays selectable and can be switched/stopped.
+		if (feed->formats.is_empty()) {
+			FeedFormat synthesized;
+			synthesized.width = p_width;
+			synthesized.height = p_height;
+			synthesized.format = feed->detected_format_name;
+			feed->formats.push_back(synthesized);
+			feed->selected_format = 0;
+			feed->synthesized_format = true;
+			feed->call_deferred("emit_signal", SNAME("format_changed"));
+		} else {
+			for (int i = 0; i < feed->formats.size(); i++) {
+				feed->formats.write[i].format = feed->detected_format_name;
+			}
+		}
+
+		if (feed->buffer_decoder) {
+			memdelete(feed->buffer_decoder);
+			feed->buffer_decoder = nullptr;
+		}
+		feed->buffer_decoder = _create_buffer_decoder(feed, p_pixel_format);
+		feed->current_pixel_format = p_pixel_format;
+	}
+
+	StreamingBuffer buffer;
+	buffer.start = const_cast<uint8_t *>(p_data);
+	buffer.length = p_length;
+	buffer.pitch = 0; // Tightly packed; decoders will derive the stride from length.
+	feed->buffer_decoder->decode(buffer);
+}
+
+void CameraFeedWeb::_on_denied_callback(void *p_context) {
+	ERR_FAIL_NULL_MSG(p_context, "Camera feed error: Null context received in denied callback.");
+	CameraFeedWeb *feed = reinterpret_cast<CameraFeedWeb *>(p_context);
+	if (feed->is_active()) {
+		feed->set_active(false);
+	}
+}
+
+void CameraFeedWeb::_on_formats_callback(void *p_context, const char *p_result) {
+	ERR_FAIL_NULL_MSG(p_context, "Camera feed error: Null context received in formats callback.");
+	ERR_FAIL_NULL_MSG(p_result, "Camera feed error: Null formats result received.");
+
+	CameraFeedWeb *feed = reinterpret_cast<CameraFeedWeb *>(p_context);
+	Variant json_variant = JSON::parse_string(String::utf8(p_result));
+	ERR_FAIL_COND_MSG(json_variant.get_type() != Variant::DICTIONARY, "Camera feed error: Formats result is not a Dictionary.");
+
+	Dictionary json_dict = json_variant;
+	int current_width = 0;
+	int current_height = 0;
+	int current_frame_rate = 0;
+	Variant current_variant = json_dict.get(KEY_CURRENT, Variant());
+	if (current_variant.get_type() == Variant::DICTIONARY) {
+		Dictionary current_dict = current_variant;
+		current_width = get_int_value(current_dict.get(KEY_WIDTH, Variant()));
+		current_height = get_int_value(current_dict.get(KEY_HEIGHT, Variant()));
+		current_frame_rate = get_int_value(current_dict.get(KEY_FRAME_RATE, Variant()));
+
+		const int facing_mode = get_int_value(current_dict.get(KEY_FACING_MODE, Variant()));
+		if (facing_mode == 1) {
+			feed->position = CameraFeed::FEED_FRONT;
+		} else if (facing_mode == 2) {
+			feed->position = CameraFeed::FEED_BACK;
+		}
+	}
+
+	if (!feed->formats.is_empty() && !feed->synthesized_format) {
+		return;
+	}
+
+	Variant v_formats = json_dict.get(KEY_FORMATS, Variant());
+	ERR_FAIL_COND_MSG(v_formats.get_type() != Variant::ARRAY, "Camera feed error: Formats result has no formats array.");
+
+	Vector<FeedFormat> new_formats;
+	Array formats_array = v_formats;
+	for (int i = 0; i < formats_array.size(); i++) {
+		Variant format_variant = formats_array[i];
+		if (format_variant.get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+
+		Dictionary format_dict = format_variant;
+		const int width = get_int_value(format_dict.get(KEY_WIDTH, Variant()));
+		const int height = get_int_value(format_dict.get(KEY_HEIGHT, Variant()));
+		if (width <= 0 || height <= 0) {
+			continue;
+		}
+
+		FeedFormat feed_format;
+		feed_format.width = width;
+		feed_format.height = height;
+		feed_format.format = feed->detected_format_name.is_empty() ? FORMAT_BROWSER : feed->detected_format_name;
+		const int frame_rate = get_int_value(format_dict.get(KEY_FRAME_RATE, Variant()));
+		if (frame_rate > 0) {
+			feed_format.frame_numerator = frame_rate;
+			feed_format.frame_denominator = 1;
+		}
+		new_formats.push_back(feed_format);
+	}
+
+	if (new_formats.is_empty()) {
+		return;
+	}
+
+	int new_selected_format = feed->selected_format;
+	if (current_width > 0 && current_height > 0) {
+		new_selected_format = -1;
+		for (int i = 0; i < new_formats.size(); i++) {
+			const FeedFormat &format = new_formats[i];
+			if ((format.width == current_width && format.height == current_height) ||
+					(format.width == current_height && format.height == current_width)) {
+				new_selected_format = i;
+				break;
+			}
+		}
+		if (new_selected_format == -1) {
+			FeedFormat current_format;
+			current_format.width = current_width;
+			current_format.height = current_height;
+			current_format.format = feed->detected_format_name.is_empty() ? FORMAT_BROWSER : feed->detected_format_name;
+			if (current_frame_rate > 0) {
+				current_format.frame_numerator = current_frame_rate;
+				current_format.frame_denominator = 1;
+			}
+			new_formats.push_back(current_format);
+			new_selected_format = new_formats.size() - 1;
+		}
+	}
+	if (new_selected_format < 0 || new_selected_format >= new_formats.size()) {
+		new_selected_format = 0;
+	}
+
+	feed->formats = new_formats;
+	feed->selected_format = new_selected_format;
+	feed->synthesized_format = false;
+	feed->call_deferred("emit_signal", SNAME("format_changed"));
+}
+
+bool CameraFeedWeb::activate_feed() {
+	if (is_active()) {
+		WARN_PRINT("Camera feed is already active.");
+		return true;
+	}
+
+	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
+	ERR_FAIL_NULL_V_MSG(driver, false, "CameraDriverWeb singleton is not initialized.");
+
+	int width = 0;
+	int height = 0;
+	if (selected_format >= 0 && selected_format < formats.size()) {
+		CameraFeed::FeedFormat f = formats[selected_format];
+		width = f.width;
+		height = f.height;
+	}
+
+	// 'this' is passed as a raw context pointer to JS. This is safe because
+	// Web builds are single-threaded - stop_stream() synchronously cancels all
+	// pending callbacks, so no callback can fire after deactivate_feed() returns.
+	driver->get_pixel_data(this, device_id, width, height, &_on_get_pixel_data, &_on_denied_callback, &_on_formats_callback);
+	return true;
+}
+
+void CameraFeedWeb::deactivate_feed() {
+	CameraDriverWeb *driver = CameraDriverWeb::get_singleton();
+	ERR_FAIL_NULL_MSG(driver, "CameraDriverWeb singleton is not initialized.");
+	driver->stop_stream(device_id);
+
+	if (buffer_decoder) {
+		memdelete(buffer_decoder);
+		buffer_decoder = nullptr;
+	}
+	current_pixel_format = -1;
+	current_frame_width = 0;
+	current_frame_height = 0;
+}
+
+bool CameraFeedWeb::set_format(int p_index, const Dictionary &p_parameters) {
+	(void)p_parameters;
+
+	ERR_FAIL_COND_V_MSG(active, false, "Feed is active.");
+	ERR_FAIL_INDEX_V_MSG(p_index, formats.size(), false, "Invalid format index.");
+
+	selected_format = p_index;
+	return true;
+}
+
+Array CameraFeedWeb::get_formats() const {
+	Array result;
+	for (const FeedFormat &feed_format : formats) {
+		Dictionary dictionary;
+		dictionary["width"] = feed_format.width;
+		dictionary["height"] = feed_format.height;
+		dictionary["format"] = detected_format_name.is_empty() ? feed_format.format : detected_format_name;
+		dictionary["frame_numerator"] = feed_format.frame_numerator;
+		dictionary["frame_denominator"] = feed_format.frame_denominator;
+		result.push_back(dictionary);
+	}
+	return result;
+}
+
+CameraFeed::FeedFormat CameraFeedWeb::get_format() const {
+	CameraFeed::FeedFormat feed_format = {};
+	if (selected_format >= 0 && selected_format < formats.size()) {
+		feed_format = formats[selected_format];
+	}
+	// If the browser has not reported selectable formats, fall back to the
+	// delivered frame size so the decoder is never sized 0x0.
+	if (current_frame_width > 0 && current_frame_height > 0) {
+		feed_format.width = current_frame_width;
+		feed_format.height = current_frame_height;
+	}
+	return feed_format;
+}
+
+CameraFeedWeb::CameraFeedWeb(const CameraInfo &info) {
+	name = info.label;
+	device_id = info.device_id;
+	// Override base class default (Y-flip) with identity.
+	// Browser delivers frames already in the correct orientation.
+	transform = Transform2D();
+}
+
+CameraFeedWeb::~CameraFeedWeb() {
+	if (is_active()) {
+		deactivate_feed();
+	}
+}
+
+void CameraWeb::_on_get_cameras_callback(void *p_context, const Vector<CameraInfo> &p_camera_info) {
+	CameraWebRequest *request = static_cast<CameraWebRequest *>(p_context);
+	ERR_FAIL_NULL(request);
+
+	Object *server_object = ObjectDB::get_instance(request->server_id);
+	CameraWeb *server = Object::cast_to<CameraWeb>(server_object);
+	if (server == nullptr || request->request_id != server->request_id || !server->monitoring_feeds) {
+		memdelete(request);
+		return;
+	}
+	memdelete(request);
+
+	// Build a set of new device IDs for quick lookup.
+	HashSet<String> new_device_ids;
+	for (int i = 0; i < p_camera_info.size(); i++) {
+		new_device_ids.insert(p_camera_info[i].device_id);
+	}
+
+	// Remove feeds that are no longer present.
+	for (int i = server->feeds.size() - 1; i >= 0; i--) {
+		Ref<CameraFeedWeb> feed = server->feeds[i];
+		if (feed.is_valid() && !new_device_ids.has(feed->get_device_id())) {
+			if (feed->is_active()) {
+				feed->set_active(false);
+			}
+			server->remove_feed(feed);
+		}
+	}
+
+	// Build a set of existing device IDs.
+	HashSet<String> existing_device_ids;
+	for (int i = 0; i < server->feeds.size(); i++) {
+		Ref<CameraFeedWeb> feed = server->feeds[i];
+		if (feed.is_valid()) {
+			existing_device_ids.insert(feed->get_device_id());
+		}
+	}
+
+	// Add new feeds that don't already exist.
+	for (int i = 0; i < p_camera_info.size(); i++) {
+		if (!existing_device_ids.has(p_camera_info[i].device_id)) {
+			Ref<CameraFeedWeb> feed = memnew(CameraFeedWeb(p_camera_info[i]));
+			server->add_feed(feed);
+		}
+	}
+
+	server->call_deferred("emit_signal", SNAME(CameraServer::feeds_updated_signal_name));
+}
+
+void CameraWeb::_update_feeds() {
+	CameraWebRequest *request = memnew(CameraWebRequest);
+	request->server_id = get_instance_id();
+	request->request_id = request_id;
+	driver->get_cameras((void *)request, &_on_get_cameras_callback);
+}
+
+void CameraWeb::_cleanup() {
+	request_id++;
+	if (driver != nullptr) {
+		driver->stop_stream();
+		memdelete(driver);
+		driver = nullptr;
+	}
+}
+
+void CameraWeb::set_monitoring_feeds(bool p_monitoring_feeds) {
+	if (p_monitoring_feeds == monitoring_feeds) {
+		return;
+	}
+
+	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
+	if (p_monitoring_feeds) {
+		if (driver == nullptr) {
+			driver = memnew(CameraDriverWeb);
+		}
+		request_id++;
+		_update_feeds();
+	} else {
+		_cleanup();
+	}
+}
+
+CameraWeb::~CameraWeb() {
+	_cleanup();
+}

--- a/modules/camera/camera_web.h
+++ b/modules/camera/camera_web.h
@@ -54,6 +54,7 @@ class CameraFeedWeb : public CameraFeed {
 
 	static BufferDecoder *_create_buffer_decoder(CameraFeedWeb *p_feed, int p_pixel_format);
 	static String _get_format_name(int p_pixel_format);
+	Size2i _get_requested_size() const;
 	static void _on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_pixel_format, const int p_facing_mode, const char *p_error);
 	static void _on_denied_callback(void *p_context);
 	static void _on_formats_callback(void *p_context, const char *p_result);

--- a/modules/camera/camera_web.h
+++ b/modules/camera/camera_web.h
@@ -60,11 +60,11 @@ class CameraFeedWeb : public CameraFeed {
 	static void _on_formats_callback(void *p_context, const char *p_result);
 
 public:
-	bool activate_feed() override;
-	void deactivate_feed() override;
-	bool set_format(int p_index, const Dictionary &p_parameters) override;
-	Array get_formats() const override;
-	FeedFormat get_format() const override;
+	virtual bool activate_feed() override;
+	virtual void deactivate_feed() override;
+	virtual bool set_format(int p_index, const Dictionary &p_parameters) override;
+	virtual Array get_formats() const override;
+	virtual FeedFormat get_format() const override;
 	String get_device_id() const { return device_id; }
 
 	CameraFeedWeb(const CameraInfo &info);
@@ -81,7 +81,7 @@ class CameraWeb : public CameraServer {
 	static void _on_get_cameras_callback(void *p_context, const Vector<CameraInfo> &p_camera_info);
 
 public:
-	void set_monitoring_feeds(bool p_monitoring_feeds) override;
+	virtual void set_monitoring_feeds(bool p_monitoring_feeds) override;
 
 	~CameraWeb();
 };

--- a/modules/camera/camera_web.h
+++ b/modules/camera/camera_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  camera_web.h                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,59 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
-#endif
+#include "servers/camera/camera_feed.h"
+#include "servers/camera/camera_server.h"
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+#include "modules/camera/buffer_decoder.h"
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
-}
+// Shared camera data types, kept in a platform/web-level header so this
+// module does not need to include the full CameraDriverWeb driver header.
+#include "platform/web/camera_types_web.h"
 
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+class CameraDriverWeb;
+
+class CameraFeedWeb : public CameraFeed {
+	GDSOFTCLASS(CameraFeedWeb, CameraFeed);
+
+	String device_id;
+	BufferDecoder *buffer_decoder = nullptr;
+	int current_pixel_format = -1;
+	int current_frame_width = 0;
+	int current_frame_height = 0;
+	String detected_format_name;
+	bool synthesized_format = false;
+
+	static BufferDecoder *_create_buffer_decoder(CameraFeedWeb *p_feed, int p_pixel_format);
+	static String _get_format_name(int p_pixel_format);
+	static void _on_get_pixel_data(void *p_context, const uint8_t *p_data, const int p_length, const int p_width, const int p_height, const int p_pixel_format, const int p_facing_mode, const char *p_error);
+	static void _on_denied_callback(void *p_context);
+	static void _on_formats_callback(void *p_context, const char *p_result);
+
+public:
+	bool activate_feed() override;
+	void deactivate_feed() override;
+	bool set_format(int p_index, const Dictionary &p_parameters) override;
+	Array get_formats() const override;
+	FeedFormat get_format() const override;
+	String get_device_id() const { return device_id; }
+
+	CameraFeedWeb(const CameraInfo &info);
+	~CameraFeedWeb();
+};
+
+class CameraWeb : public CameraServer {
+	GDSOFTCLASS(CameraWeb, CameraServer);
+
+	CameraDriverWeb *driver = nullptr;
+	uint64_t request_id = 0;
+	void _cleanup();
+	void _update_feeds();
+	static void _on_get_cameras_callback(void *p_context, const Vector<CameraInfo> &p_camera_info);
+
+public:
+	void set_monitoring_feeds(bool p_monitoring_feeds) override;
+
+	~CameraWeb();
+};

--- a/modules/camera/config.py
+++ b/modules/camera/config.py
@@ -10,6 +10,7 @@ def can_build(env, platform):
         or platform == "android"
         or platform == "ios"
         or platform == "visionos"
+        or platform == "web"
     )
 
 

--- a/platform/web/SCsub
+++ b/platform/web/SCsub
@@ -22,6 +22,7 @@ if "serve" in COMMAND_LINE_TARGETS or "run" in COMMAND_LINE_TARGETS:
 
 web_files = [
     "audio_driver_web.cpp",
+    "camera_driver_web.cpp",
     "webmidi_driver.cpp",
     "display_server_web.cpp",
     "http_client_web.cpp",
@@ -36,6 +37,7 @@ if env["target"] == "editor":
 sys_env = env.Clone()
 sys_env.AddJSLibraries([
     "js/libs/library_godot_audio.js",
+    "js/libs/library_godot_camera.js",
     "js/libs/library_godot_display.js",
     "js/libs/library_godot_emscripten.js",
     "js/libs/library_godot_fetch.js",

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -1,0 +1,133 @@
+/**************************************************************************/
+/*  camera_driver_web.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "camera_driver_web.h"
+
+#include "godot_camera.h"
+
+#include "core/io/json.h"
+
+namespace {
+const String KEY_CAMERAS("cameras");
+const String KEY_ERROR("error");
+const String KEY_ID("id");
+const String KEY_LABEL("label");
+} // namespace
+
+CameraDriverWeb *CameraDriverWeb::singleton = nullptr;
+
+CameraDriverWeb *CameraDriverWeb::get_singleton() {
+	return singleton;
+}
+
+void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, const char *json_ptr) {
+	// Always call the user callback, even on error, so callers can finish the
+	// pending camera list update regardless of outcome.
+	CameraDriverWebGetCamerasCallback on_get_cameras_callback =
+			reinterpret_cast<CameraDriverWebGetCamerasCallback>(callback);
+
+	if (!json_ptr) {
+		ERR_PRINT("CameraDriverWeb::_on_get_cameras_callback: json_ptr is null.");
+		on_get_cameras_callback(context, Vector<CameraInfo>());
+		return;
+	}
+	String json_string = String::utf8(json_ptr);
+	Variant json_variant = JSON::parse_string(json_string);
+
+	if (json_variant.get_type() != Variant::DICTIONARY) {
+		ERR_PRINT("CameraDriverWeb::_on_get_cameras_callback: Failed to parse JSON response or response is not a Dictionary.");
+		on_get_cameras_callback(context, Vector<CameraInfo>());
+		return;
+	}
+
+	Dictionary json_dict = json_variant;
+	Variant v_error = json_dict[KEY_ERROR];
+	if (v_error.get_type() == Variant::STRING) {
+		String error_str = v_error;
+		ERR_PRINT(vformat("Camera error from JS: %s", error_str));
+		on_get_cameras_callback(context, Vector<CameraInfo>());
+		return;
+	}
+
+	Variant v_devices = json_dict.get(KEY_CAMERAS, Variant());
+	if (v_devices.get_type() != Variant::ARRAY) {
+		ERR_PRINT("Camera error: 'cameras' is not an array or missing.");
+		on_get_cameras_callback(context, Vector<CameraInfo>());
+		return;
+	}
+
+	Array devices_array = v_devices;
+	Vector<CameraInfo> camera_info;
+	for (int i = 0; i < devices_array.size(); i++) {
+		Variant device_variant = devices_array.get(i);
+		if (device_variant.get_type() != Variant::DICTIONARY) {
+			continue;
+		}
+
+		Dictionary device_dict = device_variant;
+		Variant id_variant = device_dict.get(KEY_ID, Variant());
+		Variant label_variant = device_dict.get(KEY_LABEL, Variant());
+		if (id_variant.get_type() != Variant::STRING || label_variant.get_type() != Variant::STRING) {
+			WARN_PRINT("Camera info entry missing required keys (id, label).");
+			continue;
+		}
+
+		CameraInfo info;
+		info.device_id = id_variant;
+		info.label = label_variant;
+
+		camera_info.push_back(info);
+	}
+
+	on_get_cameras_callback(context, camera_info);
+}
+
+void CameraDriverWeb::get_cameras(void *p_context, CameraDriverWebGetCamerasCallback p_callback) {
+	godot_js_camera_get_cameras(p_context, (void *)p_callback, &_on_get_cameras_callback);
+}
+
+void CameraDriverWeb::get_pixel_data(void *p_context, const String &p_device_id, const int p_width, const int p_height, void (*p_callback)(void *, const uint8_t *, const int, const int, const int, const int, const int, const char *), void (*p_denied_callback)(void *), CameraDriverWebFormatsCallback p_formats_callback) {
+	godot_js_camera_get_pixel_data(p_context, p_device_id.utf8().get_data(), p_width, p_height, p_callback, p_denied_callback, p_formats_callback);
+}
+
+void CameraDriverWeb::stop_stream(const String &p_device_id) {
+	godot_js_camera_stop_stream(p_device_id.utf8().get_data());
+}
+
+CameraDriverWeb::CameraDriverWeb() {
+	ERR_FAIL_COND_MSG(singleton != nullptr, "CameraDriverWeb singleton already exists.");
+	singleton = this;
+}
+
+CameraDriverWeb::~CameraDriverWeb() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -85,8 +85,7 @@ void CameraDriverWeb::_on_get_cameras_callback(void *context, void *callback, co
 
 	Array devices_array = v_devices;
 	Vector<CameraInfo> camera_info;
-	for (int i = 0; i < devices_array.size(); i++) {
-		Variant device_variant = devices_array.get(i);
+	for (Variant device_variant : devices_array) {
 		if (device_variant.get_type() != Variant::DICTIONARY) {
 			continue;
 		}

--- a/platform/web/camera_driver_web.cpp
+++ b/platform/web/camera_driver_web.cpp
@@ -121,6 +121,10 @@ void CameraDriverWeb::stop_stream(const String &p_device_id) {
 	godot_js_camera_stop_stream(p_device_id.utf8().get_data());
 }
 
+void CameraDriverWeb::abort_stream(void *p_context) {
+	godot_js_camera_abort(p_context);
+}
+
 CameraDriverWeb::CameraDriverWeb() {
 	ERR_FAIL_COND_MSG(singleton != nullptr, "CameraDriverWeb singleton already exists.");
 	singleton = this;

--- a/platform/web/camera_driver_web.h
+++ b/platform/web/camera_driver_web.h
@@ -47,6 +47,7 @@ public:
 	void get_cameras(void *p_context, CameraDriverWebGetCamerasCallback p_callback);
 	void get_pixel_data(void *p_context, const String &p_device_id, const int p_width, const int p_height, void (*p_callback)(void *, const uint8_t *, const int, const int, const int, const int, const int, const char *), void (*p_denied_callback)(void *), CameraDriverWebFormatsCallback p_formats_callback);
 	void stop_stream(const String &p_device_id = String());
+	void abort_stream(void *p_context);
 
 	CameraDriverWeb();
 	~CameraDriverWeb();

--- a/platform/web/camera_driver_web.h
+++ b/platform/web/camera_driver_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  camera_driver_web.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,26 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
-#endif
+#include "camera_types_web.h"
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+#include "core/templates/vector.h"
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
-}
+using CameraDriverWebGetCamerasCallback = void (*)(void *p_context, const Vector<CameraInfo> &p_camera_info);
+using CameraDriverWebFormatsCallback = void (*)(void *p_context, const char *p_result);
 
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+class CameraDriverWeb {
+private:
+	static CameraDriverWeb *singleton;
+	static void _on_get_cameras_callback(void *context, void *callback, const char *json_ptr);
+
+public:
+	static CameraDriverWeb *get_singleton();
+	void get_cameras(void *p_context, CameraDriverWebGetCamerasCallback p_callback);
+	void get_pixel_data(void *p_context, const String &p_device_id, const int p_width, const int p_height, void (*p_callback)(void *, const uint8_t *, const int, const int, const int, const int, const int, const char *), void (*p_denied_callback)(void *), CameraDriverWebFormatsCallback p_formats_callback);
+	void stop_stream(const String &p_device_id = String());
+
+	CameraDriverWeb();
+	~CameraDriverWeb();
+};

--- a/platform/web/camera_types_web.h
+++ b/platform/web/camera_types_web.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  camera_types_web.h                                                    */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
-#endif
+// Shared data types used by both the Web camera driver (platform/web) and the
+// camera module (modules/camera). Kept in a dedicated header so the module
+// does not need to include the full camera driver header.
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+#include "core/string/ustring.h"
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
-}
-
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+struct CameraInfo {
+	String device_id;
+	String label;
+};

--- a/platform/web/godot_camera.h
+++ b/platform/web/godot_camera.h
@@ -54,6 +54,8 @@ extern void godot_js_camera_get_pixel_data(
 
 extern void godot_js_camera_stop_stream(const char *p_device_id);
 
+extern void godot_js_camera_abort(void *p_context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/platform/web/godot_camera.h
+++ b/platform/web/godot_camera.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  godot_camera.h                                                        */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,48 +28,32 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#if defined(LINUXBSD_ENABLED)
-#include "camera_linux.h"
-#endif
-#if defined(WINDOWS_ENABLED)
-#include "camera_win.h"
-#endif
-#if defined(MACOS_ENABLED)
-#include "camera_apple.h"
-#endif
-#if defined(ANDROID_ENABLED)
-#include "camera_android.h"
-#endif
-#if defined(WEB_ENABLED)
-#include "camera_web.h"
+#include <emscripten.h>
+
+#include <cstdint>
+
+#ifdef __cplusplus
+extern "C" {
 #endif
 
-void initialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+extern void godot_js_camera_get_cameras(
+		void *p_context,
+		void *p_callback,
+		void (*p_callback_ptr)(void *p_context, void *p_callback, const char *p_result));
 
-#if defined(LINUXBSD_ENABLED)
-	CameraServer::make_default<CameraLinux>();
-#endif
-#if defined(WINDOWS_ENABLED)
-	CameraServer::make_default<CameraWindows>();
-#endif
-#if defined(MACOS_ENABLED)
-	CameraServer::make_default<CameraApple>();
-#endif
-#if defined(ANDROID_ENABLED)
-	CameraServer::make_default<CameraAndroid>();
-#endif
-#if defined(WEB_ENABLED)
-	CameraServer::make_default<CameraWeb>();
-#endif
+extern void godot_js_camera_get_pixel_data(
+		void *p_context,
+		const char *p_device_id,
+		const int p_width,
+		const int p_height,
+		void (*p_callback)(void *p_context, const uint8_t *p_data, const int p_size, const int p_width, const int p_height, const int p_pixel_format, const int p_facing_mode, const char *p_error),
+		void (*p_denied_callback)(void *p_context),
+		void (*p_formats_callback)(void *p_context, const char *p_result));
+
+extern void godot_js_camera_stop_stream(const char *p_device_id);
+
+#ifdef __cplusplus
 }
-
-void uninitialize_camera_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-}
+#endif

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -59,11 +59,20 @@ const GodotCamera = {
 		cameras: new Map(),
 
 		/**
-		 * Shared barrier that delays the next camera start until the previous
-		 * stop has had a chance to release browser camera resources.
+		 * Serialized operation queue. All camera start/stop/switch operations
+		 * are enqueued here so they never interleave in the JS event loop.
 		 * @type {Promise<void>}
 		 */
-		cameraShutdownBarrier: Promise.resolve(),
+		opQueue: Promise.resolve(),
+
+		/**
+		 * Cancellation generation for each context pointer (C++ CameraFeedWeb*).
+		 * An operation captures the current generation when it starts and is
+		 * canceled only when abort() advances that generation. Future operations
+		 * using the same context are therefore not canceled by an earlier stop.
+		 * @type {Map<number, number>}
+		 */
+		contextGenerations: new Map(),
 
 		/**
 		 * Pixel format codes passed to the C callback.
@@ -350,39 +359,42 @@ const GodotCamera = {
 		},
 
 		/**
-		 * Waits for the previous camera stop barrier to complete.
-		 * @returns {Promise<void>}
+		 * Enqueues an async operation so that start/stop/switch calls never
+		 * interleave in the JS event loop.
+		 * @param {Function} fn Async function to run exclusively
+		 * @returns {Promise<*>}
 		 */
-		waitForCameraShutdown: function () {
-			const barrier = this.cameraShutdownBarrier;
-			if (!barrier || typeof barrier.then !== 'function') {
-				this.cameraShutdownBarrier = Promise.resolve();
-				return this.cameraShutdownBarrier;
+		runExclusive: function (fn) {
+			if (!GodotCamera.opQueue || typeof GodotCamera.opQueue.then !== 'function') {
+				GodotCamera.opQueue = Promise.resolve();
 			}
-			return barrier;
+			const next = GodotCamera.opQueue.then(() => fn());
+			// Prevent a rejection from permanently blocking the queue.
+			GodotCamera.opQueue = next.catch(() => {});
+			return next;
 		},
 
 		/**
-		 * Enqueues a barrier after stopping camera resources so the next
-		 * getUserMedia() does not race the previous camera's teardown.
-		 *
-		 * Rationale (from Gecko/libwebrtc): on Android the device close is
-		 * asynchronous - Gecko's VideoCaptureAndroid.stopCapture() and
-		 * libwebrtc's Camera2Session dispatch CameraDevice.close() to the camera
-		 * thread and return without waiting for StateCallback.onClosed. Opening
-		 * another camera before that completes makes the new open contend for the
-		 * still-held device. 500ms covers that release window (a few hundred ms
-		 * in practice); this is why a manual stop-then-switch never stalls.
-		 * @returns {void}
+		 * Returns the current cancellation generation for a context.
+		 * @param {number} context C++ CameraFeedWeb* context
+		 * @returns {number} Current generation
 		 */
-		queueCameraShutdownBarrier: function () {
-			this.cameraShutdownBarrier = new Promise((resolve) => {
-				setTimeout(resolve, 500);
-			});
+		getContextGeneration: function (context) {
+			return GodotCamera.contextGenerations.get(context) || 0;
 		},
 
 		/**
-		 * Stops all tracks in a stream and queues the next-start barrier once.
+		 * Checks whether an operation was canceled after it started.
+		 * @param {number} context C++ CameraFeedWeb* context
+		 * @param {number} generation Generation captured at operation start
+		 * @returns {boolean} True when the operation is stale
+		 */
+		isContextCanceled: function (context, generation) {
+			return GodotCamera.getContextGeneration(context) !== generation;
+		},
+
+		/**
+		 * Stops all tracks in a stream.
 		 * @param {MediaStream|null} stream Stream to stop
 		 * @returns {boolean} True if a stream was stopped
 		 */
@@ -391,8 +403,31 @@ const GodotCamera = {
 				return false;
 			}
 			stream.getTracks().forEach((track) => track.stop());
-			GodotCamera.queueCameraShutdownBarrier();
 			return true;
+		},
+
+		/**
+		 * Tears down resources for one or all cameras without going through the
+		 * op-queue.  Called internally from within runExclusive() tasks where
+		 * queuing again would deadlock, and from cleanup() at shutdown.
+		 * @param {string|undefined} deviceId Device to stop, or undefined for all
+		 */
+		_stopInternal: function (deviceId) {
+			const cameras = GodotCamera.cameras;
+			if (deviceId && cameras.has(deviceId)) {
+				const camera = cameras.get(deviceId);
+				if (camera) {
+					GodotCamera.cleanupCamera(camera);
+				}
+				cameras.delete(deviceId);
+			} else if (!deviceId) {
+				cameras.forEach((camera) => {
+					if (camera) {
+						GodotCamera.cleanupCamera(camera);
+					}
+				});
+				cameras.clear();
+			}
 		},
 
 		/**
@@ -400,7 +435,7 @@ const GodotCamera = {
 		 * @returns {void}
 		 */
 		cleanup: function () {
-			this.api.stop();
+			GodotCamera._stopInternal();
 
 			// Free cached Wasm heap buffer.
 			if (this._cachedDataPtr) {
@@ -527,15 +562,176 @@ const GodotCamera = {
 		},
 
 		/**
-		 * Stops a stream created by an async startup path that lost ownership.
-		 * @param {CameraResource} camera Camera resource
-		 * @returns {void}
+		 * Creates an empty camera resource.
+		 * @returns {CameraResource} Camera resource
 		 */
-		stopStaleStartupStream: function (camera) {
-			if (camera.stream) {
-				GodotCamera.stopStream(camera.stream);
+		createCameraResource: function () {
+			return {
+				video: null,
+				canvas: null,
+				canvasContext: null,
+				stream: null,
+				animationFrameId: null,
+				permissionListener: null,
+				permissionStatus: null,
+				trackProcessor: null,
+				frameReader: null,
+				useWebCodecs: false,
+				facingMode: 0,
+			};
+		},
+
+		/**
+		 * Creates the hidden video element used by the Canvas 2D fallback.
+		 * @returns {HTMLVideoElement} Video element
+		 */
+		createVideoElement: function () {
+			const video = document.createElement('video');
+			video.style.display = 'none';
+			video.autoplay = true;
+			video.playsInline = true;
+			video.muted = true;
+			document.body.appendChild(video);
+			return video;
+		},
+
+		/**
+		 * Creates getUserMedia constraints for a camera request.
+		 * @param {string|null} deviceId Camera device ID
+		 * @param {number} width Desired width
+		 * @param {number} height Desired height
+		 * @returns {MediaStreamConstraints} Media constraints
+		 */
+		createConstraints: function (deviceId, width, height) {
+			return {
+				video: {
+					deviceId: deviceId ? { exact: deviceId } : undefined,
+					width: width > 0 ? { ideal: width } : undefined,
+					height: height > 0 ? { ideal: height } : undefined,
+					// Prefer a native sensor mode over a cropped/downscaled frame.
+					resizeMode: { ideal: 'none' },
+				},
+			};
+		},
+
+		/**
+		 * Discards a camera resource created by a failed or canceled start.
+		 * @param {string} cameraId Camera identifier
+		 * @param {CameraResource} camera Camera resource
+		 */
+		discardCamera: function (cameraId, camera) {
+			GodotCamera.cleanupCamera(camera);
+			if (GodotCamera.isCurrentCamera(cameraId, camera)) {
+				GodotCamera.cameras.delete(cameraId);
 			}
-			camera.stream = null;
+		},
+
+		/**
+		 * Opens a camera and starts frame capture for both regular activation and
+		 * feed switching.
+		 * @param {Object} request Camera start request
+		 * @returns {Promise<CameraResource|null>} Camera resource, or null if canceled
+		 */
+		startCamera: async function (request) {
+			const {
+				context,
+				operationGeneration,
+				deviceId,
+				width,
+				height,
+				callback,
+				deniedCallback,
+				formatsCallback,
+				timeoutMessage,
+				playTimeoutMessage,
+				attempts = 2,
+			} = request;
+			const cameraId = deviceId || 'default';
+			const cameras = GodotCamera.cameras;
+			let camera = cameras.get(cameraId);
+			if (!camera) {
+				camera = GodotCamera.createCameraResource();
+				cameras.set(cameraId, camera);
+			}
+
+			if (camera.stream) {
+				return camera;
+			}
+
+			try {
+				camera.video = GodotCamera.createVideoElement();
+				const stream = await GodotCamera.getUserMediaWithRetry(
+					GodotCamera.createConstraints(deviceId, width, height),
+					attempts,
+					12000,
+					timeoutMessage
+				);
+				if (GodotCamera.isContextCanceled(context, operationGeneration)
+					|| !GodotCamera.isCurrentCamera(cameraId, camera)) {
+					GodotCamera.stopStream(stream);
+					GodotCamera.discardCamera(cameraId, camera);
+					return null;
+				}
+				camera.stream = stream;
+
+				const [videoTrack] = stream.getVideoTracks();
+				videoTrack.addEventListener('ended', () => {
+					GodotCamera.api.stop(cameraId);
+				});
+
+				if (navigator.permissions && navigator.permissions.query) {
+					try {
+						const permissionStatus = await navigator.permissions.query({ name: 'camera' });
+						camera.permissionStatus = permissionStatus;
+						camera.permissionListener = () => {
+							if (permissionStatus.state === 'denied') {
+								GodotRuntime.print('Camera permission denied, stopping stream');
+								GodotCamera.api.stop(cameraId);
+								deniedCallback(context);
+							}
+						};
+						permissionStatus.addEventListener('change', camera.permissionListener);
+					} catch (e) {
+						// Camera permission queries are not supported by all browsers.
+					}
+				}
+
+				if (GodotCamera.isContextCanceled(context, operationGeneration)
+					|| !GodotCamera.isCurrentCamera(cameraId, camera)) {
+					GodotCamera.discardCamera(cameraId, camera);
+					return null;
+				}
+
+				camera.video.srcObject = stream;
+				await GodotCamera.waitWithTimeout(
+					camera.video.play(),
+					3000,
+					playTimeoutMessage
+				);
+				if (GodotCamera.isContextCanceled(context, operationGeneration)
+					|| !GodotCamera.isCurrentCamera(cameraId, camera)) {
+					GodotCamera.discardCamera(cameraId, camera);
+					return null;
+				}
+
+				camera.facingMode = GodotCamera.getFacingMode(stream);
+				GodotCamera.sendFormatsCallbackResult(
+					formatsCallback,
+					context,
+					GodotCamera.getActiveFormats(videoTrack, camera.facingMode)
+				);
+
+				if (GodotCamera.isWebCodecsSupported()) {
+					camera.useWebCodecs = true;
+					GodotCamera.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
+				} else {
+					GodotCamera.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+				}
+				return camera;
+			} catch (error) {
+				GodotCamera.discardCamera(cameraId, camera);
+				throw error;
+			}
 		},
 
 		/**
@@ -792,133 +988,35 @@ const GodotCamera = {
 				const callback = GodotRuntime.get_func(callbackPtr);
 				const deniedCallback = GodotRuntime.get_func(deniedCallbackPtr);
 				const formatsCallback = GodotRuntime.get_func(formatsCallbackPtr);
-				const cameraId = deviceId || 'default';
-				let camera = null;
+				const operationGeneration = GodotCamera.getContextGeneration(context);
 
-				try {
-					await GodotCamera.waitForCameraShutdown();
-
-					const cameras = GodotCamera.cameras;
-					camera = cameras.get(cameraId);
-					if (!camera) {
-						camera = {
-							video: null,
-							canvas: null,
-							canvasContext: null,
-							stream: null,
-							animationFrameId: null,
-							permissionListener: null,
-							permissionStatus: null,
-							trackProcessor: null,
-							frameReader: null,
-							useWebCodecs: false,
-							facingMode: 0,
-						};
-						cameras.set(cameraId, camera);
-					}
-
-					if (!camera.stream) {
-						// Create video element (needed for Canvas 2D fallback).
-						camera.video = document.createElement('video');
-						camera.video.style.display = 'none';
-						camera.video.autoplay = true;
-						camera.video.playsInline = true;
-						camera.video.muted = true;
-						document.body.appendChild(camera.video);
-
-						const constraints = {
-							video: {
-								deviceId: deviceId ? { exact: deviceId } : undefined,
-								width: width > 0 ? { ideal: width } : undefined,
-								height: height > 0 ? { ideal: height } : undefined,
-								// Prefer a native sensor mode over a cropped/downscaled frame.
-								resizeMode: { ideal: 'none' },
-							},
-						};
-						// 12s timeout exceeds libwebrtc's ~11s open-retry budget so a
-						// busy device rejects cleanly with AbortError (then retried)
-						// instead of a race timeout that leaves the request pending.
-						const stream = await GodotCamera.getUserMediaWithRetry(
-							constraints,
-							2,
-							12000,
-							'Camera start timed out while waiting for getUserMedia().'
-						);
-						if (!GodotCamera.isCurrentCamera(cameraId, camera)) {
-							GodotCamera.stopStream(stream);
+				await GodotCamera.runExclusive(async () => {
+					try {
+						if (GodotCamera.isContextCanceled(context, operationGeneration)) {
 							return;
 						}
-						camera.stream = stream;
-
-						const [videoTrack] = camera.stream.getVideoTracks();
-						videoTrack.addEventListener('ended', () => {
-							GodotCamera.api.stop(cameraId);
-						});
-
-						if (navigator.permissions && navigator.permissions.query) {
-							try {
-								const permissionStatus = await navigator.permissions.query({ name: 'camera' });
-								// eslint-disable-next-line require-atomic-updates
-								camera.permissionStatus = permissionStatus;
-								camera.permissionListener = () => {
-									if (permissionStatus.state === 'denied') {
-										GodotRuntime.print('Camera permission denied, stopping stream');
-										if (camera.permissionListener) {
-											permissionStatus.removeEventListener('change', camera.permissionListener);
-										}
-										GodotCamera.api.stop(cameraId);
-										deniedCallback(context);
-									}
-								};
-								permissionStatus.addEventListener('change', camera.permissionListener);
-							} catch (e) {
-								// Some browsers don't support 'camera' permission query.
-								// This is not critical - we can still use the camera.
-							}
-						}
-						if (!GodotCamera.isCurrentCamera(cameraId, camera)) {
-							GodotCamera.stopStaleStartupStream(camera);
-							return;
-						}
-
-						camera.video.srcObject = camera.stream;
-						await GodotCamera.waitWithTimeout(
-							camera.video.play(),
-							3000,
-							'Camera start timed out while waiting for video.play().'
-						);
-						if (!GodotCamera.isCurrentCamera(cameraId, camera)) {
-							GodotCamera.stopStaleStartupStream(camera);
-							return;
-						}
-
-						// Cache facing mode once (doesn't change during stream).
-						camera.facingMode = GodotCamera.getFacingMode(camera.stream);
-						GodotCamera.sendFormatsCallbackResult(
-							formatsCallback,
+						await GodotCamera.startCamera({
 							context,
-							GodotCamera.getActiveFormats(videoTrack, camera.facingMode)
-						);
-
-						// Choose capture method:
-						// 1. WebCodecs + MediaStreamTrackProcessor when available.
-						// 2. Canvas 2D as the single compatibility fallback.
-						if (GodotCamera.isWebCodecsSupported()) {
-							camera.useWebCodecs = true;
-							GodotCamera.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
-						} else {
-							GodotCamera.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+							operationGeneration,
+							deviceId,
+							width,
+							height,
+							callback,
+							deniedCallback,
+							formatsCallback,
+							timeoutMessage: 'Camera start timed out while waiting for getUserMedia().',
+							playTimeoutMessage: 'Camera start timed out while waiting for video.play().',
+						});
+					} catch (error) {
+						if (GodotCamera.isContextCanceled(context, operationGeneration)) {
+							return;
+						}
+						GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, 0, error.message);
+						if (error && (error.name === 'SecurityError' || error.name === 'NotAllowedError')) {
+							deniedCallback(context);
 						}
 					}
-				} catch (error) {
-					if (camera) {
-						GodotCamera.cleanupCamera(camera);
-					}
-					GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, 0, error.message);
-					if (error && (error.name === 'SecurityError' || error.name === 'NotAllowedError')) {
-						deniedCallback(context);
-					}
-				}
+				}); // end runExclusive
 			},
 
 			/**
@@ -927,21 +1025,18 @@ const GodotCamera = {
 			 * @returns {void}
 			 */
 			stop: function (deviceId) {
-				const cameras = GodotCamera.cameras;
+				GodotCamera.runExclusive(() => {
+					GodotCamera._stopInternal(deviceId || undefined);
+				});
+			},
 
-				if (deviceId && cameras.has(deviceId)) {
-					const camera = cameras.get(deviceId);
-					if (camera) {
-						GodotCamera.cleanupCamera(camera);
-					}
-				} else {
-					cameras.forEach((camera) => {
-						if (camera) {
-							GodotCamera.cleanupCamera(camera);
-						}
-					});
-					cameras.clear();
-				}
+			/**
+			 * Cancels any in-flight open for the given context pointer.
+			 * @param {number} context C++ CameraFeedWeb* context
+			 */
+			abort: function (context) {
+				const generation = GodotCamera.getContextGeneration(context);
+				GodotCamera.contextGenerations.set(context, generation + 1);
 			},
 		},
 	},
@@ -981,6 +1076,14 @@ const GodotCamera = {
 	godot_js_camera_stop_stream: function (deviceIdPtr) {
 		const deviceId = deviceIdPtr ? GodotRuntime.parseString(deviceIdPtr) : undefined;
 		GodotCamera.api.stop(deviceId);
+	},
+
+	/**
+	 * Native binding for canceling an in-flight camera open.
+	 * @param {number} context C++ CameraFeedWeb* context
+	 */
+	godot_js_camera_abort: function (context) {
+		GodotCamera.api.abort(context);
 	},
 };
 

--- a/platform/web/js/libs/library_godot_camera.js
+++ b/platform/web/js/libs/library_godot_camera.js
@@ -1,0 +1,988 @@
+/**************************************************************************/
+/*  library_godot_camera.js                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+/**
+ * @typedef {{
+ *   deviceId: string
+ *   label: string
+ * }} CameraInfo
+ *
+ * @typedef {{
+ *   video: HTMLVideoElement|null
+ *   canvas: HTMLCanvasElement|null
+ *   canvasContext: CanvasRenderingContext2D|null
+ *   stream: MediaStream|null
+ *   animationFrameId: number|null
+ *   permissionListener: Function|null
+ *   permissionStatus: PermissionStatus|null
+ *   trackProcessor: MediaStreamTrackProcessor|null
+ *   frameReader: ReadableStreamDefaultReader|null
+ *   useWebCodecs: boolean
+ * }} CameraResource
+ */
+
+const GodotCamera = {
+	$GodotCamera__deps: ['$GodotRuntime', '$GodotConfig', '$GodotOS'],
+	$GodotCamera__postset: 'GodotOS.atexit(function(resolve, reject) { GodotCamera.cleanup(); resolve(); });',
+	$GodotCamera: {
+		/**
+		 * Map to manage resources for each camera.
+		 * @type {Map<string, CameraResource>}
+		 */
+		cameras: new Map(),
+
+		/**
+		 * Shared barrier that delays the next camera start until the previous
+		 * stop has had a chance to release browser camera resources.
+		 * @type {Promise<void>}
+		 */
+		cameraShutdownBarrier: Promise.resolve(),
+
+		/**
+		 * Pixel format codes passed to the C callback.
+		 * Must match the values used in modules/camera/camera_web.cpp.
+		 */
+		FORMAT_CODE_RGBA: 0,
+		FORMAT_CODE_NV12: 1,
+		FORMAT_CODE_I420: 2,
+
+		/**
+		 * Builds the VideoFrame.copyTo options for a given source format.
+		 * Preserves 4:2:0 YUV sources (NV12, I420, I420A) as planar data so the
+		 * C++ side can feed them to set_ycbcr_images without a color conversion.
+		 * Other formats fall through to RGBA and rely on the browser to convert.
+		 * @param {string} srcFormat VideoFrame.format ('NV12', 'I420', 'I420A', 'RGBA', ...)
+		 * @param {{x:number,y:number,width:number,height:number}} rect
+		 * @returns {{totalSize:number,options:Object,formatCode:number}}
+		 */
+		getCopyToOptions: function (srcFormat, rect) {
+			const width = rect.width;
+			const height = rect.height;
+			// Round chroma dimensions up for odd sizes.
+			const chromaWidth = (width + 1) >> 1;
+			const chromaHeight = (height + 1) >> 1;
+			const ySize = width * height;
+			const chromaSize = chromaWidth * chromaHeight;
+
+			if (srcFormat === 'NV12') {
+				// Chrome rejects an explicit YUV `format`; omit it to copy the
+				// native NV12 planes (Y + interleaved Cb/Cr).
+				const uvStride = chromaWidth * 2;
+				return {
+					totalSize: ySize + uvStride * chromaHeight,
+					options: {
+						rect: rect,
+						layout: [
+							{ offset: 0, stride: width },
+							{ offset: ySize, stride: uvStride },
+						],
+					},
+					formatCode: GodotCamera.FORMAT_CODE_NV12,
+				};
+			}
+
+			if (srcFormat === 'I420' || srcFormat === 'I420A') {
+				// Y + U/V planes. I420A's trailing alpha plane is included for
+				// copyTo (one layout entry per plane) but ignored downstream.
+				const layout = [
+					{ offset: 0, stride: width },
+					{ offset: ySize, stride: chromaWidth },
+					{ offset: ySize + chromaSize, stride: chromaWidth },
+				];
+				let totalSize = ySize + chromaSize * 2;
+				if (srcFormat === 'I420A') {
+					layout.push({ offset: totalSize, stride: width });
+					totalSize += ySize;
+				}
+				return {
+					totalSize: totalSize,
+					options: {
+						rect: rect,
+						layout: layout,
+					},
+					formatCode: GodotCamera.FORMAT_CODE_I420,
+				};
+			}
+
+			return {
+				totalSize: width * height * 4,
+				options: {
+					rect: rect,
+					layout: [{ offset: 0, stride: width * 4 }],
+					format: 'RGBA',
+				},
+				formatCode: GodotCamera.FORMAT_CODE_RGBA,
+			};
+		},
+
+		/**
+		 * Gets the visible pixel rectangle to copy from a VideoFrame.
+		 * @param {VideoFrame} videoFrame
+		 * @returns {{x:number,y:number,width:number,height:number}}
+		 */
+		getVisibleFrameRect: function (videoFrame) {
+			const rect = videoFrame.visibleRect;
+			if (rect) {
+				return {
+					x: rect.x,
+					y: rect.y,
+					width: rect.width,
+					height: rect.height,
+				};
+			}
+			return {
+				x: 0,
+				y: 0,
+				width: videoFrame.displayWidth,
+				height: videoFrame.displayHeight,
+			};
+		},
+
+		/**
+		 * Cached Wasm heap pointer for frame data copy.
+		 * Avoids per-frame malloc/free overhead and fragmentation.
+		 * @type {number}
+		 */
+		_cachedDataPtr: 0,
+
+		/**
+		 * Size of the cached Wasm heap buffer.
+		 * @type {number}
+		 */
+		_cachedDataSize: 0,
+
+		/**
+		 * Copies pixel data into the cached Wasm heap buffer, reallocating if the size changed.
+		 * @param {Uint8Array} p_data - Pixel data to copy.
+		 */
+		_heapCopyPixelData(p_data) {
+			if (GodotCamera._cachedDataSize !== p_data.length) {
+				if (GodotCamera._cachedDataPtr) {
+					GodotRuntime.free(GodotCamera._cachedDataPtr);
+				}
+				GodotCamera._cachedDataPtr = GodotRuntime.malloc(p_data.length);
+				GodotCamera._cachedDataSize = p_data.length;
+			}
+			GodotRuntime.heapCopy(HEAPU8, p_data, GodotCamera._cachedDataPtr);
+		},
+
+		/**
+		 * Common native camera resolutions, grouped by aspect ratio, checked
+		 * against active camera capabilities.
+		 */
+		commonResolutions: [
+			// 16:9
+			{ width: 640, height: 360 }, // nHD (16:9)
+			{ width: 848, height: 480 }, // FWVGA (16:9)
+			{ width: 1280, height: 720 }, // HD 720p (16:9)
+			{ width: 1920, height: 1080 }, // Full HD 1080p (16:9)
+			{ width: 3840, height: 2160 }, // 4K UHD 2160p (16:9)
+			// 16:10
+			{ width: 1280, height: 800 }, // WXGA (16:10)
+			{ width: 1920, height: 1200 }, // WUXGA (16:10)
+			// 4:3
+			{ width: 320, height: 240 }, // QVGA (4:3)
+			{ width: 640, height: 480 }, // VGA (4:3)
+			{ width: 800, height: 600 }, // SVGA (4:3)
+			{ width: 1280, height: 960 }, // 960p (4:3)
+			{ width: 1600, height: 1200 }, // UXGA (4:3)
+			{ width: 2048, height: 1536 }, // QXGA (4:3)
+			// max size
+			{ width: 99999, height: 99999 },
+		],
+
+		/**
+		 * Gets supported formats based on active track capabilities.
+		 * @param {Object} capabilities MediaTrackCapabilities object
+		 * @returns {Array<{width:number,height:number,frameRate:number}>} Supported resolutions with frame rate
+		 */
+		getSupportedFormats: function (capabilities) {
+			const widthRange = capabilities.width || {};
+			const heightRange = capabilities.height || {};
+			const frameRateRange = capabilities.frameRate || {};
+			const maxWidth = widthRange.max || 0;
+			const maxHeight = heightRange.max || 0;
+			const minWidth = widthRange.min || 1;
+			const minHeight = heightRange.min || 1;
+			const maxFrameRate = Math.round(frameRateRange.max || 0);
+
+			if (maxWidth <= 0 || maxHeight <= 0) {
+				return [];
+			}
+
+			return GodotCamera.commonResolutions
+				.filter((res) => res.width >= minWidth
+					&& res.width <= maxWidth
+					&& res.height >= minHeight
+					&& res.height <= maxHeight)
+				.map((res) => ({
+					width: res.width,
+					height: res.height,
+					frameRate: maxFrameRate,
+				}))
+				.sort((a, b) => {
+					const areaA = a.width * a.height;
+					const areaB = b.width * b.height;
+					if (areaA !== areaB) {
+						return areaA - areaB;
+					}
+					return a.width - b.width;
+				});
+		},
+
+		/**
+		 * Checks if WebCodecs API is supported for camera capture.
+		 * @returns {boolean} True if MediaStreamTrackProcessor and VideoFrame are available
+		 */
+		isWebCodecsSupported: function () {
+			return 'MediaStreamTrackProcessor' in window && 'VideoFrame' in window;
+		},
+
+		/**
+		 * Awaits a promise with a timeout.
+		 * @param {Promise<*>} promise Promise to await
+		 * @param {number} timeoutMs Timeout in milliseconds
+		 * @param {string} timeoutMessage Error message on timeout
+		 * @returns {Promise<*>}
+		 */
+		waitWithTimeout: function (promise, timeoutMs, timeoutMessage) {
+			let timeoutId = null;
+			const timeoutPromise = new Promise((_, reject) => {
+				timeoutId = setTimeout(() => {
+					reject(new Error(timeoutMessage));
+				}, timeoutMs);
+			});
+			return Promise.race([promise, timeoutPromise]).finally(() => {
+				if (timeoutId !== null) {
+					clearTimeout(timeoutId);
+				}
+			});
+		},
+
+		/**
+		 * Opens a camera stream with a timeout and stops late streams after timeout.
+		 * @param {Object} constraints getUserMedia constraints
+		 * @param {number} timeoutMs Timeout in milliseconds
+		 * @param {string} timeoutMessage Error message on timeout
+		 * @returns {Promise<MediaStream>}
+		 */
+		getUserMediaWithTimeout: function (constraints, timeoutMs, timeoutMessage) {
+			const streamPromise = navigator.mediaDevices.getUserMedia(constraints);
+			return GodotCamera.waitWithTimeout(streamPromise, timeoutMs, timeoutMessage).catch((error) => {
+				streamPromise.then((stream) => {
+					GodotCamera.stopStream(stream);
+				}, () => {});
+				throw error;
+			});
+		},
+
+		/**
+		 * Opens a camera with retry on transient "device busy" errors, used when
+		 * switching cameras: opening one camera right after stopping another can
+		 * fail while the previous device is still being released (Android).
+		 *
+		 * Rationale (from Gecko/libwebrtc), which dictates the error handling:
+		 * - A failed open is bounded, not infinite. libwebrtc's CameraCapturer
+		 *   retries the open MAX_OPEN_CAMERA_ATTEMPTS=3 times, OPEN_CAMERA_DELAY_MS
+		 *   =500ms apart, each guarded by OPEN_CAMERA_TIMEOUT=10000ms, then reports
+		 *   failure. Gecko surfaces that to JS as an AbortError ("Starting video
+		 *   failed", MediaManager.cpp). Worst case is ~11s.
+		 * - So timeoutMs must exceed ~11s: getUserMedia then rejects cleanly with
+		 *   that AbortError. A shorter race timeout would fire first and leave the
+		 *   underlying request pending on Gecko's single, serialized VideoCapture
+		 *   thread; retrying then just queues a second open behind the first and
+		 *   makes the contention worse.
+		 * - Hence we retry only on cleanly-thrown busy errors (AbortError /
+		 *   NotReadableError), never on the race timeout.
+		 * @param {Object} constraints getUserMedia constraints
+		 * @param {number} attempts Maximum number of attempts
+		 * @param {number} timeoutMs Per-attempt timeout (must exceed ~11s; see above)
+		 * @param {string} timeoutMessage Error message on timeout
+		 * @returns {Promise<MediaStream>}
+		 */
+		getUserMediaWithRetry: async function (constraints, attempts, timeoutMs, timeoutMessage) {
+			let lastError = null;
+			for (let i = 0; i < attempts; i++) {
+				try {
+					// eslint-disable-next-line no-await-in-loop
+					return await GodotCamera.getUserMediaWithTimeout(constraints, timeoutMs, timeoutMessage);
+				} catch (error) {
+					lastError = error;
+					const name = error ? error.name : null;
+					if ((name !== 'NotReadableError' && name !== 'AbortError') || i === attempts - 1) {
+						throw error;
+					}
+					// Back off to give the previous camera time to finish releasing.
+					// eslint-disable-next-line no-await-in-loop
+					await new Promise((resolve) => {
+						setTimeout(resolve, 300 * (i + 1));
+					});
+				}
+			}
+			throw lastError;
+		},
+
+		/**
+		 * Waits for the previous camera stop barrier to complete.
+		 * @returns {Promise<void>}
+		 */
+		waitForCameraShutdown: function () {
+			const barrier = this.cameraShutdownBarrier;
+			if (!barrier || typeof barrier.then !== 'function') {
+				this.cameraShutdownBarrier = Promise.resolve();
+				return this.cameraShutdownBarrier;
+			}
+			return barrier;
+		},
+
+		/**
+		 * Enqueues a barrier after stopping camera resources so the next
+		 * getUserMedia() does not race the previous camera's teardown.
+		 *
+		 * Rationale (from Gecko/libwebrtc): on Android the device close is
+		 * asynchronous - Gecko's VideoCaptureAndroid.stopCapture() and
+		 * libwebrtc's Camera2Session dispatch CameraDevice.close() to the camera
+		 * thread and return without waiting for StateCallback.onClosed. Opening
+		 * another camera before that completes makes the new open contend for the
+		 * still-held device. 500ms covers that release window (a few hundred ms
+		 * in practice); this is why a manual stop-then-switch never stalls.
+		 * @returns {void}
+		 */
+		queueCameraShutdownBarrier: function () {
+			this.cameraShutdownBarrier = new Promise((resolve) => {
+				setTimeout(resolve, 500);
+			});
+		},
+
+		/**
+		 * Stops all tracks in a stream and queues the next-start barrier once.
+		 * @param {MediaStream|null} stream Stream to stop
+		 * @returns {boolean} True if a stream was stopped
+		 */
+		stopStream: function (stream) {
+			if (!stream) {
+				return false;
+			}
+			stream.getTracks().forEach((track) => track.stop());
+			GodotCamera.queueCameraShutdownBarrier();
+			return true;
+		},
+
+		/**
+		 * Cleanup all camera resources.
+		 * @returns {void}
+		 */
+		cleanup: function () {
+			this.api.stop();
+
+			// Free cached Wasm heap buffer.
+			if (this._cachedDataPtr) {
+				GodotRuntime.free(this._cachedDataPtr);
+				this._cachedDataPtr = 0;
+				this._cachedDataSize = 0;
+			}
+		},
+
+		/**
+		 * Sends a JSON result to the callback function.
+		 * @param {Function} callback Callback function pointer
+		 * @param {number} callbackPtr Context value to pass to callback
+		 * @param {number} context Context value to pass to callback
+		 * @param {Object} result Result object to stringify
+		 * @returns {void}
+		 */
+		sendCamerasCallbackResult: function (callback, callbackPtr, context, result) {
+			const jsonStr = JSON.stringify(result);
+			const strPtr = GodotRuntime.allocString(jsonStr);
+			callback(context, callbackPtr, strPtr);
+			GodotRuntime.free(strPtr);
+		},
+
+		/**
+		 * Sends active camera formats to the callback function.
+		 * @param {Function} callback Callback function pointer
+		 * @param {number} context Context value to pass to callback
+		 * @param {Object} result Result object to stringify
+		 * @returns {void}
+		 */
+		sendFormatsCallbackResult: function (callback, context, result) {
+			const jsonStr = JSON.stringify(result);
+			const strPtr = GodotRuntime.allocString(jsonStr);
+			callback(context, strPtr);
+			GodotRuntime.free(strPtr);
+		},
+
+		/**
+		 * Sends pixel data or error to the callback function.
+		 * @param {Function} callback Callback function pointer
+		 * @param {number} context Context value to pass to callback
+		 * @param {number} dataPtr Pointer to pixel data
+		 * @param {number} dataLen Length of pixel data
+		 * @param {number} width Image width
+		 * @param {number} height Image height
+		 * @param {number} formatCode Pixel format code (FORMAT_CODE_RGBA, FORMAT_CODE_NV12, ...)
+		 * @param {number} facingMode Camera facing mode (0=unknown, 1=user/front, 2=environment/back)
+		 * @param {string|null} errorMsg Error message if any
+		 * @returns {void}
+		 */
+		sendGetPixelDataCallback: function (callback, context, dataPtr, dataLen, width, height, formatCode, facingMode, errorMsg) {
+			const errorMsgPtr = errorMsg ? GodotRuntime.allocString(errorMsg) : 0;
+			callback(context, dataPtr, dataLen, width, height, formatCode, facingMode, errorMsgPtr);
+			if (errorMsgPtr) {
+				GodotRuntime.free(errorMsgPtr);
+			}
+		},
+
+		/**
+		 * Converts facingMode string to numeric value.
+		 * @param {MediaStream|null} stream Media stream to get facing mode from
+		 * @returns {number} 0=unknown, 1=user/front, 2=environment/back
+		 */
+		getFacingMode: function (stream) {
+			if (!stream) {
+				return 0;
+			}
+			const [videoTrack] = stream.getVideoTracks();
+			if (!videoTrack) {
+				return 0;
+			}
+			const settings = videoTrack.getSettings();
+			switch (settings.facingMode) {
+			case 'user':
+				return 1; // Front camera
+			case 'environment':
+				return 2; // Back camera
+			default:
+				return 0; // Unknown
+			}
+		},
+
+		/**
+		 * Gets the active format metadata from an active stream track.
+		 * @param {MediaStreamTrack} videoTrack Active video track
+		 * @param {number} facingMode Numeric facing mode
+		 * @returns {{formats:Array<{width:number,height:number,frameRate:number}>,current:{width:number,height:number,frameRate:number,facingMode:number}}}
+		 */
+		getActiveFormats: function (videoTrack, facingMode) {
+			const settings = videoTrack.getSettings ? videoTrack.getSettings() : {};
+			const capabilities = videoTrack.getCapabilities ? videoTrack.getCapabilities() : {};
+			const current = {
+				width: settings.width || 0,
+				height: settings.height || 0,
+				frameRate: Math.round(settings.frameRate || 0),
+				facingMode,
+			};
+			const formats = GodotCamera.getSupportedFormats(capabilities);
+			const hasCurrentFormat = formats.some((format) => (format.width === current.width && format.height === current.height)
+				|| (format.width === current.height && format.height === current.width));
+			if (!hasCurrentFormat && current.width > 0 && current.height > 0) {
+				formats.push({
+					width: current.width,
+					height: current.height,
+					frameRate: current.frameRate,
+				});
+			}
+
+			return {
+				formats,
+				current,
+			};
+		},
+
+		/**
+		 * Checks whether an async startup path still owns the active camera resource.
+		 * @param {string} cameraId Camera identifier
+		 * @param {CameraResource} camera Camera resource captured before awaiting
+		 * @returns {boolean} True if the resource is still current
+		 */
+		isCurrentCamera: function (cameraId, camera) {
+			return GodotCamera.cameras.get(cameraId) === camera;
+		},
+
+		/**
+		 * Stops a stream created by an async startup path that lost ownership.
+		 * @param {CameraResource} camera Camera resource
+		 * @returns {void}
+		 */
+		stopStaleStartupStream: function (camera) {
+			if (camera.stream) {
+				GodotCamera.stopStream(camera.stream);
+			}
+			camera.stream = null;
+		},
+
+		/**
+		 * Sets up WebCodecs-based frame capture using MediaStreamTrackProcessor.
+		 * @param {CameraResource} camera Camera resource
+		 * @param {string} cameraId Camera identifier
+		 * @param {Function} callback Callback function for frame data
+		 * @param {number} context Context value to pass to callback
+		 * @param {Function} deniedCallback Callback for permission denied
+		 * @returns {void}
+		 */
+		setupWebCodecsCapture: function (camera, cameraId, callback, context, deniedCallback) {
+			const [videoTrack] = camera.stream.getVideoTracks();
+
+			camera.trackProcessor = new MediaStreamTrackProcessor({ track: videoTrack });
+			camera.frameReader = camera.trackProcessor.readable.getReader();
+
+			const processFrames = async () => {
+				const cameras = GodotCamera.cameras;
+				try {
+					while (true) {
+						const currentCamera = cameras.get(cameraId);
+						if (!currentCamera || !currentCamera.useWebCodecs) {
+							break;
+						}
+
+						// eslint-disable-next-line no-await-in-loop
+						const { done, value: videoFrame } = await currentCamera.frameReader.read();
+						if (done) {
+							break;
+						}
+
+						try {
+							const frameRect = GodotCamera.getVisibleFrameRect(videoFrame);
+							const copyTo = GodotCamera.getCopyToOptions(videoFrame.format, frameRect);
+							const pixelBuffer = new Uint8Array(copyTo.totalSize);
+
+							// eslint-disable-next-line no-await-in-loop
+							await videoFrame.copyTo(pixelBuffer, copyTo.options);
+
+							GodotCamera._heapCopyPixelData(pixelBuffer);
+
+							GodotCamera.sendGetPixelDataCallback(
+								callback,
+								context,
+								GodotCamera._cachedDataPtr,
+								pixelBuffer.length,
+								frameRect.width,
+								frameRect.height,
+								copyTo.formatCode,
+								currentCamera.facingMode,
+								null
+							);
+						} finally {
+							videoFrame.close();
+						}
+					}
+				} catch (error) {
+					GodotRuntime.print('WebCodecs error, falling back to Canvas 2D:', error.message);
+					const currentCamera = cameras.get(cameraId);
+					if (currentCamera) {
+						// Clean up WebCodecs resources before fallback.
+						if (currentCamera.frameReader) {
+							currentCamera.frameReader.cancel().catch(() => {});
+							currentCamera.frameReader = null;
+						}
+						currentCamera.trackProcessor = null;
+						currentCamera.useWebCodecs = false;
+
+						GodotCamera.setupCanvas2DCapture(currentCamera, cameraId, callback, context, deniedCallback);
+					}
+				}
+			};
+
+			processFrames();
+		},
+
+		/**
+		 * Sets up Canvas 2D-based frame capture (fallback method).
+		 * @param {CameraResource} camera Camera resource
+		 * @param {string} cameraId Camera identifier
+		 * @param {Function} callback Callback function for frame data
+		 * @param {number} context Context value to pass to callback
+		 * @param {Function} deniedCallback Callback for permission denied
+		 * @returns {void}
+		 */
+		setupCanvas2DCapture: function (camera, cameraId, callback, context, deniedCallback) {
+			if (camera.animationFrameId) {
+				cancelAnimationFrame(camera.animationFrameId);
+			}
+
+			const captureFrame = () => {
+				const cameras = GodotCamera.cameras;
+				const currentCamera = cameras.get(cameraId);
+				if (!currentCamera) {
+					return;
+				}
+
+				const { video, stream } = currentCamera;
+
+				if (!stream || !stream.active) {
+					GodotRuntime.print('Stream is not active, stopping');
+					GodotCamera.api.stop(cameraId);
+					return;
+				}
+
+				if (video.readyState === video.HAVE_ENOUGH_DATA) {
+					const _width = video.videoWidth;
+					const _height = video.videoHeight;
+
+					if (!currentCamera.canvas) {
+						currentCamera.canvas = document.createElement('canvas');
+						currentCamera.canvas.style.display = 'none';
+						document.body.appendChild(currentCamera.canvas);
+					}
+
+					if (currentCamera.canvas.width !== _width || currentCamera.canvas.height !== _height) {
+						currentCamera.canvas.width = _width;
+						currentCamera.canvas.height = _height;
+						currentCamera.canvasContext = null;
+					}
+
+					if (!currentCamera.canvasContext) {
+						currentCamera.canvasContext = currentCamera.canvas.getContext('2d', { willReadFrequently: true });
+					}
+
+					try {
+						currentCamera.canvasContext.drawImage(video, 0, 0, _width, _height);
+						const imageData = currentCamera.canvasContext.getImageData(0, 0, _width, _height);
+						const pixelData = imageData.data;
+
+						GodotCamera._heapCopyPixelData(pixelData);
+
+						GodotCamera.sendGetPixelDataCallback(
+							callback,
+							context,
+							GodotCamera._cachedDataPtr,
+							pixelData.length,
+							_width,
+							_height,
+							GodotCamera.FORMAT_CODE_RGBA,
+							currentCamera.facingMode,
+							null
+						);
+					} catch (error) {
+						GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, 0, error.message);
+
+						if (error.name === 'SecurityError' || error.name === 'NotAllowedError') {
+							GodotRuntime.print('Security error, stopping stream:', error);
+							GodotCamera.api.stop(cameraId);
+							deniedCallback(context);
+						}
+						return;
+					}
+				}
+
+				currentCamera.animationFrameId = requestAnimationFrame(captureFrame);
+			};
+
+			camera.animationFrameId = requestAnimationFrame(captureFrame);
+		},
+
+		/**
+		 * Cleans up resources for a specific camera.
+		 * @param {CameraResource} camera Camera resource to cleanup
+		 * @returns {void}
+		 */
+		cleanupCamera: function (camera) {
+			if (camera.frameReader) {
+				camera.frameReader.cancel().catch(() => {});
+				camera.frameReader = null;
+			}
+			if (camera.trackProcessor) {
+				camera.trackProcessor = null;
+			}
+
+			if (camera.animationFrameId) {
+				cancelAnimationFrame(camera.animationFrameId);
+			}
+
+			GodotCamera.stopStream(camera.stream);
+
+			if (camera.video && camera.video.parentNode) {
+				camera.video.pause();
+				camera.video.srcObject = null;
+				camera.video.load();
+				camera.video.parentNode.removeChild(camera.video);
+			}
+
+			if (camera.canvas && camera.canvas instanceof HTMLCanvasElement && camera.canvas.parentNode) {
+				camera.canvas.parentNode.removeChild(camera.canvas);
+			}
+
+			if (camera.permissionListener && camera.permissionStatus) {
+				camera.permissionStatus.removeEventListener('change', camera.permissionListener);
+				camera.permissionListener = null;
+				camera.permissionStatus = null;
+			}
+
+			// Null out references to help GC.
+			camera.animationFrameId = null;
+			camera.canvasContext = null;
+			camera.stream = null;
+			camera.video = null;
+			camera.canvas = null;
+			camera.useWebCodecs = false;
+		},
+
+		api: {
+			/**
+			 * Gets list of available cameras.
+			 * Calls callback with JSON containing array of camera info.
+			 * @param {number} context Context value to pass to callback
+			 * @param {number} callbackPtr1 Pointer to callback function
+			 * @param {number} callbackPtr2 Pointer to callback function
+			 * @returns {Promise<void>}
+			 */
+			getCameras: async function (context, callbackPtr1, callbackPtr2) {
+				const callback = GodotRuntime.get_func(callbackPtr2);
+				const result = { error: null, cameras: null };
+
+				try {
+					// Request camera access permission first.
+					const initialStream = await navigator.mediaDevices.getUserMedia({ video: true, audio: false });
+					GodotCamera.stopStream(initialStream);
+
+					const devices = await navigator.mediaDevices.enumerateDevices();
+					const videoDevices = devices.filter((device) => device.kind === 'videoinput');
+
+					result.cameras = videoDevices.map((device, index) => ({
+						id: device.deviceId,
+						label: device.label || `Camera ${index}`,
+					}));
+				} catch (error) {
+					result.error = error.message;
+				}
+
+				GodotCamera.sendCamerasCallbackResult(callback, callbackPtr1, context, result);
+			},
+
+			/**
+			 * Starts capturing pixel data from camera.
+			 * Continuously calls callback with pixel data.
+			 * @param {number} context Context value to pass to callback
+			 * @param {string|null} deviceId Camera device ID
+			 * @param {number} width Desired capture width
+			 * @param {number} height Desired capture height
+			 * @param {number} callbackPtr Pointer to callback function
+			 * @param {number} deniedCallbackPtr Pointer to callback function
+			 * @param {number} formatsCallbackPtr Pointer to formats callback function
+			 * @returns {Promise<void>}
+			 */
+			getPixelData: async function (context, deviceId, width, height, callbackPtr, deniedCallbackPtr, formatsCallbackPtr) {
+				const callback = GodotRuntime.get_func(callbackPtr);
+				const deniedCallback = GodotRuntime.get_func(deniedCallbackPtr);
+				const formatsCallback = GodotRuntime.get_func(formatsCallbackPtr);
+				const cameraId = deviceId || 'default';
+				let camera = null;
+
+				try {
+					await GodotCamera.waitForCameraShutdown();
+
+					const cameras = GodotCamera.cameras;
+					camera = cameras.get(cameraId);
+					if (!camera) {
+						camera = {
+							video: null,
+							canvas: null,
+							canvasContext: null,
+							stream: null,
+							animationFrameId: null,
+							permissionListener: null,
+							permissionStatus: null,
+							trackProcessor: null,
+							frameReader: null,
+							useWebCodecs: false,
+							facingMode: 0,
+						};
+						cameras.set(cameraId, camera);
+					}
+
+					if (!camera.stream) {
+						// Create video element (needed for Canvas 2D fallback).
+						camera.video = document.createElement('video');
+						camera.video.style.display = 'none';
+						camera.video.autoplay = true;
+						camera.video.playsInline = true;
+						camera.video.muted = true;
+						document.body.appendChild(camera.video);
+
+						const constraints = {
+							video: {
+								deviceId: deviceId ? { exact: deviceId } : undefined,
+								width: width > 0 ? { ideal: width } : undefined,
+								height: height > 0 ? { ideal: height } : undefined,
+								// Prefer a native sensor mode over a cropped/downscaled frame.
+								resizeMode: { ideal: 'none' },
+							},
+						};
+						// 12s timeout exceeds libwebrtc's ~11s open-retry budget so a
+						// busy device rejects cleanly with AbortError (then retried)
+						// instead of a race timeout that leaves the request pending.
+						const stream = await GodotCamera.getUserMediaWithRetry(
+							constraints,
+							2,
+							12000,
+							'Camera start timed out while waiting for getUserMedia().'
+						);
+						if (!GodotCamera.isCurrentCamera(cameraId, camera)) {
+							GodotCamera.stopStream(stream);
+							return;
+						}
+						camera.stream = stream;
+
+						const [videoTrack] = camera.stream.getVideoTracks();
+						videoTrack.addEventListener('ended', () => {
+							GodotCamera.api.stop(cameraId);
+						});
+
+						if (navigator.permissions && navigator.permissions.query) {
+							try {
+								const permissionStatus = await navigator.permissions.query({ name: 'camera' });
+								// eslint-disable-next-line require-atomic-updates
+								camera.permissionStatus = permissionStatus;
+								camera.permissionListener = () => {
+									if (permissionStatus.state === 'denied') {
+										GodotRuntime.print('Camera permission denied, stopping stream');
+										if (camera.permissionListener) {
+											permissionStatus.removeEventListener('change', camera.permissionListener);
+										}
+										GodotCamera.api.stop(cameraId);
+										deniedCallback(context);
+									}
+								};
+								permissionStatus.addEventListener('change', camera.permissionListener);
+							} catch (e) {
+								// Some browsers don't support 'camera' permission query.
+								// This is not critical - we can still use the camera.
+							}
+						}
+						if (!GodotCamera.isCurrentCamera(cameraId, camera)) {
+							GodotCamera.stopStaleStartupStream(camera);
+							return;
+						}
+
+						camera.video.srcObject = camera.stream;
+						await GodotCamera.waitWithTimeout(
+							camera.video.play(),
+							3000,
+							'Camera start timed out while waiting for video.play().'
+						);
+						if (!GodotCamera.isCurrentCamera(cameraId, camera)) {
+							GodotCamera.stopStaleStartupStream(camera);
+							return;
+						}
+
+						// Cache facing mode once (doesn't change during stream).
+						camera.facingMode = GodotCamera.getFacingMode(camera.stream);
+						GodotCamera.sendFormatsCallbackResult(
+							formatsCallback,
+							context,
+							GodotCamera.getActiveFormats(videoTrack, camera.facingMode)
+						);
+
+						// Choose capture method:
+						// 1. WebCodecs + MediaStreamTrackProcessor when available.
+						// 2. Canvas 2D as the single compatibility fallback.
+						if (GodotCamera.isWebCodecsSupported()) {
+							camera.useWebCodecs = true;
+							GodotCamera.setupWebCodecsCapture(camera, cameraId, callback, context, deniedCallback);
+						} else {
+							GodotCamera.setupCanvas2DCapture(camera, cameraId, callback, context, deniedCallback);
+						}
+					}
+				} catch (error) {
+					if (camera) {
+						GodotCamera.cleanupCamera(camera);
+					}
+					GodotCamera.sendGetPixelDataCallback(callback, context, 0, 0, 0, 0, 0, 0, error.message);
+					if (error && (error.name === 'SecurityError' || error.name === 'NotAllowedError')) {
+						deniedCallback(context);
+					}
+				}
+			},
+
+			/**
+			 * Stops camera stream(s).
+			 * @param {string|null} deviceId Device ID to stop, or null to stop all
+			 * @returns {void}
+			 */
+			stop: function (deviceId) {
+				const cameras = GodotCamera.cameras;
+
+				if (deviceId && cameras.has(deviceId)) {
+					const camera = cameras.get(deviceId);
+					if (camera) {
+						GodotCamera.cleanupCamera(camera);
+					}
+				} else {
+					cameras.forEach((camera) => {
+						if (camera) {
+							GodotCamera.cleanupCamera(camera);
+						}
+					});
+					cameras.clear();
+				}
+			},
+		},
+	},
+
+	/**
+	 * Native binding for getting list of cameras.
+	 * @param {number} context Context value to pass to callback
+	 * @param {number} callbackPtr1 Pointer to callback function
+	 * @param {number} callbackPtr2 Pointer to callback function
+	 * @returns {Promise<void>}
+	 */
+	godot_js_camera_get_cameras: function (context, callbackPtr1, callbackPtr2) {
+		return GodotCamera.api.getCameras(context, callbackPtr1, callbackPtr2);
+	},
+
+	/**
+	 * Native binding for getting pixel data from camera.
+	 * @param {number} context Context value to pass to callback
+	 * @param {number} deviceIdPtr Pointer to device ID string
+	 * @param {number} width Desired capture width
+	 * @param {number} height Desired capture height
+	 * @param {number} callbackPtr Pointer to callback function
+	 * @param {number} deniedCallbackPtr Pointer to denied callback function
+	 * @param {number} formatsCallbackPtr Pointer to formats callback function
+	 * @returns {*}
+	 */
+	godot_js_camera_get_pixel_data: function (context, deviceIdPtr, width, height, callbackPtr, deniedCallbackPtr, formatsCallbackPtr) {
+		const deviceId = deviceIdPtr ? GodotRuntime.parseString(deviceIdPtr) : undefined;
+		return GodotCamera.api.getPixelData(context, deviceId, width, height, callbackPtr, deniedCallbackPtr, formatsCallbackPtr);
+	},
+
+	/**
+	 * Native binding for stopping camera stream.
+	 * @param {number} deviceIdPtr Pointer to device ID string
+	 * @returns {void}
+	 */
+	godot_js_camera_stop_stream: function (deviceIdPtr) {
+		const deviceId = deviceIdPtr ? GodotRuntime.parseString(deviceIdPtr) : undefined;
+		GodotCamera.api.stop(deviceId);
+	},
+};
+
+autoAddDeps(GodotCamera, '$GodotCamera');
+mergeInto(LibraryManager.library, GodotCamera);

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -67,6 +67,8 @@ void CameraFeed::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("frame_changed"));
 	ADD_SIGNAL(MethodInfo("format_changed"));
+	ADD_SIGNAL(MethodInfo("activation_status_changed", PropertyInfo(Variant::INT, "status", PROPERTY_HINT_ENUM, "Inactive,Activating,Active")));
+	ADD_SIGNAL(MethodInfo("activation_failed", PropertyInfo(Variant::STRING, "error")));
 
 	ADD_GROUP("Feed", "feed_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "feed_is_active"), "set_active", "is_active");
@@ -82,6 +84,10 @@ void CameraFeed::_bind_methods() {
 	BIND_ENUM_CONSTANT(FEED_UNSPECIFIED);
 	BIND_ENUM_CONSTANT(FEED_FRONT);
 	BIND_ENUM_CONSTANT(FEED_BACK);
+
+	BIND_ENUM_CONSTANT(FEED_INACTIVE);
+	BIND_ENUM_CONSTANT(FEED_ACTIVATING);
+	BIND_ENUM_CONSTANT(FEED_ACTIVE);
 }
 
 int CameraFeed::get_id() const {
@@ -92,6 +98,24 @@ bool CameraFeed::is_active() const {
 	return active;
 }
 
+CameraFeed::FeedActivationStatus CameraFeed::get_activation_status() const {
+	return activation_status;
+}
+
+void CameraFeed::_set_activation_status(FeedActivationStatus p_status) {
+	if (activation_status == p_status) {
+		return;
+	}
+
+	activation_status = p_status;
+	if (p_status == FEED_ACTIVE) {
+		active = true;
+	} else if (p_status == FEED_INACTIVE) {
+		active = false;
+	}
+	call_deferred("emit_signal", SNAME("activation_status_changed"), (int)p_status);
+}
+
 void CameraFeed::set_active(bool p_is_active) {
 	if (p_is_active == active) {
 		// all good
@@ -99,11 +123,14 @@ void CameraFeed::set_active(bool p_is_active) {
 		// attempt to activate this feed
 		if (activate_feed()) {
 			active = true;
+			if (activation_status != FEED_ACTIVATING) {
+				_set_activation_status(FEED_ACTIVE);
+			}
 		}
 	} else {
 		// just deactivate it
 		deactivate_feed();
-		active = false;
+		_set_activation_status(FEED_INACTIVE);
 	}
 }
 

--- a/servers/camera/camera_feed.h
+++ b/servers/camera/camera_feed.h
@@ -57,6 +57,12 @@ public:
 		FEED_BACK // this is a camera on the back of the device
 	};
 
+	enum FeedActivationStatus {
+		FEED_INACTIVE = 0,
+		FEED_ACTIVATING = 1,
+		FEED_ACTIVE = 2,
+	};
+
 private:
 	int id; // unique id for this, for internal use in case feeds are removed
 	const StringName format_changed_signal_name = "format_changed";
@@ -83,8 +89,11 @@ protected:
 	int selected_format = -1;
 
 	bool active; // only when active do we actually update the camera texture each frame
+	FeedActivationStatus activation_status = FEED_INACTIVE;
 	RID texture[CameraServer::FEED_IMAGES]; // texture images needed for this
 
+	FeedActivationStatus get_activation_status() const;
+	void _set_activation_status(FeedActivationStatus p_status);
 	static void _bind_methods();
 
 public:
@@ -132,3 +141,4 @@ public:
 
 VARIANT_ENUM_CAST(CameraFeed::FeedDataType);
 VARIANT_ENUM_CAST(CameraFeed::FeedPosition);
+VARIANT_ENUM_CAST(CameraFeed::FeedActivationStatus);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixed: https://github.com/godotengine/godot-proposals/issues/12493

Current Limitation:
~~The `platform/web/js/libs/library_godot_camera.js` library includes certain functionalities that are inherently asynchronous. We are currently investigating how to execute these functions synchronously, as this is a requirement for our project, but haven't yet found a solution.~~
~~I was able to build with JSPI and call asynchronous functions synchronously in Chrome. However, JSPI only works in Chrome and Edge 137.~~
~~https://webassembly.org/features/~~
~~https://learn.microsoft.com/en-us/microsoft-edge/web-platform/release-notes/137#javascript-promise-integration-jspi-in-webassembly~~

Supported browsers:

- Chrome v137.0.7151.69
- Firefox ESR v128.11.0esr
- Safari v18.5(20621.2.5.11.8)