### PR TITLE
Add support for `OS.get_version_alias()` on Android

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -598,8 +598,9 @@
 		<method name="get_version_alias" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the branded version used in marketing, followed by the build number (on Windows) or the version number (on macOS). Examples include [code]11 (build 22000)[/code] and [code]Sequoia (15.0.0)[/code]. This value can then be appended to [method get_name] to get a full, human-readable operating system name and version combination for the operating system. Windows feature updates such as 24H2 are not contained in the resulting string, but Windows Server is recognized as such (e.g. [code]2025 (build 26100)[/code] for Windows Server 2025).
-				[b]Note:[/b] This method is only supported on Windows and macOS. On other operating systems, it returns the same value as [method get_version].
+				Returns the branded version used in marketing, followed by the build number (on Windows), the version number (on macOS), or the SDK version and incremental build number (on Android). Examples include [code]11 (build 22000)[/code], [code]Sequoia (15.0.0)[/code], and [code]15 (SDK 35 build abc528-11988f)[/code].
+				This value can then be appended to [method get_name] to get a full, human-readable operating system name and version combination for the operating system. Windows feature updates such as 24H2 are not contained in the resulting string, but Windows Server is recognized as such (e.g. [code]2025 (build 26100)[/code] for Windows Server 2025).
+				[b]Note:[/b] This method is only supported on Windows, macOS, and Android. On other operating systems, it returns the same value as [method get_version].
 			</description>
 		</method>
 		<method name="get_video_adapter_driver_info" qualifiers="const">

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -327,6 +327,14 @@ String OS_Android::get_version() const {
 	return "";
 }
 
+String OS_Android::get_version_alias() const {
+	String release = get_system_property("ro.build.version.release_or_codename");
+	String sdk_version = get_system_property("ro.build.version.sdk");
+	String build = get_system_property("ro.build.version.incremental");
+
+	return vformat("%s (SDK %s build %s)", release, sdk_version, build);
+}
+
 MainLoop *OS_Android::get_main_loop() const {
 	return main_loop;
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -123,6 +123,8 @@ public:
 	virtual String get_name() const override;
 	virtual String get_distribution_name() const override;
 	virtual String get_version() const override;
+	virtual String get_version_alias() const override;
+
 	virtual MainLoop *get_main_loop() const override;
 
 	void main_loop_begin();


### PR DESCRIPTION
This PR adds support for `OS.get_version_alias()` on Android. It returns android release string and sdk_version+incremental, for eg. `15 (SDK 35 build abc528-11988f)` on my Android 15 device.
