### PR TITLE
Wayland: Center pointer on capture

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -388,7 +388,15 @@ void DisplayServerWayland::_mouse_update_mode() {
 	if (wanted_mouse_mode == DisplayServer::MOUSE_MODE_CAPTURED) {
 		WindowData *pointed_win = windows.getptr(wayland_thread.pointer_get_pointed_window_id());
 		ERR_FAIL_NULL(pointed_win);
-		wayland_thread.pointer_set_hint(pointed_win->rect.size / 2);
+
+		Point2 hint = pointed_win->rect.size / 2;
+
+		wayland_thread.pointer_set_hint(hint);
+
+		// We need to override the position or it will self-reset on the next pointer
+		// frame event.
+		wayland_thread.pointer_override_position(hint);
+		Input::get_singleton()->set_mouse_position(hint);
 	}
 
 	mouse_mode = wanted_mouse_mode;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4249,6 +4249,15 @@ void WaylandThread::pointer_set_hint(const Point2i &p_hint) {
 	}
 }
 
+void WaylandThread::pointer_override_position(const Point2i &p_pos) {
+	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+	if (!ss) {
+		return;
+	}
+
+	ss->pointer_data_buffer.position = p_pos;
+}
+
 WaylandThread::PointerConstraint WaylandThread::pointer_get_constraint() const {
 	return pointer_constraint;
 }

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -1061,6 +1061,7 @@ public:
 
 	void pointer_set_constraint(PointerConstraint p_constraint);
 	void pointer_set_hint(const Point2i &p_hint);
+	void pointer_override_position(const Point2i &p_pos);
 	PointerConstraint pointer_get_constraint() const;
 	DisplayServer::WindowID pointer_get_pointed_window_id() const;
 	DisplayServer::WindowID pointer_get_last_pointed_window_id() const;


### PR DESCRIPTION
Fixes #106656.

This behavior better emulates what the X11 backend does, from what I can tell.

This patch also adds a special WaylandThread method that literally overrides the current pointer position since a pointer frame would send an updated event with the old position.