### PR TITLE
Fix ambiguous AnimationNode's parameter type in default value and make `validate_type_match()` static function

### DIFF
--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -45,9 +45,9 @@ Variant AnimationNodeBlendSpace1D::get_parameter_default_value(const StringName 
 	}
 
 	if (p_parameter == closest) {
-		return -1;
+		return (int)-1;
 	} else {
-		return 0;
+		return 0.0;
 	}
 }
 

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -46,7 +46,7 @@ Variant AnimationNodeBlendSpace2D::get_parameter_default_value(const StringName 
 	}
 
 	if (p_parameter == closest) {
-		return -1;
+		return (int)-1;
 	} else {
 		return Vector2();
 	}

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -55,7 +55,7 @@ Variant AnimationNodeAnimation::get_parameter_default_value(const StringName &p_
 	if (p_parameter == backward) {
 		return false;
 	}
-	return 0;
+	return 0.0;
 }
 
 AnimationNode::NodeTimeInfo AnimationNodeAnimation::get_node_time_info() const {
@@ -438,10 +438,10 @@ Variant AnimationNodeOneShot::get_parameter_default_value(const StringName &p_pa
 	} else if (p_parameter == active || p_parameter == internal_active) {
 		return false;
 	} else if (p_parameter == time_to_restart) {
-		return -1;
-	} else {
-		return 0.0;
+		return -1.0;
 	}
+
+	return 0.0;
 }
 
 bool AnimationNodeOneShot::is_parameter_read_only(const StringName &p_parameter) const {
@@ -774,7 +774,7 @@ Variant AnimationNodeAdd2::get_parameter_default_value(const StringName &p_param
 		return ret;
 	}
 
-	return 0;
+	return 0.0;
 }
 
 String AnimationNodeAdd2::get_caption() const {
@@ -815,7 +815,7 @@ Variant AnimationNodeAdd3::get_parameter_default_value(const StringName &p_param
 		return ret;
 	}
 
-	return 0;
+	return 0.0;
 }
 
 String AnimationNodeAdd3::get_caption() const {
@@ -859,7 +859,7 @@ Variant AnimationNodeBlend2::get_parameter_default_value(const StringName &p_par
 		return ret;
 	}
 
-	return 0; // For blend amount.
+	return 0.0; // For blend amount.
 }
 
 String AnimationNodeBlend2::get_caption() const {
@@ -900,7 +900,7 @@ Variant AnimationNodeBlend3::get_parameter_default_value(const StringName &p_par
 		return ret;
 	}
 
-	return 0; // For blend amount.
+	return 0.0; // For blend amount.
 }
 
 String AnimationNodeBlend3::get_caption() const {
@@ -940,7 +940,7 @@ Variant AnimationNodeSub2::get_parameter_default_value(const StringName &p_param
 		return ret;
 	}
 
-	return 0;
+	return 0.0;
 }
 
 String AnimationNodeSub2::get_caption() const {
@@ -1146,7 +1146,7 @@ Variant AnimationNodeTransition::get_parameter_default_value(const StringName &p
 	if (p_parameter == prev_xfading) {
 		return 0.0;
 	} else if (p_parameter == prev_index || p_parameter == current_index) {
-		return -1;
+		return (int)-1;
 	} else {
 		return String();
 	}

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -77,7 +77,11 @@ void AnimationNode::set_parameter(const StringName &p_name, const Variant &p_val
 
 	const AHashMap<StringName, int>::Iterator it = property_cache.find(p_name);
 	if (it) {
-		process_state->tree->property_map.get_by_index(it->value).value.first = p_value;
+		Pair<Variant, bool> &prop = process_state->tree->property_map.get_by_index(it->value).value;
+		Variant value = p_value;
+		if (Animation::validate_type_match(prop.first, value)) {
+			prop.first = value;
+		}
 		return;
 	}
 
@@ -921,7 +925,11 @@ bool AnimationTree::_set(const StringName &p_name, const Variant &p_value) {
 		if (is_inside_tree() && property_map[p_name].second) {
 			return false; // Prevent to set property by user.
 		}
-		property_map[p_name].first = p_value;
+		Pair<Variant, bool> &prop = property_map[p_name];
+		Variant value = p_value;
+		if (Animation::validate_type_match(prop.first, value)) {
+			prop.first = value;
+		}
 		return true;
 	}
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -75,20 +75,6 @@ void Tweener::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("finished"));
 }
 
-bool Tween::_validate_type_match(const Variant &p_from, Variant &r_to) {
-	if (p_from.get_type() != r_to.get_type()) {
-		// Cast r_to between double and int to avoid minor annoyances.
-		if (p_from.get_type() == Variant::FLOAT && r_to.get_type() == Variant::INT) {
-			r_to = double(r_to);
-		} else if (p_from.get_type() == Variant::INT && r_to.get_type() == Variant::FLOAT) {
-			r_to = int(r_to);
-		} else {
-			ERR_FAIL_V_MSG(false, "Type mismatch between initial and final value: " + Variant::get_type_name(p_from.get_type()) + " and " + Variant::get_type_name(r_to.get_type()));
-		}
-	}
-	return true;
-}
-
 void Tween::_start_tweeners() {
 	if (tweeners.is_empty()) {
 		dead = true;
@@ -122,7 +108,7 @@ Ref<PropertyTweener> Tween::tween_property(const Object *p_target, const NodePat
 	const Variant &prop_value = p_target->get_indexed(property_subnames);
 #endif
 
-	if (!_validate_type_match(prop_value, p_to)) {
+	if (!Animation::validate_type_match(prop_value, p_to)) {
 		return nullptr;
 	}
 
@@ -153,7 +139,7 @@ Ref<CallbackTweener> Tween::tween_callback(const Callable &p_callback) {
 Ref<MethodTweener> Tween::tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration) {
 	CHECK_VALID();
 
-	if (!_validate_type_match(p_from, p_to)) {
+	if (!Animation::validate_type_match(p_from, p_to)) {
 		return nullptr;
 	}
 
@@ -562,7 +548,7 @@ Ref<PropertyTweener> PropertyTweener::from(const Variant &p_value) {
 	ERR_FAIL_COND_V(tween.is_null(), nullptr);
 
 	Variant from_value = p_value;
-	if (!tween->_validate_type_match(final_val, from_value)) {
+	if (!Animation::validate_type_match(final_val, from_value)) {
 		return nullptr;
 	}
 

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -135,7 +135,6 @@ private:
 
 	void _start_tweeners();
 	void _stop_internal(bool p_reset);
-	bool _validate_type_match(const Variant &p_from, Variant &r_to);
 
 protected:
 	static void _bind_methods();

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5660,6 +5660,20 @@ bool Animation::is_variant_interpolatable(const Variant p_value) {
 	return (type >= Variant::BOOL && type <= Variant::STRING_NAME) || type == Variant::ARRAY || type >= Variant::PACKED_INT32_ARRAY; // PackedByteArray is unsigned, so it would be better to ignore since blending uses float.
 }
 
+bool Animation::validate_type_match(const Variant &p_from, Variant &r_to) {
+	if (p_from.get_type() != r_to.get_type()) {
+		// Cast r_to between double and int to avoid minor annoyances.
+		if (p_from.get_type() == Variant::FLOAT && r_to.get_type() == Variant::INT) {
+			r_to = double(r_to);
+		} else if (p_from.get_type() == Variant::INT && r_to.get_type() == Variant::FLOAT) {
+			r_to = int(r_to);
+		} else {
+			ERR_FAIL_V_MSG(false, "Type mismatch between initial and final value: " + Variant::get_type_name(p_from.get_type()) + " and " + Variant::get_type_name(r_to.get_type()));
+		}
+	}
+	return true;
+}
+
 Variant Animation::cast_to_blendwise(const Variant p_value) {
 	switch (p_value.get_type()) {
 		case Variant::BOOL:

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -540,6 +540,7 @@ public:
 
 	// Helper functions for Variant.
 	static bool is_variant_interpolatable(const Variant p_value);
+	static bool validate_type_match(const Variant &p_from, Variant &r_to);
 
 	static Variant cast_to_blendwise(const Variant p_value);
 	static Variant cast_from_blendwise(const Variant p_value, const Variant::Type p_type);


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/105275
- Supersedes/Closes https://github.com/godotengine/godot/pull/106440

The cause of this problem is the following implicit cast:

```cpp
Variant val = 0.0;
WARN_PRINT(stringify_variant(val)); // 0.0
val = 0;
WARN_PRINT(stringify_variant(val)); // 0
```

Considering the behavior of the Variant type, unless fundamental changes are made to the Variant type, it seems that the only solution is the approach suggested by @KoBeWi .

There are two places where problems occur:

- `AnimationTree::_set()`
- `AnimationNode::set_parameter()`

However, even with these validations, the `property_map` may initially be set to the wrong type due to incorrect default parameter types.

In the former case `AnimationTree::_set()`, I assume that the type may have been saved incorrectly in past projects when the parameter was not changed after placing the AnimationNode. Below is an MRP that intentionally reproduces that situation.

[replicate-tweening-blend-amount_issue.zip](https://github.com/user-attachments/files/20536567/replicate-tweening-blend-amount_issue.zip)

If you save that MRP after applying this PR, the stored type should be fixed in `cube.tscn`.

This PR fixes the type of the parameter's default value, adds validation, and makes the validation function static. Since the utilities related to Variant conversion are already collected in the Animation class, so I will integrate them there.