### PR TITLE
Warn when classes are registered out of order

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -95,6 +95,12 @@ MethodDefinition D_METHOD(const char *p_name, const VarArgs... p_args) {
 
 #endif // DEBUG_ENABLED
 
+#if defined(DEV_ENABLED) && !defined(TESTS_ENABLED)
+#define GDCLASS_WARN_REGISTER_SECOND_TIME(m_class_name) WARN_PRINT(vformat("Minor bug, please report: Object class %s was explicitly registered after it had already been added to ClassDB.", m_class_name));
+#else
+#define GDCLASS_WARN_REGISTER_SECOND_TIME(m_class_name)
+#endif
+
 class ClassDB {
 	friend class Object;
 
@@ -251,7 +257,9 @@ public:
 	static void register_class(bool p_virtual = false) {
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
-		T::initialize_class();
+		if (unlikely(!T::initialize_class())) {
+			GDCLASS_WARN_REGISTER_SECOND_TIME(T::get_class_static());
+		}
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
@@ -266,7 +274,9 @@ public:
 	static void register_abstract_class() {
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
-		T::initialize_class();
+		if (unlikely(!T::initialize_class())) {
+			GDCLASS_WARN_REGISTER_SECOND_TIME(T::get_class_static());
+		}
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
 		t->exposed = true;
@@ -279,7 +289,9 @@ public:
 	static void register_internal_class() {
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
-		T::initialize_class();
+		if (unlikely(!T::initialize_class())) {
+			GDCLASS_WARN_REGISTER_SECOND_TIME(T::get_class_static());
+		}
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
 		t->creation_func = &creator<T>;
@@ -294,7 +306,9 @@ public:
 	static void register_runtime_class() {
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
-		T::initialize_class();
+		if (unlikely(!T::initialize_class())) {
+			GDCLASS_WARN_REGISTER_SECOND_TIME(T::get_class_static());
+		}
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
 		ERR_FAIL_COND_MSG(t->inherits_ptr && !t->inherits_ptr->creation_func, vformat("Cannot register runtime class '%s' that descends from an abstract parent class.", T::get_class_static()));
@@ -319,7 +333,9 @@ public:
 	static void register_custom_instance_class() {
 		Locker::Lock lock(Locker::STATE_WRITE);
 		static_assert(std::is_same_v<typename T::self_type, T>, "Class not declared properly, please use GDCLASS.");
-		T::initialize_class();
+		if (unlikely(!T::initialize_class())) {
+			GDCLASS_WARN_REGISTER_SECOND_TIME(T::get_class_static());
+		}
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
 		t->creation_func = &_create_ptr_func<T>;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1700,15 +1700,16 @@ Variant Object::_get_indexed_bind(const NodePath &p_name) const {
 	return get_indexed(p_name.get_as_property_path().get_subnames());
 }
 
-void Object::initialize_class() {
+bool Object::initialize_class() {
 	static bool initialized = false;
 	if (initialized) {
-		return;
+		return false;
 	}
 	_add_class_to_classdb(get_class_static(), StringName());
 	_bind_methods();
 	_bind_compatibility_methods();
 	initialized = true;
+	return true;
 }
 
 StringName Object::get_translation_domain() const {


### PR DESCRIPTION
The main initialization process is a mess.

Type registration is interspersed with registering singletons, servers, constants, and settings.
One of the reasons is that the code is defensively coded: If something isn't as expected, we try to make it right automatically.

I propose to make a first step towards sanitization, by warning when classes are registered out of order. This should enforce making intentional decisions about classes:
- Should they even be registered? (or use `GDSOFTCLASS` instead)
- If yes, during which phase should they be registered?
- Should they be exposed or registered as internal?

This PR does not make any decisions yet. Instead, it uses a conservative approach, and only prints during dev builds, giving us a window to sanitize our registration order. The check is further disabled for unit test builds because some unit tests monitor output, causing tests to fail on incorrect initialization order.
In the future, the scope of these warnings should be escalated to `DEBUG_ENABLED`. 

_Note: There are a hundred warnings or so currently when starting the editor with `DEV_ENABLED`._