### PR TITLE
Shader Baker: Fix build with `deprecated=no`

### DIFF
--- a/editor/plugins/shader_baker_export_plugin.cpp
+++ b/editor/plugins/shader_baker_export_plugin.cpp
@@ -111,9 +111,9 @@ bool ShaderBakerExportPlugin::_begin_customize_resources(const Ref<EditorExportP
 
 	StringBuilder to_hash;
 	to_hash.append("[GodotVersionNumber]");
-	to_hash.append(VERSION_NUMBER);
+	to_hash.append(GODOT_VERSION_NUMBER);
 	to_hash.append("[GodotVersionHash]");
-	to_hash.append(VERSION_HASH);
+	to_hash.append(GODOT_VERSION_HASH);
 	to_hash.append("[Renderer]");
 	to_hash.append(shader_cache_renderer_name);
 	customization_configuration_hash = to_hash.as_string().hash64();


### PR DESCRIPTION
Shader Baker was using the unadorned `VERSION_NUMBER` and `VERSION_HASH` symbols, which are no longer defined when `deprecated=no` is set.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
