### PR TITLE
Don't update scene tree when calling `Translation::set_locale()`

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -30,7 +30,6 @@
 
 #include "translation.h"
 
-#include "core/os/os.h"
 #include "core/os/thread.h"
 #include "core/string/translation_server.h"
 
@@ -74,21 +73,6 @@ void Translation::_set_messages(const Dictionary &p_messages) {
 
 void Translation::set_locale(const String &p_locale) {
 	locale = TranslationServer::get_singleton()->standardize_locale(p_locale);
-
-	if (Thread::is_main_thread()) {
-		_notify_translation_changed_if_applies();
-	} else {
-		// This has to happen on the main thread (bypassing the ResourceLoader per-thread call queue)
-		// because it interacts with the generally non-thread-safe window management, leading to
-		// different issues across platforms otherwise.
-		MessageQueue::get_main_singleton()->push_callable(callable_mp(this, &Translation::_notify_translation_changed_if_applies));
-	}
-}
-
-void Translation::_notify_translation_changed_if_applies() {
-	if (OS::get_singleton()->get_main_loop() && TranslationServer::get_singleton()->get_loaded_locales().has(get_locale())) {
-		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TRANSLATION_CHANGED);
-	}
 }
 
 void Translation::add_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {

--- a/core/string/translation.h
+++ b/core/string/translation.h
@@ -45,8 +45,6 @@ class Translation : public Resource {
 	virtual Dictionary _get_messages() const;
 	virtual void _set_messages(const Dictionary &p_messages);
 
-	void _notify_translation_changed_if_applies();
-
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
Calling `Translation::set_locale()` automatically propagates `NOTIFICATION_TRANSLATION_CHANGED` in the scene tree if translation for the target locale exists.

This behavior was added in https://github.com/godotengine/godot/commit/db3b05d2893dcaddeb3bcb10b845ff150eb50895 and has never been documented.

It seems strange and unreasonable:

- The `Translation` object might not be registered in the translation server. In this case, it refreshes the scene tree for nothing.
- This logic won't be executed when loading a translation for the default `en` locale (e.g., for projects using identifiers for translatable fields instead of actual text).
- When loading a large number of different translations, it's easy to cause the scene tree to refresh multiple times, which is unnecessary.

I don't know if there are any user code that depend on this behavior, but I think we can try to remove it in beta.