### PR TITLE
Add support for taking embedded window screenshots.

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -548,7 +548,8 @@ private:
 
 	void _request_screenshot();
 	void _screenshot(bool p_use_utc = false);
-	void _save_screenshot(NodePath p_path);
+	void _save_screenshot(const String &p_path);
+	void _save_screenshot_with_embedded_process(int64_t p_w, int64_t p_h, const String &p_emb_path, const Rect2i &p_rect, const String &p_path);
 
 	void _check_system_theme_changed();
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -189,6 +189,14 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	return OK;
 }
 
+bool EditorRun::request_screenshot(const Callable &p_callback) {
+	if (instance_rq_screenshot_callback) {
+		return instance_rq_screenshot_callback(p_callback);
+	} else {
+		return false;
+	}
+}
+
 bool EditorRun::has_child_process(OS::ProcessID p_pid) const {
 	for (const OS::ProcessID &E : pids) {
 		if (E == p_pid) {

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -33,6 +33,7 @@
 #include "core/os/os.h"
 
 typedef void (*EditorRunInstanceStarting)(int p_index, List<String> &r_arguments);
+typedef bool (*EditorRunInstanceRequestScreenshot)(const Callable &p_callback);
 
 class EditorRun {
 public:
@@ -58,6 +59,7 @@ private:
 
 public:
 	inline static EditorRunInstanceStarting instance_starting_callback = nullptr;
+	inline static EditorRunInstanceRequestScreenshot instance_rq_screenshot_callback = nullptr;
 
 	Status get_status() const;
 	String get_running_scene() const;
@@ -70,6 +72,8 @@ public:
 	bool has_child_process(OS::ProcessID p_pid) const;
 	int get_child_process_count() const { return pids.size(); }
 	OS::ProcessID get_current_process() const;
+
+	static bool request_screenshot(const Callable &p_callback);
 
 	static WindowPlacement get_window_placement();
 

--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
+#include "core/debugger/engine_debugger.h"
 #include "core/string/translation_server.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
@@ -225,6 +226,61 @@ void GameViewDebugger::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("session_stopped"));
 }
 
+bool GameViewDebugger::add_screenshot_callback(const Callable &p_callaback, const Rect2i &p_rect) {
+	bool found = false;
+	for (Ref<EditorDebuggerSession> &I : sessions) {
+		if (I->is_active()) {
+			ScreenshotCB sd;
+			sd.cb = p_callaback;
+			sd.rect = p_rect;
+			screenshot_callbacks[scr_rq_id] = sd;
+
+			Array arr;
+			arr.append(scr_rq_id);
+			I->send_message("scene:rq_screenshot", arr);
+			scr_rq_id++;
+			found = true;
+		}
+	}
+	return found;
+}
+
+bool GameViewDebugger::_msg_get_screenshot(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 4, false, "get_screenshot: invalid number of arguments");
+
+	int64_t id = p_args[0];
+	int64_t w = p_args[1];
+	int64_t h = p_args[2];
+	const String &path = p_args[3];
+
+	if (screenshot_callbacks.has(id)) {
+		if (screenshot_callbacks[id].cb.is_valid()) {
+			screenshot_callbacks[id].cb.call(w, h, path, screenshot_callbacks[id].rect);
+		}
+		screenshot_callbacks.erase(id);
+	}
+	return true;
+}
+
+bool GameViewDebugger::capture(const String &p_message, const Array &p_data, int p_session) {
+	Ref<EditorDebuggerSession> session = get_session(p_session);
+	ERR_FAIL_COND_V(session.is_null(), true);
+
+	if (p_message == "game_view:get_screenshot") {
+		return _msg_get_screenshot(p_data);
+	} else {
+		// Any other messages with this prefix should be ignored.
+		WARN_PRINT("GameViewDebugger unknown message: " + p_message);
+		return false;
+	}
+
+	return true;
+}
+
+bool GameViewDebugger::has_capture(const String &p_capture) const {
+	return p_capture == "game_view";
+}
+
 GameViewDebugger::GameViewDebugger() {
 	EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &GameViewDebugger::_feature_profile_changed));
 }
@@ -278,6 +334,23 @@ void GameView::_instance_starting(int p_idx, List<String> &r_arguments) {
 	}
 
 	_update_arguments_for_instance(p_idx, r_arguments);
+}
+
+bool GameView::_instance_rq_screenshot_static(const Callable &p_callback) {
+	ERR_FAIL_NULL_V(singleton, false);
+	return singleton->_instance_rq_screenshot(p_callback);
+}
+
+bool GameView::_instance_rq_screenshot(const Callable &p_callback) {
+	if (debugger.is_null() || window_wrapper->get_window_enabled() || !embedded_process || !embedded_process->is_embedding_completed()) {
+		return false;
+	}
+	Rect2 r = embedded_process->get_adjusted_embedded_window_rect(embedded_process->get_rect());
+	r.position += embedded_process->get_global_position();
+#ifndef MACOS_ENABLED
+	r.position -= embedded_process->get_window()->get_position();
+#endif
+	return debugger->add_screenshot_callback(p_callback, r);
 }
 
 void GameView::_show_update_window_wrapper() {
@@ -749,6 +822,7 @@ void GameView::_notification(int p_what) {
 				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));
 				EditorRunBar::get_singleton()->connect("stop_pressed", callable_mp(this, &GameView::_stop_pressed));
 				EditorRun::instance_starting_callback = _instance_starting_static;
+				EditorRun::instance_rq_screenshot_callback = _instance_rq_screenshot_static;
 
 				// Listen for project settings changes to update the window size and aspect ratio.
 				ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &GameView::_editor_or_project_settings_changed));

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -60,10 +60,25 @@ private:
 
 	void _feature_profile_changed();
 
+	struct ScreenshotCB {
+		Callable cb;
+		Rect2i rect;
+	};
+
+	int64_t scr_rq_id = 0;
+	HashMap<uint64_t, ScreenshotCB> screenshot_callbacks;
+
+	bool _msg_get_screenshot(const Array &p_args);
+
 protected:
 	static void _bind_methods();
 
 public:
+	virtual bool capture(const String &p_message, const Array &p_data, int p_session) override;
+	virtual bool has_capture(const String &p_capture) const override;
+
+	bool add_screenshot_callback(const Callable &p_callaback, const Rect2i &p_rect);
+
 	void set_suspend(bool p_enabled);
 	void next_frame();
 
@@ -173,6 +188,8 @@ class GameView : public VBoxContainer {
 	void _play_pressed();
 	static void _instance_starting_static(int p_idx, List<String> &r_arguments);
 	void _instance_starting(int p_idx, List<String> &r_arguments);
+	static bool _instance_rq_screenshot_static(const Callable &p_callback);
+	bool _instance_rq_screenshot(const Callable &p_callback);
 	void _stop_pressed();
 	void _embedding_completed();
 	void _embedding_failed();

--- a/platform/macos/editor/embedded_game_view_plugin.h
+++ b/platform/macos/editor/embedded_game_view_plugin.h
@@ -60,7 +60,6 @@ class GameViewDebuggerMacOS : public GameViewDebugger {
 
 public:
 	virtual bool capture(const String &p_message, const Array &p_data, int p_session) override;
-	virtual bool has_capture(const String &p_capture) const override;
 
 	GameViewDebuggerMacOS(EmbeddedProcessMacOS *p_embedded_process);
 };

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -109,10 +109,6 @@ void GameViewDebuggerMacOS::_init_capture_message_handlers() {
 	parse_message_handlers["game_view:joy_stop"] = &GameViewDebuggerMacOS::_msg_joy_stop;
 }
 
-bool GameViewDebuggerMacOS::has_capture(const String &p_capture) const {
-	return p_capture == "game_view";
-}
-
 bool GameViewDebuggerMacOS::capture(const String &p_message, const Array &p_data, int p_session) {
 	Ref<EditorDebuggerSession> session = get_session(p_session);
 	ERR_FAIL_COND_V(session.is_null(), true);
@@ -121,9 +117,7 @@ bool GameViewDebuggerMacOS::capture(const String &p_message, const Array &p_data
 	if (fn_ptr) {
 		return (this->**fn_ptr)(p_data);
 	} else {
-		// Any other messages with this prefix should be ignored.
-		WARN_PRINT("GameViewDebuggerMacOS unknown message: " + p_message);
-		return ERR_SKIP;
+		return GameViewDebugger::capture(p_message, p_data, p_session);
 	}
 
 	return true;

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -119,6 +119,7 @@ private:
 #ifndef _3D_DISABLED
 	static Error _msg_runtime_node_select_reset_camera_3d(const Array &p_args);
 #endif
+	static Error _msg_rq_screenshot(const Array &p_args);
 
 public:
 	static Error parse_message(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);


### PR DESCRIPTION
Adds debug command to request saving screenshot of running process and use it to overlay embedded window when taking editor screenshot.

Fixes https://github.com/godotengine/godot/issues/106912

![editor_screenshot_2025-06-02T104140](https://github.com/user-attachments/assets/859683e0-40b7-428b-b8c9-8e82048aa3b1)
