### PR TITLE
Add file search QoL when focused on folder text box

### DIFF
--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -395,6 +395,7 @@ FindInFilesDialog::FindInFilesDialog() {
 
 		_folder_line_edit = memnew(LineEdit);
 		_folder_line_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		_folder_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FindInFilesDialog::_on_search_text_submitted));
 		hbc->add_child(_folder_line_edit);
 
 		Button *folder_button = memnew(Button);


### PR DESCRIPTION
Small QoL fix that I noticed that was bugging me a ton when using Ctrl + Shift + F to search in the script editor.

Before, it wouldn't let you search if you were focused on the text edit field for the folder, this fixes that.