### PR TITLE
TileSet: Fix `-Wmaybe-uninitialized` warning on CompatibilityShapeData

### DIFF
--- a/scene/resources/2d/tile_set.h
+++ b/scene/resources/2d/tile_set.h
@@ -151,8 +151,8 @@ class TileSet : public Resource {
 private:
 	struct CompatibilityShapeData {
 		Vector2i autotile_coords;
-		bool one_way;
-		float one_way_margin;
+		bool one_way = false;
+		float one_way_margin = 0.0f;
 #ifndef PHYSICS_2D_DISABLED
 		Ref<Shape2D> shape;
 #endif // PHYSICS_2D_DISABLED


### PR DESCRIPTION
Warning noticed on https://github.com/godotengine/godot/actions/runs/15273288687/job/42953700846?pr=105146, probably because that PR changes CowData and forced recompiling most of the engine, exposing new warnings for updated compilers.