### PR TITLE
Add missing `TRANSLATION_CHANGED` notifications.

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -134,6 +134,7 @@ void MenuButton::_notification(int p_what) {
 			DisplayServer::get_singleton()->accessibility_update_set_popup_type(ae, DisplayServer::AccessibilityPopupType::POPUP_MENU);
 		} break;
 
+		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
 		} break;

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -387,6 +387,7 @@ void PopupPanel::_notification(int p_what) {
 #endif
 		} break;
 
+		case Control::NOTIFICATION_TRANSLATION_CHANGED:
 		case Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			if (is_visible()) {
 				_update_shadow_offsets();


### PR DESCRIPTION
Adds few missing notifications to ensure layout changes applied correctly when translation changed (`NOTIFICATION_LAYOUT_DIRECTION_CHANGED` is emitted only when layout direction is changed via `set_layout_direction` method).