### PR TITLE
GDScript call stack as reverse linked list with fixed coroutines

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -661,7 +661,6 @@
 		</member>
 		<member name="debug/settings/gdscript/always_track_call_stacks" type="bool" setter="" getter="" default="false">
 			Whether GDScript call stacks will be tracked in release builds, thus allowing [method Engine.capture_script_backtraces] to function.
-			Enabling this comes at the cost of roughly 40 KiB for every thread that runs any GDScript code.
 			[b]Note:[/b] This setting has no effect on editor builds or debug builds, where GDScript call stacks are tracked regardless.
 		</member>
 		<member name="debug/settings/gdscript/always_track_local_variables" type="bool" setter="" getter="" default="false">

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2329,8 +2329,6 @@ void GDScriptLanguage::finish() {
 	}
 	finishing = true;
 
-	_call_stack.free();
-
 	// Clear the cache before parsing the script_list
 	GDScriptCache::clear();
 
@@ -2922,7 +2920,19 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 	return c->identifier != nullptr ? String(c->identifier->name) : String();
 }
 
-thread_local GDScriptLanguage::CallStack GDScriptLanguage::_call_stack;
+thread_local GDScriptLanguage::CallLevel *GDScriptLanguage::_call_stack = nullptr;
+thread_local uint32_t GDScriptLanguage::_call_stack_size = 0;
+
+GDScriptLanguage::CallLevel *GDScriptLanguage::_get_stack_level(uint32_t p_level) {
+	ERR_FAIL_UNSIGNED_INDEX_V(p_level, _call_stack_size, nullptr);
+	CallLevel *level = _call_stack; // Start from top
+	uint32_t level_index = 0;
+	while (p_level > level_index) {
+		level_index++;
+		level = level->prev;
+	}
+	return level;
+}
 
 GDScriptLanguage::GDScriptLanguage() {
 	ERR_FAIL_COND(singleton);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -437,30 +437,21 @@ class GDScriptLanguage : public ScriptLanguage {
 		GDScriptInstance *instance = nullptr;
 		int *ip = nullptr;
 		int *line = nullptr;
+		CallLevel *prev = nullptr; // Reverse linked list (stack).
 	};
 
 	static thread_local int _debug_parse_err_line;
 	static thread_local String _debug_parse_err_file;
 	static thread_local String _debug_error;
-	struct CallStack {
-		CallLevel *levels = nullptr;
-		int stack_pos = 0;
 
-		void free() {
-			if (levels) {
-				memdelete_arr(levels);
-				levels = nullptr;
-			}
-		}
-		~CallStack() {
-			free();
-		}
-	};
+	static thread_local CallLevel *_call_stack;
+	static thread_local uint32_t _call_stack_size;
+	uint32_t _debug_max_call_stack = 0;
 
-	static thread_local CallStack _call_stack;
-	int _debug_max_call_stack = 0;
 	bool track_call_stack = false;
 	bool track_locals = false;
+
+	static CallLevel *_get_stack_level(uint32_t p_level);
 
 	void _add_global(const StringName &p_name, const Variant &p_value);
 	void _remove_global(const StringName &p_name);
@@ -492,13 +483,9 @@ public:
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);
 
-	_FORCE_INLINE_ void enter_function(GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
+	_FORCE_INLINE_ void enter_function(CallLevel *call_level, GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
 		if (!track_call_stack) {
 			return;
-		}
-
-		if (unlikely(_call_stack.levels == nullptr)) {
-			_call_stack.levels = memnew_arr(CallLevel, _debug_max_call_stack + 1);
 		}
 
 #ifdef DEBUG_ENABLED
@@ -508,7 +495,7 @@ public:
 		}
 #endif
 
-		if (unlikely(_call_stack.stack_pos >= _debug_max_call_stack)) {
+		if (unlikely(_call_stack_size >= _debug_max_call_stack)) {
 			_debug_error = vformat("Stack overflow (stack size: %s). Check for infinite recursion in your script.", _debug_max_call_stack);
 
 #ifdef DEBUG_ENABLED
@@ -520,13 +507,14 @@ public:
 			return;
 		}
 
-		CallLevel &call_level = _call_stack.levels[_call_stack.stack_pos];
-		call_level.stack = p_stack;
-		call_level.instance = p_instance;
-		call_level.function = p_function;
-		call_level.ip = p_ip;
-		call_level.line = p_line;
-		_call_stack.stack_pos++;
+		call_level->prev = _call_stack;
+		_call_stack = call_level;
+		call_level->stack = p_stack;
+		call_level->instance = p_instance;
+		call_level->function = p_function;
+		call_level->ip = p_ip;
+		call_level->line = p_line;
+		_call_stack_size++;
 	}
 
 	_FORCE_INLINE_ void exit_function() {
@@ -536,35 +524,42 @@ public:
 
 #ifdef DEBUG_ENABLED
 		ScriptDebugger *script_debugger = EngineDebugger::get_script_debugger();
-		if (script_debugger != nullptr && script_debugger->get_lines_left() > 0 && script_debugger->get_depth() >= 0) {
+		if (script_debugger && script_debugger->get_lines_left() > 0 && script_debugger->get_depth() >= 0) {
 			script_debugger->set_depth(script_debugger->get_depth() - 1);
 		}
 #endif
 
-		if (unlikely(_call_stack.stack_pos == 0)) {
-			_debug_error = "Stack Underflow (Engine Bug)";
-
+		if (unlikely(_call_stack_size == 0)) {
 #ifdef DEBUG_ENABLED
-			if (script_debugger != nullptr) {
+			if (script_debugger) {
+				_debug_error = "Stack Underflow (Engine Bug)";
 				script_debugger->debug(this);
+			} else {
+				ERR_PRINT("Stack underflow! (Engine Bug)");
 			}
+#else // !DEBUG_ENABLED
+			ERR_PRINT("Stack underflow! (Engine Bug)");
 #endif
-
 			return;
 		}
 
-		_call_stack.stack_pos--;
+		_call_stack_size--;
+		_call_stack = _call_stack->prev;
 	}
 
 	virtual Vector<StackInfo> debug_get_current_stack_info() override {
 		Vector<StackInfo> csi;
-		csi.resize(_call_stack.stack_pos);
-		for (int i = 0; i < _call_stack.stack_pos; i++) {
-			csi.write[_call_stack.stack_pos - i - 1].line = _call_stack.levels[i].line ? *_call_stack.levels[i].line : 0;
-			if (_call_stack.levels[i].function) {
-				csi.write[_call_stack.stack_pos - i - 1].func = _call_stack.levels[i].function->get_name();
-				csi.write[_call_stack.stack_pos - i - 1].file = _call_stack.levels[i].function->get_script()->get_script_path();
+		csi.resize(_call_stack_size);
+		CallLevel *cl = _call_stack;
+		uint32_t idx = 0;
+		while (cl) {
+			csi.write[idx].line = *cl->line;
+			if (cl->function) {
+				csi.write[idx].func = cl->function->get_name();
+				csi.write[idx].file = cl->function->get_script()->get_script_path();
 			}
+			idx++;
+			cl = cl->prev;
 		}
 		return csi;
 	}

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -223,6 +223,7 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 		GDScriptFunctionState *gdfs = Object::cast_to<GDScriptFunctionState>(ret);
 		if (gdfs && gdfs->function == function) {
 			completed = false;
+			// Keep the first state alive via reference.
 			gdfs->first_state = first_state.is_valid() ? first_state : Ref<GDScriptFunctionState>(this);
 		}
 	}
@@ -231,14 +232,6 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 	state.result = Variant();
 
 	if (completed) {
-		if (first_state.is_valid()) {
-			first_state->emit_signal(SNAME("completed"), ret);
-		} else {
-			emit_signal(SNAME("completed"), ret);
-		}
-
-		GDScriptLanguage::get_singleton()->exit_function();
-
 		_clear_stack();
 	}
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -575,6 +575,7 @@ public:
 	static constexpr int MAX_CALL_DEPTH = 2048; // Limit to try to avoid crash because of a stack overflow.
 
 	struct CallState {
+		Signal completed;
 		GDScript *script = nullptr;
 		GDScriptInstance *instance = nullptr;
 #ifdef DEBUG_ENABLED


### PR DESCRIPTION
* GDScript call stack as reverse linked list with issues fixed (originally proposed by @reduz in GH-91006).
* Fix coroutine issues with call stack by resuming async call chain inside `GDScriptFunction::call()`.
* Fix GH-106489.
* Supersedes #106758.

Note: The issue with the original implementation was that it was crashing in coroutine tests -- it's resolved here.

Merging this will help [Sentry SDK](https://github.com/getsentry/sentry-godot) to display accurate stack traces to users.

## Coroutine issue explanation

### Why it happens

1. Function is entered, awaited, and therefore exited (we're not interested in details at this point).
2. Later, the function is resumed with a function-state object (now we're interested in details).
3. Inside `call()`: `line` variable is local, and `enter_function()` is passed a reference to this variable.
4. `enter_function()` initializes `CallLevel` with a pointer to the `line` variable (which is scoped to `call()`).
5. The `line` variable is continuously updated during GDScript function execution using OPCODE_LINE operation. 
6. The GDScript function execution ends, `call()` is exited, and `line` is popped off the stack, but the `CallLevel` instance still lives on due to specifics of the resumed function execution (`exit_function()` isn't called yet).
7. The next function-state object is resumed via signal, and steps 2–6 repeat until no function-state objects remain in the resume chain.
8. Resumed functions finally exit, but the `CallLevel` frames overstayed the lifetime of their `line` variables.

**Conclusion:** Because `CallLevel` in GDScript call stack outlives `call()`'s scope for resumed coroutines, `CallLevel*` and `int *line` pointers can sometimes point to heaven-knows-what. 

**Note:** This PR ensures that function-state execution remains within the `call()` scope, and doesn't cause issues with `CallLevel` being freed before it's removed from the GDScript call stack.

### Explaining on example

Consider this code:
```gdscript
func _ready() -> void:
	await f1()
	for b in Engine.capture_script_backtraces(): print(b)

func f1():
	print("starting f1")
	await f2()
	print("finishing f1")

func f2():
	print("starting f2")
	await f3()
	print("finishing f2")

func f3():
	print("starting f3")
	await get_tree().process_frame
	print("finishing f3")

```

Output:
> Note: Lines starting with "debug: " are print_line() statements I placed in the native code.
```
debug: call( @implicit_new ): entering
debug: enter_function( @implicit_new )    [ call_level.line: 0 ]
debug: exit_function( @implicit_new )    [ call_level.line: 0 ]
debug: call( @implicit_new ): exiting
debug: call( _ready ): entering
debug: enter_function( _ready )    [ call_level.line: 4 ]
debug: call( f1 ): entering
debug: enter_function( f1 )    [ call_level.line: 9 ]
starting f1
debug: call( f2 ): entering
debug: enter_function( f2 )    [ call_level.line: 15 ]
starting f2
debug: call( f3 ): entering
debug: enter_function( f3 )    [ call_level.line: 21 ]
starting f3
debug: exit_function( f3 )    [ call_level.line: 23 ]
debug: call( f3 ): exiting
debug: exit_function( f2 )    [ call_level.line: 17 ]
debug: call( f2 ): exiting
debug: exit_function( f1 )    [ call_level.line: 11 ]
debug: call( f1 ): exiting
debug: exit_function( _ready )    [ call_level.line: 5 ]
debug: call( _ready ): exiting
debug: call( f3 ): entering
debug: enter_function( f3 )    [ call_level.line: 23 ]
finishing f3
debug: call( f3 ): exiting
debug: call( f2 ): entering
debug: enter_function( f2 )    [ call_level.line: 17 ]
finishing f2
debug: call( f2 ): exiting
debug: call( f1 ): entering
debug: enter_function( f1 )    [ call_level.line: 11 ]
finishing f1
debug: call( f1 ): exiting
debug: call( _ready ): entering
debug: enter_function( _ready )    [ call_level.line: 5 ]
GDScript backtrace (most recent call first):
    [0] _ready (res://main.gd:6)
    [1] f1 (res://main.gd:32765)
    [2] f2 (res://main.gd:32765)
    [3] f3 (res://main.gd:32765)
debug: call( _ready ): exiting
debug: exit_function( _ready )    [ call_level.line: 6 ]
debug: exit_function( f1 )    [ call_level.line: 32765 ]
debug: exit_function( f2 )    [ call_level.line: 32765 ]
debug: exit_function( f3 )    [ call_level.line: 32765 ]
```
Notice that the backtrace reports crazy line numbers, and how `call(f1)` already exited, but the associated CallLevel frame lingers slightly longer in the end (`exit_function(f1)`). This only happens for resumed functions.
