### PR TITLE
SCons: Remove majority of 32-bit support

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -22,19 +22,11 @@ jobs:
           - name: Editor (target=editor)
             cache-name: android-editor
             target: editor
-            scons-flags: >-
-              arch=arm64
-              production=yes
+            scons-flags: production=yes
 
-          - name: Template arm32 (target=template_release, arch=arm32)
-            cache-name: android-template-arm32
+          - name: Template (target=template_release)
+            cache-name: android-template
             target: template_release
-            scons-flags: arch=arm32
-
-          - name: Template arm64 (target=template_release, arch=arm64)
-            cache-name: android-template-arm64
-            target: template_release
-            scons-flags: arch=arm64
 
     steps:
       - name: Checkout

--- a/SConstruct
+++ b/SConstruct
@@ -731,13 +731,6 @@ elif env.msvc:
         )
         Exit(255)
 
-# Default architecture flags.
-if env["arch"] == "x86_32":
-    if env.msvc:
-        env.Append(CCFLAGS=["/arch:SSE2"])
-    else:
-        env.Append(CCFLAGS=["-msse2", "-mfpmath=sse", "-mstackrealign"])
-
 # Explicitly specify colored output.
 if methods.using_gcc(env):
     env.AppendUnique(CCFLAGS=["-fdiagnostics-color" if is_stderr_color() else "-fno-diagnostics-color"])

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -224,39 +224,18 @@ String Engine::get_license_text() const {
 String Engine::get_architecture_name() const {
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	return "x86_64";
-
-#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
-	return "x86_32";
-
 #elif defined(__aarch64__) || defined(_M_ARM64) || defined(_M_ARM64EC)
 	return "arm64";
-
-#elif defined(__arm__) || defined(_M_ARM)
-	return "arm32";
-
 #elif defined(__riscv)
-#if __riscv_xlen == 8
 	return "rv64";
-#else
-	return "riscv";
-#endif
-
-#elif defined(__powerpc__)
-#if defined(__powerpc64__)
+#elif defined(__powerpc64__)
 	return "ppc64";
-#else
-	return "ppc";
-#endif
-
 #elif defined(__loongarch64)
 	return "loongarch64";
-
-#elif defined(__wasm__)
-#if defined(__wasm64__)
+#elif defined(__wasm64__)
 	return "wasm64";
 #elif defined(__wasm32__)
 	return "wasm32";
-#endif
 #endif
 }
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -502,68 +502,30 @@ bool OS::has_feature(const String &p_feature) {
 	if (sizeof(void *) == 4 && p_feature == "32") {
 		return true;
 	}
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 #if defined(MACOS_ENABLED)
 	if (p_feature == "universal") {
 		return true;
 	}
 #endif
-	if (p_feature == "x86_64") {
+	if (p_feature == "x86_64" || p_feature == "x86") {
 		return true;
 	}
-#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
-	if (p_feature == "x86_32") {
-		return true;
-	}
-#endif
-	if (p_feature == "x86") {
-		return true;
-	}
-#elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
-#if defined(__aarch64__) || defined(_M_ARM64)
+#elif defined(__aarch64__) || defined(_M_ARM64)
 #if defined(MACOS_ENABLED)
 	if (p_feature == "universal") {
 		return true;
 	}
 #endif
-	if (p_feature == "arm64") {
-		return true;
-	}
-#elif defined(__arm__) || defined(_M_ARM)
-	if (p_feature == "arm32") {
-		return true;
-	}
-#endif
-#if defined(__ARM_ARCH_7A__)
-	if (p_feature == "armv7a" || p_feature == "armv7") {
-		return true;
-	}
-#endif
-#if defined(__ARM_ARCH_7S__)
-	if (p_feature == "armv7s" || p_feature == "armv7") {
-		return true;
-	}
-#endif
-	if (p_feature == "arm") {
+	if (p_feature == "arm64" || p_feature == "arm") {
 		return true;
 	}
 #elif defined(__riscv)
-#if __riscv_xlen == 8
-	if (p_feature == "rv64") {
-		return true;
-	}
-#endif
-	if (p_feature == "riscv") {
+	if (p_feature == "rv64" || p_feature == "riscv") {
 		return true;
 	}
 #elif defined(__powerpc__)
-#if defined(__powerpc64__)
-	if (p_feature == "ppc64") {
-		return true;
-	}
-#endif
-	if (p_feature == "ppc") {
+	if (p_feature == "ppc64" || p_feature == "ppc") {
 		return true;
 	}
 #elif defined(__wasm__)
@@ -698,9 +660,9 @@ Error OS::setup_remote_filesystem(const String &p_server_host, int p_port, const
 }
 
 OS::PreferredTextureFormat OS::get_preferred_texture_format() const {
-#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64)
 	return PREFERRED_TEXTURE_FORMAT_ETC2_ASTC; // By rule, ARM hardware uses ETC texture compression.
-#elif defined(__x86_64__) || defined(_M_X64) || defined(i386) || defined(__i386__) || defined(__i386) || defined(_M_IX86)
+#elif defined(__x86_64__) || defined(_M_X64)
 	return PREFERRED_TEXTURE_FORMAT_S3TC_BPTC; // By rule, X86 hardware prefers S3TC and derivatives.
 #else
 	return PREFERRED_TEXTURE_FORMAT_S3TC_BPTC; // Override in platform if needed.

--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -70,18 +70,18 @@ public:
 _ALWAYS_INLINE_ static void _cpu_pause() {
 #if defined(_MSC_VER)
 // ----- MSVC.
-#if defined(_M_ARM) || defined(_M_ARM64) // ARM.
+#if defined(_M_ARM64) // ARM.
 	__yield();
-#elif defined(_M_IX86) || defined(_M_X64) // x86.
+#elif defined(_M_X64) // x86.
 	_mm_pause();
 #endif
 #elif defined(__GNUC__) || defined(__clang__)
 // ----- GCC/Clang.
-#if defined(__i386__) || defined(__x86_64__) // x86.
+#if defined(__x86_64__) // x86.
 	__builtin_ia32_pause();
-#elif defined(__arm__) || defined(__aarch64__) // ARM.
+#elif defined(__aarch64__) // ARM.
 	asm volatile("yield");
-#elif defined(__powerpc__) || defined(__ppc__) || defined(__PPC__) // PowerPC.
+#elif defined(__powerpc__) // PowerPC.
 	asm volatile("or 27,27,27");
 #elif defined(__riscv) // RISC-V.
 	asm volatile(".insn i 0x0F, 0, x0, x0, 0x010");

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -609,12 +609,7 @@ static _FORCE_INLINE_ uint32_t fastmod(const uint32_t n, const uint64_t c, const
 #if defined(_MSC_VER)
 	// Returns the upper 64 bits of the product of two 64-bit unsigned integers.
 	// This intrinsic function is required since MSVC does not support unsigned 128-bit integers.
-#if defined(_M_X64) || defined(_M_ARM64)
 	return __umulh(c * n, d);
-#else
-	// Fallback to the slower method for 32-bit platforms.
-	return n % d;
-#endif // _M_X64 || _M_ARM64
 #else
 #ifdef __SIZEOF_INT128__
 	// Prevent compiler warning, because we know what we are doing.

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -22,7 +22,7 @@
 		<method name="get_architecture_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the name of the CPU architecture the Godot binary was built for. Possible return values include [code]"x86_64"[/code], [code]"x86_32"[/code], [code]"arm64"[/code], [code]"arm32"[/code], [code]"rv64"[/code], [code]"riscv"[/code], [code]"ppc64"[/code], [code]"ppc"[/code], [code]"wasm64"[/code], and [code]"wasm32"[/code].
+				Returns the name of the CPU architecture the Godot binary was built for. Possible return values include [code]"x86_64"[/code], [code]"arm64"[/code], [code]"rv64"[/code], [code]"ppc64"[/code], [code]"loongarch64"[/code], [code]"wasm64"[/code], and [code]"wasm32"[/code].
 				To detect whether the current build is 64-bit, or the type of architecture, don't use the architecture name. Instead, use [method OS.has_feature] to check for the [code]"64"[/code] feature tag, or tags such as [code]"x86"[/code] or [code]"arm"[/code]. See the [url=$DOCS_URL/tutorials/export/feature_tags.html]Feature Tags[/url] documentation for more details.
 				[b]Note:[/b] This method does [i]not[/i] return the name of the system's CPU architecture (like [method OS.get_processor_name]). For example, when running an [code]x86_32[/code] Godot binary on an [code]x86_64[/code] system, the returned value will still be [code]"x86_32"[/code].
 			</description>

--- a/methods.py
+++ b/methods.py
@@ -1425,10 +1425,6 @@ def generate_vs_project(env, original_args, project_name="godot"):
             for t in conf["targets"]:
                 godot_target = t
 
-                # Windows x86 is a special little flower that requires a project platform == Win32 but a solution platform == x86.
-                if godot_platform == "windows" and godot_target == "editor" and godot_arch == "x86_32":
-                    sln_plat = "x86"
-
                 configurations += [
                     f'<ProjectConfiguration Include="{godot_target}|{proj_plat}">',
                     f"  <Configuration>{godot_target}</Configuration>",

--- a/misc/scripts/install_d3d12_sdk_windows.py
+++ b/misc/scripts/install_d3d12_sdk_windows.py
@@ -43,9 +43,6 @@ color_print(f"{Ansi.BOLD}[1/3] Mesa NIR")
 for arch in [
     "arm64-llvm",
     "arm64-msvc",
-    "x86_32-gcc",
-    "x86_32-llvm",
-    "x86_32-msvc",
     "x86_64-gcc",
     "x86_64-llvm",
     "x86_64-msvc",

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,12 +1,6 @@
 def can_build(env, platform):
     # Supported architectures and platforms depend on the Embree library.
-    if env["arch"] == "arm64" and platform == "windows" and env.msvc:
-        return False
-    if env["arch"] in ["x86_64", "arm64", "wasm32"]:
-        return True
-    if env["arch"] == "x86_32" and platform == "windows":
-        return True
-    return False
+    return env["arch"] in ["x86_64", "arm64", "wasm32"]
 
 
 def configure(env):

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -54,15 +54,9 @@ env.Depends(lib, thirdparty_obj)
 
 lib_arch_dir = ""
 triple_target_dir = ""
-if env["arch"] == "arm32":
-    lib_arch_dir = "armeabi-v7a"
-    triple_target_dir = "arm-linux-androideabi"
-elif env["arch"] == "arm64":
+if env["arch"] == "arm64":
     lib_arch_dir = "arm64-v8a"
     triple_target_dir = "aarch64-linux-android"
-elif env["arch"] == "x86_32":
-    lib_arch_dir = "x86"
-    triple_target_dir = "i686-linux-android"
 elif env["arch"] == "x86_64":
     lib_arch_dir = "x86_64"
     triple_target_dir = "x86_64-linux-android"

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -116,7 +116,7 @@ def detect_swappy():
 
 def configure(env: "SConsEnvironment"):
     # Validate arch.
-    supported_arches = ["x86_32", "x86_64", "arm32", "arm64"]
+    supported_arches = ["x86_64", "arm64"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
     if get_min_sdk_version(env["ndk_platform"]) < get_min_target_api():
@@ -131,12 +131,8 @@ def configure(env: "SConsEnvironment"):
 
     # Architecture
 
-    if env["arch"] == "arm32":
-        target_triple = "armv7a-linux-androideabi"
-    elif env["arch"] == "arm64":
+    if env["arch"] == "arm64":
         target_triple = "aarch64-linux-android"
-    elif env["arch"] == "x86_32":
-        target_triple = "i686-linux-android"
     elif env["arch"] == "x86_64":
         target_triple = "x86_64-linux-android"
 
@@ -205,18 +201,9 @@ def configure(env: "SConsEnvironment"):
     if get_min_sdk_version(env["ndk_platform"]) >= 24:
         env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
 
-    if env["arch"] == "x86_32":
-        if has_swappy:
-            env.Append(LIBPATH=["#thirdparty/swappy-frame-pacing/x86"])
-    elif env["arch"] == "x86_64":
+    if env["arch"] == "x86_64":
         if has_swappy:
             env.Append(LIBPATH=["#thirdparty/swappy-frame-pacing/x86_64"])
-    elif env["arch"] == "arm32":
-        env.Append(CCFLAGS=["-march=armv7-a", "-mfloat-abi=softfp"])
-        env.Append(CPPDEFINES=["__ARM_ARCH_7__", "__ARM_ARCH_7A__"])
-        env.Append(CPPDEFINES=["__ARM_NEON__"])
-        if has_swappy:
-            env.Append(LIBPATH=["#thirdparty/swappy-frame-pacing/armeabi-v7a"])
     elif env["arch"] == "arm64":
         env.Append(CCFLAGS=["-mfix-cortex-a53-835769"])
         env.Append(CPPDEFINES=["__ARM_ARCH_8A__"])

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -844,19 +844,9 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 	if (p_feature == "mobile") {
 		return true;
 	}
-#if defined(__aarch64__)
 	if (p_feature == "arm64-v8a" || p_feature == "arm64") {
 		return true;
 	}
-#elif defined(__ARM_ARCH_7A__)
-	if (p_feature == "armeabi-v7a" || p_feature == "armeabi" || p_feature == "arm32") {
-		return true;
-	}
-#elif defined(__arm__)
-	if (p_feature == "armeabi" || p_feature == "arm") {
-		return true;
-	}
-#endif
 
 	if (godot_java->has_feature(p_feature)) {
 		return true;

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -73,7 +73,7 @@ def get_flags():
 
 def configure(env: "SConsEnvironment"):
     # Validate arch.
-    supported_arches = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "loongarch64"]
+    supported_arches = ["x86_64", "arm64", "rv64", "ppc64", "loongarch64"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
     ## Build type
@@ -86,10 +86,7 @@ def configure(env: "SConsEnvironment"):
     # Cross-compilation
     # TODO: Support cross-compilation on architectures other than x86.
     host_is_64_bit = sys.maxsize > 2**32
-    if host_is_64_bit and env["arch"] == "x86_32":
-        env.Append(CCFLAGS=["-m32"])
-        env.Append(LINKFLAGS=["-m32"])
-    elif not host_is_64_bit and env["arch"] == "x86_64":
+    if not host_is_64_bit:
         env.Append(CCFLAGS=["-m64"])
         env.Append(LINKFLAGS=["-m64"])
 
@@ -259,7 +256,7 @@ def configure(env: "SConsEnvironment"):
         env["builtin_libvorbis"] = False  # Needed to link against system libtheora
         env.ParseConfig("pkg-config theora theoradec --cflags --libs")
     else:
-        if env["arch"] in ["x86_64", "x86_32"]:
+        if env["arch"] == "x86_64":
             env["x86_libtheora_opt_gcc"] = True
 
     if not env["builtin_libvorbis"]:
@@ -471,14 +468,10 @@ def configure(env: "SConsEnvironment"):
             env.Prepend(CPPPATH=[env["accesskit_sdk_path"] + "/include"])
             if env["arch"] == "arm64":
                 env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/linux/arm64/static/"])
-            elif env["arch"] == "arm32":
-                env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/linux/arm32/static/"])
             elif env["arch"] == "rv64":
                 env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/linux/riscv64gc/static/"])
             elif env["arch"] == "x86_64":
                 env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/linux/x86_64/static/"])
-            elif env["arch"] == "x86_32":
-                env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/linux/x86/static/"])
             env.Append(LIBS=["accesskit"])
         else:
             env.Append(CPPDEFINES=["ACCESSKIT_DYNAMIC"])

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -95,17 +95,13 @@ if env["windows_subsystem"] == "gui":
 
 if env["d3d12"]:
     dxc_target_aliases = {
-        "x86_32": "x86",
         "x86_64": "x64",
-        "arm32": "arm",
         "arm64": "arm64",
     }
     dxc_arch_subdir = dxc_target_aliases[env["arch"]]
 
     agility_target_aliases = {
-        "x86_32": "win32",
         "x86_64": "x64",
-        "arm32": "arm",
         "arm64": "arm64",
     }
     agility_arch_subdir = agility_target_aliases[env["arch"]]

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -183,10 +183,6 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	frame.AddrPC.Offset = context->Pc;
 	frame.AddrStack.Offset = context->Sp;
 	frame.AddrFrame.Offset = context->Fp;
-#elif defined(_M_ARM)
-	frame.AddrPC.Offset = context->Pc;
-	frame.AddrStack.Offset = context->Sp;
-	frame.AddrFrame.Offset = context->R11;
 #else
 	frame.AddrPC.Offset = context->Eip;
 	frame.AddrStack.Offset = context->Esp;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7041,7 +7041,7 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 
 	if (rendering_driver == "opengl3") {
 		// There's no native OpenGL drivers on Windows for ARM, always enable fallback.
-#if defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64)
 		fallback = true;
 		show_warning = false;
 #else

--- a/platform/windows/msvs.py
+++ b/platform/windows/msvs.py
@@ -4,7 +4,7 @@ import methods
 # Tuples with the name of the arch that will be used in VS, mapped to our internal arch names.
 # For Windows platforms, Win32 is what VS wants. For other platforms, it can be different.
 def get_platforms():
-    return [("Win32", "x86_32"), ("x64", "x86_64")]
+    return [("x64", "x86_64")]
 
 
 def get_configurations():

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -17,20 +17,16 @@ compatibility_platform_aliases = {
 }
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32", "loongarch64"]
+architectures = ["x86_64", "arm64", "rv64", "ppc64", "wasm32", "loongarch64"]
 architecture_aliases = {
-    "x86": "x86_32",
     "x64": "x86_64",
     "amd64": "x86_64",
-    "armv7": "arm32",
     "armv8": "arm64",
     "arm64v8": "arm64",
     "aarch64": "arm64",
     "rv": "rv64",
     "riscv": "rv64",
     "riscv64": "rv64",
-    "ppcle": "ppc32",
-    "ppc": "ppc32",
     "ppc64le": "ppc64",
     "loong64": "loongarch64",
 }
@@ -42,9 +38,6 @@ def detect_arch():
         return host_machine
     elif host_machine in architecture_aliases.keys():
         return architecture_aliases[host_machine]
-    elif "86" in host_machine:
-        # Catches x86, i386, i486, i586, i686, etc.
-        return "x86_32"
     else:
         methods.print_warning(f'Unsupported CPU architecture: "{host_machine}". Falling back to x86_64.')
         return "x86_64"


### PR DESCRIPTION
- Related: #106390

Inspired by the above PR, this bites the bullet and removes the majority of 32-bit architecture support/references in the repo; the only holdout is `wasm32`. This is admittedly jumping the gun a bit in terms of how quickly we'd likely want to transition away from these architectures, but it gives a reasonable blueprint to how such a transition would look