### PR TITLE
GLTF: Don't export AnimationPlayer nodes as glTF nodes

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5962,6 +5962,9 @@ void GLTFDocument::_convert_scene_node(Ref<GLTFState> p_state, Node *p_current, 
 	} else if (Object::cast_to<AnimationPlayer>(p_current)) {
 		AnimationPlayer *animation_player = Object::cast_to<AnimationPlayer>(p_current);
 		p_state->animation_players.push_back(animation_player);
+		if (animation_player->get_child_count() == 0) {
+			gltf_node->set_parent(-2); // Don't export AnimationPlayer nodes as glTF nodes (unless they have children).
+		}
 	}
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());


### PR DESCRIPTION
When exporting glTF files with animations in them, it will generate a useless glTF node corresponding to that Godot node.

![Screenshot 2025-05-25 at 11 52 00 AM_animplayer](https://github.com/user-attachments/assets/1de6000a-243a-40fe-9c15-892bd861c23f)

This PR fixes that, making it not export the `AnimationPlayer` node, as long as it has no children. Edge case note: If, for some strange reason, that behavior was still desired, it is possible to override this in a GLTFDocumentExtension.
