### PR TITLE
[Feature Proposal] Implement a zero copy way to construct `StringName`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1076,7 +1076,11 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 		Variant *V = &metadata.insert(p_name, p_value)->value;
 
 		const String &sname = p_name;
-		metadata_properties["metadata/" + sname] = V;
+		StringName property_key = StringName::search("metadata/", sname);
+		if (property_key.is_empty()) {
+			property_key = "metadata/" + sname;
+		}
+		metadata_properties[property_key] = V;
 		if (!sname.begins_with("_")) {
 			notify_property_list_changed();
 		}

--- a/core/string/distributed_string_view.h
+++ b/core/string/distributed_string_view.h
@@ -1,0 +1,94 @@
+/**************************************************************************/
+/*  distributed_string_view.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/string/ustring.h"
+#include "core/templates/span.h"
+
+class DistributedStringView {
+	template <size_t N>
+	static constexpr Span<char> to_span(const char (&p_cstr)[N]) { return Span(p_cstr); }
+	template <size_t N>
+	static constexpr Span<wchar_t> to_span(const wchar_t (&p_cstr)[N]) { return Span(p_cstr); }
+	static Span<char32_t> to_span(const String &p_str) { return p_str.span(); }
+	template <typename T>
+	static constexpr Span<T> to_span(const Span<T> &p_span) { return p_span; }
+
+	template <typename T>
+	static constexpr uint32_t _increment_hash(uint32_t hashv, const Span<T> &part) {
+		using unsigned_char = std::conditional_t<sizeof(T) == 1, uint8_t,
+				std::conditional_t<sizeof(T) == 2, uint16_t, uint32_t>>;
+
+		for (const T &c : part) {
+			hashv = ((hashv << 5) + hashv) + static_cast<unsigned_char>(c);
+		}
+		return hashv;
+	}
+
+	template <typename T>
+	static constexpr bool _increment_equal(const Span<char32_t> &ref, const Span<T> &part) {
+		if (ref.size() < part.size()) {
+			return false;
+		}
+		for (uint64_t i = 0; i < part.size(); ++i) {
+			if (ref[i] != static_cast<char32_t>(part[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+public:
+	template <typename... Parts>
+	static constexpr uint32_t size(Parts... parts) {
+		uint32_t total_size = 0;
+		((total_size += to_span(parts).size()), ...);
+		return total_size;
+	}
+	template <typename... Parts>
+	static constexpr uint32_t hash(Parts... parts) {
+		uint32_t hashv = 5381;
+		((hashv = _increment_hash(hashv, to_span(parts))), ...);
+		return hashv;
+	}
+
+	template <typename... Parts>
+	static constexpr bool equal(const String &ref, Parts... parts) {
+		Span<char32_t> ref_span = ref.span();
+		if (ref_span.size() != size(parts...)) {
+			return false;
+		}
+		bool result = true;
+		uint32_t index = 0;
+		((result = result && _increment_equal(Span(ref_span.ptr() + index, ref_span.size() - index), to_span(parts)) && (index += to_span(parts).size())), ...);
+		return result;
+	}
+};

--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -407,6 +407,27 @@ StringName StringName::search(const String &p_name) {
 	return StringName(); //does not exist
 }
 
+StringName::_Data *StringName::get_data_by_hash(const uint32_t p_hash) {
+	const uint32_t idx = p_hash & Table::TABLE_MASK;
+
+	MutexLock lock(Table::mutex);
+	_Data *_data = Table::table[idx];
+	return _data;
+}
+
+StringName StringName::check_data(_Data *p_data) {
+	if (p_data && p_data->refcount.ref()) {
+#ifdef DEBUG_ENABLED
+		if (unlikely(debug_stringname)) {
+			p_data->debug_references++;
+		}
+#endif
+		return StringName(p_data);
+	}
+
+	return StringName(); //does not exist
+}
+
 bool operator==(const String &p_name, const StringName &p_string_name) {
 	return p_string_name.operator==(p_name);
 }


### PR DESCRIPTION
While benchmarking MRP of #78645 I found a small hotspot in `Object::set_meta()` due to string concatenation. I recall that it is a common pattern to convert `StringName` to `String`, operate it (add prefix/suffix or concat two of them) then convert it back, because `StringName` itself is immutable. The bad thing is this cause memory allocation and copy, which could be avoided if target `StringName` already exists.

I implement `StringName::join()` which takes a bunch of `Span`s, checks if the concatenation result already exists, and reuse the `_Data` block when possible. If the result is a new string simply construct it like before. 

I test with mrp from #78645, it shows an about 45% speed up in `Object::set_meta()` (time percent from 10% to 6.5%)

Master:
![master](https://github.com/user-attachments/assets/216ddaaf-efd2-46ac-993a-60e87488572a)

This PR:
![pr](https://github.com/user-attachments/assets/9a868058-3f40-4e98-ba7e-68df18cab490)

