### PR TITLE
Add the ability in 3D to collision snap faces to the normal of a target node

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2520,7 +2520,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					begin_transform(TRANSFORM_SCALE, true);
 				}
 			}
-			if (ED_IS_SHORTCUT("spatial_editor/collision_reposition", p_event) && editor_selection->get_top_selected_node_list().size() == 1 && !collision_reposition) {
+			if (ED_IS_SHORTCUT("spatial_editor/collision_reposition", p_event) && editor_selection->get_top_selected_node_list().size() >= 1 && !collision_reposition) {
 				if (_edit.mode == TRANSFORM_NONE || _edit.instant) {
 					if (_edit.mode == TRANSFORM_NONE) {
 						_compute_edit(_edit.mouse_pos);
@@ -3290,8 +3290,42 @@ void Node3DEditorViewport::_notification(int p_what) {
 					}
 				} else {
 					const List<Node *> &selection = editor_selection->get_top_selected_node_list();
-					if (selection.size() == 1) {
-						selected_node = Object::cast_to<Node3D>(selection.front()->get());
+					if (selection.size() >= 1) {
+						if (selection.size() == 1) {
+							selected_node = Object::cast_to<Node3D>(selection.front()->get());
+						} else {
+							Vector3 center = Vector3();
+							int valid_nodes = 0;
+
+							for (Node *E : selection) {
+								Node3D *sp = Object::cast_to<Node3D>(E);
+								if (sp) {
+									center += sp->get_global_position();
+									valid_nodes++;
+								}
+							}
+
+							if (valid_nodes > 0) {
+								center /= valid_nodes;
+
+								Vector3 collision_pos = spatial_editor->snap_point(_get_instance_position(_edit.mouse_pos, nullptr));
+								Vector3 offset = collision_pos - center;
+
+								for (Node *E : selection) {
+									Node3D *sp = Object::cast_to<Node3D>(E);
+									if (sp) {
+										sp->set_global_position(sp->get_global_position() + offset);
+									}
+								}
+
+								if (!ruler->is_inside_tree()) {
+									double snap = EDITOR_GET("interface/inspector/default_float_step");
+									int snap_step_decimals = Math::range_step_decimals(snap);
+									set_message(TTR("Translating:") + " (" + String::num(collision_pos.x, snap_step_decimals) + ", " +
+											String::num(collision_pos.y, snap_step_decimals) + ", " + String::num(collision_pos.z, snap_step_decimals) + ")");
+								}
+							}
+						}
 					}
 				}
 
@@ -4519,12 +4553,11 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 	if (!preview_node->is_inside_tree() && !ruler->is_inside_tree()) {
 		const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 
-		Node3D *first_selected_node = Object::cast_to<Node3D>(selection.front()->get());
-
-		Array children = first_selected_node->get_children();
-
-		if (first_selected_node) {
-			_insert_rid_recursive(first_selected_node, rids);
+		for (Node *E : selection) {
+			Node3D *selected_node = Object::cast_to<Node3D>(E);
+			if (selected_node) {
+				_insert_rid_recursive(selected_node, rids);
+			}
 		}
 	}
 
@@ -4549,16 +4582,46 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 		const Vector3 bb_basis_z = bb_basis_x.cross(bb_basis_y);
 		const Basis bb_basis = Basis(bb_basis_x, bb_basis_y, bb_basis_z);
 
-		// This normal-aligned Basis allows us to create an AABB that can fit on the surface plane as snugly as possible.
-		const Transform3D bb_transform = Transform3D(bb_basis, p_node->get_transform().origin);
-		const AABB p_node_bb = _calculate_spatial_bounds(p_node, true, &bb_transform);
-		// The x-axis's alignment with the surface normal also makes it trivial to get the distance from `p_node`'s origin at (0, 0, 0) to the correct AABB face.
-		const float offset_distance = -p_node_bb.position.x;
+		if (p_node == nullptr) {
+			const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+			Vector3 center;
+			int valid_nodes = 0;
+			AABB combined_aabb;
+			bool first = true;
 
-		// `result_offset` is in global space.
-		const Vector3 result_offset = result.position + result.normal * offset_distance;
+			for (Node *E : selection) {
+				Node3D *sp = Object::cast_to<Node3D>(E);
+				if (sp) {
+					center += sp->get_global_position();
+					valid_nodes++;
 
-		return result_offset;
+					AABB node_aabb = _calculate_spatial_bounds(sp, true);
+					Transform3D node_xform = sp->get_global_transform();
+					node_aabb = node_xform.xform(node_aabb);
+
+					if (first) {
+						combined_aabb = node_aabb;
+						first = false;
+					} else {
+						combined_aabb.merge_with(node_aabb);
+					}
+				}
+			}
+
+			if (valid_nodes > 0) {
+				center /= valid_nodes;
+
+				const Transform3D bb_transform = Transform3D(bb_basis, center);
+				const AABB transformed_aabb = bb_transform.affine_inverse().xform(combined_aabb);
+				const float offset_distance = -transformed_aabb.position.x;
+				return result.position + result.normal * offset_distance;
+			}
+		} else {
+			const Transform3D bb_transform = Transform3D(bb_basis, p_node->get_transform().origin);
+			const AABB p_node_bb = _calculate_spatial_bounds(p_node, true, &bb_transform);
+			const float offset_distance = -p_node_bb.position.x;
+			return result.position + result.normal * offset_distance;
+		}
 	}
 
 	const bool is_orthogonal = camera->get_projection() == Camera3D::PROJECTION_ORTHOGONAL;

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -260,6 +260,10 @@ private:
 	bool lock_rotation;
 	bool transform_gizmo_visible = true;
 	bool collision_reposition = false;
+	bool collision_reposition_warning_shown = false;
+	Transform3D collision_reposition_original_transform;
+	bool collision_reposition_normal_applied = false;
+	int collision_reposition_alignment_axis = 1; // 0=X, 1=Y, 2=Z, 3=-X, 4=-Y, 5=-Z
 	real_t gizmo_scale;
 
 	bool freelook_active;
@@ -491,6 +495,13 @@ private:
 	void _list_select(Ref<InputEventMouseButton> b);
 	Point2 _get_warped_mouse_motion(const Ref<InputEventMouseMotion> &p_ev_mouse_motion) const;
 
+	struct CollisionResult {
+		Vector3 position;
+		Vector3 normal;
+		bool has_collision = false;
+	};
+
+	CollisionResult _get_instance_position_and_normal(const Point2 &p_pos, Node3D *p_node) const;
 	Vector3 _get_instance_position(const Point2 &p_pos, Node3D *p_node) const;
 	static AABB _calculate_spatial_bounds(const Node3D *p_parent, bool p_omit_top_level = false, const Transform3D *p_bounds_orientation = nullptr);
 
@@ -825,6 +836,7 @@ private:
 	Ref<Environment> viewport_environment;
 
 	Node3D *selected = nullptr;
+	Node3D *active_node = nullptr;
 
 	Node3DEditorViewport *freelook_viewport = nullptr;
 
@@ -992,6 +1004,7 @@ public:
 
 	VSplitContainer *get_shader_split();
 
+	Node3D *get_active_node() { return active_node; }
 	Node3D *get_single_selected_node() { return selected; }
 	bool is_current_selected_gizmo(const EditorNode3DGizmo *p_gizmo);
 	bool is_subgizmo_selected(int p_id);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Requires and includes: https://github.com/godotengine/godot/pull/106794

Related: https://github.com/godotengine/godot/pull/100415

https://github.com/godotengine/godot/pull/96740 added the ability to snap 3D nodes using collisions. This PR adds the ability to snap nodes to the normal of the target node. When multiple nodes are selected the active node (see: https://github.com/godotengine/godot/pull/102176) is designated as the reference node which all others in the selection group will snap relative to it. 

Below are the keys that allow you select or cycle through the faces.

		// - Alt+Q: Cycle through all 6 axes (+X, +Y, +Z, -X, -Y, -Z)
		// - Alt+X: Set to +X axis (or Alt+Shift+X for -X axis)
		// - Alt+Y: Set to +Y axis (or Alt+Shift+Y for -Y axis)
		// - Alt+Z: Set to +Z axis (or Alt+Shift+Z for -Z axis)

Note the added information to the text at the bottom left of the viewport.

Single Node:

https://github.com/user-attachments/assets/81537b4d-de36-4538-988b-7b5a447c014b


Multi-Nodes:

https://github.com/user-attachments/assets/e5dbcce3-d20a-4e55-bc34-21edae8b8b4c

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/12710.*