### PR TITLE
JavaClassWrapper: Don't discard overloaded methods that differ by object type

### DIFF
--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -1600,9 +1600,12 @@ Ref<JavaClass> JavaClassWrapper::_wrap(const String &p_class, bool p_allow_priva
 				if (_new != existing) {
 					this_valid = false;
 					break;
+				} else if ((_new == Variant::OBJECT || _new == Variant::ARRAY) && E->get().param_sigs[j] != mi.param_sigs[j]) {
+					this_valid = false;
+					break;
 				}
 				new_likeliness += new_l;
-				existing_likeliness = existing_l;
+				existing_likeliness += existing_l;
 			}
 
 			if (!this_valid) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106320

This attempts to fix [this code](https://github.com/godotengine/godot/blob/2cde9292c33243f6fadaf2d584813da2e7f73852/platform/android/java_class_wrapper.cpp#L1585-L1618), which I think is about dealing with Java methods that would have the exact same Godot types, and choosing to discard the "least likely" of the two.

This PR adds an exception for object arguments: normally, if the parameter types were the same, there would be ambiguity, but for objects we can additionally check if they are the same class type, and if not, there is no ambiguity.

And it also fixes another bug that I noticed: I'm pretty sure it should be adding the `existing_likeliness` up, otherwise, it would be pretty easy for the new method to unfairly have a higher "likeliness", since only the last parameter would count.
