### PR TITLE
Fix Variant Property not respecting the bottom editor value

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1107,6 +1107,10 @@ void EditorProperty::set_bottom_editor(Control *p_control) {
 	}
 }
 
+Control *EditorProperty::get_bottom_editor() const {
+	return bottom_editor;
+}
+
 Variant EditorProperty::_get_cache_value(const StringName &p_prop, bool &r_valid) const {
 	return object->get(p_prop, &r_valid);
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1107,10 +1107,6 @@ void EditorProperty::set_bottom_editor(Control *p_control) {
 	}
 }
 
-Control *EditorProperty::get_bottom_editor() const {
-	return bottom_editor;
-}
-
 Variant EditorProperty::_get_cache_value(const StringName &p_prop, bool &r_valid) const {
 	return object->get(p_prop, &r_valid);
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -223,7 +223,7 @@ public:
 
 	void set_label_reference(Control *p_control);
 	void set_bottom_editor(Control *p_control);
-	Control *get_bottom_editor() const;
+	inline Control *get_bottom_editor() const { return bottom_editor; }
 
 	void set_use_folding(bool p_use_folding);
 	bool is_using_folding() const;

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -223,6 +223,7 @@ public:
 
 	void set_label_reference(Control *p_control);
 	void set_bottom_editor(Control *p_control);
+	Control *get_bottom_editor() const;
 
 	void set_use_folding(bool p_use_folding);
 	bool is_using_folding() const;

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -109,6 +109,10 @@ void EditorPropertyVariant::update_property() {
 
 		if (sub_property) {
 			memdelete(sub_property);
+			if (get_bottom_editor()) {
+				memdelete(get_bottom_editor());
+				set_bottom_editor(nullptr);
+			}
 			sub_property = nullptr;
 		}
 
@@ -128,10 +132,20 @@ void EditorPropertyVariant::update_property() {
 		sub_property->connect(SNAME("property_changed"), callable_mp((EditorProperty *)this, &EditorProperty::emit_changed));
 		content->add_child(sub_property);
 		content->move_child(sub_property, 0);
-		sub_property->update_property();
-	} else if (sub_property) {
-		sub_property->update_property();
 	}
+
+	if (sub_property) {
+		sub_property->update_property();
+
+		Control *sub_property_bottom_editor = sub_property->get_bottom_editor();
+		if (sub_property_bottom_editor) {
+			sub_property->set_bottom_editor(nullptr);
+			sub_property->remove_child(sub_property_bottom_editor);
+			add_child(sub_property_bottom_editor);
+			set_bottom_editor(sub_property_bottom_editor);
+		}
+	}
+
 	new_type = Variant::VARIANT_MAX;
 }
 


### PR DESCRIPTION
Currently many properties have the ability to use a space below the property to display their information. However, the new variant property editor (introduced in #89324) does not support this for the nested EditorProperties, instead keeping the bottom editor entirely within its borders. This is especially seen on the array editors that place large nodes into the bottom editor, but is also visible in matrix properties such as Rect or Projection.

This PR allows the EditorPropertyVariant to take the bottom panel of the internal property in order to display it properly beneath the space given.

This is the current master:
<img width="536" alt="Screenshot 2025-05-27 at 2 39 55 AM" src="https://github.com/user-attachments/assets/09f04aa7-628f-47f4-a0d2-b9af390c4388" />

This is how it should look:
<img width="520" alt="Screenshot 2025-05-27 at 2 40 19 AM" src="https://github.com/user-attachments/assets/0829e675-fbfe-4dad-8f77-34127b77e4a6" />
