### PR TITLE
Fix `FixedVector` move and copy semantics.

### DIFF
--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -51,6 +51,7 @@ class FixedVector {
 
 public:
 	_FORCE_INLINE_ constexpr FixedVector() = default;
+
 	constexpr FixedVector(std::initializer_list<T> p_init) {
 		ERR_FAIL_COND(p_init.size() > CAPACITY);
 		for (const T &element : p_init) {
@@ -58,9 +59,7 @@ public:
 		}
 	}
 
-	template <uint32_t p_capacity>
-	constexpr FixedVector(const FixedVector<T, p_capacity> &p_from) {
-		ERR_FAIL_COND(p_from.size() > CAPACITY);
+	constexpr FixedVector(const FixedVector &p_from) {
 		if constexpr (std::is_trivially_copyable_v<T>) {
 			// Copy size and all provided elements at once.
 			memcpy((void *)&_size, (void *)&p_from._size, sizeof(_size) + DATA_PADDING + p_from.size() * sizeof(T));
@@ -71,13 +70,46 @@ public:
 		}
 	}
 
-	template <uint32_t p_capacity>
-	constexpr FixedVector(FixedVector<T, p_capacity> &&p_from) {
-		ERR_FAIL_COND(p_from.size() > CAPACITY);
+	constexpr FixedVector(FixedVector &&p_from) {
 		// Copy size and all provided elements at once.
 		// Note: Assumes trivial relocatability.
 		memcpy((void *)&_size, (void *)&p_from._size, sizeof(_size) + DATA_PADDING + p_from.size() * sizeof(T));
 		p_from._size = 0;
+	}
+
+	constexpr FixedVector &operator=(const FixedVector &p_from) {
+		if constexpr (std::is_trivially_copyable_v<T>) {
+			// Copy size and all provided elements at once.
+			memcpy((void *)&_size, (void *)&p_from._size, sizeof(_size) + DATA_PADDING + p_from.size() * sizeof(T));
+		} else {
+			// Destruct extraneous elements.
+			if constexpr (!std::is_trivially_destructible_v<T>) {
+				for (uint32_t i = p_from.size(); i < _size; i++) {
+					ptr()[i].~T();
+				}
+			}
+
+			_size = 0; // Loop-assign the rest.
+			for (const T &element : p_from) {
+				ptr()[_size++] = element;
+			}
+		}
+		return *this;
+	}
+
+	constexpr FixedVector &operator=(FixedVector &&p_from) {
+		// Destruct extraneous elements.
+		if constexpr (!std::is_trivially_destructible_v<T>) {
+			for (uint32_t i = p_from.size(); i < _size; i++) {
+				ptr()[i].~T();
+			}
+		}
+
+		// Relocate elements (and size) into our buffer.
+		memcpy((void *)&_size, (void *)&p_from._size, sizeof(_size) + DATA_PADDING + p_from.size() * sizeof(T));
+		p_from._size = 0;
+
+		return *this;
 	}
 
 	~FixedVector() {
@@ -133,6 +165,12 @@ public:
 	constexpr void push_back(const T &p_val) {
 		ERR_FAIL_COND(_size >= CAPACITY);
 		memnew_placement(ptr() + _size, T(p_val));
+		_size++;
+	}
+
+	constexpr void push_back(T &&p_val) {
+		ERR_FAIL_COND(_size >= CAPACITY);
+		memnew_placement(ptr() + _size, T(std::move(p_val)));
 		_size++;
 	}
 


### PR DESCRIPTION
[A comment](https://github.com/godotengine/godot/pull/106928#issuecomment-2922664215) made me re-examine `FixedVector` move semantics.

It looks like C++ had auto-generated move semantics (and copy constructors) for the type, simply copying the buffer without regards to type copying. This is because of the templates, and non-explicit move semantics.
This fixes the issue, and adds some basic tests for it.

We do not have users of `FixedVector` yet, so there should be no affected code.