### PR TITLE
Fix LineEdit continues to force showing the caret after drag is aborted

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1636,6 +1636,14 @@ void LineEdit::_notification(int p_what) {
 			}
 			drag_action = false;
 			drag_caret_force_displayed = false;
+			queue_redraw();
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			if (drag_caret_force_displayed) {
+				drag_caret_force_displayed = false;
+				queue_redraw();
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107054

Before

https://github.com/user-attachments/assets/b55c9900-d4e1-4839-a60f-8da189141e4b



After

https://github.com/user-attachments/assets/a97d6e0e-74a2-4b2a-8a5b-7b4b103d3609

