### PR TITLE
Fix Android editor UI

### DIFF
--- a/platform/android/java/editor/src/main/res/values/themes.xml
+++ b/platform/android/java/editor/src/main/res/values/themes.xml
@@ -3,6 +3,7 @@
 	<style name="GodotEditorTheme" parent="@android:style/Theme.DeviceDefault.NoActionBar.Fullscreen">
 		<item name="android:statusBarColor">@android:color/transparent</item>
 		<item name ="android:navigationBarColor">@android:color/transparent</item>
+		<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>
 	</style>
 
 	<style name="GodotEditorSplashScreenTheme" parent="Theme.SplashScreen.IconBackground">


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/106152 bumped the target SDK to 35 which caused an issue on Android 15 devices. The editor is now rendering behind the navigation bar and display cutouts, even when fullscreen mode is disabled.

This issue is because Android 15 [enforced edge-to-edge](https://developer.android.com/about/versions/15/behavior-changes-15#edge-to-edge) mode for all apps. As a result, we would need to update our editor layout to properly support this mode. However, for now, we’re opting out of this enforcement as a temporary workaround. This solution will need to be revisited once Android 16 is released which likely would remove this opt-out attribute.

Before:

![before](https://github.com/user-attachments/assets/40211d46-943c-484e-adcb-c1f158fc7cc0)

After:

![after](https://github.com/user-attachments/assets/84413fff-adf5-4a1d-8f58-8e01d12692be)

Note: This enforcement also impacts all projects built with target SDK 35. Developers can either update their project layouts for edge-to-edge mode or temporarily opt out by setting `<item name="android:windowOptOutEdgeToEdgeEnforcement">true</item>` using the new Custom Theme Attributes export option.