### PR TITLE
Expose `WorkerThreadPool.get_caller_task_id()`

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -861,6 +861,8 @@ void WorkerThreadPool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_group_task_completed", "group_id"), &WorkerThreadPool::is_group_task_completed);
 	ClassDB::bind_method(D_METHOD("get_group_processed_element_count", "group_id"), &WorkerThreadPool::get_group_processed_element_count);
 	ClassDB::bind_method(D_METHOD("wait_for_group_task_completion", "group_id"), &WorkerThreadPool::wait_for_group_task_completion);
+
+	ClassDB::bind_method(D_METHOD("get_caller_task_id"), &WorkerThreadPool::get_caller_task_id);
 }
 
 WorkerThreadPool *WorkerThreadPool::get_named_pool(const StringName &p_name) {

--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -72,6 +72,14 @@
 				[b]Warning:[/b] Every task must be waited for completion using [method wait_for_task_completion] or [method wait_for_group_task_completion] at some point so that any allocated resources inside the task can be cleaned up.
 			</description>
 		</method>
+		<method name="get_caller_task_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the task ID of the current thread calling this method, or [code]-1[/code] if the task is a group task, invalid or the current thread is not part of the thread pool (e.g. the main thread).
+				Can be used by a task to get its own task ID, or to determine whether the current code is running inside the worker thread pool.
+				[b]Note:[/b] Group tasks have their own IDs, so this method will return [code]-1[/code] for group tasks.
+			</description>
+		</method>
 		<method name="get_group_processed_element_count" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="group_id" type="int" />


### PR DESCRIPTION
I was looking for a way to interact with the WorkerThreadPool from inside a task. For that, it needs to know its task ID. Turns out `get_caller_task_id()` exists to facilitate that (and is used in some places from C++), but is not currently exposed.

Existing code (like in `ResourceLoader`) uses this similarly, or to determine whether it is running inside the thread pool. It makes sense to me to be able to do that in user/game/plugin code too.

To quote bruvzg on RC:
> Should we expose that?

> Probably. I do not see any reason why it would be bad to exposed it.

This is also helpful to solve some of the pains discussed in https://github.com/godotengine/godot-proposals/issues/11201.