### PR TITLE
Improve initializations order, especially with regards to type registration, physics, and navigation.

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -82,6 +82,8 @@
 #ifndef DISABLE_DEPRECATED
 #include "core/io/packed_data_container.h"
 #endif
+#include "main/performance.h"
+#include "servers/text_server.h"
 
 static Ref<ResourceFormatSaverBinary> resource_saver_binary;
 static Ref<ResourceFormatLoaderBinary> resource_loader_binary;
@@ -131,6 +133,16 @@ void register_core_types() {
 	ObjectDB::setup();
 
 	StringName::setup();
+	CoreStringNames::create();
+
+	GDREGISTER_CLASS(Object);
+	GDREGISTER_CLASS(RefCounted);
+	GDREGISTER_CLASS(WeakRef);
+
+	GDREGISTER_CLASS(Resource);
+	GDREGISTER_VIRTUAL_CLASS(MissingResource);
+
+	GDREGISTER_CLASS(Time);
 	_time = memnew(Time);
 	ResourceLoader::initialize();
 
@@ -138,7 +150,8 @@ void register_core_types() {
 
 	Variant::register_types();
 
-	CoreStringNames::create();
+	GDREGISTER_CLASS(ResourceFormatSaver);
+	GDREGISTER_CLASS(ResourceFormatLoader);
 
 	if (GD_IS_CLASS_ENABLED(Translation)) {
 		resource_format_po.instantiate();
@@ -161,7 +174,7 @@ void register_core_types() {
 		ResourceLoader::add_resource_format_loader(resource_format_image);
 	}
 
-	GDREGISTER_CLASS(Object);
+	GDREGISTER_CLASS(ProjectSettings);
 
 	GDREGISTER_ABSTRACT_CLASS(Script);
 	GDREGISTER_ABSTRACT_CLASS(ScriptLanguage);
@@ -169,16 +182,12 @@ void register_core_types() {
 	GDREGISTER_VIRTUAL_CLASS(ScriptExtension);
 	GDREGISTER_VIRTUAL_CLASS(ScriptLanguageExtension);
 
-	GDREGISTER_CLASS(RefCounted);
-	GDREGISTER_CLASS(WeakRef);
-	GDREGISTER_CLASS(Resource);
-	GDREGISTER_VIRTUAL_CLASS(MissingResource);
 	GDREGISTER_CLASS(Image);
 
 	GDREGISTER_CLASS(Shortcut);
 	GDREGISTER_ABSTRACT_CLASS(InputEvent);
-	GDREGISTER_ABSTRACT_CLASS(InputEventWithModifiers);
 	GDREGISTER_ABSTRACT_CLASS(InputEventFromWindow);
+	GDREGISTER_ABSTRACT_CLASS(InputEventWithModifiers);
 	GDREGISTER_CLASS(InputEventKey);
 	GDREGISTER_CLASS(InputEventShortcut);
 	GDREGISTER_ABSTRACT_CLASS(InputEventMouse);
@@ -249,9 +258,6 @@ void register_core_types() {
 	GDREGISTER_CLASS(UndoRedo);
 	GDREGISTER_CLASS(TriangleMesh);
 
-	GDREGISTER_CLASS(ResourceFormatLoader);
-	GDREGISTER_CLASS(ResourceFormatSaver);
-
 	GDREGISTER_ABSTRACT_CLASS(FileAccess);
 	GDREGISTER_ABSTRACT_CLASS(DirAccess);
 	GDREGISTER_CLASS(CoreBind::Thread);
@@ -299,15 +305,31 @@ void register_core_types() {
 
 	ip = IP::create();
 
+	GDREGISTER_CLASS(CoreBind::Geometry2D);
 	_geometry_2d = memnew(CoreBind::Geometry2D);
+
+	GDREGISTER_CLASS(CoreBind::Geometry3D);
 	_geometry_3d = memnew(CoreBind::Geometry3D);
 
+	GDREGISTER_CLASS(CoreBind::ResourceLoader);
 	_resource_loader = memnew(CoreBind::ResourceLoader);
+
+	GDREGISTER_CLASS(CoreBind::ResourceSaver);
 	_resource_saver = memnew(CoreBind::ResourceSaver);
+
+	GDREGISTER_CLASS(CoreBind::OS);
 	_os = memnew(CoreBind::OS);
+
+	GDREGISTER_CLASS(CoreBind::Engine);
 	_engine = memnew(CoreBind::Engine);
+
+	GDREGISTER_CLASS(CoreBind::Special::ClassDB);
 	_classdb = memnew(CoreBind::Special::ClassDB);
+
+	GDREGISTER_CLASS(CoreBind::Marshalls);
 	_marshalls = memnew(CoreBind::Marshalls);
+
+	GDREGISTER_CLASS(CoreBind::EngineDebugger);
 	_engine_debugger = memnew(CoreBind::EngineDebugger);
 
 	GDREGISTER_NATIVE_STRUCT(ObjectID, "uint64_t id = 0");
@@ -315,6 +337,17 @@ void register_core_types() {
 	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time");
 
 	worker_thread_pool = memnew(WorkerThreadPool);
+
+	GDREGISTER_ABSTRACT_CLASS(Input);
+	GDREGISTER_CLASS(Expression);
+
+	GDREGISTER_CLASS(TextServerManager);
+
+	GDREGISTER_CLASS(InputMap);
+
+	GDREGISTER_CLASS(TranslationServer);
+
+	GDREGISTER_CLASS(Performance);
 
 	OS::get_singleton()->benchmark_end_measure("Core", "Register Types");
 }
@@ -330,34 +363,14 @@ void register_core_settings() {
 }
 
 void register_early_core_singletons() {
-	GDREGISTER_CLASS(CoreBind::Engine);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Engine", CoreBind::Engine::get_singleton()));
-
-	GDREGISTER_CLASS(ProjectSettings);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ProjectSettings", ProjectSettings::get_singleton()));
-
-	GDREGISTER_CLASS(CoreBind::OS);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("OS", CoreBind::OS::get_singleton()));
-
-	GDREGISTER_CLASS(Time);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Time", Time::get_singleton()));
 }
 
 void register_core_singletons() {
 	OS::get_singleton()->benchmark_begin_measure("Core", "Register Singletons");
-
-	GDREGISTER_ABSTRACT_CLASS(IP);
-	GDREGISTER_CLASS(CoreBind::Geometry2D);
-	GDREGISTER_CLASS(CoreBind::Geometry3D);
-	GDREGISTER_CLASS(CoreBind::ResourceLoader);
-	GDREGISTER_CLASS(CoreBind::ResourceSaver);
-	GDREGISTER_CLASS(CoreBind::Special::ClassDB);
-	GDREGISTER_CLASS(CoreBind::Marshalls);
-	GDREGISTER_CLASS(TranslationServer);
-	GDREGISTER_ABSTRACT_CLASS(Input);
-	GDREGISTER_CLASS(InputMap);
-	GDREGISTER_CLASS(Expression);
-	GDREGISTER_CLASS(CoreBind::EngineDebugger);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("IP", IP::get_singleton(), "IP"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Geometry2D", CoreBind::Geometry2D::get_singleton()));

--- a/drivers/unix/ip_unix.h
+++ b/drivers/unix/ip_unix.h
@@ -35,7 +35,7 @@
 #include "core/io/ip.h"
 
 class IPUnix : public IP {
-	GDCLASS(IPUnix, IP);
+	GDSOFTCLASS(IPUnix, IP);
 
 	virtual void _resolve_hostname(List<IPAddress> &r_addresses, const String &p_hostname, Type p_type = TYPE_ANY) const override;
 

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -127,6 +127,11 @@
 #include "editor/plugins/tool_button_editor_plugin.h"
 #include "editor/plugins/voxel_gi_editor_plugin.h"
 #include "editor/register_exporters.h"
+#include "engine_update_label.h"
+#include "plugins/asset_library_editor_plugin.h"
+#include "project_manager/project_dialog.h"
+#include "project_manager/project_list.h"
+#include "project_manager/quick_settings_dialog.h"
 #ifndef DISABLE_DEPRECATED
 #include "editor/plugins/parallax_background_editor_plugin.h"
 #include "editor/plugins/skeleton_ik_3d_editor_plugin.h"
@@ -275,6 +280,14 @@ void register_editor_types() {
 #ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<ParallaxBackgroundEditorPlugin>();
 #endif
+
+	GDREGISTER_INTERNAL_CLASS(ProjectList);
+	GDREGISTER_INTERNAL_CLASS(ProjectListItemControl);
+	GDREGISTER_INTERNAL_CLASS(EditorAssetLibrary);
+	GDREGISTER_INTERNAL_CLASS(EditorAssetLibraryItemDownload);
+	GDREGISTER_INTERNAL_CLASS(EngineUpdateLabel);
+	GDREGISTER_INTERNAL_CLASS(QuickSettingsDialog);
+	GDREGISTER_INTERNAL_CLASS(ProjectDialog);
 
 	// For correct doc generation.
 	GLOBAL_DEF("editor/run/main_run_args", "");

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -139,6 +139,7 @@ static void _editor_init() {
 void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
 		GDREGISTER_CLASS(GDScript);
+		GDREGISTER_ABSTRACT_CLASS(GDScriptNativeClass);
 
 		script_language_gd = memnew(GDScriptLanguage);
 		ScriptServer::register_language(script_language_gd);
@@ -155,12 +156,12 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 	}
 
 #ifdef TOOLS_ENABLED
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SERVERS) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
 		EditorNode::add_init_callback(_editor_init);
 
 		gdscript_translation_parser_plugin.instantiate();
 		EditorTranslationParser::get_singleton()->add_parser(gdscript_translation_parser_plugin, EditorTranslationParser::STANDARD);
-	} else if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+
 		GDREGISTER_CLASS(GDScriptSyntaxHighlighter);
 	}
 #endif // TOOLS_ENABLED

--- a/modules/navigation_3d/register_types.cpp
+++ b/modules/navigation_3d/register_types.cpp
@@ -58,8 +58,8 @@ void initialize_navigation_3d_module(ModuleInitializationLevel p_level) {
 		NavigationServer3DManager::set_default_server(new_navigation_server_3d);
 
 #ifndef DISABLE_DEPRECATED
-		_nav_mesh_generator = memnew(NavigationMeshGenerator);
 		GDREGISTER_CLASS(NavigationMeshGenerator);
+		_nav_mesh_generator = memnew(NavigationMeshGenerator);
 		Engine::get_singleton()->add_singleton(Engine::Singleton("NavigationMeshGenerator", NavigationMeshGenerator::get_singleton()));
 #endif // DISABLE_DEPRECATED
 	}

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -59,7 +59,7 @@ static void _editor_init_callback() {
 #endif
 
 void initialize_websocket_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 #ifdef WEB_ENABLED
 		EMWSPeer::initialize();
 #else

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -40,15 +40,15 @@ static JavaClassWrapper *java_class_wrapper = nullptr;
 #endif
 
 void register_android_api() {
+	GDREGISTER_CLASS(JNISingleton);
+	GDREGISTER_CLASS(JavaClass);
+	GDREGISTER_CLASS(JavaObject);
+	GDREGISTER_CLASS(JavaClassWrapper);
 #if !defined(ANDROID_ENABLED)
 	// On Android platforms, the `java_class_wrapper` instantiation occurs in
 	// `platform/android/java_godot_lib_jni.cpp#Java_org_godotengine_godot_GodotLib_setup`
 	java_class_wrapper = memnew(JavaClassWrapper);
 #endif
-	GDREGISTER_CLASS(JNISingleton);
-	GDREGISTER_CLASS(JavaClass);
-	GDREGISTER_CLASS(JavaObject);
-	GDREGISTER_CLASS(JavaClassWrapper);
 	Engine::get_singleton()->add_singleton(Engine::Singleton("JavaClassWrapper", JavaClassWrapper::get_singleton()));
 }
 

--- a/platform/macos/native_menu_macos.h
+++ b/platform/macos/native_menu_macos.h
@@ -38,7 +38,7 @@
 #import <ApplicationServices/ApplicationServices.h>
 
 class NativeMenuMacOS : public NativeMenu {
-	GDCLASS(NativeMenuMacOS, NativeMenu)
+	GDSOFTCLASS(NativeMenuMacOS, NativeMenu)
 
 	struct MenuData {
 		NSMenu *menu = nullptr;

--- a/scene/2d/physics/static_body_2d.h
+++ b/scene/2d/physics/static_body_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/2d/physics/physics_body_2d.h"
+#include "scene/resources/physics_material.h"
 
 class NavigationPolygon;
 class NavigationMeshSourceGeometryData2D;

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -32,6 +32,7 @@
 
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
+#include "servers/physics_server_3d.h"
 
 class CollisionObject3D : public Node3D {
 	GDCLASS(CollisionObject3D, Node3D);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -366,6 +366,24 @@ void register_scene_types() {
 
 	Node::init_node_hrcr();
 
+	GDREGISTER_CLASS(Node);
+	GDREGISTER_VIRTUAL_CLASS(MissingNode);
+	GDREGISTER_ABSTRACT_CLASS(InstancePlaceholder);
+
+	GDREGISTER_ABSTRACT_CLASS(CanvasItem);
+	GDREGISTER_CLASS(Node2D);
+	GDREGISTER_CLASS(Control);
+
+	GDREGISTER_VIRTUAL_CLASS(Texture);
+	GDREGISTER_VIRTUAL_CLASS(Texture2D);
+	GDREGISTER_VIRTUAL_CLASS(Texture3D);
+	GDREGISTER_CLASS(CanvasTexture);
+
+	GDREGISTER_VIRTUAL_CLASS(Material);
+	GDREGISTER_CLASS(PlaceholderMaterial);
+	GDREGISTER_CLASS(ShaderMaterial);
+	GDREGISTER_CLASS(CanvasItemMaterial);
+
 	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
 		resource_loader_stream_texture.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
@@ -405,12 +423,6 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); // may take time to init
 
-	GDREGISTER_CLASS(Object);
-
-	GDREGISTER_CLASS(Node);
-	GDREGISTER_VIRTUAL_CLASS(MissingNode);
-	GDREGISTER_ABSTRACT_CLASS(InstancePlaceholder);
-
 	GDREGISTER_ABSTRACT_CLASS(Viewport);
 	GDREGISTER_CLASS(SubViewport);
 	GDREGISTER_CLASS(ViewportTexture);
@@ -438,7 +450,7 @@ void register_scene_types() {
 
 	OS::get_singleton()->yield(); // may take time to init
 
-	GDREGISTER_CLASS(Control);
+	GDREGISTER_VIRTUAL_CLASS(Range);
 	GDREGISTER_CLASS(Button);
 	GDREGISTER_CLASS(Label);
 	GDREGISTER_ABSTRACT_CLASS(ScrollBar);
@@ -454,10 +466,10 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CheckButton);
 	GDREGISTER_CLASS(LinkButton);
 	GDREGISTER_CLASS(Panel);
-	GDREGISTER_VIRTUAL_CLASS(Range);
 
 	OS::get_singleton()->yield(); // may take time to init
 
+	GDREGISTER_CLASS(Container);
 	GDREGISTER_CLASS(TextureRect);
 	GDREGISTER_CLASS(ColorRect);
 	GDREGISTER_CLASS(NinePatchRect);
@@ -469,7 +481,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(HSeparator);
 	GDREGISTER_CLASS(VSeparator);
 	GDREGISTER_CLASS(TextureButton);
-	GDREGISTER_CLASS(Container);
 	GDREGISTER_CLASS(BoxContainer);
 	GDREGISTER_CLASS(HBoxContainer);
 	GDREGISTER_CLASS(VBoxContainer);
@@ -493,8 +504,6 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(VideoStream);
 
 #ifndef ADVANCED_GUI_DISABLED
-	GDREGISTER_CLASS(FileDialog);
-
 	GDREGISTER_CLASS(PopupMenu);
 	GDREGISTER_CLASS(Tree);
 
@@ -516,6 +525,7 @@ void register_scene_types() {
 
 	GDREGISTER_CLASS(AcceptDialog);
 	GDREGISTER_CLASS(ConfirmationDialog);
+	GDREGISTER_CLASS(FileDialog);
 
 	GDREGISTER_CLASS(SubViewportContainer);
 	GDREGISTER_CLASS(SplitContainer);
@@ -596,16 +606,6 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(GeometryInstance3D);
 	GDREGISTER_CLASS(Camera3D);
 	GDREGISTER_CLASS(AudioListener3D);
-#ifndef XR_DISABLED
-	GDREGISTER_CLASS(XRCamera3D);
-	GDREGISTER_CLASS(XRNode3D);
-	GDREGISTER_CLASS(XRController3D);
-	GDREGISTER_CLASS(XRAnchor3D);
-	GDREGISTER_CLASS(XROrigin3D);
-	GDREGISTER_CLASS(XRBodyModifier3D);
-	GDREGISTER_CLASS(XRHandModifier3D);
-	GDREGISTER_CLASS(XRFaceModifier3D);
-#endif // XR_DISABLED
 	GDREGISTER_CLASS(MeshInstance3D);
 	GDREGISTER_CLASS(OccluderInstance3D);
 	GDREGISTER_ABSTRACT_CLASS(Occluder3D);
@@ -650,6 +650,17 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SpringBoneCollisionSphere3D);
 	GDREGISTER_CLASS(SpringBoneCollisionCapsule3D);
 	GDREGISTER_CLASS(SpringBoneCollisionPlane3D);
+
+#ifndef XR_DISABLED
+	GDREGISTER_CLASS(XRCamera3D);
+	GDREGISTER_CLASS(XRNode3D);
+	GDREGISTER_CLASS(XRController3D);
+	GDREGISTER_CLASS(XRAnchor3D);
+	GDREGISTER_CLASS(XROrigin3D);
+	GDREGISTER_CLASS(XRBodyModifier3D);
+	GDREGISTER_CLASS(XRHandModifier3D);
+	GDREGISTER_CLASS(XRFaceModifier3D);
+#endif // XR_DISABLED
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -836,18 +847,11 @@ void register_scene_types() {
 	GDREGISTER_CLASS(VisualShaderNodeParticleAccelerator);
 	GDREGISTER_CLASS(VisualShaderNodeParticleEmit);
 
-	GDREGISTER_VIRTUAL_CLASS(Material);
-	GDREGISTER_CLASS(PlaceholderMaterial);
-	GDREGISTER_CLASS(ShaderMaterial);
-	GDREGISTER_ABSTRACT_CLASS(CanvasItem);
-	GDREGISTER_CLASS(CanvasTexture);
-	GDREGISTER_CLASS(CanvasItemMaterial);
 	SceneTree::add_idle_callback(CanvasItemMaterial::flush_changes);
 	CanvasItemMaterial::init_shaders();
 
 	/* REGISTER 2D */
 
-	GDREGISTER_CLASS(Node2D);
 	GDREGISTER_CLASS(CanvasGroup);
 	GDREGISTER_CLASS(CPUParticles2D);
 	GDREGISTER_CLASS(GPUParticles2D);
@@ -997,8 +1001,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(CameraAttributesPhysical);
 	GDREGISTER_CLASS(CameraAttributesPractical);
 	GDREGISTER_CLASS(World2D);
-	GDREGISTER_VIRTUAL_CLASS(Texture);
-	GDREGISTER_VIRTUAL_CLASS(Texture2D);
 	GDREGISTER_CLASS(Sky);
 	GDREGISTER_CLASS(CompressedTexture2D);
 	GDREGISTER_CLASS(PortableCompressedTexture2D);
@@ -1013,7 +1015,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(ExternalTexture);
 	GDREGISTER_VIRTUAL_CLASS(TextureLayered);
 	GDREGISTER_ABSTRACT_CLASS(ImageTextureLayered);
-	GDREGISTER_VIRTUAL_CLASS(Texture3D);
 	GDREGISTER_CLASS(ImageTexture3D);
 	GDREGISTER_CLASS(CompressedTexture3D);
 	GDREGISTER_CLASS(Cubemap);
@@ -1111,35 +1112,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(NavigationLink2D);
 	GDREGISTER_CLASS(PolygonPathFinder);
 
-	OS::get_singleton()->yield(); // may take time to init
-
-	// 2D nodes that support navmesh baking need to server register their source geometry parsers.
-	MeshInstance2D::navmesh_parse_init();
-	MultiMeshInstance2D::navmesh_parse_init();
-	NavigationObstacle2D::navmesh_parse_init();
-	Polygon2D::navmesh_parse_init();
-#ifndef DISABLE_DEPRECATED
-	TileMap::navmesh_parse_init();
-#endif
-	TileMapLayer::navmesh_parse_init();
-#ifndef PHYSICS_2D_DISABLED
-	StaticBody2D::navmesh_parse_init();
-#endif // PHYSICS_2D_DISABLED
 #endif // NAVIGATION_2D_DISABLED
-
-#ifndef NAVIGATION_3D_DISABLED
-	// 3D nodes that support navmesh baking need to server register their source geometry parsers.
-	MeshInstance3D::navmesh_parse_init();
-	MultiMeshInstance3D::navmesh_parse_init();
-	NavigationObstacle3D::navmesh_parse_init();
-#ifndef PHYSICS_3D_DISABLED
-	StaticBody3D::navmesh_parse_init();
-#endif // PHYSICS_3D_DISABLED
-#endif // NAVIGATION_3D_DISABLED
-
-#if !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
-	OS::get_singleton()->yield(); // may take time to init
-#endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
 
 	GDREGISTER_ABSTRACT_CLASS(SceneState);
 	GDREGISTER_CLASS(PackedScene);
@@ -1437,8 +1410,6 @@ void unregister_scene_types() {
 
 void register_scene_singletons() {
 	OS::get_singleton()->benchmark_begin_measure("Scene", "Register Singletons");
-
-	GDREGISTER_CLASS(ThemeDB);
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ThemeDB", ThemeDB::get_singleton()));
 

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -32,6 +32,12 @@
 #include "navigation_server_2d.compat.inc"
 
 #include "core/config/project_settings.h"
+#include "scene/2d/mesh_instance_2d.h"
+#include "scene/2d/multimesh_instance_2d.h"
+#include "scene/2d/navigation/navigation_obstacle_2d.h"
+#include "scene/2d/physics/static_body_2d.h"
+#include "scene/2d/polygon_2d.h"
+#include "scene/2d/tile_map.h"
 #include "scene/main/node.h"
 #include "servers/navigation/navigation_globals.h"
 #include "servers/navigation_server_2d_dummy.h"
@@ -572,6 +578,20 @@ void NavigationServer2DManager::initialize_server() {
 
 	ERR_FAIL_NULL_MSG(navigation_server_2d, "Failed to initialize NavigationServer2D.");
 	navigation_server_2d->init();
+
+	// 2D nodes that support navmesh baking need to server register their source geometry parsers.
+	MeshInstance2D::navmesh_parse_init();
+	MultiMeshInstance2D::navmesh_parse_init();
+	NavigationObstacle2D::navmesh_parse_init();
+	Polygon2D::navmesh_parse_init();
+
+#ifndef DISABLE_DEPRECATED
+	TileMap::navmesh_parse_init();
+#endif
+	TileMapLayer::navmesh_parse_init();
+#ifndef PHYSICS_2D_DISABLED
+	StaticBody2D::navmesh_parse_init();
+#endif // PHYSICS_2D_DISABLED
 }
 
 void NavigationServer2DManager::finalize_server() {

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -32,6 +32,14 @@
 #include "navigation_server_3d.compat.inc"
 
 #include "core/config/project_settings.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/multimesh_instance_3d.h"
+#ifndef NAVIGATION_3D_DISABLED
+#include "scene/3d/navigation/navigation_obstacle_3d.h"
+#endif
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/3d/physics/static_body_3d.h"
+#endif
 #include "scene/main/node.h"
 #include "servers/navigation/navigation_globals.h"
 #include "servers/navigation_server_3d_dummy.h"
@@ -1061,6 +1069,16 @@ void NavigationServer3DManager::initialize_server() {
 	// Should be impossible, but make sure it's not null.
 	ERR_FAIL_NULL_MSG(navigation_server_3d, "Failed to initialize NavigationServer3D.");
 	navigation_server_3d->init();
+
+#ifndef NAVIGATION_3D_DISABLED
+	// 3D nodes that support navmesh baking need to server register their source geometry parsers.
+	MeshInstance3D::navmesh_parse_init();
+	MultiMeshInstance3D::navmesh_parse_init();
+	NavigationObstacle3D::navmesh_parse_init();
+#ifndef PHYSICS_3D_DISABLED
+	StaticBody3D::navmesh_parse_init();
+#endif // PHYSICS_3D_DISABLED
+#endif // NAVIGATION_3D_DISABLED
 }
 
 void NavigationServer3DManager::finalize_server() {

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -125,6 +125,8 @@ class PhysicsServer2DDummy : public PhysicsServer2D {
 	PhysicsDirectBodyState2DDummy *body_state_dummy = nullptr;
 
 public:
+	static PhysicsServer2D *create() { return memnew(PhysicsServer2DDummy); }
+
 	virtual RID world_boundary_shape_create() override { return RID(); }
 	virtual RID separation_ray_shape_create() override { return RID(); }
 	virtual RID segment_shape_create() override { return RID(); }

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -129,6 +129,10 @@ class PhysicsServer3DDummy : public PhysicsServer3D {
 	PhysicsDirectSpaceState3DDummy *space_state_dummy = nullptr;
 
 public:
+	static PhysicsServer3D *create() {
+		return memnew(PhysicsServer3DDummy);
+	}
+
 	virtual RID world_boundary_shape_create() override { return RID(); }
 	virtual RID separation_ray_shape_create() override { return RID(); }
 	virtual RID sphere_shape_create() override { return RID(); }

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -113,18 +113,6 @@
 
 ShaderTypes *shader_types = nullptr;
 
-#ifndef PHYSICS_2D_DISABLED
-static PhysicsServer2D *_create_dummy_physics_server_2d() {
-	return memnew(PhysicsServer2DDummy);
-}
-#endif // PHYSICS_2D_DISABLED
-
-#ifndef PHYSICS_3D_DISABLED
-static PhysicsServer3D *_create_dummy_physics_server_3d() {
-	return memnew(PhysicsServer3DDummy);
-}
-#endif // PHYSICS_3D_DISABLED
-
 static bool has_server_feature_callback(const String &p_feature) {
 	if (RenderingServer::get_singleton()) {
 		if (RenderingServer::get_singleton()->has_os_feature(p_feature)) {
@@ -143,7 +131,6 @@ void register_server_types() {
 
 	shader_types = memnew(ShaderTypes);
 
-	GDREGISTER_CLASS(TextServerManager);
 	GDREGISTER_ABSTRACT_CLASS(TextServer);
 	GDREGISTER_CLASS(TextServerExtension);
 	GDREGISTER_CLASS(TextServerDummy);
@@ -275,7 +262,11 @@ void register_server_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer2DExtension);
+
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectBodyState2DExtension);
+
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState2D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectSpaceState2DExtension);
 
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionRayResult, "Vector2 position;Vector2 normal;RID rid;ObjectID collider_id;Object *collider;int shape");
@@ -283,8 +274,6 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionShapeRestInfo, "Vector2 point;Vector2 normal;RID rid;ObjectID collider_id;int shape;Vector2 linear_velocity");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer2DExtensionMotionResult, "Vector2 travel;Vector2 remainder;Vector2 collision_point;Vector2 collision_normal;Vector2 collider_velocity;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;int collision_local_shape;ObjectID collider_id;RID collider;int collider_shape");
 
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState2D);
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState2D);
 	GDREGISTER_CLASS(PhysicsRayQueryParameters2D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters2D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters2D);
@@ -293,7 +282,6 @@ void register_server_types() {
 
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, PhysicsServer2DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"), "DEFAULT");
 
-	PhysicsServer2DManager::get_singleton()->register_server("Dummy", callable_mp_static(_create_dummy_physics_server_2d));
 #endif // PHYSICS_2D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
@@ -305,12 +293,16 @@ void register_server_types() {
 #ifndef PHYSICS_3D_DISABLED
 	// Physics 3D
 	GDREGISTER_CLASS(PhysicsServer3DManager);
-	Engine::get_singleton()->add_singleton(Engine::Singleton("PhysicsServer3DManager", PhysicsServer3DManager::get_singleton(), "PhysicsServer3DManager"));
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DExtension);
+
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectBodyState3DExtension);
+
+	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState3D);
 	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectSpaceState3DExtension)
+
 	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DRenderingServerHandler)
 
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionRayResult, "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape;int face_index");
@@ -319,8 +311,6 @@ void register_server_types() {
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionCollision, "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape");
 	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionResult, "Vector3 travel;Vector3 remainder;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count");
 
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectBodyState3D);
-	GDREGISTER_ABSTRACT_CLASS(PhysicsDirectSpaceState3D);
 	GDREGISTER_CLASS(PhysicsRayQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters3D);
@@ -329,11 +319,12 @@ void register_server_types() {
 
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, PhysicsServer3DManager::setting_property_name, PROPERTY_HINT_ENUM, "DEFAULT"), "DEFAULT");
 
-	PhysicsServer3DManager::get_singleton()->register_server("Dummy", callable_mp_static(_create_dummy_physics_server_3d));
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef XR_DISABLED
 	GDREGISTER_ABSTRACT_CLASS(XRInterface);
+	GDREGISTER_ABSTRACT_CLASS(XRTracker);
+	GDREGISTER_CLASS(XRPositionalTracker);
 	GDREGISTER_CLASS(XRVRS);
 	GDREGISTER_CLASS(XRBodyTracker);
 	GDREGISTER_CLASS(XRControllerTracker);
@@ -341,9 +332,7 @@ void register_server_types() {
 	GDREGISTER_CLASS(XRHandTracker);
 	GDREGISTER_CLASS(XRInterfaceExtension); // can't register this as virtual because we need a creation function for our extensions.
 	GDREGISTER_CLASS(XRPose);
-	GDREGISTER_CLASS(XRPositionalTracker);
 	GDREGISTER_CLASS(XRServer);
-	GDREGISTER_ABSTRACT_CLASS(XRTracker);
 #endif // XR_DISABLED
 
 	if (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {


### PR DESCRIPTION
I've used the warnings introduced in https://github.com/godotengine/godot/pull/106873 to sanitize initialization order a bit, reducing the number of warnings by a few tens.
This may fix some subtle bugs, but may also introduce regressions if I've changed anything incorrectly. Hopefully though, it should be better overall than before.

This should be the hardest part of fixing the warnings introduced by https://github.com/godotengine/godot/pull/106873. Most of the rest should be switching to `GDSOFTCLASS`, or adding `GDREGISTER_CLASS` calls in the appropriate spots.

Tagging @smix8 and @mihe for navigation and physics changes, respectively.

## Changes
- `register_core_types` registers important types first (`Object`, `RefCounted`, etc.)
    - Other registrations are moved around to be in correct order.
- Many classes are now registered before creating the singletons.
- `register_server_types` is called before creating server singletons. 
    - Physics servers are created and registered right after one another, coupling the parts closer together.
- `register_scene_types` is called before creating scene singletons.
    - Previously, some navigation initialization was happening here. I moved this to the navigation server initialization functions.
- `GDScript` editor types are registered and handled during `EDITOR` initialization instead of `SERVERS`, as this is where it's expected.
- Websockets are initialized during `SCENE` instead of `CORE`, as this is where it's expected.
- Some macOS classes are made to be `GDSOFTCLASS` as they're not meant to be exposed. This should be followed up with similar changes for other platforms.
- `register_scene_types` and `register_server_types` are rearranged for expected order.
- Possibly more I forgot.
