### PR TITLE
Wayland: Add missing return in selection logic

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4566,6 +4566,7 @@ void WaylandThread::selection_set_text(const String &p_text) {
 
 	if (ss->wl_data_device == nullptr) {
 		DEBUG_LOG_WAYLAND_THREAD("Couldn't set selection, seat doesn't have wl_data_device.");
+		return;
 	}
 
 	ss->selection_data = p_text.to_utf8_buffer();


### PR DESCRIPTION
Should fix #106745.
Fixup to #101779.

This slipped under the radar... until for some reason optimized builds started crashing, perhaps due to timing-related shenanigans, no idea.