### PR TITLE
Add vector components to 3D ruler tool

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -222,11 +222,19 @@ private:
 	Node3D *ruler_start_point = nullptr;
 	Node3D *ruler_end_point = nullptr;
 	Ref<ImmediateMesh> geometry;
+	Ref<ImmediateMesh> geometry_xray;
 	MeshInstance3D *ruler_line = nullptr;
 	MeshInstance3D *ruler_line_xray = nullptr;
 	Label *ruler_label = nullptr;
 	Ref<StandardMaterial3D> ruler_material;
 	Ref<StandardMaterial3D> ruler_material_xray;
+	Ref<StandardMaterial3D> ruler_triangle_material;
+	Ref<StandardMaterial3D> ruler_triangle_material_xray;
+	MeshInstance3D *ruler_triangle_lines = nullptr;
+	MeshInstance3D *ruler_triangle_lines_xray = nullptr;
+	Label *ruler_label_x = nullptr;
+	Label *ruler_label_y = nullptr;
+	Label *ruler_label_z = nullptr;
 
 	int index;
 	ViewType view_type;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

https://github.com/godotengine/godot/pull/100162 added ruler functionality to 3D, and this PR builds on-top of it.

Related: https://github.com/godotengine/godot/pull/100415

The PR enables the 3D ruler tool to display the components of the measurement vector to allow users to get more details similar to the 2D measurement tool. This also fixes some z-fighting issues in the current state of the measurement tool. 

The `shift` key will activate it, since it can be too noisy in specific situations. 

https://github.com/user-attachments/assets/13c9f16a-c182-4a9f-b004-d47163c33452

