### PR TITLE
Align autoload popup columns to the left

### DIFF
--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -957,10 +957,12 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	tree->set_column_titles_visible(true);
 
 	tree->set_column_title(0, TTRC("Name"));
+	tree->set_column_title_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
 	tree->set_column_expand(0, true);
 	tree->set_column_expand_ratio(0, 1);
 
 	tree->set_column_title(1, TTRC("Path"));
+	tree->set_column_title_alignment(1, HORIZONTAL_ALIGNMENT_LEFT);
 	tree->set_column_expand(1, true);
 	tree->set_column_clip_content(1, true);
 	tree->set_column_expand_ratio(1, 2);


### PR DESCRIPTION
- Fixes #106776 

The column titles are aligned to the left, instead of the current center alignment.

![CleanShot-000120-godot macos editor dev arm64](https://github.com/user-attachments/assets/01d4e4f9-9876-4bc3-8410-1c7e671f35a2)
