### PR TITLE
Linux: Generate synthetic initial joystick axis events

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -1207,7 +1207,6 @@ void Input::release_pressed_events() {
 	physical_keys_pressed.clear();
 	key_label_pressed.clear();
 	joy_buttons_pressed.clear();
-	_joy_axis.clear();
 
 	for (KeyValue<StringName, Input::ActionState> &E : action_states) {
 		if (E.value.cache.pressed) {

--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -326,6 +326,12 @@ void JoypadLinux::setup_joypad_properties(Joypad &p_joypad) {
 			if (ioctl(p_joypad.fd, EVIOCGABS(i), p_joypad.abs_info[i]) < 0) {
 				memdelete(p_joypad.abs_info[i]);
 				p_joypad.abs_info[i] = nullptr;
+			} else {
+				JoypadEvent joypad_event;
+				joypad_event.type = EV_ABS;
+				joypad_event.code = i;
+				joypad_event.value = p_joypad.abs_info[i]->value;
+				p_joypad.events.push_back(joypad_event);
 			}
 		}
 	}


### PR DESCRIPTION
This ensures that the initial positions of axes are reported to the game. This is particularly useful for throttles, which will often start the game in a non-neutral position.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
