### PR TITLE
Implement `is_key_just_pressed/released`

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -116,8 +116,14 @@ bool Input::is_mouse_mode_override_enabled() {
 void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_anything_pressed"), &Input::is_anything_pressed);
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &Input::is_key_pressed);
+	ClassDB::bind_method(D_METHOD("is_key_just_pressed", "keycode"), &Input::is_key_just_pressed);
+	ClassDB::bind_method(D_METHOD("is_key_just_released", "keycode"), &Input::is_key_just_released);
 	ClassDB::bind_method(D_METHOD("is_physical_key_pressed", "keycode"), &Input::is_physical_key_pressed);
+	ClassDB::bind_method(D_METHOD("is_physical_key_just_pressed", "keycode"), &Input::is_physical_key_just_pressed);
+	ClassDB::bind_method(D_METHOD("is_physical_key_just_released", "keycode"), &Input::is_physical_key_just_released);
 	ClassDB::bind_method(D_METHOD("is_key_label_pressed", "keycode"), &Input::is_key_label_pressed);
+	ClassDB::bind_method(D_METHOD("is_key_label_just_pressed", "keycode"), &Input::is_key_label_just_pressed);
+	ClassDB::bind_method(D_METHOD("is_key_label_just_released", "keycode"), &Input::is_key_label_just_released);
 	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &Input::is_joy_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action", "exact_match"), &Input::is_action_pressed, DEFVAL(false));
@@ -319,6 +325,26 @@ bool Input::is_key_pressed(Key p_keycode) const {
 	return keys_pressed.has(p_keycode);
 }
 
+bool Input::is_key_just_pressed(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+
+	if (disable_input) {
+		return false;
+	}
+
+	return keys_just_pressed.has(p_keycode);
+}
+
+bool Input::is_key_just_released(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+
+	if (disable_input) {
+		return false;
+	}
+
+	return keys_just_released.has(p_keycode);
+}
+
 bool Input::is_physical_key_pressed(Key p_keycode) const {
 	_THREAD_SAFE_METHOD_
 
@@ -329,6 +355,25 @@ bool Input::is_physical_key_pressed(Key p_keycode) const {
 	return physical_keys_pressed.has(p_keycode);
 }
 
+bool Input::is_physical_key_just_pressed(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+
+	if (disable_input) {
+		return false;
+	}
+
+	return physical_keys_just_pressed.has(p_keycode);
+}
+bool Input::is_physical_key_just_released(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+
+	if (disable_input) {
+		return false;
+	}
+
+	return physical_keys_just_released.has(p_keycode);
+}
+
 bool Input::is_key_label_pressed(Key p_keycode) const {
 	_THREAD_SAFE_METHOD_
 
@@ -337,6 +382,26 @@ bool Input::is_key_label_pressed(Key p_keycode) const {
 	}
 
 	return key_label_pressed.has(p_keycode);
+}
+
+bool Input::is_key_label_just_pressed(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+
+	if (disable_input) {
+		return false;
+	}
+
+	return key_label_just_pressed.has(p_keycode);
+}
+
+bool Input::is_key_label_just_released(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+
+	if (disable_input) {
+		return false;
+	}
+
+	return key_label_just_released.has(p_keycode);
 }
 
 bool Input::is_mouse_button_pressed(MouseButton p_button) const {
@@ -672,23 +737,44 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && !k->is_echo() && k->get_keycode() != Key::NONE) {
 		if (k->is_pressed()) {
+			keys_just_pressed.insert(k->get_keycode());
 			keys_pressed.insert(k->get_keycode());
 		} else {
 			keys_pressed.erase(k->get_keycode());
+			keys_just_pressed.erase(k->get_keycode());
+		}
+		if (k->is_released()) {
+			keys_just_released.insert(k->get_keycode());
+		} else {
+			keys_just_released.erase(k->get_keycode());
 		}
 	}
 	if (k.is_valid() && !k->is_echo() && k->get_physical_keycode() != Key::NONE) {
 		if (k->is_pressed()) {
 			physical_keys_pressed.insert(k->get_physical_keycode());
+			physical_keys_just_pressed.insert(k->get_physical_keycode());
 		} else {
 			physical_keys_pressed.erase(k->get_physical_keycode());
+			physical_keys_just_pressed.erase(k->get_physical_keycode());
+		}
+		if (k->is_released()) {
+			physical_keys_just_released.insert(k->get_physical_keycode());
+		} else {
+			physical_keys_just_released.erase(k->get_physical_keycode());
 		}
 	}
 	if (k.is_valid() && !k->is_echo() && k->get_key_label() != Key::NONE) {
 		if (k->is_pressed()) {
 			key_label_pressed.insert(k->get_key_label());
+			key_label_just_pressed.insert(k->get_key_label());
 		} else {
 			key_label_pressed.erase(k->get_key_label());
+			key_label_just_pressed.erase(k->get_key_label());
+		}
+		if (k->is_released()) {
+			key_label_just_released.insert(k->get_key_label());
+		} else {
+			key_label_just_released.erase(k->get_key_label());
 		}
 	}
 
@@ -1204,8 +1290,11 @@ void Input::release_pressed_events() {
 	flush_buffered_events(); // this is needed to release actions strengths
 
 	keys_pressed.clear();
+	keys_just_pressed.clear();
 	physical_keys_pressed.clear();
+	physical_keys_just_pressed.clear();
 	key_label_pressed.clear();
+	key_label_just_pressed.clear();
 	joy_buttons_pressed.clear();
 	_joy_axis.clear();
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -82,6 +82,13 @@ public:
 
 	typedef void (*EventDispatchFunc)(const Ref<InputEvent> &p_event);
 
+	RBSet<Key> key_label_just_pressed;
+	RBSet<Key> key_label_just_released;
+	RBSet<Key> physical_keys_just_pressed;
+	RBSet<Key> physical_keys_just_released;
+	RBSet<Key> keys_just_pressed;
+	RBSet<Key> keys_just_released;
+
 private:
 	BitField<MouseButtonMask> mouse_button_mask = MouseButtonMask::NONE;
 
@@ -299,8 +306,14 @@ public:
 	bool is_anything_pressed() const;
 	bool is_anything_pressed_except_mouse() const;
 	bool is_key_pressed(Key p_keycode) const;
+	bool is_key_just_pressed(Key p_keycode) const;
+	bool is_key_just_released(Key p_keycode) const;
 	bool is_physical_key_pressed(Key p_keycode) const;
+	bool is_physical_key_just_pressed(Key p_keycode) const;
+	bool is_physical_key_just_released(Key p_keycode) const;
 	bool is_key_label_pressed(Key p_keycode) const;
+	bool is_key_label_just_pressed(Key p_keycode) const;
+	bool is_key_label_just_released(Key p_keycode) const;
 	bool is_mouse_button_pressed(MouseButton p_button) const;
 	bool is_joy_button_pressed(int p_device, JoyButton p_button) const;
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -257,6 +257,42 @@
 				Returns [code]true[/code] if the system knows the specified device. This means that it sets all button and axis indices. Unknown joypads are not expected to match these constants, but you can still retrieve events from them.
 			</description>
 		</method>
+		<method name="is_key_just_pressed" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] when the user has [i]started[/i] pressing the Latin key in the current keyboard layout in the current frame. It will only return [code]true[/code] on the frame or tick that the user pressed down the button. You can pass a [enum Key] constant.
+				This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
+				[method is_key_just_pressed] is only recommended over [method is_physical_key_just_pressed] in non-game applications. This ensures that shortcut keys behave as expected depending on the user's keyboard layout, as keyboard shortcuts are generally dependent on the keyboard layout in non-game applications. If in doubt, use [method is_physical_key_just_pressed].
+				[b]Note:[/b] Due to keyboard ghosting, [method is_key_just_pressed] may return [code]false[/code] even if one of the key is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
+				[b]Note:[/b] Returning [code]true[/code] does not imply that the key is [i]still[/i] pressed. A key can be pressed and released again rapidly, and [code]true[/code] will still be returned so as not to miss input.
+			</description>
+		</method>
+		<method name="is_key_just_released" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] when the user [i]stops[/i] pressing the Latin key in the current keyboard layout in the current frame. It will only return [code]true[/code] on the frame or tick that the user releases the button. You can pass a [enum Key] constant.
+				[method is_key_just_released] is only recommended over [method is_physical_key_just_released] in non-game applications. This ensures that shortcut keys behave as expected depending on the user's keyboard layout, as keyboard shortcuts are generally dependent on the keyboard layout in non-game applications. If in doubt, use [method is_physical_key_just_released].
+			</description>
+		</method>
+		<method name="is_key_label_just_pressed" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] when the user has [i]started[/i] pressing the key with the [param keycode] printed on it in the current frame. It will only return [code]true[/code] on the frame or tick that the user pressed down the button. You can pass a [enum Key] constant or any Unicode character code.
+				This is useful for code that needs to run only once when an action is pressed, instead of every frame while it's pressed.
+				[b]Note:[/b] Returning [code]true[/code] does not imply that the key is [i]still[/i] pressed. A key can be pressed and released again rapidly, and [code]true[/code] will still be returned so as not to miss input.
+			</description>
+		</method>
+		<method name="is_key_label_just_released" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] when the user [i]stops[/i] pressing the key with the [param keycode] printed on it in the current frame. It will only return [code]true[/code] on the frame or tick that the user releases the button. You can pass a [enum Key] constant or any Unicode character code.
+				[b]Note:[/b] Returning [code]true[/code] does not imply that the key is [i]still[/i] not pressed. A key can be released and pressed again rapidly, and [code]true[/code] will still be returned so as not to miss input.
+			</description>
+		</method>
 		<method name="is_key_label_pressed" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="keycode" type="int" enum="Key" />
@@ -278,6 +314,24 @@
 			<param index="0" name="button" type="int" enum="MouseButton" />
 			<description>
 				Returns [code]true[/code] if you are pressing the mouse button specified with [enum MouseButton].
+			</description>
+		</method>
+		<method name="is_physical_key_just_pressed" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] when the user has [i]started[/i] pressing the physical location on the 101/102-key US QWERTY keyboard in the current frame. It will only return [code]true[/code] on the frame or tick that the user pressed down the button. You can pass a [enum Key] constant.
+				[method is_physical_key_just_pressed] is recommended over [method is_key_just_pressed] for in-game actions, as it will make [kbd]W[/kbd]/[kbd]A[/kbd]/[kbd]S[/kbd]/[kbd]D[/kbd] layouts work regardless of the user's keyboard layout. [method is_physical_key_just_pressed] will also ensure that the top row number keys work on any keyboard layout. If in doubt, use [method is_physical_key_just_pressed].
+				[b]Note:[/b] Due to keyboard ghosting, [method is_physical_key_just_pressed] may return [code]false[/code] even if one of the action's keys is pressed. See [url=$DOCS_URL/tutorials/inputs/input_examples.html#keyboard-events]Input examples[/url] in the documentation for more information.
+				[b]Note:[/b] Returning [code]true[/code] does not imply that the key is [i]still[/i] pressed. A key can be pressed and released again rapidly, and [code]true[/code] will still be returned so as not to miss input.
+			</description>
+		</method>
+		<method name="is_physical_key_just_released" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] when the user [i]stops[/i] pressing the physical location on the 101/102-key US QWERTY keyboard in the current frame. It will only return [code]true[/code] on the frame or tick that the user releases the button. You can pass a [enum Key] constant.
+				[method is_physical_key_just_released] is recommended over [method is_key_just_released] for in-game actions, as it will make [kbd]W[/kbd]/[kbd]A[/kbd]/[kbd]S[/kbd]/[kbd]D[/kbd] layouts work regardless of the user's keyboard layout. [method is_physical_key_just_released] will also ensure that the top row number keys work on any keyboard layout. If in doubt, use [method is_physical_key_just_released].
 			</description>
 		</method>
 		<method name="is_physical_key_pressed" qualifiers="const">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -714,6 +714,13 @@ bool SceneTree::process(double p_time) {
 
 	_call_idle_callbacks();
 
+	Input::get_singleton()->keys_just_pressed.clear();
+	Input::get_singleton()->keys_just_released.clear();
+	Input::get_singleton()->physical_keys_just_pressed.clear();
+	Input::get_singleton()->physical_keys_just_released.clear();
+	Input::get_singleton()->key_label_just_pressed.clear();
+	Input::get_singleton()->key_label_just_released.clear();
+
 #ifdef TOOLS_ENABLED
 #ifndef _3D_DISABLED
 	if (Engine::get_singleton()->is_editor_hint()) {


### PR DESCRIPTION
Fixes godotengine/godot-proposals#2016
Fixes godotengine/godot-proposals#8174

Implemented methods:
`is_key_just_pressed`
`is_key_just_released`
`is_key_label_just_pressed`
`is_key_label_just_released`
`is_physical_key_just_pressed`
`is_physical_key_just_released`