### PR TITLE
Fix MenuBar min size not updating after child rename

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -519,13 +519,14 @@ void MenuBar::_refresh_menu_names() {
 	bool is_global = !global_menu_tag.is_empty();
 	RID main_menu = is_global ? nmenu->get_system_menu(NativeMenu::MAIN_MENU_ID) : RID();
 
+	bool dirty = false;
 	Vector<PopupMenu *> popups = _get_popups();
 	for (int i = 0; i < popups.size(); i++) {
 		String menu_name = popups[i]->get_title().is_empty() ? String(popups[i]->get_name()) : popups[i]->get_title();
 		if (!popups[i]->has_meta("_menu_name") && menu_name != get_menu_title(i)) {
 			menu_cache.write[i].name = menu_name;
 			shape(menu_cache.write[i]);
-			queue_redraw();
+			dirty = true;
 			if (is_global && menu_cache[i].submenu_rid.is_valid()) {
 				int item_idx = nmenu->find_item_index_with_submenu(main_menu, menu_cache[i].submenu_rid);
 				if (item_idx >= 0) {
@@ -533,6 +534,11 @@ void MenuBar::_refresh_menu_names() {
 				}
 			}
 		}
+	}
+
+	if (dirty && !is_global) {
+		queue_redraw();
+		update_minimum_size();
 	}
 }
 


### PR DESCRIPTION
To reproduce the issue:

1. Create a `MenuBar`.
2. Add a `PopupMenu` child for it.
3. Rename the `PopupMenu` node so the button text is shorter on the menu bar.
4. Try to resize the menu bar: you can't make it narrower than its original width.
5. Switch to another scene and then back: now you can shrink the menu bar.