### PR TITLE
Texture format error on export: Show project setting

### DIFF
--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -44,6 +44,7 @@ class LinkButton;
 class MenuButton;
 class OptionButton;
 class PopupMenu;
+class ProjectExportDialog;
 class RichTextLabel;
 class TabContainer;
 class Tree;
@@ -52,6 +53,7 @@ class TreeItem;
 class ProjectExportTextureFormatError : public HBoxContainer {
 	GDCLASS(ProjectExportTextureFormatError, HBoxContainer);
 
+	ProjectExportDialog *export_dialog = nullptr;
 	Label *texture_format_error_label = nullptr;
 	LinkButton *fix_texture_format_button = nullptr;
 	String setting_identifier;
@@ -63,7 +65,7 @@ protected:
 
 public:
 	void show_for_texture_format(const String &p_friendly_name, const String &p_setting_identifier);
-	ProjectExportTextureFormatError();
+	ProjectExportTextureFormatError(ProjectExportDialog *p_export_dialog);
 };
 
 class ProjectExportDialog : public ConfirmationDialog {

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -80,6 +80,10 @@ void ProjectSettingsEditor::popup_for_override(const String &p_override) {
 	general_settings_inspector->set_current_section(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX + p_override.get_slicec('/', 0));
 }
 
+void ProjectSettingsEditor::set_filter(const String &p_filter) {
+	search_box->set_text(p_filter);
+}
+
 void ProjectSettingsEditor::queue_save() {
 	settings_changed = true;
 	timer->start();

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -144,6 +144,8 @@ public:
 	void update_plugins();
 	void init_autoloads();
 
+	void set_filter(const String &p_filter);
+
 	EditorAutoloadSettings *get_autoload_settings() { return autoload_settings; }
 	GroupSettingsEditor *get_group_settings() { return group_settings; }
 	TabContainer *get_tabs() { return tab_container; }


### PR DESCRIPTION
Changing the project setting manually will prompt for a restart, which will trigger the required re-import of textures.

Previously the project setting would be changed automatically but textures would not be re-imported, which could be unexpected (would lead to exports with missing textures).

New behavior:

https://github.com/user-attachments/assets/a32d852b-19b3-4c1f-a877-26671725faa1

- Fixes https://github.com/godotengine/godot/issues/106992

Advantages over changing the setting automatically and showing a restart dialog:

- Less magic, makes clear that there's a *Project* Setting and where it's located.
- Allows the user to hover the project setting for more documentation.
- The user could understand that they would probably want to turn the project setting back off if they ever decide to uncheck the checkbox in the export settings.