### PR TITLE
 Improve the `PhysicsShapeQueryParameters3D`'s description

### DIFF
--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsShapeQueryParameters2D" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Provides parameters for [method PhysicsDirectSpaceState2D.intersect_shape].
+		Provides parameters for [PhysicsDirectSpaceState2D]'s methods.
 	</brief_description>
 	<description>
-		By changing various properties of this object, such as the shape, you can configure the parameters for [method PhysicsDirectSpaceState2D.intersect_shape].
+		By changing various properties of this object, such as the shape, you can configure the parameters for [PhysicsDirectSpaceState2D]'s methods.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PhysicsShapeQueryParameters3D" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Provides parameters for [method PhysicsDirectSpaceState3D.intersect_shape].
+		Provides parameters for [PhysicsDirectSpaceState3D]'s methods.
 	</brief_description>
 	<description>
-		By changing various properties of this object, such as the shape, you can configure the parameters for [method PhysicsDirectSpaceState3D.intersect_shape].
+		By changing various properties of this object, such as the shape, you can configure the parameters for [PhysicsDirectSpaceState3D]'s methods.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Apparently I broke this previous PR so I'm remaking it

https://github.com/godotengine/godot/pull/104293



Made it clearer that this class is used in several of PhysicsDirectSpaceState3D's methods and not just on intersect_shape()

As you can see, this was looking kinda contradictory :

![image](https://github.com/user-attachments/assets/e7e83ff9-2744-4c08-8f7d-24671015fdcc)
