### PR TITLE
Rename internal fields and variables in `AHashMap`, `HashMap` and `HashSet`

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -32,19 +32,6 @@
 
 #include "core/templates/hash_map.h"
 
-struct HashMapData {
-	union {
-		uint64_t data;
-		struct
-		{
-			uint32_t hash;
-			uint32_t hash_to_key;
-		};
-	};
-};
-
-static_assert(sizeof(HashMapData) == 8);
-
 /**
  * An array-based implementation of a hash map. It is very efficient in terms of performance and
  * memory usage. Works like a dynamic array, adding elements to the end of the array, and
@@ -91,13 +78,20 @@ public:
 	static_assert(EMPTY_HASH == 0, "EMPTY_HASH must always be 0 for the memcpy() optimization.");
 
 private:
+	struct Metadata {
+		uint32_t hash;
+		uint32_t element_idx;
+	};
+
+	static_assert(sizeof(Metadata) == 8);
+
 	typedef KeyValue<TKey, TValue> MapKeyValue;
-	MapKeyValue *elements = nullptr;
-	HashMapData *map_data = nullptr;
+	MapKeyValue *_elements = nullptr;
+	Metadata *_metadata = nullptr;
 
 	// Due to optimization, this is `capacity - 1`. Use + 1 to get normal capacity.
-	uint32_t capacity = 0;
-	uint32_t num_elements = 0;
+	uint32_t _capacity_mask = 0;
+	uint32_t _size = 0;
 
 	uint32_t _hash(const TKey &p_key) const {
 		uint32_t hash = Hasher::hash(p_key);
@@ -109,119 +103,118 @@ private:
 		return hash;
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_resize_count(uint32_t p_capacity) {
-		return p_capacity ^ (p_capacity + 1) >> 2; // = get_capacity() * 0.75 - 1; Works only if p_capacity = 2^n - 1.
+	static _FORCE_INLINE_ uint32_t _get_resize_count(uint32_t p_capacity_mask) {
+		return p_capacity_mask ^ (p_capacity_mask + 1) >> 2; // = get_capacity() * 0.75 - 1; Works only if p_capacity_mask = 2^n - 1.
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_probe_length(uint32_t p_pos, uint32_t p_hash, uint32_t p_local_capacity) {
-		const uint32_t original_pos = p_hash & p_local_capacity;
-		return (p_pos - original_pos + p_local_capacity + 1) & p_local_capacity;
+	static _FORCE_INLINE_ uint32_t _get_probe_length(uint32_t p_meta_idx, uint32_t p_hash, uint32_t p_capacity) {
+		const uint32_t original_idx = p_hash & p_capacity;
+		return (p_meta_idx - original_idx + p_capacity + 1) & p_capacity;
 	}
 
-	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos, uint32_t &r_hash_pos) const {
-		if (unlikely(elements == nullptr)) {
-			return false; // Failed lookups, no elements.
+	bool _lookup_idx(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx) const {
+		if (unlikely(_elements == nullptr)) {
+			return false; // Failed lookups, no _elements.
 		}
-		return _lookup_pos_with_hash(p_key, r_pos, r_hash_pos, _hash(p_key));
+		return _lookup_idx_with_hash(p_key, r_element_idx, r_meta_idx, _hash(p_key));
 	}
 
-	bool _lookup_pos_with_hash(const TKey &p_key, uint32_t &r_pos, uint32_t &r_hash_pos, uint32_t p_hash) const {
-		if (unlikely(elements == nullptr)) {
-			return false; // Failed lookups, no elements.
+	bool _lookup_idx_with_hash(const TKey &p_key, uint32_t &r_element_idx, uint32_t &r_meta_idx, uint32_t p_hash) const {
+		if (unlikely(_elements == nullptr)) {
+			return false; // Failed lookups, no _elements.
 		}
 
-		uint32_t pos = p_hash & capacity;
-		HashMapData data = map_data[pos];
-		if (data.hash == p_hash && Comparator::compare(elements[data.hash_to_key].key, p_key)) {
-			r_pos = data.hash_to_key;
-			r_hash_pos = pos;
+		uint32_t meta_idx = p_hash & _capacity_mask;
+		Metadata metadata = _metadata[meta_idx];
+		if (metadata.hash == p_hash && Comparator::compare(_elements[metadata.element_idx].key, p_key)) {
+			r_element_idx = metadata.element_idx;
+			r_meta_idx = meta_idx;
 			return true;
 		}
 
-		if (data.data == EMPTY_HASH) {
+		if (metadata.hash == EMPTY_HASH) {
 			return false;
 		}
 
 		// A collision occurred.
-		pos = (pos + 1) & capacity;
+		meta_idx = (meta_idx + 1) & _capacity_mask;
 		uint32_t distance = 1;
 		while (true) {
-			data = map_data[pos];
-			if (data.hash == p_hash && Comparator::compare(elements[data.hash_to_key].key, p_key)) {
-				r_pos = data.hash_to_key;
-				r_hash_pos = pos;
+			metadata = _metadata[meta_idx];
+			if (metadata.hash == p_hash && Comparator::compare(_elements[metadata.element_idx].key, p_key)) {
+				r_element_idx = metadata.element_idx;
+				r_meta_idx = meta_idx;
 				return true;
 			}
 
-			if (data.data == EMPTY_HASH) {
+			if (metadata.hash == EMPTY_HASH) {
 				return false;
 			}
 
-			if (distance > _get_probe_length(pos, data.hash, capacity)) {
+			if (distance > _get_probe_length(meta_idx, metadata.hash, _capacity_mask)) {
 				return false;
 			}
 
-			pos = (pos + 1) & capacity;
+			meta_idx = (meta_idx + 1) & _capacity_mask;
 			distance++;
 		}
 	}
 
-	uint32_t _insert_with_hash(uint32_t p_hash, uint32_t p_index) {
-		uint32_t pos = p_hash & capacity;
+	uint32_t _insert_metadata(uint32_t p_hash, uint32_t p_element_idx) {
+		uint32_t meta_idx = p_hash & _capacity_mask;
 
-		if (map_data[pos].data == EMPTY_HASH) {
-			uint64_t data = ((uint64_t)p_index << 32) | p_hash;
-			map_data[pos].data = data;
-			return pos;
+		if (_metadata[meta_idx].hash == EMPTY_HASH) {
+			_metadata[meta_idx] = Metadata{ p_hash, p_element_idx };
+			return meta_idx;
 		}
 
 		uint32_t distance = 1;
-		pos = (pos + 1) & capacity;
-		HashMapData c_data;
-		c_data.hash = p_hash;
-		c_data.hash_to_key = p_index;
+		meta_idx = (meta_idx + 1) & _capacity_mask;
+		Metadata metadata;
+		metadata.hash = p_hash;
+		metadata.element_idx = p_element_idx;
 
 		while (true) {
-			if (map_data[pos].data == EMPTY_HASH) {
+			if (_metadata[meta_idx].hash == EMPTY_HASH) {
 #ifdef DEV_ENABLED
 				if (unlikely(distance > 12)) {
 					WARN_PRINT("Excessive collision count (" +
 							itos(distance) + "), is the right hash function being used?");
 				}
 #endif
-				map_data[pos] = c_data;
-				return pos;
+				_metadata[meta_idx] = metadata;
+				return meta_idx;
 			}
 
 			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(pos, map_data[pos].hash, capacity);
+			uint32_t existing_probe_len = _get_probe_length(meta_idx, _metadata[meta_idx].hash, _capacity_mask);
 			if (existing_probe_len < distance) {
-				SWAP(c_data, map_data[pos]);
+				SWAP(metadata, _metadata[meta_idx]);
 				distance = existing_probe_len;
 			}
 
-			pos = (pos + 1) & capacity;
+			meta_idx = (meta_idx + 1) & _capacity_mask;
 			distance++;
 		}
 	}
 
 	void _resize_and_rehash(uint32_t p_new_capacity) {
-		uint32_t real_old_capacity = capacity + 1;
+		uint32_t real_old_capacity = _capacity_mask + 1;
 		// Capacity can't be 0 and must be 2^n - 1.
-		capacity = MAX(4u, p_new_capacity);
-		uint32_t real_capacity = next_power_of_2(capacity);
-		capacity = real_capacity - 1;
+		_capacity_mask = MAX(4u, p_new_capacity);
+		uint32_t real_capacity = next_power_of_2(_capacity_mask);
+		_capacity_mask = real_capacity - 1;
 
-		HashMapData *old_map_data = map_data;
+		Metadata *old_map_data = _metadata;
 
-		map_data = reinterpret_cast<HashMapData *>(Memory::alloc_static_zeroed(sizeof(HashMapData) * real_capacity));
-		elements = reinterpret_cast<MapKeyValue *>(Memory::realloc_static(elements, sizeof(MapKeyValue) * (_get_resize_count(capacity) + 1)));
+		_metadata = reinterpret_cast<Metadata *>(Memory::alloc_static_zeroed(sizeof(Metadata) * real_capacity));
+		_elements = reinterpret_cast<MapKeyValue *>(Memory::realloc_static(_elements, sizeof(MapKeyValue) * (_get_resize_count(_capacity_mask) + 1)));
 
-		if (num_elements != 0) {
+		if (_size != 0) {
 			for (uint32_t i = 0; i < real_old_capacity; i++) {
-				HashMapData data = old_map_data[i];
-				if (data.data != EMPTY_HASH) {
-					_insert_with_hash(data.hash, data.hash_to_key);
+				Metadata metadata = old_map_data[i];
+				if (metadata.hash != EMPTY_HASH) {
+					_insert_metadata(metadata.hash, metadata.element_idx);
 				}
 			}
 		}
@@ -230,149 +223,148 @@ private:
 	}
 
 	int32_t _insert_element(const TKey &p_key, const TValue &p_value, uint32_t p_hash) {
-		if (unlikely(elements == nullptr)) {
+		if (unlikely(_elements == nullptr)) {
 			// Allocate on demand to save memory.
 
-			uint32_t real_capacity = capacity + 1;
-			map_data = reinterpret_cast<HashMapData *>(Memory::alloc_static_zeroed(sizeof(HashMapData) * real_capacity));
-			elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(capacity) + 1)));
+			uint32_t real_capacity = _capacity_mask + 1;
+			_metadata = reinterpret_cast<Metadata *>(Memory::alloc_static_zeroed(sizeof(Metadata) * real_capacity));
+			_elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(_capacity_mask) + 1)));
 		}
 
-		if (unlikely(num_elements > _get_resize_count(capacity))) {
-			_resize_and_rehash(capacity * 2);
+		if (unlikely(_size > _get_resize_count(_capacity_mask))) {
+			_resize_and_rehash(_capacity_mask * 2);
 		}
 
-		memnew_placement(&elements[num_elements], MapKeyValue(p_key, p_value));
+		memnew_placement(&_elements[_size], MapKeyValue(p_key, p_value));
 
-		_insert_with_hash(p_hash, num_elements);
-		num_elements++;
-		return num_elements - 1;
+		_insert_metadata(p_hash, _size);
+		_size++;
+		return _size - 1;
 	}
 
 	void _init_from(const AHashMap &p_other) {
-		capacity = p_other.capacity;
-		uint32_t real_capacity = capacity + 1;
-		num_elements = p_other.num_elements;
+		_capacity_mask = p_other._capacity_mask;
+		uint32_t real_capacity = _capacity_mask + 1;
+		_size = p_other._size;
 
-		if (p_other.num_elements == 0) {
+		if (p_other._size == 0) {
 			return;
 		}
 
-		map_data = reinterpret_cast<HashMapData *>(Memory::alloc_static(sizeof(HashMapData) * real_capacity));
-		elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(capacity) + 1)));
+		_metadata = reinterpret_cast<Metadata *>(Memory::alloc_static(sizeof(Metadata) * real_capacity));
+		_elements = reinterpret_cast<MapKeyValue *>(Memory::alloc_static(sizeof(MapKeyValue) * (_get_resize_count(_capacity_mask) + 1)));
 
 		if constexpr (std::is_trivially_copyable_v<TKey> && std::is_trivially_copyable_v<TValue>) {
-			void *destination = elements;
-			const void *source = p_other.elements;
-			memcpy(destination, source, sizeof(MapKeyValue) * num_elements);
+			void *destination = _elements;
+			const void *source = p_other._elements;
+			memcpy(destination, source, sizeof(MapKeyValue) * _size);
 		} else {
-			for (uint32_t i = 0; i < num_elements; i++) {
-				memnew_placement(&elements[i], MapKeyValue(p_other.elements[i]));
+			for (uint32_t i = 0; i < _size; i++) {
+				memnew_placement(&_elements[i], MapKeyValue(p_other._elements[i]));
 			}
 		}
 
-		memcpy(map_data, p_other.map_data, sizeof(HashMapData) * real_capacity);
+		memcpy(_metadata, p_other._metadata, sizeof(Metadata) * real_capacity);
 	}
 
 public:
 	/* Standard Godot Container API */
 
-	_FORCE_INLINE_ uint32_t get_capacity() const { return capacity + 1; }
-	_FORCE_INLINE_ uint32_t size() const { return num_elements; }
+	_FORCE_INLINE_ uint32_t get_capacity() const { return _capacity_mask + 1; }
+	_FORCE_INLINE_ uint32_t size() const { return _size; }
 
 	_FORCE_INLINE_ bool is_empty() const {
-		return num_elements == 0;
+		return _size == 0;
 	}
 
 	void clear() {
-		if (elements == nullptr || num_elements == 0) {
+		if (_elements == nullptr || _size == 0) {
 			return;
 		}
 
-		memset(map_data, EMPTY_HASH, (capacity + 1) * sizeof(HashMapData));
+		memset(_metadata, EMPTY_HASH, (_capacity_mask + 1) * sizeof(Metadata));
 		if constexpr (!(std::is_trivially_destructible_v<TKey> && std::is_trivially_destructible_v<TValue>)) {
-			for (uint32_t i = 0; i < num_elements; i++) {
-				elements[i].key.~TKey();
-				elements[i].value.~TValue();
+			for (uint32_t i = 0; i < _size; i++) {
+				_elements[i].key.~TKey();
+				_elements[i].value.~TValue();
 			}
 		}
 
-		num_elements = 0;
+		_size = 0;
 	}
 
 	TValue &get(const TKey &p_key) {
-		uint32_t pos = 0;
-		uint32_t hash_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, hash_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 		CRASH_COND_MSG(!exists, "AHashMap key not found.");
-		return elements[pos].value;
+		return _elements[element_idx].value;
 	}
 
 	const TValue &get(const TKey &p_key) const {
-		uint32_t pos = 0;
-		uint32_t hash_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, hash_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 		CRASH_COND_MSG(!exists, "AHashMap key not found.");
-		return elements[pos].value;
+		return _elements[element_idx].value;
 	}
 
 	const TValue *getptr(const TKey &p_key) const {
-		uint32_t pos = 0;
-		uint32_t hash_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, hash_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 
 		if (exists) {
-			return &elements[pos].value;
+			return &_elements[element_idx].value;
 		}
 		return nullptr;
 	}
 
 	TValue *getptr(const TKey &p_key) {
-		uint32_t pos = 0;
-		uint32_t hash_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, hash_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 
 		if (exists) {
-			return &elements[pos].value;
+			return &_elements[element_idx].value;
 		}
 		return nullptr;
 	}
 
 	bool has(const TKey &p_key) const {
-		uint32_t _pos = 0;
-		uint32_t h_pos = 0;
-		return _lookup_pos(p_key, _pos, h_pos);
+		uint32_t _idx = 0;
+		uint32_t meta_idx = 0;
+		return _lookup_idx(p_key, _idx, meta_idx);
 	}
 
 	bool erase(const TKey &p_key) {
-		uint32_t pos = 0;
-		uint32_t element_pos = 0;
-		bool exists = _lookup_pos(p_key, element_pos, pos);
+		uint32_t meta_idx = 0;
+		uint32_t element_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 
 		if (!exists) {
 			return false;
 		}
 
-		uint32_t next_pos = (pos + 1) & capacity;
-		while (map_data[next_pos].hash != EMPTY_HASH && _get_probe_length(next_pos, map_data[next_pos].hash, capacity) != 0) {
-			SWAP(map_data[next_pos], map_data[pos]);
+		uint32_t next_meta_idx = (meta_idx + 1) & _capacity_mask;
+		while (_metadata[next_meta_idx].hash != EMPTY_HASH && _get_probe_length(next_meta_idx, _metadata[next_meta_idx].hash, _capacity_mask) != 0) {
+			SWAP(_metadata[next_meta_idx], _metadata[meta_idx]);
 
-			pos = next_pos;
-			next_pos = (next_pos + 1) & capacity;
+			meta_idx = next_meta_idx;
+			next_meta_idx = (next_meta_idx + 1) & _capacity_mask;
 		}
 
-		map_data[pos].data = EMPTY_HASH;
-		elements[element_pos].key.~TKey();
-		elements[element_pos].value.~TValue();
-		num_elements--;
+		_metadata[meta_idx].hash = EMPTY_HASH;
+		_elements[element_idx].key.~TKey();
+		_elements[element_idx].value.~TValue();
+		_size--;
 
-		if (element_pos < num_elements) {
-			void *destination = &elements[element_pos];
-			const void *source = &elements[num_elements];
-			memcpy(destination, source, sizeof(MapKeyValue));
-			uint32_t h_pos = 0;
-			_lookup_pos(elements[num_elements].key, pos, h_pos);
-			map_data[h_pos].hash_to_key = element_pos;
+		if (element_idx < _size) {
+			memcpy((void *)&_elements[element_idx], (const void *)&_elements[_size], sizeof(MapKeyValue));
+			uint32_t moved_element_idx = 0;
+			uint32_t moved_meta_idx = 0;
+			_lookup_idx(_elements[_size].key, moved_element_idx, moved_meta_idx);
+			_metadata[moved_meta_idx].element_idx = element_idx;
 		}
 
 		return true;
@@ -384,25 +376,25 @@ public:
 		if (p_old_key == p_new_key) {
 			return true;
 		}
-		uint32_t pos = 0;
-		uint32_t element_pos = 0;
-		ERR_FAIL_COND_V(_lookup_pos(p_new_key, element_pos, pos), false);
-		ERR_FAIL_COND_V(!_lookup_pos(p_old_key, element_pos, pos), false);
-		MapKeyValue &element = elements[element_pos];
+		uint32_t meta_idx = 0;
+		uint32_t element_idx = 0;
+		ERR_FAIL_COND_V(_lookup_idx(p_new_key, element_idx, meta_idx), false);
+		ERR_FAIL_COND_V(!_lookup_idx(p_old_key, element_idx, meta_idx), false);
+		MapKeyValue &element = _elements[element_idx];
 		const_cast<TKey &>(element.key) = p_new_key;
 
-		uint32_t next_pos = (pos + 1) & capacity;
-		while (map_data[next_pos].hash != EMPTY_HASH && _get_probe_length(next_pos, map_data[next_pos].hash, capacity) != 0) {
-			SWAP(map_data[next_pos], map_data[pos]);
+		uint32_t next_meta_idx = (meta_idx + 1) & _capacity_mask;
+		while (_metadata[next_meta_idx].hash != EMPTY_HASH && _get_probe_length(next_meta_idx, _metadata[next_meta_idx].hash, _capacity_mask) != 0) {
+			SWAP(_metadata[next_meta_idx], _metadata[meta_idx]);
 
-			pos = next_pos;
-			next_pos = (next_pos + 1) & capacity;
+			meta_idx = next_meta_idx;
+			next_meta_idx = (next_meta_idx + 1) & _capacity_mask;
 		}
 
-		map_data[pos].data = EMPTY_HASH;
+		_metadata[meta_idx].hash = EMPTY_HASH;
 
 		uint32_t hash = _hash(p_new_key);
-		_insert_with_hash(hash, element_pos);
+		_insert_metadata(hash, element_idx);
 
 		return true;
 	}
@@ -411,9 +403,9 @@ public:
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
 		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
-		if (elements == nullptr) {
-			capacity = MAX(4u, p_new_capacity);
-			capacity = next_power_of_2(capacity) - 1;
+		if (_elements == nullptr) {
+			_capacity_mask = MAX(4u, p_new_capacity);
+			_capacity_mask = next_power_of_2(_capacity_mask) - 1;
 			return; // Unallocated yet.
 		}
 		if (p_new_capacity <= get_capacity()) {
@@ -528,26 +520,26 @@ public:
 	};
 
 	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(elements, elements, elements + num_elements);
+		return Iterator(_elements, _elements, _elements + _size);
 	}
 	_FORCE_INLINE_ Iterator end() {
-		return Iterator(elements + num_elements, elements, elements + num_elements);
+		return Iterator(_elements + _size, _elements, _elements + _size);
 	}
 	_FORCE_INLINE_ Iterator last() {
-		if (unlikely(num_elements == 0)) {
+		if (unlikely(_size == 0)) {
 			return Iterator(nullptr, nullptr, nullptr);
 		}
-		return Iterator(elements + num_elements - 1, elements, elements + num_elements);
+		return Iterator(_elements + _size - 1, _elements, _elements + _size);
 	}
 
 	Iterator find(const TKey &p_key) {
-		uint32_t pos = 0;
-		uint32_t h_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, h_pos);
+		uint32_t meta_idx = 0;
+		uint32_t element_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 		if (!exists) {
 			return end();
 		}
-		return Iterator(elements + pos, elements, elements + num_elements);
+		return Iterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
 	void remove(const Iterator &p_iter) {
@@ -557,104 +549,104 @@ public:
 	}
 
 	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(elements, elements, elements + num_elements);
+		return ConstIterator(_elements, _elements, _elements + _size);
 	}
 	_FORCE_INLINE_ ConstIterator end() const {
-		return ConstIterator(elements + num_elements, elements, elements + num_elements);
+		return ConstIterator(_elements + _size, _elements, _elements + _size);
 	}
 	_FORCE_INLINE_ ConstIterator last() const {
-		if (unlikely(num_elements == 0)) {
+		if (unlikely(_size == 0)) {
 			return ConstIterator(nullptr, nullptr, nullptr);
 		}
-		return ConstIterator(elements + num_elements - 1, elements, elements + num_elements);
+		return ConstIterator(_elements + _size - 1, _elements, _elements + _size);
 	}
 
 	ConstIterator find(const TKey &p_key) const {
-		uint32_t pos = 0;
-		uint32_t h_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, h_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 		if (!exists) {
 			return end();
 		}
-		return ConstIterator(elements + pos, elements, elements + num_elements);
+		return ConstIterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
 	/* Indexing */
 
 	const TValue &operator[](const TKey &p_key) const {
-		uint32_t pos = 0;
-		uint32_t h_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, h_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 		CRASH_COND(!exists);
-		return elements[pos].value;
+		return _elements[element_idx].value;
 	}
 
 	TValue &operator[](const TKey &p_key) {
-		uint32_t pos = 0;
-		uint32_t h_pos = 0;
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
 		uint32_t hash = _hash(p_key);
-		bool exists = _lookup_pos_with_hash(p_key, pos, h_pos, hash);
+		bool exists = _lookup_idx_with_hash(p_key, element_idx, meta_idx, hash);
 
 		if (exists) {
-			return elements[pos].value;
+			return _elements[element_idx].value;
 		} else {
-			pos = _insert_element(p_key, TValue(), hash);
-			return elements[pos].value;
+			element_idx = _insert_element(p_key, TValue(), hash);
+			return _elements[element_idx].value;
 		}
 	}
 
 	/* Insert */
 
 	Iterator insert(const TKey &p_key, const TValue &p_value) {
-		uint32_t pos = 0;
-		uint32_t h_pos = 0;
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
 		uint32_t hash = _hash(p_key);
-		bool exists = _lookup_pos_with_hash(p_key, pos, h_pos, hash);
+		bool exists = _lookup_idx_with_hash(p_key, element_idx, meta_idx, hash);
 
 		if (!exists) {
-			pos = _insert_element(p_key, p_value, hash);
+			element_idx = _insert_element(p_key, p_value, hash);
 		} else {
-			elements[pos].value = p_value;
+			_elements[element_idx].value = p_value;
 		}
-		return Iterator(elements + pos, elements, elements + num_elements);
+		return Iterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
 	// Inserts an element without checking if it already exists.
 	Iterator insert_new(const TKey &p_key, const TValue &p_value) {
 		DEV_ASSERT(!has(p_key));
 		uint32_t hash = _hash(p_key);
-		uint32_t pos = _insert_element(p_key, p_value, hash);
-		return Iterator(elements + pos, elements, elements + num_elements);
+		uint32_t element_idx = _insert_element(p_key, p_value, hash);
+		return Iterator(_elements + element_idx, _elements, _elements + _size);
 	}
 
 	/* Array methods. */
 
 	// Unsafe. Changing keys and going outside the bounds of an array can lead to undefined behavior.
 	KeyValue<TKey, TValue> *get_elements_ptr() {
-		return elements;
+		return _elements;
 	}
 
 	// Returns the element index. If not found, returns -1.
 	int get_index(const TKey &p_key) {
-		uint32_t pos = 0;
-		uint32_t h_pos = 0;
-		bool exists = _lookup_pos(p_key, pos, h_pos);
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		bool exists = _lookup_idx(p_key, element_idx, meta_idx);
 		if (!exists) {
 			return -1;
 		}
-		return pos;
+		return element_idx;
 	}
 
 	KeyValue<TKey, TValue> &get_by_index(uint32_t p_index) {
-		CRASH_BAD_UNSIGNED_INDEX(p_index, num_elements);
-		return elements[p_index];
+		CRASH_BAD_UNSIGNED_INDEX(p_index, _size);
+		return _elements[p_index];
 	}
 
 	bool erase_by_index(uint32_t p_index) {
 		if (p_index >= size()) {
 			return false;
 		}
-		return erase(elements[p_index].key);
+		return erase(_elements[p_index].key);
 	}
 
 	/* Constructors */
@@ -692,11 +684,11 @@ public:
 
 	AHashMap(uint32_t p_initial_capacity) {
 		// Capacity can't be 0 and must be 2^n - 1.
-		capacity = MAX(4u, p_initial_capacity);
-		capacity = next_power_of_2(capacity) - 1;
+		_capacity_mask = MAX(4u, p_initial_capacity);
+		_capacity_mask = next_power_of_2(_capacity_mask) - 1;
 	}
 	AHashMap() :
-			capacity(INITIAL_CAPACITY - 1) {
+			_capacity_mask(INITIAL_CAPACITY - 1) {
 	}
 
 	AHashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
@@ -707,19 +699,19 @@ public:
 	}
 
 	void reset() {
-		if (elements != nullptr) {
+		if (_elements != nullptr) {
 			if constexpr (!(std::is_trivially_destructible_v<TKey> && std::is_trivially_destructible_v<TValue>)) {
-				for (uint32_t i = 0; i < num_elements; i++) {
-					elements[i].key.~TKey();
-					elements[i].value.~TValue();
+				for (uint32_t i = 0; i < _size; i++) {
+					_elements[i].key.~TKey();
+					_elements[i].value.~TValue();
 				}
 			}
-			Memory::free_static(elements);
-			Memory::free_static(map_data);
-			elements = nullptr;
+			Memory::free_static(_elements);
+			Memory::free_static(_metadata);
+			_elements = nullptr;
 		}
-		capacity = INITIAL_CAPACITY - 1;
-		num_elements = 0;
+		_capacity_mask = INITIAL_CAPACITY - 1;
+		_size = 0;
 	}
 
 	~AHashMap() {

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -72,13 +72,13 @@ public:
 	static constexpr uint32_t EMPTY_HASH = 0;
 
 private:
-	HashMapElement<TKey, TValue> **elements = nullptr;
-	uint32_t *hashes = nullptr;
-	HashMapElement<TKey, TValue> *head_element = nullptr;
-	HashMapElement<TKey, TValue> *tail_element = nullptr;
+	HashMapElement<TKey, TValue> **_elements = nullptr;
+	uint32_t *_hashes = nullptr;
+	HashMapElement<TKey, TValue> *_head_element = nullptr;
+	HashMapElement<TKey, TValue> *_tail_element = nullptr;
 
-	uint32_t capacity_index = 0;
-	uint32_t num_elements = 0;
+	uint32_t _capacity_idx = 0;
+	uint32_t _size = 0;
 
 	_FORCE_INLINE_ static uint32_t _hash(const TKey &p_key) {
 		uint32_t hash = Hasher::hash(p_key);
@@ -90,97 +90,97 @@ private:
 		return hash;
 	}
 
-	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_pos, const uint32_t p_capacity) {
-		r_pos++;
+	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_idx, const uint32_t p_capacity) {
+		r_idx++;
 		// `if` is faster than both fastmod and mod.
-		if (unlikely(r_pos == p_capacity)) {
-			r_pos = 0;
+		if (unlikely(r_idx == p_capacity)) {
+			r_idx = 0;
 		}
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_pos, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
-		const uint32_t original_pos = fastmod(p_hash, p_capacity_inv, p_capacity);
-		const uint32_t distance_pos = p_pos - original_pos + p_capacity;
+	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_idx, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
+		const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
+		const uint32_t distance_idx = p_idx - original_idx + p_capacity;
 		// At most p_capacity over 0, so we can use an if (faster than fastmod).
-		return distance_pos >= p_capacity ? distance_pos - p_capacity : distance_pos;
+		return distance_idx >= p_capacity ? distance_idx - p_capacity : distance_idx;
 	}
 
-	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) const {
-		return elements != nullptr && num_elements > 0 && _lookup_pos_unchecked(p_key, _hash(p_key), r_pos);
+	bool _lookup_idx(const TKey &p_key, uint32_t &r_idx) const {
+		return _elements != nullptr && _size > 0 && _lookup_idx_unchecked(p_key, _hash(p_key), r_idx);
 	}
 
-	/// Note: Assumes that elements != nullptr
-	bool _lookup_pos_unchecked(const TKey &p_key, uint32_t p_hash, uint32_t &r_pos) const {
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t pos = fastmod(p_hash, capacity_inv, capacity);
+	/// Note: Assumes that _elements != nullptr
+	bool _lookup_idx_unchecked(const TKey &p_key, uint32_t p_hash, uint32_t &r_idx) const {
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
+		uint32_t idx = fastmod(p_hash, capacity_inv, capacity);
 		uint32_t distance = 0;
 
 		while (true) {
-			if (hashes[pos] == EMPTY_HASH) {
+			if (_hashes[idx] == EMPTY_HASH) {
 				return false;
 			}
 
-			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
+			if (distance > _get_probe_length(idx, _hashes[idx], capacity, capacity_inv)) {
 				return false;
 			}
 
-			if (hashes[pos] == p_hash && Comparator::compare(elements[pos]->data.key, p_key)) {
-				r_pos = pos;
+			if (_hashes[idx] == p_hash && Comparator::compare(_elements[idx]->data.key, p_key)) {
+				r_idx = idx;
 				return true;
 			}
 
-			_increment_mod(pos, capacity);
+			_increment_mod(idx, capacity);
 			distance++;
 		}
 	}
 
 	void _insert_element(uint32_t p_hash, HashMapElement<TKey, TValue> *p_value) {
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
 		uint32_t hash = p_hash;
 		HashMapElement<TKey, TValue> *value = p_value;
 		uint32_t distance = 0;
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
+		uint32_t idx = fastmod(hash, capacity_inv, capacity);
 
 		while (true) {
-			if (hashes[pos] == EMPTY_HASH) {
-				elements[pos] = value;
-				hashes[pos] = hash;
+			if (_hashes[idx] == EMPTY_HASH) {
+				_elements[idx] = value;
+				_hashes[idx] = hash;
 
-				num_elements++;
+				_size++;
 
 				return;
 			}
 
 			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(pos, hashes[pos], capacity, capacity_inv);
+			uint32_t existing_probe_len = _get_probe_length(idx, _hashes[idx], capacity, capacity_inv);
 			if (existing_probe_len < distance) {
-				SWAP(hash, hashes[pos]);
-				SWAP(value, elements[pos]);
+				SWAP(hash, _hashes[idx]);
+				SWAP(value, _elements[idx]);
 				distance = existing_probe_len;
 			}
 
-			_increment_mod(pos, capacity);
+			_increment_mod(idx, capacity);
 			distance++;
 		}
 	}
 
-	void _resize_and_rehash(uint32_t p_new_capacity_index) {
-		uint32_t old_capacity = hash_table_size_primes[capacity_index];
+	void _resize_and_rehash(uint32_t p_new_capacity_idx) {
+		uint32_t old_capacity = hash_table_size_primes[_capacity_idx];
 
 		// Capacity can't be 0.
-		capacity_index = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_index);
+		_capacity_idx = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_idx);
 
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
 
-		HashMapElement<TKey, TValue> **old_elements = elements;
-		uint32_t *old_hashes = hashes;
+		HashMapElement<TKey, TValue> **old_elements = _elements;
+		uint32_t *old_hashes = _hashes;
 
-		num_elements = 0;
+		_size = 0;
 		static_assert(EMPTY_HASH == 0, "Assuming EMPTY_HASH = 0 for alloc_static_zeroed call");
-		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
-		elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static_zeroed(sizeof(HashMapElement<TKey, TValue> *) * capacity));
+		_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
+		_elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static_zeroed(sizeof(HashMapElement<TKey, TValue> *) * capacity));
 
 		if (old_capacity == 0) {
 			// Nothing to do.
@@ -200,33 +200,33 @@ private:
 	}
 
 	_FORCE_INLINE_ HashMapElement<TKey, TValue> *_insert(const TKey &p_key, const TValue &p_value, uint32_t p_hash, bool p_front_insert = false) {
-		uint32_t capacity = hash_table_size_primes[capacity_index];
-		if (unlikely(elements == nullptr)) {
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		if (unlikely(_elements == nullptr)) {
 			// Allocate on demand to save memory.
 
 			static_assert(EMPTY_HASH == 0, "Assuming EMPTY_HASH = 0 for alloc_static_zeroed call");
-			hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
-			elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static_zeroed(sizeof(HashMapElement<TKey, TValue> *) * capacity));
+			_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
+			_elements = reinterpret_cast<HashMapElement<TKey, TValue> **>(Memory::alloc_static_zeroed(sizeof(HashMapElement<TKey, TValue> *) * capacity));
 		}
 
-		if (num_elements + 1 > MAX_OCCUPANCY * capacity) {
-			ERR_FAIL_COND_V_MSG(capacity_index + 1 == HASH_TABLE_SIZE_MAX, nullptr, "Hash table maximum capacity reached, aborting insertion.");
-			_resize_and_rehash(capacity_index + 1);
+		if (_size + 1 > MAX_OCCUPANCY * capacity) {
+			ERR_FAIL_COND_V_MSG(_capacity_idx + 1 == HASH_TABLE_SIZE_MAX, nullptr, "Hash table maximum capacity reached, aborting insertion.");
+			_resize_and_rehash(_capacity_idx + 1);
 		}
 
 		HashMapElement<TKey, TValue> *elem = Allocator::new_allocation(HashMapElement<TKey, TValue>(p_key, p_value));
 
-		if (tail_element == nullptr) {
-			head_element = elem;
-			tail_element = elem;
+		if (_tail_element == nullptr) {
+			_head_element = elem;
+			_tail_element = elem;
 		} else if (p_front_insert) {
-			head_element->prev = elem;
-			elem->next = head_element;
-			head_element = elem;
+			_head_element->prev = elem;
+			elem->next = _head_element;
+			_head_element = elem;
 		} else {
-			tail_element->next = elem;
-			elem->prev = tail_element;
-			tail_element = elem;
+			_tail_element->next = elem;
+			elem->prev = _tail_element;
+			_tail_element = elem;
 		}
 
 		_insert_element(p_hash, elem);
@@ -234,33 +234,33 @@ private:
 	}
 
 public:
-	_FORCE_INLINE_ uint32_t get_capacity() const { return hash_table_size_primes[capacity_index]; }
-	_FORCE_INLINE_ uint32_t size() const { return num_elements; }
+	_FORCE_INLINE_ uint32_t get_capacity() const { return hash_table_size_primes[_capacity_idx]; }
+	_FORCE_INLINE_ uint32_t size() const { return _size; }
 
 	/* Standard Godot Container API */
 
 	bool is_empty() const {
-		return num_elements == 0;
+		return _size == 0;
 	}
 
 	void clear() {
-		if (elements == nullptr || num_elements == 0) {
+		if (_elements == nullptr || _size == 0) {
 			return;
 		}
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		for (uint32_t i = 0; i < capacity; i++) {
-			if (hashes[i] == EMPTY_HASH) {
+			if (_hashes[i] == EMPTY_HASH) {
 				continue;
 			}
 
-			hashes[i] = EMPTY_HASH;
-			Allocator::delete_allocation(elements[i]);
-			elements[i] = nullptr;
+			_hashes[i] = EMPTY_HASH;
+			Allocator::delete_allocation(_elements[i]);
+			_elements[i] = nullptr;
 		}
 
-		tail_element = nullptr;
-		head_element = nullptr;
-		num_elements = 0;
+		_tail_element = nullptr;
+		_head_element = nullptr;
+		_size = 0;
 	}
 
 	void sort() {
@@ -275,118 +275,118 @@ public:
 
 		using E = HashMapElement<TKey, TValue>;
 		SortList<E, KeyValue<TKey, TValue>, &E::data, &E::prev, &E::next, C> sorter;
-		sorter.sort(head_element, tail_element);
+		sorter.sort(_head_element, _tail_element);
 	}
 
 	TValue &get(const TKey &p_key) {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
-		return elements[pos]->data.value;
+		return _elements[idx]->data.value;
 	}
 
 	const TValue &get(const TKey &p_key) const {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 		CRASH_COND_MSG(!exists, "HashMap key not found.");
-		return elements[pos]->data.value;
+		return _elements[idx]->data.value;
 	}
 
 	const TValue *getptr(const TKey &p_key) const {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 
 		if (exists) {
-			return &elements[pos]->data.value;
+			return &_elements[idx]->data.value;
 		}
 		return nullptr;
 	}
 
 	TValue *getptr(const TKey &p_key) {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 
 		if (exists) {
-			return &elements[pos]->data.value;
+			return &_elements[idx]->data.value;
 		}
 		return nullptr;
 	}
 
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
-		uint32_t _pos = 0;
-		return _lookup_pos(p_key, _pos);
+		uint32_t _idx = 0;
+		return _lookup_idx(p_key, _idx);
 	}
 
 	bool erase(const TKey &p_key) {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 
 		if (!exists) {
 			return false;
 		}
 
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t next_pos = fastmod((pos + 1), capacity_inv, capacity);
-		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], capacity, capacity_inv) != 0) {
-			SWAP(hashes[next_pos], hashes[pos]);
-			SWAP(elements[next_pos], elements[pos]);
-			pos = next_pos;
-			_increment_mod(next_pos, capacity);
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
+		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
+		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
+			SWAP(_hashes[next_idx], _hashes[idx]);
+			SWAP(_elements[next_idx], _elements[idx]);
+			idx = next_idx;
+			_increment_mod(next_idx, capacity);
 		}
 
-		hashes[pos] = EMPTY_HASH;
+		_hashes[idx] = EMPTY_HASH;
 
-		if (head_element == elements[pos]) {
-			head_element = elements[pos]->next;
+		if (_head_element == _elements[idx]) {
+			_head_element = _elements[idx]->next;
 		}
 
-		if (tail_element == elements[pos]) {
-			tail_element = elements[pos]->prev;
+		if (_tail_element == _elements[idx]) {
+			_tail_element = _elements[idx]->prev;
 		}
 
-		if (elements[pos]->prev) {
-			elements[pos]->prev->next = elements[pos]->next;
+		if (_elements[idx]->prev) {
+			_elements[idx]->prev->next = _elements[idx]->next;
 		}
 
-		if (elements[pos]->next) {
-			elements[pos]->next->prev = elements[pos]->prev;
+		if (_elements[idx]->next) {
+			_elements[idx]->next->prev = _elements[idx]->prev;
 		}
 
-		Allocator::delete_allocation(elements[pos]);
-		elements[pos] = nullptr;
+		Allocator::delete_allocation(_elements[idx]);
+		_elements[idx] = nullptr;
 
-		num_elements--;
+		_size--;
 		return true;
 	}
 
 	// Replace the key of an entry in-place, without invalidating iterators or changing the entries position during iteration.
 	// p_old_key must exist in the map and p_new_key must not, unless it is equal to p_old_key.
 	bool replace_key(const TKey &p_old_key, const TKey &p_new_key) {
-		ERR_FAIL_COND_V(elements == nullptr || num_elements == 0, false);
+		ERR_FAIL_COND_V(_elements == nullptr || _size == 0, false);
 		if (p_old_key == p_new_key) {
 			return true;
 		}
 		const uint32_t new_hash = _hash(p_new_key);
-		uint32_t pos = 0;
-		ERR_FAIL_COND_V(_lookup_pos_unchecked(p_new_key, new_hash, pos), false);
-		ERR_FAIL_COND_V(!_lookup_pos(p_old_key, pos), false);
-		HashMapElement<TKey, TValue> *element = elements[pos];
+		uint32_t idx = 0;
+		ERR_FAIL_COND_V(_lookup_idx_unchecked(p_new_key, new_hash, idx), false);
+		ERR_FAIL_COND_V(!_lookup_idx(p_old_key, idx), false);
+		HashMapElement<TKey, TValue> *element = _elements[idx];
 
-		// Delete the old entries in hashes and elements.
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t next_pos = fastmod((pos + 1), capacity_inv, capacity);
-		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], capacity, capacity_inv) != 0) {
-			SWAP(hashes[next_pos], hashes[pos]);
-			SWAP(elements[next_pos], elements[pos]);
-			pos = next_pos;
-			_increment_mod(next_pos, capacity);
+		// Delete the old entries in _hashes and _elements.
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
+		uint32_t next_idx = fastmod((idx + 1), capacity_inv, capacity);
+		while (_hashes[next_idx] != EMPTY_HASH && _get_probe_length(next_idx, _hashes[next_idx], capacity, capacity_inv) != 0) {
+			SWAP(_hashes[next_idx], _hashes[idx]);
+			SWAP(_elements[next_idx], _elements[idx]);
+			idx = next_idx;
+			_increment_mod(next_idx, capacity);
 		}
-		hashes[pos] = EMPTY_HASH;
-		elements[pos] = nullptr;
+		_hashes[idx] = EMPTY_HASH;
+		_elements[idx] = nullptr;
 		// _insert_element will increment this again.
-		num_elements--;
+		_size--;
 
 		// Update the HashMapElement with the new key and reinsert it.
 		const_cast<TKey &>(element->data.key) = p_new_key;
@@ -399,22 +399,22 @@ public:
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
 		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
-		uint32_t new_index = capacity_index;
+		uint32_t new_idx = _capacity_idx;
 
-		while (hash_table_size_primes[new_index] < p_new_capacity) {
-			ERR_FAIL_COND_MSG(new_index + 1 == (uint32_t)HASH_TABLE_SIZE_MAX, nullptr);
-			new_index++;
+		while (hash_table_size_primes[new_idx] < p_new_capacity) {
+			ERR_FAIL_COND_MSG(new_idx + 1 == (uint32_t)HASH_TABLE_SIZE_MAX, nullptr);
+			new_idx++;
 		}
 
-		if (new_index == capacity_index) {
+		if (new_idx == _capacity_idx) {
 			return;
 		}
 
-		if (elements == nullptr) {
-			capacity_index = new_index;
+		if (_elements == nullptr) {
+			_capacity_idx = new_idx;
 			return; // Unallocated yet.
 		}
-		_resize_and_rehash(new_index);
+		_resize_and_rehash(new_idx);
 	}
 
 	/** Iterator API **/
@@ -496,22 +496,22 @@ public:
 	};
 
 	_FORCE_INLINE_ Iterator begin() {
-		return Iterator(head_element);
+		return Iterator(_head_element);
 	}
 	_FORCE_INLINE_ Iterator end() {
 		return Iterator(nullptr);
 	}
 	_FORCE_INLINE_ Iterator last() {
-		return Iterator(tail_element);
+		return Iterator(_tail_element);
 	}
 
 	_FORCE_INLINE_ Iterator find(const TKey &p_key) {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 		if (!exists) {
 			return end();
 		}
-		return Iterator(elements[pos]);
+		return Iterator(_elements[idx]);
 	}
 
 	_FORCE_INLINE_ void remove(const Iterator &p_iter) {
@@ -521,41 +521,41 @@ public:
 	}
 
 	_FORCE_INLINE_ ConstIterator begin() const {
-		return ConstIterator(head_element);
+		return ConstIterator(_head_element);
 	}
 	_FORCE_INLINE_ ConstIterator end() const {
 		return ConstIterator(nullptr);
 	}
 	_FORCE_INLINE_ ConstIterator last() const {
-		return ConstIterator(tail_element);
+		return ConstIterator(_tail_element);
 	}
 
 	_FORCE_INLINE_ ConstIterator find(const TKey &p_key) const {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 		if (!exists) {
 			return end();
 		}
-		return ConstIterator(elements[pos]);
+		return ConstIterator(_elements[idx]);
 	}
 
 	/* Indexing */
 
 	const TValue &operator[](const TKey &p_key) const {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t idx = 0;
+		bool exists = _lookup_idx(p_key, idx);
 		CRASH_COND(!exists);
-		return elements[pos]->data.value;
+		return _elements[idx]->data.value;
 	}
 
 	TValue &operator[](const TKey &p_key) {
 		const uint32_t hash = _hash(p_key);
-		uint32_t pos = 0;
-		bool exists = elements && num_elements > 0 && _lookup_pos_unchecked(p_key, hash, pos);
+		uint32_t idx = 0;
+		bool exists = _elements && _size > 0 && _lookup_idx_unchecked(p_key, hash, idx);
 		if (!exists) {
 			return _insert(p_key, TValue(), hash)->data.value;
 		} else {
-			return elements[pos]->data.value;
+			return _elements[idx]->data.value;
 		}
 	}
 
@@ -563,22 +563,22 @@ public:
 
 	Iterator insert(const TKey &p_key, const TValue &p_value, bool p_front_insert = false) {
 		const uint32_t hash = _hash(p_key);
-		uint32_t pos = 0;
-		bool exists = elements && num_elements > 0 && _lookup_pos_unchecked(p_key, hash, pos);
+		uint32_t idx = 0;
+		bool exists = _elements && _size > 0 && _lookup_idx_unchecked(p_key, hash, idx);
 		if (!exists) {
 			return Iterator(_insert(p_key, p_value, hash, p_front_insert));
 		} else {
-			elements[pos]->data.value = p_value;
-			return Iterator(elements[pos]);
+			_elements[idx]->data.value = p_value;
+			return Iterator(_elements[idx]);
 		}
 	}
 
 	/* Constructors */
 
 	HashMap(const HashMap &p_other) {
-		reserve(hash_table_size_primes[p_other.capacity_index]);
+		reserve(hash_table_size_primes[p_other._capacity_idx]);
 
-		if (p_other.num_elements == 0) {
+		if (p_other._size == 0) {
 			return;
 		}
 
@@ -591,13 +591,13 @@ public:
 		if (this == &p_other) {
 			return; // Ignore self assignment.
 		}
-		if (num_elements != 0) {
+		if (_size != 0) {
 			clear();
 		}
 
-		reserve(hash_table_size_primes[p_other.capacity_index]);
+		reserve(hash_table_size_primes[p_other._capacity_idx]);
 
-		if (p_other.elements == nullptr) {
+		if (p_other._elements == nullptr) {
 			return; // Nothing to copy.
 		}
 
@@ -608,11 +608,11 @@ public:
 
 	HashMap(uint32_t p_initial_capacity) {
 		// Capacity can't be 0.
-		capacity_index = 0;
+		_capacity_idx = 0;
 		reserve(p_initial_capacity);
 	}
 	HashMap() {
-		capacity_index = MIN_CAPACITY_INDEX;
+		_capacity_idx = MIN_CAPACITY_INDEX;
 	}
 
 	HashMap(std::initializer_list<KeyValue<TKey, TValue>> p_init) {
@@ -622,27 +622,27 @@ public:
 		}
 	}
 
-	uint32_t debug_get_hash(uint32_t p_index) {
-		if (num_elements == 0) {
+	uint32_t debug_get_hash(uint32_t p_idx) {
+		if (_size == 0) {
 			return 0;
 		}
-		ERR_FAIL_INDEX_V(p_index, get_capacity(), 0);
-		return hashes[p_index];
+		ERR_FAIL_INDEX_V(p_idx, get_capacity(), 0);
+		return _hashes[p_idx];
 	}
-	Iterator debug_get_element(uint32_t p_index) {
-		if (num_elements == 0) {
+	Iterator debug_get_element(uint32_t p_idx) {
+		if (_size == 0) {
 			return Iterator();
 		}
-		ERR_FAIL_INDEX_V(p_index, get_capacity(), Iterator());
-		return Iterator(elements[p_index]);
+		ERR_FAIL_INDEX_V(p_idx, get_capacity(), Iterator());
+		return Iterator(_elements[p_idx]);
 	}
 
 	~HashMap() {
 		clear();
 
-		if (elements != nullptr) {
-			Memory::free_static(elements);
-			Memory::free_static(hashes);
+		if (_elements != nullptr) {
+			Memory::free_static(_elements);
+			Memory::free_static(_hashes);
 		}
 	}
 };

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -52,13 +52,13 @@ public:
 	static constexpr uint32_t EMPTY_HASH = 0;
 
 private:
-	TKey *keys = nullptr;
-	uint32_t *hash_to_key = nullptr;
-	uint32_t *key_to_hash = nullptr;
-	uint32_t *hashes = nullptr;
+	TKey *_keys = nullptr;
+	uint32_t *_hash_idx_to_key_idx = nullptr;
+	uint32_t *_key_idx_to_hash_idx = nullptr;
+	uint32_t *_hashes = nullptr;
 
-	uint32_t capacity_index = 0;
-	uint32_t num_elements = 0;
+	uint32_t _capacity_idx = 0;
+	uint32_t _size = 0;
 
 	_FORCE_INLINE_ uint32_t _hash(const TKey &p_key) const {
 		uint32_t hash = Hasher::hash(p_key);
@@ -70,97 +70,97 @@ private:
 		return hash;
 	}
 
-	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_pos, const uint32_t p_capacity) {
-		r_pos++;
+	_FORCE_INLINE_ static constexpr void _increment_mod(uint32_t &r_idx, const uint32_t p_capacity) {
+		r_idx++;
 		// `if` is faster than both fastmod and mod.
-		if (unlikely(r_pos == p_capacity)) {
-			r_pos = 0;
+		if (unlikely(r_idx == p_capacity)) {
+			r_idx = 0;
 		}
 	}
 
-	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_pos, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
-		const uint32_t original_pos = fastmod(p_hash, p_capacity_inv, p_capacity);
-		const uint32_t distance_pos = p_pos - original_pos + p_capacity;
+	static _FORCE_INLINE_ uint32_t _get_probe_length(const uint32_t p_hash_idx, const uint32_t p_hash, const uint32_t p_capacity, const uint64_t p_capacity_inv) {
+		const uint32_t original_idx = fastmod(p_hash, p_capacity_inv, p_capacity);
+		const uint32_t distance_idx = p_hash_idx - original_idx + p_capacity;
 		// At most p_capacity over 0, so we can use an if (faster than fastmod).
-		return distance_pos >= p_capacity ? distance_pos - p_capacity : distance_pos;
+		return distance_idx >= p_capacity ? distance_idx - p_capacity : distance_idx;
 	}
 
-	bool _lookup_pos(const TKey &p_key, uint32_t &r_pos) const {
-		if (keys == nullptr || num_elements == 0) {
+	bool _lookup_key_idx(const TKey &p_key, uint32_t &r_key_idx) const {
+		if (_keys == nullptr || _size == 0) {
 			return false; // Failed lookups, no elements
 		}
 
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
 		uint32_t hash = _hash(p_key);
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
+		uint32_t hash_idx = fastmod(hash, capacity_inv, capacity);
 		uint32_t distance = 0;
 
 		while (true) {
-			if (hashes[pos] == EMPTY_HASH) {
+			if (_hashes[hash_idx] == EMPTY_HASH) {
 				return false;
 			}
 
-			if (hashes[pos] == hash && Comparator::compare(keys[hash_to_key[pos]], p_key)) {
-				r_pos = hash_to_key[pos];
+			if (_hashes[hash_idx] == hash && Comparator::compare(_keys[_hash_idx_to_key_idx[hash_idx]], p_key)) {
+				r_key_idx = _hash_idx_to_key_idx[hash_idx];
 				return true;
 			}
 
-			if (distance > _get_probe_length(pos, hashes[pos], capacity, capacity_inv)) {
+			if (distance > _get_probe_length(hash_idx, _hashes[hash_idx], capacity, capacity_inv)) {
 				return false;
 			}
 
-			_increment_mod(pos, capacity);
+			_increment_mod(hash_idx, capacity);
 			distance++;
 		}
 	}
 
-	uint32_t _insert_with_hash(uint32_t p_hash, uint32_t p_index) {
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
+	uint32_t _insert_with_hash(uint32_t p_hash, uint32_t p_key_idx) {
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
 		uint32_t hash = p_hash;
-		uint32_t index = p_index;
+		uint32_t key_idx = p_key_idx;
 		uint32_t distance = 0;
-		uint32_t pos = fastmod(hash, capacity_inv, capacity);
+		uint32_t hash_idx = fastmod(hash, capacity_inv, capacity);
 
 		while (true) {
-			if (hashes[pos] == EMPTY_HASH) {
-				hashes[pos] = hash;
-				key_to_hash[index] = pos;
-				hash_to_key[pos] = index;
-				return pos;
+			if (_hashes[hash_idx] == EMPTY_HASH) {
+				_hashes[hash_idx] = hash;
+				_key_idx_to_hash_idx[key_idx] = hash_idx;
+				_hash_idx_to_key_idx[hash_idx] = key_idx;
+				return hash_idx;
 			}
 
 			// Not an empty slot, let's check the probing length of the existing one.
-			uint32_t existing_probe_len = _get_probe_length(pos, hashes[pos], capacity, capacity_inv);
+			uint32_t existing_probe_len = _get_probe_length(hash_idx, _hashes[hash_idx], capacity, capacity_inv);
 			if (existing_probe_len < distance) {
-				key_to_hash[index] = pos;
-				SWAP(hash, hashes[pos]);
-				SWAP(index, hash_to_key[pos]);
+				_key_idx_to_hash_idx[key_idx] = hash_idx;
+				SWAP(hash, _hashes[hash_idx]);
+				SWAP(key_idx, _hash_idx_to_key_idx[hash_idx]);
 				distance = existing_probe_len;
 			}
 
-			_increment_mod(pos, capacity);
+			_increment_mod(hash_idx, capacity);
 			distance++;
 		}
 	}
 
-	void _resize_and_rehash(uint32_t p_new_capacity_index) {
+	void _resize_and_rehash(uint32_t p_new_capacity_idx) {
 		// Capacity can't be 0.
-		capacity_index = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_index);
+		_capacity_idx = MAX((uint32_t)MIN_CAPACITY_INDEX, p_new_capacity_idx);
 
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
 
-		uint32_t *old_hashes = hashes;
-		uint32_t *old_key_to_hash = key_to_hash;
+		uint32_t *old_hashes = _hashes;
+		uint32_t *old_key_to_hash = _key_idx_to_hash_idx;
 
 		static_assert(EMPTY_HASH == 0, "Assuming EMPTY_HASH = 0 for alloc_static_zeroed call");
-		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
-		keys = reinterpret_cast<TKey *>(Memory::realloc_static(keys, sizeof(TKey) * capacity));
-		key_to_hash = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-		hash_to_key = reinterpret_cast<uint32_t *>(Memory::realloc_static(hash_to_key, sizeof(uint32_t) * capacity));
+		_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
+		_keys = reinterpret_cast<TKey *>(Memory::realloc_static(_keys, sizeof(TKey) * capacity));
+		_key_idx_to_hash_idx = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+		_hash_idx_to_key_idx = reinterpret_cast<uint32_t *>(Memory::realloc_static(_hash_idx_to_key_idx, sizeof(uint32_t) * capacity));
 
-		for (uint32_t i = 0; i < num_elements; i++) {
+		for (uint32_t i = 0; i < _size; i++) {
 			uint32_t h = old_hashes[old_key_to_hash[i]];
 			_insert_with_hash(h, i);
 		}
@@ -169,127 +169,127 @@ private:
 		Memory::free_static(old_key_to_hash);
 	}
 
+	// Returns key index.
 	_FORCE_INLINE_ int32_t _insert(const TKey &p_key) {
-		uint32_t capacity = hash_table_size_primes[capacity_index];
-		if (unlikely(keys == nullptr)) {
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		if (unlikely(_keys == nullptr)) {
 			// Allocate on demand to save memory.
 
 			static_assert(EMPTY_HASH == 0, "Assuming EMPTY_HASH = 0 for alloc_static_zeroed call");
-			hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
-			keys = reinterpret_cast<TKey *>(Memory::alloc_static(sizeof(TKey) * capacity));
-			key_to_hash = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-			hash_to_key = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+			_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static_zeroed(sizeof(uint32_t) * capacity));
+			_keys = reinterpret_cast<TKey *>(Memory::alloc_static(sizeof(TKey) * capacity));
+			_key_idx_to_hash_idx = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+			_hash_idx_to_key_idx = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
 		}
 
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t key_idx = 0;
+		bool exists = _lookup_key_idx(p_key, key_idx);
 
 		if (exists) {
-			return pos;
+			return key_idx;
 		} else {
-			if (num_elements + 1 > MAX_OCCUPANCY * capacity) {
-				ERR_FAIL_COND_V_MSG(capacity_index + 1 == HASH_TABLE_SIZE_MAX, -1, "Hash table maximum capacity reached, aborting insertion.");
-				_resize_and_rehash(capacity_index + 1);
+			if (_size + 1 > MAX_OCCUPANCY * capacity) {
+				ERR_FAIL_COND_V_MSG(_capacity_idx + 1 == HASH_TABLE_SIZE_MAX, -1, "Hash table maximum capacity reached, aborting insertion.");
+				_resize_and_rehash(_capacity_idx + 1);
 			}
 
 			uint32_t hash = _hash(p_key);
-			memnew_placement(&keys[num_elements], TKey(p_key));
-			_insert_with_hash(hash, num_elements);
-			num_elements++;
-			return num_elements - 1;
+			memnew_placement(&_keys[_size], TKey(p_key));
+			_insert_with_hash(hash, _size);
+			_size++;
+			return _size - 1;
 		}
 	}
 
 	void _init_from(const HashSet &p_other) {
-		capacity_index = p_other.capacity_index;
-		num_elements = p_other.num_elements;
+		_capacity_idx = p_other._capacity_idx;
+		_size = p_other._size;
 
-		if (p_other.num_elements == 0) {
+		if (p_other._size == 0) {
 			return;
 		}
 
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
 
-		hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-		keys = reinterpret_cast<TKey *>(Memory::alloc_static(sizeof(TKey) * capacity));
-		key_to_hash = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
-		hash_to_key = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+		_hashes = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+		_keys = reinterpret_cast<TKey *>(Memory::alloc_static(sizeof(TKey) * capacity));
+		_key_idx_to_hash_idx = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
+		_hash_idx_to_key_idx = reinterpret_cast<uint32_t *>(Memory::alloc_static(sizeof(uint32_t) * capacity));
 
-		for (uint32_t i = 0; i < num_elements; i++) {
-			memnew_placement(&keys[i], TKey(p_other.keys[i]));
-			key_to_hash[i] = p_other.key_to_hash[i];
+		for (uint32_t i = 0; i < _size; i++) {
+			memnew_placement(&_keys[i], TKey(p_other._keys[i]));
+			_key_idx_to_hash_idx[i] = p_other._key_idx_to_hash_idx[i];
 		}
 
 		for (uint32_t i = 0; i < capacity; i++) {
-			hashes[i] = p_other.hashes[i];
-			hash_to_key[i] = p_other.hash_to_key[i];
+			_hashes[i] = p_other._hashes[i];
+			_hash_idx_to_key_idx[i] = p_other._hash_idx_to_key_idx[i];
 		}
 	}
 
 public:
-	_FORCE_INLINE_ uint32_t get_capacity() const { return hash_table_size_primes[capacity_index]; }
-	_FORCE_INLINE_ uint32_t size() const { return num_elements; }
+	_FORCE_INLINE_ uint32_t get_capacity() const { return hash_table_size_primes[_capacity_idx]; }
+	_FORCE_INLINE_ uint32_t size() const { return _size; }
 
 	/* Standard Godot Container API */
 
 	bool is_empty() const {
-		return num_elements == 0;
+		return _size == 0;
 	}
 
 	void clear() {
-		if (keys == nullptr || num_elements == 0) {
+		if (_keys == nullptr || _size == 0) {
 			return;
 		}
-		uint32_t capacity = hash_table_size_primes[capacity_index];
+		uint32_t capacity = hash_table_size_primes[_capacity_idx];
 		for (uint32_t i = 0; i < capacity; i++) {
-			hashes[i] = EMPTY_HASH;
+			_hashes[i] = EMPTY_HASH;
 		}
-		for (uint32_t i = 0; i < num_elements; i++) {
-			keys[i].~TKey();
+		for (uint32_t i = 0; i < _size; i++) {
+			_keys[i].~TKey();
 		}
 
-		num_elements = 0;
+		_size = 0;
 	}
 
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
-		uint32_t _pos = 0;
-		return _lookup_pos(p_key, _pos);
+		uint32_t _idx = 0;
+		return _lookup_key_idx(p_key, _idx);
 	}
 
 	bool erase(const TKey &p_key) {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t key_idx = 0;
+		bool exists = _lookup_key_idx(p_key, key_idx);
 
 		if (!exists) {
 			return false;
 		}
 
-		uint32_t key_pos = pos;
-		pos = key_to_hash[pos]; //make hash pos
+		uint32_t hash_idx = _key_idx_to_hash_idx[key_idx];
 
-		const uint32_t capacity = hash_table_size_primes[capacity_index];
-		const uint64_t capacity_inv = hash_table_size_primes_inv[capacity_index];
-		uint32_t next_pos = fastmod(pos + 1, capacity_inv, capacity);
-		while (hashes[next_pos] != EMPTY_HASH && _get_probe_length(next_pos, hashes[next_pos], capacity, capacity_inv) != 0) {
-			uint32_t kpos = hash_to_key[pos];
-			uint32_t kpos_next = hash_to_key[next_pos];
-			SWAP(key_to_hash[kpos], key_to_hash[kpos_next]);
-			SWAP(hashes[next_pos], hashes[pos]);
-			SWAP(hash_to_key[next_pos], hash_to_key[pos]);
+		const uint32_t capacity = hash_table_size_primes[_capacity_idx];
+		const uint64_t capacity_inv = hash_table_size_primes_inv[_capacity_idx];
+		uint32_t next_hash_idx = fastmod(hash_idx + 1, capacity_inv, capacity);
+		while (_hashes[next_hash_idx] != EMPTY_HASH && _get_probe_length(next_hash_idx, _hashes[next_hash_idx], capacity, capacity_inv) != 0) {
+			uint32_t cur_key_idx = _hash_idx_to_key_idx[hash_idx];
+			uint32_t next_key_idx = _hash_idx_to_key_idx[next_hash_idx];
+			SWAP(_key_idx_to_hash_idx[cur_key_idx], _key_idx_to_hash_idx[next_key_idx]);
+			SWAP(_hashes[next_hash_idx], _hashes[hash_idx]);
+			SWAP(_hash_idx_to_key_idx[next_hash_idx], _hash_idx_to_key_idx[hash_idx]);
 
-			pos = next_pos;
-			_increment_mod(next_pos, capacity);
+			hash_idx = next_hash_idx;
+			_increment_mod(next_hash_idx, capacity);
 		}
 
-		hashes[pos] = EMPTY_HASH;
-		keys[key_pos].~TKey();
-		num_elements--;
-		if (key_pos < num_elements) {
-			// Not the last key, move the last one here to keep keys lineal
-			memnew_placement(&keys[key_pos], TKey(keys[num_elements]));
-			keys[num_elements].~TKey();
-			key_to_hash[key_pos] = key_to_hash[num_elements];
-			hash_to_key[key_to_hash[num_elements]] = key_pos;
+		_hashes[hash_idx] = EMPTY_HASH;
+		_keys[key_idx].~TKey();
+		_size--;
+		if (key_idx < _size) {
+			// Not the last key, move the last one here to keep keys contiguous.
+			memnew_placement(&_keys[key_idx], TKey(_keys[_size]));
+			_keys[_size].~TKey();
+			_key_idx_to_hash_idx[key_idx] = _key_idx_to_hash_idx[_size];
+			_hash_idx_to_key_idx[_key_idx_to_hash_idx[_size]] = key_idx;
 		}
 
 		return true;
@@ -299,102 +299,102 @@ public:
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
 		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
-		uint32_t new_index = capacity_index;
+		uint32_t new_capacity_idx = _capacity_idx;
 
-		while (hash_table_size_primes[new_index] < p_new_capacity) {
-			ERR_FAIL_COND_MSG(new_index + 1 == (uint32_t)HASH_TABLE_SIZE_MAX, nullptr);
-			new_index++;
+		while (hash_table_size_primes[new_capacity_idx] < p_new_capacity) {
+			ERR_FAIL_COND_MSG(new_capacity_idx + 1 == (uint32_t)HASH_TABLE_SIZE_MAX, nullptr);
+			new_capacity_idx++;
 		}
 
-		if (new_index == capacity_index) {
+		if (new_capacity_idx == _capacity_idx) {
 			return;
 		}
 
-		if (keys == nullptr) {
-			capacity_index = new_index;
+		if (_keys == nullptr) {
+			_capacity_idx = new_capacity_idx;
 			return; // Unallocated yet.
 		}
-		_resize_and_rehash(new_index);
+		_resize_and_rehash(new_capacity_idx);
 	}
 
 	/** Iterator API **/
 
 	struct Iterator {
 		_FORCE_INLINE_ const TKey &operator*() const {
-			return keys[index];
+			return _keys[_key_idx];
 		}
 		_FORCE_INLINE_ const TKey *operator->() const {
-			return &keys[index];
+			return &_keys[_key_idx];
 		}
 		_FORCE_INLINE_ Iterator &operator++() {
-			index++;
-			if (index >= (int32_t)num_keys) {
-				index = -1;
-				keys = nullptr;
-				num_keys = 0;
+			_key_idx++;
+			if (_key_idx >= (int32_t)_num_keys) {
+				_key_idx = -1;
+				_keys = nullptr;
+				_num_keys = 0;
 			}
 			return *this;
 		}
 		_FORCE_INLINE_ Iterator &operator--() {
-			index--;
-			if (index < 0) {
-				index = -1;
-				keys = nullptr;
-				num_keys = 0;
+			_key_idx--;
+			if (_key_idx < 0) {
+				_key_idx = -1;
+				_keys = nullptr;
+				_num_keys = 0;
 			}
 			return *this;
 		}
 
-		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return keys == b.keys && index == b.index; }
-		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return keys != b.keys || index != b.index; }
+		_FORCE_INLINE_ bool operator==(const Iterator &b) const { return _keys == b._keys && _key_idx == b._key_idx; }
+		_FORCE_INLINE_ bool operator!=(const Iterator &b) const { return _keys != b._keys || _key_idx != b._key_idx; }
 
 		_FORCE_INLINE_ explicit operator bool() const {
-			return keys != nullptr;
+			return _keys != nullptr;
 		}
 
-		_FORCE_INLINE_ Iterator(const TKey *p_keys, uint32_t p_num_keys, int32_t p_index = -1) {
-			keys = p_keys;
-			num_keys = p_num_keys;
-			index = p_index;
+		_FORCE_INLINE_ Iterator(const TKey *p_keys, uint32_t p_num_keys, int32_t p_key_idx = -1) {
+			_keys = p_keys;
+			_num_keys = p_num_keys;
+			_key_idx = p_key_idx;
 		}
 		_FORCE_INLINE_ Iterator() {}
 		_FORCE_INLINE_ Iterator(const Iterator &p_it) {
-			keys = p_it.keys;
-			num_keys = p_it.num_keys;
-			index = p_it.index;
+			_keys = p_it._keys;
+			_num_keys = p_it._num_keys;
+			_key_idx = p_it._key_idx;
 		}
 		_FORCE_INLINE_ void operator=(const Iterator &p_it) {
-			keys = p_it.keys;
-			num_keys = p_it.num_keys;
-			index = p_it.index;
+			_keys = p_it._keys;
+			_num_keys = p_it._num_keys;
+			_key_idx = p_it._key_idx;
 		}
 
 	private:
-		const TKey *keys = nullptr;
-		uint32_t num_keys = 0;
-		int32_t index = -1;
+		const TKey *_keys = nullptr;
+		uint32_t _num_keys = 0;
+		int32_t _key_idx = -1;
 	};
 
 	_FORCE_INLINE_ Iterator begin() const {
-		return num_elements ? Iterator(keys, num_elements, 0) : Iterator();
+		return _size ? Iterator(_keys, _size, 0) : Iterator();
 	}
 	_FORCE_INLINE_ Iterator end() const {
 		return Iterator();
 	}
 	_FORCE_INLINE_ Iterator last() const {
-		if (num_elements == 0) {
+		if (_size == 0) {
 			return Iterator();
 		}
-		return Iterator(keys, num_elements, num_elements - 1);
+		return Iterator(_keys, _size, _size - 1);
 	}
 
 	_FORCE_INLINE_ Iterator find(const TKey &p_key) const {
-		uint32_t pos = 0;
-		bool exists = _lookup_pos(p_key, pos);
+		uint32_t key_idx = 0;
+		bool exists = _lookup_key_idx(p_key, key_idx);
 		if (!exists) {
 			return end();
 		}
-		return Iterator(keys, num_elements, pos);
+		return Iterator(_keys, _size, key_idx);
 	}
 
 	_FORCE_INLINE_ void remove(const Iterator &p_iter) {
@@ -406,8 +406,8 @@ public:
 	/* Insert */
 
 	Iterator insert(const TKey &p_key) {
-		uint32_t pos = _insert(p_key);
-		return Iterator(keys, num_elements, pos);
+		uint32_t key_idx = _insert(p_key);
+		return Iterator(_keys, _size, key_idx);
 	}
 
 	/* Constructors */
@@ -423,26 +423,26 @@ public:
 
 		clear();
 
-		if (keys != nullptr) {
-			Memory::free_static(keys);
-			Memory::free_static(key_to_hash);
-			Memory::free_static(hash_to_key);
-			Memory::free_static(hashes);
-			keys = nullptr;
-			hashes = nullptr;
-			hash_to_key = nullptr;
-			key_to_hash = nullptr;
+		if (_keys != nullptr) {
+			Memory::free_static(_keys);
+			Memory::free_static(_key_idx_to_hash_idx);
+			Memory::free_static(_hash_idx_to_key_idx);
+			Memory::free_static(_hashes);
+			_keys = nullptr;
+			_hashes = nullptr;
+			_hash_idx_to_key_idx = nullptr;
+			_key_idx_to_hash_idx = nullptr;
 		}
 
 		_init_from(p_other);
 	}
 
 	bool operator==(const HashSet &p_other) const {
-		if (num_elements != p_other.num_elements) {
+		if (_size != p_other._size) {
 			return false;
 		}
-		for (uint32_t i = 0; i < num_elements; i++) {
-			if (!p_other.has(keys[i])) {
+		for (uint32_t i = 0; i < _size; i++) {
+			if (!p_other.has(_keys[i])) {
 				return false;
 			}
 		}
@@ -454,11 +454,11 @@ public:
 
 	HashSet(uint32_t p_initial_capacity) {
 		// Capacity can't be 0.
-		capacity_index = 0;
+		_capacity_idx = 0;
 		reserve(p_initial_capacity);
 	}
 	HashSet() {
-		capacity_index = MIN_CAPACITY_INDEX;
+		_capacity_idx = MIN_CAPACITY_INDEX;
 	}
 
 	HashSet(std::initializer_list<TKey> p_init) {
@@ -471,27 +471,27 @@ public:
 	void reset() {
 		clear();
 
-		if (keys != nullptr) {
-			Memory::free_static(keys);
-			Memory::free_static(key_to_hash);
-			Memory::free_static(hash_to_key);
-			Memory::free_static(hashes);
-			keys = nullptr;
-			hashes = nullptr;
-			hash_to_key = nullptr;
-			key_to_hash = nullptr;
+		if (_keys != nullptr) {
+			Memory::free_static(_keys);
+			Memory::free_static(_key_idx_to_hash_idx);
+			Memory::free_static(_hash_idx_to_key_idx);
+			Memory::free_static(_hashes);
+			_keys = nullptr;
+			_hashes = nullptr;
+			_hash_idx_to_key_idx = nullptr;
+			_key_idx_to_hash_idx = nullptr;
 		}
-		capacity_index = MIN_CAPACITY_INDEX;
+		_capacity_idx = MIN_CAPACITY_INDEX;
 	}
 
 	~HashSet() {
 		clear();
 
-		if (keys != nullptr) {
-			Memory::free_static(keys);
-			Memory::free_static(key_to_hash);
-			Memory::free_static(hash_to_key);
-			Memory::free_static(hashes);
+		if (_keys != nullptr) {
+			Memory::free_static(_keys);
+			Memory::free_static(_key_idx_to_hash_idx);
+			Memory::free_static(_hash_idx_to_key_idx);
+			Memory::free_static(_hashes);
 		}
 	}
 };


### PR DESCRIPTION
`AHashMap`, `HashMap` and `HashSet` have inconsistent field and variable names - not only between themselves, but also internally, and across the codebase.
When I personally tried to understand the code, this threw me off many times, and made the classes extremely hard to understand and compare.

I've renamed variables to be consistent. This should help these classes be more maintainable.

## Change List

**HashMapData name:** `AHashMap` uses (globally declared) `HashMapData` to store `hash` and `element_idx`. However, the name makes it sounds like it stores data.
**Solution:** I've renamed the field to `AHashMap::Metadata`. This is consistent with naming terminology of hash maps in other libraries.

**`AHashMap::Metadata` is a struct of a union of a struct or `uint64_t`:** This is very confusing. 
**Solution:** I've changed `Metadata` to be a `struct`, and whenever both elements are assigned at once, a `Metadata` instance is used, instead of assigning `.data` union. I tested performance (`get`, `get missing`, `insert`, `insert existing`, `erase`), and found no regressions (if anything, it's 1-2% faster now).

**Indexes are inconsistently named:** Indexes are named `pos`, `index`, `idx`, `kpos`, `hpos`, among others. Further, in `AHashMap` and `HashSet`, `pos` may refer to either key or hash index inconsistently, even within the same function. This makes it extremely difficult to know at a glance which kind of index you're looking at.
**Solution:** `HashMap` has only one kind of index. All indices are called `idx`. `AHashMap` has elements and metadata, so it now uses `metadata_idx` and `element_idx`. `HashSet` has hashes and keys, so it now uses `hash_idx` and `key_idx`. `capacity_idx` is now consistently named `capacity_idx`.

**Fields are indistinguishable from local variables:** For example, `AHashMap` has local `capacity` and the field `capacity`. 
**Solution:** Private fields are prefixed with underscore `_` to mark them as such.

**capacity is indistinguishable from capacity mask:** `AHashMap` has field `capacity`, but it's actually `capacity - 1`.
**Solution:** I've renamed the field to `_capacity_mask`.

**num_elements is inconsistent with `size` of other containers:** Other collections like `Array` use `size()` to refer to the number of elements in the collection. The public APIs of hash maps also use `size()`, but the internal field is called `num_elements`.
**Solution:** `num_elements` is renamed to `size` for consistency.

There are other, smaller changes to pull everything together, but I think this covers the big ones.