### PR TITLE
Use temporary for quaternion editing

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1030,6 +1030,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property, &is_valid_revert);
 			ERR_FAIL_COND(!is_valid_revert);
 			emit_changed(_get_revert_property(), revert_value);
+			_refresh_edit_from_internal();
 			update_property();
 		}
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -157,6 +157,7 @@ protected:
 
 	virtual Variant _get_cache_value(const StringName &p_prop, bool &r_valid) const;
 	virtual StringName _get_revert_property() const;
+	virtual void _refresh_edit_from_internal() {}
 
 	void _update_property_bg();
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2112,14 +2112,26 @@ void EditorPropertyQuaternion::_custom_value_changed(double val) {
 	_value_changed(-1, "");
 }
 
-void EditorPropertyQuaternion::_value_changed(double val, const String &p_name) {
-	Quaternion p;
-	p.x = spin[0]->get_value();
-	p.y = spin[1]->get_value();
-	p.z = spin[2]->get_value();
-	p.w = spin[3]->get_value();
+void EditorPropertyQuaternion::_refresh_edit_from_internal() {
+	edit_quaternion = get_edited_property_value();
+	refresh_button->hide();
+	update_property();
+}
 
+void EditorPropertyQuaternion::_refresh_internal_quaternion_from_edit(const String &p_name) {
+	Quaternion p = edit_quaternion;
+	p.normalize();
 	emit_changed(get_edited_property(), p, p_name);
+}
+
+void EditorPropertyQuaternion::_value_changed(double val, const String &p_name) {
+	edit_quaternion.x = spin[0]->get_value();
+	edit_quaternion.y = spin[1]->get_value();
+	edit_quaternion.z = spin[2]->get_value();
+	edit_quaternion.w = spin[3]->get_value();
+
+	_refresh_internal_quaternion_from_edit(p_name);
+	refresh_button->show();
 }
 
 bool EditorPropertyQuaternion::is_grabbing_euler() {
@@ -2131,7 +2143,7 @@ bool EditorPropertyQuaternion::is_grabbing_euler() {
 }
 
 void EditorPropertyQuaternion::update_property() {
-	Quaternion val = get_edited_property_value();
+	Quaternion val = edit_quaternion;
 	spin[0]->set_value_no_signal(val.x);
 	spin[1]->set_value_no_signal(val.y);
 	spin[2]->set_value_no_signal(val.z);
@@ -2153,6 +2165,9 @@ void EditorPropertyQuaternion::_warning_pressed() {
 
 void EditorPropertyQuaternion::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			_refresh_edit_from_internal();
+		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 4; i++) {
@@ -2232,6 +2247,12 @@ EditorPropertyQuaternion::EditorPropertyQuaternion() {
 			spin[i]->set_h_size_flags(SIZE_EXPAND_FILL);
 		}
 	}
+
+	refresh_button = memnew(Button);
+	refresh_button->set_text("Refresh");
+	default_layout->add_child(refresh_button);
+	refresh_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyQuaternion::_refresh_edit_from_internal));
+	refresh_button->hide();
 
 	warning = memnew(Button);
 	warning->set_text(TTR("Temporary Euler may be changed implicitly!"));

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -512,8 +512,10 @@ class EditorPropertyQuaternion : public EditorProperty {
 	VBoxContainer *edit_custom_bc = nullptr;
 	EditorSpinSlider *euler[3];
 	Button *edit_button = nullptr;
+	Button *refresh_button = nullptr;
 
 	Vector3 edit_euler;
+	Quaternion edit_quaternion;
 
 	void _value_changed(double p_val, const String &p_name);
 	void _edit_custom_value();
@@ -522,7 +524,10 @@ class EditorPropertyQuaternion : public EditorProperty {
 
 	bool is_grabbing_euler();
 
+	void _refresh_internal_quaternion_from_edit(const String &p_name);
+
 protected:
+	virtual void _refresh_edit_from_internal() override;
 	virtual void _set_read_only(bool p_read_only) override;
 	void _notification(int p_what);
 


### PR DESCRIPTION
This is a quick draft PR to illustrate what I was referring to with temporary quaternions in #106352 .
Just to stimulate discussion really.

Related to #106352
Related to #106335

https://github.com/user-attachments/assets/f19ca177-6036-4d05-a82f-e44f29a24699

## Notes
* Ideally someone else can take this over if wanted to go with this kind of approach, as I'm not really an editor specialist. It would probably need a lot of tweaking.
* Button would need an icon and maybe be better going next to the "revert" button.
* Could be made more generic (as also useful for normalized `Vector3` etc).
* Could maybe handle the refresh from internal in the update call but that might need a bool, so might be compat breaking.
* Completely untested. :grin: 

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
