### PR TITLE
Un-support `force_trivial` parameter for `LocalVector`. Instead, users should use `resize_uninitialized`.

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -769,7 +769,7 @@ private:
 
 	// for collision pairing,
 	// maintain a list of all items moved etc on each frame / tick
-	LocalVector<BVHHandle, uint32_t, true> changed_items;
+	LocalVector<BVHHandle> changed_items;
 	uint32_t _tick = 1; // Start from 1 so items with 0 indicate never updated.
 
 	class BVHLockedFunction {

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -202,7 +202,7 @@ void item_remove(BVHHandle p_handle) {
 
 	// swap back and decrement for fast unordered remove
 	_active_refs[active_ref_id] = ref_id_moved_back;
-	_active_refs.resize(_active_refs.size() - 1);
+	_active_refs.resize_uninitialized(_active_refs.size() - 1);
 
 	// keep the moved active reference up to date
 	_extra[ref_id_moved_back].active_ref_id = active_ref_id;

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -172,13 +172,13 @@ PooledList<TLeaf, uint32_t, true> _leaves;
 // we can maintain an un-ordered list of which references are active,
 // in order to do a slow incremental optimize of the tree over each frame.
 // This will work best if dynamic objects and static objects are in a different tree.
-LocalVector<uint32_t, uint32_t, true> _active_refs;
+LocalVector<uint32_t> _active_refs;
 uint32_t _current_active_ref = 0;
 
 // instead of translating directly to the userdata output,
 // we keep an intermediate list of hits as reference IDs, which can be used
 // for pairing collision detection
-LocalVector<uint32_t, uint32_t, true> _cull_hits;
+LocalVector<uint32_t> _cull_hits;
 
 // We can now have a user definable number of trees.
 // This allows using e.g. a non-pairable and pairable tree,

--- a/core/templates/pooled_list.h
+++ b/core/templates/pooled_list.h
@@ -56,8 +56,8 @@
 
 template <typename T, typename U = uint32_t, bool force_trivial = false, bool zero_on_first_request = false>
 class PooledList {
-	LocalVector<T, U, force_trivial> list;
-	LocalVector<U, U, true> freelist;
+	LocalVector<T, U> list;
+	LocalVector<U, U> freelist;
 
 	// not all list members are necessarily used
 	U _used_size;
@@ -102,13 +102,17 @@ public:
 			// pop from freelist
 			int new_size = freelist.size() - 1;
 			r_id = freelist[new_size];
-			freelist.resize(new_size);
+			freelist.resize_uninitialized(new_size);
 
 			return &list[r_id];
 		}
 
 		r_id = list.size();
-		list.resize(r_id + 1);
+		if constexpr (force_trivial || std::is_trivially_constructible_v<T>) {
+			list.resize_uninitialized(r_id + 1);
+		} else {
+			list.resize_initialized(r_id + 1);
+		}
 
 		static_assert((!zero_on_first_request) || (__is_pod(T)), "zero_on_first_request requires trivial type");
 		if constexpr (zero_on_first_request && __is_pod(T)) {
@@ -169,7 +173,7 @@ public:
 
 		// expand the active map (this should be in sync with the pool list
 		if (_pool.used_size() > _active_map.size()) {
-			_active_map.resize(_pool.used_size());
+			_active_map.resize_uninitialized(_pool.used_size());
 		}
 
 		// store in the active map


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/104522

The parameter `force_trivial` was always just a way to resize the `LocalVector` without calling default initializers (to save time).
Now, this is no longer required - users can simply call `resize_uninitialized`! This makes it explicit where a resize is happening without filling values.

This PR should not change behavior, just simplify matters and improve code style.

## Notes
- I've checked `changed_items` and `_cull_hits`, they never called `resize` so the `force_trivial` parameter was useless for both.
- `force_trivial` behavior handling is bubbled up to `PooledList`. It is somewhat questionable whether it is appropriate here, because it is only used to create one object at a time. Still, this is outside the scope of this PR to change.
- `_active_map` and `freelist` use a trivial type so they don't initialize on `resize` (regardless of `force_trivial`). I took the opportunity to make this explicit using `resize_uninitialized`, as we'll make that a goal soon anyway.
