### PR TITLE
Fix category names in help search dialog not translated

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -541,6 +541,7 @@ TreeItem *EditorHelpSearch::Runner::_create_category_item(TreeItem *p_parent, co
 	TreeItem *item = nullptr;
 	if (_find_or_create_item(p_parent, item_meta, item)) {
 		item->set_icon(0, ui_service->get_editor_theme_icon(p_icon));
+		item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_ALWAYS);
 		item->set_text(0, p_text);
 		item->set_metadata(0, item_meta);
 	}


### PR DESCRIPTION
Category names such as "Methods", "Constructors", and "Theme Properties" are currently not translated.