### PR TITLE
Fix `AudioStreamSynchronized` pops and clicks when changing the volume of a sync stream

### DIFF
--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -47,7 +47,7 @@ private:
 
 	int stream_count = 0;
 	Ref<AudioStream> audio_streams[MAX_STREAMS];
-	float audio_stream_volume_db[MAX_STREAMS] = {};
+	float audio_stream_volume_linear[MAX_STREAMS] = {};
 	HashSet<AudioStreamPlaybackSynchronized *> playbacks;
 
 public:
@@ -90,6 +90,8 @@ private:
 	Ref<AudioStreamPlayback> playback[AudioStreamSynchronized::MAX_STREAMS];
 
 	int play_order[AudioStreamSynchronized::MAX_STREAMS];
+
+	float stream_volume_linear_previous[AudioStreamSynchronized::MAX_STREAMS];
 
 	double stream_todo = 0.0;
 	int fade_index = -1;


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/106900

Sync streams should no longer click and pop when changing volume. Under the hood, this also switches to using a linear value for volume instead of a dB value in order to avoid calling `Math::db_to_linear()` a bunch