### PR TITLE
Make svg files respect `interface/theme/icon_saturation` setting when imported for editor use

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -35,6 +35,7 @@
 #include "core/io/image_loader.h"
 #include "core/version.h"
 #include "editor/editor_file_system.h"
+#include "editor/editor_settings.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/import/resource_importer_texture_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -794,9 +795,8 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 
 	// Load the editor-only image.
 	Ref<Image> editor_image;
-	bool import_editor_image = use_editor_scale || convert_editor_colors;
 
-	if (import_editor_image) {
+	if (use_editor_scale || convert_editor_colors) {
 		float editor_scale = use_editor_scale ? scale * EDSCALE : scale;
 
 		int32_t editor_loader_flags = loader_flags;
@@ -810,6 +810,11 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 		if (err != OK) {
 			WARN_PRINT(vformat("Failed to import an image resource for editor use from '%s'.", p_source_file));
 		} else {
+			if (convert_editor_colors) {
+				float image_saturation = EDITOR_GET("interface/theme/icon_saturation");
+				editor_image->adjust_bcs(1.0, 1.0, image_saturation);
+			}
+
 			images_imported.push_back(editor_image);
 		}
 	}


### PR DESCRIPTION
Fixes #96129. This pr partially solves the awkward situation of `icon_saturation`.

As already described in #64938, users are asked to restart the editor or manually reimport. I think we should find a better way to deal with this. Maybe a note to ask for a restart or a fully dynamic behaviour.