### PR TITLE
Fix alphabetical order of codespell ignore list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ ignore-words-list = [
 	"inout",
 	"labelin",
 	"lod",
+	"masia",
 	"mis",
 	"nd",
 	"numer",
@@ -89,5 +90,4 @@ ignore-words-list = [
 	"textin",
 	"thirdparty",
 	"vai",
-	"Masia",
 ]


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/102330 added an entry to the codespell ignore list, but it didn't follow the alphabetical order. This PR fixes this.