### PR TITLE
Core: Implement `RequiredBind<T>`

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -88,7 +88,7 @@ static String get_property_info_type_name(const PropertyInfo &p_info) {
 }
 
 static String get_type_meta_name(const GodotTypeInfo::Metadata metadata) {
-	static const char *argmeta[13] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double", "char16", "char32" };
+	static const char *argmeta[14] = { "none", "int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64", "float", "double", "char16", "char32", "required" };
 	return argmeta[metadata];
 }
 

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -167,6 +167,17 @@ struct PtrToArg<const T *> {
 	}
 };
 
+template <typename T>
+struct PtrToArg<RequiredBind<T>> {
+	_FORCE_INLINE_ static RequiredBind<T> convert(const void *p_ptr) {
+		return RequiredBind<T>(*reinterpret_cast<T *const *>(p_ptr));
+	}
+	typedef RequiredBind<T> EncodeT;
+	_FORCE_INLINE_ static void encode(RequiredBind<T> p_val, const void *p_ptr) {
+		*(const_cast<RequiredBind<T> *>(reinterpret_cast<const RequiredBind<T> *>(p_ptr))) = p_val;
+	}
+};
+
 // This is for ObjectID.
 
 template <>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -50,6 +50,7 @@ enum Metadata {
 	METADATA_REAL_IS_DOUBLE,
 	METADATA_INT_IS_CHAR16,
 	METADATA_INT_IS_CHAR32,
+	METADATA_OBJECT_IS_REQUIRED,
 };
 }
 
@@ -175,6 +176,15 @@ template <typename T>
 struct GetTypeInfo<T *, std::enable_if_t<std::is_base_of_v<Object, T>>> {
 	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
 	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_NONE;
+	static inline PropertyInfo get_class_info() {
+		return PropertyInfo(StringName(T::get_class_static()));
+	}
+};
+
+template <typename T>
+struct GetTypeInfo<RequiredBind<T>> {
+	static const Variant::Type VARIANT_TYPE = Variant::OBJECT;
+	static const GodotTypeInfo::Metadata METADATA = GodotTypeInfo::METADATA_OBJECT_IS_REQUIRED;
 	static inline PropertyInfo get_class_info() {
 		return PropertyInfo(StringName(T::get_class_static()));
 	}

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -1045,6 +1045,14 @@ struct VariantInternalAccessor<Object *> {
 	static _FORCE_INLINE_ void set(Variant *v, const Object *p_value) { VariantInternal::object_assign(v, p_value); }
 };
 
+template <typename T>
+struct VariantInternalAccessor<RequiredBind<T>> {
+	static _FORCE_INLINE_ RequiredBind<T> get(const Variant *v) { return RequiredBind<T>(*VariantInternal::get_object(v)); }
+	static _FORCE_INLINE_ void set(Variant *v, const RequiredBind<T> &p_required) {
+		VariantInternal::object_assign(v, static_cast<T *>(p_required));
+	}
+};
+
 template <>
 struct VariantInternalAccessor<Variant> {
 	static _FORCE_INLINE_ Variant &get(Variant *v) { return *v; }

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1816,7 +1816,7 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name, InternalM
 	emit_signal(SNAME("child_order_changed"));
 }
 
-void Node::add_child(Node *p_child, bool p_force_readable_name, InternalMode p_internal) {
+void Node::add_child(const RequiredBind<Node> &p_child, bool p_force_readable_name, InternalMode p_internal) {
 	ERR_FAIL_COND_MSG(data.inside_tree && !Thread::is_main_thread(), "Adding children to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_child\",node).");
 
 	ERR_THREAD_GUARD
@@ -1840,7 +1840,7 @@ void Node::add_child(Node *p_child, bool p_force_readable_name, InternalMode p_i
 	_add_child_nocheck(p_child, p_child->data.name, p_internal);
 }
 
-void Node::add_sibling(Node *p_sibling, bool p_force_readable_name) {
+void Node::add_sibling(const RequiredBind<Node> &p_sibling, bool p_force_readable_name) {
 	ERR_FAIL_COND_MSG(data.inside_tree && !Thread::is_main_thread(), "Adding a sibling to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_sibling\",node).");
 	ERR_FAIL_NULL(p_sibling);
 	ERR_FAIL_COND_MSG(p_sibling == this, vformat("Can't add sibling '%s' to itself.", p_sibling->get_name())); // adding to itself!
@@ -1852,7 +1852,7 @@ void Node::add_sibling(Node *p_sibling, bool p_force_readable_name) {
 	data.parent->_move_child(p_sibling, get_index() + 1);
 }
 
-void Node::remove_child(Node *p_child) {
+void Node::remove_child(const RequiredBind<Node> &p_child) {
 	ERR_FAIL_COND_MSG(data.inside_tree && !Thread::is_main_thread(), "Removing children from a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"remove_child\",node).");
 	ERR_FAIL_NULL(p_child);
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy adding/removing children, `remove_child()` can't be called at this time. Consider using `remove_child.call_deferred(child)` instead.");
@@ -2035,7 +2035,7 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 	return current;
 }
 
-Node *Node::get_node(const NodePath &p_path) const {
+RequiredBind<Node> Node::get_node(const NodePath &p_path) const {
 	Node *node = get_node_or_null(p_path);
 
 	if (unlikely(!node)) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -485,15 +485,15 @@ public:
 
 	InternalMode get_internal_mode() const;
 
-	void add_child(Node *p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
-	void add_sibling(Node *p_sibling, bool p_force_readable_name = false);
-	void remove_child(Node *p_child);
+	void add_child(const RequiredBind<Node> &p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
+	void add_sibling(const RequiredBind<Node> &p_sibling, bool p_force_readable_name = false);
+	void remove_child(const RequiredBind<Node> &p_child);
 
 	int get_child_count(bool p_include_internal = true) const;
 	Node *get_child(int p_index, bool p_include_internal = true) const;
 	TypedArray<Node> get_children(bool p_include_internal = true) const;
 	bool has_node(const NodePath &p_path) const;
-	Node *get_node(const NodePath &p_path) const;
+	RequiredBind<Node> get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;
 	Node *find_child(const String &p_pattern, bool p_recursive = true, bool p_owned = true) const;
 	TypedArray<Node> find_children(const String &p_pattern, const String &p_type = "", bool p_recursive = true, bool p_owned = true) const;


### PR DESCRIPTION
- Implements godotengine/godot-proposals#2241

An extremely minimalistic implementation of the above proposal, via the wrapper class `RequiredBind<T>`. This is designed as a drop-in replacement for object pointer types, allowing them to be bound with "required" metadata. This is with the intent of being merged in 4.5, in order for this paradigm to be added to GDExtension as early as possible.