### PR TITLE
Poison `CowData` pointer during destruction in sanitizer builds.

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -39,6 +39,10 @@
 #include <initializer_list>
 #include <type_traits>
 
+#ifdef ASAN_ENABLED
+#include <sanitizer/asan_interface.h>
+#endif
+
 static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
 
 // Silences false-positive warnings.
@@ -246,17 +250,21 @@ void CowData<T>::_unref() {
 	T *prev_ptr = _ptr;
 	_ptr = nullptr;
 
-	destruct_arr_placement(prev_ptr, current_size);
+#ifdef ASAN_ENABLED
+	// Access during destruction is illegal in C++, and results in undefined behavior.
+	// In address sanitizer builds, we can poison ourselves (_ptr) to catch this.
+	__asan_poison_memory_region(this, sizeof(CowData));
+#endif
 
-	// Safety check; none of the destructors should have added elements during destruction.
-	DEV_ASSERT(!_ptr);
+	destruct_arr_placement(prev_ptr, current_size);
 
 	// Free Memory.
 	Memory::free_static((uint8_t *)prev_ptr - DATA_OFFSET, false);
 
-#ifdef DEBUG_ENABLED
-	// If any destructors access us through pointers, it is a bug.
-	// We can't really test for that, but we can at least check no items have been added.
+#ifdef ASAN_ENABLED
+	__asan_unpoison_memory_region(this, sizeof(CowData));
+#elif defined(DEBUG_ENABLED)
+	// In a non-asan build, the best we can do is catch if elements were added during destruction.
 	ERR_FAIL_COND_MSG(_ptr != nullptr, "Internal bug, please report: CowData was modified during destruction.");
 #endif
 }

--- a/tests/core/templates/test_vector.cpp
+++ b/tests/core/templates/test_vector.cpp
@@ -692,6 +692,8 @@ struct CyclicVectorHolder {
 	}
 };
 
+// Disable this test with ASAN, it will otherwise (rightfully) complain about use-after-poison.
+#ifndef ASAN_ENABLED
 TEST_CASE("[Vector] Cyclic Reference") {
 	// Create a stack-space vector.
 	Vector<CyclicVectorHolder> vector;
@@ -703,5 +705,6 @@ TEST_CASE("[Vector] Cyclic Reference") {
 	vector.ptrw()[0].is_destructing = true;
 	// The vector goes out of scope and destructs, calling CyclicVectorHolder's destructor.
 }
+#endif
 
 } // namespace TestVector


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/105146/
    - In particular, this PR is sanitizer-build only, but it also finds improper `read` instead of just improper `write`. I think both PRs are warranted.

Finally! I have found a way to sanely track down https://github.com/godotengine/godot/issues/101830.
The builds currently fail for `master` because the asan builds are correctly detecting misuse of `CowData`. We're going to need to address the issue before we can merge this PR.

The way this works is to 'poison' `CowData` while it destructs. This makes sanitizers complain when the destructing `CowData` is accessed during destruction. 
`CowData` (like all other objects) should not be accessed during destruction because it may be in a half-destructed state (e.g. parts of the objects already deallocated).
