### PR TITLE
Refactor `BoneAttachment` property registration

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -9,42 +9,16 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_external_skeleton" qualifiers="const">
-			<return type="NodePath" />
-			<description>
-				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
-			</description>
-		</method>
 		<method name="get_skeleton">
 			<return type="Skeleton3D" />
 			<description>
 				Returns the parent or external [Skeleton3D] node if it exists, otherwise returns [code]null[/code].
 			</description>
 		</method>
-		<method name="get_use_external_skeleton" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns whether the BoneAttachment3D node is using an external [Skeleton3D] rather than attempting to use its parent node as the [Skeleton3D].
-			</description>
-		</method>
 		<method name="on_skeleton_update">
 			<return type="void" />
 			<description>
 				A function that is called automatically when the [Skeleton3D] is updated. This function is where the [BoneAttachment3D] node updates its position so it is correctly bound when it is [i]not[/i] set to override the bone pose.
-			</description>
-		</method>
-		<method name="set_external_skeleton">
-			<return type="void" />
-			<param index="0" name="external_skeleton" type="NodePath" />
-			<description>
-				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. See [method set_use_external_skeleton] to enable the external [Skeleton3D] node.
-			</description>
-		</method>
-		<method name="set_use_external_skeleton">
-			<return type="void" />
-			<param index="0" name="use_external_skeleton" type="bool" />
-			<description>
-				Sets whether the BoneAttachment3D node will use an external [Skeleton3D] node rather than attempting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the BoneAttachment3D node will use the external [Skeleton3D] node set in [method set_external_skeleton].
 			</description>
 		</method>
 	</methods>
@@ -55,10 +29,16 @@
 		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
 			The name of the attached bone.
 		</member>
+		<member name="external_skeleton" type="NodePath" setter="set_external_skeleton" getter="get_external_skeleton">
+			The [NodePath] to the external [Skeleton3D] node.
+		</member>
 		<member name="override_pose" type="bool" setter="set_override_pose" getter="get_override_pose" default="false">
-			Whether the BoneAttachment3D node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the BoneAttachment3D node can change the pose of the bone. When set to [code]false[/code], the BoneAttachment3D will always be set to the bone's transform.
+			Whether the [BoneAttachment3D] node will override the bone pose of the bone it is attached to. When set to [code]true[/code], the [BoneAttachment3D] node can change the pose of the bone. When set to [code]false[/code], the [BoneAttachment3D] will always be set to the bone's transform.
 			[b]Note:[/b] This override performs interruptively in the skeleton update process using signals due to the old design. It may cause unintended behavior when used at the same time with [SkeletonModifier3D].
 		</member>
 		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" overrides="Node" enum="Node.PhysicsInterpolationMode" default="2" />
+		<member name="use_external_skeleton" type="bool" setter="set_use_external_skeleton" getter="get_use_external_skeleton" default="false">
+			Whether the [BoneAttachment3D] node will use an external [Skeleton3D] node rather than attempting to use its parent node as the [Skeleton3D]. When set to [code]true[/code], the [BoneAttachment3D] node will use the external [Skeleton3D] node set in [member external_skeleton].
+		</member>
 	</members>
 </class>

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -51,36 +51,9 @@ void BoneAttachment3D::_validate_property(PropertyInfo &p_property) const {
 			p_property.hint_string = "";
 		}
 	}
-}
 
-bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
-	if (p_path == SNAME("use_external_skeleton")) {
-		set_use_external_skeleton(p_value);
-		return true;
-	} else if (p_path == SNAME("external_skeleton")) {
-		set_external_skeleton(p_value);
-		return true;
-	}
-
-	return false;
-}
-
-bool BoneAttachment3D::_get(const StringName &p_path, Variant &r_ret) const {
-	if (p_path == SNAME("use_external_skeleton")) {
-		r_ret = get_use_external_skeleton();
-		return true;
-	} else if (p_path == SNAME("external_skeleton")) {
-		r_ret = get_external_skeleton();
-		return true;
-	}
-
-	return false;
-}
-
-void BoneAttachment3D::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::BOOL, "use_external_skeleton", PROPERTY_HINT_NONE, ""));
-	if (use_external_skeleton) {
-		p_list->push_back(PropertyInfo(Variant::NODE_PATH, "external_skeleton", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton3D"));
+	if (p_property.name == "external_skeleton" && !use_external_skeleton) {
+		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }
 
@@ -111,7 +84,7 @@ void BoneAttachment3D::_update_external_skeleton_cache() {
 		Node *node = get_node(external_skeleton_node);
 		ERR_FAIL_NULL_MSG(node, "Cannot update external skeleton cache: Node cannot be found!");
 
-		// Make sure it's a skeleton3D
+		// Make sure it's a Skeleton3D.
 		Skeleton3D *sk = Object::cast_to<Skeleton3D>(node);
 		ERR_FAIL_NULL_MSG(sk, "Cannot update external skeleton cache: Skeleton3D Nodepath does not point to a Skeleton3D node!");
 
@@ -125,7 +98,7 @@ void BoneAttachment3D::_update_external_skeleton_cache() {
 					Node *node = parent_attachment->get_node(parent_attachment->external_skeleton_node);
 					ERR_FAIL_NULL_MSG(node, "Cannot update external skeleton cache: Parent's Skeleton3D node cannot be found!");
 
-					// Make sure it's a skeleton3D
+					// Make sure it's a Skeleton3D.
 					Skeleton3D *sk = Object::cast_to<Skeleton3D>(node);
 					ERR_FAIL_NULL_MSG(sk, "Cannot update external skeleton cache: Parent Skeleton3D Nodepath does not point to a Skeleton3D node!");
 
@@ -244,12 +217,12 @@ int BoneAttachment3D::get_bone_idx() const {
 	return bone_idx;
 }
 
-void BoneAttachment3D::set_override_pose(bool p_override) {
-	if (override_pose == p_override) {
+void BoneAttachment3D::set_override_pose(bool p_override_pose) {
+	if (override_pose == p_override_pose) {
 		return;
 	}
 
-	override_pose = p_override;
+	override_pose = p_override_pose;
 	set_notify_transform(override_pose);
 	set_process_internal(override_pose);
 	if (!override_pose && bone_idx >= 0) {
@@ -266,8 +239,8 @@ bool BoneAttachment3D::get_override_pose() const {
 	return override_pose;
 }
 
-void BoneAttachment3D::set_use_external_skeleton(bool p_use_external) {
-	use_external_skeleton = p_use_external;
+void BoneAttachment3D::set_use_external_skeleton(bool p_use_external_skeleton) {
+	use_external_skeleton = p_use_external_skeleton;
 
 	if (use_external_skeleton) {
 		_check_unbind();
@@ -283,8 +256,8 @@ bool BoneAttachment3D::get_use_external_skeleton() const {
 	return use_external_skeleton;
 }
 
-void BoneAttachment3D::set_external_skeleton(NodePath p_path) {
-	external_skeleton_node = p_path;
+void BoneAttachment3D::set_external_skeleton(NodePath p_external_skeleton) {
+	external_skeleton_node = p_external_skeleton;
 	_update_external_skeleton_cache();
 	notify_property_list_changed();
 }
@@ -398,4 +371,6 @@ void BoneAttachment3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bone_name"), "set_bone_name", "get_bone_name");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bone_idx"), "set_bone_idx", "get_bone_idx");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_pose"), "set_override_pose", "get_override_pose");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_external_skeleton"), "set_use_external_skeleton", "get_use_external_skeleton");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "external_skeleton", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton3D"), "set_external_skeleton", "get_external_skeleton");
 }

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -56,9 +56,6 @@ class BoneAttachment3D : public Node3D {
 
 protected:
 	void _validate_property(PropertyInfo &p_property) const;
-	bool _get(const StringName &p_path, Variant &r_ret) const;
-	bool _set(const StringName &p_path, const Variant &p_value);
-	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 
 	static void _bind_methods();
@@ -82,12 +79,12 @@ public:
 	void set_bone_idx(const int &p_idx);
 	int get_bone_idx() const;
 
-	void set_override_pose(bool p_override);
+	void set_override_pose(bool p_override_pose);
 	bool get_override_pose() const;
 
-	void set_use_external_skeleton(bool p_external_skeleton);
+	void set_use_external_skeleton(bool p_use_external_skeleton);
 	bool get_use_external_skeleton() const;
-	void set_external_skeleton(NodePath p_skeleton);
+	void set_external_skeleton(NodePath p_external_skeleton);
 	NodePath get_external_skeleton() const;
 
 	virtual void on_skeleton_update();


### PR DESCRIPTION
- Separate from https://github.com/godotengine/godot/pull/106838

Not sure if BoneAttachment's property registration is outdated in some parts of the code, but most of them can be replaced with _validate_property().