### PR TITLE
Core: Add `FixedArray` type, analogous to `std::array`

### DIFF
--- a/core/templates/fixed_array.h
+++ b/core/templates/fixed_array.h
@@ -1,0 +1,140 @@
+/**************************************************************************/
+/*  fixed_array.h                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/span.h"
+
+/**
+ * A high performance array of fixed size, analogous to std::array.
+ * Especially useful if you need to create arrays statically,
+ * or return a known number of elements from a function.
+ *
+ */
+template <class T, uint32_t SIZE>
+class FixedArray {
+	alignas(T) uint8_t _data[SIZE * sizeof(T)];
+
+public:
+	constexpr FixedArray() {
+		for (uint32_t i = 0; i < SIZE; i++) {
+			memnew_placement(ptr() + i, T);
+		}
+	}
+
+	constexpr FixedArray(std::initializer_list<T> p_init) {
+		CRASH_COND(p_init.size() != SIZE);
+
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			memcpy((void *)_data, (void *)p_init.begin(), SIZE * sizeof(T));
+		} else {
+			for (uint32_t i = 0; i < SIZE; i++) {
+				memnew_placement(ptr() + i, T(p_init.begin()[i]));
+			}
+		}
+	}
+
+	constexpr FixedArray(const FixedArray &p_from) {
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			memcpy((void *)_data, (void *)p_from._data, SIZE * sizeof(T));
+		} else {
+			for (uint32_t i = 0; i < SIZE; i++) {
+				memnew_placement(ptr() + i, T(p_from.ptr()[i]));
+			}
+		}
+	}
+
+	constexpr FixedArray(FixedArray &&p_from) {
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			memcpy((void *)_data, (void *)p_from._data, SIZE * sizeof(T));
+		} else {
+			for (uint32_t i = 0; i < SIZE; i++) {
+				memnew_placement(ptr() + i, T(std::move(p_from.ptr()[i])));
+			}
+		}
+	}
+
+	constexpr FixedArray &operator=(const FixedArray &p_from) {
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			memcpy((void *)_data, (void *)p_from._data, SIZE * sizeof(T));
+		} else {
+			for (uint32_t i = 0; i < SIZE; i++) {
+				ptr()[i] = p_from.ptr()[i];
+			}
+		}
+		return *this;
+	}
+
+	constexpr FixedArray &operator=(FixedArray &&p_from) {
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			memcpy((void *)_data, (void *)p_from._data, SIZE * sizeof(T));
+		} else {
+			for (uint32_t i = 0; i < SIZE; i++) {
+				ptr()[i] = std::move(p_from.ptr()[i]);
+			}
+		}
+		return *this;
+	}
+
+	~FixedArray() {
+		if constexpr (!std::is_trivially_destructible_v<T>) {
+			for (uint32_t i = 0; i < SIZE; i++) {
+				ptr()[i].~T();
+			}
+		}
+	}
+
+	_FORCE_INLINE_ constexpr T *ptr() { return (T *)(_data); }
+	_FORCE_INLINE_ constexpr const T *ptr() const { return (const T *)(_data); }
+
+	_FORCE_INLINE_ constexpr operator Span<T>() const { return Span<T>(ptr(), SIZE); }
+	_FORCE_INLINE_ constexpr Span<T> span() const { return operator Span<T>(); }
+
+	_FORCE_INLINE_ static constexpr uint32_t size() { return SIZE; }
+
+	// NOTE: Subscripts sanity check the bounds to avoid undefined behavior.
+	//       This is slower than direct buffer access and can prevent autovectorization.
+	//       If the bounds are known, use ptr() subscript instead.
+	constexpr const T &operator[](uint32_t p_index) const {
+		CRASH_COND(p_index >= SIZE);
+		return ptr()[p_index];
+	}
+
+	constexpr T &operator[](uint32_t p_index) {
+		CRASH_COND(p_index >= SIZE);
+		return ptr()[p_index];
+	}
+
+	_FORCE_INLINE_ constexpr T *begin() { return ptr(); }
+	_FORCE_INLINE_ constexpr T *end() { return ptr() + SIZE; }
+
+	_FORCE_INLINE_ constexpr const T *begin() const { return ptr(); }
+	_FORCE_INLINE_ constexpr const T *end() const { return ptr() + SIZE; }
+};

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -53,8 +53,13 @@ public:
 	_FORCE_INLINE_ constexpr FixedVector() = default;
 	constexpr FixedVector(std::initializer_list<T> p_init) {
 		ERR_FAIL_COND(p_init.size() > CAPACITY);
-		for (const T &element : p_init) {
-			memnew_placement(ptr() + _size++, T(element));
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			memcpy((void *)_data, (void *)p_init.begin(), p_init.size() * sizeof(T));
+			_size = p_init.size();
+		} else {
+			for (const T &element : p_init) {
+				memnew_placement(ptr() + _size++, T(element));
+			}
 		}
 	}
 

--- a/tests/core/templates/test_fixed_array.h
+++ b/tests/core/templates/test_fixed_array.h
@@ -1,0 +1,86 @@
+/**************************************************************************/
+/*  test_fixed_array.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/templates/fixed_array.h"
+
+#include "tests/test_macros.h"
+
+namespace TestFixedArray {
+
+struct MoveOnly {
+	MoveOnly() = default;
+	MoveOnly(const MoveOnly &p) = delete;
+	MoveOnly(MoveOnly &&p) = default;
+	MoveOnly &operator=(const MoveOnly &p) = delete;
+	MoveOnly &operator=(MoveOnly &&p) = default;
+};
+
+TEST_CASE("[FixedArray] Basic Checks") {
+	FixedArray<uint16_t, 3> vector = { 1, 2, 3 };
+	CHECK_EQ(vector.size(), 3);
+	CHECK_EQ(vector[0], 1);
+	CHECK_EQ(vector[1], 2);
+	CHECK_EQ(vector[2], 3);
+
+	FixedArray<uint16_t, 3> vector1 = vector;
+	CHECK_EQ(vector1.size(), 3);
+	CHECK_EQ(vector1[0], 1);
+	CHECK_EQ(vector1[1], 2);
+	CHECK_EQ(vector1[2], 3);
+
+	// Test that move-only types can be used.
+	FixedArray<MoveOnly, 3> a;
+	FixedArray<MoveOnly, 3> b(a);
+	a = std::move(b);
+}
+
+TEST_CASE("[FixedArray] Alignment Checks") {
+	FixedArray<uint16_t, 4> vector_uint16;
+	CHECK((size_t)&vector_uint16[0] % alignof(uint16_t) == 0);
+	CHECK((size_t)&vector_uint16[1] % alignof(uint16_t) == 0);
+	CHECK((size_t)&vector_uint16[2] % alignof(uint16_t) == 0);
+	CHECK((size_t)&vector_uint16[3] % alignof(uint16_t) == 0);
+
+	FixedArray<uint32_t, 4> vector_uint32;
+	CHECK((size_t)&vector_uint32[0] % alignof(uint32_t) == 0);
+	CHECK((size_t)&vector_uint32[1] % alignof(uint32_t) == 0);
+	CHECK((size_t)&vector_uint32[2] % alignof(uint32_t) == 0);
+	CHECK((size_t)&vector_uint32[3] % alignof(uint32_t) == 0);
+
+	FixedArray<uint64_t, 4> vector_uint64;
+	CHECK((size_t)&vector_uint64[0] % alignof(uint64_t) == 0);
+	CHECK((size_t)&vector_uint64[1] % alignof(uint64_t) == 0);
+	CHECK((size_t)&vector_uint64[2] % alignof(uint64_t) == 0);
+	CHECK((size_t)&vector_uint64[3] % alignof(uint64_t) == 0);
+}
+
+} //namespace TestFixedArray

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -97,6 +97,7 @@
 #include "tests/core/string/test_translation_server.h"
 #include "tests/core/templates/test_a_hash_map.h"
 #include "tests/core/templates/test_command_queue.h"
+#include "tests/core/templates/test_fixed_array.h"
 #include "tests/core/templates/test_fixed_vector.h"
 #include "tests/core/templates/test_hash_map.h"
 #include "tests/core/templates/test_hash_set.h"


### PR DESCRIPTION
This is a high performance Vector-like object. In practice, we can use it to return a known number of objects from a function without allocation, or define static properties that aren't well suited as `[]` arrays. The type is fairly simple, and builds off the existing [`FixedVector` type](https://github.com/godotengine/godot/pull/104055).

It is analogous to `std::array`. As discussed in the core meeting, we want to avoid using STL, because we want the freedom to define our own interfaces.

I also saw that `initializer_list` init could be optimized with a `memcpy` call (in `FixedVector` as well). Compilers are known to optimize `memcpy` for small number of bytes by unrolling, so this should give us the best performance in all situations.

## Motivation

Some of the reasoning behind this data type is given by the [`std::array` documentation](https://en.cppreference.com/w/cpp/container/array.html).

One of the most important improvements over `T[]` is that `T[]` cannot be returned from functions. This is a limitation in C++ that is unlikely to be addressed. In the same vein, `T[]` cannot be assigned to.
Another reason is that `T[]` automatically decays to `T*`, which is unhelpful because size information is lost. 
Finally, you cannot overload functions onto `T[]`. For example, instead of our usual Godot-style `array.size()`, you need to use `std::size`, leading to inconsistency. In the future, we may want to expand `FixedArray` to support more Godot-style APIs, for consistency with other Godot containers.