### PR TITLE
Expose `get_rpc_config` and `get_node_rpc_config`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -172,6 +172,8 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
 	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
 
+	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Script::_get_rpc_config_bind);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -172,8 +172,6 @@ void Script::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_tool"), &Script::is_tool);
 	ClassDB::bind_method(D_METHOD("is_abstract"), &Script::is_abstract);
 
-	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Script::get_rpc_config);
-
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "source_code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_source_code", "get_source_code");
 }
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -135,6 +135,10 @@ protected:
 
 	void _set_debugger_break_language();
 
+	Variant _get_rpc_config_bind() const {
+		return get_rpc_config().duplicate(true);
+	}
+
 public:
 	virtual void reload_from_file() override;
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -191,7 +191,7 @@ public:
 
 	virtual bool is_placeholder_fallback_enabled() const { return false; }
 
-	virtual Variant get_rpc_config() const = 0;
+	virtual const Variant get_rpc_config() const = 0;
 
 	Script() {}
 };

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -209,7 +209,7 @@ public:
 
 	GDVIRTUAL0RC_REQUIRED(Variant, _get_rpc_config)
 
-	virtual Variant get_rpc_config() const override {
+	virtual const Variant get_rpc_config() const override {
 		Variant ret;
 		GDVIRTUAL_CALL(_get_rpc_config, ret);
 		return ret;

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -495,6 +495,13 @@
 				Fetches a node by [NodePath]. Similar to [method get_node], but does not generate an error if [param path] does not point to a valid node.
 			</description>
 		</method>
+		<method name="get_node_rpc_config" qualifiers="const">
+			<return type="Variant" />
+			<description>
+				Returns a [Dictionary] mapping method names to their RPC configuration defined for this node using [method rpc_config].
+				[b]Note:[/b] This method only returns the RPC configuration assigned via [method rpc_config]. See [method Script.get_rpc_config] to retrieve the RPCs defined by the [Script].
+			</description>
+		</method>
 		<method name="get_orphan_node_ids" qualifiers="static">
 			<return type="int[]" />
 			<description>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -538,12 +538,6 @@
 				[b]Note:[/b] The returned value will be larger than expected if running at a framerate lower than [member Engine.physics_ticks_per_second] / [member Engine.max_physics_steps_per_frame] FPS. This is done to avoid "spiral of death" scenarios where performance would plummet due to an ever-increasing number of physics steps per frame. This behavior affects both [method _process] and [method _physics_process]. As a result, avoid using [code]delta[/code] for time measurements in real-world seconds. Use the [Time] singleton's methods for this purpose instead, such as [method Time.get_ticks_usec].
 			</description>
 		</method>
-		<method name="get_rpc_config" qualifiers="const">
-			<return type="Variant" />
-			<description>
-				Returns a [Dictionary] mapping method names to their RPC configuration defined for this node using [method rpc_config].
-			</description>
-		</method>
 		<method name="get_scene_instance_load_placeholder" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -58,6 +58,12 @@
 				Returns the default value of the specified property.
 			</description>
 		</method>
+		<method name="get_rpc_config" qualifiers="const">
+			<return type="Variant" />
+			<description>
+				Returns a [Dictionary] mapping method names to their RPC configuration defined by this script.
+			</description>
+		</method>
 		<method name="get_script_constant_map">
 			<return type="Dictionary" />
 			<description>

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -58,12 +58,6 @@
 				Returns the default value of the specified property.
 			</description>
 		</method>
-		<method name="get_rpc_config" qualifiers="const">
-			<return type="Variant" />
-			<description>
-				Returns a [Dictionary] mapping method names to their RPC configuration defined by this script.
-			</description>
-		</method>
 		<method name="get_script_constant_map">
 			<return type="Dictionary" />
 			<description>

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -251,3 +251,10 @@ Validate extension JSON: Error: Field 'classes/InputMap/methods/add_action/argum
 Validate extension JSON: Error: Field 'global_enums/KeyModifierMask/values/KEY_MODIFIER_MASK': value changed value in new API, from 532676600.0 to 2130706432.
 
 Precision of string-serialized Variant constants increased.
+
+
+GH-106848
+---------
+Validate extension JSON: API was removed: classes/Node/methods/get_rpc_config
+
+Change Node `get_rpc_config` to `get_node_rpc_config`. Compatibility method registered.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -922,7 +922,7 @@ void GDScript::get_members(HashSet<StringName> *p_members) {
 	}
 }
 
-Variant GDScript::get_rpc_config() const {
+const Variant GDScript::get_rpc_config() const {
 	return rpc_config;
 }
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -346,7 +346,7 @@ public:
 	virtual void get_constants(HashMap<StringName, Variant> *p_constants) override;
 	virtual void get_members(HashSet<StringName> *p_members) override;
 
-	virtual Variant get_rpc_config() const override;
+	virtual const Variant get_rpc_config() const override;
 
 	void unload_static() const;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2737,7 +2737,7 @@ int CSharpScript::get_member_line(const StringName &p_member) const {
 	return -1;
 }
 
-Variant CSharpScript::get_rpc_config() const {
+const Variant CSharpScript::get_rpc_config() const {
 	return rpc_config;
 }
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -289,7 +289,7 @@ public:
 
 	int get_member_line(const StringName &p_member) const override;
 
-	Variant get_rpc_config() const override;
+	const Variant get_rpc_config() const override;
 
 #ifdef TOOLS_ENABLED
 	bool is_placeholder_fallback_enabled() const override {

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -105,7 +105,7 @@ const SceneRPCInterface::RPCConfigCache &SceneRPCInterface::_get_node_config(con
 		return rpc_cache[oid];
 	}
 	RPCConfigCache cache;
-	_parse_rpc_config(p_node->get_rpc_config(), true, cache);
+	_parse_rpc_config(p_node->get_node_rpc_config(), true, cache);
 	if (p_node->get_script_instance()) {
 		_parse_rpc_config(p_node->get_script_instance()->get_rpc_config(), false, cache);
 	}

--- a/scene/main/node.compat.inc
+++ b/scene/main/node.compat.inc
@@ -34,8 +34,13 @@ void Node::_set_name_bind_compat_76560(const String &p_name) {
 	set_name(p_name);
 }
 
+Variant Node::_get_rpc_config_bind_compat_106848() const {
+	return _get_node_rpc_config_bind();
+}
+
 void Node::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("set_name", "name"), &Node::_set_name_bind_compat_76560);
+	ClassDB::bind_compatibility_method(D_METHOD("get_rpc_config"), &Node::_get_rpc_config_bind_compat_106848);
 }
 
 #endif

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3980,6 +3980,7 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_multiplayer"), &Node::get_multiplayer);
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "config"), &Node::rpc_config);
+	ClassDB::bind_method(D_METHOD("get_node_rpc_config"), &Node::_get_node_rpc_config_bind);
 
 	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Node::set_editor_description);
 	ClassDB::bind_method(D_METHOD("get_editor_description"), &Node::get_editor_description);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -849,7 +849,7 @@ void Node::rpc_config(const StringName &p_method, const Variant &p_config) {
 	}
 }
 
-Variant Node::get_rpc_config() const {
+const Variant Node::get_node_rpc_config() const {
 	return data.rpc_config;
 }
 
@@ -3980,7 +3980,6 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_multiplayer"), &Node::get_multiplayer);
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "config"), &Node::rpc_config);
-	ClassDB::bind_method(D_METHOD("get_rpc_config"), &Node::get_rpc_config);
 
 	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Node::set_editor_description);
 	ClassDB::bind_method(D_METHOD("get_editor_description"), &Node::get_editor_description);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -388,6 +388,10 @@ protected:
 
 	void _validate_property(PropertyInfo &p_property) const;
 
+	Variant _get_node_rpc_config_bind() const {
+		return get_node_rpc_config().duplicate(true);
+	}
+
 protected:
 	virtual bool _uses_signal_mutex() const override { return false; } // Node uses thread guards instead.
 
@@ -414,6 +418,7 @@ protected:
 
 #ifndef DISABLE_DEPRECATED
 	void _set_name_bind_compat_76560(const String &p_name);
+	Variant _get_rpc_config_bind_compat_106848() const;
 	static void _bind_compatibility_methods();
 #endif
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -210,7 +210,7 @@ private:
 		void *process_group = nullptr; // to avoid cyclic dependency
 
 		int multiplayer_authority = 1; // Server by default.
-		Variant rpc_config = Dictionary();
+		Variant rpc_config;
 
 		// Variables used to properly sort the node when processing, ignored otherwise.
 		int process_priority = 0;
@@ -786,7 +786,7 @@ public:
 	bool is_multiplayer_authority() const;
 
 	void rpc_config(const StringName &p_method, const Variant &p_config); // config a local method for RPC
-	Variant get_rpc_config() const;
+	const Variant get_node_rpc_config() const;
 
 	template <typename... VarArgs>
 	Error rpc(const StringName &p_method, VarArgs... p_args);


### PR DESCRIPTION
This PR reverts #96024 which was changed after the initial review making the API more confusing, and re-apply the changes with the original names (`Node::get_node_rpc_config`, `Script::get_rpc_config`).

Additionally, this revert const-ness of the base functions, and provide dedicated bindings that duplicates the Variant (so we are sure we cannot modify the retrieved member variable).

I added a note to the documentation mentioning the difference between `Node::get_node_rpc_config` and `Script::get_rpc_config`.

I also added a compatibility method since this change has shipped in 4.4 .

Closes #106705