### PR TITLE
Vulkan Mobile: Fix lightmap instances count

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3320,7 +3320,7 @@ RenderForwardMobile::RenderForwardMobile() {
 
 	{
 		//lightmaps
-		scene_state.max_lightmaps = 2;
+		scene_state.max_lightmaps = MAX_LIGHTMAPS;
 		defines += "\n#define MAX_LIGHTMAP_TEXTURES " + itos(scene_state.max_lightmaps) + "\n";
 		defines += "\n#define MAX_LIGHTMAPS " + itos(scene_state.max_lightmaps) + "\n";
 


### PR DESCRIPTION
Closes: #106906

The max instances of LightmapGI is hardcoded with the magic number 2 instead of using the appropriate enum `MAX_LIGHTMAPS`. This PR fixes it.

It only works because @BlueCube3310 fixed the `_fill_render_list` initialization in #106748. That PR not only fixes the editor but also several bugs like lightmap flickering when loading/unloading in runtime.

MRP: [lightmap-bug.zip](https://github.com/user-attachments/files/20492110/lightmap-bug.zip)

**4.5.dev4**

https://github.com/user-attachments/assets/5873a3fb-da7c-42a0-a3fb-27c864b0411b

**This PR**

https://github.com/user-attachments/assets/14f620bf-28e0-428a-a144-9dbe509566ae

