### PR TITLE
Add `WorkerThreadPool.get_caller_group_id`

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -740,6 +740,15 @@ WorkerThreadPool::TaskID WorkerThreadPool::get_caller_task_id() const {
 	}
 }
 
+WorkerThreadPool::GroupID WorkerThreadPool::get_caller_group_id() const {
+	int th_index = get_thread_index();
+	if (th_index != -1 && threads[th_index].current_task && threads[th_index].current_task->group) {
+		return threads[th_index].current_task->group->self;
+	} else {
+		return INVALID_TASK_ID;
+	}
+}
+
 #ifdef THREADS_ENABLED
 uint32_t WorkerThreadPool::_thread_enter_unlock_allowance_zone(THREADING_NAMESPACE::unique_lock<THREADING_NAMESPACE::mutex> &p_ulock) {
 	for (uint32_t i = 0; i < MAX_UNLOCKABLE_LOCKS; i++) {
@@ -856,13 +865,13 @@ void WorkerThreadPool::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_task", "action", "high_priority", "description"), &WorkerThreadPool::add_task, DEFVAL(false), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("is_task_completed", "task_id"), &WorkerThreadPool::is_task_completed);
 	ClassDB::bind_method(D_METHOD("wait_for_task_completion", "task_id"), &WorkerThreadPool::wait_for_task_completion);
+	ClassDB::bind_method(D_METHOD("get_caller_task_id"), &WorkerThreadPool::get_caller_task_id);
 
 	ClassDB::bind_method(D_METHOD("add_group_task", "action", "elements", "tasks_needed", "high_priority", "description"), &WorkerThreadPool::add_group_task, DEFVAL(-1), DEFVAL(false), DEFVAL(String()));
 	ClassDB::bind_method(D_METHOD("is_group_task_completed", "group_id"), &WorkerThreadPool::is_group_task_completed);
 	ClassDB::bind_method(D_METHOD("get_group_processed_element_count", "group_id"), &WorkerThreadPool::get_group_processed_element_count);
 	ClassDB::bind_method(D_METHOD("wait_for_group_task_completion", "group_id"), &WorkerThreadPool::wait_for_group_task_completion);
-
-	ClassDB::bind_method(D_METHOD("get_caller_task_id"), &WorkerThreadPool::get_caller_task_id);
+	ClassDB::bind_method(D_METHOD("get_caller_group_id"), &WorkerThreadPool::get_caller_group_id);
 }
 
 WorkerThreadPool *WorkerThreadPool::get_named_pool(const StringName &p_name) {

--- a/core/object/worker_thread_pool.h
+++ b/core/object/worker_thread_pool.h
@@ -274,6 +274,7 @@ public:
 	static WorkerThreadPool *get_singleton() { return singleton; }
 	int get_thread_index() const;
 	TaskID get_caller_task_id() const;
+	GroupID get_caller_group_id() const;
 
 #ifdef THREADS_ENABLED
 	_ALWAYS_INLINE_ static uint32_t thread_enter_unlock_allowance_zone(const MutexLock<BinaryMutex> &p_lock) { return _thread_enter_unlock_allowance_zone(p_lock._get_lock()); }

--- a/doc/classes/WorkerThreadPool.xml
+++ b/doc/classes/WorkerThreadPool.xml
@@ -72,6 +72,12 @@
 				[b]Warning:[/b] Every task must be waited for completion using [method wait_for_task_completion] or [method wait_for_group_task_completion] at some point so that any allocated resources inside the task can be cleaned up.
 			</description>
 		</method>
+		<method name="get_caller_group_id" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the task group ID of the current thread calling this method, or [code]-1[/code] if invalid or the current thread is not part of a task group.
+			</description>
+		</method>
 		<method name="get_caller_task_id" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
Small addition to the https://github.com/godotengine/godot/pull/107029

Adds and exposes `get_caller_group_id`.

Usage example:

```gdscript
func _task_func(_index):
	# do stuff
	OS.delay_msec(10)
	# call cleanup
	var id = WorkerThreadPool.get_caller_group_id()
	call_deferred("_cleanup_func", id)
	
func _cleanup_func(id):
	# response to single task completion (e.g, update progress bar)
	if WorkerThreadPool.is_group_task_completed(id):
		WorkerThreadPool.wait_for_group_task_completion(id)
		print("task group %d is done" % id)

func _ready() -> void:
	WorkerThreadPool.add_group_task(_task_func, 200, -1, false, "test group")
```