### PR TITLE
Allow binding enum display names

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1140,7 +1140,7 @@ MethodBind *ClassDB::get_method_with_compatibility(const StringName &p_class, co
 	return nullptr;
 }
 
-void ClassDB::bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield) {
+void ClassDB::bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield, const String &p_display_name) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
 	ClassInfo *type = classes.getptr(p_class);
@@ -1160,16 +1160,21 @@ void ClassDB::bind_integer_constant(const StringName &p_class, const StringName 
 		}
 
 		ClassInfo::EnumInfo *constants_list = type->enum_map.getptr(enum_name);
-
-		if (constants_list) {
-			constants_list->constants.push_back(p_name);
-			constants_list->is_bitfield = p_is_bitfield;
-		} else {
+		if (!constants_list) {
 			ClassInfo::EnumInfo new_list;
 			new_list.is_bitfield = p_is_bitfield;
-			new_list.constants.push_back(p_name);
-			type->enum_map[enum_name] = new_list;
+			HashMap<StringName, ClassDB::ClassInfo::EnumInfo>::Iterator I = type->enum_map.insert(enum_name, new_list);
+			constants_list = &I->value;
 		}
+
+		constants_list->constants.push_back(p_name);
+#ifdef TOOLS_ENABLED
+		if (!p_display_name.is_empty()) {
+			constants_list->display_names.push_back(p_display_name);
+		}
+#endif
+		DEV_ASSERT(constants_list->display_names.is_empty() || constants_list->display_names.size() == constants_list->constants.size());
+		DEV_ASSERT(constants_list->is_bitfield == p_is_bitfield);
 	}
 
 #ifdef DEBUG_ENABLED
@@ -1307,6 +1312,29 @@ void ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_
 
 		type = type->inherits_ptr;
 	}
+}
+
+PackedStringArray ClassDB::get_enum_display_names(const StringName &p_class, const StringName &p_enum) {
+	Locker::Lock lock(Locker::STATE_READ);
+	PackedStringArray ret;
+
+	ClassInfo *type = classes.getptr(p_class);
+	while (type) {
+		const ClassInfo::EnumInfo *constants = type->enum_map.getptr(p_enum);
+		if (constants) {
+			ret.resize(constants->display_names.size());
+			String *ret_write = ret.ptrw();
+
+			int i = 0;
+			for (const String &display_name : constants->display_names) {
+				ret_write[i] = display_name;
+				i++;
+			}
+			break;
+		}
+		type = type->inherits_ptr;
+	}
+	return ret;
 }
 
 void ClassDB::set_method_error_return_values(const StringName &p_class, const StringName &p_method, const Vector<Error> &p_values) {
@@ -1882,6 +1910,7 @@ int ClassDB::get_method_argument_count(const StringName &p_class, const StringNa
 void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method) {
 	_bind_method_custom(p_class, p_method, false);
 }
+
 void ClassDB::bind_compatibility_method_custom(const StringName &p_class, MethodBind *p_method) {
 	_bind_method_custom(p_class, p_method, true);
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -131,6 +131,9 @@ public:
 		AHashMap<StringName, int64_t> constant_map;
 		struct EnumInfo {
 			List<StringName> constants;
+#ifdef TOOLS_ENABLED
+			List<String> display_names;
+#endif
 			bool is_bitfield = false;
 		};
 
@@ -502,7 +505,7 @@ public:
 	static void add_extension_class_virtual_method(const StringName &p_class, const GDExtensionClassVirtualMethodInfo *p_method_info);
 	static Vector<uint32_t> get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
 
-	static void bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
+	static void bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false, const String &p_display_name = String());
 	static void get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);
 	static int64_t get_integer_constant(const StringName &p_class, const StringName &p_name, bool *p_success = nullptr);
 	static bool has_integer_constant(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
@@ -511,6 +514,7 @@ public:
 	static StringName get_integer_constant_bitfield(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 	static void get_enum_list(const StringName &p_class, List<StringName> *p_enums, bool p_no_inheritance = false);
 	static void get_enum_constants(const StringName &p_class, const StringName &p_enum, List<StringName> *p_constants, bool p_no_inheritance = false);
+	static PackedStringArray get_enum_display_names(const StringName &p_class, const StringName &p_enum);
 	static bool has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 	static bool is_enum_bitfield(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false);
 
@@ -553,6 +557,9 @@ public:
 
 #define BIND_ENUM_CONSTANT(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), #m_constant, m_constant);
+
+#define BIND_NAMED_ENUM_CONSTANT(m_constant, m_display_name) \
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), #m_constant, m_constant, false, m_display_name);
 
 #define BIND_BITFIELD_FLAG(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_bitfield_name(m_constant), #m_constant, m_constant, true);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3775,7 +3775,13 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		case Variant::INT: {
 			if (p_hint == PROPERTY_HINT_ENUM) {
 				EditorPropertyEnum *editor = memnew(EditorPropertyEnum);
-				Vector<String> options = p_hint_text.split(",");
+				Vector<String> options;
+				if (p_hint_text.begins_with("*")) {
+					// This is not supported officially. For internal use by engine classes.
+					options = ClassDB::get_enum_display_names(p_object->get_class_name(), p_hint_text.substr(1));
+				} else {
+					options = p_hint_text.split(",", false);
+				}
 				editor->setup(options);
 				return editor;
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4270,7 +4270,7 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Tooltip", "tooltip_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "tooltip_text", PROPERTY_HINT_MULTILINE_TEXT), "set_tooltip_text", "get_tooltip_text");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "tooltip_auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_tooltip_auto_translate_mode", "get_tooltip_auto_translate_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "tooltip_auto_translate_mode", PROPERTY_HINT_ENUM, "*AutoTranslateMode"), "set_tooltip_auto_translate_mode", "get_tooltip_auto_translate_mode");
 
 	ADD_GROUP("Focus", "focus_");
 	ADD_PROPERTYI(PropertyInfo(Variant::NODE_PATH, "focus_neighbor_left", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Control"), "set_focus_neighbor", "get_focus_neighbor", SIDE_LEFT);
@@ -4279,7 +4279,7 @@ void Control::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::NODE_PATH, "focus_neighbor_bottom", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Control"), "set_focus_neighbor", "get_focus_neighbor", SIDE_BOTTOM);
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "focus_next", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Control"), "set_focus_next", "get_focus_next");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "focus_previous", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Control"), "set_focus_previous", "get_focus_previous");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "focus_mode", PROPERTY_HINT_ENUM, "None,Click,All,Accessibility"), "set_focus_mode", "get_focus_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "focus_mode", PROPERTY_HINT_ENUM, "*FocusMode"), "set_focus_mode", "get_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "focus_behavior_recursive", PROPERTY_HINT_ENUM, "Inherited,Disabled,Enabled"), "set_focus_behavior_recursive", "get_focus_behavior_recursive");
 
 	ADD_GROUP("Mouse", "mouse_");
@@ -4304,10 +4304,10 @@ void Control::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "theme", PROPERTY_HINT_RESOURCE_TYPE, "Theme"), "set_theme", "get_theme");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "theme_type_variation", PROPERTY_HINT_ENUM_SUGGESTION), "set_theme_type_variation", "get_theme_type_variation");
 
-	BIND_ENUM_CONSTANT(FOCUS_NONE);
-	BIND_ENUM_CONSTANT(FOCUS_CLICK);
-	BIND_ENUM_CONSTANT(FOCUS_ALL);
-	BIND_ENUM_CONSTANT(FOCUS_ACCESSIBILITY);
+	BIND_NAMED_ENUM_CONSTANT(FOCUS_NONE, "None");
+	BIND_NAMED_ENUM_CONSTANT(FOCUS_CLICK, "Click");
+	BIND_NAMED_ENUM_CONSTANT(FOCUS_ALL, "All");
+	BIND_NAMED_ENUM_CONSTANT(FOCUS_ACCESSIBILITY, "Accessibility");
 
 	BIND_ENUM_CONSTANT(FOCUS_BEHAVIOR_INHERITED);
 	BIND_ENUM_CONSTANT(FOCUS_BEHAVIOR_DISABLED);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3977,9 +3977,9 @@ void Node::_bind_methods() {
 	BIND_ENUM_CONSTANT(INTERNAL_MODE_FRONT);
 	BIND_ENUM_CONSTANT(INTERNAL_MODE_BACK);
 
-	BIND_ENUM_CONSTANT(AUTO_TRANSLATE_MODE_INHERIT);
-	BIND_ENUM_CONSTANT(AUTO_TRANSLATE_MODE_ALWAYS);
-	BIND_ENUM_CONSTANT(AUTO_TRANSLATE_MODE_DISABLED);
+	BIND_NAMED_ENUM_CONSTANT(AUTO_TRANSLATE_MODE_INHERIT, "Inherit");
+	BIND_NAMED_ENUM_CONSTANT(AUTO_TRANSLATE_MODE_ALWAYS, "Always");
+	BIND_NAMED_ENUM_CONSTANT(AUTO_TRANSLATE_MODE_DISABLED, "Disabled");
 
 	ADD_SIGNAL(MethodInfo("ready"));
 	ADD_SIGNAL(MethodInfo("renamed"));
@@ -4014,7 +4014,7 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "physics_interpolation_mode", PROPERTY_HINT_ENUM, "Inherit,On,Off"), "set_physics_interpolation_mode", "get_physics_interpolation_mode");
 
 	ADD_GROUP("Auto Translate", "auto_translate_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_auto_translate_mode", "get_auto_translate_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "*AutoTranslateMode"), "set_auto_translate_mode", "get_auto_translate_mode");
 
 	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");


### PR DESCRIPTION
When defining class' enums, you need to define their constants, and then separately enum hint, if you want the enum to be used in the inspector. If you want to reuse the enum multiple times, you need to copy the same hint for every property. And if you decide to add some new values to the enum, you have to remember to update the hints.

This PR solves that by allowing to bind constant's display name. I added new `BIND_NAMED_ENUM_CONSTANT()`, which takes additional String parameter. In `PROPERTY_HINT_ENUM`, instead of repeating the names, you can now use `*EnumName`, which will automatically fetch the bound value names.

I came up with this just today and made a quick implementation, so putting as draft for now for potential discussion xd
I applied the new hint style to some properties as an example.