### PR TITLE
Editor: Make the description area in “Create New Node” dialog resizable

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -890,10 +890,14 @@ CreateDialog::CreateDialog() {
 	recent->add_theme_constant_override("draw_guides", 1);
 	recent->set_theme_type_variation("ItemListSecondary");
 
-	VBoxContainer *vbc = memnew(VBoxContainer);
-	vbc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	vbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	hsc->add_child(vbc);
+	VSplitContainer *right_vsc = memnew(VSplitContainer);
+	right_vsc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
+	right_vsc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	hsc->add_child(right_vsc);
+
+	VBoxContainer *search_vbc = memnew(VBoxContainer);
+	search_vbc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	right_vsc->add_child(search_vbc);
 
 	search_box = memnew(LineEdit);
 	search_box->set_accessibility_name(TTRC("Search"));
@@ -911,7 +915,7 @@ CreateDialog::CreateDialog() {
 	favorite->set_accessibility_name(TTRC("(Un)favorite"));
 	favorite->connect(SceneStringName(pressed), callable_mp(this, &CreateDialog::_favorite_toggled));
 	search_hb->add_child(favorite);
-	vbc->add_margin_child(TTR("Search:"), search_hb);
+	search_vbc->add_margin_child(TTR("Search:"), search_hb);
 
 	search_options = memnew(Tree);
 	search_options->set_accessibility_name(TTRC("Matches"));
@@ -919,13 +923,18 @@ CreateDialog::CreateDialog() {
 	search_options->connect("item_activated", callable_mp(this, &CreateDialog::_confirmed));
 	search_options->connect("cell_selected", callable_mp(this, &CreateDialog::_item_selected));
 	search_options->connect("button_clicked", callable_mp(this, &CreateDialog::_script_button_clicked));
-	vbc->add_margin_child(TTR("Matches:"), search_options, true);
+	search_vbc->add_margin_child(TTR("Matches:"), search_options, true);
+
+	VBoxContainer *description_vbc = memnew(VBoxContainer);
+	description_vbc->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
+	right_vsc->add_child(description_vbc);
 
 	help_bit = memnew(EditorHelpBit);
 	help_bit->set_accessibility_name(TTRC("Description"));
-	help_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);
 	help_bit->connect("request_hide", callable_mp(this, &CreateDialog::_hide_requested));
-	vbc->add_margin_child(TTR("Description:"), help_bit);
+	help_bit->set_content_height_limits(80 * EDSCALE, 300 * EDSCALE);
+	help_bit->set_allow_resizing(true);
+	description_vbc->add_margin_child(TTR("Description:"), help_bit, true);
 
 	register_text_enter(search_box);
 	set_hide_on_ok(false);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -4483,12 +4483,30 @@ void EditorHelpBit::set_content_height_limits(float p_min, float p_max) {
 }
 
 void EditorHelpBit::update_content_height() {
-	float content_height = content->get_content_height();
-	const Ref<StyleBox> style = content->get_theme_stylebox(CoreStringName(normal));
-	if (style.is_valid()) {
-		content_height += style->get_content_margin(SIDE_TOP) + style->get_content_margin(SIDE_BOTTOM);
+	if (allow_resizing) {
+		content->set_custom_minimum_size(Size2(content->get_custom_minimum_size().x, content_min_height));
+	} else {
+		float content_height = content->get_content_height();
+		const Ref<StyleBox> style = content->get_theme_stylebox(CoreStringName(normal));
+		if (style.is_valid()) {
+			content_height += style->get_content_margin(SIDE_TOP) + style->get_content_margin(SIDE_BOTTOM);
+		}
+		content->set_custom_minimum_size(Size2(content->get_custom_minimum_size().x, CLAMP(content_height, content_min_height, content_max_height)));
 	}
-	content->set_custom_minimum_size(Size2(content->get_custom_minimum_size().x, CLAMP(content_height, content_min_height, content_max_height)));
+}
+
+void EditorHelpBit::set_allow_resizing(bool p_allow) {
+	if (allow_resizing != p_allow) {
+		allow_resizing = p_allow;
+		if (allow_resizing) {
+			content->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+		} else {
+			content->set_v_size_flags(Control::SIZE_SHRINK_END);
+		}
+		if (is_inside_tree()) {
+			call_deferred("update_content_height");
+		}
+	}
 }
 
 EditorHelpBit::EditorHelpBit(const String &p_symbol, const String &p_prologue, bool p_use_class_prefix, bool p_allow_selection) {

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -331,6 +331,7 @@ class EditorHelpBit : public VBoxContainer {
 
 	float content_min_height = 0.0;
 	float content_max_height = 0.0;
+	bool allow_resizing = false;
 
 	static HelpData _get_class_help_data(const StringName &p_class_name);
 	static HelpData _get_enum_help_data(const StringName &p_class_name, const StringName &p_enum_name);
@@ -355,6 +356,7 @@ public:
 	void set_custom_text(const String &p_type, const String &p_name, const String &p_description);
 
 	void set_content_height_limits(float p_min, float p_max);
+	void set_allow_resizing(bool p_allow);
 	void update_content_height();
 
 	EditorHelpBit(const String &p_symbol = String(), const String &p_prologue = String(), bool p_use_class_prefix = false, bool p_allow_selection = true);


### PR DESCRIPTION
Discussed in [godot-proposals#12517](https://github.com/godotengine/godot-proposals/issues/12517)

**Changes:**
- Refactor `CreateDialog` to use `VSplitContainer` to allow manual resizing.
- Introduce resizing capability in `EditorHelpBit`, allowing dynamic height adjustments.
- Update related methods to support new resizing behavior.

**Testing:**
Tested the "Create New Node" dialog on macOS. I did not observe any behavior differences compared to the `master` branch, except for the resizable description area. Opening, closing, and resizing the dialog all worked as expected.
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
