### PR TITLE
Fix `bar_beats` description of `ResourceImporterMP3` and `ResourceImporterOggVorbis`

### DIFF
--- a/modules/minimp3/doc_classes/ResourceImporterMP3.xml
+++ b/modules/minimp3/doc_classes/ResourceImporterMP3.xml
@@ -13,7 +13,7 @@
 	</tutorials>
 	<members>
 		<member name="bar_beats" type="int" setter="" getter="" default="4">
-			The number of bars within a single beat in the audio track. This is only relevant for music that wishes to make use of interactive music functionality, not sound effects.
+			The number of beats within a single bar in the audio track. This is only relevant for music that wishes to make use of interactive music functionality, not sound effects.
 			A more convenient editor for [member bar_beats] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="beat_count" type="int" setter="" getter="" default="0">

--- a/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
+++ b/modules/vorbis/doc_classes/ResourceImporterOggVorbis.xml
@@ -29,7 +29,7 @@
 	</methods>
 	<members>
 		<member name="bar_beats" type="int" setter="" getter="" default="4">
-			The number of bars within a single beat in the audio track. This is only relevant for music that wishes to make use of interactive music functionality, not sound effects.
+			The number of beats within a single bar in the audio track. This is only relevant for music that wishes to make use of interactive music functionality, not sound effects.
 			A more convenient editor for [member bar_beats] is provided in the [b]Advanced Import Settings[/b] dialog, as it lets you preview your changes without having to reimport the audio.
 		</member>
 		<member name="beat_count" type="int" setter="" getter="" default="0">


### PR DESCRIPTION
The description of bar_beats talks about the "number of bars in a beat", but in music, we usually talk about the number of beats in a bar.
The property is also named "bar_beatS", which makes me think that at least one thing is inverted here, probably the description.

(Not a 100% sure on this one, correct me if I'm wrong)