### PR TITLE
Detect UV2 for AO textures

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4889,6 +4889,15 @@ Error GLTFDocument::_parse_materials(Ref<GLTFState> p_state) {
 				material->set_ao_texture_channel(BaseMaterial3D::TEXTURE_CHANNEL_RED);
 				material->set_feature(BaseMaterial3D::FEATURE_AMBIENT_OCCLUSION, true);
 			}
+
+			if (bct.has("texCoord")) {
+				const int &text_coord = bct["texCoord"];
+
+				// only two UV coordinates are supported so anything higher than zero means UV2
+				if (text_coord > 0) {
+					material->set_flag(BaseMaterial3D::FLAG_AO_ON_UV2, true);
+				}
+			}
 		}
 
 		if (material_dict.has("emissiveFactor")) {


### PR DESCRIPTION
When the `occlusionTexture` in a GLTF document uses a `texCoord` index other than `0` the `FLAG_AO_ON_UV2` should be enabled. This allows using the second set of UV coordinates for occlusion textures.