### PR TITLE
Add `extra_update` option to `BoneAttachment3D` to handle update timing

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -9,42 +9,16 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_external_skeleton" qualifiers="const">
-			<return type="NodePath" />
-			<description>
-				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
-			</description>
-		</method>
 		<method name="get_skeleton">
 			<return type="Skeleton3D" />
 			<description>
 				Returns the parent or external [Skeleton3D] node if it exists, otherwise returns [code]null[/code].
 			</description>
 		</method>
-		<method name="get_use_external_skeleton" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns whether the BoneAttachment3D node is using an external [Skeleton3D] rather than attempting to use its parent node as the [Skeleton3D].
-			</description>
-		</method>
 		<method name="on_skeleton_update">
 			<return type="void" />
 			<description>
 				A function that is called automatically when the [Skeleton3D] is updated. This function is where the [BoneAttachment3D] node updates its position so it is correctly bound when it is [i]not[/i] set to override the bone pose.
-			</description>
-		</method>
-		<method name="set_external_skeleton">
-			<return type="void" />
-			<param index="0" name="external_skeleton" type="NodePath" />
-			<description>
-				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. See [method set_use_external_skeleton] to enable the external [Skeleton3D] node.
-			</description>
-		</method>
-		<method name="set_use_external_skeleton">
-			<return type="void" />
-			<param index="0" name="use_external_skeleton" type="bool" />
-			<description>
-				Sets whether the BoneAttachment3D node will use an external [Skeleton3D] node rather than attempting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the BoneAttachment3D node will use the external [Skeleton3D] node set in [method set_external_skeleton].
 			</description>
 		</method>
 	</methods>
@@ -55,10 +29,35 @@
 		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
 			The name of the attached bone.
 		</member>
+		<member name="external_skeleton" type="NodePath" setter="set_external_skeleton" getter="get_external_skeleton">
+			The [NodePath] to the external [Skeleton3D] node.
+		</member>
+		<member name="extra_update" type="int" setter="set_extra_update" getter="get_extra_update" enum="BoneAttachment3D.ExtraUpdate" default="0">
+			An enum that defines when the [BoneAttachment3D] node should update its transform in relation to the [Skeleton3D] update.
+			[b]Note:[/b] This is only available when the [member override_pose] is set to [code]false[/code].
+		</member>
 		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
-			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
+			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the [BoneAttachment3D] node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
 			[b]Note:[/b] This override performs interruptively in the skeleton update process using signals due to the old design. It may cause unintended behavior when used at the same time with [SkeletonModifier3D].
 		</member>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
+		<member name="subscribe_modifier" type="NodePath" setter="set_subscribe_modifier" getter="get_subscribe_modifier">
+			The [NodePath] to a [SkeletonModifier3D] node that the [BoneAttachment3D] will subscribe to. When the subscribed modifier is processed by the [Skeleton3D], the [BoneAttachment3D] will update its transform.
+			[b]Note:[/b] This is only available when the [member extra_update] is set to [constant EXTRA_UPDATE_SUBSCRIBE_MODIFIER].
+		</member>
+		<member name="use_external_skeleton" type="bool" setter="set_use_external_skeleton" getter="get_use_external_skeleton" default="false">
+			Whether the BoneAttachment3D node will use an external [Skeleton3D] node rather than attempting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the [BoneAttachment3D] node will use the external [Skeleton3D] node set in [member external_skeleton].
+		</member>
 	</members>
+	<constants>
+		<constant name="EXTRA_UPDATE_NONE" value="0" enum="ExtraUpdate">
+			A [BoneAttachment3D]'s transform will only be updated after the [Skeleton3D] processes all own [SkeletonModifier3D]'s.
+		</constant>
+		<constant name="EXTRA_UPDATE_BEFORE_SKELETON_UPDATE" value="1" enum="ExtraUpdate">
+			A [BoneAttachment3D]'s transform will be updated before the [Skeleton3D] processes all own [SkeletonModifier3D]'s but also the [Skeleton3D] processes all own [SkeletonModifier3D]'s.
+		</constant>
+		<constant name="EXTRA_UPDATE_SUBSCRIBE_MODIFIER" value="2" enum="ExtraUpdate">
+			A [BoneAttachment3D]'s transform will be updated after processing the [member subscribe_modifier] but also the [Skeleton3D] processes all own [SkeletonModifier3D]'s.
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -411,6 +411,11 @@
 				Emitted when the value of [member show_rest_only] changes.
 			</description>
 		</signal>
+		<signal name="skeleton_update_started">
+			<description>
+				Emitted when the update process started. This means that the dirty poses by the scene process has brern solved and before processing the [SkeletonModifier3D]s.
+			</description>
+		</signal>
 		<signal name="skeleton_updated">
 			<description>
 				Emitted when the final pose has been calculated will be applied to the skin in the update process.

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -35,7 +35,17 @@
 class BoneAttachment3D : public Node3D {
 	GDCLASS(BoneAttachment3D, Node3D);
 
-	bool bound = false;
+public:
+	enum ExtraUpdate {
+		EXTRA_UPDATE_NONE,
+		EXTRA_UPDATE_BEFORE_SKELETON_UPDATE,
+		EXTRA_UPDATE_SUBSCRIBE_MODIFIER,
+	};
+
+private:
+	bool bound_skeleton = false;
+	bool bound_subscribe = false;
+
 	String bone_name;
 	int bone_idx = -1;
 
@@ -47,18 +57,29 @@ class BoneAttachment3D : public Node3D {
 	NodePath external_skeleton_node;
 	ObjectID external_skeleton_node_cache;
 
+	ExtraUpdate extra_update = EXTRA_UPDATE_NONE;
+	NodePath subscribe_modifier;
+	ObjectID subscribe_node_cache;
+
+	void _validate_bind_states();
+
 	void _check_bind();
+	void _check_bind_skeleton();
+	void _check_bind_subscribe();
+
 	void _check_unbind();
+	void _check_unbind_skeleton();
+	void _check_unbind_subscribe();
 
 	bool updating = false;
 	void _transform_changed();
+
+	void _update_node_cache();
 	void _update_external_skeleton_cache();
+	void _update_subscribe_node_cache();
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
-	bool _get(const StringName &p_path, Variant &r_ret) const;
-	bool _set(const StringName &p_path, const Variant &p_value);
-	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 
 	static void _bind_methods();
@@ -85,10 +106,15 @@ public:
 	void set_override_pose(bool p_override);
 	bool get_override_pose() const;
 
-	void set_use_external_skeleton(bool p_external_skeleton);
+	void set_use_external_skeleton(bool p_use_external_skeleton);
 	bool get_use_external_skeleton() const;
-	void set_external_skeleton(NodePath p_skeleton);
+	void set_external_skeleton(NodePath p_external_skeleton);
 	NodePath get_external_skeleton() const;
+
+	void set_extra_update(ExtraUpdate p_extra_update);
+	ExtraUpdate get_extra_update() const;
+	void set_subscribe_modifier(NodePath p_subscribe_modifier);
+	NodePath get_subscribe_modifier() const;
 
 	virtual void on_skeleton_update();
 
@@ -98,3 +124,5 @@ public:
 
 	BoneAttachment3D();
 };
+
+VARIANT_ENUM_CAST(BoneAttachment3D::ExtraUpdate);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -337,6 +337,8 @@ void Skeleton3D::_notification(int p_what) {
 			// Update bone transforms to apply unprocessed poses.
 			force_update_all_dirty_bones();
 
+			emit_signal(SceneStringName(skeleton_update_started));
+
 			updating = true;
 
 			Bone *bonesptr = bones.ptr();
@@ -1323,6 +1325,7 @@ void Skeleton3D::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("rest_updated"));
 	ADD_SIGNAL(MethodInfo("pose_updated"));
+	ADD_SIGNAL(MethodInfo("skeleton_update_started"));
 	ADD_SIGNAL(MethodInfo("skeleton_updated"));
 	ADD_SIGNAL(MethodInfo("bone_enabled_changed", PropertyInfo(Variant::INT, "bone_idx")));
 	ADD_SIGNAL(MethodInfo("bone_list_changed"));

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -90,6 +90,7 @@ public:
 	const StringName RESET = "RESET";
 
 	const StringName pose_updated = "pose_updated";
+	const StringName skeleton_update_started = "skeleton_update_started";
 	const StringName skeleton_updated = "skeleton_updated";
 	const StringName bone_enabled_changed = "bone_enabled_changed";
 	const StringName show_rest_only_changed = "show_rest_only_changed";


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/106741

Currently BoneAttachment only updates once per frame by the skeleton's final result. That is sufficient for equipment, but for IK targets the update timing is late.

Godot 3.x had updates occurring on every pose changed, which was obviously overkill. Then, in my opinion, IK targets need two updates:

1. At arbitrary timing (`AnimationMixer.mixer_applied` or `SkeletonModifier3D.modification_processed`)
2. On `skeleton_updated` to reflect changes made by **other** SkeletonModifiers

Currently only 2 is done. The reason why 2 is needed instead of just 1 is that when other SkeletonModifiers modify the ancestor bone of the IK target, the final rendered appearance must match.

However, when a bone is modified by a non-SkeletonModifier in the scene, not just by AnimationMixer.mixer_applied, we would want to subscribe to it, so I add an `update_pose_started` signal to the Skeleton and connect it to the BoneAttachment.

This makes the BoneAttachment have additional two options `extra_update` and `subscribe_modifier`.

![image](https://github.com/user-attachments/assets/4b236178-a042-4a8e-8b02-4f196ecc89a5)

**enum ExtraUpdate:**
- EXTRA_UPDATE_NONE
  - A BoneAttachment3D's transform will only be updated after the Skeleton3D processes all own SkeletonModifier3D's.
- EXTRA_UPDATE_BEFORE_SKELETON_UPDATE
  - A BoneAttachment3D's transform will be updated before the Skeleton3D processes all own SkeletonModifier3D's but also the Skeleton3D processes all own SkeletonModifier3D's.
- EXTRA_UPDATE_SUBSCRIBE_MODIFIER
  - A BoneAttachment3D's transform will be updated after processing the `subscribe_modifier` but also the Skeleton3D processes all own SkeletonModifier3D's

They are only available when override_pose is disabled. This is because override_pose is meant to allow writing to bone poses, but since BoneAttachment uses signals to link with Skeleton, the update order is not guaranteed when a BoneAttachment is attached to multiple bones.

Includes some refactoring.