### PR TITLE
Make `settings_changed` signal less emitted

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -96,6 +96,7 @@ protected:
 	HashMap<StringName, PropertyInfo> custom_prop_info;
 	bool using_datapack = false;
 	bool project_loaded = false;
+	bool block_changed = false;
 	List<String> input_presets;
 
 	HashSet<String> custom_features;
@@ -117,7 +118,6 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
-	void _queue_changed();
 	void _emit_changed();
 
 	static inline ProjectSettings *singleton = nullptr;
@@ -159,6 +159,9 @@ public:
 	void refresh_global_class_list();
 	void store_global_class_list(const Array &p_classes);
 	String get_global_class_list_path() const;
+
+	void queue_changed();
+	void set_block_changed(bool p_block) { block_changed = p_block; }
 
 	bool has_setting(const String &p_var) const;
 	String localize_path(const String &p_path) const;

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_sectioned_inspector.h"
 
+#include "core/config/project_settings.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_string_names.h"
@@ -69,8 +70,18 @@ class SectionedInspectorFilter : public Object {
 			name = section + "/" + name;
 		}
 
+		ProjectSettings *ps = ProjectSettings::get_singleton();
+		if (ps) {
+			// Small hack to block emitting of "settings_changed" signal unnecessarily.
+			// It's handled by ProjectSettingsEditor.
+			ps->set_block_changed(true);
+		}
+
 		bool valid;
 		edited->set(name, p_value, &valid);
+		if (ps) {
+			ps->set_block_changed(false);
+		}
 		return valid;
 	}
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -82,6 +82,7 @@ void ProjectSettingsEditor::_save() {
 	settings_changed = false;
 	if (ps) {
 		ps->save();
+		ps->queue_changed();
 	}
 }
 
@@ -792,7 +793,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	tab_container->add_child(plugin_settings);
 
 	timer = memnew(Timer);
-	timer->set_wait_time(1.5);
+	timer->set_wait_time(1.0);
 	timer->connect("timeout", callable_mp(this, &ProjectSettingsEditor::_save));
 	timer->set_one_shot(true);
 	add_child(timer);


### PR DESCRIPTION
When testing another PR it kind of annoyed me that changing project's title will update 3D editor's viewports with every letter you type. I looked into it and discovered that:
- ProjectSettings will try to emit the signal at launch for every defined setting (fortunately it's limited to once per frame)
- The signal is emitted every time you change a setting, potentially many times per second
- The signal is emitted after a timeout from changing settings
- The signal is emitted every time you save

The last two actually have the same cause (reminder #100244), i.e. the settings are "changed" when saving, which emits changed signal needlessly.

I added a way to block emitting the signal and applied it in GLOBAL_DEF and in ProjectSettings' inspector. Now the signal is only emitted on the save Timer's timeout and when settings are changed from code. The downside is that when you change a setting in the editor, you may not see the effect immediately (e.g. when changing project title).

EditorSettings have similar problem, but almost nothing uses its equivalent signal. Most of the editor uses the notification, which is emitted by the settings dialog.