### PR TITLE
Android Editor: Disable `nomedia` file creation for Android 11 (api level 30)

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1069,15 +1069,19 @@ void EditorFileSystem::scan() {
 	if (first_scan) {
 		_first_scan_filesystem();
 #ifdef ANDROID_ENABLED
-		const String nomedia_file_path = ProjectSettings::get_singleton()->get_resource_path().path_join(".nomedia");
-		if (!FileAccess::exists(nomedia_file_path)) {
-			// Create a .nomedia file to hide assets from media apps on Android.
-			Ref<FileAccess> f = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
-			if (f.is_null()) {
-				// .nomedia isn't so critical.
-				ERR_PRINT("Couldn't create .nomedia in project path.");
-			} else {
-				f->close();
+		// Android 11 has some issues with nomedia files, so it's disabled there. See GH-106479 and GH-105399 for details.
+		String sdk_version = OS::get_singleton()->get_version().get_slicec('.', 0);
+		if (sdk_version != "30") {
+			const String nomedia_file_path = ProjectSettings::get_singleton()->get_resource_path().path_join(".nomedia");
+			if (!FileAccess::exists(nomedia_file_path)) {
+				// Create a .nomedia file to hide assets from media apps on Android.
+				Ref<FileAccess> f = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
+				if (f.is_null()) {
+					// .nomedia isn't so critical.
+					ERR_PRINT("Couldn't create .nomedia in project path.");
+				} else {
+					f->close();
+				}
 			}
 		}
 #endif

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -739,14 +739,18 @@ void ProjectDialog::ok_pressed() {
 	hide();
 	if (mode == MODE_NEW || mode == MODE_IMPORT || mode == MODE_INSTALL) {
 #ifdef ANDROID_ENABLED
-		// Create a .nomedia file to hide assets from media apps on Android.
-		const String nomedia_file_path = path.path_join(".nomedia");
-		Ref<FileAccess> f2 = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
-		if (f2.is_null()) {
-			// .nomedia isn't so critical.
-			ERR_PRINT("Couldn't create .nomedia in project path.");
-		} else {
-			f2->close();
+		// Android 11 has some issues with nomedia files, so it's disabled there. See GH-106479, GH-105399 for details.
+		String sdk_version = OS::get_singleton()->get_version().get_slicec('.', 0);
+		if (sdk_version != "30") {
+			// Create a .nomedia file to hide assets from media apps on Android.
+			const String nomedia_file_path = path.path_join(".nomedia");
+			Ref<FileAccess> f2 = FileAccess::open(nomedia_file_path, FileAccess::WRITE);
+			if (f2.is_null()) {
+				// .nomedia isn't so critical.
+				ERR_PRINT("Couldn't create .nomedia in project path.");
+			} else {
+				f2->close();
+			}
 		}
 #endif
 		emit_signal(SNAME("project_created"), path, edit_check_box->is_pressed());

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -315,7 +315,7 @@ String OS_Android::get_version() const {
 	}
 
 	// Handles stock Android.
-	String sdk_version = get_system_property("ro.build.version.sdk_int");
+	String sdk_version = get_system_property("ro.build.version.sdk");
 	String build = get_system_property("ro.build.version.incremental");
 	if (!sdk_version.is_empty()) {
 		if (!build.is_empty()) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106479
Fixes https://github.com/godotengine/godot/issues/105399

Also fixes `OS.get_version()` on Android. It seems it was broken from the start and probably never worked.

