### PR TITLE
Clarify `SceneTree.get_frame()` description

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -109,7 +109,7 @@
 		<method name="get_frame" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns how many frames have been processed, since the application started. This is [i]not[/i] a measurement of elapsed time.
+				Returns how many physics process steps have been processed, since the application started. This is [i]not[/i] a measurement of elapsed time. See also [signal physics_frame]. For the number of frames rendered, see [method Engine.get_process_frames].
 			</description>
 		</method>
 		<method name="get_multiplayer" qualifiers="const">


### PR DESCRIPTION
fixes #90539
supersedes #91389 (Seems abandoned, @ZoZoHatch)

Reflect that SceneTree.get_frame() returns physics steps that have been processed, not frames rendered.

Add reference to physics_frame signal.

Add reference to Engine.get_process_frames

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
