### PR TITLE
Update the windows CI emoji to an actual window

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -36,7 +36,7 @@ jobs:
     uses: ./.github/workflows/macos_builds.yml
 
   windows-build:
-    name: 🏁 Windows
+    name: 🪟 Windows
     needs: static-checks
     uses: ./.github/workflows/windows_builds.yml
 

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -1,4 +1,4 @@
-name: 🏁 Windows Builds
+name: 🪟 Windows Builds
 on:
   workflow_call:
 


### PR DESCRIPTION
I was just thinking - why are we using 🏁 as CI icon for windows when we have 🪟 ?!

![CleanShot-000128-Safari](https://github.com/user-attachments/assets/e340e328-6d6c-4a68-88c6-e6fca7d3ec0b)
