### PR TITLE
Implement materialX shader loading

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "thirdparty/materialx"]
+	path = thirdparty/materialx
+	url = https://github.com/AcademySoftwareFoundation/MaterialX.git

--- a/modules/mtlx/MaterialXCore/Generated.h
+++ b/modules/mtlx/MaterialXCore/Generated.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  resource_loader_materialx.h                                           */
+/*  Generated.h                                                           */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,14 +30,30 @@
 
 #pragma once
 
-#include "core/io/resource_loader.h"
+//
+// Copyright Contributors to the MaterialX Project
+// SPDX-License-Identifier: Apache-2.0
+//
 
-class ResourceFormatLoaderMtlx : public ResourceFormatLoader {
-	GDCLASS(ResourceFormatLoaderMtlx, ResourceFormatLoader);
+#ifndef MATERIALX_GENERATED_H
+#define MATERIALX_GENERATED_H
 
-public:
-	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
-	virtual bool handles_type(const String &p_type) const override;
-	virtual String get_resource_type(const String &p_path) const override;
-};
+#define MATERIALX_MAJOR_VERSION 1
+#define MATERIALX_MINOR_VERSION 38
+#define MATERIALX_BUILD_VERSION 10
+
+/* #undef MATERIALX_BUILD_SHARED_LIBS */
+
+// Establish namespace:
+namespace MaterialX_v1_38_10 {
+}
+
+// Establish alias to allow downstream clients to still use the MaterialX namespace:
+namespace MaterialX = MaterialX_v1_38_10;
+
+// All code in this project must use these macros for opening and closing the
+// global MaterialX namespace:
+#define MATERIALX_NAMESPACE_BEGIN namespace MaterialX_v1_38_10 {
+#define MATERIALX_NAMESPACE_END }
+
+#endif

--- a/modules/mtlx/README.md
+++ b/modules/mtlx/README.md
@@ -8,9 +8,7 @@ Converting some materialx nodes and shaders into godot visual shaders
 
 ## TODO
 
-* Vendoring MaterialX
 * Implementing all the MaterialX nodes and shaders
-* Loading the standard library
 * Color Management
 * Unit Management
 * ResourceSaver and ResourceImporter

--- a/modules/mtlx/README.md
+++ b/modules/mtlx/README.md
@@ -1,0 +1,16 @@
+# Overview
+
+MaterialX is an open standard for the transfer of rich material and look-development content between applications and renderers. This module allows you to use MaterialX within your Godot projects.
+
+## Features
+
+Converting some materialx nodes and shaders into godot visual shaders
+
+## TODO
+
+* Vendoring MaterialX
+* Implementing all the MaterialX nodes and shaders
+* Loading the standard library
+* Color Management
+* Unit Management
+* ResourceSaver and ResourceImporter

--- a/modules/mtlx/SCsub
+++ b/modules/mtlx/SCsub
@@ -1,0 +1,44 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+Import("env_modules")
+
+env_materialx = env_modules.Clone()
+
+if env.msvc:
+    env_materialx.Append(CCFLAGS="/EHsc")
+else:
+    env_materialx.Append(CCFLAGS="-fexceptions")
+
+env_materialx.Prepend(
+    CPPPATH=["#modules/mtlx", "/nix/store/7bwfgs2nh289ynlljfm3dl0ybb1byp7k-python3.12-materialx-1.38.10/include"]
+)
+env.Append(LIBPATH=["/nix/store/7bwfgs2nh289ynlljfm3dl0ybb1byp7k-python3.12-materialx-1.38.10/lib"])
+env.Append(
+    LIBS=[
+        "MaterialXCore",
+        "MaterialXFormat",
+        "MaterialXGenGlsl",
+        "MaterialXGenMdl",
+        "MaterialXGenMsl",
+        "MaterialXGenOsl",
+        "MaterialXGenShader",
+        "MaterialXRender",
+        "MaterialXRenderGlsl",
+        "MaterialXRenderHw",
+        "MaterialXRenderOsl",
+    ]
+)
+
+if env["platform"] == "macos" or env["platform"] == "ios":
+    env_materialx.Append(CPPDEFINES=["DMATERIALXVIEW_METAL_BACKEND=1"])
+elif env["platform"] == "linux":
+    env_materialx.Append(CPPDEFINES=["__linux__"])
+
+env_materialx.Append(CPPDEFINES=["GL_SILENCE_DEPRECATION"])
+
+module_objs = []
+
+env_materialx.add_source_files(module_objs, "*.cpp")
+env.modules_sources += module_objs

--- a/modules/mtlx/SCsub
+++ b/modules/mtlx/SCsub
@@ -21,6 +21,10 @@ env_thirdparty.disable_warnings()
 env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXCore/*.cpp")
 env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXFormat/*.cpp")
 env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXFormat/External/PugiXML/*.cpp")
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXGenGlsl/*.cpp")
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXGenGlsl/Nodes/*.cpp")
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXGenShader/*.cpp")
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXGenShader/Nodes/*.cpp")
 env.modules_sources += thirdparty_obj
 
 if env["platform"] == "macos" or env["platform"] == "ios":

--- a/modules/mtlx/SCsub
+++ b/modules/mtlx/SCsub
@@ -11,7 +11,7 @@ if env.msvc:
 else:
     env_materialx.Append(CCFLAGS="-fexceptions")
 
-env_materialx.Prepend(CPPPATH=["#modules/mtlx", "#thirdparty/materialx/source"])
+env_materialx.Prepend(CPPPATH=["#modules/mtlx", "#modules/mtlx/MaterialXCore", "#thirdparty/materialx/source"])
 
 thirdparty_obj = []
 

--- a/modules/mtlx/SCsub
+++ b/modules/mtlx/SCsub
@@ -11,25 +11,17 @@ if env.msvc:
 else:
     env_materialx.Append(CCFLAGS="-fexceptions")
 
-env_materialx.Prepend(
-    CPPPATH=["#modules/mtlx", "/nix/store/7bwfgs2nh289ynlljfm3dl0ybb1byp7k-python3.12-materialx-1.38.10/include"]
-)
-env.Append(LIBPATH=["/nix/store/7bwfgs2nh289ynlljfm3dl0ybb1byp7k-python3.12-materialx-1.38.10/lib"])
-env.Append(
-    LIBS=[
-        "MaterialXCore",
-        "MaterialXFormat",
-        "MaterialXGenGlsl",
-        "MaterialXGenMdl",
-        "MaterialXGenMsl",
-        "MaterialXGenOsl",
-        "MaterialXGenShader",
-        "MaterialXRender",
-        "MaterialXRenderGlsl",
-        "MaterialXRenderHw",
-        "MaterialXRenderOsl",
-    ]
-)
+env_materialx.Prepend(CPPPATH=["#modules/mtlx", "#thirdparty/materialx/source"])
+
+thirdparty_obj = []
+
+env_thirdparty = env_materialx.Clone()
+env_thirdparty.disable_warnings()
+
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXCore/*.cpp")
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXFormat/*.cpp")
+env_thirdparty.add_source_files(thirdparty_obj, "#thirdparty/materialx/source/MaterialXFormat/External/PugiXML/*.cpp")
+env.modules_sources += thirdparty_obj
 
 if env["platform"] == "macos" or env["platform"] == "ios":
     env_materialx.Append(CPPDEFINES=["DMATERIALXVIEW_METAL_BACKEND=1"])
@@ -38,7 +30,8 @@ elif env["platform"] == "linux":
 
 env_materialx.Append(CPPDEFINES=["GL_SILENCE_DEPRECATION"])
 
-module_objs = []
+module_obj = []
 
-env_materialx.add_source_files(module_objs, "*.cpp")
-env.modules_sources += module_objs
+env_materialx.add_source_files(module_obj, "*.cpp")
+env.modules_sources += module_obj
+env.Depends(module_obj, thirdparty_obj)

--- a/modules/mtlx/config.py
+++ b/modules/mtlx/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return platform == "linuxbsd"
+    return True
 
 
 def configure(env):

--- a/modules/mtlx/config.py
+++ b/modules/mtlx/config.py
@@ -1,0 +1,14 @@
+def can_build(env, platform):
+    return platform == "linuxbsd"
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return ["ResourceFormatLoaderMtlx"]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/mtlx/doc_classes/ResourceFormatLoaderMtlx.xml
+++ b/modules/mtlx/doc_classes/ResourceFormatLoaderMtlx.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceFormatLoaderMtlx" inherits="ResourceFormatLoader" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/mtlx/materialx_shader.h
+++ b/modules/mtlx/materialx_shader.h
@@ -61,7 +61,6 @@ public:
 	Error save_file(const String &p_path = "");
 
 private:
-	void _connect_or_default(mx::NodePtr p_shader, std::string p_outgoing_port, int p_incoming_port);
 	void _connection_or_default(Ref<VisualShaderNode> p_shader_node, int p_port, const mx::NodePtr &p_mtlx_node, std::string p_input);
 
 	Ref<VisualShaderNode> _read_node(const mx::NodePtr &node, int p_id);

--- a/modules/mtlx/register_types.cpp
+++ b/modules/mtlx/register_types.cpp
@@ -1,0 +1,52 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+
+#include "resource_loader_materialx.h"
+
+#include "core/io/resource.h"
+#include "modules/register_module_types.h"
+
+static Ref<ResourceFormatLoaderMtlx> resource_loader_mtlx;
+
+void initialize_mtlx_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		resource_loader_mtlx.instantiate();
+		ResourceLoader::add_resource_format_loader(resource_loader_mtlx);
+	}
+}
+
+void uninitialize_mtlx_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		ResourceLoader::remove_resource_format_loader(resource_loader_mtlx);
+		resource_loader_mtlx.unref();
+	}
+}

--- a/modules/mtlx/register_types.cpp
+++ b/modules/mtlx/register_types.cpp
@@ -30,15 +30,19 @@
 
 #include "register_types.h"
 
+#include "materialx_shader.h"
 #include "resource_loader_materialx.h"
 
 #include "core/io/resource.h"
+#include "core/object/class_db.h"
 #include "modules/register_module_types.h"
 
 static Ref<ResourceFormatLoaderMtlx> resource_loader_mtlx;
 
 void initialize_mtlx_module(ModuleInitializationLevel p_level) {
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
+		GDREGISTER_CLASS(MaterialXShader);
+
 		resource_loader_mtlx.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_mtlx);
 	}

--- a/modules/mtlx/register_types.h
+++ b/modules/mtlx/register_types.h
@@ -1,0 +1,36 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_mtlx_module(ModuleInitializationLevel p_level);
+void uninitialize_mtlx_module(ModuleInitializationLevel p_level);

--- a/modules/mtlx/resource_loader_materialx.cpp
+++ b/modules/mtlx/resource_loader_materialx.cpp
@@ -1,0 +1,826 @@
+/**************************************************************************/
+/*  resource_loader_materialx.cpp                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_loader_materialx.h"
+
+#include "core/config/project_settings.h"
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_loader.h"
+#include "core/math/vector4.h"
+#include "core/object/class_db.h"
+#include "core/string/print_string.h"
+#include "core/string/string_name.h"
+#include "core/templates/hash_map.h"
+#include "core/variant/variant.h"
+#include "scene/resources/material.h"
+#include "scene/resources/texture.h"
+#include "scene/resources/visual_shader.h"
+#include "scene/resources/visual_shader_nodes.h"
+
+#include <MaterialXCore/Document.h>
+#include <MaterialXCore/Element.h>
+#include <MaterialXCore/Interface.h>
+#include <MaterialXCore/Node.h>
+#include <MaterialXCore/Unit.h>
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/Util.h>
+#include <MaterialXFormat/XmlIo.h>
+
+Ref<Resource> ResourceFormatLoaderMtlx::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	// Prepare + Load MaterialX document.
+	mx::DocumentPtr doc = mx::createDocument();
+
+	String resource_path = ProjectSettings::get_singleton()->globalize_path(p_original_path);
+	resource_base_path = resource_path.get_base_dir();
+	mx::FilePath mx_absolute_path = mx::FilePath(resource_path.utf8().get_data());
+
+	mx::readFromXmlFile(doc, mx_absolute_path);
+
+	// Make sure that worked.
+	std::string message;
+	bool document_valid = doc->validate(&message);
+	if (!document_valid) {
+		*r_error = ERR_PARSE_ERROR;
+		String msg = vformat("The MaterialX document is invalid: [%s] %s", resource_path, message.c_str());
+		ERR_FAIL_V_MSG(Ref<Resource>(), msg);
+	}
+
+	// Convert MaterialX document into VisualShader
+	Ref<ShaderMaterial> mat;
+	mat.instantiate();
+	shader.instantiate();
+
+	int node_i = 2;
+	for (mx::NodeGraphPtr graph : doc->getNodeGraphs()) {
+		String graph_name = graph->getName().c_str();
+		if (!graph_name.begins_with("NG_")) {
+			WARN_PRINT(graph_name);
+			continue;
+		}
+
+		print_line(vformat("MaterialX nodegraph %s", graph_name));
+		std::vector<mx::ElementPtr> sorted_nodes = graph->topologicalSort();
+
+		for (const mx::ElementPtr &element : sorted_nodes) {
+			if (element->getCategory() == "output") {
+				StringName key = element->getName().c_str();
+				StringName output_node = element->getAttribute("nodename").c_str();
+				output_to_node_map[key] = output_node;
+				continue;
+			}
+
+			const mx::NodePtr &node = element->asA<mx::Node>();
+			if (!node) {
+				continue;
+			}
+
+			Ref<VisualShaderNode> new_node = _read_node(node, node_i);
+			if (new_node.is_null()) {
+				continue;
+			}
+
+			node_id_map[node->getName().c_str()] = node_i;
+
+			Ref<VisualShaderNodeFrame> frame_node;
+			frame_node.instantiate();
+			frame_node->set_title(node->getName().c_str());
+
+			shader->add_node(VisualShader::TYPE_FRAGMENT, new_node, Vector2(150, -200 + 100 * node_i), node_i);
+			shader->add_node(VisualShader::TYPE_FRAGMENT, frame_node, Vector2(150, 0 + 100 * node_i), node_i + 1);
+			shader->attach_node_to_frame(VisualShader::TYPE_FRAGMENT, node_i, node_i + 1);
+
+			node_i += 2;
+		}
+	}
+
+	for (mx::ElementPtr element : doc->getChildren()) {
+		std::string shader_type = element->getCategory();
+		if (shader_type == "disney_principled") {
+		} else if (shader_type == "gltf_pbr") {
+		} else if (shader_type == "open_pbr_surface") {
+		} else if (shader_type == "standard_surface") {
+			mx::NodePtr shader_node = element->asA<mx::Node>();
+
+			_connect_or_default(shader_node, "base_color", 0); // Albedo
+			//_connect_or_default(shader_node, "opacity", 1); // Alpha
+			_connect_or_default(shader_node, "metalness", 2); // Metallic
+			_connect_or_default(shader_node, "roughness", 3); // Roughness
+			_connect_or_default(shader_node, "specular", 4); // Specular
+			//_connect_or_default(shader_node, "emission", 5); // Emission
+			//_connect_or_default(shader_node, "base_color", 6); // AO
+			//_connect_or_default(shader_node, "base_color", 7); // AO Light Effect
+
+			_connect_or_default(shader_node, "normal", 8); // Normal
+			//_connect_or_default(shader_node, "base_color", 9); // Normal Map
+			//_connect_or_default(shader_node, "base_color", 10); // Normal Map Depth
+
+			//_connect_or_default(shader_node, "base_color", 11); // Bent Normal Map
+
+			//_connect_or_default(shader_node, "base_color", 12); // Rim
+			//_connect_or_default(shader_node, "base_color", 13); // Rim Tint
+			//_connect_or_default(shader_node, "base_color", 14); // Clearcoat
+			//_connect_or_default(shader_node, "base_color", 15); // Clearcoat Roughness
+			//_connect_or_default(shader_node, "base_color", 16); // Anisotropy
+			//_connect_or_default(shader_node, "base_color", 17); // Anisotropy Flow
+			//_connect_or_default(shader_node, "base_color", 18); // Subsurf Scatter
+			//_connect_or_default(shader_node, "base_color", 19); // Backlight
+
+			//_connect_or_default(shader_node, "base_color", 20); // Alpha Scissor Threshold
+			//_connect_or_default(shader_node, "base_color", 21); // Alpha Hash Scale
+			//_connect_or_default(shader_node, "base_color", 22); // Alpha AA Edge
+			//_connect_or_default("base_color", 23); // Alpha UV
+
+			//_connect_or_default(shader_node, "base_color", 24); // Depth
+		} else if (shader_type == "usd_preview_surface") {
+		} else {
+			WARN_PRINT(vformat("Unknown shader type [%s]", shader_type.c_str()));
+		}
+	}
+
+	for (NodeConnection connection : node_connections) {
+		if (!node_id_map.has(connection.node_out) || !node_id_map.has(connection.node_in)) {
+			ERR_PRINT(vformat("Cannot connect nodes [%s] -> [%s]", connection.node_out, connection.node_in));
+			continue;
+		}
+
+		int node_out_id = node_id_map.get(connection.node_out);
+		int node_in_id = node_id_map.get(connection.node_in);
+		shader->connect_nodes(VisualShader::TYPE_FRAGMENT, node_out_id, 0, node_in_id, connection.node_in_port);
+	}
+
+	mat->set_shader(shader);
+	return mat;
+}
+
+void ResourceFormatLoaderMtlx::get_recognized_extensions(List<String> *p_extensions) const {
+	if (!p_extensions->find("mtlx")) {
+		p_extensions->push_back("mtlx");
+	}
+}
+
+bool ResourceFormatLoaderMtlx::handles_type(const String &p_type) const {
+	return ClassDB::is_parent_class(p_type, "ShaderMaterial");
+}
+
+String ResourceFormatLoaderMtlx::get_resource_type(const String &p_path) const {
+	String el = p_path.get_extension().to_lower();
+	if (el == "mtlx") {
+		return "ShaderMaterial";
+	}
+	return "";
+}
+
+void ResourceFormatLoaderMtlx::_connect_or_default(mx::NodePtr p_shader, std::string p_outgoing_port, int p_incoming_port) {
+	Ref<VisualShaderNodeOutput> output = shader->get_node(VisualShader::TYPE_FRAGMENT, VisualShader::NODE_ID_OUTPUT);
+
+	mx::OutputPtr graph_output = p_shader->getConnectedOutput(p_outgoing_port);
+	if (graph_output) {
+		StringName node_output = output_to_node_map[graph_output->getName().c_str()];
+		if (node_id_map.has(node_output)) {
+			int node_id = node_id_map.get(node_output);
+			shader->connect_nodes(VisualShader::TYPE_FRAGMENT, node_id, 0, VisualShader::NODE_ID_OUTPUT, p_incoming_port);
+		} else {
+			ERR_PRINT(vformat("Cannot connect nodes [%s] -> [output]", node_output));
+		}
+
+		return;
+	}
+
+	Variant def_value = _get_mtlx_value_as_port_value(p_shader->getInputValue(p_outgoing_port));
+	output->set_input_port_default_value(p_incoming_port, def_value);
+}
+
+void ResourceFormatLoaderMtlx::_connection_or_default(Ref<VisualShaderNode> p_shader_node, int p_port, const mx::NodePtr &p_mtlx_node, std::string p_input) {
+	std::string nodename = p_mtlx_node->getConnectedNodeName(p_input);
+	if (!nodename.empty()) {
+		ResourceFormatLoaderMtlx::NodeConnection connection;
+		connection.node_out = nodename.c_str();
+		connection.node_in = p_mtlx_node->getName().c_str();
+		connection.node_in_port = p_port;
+		node_connections.push_back(connection);
+	} else {
+		Variant value = _get_mtlx_value_as_port_value(p_mtlx_node->getInputValue(p_input));
+		p_shader_node->set_input_port_default_value(p_port, value);
+	}
+}
+
+Ref<VisualShaderNode> ResourceFormatLoaderMtlx::_read_node(const mx::NodePtr &p_node, int p_id) {
+	std::string category = p_node->getCategory();
+	if (category == "image") {
+		Ref<VisualShaderNodeTexture> texture_node;
+		texture_node.instantiate();
+
+		String file = p_node->getInput("file")->getValueString().c_str();
+		String path = vformat("%s/%s", resource_base_path, file);
+		if (FileAccess::exists(path)) {
+			Ref<Texture2D> texture = ResourceLoader::load(path, "Texture2D");
+			texture_node->set_texture(texture);
+		}
+
+		//TODO not done
+		String layer = p_node->getInput("layer")->getValueString().c_str();
+		//String default_value = p_node->getInput("default")->asString().c_str();
+		//String texcoord = p_node->getInput("texcoord")->asString().c_str();
+		String uaddressmode = p_node->getInput("uaddressmode")->getValueString().c_str();
+		String vaddressmode = p_node->getInput("vaddressmode")->getValueString().c_str();
+		String filtertype = p_node->getInput("filtertype")->getValueString().c_str();
+
+		return texture_node;
+	} else if (category == "tiledimage") {
+		return nullptr;
+	} else if (category == "triplanarprojection") {
+		return nullptr;
+	} else if (category == "constant") {
+		return _read_constant_node(p_node);
+	} else if (category == "ramplr") {
+		return nullptr;
+	} else if (category == "ramptb") {
+		return nullptr;
+	} else if (category == "ramp4") {
+		return nullptr;
+	} else if (category == "splitlr") {
+		return nullptr;
+	} else if (category == "splittb") {
+		return nullptr;
+	} else if (category == "randomfloat") {
+		return nullptr;
+	} else if (category == "randomcolor") {
+		return nullptr;
+	} else if (category == "noise2d") {
+		return nullptr;
+	} else if (category == "noise3d") {
+		return nullptr;
+	} else if (category == "fractal3d") {
+		return nullptr;
+	} else if (category == "cellnoise2d") {
+		return nullptr;
+	} else if (category == "cellnoise3d") {
+		return nullptr;
+	} else if (category == "worleynoise2d") {
+		return nullptr;
+	} else if (category == "worleynoise3d") {
+		return nullptr;
+	} else if (category == "unifiednoise2d") {
+		return nullptr;
+	} else if (category == "unifiednoise3d") {
+		return nullptr;
+	} else if (category == "checkerboard") {
+		return nullptr;
+	} else if (category == "line") {
+		return nullptr;
+	} else if (category == "circle") {
+		return nullptr;
+	} else if (category == "cloverleaf") {
+		return nullptr;
+	} else if (category == "hexagon") {
+		return nullptr;
+	} else if (category == "grid") {
+		return nullptr;
+	} else if (category == "crosshatch") {
+		return nullptr;
+	} else if (category == "tiledcircles") {
+		return nullptr;
+	} else if (category == "tiledcloverleafs") {
+		return nullptr;
+	} else if (category == "tiledhexagons") {
+		return nullptr;
+	} else if (category == "position") {
+		return nullptr;
+	} else if (category == "normal") {
+		return nullptr;
+	} else if (category == "tangent") {
+		return nullptr;
+	} else if (category == "bitangent") {
+		return nullptr;
+	} else if (category == "bump") {
+		return nullptr;
+	} else if (category == "texcoord") {
+		return nullptr;
+	} else if (category == "geomcolor") {
+		return nullptr;
+	} else if (category == "geompropvalue") {
+		return nullptr;
+	} else if (category == "geompropvalueuniform") {
+		return nullptr;
+	} else if (category == "frame") {
+		return nullptr;
+	} else if (category == "time") {
+		return nullptr;
+	} else if (category == "add") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_ADD);
+		}
+
+		return nullptr;
+	} else if (category == "subtract") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_SUB);
+		}
+
+		return nullptr;
+	} else if (category == "multiply") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_MUL);
+		}
+
+		return nullptr;
+	} else if (category == "divide") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_DIV);
+		}
+
+		return nullptr;
+	} else if (category == "modulo") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_MOD);
+		}
+
+		return nullptr;
+	} else if (category == "fract") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_FRACT);
+		}
+
+		return nullptr;
+	} else if (category == "invert") {
+		return nullptr;
+	} else if (category == "absval") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_ABS);
+		}
+
+		return nullptr;
+	} else if (category == "sign") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_SIGN);
+		}
+
+		return nullptr;
+	} else if (category == "floor") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_FLOOR);
+		}
+
+		return nullptr;
+	} else if (category == "ceil") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_CEIL);
+		}
+
+		return nullptr;
+	} else if (category == "round") {
+		return nullptr;
+	} else if (category == "power") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_POW);
+		}
+
+		return nullptr;
+	} else if (category == "safepower") {
+		return nullptr;
+	} else if (category == "sin") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_SIN);
+		}
+
+		return nullptr;
+	} else if (category == "cos") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_COS);
+		}
+
+		return nullptr;
+	} else if (category == "tan") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_TAN);
+		}
+
+		return nullptr;
+	} else if (category == "atan") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_ATAN);
+		}
+
+		return nullptr;
+	} else if (category == "atan2") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_ATAN2);
+		}
+
+		return nullptr;
+	} else if (category == "sqrt") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_SQRT);
+		}
+
+		return nullptr;
+	} else if (category == "ln") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_LOG); //! is this log10 or ln? we require log_e
+		}
+
+		return nullptr;
+	} else if (category == "exp") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_unary_operator_node(p_node, VisualShaderNodeFloatFunc::FUNC_EXP);
+		}
+
+		return nullptr;
+	} else if (category == "clamp") {
+		Ref<VisualShaderNodeClamp> clamp_node;
+		clamp_node.instantiate();
+
+		_connection_or_default(clamp_node, 0, p_node, "in");
+		_connection_or_default(clamp_node, 1, p_node, "low");
+		_connection_or_default(clamp_node, 2, p_node, "high");
+
+		std::string type = p_node->getType();
+		if (type == "float") {
+			clamp_node->set_op_type(VisualShaderNodeClamp::OP_TYPE_FLOAT);
+		}
+
+		return clamp_node;
+	} else if (category == "trianglewave") {
+		return nullptr;
+	} else if (category == "min") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_MIN);
+		}
+
+		return nullptr;
+	} else if (category == "max") {
+		std::string type = p_node->getType();
+		if (type == "float") {
+			return _read_binary_operator_node(p_node, VisualShaderNodeFloatOp::OP_MAX);
+		}
+
+		return nullptr;
+	} else if (category == "normalize") {
+		return nullptr;
+	} else if (category == "magnitude") {
+		return nullptr;
+	} else if (category == "distance") {
+		return nullptr;
+	} else if (category == "dotproduct") {
+		return nullptr;
+	} else if (category == "crossproduct") {
+		return nullptr;
+	} else if (category == "transformpoint") {
+		return nullptr;
+	} else if (category == "transformvector") {
+		return nullptr;
+	} else if (category == "transformnormal") {
+		return nullptr;
+	} else if (category == "transformmatrix") {
+		return nullptr;
+	} else if (category == "normalmap") {
+		return nullptr;
+	} else if (category == "creatematrix") {
+		return nullptr;
+	} else if (category == "transform") {
+		return nullptr;
+	} else if (category == "determinant") {
+		return nullptr;
+	} else if (category == "invertmatrix") {
+		return nullptr;
+	} else if (category == "rotate2d") {
+		return nullptr;
+	} else if (category == "rotate3d") {
+		return nullptr;
+	} else if (category == "reflect") {
+		return nullptr;
+	} else if (category == "refract") {
+		return nullptr;
+	} else if (category == "place2d") {
+		return nullptr;
+	} else if (category == "dot") {
+		Ref<VisualShaderNodeReroute> reroute;
+		reroute.instantiate();
+
+		_connection_or_default(reroute, 0, p_node, "in");
+
+		return reroute;
+	} else if (category == "and") {
+		return nullptr;
+	} else if (category == "or") {
+		return nullptr;
+	} else if (category == "xor") {
+		return nullptr;
+	} else if (category == "not") {
+		return nullptr;
+	} else if (category == "contrast") {
+		return nullptr;
+	} else if (category == "remap") {
+		return nullptr;
+	} else if (category == "range") {
+		return nullptr;
+	} else if (category == "smoothstep") {
+		return nullptr;
+	} else if (category == "luminance") {
+		return nullptr;
+	} else if (category == "rgbtohsv") {
+		return nullptr;
+	} else if (category == "hsvtorgb") {
+		return nullptr;
+	} else if (category == "hsvadjust") {
+		return nullptr;
+	} else if (category == "saturate") {
+		return nullptr;
+	} else if (category == "colorcorrect") {
+		return nullptr;
+	} else if (category == "premult") {
+		return nullptr;
+	} else if (category == "unpremult") {
+		return nullptr;
+	} else if (category == "plus") {
+		return nullptr;
+	} else if (category == "minus") {
+		return nullptr;
+	} else if (category == "difference") {
+		return nullptr;
+	} else if (category == "burn") {
+		return nullptr;
+	} else if (category == "dodge") {
+		return nullptr;
+	} else if (category == "screen") {
+		return nullptr;
+	} else if (category == "overlay") {
+		return nullptr;
+	} else if (category == "disjointover") {
+		return nullptr;
+	} else if (category == "in") {
+		return nullptr;
+	} else if (category == "mask") {
+		return nullptr;
+	} else if (category == "matte") {
+		return nullptr;
+	} else if (category == "out") {
+		return nullptr;
+	} else if (category == "over") {
+		return nullptr;
+	} else if (category == "inside") {
+		return nullptr;
+	} else if (category == "outside") {
+		return nullptr;
+	} else if (category == "mix") {
+		Ref<VisualShaderNodeMix> mix_node;
+		mix_node.instantiate();
+
+		_connection_or_default(mix_node, 0, p_node, "fg");
+		_connection_or_default(mix_node, 1, p_node, "bg");
+		_connection_or_default(mix_node, 2, p_node, "mix");
+
+		std::string type = p_node->getType();
+		if (type == "float" || type == "integer") {
+			mix_node->set_op_type(VisualShaderNodeMix::OP_TYPE_SCALAR);
+		} else if (type == "vector2") {
+			mix_node->set_op_type(VisualShaderNodeMix::OP_TYPE_VECTOR_2D);
+		} else if (type == "vector3") {
+			mix_node->set_op_type(VisualShaderNodeMix::OP_TYPE_VECTOR_3D);
+		} else if (type == "vector4") {
+			mix_node->set_op_type(VisualShaderNodeMix::OP_TYPE_VECTOR_4D);
+		}
+
+		return mix_node;
+	} else if (category == "ifgreater") {
+		return nullptr;
+	} else if (category == "ifgreatereq") {
+		return nullptr;
+	} else if (category == "ifequal") {
+		return nullptr;
+	} else if (category == "switch") {
+		return nullptr;
+	} else if (category == "extract") {
+		return nullptr;
+	} else if (category == "convert") {
+		return nullptr;
+	} else if (category == "combine2") {
+		Ref<VisualShaderNodeVectorCompose> combine_node;
+		combine_node.instantiate();
+		combine_node->set_op_type(VisualShaderNodeVectorCompose::OP_TYPE_VECTOR_2D);
+
+		_connection_or_default(combine_node, 0, p_node, "in1");
+		_connection_or_default(combine_node, 1, p_node, "in2");
+
+		return combine_node;
+	} else if (category == "combine3") {
+		Ref<VisualShaderNodeVectorCompose> combine_node;
+		combine_node.instantiate();
+		combine_node->set_op_type(VisualShaderNodeVectorCompose::OP_TYPE_VECTOR_3D);
+
+		_connection_or_default(combine_node, 0, p_node, "in1");
+		_connection_or_default(combine_node, 1, p_node, "in2");
+		_connection_or_default(combine_node, 2, p_node, "in3");
+
+		return combine_node;
+	} else if (category == "combine4") {
+		Ref<VisualShaderNodeVectorCompose> combine_node;
+		combine_node.instantiate();
+		combine_node->set_op_type(VisualShaderNodeVectorCompose::OP_TYPE_VECTOR_4D);
+
+		_connection_or_default(combine_node, 0, p_node, "in1");
+		_connection_or_default(combine_node, 1, p_node, "in2");
+		_connection_or_default(combine_node, 2, p_node, "in3");
+		_connection_or_default(combine_node, 3, p_node, "in4");
+
+		return combine_node;
+	} else if (category == "separate2") {
+		return nullptr;
+	} else if (category == "separate3") {
+		return nullptr;
+	} else if (category == "separate4") {
+		return nullptr;
+	} else if (category == "blur") {
+		return nullptr;
+	} else if (category == "heighttonormal") {
+		return nullptr;
+	} else {
+		ERR_PRINT(vformat("Unknown node type: [%s]", category.c_str()));
+		return nullptr;
+	}
+
+	/* shader node types
+	else if (category == "surface_unlit") {
+		return nullptr;
+	} else if (category == "displacement") {
+		return nullptr;
+	} else if (category == "mix") {
+		return nullptr;
+	}*/
+}
+
+Ref<VisualShaderNodeConstant> ResourceFormatLoaderMtlx::_read_constant_node(const mx::NodePtr &p_node) const {
+	Variant value = _get_mtlx_value_as_port_value(p_node->getInput("value")->getValue());
+
+	std::string type = p_node->getType();
+	if (type == "float") {
+		Ref<VisualShaderNodeFloatConstant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "integer") {
+		Ref<VisualShaderNodeIntConstant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "vector2") {
+		Ref<VisualShaderNodeVec2Constant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "vector3") {
+		Ref<VisualShaderNodeVec3Constant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "vector4") {
+		Ref<VisualShaderNodeVec4Constant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "color3") {
+		//! Visual shaders don't seem to have a color3 constant
+		Ref<VisualShaderNodeVec3Constant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "color4") {
+		Ref<VisualShaderNodeColorConstant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else if (type == "boolean") {
+		Ref<VisualShaderNodeBooleanConstant> constant_node;
+		constant_node.instantiate();
+		constant_node->set_constant(value);
+		return constant_node;
+	} else {
+		WARN_PRINT(vformat("Could not return value of type %s", type.c_str()));
+		return Ref<VisualShaderNodeConstant>();
+	}
+}
+
+Ref<VisualShaderNodeFloatFunc> ResourceFormatLoaderMtlx::_read_unary_operator_node(const mx::NodePtr &p_node, VisualShaderNodeFloatFunc::Function p_unary_op) {
+	Ref<VisualShaderNodeFloatFunc> float_op_node;
+	float_op_node.instantiate();
+	float_op_node->set_function(p_unary_op);
+
+	_connection_or_default(float_op_node, 0, p_node, "in");
+
+	return float_op_node;
+}
+
+Ref<VisualShaderNodeFloatOp> ResourceFormatLoaderMtlx::_read_binary_operator_node(const mx::NodePtr &p_node, VisualShaderNodeFloatOp::Operator p_binary_op) {
+	Ref<VisualShaderNodeFloatOp> float_op_node;
+	float_op_node.instantiate();
+	float_op_node->set_operator(p_binary_op);
+
+	_connection_or_default(float_op_node, 0, p_node, "in1");
+	_connection_or_default(float_op_node, 1, p_node, "in2");
+
+	return float_op_node;
+}
+
+int ResourceFormatLoaderMtlx::_get_mtlx_type_as_port_type(const std::string &p_type_string) {
+	//Unused port types
+	//PORT_TYPE_SCALAR_UINT
+	//PORT_TYPE_TRANSFORM
+	//PORT_TYPE_SAMPLER
+
+	if (p_type_string == "float") {
+		return VisualShaderNode::PORT_TYPE_SCALAR;
+	} else if (p_type_string == "integer") {
+		return VisualShaderNode::PORT_TYPE_SCALAR_INT;
+	} else if (p_type_string == "vector2") {
+		return VisualShaderNode::PORT_TYPE_VECTOR_2D;
+	} else if (p_type_string == "vector3" || p_type_string == "color3") {
+		return VisualShaderNode::PORT_TYPE_VECTOR_3D;
+	} else if (p_type_string == "vector4" || p_type_string == "color4") {
+		return VisualShaderNode::PORT_TYPE_VECTOR_4D;
+	} else if (p_type_string == "boolean") {
+		return VisualShaderNode::PORT_TYPE_BOOLEAN;
+	} else {
+		return VisualShaderNode::PORT_TYPE_MAX;
+	}
+}
+
+Variant ResourceFormatLoaderMtlx::_get_mtlx_value_as_port_value(const mx::ValuePtr &p_value) {
+	if (!p_value) {
+		return Variant();
+	}
+
+	std::string type_string = p_value->getTypeString();
+	if (type_string == "float") {
+		return p_value->asA<float>();
+	} else if (type_string == "integer") {
+		return p_value->asA<int>();
+	} else if (type_string == "vector2") {
+		mx::Vector2 vector_2 = p_value->asA<mx::Vector2>();
+		return Vector2(vector_2[0], vector_2[1]);
+	} else if (type_string == "vector3") {
+		mx::Vector3 vector_3 = p_value->asA<mx::Vector3>();
+		return Vector3(vector_3[0], vector_3[1], vector_3[2]);
+	} else if (type_string == "color3") {
+		mx::Color3 vector_3 = p_value->asA<mx::Color3>();
+		return Vector3(vector_3[0], vector_3[1], vector_3[2]);
+	} else if (type_string == "vector4") {
+		mx::Vector4 vector_4 = p_value->asA<mx::Vector4>();
+		return Vector4(vector_4[0], vector_4[1], vector_4[2], vector_4[3]);
+	} else if (type_string == "color4") {
+		mx::Color4 vector_4 = p_value->asA<mx::Color4>();
+		return Vector4(vector_4[0], vector_4[1], vector_4[2], vector_4[3]);
+	} else if (type_string == "boolean") {
+		return p_value->asA<bool>();
+	} else {
+		return Variant();
+	}
+}

--- a/modules/mtlx/resource_loader_materialx.cpp
+++ b/modules/mtlx/resource_loader_materialx.cpp
@@ -139,8 +139,8 @@ Ref<Resource> ResourceFormatLoaderMtlx::load(const String &p_path, const String 
 			//_connect_or_default(shader_node, "base_color", 6); // AO
 			//_connect_or_default(shader_node, "base_color", 7); // AO Light Effect
 
-			_connect_or_default(shader_node, "normal", 8); // Normal
-			//_connect_or_default(shader_node, "base_color", 9); // Normal Map
+			//_connect_or_default(shader_node, "normal", 8); // Normal
+			_connect_or_default(shader_node, "normal", 9); // Normal Map
 			//_connect_or_default(shader_node, "base_color", 10); // Normal Map Depth
 
 			//_connect_or_default(shader_node, "base_color", 11); // Bent Normal Map
@@ -328,7 +328,7 @@ Ref<VisualShaderNode> ResourceFormatLoaderMtlx::_read_node(const mx::NodePtr &p_
 		Ref<VisualShaderNodeInput> input_node;
 		input_node.instantiate();
 
-		input_node->set_input_name("point_coord");
+		input_node->set_input_name("uv");
 
 		return input_node;
 	} else if (category == "geomcolor") {

--- a/modules/mtlx/resource_loader_materialx.cpp
+++ b/modules/mtlx/resource_loader_materialx.cpp
@@ -324,7 +324,13 @@ Ref<VisualShaderNode> ResourceFormatLoaderMtlx::_read_node(const mx::NodePtr &p_
 	} else if (category == "bump") {
 		return nullptr;
 	} else if (category == "texcoord") {
-		return nullptr;
+		//!!!!!!!!!!
+		Ref<VisualShaderNodeInput> input_node;
+		input_node.instantiate();
+
+		input_node->set_input_name("point_coord");
+
+		return input_node;
 	} else if (category == "geomcolor") {
 		return nullptr;
 	} else if (category == "geompropvalue") {
@@ -523,7 +529,17 @@ Ref<VisualShaderNode> ResourceFormatLoaderMtlx::_read_node(const mx::NodePtr &p_
 	} else if (category == "transformmatrix") {
 		return nullptr;
 	} else if (category == "normalmap") {
-		return nullptr;
+		//!!!!!!!!!!!!!!!!!!!!!!!!!
+		Ref<VisualShaderNodeReroute> noop_node;
+		noop_node.instantiate();
+
+		_connection_or_default(noop_node, 0, p_node, "in");
+		//_connection_or_default(noop_node, 1, p_node, "scale");
+		//_connection_or_default(noop_node, 2, p_node, "normal");
+		//_connection_or_default(noop_node, 3, p_node, "tangent");
+		//_connection_or_default(noop_node, 4, p_node, "bitangent");
+
+		return noop_node;
 	} else if (category == "creatematrix") {
 		return nullptr;
 	} else if (category == "transform") {
@@ -640,7 +656,22 @@ Ref<VisualShaderNode> ResourceFormatLoaderMtlx::_read_node(const mx::NodePtr &p_
 	} else if (category == "switch") {
 		return nullptr;
 	} else if (category == "extract") {
-		return nullptr;
+		Ref<VisualShaderNodeExtract> extract_node;
+		extract_node.instantiate();
+
+		_connection_or_default(extract_node, 0, p_node, "in");
+		_connection_or_default(extract_node, 1, p_node, "index");
+
+		std::string type = p_node->getType();
+		if (type == "vector2") {
+			extract_node->set_op_type(VisualShaderNodeVectorBase::OP_TYPE_VECTOR_2D);
+		} else if (type == "vector3") {
+			extract_node->set_op_type(VisualShaderNodeVectorBase::OP_TYPE_VECTOR_3D);
+		} else {
+			extract_node->set_op_type(VisualShaderNodeVectorBase::OP_TYPE_VECTOR_4D);
+		}
+
+		return extract_node;
 	} else if (category == "convert") {
 		return nullptr;
 	} else if (category == "combine2") {

--- a/modules/mtlx/resource_loader_materialx.h
+++ b/modules/mtlx/resource_loader_materialx.h
@@ -1,0 +1,77 @@
+/**************************************************************************/
+/*  resource_loader_materialx.h                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource_loader.h"
+#include "core/string/string_name.h"
+#include "scene/resources/visual_shader.h"
+#include "scene/resources/visual_shader_nodes.h"
+
+#include <MaterialXCore/Document.h>
+#include <MaterialXCore/Value.h>
+#include <MaterialXFormat/File.h>
+#include <MaterialXFormat/XmlIo.h>
+
+namespace mx = MaterialX;
+
+class ResourceFormatLoaderMtlx : public ResourceFormatLoader {
+	String resource_base_path;
+	Ref<VisualShader> shader;
+
+	HashMap<StringName, int> node_id_map;
+	HashMap<StringName, int> node_output_port_map;
+	HashMap<StringName, StringName> output_to_node_map;
+
+	typedef struct {
+		StringName node_out;
+		StringName node_in;
+		int node_in_port;
+	} NodeConnection;
+	Vector<NodeConnection> node_connections;
+
+public:
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual bool handles_type(const String &p_type) const override;
+	virtual String get_resource_type(const String &p_path) const override;
+
+private:
+	void _connect_or_default(mx::NodePtr p_shader, std::string p_outgoing_port, int p_incoming_port);
+	void _connection_or_default(Ref<VisualShaderNode> p_shader_node, int p_port, const mx::NodePtr &p_mtlx_node, std::string p_input);
+
+	Ref<VisualShaderNode> _read_node(const mx::NodePtr &node, int p_id);
+	Ref<VisualShaderNodeConstant> _read_constant_node(const mx::NodePtr &p_node) const;
+	Ref<VisualShaderNodeFloatFunc> _read_unary_operator_node(const mx::NodePtr &p_node, VisualShaderNodeFloatFunc::Function p_unary_op);
+	Ref<VisualShaderNodeFloatOp> _read_binary_operator_node(const mx::NodePtr &p_node, VisualShaderNodeFloatOp::Operator p_binary_op);
+
+	static int _get_mtlx_type_as_port_type(const std::string &p_type);
+	static Variant _get_mtlx_value_as_port_value(const mx::ValuePtr &p_value);
+};

--- a/modules/mtlx/resource_saver_materialx.cpp
+++ b/modules/mtlx/resource_saver_materialx.cpp
@@ -1,0 +1,148 @@
+/**************************************************************************/
+/*  resource_saver_materialx.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_saver_materialx.h"
+#include "MaterialXCore/Interface.h"
+#include "MaterialXFormat/XmlIo.h"
+#include "core/error/error_macros.h"
+#include "core/variant/variant.h"
+#include "materialx_shader.h"
+#include "scene/resources/visual_shader.h"
+#include "scene/resources/visual_shader_nodes.h"
+
+#include <MaterialXCore/Document.h>
+#include <MaterialXCore/Node.h>
+
+Error ResourceFormatSaverMtlx::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	Ref<MaterialXShader> shader = p_resource;
+	if (!shader.is_null()) {
+		return shader->save_file(p_path);
+	}
+	return OK;
+}
+
+bool ResourceFormatSaverMtlx::recognize(const Ref<Resource> &p_resource) const {
+	Ref<MaterialXShader> shader = p_resource;
+	return !shader.is_null();
+}
+
+void ResourceFormatSaverMtlx::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+	Ref<MaterialXShader> shader = p_resource;
+	if (!shader.is_null()) {
+		p_extensions->push_back("mtlx");
+	}
+}
+
+Error MaterialXShader::save_file(const String &p_path) {
+	mx::DocumentPtr document = mx::createDocument();
+
+	mx::NodeGraphPtr node_graph = document->addNodeGraph("super_cool_graph");
+	for (int node_id : get_node_list(VisualShader::TYPE_FRAGMENT)) {
+		Ref<VisualShaderNode> node = get_node(VisualShader::TYPE_FRAGMENT, node_id);
+
+		Ref<VisualShaderNodeFrame> frame_node = node;
+		if (!frame_node.is_null()) {
+			// ¯\_(ツ)_/¯
+			continue;
+		}
+
+		Ref<VisualShaderNodeReroute> reroute_node = node;
+		if (!reroute_node.is_null()) {
+			std::string name = vformat("dot_%d", node_id).utf8().get_data();
+			mx::NodePtr mx_node = node_graph->addNode("dot", name);
+			mx::InputPtr mx_in = mx_node->addInput("in");
+
+			VisualShaderNode::PortType port_type = reroute_node->get_input_port_type(0);
+			switch (port_type) {
+				case VisualShaderNode::PORT_TYPE_SCALAR: {
+					mx_node->setType("float");
+					mx_in->setType("float");
+					mx_in->setNodeName(""); // aaaaaaaaaaaaaaaaaaaa
+				} break;
+
+				case VisualShaderNode::PORT_TYPE_SCALAR_INT:
+				case VisualShaderNode::PORT_TYPE_SCALAR_UINT: {
+					mx_node->setType("integer");
+					mx_in->setType("integer");
+					mx_in->setNodeName(""); // aaaaaaaaaaaaaaaaaaaa
+				} break;
+
+				case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+					mx_node->setType("vector2");
+					mx_in->setType("vector2");
+					mx_in->setNodeName(""); // aaaaaaaaaaaaaaaaaaaa
+				} break;
+				case VisualShaderNode::PORT_TYPE_VECTOR_3D: {
+					mx_node->setType("vector3");
+					mx_in->setType("vector3");
+					mx_in->setNodeName(""); // aaaaaaaaaaaaaaaaaaaa
+				} break;
+				case VisualShaderNode::PORT_TYPE_VECTOR_4D: {
+					mx_node->setType("vector4");
+					mx_in->setType("vector4");
+					mx_in->setNodeName(""); // aaaaaaaaaaaaaaaaaaaa
+				} break;
+				case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+					mx_node->setType("boolean");
+					mx_in->setType("boolean");
+					mx_in->setNodeName(""); // aaaaaaaaaaaaaaaaaaaa
+				} break;
+
+				case VisualShaderNode::PORT_TYPE_TRANSFORM:
+				case VisualShaderNode::PORT_TYPE_SAMPLER:
+				case VisualShaderNode::PORT_TYPE_MAX: {
+					// ¯\_(ツ)_/¯
+				} break;
+
+					break;
+			}
+
+			continue;
+		}
+
+		Ref<VisualShaderNodeFloatConstant> float_constant_node = node;
+		if (!float_constant_node.is_null()) {
+			std::string name = vformat("float_constant_%d", node_id).utf8().get_data();
+			mx::NodePtr mx_node = node_graph->addNode("constant", name, "float");
+
+			mx::InputPtr mx_value = mx_node->addInput("value", "float");
+			mx_value->setValue(float_constant_node->get_constant());
+
+			continue;
+		}
+
+		ERR_PRINT(vformat("Couldn't save node [%d] of type [%s]", node_id, node->get_class_name()));
+	}
+
+	String content = mx::writeToXmlString(document).c_str();
+	print_line(content);
+
+	return OK;
+}

--- a/modules/mtlx/resource_saver_materialx.h
+++ b/modules/mtlx/resource_saver_materialx.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  resource_saver_materialx.h                                            */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,37 +28,15 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#include "materialx_shader.h"
-#include "resource_loader_materialx.h"
-#include "resource_saver_materialx.h"
+#include "core/io/resource_saver.h"
 
-#include "core/io/resource.h"
-#include "core/object/class_db.h"
-#include "modules/register_module_types.h"
+class ResourceFormatSaverMtlx : public ResourceFormatSaver {
+	GDCLASS(ResourceFormatSaverMtlx, ResourceFormatSaver);
 
-static Ref<ResourceFormatLoaderMtlx> resource_loader_mtlx;
-static Ref<ResourceFormatSaverMtlx> resource_saver_mtlx;
-
-void initialize_mtlx_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		GDREGISTER_CLASS(MaterialXShader);
-
-		resource_loader_mtlx.instantiate();
-		ResourceLoader::add_resource_format_loader(resource_loader_mtlx);
-
-		resource_saver_mtlx.instantiate();
-		ResourceSaver::add_resource_format_saver(resource_saver_mtlx);
-	}
-}
-
-void uninitialize_mtlx_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_mtlx);
-		resource_loader_mtlx.unref();
-
-		ResourceSaver::remove_resource_format_saver(resource_saver_mtlx);
-		resource_saver_mtlx.unref();
-	}
-}
+public:
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
+	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+};

--- a/modules/mtlx/visual_shader_node_standard_surface.cpp
+++ b/modules/mtlx/visual_shader_node_standard_surface.cpp
@@ -1,0 +1,264 @@
+/**************************************************************************/
+/*  visual_shader_node_standard_surface.cpp                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "visual_shader_node_standard_surface.h"
+
+#include "scene/resources/visual_shader.h"
+
+String VisualShaderNodeStandardSurface::get_caption() const {
+	return "Standard Surface Output";
+}
+
+int VisualShaderNodeStandardSurface::get_input_port_count() const {
+	return 42;
+}
+
+VisualShaderNode::PortType VisualShaderNodeStandardSurface::get_input_port_type(int p_port) const {
+	switch (p_port) {
+		case 0:
+			return PORT_TYPE_SCALAR; // base float
+		case 1:
+			return PORT_TYPE_VECTOR_3D; // base_color color3
+		case 2:
+			return PORT_TYPE_SCALAR; // diffuse_roughness float
+		case 3:
+			return PORT_TYPE_SCALAR; // metalness float
+
+		case 4:
+			return PORT_TYPE_SCALAR; // specular float
+		case 5:
+			return PORT_TYPE_VECTOR_3D; // specular_color color3
+		case 6:
+			return PORT_TYPE_SCALAR; // specular_roughness float
+		case 7:
+			return PORT_TYPE_SCALAR; // specular_IOR float
+		case 8:
+			return PORT_TYPE_SCALAR; // specular_anisotropy float
+		case 9:
+			return PORT_TYPE_SCALAR; // specular_rotation float
+
+		case 10:
+			return PORT_TYPE_SCALAR; // transmission float
+		case 11:
+			return PORT_TYPE_VECTOR_3D; // transmission_color color3
+		case 12:
+			return PORT_TYPE_SCALAR; // transmission_depth float
+		case 13:
+			return PORT_TYPE_VECTOR_3D; // transmission_scatter color3
+		case 14:
+			return PORT_TYPE_SCALAR; // transmission_scatter_anisotropy float
+		case 15:
+			return PORT_TYPE_SCALAR; // transmission_dispersion float
+		case 16:
+			return PORT_TYPE_SCALAR; // transmission_extra_roughness float
+
+		case 17:
+			return PORT_TYPE_SCALAR; // subsurface float
+		case 18:
+			return PORT_TYPE_VECTOR_3D; // subsurface_color color3
+		case 19:
+			return PORT_TYPE_VECTOR_3D; // subsurface_radius color3
+		case 20:
+			return PORT_TYPE_SCALAR; // subsurface_scale float
+		case 21:
+			return PORT_TYPE_SCALAR; // subsurface_anisotropy float
+
+		case 22:
+			return PORT_TYPE_SCALAR; // sheen float
+		case 23:
+			return PORT_TYPE_VECTOR_3D; // sheen_color color3
+		case 24:
+			return PORT_TYPE_SCALAR; // sheen_roughness float
+
+		case 25:
+			return PORT_TYPE_SCALAR; // coat float
+		case 26:
+			return PORT_TYPE_VECTOR_3D; // coat_color color3
+		case 27:
+			return PORT_TYPE_SCALAR; // coat_roughness float
+		case 28:
+			return PORT_TYPE_SCALAR; // coat_anisotropy float
+		case 29:
+			return PORT_TYPE_SCALAR; // coat_rotation float
+		case 30:
+			return PORT_TYPE_SCALAR; // coat_IOR float
+		case 31:
+			return PORT_TYPE_VECTOR_3D; // coat_normal vector3
+		case 32:
+			return PORT_TYPE_SCALAR; // coat_affect_color float
+		case 33:
+			return PORT_TYPE_SCALAR; // coat_affect_roughness float
+
+		case 34:
+			return PORT_TYPE_SCALAR; // thin_film_thickness float
+		case 35:
+			return PORT_TYPE_SCALAR; // thin_film_IOR float
+
+		case 36:
+			return PORT_TYPE_SCALAR; // emission float
+		case 37:
+			return PORT_TYPE_VECTOR_3D; // emission_color color3
+
+		case 38:
+			return PORT_TYPE_VECTOR_3D; // opacity color3
+
+		case 39:
+			return PORT_TYPE_BOOLEAN; // thin_walled boolean
+
+		case 40:
+			return PORT_TYPE_VECTOR_3D; // normal vector3
+		case 41:
+			return PORT_TYPE_VECTOR_3D; // tangent vector3
+
+		default:
+			return PORT_TYPE_MAX;
+	}
+}
+
+String VisualShaderNodeStandardSurface::get_input_port_name(int p_port) const {
+	switch (p_port) {
+		case 0:
+			return "base";
+		case 1:
+			return "base_color";
+		case 2:
+			return "diffuse_roughness";
+		case 3:
+			return "metalness";
+
+		case 4:
+			return "specular";
+		case 5:
+			return "specular_color";
+		case 6:
+			return "specular_roughness";
+		case 7:
+			return "specular_IOR";
+		case 8:
+			return "specular_anisotropy";
+		case 9:
+			return "specular_rotation";
+
+		case 10:
+			return "transmission";
+		case 11:
+			return "transmission_color";
+		case 12:
+			return "transmission_depth";
+		case 13:
+			return "transmission_scatter";
+		case 14:
+			return "transmission_scatter_anisotropy";
+		case 15:
+			return "transmission_dispersion";
+		case 16:
+			return "transmission_extra_roughness";
+
+		case 17:
+			return "subsurface";
+		case 18:
+			return "subsurface_color";
+		case 19:
+			return "subsurface_radius";
+		case 20:
+			return "subsurface_scale";
+		case 21:
+			return "subsurface_anisotropy";
+
+		case 22:
+			return "sheen";
+		case 23:
+			return "sheen_color";
+		case 24:
+			return "sheen_roughness";
+
+		case 25:
+			return "coat";
+		case 26:
+			return "coat_color";
+		case 27:
+			return "coat_roughness";
+		case 28:
+			return "coat_anisotropy";
+		case 29:
+			return "coat_rotation";
+		case 30:
+			return "coat_IOR";
+		case 31:
+			return "coat_normal";
+		case 32:
+			return "coat_affect_color";
+		case 33:
+			return "coat_affect_roughness";
+
+		case 34:
+			return "thin_film_thickness";
+		case 35:
+			return "thin_film_IOR";
+
+		case 36:
+			return "emission";
+		case 37:
+			return "emission_color";
+
+		case 38:
+			return "opacity";
+
+		case 39:
+			return "thin_walled";
+
+		case 40:
+			return "normal";
+		case 41:
+			return "tangent";
+		default:
+			return "";
+	}
+}
+
+int VisualShaderNodeStandardSurface::get_output_port_count() const {
+	return 0;
+}
+
+VisualShaderNode::PortType VisualShaderNodeStandardSurface::get_output_port_type(int p_port) const {
+	return PORT_TYPE_SCALAR;
+}
+
+String VisualShaderNodeStandardSurface::get_output_port_name(int p_port) const {
+	return "out";
+}
+
+String VisualShaderNodeStandardSurface::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	String code;
+
+	// hehehe  hahaaha
+
+	return code;
+}

--- a/modules/mtlx/visual_shader_node_standard_surface.h
+++ b/modules/mtlx/visual_shader_node_standard_surface.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  register_types.cpp                                                    */
+/*  visual_shader_node_standard_surface.h                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,37 +28,27 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "register_types.h"
+#pragma once
 
-#include "materialx_shader.h"
-#include "resource_loader_materialx.h"
-#include "resource_saver_materialx.h"
+#include "scene/resources/visual_shader.h"
 
-#include "core/io/resource.h"
-#include "core/object/class_db.h"
-#include "modules/register_module_types.h"
+class VisualShaderNodeStandardSurface : public VisualShaderNode {
+	GDCLASS(VisualShaderNodeStandardSurface, VisualShaderNode);
 
-static Ref<ResourceFormatLoaderMtlx> resource_loader_mtlx;
-static Ref<ResourceFormatSaverMtlx> resource_saver_mtlx;
+public:
+	virtual String get_caption() const override;
 
-void initialize_mtlx_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		GDREGISTER_CLASS(MaterialXShader);
+	virtual int get_input_port_count() const override;
+	virtual PortType get_input_port_type(int p_port) const override;
+	virtual String get_input_port_name(int p_port) const override;
 
-		resource_loader_mtlx.instantiate();
-		ResourceLoader::add_resource_format_loader(resource_loader_mtlx);
+	virtual int get_output_port_count() const override;
+	virtual PortType get_output_port_type(int p_port) const override;
+	virtual String get_output_port_name(int p_port) const override;
 
-		resource_saver_mtlx.instantiate();
-		ResourceSaver::add_resource_format_saver(resource_saver_mtlx);
-	}
-}
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
-void uninitialize_mtlx_module(ModuleInitializationLevel p_level) {
-	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
-		ResourceLoader::remove_resource_format_loader(resource_loader_mtlx);
-		resource_loader_mtlx.unref();
+	virtual Category get_category() const override { return CATEGORY_SPECIAL; }
 
-		ResourceSaver::remove_resource_format_saver(resource_saver_mtlx);
-		resource_saver_mtlx.unref();
-	}
-}
+	VisualShaderNodeStandardSurface();
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -768,6 +768,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(VisualShaderNodeVectorDistance);
 	GDREGISTER_CLASS(VisualShaderNodeVectorRefract);
 	GDREGISTER_CLASS(VisualShaderNodeMix);
+	GDREGISTER_CLASS(VisualShaderNodeExtract);
 	GDREGISTER_CLASS(VisualShaderNodeVectorCompose);
 	GDREGISTER_CLASS(VisualShaderNodeTransformCompose);
 	GDREGISTER_CLASS(VisualShaderNodeVectorDecompose);

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4828,6 +4828,96 @@ VisualShaderNodeMix::VisualShaderNodeMix() {
 	set_input_port_default_value(2, 0.5); // weight
 }
 
+////////////// Extract
+
+String VisualShaderNodeExtract::get_caption() const {
+	return "Extract";
+}
+
+int VisualShaderNodeExtract::get_input_port_count() const {
+	return 2;
+}
+
+VisualShaderNode::PortType VisualShaderNodeExtract::get_input_port_type(int p_port) const {
+	if (p_port == 0) {
+		switch (op_type) {
+			case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_2D:
+				return PORT_TYPE_VECTOR_2D;
+			case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_3D:
+				return PORT_TYPE_VECTOR_3D;
+			case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_4D:
+				return PORT_TYPE_VECTOR_4D;
+			default:
+				break;
+		}
+	}
+
+	return PORT_TYPE_SCALAR_INT;
+}
+
+String VisualShaderNodeExtract::get_input_port_name(int p_port) const {
+	if (p_port == 0) {
+		return "in";
+	} else if (p_port == 1) {
+		return "index";
+	}
+
+	return "";
+}
+
+int VisualShaderNodeExtract::get_output_port_count() const {
+	return 1;
+}
+
+String VisualShaderNodeExtract::get_output_port_name(int p_port) const {
+	return "out";
+}
+
+void VisualShaderNodeExtract::set_op_type(OpType p_op_type) {
+	op_type = p_op_type;
+	switch (p_op_type) {
+		case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_2D: {
+			float p1 = get_input_port_default_value(0);
+			float p2 = get_input_port_default_value(1);
+
+			set_input_port_default_value(0, p1);
+			set_input_port_default_value(1, p2);
+		} break;
+		case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_3D: {
+			float p1 = get_input_port_default_value(0);
+			float p2 = get_input_port_default_value(1);
+			float p3 = get_input_port_default_value(2);
+
+			set_input_port_default_value(0, p1);
+			set_input_port_default_value(1, p2);
+			set_input_port_default_value(2, p3);
+		} break;
+		case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_4D: {
+			float p1 = get_input_port_default_value(0);
+			float p2 = get_input_port_default_value(1);
+			float p3 = get_input_port_default_value(2);
+			float p4 = get_input_port_default_value(3);
+
+			set_input_port_default_value(0, p1);
+			set_input_port_default_value(1, p2);
+			set_input_port_default_value(2, p3);
+			set_input_port_default_value(3, p4);
+		} break;
+		default:
+			break;
+	}
+	emit_changed();
+}
+
+String VisualShaderNodeExtract::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	return vformat("\t%s = %s[%s]", p_output_vars[0], p_input_vars[0], p_input_vars[1]);
+}
+
+VisualShaderNodeExtract::VisualShaderNodeExtract() {
+	set_input_port_default_value(0, 0.0);
+	set_input_port_default_value(1, 0);
+}
+
 ////////////// Vector Compose
 
 String VisualShaderNodeVectorCompose::get_caption() const {

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -4869,6 +4869,10 @@ int VisualShaderNodeExtract::get_output_port_count() const {
 	return 1;
 }
 
+VisualShaderNode::PortType VisualShaderNodeExtract::get_output_port_type(int p_port) const {
+	return PORT_TYPE_SCALAR;
+}
+
 String VisualShaderNodeExtract::get_output_port_name(int p_port) const {
 	return "out";
 }
@@ -4877,31 +4881,25 @@ void VisualShaderNodeExtract::set_op_type(OpType p_op_type) {
 	op_type = p_op_type;
 	switch (p_op_type) {
 		case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_2D: {
-			float p1 = get_input_port_default_value(0);
-			float p2 = get_input_port_default_value(1);
+			Vector2 p1 = get_input_port_default_value(0);
+			int p2 = get_input_port_default_value(1);
 
 			set_input_port_default_value(0, p1);
 			set_input_port_default_value(1, p2);
 		} break;
 		case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_3D: {
-			float p1 = get_input_port_default_value(0);
-			float p2 = get_input_port_default_value(1);
-			float p3 = get_input_port_default_value(2);
+			Vector3 p1 = get_input_port_default_value(0);
+			int p2 = get_input_port_default_value(1);
 
 			set_input_port_default_value(0, p1);
 			set_input_port_default_value(1, p2);
-			set_input_port_default_value(2, p3);
 		} break;
 		case VisualShaderNodeVectorBase::OP_TYPE_VECTOR_4D: {
-			float p1 = get_input_port_default_value(0);
-			float p2 = get_input_port_default_value(1);
-			float p3 = get_input_port_default_value(2);
-			float p4 = get_input_port_default_value(3);
+			Vector4 p1 = get_input_port_default_value(0);
+			int p2 = get_input_port_default_value(1);
 
 			set_input_port_default_value(0, p1);
 			set_input_port_default_value(1, p2);
-			set_input_port_default_value(2, p3);
-			set_input_port_default_value(3, p4);
 		} break;
 		default:
 			break;
@@ -4910,11 +4908,11 @@ void VisualShaderNodeExtract::set_op_type(OpType p_op_type) {
 }
 
 String VisualShaderNodeExtract::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return vformat("\t%s = %s[%s]", p_output_vars[0], p_input_vars[0], p_input_vars[1]);
+	return vformat("\t%s = %s[%s];", p_output_vars[0], p_input_vars[0], p_input_vars[1]);
 }
 
 VisualShaderNodeExtract::VisualShaderNodeExtract() {
-	set_input_port_default_value(0, 0.0);
+	set_input_port_default_value(0, Vector3());
 	set_input_port_default_value(1, 0);
 }
 

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1975,6 +1975,7 @@ public:
 	virtual String get_input_port_name(int p_port) const override;
 
 	virtual int get_output_port_count() const override;
+	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
 	virtual void set_op_type(OpType p_op_type) override;

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1964,6 +1964,27 @@ VARIANT_ENUM_CAST(VisualShaderNodeMix::OpType)
 /// COMPOSE
 ///////////////////////////////////////
 
+class VisualShaderNodeExtract : public VisualShaderNodeVectorBase {
+	GDCLASS(VisualShaderNodeExtract, VisualShaderNodeVectorBase);
+
+public:
+	virtual String get_caption() const override;
+
+	virtual int get_input_port_count() const override;
+	virtual PortType get_input_port_type(int p_port) const override;
+	virtual String get_input_port_name(int p_port) const override;
+
+	virtual int get_output_port_count() const override;
+	virtual String get_output_port_name(int p_port) const override;
+
+	virtual void set_op_type(OpType p_op_type) override;
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
+
+	VisualShaderNodeExtract();
+};
+
+///////////////////////////////////////
+
 class VisualShaderNodeVectorCompose : public VisualShaderNodeVectorBase {
 	GDCLASS(VisualShaderNodeVectorCompose, VisualShaderNodeVectorBase);
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/714
Supersedes and initially based on https://github.com/godotengine/godot/pull/90918

@fire this is how far I've gotten so far. Not all nodes are implemented but they're enough that I can load materials from https://matlib.gpuopen.com/main/materials/all without missing nodes so it should be enough to make this progress public.

It might be worth checking the `image` node for correctness but other nodes should be fine I think.

The main issue is the conversion between standard_surface and godot's shaders. I tried my best by looking at `thirdparty/materialx/libraries/bxdf/standard_surface_to_gltf_pbr.mtlx` but even that doesn't do it quite right. I don't think I can really get much further on that without actually reading what the standard surface model is and understanding how these materials actually get converted into glsl and into spirv on the gpu.

Beyond that, as the README mentions I'd like for it to be possible to edit materialx graphs from within th editor and be able to actually save to materialx. It would also be useful to be able to bake materialx graphs down into whatever it is we bake into.

Finally there's the more niche features of materialx like color management, unit conversion and custom nodes but that's quite a bit further down the road.

![image](https://github.com/user-attachments/assets/b2d80c4f-5426-4431-9bf2-49b7b94709f9)
![image](https://github.com/user-attachments/assets/845e306d-0719-45d7-9e29-d85660400061)
