### PR TITLE
Fix `ResourceSaver` saving default value of `Resource`

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/missing_resource.h"
 #include "core/object/script_language.h"
+#include "scene/property_utils.h"
 
 void ResourceLoaderText::_printerr() {
 	ERR_PRINT(vformat("%s:%d - Parse Error: %s.", res_path, lines, error_text));
@@ -1935,7 +1936,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 					}
 				}
 
-				Variant default_value = ClassDB::class_get_default_property_value(res->get_class(), name);
+				Variant default_value = PropertyUtils::get_property_default_value(res.ptr(), name);
 
 				if (default_value.get_type() != Variant::NIL && bool(Variant::evaluate(Variant::OP_EQUAL, value, default_value))) {
 					continue;


### PR DESCRIPTION
This PR solves the issue mentioned in this previous PR #80897.
That PR seems to be inactive for a few while, and according to the discussion https://github.com/godotengine/godot/pull/80897#pullrequestreview-1590031898 done by @dalexeev and @RandomShaper, this PR is proposed. The original PR just needs a few changes to fix the issue #80894.

Since I am new to this community yet, I am still learning the convention (and what considered as common sense) here. Hope this PR is not offensive.
Happy to close (abort) this PR if the original authors continue on their work.

If this PR is considered valid, I want to ask that:
* Should I add the two paticipants as author (make me commiter) or co-autor in the commit ?
* Should I add `close` statement to the linked issues and that original PR and related PR mentioned ?

---
Added by  @RandomShaper:
Fixes #80894.
Supersedes #80897.