### PR TITLE
Update version.py

### DIFF
--- a/version.py
+++ b/version.py
@@ -3,6 +3,7 @@ name = "Godot Engine"
 major = 4
 minor = 5
 patch = 0
+fix = 1
 status = "dev"
 module_config = ""
 website = "https://godotengine.org"


### PR DESCRIPTION

Adds a field: fix for the version number, for example Godot 4.5.0.1, in such fixes you could add small but useful options or fix bugs without having to wait for a big update like 4.5.1. I managed to compile but the version with the fix number is not displayed, I tested on 3.6