### PR TITLE
Add `process/resize_interpolation_mode` for use with `process/size_limit`

### DIFF
--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -87,8 +87,11 @@
 			- In 2D, a [CanvasItemMaterial] will need to be created and configured to use the [constant CanvasItemMaterial.BLEND_MODE_PREMULT_ALPHA] blend mode on [CanvasItem]s that use this texture. In custom [code]@canvas_item[/code] shaders, [code]render_mode blend_premul_alpha;[/code] should be used.
 			- In 3D, a [BaseMaterial3D] will need to be created and configured to use the [constant BaseMaterial3D.BLEND_MODE_PREMULT_ALPHA] blend mode on materials that use this texture. In custom [code]spatial[/code] shaders, [code]render_mode blend_premul_alpha;[/code] should be used.
 		</member>
+		<member name="process/resize_interpolation_mode" type="int" setter="" getter="" default="4">
+			Selects which interpolation mode to use when automatically resizing textures on import (see [enum Image.Interpolation]). Used in conjunction with [member process/size_limit].
+		</member>
 		<member name="process/size_limit" type="int" setter="" getter="" default="0">
-			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is performed using cubic interpolation.
+			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is done using the interpolation mode specified in [member process/resize_interpolation_mode].
 			This can be used to reduce memory usage without affecting the source images, or avoid issues with textures not displaying on mobile/web platforms (as these usually can't display textures larger than 4096×4096).
 			[b]Note:[/b] Even if this is set to [code]0[/code], import size is limited to the following dimensions for technical reasons. Depending on [member compress/mode], textures will be downsampled on import if necessary:
 			- [b]Lossy:[/b] 16383 pixels width or height, whichever is larger;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -252,6 +252,7 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 
 	// Maximum bound is the highest allowed value for lossy compression (the lowest common denominator).
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/size_limit", PROPERTY_HINT_RANGE, "0,16383,1"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/resize_interpolation_mode", PROPERTY_HINT_ENUM, "Nearest,Bilinear,Cubic,Trilinear,Lanczos"), 4 /* Lanczos */));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "detect_3d/compress_to", PROPERTY_HINT_ENUM, "Disabled,VRAM Compressed,Basis Universal"), (p_preset == PRESET_DETECT) ? 1 : 0));
 
@@ -514,6 +515,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	const bool hdr_as_srgb = p_options["process/hdr_as_srgb"];
 	const bool hdr_clamp_exposure = p_options["process/hdr_clamp_exposure"];
 	int size_limit = p_options["process/size_limit"];
+	Image::Interpolation resize_interpolation_mode = Image::Interpolation((int)p_options["process/resize_interpolation_mode"]);
 
 	bool using_fallback_size_limit = false;
 	if (size_limit == 0) {
@@ -605,7 +607,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 					// Only warn if downsizing occurred when the user did not explicitly request it.
 					WARN_PRINT(vformat("%s: Texture was downsized on import as its width (%d pixels) exceeded the importable size limit (%d pixels).", p_source_file, target_image->get_width(), size_limit));
 				}
-				target_image->resize(new_width, new_height, Image::INTERPOLATE_CUBIC);
+				target_image->resize(new_width, new_height, resize_interpolation_mode);
 			} else {
 				int new_height = size_limit;
 				int new_width = target_image->get_width() * new_height / target_image->get_height();
@@ -614,7 +616,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 					// Only warn if downsizing occurred when the user did not explicitly request it.
 					WARN_PRINT(vformat("%s: Texture was downsized on import as its height (%d pixels) exceeded the importable size limit (%d pixels).", p_source_file, target_image->get_height(), size_limit));
 				}
-				target_image->resize(new_width, new_height, Image::INTERPOLATE_CUBIC);
+				target_image->resize(new_width, new_height, resize_interpolation_mode);
 			}
 
 			if (normal == 1) {


### PR DESCRIPTION
Resolves https://github.com/godotengine/godot-proposals/issues/9126

I've also changed the default mode to be Lanczos since it is the best fit, and to mitigate this issue https://github.com/godotengine/godot/issues/107008