### PR TITLE
Minor rendering and XR changes to allow Meta environment depth API to work entirely from GDExtension

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2261,10 +2261,6 @@ void OpenXRAPI::pre_render() {
 		create_main_swapchains(swapchain_size);
 	}
 
-	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
-		wrapper->on_pre_render();
-	}
-
 	void *view_locate_info_next_pointer = nullptr;
 	for (OpenXRExtensionWrapper *extension : frame_info_extensions) {
 		void *np = extension->set_view_locate_info_and_get_next_pointer(view_locate_info_next_pointer);
@@ -2335,6 +2331,10 @@ void OpenXRAPI::pre_render() {
 
 	// Reset this, we haven't found a viewport for output yet
 	render_state.has_xr_viewport = false;
+
+	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+		wrapper->on_pre_render();
+	}
 }
 
 bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2655,6 +2655,22 @@ void TextureStorage::_texture_format_from_rd(RD::DataFormat p_rd_format, Texture
 			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;
 			r_format.swizzle_a = RD::TEXTURE_SWIZZLE_A;
 		} break; // astc 8x8
+		case RD::DATA_FORMAT_D16_UNORM: {
+			r_format.image_format = Image::FORMAT_RH;
+			r_format.rd_format = RD::DATA_FORMAT_D16_UNORM;
+			r_format.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+			r_format.swizzle_g = RD::TEXTURE_SWIZZLE_G;
+			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;
+			r_format.swizzle_a = RD::TEXTURE_SWIZZLE_A;
+		} break;
+		case RD::DATA_FORMAT_D32_SFLOAT: {
+			r_format.image_format = Image::FORMAT_RF;
+			r_format.rd_format = RD::DATA_FORMAT_D32_SFLOAT;
+			r_format.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+			r_format.swizzle_g = RD::TEXTURE_SWIZZLE_G;
+			r_format.swizzle_b = RD::TEXTURE_SWIZZLE_B;
+			r_format.swizzle_a = RD::TEXTURE_SWIZZLE_A;
+		} break;
 
 		default: {
 			ERR_FAIL_MSG("Unsupported image format");

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -732,9 +732,6 @@ void RendererViewport::draw_viewports(bool p_swap_buffers) {
 	Ref<XRInterface> xr_interface;
 	XRServer *xr_server = XRServer::get_singleton();
 	if (xr_server != nullptr) {
-		// let our XR server know we're about to render our frames so we can get our frame timing
-		xr_server->pre_render();
-
 		// retrieve the interface responsible for rendering
 		xr_interface = xr_server->get_primary_interface();
 	}

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -73,6 +73,15 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	uint64_t time_usec = OS::get_singleton()->get_ticks_usec();
 
 	RENDER_TIMESTAMP("Prepare Render Frame");
+
+#ifndef XR_DISABLED
+	XRServer *xr_server = XRServer::get_singleton();
+	if (xr_server != nullptr) {
+		// Let XR server know we're about to render a frame.
+		xr_server->pre_render();
+	}
+#endif // XR_DISABLED
+
 	RSG::scene->update(); //update scenes stuff before updating instances
 	RSG::canvas->update();
 
@@ -88,7 +97,6 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 	RSG::rasterizer->end_frame(p_swap_buffers);
 
 #ifndef XR_DISABLED
-	XRServer *xr_server = XRServer::get_singleton();
 	if (xr_server != nullptr) {
 		// let our XR server know we're done so we can get our frame timing
 		xr_server->end_frame();


### PR DESCRIPTION
This PR attempts to make the smallest, non-hacky changes to Godot's rendering and XR systems to allow implementing the Meta environment depth API entirely from GDExtension.

Here are the changes:

1. Allow using `RenderingDevice::texture_create_from_extension()` to create textures with depth formats
2. Make it so that `XRServer::pre_render()` (and hence `OpenXRExtensionWrapper::on_pre_render()`) will run before `RSG::scene->update()` so that changes to materials will take effect for the current frame (as opposed to being queued until the beginning of the next frame, at which point the environment depth information is no longer valid)

I think change nr 1 is fairly minor, and hopefully uncontroversial, but I'm looking forward hearing what the rendering folks think

Change nr 2 is a little deeper, and means that `XRInterface::pre_render()` and `OpenXRExtensionWrapper::on_pre_render()` will happen a little earlier than they used to, but looking at all our current uses of those virtual methods, I think this should be fine.

Also, I think it does make more sense for `RenderingServerDefault::_draw()` to call `XRServer::pre_render()` (which marks the beggining of the frame) because it's also responsible for calling `XRServer::end_frame()` (which marks the end of the frame) - this way both life cycle functions are called in the same place.

See https://github.com/GodotVR/godot_openxr_vendors/pull/273 for the actual Meta environment depth API implementation

_(NOTE: This supersedes https://github.com/godotengine/godot/pull/103095 which attempted to do the same thing, but was a little more hacky.)_
