### PR TITLE
D3D12: Fix inconsistent value for `DCOMP_ENABLED` in platform code

### DIFF
--- a/drivers/d3d12/SCsub
+++ b/drivers/d3d12/SCsub
@@ -45,6 +45,7 @@ if env["use_pix"]:
 
 if "dcomp" in env.get("supported", []):
     env_d3d12_rdd.Append(CPPDEFINES=["DCOMP_ENABLED"])
+    env.Append(CPPDEFINES=["DCOMP_ENABLED"])  # Used in header included in platform.
 
 
 # Mesa (SPIR-V to DXIL functionality).


### PR DESCRIPTION
- Follow-up to #106400.
- Fixes #106826.

CC @lrahmann @zhangjiangen11