### PR TITLE
Correctly place viewport and use viewport relative rect for the final blit in Compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -431,9 +431,9 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 	Vector2 p2 = Vector2(flip_x ? p_screen_rect.position.x : screen_rect_end.x, flip_y ? p_screen_rect.position.y : screen_rect_end.y);
 	Vector2 size = p2 - p1;
 
-	Rect2 screenrect = Rect2(p1 / p_screen_rect.size, (size) / p_screen_rect.size);
+	Rect2 screenrect = Rect2(Vector2(flip_x ? 1.0 : 0.0, flip_y ? 1.0 : 0.0), Vector2(flip_x ? -1.0 : 1.0, flip_y ? -1.0 : 1.0));
 
-	glViewport(0, 0, Math::abs(size.x), Math::abs(size.y));
+	glViewport(int(MIN(p1.x, p2.x)), int(MIN(p1.y, p2.y)), Math::abs(size.x), Math::abs(size.y));
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(GL_TEXTURE_2D, rt->color);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/106890

The screen rect is a 0-1 range rect relative to the viewport, not the window. Further, previously the viewport was out of place since it was always located at 0,0. This led to a situation where the destination rect would try to render to an area outside the viewport and get culled. 

This fix works by always using 0-1 values for the screen rect, so they are always inside the viewport. It also preserves the flip_x, and flip_y hacks. Then it uses the viewport solely to determine where in the window the viewport is blitted. 