### PR TITLE
Fix missing ibl reconstruction from DFG multiscattering

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2078,7 +2078,7 @@ void fragment_shader(in SceneData scene_data) {
 
 		// cheap luminance approximation
 		float f90 = clamp(50.0 * f0.g, metallic, 1.0);
-		indirect_specular_light *= energy_compensation * (f90 * envBRDF.x + f0 * envBRDF.y);
+		indirect_specular_light *= energy_compensation * ((f90 - f0) * envBRDF.x + f0 * envBRDF.y);
 #endif
 	}
 


### PR DESCRIPTION
- *Production edit: Follow-up to
https://github.com/godotengine/godot/pull/103934.*

Since Godot uses a modified DFG LUT for multi-scattering, it's necessary to reconstruct it when applying the DFG in IBL. For more details, see https://google.github.io/filament/Filament.html#listing_multiscatteriblevaluation.

Note: Google Filament sets _f90 = 1_, but to maintain consistent behavior across renders, its calculation with the cheap luminance approximation must be preserved.