### PR TITLE
[3.x] Fix `unzSeekCurrentFile` not resetting `total_out_64`.

### DIFF
--- a/thirdparty/minizip/patches/godot-seek.patch
+++ b/thirdparty/minizip/patches/godot-seek.patch
@@ -145,7 +145,7 @@ index ea05b7d62a..981ba3c0cb 100644
  
      s->pfile_in_zip_read = pfile_in_zip_read_info;
                  s->encrypted = 0;
-@@ -1510,6 +1544,85 @@ extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method,
+@@ -1510,6 +1544,87 @@ extern int ZEXPORT unzOpenCurrentFile3(unzFile file, int* method,
      return UNZ_OK;
  }
  
@@ -178,6 +178,7 @@ index ea05b7d62a..981ba3c0cb 100644
 +                        pfile_in_zip_read_info->extra_size + pos;
 +
 +        pfile_in_zip_read_info->stream.avail_in = (uInt)0;
++        pfile_in_zip_read_info->total_out_64 = pos;
 +        pfile_in_zip_read_info->stream.total_out = pos;
 +
 +        return ZSEEK64(pfile_in_zip_read_info->z_filefunc,
@@ -202,6 +203,7 @@ index ea05b7d62a..981ba3c0cb 100644
 +
 +            pfile_in_zip_read_info->stream.avail_in = (uInt)0;
 +            pfile_in_zip_read_info->stream.total_out = 0;
++            pfile_in_zip_read_info->total_out_64 = 0;
 +            pfile_in_zip_read_info->stream.next_in = 0;
 +        }
 +

--- a/thirdparty/minizip/unzip.c
+++ b/thirdparty/minizip/unzip.c
@@ -1573,6 +1573,7 @@ extern int ZEXPORT unzSeekCurrentFile(unzFile file, int pos) {
                         pfile_in_zip_read_info->extra_size + pos;
 
         pfile_in_zip_read_info->stream.avail_in = (uInt)0;
+        pfile_in_zip_read_info->total_out_64 = pos;
         pfile_in_zip_read_info->stream.total_out = pos;
 
         return ZSEEK64(pfile_in_zip_read_info->z_filefunc,
@@ -1597,6 +1598,7 @@ extern int ZEXPORT unzSeekCurrentFile(unzFile file, int pos) {
 
             pfile_in_zip_read_info->stream.avail_in = (uInt)0;
             pfile_in_zip_read_info->stream.total_out = 0;
+            pfile_in_zip_read_info->total_out_64 = 0;
             pfile_in_zip_read_info->stream.next_in = 0;
         }
 


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/106869 for 3.x
