### PR TITLE
Fix Area3D signal emissions when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -113,12 +113,14 @@ void JoltArea3D::_add_shape_pair(Overlap &p_overlap, const JPH::BodyID &p_body_i
 	p_overlap.rid = other_object->get_rid();
 	p_overlap.instance_id = other_object->get_instance_id();
 
-	ShapeIndexPair &shape_indices = p_overlap.shape_pairs[{ p_other_shape_id, p_self_shape_id }];
+	HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair>::Iterator shape_pair = p_overlap.shape_pairs.find(ShapeIDPair(p_other_shape_id, p_self_shape_id));
+	if (shape_pair == p_overlap.shape_pairs.end()) {
+		const int other_shape_index = other_object->find_shape_index(p_other_shape_id);
+		const int self_shape_index = find_shape_index(p_self_shape_id);
+		shape_pair = p_overlap.shape_pairs.insert(ShapeIDPair(p_other_shape_id, p_self_shape_id), ShapeIndexPair(other_shape_index, self_shape_index));
+	}
 
-	shape_indices.other = other_object->find_shape_index(p_other_shape_id);
-	shape_indices.self = find_shape_index(p_self_shape_id);
-
-	p_overlap.pending_added.push_back(shape_indices);
+	p_overlap.pending_added.push_back(shape_pair->value);
 
 	_events_changed();
 }
@@ -143,12 +145,20 @@ void JoltArea3D::_flush_events(OverlapsById &p_objects, const Callable &p_callba
 		Overlap &overlap = E->value;
 
 		if (p_callback.is_valid()) {
-			for (ShapeIndexPair &shape_indices : overlap.pending_removed) {
-				_report_event(p_callback, PhysicsServer3D::AREA_BODY_REMOVED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
+			for (const ShapeIndexPair &shape_indices : overlap.pending_added) {
+				int &ref_count = overlap.ref_counts[shape_indices];
+				if (ref_count++ == 0) {
+					_report_event(p_callback, PhysicsServer3D::AREA_BODY_ADDED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
+				}
 			}
 
-			for (ShapeIndexPair &shape_indices : overlap.pending_added) {
-				_report_event(p_callback, PhysicsServer3D::AREA_BODY_ADDED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
+			for (const ShapeIndexPair &shape_indices : overlap.pending_removed) {
+				int &ref_count = overlap.ref_counts[shape_indices];
+				ERR_CONTINUE(ref_count <= 0);
+				if (--ref_count == 0) {
+					_report_event(p_callback, PhysicsServer3D::AREA_BODY_REMOVED, overlap.rid, overlap.instance_id, shape_indices.other, shape_indices.self);
+					overlap.ref_counts.erase(shape_indices);
+				}
 			}
 		}
 

--- a/modules/jolt_physics/objects/jolt_area_3d.h
+++ b/modules/jolt_physics/objects/jolt_area_3d.h
@@ -73,6 +73,12 @@ private:
 		ShapeIndexPair(int p_other, int p_self) :
 				other(p_other), self(p_self) {}
 
+		static uint32_t hash(const ShapeIndexPair &p_pair) {
+			uint32_t hash = hash_murmur3_one_32(p_pair.other);
+			hash = hash_murmur3_one_32(p_pair.self, hash);
+			return hash_fmix32(hash);
+		}
+
 		friend bool operator==(const ShapeIndexPair &p_lhs, const ShapeIndexPair &p_rhs) {
 			return (p_lhs.other == p_rhs.other) && (p_lhs.self == p_rhs.self);
 		}
@@ -80,6 +86,7 @@ private:
 
 	struct Overlap {
 		HashMap<ShapeIDPair, ShapeIndexPair, ShapeIDPair> shape_pairs;
+		HashMap<ShapeIndexPair, int, ShapeIndexPair> ref_counts;
 		LocalVector<ShapeIndexPair> pending_added;
 		LocalVector<ShapeIndexPair> pending_removed;
 		RID rid;

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -304,7 +304,10 @@ void JoltShapedObject3D::commit_shapes(bool p_optimize_compound) {
 		return;
 	}
 
-	previous_jolt_shape = jolt_shape;
+	if (previous_jolt_shape == nullptr) {
+		previous_jolt_shape = jolt_shape;
+	}
+
 	jolt_shape = new_shape;
 
 	space->get_body_iface().SetShape(jolt_body->GetID(), jolt_shape, false, JPH::EActivation::DontActivate);

--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.h
@@ -120,7 +120,6 @@ class JoltContactListener3D final
 
 	void _flush_contacts();
 	void _flush_area_enters();
-	void _flush_area_shifts();
 	void _flush_area_exits();
 
 public:


### PR DESCRIPTION
Fixes #106629.
Allows for #105746.

This pull request adds reference counting of the shape index pairs that are managed in `JoltArea3D`, and changes its event emitting of `PhysicsServer3D::AREA_BODY_ADDED` and `PhysicsServer3D::AREA_BODY_REMOVED` to instead only happen when this reference counter gets set to/from zero.

This is necessary due to triangle-based shapes like ConcavePolygonShape3D (and presumably HeightMapShape3D) currently being able to produce multiple contacts/overlaps/manifolds for different triangles, that all have different Jolt sub-shape pairs, but that resolve down to the same shape index pair, which I failed to take into account when first implementing support for Area3D, resulting in it emitting events when it shouldn't.

This reference counting will also come in handy for #105746, which I believe should make the above mentioned multiple contacts/overlaps/manifolds non-existent, but which should still benefit from this reference counting for managing the moving of the single contact/overlap/manifold as it moves between different triangles.

This pull request also fixes an issue where removing or adding shapes to a body that's overlapping with an Area3D would similarly result in borked signal emissions, which turned out to be part me having screwed up `JoltContactListener3D::_flush_area_shifts` when first implementing Area3D support and part regression from #101189.

Note however that there is still a slight discrepancy in how these signal emissions happen when comparing with Godot Physics. For example, if you have a RigidBody3D with three shapes that's enveloped by an Area3D, and you remove the middle one, Godot Physics will emit two exit events, one for index 1 and one for index 2, and then an enter event for index 1. With Jolt, as of this pull request, you will instead only get a single event, which is the exit event for index 2.

It might be worth taking a closer look at that discrepancy at some later point, but I don't think it needs to prevent this PR from being merged.