### PR TITLE
Improve `EditorInspectorCategory`

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -303,29 +303,36 @@ public:
 class EditorInspectorCategory : public Control {
 	GDCLASS(EditorInspectorCategory, Control);
 
-	friend class EditorInspector;
-
 	// Right-click context menu options.
 	enum ClassMenuOption {
 		MENU_OPEN_DOCS,
+		MENU_UNFAVORITE_ALL,
 	};
 
+	PropertyInfo info;
 	Ref<Texture2D> icon;
 	String label;
 	String doc_class_name;
 	PopupMenu *menu = nullptr;
 	bool is_favorite = false;
+	bool menu_icon_dirty = true;
 
 	void _handle_menu_option(int p_option);
+	void _popup_context_menu(const Point2i &p_position);
+	void _update_icon();
 
 protected:
+	static void _bind_methods();
+
 	void _notification(int p_what);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 	void _accessibility_action_menu(const Variant &p_data);
 
 public:
-	void set_as_favorite(EditorInspector *p_for_inspector);
+	void set_as_favorite();
+	void set_property_info(const PropertyInfo &p_info);
+	void set_doc_class_name(const String &p_name);
 
 	virtual Size2 get_minimum_size() const override;
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
@@ -555,7 +562,6 @@ public:
 class EditorInspector : public ScrollContainer {
 	GDCLASS(EditorInspector, ScrollContainer);
 
-	friend class EditorInspectorCategory;
 	friend class EditorPropertyResource;
 
 	enum {
@@ -564,15 +570,9 @@ class EditorInspector : public ScrollContainer {
 	static Ref<EditorInspectorPlugin> inspector_plugins[MAX_PLUGINS];
 	static int inspector_plugin_count;
 
-	// Right-click context menu options.
-	enum ClassMenuOption {
-		MENU_UNFAVORITE_ALL,
-	};
-
 	bool can_favorite = false;
 	PackedStringArray current_favorites;
 	VBoxContainer *favorites_section = nullptr;
-	EditorInspectorCategory *favorites_category = nullptr;
 	VBoxContainer *favorites_vbox = nullptr;
 	VBoxContainer *favorites_groups_vbox = nullptr;
 	HSeparator *favorites_separator = nullptr;
@@ -686,8 +686,6 @@ class EditorInspector : public ScrollContainer {
 
 	void _add_meta_confirm();
 	void _show_add_meta_dialog();
-
-	void _handle_menu_option(int p_option);
 
 protected:
 	static void _bind_methods();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -938,6 +938,7 @@ void EditorNode::_notification(int p_what) {
 			use_system_accent_color = EDITOR_GET("interface/theme/use_system_accent_color");
 
 			if (EditorThemeManager::is_generated_theme_outdated()) {
+				class_icon_cache.clear();
 				_update_theme();
 				_build_icon_type_cache();
 				recent_scenes->reset_size();


### PR DESCRIPTION
The current implementation of `EditorInspectorCategory` is hacky and unnecessarily complicated: Its context menu handling is spread in both `EditorInspector` and `EditorInspectorCategory`, requiring these two classes marking each other as `friend` :(

This PR:
- Simplified the implementation and removed the hacks.
- Adapted the control to locale & theme changes.
- Made the context menu lazy-created.