### PR TITLE
Add warning when system font fallback is used.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -681,6 +681,9 @@
 		<member name="debug/settings/stdout/verbose_stdout" type="bool" setter="" getter="" default="false">
 			Print more information to standard output when running. It displays information such as memory leaks, which scenes and resources are being loaded, etc. This can also be enabled using the [code]--verbose[/code] or [code]-v[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url], even on an exported project. See also [method OS.is_stdout_verbose] and [method @GlobalScope.print_verbose].
 		</member>
+		<member name="debug/settings/ui/show_system_font_fallback_warnings" type="int" setter="" getter="" default="1">
+			If enabled, produces a warning when system font fallback is used.
+		</member>
 		<member name="debug/shader_language/warnings/device_limit_exceeded" type="bool" setter="" getter="" default="true">
 			When set to [code]true[/code], produces a warning when the shader exceeds certain device limits. Currently, the only device limit checked is the limit on uniform buffer size. More device limits will be added in the future.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2081,6 +2081,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.
 		OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");
 	}
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "debug/settings/ui/show_system_font_fallback_warnings", PROPERTY_HINT_ENUM, "Never,When Running From Editor,Always"), 1);
 
 	register_early_core_singletons();
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -694,6 +694,11 @@ class TextServerAdvanced : public TextServerExtension {
 
 	Mutex ft_mutex;
 
+#ifdef DEBUG_ENABLED
+	int sys_fb_warn = 0;
+	HashSet<String> sys_fb_warn_list;
+#endif
+
 	// HarfBuzz bitmap font interface.
 
 	static hb_font_funcs_t *funcs;

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -596,6 +596,11 @@ class TextServerFallback : public TextServerExtension {
 
 	Mutex ft_mutex;
 
+#ifdef DEBUG_ENABLED
+	int sys_fb_warn = 0;
+	HashSet<String> sys_fb_warn_list;
+#endif
+
 protected:
 	static void _bind_methods() {}
 


### PR DESCRIPTION
Adds warning displayed when system fallback font is used, warning can be disabled from the project settings, only enabled for debug builds, and by default is displayed only when running from editor with attached debugger. It is not displayed when system fonts are used directly (using `SystemFont` class).

Warning include used system font and text string that triggered it (without duplication):

<img width="1243" alt="Screenshot 2025-06-01 at 16 32 53" src="https://github.com/user-attachments/assets/cb51b232-bea3-4743-a279-568dd0f441a8" />

System font fallback is useful, but is a constant source of confusion, since different platforms have different fallback capabilities and sets of available fonts.

See following issues for example, there are multiple other similar issues:
https://github.com/godotengine/godot/issues/106824
https://github.com/godotengine/godot/issues/84590
https://github.com/godotengine/godot/issues/78921
https://github.com/godotengine/godot/issues/77903
