### PR TITLE
Workaround X11 crash issue

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -4711,9 +4711,6 @@ void DisplayServerX11::process_events() {
 		MutexLock mutex_lock(events_mutex);
 		events = polled_events;
 		polled_events.clear();
-
-		// Check for more pending events to avoid an extra frame delay.
-		_check_pending_events(events);
 	}
 
 	for (uint32_t event_index = 0; event_index < events.size(); ++event_index) {


### PR DESCRIPTION
As discovered in #75308, checking for pending events during the process_events function can cause a race condition in libx11, leading to the 'poll_for_event: Assertion `!xcb_xlib_threads_sequence_lost' failed' crash.

This PR removes the second pending events check. Unfortunately, this essentially reverts #54326, but I would rather have occasional 1 frame latency than a game that crashes.