### PR TITLE
Remove parentheses around "All" option in the feature tag menu

### DIFF
--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -338,7 +338,7 @@ void ProjectSettingsEditor::_add_feature_overrides() {
 	}
 
 	feature_box->clear();
-	feature_box->add_item(TTRC("(All)"), FEATURE_ALL); // So it is always on top.
+	feature_box->add_item(TTRC("All"), FEATURE_ALL); // So it is always on top.
 	feature_box->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_ALWAYS);
 	feature_box->add_item(TTRC("Custom"), FEATURE_CUSTOM);
 	feature_box->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_ALWAYS);


### PR DESCRIPTION
#105307 added a separator in the menu to distinguish between special values and feature tag names. Therefore, it is no longer necessary to add parentheses around the All option :)