### PR TITLE
Fix `Camera3D` gizmo representation for frustum projection

### DIFF
--- a/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/camera_3d_gizmo_plugin.cpp
@@ -232,22 +232,30 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		} break;
 
 		case Camera3D::PROJECTION_FRUSTUM: {
-			float hsize = camera->get_size() / 2.0;
+			float hsize, vsize;
+			if (camera->get_keep_aspect_mode() == Camera3D::KEEP_WIDTH) {
+				hsize = camera->get_size() / 2.0;
+				vsize = hsize / viewport_aspect;
+			} else {
+				vsize = camera->get_size() / 2.0;
+				hsize = vsize * viewport_aspect;
+			}
 
 			Vector3 side = Vector3(hsize, 0, -camera->get_near()).normalized();
-			side.x *= size_factor.x;
 			Vector3 nside = Vector3(-side.x, side.y, side.z);
-			Vector3 up = Vector3(0, hsize * size_factor.y, 0);
-			Vector3 offset = Vector3(camera->get_frustum_offset().x, camera->get_frustum_offset().y, 0.0);
+
+			float multiplier = side.x / hsize;
+			Vector3 up = Vector3(0, vsize * multiplier, 0);
+			Vector3 offset = Vector3(camera->get_frustum_offset().x * multiplier, camera->get_frustum_offset().y * multiplier, 0.0);
 
 			ADD_TRIANGLE(Vector3(), side + up + offset, side - up + offset);
 			ADD_TRIANGLE(Vector3(), nside + up + offset, nside - up + offset);
 			ADD_TRIANGLE(Vector3(), side + up + offset, nside + up + offset);
 			ADD_TRIANGLE(Vector3(), side - up + offset, nside - up + offset);
 
-			side.x = MIN(side.x, hsize * 0.25);
+			side.x *= 0.25;
 			nside.x = -side.x;
-			Vector3 tup(0, up.y + hsize / 2, side.z);
+			Vector3 tup(0, up.y + side.x, side.z);
 			ADD_TRIANGLE(tup + offset, side + up + offset, nside + up + offset);
 		} break;
 	}


### PR DESCRIPTION
- Added check to handle both `KEEP_WIDTH` and `KEEP_HEIGHT`
- Scaled `up`/`offset` vectors to maintain ratio with normalized `side` vector

Fixes #106793

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
