### PR TITLE
Fix Animation Editor skips to 1th frame when stopped.

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -110,12 +110,20 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				frame->set_value(0);
 			} else if (last_active) {
 				// Need the last frame after it stopped.
+				if (last_playing_speed > 0) {
+					// Stop at the end when playing forwards
+					player->seek_internal(player->get_current_animation_length(), true, true, false);
+				} else {
+					// Stop at the beginning when playing backwards
+					player->seek_internal(0, true, true, false);
+				}
 				frame->set_value(player->get_current_animation_position());
 				track_editor->set_anim_pos(player->get_current_animation_position());
 				stop->set_button_icon(stop_icon);
 			}
 
 			last_active = player->is_playing();
+			last_playing_speed = player->get_playing_speed();
 
 			updating = false;
 		} break;

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -113,6 +113,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Ref<ImageTexture> autoplay_reset_icon;
 
 	bool last_active = false;
+	float last_playing_speed = 1;
 	float timeline_position = 0;
 
 	EditorFileDialog *file = nullptr;


### PR DESCRIPTION
Fix : AnimationPlayer animation skips to the beginning and changes the values when finished in the editor fixes #106095

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
