### PR TITLE
Remove obsolete `VMap` forward declaration.

### DIFF
--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -38,9 +38,6 @@
 class VisualShaderNodeParameter;
 class VisualShaderNode;
 
-template <typename T, typename V>
-class VMap;
-
 class VisualShader : public Shader {
 	GDCLASS(VisualShader, Shader);
 


### PR DESCRIPTION
`VMap` was removed in https://github.com/godotengine/godot/pull/100446.

There appears to be one last forward declaration for it.