### PR TITLE
Reorganize scroll and zoom elements in the audio import dialog

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -184,7 +184,6 @@ void AudioStreamImportSettingsDialog::_preview_zoom_in() {
 		return;
 	}
 	float page_size = zoom_bar->get_page();
-	zoom_spacer->hide();
 	zoom_bar->set_page(page_size * 0.5);
 	zoom_bar->set_value(zoom_bar->get_value() + page_size * 0.25);
 	zoom_bar->show();
@@ -202,7 +201,6 @@ void AudioStreamImportSettingsDialog::_preview_zoom_out() {
 	zoom_bar->set_value(zoom_bar->get_value() - page_size * 0.5);
 	if (zoom_bar->get_value() == 0) {
 		zoom_bar->hide();
-		zoom_spacer->show();
 	}
 
 	_preview->queue_redraw();
@@ -217,7 +215,6 @@ void AudioStreamImportSettingsDialog::_preview_zoom_reset() {
 	zoom_bar->set_page(zoom_bar->get_max());
 	zoom_bar->set_value(0);
 	zoom_bar->hide();
-	zoom_spacer->show();
 
 	_preview->queue_redraw();
 	_indicator->queue_redraw();
@@ -615,30 +612,15 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	_preview->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbox->add_child(_preview);
 
-	HBoxContainer *zoom_hbox = memnew(HBoxContainer);
 	zoom_bar = memnew(HScrollBar);
 	zoom_bar->hide();
-	zoom_in = memnew(Button);
-	zoom_in->set_accessibility_name(TTRC("Zoom In"));
-	zoom_in->set_flat(true);
-	zoom_reset = memnew(Button);
-	zoom_reset->set_accessibility_name(TTRC("Reset Zoom"));
-	zoom_reset->set_flat(true);
-	zoom_out = memnew(Button);
-	zoom_out->set_accessibility_name(TTRC("Zoom Out"));
-	zoom_out->set_flat(true);
-	zoom_hbox->add_child(zoom_bar);
-	zoom_spacer = zoom_hbox->add_spacer();
+	vbox->add_child(zoom_bar);
 	zoom_bar->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	zoom_bar->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	zoom_hbox->add_child(zoom_out);
-	zoom_hbox->add_child(zoom_reset);
-	zoom_hbox->add_child(zoom_in);
-	zoom_in->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_in));
-	zoom_reset->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_reset));
-	zoom_out->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_out));
 	zoom_bar->connect(SceneStringName(value_changed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_offset_changed));
-	vbox->add_child(zoom_hbox);
+
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	hbox->add_theme_constant_override("separation", 0);
+	vbox->add_child(hbox);
 
 	_indicator = memnew(Control);
 	_indicator->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
@@ -646,10 +628,6 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 	_indicator->connect(SceneStringName(gui_input), callable_mp(this, &AudioStreamImportSettingsDialog::_on_input_indicator));
 	_indicator->connect(SceneStringName(mouse_exited), callable_mp(this, &AudioStreamImportSettingsDialog::_on_indicator_mouse_exited));
 	_preview->add_child(_indicator);
-
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	hbox->add_theme_constant_override("separation", 0);
-	vbox->add_child(hbox);
 
 	_play_button = memnew(Button);
 	_play_button->set_accessibility_name(TTRC("Play"));
@@ -671,6 +649,22 @@ AudioStreamImportSettingsDialog::AudioStreamImportSettingsDialog() {
 
 	_duration_label = memnew(Label);
 	hbox->add_child(_duration_label);
+
+	zoom_in = memnew(Button);
+	zoom_in->set_accessibility_name(TTRC("Zoom In"));
+	zoom_in->set_flat(true);
+	zoom_reset = memnew(Button);
+	zoom_reset->set_accessibility_name(TTRC("Reset Zoom"));
+	zoom_reset->set_flat(true);
+	zoom_out = memnew(Button);
+	zoom_out->set_accessibility_name(TTRC("Zoom Out"));
+	zoom_out->set_flat(true);
+	hbox->add_child(zoom_out);
+	hbox->add_child(zoom_reset);
+	hbox->add_child(zoom_in);
+	zoom_in->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_in));
+	zoom_reset->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_reset));
+	zoom_out->connect(SceneStringName(pressed), callable_mp(this, &AudioStreamImportSettingsDialog::_preview_zoom_out));
 
 	singleton = this;
 }

--- a/editor/import/audio_stream_import_settings.h
+++ b/editor/import/audio_stream_import_settings.h
@@ -35,7 +35,6 @@
 #include "scene/gui/color_rect.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/spin_box.h"
-#include "scene/resources/texture.h"
 
 class CheckBox;
 
@@ -59,7 +58,6 @@ class AudioStreamImportSettingsDialog : public ConfirmationDialog {
 	Label *_duration_label = nullptr;
 
 	HScrollBar *zoom_bar = nullptr;
-	Control *zoom_spacer = nullptr;
 	Button *zoom_in = nullptr;
 	Button *zoom_reset = nullptr;
 	Button *zoom_out = nullptr;


### PR DESCRIPTION
This is a simple change to make the scrollbar have the same size as all other scrolls in editor, as well as to cover the audio wave in its entirety.

|Before|After|
|-|-|
|![Screenshot_20250526_002214](https://github.com/user-attachments/assets/a90a6ba9-a7bb-4b79-a9c7-ac79810219b7)|![Screenshot_20250526_001207](https://github.com/user-attachments/assets/f3672441-02bc-4354-b8bc-9583ac8e44a2)|