### PR TITLE
Fix CodeEdit hover word lookup

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -59,34 +59,6 @@ static _FORCE_INLINE_ char32_t lower_case(char32_t c) {
 	return (is_ascii_upper_case(c) ? (c + ('a' - 'A')) : c);
 }
 
-bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end) {
-	const String &s = p_s;
-	int beg = CLAMP(p_col, 0, s.length());
-	int end = beg;
-
-	if (s[beg] > 32 || beg == s.length()) {
-		bool symbol = beg < s.length() && is_symbol(s[beg]);
-
-		while (beg > 0 && s[beg - 1] > 32 && (symbol == is_symbol(s[beg - 1]))) {
-			beg--;
-		}
-		while (end < s.length() && s[end + 1] > 32 && (symbol == is_symbol(s[end + 1]))) {
-			end++;
-		}
-
-		if (end < s.length()) {
-			end += 1;
-		}
-
-		r_beg = beg;
-		r_end = end;
-
-		return true;
-	} else {
-		return false;
-	}
-}
-
 Error String::parse_url(String &r_scheme, String &r_host, int &r_port, String &r_path, String &r_fragment) const {
 	// Splits the URL into scheme, host, port, path, fragment. Strip credentials when present.
 	String base = *this;

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -791,8 +791,6 @@ _FORCE_INLINE_ String ETRN(const String &p_text, const String &p_text_plural, in
 	return p_text_plural;
 }
 
-bool select_word(const String &p_s, int p_col, int &r_beg, int &r_end);
-
 template <typename... P>
 _FORCE_INLINE_ Vector<String> sarray(P... p_args) {
 	return Vector<String>({ String(p_args)... });

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2406,7 +2406,7 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &ev) {
 			}
 		}
 
-		String word_at_pos = tx->get_word_at_pos(local_pos);
+		String word_at_pos = tx->get_lookup_word(mouse_line, mouse_column);
 		if (word_at_pos.is_empty()) {
 			word_at_pos = tx->get_word_under_caret(selection_clicked);
 		}

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -504,6 +504,7 @@ public:
 
 	String get_text_for_symbol_lookup() const;
 	String get_text_with_cursor_char(int p_line, int p_column) const;
+	String get_lookup_word(int p_line, int p_column) const;
 
 	void set_symbol_lookup_word_as_valid(bool p_valid);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3631,22 +3631,24 @@ String TextEdit::get_tooltip(const Point2 &p_pos) const {
 		return Control::get_tooltip(p_pos);
 	}
 	Point2i pos = get_line_column_at_pos(p_pos);
-	int row = pos.y;
+	int line = pos.y;
 	int col = pos.x;
 
-	String s = text[row];
-	if (s.length() == 0) {
+	const String &text_line = text[line];
+	if (text_line.is_empty()) {
 		return Control::get_tooltip(p_pos);
 	}
-	int beg, end;
-	if (select_word(s, col, beg, end)) {
-		Variant args[1] = { s.substr(beg, end - beg) };
-		const Variant *argp[] = { &args[0] };
-		Callable::CallError ce;
-		Variant ret;
-		tooltip_callback.callp(argp, 1, ret, ce);
-		ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, "", "Failed to call custom tooltip.");
-		return ret;
+	const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(line)->get_rid());
+	for (int i = 0; i < words.size(); i = i + 2) {
+		if (words[i] <= col && words[i + 1] >= col) {
+			Variant args[1] = { text_line.substr(words[i], words[i + 1] - words[i]) };
+			const Variant *argp[] = { &args[0] };
+			Callable::CallError ce;
+			Variant ret;
+			tooltip_callback.callp(argp, 1, ret, ce);
+			ERR_FAIL_COND_V_MSG(ce.error != Callable::CallError::CALL_OK, "", "Failed to call custom tooltip.");
+			return ret;
+		}
 	}
 
 	return Control::get_tooltip(p_pos);
@@ -4922,43 +4924,29 @@ Point2 TextEdit::get_local_mouse_pos() const {
 
 String TextEdit::get_word_at_pos(const Vector2 &p_pos) const {
 	Point2i pos = get_line_column_at_pos(p_pos, false, false);
-	int row = pos.y;
+	int line = pos.y;
 	int col = pos.x;
-	if (row < 0 || col < 0) {
-		return "";
-	}
+	return get_word(line, col);
+}
 
-	String s = text[row];
-	if (s.length() == 0) {
-		return "";
+String TextEdit::get_word(int p_line, int p_column) const {
+	if (p_line < 0 || p_column < 0) {
+		return String();
 	}
-	int beg, end;
-	if (select_word(s, col, beg, end)) {
-		bool inside_quotes = false;
-		char32_t selected_quote = '\0';
-		int qbegin = 0, qend = 0;
-		for (int i = 0; i < s.length(); i++) {
-			if (s[i] == '"' || s[i] == '\'') {
-				if (i == 0 || s[i - 1] != '\\') {
-					if (inside_quotes && selected_quote == s[i]) {
-						qend = i;
-						inside_quotes = false;
-						selected_quote = '\0';
-						if (col >= qbegin && col <= qend) {
-							return s.substr(qbegin, qend - qbegin);
-						}
-					} else if (!inside_quotes) {
-						qbegin = i + 1;
-						inside_quotes = true;
-						selected_quote = s[i];
-					}
-				}
-			}
+	ERR_FAIL_INDEX_V(p_line, text.size(), String());
+
+	const String &text_line = text[p_line];
+	if (text_line.is_empty()) {
+		return String();
+	}
+	ERR_FAIL_INDEX_V(p_column, text_line.size() + 1, String());
+
+	const PackedInt32Array words = TS->shaped_text_get_word_breaks(text.get_line_data(p_line)->get_rid());
+	for (int i = 0; i < words.size(); i = i + 2) {
+		if (words[i] <= p_column && words[i + 1] >= p_column) {
+			return text_line.substr(words[i], words[i + 1] - words[i]);
 		}
-
-		return s.substr(beg, end - beg);
 	}
-
 	return String();
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -919,6 +919,7 @@ public:
 	Point2 get_local_mouse_pos() const;
 
 	String get_word_at_pos(const Vector2 &p_pos) const;
+	String get_word(int p_line, int p_column) const;
 
 	Point2i get_line_column_at_pos(const Point2i &p_pos, bool p_clamp_line = true, bool p_clamp_column = true) const;
 	Point2i get_pos_at_line_column(int p_line, int p_column) const;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/102431

Fixes hovering to show tooltip when over the end of the last character of a symbol (where clicking would place the caret at the end). 
This should be useful for cases like https://github.com/godotengine/godot-proposals/issues/11365 and https://github.com/godotengine/godot/pull/102380, since selecting the entire word puts the caret at the last character.

Unifies the word detection behavior to the one that the rest of the TextEdit uses.
This fixes hovering to show tooltip not working correctly when next to unicode word break characters. Custom word separators are now respected too.
Removed the old word detection function.

Moves the string detection logic to use CodeEdit's delimiter system. Though this means it won't work in comments anymore.

Also made the tooltip hover work when text is selected. There shouldn't be any problem with allowing this, since the tooltip doesn't show if mouse buttons are held. Related: https://github.com/godotengine/godot-proposals/discussions/12492
