### PR TITLE
TileSet: Fix potential crash updating stale atlas source editor toolbar

### DIFF
--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -894,10 +894,9 @@ void TileSetAtlasSourceEditor::_update_current_tile_data_editor() {
 
 	// Get the correct editor for the TileData's property.
 	if (current_tile_data_editor) {
-		current_tile_data_editor_toolbar = current_tile_data_editor->get_toolbar();
 		current_property = property;
 		current_tile_data_editor->set_visible(tools_button_group->get_pressed_button() == tool_paint_button);
-		current_tile_data_editor_toolbar->set_visible(tools_button_group->get_pressed_button() == tool_paint_button);
+		current_tile_data_editor->get_toolbar()->set_visible(tools_button_group->get_pressed_button() == tool_paint_button);
 	}
 }
 
@@ -1031,6 +1030,10 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 
 void TileSetAtlasSourceEditor::_update_toolbar() {
 	// Show the tools and settings.
+	Control *current_tile_data_editor_toolbar = nullptr;
+	if (current_tile_data_editor) {
+		current_tile_data_editor_toolbar = current_tile_data_editor->get_toolbar();
+	}
 	if (tools_button_group->get_pressed_button() == tool_setup_atlas_source_button) {
 		if (current_tile_data_editor_toolbar) {
 			current_tile_data_editor_toolbar->hide();

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.h
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.h
@@ -142,7 +142,6 @@ private:
 
 	// -- Tile data editors --
 	String current_property;
-	Control *current_tile_data_editor_toolbar = nullptr;
 	HashMap<String, TileDataEditor *> tile_data_editors;
 	TileDataEditor *current_tile_data_editor = nullptr;
 	void _tile_data_editors_tree_selected();


### PR DESCRIPTION
I haven't tried to reproduce the issue myself, but based on the stacktrace this should fix https://bugzilla.redhat.com/show_bug.cgi?id=2364979

The pointer would be stale and potentially pointing at freed instances (which don't evaluate as `nullptr`) and thus crash.
Caching this here doesn't seem critical so it's simpler not to. Otherwise this could use ObjectID instead of a node pointer.

We discussed this on RC a few weeks ago: https://chat.godotengine.org/channel/2d?msg=tEqxZ2NHsYckW3tSQ