### PR TITLE
Rename `String::resize` to `resize_uninitialized`

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -824,7 +824,7 @@ Error ProjectSettings::_load_settings_binary(const String &p_path) {
 	for (uint32_t i = 0; i < count; i++) {
 		uint32_t slen = f->get_32();
 		CharString cs;
-		cs.resize(slen + 1);
+		cs.resize_uninitialized(slen + 1);
 		cs[slen] = 0;
 		f->get_buffer((uint8_t *)cs.ptr(), slen);
 		String key = String::utf8(cs.ptr(), slen);

--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1045,7 +1045,7 @@ static void gdextension_string_operator_plus_eq_c32str(GDExtensionStringPtr p_se
 
 static GDExtensionInt gdextension_string_resize(GDExtensionStringPtr p_self, GDExtensionInt p_length) {
 	String *self = (String *)p_self;
-	return (*self).resize(p_length);
+	return (*self).resize_uninitialized(p_length);
 }
 
 static void gdextension_string_name_new_with_latin1_chars(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents, GDExtensionBool p_is_static) {

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -769,7 +769,7 @@ bool FileAccess::store_pascal_string(const String &p_string) {
 String FileAccess::get_pascal_string() {
 	uint32_t sl = get_32();
 	CharString cs;
-	cs.resize(sl + 1);
+	cs.resize_uninitialized(sl + 1);
 	get_buffer((uint8_t *)cs.ptr(), sl);
 	cs[sl] = 0;
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -306,7 +306,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	for (int i = 0; i < file_count; i++) {
 		uint32_t sl = f->get_32();
 		CharString cs;
-		cs.resize(sl + 1);
+		cs.resize_uninitialized(sl + 1);
 		f->get_buffer((uint8_t *)cs.ptr(), sl);
 		cs[sl] = 0;
 

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -553,7 +553,7 @@ Ref<PListNode> PList::read_bplist_obj(Ref<FileAccess> p_file, uint64_t p_offset_
 				marker_size = read_bplist_var_size_int(p_file, std::pow(2, ext));
 			}
 			node->data_type = PL_NODE_TYPE_STRING;
-			node->data_string.resize(marker_size + 1);
+			node->data_string.resize_uninitialized(marker_size + 1);
 			p_file->get_buffer(reinterpret_cast<uint8_t *>(node->data_string.ptrw()), marker_size);
 		} break;
 		case 0x60: {
@@ -562,7 +562,7 @@ Ref<PListNode> PList::read_bplist_obj(Ref<FileAccess> p_file, uint64_t p_offset_
 				marker_size = read_bplist_var_size_int(p_file, std::pow(2, ext));
 			}
 			Char16String cs16;
-			cs16.resize(marker_size + 1);
+			cs16.resize_uninitialized(marker_size + 1);
 			for (uint64_t i = 0; i < marker_size; i++) {
 				cs16[i] = BSWAP16(p_file->get_16());
 			}

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -143,7 +143,7 @@ String Resource::generate_scene_unique_id() {
 	static constexpr uint32_t char_count = ('z' - 'a');
 	static constexpr uint32_t base = char_count + ('9' - '0');
 	String id;
-	id.resize(characters + 1);
+	id.resize_uninitialized(characters + 1);
 	char32_t *ptr = id.ptrw();
 	for (uint32_t i = 0; i < characters; i++) {
 		uint32_t c = random_num % base;

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -66,7 +66,7 @@ String ResourceUID::id_to_text(ID p_id) const {
 
 	// tmp_size + uid:// (6) + 1 for null.
 	String txt;
-	txt.resize(tmp_size + 7);
+	txt.resize_uninitialized(tmp_size + 7);
 
 	char32_t *p = txt.ptrw();
 	p[0] = 'u';
@@ -273,7 +273,7 @@ Error ResourceUID::load_from_cache(bool p_reset) {
 		int64_t id = f->get_64();
 		int32_t len = f->get_32();
 		Cache c;
-		c.cs.resize(len + 1);
+		c.cs.resize_uninitialized(len + 1);
 		ERR_FAIL_COND_V(c.cs.size() != len + 1, ERR_FILE_CORRUPT); // Out of memory.
 		c.cs[len] = 0;
 		int32_t rl = f->get_buffer((uint8_t *)c.cs.ptrw(), len);
@@ -333,7 +333,7 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 	for (uint32_t i = 0; i < entry_count; i++) {
 		int64_t id = p_cache_file->get_64();
 		int32_t len = p_cache_file->get_32();
-		cs.resize(len + 1);
+		cs.resize_uninitialized(len + 1);
 		ERR_FAIL_COND_V(cs.size() != len + 1, String());
 		cs[len] = 0;
 		int32_t rl = p_cache_file->get_buffer((uint8_t *)cs.ptrw(), len);

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -119,7 +119,7 @@ void _append_hex(float p_val, char32_t *string) {
 
 String Color::to_html(bool p_alpha) const {
 	String txt;
-	txt.resize(p_alpha ? 9 : 7);
+	txt.resize_uninitialized(p_alpha ? 9 : 7);
 	char32_t *ptr = txt.ptrw();
 
 	_append_hex(r, ptr + 0);

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -82,20 +82,20 @@ void OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 
 		if (ps.orig_len != 0) {
 			CharString dst_s;
-			dst_s.resize(src_s.size());
+			dst_s.resize_uninitialized(src_s.size());
 			int ret = smaz_compress(src_s.get_data(), src_s.size(), dst_s.ptrw(), src_s.size());
 			if (ret >= src_s.size()) {
 				//if compressed is larger than original, just use original
 				ps.orig_len = src_s.size();
 				ps.compressed = src_s;
 			} else {
-				dst_s.resize(ret);
+				dst_s.resize_uninitialized(ret);
 				//ps.orig_len=;
 				ps.compressed = dst_s;
 			}
 		} else {
 			ps.orig_len = 1;
-			ps.compressed.resize(1);
+			ps.compressed.resize_uninitialized(1);
 			ps.compressed[0] = 0;
 		}
 
@@ -256,7 +256,7 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 		return String::utf8(&sptr[bucket.elem[idx].str_offset], bucket.elem[idx].uncomp_size);
 	} else {
 		CharString uncomp;
-		uncomp.resize(bucket.elem[idx].uncomp_size + 1);
+		uncomp.resize_uninitialized(bucket.elem[idx].uncomp_size + 1);
 		smaz_decompress(&sptr[bucket.elem[idx].str_offset], bucket.elem[idx].comp_size, uncomp.ptrw(), bucket.elem[idx].uncomp_size);
 		return String::utf8(uncomp.get_data());
 	}
@@ -282,7 +282,7 @@ Vector<String> OptimizedTranslation::get_translated_message_list() const {
 					msgs.push_back(rstr);
 				} else {
 					CharString uncomp;
-					uncomp.resize(bucket.elem[j].uncomp_size + 1);
+					uncomp.resize_uninitialized(bucket.elem[j].uncomp_size + 1);
 					smaz_decompress(&sptr[bucket.elem[j].str_offset], bucket.elem[j].comp_size, uncomp.ptrw(), bucket.elem[j].uncomp_size);
 					String rstr = String::utf8(uncomp.get_data());
 					msgs.push_back(rstr);

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -123,7 +123,7 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_
 	}
 
 	bool need_copy = string_length > 0 && buffer.is_empty();
-	buffer.resize(next_power_of_2((uint32_t)p_size));
+	buffer.resize_uninitialized(next_power_of_2((uint32_t)p_size));
 	if (need_copy) {
 		memcpy(buffer.ptrw(), short_buffer, string_length * sizeof(char32_t));
 	}
@@ -142,7 +142,7 @@ String StringBuffer<SHORT_BUFFER_SIZE>::as_string() {
 	if (buffer.is_empty()) {
 		return String(short_buffer);
 	} else {
-		buffer.resize(string_length + 1);
+		buffer.resize_uninitialized(string_length + 1);
 		return buffer;
 	}
 }

--- a/core/string/string_builder.cpp
+++ b/core/string/string_builder.cpp
@@ -60,7 +60,7 @@ String StringBuilder::as_string() const {
 	}
 
 	String string;
-	string.resize(string_length + 1);
+	string.resize_uninitialized(string_length + 1);
 	char32_t *buffer = string.ptrw();
 
 	int current_position = 0;

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -175,7 +175,7 @@ void String::append_latin1(const Span<char> &p_cstr) {
 	}
 
 	const int prev_length = length();
-	resize(prev_length + p_cstr.size() + 1); // include 0
+	resize_uninitialized(prev_length + p_cstr.size() + 1); // include 0
 
 	const char *src = p_cstr.ptr();
 	const char *end = src + p_cstr.size();
@@ -194,7 +194,7 @@ void String::append_utf32(const Span<char32_t> &p_cstr) {
 	}
 
 	const int prev_length = length();
-	resize(prev_length + p_cstr.size() + 1);
+	resize_uninitialized(prev_length + p_cstr.size() + 1);
 	const char32_t *src = p_cstr.ptr();
 	const char32_t *end = p_cstr.ptr() + p_cstr.size();
 	char32_t *dst = ptrw() + prev_length;
@@ -223,7 +223,7 @@ void String::append_utf32(const Span<char32_t> &p_cstr) {
 // p_length <= p_char strlen
 // p_char is a valid UTF32 string
 void String::copy_from_unchecked(const char32_t *p_char, const int p_length) {
-	resize(p_length + 1); // + 1 for \0
+	resize_uninitialized(p_length + 1); // + 1 for \0
 	char32_t *dst = ptrw();
 	memcpy(dst, p_char, p_length * sizeof(char32_t));
 	*(dst + p_length) = _null;
@@ -1365,7 +1365,7 @@ String String::join(const Vector<String> &parts) const {
 	new_size += 1;
 
 	String ret;
-	ret.resize(new_size);
+	ret.resize_uninitialized(new_size);
 	char32_t *ret_ptrw = ret.ptrw();
 	const char32_t *this_ptr = ptr();
 
@@ -1404,7 +1404,7 @@ String String::to_upper() const {
 	}
 
 	String upper;
-	upper.resize(size());
+	upper.resize_uninitialized(size());
 	const char32_t *old_ptr = ptr();
 	char32_t *upper_ptrw = upper.ptrw();
 
@@ -1423,7 +1423,7 @@ String String::to_lower() const {
 	}
 
 	String lower;
-	lower.resize(size());
+	lower.resize_uninitialized(size());
 	const char32_t *old_ptr = ptr();
 	char32_t *lower_ptrw = lower.ptrw();
 
@@ -1549,7 +1549,7 @@ String String::num_int64(int64_t p_num, int base, bool capitalize_hex) {
 		chars++;
 	}
 	String s;
-	s.resize(chars + 1);
+	s.resize_uninitialized(chars + 1);
 	char32_t *c = s.ptrw();
 	c[chars] = 0;
 	n = p_num;
@@ -1584,7 +1584,7 @@ String String::num_uint64(uint64_t p_num, int base, bool capitalize_hex) {
 	} while (n);
 
 	String s;
-	s.resize(chars + 1);
+	s.resize_uninitialized(chars + 1);
 	char32_t *c = s.ptrw();
 	c[chars] = 0;
 	n = p_num;
@@ -1675,7 +1675,7 @@ String String::hex_encode_buffer(const uint8_t *p_buffer, int p_len) {
 	static const char hex[16] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
 	String ret;
-	ret.resize(p_len * 2 + 1);
+	ret.resize_uninitialized(p_len * 2 + 1);
 	char32_t *ret_ptrw = ret.ptrw();
 
 	for (int i = 0; i < p_len; i++) {
@@ -1706,7 +1706,7 @@ Vector<uint8_t> String::hex_decode() const {
 
 	Vector<uint8_t> out;
 	int len = length() / 2;
-	out.resize(len);
+	out.resize_uninitialized(len);
 	uint8_t *out_ptrw = out.ptrw();
 	for (int i = 0; i < len; i++) {
 		char32_t c;
@@ -1732,7 +1732,7 @@ CharString String::ascii(bool p_allow_extended) const {
 	}
 
 	CharString cs;
-	cs.resize(size());
+	cs.resize_uninitialized(size());
 	char *cs_ptrw = cs.ptrw();
 	const char32_t *this_ptr = ptr();
 
@@ -1755,7 +1755,7 @@ Error String::append_ascii(const Span<char> &p_range) {
 	}
 
 	const int prev_length = length();
-	resize(prev_length + p_range.size() + 1); // Include \0
+	resize_uninitialized(prev_length + p_range.size() + 1); // Include \0
 
 	const char *src = p_range.ptr();
 	const char *end = src + p_range.size();
@@ -1800,7 +1800,7 @@ Error String::append_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
 
 	const int prev_length = length();
 	// If all utf8 characters maps to ASCII, then the max size will be p_len, and we add +1 for the null termination.
-	resize(prev_length + p_len + 1);
+	resize_uninitialized(prev_length + p_len + 1);
 	char32_t *dst = ptrw() + prev_length;
 
 	Error result = Error::OK;
@@ -1946,7 +1946,7 @@ Error String::append_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
 	}
 
 	(*dst++) = 0;
-	resize(prev_length + dst - ptr());
+	resize_uninitialized(prev_length + dst - ptr());
 
 	return result;
 }
@@ -1959,7 +1959,7 @@ CharString String::utf8(Vector<uint8_t> *r_ch_length_map) const {
 
 	uint8_t *map_ptr = nullptr;
 	if (r_ch_length_map) {
-		r_ch_length_map->resize(l);
+		r_ch_length_map->resize_uninitialized(l);
 		map_ptr = r_ch_length_map->ptrw();
 	}
 
@@ -1997,7 +1997,7 @@ CharString String::utf8(Vector<uint8_t> *r_ch_length_map) const {
 		return utf8s;
 	}
 
-	utf8s.resize(fl + 1);
+	utf8s.resize_uninitialized(fl + 1);
 	uint8_t *cdst = (uint8_t *)utf8s.get_data();
 
 #define APPEND_CHAR(m_c) *(cdst++) = m_c
@@ -2124,7 +2124,7 @@ Error String::append_utf16(const char16_t *p_utf16, int p_len, bool p_default_li
 	}
 
 	const int prev_length = length();
-	resize(prev_length + str_size + 1);
+	resize_uninitialized(prev_length + str_size + 1);
 	char32_t *dst = ptrw() + prev_length;
 	dst[str_size] = 0;
 
@@ -2194,7 +2194,7 @@ Char16String String::utf16() const {
 		return utf16s;
 	}
 
-	utf16s.resize(fl + 1);
+	utf16s.resize_uninitialized(fl + 1);
 	uint16_t *cdst = (uint16_t *)utf16s.get_data();
 
 #define APPEND_CHAR(m_c) *(cdst++) = m_c
@@ -2847,7 +2847,7 @@ Vector<uint8_t> String::md5_buffer() const {
 	CryptoCore::md5((unsigned char *)cs.ptr(), cs.length(), hash);
 
 	Vector<uint8_t> ret;
-	ret.resize(16);
+	ret.resize_uninitialized(16);
 	uint8_t *ret_ptrw = ret.ptrw();
 	for (int i = 0; i < 16; i++) {
 		ret_ptrw[i] = hash[i];
@@ -2861,7 +2861,7 @@ Vector<uint8_t> String::sha1_buffer() const {
 	CryptoCore::sha1((unsigned char *)cs.ptr(), cs.length(), hash);
 
 	Vector<uint8_t> ret;
-	ret.resize(20);
+	ret.resize_uninitialized(20);
 	uint8_t *ret_ptrw = ret.ptrw();
 	for (int i = 0; i < 20; i++) {
 		ret_ptrw[i] = hash[i];
@@ -2876,7 +2876,7 @@ Vector<uint8_t> String::sha256_buffer() const {
 	CryptoCore::sha256((unsigned char *)cs.ptr(), cs.length(), hash);
 
 	Vector<uint8_t> ret;
-	ret.resize(32);
+	ret.resize_uninitialized(32);
 	uint8_t *ret_ptrw = ret.ptrw();
 	for (int i = 0; i < 32; i++) {
 		ret_ptrw[i] = hash[i];
@@ -2894,7 +2894,7 @@ String String::insert(int p_at_pos, const String &p_string) const {
 	}
 
 	String ret;
-	ret.resize(length() + p_string.length() + 1);
+	ret.resize_uninitialized(length() + p_string.length() + 1);
 	char32_t *ret_ptrw = ret.ptrw();
 	const char32_t *this_ptr = ptr();
 
@@ -2958,7 +2958,7 @@ String String::remove_char(char32_t p_char) const {
 
 	// If we found at least one occurrence of `char`, create new string, allocating enough space for the current length minus one.
 	String new_string;
-	new_string.resize(len);
+	new_string.resize_uninitialized(len);
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `char`.
@@ -2978,7 +2978,7 @@ String String::remove_char(char32_t p_char) const {
 	new_ptr[new_size] = _null;
 
 	// Shrink new string to fit.
-	new_string.resize(new_size + 1);
+	new_string.resize_uninitialized(new_size + 1);
 
 	return new_string;
 }
@@ -3013,7 +3013,7 @@ static String _remove_chars_common(const String &p_this, const T *p_chars, int p
 
 	// If we found at least one occurrence of `chars`, create new string, allocating enough space for the current length minus one.
 	String new_string;
-	new_string.resize(len);
+	new_string.resize_uninitialized(len);
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `char`.
@@ -3033,7 +3033,7 @@ static String _remove_chars_common(const String &p_this, const T *p_chars, int p
 	new_ptr[new_size] = 0;
 
 	// Shrink new string to fit.
-	new_string.resize(new_size + 1);
+	new_string.resize_uninitialized(new_size + 1);
 
 	return new_string;
 }
@@ -3747,7 +3747,7 @@ Vector<String> String::bigrams() const {
 	if (n_pairs <= 0) {
 		return b;
 	}
-	b.resize(n_pairs);
+	b.resize_initialized(n_pairs);
 	String *b_ptrw = b.ptrw();
 	for (int i = 0; i < n_pairs; i++) {
 		b_ptrw[i] = substr(i, 2);
@@ -3893,7 +3893,7 @@ static String _replace_common(const String &p_this, const String &p_key, const S
 	const int with_length = p_with.length();
 	const int old_length = p_this.length();
 
-	new_string.resize(old_length + int(found.size()) * (with_length - key_length) + 1);
+	new_string.resize_uninitialized(old_length + int(found.size()) * (with_length - key_length) + 1);
 
 	char32_t *new_ptrw = new_string.ptrw();
 	const char32_t *old_ptr = p_this.ptr();
@@ -3952,7 +3952,7 @@ static String _replace_common(const String &p_this, char const *p_key, char cons
 	const int with_length = with_string.length();
 	const int old_length = p_this.length();
 
-	new_string.resize(old_length + int(found.size()) * (with_length - key_length) + 1);
+	new_string.resize_uninitialized(old_length + int(found.size()) * (with_length - key_length) + 1);
 
 	char32_t *new_ptrw = new_string.ptrw();
 	const char32_t *old_ptr = p_this.ptr();
@@ -3998,7 +3998,7 @@ String String::replace_first(const String &p_key, const String &p_with) const {
 		const int with_length = p_with.length();
 
 		String new_string;
-		new_string.resize(old_length + (with_length - key_length) + 1);
+		new_string.resize_uninitialized(old_length + (with_length - key_length) + 1);
 
 		char32_t *new_ptrw = new_string.ptrw();
 		const char32_t *old_ptr = ptr();
@@ -4036,7 +4036,7 @@ String String::replace_first(const char *p_key, const char *p_with) const {
 		const int with_length = strlen(p_with);
 
 		String new_string;
-		new_string.resize(old_length + (with_length - key_length) + 1);
+		new_string.resize_uninitialized(old_length + (with_length - key_length) + 1);
 
 		char32_t *new_ptrw = new_string.ptrw();
 		const char32_t *old_ptr = ptr();
@@ -4091,7 +4091,7 @@ String String::replace_char(char32_t p_key, char32_t p_with) const {
 
 	// If we found at least one occurrence of `key`, create new string.
 	String new_string;
-	new_string.resize(len + 1);
+	new_string.resize_uninitialized(len + 1);
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `key`.
@@ -4144,7 +4144,7 @@ static String _replace_chars_common(const String &p_this, const T *p_keys, int p
 
 	// If we found at least one occurrence of `keys`, create new string.
 	String new_string;
-	new_string.resize(len + 1);
+	new_string.resize_uninitialized(len + 1);
 	char32_t *new_ptr = new_string.ptrw();
 
 	// Copy part of input before `key`.
@@ -4196,7 +4196,7 @@ String String::repeat(int p_count) const {
 
 	int len = length();
 	String new_string = *this;
-	new_string.resize(p_count * len + 1);
+	new_string.resize_uninitialized(p_count * len + 1);
 
 	char32_t *dst = new_string.ptrw();
 	int offset = 1;
@@ -4216,7 +4216,7 @@ String String::reverse() const {
 		return *this;
 	}
 	String new_string;
-	new_string.resize(len + 1);
+	new_string.resize_uninitialized(len + 1);
 
 	const char32_t *src = ptr();
 	char32_t *dst = new_string.ptrw();
@@ -4909,7 +4909,7 @@ String String::xml_unescape() const {
 	if (len == 0) {
 		return String();
 	}
-	str.resize(len + 1);
+	str.resize_uninitialized(len + 1);
 	char32_t *str_ptrw = str.ptrw();
 	_xml_unescape(get_data(), l, str_ptrw);
 	str_ptrw[len] = 0;
@@ -5880,7 +5880,7 @@ Vector<uint8_t> String::to_ascii_buffer() const {
 
 	Vector<uint8_t> retval;
 	size_t len = charstr.length();
-	retval.resize(len);
+	retval.resize_uninitialized(len);
 	uint8_t *w = retval.ptrw();
 	memcpy(w, charstr.ptr(), len);
 
@@ -5896,7 +5896,7 @@ Vector<uint8_t> String::to_utf8_buffer() const {
 
 	Vector<uint8_t> retval;
 	size_t len = charstr.length();
-	retval.resize(len);
+	retval.resize_uninitialized(len);
 	uint8_t *w = retval.ptrw();
 	memcpy(w, charstr.ptr(), len);
 
@@ -5912,7 +5912,7 @@ Vector<uint8_t> String::to_utf16_buffer() const {
 
 	Vector<uint8_t> retval;
 	size_t len = charstr.length() * sizeof(char16_t);
-	retval.resize(len);
+	retval.resize_uninitialized(len);
 	uint8_t *w = retval.ptrw();
 	memcpy(w, (const void *)charstr.ptr(), len);
 
@@ -5927,7 +5927,7 @@ Vector<uint8_t> String::to_utf32_buffer() const {
 
 	Vector<uint8_t> retval;
 	size_t len = s->length() * sizeof(char32_t);
-	retval.resize(len);
+	retval.resize_uninitialized(len);
 	uint8_t *w = retval.ptrw();
 	memcpy(w, (const void *)s->ptr(), len);
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -186,7 +186,9 @@ public:
 	_FORCE_INLINE_ operator Span<T>() const { return Span(ptr(), length()); }
 	_FORCE_INLINE_ Span<T> span() const { return Span(ptr(), length()); }
 
-	_FORCE_INLINE_ Error resize(int p_size) { return _cowdata.template resize<false>(p_size); }
+	/// Resizes the string. The given size must include the null terminator.
+	/// New characters are not initialized, and should be set by the caller.
+	_FORCE_INLINE_ Error resize_uninitialized(int64_t p_size) { return _cowdata.template resize<false>(p_size); }
 
 	_FORCE_INLINE_ T get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) { _cowdata.set(p_index, p_elem); }
@@ -221,7 +223,7 @@ public:
 	}
 	_FORCE_INLINE_ CharStringT<T> &operator+=(T p_char) {
 		const int lhs_len = length();
-		resize(lhs_len + 2);
+		resize_uninitialized(lhs_len + 2);
 
 		T *dst = ptrw();
 		dst[lhs_len] = p_char;
@@ -233,17 +235,17 @@ public:
 protected:
 	void copy_from(const T *p_cstr) {
 		if (!p_cstr) {
-			resize(0);
+			resize_uninitialized(0);
 			return;
 		}
 
 		size_t len = strlen(p_cstr);
 		if (len == 0) {
-			resize(0);
+			resize_uninitialized(0);
 			return;
 		}
 
-		Error err = resize(++len); // include terminating null char.
+		Error err = resize_uninitialized(++len); // include terminating null char.
 
 		ERR_FAIL_COND_MSG(err != OK, "Failed to copy C-string.");
 
@@ -320,11 +322,14 @@ public:
 
 	void remove_at(int p_index) { _cowdata.remove_at(p_index); }
 
-	_FORCE_INLINE_ void clear() { resize(0); }
+	_FORCE_INLINE_ void clear() { resize_uninitialized(0); }
 
 	_FORCE_INLINE_ char32_t get(int p_index) const { return _cowdata.get(p_index); }
 	_FORCE_INLINE_ void set(int p_index, const char32_t &p_elem) { _cowdata.set(p_index, p_elem); }
-	Error resize(int p_size) { return _cowdata.resize<false>(p_size); }
+
+	/// Resizes the string. The given size must include the null terminator.
+	/// New characters are not initialized, and should be set by the caller.
+	Error resize_uninitialized(int64_t p_size) { return _cowdata.resize<false>(p_size); }
 
 	_FORCE_INLINE_ const char32_t &operator[](int p_index) const {
 		if (unlikely(p_index == _cowdata.size())) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -685,7 +685,7 @@ struct _VariantCall {
 		if (p_instance->size() > 0) {
 			const uint8_t *r = p_instance->ptr();
 			CharString cs;
-			cs.resize(p_instance->size() + 1);
+			cs.resize_uninitialized(p_instance->size() + 1);
 			memcpy(cs.ptrw(), r, p_instance->size());
 			cs[(int)p_instance->size()] = 0;
 

--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -155,7 +155,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 
 	Char16String real_current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
-	real_current_dir_name.resize(str_len + 1);
+	real_current_dir_name.resize_uninitialized(str_len + 1);
 	GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
 	String prev_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 
@@ -165,7 +165,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 	String base = _get_root_path();
 	if (!base.is_empty()) {
 		str_len = GetCurrentDirectoryW(0, nullptr);
-		real_current_dir_name.resize(str_len + 1);
+		real_current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
 		String new_dir = String::utf16((const char16_t *)real_current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/');
 		if (!new_dir.begins_with(base)) {
@@ -175,7 +175,7 @@ Error DirAccessWindows::change_dir(String p_dir) {
 
 	if (worked) {
 		str_len = GetCurrentDirectoryW(0, nullptr);
-		real_current_dir_name.resize(str_len + 1);
+		real_current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
 		current_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 	}
@@ -447,7 +447,7 @@ String DirAccessWindows::read_link(String p_file) {
 		return f;
 	}
 	Char16String cs;
-	cs.resize(ret + 1);
+	cs.resize_uninitialized(ret + 1);
 	GetFinalPathNameByHandleW(hfile, (LPWSTR)cs.ptrw(), ret, VOLUME_NAME_DOS | FILE_NAME_NORMALIZED);
 	CloseHandle(hfile);
 
@@ -475,7 +475,7 @@ DirAccessWindows::DirAccessWindows() {
 
 	Char16String real_current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
-	real_current_dir_name.resize(str_len + 1);
+	real_current_dir_name.resize_uninitialized(str_len + 1);
 	GetCurrentDirectoryW(real_current_dir_name.size(), (LPWSTR)real_current_dir_name.ptrw());
 	current_dir = String::utf16((const char16_t *)real_current_dir_name.get_data());
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -85,7 +85,7 @@ String FileAccessWindows::fix_path(const String &p_path) const {
 	if (r_path.is_relative_path()) {
 		Char16String current_dir_name;
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
-		current_dir_name.resize(str_len + 1);
+		current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 		r_path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(r_path);
 	}

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1504,7 +1504,7 @@ bool TextServerAdvanced::_ensure_cache_for_size(FontAdvanced *p_font_data, const
 					continue;
 				}
 				unsigned int text_size = hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, nullptr, nullptr) + 1;
-				p_font_data->font_name.resize(text_size);
+				p_font_data->font_name.resize_uninitialized(text_size);
 				hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)p_font_data->font_name.ptrw());
 			}
 			if (p_font_data->font_name.is_empty() && fd->face->family_name != nullptr) {
@@ -2308,7 +2308,7 @@ Dictionary TextServerAdvanced::_font_get_ot_name_strings(const RID &p_font_rid) 
 		}
 		String text;
 		unsigned int text_size = hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, nullptr, nullptr) + 1;
-		text.resize(text_size);
+		text.resize_uninitialized(text_size);
 		hb_ot_name_get_utf32(hb_face, names[i].name_id, names[i].language, &text_size, (uint32_t *)text.ptrw());
 		if (!text.is_empty()) {
 			Dictionary &id_string = names_for_lang[String(hb_language_to_string(names[i].language))];

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -294,7 +294,7 @@
 	}
 
 	Char16String text;
-	text.resize([characters length] + 1);
+	text.resize_uninitialized([characters length] + 1);
 	[characters getCharacters:(unichar *)text.ptrw() range:NSMakeRange(0, [characters length])];
 
 	String u32text = String::utf16(text.ptr(), text.length());
@@ -680,7 +680,7 @@
 		if (!wd.im_active && length > 0 && keycode_has_unicode(KeyMappingMacOS::remap_key([event keyCode], [event modifierFlags], true))) {
 			// Fallback unicode character handler used if IME is not active.
 			Char16String text;
-			text.resize([characters length] + 1);
+			text.resize_uninitialized([characters length] + 1);
 			[characters getCharacters:(unichar *)text.ptrw() range:NSMakeRange(0, [characters length])];
 
 			String u32text = String::utf16(text.ptr(), text.length());

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -616,7 +616,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 		if (dir.is_relative_path() || dir == ".") {
 			Char16String current_dir_name;
 			size_t str_len = GetCurrentDirectoryW(0, nullptr);
-			current_dir_name.resize(str_len + 1);
+			current_dir_name.resize_uninitialized(str_len + 1);
 			GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 			if (dir == ".") {
 				dir = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/');
@@ -3390,7 +3390,7 @@ static INT_PTR input_text_dialog_cmd_proc(HWND hWnd, UINT code, WPARAM wParam, L
 		ERR_FAIL_NULL_V(text_edit, false);
 
 		Char16String text;
-		text.resize(GetWindowTextLengthW(text_edit) + 1);
+		text.resize_uninitialized(GetWindowTextLengthW(text_edit) + 1);
 		GetWindowTextW(text_edit, (LPWSTR)text.get_data(), text.size());
 
 		const Callable *callback = (const Callable *)GetWindowLongPtrW(hWnd, GWLP_USERDATA);

--- a/platform/windows/drop_target_windows.cpp
+++ b/platform/windows/drop_target_windows.cpp
@@ -41,7 +41,7 @@
 static String create_temp_dir() {
 	Char16String buf;
 	int bufsize = GetTempPathW(0, nullptr) + 1;
-	buf.resize(bufsize);
+	buf.resize_uninitialized(bufsize);
 	if (GetTempPathW(bufsize, (LPWSTR)buf.ptrw()) == 0) {
 		return "";
 	}
@@ -158,7 +158,7 @@ HRESULT DropTargetWindows::handle_hdrop_format(Vector<String> *p_files, IDataObj
 
 	for (int i = 0; i < fcount; i++) {
 		int buffsize = DragQueryFileW(hDropInfo, i, nullptr, 0);
-		buf.resize(buffsize + 1);
+		buf.resize_uninitialized(buffsize + 1);
 		if (DragQueryFileW(hDropInfo, i, (LPWSTR)buf.ptrw(), buffsize + 1) == 0) {
 			res = E_UNEXPECTED;
 			goto cleanup;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -53,7 +53,7 @@ static String fix_path(const String &p_path) {
 	if (p_path.is_relative_path()) {
 		Char16String current_dir_name;
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
-		current_dir_name.resize(str_len + 1);
+		current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
 	}

--- a/platform/windows/native_menu_windows.cpp
+++ b/platform/windows/native_menu_windows.cpp
@@ -574,7 +574,7 @@ int NativeMenuWindows::find_item_index_with_text(const RID &p_rid, const String 
 		if (GetMenuItemInfoW(md->menu, i, true, &item)) {
 			item.cch++;
 			Char16String str;
-			str.resize(item.cch);
+			str.resize_uninitialized(item.cch);
 			item.dwTypeData = (LPWSTR)str.ptrw();
 			if (GetMenuItemInfoW(md->menu, i, true, &item)) {
 				if (String::utf16((const char16_t *)str.get_data()) == p_text) {
@@ -728,7 +728,7 @@ String NativeMenuWindows::get_item_text(const RID &p_rid, int p_idx) const {
 	if (GetMenuItemInfoW(md->menu, p_idx, true, &item)) {
 		item.cch++;
 		Char16String str;
-		str.resize(item.cch);
+		str.resize_uninitialized(item.cch);
 		item.dwTypeData = (LPWSTR)str.ptrw();
 		if (GetMenuItemInfoW(md->menu, p_idx, true, &item)) {
 			return String::utf16((const char16_t *)str.get_data());

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -111,7 +111,7 @@ static String fix_path(const String &p_path) {
 	if (p_path.is_relative_path()) {
 		Char16String current_dir_name;
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
-		current_dir_name.resize(str_len + 1);
+		current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
 	}
@@ -1280,12 +1280,12 @@ Dictionary OS_Windows::execute_with_pipe(const String &p_path, const List<String
 
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
-	current_dir_name.resize(str_len + 1);
+	current_dir_name.resize_uninitialized(str_len + 1);
 	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 	if (current_dir_name.size() >= MAX_PATH) {
 		Char16String current_short_dir_name;
 		str_len = GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), nullptr, 0);
-		current_short_dir_name.resize(str_len);
+		current_short_dir_name.resize_uninitialized(str_len);
 		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.size());
 		current_dir_name = current_short_dir_name;
 	}
@@ -1386,12 +1386,12 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
-	current_dir_name.resize(str_len + 1);
+	current_dir_name.resize_uninitialized(str_len + 1);
 	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 	if (current_dir_name.size() >= MAX_PATH) {
 		Char16String current_short_dir_name;
 		str_len = GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), nullptr, 0);
-		current_short_dir_name.resize(str_len);
+		current_short_dir_name.resize_uninitialized(str_len);
 		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.size());
 		current_dir_name = current_short_dir_name;
 	}
@@ -1485,12 +1485,12 @@ Error OS_Windows::create_process(const String &p_path, const List<String> &p_arg
 
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
-	current_dir_name.resize(str_len + 1);
+	current_dir_name.resize_uninitialized(str_len + 1);
 	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 	if (current_dir_name.size() >= MAX_PATH) {
 		Char16String current_short_dir_name;
 		str_len = GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), nullptr, 0);
-		current_short_dir_name.resize(str_len);
+		current_short_dir_name.resize_uninitialized(str_len);
 		GetShortPathNameW((LPCWSTR)current_dir_name.ptr(), (LPWSTR)current_short_dir_name.ptrw(), current_short_dir_name.size());
 		current_dir_name = current_short_dir_name;
 	}
@@ -1626,7 +1626,7 @@ Vector<String> OS_Windows::get_system_fonts() const {
 		hr = family_names->GetStringLength(index, &length);
 		ERR_CONTINUE(FAILED(hr));
 
-		name.resize(length + 1);
+		name.resize_uninitialized(length + 1);
 		hr = family_names->GetString(index, (WCHAR *)name.ptrw(), length + 1);
 		ERR_CONTINUE(FAILED(hr));
 
@@ -2664,12 +2664,12 @@ OS_Windows::OS_Windows(HINSTANCE _hInstance) {
 	// Reset CWD to ensure long path is used.
 	Char16String current_dir_name;
 	size_t str_len = GetCurrentDirectoryW(0, nullptr);
-	current_dir_name.resize(str_len + 1);
+	current_dir_name.resize_uninitialized(str_len + 1);
 	GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 
 	Char16String new_current_dir_name;
 	str_len = GetLongPathNameW((LPCWSTR)current_dir_name.get_data(), nullptr, 0);
-	new_current_dir_name.resize(str_len + 1);
+	new_current_dir_name.resize_uninitialized(str_len + 1);
 	GetLongPathNameW((LPCWSTR)current_dir_name.get_data(), (LPWSTR)new_current_dir_name.ptrw(), new_current_dir_name.size());
 
 	SetCurrentDirectoryW((LPCWSTR)new_current_dir_name.get_data());

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -212,7 +212,7 @@ String RichTextLabel::_letters(int p_num, bool p_capitalize) const {
 	} while (n);
 
 	String s;
-	s.resize(chars + 1);
+	s.resize_uninitialized(chars + 1);
 	char32_t *c = s.ptrw();
 	c[chars] = 0;
 	n = p_num;

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -358,7 +358,7 @@ String ShaderPreprocessor::vector_to_string(const LocalVector<char32_t> &p_v, in
 	const int count = stop - p_start;
 
 	String result;
-	result.resize(count + 1);
+	result.resize_uninitialized(count + 1);
 	for (int i = 0; i < count; i++) {
 		result[i] = p_v[p_start + i];
 	}

--- a/tests/servers/rendering/test_shader_preprocessor.h
+++ b/tests/servers/rendering/test_shader_preprocessor.h
@@ -58,7 +58,7 @@ bool is_operator_char(unsigned char c) {
 String remove_spaces(String &p_str) {
 	String res;
 	// Result is guaranteed to not be longer than the input.
-	res.resize(p_str.size());
+	res.resize_uninitialized(p_str.size());
 	int wp = 0;
 	char32_t last = 0;
 	bool has_removed = false;
@@ -82,7 +82,7 @@ String remove_spaces(String &p_str) {
 			last = c;
 		}
 	}
-	res.resize(wp);
+	res.resize_uninitialized(wp);
 	return res;
 }
 


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/104522

As discussed in Core meetings, `resize` is ambiguous in the current codebase, because new elements are sometimes initialized, but not initialized other times, depending on the element type.

`LocalVector` and `Vector` have already received new, clearer `resize_initialized` and `resize_uninitialized` functions.
`String` is an easy contender to swap the name out directly, since there are not that many callers.
I implemented this by renaming the method, and fixing compile problems until it succeeded compiling.
