### PR TITLE
Fix `get_class_icon()` ignoring fallback

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5202,9 +5202,11 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 
 Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p_fallback) {
 	ERR_FAIL_COND_V_MSG(p_class.is_empty(), nullptr, "Class name cannot be empty.");
+	const Pair<String, String> key(p_class, p_fallback);
+
 	// Take from the local cache, if available.
 	{
-		Ref<Texture2D> *icon = class_icon_cache.getptr(p_class);
+		Ref<Texture2D> *icon = class_icon_cache.getptr(key);
 		if (icon) {
 			return *icon;
 		}
@@ -5218,7 +5220,7 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	}
 
 	Ref<Texture2D> icon = _get_class_or_script_icon(p_class, script_path, p_fallback, true);
-	class_icon_cache[p_class] = icon;
+	class_icon_cache[key] = icon;
 	return icon;
 }
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -484,7 +484,7 @@ private:
 	PrintHandlerList print_handler;
 
 	HashMap<String, Ref<Texture2D>> icon_type_cache;
-	HashMap<String, Ref<Texture2D>> class_icon_cache;
+	HashMap<Pair<String, String>, Ref<Texture2D>> class_icon_cache;
 
 	ProjectUpgradeTool *project_upgrade_tool = nullptr;
 	bool run_project_upgrade_tool = false;


### PR DESCRIPTION
Fixes crash introduced by #106866
```
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.5.dev.custom_build (b89c47bb8511433440e5e547afe4459ca3383090)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[0] EditorHelp::_add_type_icon (C:\godot_source\editor\editor_help.cpp:471)
[1] EditorHelp::_add_type_icon (C:\godot_source\editor\editor_help.cpp:471)
[2] EditorHelp::_update_doc (C:\godot_source\editor\editor_help.cpp:1015)
[3] EditorHelp::_goto_desc (C:\godot_source\editor\editor_help.cpp:695)
[4] EditorHelp::_request_help (C:\godot_source\editor\editor_help.cpp:2312)
[5] EditorHelp::_help_callback (C:\godot_source\editor\editor_help.cpp:2328)
[6] EditorHelp::go_to_help (C:\godot_source\editor\editor_help.cpp:3263)
[7] ScriptEditor::_help_class_goto (C:\godot_source\editor\plugins\script_editor_plugin.cpp:3705)
[8] call_with_variant_args_helper<ScriptEditor,String const &,0> (C:\godot_source\core\variant\binder_common.h:223)
[9] call_with_variant_args<ScriptEditor,String const &> (C:\godot_source\core\variant\binder_common.h:338)
[10] CallableCustomMethodPointer<ScriptEditor,void,String const &>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[11] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[12] Object::emit_signalp (C:\godot_source\core\object\object.cpp:1288)
[13] Node::emit_signalp (C:\godot_source\scene\main\node.cpp:4315)
[14] Object::emit_signal<Variant> (C:\godot_source\core\object\object.h:934)
[15] EditorHelpSearch::_confirmed (C:\godot_source\editor\editor_help_search.cpp:202)
[16] call_with_variant_args_helper<EditorHelpSearch> (C:\godot_source\core\variant\binder_common.h:228)
[17] call_with_variant_args<EditorHelpSearch> (C:\godot_source\core\variant\binder_common.h:338)
[18] CallableCustomMethodPointer<EditorHelpSearch,void>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[19] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[20] Object::emit_signalp (C:\godot_source\core\object\object.cpp:1288)
[21] Node::emit_signalp (C:\godot_source\scene\main\node.cpp:4315)
[22] Object::emit_signal<> (C:\godot_source\core\object\object.h:934)
[23] Tree::gui_input (C:\godot_source\scene\gui\tree.cpp:4173)
[24] Control::_call_gui_input (C:\godot_source\scene\gui\control.cpp:1866)
[25] Viewport::_gui_call_input (C:\godot_source\scene\main\viewport.cpp:1728)
[26] Viewport::_gui_input_event (C:\godot_source\scene\main\viewport.cpp:1959)
[27] Viewport::push_input (C:\godot_source\scene\main\viewport.cpp:3427)
[28] Window::_window_input (C:\godot_source\scene\main\window.cpp:1839)
[29] call_with_variant_args_helper<Window,Ref<InputEvent> const &,0> (C:\godot_source\core\variant\binder_common.h:223)
[30] call_with_variant_args<Window,Ref<InputEvent> const &> (C:\godot_source\core\variant\binder_common.h:338)
[31] CallableCustomMethodPointer<Window,void,Ref<InputEvent> const &>::call (C:\godot_source\core\object\callable_method_pointer.h:107)
[32] Callable::callp (C:\godot_source\core\variant\callable.cpp:58)
[33] Callable::call<Ref<InputEvent> > (C:\godot_source\core\variant\variant.h:953)
[34] DisplayServerWindows::_dispatch_input_event (C:\godot_source\platform\windows\display_server_windows.cpp:4414)
[35] DisplayServerWindows::_dispatch_input_events (C:\godot_source\platform\windows\display_server_windows.cpp:4385)
[36] Input::_parse_input_event_impl (C:\godot_source\core\input\input.cpp:903)
[37] Input::flush_buffered_events (C:\godot_source\core\input\input.cpp:1184)
[38] DisplayServerWindows::process_events (C:\godot_source\platform\windows\display_server_windows.cpp:3798)
[39] OS_Windows::run (C:\godot_source\platform\windows\os_windows.cpp:2278)
[40] widechar_main (C:\godot_source\platform\windows\godot_windows.cpp:97)
[42] main (C:\godot_source\platform\windows\godot_windows.cpp:136)
[43] WinMain (C:\godot_source\platform\windows\godot_windows.cpp:150)
[44] __scrt_common_main_seh (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[45] <couldn't map PC to fn name>
-- END OF C++ BACKTRACE --
```
`get_class_icon()` has a fallback argument and seems like it can be called with different fallbacks for the same icon, which means that it could incorrectly return an empty icon when there was fallback available. Some code expects the icon to never be null (as seen in the crash above).

To replicate the crash make a script that extends Node and open Node's doc page.