### PR TITLE
Fix `GDScriptAnalyzer::is_shadowing()` missing warnings for shadowed global constants

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -6153,6 +6153,15 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 		} else if (GDScriptParser::get_builtin_type(name) < Variant::VARIANT_MAX) {
 			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "built-in type");
 			return;
+		} else if (name == "PI" || name == "TAU" || name == "INF" || name == "NAN") {
+			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global constant");
+			return;
+		} else if (CoreConstants::is_global_constant(name)) {
+			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global constant");
+			return;
+		} else if (CoreConstants::is_global_enum(name)) {
+			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "global enum");
+			return;
 		}
 	}
 

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -55,7 +55,7 @@ public:
 		UNUSED_SIGNAL, // Signal is defined but never explicitly used in the class.
 		SHADOWED_VARIABLE, // A local variable/constant shadows a current class member.
 		SHADOWED_VARIABLE_BASE_CLASS, // A local variable/constant shadows a base class member.
-		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
+		SHADOWED_GLOBAL_IDENTIFIER, // A local/script variable/constant/enum/method shadows a global constant, enum, function, type, or class.
 		UNREACHABLE_CODE, // Code after a return statement.
 		UNREACHABLE_PATTERN, // Pattern in a match statement after a catch all pattern (wildcard or bind).
 		STANDALONE_EXPRESSION, // Expression not assigned to a variable.

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowing.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowing.gd
@@ -19,5 +19,9 @@ func test():
 	var base_variable_member
 	const base_function_member = 1
 	var base_const_member
+	var PI = 4
+	var OK = -1
+	var Side = -2
+	var UINT8_MAX = -3
 
 	print('warn')

--- a/modules/gdscript/tests/scripts/analyzer/warnings/shadowing.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/shadowing.out
@@ -10,4 +10,8 @@ GDTEST_OK
 ~~ WARNING at line 19: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "base_variable_member" is shadowing an already-declared variable at line 4 in the base class "ShadowingBase".
 ~~ WARNING at line 20: (SHADOWED_VARIABLE_BASE_CLASS) The local constant "base_function_member" is shadowing an already-declared function at line 6 in the base class "ShadowingBase".
 ~~ WARNING at line 21: (SHADOWED_VARIABLE_BASE_CLASS) The local variable "base_const_member" is shadowing an already-declared constant at line 3 in the base class "ShadowingBase".
+~~ WARNING at line 22: (SHADOWED_GLOBAL_IDENTIFIER) The variable "PI" has the same name as a global constant.
+~~ WARNING at line 23: (SHADOWED_GLOBAL_IDENTIFIER) The variable "OK" has the same name as a global constant.
+~~ WARNING at line 24: (SHADOWED_GLOBAL_IDENTIFIER) The variable "Side" has the same name as a global enum.
+~~ WARNING at line 25: (SHADOWED_GLOBAL_IDENTIFIER) The variable "UINT8_MAX" has the same name as a global constant.
 warn

--- a/modules/gdscript/tests/scripts/parser/features/allowed_keywords_as_identifiers.out
+++ b/modules/gdscript/tests/scripts/parser/features/allowed_keywords_as_identifiers.out
@@ -1,4 +1,8 @@
 GDTEST_OK
+~~ WARNING at line 6: (SHADOWED_GLOBAL_IDENTIFIER) The variable "PI" has the same name as a global constant.
+~~ WARNING at line 9: (SHADOWED_GLOBAL_IDENTIFIER) The variable "INF" has the same name as a global constant.
+~~ WARNING at line 12: (SHADOWED_GLOBAL_IDENTIFIER) The variable "NAN" has the same name as a global constant.
+~~ WARNING at line 15: (SHADOWED_GLOBAL_IDENTIFIER) The variable "TAU" has the same name as a global constant.
 match
 PI
 INF


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/117567

Related PRs:
- https://github.com/godotengine/godot/pull/106987
- https://github.com/godotengine/godot/pull/117308
- https://github.com/godotengine/godot/pull/117545

Changes:
- Fixes `GDScriptAnalyzer::is_shadowing()` not checking for shadowed `@GlobalScope` and `@GDScript` constants/enums.
  - They now have `SHADOWED_GLOBAL_IDENTIFIER` warnings.
- Adds test cases.

Test Script:
https://github.com/godotengine/godot/pull/106984#issuecomment-4078960627

Any help is appreciated!