### PR TITLE
Optimize Vector `ToString()` in C#

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -1117,7 +1117,63 @@ namespace Godot
         /// <returns>A string representation of this vector.</returns>
         public readonly string ToString(string? format)
         {
+            Span<char> destination = stackalloc char[64];
+            if (TryFormat(destination, out int charsWritten, format))
+            {
+                return destination[..charsWritten].ToString();
+            }
+
             return $"({X.ToString(format, CultureInfo.InvariantCulture)}, {Y.ToString(format, CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Tries to format this <see cref="Vector2"/> into the provided span of characters.
+        /// </summary>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        public readonly bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default)
+        {
+            charsWritten = 0;
+
+            // Write '('
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = '(';
+            charsWritten++;
+
+            // Write X
+            if (!X.TryFormat(destination[charsWritten..], out int xCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += xCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Y
+            if (!Y.TryFormat(destination[charsWritten..], out int yCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += yCharsWritten;
+
+            // Write ')'
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ')';
+            charsWritten++;
+
+            return true;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2I.cs
@@ -707,7 +707,63 @@ namespace Godot
         /// <returns>A string representation of this vector.</returns>
         public readonly string ToString(string? format)
         {
+            Span<char> destination = stackalloc char[64];
+            if (TryFormat(destination, out int charsWritten, format))
+            {
+                return destination[..charsWritten].ToString();
+            }
+
             return $"({X.ToString(format, CultureInfo.InvariantCulture)}, {Y.ToString(format, CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Tries to format this <see cref="Vector2I"/> into the provided span of characters.
+        /// </summary>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        public readonly bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default)
+        {
+            charsWritten = 0;
+
+            // Write '('
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = '(';
+            charsWritten++;
+
+            // Write X
+            if (!X.TryFormat(destination[charsWritten..], out int xCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += xCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Y
+            if (!Y.TryFormat(destination[charsWritten..], out int yCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += yCharsWritten;
+
+            // Write ')'
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ')';
+            charsWritten++;
+
+            return true;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -1281,7 +1281,79 @@ namespace Godot
         /// <returns>A string representation of this vector.</returns>
         public readonly string ToString(string? format)
         {
+            Span<char> destination = stackalloc char[64];
+            if (TryFormat(destination, out int charsWritten, format))
+            {
+                return destination[..charsWritten].ToString();
+            }
+
             return $"({X.ToString(format, CultureInfo.InvariantCulture)}, {Y.ToString(format, CultureInfo.InvariantCulture)}, {Z.ToString(format, CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Tries to format this <see cref="Vector3"/> into the provided span of characters.
+        /// </summary>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        public readonly bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default)
+        {
+            charsWritten = 0;
+
+            // Write '('
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = '(';
+            charsWritten++;
+
+            // Write X
+            if (!X.TryFormat(destination[charsWritten..], out int xCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += xCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Y
+            if (!Y.TryFormat(destination[charsWritten..], out int yCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += yCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Z
+            if (!Z.TryFormat(destination[charsWritten..], out int zCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += zCharsWritten;
+
+            // Write ')'
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ')';
+            charsWritten++;
+
+            return true;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3I.cs
@@ -769,7 +769,79 @@ namespace Godot
         /// <returns>A string representation of this vector.</returns>
         public readonly string ToString(string? format)
         {
+            Span<char> destination = stackalloc char[64];
+            if (TryFormat(destination, out int charsWritten, format))
+            {
+                return destination[..charsWritten].ToString();
+            }
+
             return $"({X.ToString(format, CultureInfo.InvariantCulture)}, {Y.ToString(format, CultureInfo.InvariantCulture)}, {Z.ToString(format, CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Tries to format this <see cref="Vector3I"/> into the provided span of characters.
+        /// </summary>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        public readonly bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default)
+        {
+            charsWritten = 0;
+
+            // Write '('
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = '(';
+            charsWritten++;
+
+            // Write X
+            if (!X.TryFormat(destination[charsWritten..], out int xCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += xCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Y
+            if (!Y.TryFormat(destination[charsWritten..], out int yCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += yCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Z
+            if (!Z.TryFormat(destination[charsWritten..], out int zCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += zCharsWritten;
+
+            // Write ')'
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ')';
+            charsWritten++;
+
+            return true;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4.cs
@@ -1010,7 +1010,95 @@ namespace Godot
         /// <returns>A string representation of this vector.</returns>
         public readonly string ToString(string? format)
         {
+            Span<char> destination = stackalloc char[64];
+            if (TryFormat(destination, out int charsWritten, format))
+            {
+                return destination[..charsWritten].ToString();
+            }
+
             return $"({X.ToString(format, CultureInfo.InvariantCulture)}, {Y.ToString(format, CultureInfo.InvariantCulture)}, {Z.ToString(format, CultureInfo.InvariantCulture)}, {W.ToString(format, CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Tries to format this <see cref="Vector4"/> into the provided span of characters.
+        /// </summary>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        public readonly bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default)
+        {
+            charsWritten = 0;
+
+            // Write '('
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = '(';
+            charsWritten++;
+
+            // Write X
+            if (!X.TryFormat(destination[charsWritten..], out int xCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += xCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Y
+            if (!Y.TryFormat(destination[charsWritten..], out int yCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += yCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Z
+            if (!Z.TryFormat(destination[charsWritten..], out int zCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += zCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write W
+            if (!W.TryFormat(destination[charsWritten..], out int wCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += wCharsWritten;
+
+            // Write ')'
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ')';
+            charsWritten++;
+
+            return true;
         }
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector4I.cs
@@ -795,7 +795,95 @@ namespace Godot
         /// <returns>A string representation of this vector.</returns>
         public readonly string ToString(string? format)
         {
+            Span<char> destination = stackalloc char[64];
+            if (TryFormat(destination, out int charsWritten, format))
+            {
+                return destination[..charsWritten].ToString();
+            }
+
             return $"({X.ToString(format, CultureInfo.InvariantCulture)}, {Y.ToString(format, CultureInfo.InvariantCulture)}, {Z.ToString(format, CultureInfo.InvariantCulture)}, {W.ToString(format, CultureInfo.InvariantCulture)})";
+        }
+
+        /// <summary>
+        /// Tries to format this <see cref="Vector4I"/> into the provided span of characters.
+        /// </summary>
+        /// <returns><see langword="true"/> if the formatting was successful; otherwise, <see langword="false"/>.</returns>
+        public readonly bool TryFormat(Span<char> destination, out int charsWritten, [StringSyntax(StringSyntaxAttribute.NumericFormat)] ReadOnlySpan<char> format = default)
+        {
+            charsWritten = 0;
+
+            // Write '('
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = '(';
+            charsWritten++;
+
+            // Write X
+            if (!X.TryFormat(destination[charsWritten..], out int xCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += xCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Y
+            if (!Y.TryFormat(destination[charsWritten..], out int yCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += yCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write Z
+            if (!Z.TryFormat(destination[charsWritten..], out int zCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += zCharsWritten;
+
+            // Write ', '
+            if (charsWritten + 1 >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ',';
+            destination[charsWritten + 1] = ' ';
+            charsWritten += 2;
+
+            // Write W
+            if (!W.TryFormat(destination[charsWritten..], out int wCharsWritten, format, CultureInfo.InvariantCulture))
+            {
+                return false;
+            }
+            charsWritten += wCharsWritten;
+
+            // Write ')'
+            if (charsWritten >= destination.Length)
+            {
+                return false;
+            }
+            destination[charsWritten] = ')';
+            charsWritten++;
+
+            return true;
         }
     }
 }


### PR DESCRIPTION
This PR aims to improve the performance of `ToString()` for `Vector2`, `Vector2I`, `Vector3`, `Vector3I`, `Vector4` and `Vector4I` in C#.

Each `Vector` type gets:

- A `TryFormat` method which writes the stringified vector to a `Span<char>` which is zero-allocation.
- The `ToString` method attempts to use `TryFormat` to write all elements to a span and then convert the result to a string, rather than converting each element to a string and then converting the result to a string.

### Benchmarks:

These benchmarks convert the `Vector3` `(1.23, 2.45, 3.67)` to a string.

| Method                       | Mean     | Error   | StdDev  | Gen0   | Allocated |
|----------------------------- |---------:|--------:|--------:|-------:|----------:|
| ToStringToString             | 360.1 ns | 2.81 ns | 2.63 ns | 0.0505 |     160 B |
| ToStringTryFormat            | 329.2 ns | 1.48 ns | 1.24 ns | 0.0200 |      64 B |
| ToStringTryFormatAlternative | 308.1 ns | 2.10 ns | 1.97 ns | 0.0200 |      64 B |
| TryFormatTryFormat           | 293.1 ns | 1.36 ns | 1.27 ns |      - |         - |

[GodotTryFormatBenchmarks.zip](https://github.com/user-attachments/files/20543963/GodotTryFormatBenchmarks.zip)

- `ToStringToString` is the original `ToString` method we are trying to optimise.
- `ToStringTryFormat` writes each element to a stack-allocated span and then compiles the used portions to a string. It's not as performant as the alternative approach which uses a single span.
- `ToStringTryFormatAlternative` is the new `ToString` method. It uses `TryFormat` with a default stack-allocated span of 64 chars and then converts the used portion to a string.
- `TryFormatTryFormat` is the new `TryFormat` method. It writes the characters to a span and achieves zero-allocation.

### Notes

If the buffer is not big enough for these methods they fall back to the original `ToString` implementation. May be worth increasing the buffer size for `ToString` to reduce the chance of fallback or decreasing the buffer size to slightly increase performance.

If this PR is considered to add too much boilerplate, then a simpler `ToString` method that's a bit less performant but doesn't rely on a new `TryFormat` method can be used instead:
```cs
public string ToString(string? format) {
    Span<char> xChars = stackalloc char[32];
    if (!X.TryFormat(xChars, out int xCharsWritten, format, CultureInfo.InvariantCulture)) {
        return ToStringToString();
    }
    Span<char> yChars = stackalloc char[32];
    if (!Y.TryFormat(yChars, out int yCharsWritten, format, CultureInfo.InvariantCulture)) {
        return ToStringToString();
    }
    Span<char> zChars = stackalloc char[32];
    if (!Z.TryFormat(zChars, out int zCharsWritten, format, CultureInfo.InvariantCulture)) {
        return ToStringToString();
    }
    return $"({xChars[..xCharsWritten]}, {yChars[..yCharsWritten]}, {zChars[..zCharsWritten]})";
}
```

### Conclusion

This PR:
- Improves `Vector` `ToString` speed by 15% and reduces heap allocations by 60%. 
- Adds `Vector` `TryFormat` which improves speed by 20% and reduces heap allocations to zero.