### PR TITLE
VideoStreamPlayer: Fix sync with the scene tree

### DIFF
--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -63,9 +63,9 @@ class VideoStreamPlayer : public Control {
 	bool paused_from_tree = false;
 	bool autoplay = false;
 	float volume = 1.0;
-	double last_audio_time = 0.0;
 	bool expand = false;
 	bool loop = false;
+	bool first_frame = false;
 	int buffering_ms = 500;
 	int audio_track = 0;
 	int bus_index = 0;

--- a/servers/audio/audio_rb_resampler.cpp
+++ b/servers/audio/audio_rb_resampler.cpp
@@ -120,7 +120,7 @@ bool AudioRBResampler::mix(AudioFrame *p_dest, int p_frames) {
 		return false;
 	}
 
-	int32_t increment = (src_mix_rate * MIX_FRAC_LEN) / target_mix_rate;
+	int32_t increment = (src_mix_rate * MIX_FRAC_LEN * playback_speed) / target_mix_rate;
 	int read_space = get_reader_space();
 	int target_todo = MIN(get_num_of_ready_frames(), p_frames);
 
@@ -226,6 +226,14 @@ void AudioRBResampler::clear() {
 	rb_read_pos.set(0);
 	rb_write_pos.set(0);
 	read_buf = nullptr;
+}
+
+void AudioRBResampler::set_playback_speed(double p_playback_speed) {
+	playback_speed = p_playback_speed;
+}
+
+double AudioRBResampler::get_playback_speed() const {
+	return playback_speed;
 }
 
 AudioRBResampler::AudioRBResampler() {

--- a/servers/audio/audio_rb_resampler.h
+++ b/servers/audio/audio_rb_resampler.h
@@ -42,6 +42,7 @@ struct AudioRBResampler {
 	uint32_t channels;
 	uint32_t src_mix_rate;
 	uint32_t target_mix_rate;
+	double playback_speed = 1.0;
 
 	SafeNumeric<int> rb_read_pos;
 	SafeNumeric<int> rb_write_pos;
@@ -176,6 +177,8 @@ public:
 	void clear();
 	bool mix(AudioFrame *p_dest, int p_frames);
 	int get_num_of_ready_frames();
+	void set_playback_speed(double p_playback_speed);
+	double get_playback_speed() const;
 
 	AudioRBResampler();
 	~AudioRBResampler();


### PR DESCRIPTION
Fixes #69965.

Videos will play correctly when in movie maker mode and when `time_scale` != 1.0.

When `time_scale` != 1.0, audio will play slowed down or sped up to keep sync with the image.

I thought this was going to be harder but it works very well in my tests. More testing would be welcomed.