### PR TITLE
Add --color option to command line arguments

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -183,6 +183,10 @@ bool OS::is_stdout_debug_enabled() const {
 	return _debug_stdout;
 }
 
+bool OS::is_stdout_colored() const {
+	return _colored_stdout;
+}
+
 bool OS::is_stdout_enabled() const {
 	return _stdout_enabled;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -52,6 +52,7 @@ class OS {
 	bool _delta_smoothing_enabled = false;
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
+	bool _colored_stdout = false;
 	String _local_clipboard;
 	// Assume success by default, all failure cases need to set EXIT_FAILURE explicitly.
 	int _exit_code = EXIT_SUCCESS;
@@ -255,6 +256,7 @@ public:
 
 	bool is_stdout_verbose() const;
 	bool is_stdout_debug_enabled() const;
+	bool is_stdout_colored() const;
 
 	bool is_stdout_enabled() const;
 	bool is_stderr_enabled() const;

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -35,6 +35,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/os/os.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
 #include "drivers/unix/file_access_unix_pipe.h"
@@ -1209,7 +1210,7 @@ void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, i
 	// Disable color codes if stdout is not a TTY.
 	// This prevents Godot from writing ANSI escape codes when redirecting
 	// stdout and stderr to a file.
-	const bool tty = isatty(fileno(stdout));
+	const bool tty = isatty(fileno(stdout)) || OS::get_singleton()->is_stdout_colored();
 	const char *gray = tty ? "\E[0;90m" : "";
 	const char *red = tty ? "\E[0;91m" : "";
 	const char *red_bold = tty ? "\E[1;31m" : "";

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1123,6 +1123,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			exit_err = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
 			goto error;
 
+		} else if (arg == "--color") { // force colored output
+			OS::get_singleton()->_colored_stdout = true;
 		} else if (arg == "-v" || arg == "--verbose") { // verbose output
 
 			OS::get_singleton()->_verbose_stdout = true;

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -80,7 +80,7 @@ void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file
 	}
 
 	HANDLE hCon = GetStdHandle(STD_OUTPUT_HANDLE);
-	if (OS::get_singleton()->get_stdout_type() != OS::STD_HANDLE_CONSOLE || !hCon || hCon == INVALID_HANDLE_VALUE) {
+	if (!OS::get_singleton()->is_stdout_colored() && (OS::get_singleton()->get_stdout_type() != OS::STD_HANDLE_CONSOLE || !hCon || hCon == INVALID_HANDLE_VALUE)) {
 		StdLogger::log_error(p_function, p_file, p_line, p_code, p_rationale, p_editor_notify, p_type, p_script_backtraces);
 	} else {
 		CONSOLE_SCREEN_BUFFER_INFO sbi; //original


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes godotengine/godot-proposals#12507.

This PR adds the `--color` commandline option to always include colors in stdout/stderr, so colored output can be printed from another process (e.g. `OS.execute` or `OS.execute_with_pipe` calling a Godot script with `godot --headless --color -s my_script.gd`).

Tested on Linux with an editor build, untested on Windows. Not implemented for Apple devices as MacOS seems to always include colors, and Apple Embedded never does.

If the principle is accepted, I will need to add the option to `godot --help`, and I assume the online documentation will need its own update.