### PR TITLE
Fix AddressSanitizer: heap-buffer-overflow with embree buffer padding

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -335,7 +335,9 @@ void RaycastOcclusionCull::Scenario::_update_dirty_instance(int p_idx, RID *p_in
 	int vertices_size = occ->vertices.size();
 
 	// Embree requires the last element to be readable by a 16-byte SSE load instruction, so we add padding to be safe.
-	occ_inst->xformed_vertices.resize(3 * vertices_size + 3);
+
+	occ_inst->xformed_vertices.reserve(3 * vertices_size + 3);
+	occ_inst->xformed_vertices.resize(3 * vertices_size);
 
 	const Vector3 *read_ptr = occ->vertices.ptr();
 	float *write_ptr = occ_inst->xformed_vertices.ptr();


### PR DESCRIPTION
Fixes #94548

Use reserve() instead of resize() to add padding, because embree expects size() + padding in the buffer, and asan builds abort at certain buffer sizes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
