### PR TITLE
`GDScriptInstance`: use write pointer for `members`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -154,6 +154,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	GDScriptInstance *instance = memnew(GDScriptInstance);
 	instance->base_ref_counted = p_is_ref_counted;
 	instance->members.resize(member_indices.size());
+	instance->_members = instance->members.ptrw();
 	instance->script = Ref<GDScript>(this);
 	instance->owner = p_owner;
 	instance->owner_id = p_owner->get_instance_id();
@@ -1692,7 +1693,7 @@ bool GDScriptInstance::set(const StringName &p_name, const Variant &p_value) {
 				callp(member->setter, &args, 1, err);
 				return err.error == Callable::CallError::CALL_OK;
 			} else {
-				members.write[member->index] = value;
+				_members[member->index] = value;
 				return true;
 			}
 		}
@@ -2151,6 +2152,7 @@ void GDScriptInstance::reload_members() {
 
 	//apply
 	members = new_members;
+	_members = members.ptrw();
 
 	//pass the values to the new indices
 	member_indices_cache.clear();

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -373,6 +373,7 @@ class GDScriptInstance : public ScriptInstance {
 #ifdef DEBUG_ENABLED
 	HashMap<StringName, int> member_indices_cache; //used only for hot script reloading
 #endif
+	Variant *_members = nullptr;
 	Vector<Variant> members;
 	bool base_ref_counted;
 

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -312,7 +312,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 
 		for (KeyValue<StringName, GDScript::MemberInfo> &E : gd_ref->member_indices) {
 			if (d.has(E.key)) {
-				inst->members.write[E.value.index] = d[E.key];
+				inst->_members[E.value.index] = d[E.key];
 			}
 		}
 	}

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -699,7 +699,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 #endif
 
 	bool awaited = false;
-	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->members.ptrw() : nullptr };
+	Variant *variant_addresses[ADDR_TYPE_MAX] = { stack, _constants_ptr, p_instance ? p_instance->_members : nullptr };
 
 #ifdef DEBUG_ENABLED
 	OPCODE_WHILE(ip < _code_size) {


### PR DESCRIPTION
Supersedes #105555.

Adds a `_members` variable in `GDScriptInstance`, which stores a single write pointer to `members`, and moves every write operation from `members` into it (notably the VM). This avoids a lot of unnecessary forks.

The `members` vector only ever reallocates in two places: instance creation (only once on non-debug) and script reloading (debug only). This makes the pointer safe to store.

Running production builds (`production=yes`) side-by-side on [Bunnymark](https://github.com/GaijinEntertainment/godot-das/tree/master/examples/bunnymark), I got the following averages:

100 bunnies:
| Branch      | FPS  |
|-------------|------|
| master      | 2822 |
| PR          | 2820 |
> 0.07% lower performance, too low to be considered a problem.
---

1000 bunnies:
| Branch      | FPS       |
|-------------|-----------|
| master      | 1299-1310 |
| PR          | 1302-1311 |
> On my tests, it varies between 0.61% lower and 0.92% higher. Pretty much in the margin of error.
---

10000 bunnies:
| Branch      | FPS     |
|-------------|---------|
| master      | 121-124 |
| PR          | 126-133 |
> Between 1.61% and 9.92% higher performance
---

This is a less aggressive change compared to #105555 which improves performance while not having the same penalty with a low amount of instances.

I tried to use the pointer on getters too, but performance was lower in the 1000 bunnies case.

I also noticed this solution is used for `global_array` (which I partly mimicked for `members` in this PR) and in some parts of `GDScriptFunction`, so I think it's fair to do it here. Maybe it could also be used for `static_variables`?