### PR TITLE
Fix infinite recursion on `GDScriptTests` if a script cannot be reloaded.

### DIFF
--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -655,6 +655,8 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		result.status = GDTEST_LOAD_ERROR;
 		result.output = "";
 		result.passed = false;
+		remove_print_handler(&_print_handler);
+		remove_error_handler(&_error_handler);
 		ERR_FAIL_V_MSG(result, "\nCould not reload script: '" + source_file + "'");
 	}
 


### PR DESCRIPTION
Regression from https://github.com/godotengine/godot/pull/87634.

When `ERR_FAIL_V_MSG` is triggered, printing anything will currently produce an infinite loop.
This doesn't affect `master`, as it's expected to pass the tests. Only broken dev builds can be affected.