### PR TITLE
Decrease font placeholder opacity in the editor theme

### DIFF
--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -472,7 +472,7 @@ void EditorThemeManager::_create_shared_styles(const Ref<EditorTheme> &p_theme, 
 		p_config.font_hover_pressed_color = p_config.font_hover_color.lerp(p_config.accent_color, 0.74);
 		p_config.font_disabled_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.35);
 		p_config.font_readonly_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.65);
-		p_config.font_placeholder_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.6);
+		p_config.font_placeholder_color = Color(p_config.mono_color.r, p_config.mono_color.g, p_config.mono_color.b, 0.5);
 		p_config.font_outline_color = Color(0, 0, 0, 0);
 
 		p_theme->set_color(SceneStringName(font_color), EditorStringName(Editor), p_config.font_color);


### PR DESCRIPTION
This makes placeholder text easier to distinguish from actual text in the editor. Previously, placeholder text's contrast against the background was only slightly lower than actual text.

## Preview

*Top text is actual text (written to be identical to the placeholder below), bottom text is a placeholder.*

### Dark theme

Before | After
-|-
![Image](https://github.com/user-attachments/assets/9056a59a-5b97-4093-9544-4e907b0af3b1) | ![Image](https://github.com/user-attachments/assets/a75f4461-5172-4f4c-a60e-51eea53656ee)


### Light theme

Before | After
-|-
![Image](https://github.com/user-attachments/assets/c1175235-eec0-4bae-92b7-a0712e5f5b0c) | ![Image](https://github.com/user-attachments/assets/e026a8aa-ef14-4f18-bab4-d445fd19c82d)
