### PR TITLE
Add missing headers in `FixedVector` and `Span`

### DIFF
--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#include "core/templates/span.h"
+
 /**
  * A high performance Vector of fixed capacity.
  * Especially useful if you need to create an array on the stack, to

--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/error/error_macros.h"
 #include "core/typedefs.h"
 
 // Equivalent of std::span.


### PR DESCRIPTION
My IDE indicates missing headers when I opened these two files: 

![屏幕截图_20250530_134847](https://github.com/user-attachments/assets/478ff7e2-68ac-4562-96db-5558e9c435ad)
