### PR TITLE
Fix Texture2DArray import error by updating webp saving functions

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -106,7 +106,7 @@ Vector<uint8_t> (*Image::webp_lossless_packer)(const Ref<Image> &) = nullptr;
 Vector<uint8_t> (*Image::png_packer)(const Ref<Image> &) = nullptr;
 Vector<uint8_t> (*Image::basis_universal_packer)(const Ref<Image> &, Image::UsedChannels, const BasisUniversalPackerParams &) = nullptr;
 
-Ref<Image> (*Image::webp_unpacker)(const Vector<uint8_t> &) = nullptr;
+Ref<Image> (*Image::webp_unpacker)(const Vector<uint8_t> &, Image::Format) = nullptr;
 Ref<Image> (*Image::png_unpacker)(const Vector<uint8_t> &) = nullptr;
 Ref<Image> (*Image::basis_universal_unpacker)(const Vector<uint8_t> &) = nullptr;
 Ref<Image> (*Image::basis_universal_unpacker_ptr)(const uint8_t *, int) = nullptr;

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -234,11 +234,11 @@ public:
 	// External packer function pointers.
 
 	static Vector<uint8_t> (*webp_lossy_packer)(const Ref<Image> &p_image, float p_quality);
-	static Vector<uint8_t> (*webp_lossless_packer)(const Ref<Image> &p_image, Format p_format);
+	static Vector<uint8_t> (*webp_lossless_packer)(const Ref<Image> &p_image);
 	static Vector<uint8_t> (*png_packer)(const Ref<Image> &p_image);
 	static Vector<uint8_t> (*basis_universal_packer)(const Ref<Image> &p_image, UsedChannels p_channels, const BasisUniversalPackerParams &p_basisu_params);
 
-	static Ref<Image> (*webp_unpacker)(const Vector<uint8_t> &p_buffer);
+	static Ref<Image> (*webp_unpacker)(const Vector<uint8_t> &p_buffer, Format p_format);
 	static Ref<Image> (*png_unpacker)(const Vector<uint8_t> &p_buffer);
 	static Ref<Image> (*basis_universal_unpacker)(const Vector<uint8_t> &p_buffer);
 	static Ref<Image> (*basis_universal_unpacker_ptr)(const uint8_t *p_data, int p_size);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -234,7 +234,7 @@ public:
 	// External packer function pointers.
 
 	static Vector<uint8_t> (*webp_lossy_packer)(const Ref<Image> &p_image, float p_quality);
-	static Vector<uint8_t> (*webp_lossless_packer)(const Ref<Image> &p_image);
+	static Vector<uint8_t> (*webp_lossless_packer)(const Ref<Image> &p_image, Format p_format);
 	static Vector<uint8_t> (*png_packer)(const Ref<Image> &p_image);
 	static Vector<uint8_t> (*basis_universal_packer)(const Ref<Image> &p_image, UsedChannels p_channels, const BasisUniversalPackerParams &p_basisu_params);
 

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -147,7 +147,7 @@ Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer, Image::Format p_format)
 
 	ERR_FAIL_COND_V_MSG(errdec, Ref<Image>(), "Failed decoding WebP image.");
 
-	Ref<Image> img = memnew(Image(features.width, features.height, false, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image));
+	Ref<Image> img = memnew(Image(features.width, features.height, false, p_format, dst_image));
 	return img;
 }
 
@@ -160,12 +160,12 @@ Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 	}
 
 	Vector<uint8_t> dst_image;
-	int datasize = features.width * features.height * (features.has_alpha ? 4 : 3);
+	int datasize = features.width * features.height * (p_image->get_format() == Image::FORMAT_RGBA8 ? 4 : 3);
 	dst_image.resize(datasize);
 	uint8_t *dst_w = dst_image.ptrw();
 
 	bool errdec = false;
-	if (features.has_alpha) {
+	if (p_image->get_format() == Image::FORMAT_RGBA8) {
 		errdec = WebPDecodeRGBAInto(p_buffer, p_buffer_len, dst_w, datasize, 4 * features.width) == nullptr;
 	} else {
 		errdec = WebPDecodeRGBInto(p_buffer, p_buffer_len, dst_w, datasize, 3 * features.width) == nullptr;
@@ -173,7 +173,7 @@ Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p
 
 	ERR_FAIL_COND_V_MSG(errdec, ERR_FILE_CORRUPT, "Failed decoding WebP image.");
 
-	p_image->set_data(features.width, features.height, false, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image);
+	p_image->set_data(features.width, features.height, false, p_image->get_format(), dst_image);
 
 	return OK;
 }

--- a/modules/webp/webp_common.h
+++ b/modules/webp/webp_common.h
@@ -39,6 +39,6 @@ Vector<uint8_t> _webp_lossless_pack(const Ref<Image> &p_image);
 // Helper function for those above.
 Vector<uint8_t> _webp_packer(const Ref<Image> &p_image, float p_quality, bool p_lossless);
 // Given a WebP file, unpack it into an image.
-Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer);
+Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer, Image::Format p_format);
 Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len);
 } //namespace WebPCommon

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -337,7 +337,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 			if (data_format == DATA_FORMAT_PNG && Image::png_unpacker) {
 				img = Image::png_unpacker(pv);
 			} else if (data_format == DATA_FORMAT_WEBP && Image::webp_unpacker) {
-				img = Image::webp_unpacker(pv);
+				img = Image::webp_unpacker(pv, format);
 			}
 
 			if (img.is_null() || img->is_empty()) {


### PR DESCRIPTION
When importing a Texture2DArray with lossless or lossy compression, Godot would throw an error saying that multiple image formats were used in the array. This was due to the way the webp module saved and loaded images. (See issue #106627)

In the webp module, Godot would normally save and load the image by checking the image if it contained an alhpa pixels. This would cause issues when saving a Texture2DArray because each layer would be saved with its own format, which could reseult in different format versions being used for each layer.

In the _webp_packer function, the code would check if the image had alpha pixels and then pack the image using that format. This would lead to the previously mentioned issue. I changed the function to use the format that was provided to the function if possible. If the format is not supported, it will fall back to the original behavior of checking for alpha pixels.

In the _webp_unpack function, I updated the code to unpack the image using the format that the image was saved with. This ensures that the layers in Texture2DArray would all have the same format, preventing the import error.

Fixes #106627