### PR TITLE
Cleanup header includes for AddMetadataDialog

### DIFF
--- a/editor/add_metadata_dialog.cpp
+++ b/editor/add_metadata_dialog.cpp
@@ -30,7 +30,10 @@
 
 #include "add_metadata_dialog.h"
 
+#include "editor/gui/editor_validation_panel.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
 
 AddMetadataDialog::AddMetadataDialog() {
 	VBoxContainer *vbc = memnew(VBoxContainer);

--- a/editor/add_metadata_dialog.h
+++ b/editor/add_metadata_dialog.h
@@ -30,10 +30,11 @@
 
 #pragma once
 
-#include "editor/gui/editor_validation_panel.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/line_edit.h"
-#include "scene/gui/option_button.h"
+
+class EditorValidationPanel;
+class LineEdit;
+class OptionButton;
 
 class AddMetadataDialog : public ConfirmationDialog {
 	GDCLASS(AddMetadataDialog, ConfirmationDialog);

--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -34,6 +34,7 @@
 #include "editor/debugger/script_editor_debugger.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/line_edit.h"
 
 void EditorExpressionEvaluator::on_start() {
 	expression_input->set_editable(false);

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -30,11 +30,12 @@
 
 #pragma once
 
-#include "editor/add_metadata_dialog.h"
 #include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/scroll_container.h"
 
+class AddMetadataDialog;
 class AcceptDialog;
 class Button;
 class ConfirmationDialog;

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_button.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/tree.h"
 
 static bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -43,6 +43,7 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/item_list.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/link_button.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/menu_button.h"

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_inspector.h"
 #include "editor/editor_sectioned_inspector.h"
 #include "scene/gui/center_container.h"
+#include "scene/gui/label.h"
 
 class ImportDefaultsEditorSettings : public Object {
 	GDCLASS(ImportDefaultsEditorSettings, Object)

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -43,6 +43,7 @@
 #include "scene/3d/skeleton_3d.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/progress_bar.h"

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -38,6 +38,7 @@
 #include "scene/gui/check_box.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/grid_container.h"
+#include "scene/gui/label.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/separator.h"

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -33,6 +33,7 @@
 #include "editor/editor_inspector.h"
 #include "editor/plugins/editor_plugin.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
 #include "scene/gui/margin_container.h"
 
 class CheckBox;
@@ -42,6 +43,7 @@ class GridContainer;
 class Label;
 class OptionButton;
 class PanelContainer;
+class PopupPanel;
 class Separator;
 class TextureRect;
 

--- a/editor/plugins/sub_viewport_preview_editor_plugin.cpp
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "sub_viewport_preview_editor_plugin.h"
 
+#include "scene/main/viewport.h"
+
 bool EditorInspectorPluginSubViewportPreview::can_handle(Object *p_object) {
 	return Object::cast_to<SubViewport>(p_object) != nullptr;
 }

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -34,6 +34,8 @@
 #include "editor/editor_inspector.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
 #include "servers/rendering/shader_language.h"
 
 static const char *global_var_type_names[RS::GLOBAL_VAR_TYPE_MAX] = {

--- a/modules/openxr/editor/openxr_binding_modifier_editor.cpp
+++ b/modules/openxr/editor/openxr_binding_modifier_editor.cpp
@@ -31,6 +31,7 @@
 #include "openxr_binding_modifier_editor.h"
 
 #include "editor/editor_string_names.h"
+#include "scene/gui/option_button.h"
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // EditorPropertyActionSet


### PR DESCRIPTION
Similar to #106430.

When making other fixes to `AddMetadataDialog`, I found that cleaning up its header includes results in a number of other unrelated cpp files needed to be modified.

To avoid unnecessary noises, I submit these changes as a separate PR.