### PR TITLE
Animation track start and end offsets

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -121,7 +121,6 @@ void GDExtensionSpecialCompatHashes::initialize() {
 		{ "bezier_track_set_key_in_handle", 1028302688, 1719223284 },
 		{ "bezier_track_set_key_out_handle", 1028302688, 1719223284 },
 		{ "audio_track_insert_key", 3489962123, 4021027286 },
-		{ "animation_track_insert_key", 158676774, 3976786500 },
 	});
 	mappings.insert("AnimationNode", {
 		{ "blend_animation", 11797022, 1630801826 },

--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -121,6 +121,7 @@ void GDExtensionSpecialCompatHashes::initialize() {
 		{ "bezier_track_set_key_in_handle", 1028302688, 1719223284 },
 		{ "bezier_track_set_key_out_handle", 1028302688, 1719223284 },
 		{ "audio_track_insert_key", 3489962123, 4021027286 },
+		{ "animation_track_insert_key", 2538631614, 3976786500 },
 	});
 	mappings.insert("AnimationNode", {
 		{ "blend_animation", 11797022, 1630801826 },

--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -121,7 +121,7 @@ void GDExtensionSpecialCompatHashes::initialize() {
 		{ "bezier_track_set_key_in_handle", 1028302688, 1719223284 },
 		{ "bezier_track_set_key_out_handle", 1028302688, 1719223284 },
 		{ "audio_track_insert_key", 3489962123, 4021027286 },
-		{ "animation_track_insert_key", 2538631614, 3976786500 },
+		{ "animation_track_insert_key", 158676774, 3976786500 },
 	});
 	mappings.insert("AnimationNode", {
 		{ "blend_animation", 11797022, 1630801826 },

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -50,6 +50,24 @@
 				Adds a track to the Animation.
 			</description>
 		</method>
+		<method name="animation_track_get_key_end_offset" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
+				End offset is the number of seconds cut off at the ending of the animation.
+			</description>
+		</method>
+		<method name="animation_track_set_key_start_offset" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
+				Start offset is the number of seconds cut off at the beginning of the animation.
+			</description>
+		</method>
 		<method name="animation_track_get_key_animation" qualifiers="const">
 			<return type="StringName" />
 			<param index="0" name="track_idx" type="int" />
@@ -63,8 +81,11 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="time" type="float" />
 			<param index="2" name="animation" type="StringName" />
+			<param index="3" name="start_offset" type="float" default="0" />
+			<param index="4" name="end_offset" type="float" default="0" />
 			<description>
 				Inserts a key with value [param animation] at the given [param time] (in seconds). The [param track_idx] must be the index of an Animation Track.
+				[param animation] is the [Animation] resource to play. [param start_offset] is the number of seconds cut off at the beginning of the animation, while [param end_offset] is at the ending.
 			</description>
 		</method>
 		<method name="animation_track_set_key_animation">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -50,15 +50,6 @@
 				Adds a track to the Animation.
 			</description>
 		</method>
-		<method name="animation_track_get_key_start_offset" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<description>
-				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
-				Start offset is the number of seconds cut off at the beginning of the animation.
-			</description>
-		</method>
 		<method name="animation_track_get_key_end_offset" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="track_idx" type="int" />
@@ -66,6 +57,15 @@
 			<description>
 				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
 				End offset is the number of seconds cut off at the ending of the animation.
+			</description>
+		</method>
+		<method name="animation_track_get_key_start_offset" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
+				Start offset is the number of seconds cut off at the beginning of the animation.
 			</description>
 		</method>
 		<method name="animation_track_get_key_animation" qualifiers="const">
@@ -95,15 +95,6 @@
 				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
 			</description>
 		</method>
-		<method name="animation_track_set_key_start_offset">
-			<return type="void" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<param index="2" name="offset" type="float" />
-			<description>
-				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
-			</description>
-		</method>
 		<method name="animation_track_set_key_end_offset">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -111,6 +102,15 @@
 			<param index="2" name="offset" type="float" />
 			<description>
 				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
+		<method name="animation_track_set_key_start_offset">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="offset" type="float" />
+			<description>
+				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="animation_track_set_key_animation">
@@ -130,15 +130,6 @@
 				Sets whether the track will be blended with other animations. If [code]true[/code], the animation changes depending on the blend value.
 			</description>
 		</method>
-		<method name="audio_track_get_key_start_offset" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<description>
-				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
-				Start offset is the number of seconds cut off at the beginning of the audio stream.
-			</description>
-		</method>
 		<method name="audio_track_get_key_end_offset" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="track_idx" type="int" />
@@ -146,6 +137,15 @@
 			<description>
 				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
 				End offset is the number of seconds cut off at the ending of the audio stream.
+			</description>
+		</method>
+		<method name="audio_track_get_key_start_offset" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
+				Start offset is the number of seconds cut off at the beginning of the audio stream.
 			</description>
 		</method>
 		<method name="audio_track_get_key_stream" qualifiers="const">
@@ -175,15 +175,6 @@
 				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
 			</description>
 		</method>
-		<method name="audio_track_set_key_start_offset">
-			<return type="void" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<param index="2" name="offset" type="float" />
-			<description>
-				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
-			</description>
-		</method>
 		<method name="audio_track_set_key_end_offset">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -191,6 +182,15 @@
 			<param index="2" name="offset" type="float" />
 			<description>
 				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
+			</description>
+		</method>
+		<method name="audio_track_set_key_start_offset">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="offset" type="float" />
+			<description>
+				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
 			</description>
 		</method>
 		<method name="audio_track_set_key_stream">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -50,6 +50,15 @@
 				Adds a track to the Animation.
 			</description>
 		</method>
+		<method name="animation_track_get_key_start_offset" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
+				Start offset is the number of seconds cut off at the beginning of the animation.
+			</description>
+		</method>
 		<method name="animation_track_get_key_end_offset" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="track_idx" type="int" />
@@ -57,15 +66,6 @@
 			<description>
 				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
 				End offset is the number of seconds cut off at the ending of the animation.
-			</description>
-		</method>
-		<method name="animation_track_set_key_start_offset" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<description>
-				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
-				Start offset is the number of seconds cut off at the beginning of the animation.
 			</description>
 		</method>
 		<method name="animation_track_get_key_animation" qualifiers="const">
@@ -95,15 +95,6 @@
 				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
 			</description>
 		</method>
-		<method name="animation_track_set_key_end_offset">
-			<return type="void" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<param index="2" name="offset" type="float" />
-			<description>
-				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
-			</description>
-		</method>
 		<method name="animation_track_set_key_start_offset">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -111,6 +102,15 @@
 			<param index="2" name="offset" type="float" />
 			<description>
 				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
+		<method name="animation_track_set_key_end_offset">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="offset" type="float" />
+			<description>
+				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="animation_track_set_key_animation">
@@ -130,15 +130,6 @@
 				Sets whether the track will be blended with other animations. If [code]true[/code], the animation changes depending on the blend value.
 			</description>
 		</method>
-		<method name="audio_track_get_key_end_offset" qualifiers="const">
-			<return type="float" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<description>
-				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
-				End offset is the number of seconds cut off at the ending of the audio stream.
-			</description>
-		</method>
 		<method name="audio_track_get_key_start_offset" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="track_idx" type="int" />
@@ -146,6 +137,15 @@
 			<description>
 				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
 				Start offset is the number of seconds cut off at the beginning of the audio stream.
+			</description>
+		</method>
+		<method name="audio_track_get_key_end_offset" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the end offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Audio Track.
+				End offset is the number of seconds cut off at the ending of the audio stream.
 			</description>
 		</method>
 		<method name="audio_track_get_key_stream" qualifiers="const">
@@ -175,15 +175,6 @@
 				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
 			</description>
 		</method>
-		<method name="audio_track_set_key_end_offset">
-			<return type="void" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<param index="2" name="offset" type="float" />
-			<description>
-				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
-			</description>
-		</method>
 		<method name="audio_track_set_key_start_offset">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -191,6 +182,15 @@
 			<param index="2" name="offset" type="float" />
 			<description>
 				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
+			</description>
+		</method>
+		<method name="audio_track_set_key_end_offset">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="offset" type="float" />
+			<description>
+				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Audio Track.
 			</description>
 		</method>
 		<method name="audio_track_set_key_stream">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -50,6 +50,14 @@
 				Adds a track to the Animation.
 			</description>
 		</method>
+		<method name="animation_track_get_key_animation" qualifiers="const">
+			<return type="StringName" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+				Returns the animation name at the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
 		<method name="animation_track_get_key_end_offset" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="track_idx" type="int" />
@@ -66,14 +74,6 @@
 			<description>
 				Returns the start offset of the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
 				Start offset is the number of seconds cut off at the beginning of the animation.
-			</description>
-		</method>
-		<method name="animation_track_get_key_animation" qualifiers="const">
-			<return type="StringName" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<description>
-				Returns the animation name at the key identified by [param key_idx]. The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="animation_track_insert_key">
@@ -95,6 +95,15 @@
 				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
 			</description>
 		</method>
+		<method name="animation_track_set_key_animation">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="animation" type="StringName" />
+			<description>
+				Sets the key identified by [param key_idx] to value [param animation]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
 		<method name="animation_track_set_key_end_offset">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -111,15 +120,6 @@
 			<param index="2" name="offset" type="float" />
 			<description>
 				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
-			</description>
-		</method>
-		<method name="animation_track_set_key_animation">
-			<return type="void" />
-			<param index="0" name="track_idx" type="int" />
-			<param index="1" name="key_idx" type="int" />
-			<param index="2" name="animation" type="StringName" />
-			<description>
-				Sets the key identified by [param key_idx] to value [param animation]. The [param track_idx] must be the index of an Animation Track.
 			</description>
 		</method>
 		<method name="animation_track_set_use_blend">

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -88,6 +88,31 @@
 				[param animation] is the [Animation] resource to play. [param start_offset] is the number of seconds cut off at the beginning of the animation, while [param end_offset] is at the ending.
 			</description>
 		</method>
+		<method name="animation_track_is_use_blend" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="track_idx" type="int" />
+			<description>
+				Returns [code]true[/code] if the track at [param track_idx] will be blended with other animations.
+			</description>
+		</method>
+		<method name="animation_track_set_key_end_offset">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="offset" type="float" />
+			<description>
+				Sets the end offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
+		<method name="animation_track_set_key_start_offset">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="offset" type="float" />
+			<description>
+				Sets the start offset of the key identified by [param key_idx] to value [param offset]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
 		<method name="animation_track_set_key_animation">
 			<return type="void" />
 			<param index="0" name="track_idx" type="int" />
@@ -95,6 +120,14 @@
 			<param index="2" name="animation" type="StringName" />
 			<description>
 				Sets the key identified by [param key_idx] to value [param animation]. The [param track_idx] must be the index of an Animation Track.
+			</description>
+		</method>
+		<method name="animation_track_set_use_blend">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Sets whether the track will be blended with other animations. If [code]true[/code], the animation changes depending on the blend value.
 			</description>
 		</method>
 		<method name="audio_track_get_key_end_offset" qualifiers="const">

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -2270,10 +2270,10 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 		}
 	}
 
-	RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> keys;
+	RBMap<SelectedKey, KeyInfo> keys;
 	for (SelectionSet::Element *E = selection.back(); E; E = E->prev()) {
-		AnimationKeyEdit::SelectedKey sk;
-		AnimationKeyEdit::KeyInfo ki;
+		SelectedKey sk;
+		KeyInfo ki;
 		sk.track = E->get().first;
 		sk.key = E->get().second;
 		ki.pos = animation->track_get_key_time(E->get().first, E->get().second);
@@ -2287,7 +2287,7 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 		undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
 		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 		int i = 0;
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
 			int track_idx = E->key().track;
 			int key_idx = E->key().key;
 			float time = E->value().pos;
@@ -2297,7 +2297,7 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 			i++;
 		}
 		i = 0;
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
 			undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos, i == 0);
 			i++;
 		}

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -2270,10 +2270,10 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 		}
 	}
 
-	RBMap<AnimationTrackEditor::SelectedKey, AnimationTrackEditor::KeyInfo> keys;
+	RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo> keys;
 	for (SelectionSet::Element *E = selection.back(); E; E = E->prev()) {
-		AnimationTrackEditor::SelectedKey sk;
-		AnimationTrackEditor::KeyInfo ki;
+		AnimationTrackEdit::SelectedKey sk;
+		AnimationTrackEdit::KeyInfo ki;
 		sk.track = E->get().first;
 		sk.key = E->get().second;
 		ki.pos = animation->track_get_key_time(E->get().first, E->get().second);
@@ -2287,7 +2287,7 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 		undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
 		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 		int i = 0;
-		for (RBMap<AnimationTrackEditor::SelectedKey, AnimationTrackEditor::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+		for (RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
 			int track_idx = E->key().track;
 			int key_idx = E->key().key;
 			float time = E->value().pos;
@@ -2297,7 +2297,7 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 			i++;
 		}
 		i = 0;
-		for (RBMap<AnimationTrackEditor::SelectedKey, AnimationTrackEditor::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+		for (RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
 			undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos, i == 0);
 			i++;
 		}

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -859,8 +859,8 @@ void AnimationBezierTrackEdit::set_timeline(AnimationTimelineEdit *p_timeline) {
 void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	editor = p_editor;
 	connect("clear_selection", callable_mp(editor, &AnimationTrackEditor::_clear_selection).bind(false));
-	connect("select_key", callable_mp(editor, &AnimationTrackEditor::_key_selected), CONNECT_DEFERRED);
-	connect("deselect_key", callable_mp(editor, &AnimationTrackEditor::_key_deselected), CONNECT_DEFERRED);
+	connect("select_key", callable_mp(editor, &AnimationTrackEditor::_select_key), CONNECT_DEFERRED);
+	connect("deselect_key", callable_mp(editor, &AnimationTrackEditor::_deselect_key), CONNECT_DEFERRED);
 }
 
 void AnimationBezierTrackEdit::_play_position_draw() {

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -2270,10 +2270,10 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 		}
 	}
 
-	RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo> keys;
+	RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> keys;
 	for (SelectionSet::Element *E = selection.back(); E; E = E->prev()) {
-		AnimationTrackEdit::SelectedKey sk;
-		AnimationTrackEdit::KeyInfo ki;
+		AnimationKeyEdit::SelectedKey sk;
+		AnimationKeyEdit::KeyInfo ki;
 		sk.track = E->get().first;
 		sk.key = E->get().second;
 		ki.pos = animation->track_get_key_time(E->get().first, E->get().second);
@@ -2287,7 +2287,7 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 		undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
 		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 		int i = 0;
-		for (RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
 			int track_idx = E->key().track;
 			int key_idx = E->key().key;
 			float time = E->value().pos;
@@ -2297,7 +2297,7 @@ void AnimationBezierTrackEdit::copy_selected_keys(bool p_cut) {
 			i++;
 		}
 		i = 0;
-		for (RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
+		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = keys.back(); E; E = E->prev()) {
 			undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos, i == 0);
 			i++;
 		}

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -863,31 +863,25 @@ void AnimationBezierTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 	connect("deselect_key", callable_mp(editor, &AnimationTrackEditor::_deselect_key), CONNECT_DEFERRED);
 }
 
-void AnimationBezierTrackEdit::_play_position_draw() {
-	if (animation.is_null() || play_position_pos < 0) {
+void AnimationBezierTrackEdit::_play_cursor_draw() {
+	if (animation.is_null() || play_cursor_pos < 0) {
 		return;
 	}
 
-	float scale = timeline->get_zoom_scale();
-	int h = get_size().height;
+	float limit = timeline->get_name_limit();
+	float limit_end = get_size().width - timeline->get_buttons_width();
 
-	int limit = timeline->get_name_limit();
-
-	int px = (-timeline->get_value() + play_position_pos) * scale + limit;
-
-	if (px >= limit && px < (get_size().width)) {
-		const Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
-	}
+	float h = get_size().height;
+	editor->draw_play_cursor(play_cursor, play_cursor_pos, h, limit, limit_end);
 }
 
 void AnimationBezierTrackEdit::set_play_position(real_t p_pos) {
-	play_position_pos = p_pos;
-	play_position->queue_redraw();
+	play_cursor_pos = p_pos;
+	play_cursor->queue_redraw();
 }
 
 void AnimationBezierTrackEdit::update_play_position() {
-	play_position->queue_redraw();
+	play_cursor->queue_redraw();
 }
 
 void AnimationBezierTrackEdit::set_root(Node *p_root) {
@@ -985,7 +979,7 @@ void AnimationBezierTrackEdit::_zoom_vertically(real_t p_minimum_value, real_t p
 
 void AnimationBezierTrackEdit::_zoom_changed() {
 	queue_redraw();
-	play_position->queue_redraw();
+	play_cursor->queue_redraw();
 }
 
 void AnimationBezierTrackEdit::_update_locked_tracks_after(int p_track) {
@@ -2445,11 +2439,11 @@ AnimationBezierTrackEdit::AnimationBezierTrackEdit() {
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &AnimationBezierTrackEdit::_pan_callback), callable_mp(this, &AnimationBezierTrackEdit::_zoom_callback));
 
-	play_position = memnew(Control);
-	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
-	add_child(play_position);
-	play_position->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
-	play_position->connect(SceneStringName(draw), callable_mp(this, &AnimationBezierTrackEdit::_play_position_draw));
+	play_cursor = memnew(Control);
+	play_cursor->set_mouse_filter(MOUSE_FILTER_PASS);
+	add_child(play_cursor);
+	play_cursor->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
+	play_cursor->connect(SceneStringName(draw), callable_mp(this, &AnimationBezierTrackEdit::_play_cursor_draw));
 	set_focus_mode(FOCUS_CLICK);
 
 	set_clip_contents(true);

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -55,8 +55,8 @@ class AnimationBezierTrackEdit : public Control {
 
 	AnimationTimelineEdit *timeline = nullptr;
 	Node *root = nullptr;
-	Control *play_position = nullptr; //separate control used to draw so updates for only position changed are much faster
-	real_t play_position_pos = 0;
+	Control *play_cursor = nullptr; //separate control used to draw so updates for only position changed are much faster
+	real_t play_cursor_pos = 0;
 
 	Ref<Animation> animation;
 	bool read_only = false;
@@ -99,7 +99,7 @@ class AnimationBezierTrackEdit : public Control {
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _menu_selected(int p_index);
 
-	void _play_position_draw();
+	void _play_cursor_draw();
 	bool _is_track_displayed(int p_track_index);
 	bool _is_track_curves_displayed(int p_track_index);
 

--- a/editor/animation_preview.cpp
+++ b/editor/animation_preview.cpp
@@ -139,6 +139,33 @@ Ref<AnimationPreview> AnimationPreviewGenerator::generate_preview(const Ref<Anim
 	return preview->preview;
 }
 
+void AnimationPreview::create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+	Vector<TrackKeyTime> key_times = get_key_times_with_tracks();
+	int track_count = get_track_count();
+	float track_h = track_count > 0 ? (rect.size.height - 2) / track_count : rect.size.height;
+
+	float len = get_length();
+	float pixel_begin = rect.position.x;
+	float from_x = rect.position.x;
+	float to_x = from_x + rect.size.x;
+
+	for (const TrackKeyTime &kt : key_times) {
+		float ofs = kt.time - start_ofs;
+		if (ofs < 0 || ofs > len) {
+			continue;
+		}
+		int x = pixel_begin + ofs * p_pixels_sec;
+
+		if (x < from_x || x >= to_x) {
+			continue;
+		}
+
+		int y = rect.position.y + 2 + track_h * kt.track_index + track_h / 2;
+		points.push_back(Point2(x, y));
+		points.push_back(Point2(x + 1, y));
+	}
+}
+
 void AnimationPreviewGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generate_preview", "animation"), &AnimationPreviewGenerator::generate_preview);
 

--- a/editor/animation_preview.cpp
+++ b/editor/animation_preview.cpp
@@ -53,13 +53,15 @@ void AnimationPreviewGenerator::_preview_thread(void *p_preview) {
 	Ref<AnimationPreview> anim_preview;
 	anim_preview.instantiate();
 
-	// Setze Länge
+	// set length
 	anim_preview->length = preview->base_anim->get_length();
 	if (anim_preview->length <= 0) {
 		anim_preview->length = 0.0001;
 	}
 
-	// Sammle Keyframe-Zeiten
+	anim_preview->track_count = preview->base_anim->get_track_count();
+
+	// collect key frames
 	Vector<float> key_times;
 	Vector<TrackKeyTime> track_key_times;
 
@@ -77,11 +79,11 @@ void AnimationPreviewGenerator::_preview_thread(void *p_preview) {
 		}
 	}
 
-	// Sortiere Keyframe-Zeiten
+	// sort keyframes
 	key_times.sort();
 	track_key_times.sort();
 
-	// Entferne Duplikate (optional)
+	// remove duplicated
 	if (!key_times.is_empty()) {
 		Vector<float> unique_times;
 		unique_times.push_back(key_times[0]);
@@ -94,13 +96,13 @@ void AnimationPreviewGenerator::_preview_thread(void *p_preview) {
 		key_times = unique_times;
 	}
 
-	// Aktualisiere Vorschau
+	// update preview
 	anim_preview->key_times = key_times;
 	anim_preview->track_key_times = track_key_times;
 	preview->preview = anim_preview;
 	anim_preview->version++;
 
-	// Signalisiere Abschluss
+	// fire finished
 	callable_mp(singleton, &AnimationPreviewGenerator::_update_emit).call_deferred(preview->id);
 
 	preview->generating.clear();

--- a/editor/animation_preview.cpp
+++ b/editor/animation_preview.cpp
@@ -130,7 +130,7 @@ Ref<AnimationPreview> AnimationPreviewGenerator::generate_preview(const Ref<Anim
 	return preview->preview;
 }
 
-void AnimationPreview::create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+void AnimationPreview::create_key_region_data(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	Vector<TrackKeyTime> key_times_result = get_key_times_with_tracks();
 	int curr_track_count = get_track_count();
 	float track_h = curr_track_count > 0 ? (rect.size.height - 2) / curr_track_count : rect.size.height;

--- a/editor/animation_preview.cpp
+++ b/editor/animation_preview.cpp
@@ -37,6 +37,8 @@ AnimationPreview::AnimationPreview() {
 	length = 0;
 }
 
+////
+
 void AnimationPreviewGenerator::_update_emit(ObjectID p_id) {
 	emit_signal(SNAME("preview_updated"), p_id);
 }
@@ -159,12 +161,6 @@ void AnimationPreview::create_key_region(Vector<Vector2> &points, const Rect2 &r
 	}
 }
 
-void AnimationPreviewGenerator::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("generate_preview", "animation"), &AnimationPreviewGenerator::generate_preview);
-
-	ADD_SIGNAL(MethodInfo("preview_updated", PropertyInfo(Variant::INT, "obj_id")));
-}
-
 void AnimationPreviewGenerator::clear_cache() {
 	print_line("Clearing AnimationPreview cache, size was: ", previews.size());
 	for (KeyValue<ObjectID, Preview> &E : previews) {
@@ -190,6 +186,12 @@ void AnimationPreviewGenerator::invalidate_cache(const Ref<Animation> &p_anim) {
 			previews.erase(id);
 		}
 	}
+}
+
+void AnimationPreviewGenerator::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("generate_preview", "animation"), &AnimationPreviewGenerator::generate_preview);
+
+	ADD_SIGNAL(MethodInfo("preview_updated", PropertyInfo(Variant::INT, "obj_id")));
 }
 
 AnimationPreviewGenerator *AnimationPreviewGenerator::singleton = nullptr;

--- a/editor/animation_preview.cpp
+++ b/editor/animation_preview.cpp
@@ -1,0 +1,218 @@
+/**************************************************************************/
+/*  animation_preview.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "animation_preview.h"
+#include "core/object/class_db.h"
+#include "core/os/os.h"
+#include "core/os/thread.h"
+
+
+AnimationPreview::AnimationPreview() {
+	length = 0;
+}
+
+void AnimationPreviewGenerator::_update_emit(ObjectID p_id) {
+	emit_signal(SNAME("preview_updated"), p_id);
+}
+
+void AnimationPreviewGenerator::_preview_thread(void *p_preview) {
+	Thread::set_name("AnimationPreviewGenerator");
+	Preview *preview = static_cast<Preview *>(p_preview);
+	if (!preview->base_anim.is_valid()) {
+		preview->generating.clear();
+		return;
+	}
+
+	Ref<AnimationPreview> anim_preview;
+	anim_preview.instantiate();
+
+	// Setze Länge
+	anim_preview->length = preview->base_anim->get_length();
+	if (anim_preview->length <= 0) {
+		anim_preview->length = 0.0001;
+	}
+
+	// Sammle Keyframe-Zeiten
+	Vector<float> key_times;
+	Vector<TrackKeyTime> track_key_times;
+
+	for (int i = 0; i < preview->base_anim->get_track_count(); i++) {
+		for (int j = 0; j < preview->base_anim->track_get_key_count(i); j++) {
+			float time = preview->base_anim->track_get_key_time(i, j);
+			if (!Math::is_finite(time)) {
+				continue;
+			}
+			key_times.push_back(time);
+			track_key_times.push_back({ i, time });
+			if (j % 100 == 0) { // Progressives Update
+				callable_mp(singleton, &AnimationPreviewGenerator::_update_emit).call_deferred(preview->id);
+			}
+		}
+	}
+
+	// Sortiere Keyframe-Zeiten
+	key_times.sort();
+	track_key_times.sort();
+
+	// Entferne Duplikate (optional)
+	if (!key_times.is_empty()) {
+		Vector<float> unique_times;
+		unique_times.push_back(key_times[0]);
+		for (int i = 1; i < key_times.size(); i++) {
+			if (Math::is_equal_approx(key_times[i], unique_times[unique_times.size() - 1])) {
+				continue;
+			}
+			unique_times.push_back(key_times[i]);
+		}
+		key_times = unique_times;
+	}
+
+	// Aktualisiere Vorschau
+	anim_preview->key_times = key_times;
+	anim_preview->track_key_times = track_key_times;
+	preview->preview = anim_preview;
+	anim_preview->version++;
+
+	// Signalisiere Abschluss
+	callable_mp(singleton, &AnimationPreviewGenerator::_update_emit).call_deferred(preview->id);
+
+	preview->generating.clear();
+}
+
+Ref<AnimationPreview> AnimationPreviewGenerator::generate_preview(const Ref<Animation> &p_anim) {
+	ERR_FAIL_COND_V(p_anim.is_null(), Ref<AnimationPreview>());
+
+
+	if (previews.has(p_anim->get_instance_id())) {
+		return previews[p_anim->get_instance_id()].preview;
+	}
+
+	//no preview exists
+
+	previews[p_anim->get_instance_id()] = Preview();
+
+	Preview *preview = &previews[p_anim->get_instance_id()];
+	preview->base_anim = p_anim;
+	preview->generating.set();
+	preview->id = p_anim->get_instance_id();
+
+	float len_s = preview->base_anim->get_length();
+	if (len_s == 0) {
+		len_s = 0.0001;
+	}
+
+	preview->preview.instantiate();
+	preview->preview->length = len_s;
+	
+	preview->thread = memnew(Thread);
+	preview->thread->start(_preview_thread, preview);
+
+	return preview->preview;
+}
+
+void AnimationPreviewGenerator::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("generate_preview", "animation"), &AnimationPreviewGenerator::generate_preview);
+
+	ADD_SIGNAL(MethodInfo("preview_updated", PropertyInfo(Variant::INT, "obj_id")));
+}
+
+/*
+void AnimationPreview::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_length"), &AnimationPreview::get_length);
+	ClassDB::bind_method(D_METHOD("get_key_times"), &AnimationPreview::get_key_times);
+	ClassDB::bind_method(D_METHOD("get_key_times_with_tracks"), &AnimationPreview::get_key_times_with_tracks);
+	ClassDB::bind_method(D_METHOD("get_version"), &AnimationPreview::get_version);
+}
+
+void AnimationPreviewGenerator::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("generate_preview", "animation"), &AnimationPreviewGenerator::generate_preview);
+	ClassDB::bind_method(D_METHOD("clear_cache"), &AnimationPreviewGenerator::clear_cache);
+	ClassDB::bind_method(D_METHOD("invalidate_cache", "animation"), &AnimationPreviewGenerator::invalidate_cache);
+	ADD_SIGNAL(MethodInfo("preview_updated", PropertyInfo(Variant::INT, "obj_id")));
+}
+*/
+
+void AnimationPreviewGenerator::clear_cache() {
+	print_line("Clearing AnimationPreview cache, size was: ", previews.size());
+	for (KeyValue<ObjectID, Preview> &E : previews) {
+		if (E.value.thread) {
+			E.value.thread->wait_to_finish();
+			memdelete(E.value.thread);
+			E.value.thread = nullptr;
+		}
+	}
+	previews.clear();
+}
+
+void AnimationPreviewGenerator::invalidate_cache(const Ref<Animation> &p_anim) {
+	if (p_anim.is_valid()) {
+		ObjectID id = p_anim->get_instance_id();
+		if (previews.has(id)) {
+			print_line("Invalidating cache for animation: ", p_anim->get_name());
+			if (previews[id].thread) {
+				previews[id].thread->wait_to_finish();
+				memdelete(previews[id].thread);
+				previews[id].thread = nullptr;
+			}
+			previews.erase(id);
+		}
+	}
+}
+
+AnimationPreviewGenerator *AnimationPreviewGenerator::singleton = nullptr;
+
+void AnimationPreviewGenerator::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			List<ObjectID> to_erase;
+			for (KeyValue<ObjectID, Preview> &E : previews) {
+				if (!E.value.generating.is_set()) {
+					if (E.value.thread) {
+						E.value.thread->wait_to_finish();
+						memdelete(E.value.thread);
+						E.value.thread = nullptr;
+					}
+					if (!ObjectDB::get_instance(E.key)) {
+						to_erase.push_back(E.key);
+					}
+				}
+			}
+			while (to_erase.front()) {
+				previews.erase(to_erase.front()->get());
+				to_erase.pop_front();
+			}
+		} break;
+	}
+}
+
+AnimationPreviewGenerator::AnimationPreviewGenerator() {
+	singleton = this;
+	set_process(true);
+}

--- a/editor/animation_preview.cpp
+++ b/editor/animation_preview.cpp
@@ -33,7 +33,6 @@
 #include "core/os/os.h"
 #include "core/os/thread.h"
 
-
 AnimationPreview::AnimationPreview() {
 	length = 0;
 }
@@ -111,12 +110,9 @@ void AnimationPreviewGenerator::_preview_thread(void *p_preview) {
 Ref<AnimationPreview> AnimationPreviewGenerator::generate_preview(const Ref<Animation> &p_anim) {
 	ERR_FAIL_COND_V(p_anim.is_null(), Ref<AnimationPreview>());
 
-
 	if (previews.has(p_anim->get_instance_id())) {
 		return previews[p_anim->get_instance_id()].preview;
 	}
-
-	//no preview exists
 
 	previews[p_anim->get_instance_id()] = Preview();
 
@@ -126,13 +122,10 @@ Ref<AnimationPreview> AnimationPreviewGenerator::generate_preview(const Ref<Anim
 	preview->id = p_anim->get_instance_id();
 
 	float len_s = preview->base_anim->get_length();
-	if (len_s == 0) {
-		len_s = 0.0001;
-	}
 
 	preview->preview.instantiate();
 	preview->preview->length = len_s;
-	
+
 	preview->thread = memnew(Thread);
 	preview->thread->start(_preview_thread, preview);
 
@@ -171,22 +164,6 @@ void AnimationPreviewGenerator::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("preview_updated", PropertyInfo(Variant::INT, "obj_id")));
 }
-
-/*
-void AnimationPreview::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_length"), &AnimationPreview::get_length);
-	ClassDB::bind_method(D_METHOD("get_key_times"), &AnimationPreview::get_key_times);
-	ClassDB::bind_method(D_METHOD("get_key_times_with_tracks"), &AnimationPreview::get_key_times_with_tracks);
-	ClassDB::bind_method(D_METHOD("get_version"), &AnimationPreview::get_version);
-}
-
-void AnimationPreviewGenerator::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("generate_preview", "animation"), &AnimationPreviewGenerator::generate_preview);
-	ClassDB::bind_method(D_METHOD("clear_cache"), &AnimationPreviewGenerator::clear_cache);
-	ClassDB::bind_method(D_METHOD("invalidate_cache", "animation"), &AnimationPreviewGenerator::invalidate_cache);
-	ADD_SIGNAL(MethodInfo("preview_updated", PropertyInfo(Variant::INT, "obj_id")));
-}
-*/
 
 void AnimationPreviewGenerator::clear_cache() {
 	print_line("Clearing AnimationPreview cache, size was: ", previews.size());

--- a/editor/animation_preview.h
+++ b/editor/animation_preview.h
@@ -33,8 +33,8 @@
 #include "core/object/ref_counted.h"
 #include "core/os/thread.h"
 #include "core/templates/safe_refcount.h"
-#include "scene/resources/animation.h"
 #include "scene/main/node.h"
+#include "scene/resources/animation.h"
 
 struct TrackKeyTime {
 	int track_index;
@@ -56,8 +56,6 @@ class AnimationPreview : public RefCounted {
 	friend class AnimationPreviewGenerator;
 	uint64_t version = 1;
 
-	//static void _bind_methods();
-
 public:
 	uint64_t get_version() const { return version; }
 	float get_length() const { return length; }
@@ -69,7 +67,6 @@ public:
 	void create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	AnimationPreview();
-
 };
 
 class AnimationPreviewGenerator : public Node {
@@ -100,10 +97,7 @@ public:
 			thread = p_rhs.thread;
 		}
 		Preview() {}
-		//Preview(const Ref<Animation> &p_animation) :
-		//		animation(p_animation), id(p_animation->get_instance_id()) {}
 	};
-
 
 private:
 	HashMap<ObjectID, Preview> previews;

--- a/editor/animation_preview.h
+++ b/editor/animation_preview.h
@@ -66,6 +66,8 @@ public:
 
 	int get_track_count() const { return track_count; }
 
+	void create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+
 	AnimationPreview();
 
 };

--- a/editor/animation_preview.h
+++ b/editor/animation_preview.h
@@ -51,6 +51,7 @@ class AnimationPreview : public RefCounted {
 	Vector<float> key_times;
 	Vector<TrackKeyTime> track_key_times;
 	float length;
+	int track_count;
 
 	friend class AnimationPreviewGenerator;
 	uint64_t version = 1;
@@ -62,6 +63,8 @@ public:
 	float get_length() const { return length; }
 	Vector<float> get_key_times() const { return key_times; }
 	Vector<TrackKeyTime> get_key_times_with_tracks() const { return track_key_times; }
+
+	int get_track_count() const { return track_count; }
 
 	AnimationPreview();
 

--- a/editor/animation_preview.h
+++ b/editor/animation_preview.h
@@ -48,6 +48,7 @@ class AnimationPreview : public RefCounted {
 	GDCLASS(AnimationPreview, RefCounted);
 	friend class Preview;
 
+private:
 	Vector<float> key_times;
 	Vector<TrackKeyTime> track_key_times;
 	float length;

--- a/editor/animation_preview.h
+++ b/editor/animation_preview.h
@@ -1,0 +1,123 @@
+/**************************************************************************/
+/*  animation_preview.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+#include "core/os/thread.h"
+#include "core/templates/safe_refcount.h"
+#include "scene/resources/animation.h"
+#include "scene/main/node.h"
+
+struct TrackKeyTime {
+	int track_index;
+	float time;
+	bool operator<(const TrackKeyTime &p_other) const {
+		return time < p_other.time;
+	}
+};
+
+class AnimationPreview : public RefCounted {
+	GDCLASS(AnimationPreview, RefCounted);
+	friend class Preview;
+
+	Vector<float> key_times;
+	Vector<TrackKeyTime> track_key_times;
+	float length;
+
+	friend class AnimationPreviewGenerator;
+	uint64_t version = 1;
+
+	//static void _bind_methods();
+
+public:
+	uint64_t get_version() const { return version; }
+	float get_length() const { return length; }
+	Vector<float> get_key_times() const { return key_times; }
+	Vector<TrackKeyTime> get_key_times_with_tracks() const { return track_key_times; }
+
+	AnimationPreview();
+
+};
+
+class AnimationPreviewGenerator : public Node {
+	GDCLASS(AnimationPreviewGenerator, Node);
+
+	static AnimationPreviewGenerator *singleton;
+
+public:
+	struct Preview {
+		Ref<Animation> base_anim;
+		Ref<AnimationPreview> preview;
+		SafeFlag generating;
+		ObjectID id;
+		Thread *thread = nullptr;
+
+		void operator=(const Preview &p_rhs) {
+			base_anim = p_rhs.base_anim;
+			preview = p_rhs.preview;
+			generating.set_to(p_rhs.generating.is_set());
+			id = p_rhs.id;
+			thread = p_rhs.thread;
+		}
+		Preview(const Preview &p_rhs) {
+			base_anim = p_rhs.base_anim;
+			preview = p_rhs.preview;
+			generating.set_to(p_rhs.generating.is_set());
+			id = p_rhs.id;
+			thread = p_rhs.thread;
+		}
+		Preview() {}
+		//Preview(const Ref<Animation> &p_animation) :
+		//		animation(p_animation), id(p_animation->get_instance_id()) {}
+	};
+
+
+private:
+	HashMap<ObjectID, Preview> previews;
+
+	static void _preview_thread(void *p_preview);
+
+	void _update_emit(ObjectID p_id);
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	static AnimationPreviewGenerator *get_singleton() { return singleton; }
+
+	Ref<AnimationPreview> generate_preview(const Ref<Animation> &p_animation);
+
+	void clear_cache();
+	void invalidate_cache(const Ref<Animation> &p_animation);
+
+	AnimationPreviewGenerator();
+};

--- a/editor/animation_preview.h
+++ b/editor/animation_preview.h
@@ -65,7 +65,7 @@ public:
 
 	int get_track_count() const { return track_count; }
 
-	void create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	void create_key_region_data(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	AnimationPreview();
 };

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -9392,14 +9392,6 @@ StringName AnimationMarkerEdit::get_key_name(const int p_index) const {
 	return editor->get_marker_name(p_index);
 }
 
-float AnimationMarkerEdit::get_key_width(const int p_index) const {
-	return _get_key_type_icon()->get_width();
-}
-
-float AnimationMarkerEdit::get_key_height(const int p_index) const {
-	return _get_key_type_icon()->get_height();
-}
-
 StringName AnimationMarkerEdit::get_edit_name(const int p_index) const {
 	return get_key_name(p_index);
 }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2296,6 +2296,34 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 			moving_selection_attempt = false;
 			set_moving_selection(false);
 
+			<<<<<<< animation-track-offset
+			menu->clear();
+			create_popup_menu(menu, selected);
+			menu->reset_size();
+
+			moving_selection_attempt = false;
+			set_moving_selection(false);
+
+	length = memnew(EditorSpinSlider);
+	length->set_min(SECOND_DECIMAL);
+	length->set_max(36000);
+	length->set_step(SECOND_DECIMAL);
+	length->set_allow_greater(true);
+	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
+	length->set_hide_slider(true);
+	length->set_tooltip_text(TTR("Animation length (seconds)"));
+	length->set_accessibility_name(TTRC("Animation length (seconds)"));
+	length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
+	len_hb->add_child(length);
+
+	loop = memnew(Button);
+	loop->set_flat(true);
+	loop->set_tooltip_text(TTR("Animation Looping"));
+	loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
+	loop->set_toggle_mode(true);
+	len_hb->add_child(loop);
+	add_child(len_hb);
+
 			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->popup();
 
@@ -8784,12 +8812,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	ease_selection->add_item(TTR("OutIn", "Ease Type"), Tween::EASE_OUT_IN);
 	ease_selection->select(Tween::EASE_IN_OUT); // Default
 	ease_selection->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Translation context is needed.
-	ease_fps = memnew(SpinBox);
-	ease_fps->set_min(FPS_DECIMAL);
-	ease_fps->set_max(999);
-	ease_fps->set_step(FPS_DECIMAL);
-	ease_fps->set_value(30); // Default
-	ease_fps->set_accessibility_name(TTRC("FPS:"));
+	ease_fps_sp = memnew(SpinBox);
+	ease_fps_sp->set_min(FPS_DECIMAL);
+	ease_fps_sp->set_max(999);
+	ease_fps_sp->set_step(FPS_DECIMAL);
+	ease_fps_sp->set_value(30); // Default
+	ease_fps_sp->set_accessibility_name(TTRC("FPS"));
 	ease_grid->add_child(memnew(Label(TTR("Transition Type:"))));
 	ease_grid->add_child(transition_selection);
 	ease_grid->add_child(memnew(Label(TTR("Ease Type:"))));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3056,8 +3056,8 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 					text += TTR("End (s):") + " " + rtos(eo) + "\n";
 				} break;
 				case Animation::TYPE_ANIMATION: {
-					String name = animation->animation_track_get_key_animation(track, key_idx);
-					text += TTR("Animation Clip:") + " " + name + "\n";
+					String anim_name = animation->animation_track_get_key_animation(track, key_idx);
+					text += TTR("Animation Clip:") + " " + anim_name + "\n";
 					float so = animation->animation_track_get_key_start_offset(track, key_idx);
 					text += TTR("Start (s):") + " " + rtos(so) + "\n";
 					float eo = animation->animation_track_get_key_end_offset(track, key_idx);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2284,41 +2284,33 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 	if (pos.x >= limit && pos.x <= limit_end) {
 		float scale = timeline->get_zoom_scale();
 
-	length = memnew(EditorSpinSlider);
-	length->set_min(SECOND_DECIMAL);
-	length->set_max(36000);
-	length->set_step(SECOND_DECIMAL);
-	length->set_allow_greater(true);
-	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
-	length->set_hide_slider(true);
-	length->set_tooltip_text(TTR("Animation length (seconds)"));
-	length->set_accessibility_name(TTRC("Animation length (seconds)"));
-	length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
-	len_hb->add_child(length);
+		// Can do something with menu too! show insert keyl.
+		float offset = (pos.x - limit) / scale;
+		if (!read_only) {
+			bool selected = _try_select_at_ui_pos(pos, mb->is_command_or_control_pressed() || mb->is_shift_pressed(), false);
 
-	loop = memnew(Button);
-	loop->set_flat(true);
-	loop->set_tooltip_text(TTR("Animation Looping"));
-	loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
-	loop->set_toggle_mode(true);
-	len_hb->add_child(loop);
-	add_child(len_hb);
+			menu->clear();
+			create_popup_menu(menu, selected);
+			menu->reset_size();
 
-		menu->set_position(get_screen_position() + get_local_mouse_position());
-		menu->popup();
+			moving_selection_attempt = false;
+			set_moving_selection(false);
 
-		insert_at_pos = offset + timeline->get_value();
-		accept_event();
+			menu->set_position(get_screen_position() + get_local_mouse_position());
+			menu->popup();
+
+			insert_at_pos = offset + timeline->get_value();
+			accept_event();
+		}
 	}
-}
 
-if (is_moving_selection()) {
 	if (is_moving_selection()) {
-		moving_selection_attempt = false;
-		set_moving_selection(false);
-		_move_selection_cancel();
+		if (is_moving_selection()) {
+			moving_selection_attempt = false;
+			set_moving_selection(false);
+			_move_selection_cancel();
+		}
 	}
-}
 }
 
 bool AnimationKeyEdit::is_linked(const int p_index, const int p_index_next) const {
@@ -8792,12 +8784,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	ease_selection->add_item(TTR("OutIn", "Ease Type"), Tween::EASE_OUT_IN);
 	ease_selection->select(Tween::EASE_IN_OUT); // Default
 	ease_selection->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Translation context is needed.
-	ease_fps_sp = memnew(SpinBox);
-	ease_fps_sp->set_min(FPS_DECIMAL);
-	ease_fps_sp->set_max(999);
-	ease_fps_sp->set_step(FPS_DECIMAL);
-	ease_fps_sp->set_value(30); // Default
-	ease_fps_sp->set_accessibility_name(TTRC("FPS"));
+	ease_fps = memnew(SpinBox);
+	ease_fps->set_min(FPS_DECIMAL);
+	ease_fps->set_max(999);
+	ease_fps->set_step(FPS_DECIMAL);
+	ease_fps->set_value(30); // Default
+	ease_fps->set_accessibility_name(TTRC("FPS:"));
 	ease_grid->add_child(memnew(Label(TTR("Transition Type:"))));
 	ease_grid->add_child(transition_selection);
 	ease_grid->add_child(memnew(Label(TTR("Ease Type:"))));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1680,7 +1680,10 @@ void AnimationTimelineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			int key_range = get_size().width - get_buttons_width() - get_name_limit();
+			int limit = get_name_limit();
+			int limit_end = get_size().width - get_buttons_width();
+
+			int key_range = limit_end - limit;
 
 			if (animation.is_null()) {
 				return;
@@ -1715,7 +1718,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			}
 
 			Ref<Texture2D> hsize_icon = get_editor_theme_icon(SNAME("Hsize"));
-			hsize_rect = Rect2(get_name_limit() - hsize_icon->get_width() - 8 * EDSCALE, (get_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
+			hsize_rect = Rect2(limit - hsize_icon->get_width() - 8 * EDSCALE, (get_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
 			draw_texture(hsize_icon, hsize_rect.position);
 
 			{
@@ -1774,7 +1777,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			int begin_px = -get_value() * scale;
 
 			{
-				draw_style_box(stylebox_time_unavailable, Rect2(Point2(get_name_limit(), 0), Point2(zoomw - 1, h)));
+				draw_style_box(stylebox_time_unavailable, Rect2(Point2(limit, 0), Point2(zoomw - 1, h)));
 
 				if (begin_px < zoomw && end_px > 0) {
 					if (begin_px < 0) {
@@ -1784,7 +1787,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 						end_px = zoomw;
 					}
 
-					draw_style_box(stylebox_time_available, Rect2(Point2(get_name_limit() + begin_px, 0), Point2(end_px - begin_px, h)));
+					draw_style_box(stylebox_time_available, Rect2(Point2(limit + begin_px, 0), Point2(end_px - begin_px, h)));
 				}
 			}
 #define SC_ADJ 100
@@ -1849,11 +1852,11 @@ void AnimationTimelineEdit::_notification(int p_what) {
 							int line_width = sub ? v_line_secondary_width : v_line_primary_width;
 							Color line_color = sub ? v_line_secondary_color : v_line_primary_color;
 
-							draw_line(Point2(get_name_limit() + i, 0 + line_margin), Point2(get_name_limit() + i, h - line_margin), line_color, line_width);
+							draw_line(Point2(limit + i, 0 + line_margin), Point2(limit + i, h - line_margin), line_color, line_width);
 
 							int text_margin = sub ? text_secondary_margin : text_primary_margin;
 
-							draw_string(font, Point2(get_name_limit() + i + text_margin, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), itos(frame), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? font_secondary_color : font_primary_color);
+							draw_string(font, Point2(limit + i + text_margin, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), itos(frame), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? font_secondary_color : font_primary_color);
 
 							prev_frame_ofs = i + font->get_string_size(itos(frame), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x + text_margin;
 						}
@@ -1876,11 +1879,11 @@ void AnimationTimelineEdit::_notification(int p_what) {
 						int line_width = sub ? v_line_secondary_width : v_line_primary_width;
 						Color line_color = sub ? v_line_secondary_color : v_line_primary_color;
 
-						draw_line(Point2(get_name_limit() + i, 0 + line_margin), Point2(get_name_limit() + i, h - line_margin), line_color, line_width);
+						draw_line(Point2(limit + i, 0 + line_margin), Point2(limit + i, h - line_margin), line_color, line_width);
 
 						int text_margin = sub ? text_secondary_margin : text_primary_margin;
 
-						draw_string(font, Point2(get_name_limit() + i + text_margin, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), String::num((scd - (scd % step)) / double(SC_ADJ), decimals), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? font_secondary_color : font_primary_color);
+						draw_string(font, Point2(limit + i + text_margin, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), String::num((scd - (scd % step)) / double(SC_ADJ), decimals), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? font_secondary_color : font_primary_color);
 					}
 				}
 			}
@@ -1889,6 +1892,10 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			update_values();
 		} break;
 	}
+}
+
+void AnimationTimelineEdit::set_editor(AnimationTrackEditor *p_editor) {
+	editor = p_editor;
 }
 
 void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation, bool p_read_only) {
@@ -1950,6 +1957,8 @@ void AnimationTimelineEdit::auto_fit() {
 			}
 		}
 	}
+
+
 
 	float anim_length = anim_end - anim_start;
 	int timeline_width_pixels = get_size().width - get_buttons_width() - get_name_limit();
@@ -2451,6 +2460,9 @@ bool AnimationKeyEdit::has_valid_key(const int p_index) const {
 
 /// KEY EDIT ///
 
+KeyEdit::KeyEdit() {
+}
+
 void KeyEdit::try_draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	if (has_valid_key(p_index)) {
 		draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
@@ -2517,7 +2529,44 @@ Rect2 KeyEdit::_to_global_key_rect(const int p_index, const Rect2 &p_local_rect,
 	return global_rect;
 }
 
-KeyEdit::KeyEdit() {
+Color KeyEdit::get_key_color(const int p_index) const {
+	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
+	return color;
+}
+
+void KeyEdit::draw_edit_text(const int p_index, const Rect2 &p_global_rect, const float p_clip_left, const float p_clip_right, const bool outside) {
+	float clip_r = p_clip_right - REGION_FONT_MARGIN;
+	if (get_key_count() > p_index + 1) {
+		Rect2 rect_next = get_global_key_rect(p_index + 1);
+		clip_r = MIN(rect_next.position.x - REGION_FONT_MARGIN, clip_r - REGION_FONT_MARGIN);
+	}
+
+	float text_pos = p_global_rect.position.x + REGION_FONT_MARGIN;
+	float max_width = p_global_rect.size.x - REGION_FONT_MARGIN;
+
+	if (outside) {
+		text_pos = text_pos + p_global_rect.size.x;
+		max_width = MAX(0.0, clip_r - text_pos);
+	}
+	else {
+		float text_pos = text_pos;
+		float max_width = MIN(max_width, clip_r - text_pos);
+	}
+
+	if (max_width > 0) {
+		const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+		const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+		Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
+		color.a = 0.5;
+
+		String key_name = get_edit_name(p_index);
+		Color key_color = get_key_color(p_index);
+		String edit_name = editor->_make_text_clipped(key_name, font, font_size, max_width);
+
+		int f_h = int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
+		draw_string(font, Vector2(text_pos, f_h), edit_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, key_color);
+		draw_string_outline(font, Vector2(text_pos, f_h), edit_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, 1, color);
+	}
 }
 
 double KeyEdit::get_global_move_key_time(const int p_index, bool p_ignore_moving_selection) const {
@@ -2574,7 +2623,7 @@ bool AnimationTrackEdit::is_moving_selection() const {
 }
 
 void AnimationTrackEdit::set_moving_selection(bool p_value) {
-	moving_selection = p_value;
+	editor->set_track_moving_selection(p_value);
 }
 
 float AnimationTrackEdit::get_moving_selection_offset() const {
@@ -2582,7 +2631,7 @@ float AnimationTrackEdit::get_moving_selection_offset() const {
 }
 
 void AnimationTrackEdit::set_moving_selection_offset(float p_value) {
-	moving_selection_offset = p_value;
+	editor->set_track_moving_selection_offset(p_value);
 }
 
 Vector<int> AnimationTrackEdit::get_selected_section() {
@@ -2932,9 +2981,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 	}
 }
 
-void AnimationTrackEdit::draw_timeline(const float p_clip_left, const float p_clip_right) {
-	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-
+void KeyEdit::draw_timeline(const float p_clip_left, const float p_clip_right) {
 	const int key_count = get_key_count();
 	for (int i = 0; i < key_count; i++) {
 		Rect2 global_rect = get_global_key_rect(i);
@@ -2952,10 +2999,11 @@ void AnimationTrackEdit::draw_timeline(const float p_clip_left, const float p_cl
 
 		int next_i = i + 1;
 		if (next_i < key_count) {
-			const Rect2 next_rect = get_global_key_rect(next_i);
-			if (global_rect.position.x <= p_clip_right && next_rect.position.x >= p_clip_left) {
-				if (is_linked(i, next_i)) {
-					draw_key_link(i, global_rect, next_rect, p_clip_left, p_clip_right);
+			if (is_linked(i, next_i)) {
+				const Rect2 global_rect_next = get_global_key_rect(next_i);
+
+				if (global_rect.position.x <= p_clip_right && global_rect_next.position.x >= p_clip_left) {
+					draw_key_link(i, global_rect, global_rect_next, p_clip_left, p_clip_right);
 				}
 			}
 		}
@@ -2967,6 +3015,7 @@ void AnimationTrackEdit::draw_timeline(const float p_clip_left, const float p_cl
 		try_draw_key(i, global_rect, selected, p_clip_left, p_clip_right);
 
 		if (selected) {
+			Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 			editor->_draw_rect_clipped(this, global_rect, accent_color, false, p_clip_left, p_clip_right);
 		}
 	}
@@ -2995,7 +3044,6 @@ Animation::TrackType AnimationTrackEdit::get_track_type() const {
 void AnimationTrackEdit::_zoom_changed() {
 	__zoom_changed();
 }
-
 
 bool AnimationTrackEdit::is_key_selected(const int p_index) const {
 	return editor->is_key_selected(track, p_index);
@@ -3044,12 +3092,6 @@ int AnimationTrackEdit::_get_theme_font_height(float p_scale) const {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 	return int(font->get_height(font_size) * p_scale);
-}
-
-void AnimationTrackEdit::draw_bg(const float p_clip_left, const float p_clip_right) {
-}
-
-void AnimationTrackEdit::draw_fg(const float p_clip_left, const float p_clip_right) {
 }
 
 int AnimationTrackEdit::get_track() const {
@@ -3230,6 +3272,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 
 	int limit = timeline->get_name_limit();
 	int limit_end = get_size().width - timeline->get_buttons_width();
+
 	// Left Border including space occupied by keyframes on t=0.
 	int limit_start_hitbox = limit - type_icon->get_width();
 
@@ -3352,7 +3395,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 		Point2 pos = mb->get_position();
 		bool no_mod_key_pressed = !mb->is_alt_pressed() && !mb->is_shift_pressed() && !mb->is_command_or_control_pressed();
-		if (mb->is_double_click() && !moving_selection && no_mod_key_pressed) {
+		if (mb->is_double_click() && !is_moving_selection() && no_mod_key_pressed) {
 			int x = pos.x - timeline->get_name_limit();
 			float ofs = x / timeline->get_zoom_scale() + timeline->get_value();
 			emit_signal(SNAME("timeline_changed"), ofs, false);
@@ -3405,7 +3448,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->reset_size();
 
 				moving_selection_attempt = false;
-				moving_selection = false;
+				set_moving_selection(false);
 
 				Vector2 popup_pos = get_screen_position() + update_mode_rect.position + Vector2(0, update_mode_rect.size.height);
 				menu->set_position(popup_pos);
@@ -3454,7 +3497,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->reset_size();
 
 				moving_selection_attempt = false;
-				moving_selection = false;
+				set_moving_selection(false);
 
 				Vector2 popup_pos = get_screen_position() + interp_mode_rect.position + Vector2(0, interp_mode_rect.size.height);
 				menu->set_position(popup_pos);
@@ -3474,8 +3517,8 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->reset_size();
 
 				moving_selection_attempt = false;
-				moving_selection = false;
-
+				set_moving_selection(false);
+				
 				Vector2 popup_pos = get_screen_position() + loop_wrap_rect.position + Vector2(0, loop_wrap_rect.size.height);
 				menu->set_position(popup_pos);
 				menu->popup();
@@ -3543,7 +3586,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 				menu->reset_size();
 
 				moving_selection_attempt = false;
-				moving_selection = false;
+				set_moving_selection(false);
 
 				menu->set_position(get_screen_position() + get_local_mouse_position());
 				menu->popup();
@@ -3569,7 +3612,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 		const Vector2 theme_ofs = path->get_theme_stylebox(CoreStringName(normal), SNAME("LineEdit"))->get_offset();
 
 		moving_selection_attempt = false;
-		moving_selection = false;
+		set_moving_selection(false);
 
 		path_popup->set_position(get_screen_position() + path_rect.position - theme_ofs);
 		path_popup->set_size(path_rect.size);
@@ -3582,20 +3625,20 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (mb.is_valid() && moving_selection_attempt) {
 		if (!mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
 			moving_selection_attempt = false;
-			if (moving_selection && moving_selection_effective) {
+			if (is_moving_selection() && moving_selection_effective) {
 				if (std::abs(editor->get_track_moving_selection_offset()) > CMP_EPSILON) {
 					emit_signal(SNAME("move_selection_commit"));
 				}
 			} else if (select_single_attempt != -1) {
 				try_select(select_single_attempt, true);
 			}
-			moving_selection = false;
+			set_moving_selection(false);
 			select_single_attempt = -1;
 		}
 
-		if (moving_selection && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+		if (is_moving_selection() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 			moving_selection_attempt = false;
-			moving_selection = false;
+			set_moving_selection(false);
 			emit_signal(SNAME("move_selection_cancel"));
 		}
 	}
@@ -3630,8 +3673,8 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::LEFT) && moving_selection_attempt) {
-		if (!moving_selection) {
-			moving_selection = true;
+		if (!is_moving_selection()) {
+			set_moving_selection(true);
 			emit_signal(SNAME("move_selection_begin"));
 		}
 
@@ -6475,7 +6518,7 @@ void KeyEdit::draw_key_link(const int p_index, const Rect2 &p_global_rect, const
 
 	int from_x = MAX(p_global_rect.position.x + p_global_rect.size.x, p_clip_left);
 	int to_x = MIN(p_global_rect_next.position.x, p_clip_right);
-	float yh = get_size().height / 2;
+	float yh = get_size().height / 2.0;
 
 	editor->_draw_line_clipped(this, Point2(from_x, yh), Point2(to_x, yh), color, 2, p_clip_left, p_clip_right);
 }
@@ -8234,6 +8277,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	timeline = memnew(AnimationTimelineEdit);
 	timeline_vbox->add_child(timeline);
+	timeline->set_editor(this);
 	timeline->connect("timeline_changed", callable_mp(this, &AnimationTrackEditor::_timeline_changed));
 	timeline->connect("name_limit_changed", callable_mp(this, &AnimationTrackEditor::_name_limit_changed));
 	timeline->connect("track_added", callable_mp(this, &AnimationTrackEditor::_add_track));
@@ -9048,7 +9092,7 @@ void AnimationMarkerEdit::_notification(int p_what) {
 			draw_bg(limit, get_size().width - timeline->get_buttons_width());
 
 			{
-				draw_marker_keys(this, limit, limit_end);
+				draw_timeline(limit, limit_end);
 			}
 
 			draw_fg(limit, get_size().width - timeline->get_buttons_width());
@@ -9067,22 +9111,6 @@ void AnimationMarkerEdit::_notification(int p_what) {
 	}
 }
 
-void AnimationMarkerEdit::draw_marker_keys(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right) {
-	for (int i = 0; i < get_key_count(); i++) {
-		Rect2 global_rect = get_global_key_rect(i);
-
-		if (global_rect.position.x + global_rect.size.x < p_clip_left) {
-			continue;
-		}
-
-		if (global_rect.position.x > p_clip_right) {
-			return;
-		}
-
-		bool is_selected = is_key_selected(i);
-		try_draw_key(i, global_rect, is_selected, p_clip_left, p_clip_right);
-	}
-}
 
 void AnimationMarkerEdit::draw_marker_lines(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right) {
 	for (int i = 0; i < get_key_count(); i++) {
@@ -9169,7 +9197,7 @@ void AnimationMarkerEdit::gui_input(const Ref<InputEvent> &p_event) {
 			select_single_attempt = -1;
 		}
 
-		if (moving_selection && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
+		if (is_moving_selection() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 			moving_selection_attempt = false;
 			set_moving_selection(false);
 			_move_selection_cancel();
@@ -9308,6 +9336,20 @@ StringName AnimationMarkerEdit::get_key_name(const int p_index) const {
 	return editor->get_marker_name(p_index);
 }
 
+float AnimationMarkerEdit::get_key_width(const int p_index) const {
+	Ref<Texture2D> texture = type_icon;
+	return texture->get_width();
+}
+
+float AnimationMarkerEdit::get_key_height(const int p_index) const {
+	Ref<Texture2D> texture = type_icon;
+	return texture->get_height();
+}
+
+StringName AnimationMarkerEdit::get_edit_name(const int p_index) const {
+	return get_key_name(p_index);
+}
+
 void AnimationMarkerEdit::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Ref<Texture2D> texture = p_selected ? selected_icon : type_icon;
 
@@ -9324,30 +9366,9 @@ void AnimationMarkerEdit::draw_key(const int p_index, const Rect2 &p_global_rect
 	editor->_draw_texture_region_clipped(this, texture, p_global_rect, region, p_clip_left, p_clip_right, key_color);
 
 	//
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
-
-	const int font_size = 12 * EDSCALE;
-	StringName marker_name = get_key_name(p_index);
-	Size2 string_size = font->get_string_size(marker_name, HORIZONTAL_ALIGNMENT_LEFT, -1.0, font_size);
-	float rect_center = (p_global_rect.position.x + p_global_rect.size.x / 2);
-
 	if (should_show_all_marker_names) {
-		float bottom = get_size().height + string_size.y - font->get_descent(font_size);
-		float extrusion = MAX(0, rect_center + string_size.x - p_clip_right); // How much the string would extrude outside limit_end if unadjusted.
-		Color marker_color = get_key_color(p_index);
-		float margin = 4 * EDSCALE;
-		Point2 pos = Point2(rect_center - extrusion + margin, bottom + margin);
-
-		draw_string(font, pos, marker_name, HORIZONTAL_ALIGNMENT_LEFT, -1.0, font_size, marker_color);
-		draw_string_outline(font, pos, marker_name, HORIZONTAL_ALIGNMENT_LEFT, -1.0, font_size, 1, color);
+		draw_edit_text(p_index, p_global_rect, p_clip_left, p_clip_right, true);
 	}
-}
-
-void AnimationMarkerEdit::draw_bg(const float p_clip_left, const float p_clip_right) {
-}
-
-void AnimationMarkerEdit::draw_fg(const float p_clip_left, const float p_clip_right) {
 }
 
 void AnimationMarkerEdit::draw_marker_section(CanvasItem * p_canvas_item, const float p_clip_left, const float p_clip_right) {
@@ -9418,7 +9439,7 @@ void AnimationMarkerEdit::_move_selection_begin() {
 }
 
 void AnimationMarkerEdit::_move_selection(float p_offset) {
-	moving_selection_offset = p_offset;
+	set_moving_selection_offset(p_offset);
 	queue_redraw();
 }
 
@@ -9451,7 +9472,8 @@ void AnimationMarkerEdit::_move_selection_commit() {
 		}
 	}
 
-	moving_selection = false;
+	set_moving_selection(false);
+
 	AnimationPlayer *player = AnimationPlayerEditor::get_singleton()->get_player();
 	if (player) {
 		Vector<int> selected_section = get_selected_section();
@@ -9711,6 +9733,7 @@ AnimationMarkerEdit::AnimationMarkerEdit() {
 	key_pivot.x = 0.5;
 	key_pivot.y = 1.0;
 	track_alignment = 1.0;
+
 	play_position = memnew(Control);
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2803,13 +2803,13 @@ int AnimationKeyEdit::get_key_height(const int p_index) const {
 }
 
 Rect2 AnimationKeyEdit::get_key_rect(const int p_index) const {
-	if (animation.is_null()) {
+	if (!has_valid_key(p_index)) {
 		return Rect2();
 	}
 
 	int width = get_key_width(p_index);
 	int height = get_key_height(p_index);
-	Rect2 rect = Rect2(-width / 2, -height * key_pivot, width, height);
+	Rect2 rect = Rect2(-width * key_pivot.x, -height * key_pivot.y, width, height);
 
 	return rect;
 }
@@ -3968,7 +3968,8 @@ void AnimationTrackEdit::_bind_methods() {
 }
 
 AnimationTrackEdit::AnimationTrackEdit() {
-	key_pivot = 0.5;
+	key_pivot.x = 0.5;
+	key_pivot.y = 0.5;
 	track_alignment = 0.5;
 	animationTrackDrawUtils = memnew(AnimationTrackDrawUtils);
 	animationTrackDrawUtils->canvas_item = this;
@@ -9791,7 +9792,8 @@ void AnimationMarkerEdit::_marker_rename_new_name_changed(const String &p_text) 
 }
 
 AnimationMarkerEdit::AnimationMarkerEdit() {
-	key_pivot = 1.0;
+	key_pivot.x = 0.5;
+	key_pivot.y = 1.0;
 	track_alignment = 1.0;
 	animationTrackDrawUtils = memnew(AnimationTrackDrawUtils);
 	animationTrackDrawUtils->canvas_item = this;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -764,7 +764,7 @@ void AnimationTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) const
 					if (anim.is_valid()) {
 						anim_length = anim->get_length();
 					}
-				} 
+				}
 			}
 			String hint_string = vformat("0,%.4f,0.0001,or_greater", anim_length);
 			p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("start_offset"), PROPERTY_HINT_RANGE, hint_string));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2104,6 +2104,11 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 	if (mb.is_valid() && mb->get_position().x > get_name_limit() && mb->get_position().x < (get_size().width - get_buttons_width())) {
 		if (!panner->is_panning() && mb->get_button_index() == MouseButton::LEFT) {
+			AnimationPlayer *player = AnimationPlayerEditor::get_singleton()->get_player();
+			if (player && player->is_playing()) {
+				player->stop();
+			}
+
 			int x = mb->get_position().x - get_name_limit();
 
 			float ofs = x / get_zoom_scale() + get_value();

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2802,17 +2802,48 @@ void AnimationTrackEdit::draw_key(int p_index, float p_pixels_sec, int p_x, bool
 }
 
 // Helper.
-void AnimationTrackEdit::draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled) {
-	int clip_left = timeline->get_name_limit();
-	int clip_right = get_size().width - timeline->get_buttons_width();
+void AnimationTrackEdit::draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right) {
+	if (p_clip_left > p_rect.position.x + p_rect.size.x) {
+		return;
+	}
+	if (p_clip_right < p_rect.position.x) {
+		return;
+	}
 
-	if (p_rect.position.x > clip_right) {
+	Rect2 rect = p_rect;
+	Rect2 region = p_region;
+
+	if (p_clip_left > rect.position.x) {
+		int rect_pixels = (p_clip_left - rect.position.x);
+		int region_pixels = rect_pixels * region.size.x / rect.size.x;
+
+		rect.position.x += rect_pixels;
+		rect.size.x -= rect_pixels;
+
+		region.position.x += region_pixels;
+		region.size.x -= region_pixels;
+	}
+
+	if (p_clip_right < rect.position.x + rect.size.x) {
+		int rect_pixels = rect.position.x + rect.size.x - p_clip_right;
+		int region_pixels = rect_pixels * region.size.x / rect.size.x;
+
+		rect.size.x -= rect_pixels;
+		region.size.x -= region_pixels;
+	}
+
+	draw_texture_rect_region(p_texture, rect, region);
+}
+
+// Helper.
+void AnimationTrackEdit::draw_color_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right) {
+	if (p_rect.position.x > p_clip_right) {
 		return;
 	}
-	if (p_rect.position.x + p_rect.size.x < clip_left) {
+	if (p_rect.position.x + p_rect.size.x < p_clip_left) {
 		return;
 	}
-	Rect2 clip = Rect2(clip_left, 0, clip_right - clip_left, get_size().height);
+	Rect2 clip = Rect2(p_clip_left, 0, p_clip_right - p_clip_left, get_size().height);
 	draw_rect(clip.intersection(p_rect), p_color, p_filled);
 }
 
@@ -2832,43 +2863,6 @@ void AnimationTrackEdit::draw_bg(int p_clip_left, int p_clip_right) {
 }
 
 void AnimationTrackEdit::draw_fg(int p_clip_left, int p_clip_right) {
-}
-
-void AnimationTrackEdit::draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region) {
-	int clip_left = timeline->get_name_limit();
-	int clip_right = get_size().width - timeline->get_buttons_width();
-
-	// Clip left and right.
-	if (clip_left > p_rect.position.x + p_rect.size.x) {
-		return;
-	}
-	if (clip_right < p_rect.position.x) {
-		return;
-	}
-
-	Rect2 rect = p_rect;
-	Rect2 region = p_region;
-
-	if (clip_left > rect.position.x) {
-		int rect_pixels = (clip_left - rect.position.x);
-		int region_pixels = rect_pixels * region.size.x / rect.size.x;
-
-		rect.position.x += rect_pixels;
-		rect.size.x -= rect_pixels;
-
-		region.position.x += region_pixels;
-		region.size.x -= region_pixels;
-	}
-
-	if (clip_right < rect.position.x + rect.size.x) {
-		int rect_pixels = rect.position.x + rect.size.x - clip_right;
-		int region_pixels = rect_pixels * region.size.x / rect.size.x;
-
-		rect.size.x -= rect_pixels;
-		region.size.x -= region_pixels;
-	}
-
-	draw_texture_rect_region(p_texture, rect, region);
 }
 
 int AnimationTrackEdit::get_track() const {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -66,6 +66,8 @@
 constexpr double FPS_DECIMAL = 1.0;
 constexpr double SECOND_DECIMAL = 0.0001;
 
+/// ANIMATION TRACK KEY EDIT ///
+
 void AnimationTrackKeyEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_obj"), &AnimationTrackKeyEdit::_update_obj);
 	ClassDB::bind_method(D_METHOD("_key_ofs_changed"), &AnimationTrackKeyEdit::_key_ofs_changed);
@@ -782,6 +784,8 @@ void AnimationTrackKeyEdit::set_use_fps(bool p_enable) {
 	notify_property_list_changed();
 }
 
+/// ANIMATION MULTI TRACK KEY EDIT ///
+
 void AnimationMultiTrackKeyEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_obj"), &AnimationMultiTrackKeyEdit::_update_obj);
 	ClassDB::bind_method(D_METHOD("_key_ofs_changed"), &AnimationMultiTrackKeyEdit::_key_ofs_changed);
@@ -1459,6 +1463,8 @@ void AnimationMultiTrackKeyEdit::set_use_fps(bool p_enable) {
 	use_fps = p_enable;
 	notify_property_list_changed();
 }
+
+/// ANIMATION TIMELINE EDIT ///
 
 void AnimationTimelineEdit::_zoom_changed(double) {
 	double zoom_pivot = 0; // Point on timeline to stay fixed.
@@ -2262,7 +2268,340 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	set_layout_direction(Control::LAYOUT_DIRECTION_LTR);
 }
 
-////////////////////////////////////
+/// KEY EDIT ///
+
+void AnimationKeyEdit::__play_position_draw() {
+	if (animation.is_null() || play_position_pos < 0) {
+		return;
+	}
+
+	float scale = timeline->get_zoom_scale();
+	int h = get_size().height;
+
+	int px = (play_position_pos - timeline->get_value()) * scale + timeline->get_name_limit();
+
+	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
+		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
+	}
+}
+
+bool AnimationKeyEdit::is_linked(const int p_index, const int p_index_next) const {
+	Variant current = get_key_value(p_index);
+	Variant next = get_key_value(p_index_next);
+	return current == next;
+}
+
+bool AnimationKeyEdit::_try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable) {
+	if (is_compressed()) { // Selecting compressed keyframes for editing is not possible.
+		return false;
+	}
+
+	int limit = timeline->get_name_limit();
+	int limit_end = get_size().width - timeline->get_buttons_width();
+	// Left Border including space occupied by keyframes on t=0.
+	int limit_start_hitbox = limit - type_icon->get_width();
+
+	if (p_pos.x >= limit_start_hitbox && p_pos.x <= limit_end) {
+		int key_idx = find_closest_key(p_pos);
+		if (key_idx != -1) {
+			if (p_aggregate) {
+				if (is_key_selected(key_idx)) {
+					if (p_deselectable) {
+						try_deselect(key_idx);
+						moving_selection_pivot = 0.0f;
+						moving_selection_mouse_begin_x = 0.0f;
+					}
+				} else {
+					try_select(key_idx, false);
+					moving_selection_attempt = true;
+					moving_selection_effective = false;
+					select_single_attempt = -1;
+					moving_selection_pivot = get_key_time(key_idx);
+					moving_selection_mouse_begin_x = p_pos.x;
+				}
+
+			} else {
+				if (!is_key_selected(key_idx)) {
+					try_select(key_idx, true);
+					select_single_attempt = -1;
+				} else {
+					select_single_attempt = key_idx;
+				}
+
+				moving_selection_attempt = true;
+				moving_selection_effective = false;
+				moving_selection_pivot = get_key_time(key_idx);
+				moving_selection_mouse_begin_x = p_pos.x;
+			}
+
+			if (read_only) {
+				moving_selection_attempt = false;
+				moving_selection_pivot = 0.0f;
+				moving_selection_mouse_begin_x = 0.0f;
+			}
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool AnimationKeyEdit::_is_ui_pos_in_current_section(const Point2 &p_pos) {
+	int limit = timeline->get_name_limit();
+	int limit_end = get_size().width - timeline->get_buttons_width();
+
+	if (p_pos.x >= limit && p_pos.x <= limit_end) {
+		Vector<int> section = get_selected_section();
+		if (!section.is_empty()) {
+			int start_marker = section[0];
+			int end_marker = section[1];
+			float start_offset = get_global_move_key_time(start_marker);
+			float end_offset = get_global_move_key_time(end_marker);
+			return p_pos.x >= start_offset && p_pos.x <= end_offset;
+		}
+	}
+
+	return false;
+}
+
+HBoxContainer *AnimationMarkerEdit::_create_hbox_labeled_control(const String &p_text, Control *p_control) const {
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	Label *label = memnew(Label);
+	label->set_text(p_text);
+	hbox->add_child(label);
+	hbox->add_child(p_control);
+	hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+	label->set_h_size_flags(SIZE_EXPAND_FILL);
+	label->set_stretch_ratio(1.0);
+	p_control->set_h_size_flags(SIZE_EXPAND_FILL);
+	p_control->set_stretch_ratio(1.0);
+	return hbox;
+}
+
+void AnimationMarkerEdit::_update_key_edit() {
+	_clear_key_edit();
+	if (animation.is_null()) {
+		return;
+	}
+
+	if (get_selection_count() == 1) {
+		key_edit = memnew(AnimationMarkerKeyEdit);
+		key_edit->animation = animation;
+		key_edit->animation_read_only = read_only;
+		key_edit->marker_name = editor->get_marker_name(get_first_selection());
+		key_edit->use_fps = timeline->is_using_fps();
+		key_edit->marker_edit = this;
+
+		EditorNode::get_singleton()->push_item(key_edit);
+
+		InspectorDock::get_singleton()->set_info(TTR("Marker name is read-only in the inspector."), TTR("A marker's name can only be changed by right-clicking it in the animation editor and selecting \"Rename Marker\", in order to make sure that marker names are all unique."), true);
+	} else if (get_selection_count() > 1) {
+		multi_key_edit = memnew(AnimationMultiMarkerKeyEdit);
+		multi_key_edit->animation = animation;
+		multi_key_edit->animation_read_only = read_only;
+		multi_key_edit->marker_edit = this;
+
+		for (RBMap<SelectedKey, KeyInfo>::Iterator E = selection.begin(); E != selection.end(); ++E) {
+			SelectedKey key = E->key;
+			int key_index = key.key;
+
+			StringName marker_name = editor->get_marker_name(key_index);
+			multi_key_edit->marker_names.push_back(marker_name);
+		}
+
+		EditorNode::get_singleton()->push_item(multi_key_edit);
+	}
+}
+
+/// ANIMATION KEY EDIT ///
+
+double AnimationKeyEdit::get_global_move_key_time(const int p_index) const {
+	return editor->get_global_time(get_move_key_time(p_index));
+}
+
+double AnimationKeyEdit::get_move_key_time(const int p_index) const {
+	double time = get_key_time(p_index);
+
+	bool is_selected = is_key_selected(p_index);
+	if (is_selected && is_moving_selection()) {
+		time += get_moving_selection_offset();
+	}
+
+	return time;
+}
+
+bool AnimationKeyEdit::has_valid_track() const {
+	if (animation.is_null()) {
+		return false;
+	}
+
+	if (get_key_count() == 0) {
+		return false;
+	}
+
+	return true;
+}
+
+float AnimationKeyEdit::get_key_width(const int p_index) const {
+	return _get_key_type_icon()->get_width();
+}
+
+float AnimationKeyEdit::get_key_height(const int p_index) const {
+	return _get_key_type_icon()->get_height();
+}
+
+bool AnimationKeyEdit::has_valid_key(const int p_index) const {
+	if (!_get_key_type_icon().is_valid()) {
+		return false;
+	}
+
+	return true;
+}
+
+/// KEY EDIT ///
+
+void KeyEdit::try_draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
+	if (has_valid_key(p_index)) {
+		draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
+		return;
+	}
+
+	_draw_default_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
+}
+
+void KeyEdit::_draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
+	Ref<Texture2D> texture = p_selected ? selected_icon : type_icon;
+
+	Rect2 region;
+	region.size = texture->get_size();
+
+	// Use a different color for the currently hovered key.
+	// The color multiplier is chosen to work with both dark and light editor themes,
+	// and on both unselected and selected key icons.
+	//Color color = p_index == hovering_key_idx ? get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")) : Color(1, 1, 1);
+	Color color = p_index == hovering_key_idx ? get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")) : Color(1, 1, 1);
+	editor->_draw_texture_region_clipped(this, texture, p_global_rect, region, p_clip_left, p_clip_right, color);
+}
+
+Rect2 KeyEdit::get_key_rect(const int p_index) const {
+	if (!has_valid_key(p_index)) {
+		Ref<Texture2D> texture = type_icon;
+
+		Rect2 region;
+		region.size = texture->get_size();
+
+		float width = region.size.x;
+		float height = region.size.y;
+
+		return Rect2(-width * 0.5, -height * key_pivot.y, width, height);
+	}
+
+	float width = get_key_width(p_index);
+	float height = get_key_height(p_index);
+	Rect2 rect = Rect2(-width * key_pivot.x, -height * key_pivot.y, width, height);
+
+	return rect;
+}
+
+Rect2 KeyEdit::get_global_key_rect(const int p_index, bool p_ignore_moving_selection) const {
+	Rect2 local_rect = get_key_rect(p_index);
+	return _to_global_key_rect(p_index, local_rect, p_ignore_moving_selection);
+}
+
+Rect2 KeyEdit::_to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection) const {
+	Rect2 global_rect = Rect2(p_local_rect);
+
+	global_rect.position.x += _get_pixels_sec(p_index, p_ignore_moving_selection);
+
+	float track_height = get_size().height;
+	float key_height = p_local_rect.size.y;
+
+	// Calculate normalized CLAMP bounds to keep key within track
+	float min_y = track_height > 0 ? key_height / (2.0 * track_height) : 0.0;
+	float max_y = track_height > 0 ? 1.0 - key_height / (2.0 * track_height) : 1.0;
+
+	// Position key center, adjusted for key height
+	global_rect.position.y += track_height * CLAMP(track_alignment - get_key_y(p_index), min_y, max_y);
+
+	return global_rect;
+}
+
+Rect2 KeyEdit::_to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const {
+	Rect2 local_rect = Rect2(p_global_rect);
+
+	float offset = ((get_key_time(p_index) - timeline->get_value()) * timeline->get_zoom_scale()) + timeline->get_name_limit();
+	local_rect.position.x = offset;
+	local_rect.size.x /= timeline->get_zoom_scale();
+
+	return local_rect;
+}
+
+KeyEdit::KeyEdit() {
+}
+
+float KeyEdit::_get_pixels_sec(const int p_index, bool p_ignore_moving_selection) const {
+	float local_time = _get_local_time(p_index);
+
+	if (!p_ignore_moving_selection) {
+		if (is_key_selected(p_index) && is_moving_selection()) {
+			local_time += get_moving_selection_offset();
+		}
+	}
+
+	int limit = timeline->get_name_limit();
+	float scale = timeline->get_zoom_scale();
+
+	return local_time * scale + limit;
+}
+
+float KeyEdit::_get_local_time(const int p_index, float p_offset) const {
+	return (get_key_time(p_index) + p_offset) - timeline->get_value();
+}
+
+bool KeyEdit::is_key_selectable_by_distance() const {
+	return true;
+}
+
+int KeyEdit::find_closest_key(const Point2 &p_pos) const {
+	int key_idx = -1;
+	float key_distance = 1e20;
+
+	// Select should happen in the opposite order of drawing for more accurate overlap select.
+	for (int i = get_key_count() - 1; i >= 0; i--) {
+		Rect2 rect = get_global_key_rect(i);
+
+		if (rect.has_point(p_pos)) {
+			if (is_key_selectable_by_distance()) {
+				float distance = Math::abs(rect.position.x - p_pos.x);
+				if (key_idx == -1 || distance < key_distance) {
+					key_idx = i;
+					key_distance = distance;
+				}
+			} else {
+				key_idx = i;
+				// First one does it.
+				break;
+			}
+		}
+	}
+
+	return key_idx;
+}
+
+/// ANIMATION TRACK EDIT ///
+
+bool AnimationTrackEdit::is_moving_selection() const {
+	return editor->is_track_moving_selection();
+}
+
+float AnimationTrackEdit::get_moving_selection_offset() const {
+	return editor->get_track_moving_selection_offset();
+}
+
+Vector<int> AnimationTrackEdit::get_selected_section() {
+	return Vector<int>();
+}
 
 void AnimationTrackEdit::_notification(int p_what) {
 	switch (p_what) {
@@ -2631,12 +2970,6 @@ void AnimationTrackEdit::_notification(int p_what) {
 	}
 }
 
-bool AnimationKeyEdit::is_linked(const int p_index, const int p_index_next) const {
-	Variant current = get_key_value(p_index);
-	Variant next = get_key_value(p_index_next);
-	return current == next;
-}
-
 void AnimationTrackEdit::draw_timeline(const float p_clip_left, const float p_clip_right) {
 	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 
@@ -2691,232 +3024,33 @@ void AnimationTrackEditor::_draw_markers(CanvasItem *p_canvas_item, const float 
 	}
 }
 
-StringName AnimationTrackEditor::get_marker_name(const int p_index) const {
-	PackedStringArray markers = animation->get_marker_names();
-	if (markers.size() == 0) {
-		return StringName();
-	}
-
-	if (p_index >= markers.size()) {
-		return StringName();
-	}
-
-	if (p_index < 0) {
-		return StringName();
-	}
-
-	return markers[p_index];
+int AnimationTrackEdit::get_key_count() const {
+	return editor->get_track_key_count(track);
 }
 
-int AnimationTrackEditor::get_marker_index(const StringName marker) const {
-	PackedStringArray markers = animation->get_marker_names();
-	return markers.find(marker);
+bool AnimationTrackEdit::is_compressed() const {
+	return animation->track_is_compressed(track);
 }
 
-double AnimationTrackEditor::get_marker_time(const int p_index) const {
-	StringName marker_name = get_marker_name(p_index);
-	return animation->get_marker_time(marker_name);
+Animation::TrackType AnimationTrackEdit::get_track_type() const {
+	return animation->track_get_type(track);
 }
 
-double AnimationTrackEditor::get_global_time(const float p_time) const {
-	float scale = timeline->get_zoom_scale();
-	int limit = timeline->get_name_limit();
-
-	float offset = p_time - timeline->get_value();
-	offset = offset * scale + limit;
-	return offset;
+void AnimationTrackEdit::_zoom_changed() {
+	__zoom_changed();
 }
 
-double AnimationTrackEditor::get_marker_move_key_time(const int p_index) const {
-	return marker_edit->get_move_key_time(p_index);
-}
 
-int AnimationTrackEditor::get_track_count() const {
-	return animation->get_track_count();
-}
-
-int AnimationTrackEditor::get_marker_count() const {
-	if (animation.is_null()) {
-		return 0;
-	}
-
-	return animation->get_marker_names().size();
+bool AnimationTrackEdit::is_key_selected(const int p_index) const {
+	return editor->is_key_selected(track, p_index);
 }
 
 bool AnimationTrackEdit::has_key(const int p_index) const {
 	return editor->has_track_key(track, p_index);
 }
 
-/// KEY EDIT ///
-
-double AnimationKeyEdit::get_global_move_key_time(const int p_index) const {
-	return editor->get_global_time(get_move_key_time(p_index));
-}
-
-double AnimationKeyEdit::get_move_key_time(const int p_index) const {
-	double time = get_key_time(p_index);
-
-	bool is_selected = is_key_selected(p_index);
-	if (is_selected && is_moving_selection()) {
-		time += get_moving_selection_offset();
-	}
-
-	return time;
-}
-
-bool AnimationKeyEdit::has_valid_track() const {
-	if (animation.is_null()) {
-		return false;
-	}
-
-	if (get_key_count() == 0) {
-		return false;
-	}
-
-	return true;
-}
-
-int AnimationTrackEdit::get_key_count() const {
-	return editor->get_track_key_count(track);
-}
-
-int AnimationMarkerEdit::get_key_count() const {
-	return editor->get_marker_count();
-}
-
-bool AnimationMarkerEdit::has_key(const int p_index) const {
-	return editor->has_marker(p_index);
-}
-
-float AnimationKeyEdit::get_key_width(const int p_index) const {
-	return _get_key_type_icon()->get_width();
-}
-
-float AnimationKeyEdit::get_key_height(const int p_index) const {
-	return _get_key_type_icon()->get_height();
-}
-
-bool AnimationKeyEdit::has_valid_key(const int p_index) const {
-	if (!_get_key_type_icon().is_valid()) {
-		return false;
-	}
-
-	return true;
-}
-
-void KeyEdit::try_draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
-	if (has_valid_key(p_index)) {
-		draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
-	_draw_default_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
-}
-
-void KeyEdit::_draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
-	Ref<Texture2D> texture = p_selected ? selected_icon : type_icon;
-
-	Rect2 region;
-	region.size = texture->get_size();
-
-	// Use a different color for the currently hovered key.
-	// The color multiplier is chosen to work with both dark and light editor themes,
-	// and on both unselected and selected key icons.
-	//Color color = p_index == hovering_key_idx ? get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")) : Color(1, 1, 1);
-	Color color = p_index == hovering_key_idx ? get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")) : Color(1, 1, 1);
-	editor->_draw_texture_region_clipped(this, texture, p_global_rect, region, p_clip_left, p_clip_right, color);
-}
-
-Rect2 KeyEdit::get_key_rect(const int p_index) const {
-	if (!has_valid_key(p_index)) {
-		Ref<Texture2D> texture = type_icon;
-
-		Rect2 region;
-		region.size = texture->get_size();
-
-		float width = region.size.x;
-		float height = region.size.y;
-
-		return Rect2(-width * 0.5, -height * key_pivot.y, width, height);
-	}
-
-	float width = get_key_width(p_index);
-	float height = get_key_height(p_index);
-	Rect2 rect = Rect2(-width * key_pivot.x, -height * key_pivot.y, width, height);
-
-	return rect;
-}
-
-Rect2 KeyEdit::get_global_key_rect(const int p_index, bool p_ignore_moving_selection) const {
-	Rect2 local_rect = get_key_rect(p_index);
-	return _to_global_key_rect(p_index, local_rect, p_ignore_moving_selection);
-}
-
-Rect2 KeyEdit::_to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection) const {
-	Rect2 global_rect = Rect2(p_local_rect);
-
-	global_rect.position.x += _get_pixels_sec(p_index, p_ignore_moving_selection);
-
-	float track_height = get_size().height;
-	float key_height = p_local_rect.size.y;
-
-	// Calculate normalized CLAMP bounds to keep key within track
-	float min_y = track_height > 0 ? key_height / (2.0 * track_height) : 0.0;
-	float max_y = track_height > 0 ? 1.0 - key_height / (2.0 * track_height) : 1.0;
-
-	// Position key center, adjusted for key height
-	global_rect.position.y += track_height * CLAMP(track_alignment - get_key_y(p_index), min_y, max_y);
-
-	return global_rect;
-}
-
-Rect2 KeyEdit::_to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const {
-	Rect2 local_rect = Rect2(p_global_rect);
-
-	float offset = ((get_key_time(p_index) - timeline->get_value()) * timeline->get_zoom_scale()) + timeline->get_name_limit();
-	local_rect.position.x = offset;
-	local_rect.size.x /= timeline->get_zoom_scale();
-
-	return local_rect;
-}
-
-KeyEdit::KeyEdit() {
-}
-
-bool AnimationTrackEdit::is_key_selected(const int p_index) const {
-	return editor->is_key_selected(track, p_index);
-}
-
-float KeyEdit::_get_pixels_sec(const int p_index, bool p_ignore_moving_selection) const {
-	float local_time = _get_local_time(p_index);
-
-	if (!p_ignore_moving_selection) {
-		if (is_key_selected(p_index) && is_moving_selection()) {
-			local_time += get_moving_selection_offset();
-		}
-	}
-
-	int limit = timeline->get_name_limit();
-	float scale = timeline->get_zoom_scale();
-
-	return local_time * scale + limit;
-}
-
-float KeyEdit::_get_local_time(const int p_index, float p_offset) const {
-	return (get_key_time(p_index) + p_offset) - timeline->get_value();
-}
-
 double AnimationTrackEdit::get_key_time(const int p_index) const {
 	return animation->track_get_key_time(track, p_index);
-}
-
-double AnimationMarkerEdit::get_key_time(const int p_index) const {
-	StringName marker_name = editor->get_marker_name(p_index);
-	return animation->get_marker_time(marker_name);
-}
-
-bool KeyEdit::is_key_selectable_by_distance() const {
-	return true;
 }
 
 void AnimationTrackEdit::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
@@ -2946,51 +3080,8 @@ void AnimationTrackEdit::draw_key(const int p_index, const Rect2 &p_global_rect,
 	editor->_draw_texture_region_clipped(this, texture, p_global_rect, region, p_clip_left, p_clip_right, color);
 }
 
-int KeyEdit::find_closest_key(const Point2 &p_pos) const {
-	int key_idx = -1;
-	float key_distance = 1e20;
-
-	// Select should happen in the opposite order of drawing for more accurate overlap select.
-	for (int i = get_key_count() - 1; i >= 0; i--) {
-		Rect2 rect = get_global_key_rect(i);
-
-		if (rect.has_point(p_pos)) {
-			if (is_key_selectable_by_distance()) {
-				float distance = Math::abs(rect.position.x - p_pos.x);
-				if (key_idx == -1 || distance < key_distance) {
-					key_idx = i;
-					key_distance = distance;
-				}
-			} else {
-				key_idx = i;
-				// First one does it.
-				break;
-			}
-		}
-	}
-
-	return key_idx;
-}
-
-// Helper.
-
 Variant AnimationTrackEdit::get_key_value(const int p_index) const {
 	return animation->track_get_key_value(track, p_index);
-}
-
-Variant AnimationMarkerEdit::get_key_value(const int p_index) const {
-	return editor->get_marker_name(p_index);
-}
-
-void KeyEdit::draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) {
-	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
-	color.a = 0.5;
-
-	int from_x = MAX(p_global_rect.position.x + p_global_rect.size.x, p_clip_left);
-	int to_x = MIN(p_global_rect_next.position.x, p_clip_right);
-	float yh = get_size().height / 2;
-
-	editor->_draw_line_clipped(this, Point2(from_x, yh), Point2(to_x, yh), color, 2, p_clip_left, p_clip_right);
 }
 
 int AnimationTrackEdit::_get_theme_font_height(float p_scale) const {
@@ -3033,13 +3124,6 @@ void AnimationTrackEdit::set_track(const int p_track) {
 	_update_key_type_icon();
 }
 
-void KeyEdit::_update_key_type_icon() {
-	type_icon = _get_key_type_icon();
-	selected_icon = _get_key_type_icon_selected();
-
-	queue_redraw();
-}
-
 NodePath AnimationTrackEdit::get_path() const {
 	return node_path;
 }
@@ -3070,10 +3154,6 @@ void AnimationTrackEdit::set_editor(AnimationTrackEditor *p_editor) {
 }
 
 void AnimationTrackEdit::_play_position_draw() {
-	__play_position_draw();
-}
-
-void AnimationMarkerEdit::_play_position_draw() {
 	__play_position_draw();
 }
 
@@ -3147,14 +3227,6 @@ Ref<Texture2D> AnimationTrackEdit::_get_key_type_icon_selected() const {
 	}
 
 	return get_editor_theme_icon(SNAME("KeySelected"));
-}
-
-Ref<Texture2D> AnimationMarkerEdit::_get_key_type_icon() const {
-	return get_editor_theme_icon(SNAME("Marker"));
-}
-
-Ref<Texture2D> AnimationMarkerEdit::_get_key_type_icon_selected() const {
-	return get_editor_theme_icon(SNAME("MarkerSelected"));
 }
 
 Control::CursorShape AnimationTrackEdit::get_cursor_shape(const Point2 &p_pos) const {
@@ -3923,7 +3995,7 @@ AnimationTrackEdit::AnimationTrackEdit() {
 	set_mouse_filter(MOUSE_FILTER_PASS); // Scroll has to work too for selection.
 }
 
-//////////////////////////////////////
+/// ANIMATION TRACK EDIT PLUGIN ///
 
 AnimationTrackEdit *AnimationTrackEditPlugin::create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) {
 	if (get_script_instance()) {
@@ -3952,7 +4024,8 @@ AnimationTrackEdit *AnimationTrackEditPlugin::create_method_track_edit() {
 	}
 	return nullptr;
 }
-///////////////////////////////////////
+
+/// ANIMATION TRACK EDIT GROUP ///
 
 void AnimationTrackEditGroup::_notification(int p_what) {
 	switch (p_what) {
@@ -4117,7 +4190,59 @@ AnimationTrackEditGroup::AnimationTrackEditGroup() {
 	set_mouse_filter(MOUSE_FILTER_PASS);
 }
 
-//////////////////////////////////////
+/// ANIMATION TRACK EDITOR ///
+
+StringName AnimationTrackEditor::get_marker_name(const int p_index) const {
+	PackedStringArray markers = animation->get_marker_names();
+	if (markers.size() == 0) {
+		return StringName();
+	}
+
+	if (p_index >= markers.size()) {
+		return StringName();
+	}
+
+	if (p_index < 0) {
+		return StringName();
+	}
+
+	return markers[p_index];
+}
+
+int AnimationTrackEditor::get_marker_index(const StringName marker) const {
+	PackedStringArray markers = animation->get_marker_names();
+	return markers.find(marker);
+}
+
+double AnimationTrackEditor::get_marker_time(const int p_index) const {
+	StringName marker_name = get_marker_name(p_index);
+	return animation->get_marker_time(marker_name);
+}
+
+double AnimationTrackEditor::get_global_time(const float p_time) const {
+	float scale = timeline->get_zoom_scale();
+	int limit = timeline->get_name_limit();
+
+	float offset = p_time - timeline->get_value();
+	offset = offset * scale + limit;
+	return offset;
+}
+
+double AnimationTrackEditor::get_marker_move_key_time(const int p_index) const {
+	return marker_edit->get_move_key_time(p_index);
+}
+
+int AnimationTrackEditor::get_track_count() const {
+	return animation->get_track_count();
+}
+
+int AnimationTrackEditor::get_marker_count() const {
+	if (animation.is_null()) {
+		return 0;
+	}
+
+	return animation->get_marker_names().size();
+}
 
 void AnimationTrackEditor::add_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin) {
 	if (track_edit_plugins.has(p_plugin)) {
@@ -4767,46 +4892,6 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 	_query_insert(id);
 }
 
-Vector<int> AnimationTrackEdit::get_selected_section() {
-	return Vector<int>();
-}
-
-Vector<int> AnimationMarkerEdit::get_selected_section() {
-	if (get_selection_count() >= 2) {
-		Vector<int> arr;
-		arr.push_back(-1); // with smallest time.
-		arr.push_back(-1); // with largest time.
-		double min_time = Math::INF;
-		double max_time = -Math::INF;
-
-		for (RBMap<SelectedKey, KeyInfo>::Iterator E = selection.begin(); E != selection.end(); ++E) {
-			SelectedKey key = E->key;
-			int key_index = key.key;
-
-			double time = get_key_time(key_index);
-			if (time < min_time) {
-				arr.set(0, key_index);
-				min_time = time;
-			}
-			if (time > max_time) {
-				arr.set(1, key_index);
-				max_time = time;
-			}
-		}
-		return arr;
-	}
-
-	return Vector<int>();
-}
-
-bool AnimationMarkerEdit::is_key_selected(const int p_index) const {
-	SelectedKey sk;
-	sk.key = p_index;
-	sk.track = 0;
-
-	return selection.has(sk);
-}
-
 bool AnimationTrackEditor::is_marker_selected(const int p_key) const {
 	return marker_edit->is_key_selected(p_key);
 }
@@ -5157,7 +5242,7 @@ void AnimationTrackEditor::show_inactive_player_warning(bool p_show) {
 }
 
 bool AnimationTrackEditor::is_key_selected(const int p_track, const int p_key) const {
-	AnimationKeyEdit::SelectedKey sk;
+	SelectedKey sk;
 	sk.key = p_key;
 	sk.track = p_track;
 
@@ -5185,7 +5270,7 @@ bool AnimationTrackEditor::is_bezier_editor_active() const {
 }
 
 bool AnimationTrackEditor::can_add_reset_key() const {
-	for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+	for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 		const Animation::TrackType track_type = animation->track_get_type(E.key.track);
 		if (track_type != Animation::TYPE_ANIMATION && track_type != Animation::TYPE_AUDIO && track_type != Animation::TYPE_METHOD) {
 			return true;
@@ -6144,7 +6229,7 @@ void AnimationTrackEditor::_key_selected(int p_key, bool p_single, int p_track) 
 	ERR_FAIL_INDEX(p_track, animation->get_track_count());
 	ERR_FAIL_INDEX(p_key, animation->track_get_key_count(p_track));
 
-	AnimationKeyEdit::SelectedKey sk;
+	SelectedKey sk;
 	sk.key = p_key;
 	sk.track = p_track;
 
@@ -6152,7 +6237,7 @@ void AnimationTrackEditor::_key_selected(int p_key, bool p_single, int p_track) 
 		_clear_selection();
 	}
 
-	AnimationKeyEdit::KeyInfo ki;
+	KeyInfo ki;
 	ki.pos = animation->track_get_key_time(p_track, p_key);
 	selection[sk] = ki;
 
@@ -6166,7 +6251,7 @@ void AnimationTrackEditor::_key_deselected(int p_key, int p_track) {
 	ERR_FAIL_INDEX(p_track, animation->get_track_count());
 	ERR_FAIL_INDEX(p_key, animation->track_get_key_count(p_track));
 
-	AnimationKeyEdit::SelectedKey sk;
+	SelectedKey sk;
 	sk.key = p_key;
 	sk.track = p_track;
 
@@ -6177,12 +6262,12 @@ void AnimationTrackEditor::_key_deselected(int p_key, int p_track) {
 }
 
 void AnimationTrackEditor::_move_selection_begin() {
-	moving_selection = true;
-	moving_selection_offset = 0;
+	moving_track_selection = true;
+	moving_track_selection_offset = 0;
 }
 
 void AnimationTrackEditor::_move_selection(float p_offset) {
-	moving_selection_offset = p_offset;
+	moving_track_selection_offset = p_offset;
 	_redraw_tracks();
 }
 
@@ -6263,7 +6348,7 @@ void AnimationTrackEditor::_update_key_edit() {
 		RBMap<int, List<float>> key_ofs_map;
 		RBMap<int, NodePath> base_map;
 		int first_track = -1;
-		for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+		for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 			int track = E.key.track;
 			if (first_track < 0) {
 				first_track = track;
@@ -6307,11 +6392,11 @@ void AnimationTrackEditor::_select_at_anim(const Ref<Animation> &p_anim, int p_t
 	int idx = animation->track_find_key(p_track, p_pos, Animation::FIND_MODE_APPROX);
 	ERR_FAIL_COND(idx < 0);
 
-	AnimationKeyEdit::SelectedKey sk;
+	SelectedKey sk;
 	sk.key = idx;
 	sk.track = p_track;
 
-	AnimationKeyEdit::KeyInfo ki;
+	KeyInfo ki;
 	ki.pos = p_pos;
 
 	selection.insert(sk, ki);
@@ -6326,19 +6411,19 @@ void AnimationTrackEditor::_move_selection_commit() {
 
 	List<_AnimMoveRestore> to_restore;
 
-	float motion = moving_selection_offset;
+	float motion = moving_track_selection_offset;
 	// 1 - remove the keys.
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
 	}
 	// 2 - Remove overlapped keys.
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float newtime = E->get().pos + motion;
 		int idx = animation->track_find_key(E->key().track, newtime, Animation::FIND_MODE_APPROX);
 		if (idx == -1) {
 			continue;
 		}
-		AnimationKeyEdit::SelectedKey sk;
+		SelectedKey sk;
 		sk.key = idx;
 		sk.track = E->key().track;
 		if (selection.has(sk)) {
@@ -6357,19 +6442,19 @@ void AnimationTrackEditor::_move_selection_commit() {
 	}
 
 	// 3 - Move the keys (Reinsert them).
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float newpos = E->get().pos + motion;
 		undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 	}
 
 	// 4 - (Undo) Remove inserted keys.
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float newpos = E->get().pos + motion;
 		undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newpos);
 	}
 
 	// 5 - (Undo) Reinsert keys.
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 	}
 
@@ -6382,7 +6467,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 	undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 
 	// 7 - Reselect.
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float oldpos = E->get().pos;
 		float newpos = oldpos + motion;
 
@@ -6390,7 +6475,7 @@ void AnimationTrackEditor::_move_selection_commit() {
 		undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, oldpos);
 	}
 
-	moving_selection = false;
+	moving_track_selection = false;
 	undo_redo->add_do_method(this, "_redraw_tracks");
 	undo_redo->add_undo_method(this, "_redraw_tracks");
 
@@ -6405,32 +6490,67 @@ void AnimationTrackEditor::_move_selection_commit() {
 }
 
 void AnimationTrackEditor::_move_selection_cancel() {
-	moving_selection = false;
+	moving_track_selection = false;
 	_redraw_tracks();
 }
 
-bool AnimationTrackEdit::is_moving_selection() const {
-	return editor->is_track_moving_selection();
-}
+/// KEY EDIT ///
 
-float AnimationTrackEdit::get_moving_selection_offset() const {
-	return editor->get_track_moving_selection_offset();
+void AnimationKeyEdit::__zoom_changed() {
+	queue_redraw();
+	play_position->queue_redraw();
 }
 
 bool KeyEdit::is_moving_selection() const {
 	return moving_selection;
 }
 
+void KeyEdit::set_moving_selection(bool p_value) {
+	moving_selection = p_value;
+}
+
 float KeyEdit::get_moving_selection_offset() const {
 	return moving_selection_offset;
 }
 
+void KeyEdit::set_moving_selection_offset(float p_value) {
+	moving_selection_offset = p_value;
+}
+
+void KeyEdit::_update_key_type_icon() {
+	type_icon = _get_key_type_icon();
+	selected_icon = _get_key_type_icon_selected();
+
+	queue_redraw();
+}
+
+void KeyEdit::draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) {
+	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
+	color.a = 0.5;
+
+	int from_x = MAX(p_global_rect.position.x + p_global_rect.size.x, p_clip_left);
+	int to_x = MIN(p_global_rect_next.position.x, p_clip_right);
+	float yh = get_size().height / 2;
+
+	editor->_draw_line_clipped(this, Point2(from_x, yh), Point2(to_x, yh), color, 2, p_clip_left, p_clip_right);
+}
+
+/// ANIMATION TRACK EDITOR ///
+
 bool AnimationTrackEditor::is_track_moving_selection() const {
-	return moving_selection;
+	return moving_track_selection;
+}
+
+void AnimationTrackEditor::set_track_moving_selection(bool p_value) {
+	moving_track_selection = p_value;
 }
 
 float AnimationTrackEditor::get_track_moving_selection_offset() const {
-	return moving_selection_offset;
+	return moving_track_selection_offset;
+}
+
+void AnimationTrackEditor::set_track_moving_selection_offset(float p_value) {
+	moving_track_selection_offset = p_value;
 }
 
 void AnimationTrackEditor::_box_selection_draw() {
@@ -6611,8 +6731,8 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 	if (selection.size() && animation.is_valid()) {
 		int top_track = 0x7FFFFFFF;
 		float top_time = 1e10;
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-			const AnimationKeyEdit::SelectedKey &sk = E->key();
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			const SelectedKey &sk = E->key();
 
 			float t = animation->track_get_key_time(sk.track, sk.key);
 			if (t < top_time) {
@@ -6632,8 +6752,8 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 
 		bool all_compatible = true;
 
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-			const AnimationKeyEdit::SelectedKey &sk = E->key();
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			const SelectedKey &sk = E->key();
 			int dst_track = sk.track + (start_track - top_track);
 
 			if (dst_track < 0 || dst_track >= animation->get_track_count()) {
@@ -6656,8 +6776,8 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 
 		List<Pair<int, float>> new_selection_values;
 
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-			const AnimationKeyEdit::SelectedKey &sk = E->key();
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			const SelectedKey &sk = E->key();
 
 			float t = animation->track_get_key_time(sk.track, sk.key);
 			float insert_pos = p_ofs_valid ? p_ofs : timeline->get_play_position();
@@ -6703,11 +6823,11 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 		undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 
 		// Reselect duplicated.
-		RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> new_selection;
+		RBMap<SelectedKey, KeyInfo> new_selection;
 		for (const Pair<int, float> &E : new_selection_values) {
 			undo_redo->add_do_method(this, "_select_at_anim", animation, E.first, E.second);
 		}
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 			undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->get().pos);
 		}
 
@@ -6722,8 +6842,8 @@ void AnimationTrackEditor::_anim_copy_keys(bool p_cut) {
 		int top_track = 0x7FFFFFFF;
 		float top_time = 1e10;
 
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
-			const AnimationKeyEdit::SelectedKey &sk = E->key();
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			const SelectedKey &sk = E->key();
 
 			float t = animation->track_get_key_time(sk.track, sk.key);
 			if (t < top_time) {
@@ -6743,14 +6863,14 @@ void AnimationTrackEditor::_anim_copy_keys(bool p_cut) {
 			undo_redo->create_action(TTR("Animation Cut Keys"), UndoRedo::MERGE_DISABLE, animation.ptr());
 			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
 			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				int track_idx = E->key().track;
 				int key_idx = E->key().key;
 				float time = E->value().pos;
 				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", track_idx, time);
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track_idx, time, animation->track_get_key_value(track_idx, key_idx), animation->track_get_key_transition(track_idx, key_idx));
 			}
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos);
 			}
 			undo_redo->commit_action();
@@ -6758,10 +6878,10 @@ void AnimationTrackEditor::_anim_copy_keys(bool p_cut) {
 	}
 }
 
-void AnimationTrackEditor::_set_key_clipboard(int p_top_track, float p_top_time, RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &p_keys) {
+void AnimationTrackEditor::_set_key_clipboard(int p_top_track, float p_top_time, RBMap<SelectedKey, KeyInfo> &p_keys) {
 	key_clipboard.keys.clear();
 	key_clipboard.top_track = p_top_track;
-	for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = p_keys.back(); E; E = E->prev()) {
+	for (RBMap<SelectedKey, KeyInfo>::Element *E = p_keys.back(); E; E = E->prev()) {
 		KeyClipboard::Key k;
 		k.value = animation->track_get_key_value(E->key().track, E->key().key);
 		k.transition = animation->track_get_key_transition(E->key().track, E->key().key);
@@ -6850,7 +6970,7 @@ void AnimationTrackEditor::_anim_paste_keys(float p_ofs, bool p_ofs_valid, int p
 		for (const Pair<int, float> &E : new_selection_values) {
 			undo_redo->add_do_method(this, "_select_at_anim", animation, E.first, E.second);
 		}
-		for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+		for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 			undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->get().pos);
 		}
 
@@ -6925,7 +7045,7 @@ void AnimationTrackEditor::_edit_menu_about_to_popup() {
 	edit->get_popup()->set_item_disabled(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), !player->can_apply_reset());
 
 	bool has_length = false;
-	for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+	for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 		if (animation->track_get_type(E.key.track) == Animation::TYPE_AUDIO && animation->audio_track_get_key_stream(E.key.track, E.key.key).is_valid()) {
 			has_length = true;
 			break;
@@ -7176,7 +7296,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			float len = -1e20;
 			float pivot = 0;
 
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 				float t = animation->track_get_key_time(E.key.track, E.key.key);
 				if (t < from_t) {
 					from_t = t;
@@ -7202,17 +7322,17 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			List<_AnimMoveRestore> to_restore;
 
 			// 1 - Remove the keys.
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
 			}
 			// 2 - Remove overlapped keys.
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float newtime = (E->get().pos - from_t) * s + from_t;
 				int idx = animation->track_find_key(E->key().track, newtime, Animation::FIND_MODE_APPROX);
 				if (idx == -1) {
 					continue;
 				}
-				AnimationKeyEdit::SelectedKey sk;
+				SelectedKey sk;
 				sk.key = idx;
 				sk.track = E->key().track;
 				if (selection.has(sk)) {
@@ -7232,19 +7352,19 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 #define NEW_POS(m_ofs) (((s > 0) ? m_ofs : from_t + (len - (m_ofs - from_t))) - pivot) * Math::abs(s) + pivot
 			// 3 - Move the keys (re insert them).
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float newpos = NEW_POS(E->get().pos);
 				undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 			}
 
 			// 4 - (Undo) Remove inserted keys.
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float newpos = NEW_POS(E->get().pos);
 				undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", E->key().track, newpos);
 			}
 
 			// 5 - (Undo) Reinsert keys.
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 			}
 
@@ -7257,7 +7377,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);
 
 			// 7 - Reselect.
-			for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float oldpos = E->get().pos;
 				float newpos = NEW_POS(oldpos);
 				if (newpos >= 0) {
@@ -7275,7 +7395,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		case EDIT_SET_START_OFFSET: {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Animation Set Start Offset"), UndoRedo::MERGE_ENDS);
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 				if (animation->track_get_type(E.key.track) == Animation::TYPE_AUDIO) {
 					Ref<AudioStream> stream = animation->audio_track_get_key_stream(E.key.track, E.key.key);
 					if (stream.is_null()) {
@@ -7333,7 +7453,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		case EDIT_SET_END_OFFSET: {
 			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 			undo_redo->create_action(TTR("Animation Set End Offset"), UndoRedo::MERGE_ENDS);
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 				if (animation->track_get_type(E.key.track) == Animation::TYPE_AUDIO) {
 					Ref<AudioStream> stream = animation->audio_track_get_key_stream(E.key.track, E.key.key);
 					if (stream.is_null()) {
@@ -7397,7 +7517,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			// Organize track and key.
 			HashMap<int, Vector<int>> keymap;
 			Vector<int> tracks;
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 				if (!tracks.has(E.key.track)) {
 					tracks.append(E.key.track);
 				}
@@ -7410,7 +7530,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 					case Animation::TYPE_SCALE_3D:
 					case Animation::TYPE_BLEND_SHAPE: {
 						Vector<int> keys;
-						for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+						for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 							if (E.key.track == tracks[i]) {
 								keys.append(E.key.key);
 							}
@@ -7503,11 +7623,11 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			_anim_paste_keys(-1.0, false, -1.0);
 		} break;
 		case EDIT_MOVE_FIRST_SELECTED_KEY_TO_CURSOR: {
-			if (moving_selection || selection.is_empty()) {
+			if (moving_track_selection || selection.is_empty()) {
 				break;
 			}
 			real_t from_t = 1e20;
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 				real_t t = animation->track_get_key_time(E.key.track, E.key.key);
 				if (t < from_t) {
 					from_t = t;
@@ -7518,11 +7638,11 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			_move_selection_commit();
 		} break;
 		case EDIT_MOVE_LAST_SELECTED_KEY_TO_CURSOR: {
-			if (moving_selection || selection.is_empty()) {
+			if (moving_track_selection || selection.is_empty()) {
 				break;
 			}
 			real_t to_t = -1e20;
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
 				real_t t = animation->track_get_key_time(E.key.track, E.key.key);
 				if (t > to_t) {
 					to_t = t;
@@ -7540,8 +7660,8 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			int reset_tracks = reset->get_track_count();
 			HashSet<int> tracks_added;
 
-			for (const KeyValue<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &E : selection) {
-				const AnimationKeyEdit::SelectedKey &sk = E.key;
+			for (const KeyValue<SelectedKey, KeyInfo> &E : selection) {
+				const SelectedKey &sk = E.key;
 
 				const Animation::TrackType track_type = animation->track_get_type(E.key.track);
 				if (track_type == Animation::TYPE_ANIMATION || track_type == Animation::TYPE_AUDIO || track_type == Animation::TYPE_METHOD) {
@@ -7612,7 +7732,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 				undo_redo->create_action(TTR("Animation Delete Keys"));
 
-				for (RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
+				for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 					undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
 					undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
 				}
@@ -8709,7 +8829,7 @@ AnimationTrackEditor::~AnimationTrackEditor() {
 	}
 }
 
-// AnimationTrackKeyEditEditorPlugin.
+/// ANIMATION TRACK KEY EDIT EDITOR ///
 
 void AnimationTrackKeyEditEditor::_time_edit_spun() {
 	_time_edit_entered();
@@ -8812,13 +8932,71 @@ AnimationTrackKeyEditEditor::AnimationTrackKeyEditEditor(Ref<Animation> p_animat
 	spinner->connect("value_focus_exited", callable_mp(this, &AnimationTrackKeyEditEditor::_time_edit_exited), CONNECT_DEFERRED);
 }
 
-void AnimationKeyEdit::__zoom_changed() {
-	queue_redraw();
-	play_position->queue_redraw();
+/// ANIMATION MARKER EDIT ///
+
+bool AnimationMarkerEdit::is_key_selected(const int p_index) const {
+	SelectedKey sk;
+	sk.key = p_index;
+	sk.track = 0;
+
+	return selection.has(sk);
 }
 
-void AnimationTrackEdit::_zoom_changed() {
-	__zoom_changed();
+Ref<Texture2D> AnimationMarkerEdit::_get_key_type_icon() const {
+	return get_editor_theme_icon(SNAME("Marker"));
+}
+
+Ref<Texture2D> AnimationMarkerEdit::_get_key_type_icon_selected() const {
+	return get_editor_theme_icon(SNAME("MarkerSelected"));
+}
+
+void AnimationMarkerEdit::_play_position_draw() {
+	__play_position_draw();
+}
+
+Variant AnimationMarkerEdit::get_key_value(const int p_index) const {
+	return editor->get_marker_name(p_index);
+}
+
+double AnimationMarkerEdit::get_key_time(const int p_index) const {
+	StringName marker_name = editor->get_marker_name(p_index);
+	return animation->get_marker_time(marker_name);
+}
+
+int AnimationMarkerEdit::get_key_count() const {
+	return editor->get_marker_count();
+}
+
+bool AnimationMarkerEdit::has_key(const int p_index) const {
+	return editor->has_marker(p_index);
+}
+
+Vector<int> AnimationMarkerEdit::get_selected_section() {
+	if (get_selection_count() >= 2) {
+		Vector<int> arr;
+		arr.push_back(-1); // with smallest time.
+		arr.push_back(-1); // with largest time.
+		double min_time = Math::INF;
+		double max_time = -Math::INF;
+
+		for (RBMap<SelectedKey, KeyInfo>::Iterator E = selection.begin(); E != selection.end(); ++E) {
+			SelectedKey key = E->key;
+			int key_index = key.key;
+
+			double time = get_key_time(key_index);
+			if (time < min_time) {
+				arr.set(0, key_index);
+				min_time = time;
+			}
+			if (time > max_time) {
+				arr.set(1, key_index);
+				max_time = time;
+			}
+		}
+		return arr;
+	}
+
+	return Vector<int>();
 }
 
 void AnimationMarkerEdit::_zoom_changed() {
@@ -8865,26 +9043,6 @@ int AnimationMarkerEdit::get_last_selection() {
 	return it->key.key;
 }
 
-Animation::TrackType AnimationTrackEdit::get_track_type() const {
-	return animation->track_get_type(track);
-}
-
-void AnimationKeyEdit::__play_position_draw() {
-	if (animation.is_null() || play_position_pos < 0) {
-		return;
-	}
-
-	float scale = timeline->get_zoom_scale();
-	int h = get_size().height;
-
-	int px = (play_position_pos - timeline->get_value()) * scale + timeline->get_name_limit();
-
-	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
-	}
-}
-
 void AnimationMarkerEdit::try_select(const int p_index, bool is_single) {
 	call_deferred("_select_key", editor->get_marker_name(p_index), is_single);
 }
@@ -8895,132 +9053,6 @@ void AnimationMarkerEdit::try_deselect(const int p_index) {
 
 bool AnimationMarkerEdit::is_compressed() const {
 	return false;
-}
-
-bool AnimationTrackEdit::is_compressed() const {
-	return animation->track_is_compressed(track);
-}
-
-bool AnimationKeyEdit::_try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable) {
-	if (is_compressed()) { // Selecting compressed keyframes for editing is not possible.
-		return false;
-	}
-
-	int limit = timeline->get_name_limit();
-	int limit_end = get_size().width - timeline->get_buttons_width();
-	// Left Border including space occupied by keyframes on t=0.
-	int limit_start_hitbox = limit - type_icon->get_width();
-
-	if (p_pos.x >= limit_start_hitbox && p_pos.x <= limit_end) {
-		int key_idx = find_closest_key(p_pos);
-		if (key_idx != -1) {
-			if (p_aggregate) {
-				if (is_key_selected(key_idx)) {
-					if (p_deselectable) {
-						try_deselect(key_idx);
-						moving_selection_pivot = 0.0f;
-						moving_selection_mouse_begin_x = 0.0f;
-					}
-				} else {
-					try_select(key_idx, false);
-					moving_selection_attempt = true;
-					moving_selection_effective = false;
-					select_single_attempt = -1;
-					moving_selection_pivot = get_key_time(key_idx);
-					moving_selection_mouse_begin_x = p_pos.x;
-				}
-
-			} else {
-				if (!is_key_selected(key_idx)) {
-					try_select(key_idx, true);
-					select_single_attempt = -1;
-				} else {
-					select_single_attempt = key_idx;
-				}
-
-				moving_selection_attempt = true;
-				moving_selection_effective = false;
-				moving_selection_pivot = get_key_time(key_idx);
-				moving_selection_mouse_begin_x = p_pos.x;
-			}
-
-			if (read_only) {
-				moving_selection_attempt = false;
-				moving_selection_pivot = 0.0f;
-				moving_selection_mouse_begin_x = 0.0f;
-			}
-			return true;
-		}
-	}
-
-	return false;
-}
-
-bool AnimationKeyEdit::_is_ui_pos_in_current_section(const Point2 &p_pos) {
-	int limit = timeline->get_name_limit();
-	int limit_end = get_size().width - timeline->get_buttons_width();
-
-	if (p_pos.x >= limit && p_pos.x <= limit_end) {
-		Vector<int> section = get_selected_section();
-		if (!section.is_empty()) {
-			int start_marker = section[0];
-			int end_marker = section[1];
-			float start_offset = get_global_move_key_time(start_marker);
-			float end_offset = get_global_move_key_time(end_marker);
-			return p_pos.x >= start_offset && p_pos.x <= end_offset;
-		}
-	}
-
-	return false;
-}
-
-HBoxContainer *AnimationMarkerEdit::_create_hbox_labeled_control(const String &p_text, Control *p_control) const {
-	HBoxContainer *hbox = memnew(HBoxContainer);
-	Label *label = memnew(Label);
-	label->set_text(p_text);
-	hbox->add_child(label);
-	hbox->add_child(p_control);
-	hbox->set_h_size_flags(SIZE_EXPAND_FILL);
-	label->set_h_size_flags(SIZE_EXPAND_FILL);
-	label->set_stretch_ratio(1.0);
-	p_control->set_h_size_flags(SIZE_EXPAND_FILL);
-	p_control->set_stretch_ratio(1.0);
-	return hbox;
-}
-
-void AnimationMarkerEdit::_update_key_edit() {
-	_clear_key_edit();
-	if (animation.is_null()) {
-		return;
-	}
-
-	if (get_selection_count() == 1) {
-		key_edit = memnew(AnimationMarkerKeyEdit);
-		key_edit->animation = animation;
-		key_edit->animation_read_only = read_only;
-		key_edit->marker_name = editor->get_marker_name(get_first_selection());
-		key_edit->use_fps = timeline->is_using_fps();
-		key_edit->marker_edit = this;
-
-		EditorNode::get_singleton()->push_item(key_edit);
-
-		InspectorDock::get_singleton()->set_info(TTR("Marker name is read-only in the inspector."), TTR("A marker's name can only be changed by right-clicking it in the animation editor and selecting \"Rename Marker\", in order to make sure that marker names are all unique."), true);
-	} else if (get_selection_count() > 1) {
-		multi_key_edit = memnew(AnimationMultiMarkerKeyEdit);
-		multi_key_edit->animation = animation;
-		multi_key_edit->animation_read_only = read_only;
-		multi_key_edit->marker_edit = this;
-
-		for (RBMap<SelectedKey, KeyInfo>::Iterator E = selection.begin(); E != selection.end(); ++E) {
-			SelectedKey key = E->key;
-			int key_index = key.key;
-
-			StringName marker_name = editor->get_marker_name(key_index);
-			multi_key_edit->marker_names.push_back(marker_name);
-		}
-
-		EditorNode::get_singleton()->push_item(multi_key_edit);
-	}
 }
 
 void AnimationMarkerEdit::_clear_key_edit() {
@@ -9617,7 +9649,7 @@ void AnimationMarkerEdit::_select_key(const StringName &p_name, bool is_single) 
 	queue_redraw();
 	_update_key_edit();
 
-	//editor->_clear_selection(editor->is_selection_active());
+	editor->_clear_selection(editor->is_selection_active());
 }
 
 void AnimationMarkerEdit::_deselect_key(const StringName &p_name) {
@@ -9811,6 +9843,8 @@ AnimationMarkerEdit::AnimationMarkerEdit() {
 	marker_rename_confirm->add_child(marker_rename_error_dialog);
 }
 
+/// ANIMATION MARKER KEY EDIT ///
+
 float AnimationMarkerKeyEdit::get_time() const {
 	return animation->get_marker_time(marker_name);
 }
@@ -9870,6 +9904,8 @@ void AnimationMarkerKeyEdit::_get_property_list(List<PropertyInfo> *p_list) cons
 	p_list->push_back(PropertyInfo(Variant::COLOR, "color", PROPERTY_HINT_COLOR_NO_ALPHA));
 }
 
+/// ANIMATION MULTI MARKER KEY EDIT ///
+
 void AnimationMultiMarkerKeyEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_hide_script_from_inspector"), &AnimationMultiMarkerKeyEdit::_hide_script_from_inspector);
 	ClassDB::bind_method(D_METHOD("_hide_metadata_from_inspector"), &AnimationMultiMarkerKeyEdit::_hide_metadata_from_inspector);
@@ -9916,7 +9952,7 @@ void AnimationMultiMarkerKeyEdit::_get_property_list(List<PropertyInfo> *p_list)
 	p_list->push_back(PropertyInfo(Variant::COLOR, "color", PROPERTY_HINT_COLOR_NO_ALPHA));
 }
 
-// AnimationMarkerKeyEditEditorPlugin
+/// ANIMATION MARKER KEY EDIT EDITOR ///
 
 void AnimationMarkerKeyEditEditor::_time_edit_exited() {
 	real_t new_time = spinner->get_value();

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2572,15 +2572,14 @@ void KeyEdit::draw_edit_text(const int p_index, const Rect2 &p_global_rect, cons
 	if (outside) {
 		text_pos += p_global_rect.size.x;
 		max_width = MAX(0.0, clip_r - text_pos);
-	}
-	else {
+	} else {
 		max_width = MIN(max_width, clip_r - text_pos);
 	}
 
 	if (max_width > 0) {
 		const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 		const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-		
+
 		String key_name = get_edit_name(p_index);
 		Color key_color = get_key_color(p_index);
 		String edit_name = editor->_make_text_clipped(key_name, font, font_size, max_width);
@@ -9285,7 +9284,7 @@ void AnimationKeyEdit::_on_mouse_release(const Ref<InputEventMouseButton> &mb, b
 					accept_event();
 				}
 			}
-			
+
 		} else {
 			if (handle_timeline) {
 				// First select click should not affect play position.
@@ -9430,7 +9429,7 @@ void AnimationMarkerEdit::draw_key(const int p_index, const Rect2 &p_global_rect
 	}
 }
 
-void AnimationMarkerEdit::draw_marker_section(CanvasItem * p_canvas_item, const float p_clip_left, const float p_clip_right) {
+void AnimationMarkerEdit::draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right) {
 	float scale = timeline->get_zoom_scale();
 
 	Vector<int> section = get_selected_section();

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1744,14 +1744,14 @@ void AnimationTimelineEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
+			if (animation.is_null()) {
+				return;
+			}
+
 			float limit = get_name_limit();
 			float limit_end = get_size().width - get_buttons_width();
 
 			float key_range = limit_end - limit;
-
-			if (animation.is_null()) {
-				return;
-			}
 
 			const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 			const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
@@ -2130,8 +2130,10 @@ void AnimationTimelineEdit::_play_cursor_draw() {
 	}
 
 	float limit = get_name_limit();
-	float limit_end = play_cursor->get_size().width - get_buttons_width();
+	float limit_end = get_size().width - get_buttons_width();
 
+	float h = get_size().height;
+	editor->draw_play_cursor(play_cursor, play_cursor_pos, h, limit, limit_end);
 	editor->draw_play_cursor_head(play_cursor, play_cursor_pos, limit, limit_end);
 }
 
@@ -2392,10 +2394,6 @@ bool AnimationKeyEdit::_is_ui_pos_in_current_section(const Point2 &p_pos) {
 
 bool AnimationKeyEdit::has_valid_track() const {
 	if (animation.is_null()) {
-		return false;
-	}
-
-	if (get_key_count() == 0) {
 		return false;
 	}
 
@@ -9090,7 +9088,7 @@ void KeyEdit::draw_timeline(const float p_clip_left, const float p_clip_right) {
 
 AnimationMarkerEdit::AnimationMarkerEdit() {
 	key_pivot.x = 0.5;
-	key_pivot.y = 1.0;
+	key_pivot.y = 0.5;
 	track_alignment = 1.0;
 
 	play_cursor->connect(SceneStringName(draw), callable_mp(this, &AnimationMarkerEdit::_play_cursor_draw));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2284,44 +2284,41 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 	if (pos.x >= limit && pos.x <= limit_end) {
 		float scale = timeline->get_zoom_scale();
 
-		length = memnew(EditorSpinSlider);
-		length->set_min(SECOND_DECIMAL);
-		length->set_max(36000);
-		length->set_step(SECOND_DECIMAL);
-		length->set_allow_greater(true);
-		length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
-		length->set_hide_slider(true);
-		length->set_tooltip_text(TTR("Animation length (seconds)"));
-		length->set_accessibility_name(TTRC("Animation length (seconds)"));
-		length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
-		len_hb->add_child(length);
+	length = memnew(EditorSpinSlider);
+	length->set_min(SECOND_DECIMAL);
+	length->set_max(36000);
+	length->set_step(SECOND_DECIMAL);
+	length->set_allow_greater(true);
+	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
+	length->set_hide_slider(true);
+	length->set_tooltip_text(TTR("Animation length (seconds)"));
+	length->set_accessibility_name(TTRC("Animation length (seconds)"));
+	length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
+	len_hb->add_child(length);
 
-		loop = memnew(Button);
-		loop->set_flat(true);
-		loop->set_tooltip_text(TTR("Animation Looping"));
-		loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
-		loop->set_toggle_mode(true);
-		len_hb->add_child(loop);
-		add_child(len_hb);
+	loop = memnew(Button);
+	loop->set_flat(true);
+	loop->set_tooltip_text(TTR("Animation Looping"));
+	loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
+	loop->set_toggle_mode(true);
+	len_hb->add_child(loop);
+	add_child(len_hb);
 
-			moving_selection_attempt = false;
-			set_moving_selection(false);
+		menu->set_position(get_screen_position() + get_local_mouse_position());
+		menu->popup();
 
-			menu->set_position(get_screen_position() + get_local_mouse_position());
-			menu->popup();
-
-			insert_at_pos = offset + timeline->get_value();
-			accept_event();
-		}
+		insert_at_pos = offset + timeline->get_value();
+		accept_event();
 	}
+}
 
+if (is_moving_selection()) {
 	if (is_moving_selection()) {
-		if (is_moving_selection()) {
-			moving_selection_attempt = false;
-			set_moving_selection(false);
-			_move_selection_cancel();
-		}
+		moving_selection_attempt = false;
+		set_moving_selection(false);
+		_move_selection_cancel();
 	}
+}
 }
 
 bool AnimationKeyEdit::is_linked(const int p_index, const int p_index_next) const {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2419,6 +2419,10 @@ bool AnimationKeyEdit::has_valid_key(const int p_index) const {
 /// KEY EDIT ///
 
 KeyEdit::KeyEdit() {
+	key_pivot.x = 0.5;
+	key_pivot.y = 0.5;
+	track_alignment = 0.5;
+
 	play_cursor = memnew(Control);
 	play_cursor->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_cursor);
@@ -2469,26 +2473,20 @@ Rect2 KeyEdit::get_key_rect(const int p_index) const {
 }
 
 Rect2 KeyEdit::get_global_key_rect(const int p_index, bool p_ignore_moving_selection) const {
-	Rect2 local_rect = get_key_rect(p_index);
-	return _to_global_key_rect(p_index, local_rect, p_ignore_moving_selection);
-}
-
-Rect2 KeyEdit::_to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection) const {
-	Rect2 global_rect = Rect2(p_local_rect);
-
-	global_rect.position.x += get_global_move_key_time(p_index, p_ignore_moving_selection);
+	Rect2 rect = get_key_rect(p_index);
+	rect.position.x += get_global_move_key_time(p_index, p_ignore_moving_selection);
 
 	float track_height = get_size().height;
-	float key_height = p_local_rect.size.y;
+	float key_height = rect.size.y;
 
 	// Calculate normalized CLAMP bounds to keep key within track
 	float min_y = track_height > 0 ? key_height / (2.0 * track_height) : 0.0;
 	float max_y = track_height > 0 ? 1.0 - key_height / (2.0 * track_height) : 1.0;
 
 	// Position key center, adjusted for key height
-	global_rect.position.y += track_height * CLAMP(track_alignment - get_key_y(p_index), min_y, max_y);
+	rect.position.y += track_height * CLAMP(track_alignment - get_key_y(p_index), min_y, max_y);
 
-	return global_rect;
+	return rect;
 }
 
 Color KeyEdit::get_key_color(const int p_index) const {
@@ -3858,10 +3856,6 @@ void AnimationTrackEdit::_bind_methods() {
 }
 
 AnimationTrackEdit::AnimationTrackEdit() {
-	key_pivot.x = 0.5;
-	key_pivot.y = 0.5;
-	track_alignment = 0.5;
-
 	play_cursor->connect(SceneStringName(draw), callable_mp(this, &AnimationTrackEdit::_play_cursor_draw));
 
 	set_focus_mode(FOCUS_CLICK);
@@ -9087,8 +9081,6 @@ void KeyEdit::draw_timeline(const float p_clip_left, const float p_clip_right) {
 /// ANIMATION MARKER EDIT ///
 
 AnimationMarkerEdit::AnimationMarkerEdit() {
-	key_pivot.x = 0.5;
-	key_pivot.y = 0.5;
 	track_alignment = 1.0;
 
 	play_cursor->connect(SceneStringName(draw), callable_mp(this, &AnimationMarkerEdit::_play_cursor_draw));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2064,6 +2064,7 @@ void AnimationTimelineEdit::_play_position_draw() {
 
 	if (px >= get_name_limit() && px < (play_position->get_size().width - get_buttons_width())) {
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 		play_position->draw_texture(
 				get_editor_theme_icon(SNAME("TimelineIndicator")),
 				Point2(px - get_editor_theme_icon(SNAME("TimelineIndicator"))->get_width() * 0.5, 0),
@@ -2288,6 +2289,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			ERR_FAIL_INDEX(track, animation->get_track_count());
 
 			int limit = timeline->get_name_limit();
+			int limit_end = get_size().width - timeline->get_buttons_width();
 
 			const Ref<StyleBox> &stylebox_odd = get_theme_stylebox(SNAME("odd"), SNAME("AnimationTrackEdit"));
 			const Ref<StyleBox> &stylebox_focus = get_theme_stylebox(SNAME("focus"), SNAME("AnimationTrackEdit"));
@@ -2389,7 +2391,6 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 			{
 				float scale = timeline->get_zoom_scale();
-				int limit_end = get_size().width - timeline->get_buttons_width();
 
 				PackedStringArray section = editor->get_selected_section();
 				if (section.size() == 2) {
@@ -2426,6 +2427,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			{
 				float scale = timeline->get_zoom_scale();
 				PackedStringArray markers = animation->get_marker_names();
+
 				for (const StringName marker : markers) {
 					double time = animation->get_marker_time(marker);
 					if (editor->is_marker_selected(marker) && editor->is_marker_moving_selection()) {
@@ -2436,18 +2438,17 @@ void AnimationTrackEdit::_notification(int p_what) {
 						offset = offset * scale + limit;
 						Color marker_color = animation->get_marker_color(marker);
 						marker_color.a = 0.2;
-						draw_line(Point2(offset, 0), Point2(offset, get_size().height), marker_color, Math::round(EDSCALE));
+						animationTrackDrawUtils->_draw_vertical_line_clipped(Point2(offset, 0), get_size().height, marker_color, 2, limit, limit_end);
 					}
 				}
 			}
 
 			// Keyframes.
 
-			draw_bg(limit, get_size().width - timeline->get_buttons_width() - outer_margin);
+			draw_bg(limit, limit_end);
 
 			{
 				float scale = timeline->get_zoom_scale();
-				int limit_end = get_size().width - timeline->get_buttons_width() - outer_margin;
 
 				for (int i = 0; i < animation->track_get_key_count(track); i++) {
 					float offset = animation->track_get_key_time(track, i) - timeline->get_value();
@@ -2482,7 +2483,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				}
 			}
 
-			draw_fg(limit, get_size().width - timeline->get_buttons_width() - outer_margin);
+			draw_fg(limit, limit_end);
 
 			// Buttons.
 
@@ -2508,7 +2509,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 					get_editor_theme_icon(SNAME("UseBlendDisable")),
 				};
 
-				int ofs = get_size().width - timeline->get_buttons_width() - outer_margin;
+				int ofs = limit_end;
 
 				const Ref<Texture2D> down_icon = get_theme_icon(SNAME("select_arrow"), SNAME("Tree"));
 
@@ -2641,7 +2642,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 
 					Ref<Texture2D> icon = get_editor_theme_icon(animation->track_is_compressed(track) ? SNAME("Lock") : SNAME("Remove"));
 
-					remove_rect.position.x = ofs + ((get_size().width - ofs) - icon->get_width()) - outer_margin;
+					remove_rect.position.x = ofs + ((get_size().width - ofs) - icon->get_width()); // - outer_margin;
 					remove_rect.position.y = Math::round((get_size().height - icon->get_height()) / 2);
 					remove_rect.size = icon->get_size();
 
@@ -2920,7 +2921,6 @@ void AnimationTrackEdit::_play_position_draw() {
 
 	if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		//_draw_line_clipped(Point2(px, 0), h, color, 2, p_clip_left, int p_clip_right)
 		play_position->draw_line(Point2(px, 0), Point2(px, h), color, Math::round(2 * EDSCALE));
 	}
 }
@@ -3947,7 +3947,6 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 			Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
 
 			const Ref<StyleBox> &stylebox_header = get_theme_stylebox(SNAME("header"), SNAME("AnimationTrackEditGroup"));
-			const int outer_margin = get_theme_constant(SNAME("outer_margin"), SNAME("AnimationTrackEdit"));
 
 			float v_margin_offset = stylebox_header->get_content_margin(SIDE_TOP) - stylebox_header->get_content_margin(SIDE_BOTTOM);
 
@@ -3965,6 +3964,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 			draw_style_box(stylebox_header, Rect2(Point2(), get_size()));
 
 			int limit = timeline->get_name_limit();
+			int limit_end = get_size().width - timeline->get_buttons_width();
 
 			// Section preview.
 
@@ -4017,14 +4017,15 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 						offset = offset * scale + limit;
 						Color marker_color = editor->get_current_animation()->get_marker_color(marker);
 						marker_color.a = 0.2;
-						draw_line(Point2(offset, 0), Point2(offset, get_size().height), marker_color, Math::round(EDSCALE));
+
+						animationTrackDrawUtils->_draw_vertical_line_clipped(Point2(offset, 0), get_size().height, marker_color, 1, limit, limit_end);
 					}
 				}
 			}
 
 			draw_line(Point2(), Point2(get_size().width, 0), h_line_color, Math::round(EDSCALE));
 			draw_line(Point2(timeline->get_name_limit(), 0), Point2(timeline->get_name_limit(), get_size().height), v_line_color, Math::round(EDSCALE));
-			draw_line(Point2(get_size().width - timeline->get_buttons_width() - outer_margin, 0), Point2(get_size().width - timeline->get_buttons_width() - outer_margin, get_size().height), v_line_color, Math::round(EDSCALE));
+			draw_line(Point2(limit_end, 0), Point2(limit_end, get_size().height), v_line_color, Math::round(EDSCALE));
 
 			int ofs = stylebox_header->get_margin(SIDE_LEFT);
 			draw_texture_rect(icon, Rect2(Point2(ofs, (get_size().height - icon_size.y) / 2 + v_margin_offset).round(), icon_size));
@@ -4033,9 +4034,9 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 
 			int px = (-timeline->get_value() + timeline->get_play_position()) * timeline->get_zoom_scale() + timeline->get_name_limit();
 
-			if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
+			if (px >= limit && px < limit_end) {
 				const Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-				draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
+				animationTrackDrawUtils->_draw_vertical_line_clipped(Point2(px, 0), get_size().height, accent, 2, limit, limit_end);
 			}
 		} break;
 	}
@@ -4103,6 +4104,8 @@ void AnimationTrackEditGroup::_zoom_changed() {
 }
 
 AnimationTrackEditGroup::AnimationTrackEditGroup() {
+	animationTrackDrawUtils = memnew(AnimationTrackDrawUtils);
+	animationTrackDrawUtils->canvas_item = this;
 	set_mouse_filter(MOUSE_FILTER_PASS);
 }
 
@@ -10030,6 +10033,54 @@ void AnimationTrackDrawUtils::_draw_rect_clipped(const Rect2 &p_rect, const Colo
 	canvas_item->draw_rect(clipped_rect, p_color, p_filled);
 }
 
+void AnimationTrackDrawUtils::_draw_grid_clipped(const Rect2 &p_rect, const Color &p_color, int p_raster_size, int p_clip_left, int p_clip_right) {
+	ERR_FAIL_NULL(canvas_item);
+	ERR_FAIL_COND_MSG(p_raster_size < 1, "Raster size must be at least 1");
+
+	if (p_rect.position.x + p_rect.size.x < p_clip_left || p_rect.position.x > p_clip_right) {
+		return;
+	}
+
+	Color shadow_color = Color(0.4, 0.4, 0.4);
+	Color highlight_color = Color(0.6, 0.6, 0.6);
+	Color main_color = p_color;
+
+	float cell_width = p_rect.size.x / p_raster_size;
+	float cell_height = p_rect.size.y / p_raster_size;
+
+	for (int y = 0; y < p_raster_size; y++) {
+		for (int x = 0; x < p_raster_size; x++) {
+			Vector2 cell_pos = p_rect.position + Vector2(x * cell_width, y * cell_height);
+			Rect2 cell_rect(cell_pos, Vector2(cell_width, cell_height));
+
+			if (cell_rect.position.x + cell_rect.size.x < p_clip_left || cell_rect.position.x > p_clip_right) {
+				continue;
+			}
+
+			float x_min = cell_rect.position.x;
+			float x_max = cell_rect.position.x + cell_rect.size.x;
+
+			if (x_min < p_clip_left) {
+				x_min = p_clip_left;
+			}
+
+			if (x_max > p_clip_right) {
+				x_max = p_clip_right;
+			}
+
+			if (x_min >= x_max) {
+				continue;
+			}
+
+			Rect2 clipped_cell(Vector2(x_min, cell_rect.position.y), Vector2(x_max - x_min, cell_rect.size.y));
+			Color cell_color = (x + y) % 2 == 0 ? shadow_color : highlight_color;
+			cell_color = cell_color.lerp(main_color, main_color.a);
+
+			canvas_item->draw_rect(clipped_cell, cell_color, true);
+		}
+	}
+}
+
 void AnimationTrackDrawUtils::_draw_vertical_line_clipped(const Point2 &p_from, float p_length, const Color &p_color, float p_width, int p_clip_left, int p_clip_right) {
 	ERR_FAIL_NULL(canvas_item);
 
@@ -10046,12 +10097,10 @@ void AnimationTrackDrawUtils::_draw_vertical_line_clipped(const Point2 &p_from, 
 
 	float clipped_width = p_width;
 	if (from.x - p_width / 2.0f < p_clip_left) {
-		// Linker Rand wird abgeschnitten
 		float excess = p_clip_left - (from.x - p_width / 2.0f);
 		clipped_width -= excess;
 	}
 	if (from.x + p_width / 2.0f > p_clip_right) {
-		// Rechter Rand wird abgeschnitten
 		float excess = (from.x + p_width / 2.0f) - p_clip_right;
 		clipped_width -= excess;
 	}

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2295,26 +2295,7 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 
 			moving_selection_attempt = false;
 			set_moving_selection(false);
-			length = memnew(EditorSpinSlider);
-			length->set_min(SECOND_DECIMAL);
-			length->set_max(36000);
-			length->set_step(SECOND_DECIMAL);
-			length->set_allow_greater(true);
-			length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
-			length->set_hide_slider(true);
-			length->set_tooltip_text(TTR("Animation length (seconds)"));
-			length->set_accessibility_name(TTRC("Animation length (seconds)"));
-			length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
-			len_hb->add_child(length);
-
-			loop = memnew(Button);
-			loop->set_flat(true);
-			loop->set_tooltip_text(TTR("Animation Looping"));
-			loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
-			loop->set_toggle_mode(true);
-			len_hb->add_child(loop);
-			add_child(len_hb);
-
+			
 			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->popup();
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2296,34 +2296,6 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 			moving_selection_attempt = false;
 			set_moving_selection(false);
 
-			<<<<<<< animation-track-offset
-			menu->clear();
-			create_popup_menu(menu, selected);
-			menu->reset_size();
-
-			moving_selection_attempt = false;
-			set_moving_selection(false);
-
-	length = memnew(EditorSpinSlider);
-	length->set_min(SECOND_DECIMAL);
-	length->set_max(36000);
-	length->set_step(SECOND_DECIMAL);
-	length->set_allow_greater(true);
-	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
-	length->set_hide_slider(true);
-	length->set_tooltip_text(TTR("Animation length (seconds)"));
-	length->set_accessibility_name(TTRC("Animation length (seconds)"));
-	length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
-	len_hb->add_child(length);
-
-	loop = memnew(Button);
-	loop->set_flat(true);
-	loop->set_tooltip_text(TTR("Animation Looping"));
-	loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
-	loop->set_toggle_mode(true);
-	len_hb->add_child(loop);
-	add_child(len_hb);
-
 			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->popup();
 
@@ -8812,12 +8784,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	ease_selection->add_item(TTR("OutIn", "Ease Type"), Tween::EASE_OUT_IN);
 	ease_selection->select(Tween::EASE_IN_OUT); // Default
 	ease_selection->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Translation context is needed.
-	ease_fps = memnew(SpinBox);
-	ease_fps->set_min(FPS_DECIMAL);
-	ease_fps->set_max(999);
-	ease_fps->set_step(FPS_DECIMAL);
-	ease_fps->set_value(30); // Default
-	ease_fps->set_accessibility_name(TTRC("FPS:"));
+	ease_fps_sp = memnew(SpinBox);
+	ease_fps_sp->set_min(FPS_DECIMAL);
+	ease_fps_sp->set_max(999);
+	ease_fps_sp->set_step(FPS_DECIMAL);
+	ease_fps_sp->set_value(30); // Default
+	ease_fps_sp->set_accessibility_name(TTRC("FPS"));
 	ease_grid->add_child(memnew(Label(TTR("Transition Type:"))));
 	ease_grid->add_child(transition_selection);
 	ease_grid->add_child(memnew(Label(TTR("Ease Type:"))));
@@ -9806,64 +9778,6 @@ void AnimationMarkerEdit::_marker_rename_new_name_changed(const String &p_text) 
 }
 
 /// ANIMATION MARKER KEY EDIT ///
-AnimationMarkerEdit::AnimationMarkerEdit() {
-	play_position = memnew(Control);
-	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
-	add_child(play_position);
-	play_position->connect(SceneStringName(draw), callable_mp(this, &AnimationMarkerEdit::_play_position_draw));
-	set_focus_mode(FOCUS_CLICK);
-	set_mouse_filter(MOUSE_FILTER_PASS); // Scroll has to work too for selection.
-
-	menu = memnew(PopupMenu);
-	add_child(menu);
-	menu->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationMarkerEdit::_menu_selected));
-	menu->add_shortcut(ED_SHORTCUT("animation_marker_edit/rename_marker", TTRC("Rename Marker"), Key::R), MENU_KEY_RENAME);
-	menu->add_shortcut(ED_SHORTCUT("animation_marker_edit/delete_selection", TTRC("Delete Marker(s)"), Key::KEY_DELETE), MENU_KEY_DELETE);
-	menu->add_shortcut(ED_SHORTCUT("animation_marker_edit/toggle_marker_names", TTRC("Show All Marker Names"), Key::M), MENU_KEY_TOGGLE_MARKER_NAMES);
-
-	marker_insert_confirm = memnew(ConfirmationDialog);
-	marker_insert_confirm->set_title(TTR("Insert Marker"));
-	marker_insert_confirm->set_hide_on_ok(false);
-	marker_insert_confirm->connect(SceneStringName(confirmed), callable_mp(this, &AnimationMarkerEdit::_marker_insert_confirmed));
-	add_child(marker_insert_confirm);
-	VBoxContainer *marker_insert_vbox = memnew(VBoxContainer);
-	marker_insert_vbox->set_anchors_and_offsets_preset(Control::LayoutPreset::PRESET_FULL_RECT);
-	marker_insert_confirm->add_child(marker_insert_vbox);
-	marker_insert_new_name = memnew(LineEdit);
-	marker_insert_new_name->connect(SceneStringName(text_changed), callable_mp(this, &AnimationMarkerEdit::_marker_insert_new_name_changed));
-	marker_insert_confirm->register_text_enter(marker_insert_new_name);
-	marker_insert_vbox->add_child(_create_hbox_labeled_control(TTR("Marker Name"), marker_insert_new_name));
-	marker_insert_color = memnew(ColorPickerButton);
-	marker_insert_color->set_edit_alpha(false);
-	marker_insert_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(marker_insert_color->get_picker()));
-	marker_insert_vbox->add_child(_create_hbox_labeled_control(TTR("Marker Color"), marker_insert_color));
-	marker_insert_error_dialog = memnew(AcceptDialog);
-	marker_insert_error_dialog->set_ok_button_text(TTR("Close"));
-	marker_insert_error_dialog->set_title(TTR("Error!"));
-	marker_insert_confirm->add_child(marker_insert_error_dialog);
-
-	marker_rename_confirm = memnew(ConfirmationDialog);
-	marker_rename_confirm->set_title(TTR("Rename Marker"));
-	marker_rename_confirm->set_hide_on_ok(false);
-	marker_rename_confirm->connect(SceneStringName(confirmed), callable_mp(this, &AnimationMarkerEdit::_marker_rename_confirmed));
-	add_child(marker_rename_confirm);
-	VBoxContainer *marker_rename_vbox = memnew(VBoxContainer);
-	marker_rename_vbox->set_anchors_and_offsets_preset(Control::LayoutPreset::PRESET_FULL_RECT);
-	marker_rename_confirm->add_child(marker_rename_vbox);
-	Label *marker_rename_new_name_label = memnew(Label);
-	marker_rename_new_name_label->set_text(TTR("Change Marker Name:"));
-	marker_rename_vbox->add_child(marker_rename_new_name_label);
-	marker_rename_new_name = memnew(LineEdit);
-	marker_rename_new_name->set_accessibility_name(TTRC("Change Marker Name:"));
-	marker_rename_new_name->connect(SceneStringName(text_changed), callable_mp(this, &AnimationMarkerEdit::_marker_rename_new_name_changed));
-	marker_rename_confirm->register_text_enter(marker_rename_new_name);
-	marker_rename_vbox->add_child(marker_rename_new_name);
-
-	marker_rename_error_dialog = memnew(AcceptDialog);
-	marker_rename_error_dialog->set_ok_button_text(TTR("Close"));
-	marker_rename_error_dialog->set_title(TTR("Error!"));
-	marker_rename_confirm->add_child(marker_rename_error_dialog);
-}
 
 float AnimationMarkerKeyEdit::get_time() const {
 	return animation->get_marker_time(marker_name);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2698,7 +2698,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			if (animation.is_null()) {
 				return;
 			}
-			ERR_FAIL_INDEX(track, animation->get_track_count());
+			ERR_FAIL_INDEX(track, editor->get_track_count());
 
 			float limit = timeline->get_name_limit();
 			float limit_end = get_size().width - timeline->get_buttons_width();
@@ -2747,7 +2747,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				draw_texture(key_type_icon, Point2(ofs, (get_size().height - key_type_icon->get_height()) / 2).round());
 				ofs += key_type_icon->get_width() + h_separation;
 
-				NodePath anim_path = animation->track_get_path(track);
+				NodePath anim_path = get_path();
 				Node *node = nullptr;
 				if (root) {
 					node = root->get_node_or_null(anim_path);
@@ -3260,18 +3260,18 @@ void AnimationTrackEdit::_path_submitted(const String &p_text) {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Change Track Path"));
 	undo_redo->add_do_method(animation.ptr(), "track_set_path", track, p_text);
-	undo_redo->add_undo_method(animation.ptr(), "track_set_path", track, animation->track_get_path(track));
+	undo_redo->add_undo_method(animation.ptr(), "track_set_path", track, get_path());
 	undo_redo->commit_action();
 	path_popup->hide();
 }
 
 bool AnimationTrackEdit::_is_value_key_valid(const Variant &p_key_value, Variant::Type &r_valid_type) const {
-	if (root == nullptr || !root->has_node_and_resource(animation->track_get_path(track))) {
+	if (root == nullptr || !root->has_node_and_resource(get_path())) {
 		return false;
 	}
 	Ref<Resource> res;
 	Vector<StringName> leftover_path;
-	Node *node = root->get_node_and_resource(animation->track_get_path(track), res, leftover_path);
+	Node *node = root->get_node_and_resource(get_path(), res, leftover_path);
 
 	Object *obj = nullptr;
 	if (res.is_valid()) {
@@ -3333,7 +3333,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 
 	// Don't overlap track keys if they start at 0.
 	if (path_rect.has_point(p_pos + Size2(type_icon->get_width(), 0))) {
-		return String(animation->track_get_path(track));
+		return String(get_path());
 	}
 
 	if (update_mode_rect.has_point(p_pos)) {
@@ -3495,8 +3495,6 @@ void AnimationKeyEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::LEFT) && moving_selection_attempt) {
 		float limit = timeline->get_name_limit();
-		float limit_end = get_size().width - timeline->get_buttons_width();
-
 		float scale = timeline->get_zoom_scale();
 
 		if (!is_moving_selection()) {
@@ -3556,8 +3554,6 @@ void AnimationTrackEdit::_on_pressed(const Ref<InputEvent> &p_event) {
 
 void AnimationTrackEdit::_on_mouse_pressed(const Ref<InputEventMouseButton> &mb) {
 	float limit = timeline->get_name_limit();
-	float limit_end = get_size().width - timeline->get_buttons_width();
-
 	float scale = timeline->get_zoom_scale();
 
 	Point2 pos = mb->get_position();
@@ -3627,7 +3623,7 @@ void AnimationTrackEdit::_on_mouse_pressed(const Ref<InputEventMouseButton> &mb)
 			if (ape) {
 				AnimationPlayer *ap = ape->get_player();
 				if (ap) {
-					NodePath npath = animation->track_get_path(track);
+					NodePath npath = get_path();
 					Node *a_ap_root_node = ap->get_node_or_null(ap->get_root_node());
 					Node *nd = nullptr;
 					// We must test that we have a valid a_ap_root_node before trying to access its content to init the nd Node.
@@ -3705,7 +3701,7 @@ void AnimationTrackEdit::_on_mouse_unpressed(const Ref<InputEventMouseButton> &m
 			path->connect(SceneStringName(text_submitted), callable_mp(this, &AnimationTrackEdit::_path_submitted));
 		}
 
-		path->set_text(String(animation->track_get_path(track)));
+		path->set_text(String(get_path()));
 		const Vector2 theme_ofs = path->get_theme_stylebox(CoreStringName(normal), SNAME("LineEdit"))->get_offset();
 
 		moving_selection_attempt = false;
@@ -3731,12 +3727,12 @@ void AnimationTrackEdit::_deselect_key(const int p_index) {
 }
 
 bool AnimationTrackEdit::_lookup_key(int p_key_idx) const {
-	if (p_key_idx < 0 || p_key_idx >= animation->track_get_key_count(track)) {
+	if (p_key_idx < 0 || p_key_idx >= get_key_count()) {
 		return false;
 	}
 
 	if (animation->track_get_type(track) == Animation::TYPE_METHOD) {
-		Node *target = root->get_node_or_null(animation->track_get_path(track));
+		Node *target = root->get_node_or_null(get_path());
 		if (target) {
 			StringName method = animation->method_track_get_name(track, p_key_idx);
 			// First, check every script in the inheritance chain.
@@ -3807,7 +3803,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 
 	// Don't allow moving tracks outside their groups.
 	if (get_editor()->is_grouping_tracks()) {
-		String base_path = String(animation->track_get_path(track));
+		String base_path = String(get_path());
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 		if (d["group"] != base_path) {
 			return false;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2816,6 +2816,18 @@ void AnimationTrackEdit::draw_rect_clipped(const Rect2 &p_rect, const Color &p_c
 	draw_rect(clip.intersection(p_rect), p_color, p_filled);
 }
 
+// Helper.
+String AnimationTrackEdit::make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width) {
+	String clipped_text = text;
+	if (font->get_string_size(clipped_text, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x > max_width) {
+		while (!clipped_text.is_empty() && font->get_string_size(clipped_text + "...", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x > max_width) {
+			clipped_text = clipped_text.substr(0, clipped_text.length() - 1);
+		}
+		clipped_text += "...";
+	}
+	return clipped_text;
+}
+
 void AnimationTrackEdit::draw_bg(int p_clip_left, int p_clip_right) {
 }
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2284,18 +2284,29 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 	if (pos.x >= limit && pos.x <= limit_end) {
 		float scale = timeline->get_zoom_scale();
 
-		// Can do something with menu too! show insert keyl.
-		float offset = (pos.x - limit) / scale;
-		if (!read_only) {
-			bool selected = _try_select_at_ui_pos(pos, mb->is_command_or_control_pressed() || mb->is_shift_pressed(), false);
+		length = memnew(EditorSpinSlider);
+		length->set_min(SECOND_DECIMAL);
+		length->set_max(36000);
+		length->set_step(SECOND_DECIMAL);
+		length->set_allow_greater(true);
+		length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
+		length->set_hide_slider(true);
+		length->set_tooltip_text(TTR("Animation length (seconds)"));
+		length->set_accessibility_name(TTRC("Animation length (seconds)"));
+		length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
+		len_hb->add_child(length);
 
-			menu->clear();
-			create_popup_menu(menu, selected);
-			menu->reset_size();
+		loop = memnew(Button);
+		loop->set_flat(true);
+		loop->set_tooltip_text(TTR("Animation Looping"));
+		loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
+		loop->set_toggle_mode(true);
+		len_hb->add_child(loop);
+		add_child(len_hb);
 
 			moving_selection_attempt = false;
 			set_moving_selection(false);
-			
+
 			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->popup();
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3152,7 +3152,10 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					menu->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationTrackEdit::_menu_selected));
 				}
 				menu->clear();
-				if (animation->track_get_type(track) == Animation::TYPE_AUDIO || animation->track_get_type(track) == Animation::TYPE_ANIMATION) {
+				if (animation->track_get_type(track) == Animation::TYPE_AUDIO) {
+					menu->add_icon_item(get_editor_theme_icon(SNAME("UseBlendEnable")), TTR("Use Blend"), MENU_USE_BLEND_ENABLED);
+					menu->add_icon_item(get_editor_theme_icon(SNAME("UseBlendDisable")), TTR("Don't Use Blend"), MENU_USE_BLEND_DISABLED);
+				} else if (animation->track_get_type(track) == Animation::TYPE_ANIMATION) {
 					menu->add_icon_item(get_editor_theme_icon(SNAME("UseBlendEnable")), TTR("Use Blend"), MENU_USE_BLEND_ENABLED);
 					menu->add_icon_item(get_editor_theme_icon(SNAME("UseBlendDisable")), TTR("Don't Use Blend"), MENU_USE_BLEND_DISABLED);
 				} else {
@@ -3722,7 +3725,7 @@ void AnimationTrackEdit::_menu_selected(int p_index) {
 				undo_redo->add_do_method(animation.ptr(), "audio_track_set_use_blend", track, use_blend);
 				undo_redo->add_undo_method(animation.ptr(), "audio_track_set_use_blend", track, animation->audio_track_is_use_blend(track));
 				undo_redo->commit_action();
-			} else if (animation->track_get_type(track) == Animation::TYPE_AUDIO) {
+			} else if (animation->track_get_type(track) == Animation::TYPE_ANIMATION) {
 				undo_redo->create_action(TTR("Change Animation Use Blend"));
 				undo_redo->add_do_method(animation.ptr(), "animation_track_set_use_blend", track, use_blend);
 				undo_redo->add_undo_method(animation.ptr(), "animation_track_set_use_blend", track, animation->animation_track_is_use_blend(track));

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1512,14 +1512,13 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
 	length->set_hide_slider(true);
 	length->set_tooltip_text(TTR("Animation length (seconds)"));
-	length->set_accessibility_name(TTRC("Animation length"));
+	length->set_accessibility_name(TTRC("Animation length (seconds)"));
 	length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
 	len_hb->add_child(length);
 
 	loop = memnew(Button);
 	loop->set_flat(true);
 	loop->set_tooltip_text(TTR("Animation Looping"));
-	loop->set_accessibility_name(TTRC("Animation Looping"));
 	loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
 	loop->set_toggle_mode(true);
 	len_hb->add_child(loop);
@@ -2296,6 +2295,25 @@ void AnimationKeyEdit::show_popup_menu(Ref<InputEventMouseButton> &mb) {
 
 			moving_selection_attempt = false;
 			set_moving_selection(false);
+			length = memnew(EditorSpinSlider);
+			length->set_min(SECOND_DECIMAL);
+			length->set_max(36000);
+			length->set_step(SECOND_DECIMAL);
+			length->set_allow_greater(true);
+			length->set_custom_minimum_size(Vector2(70 * EDSCALE, 0));
+			length->set_hide_slider(true);
+			length->set_tooltip_text(TTR("Animation length (seconds)"));
+			length->set_accessibility_name(TTRC("Animation length (seconds)"));
+			length->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTimelineEdit::_anim_length_changed));
+			len_hb->add_child(length);
+
+			loop = memnew(Button);
+			loop->set_flat(true);
+			loop->set_tooltip_text(TTR("Animation Looping"));
+			loop->connect(SceneStringName(pressed), callable_mp(this, &AnimationTimelineEdit::_anim_loop_pressed));
+			loop->set_toggle_mode(true);
+			len_hb->add_child(loop);
+			add_child(len_hb);
 
 			menu->set_position(get_screen_position() + get_local_mouse_position());
 			menu->popup();

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -8812,12 +8812,12 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	ease_selection->add_item(TTR("OutIn", "Ease Type"), Tween::EASE_OUT_IN);
 	ease_selection->select(Tween::EASE_IN_OUT); // Default
 	ease_selection->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Translation context is needed.
-	ease_fps_sp = memnew(SpinBox);
-	ease_fps_sp->set_min(FPS_DECIMAL);
-	ease_fps_sp->set_max(999);
-	ease_fps_sp->set_step(FPS_DECIMAL);
-	ease_fps_sp->set_value(30); // Default
-	ease_fps_sp->set_accessibility_name(TTRC("FPS"));
+	ease_fps = memnew(SpinBox);
+	ease_fps->set_min(FPS_DECIMAL);
+	ease_fps->set_max(999);
+	ease_fps->set_step(FPS_DECIMAL);
+	ease_fps->set_value(30); // Default
+	ease_fps->set_accessibility_name(TTRC("FPS:"));
 	ease_grid->add_child(memnew(Label(TTR("Transition Type:"))));
 	ease_grid->add_child(transition_selection);
 	ease_grid->add_child(memnew(Label(TTR("Ease Type:"))));
@@ -9806,6 +9806,64 @@ void AnimationMarkerEdit::_marker_rename_new_name_changed(const String &p_text) 
 }
 
 /// ANIMATION MARKER KEY EDIT ///
+AnimationMarkerEdit::AnimationMarkerEdit() {
+	play_position = memnew(Control);
+	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
+	add_child(play_position);
+	play_position->connect(SceneStringName(draw), callable_mp(this, &AnimationMarkerEdit::_play_position_draw));
+	set_focus_mode(FOCUS_CLICK);
+	set_mouse_filter(MOUSE_FILTER_PASS); // Scroll has to work too for selection.
+
+	menu = memnew(PopupMenu);
+	add_child(menu);
+	menu->connect(SceneStringName(id_pressed), callable_mp(this, &AnimationMarkerEdit::_menu_selected));
+	menu->add_shortcut(ED_SHORTCUT("animation_marker_edit/rename_marker", TTRC("Rename Marker"), Key::R), MENU_KEY_RENAME);
+	menu->add_shortcut(ED_SHORTCUT("animation_marker_edit/delete_selection", TTRC("Delete Marker(s)"), Key::KEY_DELETE), MENU_KEY_DELETE);
+	menu->add_shortcut(ED_SHORTCUT("animation_marker_edit/toggle_marker_names", TTRC("Show All Marker Names"), Key::M), MENU_KEY_TOGGLE_MARKER_NAMES);
+
+	marker_insert_confirm = memnew(ConfirmationDialog);
+	marker_insert_confirm->set_title(TTR("Insert Marker"));
+	marker_insert_confirm->set_hide_on_ok(false);
+	marker_insert_confirm->connect(SceneStringName(confirmed), callable_mp(this, &AnimationMarkerEdit::_marker_insert_confirmed));
+	add_child(marker_insert_confirm);
+	VBoxContainer *marker_insert_vbox = memnew(VBoxContainer);
+	marker_insert_vbox->set_anchors_and_offsets_preset(Control::LayoutPreset::PRESET_FULL_RECT);
+	marker_insert_confirm->add_child(marker_insert_vbox);
+	marker_insert_new_name = memnew(LineEdit);
+	marker_insert_new_name->connect(SceneStringName(text_changed), callable_mp(this, &AnimationMarkerEdit::_marker_insert_new_name_changed));
+	marker_insert_confirm->register_text_enter(marker_insert_new_name);
+	marker_insert_vbox->add_child(_create_hbox_labeled_control(TTR("Marker Name"), marker_insert_new_name));
+	marker_insert_color = memnew(ColorPickerButton);
+	marker_insert_color->set_edit_alpha(false);
+	marker_insert_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(marker_insert_color->get_picker()));
+	marker_insert_vbox->add_child(_create_hbox_labeled_control(TTR("Marker Color"), marker_insert_color));
+	marker_insert_error_dialog = memnew(AcceptDialog);
+	marker_insert_error_dialog->set_ok_button_text(TTR("Close"));
+	marker_insert_error_dialog->set_title(TTR("Error!"));
+	marker_insert_confirm->add_child(marker_insert_error_dialog);
+
+	marker_rename_confirm = memnew(ConfirmationDialog);
+	marker_rename_confirm->set_title(TTR("Rename Marker"));
+	marker_rename_confirm->set_hide_on_ok(false);
+	marker_rename_confirm->connect(SceneStringName(confirmed), callable_mp(this, &AnimationMarkerEdit::_marker_rename_confirmed));
+	add_child(marker_rename_confirm);
+	VBoxContainer *marker_rename_vbox = memnew(VBoxContainer);
+	marker_rename_vbox->set_anchors_and_offsets_preset(Control::LayoutPreset::PRESET_FULL_RECT);
+	marker_rename_confirm->add_child(marker_rename_vbox);
+	Label *marker_rename_new_name_label = memnew(Label);
+	marker_rename_new_name_label->set_text(TTR("Change Marker Name:"));
+	marker_rename_vbox->add_child(marker_rename_new_name_label);
+	marker_rename_new_name = memnew(LineEdit);
+	marker_rename_new_name->set_accessibility_name(TTRC("Change Marker Name:"));
+	marker_rename_new_name->connect(SceneStringName(text_changed), callable_mp(this, &AnimationMarkerEdit::_marker_rename_new_name_changed));
+	marker_rename_confirm->register_text_enter(marker_rename_new_name);
+	marker_rename_vbox->add_child(marker_rename_new_name);
+
+	marker_rename_error_dialog = memnew(AcceptDialog);
+	marker_rename_error_dialog->set_ok_button_text(TTR("Close"));
+	marker_rename_error_dialog->set_title(TTR("Error!"));
+	marker_rename_confirm->add_child(marker_rename_error_dialog);
+}
 
 float AnimationMarkerKeyEdit::get_time() const {
 	return animation->get_marker_time(marker_name);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2475,7 +2475,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 							limit_string = int(MAX(limit_end, offset_last));
 						}
 						draw_key_link(i, scale, int(offset), int(offset_n), limit, limit_end);
-						draw_key(i, scale, int(offset), editor->is_key_selected(track, i), limit, limit_string);
+						draw_key(i, scale, int(offset), editor->is_key_selected(track, i), limit, MIN(limit_string, limit_end));
 						continue;
 					}
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -387,12 +387,25 @@ public:
 	bool _try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable);
 	bool _is_ui_pos_in_current_section(const Point2 &p_pos);
 
+	struct SelectedKey {
+		int track = 0;
+		int key = 0;
+		bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; }
+	};
+
+	struct KeyInfo {
+		float pos = 0;
+		Variant data;
+	};
+
+	RBMap<SelectedKey, KeyInfo> selection;
+
 public:
 	virtual bool has_valid_track() const override;
 	virtual Size2 get_minimum_size() const override;
 
-	double get_move_time(const int p_index) const;
-	double get_global_move_time(const int p_index) const;
+	double get_move_key_time(const int p_index) const;
+	double get_global_move_key_time(const int p_index) const;
 
 public:
 	virtual float get_key_width(const int p_index) const override;
@@ -521,18 +534,6 @@ public:
 	virtual void _move_selection_commit() override;
 	virtual void _move_selection_cancel() override;
 
-	struct SelectedKey {
-		int key = 0;
-		bool operator<(const SelectedKey &p_key) const { return key < p_key.key; }
-	};
-
-	struct KeyInfo {
-		float pos = 0;
-		Color color;
-	};
-
-	RBMap<SelectedKey, KeyInfo> selection;
-
 	void clear_selection();
 	int get_selection_count() const;
 	void insert_selection(const int p_index);
@@ -626,16 +627,6 @@ public:
 
 	virtual bool is_moving_selection() const override;
 	virtual float get_moving_selection_offset() const override;
-
-	struct SelectedKey {
-		int track = 0;
-		int key = 0;
-		bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; }
-	};
-
-	struct KeyInfo {
-		float pos = 0;
-	};
 
 	virtual Vector<int> get_selected_section() override;
 
@@ -883,7 +874,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);
 	void _select_at_anim(const Ref<Animation> &p_anim, int p_track, float p_pos);
 
-	RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo> selection;
+	RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> selection;
 
 	bool moving_selection = false;
 	float moving_selection_offset = 0.0f;
@@ -938,12 +929,12 @@ class AnimationTrackEditor : public VBoxContainer {
 	CheckBox *cleanup_all = nullptr;
 
 	ConfirmationDialog *scale_dialog = nullptr;
-	SpinBox *scale = nullptr;
+	SpinBox *scale_sp = nullptr;
 
 	ConfirmationDialog *ease_dialog = nullptr;
 	OptionButton *transition_selection = nullptr;
 	OptionButton *ease_selection = nullptr;
-	SpinBox *ease_fps = nullptr;
+	SpinBox *ease_fps_sp = nullptr;
 
 	void _select_all_tracks_for_copy();
 
@@ -1013,7 +1004,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Vector<TrackClipboard> track_clipboard;
 	KeyClipboard key_clipboard;
 
-	void _set_key_clipboard(int p_top_track, float p_top_time, RBMap<AnimationTrackEdit::SelectedKey, AnimationTrackEdit::KeyInfo> &p_keymap);
+	void _set_key_clipboard(int p_top_track, float p_top_time, RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &p_keymap);
 	void _insert_animation_key(NodePath p_path, const Variant &p_value);
 
 	void _pick_track_filter_text_changed(const String &p_newtext);
@@ -1041,7 +1032,7 @@ public:
 	PropertySelector *get_prop_selector() { return prop_selector; }
 	PropertySelector *get_method_selector() { return method_selector; }
 
-	float get_global_time(const float p_time, const float p_offset = 0) const;
+	double get_global_time(const float p_time) const;
 
 public:
 	// Public for use with callable_mp.
@@ -1138,7 +1129,7 @@ public:
 	StringName get_marker_name(const int p_index) const;
 	int get_marker_index(const StringName marker) const;
 	double get_marker_time(const int p_index) const;
-	double get_marker_move_time(const int p_index) const;
+	double get_marker_move_key_time(const int p_index) const;
 	int get_marker_count() const;
 	int get_track_count() const;
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -387,20 +387,20 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
-	Rect2 get_global_key_rect(int p_index, float p_pixels_sec, int p_x) const;
+	Rect2 get_global_key_rect(int p_index, bool ignore_moving_selection = false) const;
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual int get_key_width(int p_index, float p_pixels_sec) const;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) const;
+	virtual int get_key_width(int p_index) const;
+	virtual int get_key_height(int p_index) const;
+	virtual Rect2 get_key_rect(int p_index) const;
 	virtual bool is_key_selectable_by_distance() const;
 	virtual void draw_key(const StringName &p_name, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual void draw_bg(int p_clip_left, int p_clip_right);
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
 
 	// helper
-	float _get_pixels_sec(int p_index) const;
+	float _get_pixels_sec(int p_index, bool ignore_moving_selection = false) const;
 
 	Ref<Animation> get_animation() const;
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
@@ -529,7 +529,7 @@ protected:
 	Node *get_root() const { return root; }
 
 public:
-	Rect2 get_global_key_rect(int p_index, float p_pixels_sec, int p_x);
+	Rect2 get_global_key_rect(int p_index, bool ignore_moving_selection = false);
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
@@ -538,9 +538,9 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual int get_key_width(int p_index, float p_pixels_sec) const;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec);
+	virtual int get_key_width(int p_index) const;
+	virtual int get_key_height(int p_index) const;
+	virtual Rect2 get_key_rect(int p_index);
 	virtual bool is_key_selectable_by_distance() const;
 	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right);
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
@@ -569,7 +569,7 @@ public:
 public:
 	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
 	int _get_theme_font_height(float p_scale) const;
-	float _get_pixels_sec(int p_index, bool ignore_moving_selection = true) const;
+	float _get_pixels_sec(int p_index, bool ignore_moving_selection = false) const;
 	String make_method_text(const Dictionary &d);
 
 public:

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -569,7 +569,8 @@ public:
 public:
 	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
 	int _get_theme_font_height(float p_scale) const;
-	float _get_pixels_sec(int p_index) const;
+	float _get_pixels_sec(int p_index, bool ignore_moving_selection = true) const;
+	String make_method_text(const Dictionary &d);
 
 public:
 	AnimationTrackEdit();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -369,7 +369,7 @@ protected:
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right) {}
 	
 	void draw_timeline(const float p_clip_left, const float p_clip_right);
-	void draw_edit_text(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right, const bool outside = false);
+	void draw_edit_text(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right, const bool outside = false, const float p_offset_y = 0);
 
 public:
 	Control *play_cursor = nullptr; // Separate control used to draw so updates for only position changed are much faster.
@@ -426,6 +426,9 @@ public:
 	RBMap<SelectedKey, KeyInfo> selection;
 
 public:
+	int get_selection_count() const;
+	bool is_selection_active() const;
+
 	virtual bool has_valid_track() const override;
 	virtual Size2 get_minimum_size() const override;
 	virtual float get_track_height() const;
@@ -447,6 +450,8 @@ protected:
 	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) {}
 	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) {}
 	void show_popup_menu(Ref<InputEventMouseButton> &mb);
+
+	void _on_mouse_release(const Ref<InputEventMouseButton> &mb, bool handle_timeline = false);
 };
 
 class AnimationMarkerEdit : public AnimationKeyEdit {
@@ -558,9 +563,7 @@ public:
 	virtual void _move_selection_cancel() override;
 
 	void clear_selection();
-	int get_selection_count() const;
 	void insert_selection(const int p_index);
-	bool is_selection_active() const;
 
 	virtual Vector<int> get_selected_section() override;
 	int get_last_selection();
@@ -918,7 +921,9 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	bool moving_track_selection = false;
 	float moving_track_selection_offset = 0.0f;
-	
+
+	int get_selection_count() const { return selection.size(); }
+
 	AnimationTrackKeyEdit *key_edit = nullptr;
 	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
 	void _update_key_edit();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -374,12 +374,17 @@ protected:
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
+	virtual int get_key_width() const;
 	virtual int get_key_height() const;
 	virtual Rect2 get_key_rect(float p_pixels_sec) const;
+	virtual Rect2 get_global_key_rect(float p_pixels_sec, int p_x) const;
 	virtual bool is_key_selectable_by_distance() const;
 	virtual void draw_key(const StringName &p_name, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual void draw_bg(int p_clip_left, int p_clip_right);
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
+
+	//helper
+	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
 
 	Ref<Animation> get_animation() const;
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
@@ -527,6 +532,7 @@ public:
 	void draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
 	void draw_line_clipped(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
 	String make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
+	int _get_theme_font_height(float p_scale) const;
 
 	int get_track() const;
 	Ref<Animation> get_animation() const;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -375,7 +375,7 @@ protected:
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) = 0;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right) {}
-	
+
 	void draw_timeline(const float p_clip_left, const float p_clip_right);
 	void draw_edit_text(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right, const bool outside = false, const float p_offset_y = 0);
 
@@ -581,7 +581,7 @@ public:
 
 public:
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
-	
+
 	virtual StringName get_edit_name(const int p_index) const override; //name of the key
 
 protected:

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -376,6 +376,10 @@ public:
 	double play_cursor_pos = 0;
 
 protected:
+	bool command_or_control_pressed = false;
+	bool in_group = false;
+
+protected:
 	virtual bool is_key_selectable_by_distance() const;
 	virtual bool is_linked(const int p_index, const int p_index_next) const { return false; }
 
@@ -410,6 +414,7 @@ class AnimationKeyEdit : public KeyEdit {
 
 protected:
 	Ref<Animation> animation;
+	PopupMenu *menu = nullptr;
 
 public:
 	void set_animation(const Ref<Animation> &p_animation, bool p_read_only);
@@ -433,6 +438,12 @@ public:
 
 	virtual bool is_compressed() const = 0;
 	virtual Vector<int> get_selected_section() = 0;
+
+protected:
+	virtual void create_popup_menu(PopupMenu *p_menu, bool p_selected) {}
+	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) {}
+	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) {}
+	void show_popup_menu(Ref<InputEventMouseButton> &mb);
 };
 
 class AnimationMarkerEdit : public AnimationKeyEdit {
@@ -445,8 +456,6 @@ class AnimationMarkerEdit : public AnimationKeyEdit {
 		MENU_KEY_DELETE,
 		MENU_KEY_TOGGLE_MARKER_NAMES,
 	};
-
-	PopupMenu *menu = nullptr;
 
 	void _zoom_changed();
 
@@ -565,6 +574,11 @@ public:
 	
 	virtual StringName get_edit_name(const int p_index) const override; //name of the key
 
+protected:
+	virtual void create_popup_menu(PopupMenu *p_menu, bool p_selected) override;
+	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) override;
+	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) override;
+
 public:
 	AnimationMarkerEdit();
 };
@@ -609,8 +623,6 @@ class AnimationTrackEdit : public AnimationKeyEdit {
 	Rect2 loop_wrap_rect;
 	Rect2 remove_rect;
 
-	PopupMenu *menu = nullptr;
-
 	bool clicking_on_name = false;
 
 	void _zoom_changed();
@@ -628,10 +640,6 @@ class AnimationTrackEdit : public AnimationKeyEdit {
 	bool _lookup_key(int p_key_idx) const;
 
 	mutable int dropping_at = 0;
-
-	bool command_or_control_pressed = false;
-
-	bool in_group = false;
 
 protected:
 	static void _bind_methods();
@@ -703,6 +711,11 @@ public:
 
 public:
 	int _get_theme_font_height(float p_scale) const;
+
+protected:
+	virtual void create_popup_menu(PopupMenu *p_menu, bool p_selected) override;
+	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) override;
+	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) override;
 
 public:
 	AnimationTrackEdit();
@@ -1158,9 +1171,13 @@ public:
 	StringName get_marker_name(const int p_index) const;
 	int get_marker_index(const StringName marker) const;
 	double get_marker_time(const int p_index) const;
+	int get_marker_at_time(double p_time) const;
 	double get_marker_move_key_time(const int p_index) const;
 	int get_marker_count() const;
 	int get_track_count() const;
+	double get_length() const;
+	double set_length(double p_len, bool p_use_fps = false);
+	double get_step() const;
 	int get_track_key_count(const int p_track) const;
 	double get_global_time(const float p_time) const;
 	double get_track_key_time(const int track, const int p_index) const;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -402,7 +402,6 @@ public:
 
 protected:
 	int find_closest_key(const Point2 &p_pos) const;
-	Rect2 _to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection = false) const;
 	void _draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
 
 public:

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -70,6 +70,42 @@ public:
 	String _make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
 };
 
+class AnimationKeyEdit : public Control { //XXX
+	GDCLASS(AnimationKeyEdit, Control);
+
+protected:
+	float key_pivot = 0.0;
+	float track_alignment = 0.0;
+
+	Ref<Animation> animation;
+	bool read_only = false;
+
+	Ref<Texture2D> type_icon;
+	Ref<Texture2D> selected_icon;
+
+	//AnimationTimelineEdit *timeline = nullptr;
+	//AnimationTrackEditor *editor = nullptr;
+
+public:
+	virtual bool has_valid_key(const int p_index) const;
+
+	virtual int get_key_width(const int p_index) const;
+	virtual int get_key_height(const int p_index) const;
+	virtual Rect2 get_key_rect(const int p_index) const;
+
+	virtual bool is_key_selectable_by_distance() const;
+
+	virtual Rect2 get_global_key_rect(const int p_index, bool ignore_moving_selection = false) const;
+
+public:
+	virtual float _get_pixels_sec(const int p_index, bool ignore_moving_selection = false) const = 0;
+
+//public:
+//	virtual float get_key_time(const int p_index) const = 0;
+//	virtual bool is_key_selected(const int p_index) const = 0;
+//	virtual int get_key_count() const = 0;
+};
+
 class AnimationTrackKeyEdit : public Object {
 	GDCLASS(AnimationTrackKeyEdit, Object);
 
@@ -289,7 +325,7 @@ public:
 	AnimationTimelineEdit();
 };
 
-class AnimationMarkerEdit : public Control {
+class AnimationMarkerEdit : public AnimationKeyEdit { //XXX
 	GDCLASS(AnimationMarkerEdit, Control);
 	friend class AnimationTimelineEdit;
 
@@ -305,12 +341,6 @@ class AnimationMarkerEdit : public Control {
 	float play_position_pos = 0.0f;
 
 	HashSet<StringName> selection;
-
-	Ref<Animation> animation;
-	bool read_only = false;
-
-	Ref<Texture2D> type_icon;
-	Ref<Texture2D> selected_icon;
 
 	PopupMenu *menu = nullptr;
 
@@ -387,20 +417,21 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
-	Rect2 get_global_key_rect(int p_index, bool ignore_moving_selection = false) const;
+	bool has_marker(String p_name);
+	int get_marker_index(const StringName marker) const;
+	StringName get_marker_name(const int p_index) const;
+	double get_global_marker_time(int p_index) const;
+	int find_closest_key(const Point2 &p_pos) const;
+	float get_global_marker_pos(const StringName marker) const;
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual int get_key_width(int p_index) const;
-	virtual int get_key_height(int p_index) const;
-	virtual Rect2 get_key_rect(int p_index) const;
-	virtual bool is_key_selectable_by_distance() const;
 	virtual void draw_key(const StringName &p_name, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual void draw_bg(int p_clip_left, int p_clip_right);
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
 
 	// helper
-	float _get_pixels_sec(int p_index, bool ignore_moving_selection = false) const;
+	float _get_pixels_sec(const int p_index, bool ignore_moving_selection = false) const;
 
 	Ref<Animation> get_animation() const;
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
@@ -432,7 +463,7 @@ public:
 	AnimationMarkerEdit();
 };
 
-class AnimationTrackEdit : public Control {
+class AnimationTrackEdit : public AnimationKeyEdit { //XXX
 	GDCLASS(AnimationTrackEdit, Control);
 	friend class AnimationTimelineEdit;
 
@@ -467,8 +498,6 @@ class AnimationTrackEdit : public Control {
 	float play_position_pos = 0.0f;
 	NodePath node_path;
 
-	Ref<Animation> animation;
-	bool read_only = false;
 	int track = 0;
 
 	Rect2 check_rect;
@@ -479,9 +508,6 @@ class AnimationTrackEdit : public Control {
 	Rect2 interp_mode_rect;
 	Rect2 loop_wrap_rect;
 	Rect2 remove_rect;
-
-	Ref<Texture2D> type_icon;
-	Ref<Texture2D> selected_icon;
 
 	PopupMenu *menu = nullptr;
 
@@ -529,7 +555,18 @@ protected:
 	Node *get_root() const { return root; }
 
 public:
-	Rect2 get_global_key_rect(int p_index, bool ignore_moving_selection = false);
+	bool has_marker(String p_name);
+	int get_marker_index(const StringName marker) const;
+	StringName get_marker_name(const int p_index) const;
+	double get_global_marker_time(const int p_index) const;
+	bool has_key(int p_index);
+	float get_global_time(float p_time) const;
+	void draw_markers(float p_clip_left, float p_clip_right);
+	bool is_marker_selected(const StringName &p_marker) const;
+
+	StringName get_edit_name__type_method(const int p_index);
+	void draw_key__type_method(int p_index, int p_clip_left, int p_clip_right);
+	int find_closest_key(const Point2 &p_pos) const;
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
@@ -538,10 +575,6 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual int get_key_width(int p_index) const;
-	virtual int get_key_height(int p_index) const;
-	virtual Rect2 get_key_rect(int p_index);
-	virtual bool is_key_selectable_by_distance() const;
 	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right);
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual void draw_bg(int p_clip_left, int p_clip_right);
@@ -569,7 +602,7 @@ public:
 public:
 	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
 	int _get_theme_font_height(float p_scale) const;
-	float _get_pixels_sec(int p_index, bool ignore_moving_selection = false) const;
+	float _get_pixels_sec(const int p_index, bool ignore_moving_selection = false) const;
 	String make_method_text(const Dictionary &d);
 
 public:
@@ -605,6 +638,12 @@ protected:
 	void _notification(int p_what);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+public:
+	double get_global_marker_time(const int p_index) const;
+	float get_global_time(float p_time) const;
+	StringName get_marker_name(const int p_index) const;
+	void draw_markers(float p_clip_left, float p_clip_right);
 
 public:
 	void set_type_and_name(const Ref<Texture2D> &p_type, const String &p_name, const NodePath &p_node);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -603,7 +603,6 @@ public:
 	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
 	int _get_theme_font_height(float p_scale) const;
 	float _get_pixels_sec(const int p_index, bool ignore_moving_selection = false) const;
-	String make_method_text(const Dictionary &d);
 
 public:
 	AnimationTrackEdit();
@@ -616,6 +615,7 @@ public:
 	virtual AnimationTrackEdit *create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage);
 	virtual AnimationTrackEdit *create_audio_track_edit();
 	virtual AnimationTrackEdit *create_animation_track_edit(Object *p_object);
+	virtual AnimationTrackEdit *create_method_track_edit();
 };
 
 class AnimationTrackKeyEdit;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -63,6 +63,7 @@ public:
 
 public:
 	void _draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
+	void _draw_grid_clipped(const Rect2 &p_rect, const Color &p_color, int p_raster_size, int p_clip_left, int p_clip_right);
 	void _draw_line_clipped(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
 	void _draw_vertical_line_clipped(const Point2 &p_from, float p_length, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
 	void _draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
@@ -612,6 +613,10 @@ public:
 	void set_editor(AnimationTrackEditor *p_editor);
 	String get_node_name() const;
 
+public:
+	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
+
+public:
 	AnimationTrackEditGroup();
 };
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -74,7 +74,7 @@ class AnimationKeyEdit : public Control { //XXX
 	GDCLASS(AnimationKeyEdit, Control);
 
 protected:
-	float key_pivot = 0.0;
+	Vector2 key_pivot;
 	float track_alignment = 0.0;
 
 	Ref<Animation> animation;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -378,9 +378,7 @@ protected:
 
 	// Helper
 public:
-	//float _get_local_time(const int p_index, float p_offset = 0) const;
 	Rect2 _to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection = false) const;
-	Rect2 _to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const;
 	void _draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
 
 	virtual String _get_tooltip(const int p_index) const { return ""; }
@@ -496,6 +494,7 @@ public:
 	virtual Ref<Texture2D> _get_key_type_icon_selected() const override;
 
 	Color get_key_color(const int p_index) const;
+	StringName get_key_name(const int p_index) const;
 
 	virtual bool has_key(const int p_index) const override;
 
@@ -545,6 +544,11 @@ public:
 	virtual Vector<int> get_selected_section() override;
 	int get_last_selection();
 	int get_first_selection();
+
+public:
+	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
+	void draw_marker_lines(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
+	void draw_marker_keys(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
 
 public:
 	AnimationMarkerEdit();
@@ -1030,7 +1034,10 @@ public:
 	void _draw_vertical_line_clipped(CanvasItem *p_canvas_item, const Point2 &p_from, float p_length, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
 	void _draw_texture_region_clipped(CanvasItem *p_canvas_item, const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
 	String _make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
-	void _draw_markers(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
+
+public:
+	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
+	void draw_marker_lines(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
 
 protected:
 	static void _bind_methods();
@@ -1039,8 +1046,6 @@ protected:
 public:
 	PropertySelector *get_prop_selector() { return prop_selector; }
 	PropertySelector *get_method_selector() { return method_selector; }
-
-	double get_global_time(const float p_time) const;
 
 public:
 	// Public for use with callable_mp.
@@ -1111,10 +1116,6 @@ public:
 
 	bool is_key_selected(const int p_track, const int p_key) const;
 	bool is_selection_active() const;
-	bool is_track_moving_selection() const;
-	void set_track_moving_selection(bool p_value);
-	float get_track_moving_selection_offset() const;
-	void set_track_moving_selection_offset(float p_value);
 	bool is_marker_selection_active() const;
 	bool is_key_clipboard_active() const;
 	bool is_snap_timeline_enabled() const;
@@ -1130,6 +1131,11 @@ public:
 	float get_marker_moving_selection_offset() const;
 	bool is_function_name_pressed();
 
+	bool is_track_moving_selection() const;
+	void set_track_moving_selection(bool p_value);
+	float get_track_moving_selection_offset() const;
+	void set_track_moving_selection_offset(float p_value);
+
 	bool is_marker_selected(const int p_key) const;
 	Vector<int> get_selected_marker_section();
 
@@ -1142,8 +1148,8 @@ public:
 	double get_marker_move_key_time(const int p_index) const;
 	int get_marker_count() const;
 	int get_track_count() const;
-
 	int get_track_key_count(const int p_track) const;
+	double get_global_time(const float p_time) const;
 
 	/** If `p_from_mouse_event` is `true`, handle Shift key presses for precise snapping. */
 	void goto_prev_step(bool p_from_mouse_event);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -277,7 +277,7 @@ public:
 	AnimationTimelineEdit();
 };
 
-class KeyEdit : public Control { //XXX
+class KeyEdit : public Control {
 	GDCLASS(KeyEdit, Control);
 
 protected:
@@ -315,7 +315,6 @@ protected:
 public:
 	bool is_moving_selection() const;
 	float get_moving_selection_offset() const;
-	//int get_select_single_attempt() const;
 
 public:
 	virtual void _move_selection_begin() {}
@@ -324,7 +323,7 @@ public:
 	virtual void _move_selection_cancel() {}
 
 public:
-	virtual void try_select(const int p_index, bool is_single) = 0;
+	virtual void try_select(const int p_index, bool p_is_single) = 0;
 	virtual void try_deselect(const int p_index) = 0;
 
 public:
@@ -347,6 +346,7 @@ public:
 public:
 	int find_closest_key(const Point2 &p_pos) const;
 	virtual bool is_key_selectable_by_distance() const;
+	virtual bool is_linked(const int p_index, const int p_index_next) const { return false; }
 
 public:
 	Rect2 get_key_rect(const int p_index) const;
@@ -355,12 +355,12 @@ public:
 	void try_draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
 
 protected:
-	virtual void draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right);
+	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
 
 	// Helper
 public:
 	float _get_pixels_sec(const int p_index, bool p_ignore_moving_selection = false) const;
-	float _get_local_time(const int p_index, float offset = 0) const;
+	float _get_local_time(const int p_index, float p_offset = 0) const;
 	Rect2 _to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection = false) const;
 	Rect2 _to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const;
 	void _draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
@@ -369,7 +369,7 @@ public:
 	KeyEdit();
 };
 
-class AnimationKeyEdit : public KeyEdit { //XXX
+class AnimationKeyEdit : public KeyEdit {
 	GDCLASS(AnimationKeyEdit, KeyEdit);
 
 	virtual void _clear_selection_for_anim(const Ref<Animation> &p_anim) {}
@@ -385,11 +385,13 @@ public:
 
 public:
 	virtual bool has_valid_track() const override;
+	virtual Size2 get_minimum_size() const override;
 
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 	virtual bool has_valid_key(const int p_index) const override;
+	virtual bool is_linked(const int p_index, const int p_index_next) const override;
 
 	virtual bool is_compressed() const = 0;
 
@@ -401,7 +403,7 @@ public:
 	float play_position_pos = 0.0f;
 };
 
-class AnimationMarkerEdit : public AnimationKeyEdit { //XXX
+class AnimationMarkerEdit : public AnimationKeyEdit {
 	GDCLASS(AnimationMarkerEdit, Control);
 	friend class AnimationTimelineEdit;
 
@@ -491,7 +493,6 @@ public:
 	Ref<Animation> get_animation() const;
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
 	AnimationTrackEditor *get_editor() const { return editor; }
-	virtual Size2 get_minimum_size() const override;
 
 	void set_timeline(AnimationTimelineEdit *p_timeline);
 	void set_editor(AnimationTrackEditor *p_editor);
@@ -539,7 +540,7 @@ public:
 	AnimationMarkerEdit();
 };
 
-class AnimationTrackEdit : public AnimationKeyEdit { //XXX
+class AnimationTrackEdit : public AnimationKeyEdit {
 	GDCLASS(AnimationTrackEdit, Control);
 	friend class AnimationTimelineEdit;
 
@@ -654,7 +655,6 @@ public:
 
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
 	AnimationTrackEditor *get_editor() const { return editor; }
-	virtual Size2 get_minimum_size() const override;
 
 	void set_timeline(AnimationTimelineEdit *p_timeline);
 	void set_editor(AnimationTrackEditor *p_editor);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -369,14 +369,16 @@ public:
 
 	void try_draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
 
+	double get_move_key_time(const int p_index, bool p_ignore_moving_selection = false) const;
+	double get_global_move_key_time(const int p_index, bool p_ignore_moving_selection = false) const;
+
 protected:
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
 	virtual float get_key_y(const int p_index) const { return 0.0; }
 
 	// Helper
 public:
-	float _get_pixels_sec(const int p_index, bool p_ignore_moving_selection = false) const;
-	float _get_local_time(const int p_index, float p_offset = 0) const;
+	//float _get_local_time(const int p_index, float p_offset = 0) const;
 	Rect2 _to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection = false) const;
 	Rect2 _to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const;
 	void _draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
@@ -407,9 +409,6 @@ public:
 public:
 	virtual bool has_valid_track() const override;
 	virtual Size2 get_minimum_size() const override;
-
-	double get_move_key_time(const int p_index) const;
-	double get_global_move_key_time(const int p_index) const;
 
 public:
 	virtual float get_key_width(const int p_index) const override;
@@ -629,10 +628,13 @@ public:
 	virtual Variant get_key_value(const int p_index) const override;
 	virtual bool is_compressed() const override;
 
-	virtual bool is_moving_selection() const override;
-	virtual float get_moving_selection_offset() const override;
-
 	virtual Vector<int> get_selected_section() override;
+
+public:
+	virtual bool is_moving_selection() const;
+	virtual void set_moving_selection(bool p_value);
+	virtual float get_moving_selection_offset() const;
+	virtual void set_moving_selection_offset(float p_value);
 
 protected:
 	NodePath node_path;
@@ -838,6 +840,8 @@ class AnimationTrackEditor : public VBoxContainer {
 	ConfirmationDialog *insert_confirm = nullptr;
 	bool insert_queue = false;
 	List<InsertData> insert_data;
+
+	Vector2 get_selection_key_time_range();
 
 	void _query_insert(const InsertData &p_id);
 	Ref<Animation> _create_and_get_reset_animation();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -520,8 +520,8 @@ public:
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
 
 	//helper
-	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region);
-	void draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled = true);
+	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right);
+	void draw_color_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
 	String make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
 
 	int get_track() const;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -564,9 +564,8 @@ public:
 	void draw_markers(float p_clip_left, float p_clip_right);
 	bool is_marker_selected(const StringName &p_marker) const;
 
-	StringName get_edit_name__type_method(const int p_index);
-	void draw_key__type_method(int p_index, int p_clip_left, int p_clip_right);
 	int find_closest_key(const Point2 &p_pos) const;
+	void draw_timeline(float p_clip_left, float p_clip_right);
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -205,6 +205,8 @@ class AnimationTimelineEdit : public Range {
 	Ref<Animation> animation;
 	bool read_only = false;
 
+	AnimationTrackEditor *editor = nullptr;
+
 	AnimationTrackEdit *track_edit = nullptr;
 	int name_limit = 0;
 	Range *zoom = nullptr;
@@ -258,6 +260,9 @@ protected:
 
 public:
 	double _get_timeline_pos(const double pos) const;
+
+	void set_editor(AnimationTrackEditor *p_editor);
+	AnimationTrackEditor *get_editor() const { return editor; }
 
 public:
 	int get_name_limit() const;
@@ -356,12 +361,23 @@ public:
 
 	virtual bool is_key_selected(const int p_index) const = 0;
 
+	virtual StringName get_edit_name(const int p_index) const { return StringName(); }
+
+protected:
+	virtual void draw_bg(const float p_clip_left, const float p_clip_right) {}
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) = 0;
+	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
+	virtual void draw_fg(const float p_clip_left, const float p_clip_right) {}
+
+	void draw_timeline(const float p_clip_left, const float p_clip_right);
+	void draw_edit_text(const int p_index, const Rect2 &p_global_rect, const float p_clip_left, const float p_clip_right, const bool outside = false);
 
 public:
 	int find_closest_key(const Point2 &p_pos) const;
 	virtual bool is_key_selectable_by_distance() const;
 	virtual bool is_linked(const int p_index, const int p_index_next) const { return false; }
+
+	virtual Color get_key_color(const int p_index) const;
 
 public:
 	Rect2 get_key_rect(const int p_index) const;
@@ -373,7 +389,6 @@ public:
 	double get_global_move_key_time(const int p_index, bool p_ignore_moving_selection = false) const;
 
 protected:
-	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
 	virtual float get_key_y(const int p_index) const { return 0.0; }
 
 	// Helper
@@ -490,10 +505,17 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
+
+protected:
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
+
+public:
 	virtual Ref<Texture2D> _get_key_type_icon() const override;
 	virtual Ref<Texture2D> _get_key_type_icon_selected() const override;
 
-	Color get_key_color(const int p_index) const;
+	virtual Color get_key_color(const int p_index) const override;
 	StringName get_key_name(const int p_index) const;
 
 	virtual bool has_key(const int p_index) const override;
@@ -505,10 +527,6 @@ public:
 	virtual bool is_key_selected(const int p_index) const override;
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
-
-	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
-	virtual void draw_bg(const float p_clip_left, const float p_clip_right);
-	virtual void draw_fg(const float p_clip_left, const float p_clip_right);
 
 	// helper
 	Ref<Animation> get_animation() const;
@@ -548,7 +566,8 @@ public:
 public:
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
 	void draw_marker_lines(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
-	void draw_marker_keys(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
+	
+	virtual StringName get_edit_name(const int p_index) const override; //name of the key
 
 public:
 	AnimationMarkerEdit();
@@ -649,14 +668,15 @@ public:
 	void set_track(const int p_track);
 	Animation::TrackType get_track_type() const;
 
+protected:
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
+
 public:
 	virtual Ref<Texture2D> _get_key_type_icon() const override;
 	virtual Ref<Texture2D> _get_key_type_icon_selected() const override;
 
 	virtual bool is_key_selected(const int p_index) const override;
 	virtual bool has_key(const int p_index) const override;
-
-	void draw_timeline(float p_clip_left, float p_clip_right);
 
 	virtual int get_key_count() const override;
 	virtual double get_key_time(const int p_index) const override;
@@ -667,11 +687,6 @@ public:
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
-
-	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
-
-	virtual void draw_bg(const float p_clip_left, const float p_clip_right);
-	virtual void draw_fg(const float p_clip_left, const float p_clip_right);
 
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
 	AnimationTrackEditor *get_editor() const { return editor; }

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -504,6 +504,8 @@ protected:
 	Node *get_root() const { return root; }
 
 public:
+	Rect2 get_global_key_rect(int p_index, float p_pixels_sec, int p_x);
+
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
@@ -511,6 +513,7 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
+	virtual int get_key_width() const;
 	virtual int get_key_height() const;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec);
 	virtual bool is_key_selectable_by_distance() const;
@@ -520,8 +523,9 @@ public:
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
 
 	//helper
-	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right);
-	void draw_color_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
+	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
+	void draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
+	void draw_line_clipped(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
 	String make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
 
 	int get_track() const;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -261,6 +261,9 @@ protected:
 	void _notification(int p_what);
 
 public:
+	double _get_timeline_pos(const double pos) const;
+
+public:
 	int get_name_limit() const;
 	int get_buttons_width() const;
 
@@ -312,20 +315,37 @@ public:
 	virtual int get_key_count() const = 0;
 	virtual double get_key_time(const int p_index) const = 0;
 
-	virtual int get_key_width(const int p_index) const;
-	virtual int get_key_height(const int p_index) const;
-	virtual Rect2 get_key_rect(const int p_index) const;
+	virtual float get_key_width(const int p_index) const;
+	virtual float get_key_height(const int p_index) const;
+
+	void _draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) = 0;
 
 	virtual bool is_key_selectable_by_distance() const;
 
-	virtual Rect2 get_global_key_rect(const int p_index, bool p_ignore_moving_selection = false) const;
+	Rect2 get_global_key_rect(const int p_index, bool p_ignore_moving_selection = false) const;
+	Rect2 get_key_rect(const int p_index) const;
 
 public:
+	bool has_valid_track() const;
+
+public:
+	Rect2 _get_key_rect(const int p_index) const;
 	float _get_pixels_sec(const int p_index, bool p_ignore_moving_selection = false) const;
+	float _get_local_time(const int p_index, float offset = 0) const;
+	void _draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
 
 public:
 	Rect2 _to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection = false) const;
 	Rect2 _to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const;
+	//void _draw_simple_key_at_time(const double p_time, const float p_clip_left, const float p_clip_right, const bool p_selected = false, const bool p_hovering = false);
+	//Rect2 _get_global_key_rect_at_time(const double p_time, const bool p_selected = false) const;
+
+public:
+	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
+
+public:
+	AnimationKeyEdit();
 };
 
 
@@ -430,7 +450,7 @@ public:
 
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual void draw_key(const StringName &p_name, const int p_index, const float p_pixels_sec, const int p_x, const bool p_selected, const float p_clip_left, const float p_clip_right);
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_bg(const float p_clip_left, const float p_clip_right);
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right);
 
@@ -457,9 +477,6 @@ public:
 
 	// For use by AnimationTrackEditor.
 	void _clear_selection(bool p_update);
-
-public:
-	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
 
 public:
 	AnimationMarkerEdit();
@@ -576,7 +593,7 @@ public:
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
 	virtual void draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right);
-	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 	virtual void draw_bg(const float p_clip_left, const float p_clip_right);
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right);
@@ -601,7 +618,6 @@ public:
 	void append_to_selection(const Rect2 &p_box, bool p_deselection);
 
 public:
-	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
 	int _get_theme_font_height(float p_scale) const;
 
 public:
@@ -800,6 +816,8 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);
 	void _select_at_anim(const Ref<Animation> &p_anim, int p_track, float p_pos);
+
+	//void _draw_key_type(const int p_index, const AnimationTrackEdit &key);
 
 	//selection
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -501,6 +501,8 @@ protected:
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	Node *get_root() const { return root; }
+
 public:
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -211,7 +211,7 @@ class AnimationTimelineEdit : public Range {
 	int name_limit = 0;
 	Range *zoom = nullptr;
 	Range *h_scroll = nullptr;
-	float play_cursor_pos = 0.0f;
+	double play_cursor_pos = 0;
 
 	HBoxContainer *add_track_hb = nullptr;
 	HBoxContainer *len_hb = nullptr;
@@ -263,6 +263,7 @@ public:
 
 	void set_editor(AnimationTrackEditor *p_editor);
 	AnimationTrackEditor *get_editor() const { return editor; }
+	Control *get_play_cursor() const { return play_cursor; }
 
 public:
 	float get_name_limit() const;
@@ -319,11 +320,11 @@ protected:
 	int hovering_key_idx = -1;
 	int selected_key_idx = -1;
 
-	float insert_at_pos = 0.0f;
+	double insert_at_pos = 0.0f;
 
 	bool moving_selection_attempt = false;
 	bool moving_selection_effective = false;
-	float moving_selection_pivot = 0.0f;
+	double moving_selection_pivot = 0.0f;
 	float moving_selection_mouse_begin_x = 0.0f;
 	float moving_selection_mouse_begin_y = 0.0f;
 
@@ -372,7 +373,7 @@ protected:
 
 public:
 	Control *play_cursor = nullptr; // Separate control used to draw so updates for only position changed are much faster.
-	float play_cursor_pos = 0.0f;
+	double play_cursor_pos = 0;
 
 protected:
 	virtual bool is_key_selectable_by_distance() const;
@@ -422,6 +423,7 @@ public:
 public:
 	virtual bool has_valid_track() const override;
 	virtual Size2 get_minimum_size() const override;
+	virtual float get_track_height() const;
 
 public:
 	virtual float get_key_width(const int p_index) const override;
@@ -555,6 +557,8 @@ public:
 	virtual Vector<int> get_selected_section() override;
 	int get_last_selection();
 	int get_first_selection();
+
+	virtual float get_track_height() const override;
 
 public:
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
@@ -1036,17 +1040,18 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _update_snap_unit();
 
 public:
-	void _draw_rect_clipped(CanvasItem *p_canvas_item, const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
-	void _draw_grid_clipped(CanvasItem *p_canvas_item, const Rect2 &p_rect, const Color &p_color, int p_raster_size, int p_clip_left, int p_clip_right);
-	void _draw_line_clipped(CanvasItem *p_canvas_item, const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
-	void _draw_vertical_line_clipped(CanvasItem *p_canvas_item, const Point2 &p_from, float p_length, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
-	void _draw_texture_region_clipped(CanvasItem *p_canvas_item, const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
-	String _make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
+	void _draw_rect_clipped(CanvasItem *p_canvas_item, const Rect2 &p_rect, const Color &p_color, bool p_filled, const float p_clip_left, const float p_clip_right);
+	void _draw_grid_clipped(CanvasItem *p_canvas_item, const Rect2 &p_rect, const Color &p_color, int p_raster_size, const float p_clip_left, const float p_clip_right);
+	void _draw_line_clipped(CanvasItem *p_canvas_item, const Point2 &p_from, const Point2 &p_to, const Color &p_color, const float p_width, const float p_clip_left, const float p_clip_right);
+	void _draw_vertical_line_clipped(CanvasItem *p_canvas_item, const Point2 &p_from, const float p_length, const Color &p_color, const float p_width, const float p_clip_left, const float p_clip_right);
+	void _draw_texture_region_clipped(CanvasItem *p_canvas_item, const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, const float p_clip_left, const float p_clip_right, const Color &p_modulate = Color(1, 1, 1));
+	String _make_text_clipped(const String &text, const Ref<Font> &font, const int font_size, const float max_width);
 
 public:
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
 	void draw_marker_lines(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
-	void draw_play_position(CanvasItem *p_canvas_item, const double p_time, const float p_height, const float p_clip_left, const float p_clip_right, const bool p_draw_head = false);
+	void draw_play_position(CanvasItem *p_canvas_item, const double p_time, const float p_height, const float p_clip_left, const float p_clip_right);
+	void draw_play_cursor(CanvasItem *p_canvas_item, const double p_time, const float p_clip_left, const float p_clip_right);
 
 protected:
 	static void _bind_methods();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -56,9 +56,17 @@ class ViewPanner;
 class EditorValidationPanel;
 
 struct SelectedKey {
-	int track = 0;
-	int key = 0;
-	bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; }
+	int track = -1;
+	int key = -1;
+	StringName id = StringName();
+
+	bool operator<(const SelectedKey &p_key) const {
+		if (key != -1) {
+			return track == p_key.track ? key < p_key.key : track < p_key.track;
+		} else if (id != StringName()) {
+			return track == p_key.track && id != p_key.id;
+		}
+	}
 };
 
 struct KeyInfo {

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -248,7 +248,7 @@ class AnimationTimelineEdit : public Range {
 	void _zoom_changed(double);
 	void _anim_length_changed(double p_new_len);
 	void _anim_loop_pressed();
-	void _play_position_draw();
+	void _play_cursor_draw();
 	void _track_added(int p_track);
 	float _get_zoom_scale(double p_zoom_value) const;
 	void _scroll_to_start();
@@ -505,7 +505,7 @@ protected:
 	// Marker manipulation methods
 	virtual void _clear_selection_for_anim(const Ref<Animation> &p_anim) override;
 	void _zoom_changed();
-	void _play_position_draw();
+	void _play_cursor_draw();
 	void _menu_selected(int p_index);
 	void _insert_marker(float p_ofs);
 	void _rename_marker(const StringName &p_name);
@@ -672,7 +672,7 @@ public:
 	void _zoom_changed();
 	void _menu_selected(int p_index);
 	void _path_submitted(const String &p_text);
-	void _play_position_draw();
+	void _play_cursor_draw();
 	bool _is_value_key_valid(const Variant &p_key_value, Variant::Type &r_valid_type) const;
 	bool _lookup_key(int p_key_idx) const;
 
@@ -979,8 +979,8 @@ public:
 	// Marker drawing methods
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
 	void draw_marker_lines(CanvasItem *p_canvas_item, const float p_height, float p_clip_left, float p_clip_right);
-	void draw_play_position(CanvasItem *p_canvas_item, const double p_time, const float p_height, const float p_clip_left, const float p_clip_right);
-	void draw_play_cursor(CanvasItem *p_canvas_item, const double p_time, const float p_clip_left, const float p_clip_right);
+	void draw_play_cursor(CanvasItem *p_canvas_item, const double p_time, const float p_height, const float p_clip_left, const float p_clip_right);
+	void draw_play_cursor_head(CanvasItem *p_canvas_item, const double p_time, const float p_clip_left, const float p_clip_right);
 
 	// Editor access and configuration
 	PropertySelector *get_prop_selector() { return prop_selector; }

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -356,6 +356,7 @@ public:
 
 protected:
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
+	virtual float get_key_y(const int p_index) const { return 0.0; }
 
 	// Helper
 public:
@@ -364,6 +365,8 @@ public:
 	Rect2 _to_global_key_rect(const int p_index, const Rect2 &p_local_rect, bool p_ignore_moving_selection = false) const;
 	Rect2 _to_local_key_rect(const int p_index, const Rect2 &p_global_rect, bool p_ignore_moving_selection) const;
 	void _draw_default_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right);
+
+	virtual String _get_tooltip(const int p_index) const { return ""; }
 
 public:
 	KeyEdit();
@@ -625,6 +628,7 @@ public:
 	NodePath get_path() const;
 	int get_track() const;
 	void set_track(const int p_track);
+	Animation::TrackType get_track_type() const;
 
 public:
 	virtual Ref<Texture2D> _get_key_type_icon() const override;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -522,6 +522,7 @@ public:
 	//helper
 	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region);
 	void draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled = true);
+	String make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
 
 	int get_track() const;
 	Ref<Animation> get_animation() const;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -345,8 +345,8 @@ public:
 	virtual void _move_selection_cancel() {}
 
 public:
-	virtual void try_select(const int p_index, bool p_is_single) = 0;
-	virtual void try_deselect(const int p_index) = 0;
+	virtual void _select_key(const int p_index, bool p_is_single) = 0;
+	virtual void _deselect_key(const int p_index) = 0;
 
 protected:
 	virtual int get_key_count() const = 0;
@@ -439,8 +439,11 @@ public:
 	virtual bool is_compressed() const = 0;
 	virtual Vector<int> get_selected_section() = 0;
 
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
 protected:
 	virtual void create_popup_menu(PopupMenu *p_menu, bool p_selected) {}
+	virtual void _on_pressed(const Ref<InputEvent> &p_event) {}
 	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) {}
 	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) {}
 	void show_popup_menu(Ref<InputEventMouseButton> &mb);
@@ -466,8 +469,6 @@ class AnimationMarkerEdit : public AnimationKeyEdit {
 	void _play_position_draw();
 
 	virtual void _clear_selection_for_anim(const Ref<Animation> &p_anim) override;
-	void _select_key(const StringName &p_name, bool is_single = false);
-	void _deselect_key(const StringName &p_name);
 
 	void _insert_marker(float p_ofs);
 	void _rename_marker(const StringName &p_name);
@@ -505,8 +506,6 @@ class AnimationMarkerEdit : public AnimationKeyEdit {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
-
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	virtual float get_key_width(const int p_index) const override;
@@ -548,8 +547,8 @@ public:
 	// For use by AnimationTrackEditor.
 	void _clear_selection(bool p_update);
 
-	virtual void try_select(const int p_index, bool is_single) override;
-	virtual void try_deselect(const int p_index) override;
+	virtual void _select_key(const int p_index, bool is_single) override;
+	virtual void _deselect_key(const int p_index) override;
 
 	virtual bool is_compressed() const override;
 
@@ -576,6 +575,7 @@ public:
 
 protected:
 	virtual void create_popup_menu(PopupMenu *p_menu, bool p_selected) override;
+	virtual void _on_pressed(const Ref<InputEvent> &p_event) override;
 	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) override;
 	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) override;
 
@@ -645,8 +645,6 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-
 	Node *get_root() const { return root; }
 
 public:
@@ -706,14 +704,20 @@ public:
 	void set_in_group(bool p_enable);
 	void append_to_selection(const Rect2 &p_box, bool p_deselection);
 
-	virtual void try_select(const int p_index, bool is_single) override;
-	virtual void try_deselect(const int p_index) override;
+	virtual void _select_key(const int p_index, bool is_single) override;
+	virtual void _deselect_key(const int p_index) override;
+
+	virtual void _move_selection_begin() override;
+	virtual void _move_selection(float p_offset) override;
+	virtual void _move_selection_commit() override;
+	virtual void _move_selection_cancel() override;
 
 public:
 	int _get_theme_font_height(float p_scale) const;
 
 protected:
 	virtual void create_popup_menu(PopupMenu *p_menu, bool p_selected) override;
+	virtual void _on_pressed(const Ref<InputEvent> &p_event) override;
 	virtual void _on_mouse_pressed(const Ref<InputEventMouseButton> &mb) override;
 	virtual void _on_mouse_unpressed(const Ref<InputEventMouseButton> &mb) override;
 
@@ -914,12 +918,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	bool moving_track_selection = false;
 	float moving_track_selection_offset = 0.0f;
-
-	void _move_selection_begin();
-	void _move_selection(float p_offset);
-	void _move_selection_commit();
-	void _move_selection_cancel();
-
+	
 	AnimationTrackKeyEdit *key_edit = nullptr;
 	AnimationMultiTrackKeyEdit *multi_key_edit = nullptr;
 	void _update_key_edit();
@@ -1052,6 +1051,12 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _update_snap_unit();
 
 public:
+	void _move_selection_begin();
+	void _move_selection(float p_offset);
+	void _move_selection_commit();
+	void _move_selection_cancel();
+
+public:
 	void _draw_rect_clipped(CanvasItem *p_canvas_item, const Rect2 &p_rect, const Color &p_color, bool p_filled, const float p_clip_left, const float p_clip_right);
 	void _draw_grid_clipped(CanvasItem *p_canvas_item, const Rect2 &p_rect, const Color &p_color, int p_raster_size, const float p_clip_left, const float p_clip_right);
 	void _draw_line_clipped(CanvasItem *p_canvas_item, const Point2 &p_from, const Point2 &p_to, const Color &p_color, const float p_width, const float p_clip_left, const float p_clip_right);
@@ -1076,8 +1081,9 @@ public:
 public:
 	// Public for use with callable_mp.
 	void _clear_selection(bool p_update = false);
-	void _key_selected(int p_key, bool p_single, int p_track);
-	void _key_deselected(int p_key, int p_track);
+
+	void _select_key(const int p_key, const bool p_single, const int p_track);
+	void _deselect_key(const int p_key, const int p_track);
 
 	enum {
 		EDIT_COPY_TRACKS,

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -367,7 +367,7 @@ protected:
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) = 0;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right);
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right) {}
-
+	
 	void draw_timeline(const float p_clip_left, const float p_clip_right);
 	void draw_edit_text(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right, const bool outside = false);
 
@@ -562,7 +562,6 @@ public:
 
 public:
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
-	void draw_marker_lines(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
 	
 	virtual StringName get_edit_name(const int p_index) const override; //name of the key
 
@@ -1049,7 +1048,7 @@ public:
 
 public:
 	void draw_marker_section(CanvasItem *p_canvas_item, const float p_clip_left, const float p_clip_right);
-	void draw_marker_lines(CanvasItem *p_canvas_item, float p_clip_left, float p_clip_right);
+	void draw_marker_lines(CanvasItem *p_canvas_item, const float p_height, float p_clip_left, float p_clip_right);
 	void draw_play_position(CanvasItem *p_canvas_item, const double p_time, const float p_height, const float p_clip_left, const float p_clip_right);
 	void draw_play_cursor(CanvasItem *p_canvas_item, const double p_time, const float p_clip_left, const float p_clip_right);
 
@@ -1164,6 +1163,7 @@ public:
 	int get_track_count() const;
 	int get_track_key_count(const int p_track) const;
 	double get_global_time(const float p_time) const;
+	double get_track_key_time(const int track, const int p_index) const;
 
 	/** If `p_from_mouse_event` is `true`, handle Shift key presses for precise snapping. */
 	void goto_prev_step(bool p_from_mouse_event);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -55,6 +55,20 @@ class TextureRect;
 class ViewPanner;
 class EditorValidationPanel;
 
+class AnimationTrackDrawUtils : public Object {
+	GDCLASS(AnimationTrackDrawUtils, Object);
+
+public:
+	CanvasItem *canvas_item;
+
+public:
+	void _draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
+	void _draw_line_clipped(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
+	void _draw_vertical_line_clipped(const Point2 &p_from, float p_length, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
+	void _draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
+	String _make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
+};
+
 class AnimationTrackKeyEdit : public Object {
 	GDCLASS(AnimationTrackKeyEdit, Object);
 
@@ -372,19 +386,20 @@ protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
+	Rect2 get_global_key_rect(int p_index, float p_pixels_sec, int p_x) const;
+
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual int get_key_width() const;
-	virtual int get_key_height() const;
-	virtual Rect2 get_key_rect(float p_pixels_sec) const;
-	virtual Rect2 get_global_key_rect(float p_pixels_sec, int p_x) const;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) const;
 	virtual bool is_key_selectable_by_distance() const;
-	virtual void draw_key(const StringName &p_name, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
+	virtual void draw_key(const StringName &p_name, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual void draw_bg(int p_clip_left, int p_clip_right);
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
 
-	//helper
-	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
+	// helper
+	float _get_pixels_sec(int p_index) const;
 
 	Ref<Animation> get_animation() const;
 	AnimationTimelineEdit *get_timeline() const { return timeline; }
@@ -409,6 +424,10 @@ public:
 	// For use by AnimationTrackEditor.
 	void _clear_selection(bool p_update);
 
+public:
+	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
+
+public:
 	AnimationMarkerEdit();
 };
 
@@ -518,21 +537,14 @@ public:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
-	virtual int get_key_width() const;
-	virtual int get_key_height() const;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec);
 	virtual bool is_key_selectable_by_distance() const;
 	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right);
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual void draw_bg(int p_clip_left, int p_clip_right);
 	virtual void draw_fg(int p_clip_left, int p_clip_right);
-
-	//helper
-	void draw_texture_region_clipped(const Ref<Texture2D> &p_texture, const Rect2 &p_rect, const Rect2 &p_region, int p_clip_left, int p_clip_right, const Color &p_modulate = Color(1, 1, 1));
-	void draw_rect_clipped(const Rect2 &p_rect, const Color &p_color, bool p_filled, int p_clip_left, int p_clip_right);
-	void draw_line_clipped(const Point2 &p_from, const Point2 &p_to, const Color &p_color, float p_width, int p_clip_left, int p_clip_right);
-	String make_text_clipped(const String &text, const Ref<Font> &font, int font_size, float max_width);
-	int _get_theme_font_height(float p_scale) const;
 
 	int get_track() const;
 	Ref<Animation> get_animation() const;
@@ -553,6 +565,12 @@ public:
 	void set_in_group(bool p_enable);
 	void append_to_selection(const Rect2 &p_box, bool p_deselection);
 
+public:
+	AnimationTrackDrawUtils *animationTrackDrawUtils = nullptr;
+	int _get_theme_font_height(float p_scale) const;
+	float _get_pixels_sec(int p_index) const;
+
+public:
 	AnimationTrackEdit();
 };
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -55,6 +55,17 @@ class TextureRect;
 class ViewPanner;
 class EditorValidationPanel;
 
+struct SelectedKey {
+	int track = 0;
+	int key = 0;
+	bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; }
+};
+
+struct KeyInfo {
+	float pos = 0;
+	Variant data;
+};
+
 class AnimationTrackKeyEdit : public Object {
 	GDCLASS(AnimationTrackKeyEdit, Object);
 
@@ -306,15 +317,19 @@ protected:
 
 	bool moving_selection_attempt = false;
 	bool moving_selection_effective = false;
-	float moving_selection_offset = 0.0f;
 	float moving_selection_pivot = 0.0f;
 	float moving_selection_mouse_begin_x = 0.0f;
 	float moving_selection_mouse_begin_y = 0.0f;
+
+protected:
 	bool moving_selection = false;
+	float moving_selection_offset = 0.0f;
 
 public:
 	virtual bool is_moving_selection() const;
+	virtual void set_moving_selection(bool p_value);
 	virtual float get_moving_selection_offset() const;
+	virtual void set_moving_selection_offset(float p_value);
 
 public:
 	virtual void _move_selection_begin() {}
@@ -386,17 +401,6 @@ public:
 
 	bool _try_select_at_ui_pos(const Point2 &p_pos, bool p_aggregate, bool p_deselectable);
 	bool _is_ui_pos_in_current_section(const Point2 &p_pos);
-
-	struct SelectedKey {
-		int track = 0;
-		int key = 0;
-		bool operator<(const SelectedKey &p_key) const { return track == p_key.track ? key < p_key.key : track < p_key.track; }
-	};
-
-	struct KeyInfo {
-		float pos = 0;
-		Variant data;
-	};
 
 	RBMap<SelectedKey, KeyInfo> selection;
 
@@ -874,10 +878,10 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);
 	void _select_at_anim(const Ref<Animation> &p_anim, int p_track, float p_pos);
 
-	RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> selection;
+	RBMap<SelectedKey, KeyInfo> selection;
 
-	bool moving_selection = false;
-	float moving_selection_offset = 0.0f;
+	bool moving_track_selection = false;
+	float moving_track_selection_offset = 0.0f;
 
 	void _move_selection_begin();
 	void _move_selection(float p_offset);
@@ -1004,7 +1008,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Vector<TrackClipboard> track_clipboard;
 	KeyClipboard key_clipboard;
 
-	void _set_key_clipboard(int p_top_track, float p_top_time, RBMap<AnimationKeyEdit::SelectedKey, AnimationKeyEdit::KeyInfo> &p_keymap);
+	void _set_key_clipboard(int p_top_track, float p_top_time, RBMap<SelectedKey, KeyInfo> &p_keymap);
 	void _insert_animation_key(NodePath p_path, const Variant &p_value);
 
 	void _pick_track_filter_text_changed(const String &p_newtext);
@@ -1104,7 +1108,9 @@ public:
 	bool is_key_selected(const int p_track, const int p_key) const;
 	bool is_selection_active() const;
 	bool is_track_moving_selection() const;
+	void set_track_moving_selection(bool p_value);
 	float get_track_moving_selection_offset() const;
+	void set_track_moving_selection_offset(float p_value);
 	bool is_marker_selection_active() const;
 	bool is_key_clipboard_active() const;
 	bool is_snap_timeline_enabled() const;

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -66,6 +66,7 @@ struct SelectedKey {
 		} else if (id != StringName()) {
 			return track == p_key.track && id != p_key.id;
 		}
+		return false;
 	}
 };
 
@@ -667,10 +668,10 @@ public:
 	virtual Vector<int> get_selected_section() override;
 
 public:
-	virtual bool is_moving_selection() const;
-	virtual void set_moving_selection(bool p_value);
-	virtual float get_moving_selection_offset() const;
-	virtual void set_moving_selection_offset(float p_value);
+	virtual bool is_moving_selection() const override;
+	virtual void set_moving_selection(bool p_value) override;
+	virtual float get_moving_selection_offset() const override;
+	virtual void set_moving_selection_offset(float p_value) override;
 
 protected:
 	NodePath node_path;

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -326,6 +326,16 @@ Rect2 AnimationTrackEditSpriteFrame::_create_texture_region_sprite(int p_index, 
 	return region;
 }
 
+Rect2 AnimationTrackEditSpriteFrame::_create_region_animated_sprite(int p_index, Object *object, const Ref<Texture2D> texture) const {
+	Rect2 region;
+
+	if (texture.is_valid()) {
+		region.size = texture->get_size();
+	}
+
+	return region;
+}
+
 void AnimationTrackEditSpriteFrame::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Object *object = ObjectDB::get_instance(get_node_id());
 	Ref<Resource> resource = get_resource(p_index);

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -47,22 +47,22 @@
 AnimationTrackEditBool::AnimationTrackEditBool() {
 }
 
-int AnimationTrackEditBool::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditBool::get_key_width(int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_width();
 }
 
-int AnimationTrackEditBool::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditBool::get_key_height(int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_height();
 }
 
-Rect2 AnimationTrackEditBool::get_key_rect(int p_index, float p_pixels_sec) {
-	return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+Rect2 AnimationTrackEditBool::get_key_rect(int p_index) {
+	return AnimationTrackEdit::get_key_rect(p_index);
 }
 
 void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
+	Rect2 rect = get_global_key_rect(p_index);
 
 	if (rect.size.is_zero_approx()) {
 		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
@@ -95,22 +95,22 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 AnimationTrackEditColor::AnimationTrackEditColor() {
 }
 
-int AnimationTrackEditColor::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditColor::get_key_width(int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
-int AnimationTrackEditColor::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditColor::get_key_height(int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
-Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
-	return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+Rect2 AnimationTrackEditColor::get_key_rect(int p_index) {
+	return AnimationTrackEdit::get_key_rect(p_index);
 }
 
 void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
 
-	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
+	Rect2 rect = get_global_key_rect(p_index);
 
 	animationTrackDrawUtils->_draw_grid_clipped(rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
 
@@ -121,7 +121,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
-	int fh = get_key_height(p_index, p_pixels_sec);
+	int fh = get_key_height(p_index);
 
 	fh /= 3;
 
@@ -190,17 +190,17 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
 }
 
-int AnimationTrackEditSpriteFrame::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditSpriteFrame::get_key_width(int p_index) const {
 	return _get_theme_font_height(2.0);
 }
 
-int AnimationTrackEditSpriteFrame::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditSpriteFrame::get_key_height(int p_index) const {
 	return _get_theme_font_height(2.0);
 }
 
-Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
-	int width = get_key_width(p_index, p_pixels_sec);
-	int height = get_key_height(p_index, p_pixels_sec);
+Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index) {
+	int width = get_key_width(p_index);
+	int height = get_key_height(p_index);
 	Rect2 rect = Rect2(0, -height / 2, width, height);
 
 	return rect;
@@ -307,7 +307,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		region = _create_region_animated_sprite(p_index, object, texture);
 	}
 
-	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
+	Rect2 rect = get_global_key_rect(p_index);
 
 	if (rect.position.x + rect.size.x < p_clip_left) {
 		return;
@@ -337,11 +337,11 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
 }
 
-int AnimationTrackEditSubAnim::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditSubAnim::get_key_width(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditSubAnim::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditSubAnim::get_key_height(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -412,12 +412,12 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
 }
 
-int AnimationTrackEditVolumeDB::get_key_width(int p_index, float p_pixels_sec) const {
-	return AnimationTrackEdit::get_key_width(p_index, p_pixels_sec);
+int AnimationTrackEditVolumeDB::get_key_width(int p_index) const {
+	return AnimationTrackEdit::get_key_width(p_index);
 }
 
-int AnimationTrackEditVolumeDB::get_key_height(int p_index, float p_pixels_sec) const {
-	return AnimationTrackEdit::get_key_height(p_index, p_pixels_sec);
+int AnimationTrackEditVolumeDB::get_key_height(int p_index) const {
+	return AnimationTrackEdit::get_key_height(p_index);
 }
 
 void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -477,11 +477,11 @@ AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
-int AnimationTrackEditTypeAudio::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditTypeAudio::get_key_width(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditTypeAudio::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditTypeAudio::get_key_height(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -541,11 +541,11 @@ AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
-int AnimationTrackEditAudio::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditAudio::get_key_width(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditAudio::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditAudio::get_key_height(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -588,11 +588,11 @@ AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
-int AnimationTrackEditTypeAnimation::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditTypeAnimation::get_key_width(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditTypeAnimation::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditTypeAnimation::get_key_height(int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -679,37 +679,39 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
 
 /// KEY ///
 
-int AnimationTrackEditKey::get_key_width(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditKey::get_key_width(int p_index) const {
 	return _get_theme_font_height(1.0);
 }
 
-int AnimationTrackEditKey::get_key_height(int p_index, float p_pixels_sec) const {
+int AnimationTrackEditKey::get_key_height(int p_index) const {
 	return _get_theme_font_height(1.0);
 }
 
-Rect2 AnimationTrackEditKey::get_key_rect(int p_index, float p_pixels_sec) {
+Rect2 AnimationTrackEditKey::get_key_rect(int p_index) {
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+		return AnimationTrackEdit::get_key_rect(p_index);
 	}
 
 	StringName edit_name = get_edit_name(p_index);
 	if (edit_name.is_empty() || edit_name == "[stop]") {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+		return AnimationTrackEdit::get_key_rect(p_index);
 	}
 
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 	float len = get_length(p_index);
 
-	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, 0);
-	int height = get_key_height(p_index, p_pixels_sec);
+	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, 0);
+	int height = get_key_height(p_index);
 
 	return Rect2(region.x, 0, region.y, height);
 }
 
-int AnimationTrackEditKey::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right) {
-	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
+int AnimationTrackEditKey::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right) {
+	float p_x = ((get_animation()->track_get_key_time(get_track(), p_index) - get_timeline()->get_value()) * get_timeline()->get_zoom_scale()) + get_timeline()->get_name_limit();
+
+	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_x);
 	region = clip_key_region(region, p_clip_left, p_clip_right);
 
 	int region_begin = region.x;
@@ -770,12 +772,10 @@ void AnimationTrackEditKey::gui_input(const Ref<InputEvent> &p_event) {
 
 			float start_ofs = get_start_offset(p_index);
 			float end_ofs = get_end_offset(p_index);
-			float p_x = ((get_animation()->track_get_key_time(get_track(), p_index) - get_timeline()->get_value()) * get_timeline()->get_zoom_scale()) + get_timeline()->get_name_limit();
-			float p_pixels_sec = get_timeline()->get_zoom_scale();
 			float p_clip_left = get_timeline()->get_name_limit();
 			float p_clip_right = get_size().width - get_timeline()->get_buttons_width();
 
-			int resizing_index = handle_track_resizing(mm, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_clip_left, p_clip_right);
+			int resizing_index = handle_track_resizing(mm, start_ofs, end_ofs, len, p_index, p_clip_left, p_clip_right);
 			if (resizing_index != -1) {
 				use_hsize_cursor = true;
 				len_resizing_index = resizing_index;
@@ -985,7 +985,7 @@ StringName AnimationTrackEditKey::get_edit_name(const int p_index) {
 	return resource_name;
 }
 
-Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x) {
+Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) {
 	float anim_len = len - start_ofs - end_ofs;
 	if (anim_len < 0) {
 		WARN_PRINT("anim_len < 0");
@@ -997,8 +997,9 @@ Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const floa
 			anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 		}
 	}
-
-	float pixel_len = anim_len * p_pixels_sec;
+	float scale = get_timeline()->get_zoom_scale();
+	//float pixels_sec = _get_pixels_sec(p_index);
+	float pixel_len = anim_len * scale;
 	float pixel_begin = p_x;
 	float pixel_end = p_x + pixel_len;
 
@@ -1021,7 +1022,7 @@ bool AnimationTrackEditKey::is_key_region_outside(const Vector2 &region, int p_c
 }
 
 void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Vector2 orig_region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
+	Vector2 orig_region = calc_key_region(start_ofs, end_ofs, len, p_index, p_x);
 
 	bool is_outside = is_key_region_outside(orig_region, p_clip_left, p_clip_right);
 	if (is_outside) {
@@ -1034,7 +1035,7 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 	int region_end = region.y;
 	int region_width = region.y - region.x;
 
-	Rect2 key_rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
+	Rect2 key_rect = get_global_key_rect(p_index);
 
 	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -497,7 +497,7 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 	int y_from = (get_size().height - tex_h) / 2;
 
 	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
-	color.a *= 0.7;
+	color.a *= REGION_EDGE_ALPHA;
 
 	draw_line(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2);
 }
@@ -815,21 +815,20 @@ void AnimationTrackEditKey::gui_input(const Ref<InputEvent> &p_event) {
 			float new_ofs = prev_ofs + ofs_local;
 			float new_time = prev_time + ofs_local;
 			if (prev_time != new_time) {
-				undo_redo->create_action(TTR("Change Animation Track Clip Start Offset"));
-
-				undo_redo->add_do_method(get_animation().ptr(), "track_set_key_time", get_track(), len_resizing_index, new_time);
-				undo_redo->add_undo_method(get_animation().ptr(), "track_set_key_time", get_track(), len_resizing_index, prev_time);
-
+				undo_redo->create_action(TTR("Change Track Clip Start Offset"));
 				set_start_offset(len_resizing_index, prev_ofs, new_ofs);
-
 				undo_redo->commit_action();
+
+				emit_signal(SNAME("move_selection_begin"));
+				emit_signal(SNAME("move_selection"), ofs_local);
+				emit_signal(SNAME("move_selection_commit"));
 			}
 		} else {
 			float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
 			float prev_ofs = get_end_offset(len_resizing_index);
 			float new_ofs = prev_ofs + ofs_local;
 			if (prev_ofs != new_ofs) {
-				undo_redo->create_action(TTR("Change Animation Track Clip End Offset"));
+				undo_redo->create_action(TTR("Change Track Clip End Offset"));
 
 				set_end_offset(len_resizing_index, prev_ofs, new_ofs);
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -30,8 +30,8 @@
 
 #include "animation_track_editor_plugins.h"
 
-#include "editor/audio_stream_preview.h"
 #include "editor/animation_preview.h"
+#include "editor/audio_stream_preview.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
@@ -657,7 +657,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 	draw_rect(rect, bg);
 
 	Ref<Animation> anim = ap->get_animation(anim_name);
-		
+
 	Vector<Vector2> points;
 	Vector<Color> colors = { color };
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -812,7 +812,7 @@ int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotio
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 
-	float offset = _get_pixels_sec(p_index, true);
+	float offset = get_global_move_key_time(p_index, true);
 	Region region = _calc_key_region(p_index, start_ofs, end_ofs, len, offset);
 	region = _clip_key_region(region, p_clip_left, p_clip_right);
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -45,16 +45,7 @@
 /// BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
-}
-
-bool AnimationTrackEditBool::is_key_selectable_by_distance() const {
-	return false;
-}
-
-void AnimationTrackEditBool::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-}
-
-void AnimationTrackEditBool::_preview_changed(ObjectID p_which) {
+	font_scl = 1.0;
 }
 
 int AnimationTrackEditBool::get_key_height() const {
@@ -91,54 +82,20 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 /// COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
-}
-
-bool AnimationTrackEditColor::is_key_selectable_by_distance() const {
-	return false;
-}
-
-void AnimationTrackEditColor::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-}
-
-void AnimationTrackEditColor::_preview_changed(ObjectID p_which) {
-}
-
-int AnimationTrackEditColor::get_key_height() const {
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return font->get_height(font_size) * 0.8;
+	font_scl = 0.8;
 }
 
 Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = font->get_height(font_size) * 0.8;
+	int fh = get_key_height();
 	return Rect2(-fh / 2, 0, fh, get_size().height);
 }
 
 /// VOLUME DB ///
 
-AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
-}
-
-bool AnimationTrackEditVolumeDB::is_key_selectable_by_distance() const {
-	return false;
-}
-
-void AnimationTrackEditVolumeDB::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-}
-
-void AnimationTrackEditVolumeDB::_preview_changed(ObjectID p_which) {
-}
-
-Rect2 AnimationTrackEditVolumeDB::get_key_rect(int p_index, float p_pixels_sec) {
-	return get_key_rect_region(0.0, 0.0, 0.0, p_index, p_pixels_sec);
-}
-
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = (font->get_height(font_size) * 0.8);
+	int fh = (font->get_height(font_size) * font_scl);
 
 	fh /= 3;
 
@@ -207,7 +164,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = font->get_height(font_size) * 0.8;
+	int fh = font->get_height(font_size) * font_scl;
 
 	Rect2 rect(Vector2(p_x - fh / 2, int(get_size().height - fh) / 2), Size2(fh, fh));
 
@@ -223,101 +180,10 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 	}
 }
 
-/// AUDIO ///
-
-bool AnimationTrackEditAudio::is_key_selectable_by_distance() const {
-	return false;
-}
-
-void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
-	Object *object = ObjectDB::get_instance(id);
-
-	if (!object) {
-		return;
-	}
-
-	Ref<Resource> resource = object->call("get_stream");
-
-	if (resource.is_valid() && resource->get_instance_id() == p_which) {
-		queue_redraw();
-	}
-}
-
-int AnimationTrackEditAudio::get_key_height() const {
-	if (!ObjectDB::get_instance(id)) {
-		return AnimationTrackEdit::get_key_height();
-	}
-
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * 1.5);
-}
-
-void AnimationTrackEditAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(resource);
-	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
-}
-
-void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Ref<Resource> resource = get_resource(p_index);
-
-	if (resource.is_null()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
-	bool play = get_animation()->track_get_key_value(get_track(), p_index);
-	if (!play) {
-		Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-		int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-		int fh = font->get_height(font_size) * 0.8;
-		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
-
-		Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
-		draw_rect_clipped(rect, color);
-
-		if (p_selected) {
-			Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-			draw_rect_clipped(rect, accent, false);
-		}
-
-		return;
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	draw_key_region(resource, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-}
-
-AnimationTrackEditAudio::AnimationTrackEditAudio() {
-	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
-}
-
 /// SPRITE FRAME / FRAME_COORDS ///
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
-}
-
-bool AnimationTrackEditSpriteFrame::is_key_selectable_by_distance() const {
-	return false;
-}
-
-void AnimationTrackEditSpriteFrame::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-}
-
-void AnimationTrackEditSpriteFrame::_preview_changed(ObjectID p_which) {
-}
-
-int AnimationTrackEditSpriteFrame::get_key_height() const {
-	if (!ObjectDB::get_instance(id)) {
-		return AnimationTrackEdit::get_key_height();
-	}
-
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * 2);
+	font_scl = 2.0;
 }
 
 Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
@@ -506,39 +372,12 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 /// SUB ANIMATION ///
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
-}
-
-int AnimationTrackEditSubAnim::get_key_height() const {
-	if (!ObjectDB::get_instance(id)) {
-		return AnimationTrackEdit::get_key_height();
-	}
-
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * 1.5);
+	font_scl = 1.5;
 }
 
 void AnimationTrackEditSubAnim::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	Ref<AnimationPreview> preview = AnimationPreviewGenerator::get_singleton()->generate_preview(resource);
 	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
-}
-
-void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (!resource.is_valid()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	draw_key_region(resource, 0.0, 0.0, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-}
-
-bool AnimationTrackEditSubAnim::is_key_selectable_by_distance() const {
-	return false;
 }
 
 void AnimationTrackEditSubAnim::_preview_changed(ObjectID p_which) {
@@ -559,11 +398,54 @@ void AnimationTrackEditSubAnim::_preview_changed(ObjectID p_which) {
 	}
 }
 
+Ref<Resource> AnimationTrackEditSubAnim::get_resource(const int p_index) {
+	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
+
+	if (String(anim_name) == "[stop]") {
+		return nullptr;
+	}
+
+	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
+	if (!ap || !ap->has_animation(anim_name)) {
+		return nullptr;
+	}
+
+	Ref<Animation> anim = ap->get_animation(anim_name);
+	if (!anim.is_valid()) {
+		return nullptr;
+	}
+
+	return anim;
+}
+
+float AnimationTrackEditSubAnim::get_length(const int p_index) {
+	Ref<Resource> resource = get_resource(p_index);
+	if (resource.is_valid()) {
+		Ref<Animation> anim = resource;
+		return anim->get_length();
+	}
+
+	return AnimationTrackEditBase::get_length(p_index);
+}
+
+StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
+	StringName edit_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
+	if (!edit_name.is_empty()) {
+		return edit_name;
+	}
+
+	return AnimationTrackEditBase::get_edit_name(p_index);
+}
+
 //// VOLUME DB ////
+
+AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
+	font_scl = 1.2;
+}
 
 int AnimationTrackEditVolumeDB::get_key_height() const {
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
-	return volume_texture->get_height() * 1.2;
+	return volume_texture->get_height() * font_scl;
 }
 
 void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -632,340 +514,15 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 	draw_line(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2);
 }
 
-////////////////////////
-
-/// ANIMATION ///
-
-AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
-	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
-}
-
-void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
-	AnimationTrackEditClip::_preview_changed(p_which);
-}
-
-bool AnimationTrackEditTypeAnimation::is_key_selectable_by_distance() const {
-	return false;
-}
-
-bool AnimationTrackEditClip::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
-		Dictionary drag_data = p_data;
-		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-			Ref<Resource> res = drag_data["resource"];
-			if (res.is_valid()) {
-				return true;
-			}
-		}
-
-		if (drag_data.has("type") && String(drag_data["type"]) == "files") {
-			Vector<String> files = drag_data["files"];
-
-			if (files.size() == 1) {
-				Ref<Resource> res = ResourceLoader::load(files[0]);
-				if (res.is_valid()) {
-					return true;
-				}
-			}
-		}
-	}
-
-	return AnimationTrackEdit::can_drop_data(p_point, p_data);
-}
-
-void AnimationTrackEditClip::drop_data(const Point2 &p_point, const Variant &p_data) {
-	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
-		Ref<Resource> resource;
-		Dictionary drag_data = p_data;
-		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
-			resource = drag_data["resource"];
-		} else if (drag_data.has("type") && String(drag_data["type"]) == "files") {
-			Vector<String> files = drag_data["files"];
-
-			if (files.size() == 1) {
-				resource = ResourceLoader::load(files[0]);
-			}
-		}
-
-		if (resource.is_valid()) {
-			int x = p_point.x - get_timeline()->get_name_limit();
-			float ofs = x / get_timeline()->get_zoom_scale();
-			ofs += get_timeline()->get_value();
-
-			ofs = get_editor()->snap_time(ofs);
-
-			while (get_animation()->track_find_key(get_track(), ofs, Animation::FIND_MODE_APPROX) != -1) { //make sure insertion point is valid
-				ofs += 0.0001;
-			}
-
-			apply_data(resource, ofs);
-
-			queue_redraw();
-			return;
-		}
-	}
-
-	AnimationTrackEdit::drop_data(p_point, p_data);
-}
-
-int AnimationTrackEditTypeAudio::get_key_height() const {
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * 1.5);
-}
-
-Rect2 AnimationTrackEditAudio::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Resource> resource = get_resource(p_index);
-
-	if (resource.is_null()) {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-	}
-
-	bool value = get_animation()->track_get_key_value(get_track(), p_index);
-	if (!value) {
-		Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-		int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-		int fh = font->get_height(font_size) * 0.8;
-		return Rect2(0, 0, fh, get_size().height);
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
-}
-
-Rect2 AnimationTrackEditTypeAudio::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Resource> resource = get_resource(p_index);
-
-	if (resource.is_null()) {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
-}
-
-void AnimationTrackEditBase::set_node(Object *p_object) {
-	id = p_object->get_instance_id();
-}
-
-Rect2 AnimationTrackEditBase::get_key_rect_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec) {
-	Vector2 region = calc_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, 0);
-	return Rect2(region.x, 0, region.y, get_size().height);
-}
-
-void AnimationTrackEditTypeAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(resource);
-	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
-}
-
-void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (resource.is_null()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right); // Draw diamond.
-		return;
-	}
-
-	float len = get_length(p_index);
-	if (len == 0) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right); // Draw diamond.
-		return;
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-
-	draw_key_region(resource, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-}
-
-void AnimationTrackEditClip::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	float diff_start_ofs = 0;
-	float diff_end_ofs = 0;
-
-	if (len_resizing && p_index == len_resizing_index) {
-		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
-		if (len_resizing_start) {
-			diff_start_ofs = ofs_local;
-		} else {
-			diff_end_ofs = -ofs_local;
-		}
-	}
-
-	AnimationTrackEditBase::draw_key_region(resource, start_ofs + diff_start_ofs, end_ofs + diff_end_ofs, len, p_index, p_pixels_sec, p_x + (diff_start_ofs * p_pixels_sec), p_selected, p_clip_left, p_clip_right);
-}
-
-StringName AnimationTrackEditBase::get_edit_name(const int p_index) {
-	String resource_name = "null";
-	Ref<Resource> resource = get_resource(p_index);
-	if (resource.is_valid()) {
-		if (resource->get_path().is_resource_file()) {
-			resource_name = resource->get_path().get_file();
-		} else if (!resource->get_name().is_empty()) {
-			resource_name = resource->get_name();
-		} else {
-			resource_name = resource->get_class();
-		}
-	}
-	return resource_name;
-}
-
-Vector2 AnimationTrackEditBase::calc_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x) {
-	float anim_len = len - start_ofs - end_ofs;
-	if (anim_len < 0) {
-		WARN_PRINT("anim_len < 0");
-		anim_len = 0;
-	}
-
-	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-		anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
-	}
-
-	float pixel_len = anim_len * p_pixels_sec;
-	float pixel_begin = p_x;
-	float pixel_end = p_x + pixel_len;
-
-	return Vector2(pixel_begin, pixel_end);
-}
-
-Vector2 AnimationTrackEditBase::clip_region(Vector2 &region, int p_clip_left, int p_clip_right) {
-	float offset_x = region.x;
-	float offset_y = region.y;
-
-	region.y = CLAMP(region.y, MAX(region.x, p_clip_left), p_clip_right);
-	region.x = CLAMP(region.x, p_clip_left, MIN(region.y, p_clip_right));
-
-	return Vector2(region.x - offset_x, region.y - offset_y);
-}
-
-bool AnimationTrackEditBase::is_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right) {
-	return (region.y < p_clip_left || region.x > p_clip_right);
-}
-
-void AnimationTrackEditBase::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Vector2 region = calc_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
-	int orig_region_width = region.y - region.x;
-
-	bool is_outside = is_region_outside(region, p_clip_left, p_clip_right);
-	if (is_outside) {
-		return;
-	}
-
-	Vector2 region_shift = clip_region(region, p_clip_left, p_clip_right);
-
-	int region_begin = region.x;
-	int region_end = region.y;
-	int region_width = region.y - region.x;
-
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int h = get_size().height;
-	float fh = int(font->get_height(font_size) * 1.5);
-
-	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-
-	float thickness = 4;
-	if (orig_region_width <= thickness) {
-		Rect2 rect2 = Rect2(region_begin, (h - fh) / 2, thickness, fh);
-		draw_rect(rect2, accent_color);
-
-		if (p_selected) {
-			draw_rect(rect2, accent_color, false);
-		}
-
-		return;
-	}
-
-	Color bg_color = Color(0.25, 0.25, 0.25);
-	Rect2 rect = Rect2(region_begin, (h - fh) / 2, region_width, fh);
-	draw_rect(rect, bg_color);
-
-	Vector<Vector2> points;
-	points.resize(region_width * 2);
-
-	Vector<Color> colors;
-	if (p_selected) {
-		colors = { Color(0.75, 0.75, 0.75) };
-	} else {
-		colors = { bg_color.lightened(0.2) };
-	}
-
-	float shift_ofs = region_shift.x / p_pixels_sec;
-	create_key_region(resource, points, rect, p_pixels_sec, start_ofs + shift_ofs);
-
-	if (!points.is_empty()) {
-		draw_multiline_colors(points, colors);
-	}
-
-	Color edge_color = Color(accent_color);
-	edge_color.a = 0.7;
-	if (start_ofs > 0 && region_begin > p_clip_left) {
-		draw_rect(Rect2(region_begin, rect.position.y, 1, rect.size.y), edge_color);
-	}
-	if (end_ofs > 0 && region_end < p_clip_right) {
-		draw_rect(Rect2(region_end, rect.position.y, 1, rect.size.y), edge_color);
-	}
-
-	if (region_width > thickness) {
-		StringName edit_name = get_edit_name(p_index);
-		if (!edit_name.is_empty()) {
-			Color name_color;
-			if (p_selected) {
-				name_color = Color(accent_color);
-				name_color.a = 0.0;
-			} else {
-				Color font_color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
-				name_color = font_color;
-			}
-
-			float max_width = region_width - 2;
-
-			String clipped_edit_name = edit_name;
-			if (font->get_string_size(String(clipped_edit_name), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x > max_width) {
-				while (!clipped_edit_name.is_empty() && font->get_string_size(String(clipped_edit_name + "..."), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x > max_width) {
-					clipped_edit_name = clipped_edit_name.substr(0, clipped_edit_name.length() - 1);
-				}
-				clipped_edit_name += "...";
-			}
-
-			int f_h = int(h - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
-			draw_string(font, Point2(region_begin + 2, f_h), clipped_edit_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
-		}
-	}
-
-	if (p_selected) {
-		draw_rect(rect, accent_color, false);
-	}
-}
-
-void AnimationTrackEditClip::_preview_changed(ObjectID p_which) {
-	for (int p_index = 0; p_index < get_animation()->track_get_key_count(get_track()); p_index++) {
-		Ref<Resource> resource = get_resource(p_index);
-		if (resource.is_valid() && resource->get_instance_id() == p_which) {
-			queue_redraw();
-			return;
-		}
-	}
-}
-
-////////////////////////
-
 /// AUDIO ///
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
+	font_scl = 1.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
 void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
-	AnimationTrackEditClip::_preview_changed(p_which);
-}
-
-bool AnimationTrackEditTypeAudio::is_key_selectable_by_distance() const {
-	return false;
+	AnimationTrackEditBase::_preview_changed(p_which);
 }
 
 void AnimationTrackEditTypeAudio::apply_data(const Ref<Resource> resource, const float ofs) {
@@ -976,6 +533,96 @@ void AnimationTrackEditTypeAudio::apply_data(const Ref<Resource> resource, const
 	undo_redo->add_do_method(get_animation().ptr(), "audio_track_insert_key", get_track(), ofs, stream);
 	undo_redo->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), ofs);
 	undo_redo->commit_action();
+}
+
+Ref<Resource> AnimationTrackEditTypeAudio::get_resource(const int p_index) {
+	return get_animation()->audio_track_get_key_stream(get_track(), p_index);
+}
+
+float AnimationTrackEditTypeAudio::get_start_offset(const int p_index) {
+	return get_animation()->audio_track_get_key_start_offset(get_track(), p_index);
+}
+
+float AnimationTrackEditTypeAudio::get_end_offset(const int p_index) {
+	return get_animation()->audio_track_get_key_end_offset(get_track(), p_index);
+}
+
+float AnimationTrackEditTypeAudio::get_length(const int p_index) {
+	Ref<Resource> resource = get_resource(p_index);
+	if (resource.is_valid()) {
+		Ref<AudioStream> stream = resource;
+		return stream->get_length();
+	}
+
+	return AnimationTrackEditBase::get_length(p_index);
+}
+
+void AnimationTrackEditTypeAudio::set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, new_ofs);
+	undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
+}
+
+void AnimationTrackEditTypeAudio::set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, new_ofs);
+	undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
+}
+
+/// AUDIO ///
+
+AnimationTrackEditAudio::AnimationTrackEditAudio() {
+	font_scl = 1.5;
+	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
+}
+
+void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
+	Object *object = ObjectDB::get_instance(id);
+
+	if (!object) {
+		return;
+	}
+
+	Ref<Resource> resource = object->call("get_stream");
+
+	if (resource.is_valid() && resource->get_instance_id() == p_which) {
+		queue_redraw();
+	}
+}
+
+void AnimationTrackEditAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(resource);
+	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
+}
+
+Ref<Resource> AnimationTrackEditAudio::get_resource(const int p_index) {
+	return get_animation()->audio_track_get_key_stream(get_track(), p_index);
+}
+
+float AnimationTrackEditAudio::get_length(const int p_index) {
+	Ref<Resource> resource = get_resource(p_index);
+	if (resource.is_valid()) {
+		Ref<AudioStream> stream = resource;
+		return stream->get_length();
+	}
+
+	return AnimationTrackEditBase::get_length(p_index);
+}
+
+/// TYPE ANIMATION ///
+
+AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
+	font_scl = 1.5;
+	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
+}
+
+void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
+	AnimationTrackEditBase::_preview_changed(p_which);
+}
+
+void AnimationTrackEditTypeAnimation::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+	Ref<AnimationPreview> preview = AnimationPreviewGenerator::get_singleton()->generate_preview(resource);
+	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
 }
 
 void AnimationTrackEditTypeAnimation::apply_data(const Ref<Resource> resource, const float ofs) {
@@ -994,9 +641,70 @@ void AnimationTrackEditTypeAnimation::apply_data(const Ref<Resource> resource, c
 	undo_redo->commit_action();
 }
 
-bool AnimationTrackEditClip::handle_mouse_over_track(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right) {
-	Vector2 region = calc_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
-	clip_region(region, p_clip_left, p_clip_right);
+Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) {
+	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
+
+	if (String(anim_name) == "[stop]") {
+		return nullptr;
+	}
+
+	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
+	if (!ap || !ap->has_animation(anim_name)) {
+		return nullptr;
+	}
+
+	Ref<Animation> anim = ap->get_animation(anim_name);
+	if (!anim.is_valid()) {
+		return nullptr;
+	}
+
+	return anim;
+}
+
+float AnimationTrackEditTypeAnimation::get_start_offset(const int p_index) {
+	return get_animation()->animation_track_get_key_start_offset(get_track(), p_index);
+}
+
+float AnimationTrackEditTypeAnimation::get_end_offset(const int p_index) {
+	return get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
+}
+
+float AnimationTrackEditTypeAnimation::get_length(const int p_index) {
+	Ref<Resource> resource = get_resource(p_index);
+	if (resource.is_valid()) {
+		Ref<Animation> anim = resource;
+		return anim->get_length();
+	}
+
+	return AnimationTrackEditBase::get_length(p_index);
+}
+
+void AnimationTrackEditTypeAnimation::set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, new_ofs);
+	undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
+}
+
+void AnimationTrackEditTypeAnimation::set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->add_do_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, new_ofs);
+	undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
+}
+
+StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
+	StringName edit_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
+	if (!edit_name.is_empty()) {
+		return edit_name;
+	}
+
+	return AnimationTrackEditBase::get_edit_name(p_index);
+}
+
+/// BASE ///
+
+bool AnimationTrackEditBase::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right) {
+	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
+	clip_key_region(region, p_clip_left, p_clip_right);
 
 	int region_begin = region.x;
 	int region_end = region.y;
@@ -1045,161 +753,7 @@ bool AnimationTrackEditClip::handle_mouse_over_track(const Ref<InputEventMouseMo
 	return false;
 }
 
-Ref<Resource> AnimationTrackEditTypeAudio::get_resource(const int p_index) {
-	return get_animation()->audio_track_get_key_stream(get_track(), p_index);
-}
-
-float AnimationTrackEditTypeAudio::get_start_offset(const int p_index) {
-	return get_animation()->audio_track_get_key_start_offset(get_track(), p_index);
-}
-
-float AnimationTrackEditTypeAudio::get_end_offset(const int p_index) {
-	return get_animation()->audio_track_get_key_end_offset(get_track(), p_index);
-}
-
-float AnimationTrackEditTypeAudio::get_length(const int p_index) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (resource.is_valid()) {
-		Ref<AudioStream> stream = resource;
-		return stream->get_length();
-	}
-
-	return 0;
-}
-
-void AnimationTrackEditTypeAudio::set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, new_ofs);
-	undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
-}
-
-void AnimationTrackEditTypeAudio::set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, new_ofs);
-	undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
-}
-
-/////
-
-Ref<Resource> AnimationTrackEditAudio::get_resource(const int p_index) {
-	return get_animation()->audio_track_get_key_stream(get_track(), p_index);
-}
-
-float AnimationTrackEditAudio::get_length(const int p_index) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (resource.is_valid()) {
-		Ref<AudioStream> stream = resource;
-		return stream->get_length();
-	}
-
-	return 0;
-}
-
-/////
-
-Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) {
-	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
-
-	if (String(anim_name) == "[stop]") {
-		return nullptr;
-	}
-
-	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
-	if (!ap || !ap->has_animation(anim_name)) {
-		return nullptr;
-	}
-
-	Ref<Animation> anim = ap->get_animation(anim_name);
-	if (!anim.is_valid()) {
-		return nullptr;
-	}
-
-	return anim;
-}
-
-float AnimationTrackEditTypeAnimation::get_start_offset(const int p_index) {
-	return get_animation()->animation_track_get_key_start_offset(get_track(), p_index);
-}
-
-float AnimationTrackEditTypeAnimation::get_end_offset(const int p_index) {
-	return get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
-}
-
-float AnimationTrackEditTypeAnimation::get_length(const int p_index) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (resource.is_valid()) {
-		Ref<Animation> anim = resource;
-		return anim->get_length();
-	}
-
-	return 0;
-}
-
-void AnimationTrackEditTypeAnimation::set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, new_ofs);
-	undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
-}
-
-void AnimationTrackEditTypeAnimation::set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->add_do_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, new_ofs);
-	undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
-}
-
-StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
-	StringName edit_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
-	if (edit_name.is_empty()) {
-		edit_name = AnimationTrackEditBase::get_edit_name(p_index);
-	}
-
-	return edit_name;
-}
-
-/////
-
-Ref<Resource> AnimationTrackEditSubAnim::get_resource(const int p_index) {
-	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
-
-	if (String(anim_name) == "[stop]") {
-		return nullptr;
-	}
-
-	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
-	if (!ap || !ap->has_animation(anim_name)) {
-		return nullptr;
-	}
-
-	Ref<Animation> anim = ap->get_animation(anim_name);
-	if (!anim.is_valid()) {
-		return nullptr;
-	}
-
-	return anim;
-}
-
-float AnimationTrackEditSubAnim::get_length(const int p_index) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (resource.is_valid()) {
-		Ref<Animation> anim = resource;
-		return anim->get_length();
-	}
-
-	return 0;
-}
-
-StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
-	StringName edit_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
-	if (edit_name.is_empty()) {
-		edit_name = AnimationTrackEditBase::get_edit_name(p_index);
-	}
-
-	return edit_name;
-}
-
-/////
-
-void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
+void AnimationTrackEditBase::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -1219,7 +773,7 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 			float p_clip_left = get_timeline()->get_name_limit();
 			float p_clip_right = get_size().width - get_timeline()->get_buttons_width();
 
-			bool can_resize = handle_mouse_over_track(mm, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_clip_left, p_clip_right);
+			bool can_resize = handle_track_resizing(mm, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_clip_left, p_clip_right);
 			if (can_resize) {
 				use_hsize_cursor = true;
 			}
@@ -1309,7 +863,7 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 	AnimationTrackEdit::gui_input(p_event);
 }
 
-Control::CursorShape AnimationTrackEditClip::get_cursor_shape(const Point2 &p_pos) const {
+Control::CursorShape AnimationTrackEditBase::get_cursor_shape(const Point2 &p_pos) const {
 	if (over_drag_position || len_resizing) {
 		return Control::CURSOR_HSIZE;
 	} else {
@@ -1317,28 +871,93 @@ Control::CursorShape AnimationTrackEditClip::get_cursor_shape(const Point2 &p_po
 	}
 }
 
-////////////////////
-/// SUB ANIMATION ///
-
-int AnimationTrackEditTypeAnimation::get_key_height() const {
-	if (!ObjectDB::get_instance(id)) {
-		return AnimationTrackEdit::get_key_height();
+void AnimationTrackEditBase::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		return;
 	}
 
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * 1.5);
+	float start_ofs = get_start_offset(p_index);
+	float end_ofs = get_end_offset(p_index);
+	float len = get_length(p_index);
+
+	float diff_start_ofs = 0;
+	float diff_end_ofs = 0;
+
+	if (len_resizing && p_index == len_resizing_index) {
+		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+		if (len_resizing_start) {
+			diff_start_ofs = ofs_local;
+		} else {
+			diff_end_ofs = -ofs_local;
+		}
+	}
+
+	draw_key_region(resource, start_ofs + diff_start_ofs, end_ofs + diff_end_ofs, len, p_index, p_pixels_sec, p_x + (diff_start_ofs * p_pixels_sec), p_selected, p_clip_left, p_clip_right);
 }
 
-Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_sec) {
-	StringName anim_name = get_edit_name(p_index);
-	if (anim_name == "[stop]") {
-		Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-		int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-		int fh = font->get_height(font_size) * 0.8;
-		return Rect2(0, 0, fh, get_size().height);
+bool AnimationTrackEditBase::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+		Dictionary drag_data = p_data;
+		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+			Ref<Resource> res = drag_data["resource"];
+			if (res.is_valid()) {
+				return true;
+			}
+		}
+
+		if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+			Vector<String> files = drag_data["files"];
+
+			if (files.size() == 1) {
+				Ref<Resource> res = ResourceLoader::load(files[0]);
+				if (res.is_valid()) {
+					return true;
+				}
+			}
+		}
 	}
 
+	return AnimationTrackEdit::can_drop_data(p_point, p_data);
+}
+
+void AnimationTrackEditBase::drop_data(const Point2 &p_point, const Variant &p_data) {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+		Ref<Resource> resource;
+		Dictionary drag_data = p_data;
+		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+			resource = drag_data["resource"];
+		} else if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+			Vector<String> files = drag_data["files"];
+
+			if (files.size() == 1) {
+				resource = ResourceLoader::load(files[0]);
+			}
+		}
+
+		if (resource.is_valid()) {
+			int x = p_point.x - get_timeline()->get_name_limit();
+			float ofs = x / get_timeline()->get_zoom_scale();
+			ofs += get_timeline()->get_value();
+
+			ofs = get_editor()->snap_time(ofs);
+
+			while (get_animation()->track_find_key(get_track(), ofs, Animation::FIND_MODE_APPROX) != -1) { //make sure insertion point is valid
+				ofs += 0.0001;
+			}
+
+			apply_data(resource, ofs);
+
+			queue_redraw();
+			return;
+		}
+	}
+
+	AnimationTrackEdit::drop_data(p_point, p_data);
+}
+
+Rect2 AnimationTrackEditBase::get_key_rect(int p_index, float p_pixels_sec) {
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
 		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
@@ -1348,70 +967,182 @@ Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_
 	float end_ofs = get_end_offset(p_index);
 	float len = get_length(p_index);
 
-	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
+	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, 0);
+	return Rect2(region.x, 0, region.y, get_size().height);
 }
 
-Rect2 AnimationTrackEditSubAnim::get_key_rect(int p_index, float p_pixels_sec) {
-	String anim_name = get_edit_name(p_index);
-	if (anim_name == "[stop]") {
-		Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-		int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-		int fh = font->get_height(font_size) * 0.8;
-		return Rect2(0, 0, fh, get_size().height);
-	}
-
-	Ref<Resource> resource = get_resource(p_index);
-	if (!resource.is_valid()) {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
+void AnimationTrackEditBase::set_node(Object *p_object) {
+	id = p_object->get_instance_id();
 }
 
-void AnimationTrackEditTypeAnimation::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
-	Ref<AnimationPreview> preview = AnimationPreviewGenerator::get_singleton()->generate_preview(resource);
+void AnimationTrackEditTypeAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(resource);
 	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
 }
 
-void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Object *object = ObjectDB::get_instance(id);
-
-	if (!object) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
-	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(object);
-
-	if (!ap) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
-	StringName anim_name = get_edit_name(p_index);
-	if (anim_name == StringName("[stop]")) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right); // Draw diamond.
-		return;
-	}
-
+StringName AnimationTrackEditBase::get_edit_name(const int p_index) {
+	String resource_name = "null";
 	Ref<Resource> resource = get_resource(p_index);
-	if (!resource.is_valid()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right); // Draw diamond.
-		return;
+	if (resource.is_valid()) {
+		if (resource->get_path().is_resource_file()) {
+			resource_name = resource->get_path().get_file();
+		} else if (!resource->get_name().is_empty()) {
+			resource_name = resource->get_name();
+		} else {
+			resource_name = resource->get_class();
+		}
 	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	draw_key_region(resource, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+	return resource_name;
 }
 
-/////////
+Vector2 AnimationTrackEditBase::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x) {
+	float anim_len = len - start_ofs - end_ofs;
+	if (anim_len < 0) {
+		WARN_PRINT("anim_len < 0");
+		anim_len = 0;
+	}
+
+	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
+		anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
+	}
+
+	float pixel_len = anim_len * p_pixels_sec;
+	float pixel_begin = p_x;
+	float pixel_end = p_x + pixel_len;
+
+	return Vector2(pixel_begin, pixel_end);
+}
+
+Vector2 AnimationTrackEditBase::clip_key_region(Vector2 &region, int p_clip_left, int p_clip_right) {
+	float offset_x = region.x;
+	float offset_y = region.y;
+
+	region.y = CLAMP(region.y, MAX(region.x, p_clip_left), p_clip_right);
+	region.x = CLAMP(region.x, p_clip_left, MIN(region.y, p_clip_right));
+
+	return Vector2(region.x - offset_x, region.y - offset_y);
+}
+
+bool AnimationTrackEditBase::is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right) {
+	return (region.y < p_clip_left || region.x > p_clip_right);
+}
+
+void AnimationTrackEditBase::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
+	int orig_region_width = region.y - region.x;
+
+	bool is_outside = is_key_region_outside(region, p_clip_left, p_clip_right);
+	if (is_outside) {
+		return;
+	}
+
+	Vector2 region_shift = clip_key_region(region, p_clip_left, p_clip_right);
+
+	int region_begin = region.x;
+	int region_end = region.y;
+	int region_width = region.y - region.x;
+
+	int fh = get_key_height();
+	int h = get_size().height;
+
+	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+
+	float thickness = 4;
+	if (orig_region_width <= thickness) {
+		float thick_region_width = MAX(thickness, region_width);
+		Rect2 rect2 = Rect2(region_begin, (h - fh) / 2, thick_region_width, fh);
+		draw_rect(rect2, accent_color);
+
+		if (p_selected) {
+			draw_rect(rect2, accent_color, false);
+		}
+
+		return;
+	}
+
+	Color bg_color = Color(0.25, 0.25, 0.25);
+	Rect2 rect = Rect2(region_begin, (h - fh) / 2, region_width, fh);
+	draw_rect(rect, bg_color);
+
+	Vector<Vector2> points;
+	points.resize(region_width * 2);
+
+	Vector<Color> colors;
+	if (p_selected) {
+		colors = { Color(0.75, 0.75, 0.75) };
+	} else {
+		colors = { bg_color.lightened(0.2) };
+	}
+
+	float shift_ofs = region_shift.x / p_pixels_sec;
+	create_key_region(resource, points, rect, p_pixels_sec, start_ofs + shift_ofs);
+
+	if (!points.is_empty()) {
+		draw_multiline_colors(points, colors);
+	}
+
+	Color edge_color = Color(accent_color);
+	edge_color.a = 0.7;
+	if (start_ofs > 0 && region_begin > p_clip_left) {
+		draw_rect(Rect2(region_begin, rect.position.y, 1, rect.size.y), edge_color);
+	}
+	if (end_ofs > 0 && region_end < p_clip_right) {
+		draw_rect(Rect2(region_end, rect.position.y, 1, rect.size.y), edge_color);
+	}
+
+	if (region_width > thickness) {
+		StringName edit_name = get_edit_name(p_index);
+		if (!edit_name.is_empty()) {
+			Color name_color;
+			if (p_selected) {
+				name_color = Color(accent_color);
+				name_color.a = 0.0;
+			} else {
+				Color font_color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
+				name_color = font_color;
+			}
+
+			float max_width = region_width - 2;
+
+			Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+			int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+
+			String clipped_edit_name = edit_name;
+			if (font->get_string_size(String(clipped_edit_name), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x > max_width) {
+				while (!clipped_edit_name.is_empty() && font->get_string_size(String(clipped_edit_name + "..."), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).x > max_width) {
+					clipped_edit_name = clipped_edit_name.substr(0, clipped_edit_name.length() - 1);
+				}
+				clipped_edit_name += "...";
+			}
+
+			int f_h = int(h - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
+			draw_string(font, Point2(region_begin + 2, f_h), clipped_edit_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
+		}
+	}
+
+	if (p_selected) {
+		draw_rect(rect, accent_color, false);
+	}
+}
+
+void AnimationTrackEditBase::_preview_changed(ObjectID p_which) {
+	for (int p_index = 0; p_index < get_animation()->track_get_key_count(get_track()); p_index++) {
+		Ref<Resource> resource = get_resource(p_index);
+		if (resource.is_valid() && resource->get_instance_id() == p_which) {
+			queue_redraw();
+			return;
+		}
+	}
+}
+
+int AnimationTrackEditBase::get_key_height() const {
+	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+	return int(font->get_height(font_size) * font_scl);
+}
+
+/// PLUGIN ///
+
 AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) {
 	if (p_property == "playing" && (p_object->is_class("AudioStreamPlayer") || p_object->is_class("AudioStreamPlayer2D") || p_object->is_class("AudioStreamPlayer3D"))) {
 		AnimationTrackEditAudio *audio = memnew(AnimationTrackEditAudio);

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -785,17 +785,258 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 	draw_line(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2);
 }
 
+AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
+	//AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
+}
+
 ////////////////////////
 
-/// AUDIO ///
+/// ANIMATION ///
 
-void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
+void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
 	for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
-		Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), i);
-		if (stream.is_valid() && stream->get_instance_id() == p_which) {
+		StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), i);
+		//if (anim_name == StringName("[stop]")) {
+		//	continue;
+		//}
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
+		//if (!ap || !ap->has_animation(anim_name)) {
+			continue;
+		//}
+
+		Ref<Animation> anim = ap->get_animation(anim_name);
+		//if (!anim.is_valid()) {
+			continue;
+		//}
+
+		if (anim.is_valid() && anim->get_instance_id() == p_which) {
 			queue_redraw();
 			return;
 		}
+	}
+}
+
+bool AnimationTrackEditTypeAnimation::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+		Dictionary drag_data = p_data;
+		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+			Ref<Animation> res = drag_data["resource"];
+			if (res.is_valid()) {
+				return true;
+			}
+		}
+
+		if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+			Vector<String> files = drag_data["files"];
+
+			if (files.size() == 1) {
+				Ref<Animation> res = ResourceLoader::load(files[0]);
+				if (res.is_valid()) {
+					return true;
+				}
+			}
+		}
+	}
+
+	return AnimationTrackEdit::can_drop_data(p_point, p_data);
+}
+
+void AnimationTrackEditTypeAnimation::drop_data(const Point2 &p_point, const Variant &p_data) {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+		Ref<Animation> anim;
+		Dictionary drag_data = p_data;
+		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+			anim = drag_data["resource"];
+		} else if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+			Vector<String> files = drag_data["files"];
+
+			if (files.size() == 1) {
+				anim = ResourceLoader::load(files[0]);
+			}
+		}
+
+		if (anim.is_valid()) {
+			StringName anim_name = anim->get_name();
+			if (anim_name == StringName("[stop]")) {
+				WARN_PRINT("Cannot insert [stop] animation key.");
+				return;
+			}
+
+			int x = p_point.x - get_timeline()->get_name_limit();
+			float ofs = x / get_timeline()->get_zoom_scale();
+			ofs += get_timeline()->get_value();
+
+			ofs = get_editor()->snap_time(ofs);
+
+			while (get_animation()->track_find_key(get_track(), ofs, Animation::FIND_MODE_APPROX) != -1) { //make sure insertion point is valid
+				ofs += 0.0001;
+			}
+
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Add Animation Track Clip"));
+			undo_redo->add_do_method(get_animation().ptr(), "animation_track_insert_key", get_track(), ofs, anim_name);
+			undo_redo->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), ofs);
+			undo_redo->commit_action();
+
+			queue_redraw();
+			return;
+		}
+	}
+
+	AnimationTrackEdit::drop_data(p_point, p_data);
+}
+
+void AnimationTrackEditTypeAnimation::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (!len_resizing && mm.is_valid()) {
+		bool use_hsize_cursor = false;
+		for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
+			StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), i);
+			if (anim_name == StringName("[stop]")) {
+				continue;
+			}
+			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
+			if (!ap || !ap->has_animation(anim_name)) {
+				continue;
+			}
+
+			Ref<Animation> anim = ap->get_animation(anim_name);
+			if (!anim.is_valid()) {
+				continue;
+			}
+
+			float len = anim->get_length();
+			if (len == 0) {
+				continue;
+			}
+
+			float start_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), i);
+			float end_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), i);
+			len -= end_ofs;
+			len -= start_ofs;
+
+			if (get_animation()->track_get_key_count(get_track()) > i + 1) {
+				len = MIN(len, get_animation()->track_get_key_time(get_track(), i + 1) - get_animation()->track_get_key_time(get_track(), i));
+			}
+
+			float ofs = get_animation()->track_get_key_time(get_track(), i);
+
+			ofs -= get_timeline()->get_value();
+			ofs *= get_timeline()->get_zoom_scale();
+			ofs += get_timeline()->get_name_limit();
+
+			int end = ofs + len * get_timeline()->get_zoom_scale();
+
+			if (end >= get_timeline()->get_name_limit() && end <= get_size().width - get_timeline()->get_buttons_width() && Math::abs(mm->get_position().x - end) < 5 * EDSCALE) {
+				len_resizing_start = false;
+				use_hsize_cursor = true;
+				len_resizing_index = i;
+			}
+
+			if (ofs >= get_timeline()->get_name_limit() && ofs <= get_size().width - get_timeline()->get_buttons_width() && Math::abs(mm->get_position().x - ofs) < 5 * EDSCALE) {
+				len_resizing_start = true;
+				use_hsize_cursor = true;
+				len_resizing_index = i;
+			}
+		}
+		over_drag_position = use_hsize_cursor;
+	}
+
+	if (len_resizing && mm.is_valid()) {
+		// Rezising index is some.
+		len_resizing_rel += mm->get_relative().x;
+		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+		float prev_ofs_start = get_animation()->animation_track_get_key_start_offset(get_track(), len_resizing_index);
+		float prev_ofs_end = get_animation()->animation_track_get_key_end_offset(get_track(), len_resizing_index);
+		StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), len_resizing_index);
+		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
+		Ref<Animation> anim = ap ? ap->get_animation(anim_name) : Ref<Animation>();
+		float len = anim->get_length();
+		if (len == 0) {
+			//Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(stream);
+			float preview_len = 0.0; //preview->get_length();
+			len = preview_len;
+		}
+
+		if (len_resizing_start) {
+			len_resizing_rel = CLAMP(ofs_local, -prev_ofs_start, len - prev_ofs_end - prev_ofs_start) * get_timeline()->get_zoom_scale();
+		} else {
+			len_resizing_rel = CLAMP(ofs_local, -(len - prev_ofs_end - prev_ofs_start), prev_ofs_end) * get_timeline()->get_zoom_scale();
+		}
+
+		queue_redraw();
+		accept_event();
+		return;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && over_drag_position) {
+		len_resizing = true;
+		// In case if resizing index is not set yet reset the flag.
+		if (len_resizing_index < 0) {
+			len_resizing = false;
+			return;
+		}
+		len_resizing_from_px = mb->get_position().x;
+		len_resizing_rel = 0;
+		queue_redraw();
+		accept_event();
+		return;
+	}
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	if (len_resizing && mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+		if (len_resizing_rel == 0 || len_resizing_index < 0) {
+			len_resizing = false;
+			return;
+		}
+
+		if (len_resizing_start) {
+			float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+			float prev_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), len_resizing_index);
+			float prev_time = get_animation()->track_get_key_time(get_track(), len_resizing_index);
+			float new_ofs = prev_ofs + ofs_local;
+			float new_time = prev_time + ofs_local;
+			if (prev_time != new_time) {
+				undo_redo->create_action(TTR("Change Animation Track Clip Start Offset"));
+
+				undo_redo->add_do_method(get_animation().ptr(), "track_set_key_time", get_track(), len_resizing_index, new_time);
+				undo_redo->add_undo_method(get_animation().ptr(), "track_set_key_time", get_track(), len_resizing_index, prev_time);
+
+				undo_redo->add_do_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, new_ofs);
+				undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_start_offset", get_track(), len_resizing_index, prev_ofs);
+
+				undo_redo->commit_action();
+			}
+		} else {
+			float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
+			float prev_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), len_resizing_index);
+			float new_ofs = prev_ofs + ofs_local;
+			if (prev_ofs != new_ofs) {
+				undo_redo->create_action(TTR("Change Animation Track Clip End Offset"));
+				undo_redo->add_do_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, new_ofs);
+				undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), len_resizing_index, prev_ofs);
+				undo_redo->commit_action();
+			}
+		}
+
+		len_resizing_index = -1;
+		len_resizing = false;
+		queue_redraw();
+		accept_event();
+		return;
+	}
+
+	AnimationTrackEdit::gui_input(p_event);
+}
+
+Control::CursorShape AnimationTrackEditTypeAnimation::get_cursor_shape(const Point2 &p_pos) const {
+	if (over_drag_position || len_resizing) {
+		return Control::CURSOR_HSIZE;
+	} else {
+		return get_default_cursor_shape();
 	}
 }
 
@@ -950,6 +1191,20 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
+}
+
+////////////////////////
+
+/// AUDIO ///
+
+void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
+	for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
+		Ref<AudioStream> stream = get_animation()->audio_track_get_key_stream(get_track(), i);
+		if (stream.is_valid() && stream->get_instance_id() == p_which) {
+			queue_redraw();
+			return;
+		}
+	}
 }
 
 bool AnimationTrackEditTypeAudio::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
@@ -1186,10 +1441,20 @@ Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_
 		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 	}
 
-	String anim = get_animation()->animation_track_get_key_animation(get_track(), p_index);
+	String anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
+	Ref<Animation> anim = ap->get_animation(anim_name);
+	if (!anim.is_valid()) {
+		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+	}
 
-	if (anim != "[stop]" && ap->has_animation(anim)) {
-		float len = ap->get_animation(anim)->get_length();
+	if (anim_name != StringName("[stop]") && ap->has_animation(anim_name)) {
+		float len = anim->get_length();
+
+		if (len == 0) {
+			len = 0.0;
+			//Ref<AnimationPreview> preview = AnimationPreviewGenerator::get_singleton()->generate_preview(anim);
+			//len = preview->get_length();
+		}
 
 		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
 			len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -113,6 +113,10 @@ void AnimationTrackEditTypeMethod::draw_key(const int p_index, const Rect2 &p_gl
 	AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 }
 
+void AnimationTrackEditTypeMethod::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
+
+}
+
 StringName AnimationTrackEditTypeMethod::get_edit_name(const int p_index) const {
 	Dictionary d = animation->track_get_key_value(get_track(), p_index);
 	String method_name = _make_method_text(d);
@@ -186,8 +190,8 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, flo
 				(get_animation()->value_track_get_update_mode(get_track()) == Animation::UPDATE_CONTINUOUS ||
 						get_animation()->value_track_get_update_mode(get_track()) == Animation::UPDATE_CAPTURE) &&
 				!Math::is_zero_approx(get_animation()->track_get_key_transition(get_track(), p_index))) {
-			float start_time = get_animation()->track_get_key_time(get_track(), p_index);
-			float end_time = get_animation()->track_get_key_time(get_track(), p_index + 1);
+			float start_time = get_key_time(p_index);
+			float end_time = get_key_time(p_index + 1);
 
 			Color color_next = get_animation()->value_track_interpolate(get_track(), end_time);
 
@@ -205,7 +209,7 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, flo
 			color_samples.append(color_samples[0]);
 		}
 	} else {
-		color_samples.append(get_animation()->track_get_key_value(get_track(), p_index + 1));
+		color_samples.append(get_key_value(p_index + 1));
 	}
 
 	for (int i = 0; i < color_samples.size() - 1; i++) {
@@ -487,10 +491,6 @@ void AnimationTrackEditVolumeDB::draw_fg(const float p_clip_left, const float p_
 }
 
 void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
-	if (p_x > p_clip_right || p_next_x < p_clip_left) {
-		return;
-	}
-
 	float db = get_animation()->track_get_key_value(get_track(), p_index);
 	float db_n = get_animation()->track_get_key_value(get_track(), p_index + 1);
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -113,7 +113,7 @@ void AnimationTrackEditTypeMethod::draw_key(const int p_index, const Rect2 &p_gl
 	AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 }
 
-void AnimationTrackEditTypeMethod::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
+void AnimationTrackEditTypeMethod::draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) {
 }
 
 StringName AnimationTrackEditTypeMethod::get_edit_name(const int p_index) const {
@@ -165,13 +165,13 @@ void AnimationTrackEditColor::draw_key(const int p_index, const Rect2 &p_global_
 	editor->_draw_grid_clipped(this, p_global_rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
 }
 
-void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) {
+void AnimationTrackEditColor::draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) {
 	int fh = get_key_height(p_index);
 
 	fh /= 3;
 
-	int x_from = p_x + fh / 2 - 1;
-	int x_to = p_next_x - fh / 2 + 1;
+	int x_from = p_global_rect.position.x + fh / 2 - 1;
+	int x_to = p_global_rect_next.position.x - fh / 2 + 1;
 	x_from = MAX(x_from, p_clip_left);
 	x_to = MIN(x_to, p_clip_right);
 
@@ -499,7 +499,7 @@ void AnimationTrackEditVolumeDB::draw_fg(const float p_clip_left, const float p_
 	editor->_draw_line_clipped(this, Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
 }
 
-void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
+void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) {
 	float db = get_animation()->track_get_key_value(get_track(), p_index);
 	float db_n = get_animation()->track_get_key_value(get_track(), p_index + 1);
 
@@ -517,8 +517,8 @@ void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const float p_
 	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
 	color.a *= REGION_EDGE_ALPHA;
 
-	int from_x = p_x;
-	int to_x = p_next_x;
+	int from_x = p_global_rect.position.x;
+	int to_x = p_global_rect_next.position.x;
 	editor->_draw_line_clipped(this, Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2, p_clip_left, p_clip_right);
 }
 
@@ -763,7 +763,7 @@ float AnimationTrackEditClip::get_key_width(const int p_index) const {
 }
 
 float AnimationTrackEditClip::get_key_height(const int p_index) const {
-	return _get_theme_font_height(1.0);
+	return _get_theme_font_height(1.5);
 }
 
 int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right) {
@@ -771,8 +771,8 @@ int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotio
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 
-	float p_x = _get_pixels_sec(p_index, true);
-	Region region = _calc_key_region(p_index, start_ofs, end_ofs, len, p_x);
+	float offset = _get_pixels_sec(p_index, true);
+	Region region = _calc_key_region(p_index, start_ofs, end_ofs, len, offset);
 	region = _clip_key_region(region, p_clip_left, p_clip_right);
 
 	float region_begin = region.x;
@@ -1139,10 +1139,9 @@ StringName AnimationTrackEditClip::get_edit_name(const int p_index) const {
 	return resource_name;
 }
 
-Region AnimationTrackEditClip::_calc_key_region(const int p_index, const float start_ofs, const float end_ofs, const float len, float __offset) const {
-	float anim_len = len - start_ofs - end_ofs;
+Region AnimationTrackEditClip::_calc_key_region(const int p_index, const float p_start_ofs, const float p_end_ofs, const float p_len, float p_offset) const {
+	float anim_len = p_len - p_start_ofs - p_end_ofs;
 	if (anim_len < 0) {
-		WARN_PRINT("anim_len < 0");
 		anim_len = 0;
 	}
 
@@ -1156,7 +1155,7 @@ Region AnimationTrackEditClip::_calc_key_region(const int p_index, const float s
 	float scale = get_timeline()->get_zoom_scale();
 
 	float pixel_len = anim_len * scale;
-	float pixel_begin = __offset;
+	float pixel_begin = p_offset;
 
 	return Region(pixel_begin, pixel_len);
 }

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -912,10 +912,10 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 			float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
 			float prev_ofs = get_start_offset(len_resizing_index);
 			float prev_time = get_animation()->track_get_key_time(get_track(), len_resizing_index);
-			// Raster die neue Zeit
+
 			float new_time = editor->snap_time(prev_time + ofs_local);
 			float new_ofs = prev_ofs + (new_time - prev_time);
-			if (Math::abs(prev_time - new_time) > CMP_EPSILON) { // Prüfe relevante Änderung
+			if (Math::abs(prev_time - new_time) > CMP_EPSILON) {
 				float offset = new_time - prev_time;
 
 				undo_redo->create_action(TTR("Change Track Clip Start Offset"));
@@ -929,10 +929,9 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 		} else {
 			float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();
 			float prev_ofs = get_end_offset(len_resizing_index);
-			// Raster die neue Zeit
-			float new_time = editor->snap_time(prev_ofs + ofs_local);
-			float new_ofs = new_time; // End-Offset ist absolut
-			if (Math::abs(prev_ofs - new_ofs) > CMP_EPSILON) { // Prüfe relevante Änderung
+
+			float new_ofs = editor->snap_time(prev_ofs + ofs_local);
+			if (Math::abs(prev_ofs - new_ofs) > CMP_EPSILON) {
 				undo_redo->create_action(TTR("Change Track Clip End Offset"));
 				set_end_offset(len_resizing_index, prev_ofs, new_ofs);
 				undo_redo->commit_action();

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -461,7 +461,6 @@ bool AnimationTrackEditClip::_is_key_region_outside(const Region &region, const 
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	key_pivot.x = 0.0;
-	key_pivot.y = 0.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
@@ -542,7 +541,6 @@ String AnimationTrackEditTypeAudio::_get_tooltip(const int p_index) const {
 
 AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
 	key_pivot.x = 0.0;
-	key_pivot.y = 0.5;
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
@@ -667,7 +665,6 @@ String AnimationTrackEditTypeAnimation::_get_tooltip(const int p_index) const {
 
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	key_pivot.x = 0.0;
-	key_pivot.y = 0.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
@@ -717,7 +714,6 @@ void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
 	key_pivot.x = 0.0;
-	key_pivot.y = 0.5;
 }
 
 bool AnimationTrackEditSubAnim::has_valid_key(const int p_index) const {
@@ -799,8 +795,6 @@ void AnimationTrackEditSubAnim::_preview_changed(ObjectID p_which) {
 /// ANIMATION TRACK EDIT BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
-	key_pivot.x = 0.5;
-	key_pivot.y = 0.5;
 }
 
 float AnimationTrackEditBool::get_key_width(const int p_index) const {
@@ -830,8 +824,6 @@ void AnimationTrackEditBool::draw_key(const int p_index, const Rect2 &p_global_r
 /// ANIMATION TRACK EDIT TYPE METHOD ///
 
 AnimationTrackEditTypeMethod::AnimationTrackEditTypeMethod() {
-	key_pivot.x = 0.5;
-	key_pivot.y = 0.5;
 }
 
 float AnimationTrackEditTypeMethod::get_key_width(const int p_index) const {
@@ -890,8 +882,6 @@ String AnimationTrackEditTypeMethod::_make_method_text(const Dictionary &d) cons
 /// ANIMATION TRACK EDIT COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
-	key_pivot.x = 0.5;
-	key_pivot.y = 0.5;
 }
 
 float AnimationTrackEditColor::get_key_width(const int p_index) const {
@@ -971,7 +961,6 @@ void AnimationTrackEditColor::draw_key_link(const int p_index, const Rect2 &p_gl
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
 	key_pivot.x = 0.0;
-	key_pivot.y = 0.5;
 }
 
 void AnimationTrackEditSpriteFrame::set_node(Object *p_object) {
@@ -1117,8 +1106,6 @@ Rect2 AnimationTrackEditSpriteFrame::_create_region_animated_sprite(int p_index,
 /// ANIMATION TRACK EDIT VOLUME DB ///
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
-	key_pivot.x = 0.5;
-	key_pivot.y = 0.5;
 }
 
 float AnimationTrackEditVolumeDB::get_key_width(const int p_index) const {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -42,7 +42,7 @@
 #include "scene/animation/animation_player.h"
 #include "servers/audio/audio_stream.h"
 
-/// BOOL ///
+/// ANIMATION TRACK EDIT BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
 	key_pivot.x = 0.5;
@@ -73,7 +73,7 @@ void AnimationTrackEditBool::draw_key(const int p_index, const Rect2 &p_global_r
 	editor->_draw_texture_region_clipped(this, texture, p_global_rect, region, p_clip_left, p_clip_right);
 }
 
-/// METHOD ///
+/// ANIMATION TRACK EDIT TYPE METHOD ///
 
 AnimationTrackEditTypeMethod::AnimationTrackEditTypeMethod() {
 	key_pivot.x = 0.5;
@@ -153,7 +153,7 @@ String AnimationTrackEditTypeMethod::_make_method_text(const Dictionary &d) cons
 	return text;
 }
 
-/// COLOR ///
+/// ANIMATION TRACK EDIT COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
 	key_pivot.x = 0.5;
@@ -238,7 +238,7 @@ void AnimationTrackEditColor::draw_key_link(const int p_index, const Rect2 &p_gl
 	}
 }
 
-/// SPRITE FRAME / FRAME_COORDS ///
+/// ANIMATION TRAK EDIT SPRITE FRAME ///
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
 	key_pivot.x = 0.0;
@@ -385,7 +385,7 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 	is_coords = true;
 }
 
-/// SUB ANIMATION ///
+/// ANIMATION TRACK EDIT SUB ANIM ///
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
 	key_pivot.x = 0.0;
@@ -468,7 +468,7 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) const {
 	return AnimationTrackEditClip::get_edit_name(p_index);
 }
 
-//// VOLUME DB ////
+//// ANIMATION TRACK EDIT VOLUME DB ////
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
 	key_pivot.x = 0.5;
@@ -536,7 +536,7 @@ void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const Rect2 &p
 	editor->_draw_line_clipped(this, center, center_n, color, 2, p_clip_left, p_clip_right);
 }
 
-/// AUDIO ///
+/// ANIMATION TRACK EDIT TYPE AUDIO ///
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	key_pivot.x = 0.0;
@@ -617,7 +617,7 @@ void AnimationTrackEditTypeAudio::set_end_offset(const int p_index, const float 
 	undo_redo->add_undo_method(get_animation().ptr(), "audio_track_set_key_end_offset", get_track(), p_index, prev_ofs);
 }
 
-/// AUDIO ///
+/// ANIMATION TRACK EDIT AUDIO ///
 
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	key_pivot.x = 0.0;
@@ -667,7 +667,7 @@ float AnimationTrackEditAudio::get_length(const int p_index) const {
 	return AnimationTrackEditClip::get_length(p_index);
 }
 
-/// TYPE ANIMATION ///
+/// ANIMATION TRACK EDIT TYPE ANIMATION ///
 
 AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
 	key_pivot.x = 0.0;
@@ -792,7 +792,7 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) con
 	return AnimationTrackEditClip::get_edit_name(p_index);
 }
 
-/// KEY ///
+/// ANIMATION TRACK EDIT CLIP ///
 
 float AnimationTrackEditClip::get_key_width(const int p_index) const {
 	float start_ofs = get_start_offset(p_index);
@@ -1227,7 +1227,7 @@ void AnimationTrackEditClip::_preview_changed(ObjectID p_which) {
 	}
 }
 
-/// PLUGIN ///
+/// ANIMATION TRACK EDIT DEFAULT PLUGIN ///
 
 AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) {
 	if (p_property == "playing" && (p_object->is_class("AudioStreamPlayer") || p_object->is_class("AudioStreamPlayer2D") || p_object->is_class("AudioStreamPlayer3D"))) {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -49,12 +49,12 @@ AnimationTrackEditBool::AnimationTrackEditBool() {
 	key_pivot.y = 0.5;
 }
 
-int AnimationTrackEditBool::get_key_width(const int p_index) const {
+float AnimationTrackEditBool::get_key_width(const int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_width();
 }
 
-int AnimationTrackEditBool::get_key_height(const int p_index) const {
+float AnimationTrackEditBool::get_key_height(const int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_height();
 }
@@ -71,11 +71,6 @@ void AnimationTrackEditBool::draw_key(const int p_index, const Rect2 &p_global_r
 	Rect2 region;
 	region.size = texture->get_size();
 	animationTrackDrawUtils->_draw_texture_region_clipped(texture, p_global_rect, region, p_clip_left, p_clip_right);
-
-	if (p_selected) {
-		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		animationTrackDrawUtils->_draw_rect_clipped(p_global_rect, color, false, p_clip_left, p_clip_right);
-	}
 }
 
 /// METHOD ///
@@ -85,11 +80,11 @@ AnimationTrackEditTypeMethod::AnimationTrackEditTypeMethod() {
 	key_pivot.y = 0.5;
 }
 
-int AnimationTrackEditTypeMethod::get_key_width(const int p_index) const {
+float AnimationTrackEditTypeMethod::get_key_width(const int p_index) const {
 	return AnimationTrackEdit::get_key_width(p_index);
 }
 
-int AnimationTrackEditTypeMethod::get_key_height(const int p_index) const {
+float AnimationTrackEditTypeMethod::get_key_height(const int p_index) const {
 	return AnimationTrackEdit::get_key_height(p_index);
 }
 
@@ -153,11 +148,11 @@ AnimationTrackEditColor::AnimationTrackEditColor() {
 	key_pivot.y = 0.5;
 }
 
-int AnimationTrackEditColor::get_key_width(const int p_index) const {
+float AnimationTrackEditColor::get_key_width(const int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
-int AnimationTrackEditColor::get_key_height(const int p_index) const {
+float AnimationTrackEditColor::get_key_height(const int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
@@ -165,11 +160,6 @@ void AnimationTrackEditColor::draw_key(const int p_index, const Rect2 &p_global_
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
 
 	animationTrackDrawUtils->_draw_grid_clipped(p_global_rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
-
-	if (p_selected) {
-		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		animationTrackDrawUtils->_draw_rect_clipped(p_global_rect, accent, false, p_clip_left, p_clip_right);
-	}
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) {
@@ -248,11 +238,11 @@ void AnimationTrackEditSpriteFrame::set_node(Object *p_object) {
 	id = p_object->get_instance_id();
 }
 
-int AnimationTrackEditSpriteFrame::get_key_width(const int p_index) const {
+float AnimationTrackEditSpriteFrame::get_key_width(const int p_index) const {
 	return _get_theme_font_height(2.0);
 }
 
-int AnimationTrackEditSpriteFrame::get_key_height(const int p_index) const {
+float AnimationTrackEditSpriteFrame::get_key_height(const int p_index) const {
 	return _get_theme_font_height(2.0);
 }
 
@@ -335,17 +325,7 @@ Rect2 AnimationTrackEditSpriteFrame::_create_texture_region_sprite(int p_index, 
 
 void AnimationTrackEditSpriteFrame::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Object *object = ObjectDB::get_instance(get_node_id());
-
-	if (!object) {
-		AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
 	Ref<Resource> resource = get_resource(p_index);
-	if (!resource.is_valid()) {
-		AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
 
 	Ref<Texture2D> texture = resource;
 	Rect2 region;
@@ -364,10 +344,20 @@ void AnimationTrackEditSpriteFrame::draw_key(const int p_index, const Rect2 &p_g
 	bg.a = 0.15;
 	animationTrackDrawUtils->_draw_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
 	animationTrackDrawUtils->_draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
+}
 
-	if (p_selected) {
-		animationTrackDrawUtils->_draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
+bool AnimationTrackEditSpriteFrame::has_valid_key(const int p_index) const {
+	Object *object = ObjectDB::get_instance(get_node_id());
+	if (!object) {
+		return false;
 	}
+
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		return false;
+	}
+
+	return true;
 }
 
 void AnimationTrackEditSpriteFrame::set_as_coords() {
@@ -464,11 +454,11 @@ AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
 	key_pivot.y = 0.5;
 }
 
-int AnimationTrackEditVolumeDB::get_key_width(const int p_index) const {
+float AnimationTrackEditVolumeDB::get_key_width(const int p_index) const {
 	return AnimationTrackEdit::get_key_width(p_index);
 }
 
-int AnimationTrackEditVolumeDB::get_key_height(const int p_index) const {
+float AnimationTrackEditVolumeDB::get_key_height(const int p_index) const {
 	return AnimationTrackEdit::get_key_height(p_index);
 }
 
@@ -745,7 +735,7 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) con
 
 /// KEY ///
 
-int AnimationTrackEditClip::get_key_width(const int p_index) const {
+float AnimationTrackEditClip::get_key_width(const int p_index) const {
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 	float len = get_length(p_index);
@@ -765,45 +755,30 @@ int AnimationTrackEditClip::get_key_width(const int p_index) const {
 	return anim_len * scale;
 }
 
-int AnimationTrackEditClip::get_key_height(const int p_index) const {
+float AnimationTrackEditClip::get_key_height(const int p_index) const {
 	return _get_theme_font_height(1.0);
 }
 
 int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right) {
-	//float len = get_length(p_index);
-	//if (len == 0) {
-	//	continue;
-	//}
-	// 
-	// OLD
 	float len = get_length(p_index);
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
-	
-	float p_x = ((get_animation()->track_get_key_time(get_track(), p_index) - get_timeline()->get_value()) * get_timeline()->get_zoom_scale()) + get_timeline()->get_name_limit();
-	Vector2 region = _calc_key_region(start_ofs, end_ofs, len, p_index, p_x);
+
+	float p_x = _get_pixels_sec(p_index, true);
+	Region region = _calc_key_region(p_index, start_ofs, end_ofs, len, p_x);
 	region = _clip_key_region(region, p_clip_left, p_clip_right);
 
-	int region_begin = region.x;
-	int region_end = region.y;
-	// OLD
-
-	//Rect2 global_rect = _to_local_key_rect(p_index, p_global_rect);
-
-	//int region_begin = global_rect.position.x;
-	//int region_end = global_rect.position.x + global_rect.size.x;
+	float region_begin = region.x;
+	float region_end = (region.x + region.width);
 
 	if (region_begin >= p_clip_left && region_end <= p_clip_right && region_begin <= region_end) {
 		bool resize_start = false;
 		int can_resize = false;
 
 		float mouse_pos = mm->get_position().x;
-		//mouse_pos += _get_pixels_sec(p_index, p_ignore_moving_selection); //mm->get_position().x*timeline->get_zoom_scale() - timeline->get_name_limit()
-
+		
 		float diff_left = region_begin - mouse_pos;
 		float diff_right = mouse_pos - region_end;
-
-		//WARN_PRINT(String::num(region_begin) + " (" + String::num(diff_left) + ")" + " - " + String::num(region_end)  + " (" + String::num(diff_right) + ")" + " => (" + String::num(mouse_pos) + ")");
 
 		float resize_threshold = REGION_RESIZE_THRESHOLD * EDSCALE;
 
@@ -853,6 +828,11 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 
 			int resizing_index = handle_track_resizing(mm, p_index, global_rect, clip_left, clip_right);
 			if (resizing_index != -1) {
+				if (!has_valid_key(resizing_index)) {
+					AnimationTrackEdit::gui_input(p_event);
+					return;
+				}
+
 				use_hsize_cursor = true;
 				len_resizing_index = resizing_index;
 			}
@@ -977,28 +957,28 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 		}
 	}
 
-	float p_x_ = p_global_rect.position.x + (diff_start_ofs * scale);
+	float offset = p_global_rect.position.x + (diff_start_ofs * scale);
 	float start_ofs_ = start_ofs + diff_start_ofs;
 	float end_ofs_ = end_ofs + diff_end_ofs;
 
-	Vector2 orig_region = _calc_key_region(start_ofs_, end_ofs_, len, p_index, p_x_);
+	Region orig_region = _calc_key_region(p_index, start_ofs_, end_ofs_, len, offset);
 
 	bool is_outside = _is_key_region_outside(orig_region, p_clip_left, p_clip_right);
 	if (is_outside) {
 		return;
 	}
 
-	Vector2 region = _clip_key_region(orig_region, p_clip_left, p_clip_right);
+	Region region = _clip_key_region(orig_region, p_clip_left, p_clip_right);
 
-	int region_begin = region.x;
-	int region_end = region.y;
-	int region_width = region.y - region.x;
+	float region_begin = region.x;
+	float region_end = region.x + region.width;
+	float region_width = region.width;
 
 	Rect2 key_rect = get_global_key_rect(p_index);
 
 	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 
-	if (orig_region.y - orig_region.x <= REGION_MAX_WIDTH) {
+	if (orig_region.width <= REGION_MAX_WIDTH) {
 		Rect2 region_rect = Rect2(region_begin, key_rect.position.y, REGION_MAX_WIDTH, key_rect.size.y);
 		draw_rect(region_rect, accent_color);
 
@@ -1014,20 +994,22 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 	draw_rect(rect, bg_color);
 
 	Vector<Vector2> points;
-	points.resize(region_width * 2);
+	points.resize(Math::ceil(rect.size.x) * 2);
 
-	Vector<Color> colors;
-	if (p_selected) {
-		colors = { bg_color.lightened(0.8) };
-	} else {
-		colors = { bg_color.lightened(0.2) };
-	}
+	{
+		Vector<Color> colors;
+		if (p_selected) {
+			colors = { bg_color.lightened(0.8) };
+		} else {
+			colors = { bg_color.lightened(0.2) };
+		}
 
-	Vector2 region_shift = _calc_key_region_shift(orig_region, region);
-	get_key_region_data(resource, points, rect, scale, start_ofs_ + region_shift.x / scale);
+		Region region_shift = _calc_key_region_shift(orig_region, region);
+		get_key_region_data(resource, points, rect, scale, start_ofs_ + region_shift.x / scale);
 
-	if (!points.is_empty()) {
-		draw_multiline_colors(points, colors);
+		if (!points.is_empty()) {
+			draw_multiline_colors(points, colors);
+		}
 	}
 
 	Color edge_color = Color(accent_color);
@@ -1059,10 +1041,6 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 			int f_h = key_rect.position.y + key_rect.size.y / 2 - font->get_height(font_size) / 2 + font->get_ascent(font_size);
 			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), animationTrackDrawUtils->_make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 		}
-	}
-
-	if (p_selected) {
-		draw_rect(rect, accent_color, false);
 	}
 }
 
@@ -1149,7 +1127,7 @@ StringName AnimationTrackEditClip::get_edit_name(const int p_index) const {
 	return resource_name;
 }
 
-Vector2 AnimationTrackEditClip::_calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const {
+Region AnimationTrackEditClip::_calc_key_region(const int p_index, const float start_ofs, const float end_ofs, const float len, float __offset) const {
 	float anim_len = len - start_ofs - end_ofs;
 	if (anim_len < 0) {
 		WARN_PRINT("anim_len < 0");
@@ -1161,27 +1139,29 @@ Vector2 AnimationTrackEditClip::_calc_key_region(const float start_ofs, const fl
 			anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 		}
 	}
+
 	float scale = get_timeline()->get_zoom_scale();
+
 	float pixel_len = anim_len * scale;
-	float pixel_begin = p_x;
-	float pixel_end = p_x + pixel_len;
+	float pixel_begin = __offset;
 
-	return Vector2(pixel_begin, pixel_end);
+	return Region(pixel_begin, pixel_len);
 }
 
-Vector2 AnimationTrackEditClip::_clip_key_region(Vector2 region, const int p_clip_left, const int p_clip_right) {
-	region.y = CLAMP(region.y, MAX(region.x, p_clip_left), p_clip_right);
-	region.x = CLAMP(region.x, p_clip_left, MIN(region.y, p_clip_right));
-	ERR_FAIL_COND_V_MSG(region.x > region.y, region, "Clipped region is invalid (x > y).");
-	return region;
+Region AnimationTrackEditClip::_clip_key_region(const Region &region, const int p_clip_left, const int p_clip_right) {
+	float region_end = CLAMP(region.x + region.width, MAX(region.x, p_clip_left), p_clip_right);
+	float region_start = CLAMP(region.x, p_clip_left, MIN(region_end, p_clip_right));
+	ERR_FAIL_COND_V_MSG(region_start > region_end, region, "Clipped region is invalid (x > y).");
+
+	return Region(region_start, region_end - region_start);
 }
 
-Vector2 AnimationTrackEditClip::_calc_key_region_shift(const Vector2 &orig_region, const Vector2 &region) const {
-	return Vector2(region.x - orig_region.x, region.y - orig_region.y);
+Region AnimationTrackEditClip::_calc_key_region_shift(const Region &orig_region, const Region &region) const {
+	return Region(region.x - orig_region.x, (region.x + region.width) - (orig_region.x + orig_region.width));
 }
 
-bool AnimationTrackEditClip::_is_key_region_outside(const Vector2 &region, const int p_clip_left, const int p_clip_right) const {
-	return (region.y < p_clip_left || region.x > p_clip_right);
+bool AnimationTrackEditClip::_is_key_region_outside(const Region &region, const int p_clip_left, const int p_clip_right) const {
+	return ((region.x + region.width) < p_clip_left || region.x > p_clip_right);
 }
 
 void AnimationTrackEditClip::_preview_changed(ObjectID p_which) {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -45,6 +45,8 @@
 /// BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
+	key_pivot.x = 0.5;
+	key_pivot.y = 0.5;
 }
 
 int AnimationTrackEditBool::get_key_width(const int p_index) const {
@@ -55,10 +57,6 @@ int AnimationTrackEditBool::get_key_width(const int p_index) const {
 int AnimationTrackEditBool::get_key_height(const int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_height();
-}
-
-Rect2 AnimationTrackEditBool::get_key_rect(const int p_index) const {
-	return AnimationTrackEdit::get_key_rect(p_index);
 }
 
 void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -93,6 +91,8 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 /// COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
+	key_pivot.x = 0.5;
+	key_pivot.y = 0.5;
 }
 
 int AnimationTrackEditColor::get_key_width(const int p_index) const {
@@ -101,10 +101,6 @@ int AnimationTrackEditColor::get_key_width(const int p_index) const {
 
 int AnimationTrackEditColor::get_key_height(const int p_index) const {
 	return _get_theme_font_height(0.8);
-}
-
-Rect2 AnimationTrackEditColor::get_key_rect(const int p_index) const {
-	return AnimationTrackEdit::get_key_rect(p_index);
 }
 
 void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -188,6 +184,8 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 /// SPRITE FRAME / FRAME_COORDS ///
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
+	key_pivot.x = 0.0;
+	key_pivot.y = 0.5;
 }
 
 int AnimationTrackEditSpriteFrame::get_key_width(const int p_index) const {
@@ -196,14 +194,6 @@ int AnimationTrackEditSpriteFrame::get_key_width(const int p_index) const {
 
 int AnimationTrackEditSpriteFrame::get_key_height(const int p_index) const {
 	return _get_theme_font_height(2.0);
-}
-
-Rect2 AnimationTrackEditSpriteFrame::get_key_rect(const int p_index) const {
-	int width = get_key_width(p_index);
-	int height = get_key_height(p_index);
-	Rect2 rect = Rect2(0, -height / 2, width, height);
-
-	return rect;
 }
 
 Ref<Resource> AnimationTrackEditSpriteFrame::get_resource(const int p_index) const {
@@ -335,14 +325,22 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 /// SUB ANIMATION ///
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
+	key_pivot.x = 0.0;
+	key_pivot.y = 0.5;
 }
 
-int AnimationTrackEditSubAnim::get_key_width(const int p_index) const {
-	return _get_theme_font_height(1.5);
-}
+bool AnimationTrackEditSubAnim::has_valid_key(const int p_index) const {
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		return false;
+	}
 
-int AnimationTrackEditSubAnim::get_key_height(const int p_index) const {
-	return _get_theme_font_height(1.5);
+	StringName edit_name = get_edit_name(p_index);
+	if (edit_name.is_empty() || edit_name == "[stop]") {
+		return false;
+	}
+
+	return true;
 }
 
 void AnimationTrackEditSubAnim::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -410,6 +408,8 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) const {
 //// VOLUME DB ////
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
+	key_pivot.x = 0.5;
+	key_pivot.y = 0.5;
 }
 
 int AnimationTrackEditVolumeDB::get_key_width(const int p_index) const {
@@ -474,15 +474,18 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 /// AUDIO ///
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
+	key_pivot.x = 0.0;
+	key_pivot.y = 0.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
-int AnimationTrackEditTypeAudio::get_key_width(const int p_index) const {
-	return _get_theme_font_height(1.5);
-}
+bool AnimationTrackEditTypeAudio::has_valid_key(const int p_index) const {
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		return false;
+	}
 
-int AnimationTrackEditTypeAudio::get_key_height(const int p_index) const {
-	return _get_theme_font_height(1.5);
+	return true;
 }
 
 void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
@@ -538,15 +541,18 @@ void AnimationTrackEditTypeAudio::set_end_offset(const int p_index, const float 
 /// AUDIO ///
 
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
+	key_pivot.x = 0.0;
+	key_pivot.y = 0.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
-int AnimationTrackEditAudio::get_key_width(const int p_index) const {
-	return _get_theme_font_height(1.5);
-}
+bool AnimationTrackEditAudio::has_valid_key(const int p_index) const {
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		return false;
+	}
 
-int AnimationTrackEditAudio::get_key_height(const int p_index) const {
-	return _get_theme_font_height(1.5);
+	return true;
 }
 
 void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
@@ -585,15 +591,23 @@ float AnimationTrackEditAudio::get_length(const int p_index) const {
 /// TYPE ANIMATION ///
 
 AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
+	key_pivot.x = 0.0;
+	key_pivot.y = 0.5;
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
-int AnimationTrackEditTypeAnimation::get_key_width(const int p_index) const {
-	return _get_theme_font_height(1.5);
-}
+bool AnimationTrackEditTypeAnimation::has_valid_key(const int p_index) const {
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		return false;
+	}
 
-int AnimationTrackEditTypeAnimation::get_key_height(const int p_index) const {
-	return _get_theme_font_height(1.5);
+	StringName edit_name = get_edit_name(p_index);
+	if (edit_name.is_empty() || edit_name == "[stop]") {
+		return false;
+	}
+
+	return true;
 }
 
 void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
@@ -679,49 +693,7 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) con
 
 /// KEY ///
 
-bool AnimationTrackEditKey::__has_valid_key(const int p_index) const {
-	Ref<Resource> resource = get_resource(p_index);
-	if (!resource.is_valid()) {
-		return false;
-	}
-
-	StringName edit_name = get_edit_name(p_index);
-	if (edit_name.is_empty() || edit_name == "[stop]") {
-		return false;
-	}
-
-	return true;
-}
-
 int AnimationTrackEditKey::get_key_width(const int p_index) const {
-	/*
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	float anim_len = len - start_ofs - end_ofs;
-	if (anim_len < 0) {
-		WARN_PRINT("anim_len < 0");
-		anim_len = 0;
-	}
-
-	if (!len_resizing) {
-		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-			anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
-		}
-	}
-	float scale = get_timeline()->get_zoom_scale();
-	float pixel_len = anim_len * scale;
-	return pixel_len;
-	*/
-	return _get_theme_font_height(1.0);
-}
-
-int AnimationTrackEditKey::get_key_height(const int p_index) const {
-	return _get_theme_font_height(1.0);
-}
-
-float AnimationTrackEditKey::__get_key_width(const int p_index) const {
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 	float len = get_length(p_index);
@@ -741,14 +713,8 @@ float AnimationTrackEditKey::__get_key_width(const int p_index) const {
 	return anim_len * scale;
 }
 
-Rect2 AnimationTrackEditKey::get_key_rect(const int p_index) const {
-	if (!__has_valid_key(p_index)) {
-		return AnimationTrackEdit::get_key_rect(p_index);
-	}
-
-	int width = __get_key_width(p_index);
-	int height = get_key_height(p_index);
-	return Rect2(0.0, -height * key_pivot, width, height);
+int AnimationTrackEditKey::get_key_height(const int p_index) const {
+	return _get_theme_font_height(1.0);
 }
 
 int AnimationTrackEditKey::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right) {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -112,11 +112,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 
 	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
-	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
-	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
-	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
-	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
-	animationTrackDrawUtils->_draw_rect_clipped(rect, color, true, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_grid_clipped(rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
@@ -320,7 +316,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 	Color bg = accent;
 	bg.a = 0.15;
-
+	animationTrackDrawUtils->_draw_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
 	animationTrackDrawUtils->_draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -67,14 +67,6 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 		return;
 	}
 
-	if (rect.position.x + rect.size.x < p_clip_left) {
-		return;
-	}
-
-	if (rect.position.x > p_clip_right) {
-		return;
-	}
-
 	bool checked = get_animation()->track_get_key_value(get_track(), p_index);
 	Ref<Texture2D> texture = get_theme_icon(checked ? "checked" : "unchecked", "CheckBox");
 
@@ -105,14 +97,6 @@ int AnimationTrackEditTypeMethod::get_key_height(const int p_index) const {
 
 void AnimationTrackEditTypeMethod::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Rect2 rect = get_global_key_rect(p_index);
-
-	if (rect.position.x + rect.size.x < p_clip_left) {
-		return;
-	}
-
-	if (rect.position.x > p_clip_right) {
-		return;
-	}
 
 	float clip_r = p_clip_right - REGION_FONT_MARGIN;
 	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
@@ -380,14 +364,6 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	}
 
 	Rect2 rect = get_global_key_rect(p_index);
-
-	if (rect.position.x + rect.size.x < p_clip_left) {
-		return;
-	}
-
-	if (rect.position.x > p_clip_right) {
-		return;
-	}
 
 	Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 	Color bg = accent;

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -45,36 +45,49 @@
 /// BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
+	key_scale = 1.0;
+}
+
+int AnimationTrackEditBool::get_key_width() const {
+	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
+	return texture->get_width();
 }
 
 int AnimationTrackEditBool::get_key_height() const {
-	Ref<Texture2D> checked = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
-	return checked->get_height();
+	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
+	return texture->get_height();
 }
 
 Rect2 AnimationTrackEditBool::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Texture2D> checked = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
-	return Rect2(-checked->get_width() / 2, 0, checked->get_width(), get_size().height);
+	return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	bool checked = get_animation()->track_get_key_value(get_track(), p_index);
-	Ref<Texture2D> icon = get_theme_icon(checked ? "checked" : "unchecked", "CheckBox");
+	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
-	float x_from = p_x - icon->get_width() / 2;
-	float x_to = p_x + icon->get_width() / 2;
-
-	if (x_from > p_clip_right || x_to < p_clip_left) {
+	if (rect.size.is_zero_approx()) {
+		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 		return;
 	}
 
-	int h = int(get_size().height - icon->get_height()) / 2;
-	Vector2 ofs(x_from, h);
-	draw_texture(icon, ofs);
+	if (rect.position.x + rect.size.x < p_clip_left) {
+		return;
+	}
+
+	if (rect.position.x > p_clip_right) {
+		return;
+	}
+
+	bool checked = get_animation()->track_get_key_value(get_track(), p_index);
+	Ref<Texture2D> texture = get_theme_icon(checked ? "checked" : "unchecked", "CheckBox");
+
+	Rect2 region;
+	region.size = texture->get_size();
+	draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		draw_color_rect_clipped(Rect2(ofs, icon->get_size()), color, false, p_clip_left, p_clip_right);
+		draw_rect_clipped(rect, color, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -84,27 +97,32 @@ AnimationTrackEditColor::AnimationTrackEditColor() {
 	key_scale = 0.8;
 }
 
+int AnimationTrackEditColor::get_key_width() const {
+	return AnimationTrackEditKey::get_key_height();
+}
+
+int AnimationTrackEditColor::get_key_height() const {
+	return AnimationTrackEditKey::get_key_height();
+}
+
 Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
-	int fh = get_key_height();
-	int h = get_size().height;
-	return Rect2(-fh / 2, 0, fh, h);
+	return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
-	int fh = get_key_height();
 
-	Rect2 rect(Vector2(p_x - fh / 2, int(get_size().height - fh) / 2), Size2(fh, fh));
+	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
-	draw_color_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
-	draw_color_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
-	draw_color_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
-	draw_color_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
-	draw_color_rect_clipped(rect, color, true, p_clip_left, p_clip_right);
+	draw_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
+	draw_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
+	draw_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
+	draw_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
+	draw_rect_clipped(rect, color, true, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		draw_color_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
+		draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -344,12 +362,12 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	Color bg = accent;
 	bg.a = 0.15;
 
-	draw_color_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
+	draw_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
 
 	draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {
-		draw_color_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
+		draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -428,20 +446,19 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 //// VOLUME DB ////
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
-	key_scale = 1.2;
+	key_scale = 1.0;
+}
+
+int AnimationTrackEditVolumeDB::get_key_width() const {
+	return AnimationTrackEdit::get_key_width();
 }
 
 int AnimationTrackEditVolumeDB::get_key_height() const {
-	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
-	return volume_texture->get_height() * key_scale;
+	return AnimationTrackEdit::get_key_height();
 }
 
 void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	if (p_index == 0) {
-		draw_fg(p_clip_left, p_clip_right);
-	} else if (p_index == 1) {
-		draw_bg(p_clip_left, p_clip_right);
-	}
+	AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 }
 
 void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
@@ -461,7 +478,7 @@ void AnimationTrackEditVolumeDB::draw_fg(int p_clip_left, int p_clip_right) {
 	int y_from = (get_size().height - tex_h) / 2;
 	int db0 = y_from + (24 / 80.0) * tex_h;
 
-	draw_line(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3));
+	draw_line_clipped(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
 }
 
 void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
@@ -478,19 +495,6 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 	float h = 1.0 - ((db + 60) / 84.0);
 	float h_n = 1.0 - ((db_n + 60) / 84.0);
 
-	int from_x = p_x;
-	int to_x = p_next_x;
-
-	if (from_x < p_clip_left) {
-		h = Math::lerp(h, h_n, float(p_clip_left - from_x) / float(to_x - from_x));
-		from_x = p_clip_left;
-	}
-
-	if (to_x > p_clip_right) {
-		h_n = Math::lerp(h, h_n, float(p_clip_right - from_x) / float(to_x - from_x));
-		to_x = p_clip_right;
-	}
-
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
 	int tex_h = volume_texture->get_height();
 
@@ -499,7 +503,9 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 	Color color = get_theme_color(SceneStringName(font_color), SNAME("Label"));
 	color.a *= REGION_EDGE_ALPHA;
 
-	draw_line(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2);
+	int from_x = p_x;
+	int to_x = p_next_x;
+	draw_line_clipped(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2, p_clip_left, p_clip_right);
 }
 
 /// AUDIO ///
@@ -1111,6 +1117,10 @@ void AnimationTrackEditKey::_preview_changed(ObjectID p_which) {
 			return;
 		}
 	}
+}
+
+int AnimationTrackEditKey::get_key_width() const {
+	return get_size().height;
 }
 
 int AnimationTrackEditKey::get_key_height() const {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -892,7 +892,7 @@ void AnimationTrackEditTypeAnimation::gui_input(const Ref<InputEvent> &p_event) 
 		bool use_hsize_cursor = false;
 		for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
 			StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), i);
-			if (anim_name == StringName("[stop]")) {
+			if (anim_name.is_empty()) {
 				continue;
 			}
 			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -59,11 +59,9 @@ int AnimationTrackEditBool::get_key_height(const int p_index) const {
 	return texture->get_height();
 }
 
-void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Rect2 rect = get_global_key_rect(p_index);
-
-	if (rect.size.is_zero_approx()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+void AnimationTrackEditBool::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
+	if (p_global_rect.size.is_zero_approx()) {
+		AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 		return;
 	}
 
@@ -72,11 +70,11 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 
 	Rect2 region;
 	region.size = texture->get_size();
-	animationTrackDrawUtils->_draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_texture_region_clipped(texture, p_global_rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		animationTrackDrawUtils->_draw_rect_clipped(rect, color, false, p_clip_left, p_clip_right);
+		animationTrackDrawUtils->_draw_rect_clipped(p_global_rect, color, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -95,16 +93,14 @@ int AnimationTrackEditTypeMethod::get_key_height(const int p_index) const {
 	return AnimationTrackEdit::get_key_height(p_index);
 }
 
-void AnimationTrackEditTypeMethod::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Rect2 rect = get_global_key_rect(p_index);
-
+void AnimationTrackEditTypeMethod::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	float clip_r = p_clip_right - REGION_FONT_MARGIN;
 	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
 		Rect2 rect_next = get_global_key_rect(p_index + 1);
 		clip_r = MIN(rect_next.position.x - REGION_FONT_MARGIN, clip_r);
 	}
 
-	float text_pos = rect.position.x + rect.size.width + REGION_FONT_MARGIN;
+	float text_pos = p_global_rect.position.x + p_global_rect.size.width + REGION_FONT_MARGIN;
 	float max_width = MAX(0.0, clip_r - text_pos);
 	if (max_width > 0) {
 		const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
@@ -119,7 +115,7 @@ void AnimationTrackEditTypeMethod::draw_key(int p_index, float p_pixels_sec, int
 		draw_string(font, Vector2(text_pos, f_h), edit_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color);
 	}
 
-	AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+	AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 }
 
 StringName AnimationTrackEditTypeMethod::get_edit_name(const int p_index) const {
@@ -165,20 +161,18 @@ int AnimationTrackEditColor::get_key_height(const int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
-void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditColor::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
 
-	Rect2 rect = get_global_key_rect(p_index);
-
-	animationTrackDrawUtils->_draw_grid_clipped(rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_grid_clipped(p_global_rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		animationTrackDrawUtils->_draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
+		animationTrackDrawUtils->_draw_rect_clipped(p_global_rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
-void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) {
 	int fh = get_key_height(p_index);
 
 	fh /= 3;
@@ -302,7 +296,7 @@ Ref<Resource> AnimationTrackEditSpriteFrame::get_resource(const int p_index) con
 	return texture;
 }
 
-Rect2 AnimationTrackEditSpriteFrame::_create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture) {
+Rect2 AnimationTrackEditSpriteFrame::_create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture) const {
 	Rect2 region;
 
 	if (texture.is_valid()) {
@@ -339,17 +333,17 @@ Rect2 AnimationTrackEditSpriteFrame::_create_texture_region_sprite(int p_index, 
 	return region;
 }
 
-void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditSpriteFrame::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Object *object = ObjectDB::get_instance(get_node_id());
 
 	if (!object) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 		return;
 	}
 
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 		return;
 	}
 
@@ -478,11 +472,11 @@ int AnimationTrackEditVolumeDB::get_key_height(const int p_index) const {
 	return AnimationTrackEdit::get_key_height(p_index);
 }
 
-void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+void AnimationTrackEditVolumeDB::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
+	AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 }
 
-void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
+void AnimationTrackEditVolumeDB::draw_bg(const float p_clip_left, const float p_clip_right) {
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
 	int tex_h = volume_texture->get_height();
 
@@ -493,7 +487,7 @@ void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
 	draw_texture_rect(volume_texture, Rect2(p_clip_left, y_from, p_clip_right - p_clip_left, y_from + y_size), false, color);
 }
 
-void AnimationTrackEditVolumeDB::draw_fg(int p_clip_left, int p_clip_right) {
+void AnimationTrackEditVolumeDB::draw_fg(const float p_clip_left, const float p_clip_right) {
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
 	int tex_h = volume_texture->get_height();
 	int y_from = (get_size().height - tex_h) / 2;
@@ -502,7 +496,7 @@ void AnimationTrackEditVolumeDB::draw_fg(int p_clip_left, int p_clip_right) {
 	animationTrackDrawUtils->_draw_line_clipped(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
 }
 
-void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
 	if (p_x > p_clip_right || p_next_x < p_clip_left) {
 		return;
 	}
@@ -775,18 +769,41 @@ int AnimationTrackEditClip::get_key_height(const int p_index) const {
 	return _get_theme_font_height(1.0);
 }
 
-int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right) {
-	Rect2 rect = get_global_key_rect(p_index);
+int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right) {
+	//float len = get_length(p_index);
+	//if (len == 0) {
+	//	continue;
+	//}
+	// 
+	// OLD
+	float len = get_length(p_index);
+	float start_ofs = get_start_offset(p_index);
+	float end_ofs = get_end_offset(p_index);
+	
+	float p_x = ((get_animation()->track_get_key_time(get_track(), p_index) - get_timeline()->get_value()) * get_timeline()->get_zoom_scale()) + get_timeline()->get_name_limit();
+	Vector2 region = _calc_key_region(start_ofs, end_ofs, len, p_index, p_x);
+	region = _clip_key_region(region, p_clip_left, p_clip_right);
 
-	int region_begin = rect.position.x;
-	int region_end = rect.position.x + rect.size.x;
+	int region_begin = region.x;
+	int region_end = region.y;
+	// OLD
+
+	//Rect2 global_rect = _to_local_key_rect(p_index, p_global_rect);
+
+	//int region_begin = global_rect.position.x;
+	//int region_end = global_rect.position.x + global_rect.size.x;
 
 	if (region_begin >= p_clip_left && region_end <= p_clip_right && region_begin <= region_end) {
 		bool resize_start = false;
 		int can_resize = false;
 
-		float diff_left = region_begin - mm->get_position().x;
-		float diff_right = mm->get_position().x - region_end;
+		float mouse_pos = mm->get_position().x;
+		//mouse_pos += _get_pixels_sec(p_index, p_ignore_moving_selection); //mm->get_position().x*timeline->get_zoom_scale() - timeline->get_name_limit()
+
+		float diff_left = region_begin - mouse_pos;
+		float diff_right = mouse_pos - region_end;
+
+		//WARN_PRINT(String::num(region_begin) + " (" + String::num(diff_left) + ")" + " - " + String::num(region_end)  + " (" + String::num(diff_right) + ")" + " => (" + String::num(mouse_pos) + ")");
 
 		float resize_threshold = REGION_RESIZE_THRESHOLD * EDSCALE;
 
@@ -829,17 +846,12 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 	if (!len_resizing && mm.is_valid()) {
 		bool use_hsize_cursor = false;
 		for (int p_index = 0; p_index < get_animation()->track_get_key_count(get_track()); p_index++) {
-			float len = get_length(p_index);
-			if (len == 0) {
-				continue;
-			}
+			Rect2 global_rect = get_global_key_rect(p_index);
 
-			float start_ofs = get_start_offset(p_index);
-			float end_ofs = get_end_offset(p_index);
-			float p_clip_left = get_timeline()->get_name_limit();
-			float p_clip_right = get_size().width - get_timeline()->get_buttons_width();
+			float clip_left = get_timeline()->get_name_limit();
+			float clip_right = get_size().width - get_timeline()->get_buttons_width();
 
-			int resizing_index = handle_track_resizing(mm, start_ofs, end_ofs, len, p_index, p_clip_left, p_clip_right);
+			int resizing_index = handle_track_resizing(mm, p_index, global_rect, clip_left, clip_right);
 			if (resizing_index != -1) {
 				use_hsize_cursor = true;
 				len_resizing_index = resizing_index;
@@ -940,10 +952,10 @@ Control::CursorShape AnimationTrackEditClip::get_cursor_shape(const Point2 &p_po
 	}
 }
 
-void AnimationTrackEditClip::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 		return;
 	}
 
@@ -954,8 +966,10 @@ void AnimationTrackEditClip::draw_key(int p_index, float p_pixels_sec, int p_x, 
 	float diff_start_ofs = 0;
 	float diff_end_ofs = 0;
 
+	float scale = get_timeline()->get_zoom_scale();
+
 	if (len_resizing && p_index == len_resizing_index) {
-		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+		float ofs_local = len_resizing_rel / scale;
 		if (len_resizing_start) {
 			diff_start_ofs = ofs_local;
 		} else {
@@ -963,7 +977,7 @@ void AnimationTrackEditClip::draw_key(int p_index, float p_pixels_sec, int p_x, 
 		}
 	}
 
-	float p_x_ = p_x + (diff_start_ofs * p_pixels_sec);
+	float p_x_ = p_global_rect.position.x + (diff_start_ofs * scale);
 	float start_ofs_ = start_ofs + diff_start_ofs;
 	float end_ofs_ = end_ofs + diff_end_ofs;
 
@@ -1010,7 +1024,7 @@ void AnimationTrackEditClip::draw_key(int p_index, float p_pixels_sec, int p_x, 
 	}
 
 	Vector2 region_shift = _calc_key_region_shift(orig_region, region);
-	get_key_region_data(resource, points, rect, p_pixels_sec, start_ofs_ + region_shift.x / p_pixels_sec);
+	get_key_region_data(resource, points, rect, scale, start_ofs_ + region_shift.x / scale);
 
 	if (!points.is_empty()) {
 		draw_multiline_colors(points, colors);
@@ -1155,18 +1169,18 @@ Vector2 AnimationTrackEditClip::_calc_key_region(const float start_ofs, const fl
 	return Vector2(pixel_begin, pixel_end);
 }
 
-Vector2 AnimationTrackEditClip::_clip_key_region(Vector2 region, int p_clip_left, int p_clip_right) {
+Vector2 AnimationTrackEditClip::_clip_key_region(Vector2 region, const int p_clip_left, const int p_clip_right) {
 	region.y = CLAMP(region.y, MAX(region.x, p_clip_left), p_clip_right);
 	region.x = CLAMP(region.x, p_clip_left, MIN(region.y, p_clip_right));
 	ERR_FAIL_COND_V_MSG(region.x > region.y, region, "Clipped region is invalid (x > y).");
 	return region;
 }
 
-Vector2 AnimationTrackEditClip::_calc_key_region_shift(Vector2 &orig_region, Vector2 &region) {
+Vector2 AnimationTrackEditClip::_calc_key_region_shift(const Vector2 &orig_region, const Vector2 &region) const {
 	return Vector2(region.x - orig_region.x, region.y - orig_region.y);
 }
 
-bool AnimationTrackEditClip::_is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right) {
+bool AnimationTrackEditClip::_is_key_region_outside(const Vector2 &region, const int p_clip_left, const int p_clip_right) const {
 	return (region.y < p_clip_left || region.x > p_clip_right);
 }
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -47,12 +47,12 @@
 AnimationTrackEditBool::AnimationTrackEditBool() {
 }
 
-int AnimationTrackEditBool::get_key_width() const {
+int AnimationTrackEditBool::get_key_width(int p_index, float p_pixels_sec) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_width();
 }
 
-int AnimationTrackEditBool::get_key_height() const {
+int AnimationTrackEditBool::get_key_height(int p_index, float p_pixels_sec) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_height();
 }
@@ -82,11 +82,11 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 
 	Rect2 region;
 	region.size = texture->get_size();
-	draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		draw_rect_clipped(rect, color, false, p_clip_left, p_clip_right);
+		animationTrackDrawUtils->_draw_rect_clipped(rect, color, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -95,11 +95,11 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 AnimationTrackEditColor::AnimationTrackEditColor() {
 }
 
-int AnimationTrackEditColor::get_key_width() const {
+int AnimationTrackEditColor::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(0.8);
 }
 
-int AnimationTrackEditColor::get_key_height() const {
+int AnimationTrackEditColor::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(0.8);
 }
 
@@ -112,20 +112,20 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 
 	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
-	draw_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
-	draw_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
-	draw_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
-	draw_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
-	draw_rect_clipped(rect, color, true, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_rect_clipped(rect, color, true, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
+		animationTrackDrawUtils->_draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
-	int fh = get_key_height();
+	int fh = get_key_height(p_index, p_pixels_sec);
 
 	fh /= 3;
 
@@ -194,52 +194,37 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
 }
 
-int AnimationTrackEditSpriteFrame::get_key_width() const {
+int AnimationTrackEditSpriteFrame::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(2.0);
 }
 
-int AnimationTrackEditSpriteFrame::get_key_height() const {
+int AnimationTrackEditSpriteFrame::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(2.0);
 }
 
 Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
+	return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+}
+
+Ref<Resource> AnimationTrackEditSpriteFrame::get_resource(const int p_index) {
 	Object *object = ObjectDB::get_instance(get_node_id());
 
 	if (!object) {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+		return Ref<Resource>();
 	}
 
-	Size2 size;
-
+	Ref<Texture2D> texture;
 	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
-		Ref<Texture2D> texture = object->call("get_texture");
-		if (texture.is_null()) {
-			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-		}
+		texture = object->call("get_texture");
 
-		size = texture->get_size();
-
-		if (bool(object->call("is_region_enabled"))) {
-			size = Rect2(object->call("get_region_rect")).size;
-		}
-
-		int hframes = object->call("get_hframes");
-		int vframes = object->call("get_vframes");
-
-		if (hframes > 1) {
-			size.x /= hframes;
-		}
-		if (vframes > 1) {
-			size.y /= vframes;
-		}
 	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
-		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
-		if (sf.is_null()) {
-			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-		}
-
 		List<StringName> animations;
-		sf->get_animation_list(&animations);
+
+		Ref<SpriteFrames> sprite_frames = object->call("get_sprite_frames");
+		if (!sprite_frames.is_valid()) {
+			return Ref<Texture2D>();
+		}
+		sprite_frames->get_animation_list(&animations);
 
 		int frame = get_animation()->track_get_key_value(get_track(), p_index);
 		String animation_name;
@@ -255,48 +240,25 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 			animation_name = get_animation()->track_get_key_value(animation_track, animation_index);
 		}
 
-		Ref<Texture2D> texture = sf->get_frame_texture(animation_name, frame);
-		if (texture.is_null()) {
-			return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-		}
-
-		size = texture->get_size();
+		texture = sprite_frames->get_frame_texture(animation_name, frame);
 	}
 
-	size = size.floor();
-
-	int fh = get_key_height();
-	int fw = fh * size.width / size.height;
-
-	return Rect2(0, 0, fw, get_size().height);
+	return texture;
 }
 
-void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
-	Object *object = ObjectDB::get_instance(get_node_id());
-
-	if (!object) {
-		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-		return;
-	}
-
-	Ref<Texture2D> texture;
+Rect2 AnimationTrackEditSpriteFrame::_create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture) {
 	Rect2 region;
 
-	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
-		texture = object->call("get_texture");
-		if (texture.is_null()) {
-			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-			return;
-		}
-
+	if (texture.is_valid()) {
 		int hframes = object->call("get_hframes");
 		int vframes = object->call("get_vframes");
 
+		Variant value = get_animation()->track_get_key_value(get_track(), p_index);
 		Vector2 coords;
 		if (is_coords) {
-			coords = get_animation()->track_get_key_value(get_track(), p_index);
+			coords = value;
 		} else {
-			int frame = get_animation()->track_get_key_value(get_track(), p_index);
+			int frame = value;
 			coords.x = frame % hframes;
 			coords.y = frame / hframes;
 		}
@@ -316,42 +278,34 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 
 		region.position.x += region.size.x * coords.x;
 		region.position.y += region.size.y * coords.y;
-
-	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
-		Ref<SpriteFrames> sf = object->call("get_sprite_frames");
-		if (sf.is_null()) {
-			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-			return;
-		}
-
-		List<StringName> animations;
-		sf->get_animation_list(&animations);
-
-		int frame = get_animation()->track_get_key_value(get_track(), p_index);
-		String animation_name;
-		if (animations.size() == 1) {
-			animation_name = animations.front()->get();
-		} else {
-			// Go through other track to find if animation is set
-			String animation_path = String(get_animation()->track_get_path(get_track()));
-			animation_path = animation_path.replace(":frame", ":animation");
-			int animation_track = get_animation()->find_track(animation_path, get_animation()->track_get_type(get_track()));
-			float track_time = get_animation()->track_get_key_time(get_track(), p_index);
-			int animation_index = get_animation()->track_find_key(animation_track, track_time);
-			animation_name = get_animation()->track_get_key_value(animation_track, animation_index);
-		}
-
-		texture = sf->get_frame_texture(animation_name, frame);
-		if (texture.is_null()) {
-			AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-			return;
-		}
-
-		region.size = texture->get_size();
 	}
 
-	int height = get_key_height();
-	int width = height * region.size.width / region.size.height;
+	return region;
+}
+
+void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+	Object *object = ObjectDB::get_instance(get_node_id());
+
+	if (!object) {
+		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		return;
+	}
+
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		return;
+	}
+
+	Ref<Texture2D> texture = resource;
+	Rect2 region;
+
+	if (Object::cast_to<Sprite2D>(object) || Object::cast_to<Sprite3D>(object)) {
+		region = _create_texture_region_sprite(p_index, object, texture);
+
+	} else if (Object::cast_to<AnimatedSprite2D>(object) || Object::cast_to<AnimatedSprite3D>(object)) {
+		region = _create_region_animated_sprite(p_index, object, texture);
+	}
 
 	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
@@ -367,12 +321,10 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	Color bg = accent;
 	bg.a = 0.15;
 
-	draw_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
-
-	draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {
-		draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
+		animationTrackDrawUtils->_draw_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -385,11 +337,11 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
 }
 
-int AnimationTrackEditSubAnim::get_key_width() const {
+int AnimationTrackEditSubAnim::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditSubAnim::get_key_height() const {
+int AnimationTrackEditSubAnim::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -420,17 +372,17 @@ Ref<Resource> AnimationTrackEditSubAnim::get_resource(const int p_index) {
 	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 
 	if (String(anim_name) == "[stop]") {
-		return nullptr;
+		return Ref<Resource>();
 	}
 
 	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
 	if (!ap || !ap->has_animation(anim_name)) {
-		return nullptr;
+		return Ref<Resource>();
 	}
 
 	Ref<Animation> anim = ap->get_animation(anim_name);
 	if (!anim.is_valid()) {
-		return nullptr;
+		return Ref<Resource>();
 	}
 
 	return anim;
@@ -460,12 +412,12 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
 }
 
-int AnimationTrackEditVolumeDB::get_key_width() const {
-	return AnimationTrackEdit::get_key_width();
+int AnimationTrackEditVolumeDB::get_key_width(int p_index, float p_pixels_sec) const {
+	return AnimationTrackEdit::get_key_width(p_index, p_pixels_sec);
 }
 
-int AnimationTrackEditVolumeDB::get_key_height() const {
-	return AnimationTrackEdit::get_key_height();
+int AnimationTrackEditVolumeDB::get_key_height(int p_index, float p_pixels_sec) const {
+	return AnimationTrackEdit::get_key_height(p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -489,7 +441,7 @@ void AnimationTrackEditVolumeDB::draw_fg(int p_clip_left, int p_clip_right) {
 	int y_from = (get_size().height - tex_h) / 2;
 	int db0 = y_from + (24 / 80.0) * tex_h;
 
-	draw_line_clipped(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_line_clipped(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
 }
 
 void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
@@ -516,7 +468,7 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 
 	int from_x = p_x;
 	int to_x = p_next_x;
-	draw_line_clipped(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2, p_clip_left, p_clip_right);
+	animationTrackDrawUtils->_draw_line_clipped(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2, p_clip_left, p_clip_right);
 }
 
 /// AUDIO ///
@@ -525,11 +477,11 @@ AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
-int AnimationTrackEditTypeAudio::get_key_width() const {
+int AnimationTrackEditTypeAudio::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditTypeAudio::get_key_height() const {
+int AnimationTrackEditTypeAudio::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -589,11 +541,11 @@ AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
-int AnimationTrackEditAudio::get_key_width() const {
+int AnimationTrackEditAudio::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditAudio::get_key_height() const {
+int AnimationTrackEditAudio::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -636,11 +588,11 @@ AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
-int AnimationTrackEditTypeAnimation::get_key_width() const {
+int AnimationTrackEditTypeAnimation::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditTypeAnimation::get_key_height() const {
+int AnimationTrackEditTypeAnimation::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -670,17 +622,17 @@ Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) {
 	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 
 	if (String(anim_name) == "[stop]") {
-		return nullptr;
+		return Ref<Resource>();
 	}
 
 	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
 	if (!ap || !ap->has_animation(anim_name)) {
-		return nullptr;
+		return Ref<Resource>();
 	}
 
 	Ref<Animation> anim = ap->get_animation(anim_name);
 	if (!anim.is_valid()) {
-		return nullptr;
+		return Ref<Resource>();
 	}
 
 	return anim;
@@ -727,11 +679,11 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
 
 /// KEY ///
 
-int AnimationTrackEditKey::get_key_width() const {
+int AnimationTrackEditKey::get_key_width(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.0);
 }
 
-int AnimationTrackEditKey::get_key_height() const {
+int AnimationTrackEditKey::get_key_height(int p_index, float p_pixels_sec) const {
 	return _get_theme_font_height(1.0);
 }
 
@@ -751,7 +703,7 @@ Rect2 AnimationTrackEditKey::get_key_rect(int p_index, float p_pixels_sec) {
 	float len = get_length(p_index);
 
 	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, 0);
-	int height = get_key_height();
+	int height = get_key_height(p_index, p_pixels_sec);
 
 	return Rect2(region.x, 0, region.y, height);
 }
@@ -1145,7 +1097,7 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 			int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 
 			int f_h = int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
-			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
+			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), animationTrackDrawUtils->_make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 		}
 	}
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -89,8 +89,7 @@ float AnimationTrackEditTypeMethod::get_key_height(const int p_index) const {
 }
 
 void AnimationTrackEditTypeMethod::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
-	draw_edit_text(p_index, p_global_rect, p_clip_left, p_clip_right, true);
-
+	draw_edit_text(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right, true);
 	AnimationTrackEdit::draw_key(p_index, p_global_rect, p_selected, p_clip_left, p_clip_right);
 }
 
@@ -1017,12 +1016,12 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 	}
 
 	Color bg_color = REGION_BG_COLOR;
-	Rect2 rect = Rect2(region_begin, key_rect.position.y, region_width, key_rect.size.y);
-	draw_rect(rect, bg_color);
+	Rect2 virtual_rect = Rect2(region_begin, key_rect.position.y, region_width, key_rect.size.y);
+	draw_rect(virtual_rect, bg_color);
 
 	{
 		Vector<Vector2> points;
-		points.resize(Math::ceil(rect.size.x) * 2);
+		points.resize(Math::ceil(virtual_rect.size.x) * 2);
 
 		Vector<Color> colors;
 		if (p_selected) {
@@ -1032,7 +1031,7 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 		}
 
 		Region region_shift = _calc_key_region_shift(orig_region, region);
-		get_key_region_data(resource, points, rect, scale, start_ofs_ + region_shift.x / scale);
+		get_key_region_data(resource, points, virtual_rect, scale, start_ofs_ + region_shift.x / scale);
 
 		if (!points.is_empty()) {
 			draw_multiline_colors(points, colors);
@@ -1042,13 +1041,13 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 	Color edge_color = Color(accent_color);
 	edge_color.a = REGION_EDGE_ALPHA;
 	if (start_ofs_ > 0 && region_begin > p_clip_left) {
-		draw_rect(Rect2(region_begin, rect.position.y, 1, rect.size.y), edge_color);
+		draw_rect(Rect2(region_begin, virtual_rect.position.y, 1, virtual_rect.size.y), edge_color);
 	}
 	if (end_ofs_ > 0 && region_end < p_clip_right) {
-		draw_rect(Rect2(region_end, rect.position.y, 1, rect.size.y), edge_color);
+		draw_rect(Rect2(region_end, virtual_rect.position.y, 1, virtual_rect.size.y), edge_color);
 	}
 
-	draw_edit_text(p_index, rect, p_clip_left, p_clip_right, false);
+	draw_edit_text(p_index, virtual_rect, p_selected, p_clip_left, p_clip_right, false);
 }
 
 bool AnimationTrackEditClip::can_drop_data(const Point2 &p_point, const Variant &p_data) const {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -74,13 +74,14 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 
 	if (p_selected) {
 		Color color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		draw_rect_clipped(Rect2(ofs, icon->get_size()), color, false);
+		draw_color_rect_clipped(Rect2(ofs, icon->get_size()), color, false, p_clip_left, p_clip_right);
 	}
 }
 
 /// COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
+	key_scale = 0.8;
 }
 
 Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
@@ -91,29 +92,24 @@ Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
 
 void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
-
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = font->get_height(font_size) * REGION_DEFAULT_FONT_SCALE;
+	int fh = get_key_height();
 
 	Rect2 rect(Vector2(p_x - fh / 2, int(get_size().height - fh) / 2), Size2(fh, fh));
 
-	draw_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4));
-	draw_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4));
-	draw_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6));
-	draw_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6));
-	draw_rect_clipped(rect, color);
+	draw_color_rect_clipped(Rect2(rect.position, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
+	draw_color_rect_clipped(Rect2(rect.position + rect.size / 2, rect.size / 2), Color(0.4, 0.4, 0.4), true, p_clip_left, p_clip_right);
+	draw_color_rect_clipped(Rect2(rect.position + Vector2(rect.size.x / 2, 0), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
+	draw_color_rect_clipped(Rect2(rect.position + Vector2(0, rect.size.y / 2), rect.size / 2), Color(0.6, 0.6, 0.6), true, p_clip_left, p_clip_right);
+	draw_color_rect_clipped(rect, color, true, p_clip_left, p_clip_right);
 
 	if (p_selected) {
 		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
-		draw_rect_clipped(rect, accent, false);
+		draw_color_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = (font->get_height(font_size) * REGION_DEFAULT_FONT_SCALE);
+	int fh = get_key_height();
 
 	fh /= 3;
 
@@ -180,6 +176,7 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 /// SPRITE FRAME / FRAME_COORDS ///
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
+	key_scale = 2.0;
 }
 
 Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
@@ -245,12 +242,10 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 
 	size = size.floor();
 
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int height = int(font->get_height(font_size) * 2);
-	int width = height * size.width / size.height;
+	int fh = get_key_height();
+	int fw = fh * size.width / size.height;
 
-	return Rect2(0, 0, width, get_size().height);
+	return Rect2(0, 0, fw, get_size().height);
 }
 
 void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -332,10 +327,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 		region.size = texture->get_size();
 	}
 
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int height = int(font->get_height(font_size) * 2);
-
+	int height = get_key_height();
 	int width = height * region.size.width / region.size.height;
 
 	Rect2 rect(p_x, int(get_size().height - height) / 2, width, height);
@@ -352,12 +344,12 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	Color bg = accent;
 	bg.a = 0.15;
 
-	draw_rect_clipped(rect, bg);
+	draw_color_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
 
-	draw_texture_region_clipped(texture, rect, region);
+	draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
 
 	if (p_selected) {
-		draw_rect_clipped(rect, accent, false);
+		draw_color_rect_clipped(rect, accent, false, p_clip_left, p_clip_right);
 	}
 }
 
@@ -368,6 +360,7 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 /// SUB ANIMATION ///
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
+	key_scale = 1.5;
 }
 
 void AnimationTrackEditSubAnim::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -435,11 +428,12 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 //// VOLUME DB ////
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
+	key_scale = 1.2;
 }
 
 int AnimationTrackEditVolumeDB::get_key_height() const {
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
-	return volume_texture->get_height() * REGION_DEFAULT_FONT_SCALE;
+	return volume_texture->get_height() * key_scale;
 }
 
 void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -511,6 +505,7 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 /// AUDIO ///
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
+	key_scale = 1.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
@@ -606,6 +601,7 @@ float AnimationTrackEditAudio::get_length(const int p_index) {
 /// TYPE ANIMATION ///
 
 AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
+	key_scale = 1.5;
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
@@ -1119,7 +1115,7 @@ void AnimationTrackEditKey::_preview_changed(ObjectID p_which) {
 int AnimationTrackEditKey::get_key_height() const {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * REGION_DEFAULT_FONT_SCALE);
+	return int(font->get_height(font_size) * key_scale);
 }
 
 /// PLUGIN ///

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -70,7 +70,7 @@ void AnimationTrackEditBool::draw_key(const int p_index, const Rect2 &p_global_r
 
 	Rect2 region;
 	region.size = texture->get_size();
-	animationTrackDrawUtils->_draw_texture_region_clipped(texture, p_global_rect, region, p_clip_left, p_clip_right);
+	editor->_draw_texture_region_clipped(this, texture, p_global_rect, region, p_clip_left, p_clip_right);
 }
 
 /// METHOD ///
@@ -104,7 +104,7 @@ void AnimationTrackEditTypeMethod::draw_key(const int p_index, const Rect2 &p_gl
 		color.a = 0.5;
 
 		String method_name = get_edit_name(p_index);
-		String edit_name = animationTrackDrawUtils->_make_text_clipped(method_name, font, font_size, max_width);
+		String edit_name = editor->_make_text_clipped(method_name, font, font_size, max_width);
 
 		int f_h = int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
 		draw_string(font, Vector2(text_pos, f_h), edit_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color);
@@ -114,7 +114,6 @@ void AnimationTrackEditTypeMethod::draw_key(const int p_index, const Rect2 &p_gl
 }
 
 void AnimationTrackEditTypeMethod::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
-
 }
 
 StringName AnimationTrackEditTypeMethod::get_edit_name(const int p_index) const {
@@ -163,7 +162,7 @@ float AnimationTrackEditColor::get_key_height(const int p_index) const {
 void AnimationTrackEditColor::draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) {
 	Color color = get_animation()->track_get_key_value(get_track(), p_index);
 
-	animationTrackDrawUtils->_draw_grid_clipped(p_global_rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
+	editor->_draw_grid_clipped(this, p_global_rect, color, COLOR_EDIT_RECT_INTERVAL, p_clip_left, p_clip_right);
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) {
@@ -346,8 +345,8 @@ void AnimationTrackEditSpriteFrame::draw_key(const int p_index, const Rect2 &p_g
 	Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 	Color bg = accent;
 	bg.a = 0.15;
-	animationTrackDrawUtils->_draw_rect_clipped(rect, bg, true, p_clip_left, p_clip_right);
-	animationTrackDrawUtils->_draw_texture_region_clipped(texture, rect, region, p_clip_left, p_clip_right);
+	editor->_draw_rect_clipped(this, rect, bg, true, p_clip_left, p_clip_right);
+	editor->_draw_texture_region_clipped(this, texture, rect, region, p_clip_left, p_clip_right);
 }
 
 bool AnimationTrackEditSpriteFrame::has_valid_key(const int p_index) const {
@@ -487,7 +486,7 @@ void AnimationTrackEditVolumeDB::draw_fg(const float p_clip_left, const float p_
 	int y_from = (get_size().height - tex_h) / 2;
 	int db0 = y_from + (24 / 80.0) * tex_h;
 
-	animationTrackDrawUtils->_draw_line_clipped(Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
+	editor->_draw_line_clipped(this, Vector2(p_clip_left, db0), Vector2(p_clip_right, db0), Color(1, 1, 1, 0.3), -1.0, p_clip_left, p_clip_right);
 }
 
 void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const float p_pixels_sec, const float p_x, const float p_next_x, const float p_clip_left, const float p_clip_right) {
@@ -510,7 +509,7 @@ void AnimationTrackEditVolumeDB::draw_key_link(const int p_index, const float p_
 
 	int from_x = p_x;
 	int to_x = p_next_x;
-	animationTrackDrawUtils->_draw_line_clipped(Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2, p_clip_left, p_clip_right);
+	editor->_draw_line_clipped(this, Point2(from_x, y_from + h * tex_h), Point2(to_x, y_from + h_n * tex_h), color, 2, p_clip_left, p_clip_right);
 }
 
 /// AUDIO ///
@@ -776,7 +775,7 @@ int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotio
 		int can_resize = false;
 
 		float mouse_pos = mm->get_position().x;
-		
+
 		float diff_left = region_begin - mouse_pos;
 		float diff_right = mouse_pos - region_end;
 
@@ -993,10 +992,10 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 	Rect2 rect = Rect2(region_begin, key_rect.position.y, region_width, key_rect.size.y);
 	draw_rect(rect, bg_color);
 
-	Vector<Vector2> points;
-	points.resize(Math::ceil(rect.size.x) * 2);
-
 	{
+		Vector<Vector2> points;
+		points.resize(Math::ceil(rect.size.x) * 2);
+
 		Vector<Color> colors;
 		if (p_selected) {
 			colors = { bg_color.lightened(0.8) };
@@ -1039,7 +1038,7 @@ void AnimationTrackEditClip::draw_key(const int p_index, const Rect2 &p_global_r
 			int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 
 			int f_h = key_rect.position.y + key_rect.size.y / 2 - font->get_height(font_size) / 2 + font->get_ascent(font_size);
-			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), animationTrackDrawUtils->_make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
+			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), editor->_make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 		}
 	}
 }
@@ -1134,8 +1133,9 @@ Region AnimationTrackEditClip::_calc_key_region(const int p_index, const float s
 		anim_len = 0;
 	}
 
-	if (!len_resizing) {
-		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
+	if (!(len_resizing && len_resizing_index == p_index)) {
+		bool has_next_key = get_animation()->track_get_key_count(get_track()) > p_index + 1;
+		if (has_next_key) {
 			anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 		}
 	}

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -894,7 +894,7 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 		len_resizing_from_px = mb->get_position().x;
 		len_resizing_rel = 0;
 
-		emit_signal(SNAME("select_key"), len_resizing_index, true);
+		_select_key(len_resizing_index, true);
 
 		queue_redraw();
 		accept_event();
@@ -922,9 +922,9 @@ void AnimationTrackEditClip::gui_input(const Ref<InputEvent> &p_event) {
 				set_start_offset(len_resizing_index, prev_ofs, new_ofs);
 				undo_redo->commit_action();
 
-				emit_signal(SNAME("move_selection_begin"));
-				emit_signal(SNAME("move_selection"), offset);
-				emit_signal(SNAME("move_selection_commit"));
+				_move_selection_begin();
+				_move_selection(offset);
+				_move_selection_commit();
 			}
 		} else {
 			float ofs_local = -len_resizing_rel / get_timeline()->get_zoom_scale();

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -43,6 +43,20 @@
 #include "servers/audio/audio_stream.h"
 
 /// BOOL ///
+
+AnimationTrackEditBool::AnimationTrackEditBool() {
+}
+
+bool AnimationTrackEditBool::is_key_selectable_by_distance() const {
+	return false;
+}
+
+void AnimationTrackEditBool::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+}
+
+void AnimationTrackEditBool::_preview_changed(ObjectID p_which) {
+}
+
 int AnimationTrackEditBool::get_key_height() const {
 	Ref<Texture2D> checked = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return checked->get_height();
@@ -51,10 +65,6 @@ int AnimationTrackEditBool::get_key_height() const {
 Rect2 AnimationTrackEditBool::get_key_rect(int p_index, float p_pixels_sec) {
 	Ref<Texture2D> checked = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return Rect2(-checked->get_width() / 2, 0, checked->get_width(), get_size().height);
-}
-
-bool AnimationTrackEditBool::is_key_selectable_by_distance() const {
-	return false;
 }
 
 void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -81,6 +91,19 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 
 /// COLOR ///
 
+AnimationTrackEditColor::AnimationTrackEditColor() {
+}
+
+bool AnimationTrackEditColor::is_key_selectable_by_distance() const {
+	return false;
+}
+
+void AnimationTrackEditColor::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+}
+
+void AnimationTrackEditColor::_preview_changed(ObjectID p_which) {
+}
+
 int AnimationTrackEditColor::get_key_height() const {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
@@ -94,8 +117,23 @@ Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
 	return Rect2(-fh / 2, 0, fh, get_size().height);
 }
 
-bool AnimationTrackEditColor::is_key_selectable_by_distance() const {
+/// VOLUME DB ///
+
+AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
+}
+
+bool AnimationTrackEditVolumeDB::is_key_selectable_by_distance() const {
 	return false;
+}
+
+void AnimationTrackEditVolumeDB::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+}
+
+void AnimationTrackEditVolumeDB::_preview_changed(ObjectID p_which) {
+}
+
+Rect2 AnimationTrackEditVolumeDB::get_key_rect(int p_index, float p_pixels_sec) {
+	return get_key_rect_region(0.0, 0.0, 0.0, p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
@@ -188,6 +226,10 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 
 /// AUDIO ///
 
+bool AnimationTrackEditAudio::is_key_selectable_by_distance() const {
+	return false;
+}
+
 void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
 	Object *object = ObjectDB::get_instance(id);
 
@@ -237,11 +279,7 @@ Rect2 AnimationTrackEditAudio::get_key_rect(int p_index, float p_pixels_sec) {
 	float end_ofs = 0.0;
 	float len = stream->get_length();
 
-	return get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
-}
-
-bool AnimationTrackEditAudio::is_key_selectable_by_distance() const {
-	return false;
+	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -283,7 +321,10 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 	}
 
 	float len = stream->get_length();
+	draw_key_region(stream, 0.0, 0.0, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+}
 
+void AnimationTrackEditAudio::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	int pixel_len = len * p_pixels_sec;
 	int pixel_begin = p_x;
 	int pixel_end = p_x + pixel_len;
@@ -315,7 +356,7 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 	points.resize((to_x - from_x) * 2);
 	Vector<Color> colors = { Color(0.75, 0.75, 0.75) };
 
-	create_key_region(stream, points, rect, p_pixels_sec, 0.0);
+	create_key_region(resource, points, rect, p_pixels_sec, 0.0);
 
 	draw_multiline_colors(points, colors);
 
@@ -325,15 +366,24 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 	}
 }
 
-void AnimationTrackEditAudio::set_node(Object *p_object) {
-	id = p_object->get_instance_id();
-}
-
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
 /// SPRITE FRAME / FRAME_COORDS ///
+
+AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
+}
+
+bool AnimationTrackEditSpriteFrame::is_key_selectable_by_distance() const {
+	return false;
+}
+
+void AnimationTrackEditSpriteFrame::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+}
+
+void AnimationTrackEditSpriteFrame::_preview_changed(ObjectID p_which) {
+}
 
 int AnimationTrackEditSpriteFrame::get_key_height() const {
 	if (!ObjectDB::get_instance(id)) {
@@ -414,10 +464,6 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 	int width = height * size.width / size.height;
 
 	return Rect2(0, 0, width, get_size().height);
-}
-
-bool AnimationTrackEditSpriteFrame::is_key_selectable_by_distance() const {
-	return false;
 }
 
 void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -528,15 +574,14 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	}
 }
 
-void AnimationTrackEditSpriteFrame::set_node(Object *p_object) {
-	id = p_object->get_instance_id();
-}
-
 void AnimationTrackEditSpriteFrame::set_as_coords() {
 	is_coords = true;
 }
 
 /// SUB ANIMATION ///
+
+AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
+}
 
 int AnimationTrackEditSubAnim::get_key_height() const {
 	if (!ObjectDB::get_instance(id)) {
@@ -577,11 +622,7 @@ Rect2 AnimationTrackEditSubAnim::get_key_rect(int p_index, float p_pixels_sec) {
 	float end_ofs = 0.0;
 	float len = anim->get_length();
 
-	return get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
-}
-
-bool AnimationTrackEditSubAnim::is_key_selectable_by_distance() const {
-	return false;
+	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditSubAnim::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -622,12 +663,22 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		return;
 	}
 
-	float len = ap->get_animation(anim_name)->get_length();
+	Ref<Animation> anim = ap->get_animation(anim_name);
+	if (!anim.is_valid()) {
+		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+		return;
+	}
+
+	float len = anim->get_length();
 
 	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
 		len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 	}
 
+	draw_key_region(anim, 0.0, 0.0, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+}
+
+void AnimationTrackEditSubAnim::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	int pixel_len = len * p_pixels_sec;
 	int pixel_begin = p_x;
 	int pixel_end = p_x + pixel_len;
@@ -656,12 +707,10 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 	bg.b = 1 - color.b;
 	draw_rect(rect, bg);
 
-	Ref<Animation> anim = ap->get_animation(anim_name);
-
 	Vector<Vector2> points;
 	Vector<Color> colors = { color };
 
-	create_key_region(anim, points, rect, p_pixels_sec, 0.0);
+	create_key_region(resource, points, rect, p_pixels_sec, 0.0);
 
 	if (points.size() > 2) {
 		draw_multiline_colors(points, colors);
@@ -669,6 +718,7 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 
 	int limit = to_x - from_x - 4;
 	if (limit > 0) {
+		String anim_name = resource->get_name(); //TODO: check if works
 		draw_string(font, Point2(from_x + 2, int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), anim_name, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, color);
 	}
 
@@ -678,8 +728,31 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 	}
 }
 
-void AnimationTrackEditSubAnim::set_node(Object *p_object) {
-	id = p_object->get_instance_id();
+bool AnimationTrackEditSubAnim::is_key_selectable_by_distance() const {
+	return false;
+}
+
+void AnimationTrackEditSubAnim::_preview_changed(ObjectID p_which) {
+	Object *object = ObjectDB::get_instance(id);
+
+	if (!object) {
+		return;
+	}
+
+	StringName anim_name = object->call("get_animation");
+	if (anim_name == StringName("[stop]")) {
+		return;
+	}
+	AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(get_root()->get_node_or_null(get_animation()->track_get_path(get_track())));
+	if (!ap || !ap->has_animation(anim_name)) {
+		return;
+	}
+
+	Ref<Animation> anim = ap->get_animation(anim_name);
+
+	if (anim.is_valid() && anim->get_instance_id() == p_which) {
+		queue_redraw();
+	}
 }
 
 //// VOLUME DB ////
@@ -687,6 +760,14 @@ void AnimationTrackEditSubAnim::set_node(Object *p_object) {
 int AnimationTrackEditVolumeDB::get_key_height() const {
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
 	return volume_texture->get_height() * 1.2;
+}
+
+void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+	if (p_index == 0) {
+		draw_fg(p_clip_left, p_clip_right);
+	} else if (p_index == 1) {
+		draw_bg(p_clip_left, p_clip_right);
+	}
 }
 
 void AnimationTrackEditVolumeDB::draw_bg(int p_clip_left, int p_clip_right) {
@@ -754,6 +835,10 @@ AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
 ////////////////////////
 
 /// ANIMATION ///
+
+bool AnimationTrackEditTypeAnimation::is_key_selectable_by_distance() const {
+	return false;
+}
 
 void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
 	for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
@@ -868,71 +953,24 @@ Rect2 AnimationTrackEditTypeAudio::get_key_rect(int p_index, float p_pixels_sec)
 	float end_ofs = get_animation()->audio_track_get_key_end_offset(get_track(), p_index);
 	float len = stream->get_length();
 
-	return get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
+	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
 }
 
-Rect2 AnimationTrackEditSubAnim::get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec) {
-	len -= end_ofs;
-	len -= start_ofs;
+void AnimationTrackEditBase::set_node(Object *p_object) {
+	id = p_object->get_instance_id();
+}
 
-	if (len <= 0) {
-		len = 0;
+Rect2 AnimationTrackEditBase::get_key_rect_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec) {
+	float length = len - start_ofs - end_ofs;
+	if (length < 0) {
+		length = 0;
 	}
 
 	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-		len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
+		length = MIN(length, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
 	}
 
-	return Rect2(0, 0, len * p_pixels_sec, get_size().height);
-}
-
-Rect2 AnimationTrackEditTypeAudio::get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec) {
-	len -= end_ofs;
-	len -= start_ofs;
-
-	if (len <= 0) {
-		len = 0;
-	}
-
-	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-		len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
-	}
-
-	return Rect2(0, 0, len * p_pixels_sec, get_size().height);
-}
-
-Rect2 AnimationTrackEditAudio::get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec) {
-	len -= end_ofs;
-	len -= start_ofs;
-
-	if (len <= 0) {
-		len = 0;
-	}
-
-	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-		len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
-	}
-
-	return Rect2(0, 0, len * p_pixels_sec, get_size().height);
-}
-
-Rect2 AnimationTrackEditTypeAnimation::get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec) {
-	len -= end_ofs;
-	len -= start_ofs;
-
-	if (len <= 0) {
-		len = 0;
-	}
-
-	if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
-		len = MIN(len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
-	}
-
-	return Rect2(0, 0, len * p_pixels_sec, get_size().height);
-}
-
-bool AnimationTrackEditTypeAudio::is_key_selectable_by_distance() const {
-	return false;
+	return Rect2(0, 0, length * p_pixels_sec, get_size().height);
 }
 
 void AnimationTrackEditTypeAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -956,7 +994,7 @@ void AnimationTrackEditTypeAudio::draw_key(int p_index, float p_pixels_sec, int 
 	float start_ofs = get_animation()->audio_track_get_key_start_offset(get_track(), p_index);
 	float end_ofs = get_animation()->audio_track_get_key_end_offset(get_track(), p_index);
 
-	AnimationTrackEditClip::draw_key_region(stream, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
+	draw_key_region(stream, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 }
 
 void AnimationTrackEditClip::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -971,6 +1009,10 @@ void AnimationTrackEditClip::draw_key_region(Ref<Resource> resource, float start
 		}
 	}
 
+	AnimationTrackEditBase::draw_key_region(resource, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x + px_offset, p_selected, p_clip_left, p_clip_right);
+}
+
+void AnimationTrackEditBase::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	len -= end_ofs;
 	len -= start_ofs;
 
@@ -979,8 +1021,8 @@ void AnimationTrackEditClip::draw_key_region(Ref<Resource> resource, float start
 	}
 
 	int pixel_len = len * p_pixels_sec;
-	int pixel_begin = px_offset + p_x;
-	int pixel_end = px_offset + p_x + pixel_len;
+	int pixel_begin = p_x;
+	int pixel_end = p_x + pixel_len;
 
 	if (pixel_end < p_clip_left || pixel_begin > p_clip_right) {
 		return;
@@ -1039,6 +1081,10 @@ AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 ////////////////////////
 
 /// AUDIO ///
+
+bool AnimationTrackEditTypeAudio::is_key_selectable_by_distance() const {
+	return false;
+}
 
 void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
 	for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
@@ -1403,11 +1449,7 @@ Rect2 AnimationTrackEditTypeAnimation::get_key_rect(int p_index, float p_pixels_
 	float end_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
 	float len = anim->get_length();
 
-	return get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
-}
-
-bool AnimationTrackEditTypeAnimation::is_key_selectable_by_distance() const {
-	return false;
+	return AnimationTrackEditBase::get_key_rect_region(start_ofs, end_ofs, len, p_index, p_pixels_sec);
 }
 
 void AnimationTrackEditTypeAnimation::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -1443,11 +1485,7 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 	float start_ofs = get_animation()->animation_track_get_key_start_offset(get_track(), p_index);
 	float end_ofs = get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
 
-	AnimationTrackEditClip::draw_key_region(anim, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
-}
-
-void AnimationTrackEditTypeAnimation::set_node(Object *p_object) {
-	id = p_object->get_instance_id();
+	draw_key_region(anim, start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
 }
 
 /////////

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -47,17 +47,17 @@
 AnimationTrackEditBool::AnimationTrackEditBool() {
 }
 
-int AnimationTrackEditBool::get_key_width(int p_index) const {
+int AnimationTrackEditBool::get_key_width(const int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_width();
 }
 
-int AnimationTrackEditBool::get_key_height(int p_index) const {
+int AnimationTrackEditBool::get_key_height(const int p_index) const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
 	return texture->get_height();
 }
 
-Rect2 AnimationTrackEditBool::get_key_rect(int p_index) {
+Rect2 AnimationTrackEditBool::get_key_rect(const int p_index) const {
 	return AnimationTrackEdit::get_key_rect(p_index);
 }
 
@@ -95,15 +95,15 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 AnimationTrackEditColor::AnimationTrackEditColor() {
 }
 
-int AnimationTrackEditColor::get_key_width(int p_index) const {
+int AnimationTrackEditColor::get_key_width(const int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
-int AnimationTrackEditColor::get_key_height(int p_index) const {
+int AnimationTrackEditColor::get_key_height(const int p_index) const {
 	return _get_theme_font_height(0.8);
 }
 
-Rect2 AnimationTrackEditColor::get_key_rect(int p_index) {
+Rect2 AnimationTrackEditColor::get_key_rect(const int p_index) const {
 	return AnimationTrackEdit::get_key_rect(p_index);
 }
 
@@ -190,15 +190,15 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
 }
 
-int AnimationTrackEditSpriteFrame::get_key_width(int p_index) const {
+int AnimationTrackEditSpriteFrame::get_key_width(const int p_index) const {
 	return _get_theme_font_height(2.0);
 }
 
-int AnimationTrackEditSpriteFrame::get_key_height(int p_index) const {
+int AnimationTrackEditSpriteFrame::get_key_height(const int p_index) const {
 	return _get_theme_font_height(2.0);
 }
 
-Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index) {
+Rect2 AnimationTrackEditSpriteFrame::get_key_rect(const int p_index) const {
 	int width = get_key_width(p_index);
 	int height = get_key_height(p_index);
 	Rect2 rect = Rect2(0, -height / 2, width, height);
@@ -206,7 +206,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index) {
 	return rect;
 }
 
-Ref<Resource> AnimationTrackEditSpriteFrame::get_resource(const int p_index) {
+Ref<Resource> AnimationTrackEditSpriteFrame::get_resource(const int p_index) const {
 	Object *object = ObjectDB::get_instance(get_node_id());
 
 	if (!object) {
@@ -337,11 +337,11 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
 }
 
-int AnimationTrackEditSubAnim::get_key_width(int p_index) const {
+int AnimationTrackEditSubAnim::get_key_width(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditSubAnim::get_key_height(int p_index) const {
+int AnimationTrackEditSubAnim::get_key_height(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -368,7 +368,7 @@ void AnimationTrackEditSubAnim::_preview_changed(ObjectID p_which) {
 	}
 }
 
-Ref<Resource> AnimationTrackEditSubAnim::get_resource(const int p_index) {
+Ref<Resource> AnimationTrackEditSubAnim::get_resource(const int p_index) const {
 	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 
 	if (String(anim_name) == "[stop]") {
@@ -388,7 +388,7 @@ Ref<Resource> AnimationTrackEditSubAnim::get_resource(const int p_index) {
 	return anim;
 }
 
-float AnimationTrackEditSubAnim::get_length(const int p_index) {
+float AnimationTrackEditSubAnim::get_length(const int p_index) const {
 	Ref<Resource> resource = get_resource(p_index);
 	if (resource.is_valid()) {
 		Ref<Animation> anim = resource;
@@ -398,7 +398,7 @@ float AnimationTrackEditSubAnim::get_length(const int p_index) {
 	return AnimationTrackEditKey::get_length(p_index);
 }
 
-StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
+StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) const {
 	StringName edit_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 	if (!edit_name.is_empty()) {
 		return edit_name;
@@ -412,11 +412,11 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
 }
 
-int AnimationTrackEditVolumeDB::get_key_width(int p_index) const {
+int AnimationTrackEditVolumeDB::get_key_width(const int p_index) const {
 	return AnimationTrackEdit::get_key_width(p_index);
 }
 
-int AnimationTrackEditVolumeDB::get_key_height(int p_index) const {
+int AnimationTrackEditVolumeDB::get_key_height(const int p_index) const {
 	return AnimationTrackEdit::get_key_height(p_index);
 }
 
@@ -477,11 +477,11 @@ AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
-int AnimationTrackEditTypeAudio::get_key_width(int p_index) const {
+int AnimationTrackEditTypeAudio::get_key_width(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditTypeAudio::get_key_height(int p_index) const {
+int AnimationTrackEditTypeAudio::get_key_height(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -501,19 +501,19 @@ void AnimationTrackEditTypeAudio::apply_data(const Ref<Resource> resource, const
 	undo_redo->add_do_method(get_animation().ptr(), "audio_track_insert_key", get_track(), time, stream);
 }
 
-Ref<Resource> AnimationTrackEditTypeAudio::get_resource(const int p_index) {
+Ref<Resource> AnimationTrackEditTypeAudio::get_resource(const int p_index) const {
 	return get_animation()->audio_track_get_key_stream(get_track(), p_index);
 }
 
-float AnimationTrackEditTypeAudio::get_start_offset(const int p_index) {
+float AnimationTrackEditTypeAudio::get_start_offset(const int p_index) const {
 	return get_animation()->audio_track_get_key_start_offset(get_track(), p_index);
 }
 
-float AnimationTrackEditTypeAudio::get_end_offset(const int p_index) {
+float AnimationTrackEditTypeAudio::get_end_offset(const int p_index) const {
 	return get_animation()->audio_track_get_key_end_offset(get_track(), p_index);
 }
 
-float AnimationTrackEditTypeAudio::get_length(const int p_index) {
+float AnimationTrackEditTypeAudio::get_length(const int p_index) const {
 	Ref<Resource> resource = get_resource(p_index);
 	if (resource.is_valid()) {
 		Ref<AudioStream> stream = resource;
@@ -541,11 +541,11 @@ AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
-int AnimationTrackEditAudio::get_key_width(int p_index) const {
+int AnimationTrackEditAudio::get_key_width(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditAudio::get_key_height(int p_index) const {
+int AnimationTrackEditAudio::get_key_height(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -568,11 +568,11 @@ void AnimationTrackEditAudio::get_key_region_data(Ref<Resource> resource, Vector
 	preview->create_key_region_data(points, rect, p_pixels_sec, start_ofs);
 }
 
-Ref<Resource> AnimationTrackEditAudio::get_resource(const int p_index) {
+Ref<Resource> AnimationTrackEditAudio::get_resource(const int p_index) const {
 	return get_animation()->audio_track_get_key_stream(get_track(), p_index);
 }
 
-float AnimationTrackEditAudio::get_length(const int p_index) {
+float AnimationTrackEditAudio::get_length(const int p_index) const {
 	Ref<Resource> resource = get_resource(p_index);
 	if (resource.is_valid()) {
 		Ref<AudioStream> stream = resource;
@@ -588,11 +588,11 @@ AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
-int AnimationTrackEditTypeAnimation::get_key_width(int p_index) const {
+int AnimationTrackEditTypeAnimation::get_key_width(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
-int AnimationTrackEditTypeAnimation::get_key_height(int p_index) const {
+int AnimationTrackEditTypeAnimation::get_key_height(const int p_index) const {
 	return _get_theme_font_height(1.5);
 }
 
@@ -618,7 +618,7 @@ void AnimationTrackEditTypeAnimation::apply_data(const Ref<Resource> resource, c
 	undo_redo->add_do_method(get_animation().ptr(), "animation_track_insert_key", get_track(), time, anim_name);
 }
 
-Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) {
+Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) const {
 	StringName anim_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 
 	if (String(anim_name) == "[stop]") {
@@ -638,15 +638,15 @@ Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) {
 	return anim;
 }
 
-float AnimationTrackEditTypeAnimation::get_start_offset(const int p_index) {
+float AnimationTrackEditTypeAnimation::get_start_offset(const int p_index) const {
 	return get_animation()->animation_track_get_key_start_offset(get_track(), p_index);
 }
 
-float AnimationTrackEditTypeAnimation::get_end_offset(const int p_index) {
+float AnimationTrackEditTypeAnimation::get_end_offset(const int p_index) const {
 	return get_animation()->animation_track_get_key_end_offset(get_track(), p_index);
 }
 
-float AnimationTrackEditTypeAnimation::get_length(const int p_index) {
+float AnimationTrackEditTypeAnimation::get_length(const int p_index) const {
 	Ref<Resource> resource = get_resource(p_index);
 	if (resource.is_valid()) {
 		Ref<Animation> anim = resource;
@@ -668,7 +668,7 @@ void AnimationTrackEditTypeAnimation::set_end_offset(const int p_index, const fl
 	undo_redo->add_undo_method(get_animation().ptr(), "animation_track_set_key_end_offset", get_track(), p_index, prev_ofs);
 }
 
-StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
+StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) const {
 	StringName edit_name = get_animation()->animation_track_get_key_animation(get_track(), p_index);
 	if (!edit_name.is_empty()) {
 		return edit_name;
@@ -679,33 +679,76 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
 
 /// KEY ///
 
-int AnimationTrackEditKey::get_key_width(int p_index) const {
-	return _get_theme_font_height(1.0);
-}
-
-int AnimationTrackEditKey::get_key_height(int p_index) const {
-	return _get_theme_font_height(1.0);
-}
-
-Rect2 AnimationTrackEditKey::get_key_rect(int p_index) {
+bool AnimationTrackEditKey::__has_valid_key(const int p_index) const {
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
-		return AnimationTrackEdit::get_key_rect(p_index);
+		return false;
 	}
 
 	StringName edit_name = get_edit_name(p_index);
 	if (edit_name.is_empty() || edit_name == "[stop]") {
-		return AnimationTrackEdit::get_key_rect(p_index);
+		return false;
 	}
 
+	return true;
+}
+
+int AnimationTrackEditKey::get_key_width(const int p_index) const {
+	/*
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 	float len = get_length(p_index);
 
-	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, 0);
-	int height = get_key_height(p_index);
+	float anim_len = len - start_ofs - end_ofs;
+	if (anim_len < 0) {
+		WARN_PRINT("anim_len < 0");
+		anim_len = 0;
+	}
 
-	return Rect2(region.x, 0, region.y, height);
+	if (!len_resizing) {
+		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
+			anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
+		}
+	}
+	float scale = get_timeline()->get_zoom_scale();
+	float pixel_len = anim_len * scale;
+	return pixel_len;
+	*/
+	return _get_theme_font_height(1.0);
+}
+
+int AnimationTrackEditKey::get_key_height(const int p_index) const {
+	return _get_theme_font_height(1.0);
+}
+
+float AnimationTrackEditKey::__get_key_width(const int p_index) const {
+	float start_ofs = get_start_offset(p_index);
+	float end_ofs = get_end_offset(p_index);
+	float len = get_length(p_index);
+
+	float anim_len = len - start_ofs - end_ofs;
+	if (anim_len < 0) {
+		WARN_PRINT("anim_len < 0");
+		anim_len = 0;
+	}
+
+	if (!len_resizing) {
+		if (get_animation()->track_get_key_count(get_track()) > p_index + 1) {
+			anim_len = MIN(anim_len, get_animation()->track_get_key_time(get_track(), p_index + 1) - get_animation()->track_get_key_time(get_track(), p_index));
+		}
+	}
+	float scale = get_timeline()->get_zoom_scale();
+	return anim_len * scale;
+}
+
+Rect2 AnimationTrackEditKey::get_key_rect(const int p_index) const {
+	if (!__has_valid_key(p_index)) {
+		return AnimationTrackEdit::get_key_rect(p_index);
+	}
+
+	int width = __get_key_width(p_index);
+	int height = get_key_height(p_index);
+	return Rect2(0.0, -height * key_pivot, width, height);
 }
 
 int AnimationTrackEditKey::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right) {
@@ -970,7 +1013,7 @@ void AnimationTrackEditKey::set_node(Object *p_object) {
 	id = p_object->get_instance_id();
 }
 
-StringName AnimationTrackEditKey::get_edit_name(const int p_index) {
+StringName AnimationTrackEditKey::get_edit_name(const int p_index) const {
 	String resource_name = "null";
 	Ref<Resource> resource = get_resource(p_index);
 	if (resource.is_valid()) {
@@ -985,7 +1028,7 @@ StringName AnimationTrackEditKey::get_edit_name(const int p_index) {
 	return resource_name;
 }
 
-Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) {
+Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const {
 	float anim_len = len - start_ofs - end_ofs;
 	if (anim_len < 0) {
 		WARN_PRINT("anim_len < 0");
@@ -998,7 +1041,6 @@ Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const floa
 		}
 	}
 	float scale = get_timeline()->get_zoom_scale();
-	//float pixels_sec = _get_pixels_sec(p_index);
 	float pixel_len = anim_len * scale;
 	float pixel_begin = p_x;
 	float pixel_end = p_x + pixel_len;
@@ -1040,11 +1082,11 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 
 	if (orig_region.y - orig_region.x <= REGION_MAX_WIDTH) {
-		Rect2 rect2 = Rect2(region_begin, key_rect.position.y, REGION_MAX_WIDTH, key_rect.size.y);
-		draw_rect(rect2, accent_color);
+		Rect2 region_rect = Rect2(region_begin, key_rect.position.y, REGION_MAX_WIDTH, key_rect.size.y);
+		draw_rect(region_rect, accent_color);
 
 		if (p_selected) {
-			draw_rect(rect2, accent_color, false);
+			draw_rect(region_rect, accent_color, false);
 		}
 
 		return;
@@ -1097,7 +1139,7 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 			Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 			int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 
-			int f_h = int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
+			int f_h = key_rect.position.y + key_rect.size.y / 2 - font->get_height(font_size) / 2 + font->get_ascent(font_size);
 			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), animationTrackDrawUtils->_make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 		}
 	}

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -126,7 +126,7 @@ String AnimationTrackEditTypeMethod::_get_tooltip(const int p_index) const {
 }
 
 StringName AnimationTrackEditTypeMethod::get_edit_name(const int p_index) const {
-	Dictionary d = animation->track_get_key_value(get_track(), p_index);
+	Dictionary d = get_key_value(p_index);
 	String method_name = _make_method_text(d);
 	return method_name;
 }

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -812,12 +812,10 @@ int AnimationTrackEditClip::handle_track_resizing(const Ref<InputEventMouseMotio
 	float start_ofs = get_start_offset(p_index);
 	float end_ofs = get_end_offset(p_index);
 
-	float offset = get_global_move_key_time(p_index, true);
-	Region region = _calc_key_region(p_index, start_ofs, end_ofs, len, offset);
-	region = _clip_key_region(region, p_clip_left, p_clip_right);
+	Rect2 global_key_rect = get_global_key_rect(p_index);
 
-	float region_begin = region.x;
-	float region_end = (region.x + region.width);
+	float region_begin = global_key_rect.position.x;
+	float region_end = (global_key_rect.position.x + global_key_rect.size.x);
 
 	if (region_begin >= p_clip_left && region_end <= p_clip_right && region_begin <= region_end) {
 		bool resize_start = false;

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -199,7 +199,11 @@ int AnimationTrackEditSpriteFrame::get_key_height(int p_index, float p_pixels_se
 }
 
 Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
-	return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+	int width = get_key_width(p_index, p_pixels_sec);
+	int height = get_key_height(p_index, p_pixels_sec);
+	Rect2 rect = Rect2(0, -height / 2, width, height);
+
+	return rect;
 }
 
 Ref<Resource> AnimationTrackEditSpriteFrame::get_resource(const int p_index) {

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -45,7 +45,6 @@
 /// BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
-	font_scl = 1.0;
 }
 
 int AnimationTrackEditBool::get_key_height() const {
@@ -82,7 +81,6 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 /// COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
-	font_scl = 0.8;
 }
 
 Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
@@ -96,7 +94,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = font->get_height(font_size) * font_scl;
+	int fh = font->get_height(font_size) * REGION_DEFAULT_FONT_SCALE;
 
 	Rect2 rect(Vector2(p_x - fh / 2, int(get_size().height - fh) / 2), Size2(fh, fh));
 
@@ -115,7 +113,7 @@ void AnimationTrackEditColor::draw_key(int p_index, float p_pixels_sec, int p_x,
 void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	int fh = (font->get_height(font_size) * font_scl);
+	int fh = (font->get_height(font_size) * REGION_DEFAULT_FONT_SCALE);
 
 	fh /= 3;
 
@@ -182,7 +180,6 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 /// SPRITE FRAME / FRAME_COORDS ///
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
-	font_scl = 2.0;
 }
 
 Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
@@ -371,12 +368,11 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 /// SUB ANIMATION ///
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
-	font_scl = 1.5;
 }
 
-void AnimationTrackEditSubAnim::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+void AnimationTrackEditSubAnim::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	Ref<AnimationPreview> preview = AnimationPreviewGenerator::get_singleton()->generate_preview(resource);
-	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
+	preview->create_key_region_data(points, rect, p_pixels_sec, start_ofs);
 }
 
 void AnimationTrackEditSubAnim::_preview_changed(ObjectID p_which) {
@@ -424,7 +420,7 @@ float AnimationTrackEditSubAnim::get_length(const int p_index) {
 		return anim->get_length();
 	}
 
-	return AnimationTrackEditBase::get_length(p_index);
+	return AnimationTrackEditKey::get_length(p_index);
 }
 
 StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
@@ -433,18 +429,17 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 		return edit_name;
 	}
 
-	return AnimationTrackEditBase::get_edit_name(p_index);
+	return AnimationTrackEditKey::get_edit_name(p_index);
 }
 
 //// VOLUME DB ////
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
-	font_scl = 1.2;
 }
 
 int AnimationTrackEditVolumeDB::get_key_height() const {
 	Ref<Texture2D> volume_texture = get_editor_theme_icon(SNAME("ColorTrackVu"));
-	return volume_texture->get_height() * font_scl;
+	return volume_texture->get_height() * REGION_DEFAULT_FONT_SCALE;
 }
 
 void AnimationTrackEditVolumeDB::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
@@ -516,27 +511,23 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 /// AUDIO ///
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
-	font_scl = 1.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
 }
 
 void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
-	AnimationTrackEditBase::_preview_changed(p_which);
+	AnimationTrackEditKey::_preview_changed(p_which);
 }
 
-void AnimationTrackEditTypeAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+void AnimationTrackEditTypeAudio::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(resource);
-	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
+	preview->create_key_region_data(points, rect, p_pixels_sec, start_ofs);
 }
 
-void AnimationTrackEditTypeAudio::apply_data(const Ref<Resource> resource, const float ofs) {
+void AnimationTrackEditTypeAudio::apply_data(const Ref<Resource> resource, const float time) {
 	Ref<AudioStream> stream = resource;
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Add Audio Track Clip"));
-	undo_redo->add_do_method(get_animation().ptr(), "audio_track_insert_key", get_track(), ofs, stream);
-	undo_redo->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), ofs);
-	undo_redo->commit_action();
+	undo_redo->add_do_method(get_animation().ptr(), "audio_track_insert_key", get_track(), time, stream);
 }
 
 Ref<Resource> AnimationTrackEditTypeAudio::get_resource(const int p_index) {
@@ -558,7 +549,7 @@ float AnimationTrackEditTypeAudio::get_length(const int p_index) {
 		return stream->get_length();
 	}
 
-	return AnimationTrackEditBase::get_length(p_index);
+	return AnimationTrackEditKey::get_length(p_index);
 }
 
 void AnimationTrackEditTypeAudio::set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {
@@ -576,7 +567,6 @@ void AnimationTrackEditTypeAudio::set_end_offset(const int p_index, const float 
 /// AUDIO ///
 
 AnimationTrackEditAudio::AnimationTrackEditAudio() {
-	font_scl = 1.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
@@ -594,9 +584,9 @@ void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
 	}
 }
 
-void AnimationTrackEditAudio::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+void AnimationTrackEditAudio::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	Ref<AudioStreamPreview> preview = AudioStreamPreviewGenerator::get_singleton()->generate_preview(resource);
-	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
+	preview->create_key_region_data(points, rect, p_pixels_sec, start_ofs);
 }
 
 Ref<Resource> AnimationTrackEditAudio::get_resource(const int p_index) {
@@ -610,26 +600,25 @@ float AnimationTrackEditAudio::get_length(const int p_index) {
 		return stream->get_length();
 	}
 
-	return AnimationTrackEditBase::get_length(p_index);
+	return AnimationTrackEditKey::get_length(p_index);
 }
 
 /// TYPE ANIMATION ///
 
 AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
-	font_scl = 1.5;
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
 }
 
 void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
-	AnimationTrackEditBase::_preview_changed(p_which);
+	AnimationTrackEditKey::_preview_changed(p_which);
 }
 
-void AnimationTrackEditTypeAnimation::create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+void AnimationTrackEditTypeAnimation::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	Ref<AnimationPreview> preview = AnimationPreviewGenerator::get_singleton()->generate_preview(resource);
-	preview->create_key_region(points, rect, p_pixels_sec, start_ofs);
+	preview->create_key_region_data(points, rect, p_pixels_sec, start_ofs);
 }
 
-void AnimationTrackEditTypeAnimation::apply_data(const Ref<Resource> resource, const float ofs) {
+void AnimationTrackEditTypeAnimation::apply_data(const Ref<Resource> resource, const float time) {
 	Ref<Animation> anim = resource;
 
 	StringName anim_name = anim->get_name();
@@ -639,10 +628,7 @@ void AnimationTrackEditTypeAnimation::apply_data(const Ref<Resource> resource, c
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Add Animation Track Clip"));
-	undo_redo->add_do_method(get_animation().ptr(), "animation_track_insert_key", get_track(), ofs, anim_name);
-	undo_redo->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), ofs);
-	undo_redo->commit_action();
+	undo_redo->add_do_method(get_animation().ptr(), "animation_track_insert_key", get_track(), time, anim_name);
 }
 
 Ref<Resource> AnimationTrackEditTypeAnimation::get_resource(const int p_index) {
@@ -680,7 +666,7 @@ float AnimationTrackEditTypeAnimation::get_length(const int p_index) {
 		return anim->get_length();
 	}
 
-	return AnimationTrackEditBase::get_length(p_index);
+	return AnimationTrackEditKey::get_length(p_index);
 }
 
 void AnimationTrackEditTypeAnimation::set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {
@@ -701,12 +687,12 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
 		return edit_name;
 	}
 
-	return AnimationTrackEditBase::get_edit_name(p_index);
+	return AnimationTrackEditKey::get_edit_name(p_index);
 }
 
 /// BASE ///
 
-bool AnimationTrackEditBase::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right) {
+bool AnimationTrackEditKey::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right) {
 	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
 	region = clip_key_region(region, p_clip_left, p_clip_right);
 
@@ -720,7 +706,7 @@ bool AnimationTrackEditBase::handle_track_resizing(const Ref<InputEventMouseMoti
 		float diff_left = region_begin - mm->get_position().x;
 		float diff_right = mm->get_position().x - region_end;
 
-		float resize_threshold = REGION_RESIZE_THRESHOLD;
+		float resize_threshold = REGION_RESIZE_THRESHOLD * EDSCALE;
 
 		if (diff_left > 0) { // left outside clip
 			if (Math::abs(diff_left) < resize_threshold) {
@@ -756,7 +742,7 @@ bool AnimationTrackEditBase::handle_track_resizing(const Ref<InputEventMouseMoti
 	return false;
 }
 
-void AnimationTrackEditBase::gui_input(const Ref<InputEvent> &p_event) {
+void AnimationTrackEditKey::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	Ref<InputEventMouseMotion> mm = p_event;
@@ -865,7 +851,7 @@ void AnimationTrackEditBase::gui_input(const Ref<InputEvent> &p_event) {
 	AnimationTrackEdit::gui_input(p_event);
 }
 
-Control::CursorShape AnimationTrackEditBase::get_cursor_shape(const Point2 &p_pos) const {
+Control::CursorShape AnimationTrackEditKey::get_cursor_shape(const Point2 &p_pos) const {
 	if (over_drag_position || len_resizing) {
 		return Control::CURSOR_HSIZE;
 	} else {
@@ -873,7 +859,7 @@ Control::CursorShape AnimationTrackEditBase::get_cursor_shape(const Point2 &p_po
 	}
 }
 
-void AnimationTrackEditBase::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditKey::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
 		AnimationTrackEdit::draw_key(p_index, p_pixels_sec, p_x, p_selected, p_clip_left, p_clip_right);
@@ -899,7 +885,7 @@ void AnimationTrackEditBase::draw_key(int p_index, float p_pixels_sec, int p_x, 
 	draw_key_region(resource, start_ofs + diff_start_ofs, end_ofs + diff_end_ofs, len, p_index, p_pixels_sec, p_x + (diff_start_ofs * p_pixels_sec), p_selected, p_clip_left, p_clip_right);
 }
 
-bool AnimationTrackEditBase::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+bool AnimationTrackEditKey::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
 	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
 		Dictionary drag_data = p_data;
 		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
@@ -924,7 +910,7 @@ bool AnimationTrackEditBase::can_drop_data(const Point2 &p_point, const Variant 
 	return AnimationTrackEdit::can_drop_data(p_point, p_data);
 }
 
-void AnimationTrackEditBase::drop_data(const Point2 &p_point, const Variant &p_data) {
+void AnimationTrackEditKey::drop_data(const Point2 &p_point, const Variant &p_data) {
 	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
 		Ref<Resource> resource;
 		Dictionary drag_data = p_data;
@@ -940,16 +926,20 @@ void AnimationTrackEditBase::drop_data(const Point2 &p_point, const Variant &p_d
 
 		if (resource.is_valid()) {
 			int x = p_point.x - get_timeline()->get_name_limit();
-			float ofs = x / get_timeline()->get_zoom_scale();
-			ofs += get_timeline()->get_value();
+			float time = x / get_timeline()->get_zoom_scale();
+			time += get_timeline()->get_value();
 
-			ofs = get_editor()->snap_time(ofs);
+			time = get_editor()->snap_time(time);
 
-			while (get_animation()->track_find_key(get_track(), ofs, Animation::FIND_MODE_APPROX) != -1) { //make sure insertion point is valid
-				ofs += 0.0001;
+			while (get_animation()->track_find_key(get_track(), time, Animation::FIND_MODE_APPROX) != -1) { //make sure insertion point is valid
+				time += 0.0001;
 			}
 
-			apply_data(resource, ofs);
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Add Track Clip"));
+			apply_data(resource, time);
+			undo_redo->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), time);
+			undo_redo->commit_action();
 
 			queue_redraw();
 			return;
@@ -959,7 +949,7 @@ void AnimationTrackEditBase::drop_data(const Point2 &p_point, const Variant &p_d
 	AnimationTrackEdit::drop_data(p_point, p_data);
 }
 
-Rect2 AnimationTrackEditBase::get_key_rect(int p_index, float p_pixels_sec) {
+Rect2 AnimationTrackEditKey::get_key_rect(int p_index, float p_pixels_sec) {
 	Ref<Resource> resource = get_resource(p_index);
 	if (!resource.is_valid()) {
 		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
@@ -974,11 +964,11 @@ Rect2 AnimationTrackEditBase::get_key_rect(int p_index, float p_pixels_sec) {
 	return Rect2(region.x, 0, region.y, h);
 }
 
-void AnimationTrackEditBase::set_node(Object *p_object) {
+void AnimationTrackEditKey::set_node(Object *p_object) {
 	id = p_object->get_instance_id();
 }
 
-StringName AnimationTrackEditBase::get_edit_name(const int p_index) {
+StringName AnimationTrackEditKey::get_edit_name(const int p_index) {
 	String resource_name = "null";
 	Ref<Resource> resource = get_resource(p_index);
 	if (resource.is_valid()) {
@@ -993,7 +983,7 @@ StringName AnimationTrackEditBase::get_edit_name(const int p_index) {
 	return resource_name;
 }
 
-Vector2 AnimationTrackEditBase::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x) {
+Vector2 AnimationTrackEditKey::calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x) {
 	float anim_len = len - start_ofs - end_ofs;
 	if (anim_len < 0) {
 		WARN_PRINT("anim_len < 0");
@@ -1013,22 +1003,22 @@ Vector2 AnimationTrackEditBase::calc_key_region(const float start_ofs, const flo
 	return Vector2(pixel_begin, pixel_end);
 }
 
-Vector2 AnimationTrackEditBase::clip_key_region(Vector2 region, int p_clip_left, int p_clip_right) {
+Vector2 AnimationTrackEditKey::clip_key_region(Vector2 region, int p_clip_left, int p_clip_right) {
 	region.y = CLAMP(region.y, MAX(region.x, p_clip_left), p_clip_right);
 	region.x = CLAMP(region.x, p_clip_left, MIN(region.y, p_clip_right));
 	ERR_FAIL_COND_V_MSG(region.x > region.y, region, "Clipped region is invalid (x > y).");
 	return region;
 }
 
-Vector2 AnimationTrackEditBase::calc_key_region_shift(Vector2 &orig_region, Vector2 &region) {
+Vector2 AnimationTrackEditKey::calc_key_region_shift(Vector2 &orig_region, Vector2 &region) {
 	return Vector2(region.x - orig_region.x, region.y - orig_region.y);
 }
 
-bool AnimationTrackEditBase::is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right) {
+bool AnimationTrackEditKey::is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right) {
 	return (region.y < p_clip_left || region.x > p_clip_right);
 }
 
-void AnimationTrackEditBase::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
 	Vector2 orig_region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
 
 	bool is_outside = is_key_region_outside(orig_region, p_clip_left, p_clip_right);
@@ -1074,7 +1064,7 @@ void AnimationTrackEditBase::draw_key_region(Ref<Resource> resource, float start
 	}
 
 	Vector2 region_shift = calc_key_region_shift(orig_region, region);
-	create_key_region(resource, points, rect, p_pixels_sec, start_ofs + region_shift.x / p_pixels_sec);
+	get_key_region_data(resource, points, rect, p_pixels_sec, start_ofs + region_shift.x / p_pixels_sec);
 
 	if (!points.is_empty()) {
 		draw_multiline_colors(points, colors);
@@ -1116,7 +1106,7 @@ void AnimationTrackEditBase::draw_key_region(Ref<Resource> resource, float start
 	}
 }
 
-void AnimationTrackEditBase::_preview_changed(ObjectID p_which) {
+void AnimationTrackEditKey::_preview_changed(ObjectID p_which) {
 	for (int p_index = 0; p_index < get_animation()->track_get_key_count(get_track()); p_index++) {
 		Ref<Resource> resource = get_resource(p_index);
 		if (resource.is_valid() && resource->get_instance_id() == p_which) {
@@ -1126,10 +1116,10 @@ void AnimationTrackEditBase::_preview_changed(ObjectID p_which) {
 	}
 }
 
-int AnimationTrackEditBase::get_key_height() const {
+int AnimationTrackEditKey::get_key_height() const {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * font_scl);
+	return int(font->get_height(font_size) * REGION_DEFAULT_FONT_SCALE);
 }
 
 /// PLUGIN ///

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -45,7 +45,6 @@
 /// BOOL ///
 
 AnimationTrackEditBool::AnimationTrackEditBool() {
-	key_scale = 1.0;
 }
 
 int AnimationTrackEditBool::get_key_width() const {
@@ -94,15 +93,14 @@ void AnimationTrackEditBool::draw_key(int p_index, float p_pixels_sec, int p_x, 
 /// COLOR ///
 
 AnimationTrackEditColor::AnimationTrackEditColor() {
-	key_scale = 0.8;
 }
 
 int AnimationTrackEditColor::get_key_width() const {
-	return AnimationTrackEditKey::get_key_height();
+	return _get_theme_font_height(0.8);
 }
 
 int AnimationTrackEditColor::get_key_height() const {
-	return AnimationTrackEditKey::get_key_height();
+	return _get_theme_font_height(0.8);
 }
 
 Rect2 AnimationTrackEditColor::get_key_rect(int p_index, float p_pixels_sec) {
@@ -194,7 +192,14 @@ void AnimationTrackEditColor::draw_key_link(int p_index, float p_pixels_sec, int
 /// SPRITE FRAME / FRAME_COORDS ///
 
 AnimationTrackEditSpriteFrame::AnimationTrackEditSpriteFrame() {
-	key_scale = 2.0;
+}
+
+int AnimationTrackEditSpriteFrame::get_key_width() const {
+	return _get_theme_font_height(2.0);
+}
+
+int AnimationTrackEditSpriteFrame::get_key_height() const {
+	return _get_theme_font_height(2.0);
 }
 
 Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_sec) {
@@ -348,7 +353,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 	int height = get_key_height();
 	int width = height * region.size.width / region.size.height;
 
-	Rect2 rect(p_x, int(get_size().height - height) / 2, width, height);
+	Rect2 rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
 	if (rect.position.x + rect.size.x < p_clip_left) {
 		return;
@@ -378,7 +383,14 @@ void AnimationTrackEditSpriteFrame::set_as_coords() {
 /// SUB ANIMATION ///
 
 AnimationTrackEditSubAnim::AnimationTrackEditSubAnim() {
-	key_scale = 1.5;
+}
+
+int AnimationTrackEditSubAnim::get_key_width() const {
+	return _get_theme_font_height(1.5);
+}
+
+int AnimationTrackEditSubAnim::get_key_height() const {
+	return _get_theme_font_height(1.5);
 }
 
 void AnimationTrackEditSubAnim::get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
@@ -446,7 +458,6 @@ StringName AnimationTrackEditSubAnim::get_edit_name(const int p_index) {
 //// VOLUME DB ////
 
 AnimationTrackEditVolumeDB::AnimationTrackEditVolumeDB() {
-	key_scale = 1.0;
 }
 
 int AnimationTrackEditVolumeDB::get_key_width() const {
@@ -511,8 +522,15 @@ void AnimationTrackEditVolumeDB::draw_key_link(int p_index, float p_pixels_sec, 
 /// AUDIO ///
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
-	key_scale = 1.5;
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
+}
+
+int AnimationTrackEditTypeAudio::get_key_width() const {
+	return _get_theme_font_height(1.5);
+}
+
+int AnimationTrackEditTypeAudio::get_key_height() const {
+	return _get_theme_font_height(1.5);
 }
 
 void AnimationTrackEditTypeAudio::_preview_changed(ObjectID p_which) {
@@ -571,6 +589,14 @@ AnimationTrackEditAudio::AnimationTrackEditAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditAudio::_preview_changed));
 }
 
+int AnimationTrackEditAudio::get_key_width() const {
+	return _get_theme_font_height(1.5);
+}
+
+int AnimationTrackEditAudio::get_key_height() const {
+	return _get_theme_font_height(1.5);
+}
+
 void AnimationTrackEditAudio::_preview_changed(ObjectID p_which) {
 	Object *object = ObjectDB::get_instance(get_node_id());
 
@@ -607,8 +633,15 @@ float AnimationTrackEditAudio::get_length(const int p_index) {
 /// TYPE ANIMATION ///
 
 AnimationTrackEditTypeAnimation::AnimationTrackEditTypeAnimation() {
-	key_scale = 1.5;
 	AnimationPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAnimation::_preview_changed));
+}
+
+int AnimationTrackEditTypeAnimation::get_key_width() const {
+	return _get_theme_font_height(1.5);
+}
+
+int AnimationTrackEditTypeAnimation::get_key_height() const {
+	return _get_theme_font_height(1.5);
 }
 
 void AnimationTrackEditTypeAnimation::_preview_changed(ObjectID p_which) {
@@ -692,7 +725,36 @@ StringName AnimationTrackEditTypeAnimation::get_edit_name(const int p_index) {
 	return AnimationTrackEditKey::get_edit_name(p_index);
 }
 
-/// BASE ///
+/// KEY ///
+
+int AnimationTrackEditKey::get_key_width() const {
+	return _get_theme_font_height(1.0);
+}
+
+int AnimationTrackEditKey::get_key_height() const {
+	return _get_theme_font_height(1.0);
+}
+
+Rect2 AnimationTrackEditKey::get_key_rect(int p_index, float p_pixels_sec) {
+	Ref<Resource> resource = get_resource(p_index);
+	if (!resource.is_valid()) {
+		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+	}
+
+	StringName edit_name = get_edit_name(p_index);
+	if (edit_name.is_empty() || edit_name == "[stop]") {
+		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
+	}
+
+	float start_ofs = get_start_offset(p_index);
+	float end_ofs = get_end_offset(p_index);
+	float len = get_length(p_index);
+
+	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, 0);
+	int height = get_key_height();
+
+	return Rect2(region.x, 0, region.y, height);
+}
 
 int AnimationTrackEditKey::handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right) {
 	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, p_x);
@@ -952,21 +1014,6 @@ void AnimationTrackEditKey::drop_data(const Point2 &p_point, const Variant &p_da
 	AnimationTrackEdit::drop_data(p_point, p_data);
 }
 
-Rect2 AnimationTrackEditKey::get_key_rect(int p_index, float p_pixels_sec) {
-	Ref<Resource> resource = get_resource(p_index);
-	if (!resource.is_valid()) {
-		return AnimationTrackEdit::get_key_rect(p_index, p_pixels_sec);
-	}
-
-	float start_ofs = get_start_offset(p_index);
-	float end_ofs = get_end_offset(p_index);
-	float len = get_length(p_index);
-
-	Vector2 region = calc_key_region(start_ofs, end_ofs, len, p_index, p_pixels_sec, 0);
-	int h = get_size().height;
-	return Rect2(region.x, 0, region.y, h);
-}
-
 void AnimationTrackEditKey::set_node(Object *p_object) {
 	id = p_object->get_instance_id();
 }
@@ -1035,14 +1082,12 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 	int region_end = region.y;
 	int region_width = region.y - region.x;
 
-	int fh = get_key_height();
-	float h = get_size().height;
-	float fy = (h - fh) / 2;
+	Rect2 key_rect = get_global_key_rect(p_index, p_pixels_sec, p_x);
 
 	Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 
 	if (orig_region.y - orig_region.x <= REGION_MAX_WIDTH) {
-		Rect2 rect2 = Rect2(region_begin, fy, REGION_MAX_WIDTH, fh);
+		Rect2 rect2 = Rect2(region_begin, key_rect.position.y, REGION_MAX_WIDTH, key_rect.size.y);
 		draw_rect(rect2, accent_color);
 
 		if (p_selected) {
@@ -1053,7 +1098,7 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 	}
 
 	Color bg_color = REGION_BG_COLOR;
-	Rect2 rect = Rect2(region_begin, fy, region_width, fh);
+	Rect2 rect = Rect2(region_begin, key_rect.position.y, region_width, key_rect.size.y);
 	draw_rect(rect, bg_color);
 
 	Vector<Vector2> points;
@@ -1099,7 +1144,7 @@ void AnimationTrackEditKey::draw_key_region(Ref<Resource> resource, float start_
 			Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 			int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 
-			int f_h = int(h - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
+			int f_h = int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
 			draw_string(font, Point2(region_begin + REGION_FONT_MARGIN, f_h), make_text_clipped(edit_name, font, font_size, max_width), HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, name_color);
 		}
 	}
@@ -1117,16 +1162,6 @@ void AnimationTrackEditKey::_preview_changed(ObjectID p_which) {
 			return;
 		}
 	}
-}
-
-int AnimationTrackEditKey::get_key_width() const {
-	return get_size().height;
-}
-
-int AnimationTrackEditKey::get_key_height() const {
-	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
-	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
-	return int(font->get_height(font_size) * key_scale);
 }
 
 /// PLUGIN ///

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -34,22 +34,22 @@
 #include "editor/animation_track_editor.h"
 #include "editor/audio_stream_preview.h"
 
+// Constants for region rendering and color editing
 #define REGION_RESIZE_THRESHOLD 5.0
 #define REGION_MAX_WIDTH 4.0
 #define REGION_FONT_MARGIN 3.0
 #define REGION_BG_COLOR Color(0.25, 0.25, 0.25)
 #define REGION_EDGE_ALPHA 0.7
-
 #define COLOR_EDIT_SAMPLE_INTERVAL 64
 #define COLOR_EDIT_RECT_INTERVAL 2
 
+// Struct for defining key regions in tracks
 struct Region {
 	union {
 		struct {
 			real_t x;
 			real_t width;
 		};
-
 		struct {
 			real_t y;
 			real_t height;
@@ -62,6 +62,7 @@ struct Region {
 	bool has_point(real_t p_point) const { return p_point >= x && p_point <= get_end(); }
 };
 
+// Base class for clip-based animation track editing
 class AnimationTrackEditClip : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditClip, AnimationTrackEdit);
 
@@ -75,82 +76,78 @@ private:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
+	// Region handling methods
 	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const int p_clip_left, const int p_clip_right);
-
 	Region _calc_key_region(const int p_index, const float p_start_ofs, const float p_end_ofs, const float p_len, float p_offset = 0) const;
 	Region _clip_key_region(const Region &p_region, const int p_clip_left, const int p_clip_right);
 	Region _calc_key_region_shift(const Region &p_orig_region, const Region &p_region) const;
 	bool _is_key_region_outside(const Region &p_region, const int p_clip_left, const int p_clip_right) const;
 
 public:
+	// Node management
 	void set_node(Object *p_object);
 	ObjectID get_node_id() const { return id; }
 
+	// Input and preview handling
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void _preview_changed(ObjectID p_which);
 
-public:
+	// Key dimension overrides
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 
 protected:
+	// Drawing and resource management
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
-
-protected:
-	virtual Ref<Resource> get_resource(const int p_index) const { return nullptr; } // resource of the key (AudioStream, Animation, ...)
-	virtual float get_start_offset(const int p_index) const { return 0; } // start offset of the key
-	virtual float get_end_offset(const int p_index) const { return 0; } // end offset of the key
-	virtual float get_length(const int p_index) const { return 0; } // total length of the key
-	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the start offset of the key
-	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the end offset of the key
-	virtual StringName get_edit_name(const int p_index) const override; //name of the key
+	virtual Ref<Resource> get_resource(const int p_index) const { return nullptr; }
+	virtual float get_start_offset(const int p_index) const { return 0; }
+	virtual float get_end_offset(const int p_index) const { return 0; }
+	virtual float get_length(const int p_index) const { return 0; }
+	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
+	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
+	virtual StringName get_edit_name(const int p_index) const override;
 	virtual float get_key_scale(const int p_index) const { return 1.0; }
 
-protected:
+	// Input handling overrides
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	virtual void apply_data(const Ref<Resource> resource, const float time) {}
-	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {} // data to visualize the key if the key has a length
+	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {}
 };
 
+// Class for editing audio clip tracks
 class AnimationTrackEditTypeAudio : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditClip);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual bool has_valid_key(const int p_index) const override;
-
 protected:
+	// Resource and preview handling
+	virtual void _preview_changed(ObjectID p_which) override;
 	virtual Ref<Resource> get_resource(const int p_index) const override;
 	virtual float get_start_offset(const int p_index) const override;
 	virtual float get_end_offset(const int p_index) const override;
 	virtual float get_length(const int p_index) const override;
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
-
-protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual void apply_data(const Ref<Resource> resource, const float time) override;
 
 public:
+	// Validation and tooltip
+	virtual bool has_valid_key(const int p_index) const override;
 	virtual String _get_tooltip(const int p_index) const override;
 
 public:
 	AnimationTrackEditTypeAudio();
 };
 
+// Class for editing animation clip tracks
 class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditClip);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual bool has_valid_key(const int p_index) const override;
-	virtual String _get_tooltip(const int p_index) const override;
-
 protected:
+	// Resource and preview handling
+	virtual void _preview_changed(ObjectID p_which) override;
 	virtual Ref<Resource> get_resource(const int p_index) const override;
 	virtual float get_start_offset(const int p_index) const override;
 	virtual float get_end_offset(const int p_index) const override;
@@ -158,54 +155,59 @@ protected:
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual StringName get_edit_name(const int p_index) const override;
-
-protected:
 	virtual float get_key_scale(const int p_index) const override;
-
-protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual void apply_data(const Ref<Resource> resource, const float time) override;
+
+public:
+	// Validation and tooltip
+	virtual bool has_valid_key(const int p_index) const override;
+	virtual String _get_tooltip(const int p_index) const override;
 
 public:
 	AnimationTrackEditTypeAnimation();
 };
 
+// Class for editing audio tracks
 class AnimationTrackEditAudio : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditClip);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual bool has_valid_key(const int p_index) const override;
-
 protected:
+	// Resource and preview handling
+	virtual void _preview_changed(ObjectID p_which) override;
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual Ref<Resource> get_resource(const int p_index) const override;
 	virtual float get_length(const int p_index) const override;
+
+public:
+	// Validation
+	virtual bool has_valid_key(const int p_index) const override;
 
 public:
 	AnimationTrackEditAudio();
 };
 
+// Class for editing sub-animation tracks
 class AnimationTrackEditSubAnim : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditClip);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual bool has_valid_key(const int p_index) const override;
-
 protected:
+	// Resource and preview handling
+	virtual void _preview_changed(ObjectID p_which) override;
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-
 	virtual Ref<Resource> get_resource(const int p_index) const override;
 	virtual float get_length(const int p_index) const override;
 	virtual StringName get_edit_name(const int p_index) const override;
 
 public:
+	// Validation
+	virtual bool has_valid_key(const int p_index) const override;
+
+public:
 	AnimationTrackEditSubAnim();
 };
 
+// Class for editing boolean tracks
 class AnimationTrackEditBool : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditBool, AnimationTrackEdit);
 
@@ -214,49 +216,51 @@ private:
 	Ref<Texture2D> icon_unchecked;
 
 public:
+	// Key dimension overrides
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 
 protected:
+	// Drawing
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 public:
 	AnimationTrackEditBool();
 };
 
+// Class for editing method tracks
 class AnimationTrackEditTypeMethod : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditTypeMethod, AnimationTrackEdit);
 
-public:
-	virtual float get_key_width(const int p_index) const override;
-	virtual float get_key_height(const int p_index) const override;
-
-	virtual String _get_tooltip(const int p_index) const override;
-
-public:
-	virtual StringName get_edit_name(const int p_index) const override; //name of the key
-
 protected:
+	// Drawing and tooltip
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
-
-private:
-	// Helper
 	String _make_method_text(const Dictionary &d) const;
+
+public:
+	// Key dimension and name overrides
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
+	virtual StringName get_edit_name(const int p_index) const override;
+	virtual String _get_tooltip(const int p_index) const override;
 
 public:
 	AnimationTrackEditTypeMethod();
 };
 
+// Class for editing color tracks
 class AnimationTrackEditColor : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEdit);
 
 public:
+	// Key dimension and link overrides
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 	virtual bool is_linked(const int p_index, const int p_index_next) const override;
 
 protected:
+	// Drawing
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 
@@ -264,6 +268,7 @@ public:
 	AnimationTrackEditColor();
 };
 
+// Class for editing sprite frame tracks
 class AnimationTrackEditSpriteFrame : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
 
@@ -271,59 +276,58 @@ private:
 	ObjectID id;
 	bool is_coords = false;
 
-	//Helper
+	// Helper methods for texture regions
 	Rect2 _create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture) const;
 	Rect2 _create_region_animated_sprite(int p_index, Object *object, const Ref<Texture2D> texture) const;
 
 public:
+	// Node management
 	void set_node(Object *p_object);
 	ObjectID get_node_id() const { return id; }
-
-public:
 	void set_as_coords();
 
-public:
+	// Validation and resource
 	virtual bool has_valid_key(const int p_index) const override;
-
-public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 
 protected:
+	// Drawing and resource
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
-
-protected:
 	Ref<Resource> get_resource(const int p_index) const;
 
 public:
 	AnimationTrackEditSpriteFrame();
 };
 
+// Class for editing volume dB tracks
 class AnimationTrackEditVolumeDB : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
 
 public:
+	// Key dimension and link overrides
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 	virtual bool is_linked(const int p_index, const int p_index_next) const override;
+	virtual float get_key_y(const int p_index) const override;
 
 protected:
+	// Drawing
 	virtual void draw_bg(const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right) override;
 
 public:
-	virtual float get_key_y(const int p_index) const override;
-
-public:
 	AnimationTrackEditVolumeDB();
 };
 
+// Default plugin for creating track edit controls
 class AnimationTrackEditDefaultPlugin : public AnimationTrackEditPlugin {
 	GDCLASS(AnimationTrackEditDefaultPlugin, AnimationTrackEditPlugin);
 
 public:
+	// Track creation methods
 	virtual AnimationTrackEdit *create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) override;
 	virtual AnimationTrackEdit *create_audio_track_edit() override;
 	virtual AnimationTrackEdit *create_animation_track_edit(Object *p_object) override;

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -41,6 +41,7 @@
 #define REGION_EDGE_ALPHA 0.7
 
 #define COLOR_EDIT_SAMPLE_INTERVAL 64
+#define COLOR_EDIT_RECT_INTERVAL 2
 
 class AnimationTrackEditKey : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditKey, AnimationTrackEdit);

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -63,9 +63,6 @@ private:
 	Vector2 calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
 	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
 
-protected:
-	float key_scale = 1.0;
-
 public:
 	void set_node(Object *p_object);
 	ObjectID get_node_id() const { return id; }
@@ -102,6 +99,10 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEditKey {
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
+public:
+	virtual int get_key_width() const override;
+	virtual int get_key_height() const override;
+
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
 	virtual float get_start_offset(const int p_index) override;
@@ -122,6 +123,10 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditKey);
 
 	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual int get_key_width() const override;
+	virtual int get_key_height() const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -145,6 +150,10 @@ class AnimationTrackEditAudio : public AnimationTrackEditKey {
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
+public:
+	virtual int get_key_width() const override;
+	virtual int get_key_height() const override;
+
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -158,6 +167,10 @@ class AnimationTrackEditSubAnim : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditKey);
 
 	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual int get_key_width() const override;
+	virtual int get_key_height() const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -210,6 +223,8 @@ private:
 	bool is_coords = false;
 
 public:
+	virtual int get_key_width() const override;
+	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -114,6 +114,9 @@ protected:
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	virtual void apply_data(const Ref<Resource> resource, const float time) {}
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {}
+
+public:
+	AnimationTrackEditClip();
 };
 
 // Class for editing audio clip tracks

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -46,10 +46,8 @@
 class AnimationTrackEditBase : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditBase, AnimationTrackEdit);
 
-protected:
+private:
 	ObjectID id;
-
-	float font_scl = REGION_DEFAULT_FONT_SCALE;
 
 	bool len_resizing = false;
 	bool len_resizing_start = false;
@@ -58,22 +56,29 @@ protected:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
-public:
+	bool handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
+
+	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
+	Vector2 clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);
+	void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
+	Vector2 calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
+	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
+
+protected: // Font scaling factor, overridden by derived classes for specific track types.
+	float font_scl = REGION_DEFAULT_FONT_SCALE;
+
+public: // gui
 	void set_node(Object *p_object);
+	ObjectID get_node_id() const { return id; }
+
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void _preview_changed(ObjectID p_which);
 
-public:
+public: // draw
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override { return false; }
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-protected: // calc
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {}
-	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
-	virtual Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
-	Vector2 clip_key_region(Vector2 &region, int p_clip_left, int p_clip_right);
-	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
 
 protected: // data
 	virtual Ref<Resource> get_resource(const int p_index) { return nullptr; }
@@ -84,16 +89,12 @@ protected: // data
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
 	virtual StringName get_edit_name(const int p_index);
 
-public: // gui
-	virtual void gui_input(const Ref<InputEvent> &p_event);
-
 protected:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	virtual void apply_data(const Ref<Resource> resource, const float ofs) {}
-
-	bool handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {}
 };
 
 class AnimationTrackEditTypeAudio : public AnimationTrackEditBase {
@@ -102,15 +103,16 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEditBase {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	virtual void apply_data(const Ref<Resource> resource, const float ofs) override;
-
 	virtual Ref<Resource> get_resource(const int p_index) override;
 	virtual float get_start_offset(const int p_index) override;
 	virtual float get_end_offset(const int p_index) override;
 	virtual float get_length(const int p_index) override;
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
+
+protected: // calc
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual void apply_data(const Ref<Resource> resource, const float ofs) override;
 
 public:
 	AnimationTrackEditTypeAudio();
@@ -122,9 +124,6 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditBase {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	virtual void apply_data(const Ref<Resource> resource, const float ofs) override;
-
 	virtual Ref<Resource> get_resource(const int p_index) override;
 	virtual float get_start_offset(const int p_index) override;
 	virtual float get_end_offset(const int p_index) override;
@@ -132,6 +131,10 @@ protected:
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual StringName get_edit_name(const int p_index) override;
+
+protected:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual void apply_data(const Ref<Resource> resource, const float ofs) override;
 
 public:
 	AnimationTrackEditTypeAnimation();
@@ -170,6 +173,7 @@ public:
 class AnimationTrackEditBool : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditBool, AnimationTrackEditBase);
 
+private:
 	Ref<Texture2D> icon_checked;
 	Ref<Texture2D> icon_unchecked;
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -43,6 +43,25 @@
 #define COLOR_EDIT_SAMPLE_INTERVAL 64
 #define COLOR_EDIT_RECT_INTERVAL 2
 
+struct Region {
+	union {
+		struct {
+			real_t x;
+			real_t width;
+		};
+
+		struct {
+			real_t y;
+			real_t height;
+		};
+	};
+
+	Region(real_t p_x = 0.0, real_t p_width = 0.0) :
+			x(p_x), width(p_width) {}
+	real_t get_end() const { return x + width; }
+	bool has_point(real_t p_point) const { return p_point >= x && p_point <= get_end(); }
+};
+
 class AnimationTrackEditClip : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditClip, AnimationTrackEdit);
 
@@ -58,10 +77,10 @@ private:
 
 	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right);
 
-	Vector2 _calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const;
-	Vector2 _clip_key_region(Vector2 region, const int p_clip_left, const int p_clip_right);
-	Vector2 _calc_key_region_shift(const Vector2 &orig_region, const Vector2 &region) const;
-	bool _is_key_region_outside(const Vector2 &region, const int p_clip_left, const int p_clip_right) const;
+	Region _calc_key_region(const int p_index, const float start_ofs, const float end_ofs, const float len, float __offset = 0) const;
+	Region _clip_key_region(const Region &region, const int p_clip_left, const int p_clip_right);
+	Region _calc_key_region_shift(const Region &orig_region, const Region &region) const;
+	bool _is_key_region_outside(const Region &region, const int p_clip_left, const int p_clip_right) const;
 
 public:
 	void set_node(Object *p_object);
@@ -71,15 +90,15 @@ public:
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) const { return nullptr; } // resource of the key (AudioStream, Animation, ...)
-	virtual float get_start_offset(const int p_index) const  { return 0; } // start offset of the key
-	virtual float get_end_offset(const int p_index) const  { return 0; } // end offset of the key
-	virtual float get_length(const int p_index) const  { return 0; } // total length of the key
+	virtual float get_start_offset(const int p_index) const { return 0; } // start offset of the key
+	virtual float get_end_offset(const int p_index) const { return 0; } // end offset of the key
+	virtual float get_length(const int p_index) const { return 0; } // total length of the key
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the start offset of the key
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the end offset of the key
 	virtual StringName get_edit_name(const int p_index) const; //name of the key
@@ -185,8 +204,8 @@ private:
 	Ref<Texture2D> icon_unchecked;
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 public:
@@ -197,8 +216,8 @@ class AnimationTrackEditTypeMethod : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditTypeMethod, AnimationTrackEdit);
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 public:
@@ -216,8 +235,8 @@ class AnimationTrackEditColor : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEdit);
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
@@ -246,8 +265,11 @@ public:
 	void set_as_coords();
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual bool has_valid_key(const int p_index) const override;
+
+public:
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
@@ -261,8 +283,8 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual float get_key_width(const int p_index) const override;
+	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -43,8 +43,8 @@
 #define COLOR_EDIT_SAMPLE_INTERVAL 64
 #define COLOR_EDIT_RECT_INTERVAL 2
 
-class AnimationTrackEditKey : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditKey, AnimationTrackEdit);
+class AnimationTrackEditClip : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditClip, AnimationTrackEdit);
 
 private:
 	ObjectID id;
@@ -92,8 +92,8 @@ protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {} // data to visualize the key if the key has a length
 };
 
-class AnimationTrackEditTypeAudio : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditKey);
+class AnimationTrackEditTypeAudio : public AnimationTrackEditClip {
+	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditClip);
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
@@ -116,8 +116,8 @@ public:
 	AnimationTrackEditTypeAudio();
 };
 
-class AnimationTrackEditTypeAnimation : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditKey);
+class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
+	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditClip);
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
@@ -141,8 +141,8 @@ public:
 	AnimationTrackEditTypeAnimation();
 };
 
-class AnimationTrackEditAudio : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditKey);
+class AnimationTrackEditAudio : public AnimationTrackEditClip {
+	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditClip);
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
@@ -158,8 +158,8 @@ public:
 	AnimationTrackEditAudio();
 };
 
-class AnimationTrackEditSubAnim : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditKey);
+class AnimationTrackEditSubAnim : public AnimationTrackEditClip {
+	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditClip);
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
@@ -177,8 +177,8 @@ public:
 	AnimationTrackEditSubAnim();
 };
 
-class AnimationTrackEditBool : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditBool, AnimationTrackEditKey);
+class AnimationTrackEditBool : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditBool, AnimationTrackEdit);
 
 private:
 	Ref<Texture2D> icon_checked;
@@ -193,8 +193,27 @@ public:
 	AnimationTrackEditBool();
 };
 
-class AnimationTrackEditColor : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditColor, AnimationTrackEditKey);
+class AnimationTrackEditTypeMethod : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditTypeMethod, AnimationTrackEdit);
+
+public:
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+public:
+	StringName get_edit_name(const int p_index) const; //name of the key
+
+private:
+	// Helper
+	String _make_method_text(const Dictionary &d) const;
+
+public:
+	AnimationTrackEditTypeMethod();
+};
+
+class AnimationTrackEditColor : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditColor, AnimationTrackEdit);
 
 public:
 	virtual int get_key_width(const int p_index) const override;
@@ -208,15 +227,20 @@ public:
 	AnimationTrackEditColor();
 };
 
-class AnimationTrackEditSpriteFrame : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEditKey);
+class AnimationTrackEditSpriteFrame : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
 
 private:
+	ObjectID id;
 	bool is_coords = false;
 
 	//Helper
 	Rect2 _create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture);
 	Rect2 _create_region_animated_sprite(int p_index, Object *object, const Ref<Texture2D> texture);
+
+public:
+	void set_node(Object *p_object);
+	ObjectID get_node_id() const { return id; }
 
 public:
 	void set_as_coords();
@@ -227,14 +251,14 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
-	virtual Ref<Resource> get_resource(const int p_index) const override;
+	Ref<Resource> get_resource(const int p_index) const;
 
 public:
 	AnimationTrackEditSpriteFrame();
 };
 
-class AnimationTrackEditVolumeDB : public AnimationTrackEditKey {
-	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEditKey);
+class AnimationTrackEditVolumeDB : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
 
 public:
 	virtual int get_key_width(const int p_index) const override;
@@ -257,4 +281,5 @@ public:
 	virtual AnimationTrackEdit *create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) override;
 	virtual AnimationTrackEdit *create_audio_track_edit() override;
 	virtual AnimationTrackEdit *create_animation_track_edit(Object *p_object) override;
+	virtual AnimationTrackEdit *create_method_track_edit() override;
 };

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -223,6 +223,9 @@ public:
 public:
 	StringName get_edit_name(const int p_index) const; //name of the key
 
+protected:
+	virtual void draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) override;
+
 private:
 	// Helper
 	String _make_method_text(const Dictionary &d) const;

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -74,6 +74,7 @@ public:
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
+	virtual int get_key_width() const override;
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override { return false; }
@@ -177,6 +178,7 @@ private:
 	Ref<Texture2D> icon_unchecked;
 
 public:
+	virtual int get_key_width() const override;
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
@@ -189,6 +191,8 @@ class AnimationTrackEditColor : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEditKey);
 
 public:
+	virtual int get_key_width() const override;
+	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
@@ -220,6 +224,7 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEditKey);
 
 public:
+	virtual int get_key_width() const override;
 	virtual int get_key_height() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -133,6 +133,9 @@ protected:
 	virtual void apply_data(const Ref<Resource> resource, const float time) override;
 
 public:
+	virtual String _get_tooltip(const int p_index) const override;
+
+public:
 	AnimationTrackEditTypeAudio();
 };
 
@@ -143,6 +146,7 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
 
 public:
 	virtual bool has_valid_key(const int p_index) const override;
+	virtual String _get_tooltip(const int p_index) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) const override;
@@ -224,6 +228,8 @@ public:
 	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
+	virtual String _get_tooltip(const int p_index) const override;
+
 public:
 	StringName get_edit_name(const int p_index) const; //name of the key
 
@@ -293,11 +299,18 @@ public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
+	virtual bool is_linked(const int p_index, const int p_index_next) const override;
 
 protected:
 	virtual void draw_bg(const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
+
+	virtual float get_key_y(const int p_index) const override;
+
+private:
+	float get_min_key_y() const;
+	float get_max_key_y() const;
 
 public:
 	AnimationTrackEditVolumeDB();

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -71,6 +71,7 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
 
 	void set_node(Object *p_object);
 
@@ -105,7 +106,8 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
-
+	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
+	
 	void set_node(Object *p_object);
 };
 
@@ -135,6 +137,7 @@ public:
 
 	virtual void handle_data(const float ofs, const Ref<Resource> resource) = 0;
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) = 0;
+	bool handle_track_over(Ref<InputEventMouseMotion> mm, float start_ofs, float end_ofs, float len, int i);
 
 	virtual int get_key_height() const = 0;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) = 0;
@@ -158,6 +161,7 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
 
 	AnimationTrackEditTypeAudio();
 };
@@ -180,6 +184,7 @@ public:
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
 
 	void set_node(Object *p_object);
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -75,7 +75,7 @@ private:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
-	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right);
+	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const int p_clip_left, const int p_clip_right);
 
 	Region _calc_key_region(const int p_index, const float p_start_ofs, const float p_end_ofs, const float p_len, float p_offset = 0) const;
 	Region _clip_key_region(const Region &p_region, const int p_clip_left, const int p_clip_right);
@@ -92,6 +92,8 @@ public:
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
+
+protected:
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
@@ -101,7 +103,7 @@ protected:
 	virtual float get_length(const int p_index) const { return 0; } // total length of the key
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the start offset of the key
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the end offset of the key
-	virtual StringName get_edit_name(const int p_index) const; //name of the key
+	virtual StringName get_edit_name(const int p_index) const override; //name of the key
 	virtual float get_key_scale(const int p_index) const { return 1.0; }
 
 protected:
@@ -214,6 +216,8 @@ private:
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
+
+protected:
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 public:
@@ -226,14 +230,14 @@ class AnimationTrackEditTypeMethod : public AnimationTrackEdit {
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
-	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 	virtual String _get_tooltip(const int p_index) const override;
 
 public:
-	StringName get_edit_name(const int p_index) const; //name of the key
+	virtual StringName get_edit_name(const int p_index) const override; //name of the key
 
 protected:
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 
 private:
@@ -250,9 +254,10 @@ class AnimationTrackEditColor : public AnimationTrackEdit {
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
-	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
+	virtual bool is_linked(const int p_index, const int p_index_next) const override;
 
 protected:
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 
 public:
@@ -283,6 +288,8 @@ public:
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
+
+protected:
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
@@ -298,14 +305,15 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEdit {
 public:
 	virtual float get_key_width(const int p_index) const override;
 	virtual float get_key_height(const int p_index) const override;
-	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual bool is_linked(const int p_index, const int p_index_next) const override;
 
 protected:
 	virtual void draw_bg(const float p_clip_left, const float p_clip_right) override;
-	virtual void draw_fg(const float p_clip_left, const float p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
+	virtual void draw_fg(const float p_clip_left, const float p_clip_right) override;
 
+public:
 	virtual float get_key_y(const int p_index) const override;
 
 public:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -308,10 +308,6 @@ protected:
 
 	virtual float get_key_y(const int p_index) const override;
 
-private:
-	float get_min_key_y() const;
-	float get_max_key_y() const;
-
 public:
 	AnimationTrackEditVolumeDB();
 };

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -102,6 +102,7 @@ protected:
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the start offset of the key
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the end offset of the key
 	virtual StringName get_edit_name(const int p_index) const; //name of the key
+	virtual float get_key_scale(const int p_index) const { return 1.0; }
 
 protected:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
@@ -151,6 +152,9 @@ protected:
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual StringName get_edit_name(const int p_index) const override;
+
+protected:
+	virtual float get_key_scale(const int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -40,22 +40,30 @@ class AnimationTrackEditBase : public AnimationTrackEdit {
 protected:
 	ObjectID id;
 
-public:
-	virtual void _preview_changed(ObjectID p_which) = 0;
+	float font_scl = 1.5;
+
+	bool len_resizing = false;
+	bool len_resizing_start = false;
+	int len_resizing_index = 0;
+	float len_resizing_from_px = 0.0f;
+	float len_resizing_rel = 0.0f;
+	bool over_drag_position = false;
 
 public:
-	virtual int get_key_height() const = 0;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) = 0;
-	virtual bool is_key_selectable_by_distance() const = 0;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) = 0;
+	virtual void _preview_changed(ObjectID p_which);
+
+public:
+	virtual int get_key_height() const;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec);
+	virtual bool is_key_selectable_by_distance() const { return false; }
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 
 protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) = 0;
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {}
 	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
-	Rect2 get_key_rect_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec);
-	virtual Vector2 calc_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
-	Vector2 clip_region(Vector2 &region, int p_clip_left, int p_clip_right);
-	bool is_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
+	virtual Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
+	Vector2 clip_key_region(Vector2 &region, int p_clip_left, int p_clip_right);
+	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) { return nullptr; }
@@ -67,49 +75,24 @@ protected:
 	virtual StringName get_edit_name(const int p_index);
 
 public:
-	void set_node(Object *p_object);
-};
-
-class AnimationTrackEditClip : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditClip, AnimationTrackEditBase);
-
-public:
-	virtual void _preview_changed(ObjectID p_which) override;
-
-protected:
-	bool len_resizing = false;
-	bool len_resizing_start = false;
-	int len_resizing_index = 0;
-	float len_resizing_from_px = 0.0f;
-	float len_resizing_rel = 0.0f;
-	bool over_drag_position = false;
-
-	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-public:
 	virtual void gui_input(const Ref<InputEvent> &p_event);
 
 protected:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
-	virtual void apply_data(const Ref<Resource> resource, const float ofs) = 0;
+	virtual void apply_data(const Ref<Resource> resource, const float ofs) {}
 
-protected:
-	bool handle_mouse_over_track(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
+	bool handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
+
+public:
+	void set_node(Object *p_object);
 };
 
-class AnimationTrackEditTypeAudio : public AnimationTrackEditClip {
-	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditClip);
+class AnimationTrackEditTypeAudio : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditBase);
 
-public:
 	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -126,133 +109,10 @@ public:
 	AnimationTrackEditTypeAudio();
 };
 
-class AnimationTrackEditBool : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditBool, AnimationTrackEditBase);
+class AnimationTrackEditTypeAnimation : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditBase);
 
-	Ref<Texture2D> icon_checked;
-	Ref<Texture2D> icon_unchecked;
-
-public:
 	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-
-public:
-	AnimationTrackEditBool();
-};
-
-class AnimationTrackEditColor : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditColor, AnimationTrackEditBase);
-
-public:
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
-
-public:
-	AnimationTrackEditColor();
-};
-
-class AnimationTrackEditAudio : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditBase);
-
-public:
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	//virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
-
-protected:
-	virtual Ref<Resource> get_resource(const int p_index) override;
-	virtual float get_length(const int p_index) override;
-
-public:
-	AnimationTrackEditAudio();
-};
-
-class AnimationTrackEditSpriteFrame : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
-
-public:
-	virtual void _preview_changed(ObjectID p_which) override;
-
-private:
-	bool is_coords = false;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-
-public:
-	void set_as_coords();
-
-public:
-	AnimationTrackEditSpriteFrame();
-};
-
-class AnimationTrackEditSubAnim : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditBase);
-
-public:
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	//virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
-
-protected:
-	virtual Ref<Resource> get_resource(const int p_index) override;
-	virtual float get_length(const int p_index) override;
-	virtual StringName get_edit_name(const int p_index) override;
-
-public:
-	AnimationTrackEditSubAnim();
-};
-
-class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
-	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditClip);
-
-public:
-	virtual void _preview_changed(ObjectID p_which) override;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -270,20 +130,91 @@ public:
 	AnimationTrackEditTypeAnimation();
 };
 
-class AnimationTrackEditVolumeDB : public AnimationTrackEditBase {
-	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
+class AnimationTrackEditAudio : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditBase);
+
+	virtual void _preview_changed(ObjectID p_which) override;
+
+protected:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+
+	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual float get_length(const int p_index) override;
 
 public:
+	AnimationTrackEditAudio();
+};
+
+class AnimationTrackEditSubAnim : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditBase);
+
 	virtual void _preview_changed(ObjectID p_which) override;
+
+protected:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+
+	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual float get_length(const int p_index) override;
+	virtual StringName get_edit_name(const int p_index) override;
+
+public:
+	AnimationTrackEditSubAnim();
+};
+
+class AnimationTrackEditBool : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditBool, AnimationTrackEditBase);
+
+	Ref<Texture2D> icon_checked;
+	Ref<Texture2D> icon_unchecked;
 
 public:
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+public:
+	AnimationTrackEditBool();
+};
+
+class AnimationTrackEditColor : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditColor, AnimationTrackEditBase);
+
+public:
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
+
+public:
+	AnimationTrackEditColor();
+};
+
+class AnimationTrackEditSpriteFrame : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
+
+private:
+	bool is_coords = false;
+
+public:
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+public:
+	void set_as_coords();
+
+public:
+	AnimationTrackEditSpriteFrame();
+};
+
+class AnimationTrackEditVolumeDB : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
+
+public:
+	virtual int get_key_height() const override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+protected:
 	virtual void draw_bg(int p_clip_left, int p_clip_right) override;
 	virtual void draw_fg(int p_clip_left, int p_clip_right) override;
 	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -55,7 +55,7 @@ private:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
-	bool handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
+	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
 
 	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
 	Vector2 clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -58,11 +58,10 @@ private:
 
 	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right);
 
-	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const;
-	Vector2 clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);
-	void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
-	Vector2 calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
-	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
+	Vector2 _calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const;
+	Vector2 _clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);
+	Vector2 _calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
+	bool _is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
 
 public:
 	void set_node(Object *p_object);

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -34,85 +34,32 @@
 #include "editor/animation_track_editor.h"
 #include "editor/audio_stream_preview.h"
 
-class AnimationTrackEditBool : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditBool, AnimationTrackEdit);
-	Ref<Texture2D> icon_checked;
-	Ref<Texture2D> icon_unchecked;
+class AnimationTrackEditBase : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditBase, AnimationTrackEdit);
 
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-};
-
-class AnimationTrackEditColor : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditColor, AnimationTrackEdit);
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
-};
-
-class AnimationTrackEditAudio : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditAudio, AnimationTrackEdit);
-
+protected:
 	ObjectID id;
 
-	void _preview_changed(ObjectID p_which);
+protected:
+	virtual void _preview_changed(ObjectID p_which) = 0;
 
 public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) = 0;
+	virtual int get_key_height() const = 0;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) = 0;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) = 0;
+	virtual bool is_key_selectable_by_distance() const = 0;
 
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
-	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
-
-	void set_node(Object *p_object);
-
-	AnimationTrackEditAudio();
-};
-
-class AnimationTrackEditSpriteFrame : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
-
-	ObjectID id;
-	bool is_coords = false;
+protected:
+	Rect2 get_key_rect_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec);
+	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right); //B
 
 public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-	void set_node(Object *p_object);
-	void set_as_coords();
-};
-
-class AnimationTrackEditSubAnim : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEdit);
-
-	ObjectID id;
-
-public:
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
-	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
-
 	void set_node(Object *p_object);
 };
 
-class AnimationTrackEditClip : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditClip, AnimationTrackEdit);
+class AnimationTrackEditClip : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditClip, AnimationTrackEditBase);
 
 protected:
 	bool len_resizing = false;
@@ -122,83 +69,185 @@ protected:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
-	virtual void _preview_changed(ObjectID p_which) = 0;
-
-public:
-	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
-	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
-
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
-
-	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
+	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) = 0;
 
+protected:
 	virtual void handle_data(const float ofs, const Ref<Resource> resource) = 0;
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) = 0;
-	bool handle_track_over(Ref<InputEventMouseMotion> mm, float start_ofs, float end_ofs, float len, int i);
 
-	virtual int get_key_height() const = 0;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) = 0;
-	virtual bool is_key_selectable_by_distance() const = 0;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) = 0;
+protected:
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
+	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
+
+	bool handle_track_over(Ref<InputEventMouseMotion> mm, float start_ofs, float end_ofs, float len, int i);
 };
 
 class AnimationTrackEditTypeAudio : public AnimationTrackEditClip {
-	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEdit);
+	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditClip);
 
+protected:
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override; //
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override; //
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
 
+protected:
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void handle_data(const float ofs, const Ref<Resource> resource) override;
 
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
-
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
-	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
-
+public:
 	AnimationTrackEditTypeAudio();
 };
 
-class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
-	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEdit);
+class AnimationTrackEditBool : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditBool, AnimationTrackEditBase);
+	Ref<Texture2D> icon_checked;
+	Ref<Texture2D> icon_unchecked;
 
-	ObjectID id;
+protected:
+	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
+
+public:
+	AnimationTrackEditBool();
+};
+
+class AnimationTrackEditColor : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditColor, AnimationTrackEditBase);
+
+protected:
+	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
+
+protected:
+	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
+
+public:
+	AnimationTrackEditColor();
+};
+
+class AnimationTrackEditAudio : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditBase);
+
+protected:
+	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
+
+protected:
+	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
+
+public:
+	AnimationTrackEditAudio();
+};
+
+class AnimationTrackEditSpriteFrame : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
+
+private:
+	bool is_coords = false;
+
+protected:
+	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
+
+public:
+	void set_as_coords();
+
+public:
+	AnimationTrackEditSpriteFrame();
+};
+
+class AnimationTrackEditSubAnim : public AnimationTrackEditBase {
+	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditBase);
+
+protected:
+	virtual void _preview_changed(ObjectID p_which) override;
+
+public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
+
+protected:
+	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
+
+public:
+	AnimationTrackEditSubAnim();
+};
+
+class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
+	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditClip);
 
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-
 	virtual void handle_data(const float ofs, const Ref<Resource> resource) override;
 
+public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
 
-	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
-	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
-
-	void set_node(Object *p_object);
-
+public:
 	AnimationTrackEditTypeAnimation();
 };
 
-class AnimationTrackEditVolumeDB : public AnimationTrackEdit {
+class AnimationTrackEditVolumeDB : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
 
+protected:
+	virtual void _preview_changed(ObjectID p_which) override;
+
 public:
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual bool is_key_selectable_by_distance() const override;
+
+protected:
 	virtual void draw_bg(int p_clip_left, int p_clip_right) override;
 	virtual void draw_fg(int p_clip_left, int p_clip_right) override;
-	virtual int get_key_height() const override;
 	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
+
+public:
+	AnimationTrackEditVolumeDB();
 };
 
 class AnimationTrackEditDefaultPlugin : public AnimationTrackEditPlugin {

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -40,7 +40,7 @@ class AnimationTrackEditBase : public AnimationTrackEdit {
 protected:
 	ObjectID id;
 
-protected:
+public:
 	virtual void _preview_changed(ObjectID p_which) = 0;
 
 public:
@@ -54,7 +54,17 @@ protected:
 	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right); //B
 	Rect2 get_key_rect_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec);
 	virtual Vector2 calc_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
-	float clip_region(Vector2 &region, int p_clip_left, int p_clip_right);
+	Vector2 clip_region(Vector2 &region, int p_clip_left, int p_clip_right);
+	bool is_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
+
+protected:
+	virtual Ref<Resource> get_resource(const int p_index) { return nullptr; }
+	virtual float get_start_offset(const int p_index) { return 0; }
+	virtual float get_end_offset(const int p_index) { return 0; }
+	virtual float get_length(const int p_index) { return 0; }
+	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
+	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
+	virtual StringName get_edit_name(const int p_index) { return StringName(""); }
 
 public:
 	void set_node(Object *p_object);
@@ -62,6 +72,9 @@ public:
 
 class AnimationTrackEditClip : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditClip, AnimationTrackEditBase);
+
+public:
+	virtual void _preview_changed(ObjectID p_which) override;
 
 protected:
 	bool len_resizing = false;
@@ -74,7 +87,7 @@ protected:
 	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 public:
-	virtual void gui_input(const Ref<InputEvent> &p_event) = 0;
+	virtual void gui_input(const Ref<InputEvent> &p_event);
 
 protected:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
@@ -89,10 +102,8 @@ protected:
 class AnimationTrackEditTypeAudio : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEditClip);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
 public:
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
 	virtual int get_key_height() const override;
@@ -104,6 +115,13 @@ protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual void apply_data(const Ref<Resource> resource, const float ofs) override;
 
+	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual float get_start_offset(const int p_index) override;
+	virtual float get_end_offset(const int p_index) override;
+	virtual float get_length(const int p_index) override;
+	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
+	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
+
 public:
 	AnimationTrackEditTypeAudio();
 };
@@ -111,10 +129,11 @@ public:
 class AnimationTrackEditBool : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditBool, AnimationTrackEditBase);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
 	Ref<Texture2D> icon_checked;
 	Ref<Texture2D> icon_unchecked;
+
+public:
+	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
 	virtual int get_key_height() const override;
@@ -132,6 +151,7 @@ public:
 class AnimationTrackEditColor : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEditBase);
 
+public:
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
@@ -151,6 +171,7 @@ public:
 class AnimationTrackEditAudio : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditAudio, AnimationTrackEditBase);
 
+public:
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
@@ -163,6 +184,10 @@ protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
 
+protected:
+	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual float get_length(const int p_index) override;
+
 public:
 	AnimationTrackEditAudio();
 };
@@ -170,6 +195,7 @@ public:
 class AnimationTrackEditSpriteFrame : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditSpriteFrame, AnimationTrackEdit);
 
+public:
 	virtual void _preview_changed(ObjectID p_which) override;
 
 private:
@@ -194,6 +220,7 @@ public:
 class AnimationTrackEditSubAnim : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditSubAnim, AnimationTrackEditBase);
 
+public:
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
@@ -206,6 +233,11 @@ protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
 
+protected:
+	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual float get_length(const int p_index) override;
+	virtual StringName get_edit_name(const int p_index) override;
+
 public:
 	AnimationTrackEditSubAnim();
 };
@@ -213,10 +245,8 @@ public:
 class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEditClip);
 
-	virtual void _preview_changed(ObjectID p_which) override;
-
 public:
-	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
 	virtual int get_key_height() const override;
@@ -228,6 +258,14 @@ protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 	virtual void apply_data(const Ref<Resource> resource, const float ofs) override;
 
+	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual float get_start_offset(const int p_index) override;
+	virtual float get_end_offset(const int p_index) override;
+	virtual float get_length(const int p_index) override;
+	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
+	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
+	virtual StringName get_edit_name(const int p_index) override;
+
 public:
 	AnimationTrackEditTypeAnimation();
 };
@@ -235,6 +273,7 @@ public:
 class AnimationTrackEditVolumeDB : public AnimationTrackEditBase {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEdit);
 
+public:
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -56,9 +56,9 @@ private:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
-	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
+	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right);
 
-	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
+	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x);
 	Vector2 clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);
 	void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	Vector2 calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
@@ -72,9 +72,9 @@ public:
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
+	virtual Rect2 get_key_rect(int p_index) override;
 	virtual bool is_key_selectable_by_distance() const override { return false; }
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
@@ -101,8 +101,8 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -126,8 +126,8 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -152,8 +152,8 @@ class AnimationTrackEditAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -170,8 +170,8 @@ class AnimationTrackEditSubAnim : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -192,9 +192,9 @@ private:
 	Ref<Texture2D> icon_unchecked;
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
+	virtual Rect2 get_key_rect(int p_index) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 public:
@@ -205,9 +205,9 @@ class AnimationTrackEditColor : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEditKey);
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
+	virtual Rect2 get_key_rect(int p_index) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
@@ -231,9 +231,9 @@ public:
 	void set_as_coords();
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
+	virtual Rect2 get_key_rect(int p_index) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
@@ -247,8 +247,8 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEditKey);
 
 public:
-	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
-	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_width(int p_index) const override;
+	virtual int get_key_height(int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -58,7 +58,7 @@ private:
 
 	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right);
 
-	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x);
+	Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const;
 	Vector2 clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);
 	void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	Vector2 calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
@@ -72,20 +72,22 @@ public:
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
-	virtual Rect2 get_key_rect(int p_index) override;
-	virtual bool is_key_selectable_by_distance() const override { return false; }
+	bool __has_valid_key(const int p_index) const;
+	float __get_key_width(const int p_index) const;
+
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
+	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
-	virtual Ref<Resource> get_resource(const int p_index) { return nullptr; } // resource of the key (AudioStream, Animation, ...)
-	virtual float get_start_offset(const int p_index) { return 0; } // start offset of the key
-	virtual float get_end_offset(const int p_index) { return 0; } // end offset of the key
-	virtual float get_length(const int p_index) { return 0; } // total length of the key
+	virtual Ref<Resource> get_resource(const int p_index) const { return nullptr; } // resource of the key (AudioStream, Animation, ...)
+	virtual float get_start_offset(const int p_index) const  { return 0; } // start offset of the key
+	virtual float get_end_offset(const int p_index) const  { return 0; } // end offset of the key
+	virtual float get_length(const int p_index) const  { return 0; } // total length of the key
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the start offset of the key
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {} //sets the end offset of the key
-	virtual StringName get_edit_name(const int p_index); //name of the key
+	virtual StringName get_edit_name(const int p_index) const; //name of the key
 
 protected:
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
@@ -101,14 +103,14 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
 
 protected:
-	virtual Ref<Resource> get_resource(const int p_index) override;
-	virtual float get_start_offset(const int p_index) override;
-	virtual float get_end_offset(const int p_index) override;
-	virtual float get_length(const int p_index) override;
+	virtual Ref<Resource> get_resource(const int p_index) const override;
+	virtual float get_start_offset(const int p_index) const override;
+	virtual float get_end_offset(const int p_index) const override;
+	virtual float get_length(const int p_index) const override;
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 
@@ -126,17 +128,17 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
 
 protected:
-	virtual Ref<Resource> get_resource(const int p_index) override;
-	virtual float get_start_offset(const int p_index) override;
-	virtual float get_end_offset(const int p_index) override;
-	virtual float get_length(const int p_index) override;
+	virtual Ref<Resource> get_resource(const int p_index) const override;
+	virtual float get_start_offset(const int p_index) const override;
+	virtual float get_end_offset(const int p_index) const override;
+	virtual float get_length(const int p_index) const override;
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) override;
-	virtual StringName get_edit_name(const int p_index) override;
+	virtual StringName get_edit_name(const int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -152,13 +154,13 @@ class AnimationTrackEditAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	virtual Ref<Resource> get_resource(const int p_index) override;
-	virtual float get_length(const int p_index) override;
+	virtual Ref<Resource> get_resource(const int p_index) const override;
+	virtual float get_length(const int p_index) const override;
 
 public:
 	AnimationTrackEditAudio();
@@ -170,15 +172,15 @@ class AnimationTrackEditSubAnim : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
 
-	virtual Ref<Resource> get_resource(const int p_index) override;
-	virtual float get_length(const int p_index) override;
-	virtual StringName get_edit_name(const int p_index) override;
+	virtual Ref<Resource> get_resource(const int p_index) const override;
+	virtual float get_length(const int p_index) const override;
+	virtual StringName get_edit_name(const int p_index) const override;
 
 public:
 	AnimationTrackEditSubAnim();
@@ -192,9 +194,9 @@ private:
 	Ref<Texture2D> icon_unchecked;
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
-	virtual Rect2 get_key_rect(int p_index) override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
+	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 public:
@@ -205,9 +207,9 @@ class AnimationTrackEditColor : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEditKey);
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
-	virtual Rect2 get_key_rect(int p_index) override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
+	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
@@ -231,13 +233,13 @@ public:
 	void set_as_coords();
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
-	virtual Rect2 get_key_rect(int p_index) override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
+	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
-	virtual Ref<Resource> get_resource(const int p_index) override;
+	virtual Ref<Resource> get_resource(const int p_index) const override;
 
 public:
 	AnimationTrackEditSpriteFrame();
@@ -247,8 +249,8 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEditKey);
 
 public:
-	virtual int get_key_width(int p_index) const override;
-	virtual int get_key_height(int p_index) const override;
+	virtual int get_key_width(const int p_index) const override;
+	virtual int get_key_height(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -72,12 +72,8 @@ public:
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
-	bool __has_valid_key(const int p_index) const;
-	float __get_key_width(const int p_index) const;
-
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
@@ -103,8 +99,7 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual bool has_valid_key(const int p_index) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) const override;
@@ -128,8 +123,7 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual bool has_valid_key(const int p_index) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) const override;
@@ -154,8 +148,7 @@ class AnimationTrackEditAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual bool has_valid_key(const int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -172,8 +165,7 @@ class AnimationTrackEditSubAnim : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width(const int p_index) const override;
-	virtual int get_key_height(const int p_index) const override;
+	virtual bool has_valid_key(const int p_index) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -196,7 +188,6 @@ private:
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 public:
@@ -209,7 +200,6 @@ class AnimationTrackEditColor : public AnimationTrackEditKey {
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:
@@ -235,7 +225,6 @@ public:
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual Rect2 get_key_rect(const int p_index) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -51,7 +51,7 @@ public:
 
 protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) = 0;
-	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right); //B
+	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	Rect2 get_key_rect_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec);
 	virtual Vector2 calc_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
 	Vector2 clip_region(Vector2 &region, int p_clip_left, int p_clip_right);
@@ -64,7 +64,7 @@ protected:
 	virtual float get_length(const int p_index) { return 0; }
 	virtual void set_start_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
-	virtual StringName get_edit_name(const int p_index) { return StringName(""); }
+	virtual StringName get_edit_name(const int p_index);
 
 public:
 	void set_node(Object *p_object);
@@ -182,7 +182,7 @@ public:
 
 protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
+	//virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -231,7 +231,7 @@ public:
 
 protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
+	//virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override; //C
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -56,12 +56,12 @@ private:
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
-	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_clip_left, const int p_clip_right);
+	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right);
 
 	Vector2 _calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const int p_x) const;
-	Vector2 _clip_key_region(Vector2 region, int p_clip_left, int p_clip_right);
-	Vector2 _calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
-	bool _is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
+	Vector2 _clip_key_region(Vector2 region, const int p_clip_left, const int p_clip_right);
+	Vector2 _calc_key_region_shift(const Vector2 &orig_region, const Vector2 &region) const;
+	bool _is_key_region_outside(const Vector2 &region, const int p_clip_left, const int p_clip_right) const;
 
 public:
 	void set_node(Object *p_object);
@@ -73,7 +73,7 @@ public:
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) const { return nullptr; } // resource of the key (AudioStream, Animation, ...)
@@ -187,7 +187,7 @@ private:
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 public:
 	AnimationTrackEditBool();
@@ -199,7 +199,7 @@ class AnimationTrackEditTypeMethod : public AnimationTrackEdit {
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 public:
 	StringName get_edit_name(const int p_index) const; //name of the key
@@ -218,10 +218,10 @@ class AnimationTrackEditColor : public AnimationTrackEdit {
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
-	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) override;
 
 public:
 	AnimationTrackEditColor();
@@ -235,8 +235,8 @@ private:
 	bool is_coords = false;
 
 	//Helper
-	Rect2 _create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture);
-	Rect2 _create_region_animated_sprite(int p_index, Object *object, const Ref<Texture2D> texture);
+	Rect2 _create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture) const;
+	Rect2 _create_region_animated_sprite(int p_index, Object *object, const Ref<Texture2D> texture) const;
 
 public:
 	void set_node(Object *p_object);
@@ -248,7 +248,7 @@ public:
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
 	Ref<Resource> get_resource(const int p_index) const;
@@ -263,12 +263,12 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEdit {
 public:
 	virtual int get_key_width(const int p_index) const override;
 	virtual int get_key_height(const int p_index) const override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
-	virtual void draw_bg(int p_clip_left, int p_clip_right) override;
-	virtual void draw_fg(int p_clip_left, int p_clip_right) override;
-	virtual void draw_key_link(int p_index, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
+	virtual void draw_bg(const float p_clip_left, const float p_clip_right) override;
+	virtual void draw_fg(const float p_clip_left, const float p_clip_right) override;
+	virtual void draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) override;
 
 public:
 	AnimationTrackEditVolumeDB();

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -31,6 +31,8 @@
 #pragma once
 
 #include "editor/animation_track_editor.h"
+#include "editor/animation_preview.h"
+#include "editor/audio_stream_preview.h"
 
 class AnimationTrackEditBool : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditBool, AnimationTrackEdit);
@@ -68,6 +70,8 @@ public:
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
+	virtual void create_key_region(Vector<Vector2> &points, Ref<AudioStreamPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+
 	void set_node(Object *p_object);
 
 	AnimationTrackEditAudio();
@@ -100,14 +104,15 @@ public:
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
+	virtual void create_key_region(Vector<Vector2> &points, Ref<AnimationPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+
 	void set_node(Object *p_object);
 };
 
-class AnimationTrackEditTypeAudio : public AnimationTrackEdit {
-	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEdit);
+class AnimationTrackEditClip : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditClip, AnimationTrackEdit);
 
-	void _preview_changed(ObjectID p_which);
-
+protected:
 	bool len_resizing = false;
 	bool len_resizing_start = false;
 	int len_resizing_index = 0;
@@ -115,48 +120,65 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEdit {
 	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
+	virtual void _preview_changed(ObjectID p_which) = 0;
+
+public:
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const; //X
+	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
+
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
+
+	//virtual void draw_clip_key(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
+
+public:
+	virtual void gui_input(const Ref<InputEvent> &p_event) = 0;
+
+	virtual void handle_data(const float ofs, const Ref<Resource> resource) = 0;
+
+	virtual int get_key_height() const = 0;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) = 0;
+	virtual bool is_key_selectable_by_distance() const = 0;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) = 0;
+};
+
+class AnimationTrackEditTypeAudio : public AnimationTrackEditClip {
+	GDCLASS(AnimationTrackEditTypeAudio, AnimationTrackEdit);
+
+	virtual void _preview_changed(ObjectID p_which) override;
+
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
-	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
-	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
+	virtual void handle_data(const float ofs, const Ref<Resource> resource) override;
 
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+	virtual void create_key_region(Vector<Vector2> &points, Ref<AudioStreamPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	AnimationTrackEditTypeAudio();
 };
 
-class AnimationTrackEditTypeAnimation : public AnimationTrackEdit {
+class AnimationTrackEditTypeAnimation : public AnimationTrackEditClip {
 	GDCLASS(AnimationTrackEditTypeAnimation, AnimationTrackEdit);
 
 	ObjectID id;
 
-	void _preview_changed(ObjectID p_which);
-
-	bool len_resizing = false;
-	bool len_resizing_start = false;
-	int len_resizing_index = 0;
-	float len_resizing_from_px = 0.0f;
-	float len_resizing_rel = 0.0f;
-	bool over_drag_position = false;
+	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
-	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
-	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
+	virtual void handle_data(const float ofs, const Ref<Resource> resource) override;
 
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+	virtual void create_key_region(Vector<Vector2> &points, Ref<AnimationPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	void set_node(Object *p_object);
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -71,8 +71,8 @@ public:
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override { return false; }
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
@@ -100,8 +100,8 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -125,8 +125,8 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 
 protected:
 	virtual Ref<Resource> get_resource(const int p_index) override;
@@ -151,8 +151,8 @@ class AnimationTrackEditAudio : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -169,8 +169,8 @@ class AnimationTrackEditSubAnim : public AnimationTrackEditKey {
 	virtual void _preview_changed(ObjectID p_which) override;
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 
 protected:
 	virtual void get_key_region_data(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
@@ -191,8 +191,8 @@ private:
 	Ref<Texture2D> icon_unchecked;
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
@@ -204,8 +204,8 @@ class AnimationTrackEditColor : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditColor, AnimationTrackEditKey);
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
@@ -222,14 +222,21 @@ class AnimationTrackEditSpriteFrame : public AnimationTrackEditKey {
 private:
 	bool is_coords = false;
 
-public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+	//Helper
+	Rect2 _create_texture_region_sprite(int p_index, Object *object, const Ref<Texture2D> texture);
+	Rect2 _create_region_animated_sprite(int p_index, Object *object, const Ref<Texture2D> texture);
 
 public:
 	void set_as_coords();
+
+public:
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+protected:
+	virtual Ref<Resource> get_resource(const int p_index) override;
 
 public:
 	AnimationTrackEditSpriteFrame();
@@ -239,8 +246,8 @@ class AnimationTrackEditVolumeDB : public AnimationTrackEditKey {
 	GDCLASS(AnimationTrackEditVolumeDB, AnimationTrackEditKey);
 
 public:
-	virtual int get_key_width() const override;
-	virtual int get_key_height() const override;
+	virtual int get_key_width(int p_index, float p_pixels_sec) const override;
+	virtual int get_key_height(int p_index, float p_pixels_sec) const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
 protected:

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -77,10 +77,10 @@ private:
 
 	int handle_track_resizing(const Ref<InputEventMouseMotion> mm, const int p_index, const Rect2 p_global_rect, const int p_clip_left, const int p_clip_right);
 
-	Region _calc_key_region(const int p_index, const float start_ofs, const float end_ofs, const float len, float __offset = 0) const;
-	Region _clip_key_region(const Region &region, const int p_clip_left, const int p_clip_right);
-	Region _calc_key_region_shift(const Region &orig_region, const Region &region) const;
-	bool _is_key_region_outside(const Region &region, const int p_clip_left, const int p_clip_right) const;
+	Region _calc_key_region(const int p_index, const float p_start_ofs, const float p_end_ofs, const float p_len, float p_offset = 0) const;
+	Region _clip_key_region(const Region &p_region, const int p_clip_left, const int p_clip_right);
+	Region _calc_key_region_shift(const Region &p_orig_region, const Region &p_region) const;
+	bool _is_key_region_outside(const Region &p_region, const int p_clip_left, const int p_clip_right) const;
 
 public:
 	void set_node(Object *p_object);
@@ -228,7 +228,7 @@ public:
 	StringName get_edit_name(const int p_index) const; //name of the key
 
 protected:
-	virtual void draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) override;
+	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 
 private:
 	// Helper
@@ -247,7 +247,7 @@ public:
 	virtual void draw_key(const int p_index, const Rect2 &p_global_rect, const bool p_selected, const float p_clip_left, const float p_clip_right) override;
 
 protected:
-	virtual void draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) override;
+	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 
 public:
 	AnimationTrackEditColor();
@@ -297,7 +297,7 @@ public:
 protected:
 	virtual void draw_bg(const float p_clip_left, const float p_clip_right) override;
 	virtual void draw_fg(const float p_clip_left, const float p_clip_right) override;
-	virtual void draw_key_link(int p_index, float p_pixels_sec, float p_x, float p_next_x, float p_clip_left, float p_clip_right) override;
+	virtual void draw_key_link(const int p_index, const Rect2 &p_global_rect, const Rect2 &p_global_rect_next, const float p_clip_left, const float p_clip_right) override;
 
 public:
 	AnimationTrackEditVolumeDB();

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -136,13 +136,31 @@ class AnimationTrackEditTypeAnimation : public AnimationTrackEdit {
 
 	ObjectID id;
 
+	void _preview_changed(ObjectID p_which);
+
+	bool len_resizing = false;
+	bool len_resizing_start = false;
+	int len_resizing_index = 0;
+	float len_resizing_from_px = 0.0f;
+	float len_resizing_rel = 0.0f;
+	bool over_drag_position = false;
+
 public:
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
+	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
+
 	virtual int get_key_height() const override;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+
 	void set_node(Object *p_object);
+
+	AnimationTrackEditTypeAnimation();
 };
 
 class AnimationTrackEditVolumeDB : public AnimationTrackEdit {

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -34,13 +34,22 @@
 #include "editor/animation_track_editor.h"
 #include "editor/audio_stream_preview.h"
 
+#define REGION_RESIZE_THRESHOLD (5.0 * EDSCALE)
+#define REGION_MAX_WIDTH 4.0
+#define REGION_FONT_MARGIN 3.0
+#define REGION_DEFAULT_FONT_SCALE 1.5
+#define REGION_BG_COLOR Color(0.25, 0.25, 0.25)
+#define REGION_EDGE_ALPHA 0.7
+
+#define COLOR_EDIT_SAMPLE_INTERVAL 64
+
 class AnimationTrackEditBase : public AnimationTrackEdit {
 	GDCLASS(AnimationTrackEditBase, AnimationTrackEdit);
 
 protected:
 	ObjectID id;
 
-	float font_scl = 1.5;
+	float font_scl = REGION_DEFAULT_FONT_SCALE;
 
 	bool len_resizing = false;
 	bool len_resizing_start = false;
@@ -50,22 +59,23 @@ protected:
 	bool over_drag_position = false;
 
 public:
+	void set_node(Object *p_object);
 	virtual void _preview_changed(ObjectID p_which);
 
 public:
-	virtual int get_key_height() const;
-	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec);
-	virtual bool is_key_selectable_by_distance() const { return false; }
-	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual bool is_key_selectable_by_distance() const override { return false; }
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-protected:
+protected: // calc
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {}
 	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	virtual Vector2 calc_key_region(const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x);
 	Vector2 clip_key_region(Vector2 &region, int p_clip_left, int p_clip_right);
 	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
 
-protected:
+protected: // data
 	virtual Ref<Resource> get_resource(const int p_index) { return nullptr; }
 	virtual float get_start_offset(const int p_index) { return 0; }
 	virtual float get_end_offset(const int p_index) { return 0; }
@@ -74,19 +84,16 @@ protected:
 	virtual void set_end_offset(const int p_index, const float prev_ofs, const float new_ofs) {}
 	virtual StringName get_edit_name(const int p_index);
 
-public:
+public: // gui
 	virtual void gui_input(const Ref<InputEvent> &p_event);
 
 protected:
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
-	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
-	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
+	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	virtual void apply_data(const Ref<Resource> resource, const float ofs) {}
 
 	bool handle_track_resizing(const Ref<InputEventMouseMotion> mm, const float start_ofs, const float end_ofs, const float len, const int p_index, const float p_pixels_sec, const int p_x, const int p_clip_left, const int p_clip_right);
-
-public:
-	void set_node(Object *p_object);
 };
 
 class AnimationTrackEditTypeAudio : public AnimationTrackEditBase {
@@ -137,7 +144,6 @@ class AnimationTrackEditAudio : public AnimationTrackEditBase {
 
 protected:
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) override;
-
 	virtual Ref<Resource> get_resource(const int p_index) override;
 	virtual float get_length(const int p_index) override;
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -70,7 +70,7 @@ public:
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-	virtual void create_key_region(Vector<Vector2> &points, Ref<AudioStreamPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	void set_node(Object *p_object);
 
@@ -104,7 +104,7 @@ public:
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-	virtual void create_key_region(Vector<Vector2> &points, Ref<AnimationPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	void set_node(Object *p_object);
 };
@@ -123,17 +123,18 @@ protected:
 	virtual void _preview_changed(ObjectID p_which) = 0;
 
 public:
-	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const; //X
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data);
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const;
 
-	//virtual void draw_clip_key(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
+	virtual void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) = 0;
 
 	virtual void handle_data(const float ofs, const Ref<Resource> resource) = 0;
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) = 0;
 
 	virtual int get_key_height() const = 0;
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) = 0;
@@ -156,7 +157,7 @@ public:
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-	virtual void create_key_region(Vector<Vector2> &points, Ref<AudioStreamPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	AnimationTrackEditTypeAudio();
 };
@@ -178,7 +179,7 @@ public:
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
 
-	virtual void create_key_region(Vector<Vector2> &points, Ref<AnimationPreview> preview, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	void set_node(Object *p_object);
 

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -37,7 +37,6 @@
 #define REGION_RESIZE_THRESHOLD 5.0
 #define REGION_MAX_WIDTH 4.0
 #define REGION_FONT_MARGIN 3.0
-#define REGION_DEFAULT_FONT_SCALE 1.5
 #define REGION_BG_COLOR Color(0.25, 0.25, 0.25)
 #define REGION_EDGE_ALPHA 0.7
 
@@ -63,6 +62,9 @@ private:
 	void draw_key_region(Ref<Resource> resource, float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right);
 	Vector2 calc_key_region_shift(Vector2 &orig_region, Vector2 &region);
 	bool is_key_region_outside(const Vector2 &region, int p_clip_left, int p_clip_right);
+
+protected:
+	float key_scale = 1.0;
 
 public:
 	void set_node(Object *p_object);

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -30,8 +30,8 @@
 
 #pragma once
 
-#include "editor/animation_track_editor.h"
 #include "editor/animation_preview.h"
+#include "editor/animation_track_editor.h"
 #include "editor/audio_stream_preview.h"
 
 class AnimationTrackEditBool : public AnimationTrackEdit {
@@ -107,7 +107,7 @@ public:
 
 	virtual void create_key_region(Ref<Resource> resource, Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 	virtual Rect2 get_key_rect_region(float start_ofs, float end_ofs, float len, int p_index, float p_pixels_sec);
-	
+
 	void set_node(Object *p_object);
 };
 

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -177,8 +177,6 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 		return previews[p_stream->get_instance_id()].preview;
 	}
 
-	//no preview exists
-
 	previews[p_stream->get_instance_id()] = Preview();
 
 	Preview *preview = &previews[p_stream->get_instance_id()];

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -211,7 +211,7 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 	return preview->preview;
 }
 
-void AudioStreamPreview::create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+void AudioStreamPreview::create_key_region_data(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	float preview_len = get_length();
 	float pixel_begin = rect.position.x;
 	float from_x = rect.position.x;

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -187,20 +187,17 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 	preview->generating.set();
 	preview->id = p_stream->get_instance_id();
 
-	float len_s = preview->base_stream->get_length();
-	if (len_s == 0) {
-		len_s = 60 * 5; //five minutes
-	}
-
-	int frames = AudioServer::get_singleton()->get_mix_rate() * len_s;
-
 	Vector<uint8_t> maxmin;
-	int pw = frames / 20;
-	maxmin.resize(pw * 2);
-	{
-		uint8_t *ptr = maxmin.ptrw();
-		for (int i = 0; i < pw * 2; i++) {
-			ptr[i] = 127;
+	float len_s = preview->base_stream->get_length();
+	if (len_s != 0) {
+		int frames = AudioServer::get_singleton()->get_mix_rate() * len_s;
+		int pw = frames / 20;
+		maxmin.resize(pw * 2);
+		{
+			uint8_t *ptr = maxmin.ptrw();
+			for (int i = 0; i < pw * 2; i++) {
+				ptr[i] = 127;
+			}
 		}
 	}
 

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -214,23 +214,26 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 void AudioStreamPreview::create_key_region_data(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
 	float preview_len = get_length();
 	float pixel_begin = rect.position.x;
+
 	float from_x = rect.position.x;
-	float to_x = from_x + rect.size.x;
+	float to_x = rect.position.x + rect.size.x;
 
-	int pixel_len = preview_len * p_pixels_sec;
+	float pixel_len = preview_len * p_pixels_sec;
 
-	for (int i = from_x; i < to_x; i++) {
-		float ofs = (i - pixel_begin) * preview_len / pixel_len;
-		float ofs_n = ((i + 1) - pixel_begin) * preview_len / pixel_len;
+	for (int i = 0; i < points.size(); i++) {
+		int pixel_idx = i / 2;
+		bool is_min = (i % 2 == 0);
+
+		float pixel_x = from_x + pixel_idx;
+		float ofs = (pixel_x - pixel_begin) * preview_len / pixel_len;
+		float ofs_n = (pixel_x + 1 - pixel_begin) * preview_len / pixel_len;
 		ofs += start_ofs;
 		ofs_n += start_ofs;
 
-		float max = get_max(ofs, ofs_n) * 0.5 + 0.5;
-		float min = get_min(ofs, ofs_n) * 0.5 + 0.5;
+		float value = is_min ? get_min(ofs, ofs_n) : get_max(ofs, ofs_n);
+		value = value * 0.5f + 0.5f;
 
-		int idx = i - from_x;
-		points.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
-		points.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
+		points.write[i] = Vector2(pixel_x, rect.position.y + value * rect.size.y);
 	}
 }
 

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -213,6 +213,29 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 	return preview->preview;
 }
 
+void AudioStreamPreview::create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs) {
+	float preview_len = get_length();
+	float pixel_begin = rect.position.x;
+	float from_x = rect.position.x;
+	float to_x = from_x + rect.size.x;
+
+	int pixel_len = preview_len * p_pixels_sec;
+
+	for (int i = from_x; i < to_x; i++) {
+		float ofs = (i - pixel_begin) * preview_len / pixel_len;
+		float ofs_n = ((i + 1) - pixel_begin) * preview_len / pixel_len;
+		ofs += start_ofs;
+		ofs_n += start_ofs;
+
+		float max = get_max(ofs, ofs_n) * 0.5 + 0.5;
+		float min = get_min(ofs, ofs_n) * 0.5 + 0.5;
+
+		int idx = i - from_x;
+		points.write[idx * 2 + 0] = Vector2(i, rect.position.y + min * rect.size.y);
+		points.write[idx * 2 + 1] = Vector2(i, rect.position.y + max * rect.size.y);
+	}
+}
+
 void AudioStreamPreviewGenerator::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generate_preview", "stream"), &AudioStreamPreviewGenerator::generate_preview);
 

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -216,7 +216,6 @@ void AudioStreamPreview::create_key_region_data(Vector<Vector2> &points, const R
 	float pixel_begin = rect.position.x;
 
 	float from_x = rect.position.x;
-	float to_x = rect.position.x + rect.size.x;
 
 	float pixel_len = preview_len * p_pixels_sec;
 

--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -50,7 +50,7 @@ public:
 	float get_max(float p_time, float p_time_next) const;
 	float get_min(float p_time, float p_time_next) const;
 
-	void create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+	void create_key_region_data(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
 
 	AudioStreamPreview();
 };

--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -88,6 +88,7 @@ class AudioStreamPreviewGenerator : public Node {
 		Preview() {}
 	};
 
+private:
 	HashMap<ObjectID, Preview> previews;
 
 	static void _preview_thread(void *p_preview);

--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -50,6 +50,8 @@ public:
 	float get_max(float p_time, float p_time_next) const;
 	float get_min(float p_time, float p_time_next) const;
 
+	void create_key_region(Vector<Vector2> &points, const Rect2 &rect, const float p_pixels_sec, float start_ofs);
+
 	AudioStreamPreview();
 };
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -73,6 +73,7 @@
 #include "servers/rendering_server.h"
 
 #include "editor/audio_stream_preview.h"
+#include "editor/animation_preview.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/dependency_editor.h"
@@ -8501,6 +8502,9 @@ EditorNode::EditorNode() {
 
 	audio_preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(audio_preview_gen);
+
+	anim_preview_gen = memnew(AnimationPreviewGenerator);
+	add_child(anim_preview_gen);
 
 	add_editor_plugin(memnew(DebuggerEditorPlugin(debug_menu)));
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -72,8 +72,8 @@
 #include "servers/navigation_server_3d.h"
 #include "servers/rendering_server.h"
 
-#include "editor/audio_stream_preview.h"
 #include "editor/animation_preview.h"
+#include "editor/audio_stream_preview.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/dependency_editor.h"

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -62,6 +62,7 @@ class Window;
 
 class AudioStreamImportSettingsDialog;
 class AudioStreamPreviewGenerator;
+class AnimationPreviewGenerator;
 class BackgroundProgress;
 class DependencyEditor;
 class DependencyErrorDialog;
@@ -416,6 +417,7 @@ private:
 	EditorMainScreen *editor_main_screen = nullptr;
 
 	AudioStreamPreviewGenerator *audio_preview_gen = nullptr;
+	AnimationPreviewGenerator *anim_preview_gen = nullptr;
 	ProgressDialog *progress_dialog = nullptr;
 	BackgroundProgress *progress_hb = nullptr;
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -296,7 +296,7 @@ void AnimationPlayerEditor::_play_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		PackedStringArray markers = track_editor->get_selected_section();
+		PackedStringArray markers = track_editor->get_selected_marker_section();
 		if (markers.size() == 2) {
 			StringName start_marker = markers[0];
 			StringName end_marker = markers[1];
@@ -320,7 +320,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek_internal(time, true, true, true);
-		PackedStringArray markers = track_editor->get_selected_section();
+		PackedStringArray markers = track_editor->get_selected_marker_section();
 		if (markers.size() == 2) {
 			StringName start_marker = markers[0];
 			StringName end_marker = markers[1];
@@ -348,7 +348,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		PackedStringArray markers = track_editor->get_selected_section();
+		PackedStringArray markers = track_editor->get_selected_marker_section();
 		if (markers.size() == 2) {
 			StringName start_marker = markers[0];
 			StringName end_marker = markers[1];
@@ -372,7 +372,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek_internal(time, true, true, true);
-		PackedStringArray markers = track_editor->get_selected_section();
+		PackedStringArray markers = track_editor->get_selected_marker_section();
 		if (markers.size() == 2) {
 			StringName start_marker = markers[0];
 			StringName end_marker = markers[1];

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -296,10 +296,10 @@ void AnimationPlayerEditor::_play_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		PackedStringArray markers = track_editor->get_selected_marker_section();
-		if (markers.size() == 2) {
-			StringName start_marker = markers[0];
-			StringName end_marker = markers[1];
+		Vector<int> marker_section = track_editor->get_selected_marker_section();
+		if (marker_section.size() == 2) {
+			StringName start_marker = track_editor->get_marker_name(marker_section[0]);
+			StringName end_marker = track_editor->get_marker_name(marker_section[1]);
 			player->play_section_with_markers(current, start_marker, end_marker);
 		} else {
 			player->play(current);
@@ -320,10 +320,10 @@ void AnimationPlayerEditor::_play_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek_internal(time, true, true, true);
-		PackedStringArray markers = track_editor->get_selected_marker_section();
-		if (markers.size() == 2) {
-			StringName start_marker = markers[0];
-			StringName end_marker = markers[1];
+		Vector<int> marker_section = track_editor->get_selected_marker_section();
+		if (marker_section.size() == 2) {
+			StringName start_marker = track_editor->get_marker_name(marker_section[0]);
+			StringName end_marker = track_editor->get_marker_name(marker_section[1]);
 			player->play_section_with_markers(current, start_marker, end_marker);
 		} else {
 			player->play(current);
@@ -348,10 +348,10 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
-		PackedStringArray markers = track_editor->get_selected_marker_section();
-		if (markers.size() == 2) {
-			StringName start_marker = markers[0];
-			StringName end_marker = markers[1];
+		Vector<int> marker_section = track_editor->get_selected_marker_section();
+		if (marker_section.size() == 2) {
+			StringName start_marker = track_editor->get_marker_name(marker_section[0]);
+			StringName end_marker = track_editor->get_marker_name(marker_section[1]);
 			player->play_section_with_markers_backwards(current, start_marker, end_marker);
 		} else {
 			player->play_backwards(current);
@@ -372,10 +372,10 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 		}
 		ERR_FAIL_COND_EDMSG(!_validate_tracks(player->get_animation(current)), "Animation tracks may have any invalid key, abort playing.");
 		player->seek_internal(time, true, true, true);
-		PackedStringArray markers = track_editor->get_selected_marker_section();
-		if (markers.size() == 2) {
-			StringName start_marker = markers[0];
-			StringName end_marker = markers[1];
+		Vector<int> marker_section = track_editor->get_selected_marker_section();
+		if (marker_section.size() == 2) {
+			StringName start_marker = track_editor->get_marker_name(marker_section[0]);
+			StringName end_marker = track_editor->get_marker_name(marker_section[1]);
 			player->play_section_with_markers_backwards(current, start_marker, end_marker);
 		} else {
 			player->play_backwards(current);

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -8,6 +8,13 @@ Add new entries at the end of the file.
 
 ## Changes between 4.4-stable and 4.5-stable
 
+GH-106882
+--------
+Validate extension JSON: Error: Field 'classes/Animation/methods/animation_track_insert_key/arguments': size changed value in new API, from 3 to 5.
+
+Optional argument added. Compatibility methods registered.
+
+
 GH-98194
 --------
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_show/arguments': size changed value in new API, from 7 to 8.

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -2004,7 +2004,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 								}
 
 							} else {
-								if(playing_caches.has(t)) {
+								if (playing_caches.has(t)) {
 									playing_caches.erase(t);
 
 									animation_playback->stop(true);

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1884,9 +1884,9 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						double next_key = idx + 1;
 						if (next_key < a->track_get_key_count(i)) {
 							double next_key_time = a->track_get_key_time(i, next_key);
-							double end = key_time + len_ofs;
-							double clamped_end = MIN(end, next_key_time);
-							double cropped_len = clamped_end - end;
+							double end_time = key_time + len_ofs;
+							double clamped_end = MIN(end_time, next_key_time);
+							double cropped_len = clamped_end - end_time;
 							if (cropped_len < 0) {
 								end_ofs -= cropped_len;
 								len_ofs += cropped_len;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1808,7 +1808,6 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					AHashMap<int, PlayingAnimationInfo> &map = track_info.anim_info;
 
 					AnimationPlayer *animation_playback = Object::cast_to<AnimationPlayer>(t_obj);
-					float animation_playback_speed_scale = animation_playback->get_speed_scale();
 
 					// Find animation.
 					int idx = -1;

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1840,7 +1840,6 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 
 					// Handle stop keys
 					StringName anim_name = a->animation_track_get_key_animation(i, idx);
-					int curr_idx = idx;
 					while (String(anim_name) == "[stop]" && idx > 0) {
 						idx = idx - 1;
 						anim_name = a->animation_track_get_key_animation(i, idx);

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -394,14 +394,6 @@ void AnimationMixer::get_animation_list(List<StringName> *p_animations) const {
 }
 
 Ref<Animation> AnimationMixer::get_animation(const StringName &p_name) const {
-	if (p_name == "[stop]") {
-		int a = 0;
-	}
-
-	if (p_name.is_empty()) {
-		int a = 0;
-	}
-
 	ERR_FAIL_COND_V_MSG(!animation_set.has(p_name), Ref<Animation>(), vformat("Animation not found: \"%s\".", p_name));
 	const AnimationData &anim_data = animation_set[p_name];
 	return anim_data.animation;
@@ -1712,7 +1704,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					track_info.loop = a->get_loop_mode() != Animation::LOOP_NONE;
 					track_info.backward = backward;
 					track_info.use_blend = a->audio_track_is_use_blend(i);
-					AHashMap<int, PlayingAudioStreamInfo>& map = track_info.stream_info;
+					AHashMap<int, PlayingAudioStreamInfo> &map = track_info.stream_info;
 
 					// Main process to fire key is started from here.
 					if (p_update_only) {
@@ -1729,8 +1721,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 							t->audio_stream_playback->stop_stream(map[idx].index);
 							map.erase(idx);
 						}
-					}
-					else {
+					} else {
 						List<int> to_play;
 						a->track_get_key_indices_in_range(i, time, delta, &to_play, looped_flag);
 						if (to_play.size()) {
@@ -1786,8 +1777,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						pasi.start = time;
 						if (len && Animation::is_greater_approx(end_ofs, 0)) { // Force an end at a time.
 							pasi.len = len - start_ofs - end_ofs;
-						}
-						else {
+						} else {
 							pasi.len = 0;
 						}
 						map[idx] = pasi;
@@ -1828,7 +1818,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						if (idx < 0 && a->track_get_key_count(i) > 0 && time < a->track_get_key_time(i, 0)) {
 							idx = 0;
 						}
-						
+
 						// Discard previous animation when seeking.
 						if (map.has(idx)) {
 							map.erase(idx);
@@ -1856,7 +1846,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						anim_name = a->animation_track_get_key_animation(i, idx);
 					}
 
-					while (String(anim_name) == "[stop]" && idx < a->track_get_key_count(i)-1) {
+					while (String(anim_name) == "[stop]" && idx < a->track_get_key_count(i) - 1) {
 						idx = idx + 1;
 						anim_name = a->animation_track_get_key_animation(i, idx);
 					}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -394,6 +394,14 @@ void AnimationMixer::get_animation_list(List<StringName> *p_animations) const {
 }
 
 Ref<Animation> AnimationMixer::get_animation(const StringName &p_name) const {
+	if (p_name == "[stop]") {
+		int a = 0;
+	}
+
+	if (p_name.is_empty()) {
+		int a = 0;
+	}
+
 	ERR_FAIL_COND_V_MSG(!animation_set.has(p_name), Ref<Animation>(), vformat("Animation not found: \"%s\".", p_name));
 	const AnimationData &anim_data = animation_set[p_name];
 	return anim_data.animation;
@@ -1848,12 +1856,12 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						anim_name = a->animation_track_get_key_animation(i, idx);
 					}
 
-					while (String(anim_name) == "[stop]" && idx < a->track_get_key_count(i)) {
+					while (String(anim_name) == "[stop]" && idx < a->track_get_key_count(i)-1) {
 						idx = idx + 1;
 						anim_name = a->animation_track_get_key_animation(i, idx);
 					}
 
-					if (String(anim_name) == "[stop]") {
+					if (String(anim_name) == "[stop]" || anim_name.is_empty()) {
 						animation_playback->stop(true);
 						if (playing_caches.has(t)) {
 							playing_caches.erase(t);

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -37,7 +37,6 @@
 #include "scene/resources/animation_library.h"
 #include "scene/resources/audio_stream_polyphonic.h"
 
-
 class AnimatedValuesBackup;
 //class AnimationPlayer;
 

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -37,7 +37,9 @@
 #include "scene/resources/animation_library.h"
 #include "scene/resources/audio_stream_polyphonic.h"
 
+
 class AnimatedValuesBackup;
+//class AnimationPlayer;
 
 class AnimationMixer : public Node {
 	GDCLASS(AnimationMixer, Node);
@@ -295,8 +297,37 @@ protected:
 		}
 	};
 
+	// Animation information for each animation placed on the track.
+	struct PlayingAnimationInfo {
+		StringName anim_name; //AnimationPlayer::ID index = -1; // ID retrieved from AudioStreamPlaybackPolyphonic.
+		double start = 0.0;
+		double len = 0.0;
+	};
+
+	// Animation information for mixng and ending.
+	struct PlayingAnimationTrackInfo {
+		AHashMap<int, PlayingAnimationInfo> anim_info;
+		double length = 0.0;
+		double time = 0.0;
+		real_t weight = 0.0;
+		bool loop = false;
+		bool backward = false;
+		bool use_blend = false;
+	};
+
 	struct TrackCacheAnimation : public TrackCache {
-		bool playing = false;
+		//bool playing = false;
+		//Ref<Animation> animation;
+		//Ref<AnimationPlayer> animation_player;
+		StringName anim_name;
+		HashMap<ObjectID, PlayingAnimationTrackInfo> playing_anims; // Key is Animation resource ObjectID.
+
+		TrackCacheAnimation(const TrackCacheAnimation &p_other) :
+				TrackCache(p_other),
+				//animation(p_other.animation),
+				//animation_player(p_other.animation_player),
+				anim_name(p_other.anim_name),
+				playing_anims(p_other.playing_anims) {}
 
 		TrackCacheAnimation() {
 			type = Animation::TYPE_ANIMATION;
@@ -308,10 +339,12 @@ protected:
 	AHashMap<Ref<Animation>, LocalVector<TrackCache *>> animation_track_num_to_track_cache;
 	HashSet<TrackCache *> playing_caches;
 	Vector<Node *> playing_audio_stream_players;
+	Vector<Node *> playing_animation_players;
 
 	// Helpers.
 	void _clear_caches();
 	void _clear_audio_streams();
+	void _clear_animations();
 	void _clear_playing_caches();
 	void _init_root_motion_cache();
 	bool _update_caches();

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -318,7 +318,7 @@ protected:
 	};
 
 	struct TrackCacheAnimation : public TrackCache {
-		//bool playing = false;
+		bool playing = false;
 		//Ref<Animation> animation;
 		//Ref<AnimationPlayer> animation_player;
 		StringName anim_name;

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -299,10 +299,9 @@ protected:
 
 	// Animation information for each animation placed on the track.
 	struct PlayingAnimationInfo {
-		StringName anim_name; //AnimationPlayer::ID index = -1; // ID retrieved from AudioStreamPlaybackPolyphonic.
+		StringName anim_name;
 		double start = 0.0;
 		double len = 0.0;
-		//double overlap_time = 0.0;
 		double anim_time = 0.0;
 		double anim_overlap_start = 0.0;
 		double anim_overlap_end = 0.0;

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -302,6 +302,10 @@ protected:
 		StringName anim_name; //AnimationPlayer::ID index = -1; // ID retrieved from AudioStreamPlaybackPolyphonic.
 		double start = 0.0;
 		double len = 0.0;
+		//double overlap_time = 0.0;
+		double anim_time = 0.0;
+		double anim_overlap_start = 0.0;
+		double anim_overlap_end = 0.0;
 	};
 
 	// Animation information for mixng and ending.

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -70,42 +70,36 @@ bool AnimationPlayer::_get(const StringName &p_name, Variant &r_ret) const {
 
 	if (name == "playback/play") { // For backward compatibility.
 
-r_ret = get_current_animation();
+		r_ret = get_current_animation();
 
-	}
- else if (name.begins_with("next/")) {
-	 String which = name.get_slicec('/', 1);
-	 r_ret = animation_get_next(which);
+	} else if (name.begins_with("next/")) {
+		String which = name.get_slicec('/', 1);
+		r_ret = animation_get_next(which);
 
-	}
- else if (p_name == SceneStringName(blend_times)) {
-	 Vector<BlendKey> keys;
-	 for (const KeyValue<BlendKey, double>& E : blend_times) {
-		 keys.ordered_insert(E.key);
-	 }
+	} else if (p_name == SceneStringName(blend_times)) {
+		Vector<BlendKey> keys;
+		for (const KeyValue<BlendKey, double> &E : blend_times) {
+			keys.ordered_insert(E.key);
+		}
 
-	 Array array;
-	 for (int i = 0; i < keys.size(); i++) {
-		 array.push_back(keys[i].from);
-		 array.push_back(keys[i].to);
-		 array.push_back(blend_times.get(keys[i]));
-	 }
+		Array array;
+		for (int i = 0; i < keys.size(); i++) {
+			array.push_back(keys[i].from);
+			array.push_back(keys[i].to);
+			array.push_back(blend_times.get(keys[i]));
+		}
 
-	 r_ret = array;
+		r_ret = array;
 #ifndef DISABLE_DEPRECATED
-	}
- else if (name == "method_call_mode") {
-	 r_ret = get_callback_mode_method();
-	}
- else if (name == "playback_process_mode") {
-	 r_ret = get_callback_mode_process();
-	}
- else if (name == "playback_active") {
-	 r_ret = is_active();
+	} else if (name == "method_call_mode") {
+		r_ret = get_callback_mode_method();
+	} else if (name == "playback_process_mode") {
+		r_ret = get_callback_mode_process();
+	} else if (name == "playback_active") {
+		r_ret = is_active();
 #endif // DISABLE_DEPRECATED
-	}
- else {
-	 return false;
+	} else {
+		return false;
 	}
 
 	return true;
@@ -133,17 +127,17 @@ void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void AnimationPlayer::_get_property_list(List<PropertyInfo>* p_list) const {
+void AnimationPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> anim_names;
 
-	for (const KeyValue<StringName, AnimationData>& E : animation_set) {
+	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		AHashMap<StringName, StringName>::ConstIterator F = animation_next_set.find(E.key);
 		if (F && F->value != StringName()) {
 			anim_names.push_back(PropertyInfo(Variant::STRING, "next/" + String(E.key), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
 
-	for (const PropertyInfo& E : anim_names) {
+	for (const PropertyInfo &E : anim_names) {
 		p_list->push_back(E);
 	}
 
@@ -152,17 +146,17 @@ void AnimationPlayer::_get_property_list(List<PropertyInfo>* p_list) const {
 
 void AnimationPlayer::_notification(int p_what) {
 	switch (p_what) {
-	case NOTIFICATION_READY: {
-		if (!Engine::get_singleton()->is_editor_hint() && animation_set.has(autoplay)) {
-			set_active(active);
-			play(autoplay);
-			_check_immediately_after_start();
-		}
-	} break;
+		case NOTIFICATION_READY: {
+			if (!Engine::get_singleton()->is_editor_hint() && animation_set.has(autoplay)) {
+				set_active(active);
+				play(autoplay);
+				_check_immediately_after_start();
+			}
+		} break;
 	}
 }
 
-void AnimationPlayer::_process_playback_data(PlaybackData& cd, double p_delta, float p_blend, bool p_seeked, bool p_internal_seeked, bool p_started, bool p_is_current, bool p_ignore_loop) {
+void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_internal_seeked, bool p_started, bool p_is_current, bool p_ignore_loop) {
 	double speed = speed_scale * cd.speed_scale;
 	bool backwards = std::signbit(speed); // Negative zero means playing backwards too.
 	double delta = p_started ? 0 : p_delta * speed;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -115,12 +115,12 @@ void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
 	if (Engine::get_singleton()->is_editor_hint() && p_property.name == "current_animation") {
 		List<String> names;
 
-		for (const KeyValue<StringName, AnimationData>& E : animation_set) {
+		for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 			names.push_back(E.key);
 		}
 		names.push_front("[stop]");
 		String hint;
-		for (List<String>::Element* E = names.front(); E; E = E->next()) {
+		for (List<String>::Element *E = names.front(); E; E = E->next()) {
 			if (E != names.front()) {
 				hint += ",";
 			}
@@ -128,8 +128,7 @@ void AnimationPlayer::_validate_property(PropertyInfo &p_property) const {
 		}
 
 		p_property.hint_string = hint;
-	}
-	else if (!auto_capture && p_property.name.begins_with("playback_auto_capture_")) {
+	} else if (!auto_capture && p_property.name.begins_with("playback_auto_capture_")) {
 		p_property.usage = PROPERTY_USAGE_NONE;
 	}
 }

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -549,7 +549,6 @@ void AnimationPlayer::_capture(const StringName &p_name, bool p_from_end, double
 		double current_pos = playback.current.pos;
 		if (playback.assigned != name) {
 			current_pos = p_from_end ? anim->get_length() : 0;
-
 		}
 		for (int i = 0; i < anim->get_track_count(); i++) {
 			if (anim->track_get_type(i) != Animation::TYPE_VALUE) {

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -549,6 +549,7 @@ void AnimationPlayer::_capture(const StringName &p_name, bool p_from_end, double
 		double current_pos = playback.current.pos;
 		if (playback.assigned != name) {
 			current_pos = p_from_end ? anim->get_length() : 0;
+
 		}
 		for (int i = 0; i < anim->get_track_count(); i++) {
 			if (anim->track_get_type(i) != Animation::TYPE_VALUE) {

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -129,7 +129,7 @@ private:
 
 	void _play(const StringName &p_name, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void _capture(const StringName &p_name, bool p_from_end = false, double p_duration = -1.0, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);
-	void _process_playback_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_internal_seeked, bool p_started, bool p_is_current = false);
+	void _process_playback_data(PlaybackData &cd, double p_delta, float p_blend, bool p_seeked, bool p_internal_seeked, bool p_started, bool p_is_current = false, bool p_ignore_loop = false);
 	void _blend_playback_data(double p_delta, bool p_started);
 	void _stop_internal(bool p_reset, bool p_keep_state);
 	void _check_immediately_after_start();

--- a/scene/resources/animation.compat.inc
+++ b/scene/resources/animation.compat.inc
@@ -30,7 +30,7 @@
 
 #ifndef DISABLE_DEPRECATED
 
-int Animation::animation_track_insert_key_bind_compat_106882(int p_track, double p_time, const StringName &p_animation) {
+int Animation::_animation_track_insert_key_bind_compat_106882(int p_track, double p_time, const StringName &p_animation) {
 	return animation_track_insert_key(p_track, p_time, p_animation, 0, 0);
 }
 
@@ -59,6 +59,7 @@ int Animation::_track_find_key_bind_compat_92861(int p_track, double p_time, Fin
 }
 
 void Animation::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("animation_track_insert_key", "track_idx", "time", "animation"), &Animation::_animation_track_insert_key_bind_compat_106882);
 	ClassDB::bind_compatibility_method(D_METHOD("position_track_interpolate", "track_idx", "time_sec"), &Animation::_position_track_interpolate_bind_compat_86629);
 	ClassDB::bind_compatibility_method(D_METHOD("rotation_track_interpolate", "track_idx", "time_sec"), &Animation::_rotation_track_interpolate_bind_compat_86629);
 	ClassDB::bind_compatibility_method(D_METHOD("scale_track_interpolate", "track_idx", "time_sec"), &Animation::_scale_track_interpolate_bind_compat_86629);

--- a/scene/resources/animation.compat.inc
+++ b/scene/resources/animation.compat.inc
@@ -30,6 +30,10 @@
 
 #ifndef DISABLE_DEPRECATED
 
+int Animation::animation_track_insert_key_bind_compat_106882(int p_track, double p_time, const StringName &p_animation) {
+	return animation_track_insert_key(p_track, p_time, p_animation, 0, 0);
+}
+
 Vector3 Animation::_position_track_interpolate_bind_compat_86629(int p_track, double p_time) const {
 	return position_track_interpolate(p_track, p_time, false);
 }

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -146,7 +146,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (what == "use_blend") {
 			if (track_get_type(track) == TYPE_AUDIO) {
 				audio_track_set_use_blend(track, p_value);
-			} else if(track_get_type(track) == TYPE_ANIMATION) {
+			} else if (track_get_type(track) == TYPE_ANIMATION) {
 				animation_track_set_use_blend(track, p_value);
 			}
 		} else if (what == "interp") {
@@ -3951,7 +3951,6 @@ real_t Animation::animation_track_get_key_end_offset(int p_track, int p_key) con
 
 	return at->values[p_key].value.end_offset;
 }
-
 
 void Animation::animation_track_set_use_blend(int p_track, bool p_enable) {
 	ERR_FAIL_INDEX(p_track, tracks.size());

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -590,6 +590,8 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (what == "use_blend") {
 			if (track_get_type(track) == TYPE_AUDIO) {
 				r_ret = audio_track_is_use_blend(track);
+			} else if (track_get_type(track) == TYPE_ANIMATION) {
+				r_ret = animation_track_is_use_blend(track);
 			}
 		} else if (what == "interp") {
 			r_ret = track_get_interpolation_type(track);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3839,7 +3839,7 @@ bool Animation::audio_track_is_use_blend(int p_track) const {
 
 //
 
-int Animation::animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, real_t p_start_offset, real_t p_end_offset) {
+int Animation::animation_track_insert_key(int p_track, double p_time, const StringName &p_animation, real_t p_start_offset, real_t p_end_offset) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, -1);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -442,7 +442,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 						if (!d2.has("end_offset")) {
 							continue;
 						}
-						if (!d2.has("stream")) {
+						if (!d2.has("animation")) {
 							continue;
 						}
 
@@ -904,7 +904,7 @@ void Animation::_get_property_list(List<PropertyInfo> *p_list) const {
 			p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/loop_wrap", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 			p_list->push_back(PropertyInfo(Variant::ARRAY, "tracks/" + itos(i) + "/keys", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		}
-		if (track_get_type(i) == TYPE_AUDIO) {
+		if (track_get_type(i) == TYPE_AUDIO || track_get_type(i) == TYPE_ANIMATION) {
 			p_list->push_back(PropertyInfo(Variant::BOOL, "tracks/" + itos(i) + "/use_blend", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
@@ -1853,11 +1853,9 @@ int Animation::track_insert_key(int p_track, double p_time, const Variant &p_key
 
 			TKey<AnimationKey> ak;
 			ak.time = p_time;
-			//ak.value = p_key;
 			ak.value.start_offset = k["start_offset"];
 			ak.value.end_offset = k["end_offset"];
 			ak.value.animation = k["animation"];
-
 			ret = _insert(p_time, at->values, ak);
 
 		} break;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -421,7 +421,7 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				ERR_FAIL_COND_V(!d.has("clips"), false);
 
 				Vector<real_t> times = d["times"];
-				Vector<String> clips = d["clips"];
+				Array clips = d["clips"]; //Vector<String> clips = d["clips"];
 
 				ERR_FAIL_COND_V(clips.size() != times.size(), false);
 
@@ -429,15 +429,30 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 					int valcount = times.size();
 
 					const real_t *rt = times.ptr();
-					const String *rc = clips.ptr();
+					//const String *rc = clips.ptr();
 
-					an->values.resize(valcount);
+					an->values.clear(); //an->values.resize(valcount);
 
 					for (int i = 0; i < valcount; i++) {
-						TKey<StringName> ak;
-						ak.time = rt[i];
-						ak.value = rc[i];
-						an->values.write[i] = ak;
+						Dictionary d2 = clips[i];
+						if (!d2.has("start_offset")) {
+							continue;
+						}
+						if (!d2.has("end_offset")) {
+							continue;
+						}
+						if (!d2.has("stream")) {
+							continue;
+						}
+
+						TKey<AnimationKey> ak;
+						ak.time = rt[i]; //d["time"];
+						//ak.value = rc[i];
+						ak.value.start_offset = d2["start_offset"];
+						ak.value.end_offset = d2["end_offset"];
+						ak.value.animation = d2["animation"];
+
+						an->values.push_back(ak); //an->values.write[i] = ak;
 					}
 				}
 
@@ -831,21 +846,28 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				Dictionary d;
 
 				Vector<real_t> key_times;
-				Vector<String> clips;
+				Array clips; //Vector<String> clips;
 
 				int kk = an->values.size();
 
 				key_times.resize(kk);
-				clips.resize(kk);
+				//clips.resize(kk);
 
 				real_t *wti = key_times.ptrw();
-				String *wcl = clips.ptrw();
+				//String *wcl = clips.ptrw();
 
-				const TKey<StringName> *vls = an->values.ptr();
+				int idx = 0;
+
+				const TKey<AnimationKey> *vls = an->values.ptr();
 
 				for (int i = 0; i < kk; i++) {
 					wti[i] = vls[i].time;
-					wcl[i] = vls[i].value;
+					Dictionary clip; //wcl[i] = vls[i].value;
+					clip["start_offset"] = vls[i].value.start_offset;
+					clip["end_offset"] = vls[i].value.end_offset;
+					clip["animation"] = vls[i].value.animation;
+					clips.push_back(clip);
+					idx++;
 				}
 
 				d["times"] = key_times;
@@ -1824,9 +1846,17 @@ int Animation::track_insert_key(int p_track, double p_time, const Variant &p_key
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 
-			TKey<StringName> ak;
+			Dictionary k = p_key;
+			ERR_FAIL_COND_V(!k.has("start_offset"), -1);
+			ERR_FAIL_COND_V(!k.has("end_offset"), -1);
+			ERR_FAIL_COND_V(!k.has("stream"), -1);
+
+			TKey<AnimationKey> ak;
 			ak.time = p_time;
-			ak.value = p_key;
+			//ak.value = p_key;
+			ak.value.start_offset = k["start_offset"];
+			ak.value.end_offset = k["end_offset"];
+			ak.value.animation = k["animation"];
 
 			ret = _insert(p_time, at->values, ak);
 
@@ -1966,7 +1996,11 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_INDEX_V(p_key_idx, at->values.size(), Variant());
 
-			return at->values[p_key_idx].value;
+			Dictionary k;
+			k["start_offset"] = at->values[p_key_idx].value.start_offset;
+			k["end_offset"] = at->values[p_key_idx].value.end_offset;
+			k["animation"] = at->values[p_key_idx].value.animation;
+			return k;
 
 		} break;
 	}
@@ -2146,7 +2180,7 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, at->values.size());
-			TKey<StringName> key = at->values[p_key_idx];
+			TKey<AnimationKey> key = at->values[p_key_idx];
 			key.time = p_time;
 			at->values.remove_at(p_key_idx);
 			_insert(p_time, at->values, key);
@@ -2341,7 +2375,14 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_INDEX(p_key_idx, at->values.size());
 
-			at->values.write[p_key_idx].value = p_value;
+			Dictionary k = p_value;
+			ERR_FAIL_COND(!k.has("start_offset"));
+			ERR_FAIL_COND(!k.has("end_offset"));
+			ERR_FAIL_COND(!k.has("animation"));
+
+			at->values.write[p_key_idx].value.start_offset = k["start_offset"];
+			at->values.write[p_key_idx].value.end_offset = k["end_offset"];
+			at->values.write[p_key_idx].value.animation = k["animation"];
 
 		} break;
 	}
@@ -3800,16 +3841,24 @@ bool Animation::audio_track_is_use_blend(int p_track) const {
 
 //
 
-int Animation::animation_track_insert_key(int p_track, double p_time, const StringName &p_animation) {
+int Animation::animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, real_t p_start_offset, real_t p_end_offset) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, -1);
 
 	AnimationTrack *at = static_cast<AnimationTrack *>(t);
 
-	TKey<StringName> k;
+	TKey<AnimationKey> k;
 	k.time = p_time;
-	k.value = p_animation;
+	k.value.animation = p_animation;
+	k.value.start_offset = p_start_offset;
+	if (k.value.start_offset < 0) {
+		k.value.start_offset = 0;
+	}
+	k.value.end_offset = p_end_offset;
+	if (k.value.end_offset < 0) {
+		k.value.end_offset = 0;
+	}
 
 	int key = _insert(p_time, at->values, k);
 
@@ -3827,7 +3876,42 @@ void Animation::animation_track_set_key_animation(int p_track, int p_key, const 
 
 	ERR_FAIL_INDEX(p_key, at->values.size());
 
-	at->values.write[p_key].value = p_animation;
+	at->values.write[p_key].value.animation = p_animation;
+
+	emit_changed();
+}
+
+void Animation::animation_track_set_key_start_offset(int p_track, int p_key, real_t p_offset) {
+	ERR_FAIL_INDEX(p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_ANIMATION);
+
+	AnimationTrack *at = static_cast<AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX(p_key, at->values.size());
+
+	if (p_offset < 0) {
+		p_offset = 0;
+	}
+
+	at->values.write[p_key].value.start_offset = p_offset;
+
+	emit_changed();
+}
+
+void Animation::animation_track_set_key_end_offset(int p_track, int p_key, real_t p_offset) {
+	ERR_FAIL_INDEX(p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_ANIMATION);
+
+	AnimationTrack *at = static_cast<AnimationTrack *>(t);
+	ERR_FAIL_INDEX(p_key, at->values.size());
+
+	if (p_offset < 0) {
+		p_offset = 0;
+	}
+
+	at->values.write[p_key].value.end_offset = p_offset;
 
 	emit_changed();
 }
@@ -3841,7 +3925,31 @@ StringName Animation::animation_track_get_key_animation(int p_track, int p_key) 
 
 	ERR_FAIL_INDEX_V(p_key, at->values.size(), StringName());
 
-	return at->values[p_key].value;
+	return at->values[p_key].value.animation;
+}
+
+real_t Animation::animation_track_get_key_start_offset(int p_track, int p_key) const {
+	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0.0);
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, 0.0);
+
+	AnimationTrack *at = static_cast<AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX_V(p_key, at->values.size(), 0);
+
+	return at->values[p_key].value.start_offset;
+}
+
+real_t Animation::animation_track_get_key_end_offset(int p_track, int p_key) const {
+	ERR_FAIL_INDEX_V(p_track, tracks.size(), 0.0);
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_ANIMATION, 0.0);
+
+	AnimationTrack *at = static_cast<AnimationTrack *>(t);
+
+	ERR_FAIL_INDEX_V(p_key, at->values.size(), 0);
+
+	return at->values[p_key].value.end_offset;
 }
 
 void Animation::set_length(real_t p_length) {
@@ -4038,9 +4146,13 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("audio_track_set_use_blend", "track_idx", "enable"), &Animation::audio_track_set_use_blend);
 	ClassDB::bind_method(D_METHOD("audio_track_is_use_blend", "track_idx"), &Animation::audio_track_is_use_blend);
 
-	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track_idx", "time", "animation"), &Animation::animation_track_insert_key);
+	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track", "time", "animation", "start_offset", "end_offset"), &Animation::animation_track_insert_key, DEFVAL(0.0), DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "track_idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_start_offset", "track", "key", "offset"), &Animation::animation_track_set_key_start_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_end_offset", "track", "key", "offset"), &Animation::animation_track_set_key_end_offset);
 	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "track_idx", "key_idx"), &Animation::animation_track_get_key_animation);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_start_offset", "track", "key"), &Animation::animation_track_get_key_start_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_end_offset", "track", "key"), &Animation::animation_track_get_key_end_offset);
 
 	ClassDB::bind_method(D_METHOD("add_marker", "name", "time"), &Animation::add_marker);
 	ClassDB::bind_method(D_METHOD("remove_marker", "name"), &Animation::remove_marker);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -848,23 +848,21 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				Dictionary d;
 
 				Vector<real_t> key_times;
-				Array clips; //Vector<String> clips;
+				Array clips;
 
 				int kk = an->values.size();
 
 				key_times.resize(kk);
-				//clips.resize(kk);
 
 				real_t *wti = key_times.ptrw();
-				//String *wcl = clips.ptrw();
 
 				int idx = 0;
 
 				const TKey<AnimationKey> *vls = an->values.ptr();
 
 				for (int i = 0; i < kk; i++) {
-					wti[i] = vls[i].time;
-					Dictionary clip; //wcl[i] = vls[i].value;
+					wti[idx] = vls[i].time;
+					Dictionary clip;
 					clip["start_offset"] = vls[i].value.start_offset;
 					clip["end_offset"] = vls[i].value.end_offset;
 					clip["animation"] = vls[i].value.animation;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4165,13 +4165,13 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("audio_track_set_use_blend", "track_idx", "enable"), &Animation::audio_track_set_use_blend);
 	ClassDB::bind_method(D_METHOD("audio_track_is_use_blend", "track_idx"), &Animation::audio_track_is_use_blend);
 
-	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track", "time", "animation", "start_offset", "end_offset"), &Animation::animation_track_insert_key, DEFVAL(0.0), DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("animation_track_insert_key", "track_idx", "time", "animation", "start_offset", "end_offset"), &Animation::animation_track_insert_key, DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "track_idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
-	ClassDB::bind_method(D_METHOD("animation_track_set_key_start_offset", "track", "key", "offset"), &Animation::animation_track_set_key_start_offset);
-	ClassDB::bind_method(D_METHOD("animation_track_set_key_end_offset", "track", "key", "offset"), &Animation::animation_track_set_key_end_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_start_offset", "track_idx", "key_idx", "offset"), &Animation::animation_track_set_key_start_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_set_key_end_offset", "track_idx", "key_idx", "offset"), &Animation::animation_track_set_key_end_offset);
 	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "track_idx", "key_idx"), &Animation::animation_track_get_key_animation);
-	ClassDB::bind_method(D_METHOD("animation_track_get_key_start_offset", "track", "key"), &Animation::animation_track_get_key_start_offset);
-	ClassDB::bind_method(D_METHOD("animation_track_get_key_end_offset", "track", "key"), &Animation::animation_track_get_key_end_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_start_offset", "track_idx", "key_idx"), &Animation::animation_track_get_key_start_offset);
+	ClassDB::bind_method(D_METHOD("animation_track_get_key_end_offset", "track_idx", "key_idx"), &Animation::animation_track_get_key_end_offset);
 	ClassDB::bind_method(D_METHOD("animation_track_set_use_blend", "track_idx", "enable"), &Animation::animation_track_set_use_blend);
 	ClassDB::bind_method(D_METHOD("animation_track_is_use_blend", "track_idx"), &Animation::animation_track_is_use_blend);
 

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -404,6 +404,7 @@ protected:
 	static bool inform_variant_array(int &r_min, int &r_max); // Returns true if max and min are swapped.
 
 #ifndef DISABLE_DEPRECATED
+	int animation_track_insert_key_bind_compat_106882(int p_track, double p_time, const StringName &p_animation);
 	Vector3 _position_track_interpolate_bind_compat_86629(int p_track, double p_time) const;
 	Quaternion _rotation_track_interpolate_bind_compat_86629(int p_track, double p_time) const;
 	Vector3 _scale_track_interpolate_bind_compat_86629(int p_track, double p_time) const;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -506,7 +506,7 @@ public:
 	void audio_track_set_use_blend(int p_track, bool p_enable);
 	bool audio_track_is_use_blend(int p_track) const;
 
-	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, real_t p_start_offset = 0.0, real_t p_end_offset = 0.0);
+	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, real_t p_start_offset = 0, real_t p_end_offset = 0);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
 	void animation_track_set_key_start_offset(int p_track, int p_key, real_t p_offset);
 	void animation_track_set_key_end_offset(int p_track, int p_key, real_t p_offset);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -238,6 +238,7 @@ private:
 
 	struct AnimationTrack : public Track {
 		Vector<TKey<AnimationKey>> values;
+		bool use_blend = true;
 
 		AnimationTrack() {
 			type = TYPE_ANIMATION;
@@ -512,6 +513,8 @@ public:
 	StringName animation_track_get_key_animation(int p_track, int p_key) const;
 	real_t animation_track_get_key_start_offset(int p_track, int p_key) const;
 	real_t animation_track_get_key_end_offset(int p_track, int p_key) const;
+	void animation_track_set_use_blend(int p_track, bool p_enable);
+	bool animation_track_is_use_blend(int p_track) const;
 
 	void track_set_interpolation_loop_wrap(int p_track, bool p_enable);
 	bool track_get_interpolation_loop_wrap(int p_track) const;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -217,6 +217,14 @@ private:
 		}
 	};
 
+	struct AnimationKey {
+		StringName animation;
+		real_t start_offset = 0.0; // Offset from start.
+		real_t end_offset = 0.0; // Offset from end, if 0 then full length or infinite.
+		AnimationKey() {
+		}
+	};
+
 	struct AudioTrack : public Track {
 		Vector<TKey<AudioKey>> values;
 		bool use_blend = true;
@@ -229,7 +237,7 @@ private:
 	/* ANIMATION TRACK */
 
 	struct AnimationTrack : public Track {
-		Vector<TKey<StringName>> values;
+		Vector<TKey<AnimationKey>> values;
 
 		AnimationTrack() {
 			type = TYPE_ANIMATION;
@@ -497,9 +505,13 @@ public:
 	void audio_track_set_use_blend(int p_track, bool p_enable);
 	bool audio_track_is_use_blend(int p_track) const;
 
-	int animation_track_insert_key(int p_track, double p_time, const StringName &p_animation);
+	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, real_t p_start_offset = 0.0, real_t p_end_offset = 0.0);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
+	void animation_track_set_key_start_offset(int p_track, int p_key, real_t p_offset);
+	void animation_track_set_key_end_offset(int p_track, int p_key, real_t p_offset);
 	StringName animation_track_get_key_animation(int p_track, int p_key) const;
+	real_t animation_track_get_key_start_offset(int p_track, int p_key) const;
+	real_t animation_track_get_key_end_offset(int p_track, int p_key) const;
 
 	void track_set_interpolation_loop_wrap(int p_track, bool p_enable);
 	bool track_get_interpolation_loop_wrap(int p_track) const;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -506,7 +506,7 @@ public:
 	void audio_track_set_use_blend(int p_track, bool p_enable);
 	bool audio_track_is_use_blend(int p_track) const;
 
-	int animation_track_insert_key(int p_track, float p_time, const StringName &p_animation, real_t p_start_offset = 0, real_t p_end_offset = 0);
+	int animation_track_insert_key(int p_track, double p_time, const StringName &p_animation, real_t p_start_offset = 0, real_t p_end_offset = 0);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
 	void animation_track_set_key_start_offset(int p_track, int p_key, real_t p_offset);
 	void animation_track_set_key_end_offset(int p_track, int p_key, real_t p_offset);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -404,7 +404,7 @@ protected:
 	static bool inform_variant_array(int &r_min, int &r_max); // Returns true if max and min are swapped.
 
 #ifndef DISABLE_DEPRECATED
-	int animation_track_insert_key_bind_compat_106882(int p_track, double p_time, const StringName &p_animation);
+	int _animation_track_insert_key_bind_compat_106882(int p_track, double p_time, const StringName &p_animation);
 	Vector3 _position_track_interpolate_bind_compat_86629(int p_track, double p_time) const;
 	Quaternion _rotation_track_interpolate_bind_compat_86629(int p_track, double p_time) const;
 	Vector3 _scale_track_interpolate_bind_compat_86629(int p_track, double p_time) const;


### PR DESCRIPTION
- Extended animation track to support custom offset adjustments for animation tracks.
- Added functionality to resize animation clips using mouse drag operations in timeline.
- Mouse prioritization for animation clips to improve interaction accuracy in timeline.
- Now handles [Stop] clips more accurately in timeline.

- started implementing animation interpolation in timeline. (deactivated)

@fire