### PR TITLE
Add More Annotations to GDScript

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1925,6 +1925,27 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 		}
 	}
 
+	if (p_function->must_call_super) {
+		if (p_is_lambda) {
+			push_error(R"(Cannot be used in lambda expressions)", p_function);
+		} else {
+			if (p_function->body->statements.size() == 0) {
+				push_error(R"(Must call the base class function)", p_function);
+				return;
+			}
+			GDScriptParser::Node *node = p_function->body->statements[0];
+			bool is_super = false;
+			if (node->type == GDScriptParser::Node::Type::CALL) {
+				GDScriptParser::CallNode *call_node = static_cast<GDScriptParser::CallNode *>(node);
+				if (!call_node->is_super) {
+					push_error(R"(Must call the base class function)", p_function);
+				}
+			} else {
+				push_error(R"(Must call the base class function)", p_function);
+			}
+		}
+	}
+
 	parser->current_function = previous_function;
 	static_context = previous_static_context;
 }

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1806,7 +1806,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 		BitField<MethodFlags> method_flags = {};
 		StringName native_base;
 		GDScriptParser::Node::AccessLevel acceess_level = GDScriptParser::Node::PUBLIC;
-		if (!p_is_lambda && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, &native_base)) {
+		if (!p_is_lambda && get_function_signature(p_function, false, base_type, function_name, parent_return_type, parameters_types, default_par_count, method_flags, acceess_level, &native_base)) {
 			bool valid = p_function->is_static == method_flags.has_flag(METHOD_FLAG_STATIC);
 
 			if (p_function->return_type != nullptr) {
@@ -4822,6 +4822,18 @@ void GDScriptAnalyzer::reduce_subscript(GDScriptParser::SubscriptNode *p_subscri
 					p_subscript->reduced_value = value;
 					result_type = type_from_variant(value, p_subscript);
 				}
+			}
+		}
+
+		for (GDScriptParser::ClassNode::Member member : base_type.class_type->members) {
+			if (member.get_name() == p_subscript->attribute->name) {
+				for (GDScriptParser::AnnotationNode *annotation : member.get_source_node()->annotations) {
+					if (annotation->name == "@protected" || annotation->name == "@protected") {
+						push_error(R"(Access restricted.)", p_subscript);
+						break;
+					}
+				}
+				break;
 			}
 		}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3656,6 +3656,9 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			base_type.is_meta_type = false; // For `to_string()`.
 			push_error(vformat(R"*(Cannot call non-static function "%s()" on the class "%s" directly. Make an instance instead.)*", p_call->function_name, base_type.to_string()), p_call);
 		} else if (is_self && !p_call->is_static) {
+			if (access_level < GDScriptParser::Node::AccessLevel::PROTECTED) {
+				push_error(R"(Access restricted.)", p_call);
+			}
 			mark_lambda_use_self();
 		} else if (!is_self && access_level < GDScriptParser::Node::AccessLevel::PUBLIC) {
 			push_error(R"(Access restricted.)", p_call);

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4199,6 +4199,7 @@ void GDScriptAnalyzer::reduce_identifier_from_base(GDScriptParser::IdentifierNod
 					if (is_base && (!base.is_meta_type || member.variable->is_static)) {
 						p_identifier->set_datatype(member.get_datatype());
 						p_identifier->source = member.variable->is_static ? GDScriptParser::IdentifierNode::STATIC_VARIABLE : GDScriptParser::IdentifierNode::MEMBER_VARIABLE;
+						p_identifier->is_base = is_base;
 						p_identifier->variable_source = member.variable;
 						member.variable->usages += 1;
 						return;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3657,6 +3657,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 			push_error(vformat(R"*(Cannot call non-static function "%s()" on the class "%s" directly. Make an instance instead.)*", p_call->function_name, base_type.to_string()), p_call);
 		} else if (is_self && !p_call->is_static) {
 			mark_lambda_use_self();
+		} else if (!is_self && access_level < GDScriptParser::Node::AccessLevel::PUBLIC) {
+			push_error(R"(Access restricted.)", p_call);
 		}
 
 		if (!p_is_root && !p_is_await && return_type.is_hard_type() && return_type.kind == GDScriptParser::DataType::BUILTIN && return_type.builtin_type == Variant::NIL) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3614,6 +3614,8 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		p_call->is_static = method_flags.has_flag(METHOD_FLAG_STATIC);
 		if (p_call->is_super && method_flags.has_flag(METHOD_FLAG_VIRTUAL)) {
 			push_error(vformat(R"*(Cannot call the parent class' virtual function "%s()" because it hasn't been defined.)*", p_call->function_name), p_call);
+		} else if (p_call->is_super && access_level < GDScriptParser::Node::AccessLevel::PROTECTED) {
+			push_error(R"(Access restricted.)", p_call);
 		}
 
 		// If the function requires typed arrays we must make literals be typed.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -4475,6 +4475,18 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 			} else {
 				push_error(vformat(R"*(Cannot access %s "%s" from a static variable initializer.)*", source_type, p_identifier->name), p_identifier);
 			}
+		} else if (!static_context && source_is_instance_variable) {
+			switch (p_identifier->variable_source->access_level) {
+				case GDScriptParser::Node::AccessLevel::PRIVATE: {
+					if (p_identifier->is_base || p_identifier->source != GDScriptParser::IdentifierNode::MEMBER_VARIABLE) {
+						push_error(R"(Access restricted.)", p_identifier);
+					}
+				} break;
+				case GDScriptParser::Node::AccessLevel::PROTECTED: {
+				} break;
+				default:
+					break;
+			}
 		}
 
 		if (current_lambda != nullptr) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -128,7 +128,7 @@ class GDScriptAnalyzer {
 	GDScriptParser::DataType type_from_variant(const Variant &p_value, const GDScriptParser::Node *p_source);
 	GDScriptParser::DataType type_from_property(const PropertyInfo &p_property, bool p_is_arg = false, bool p_is_readonly = false) const;
 	GDScriptParser::DataType make_global_class_meta_type(const StringName &p_class_name, const GDScriptParser::Node *p_source);
-	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, BitField<MethodFlags> &r_method_flags, StringName *r_native_class = nullptr);
+	bool get_function_signature(GDScriptParser::Node *p_source, bool p_is_constructor, GDScriptParser::DataType base_type, const StringName &p_function, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, BitField<MethodFlags> &r_method_flags, GDScriptParser::Node::AccessLevel &access_level, StringName *r_native_class = nullptr);
 	bool function_signature_from_info(const MethodInfo &p_info, GDScriptParser::DataType &r_return_type, List<GDScriptParser::DataType> &r_par_types, int &r_default_arg_count, BitField<MethodFlags> &r_method_flags);
 	void validate_call_arg(const List<GDScriptParser::DataType> &p_par_types, int p_default_args_count, bool p_is_vararg, const GDScriptParser::CallNode *p_call);
 	void validate_call_arg(const MethodInfo &p_method, const GDScriptParser::CallNode *p_call);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4360,6 +4360,28 @@ bool GDScriptParser::must_call_super_annotation(AnnotationNode *p_annotation, No
 	return true;
 }
 
+bool GDScriptParser::protected_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::CONSTANT && p_target->type != Node::VARIABLE && p_target->type != Node::FUNCTION && p_target->type != Node::CLASS && p_target->type != Node::SIGNAL,
+			false, R"(@protected can only be applied to constants, variables, signals, functions, and classes.)");
+	if (p_target->access_level != GDScriptParser::Node::AccessLevel::PUBLIC) {
+		push_error(R"(Only one of @protected/@private is allowed, and it can be used only once.)", p_target);
+		return false;
+	}
+	p_target->access_level = GDScriptParser::Node::AccessLevel::PROTECTED;
+	return true;
+}
+
+bool GDScriptParser::private_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::CONSTANT && p_target->type != Node::VARIABLE && p_target->type != Node::FUNCTION && p_target->type != Node::CLASS && p_target->type != Node::SIGNAL,
+			false, R"(@private can only be applied to constants, variables, signals, functions, and classes.)");
+	if (p_target->access_level != GDScriptParser::Node::AccessLevel::PUBLIC) {
+		push_error(R"(Only one of @protected/@private is allowed, and it can be used only once.)", p_target);
+		return false;
+	}
+	p_target->access_level = GDScriptParser::Node::AccessLevel::PRIVATE;
+	return true;
+}
+
 bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@onready" annotation can only be applied to class variables.)");
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -96,6 +96,9 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@tool"), AnnotationInfo::SCRIPT, &GDScriptParser::tool_annotation);
 		register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
+		register_annotation(MethodInfo("@must_call_super"), AnnotationInfo::FUNCTION, &GDScriptParser::must_call_super_annotation);
+		register_annotation(MethodInfo("@protected"), AnnotationInfo::CLASS_LEVEL, &GDScriptParser::protected_annotation);
+		register_annotation(MethodInfo("@private"), AnnotationInfo::CLASS_LEVEL, &GDScriptParser::private_annotation);
 		// Onready annotation.
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4349,6 +4349,17 @@ bool GDScriptParser::static_unload_annotation(AnnotationNode *p_annotation, Node
 	return true;
 }
 
+bool GDScriptParser::must_call_super_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::FUNCTION, false, R"("@must_call_super" annotation can only be applied to functions.)");
+	FunctionNode *func_node = static_cast<FunctionNode *>(p_target);
+	if (func_node->must_call_super) {
+		push_error(vformat(R"("%s" annotation can only be used once per function.)", p_annotation->name), p_annotation);
+		return false;
+	}
+	func_node->must_call_super = true;
+	return true;
+}
+
 bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, R"("@onready" annotation can only be applied to class variables.)");
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -921,6 +921,7 @@ public:
 			FunctionNode *function_source;
 		};
 		bool function_source_is_static = false; // For non-GDScript scripts.
+		bool is_base = false;
 
 		FunctionNode *source_function = nullptr; // TODO: Rename to disambiguate `function_source`.
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1529,6 +1529,7 @@ private:
 	bool tool_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool must_call_super_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1538,6 +1538,8 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool must_call_super_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool protected_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool private_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -336,7 +336,15 @@ public:
 			WHILE,
 		};
 
+		enum AccessLevel {
+			PRIVATE,
+			PROTECTED,
+			FRIEND,
+			PUBLIC
+		};
+
 		Type type = NONE;
+		AccessLevel access_level = PUBLIC;
 		int start_line = 0, end_line = 0;
 		int start_column = 0, end_column = 0;
 		int leftmost_column = 0, rightmost_column = 0;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -856,6 +856,7 @@ public:
 		SuiteNode *body = nullptr;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
+		bool must_call_super = false;
 		Variant rpc_config;
 		MethodInfo info;
 		LambdaNode *source_lambda = nullptr;


### PR DESCRIPTION
GDScript currently has limited static checks. We should introduce annotations like Dart's [meta](https://pub.dev/packages/meta), such as:

@mustCallSuper (mandatory parent call)
@protected (function visibility)