### PR TITLE
Fix various race conditions with capturing of script backtraces

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -92,15 +92,7 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 // Main error printing function.
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const char *p_error, const char *p_message, bool p_editor_notify, ErrorHandlerType p_type) {
 	if (OS::get_singleton()) {
-		Vector<Ref<ScriptBacktrace>> script_backtraces;
-
-		// If script languages aren't initialized, we could be in the process of shutting down, in which case we don't want to allocate any objects, as we could be
-		// logging ObjectDB leaks, where ObjectDB would be locked, thus causing a deadlock.
-		if (ScriptServer::are_languages_initialized()) {
-			script_backtraces = ScriptServer::capture_script_backtraces(false);
-		}
-
-		OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, p_message, p_editor_notify, (Logger::ErrorType)p_type, script_backtraces);
+		OS::get_singleton()->print_error(p_function, p_file, p_line, p_error, p_message, p_editor_notify, (Logger::ErrorType)p_type, ScriptServer::capture_script_backtraces(false));
 	} else {
 		// Fallback if errors happen before OS init or after it's destroyed.
 		const char *err_details = (p_message && *p_message) ? p_message : p_error;

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -146,14 +146,11 @@ static void handle_crash(int sig) {
 	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
-	if (ScriptServer::are_languages_initialized()) {
-		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
-		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			if (!backtrace->is_empty()) {
-				print_error(backtrace->format());
-				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
-				print_error("================================================================");
-			}
+	for (const Ref<ScriptBacktrace> &backtrace : ScriptServer::capture_script_backtraces(false)) {
+		if (!backtrace->is_empty()) {
+			print_error(backtrace->format());
+			print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+			print_error("================================================================");
 		}
 	}
 

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -176,14 +176,11 @@ static void handle_crash(int sig) {
 	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
-	if (ScriptServer::are_languages_initialized()) {
-		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
-		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			if (!backtrace->is_empty()) {
-				print_error(backtrace->format());
-				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
-				print_error("================================================================");
-			}
+	for (const Ref<ScriptBacktrace> &backtrace : ScriptServer::capture_script_backtraces(false)) {
+		if (!backtrace->is_empty()) {
+			print_error(backtrace->format());
+			print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+			print_error("================================================================");
 		}
 	}
 

--- a/platform/windows/crash_handler_windows_seh.cpp
+++ b/platform/windows/crash_handler_windows_seh.cpp
@@ -230,14 +230,11 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 
 	SymCleanup(process);
 
-	if (ScriptServer::are_languages_initialized()) {
-		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
-		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			if (!backtrace->is_empty()) {
-				print_error(backtrace->format());
-				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
-				print_error("================================================================");
-			}
+	for (const Ref<ScriptBacktrace> &backtrace : ScriptServer::capture_script_backtraces(false)) {
+		if (!backtrace->is_empty()) {
+			print_error(backtrace->format());
+			print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+			print_error("================================================================");
 		}
 	}
 

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -184,14 +184,11 @@ extern void CrashHandlerException(int signal) {
 	print_error("-- END OF C++ BACKTRACE --");
 	print_error("================================================================");
 
-	if (ScriptServer::are_languages_initialized()) {
-		Vector<Ref<ScriptBacktrace>> script_backtraces = ScriptServer::capture_script_backtraces(false);
-		for (const Ref<ScriptBacktrace> &backtrace : script_backtraces) {
-			if (!backtrace->is_empty()) {
-				print_error(backtrace->format());
-				print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
-				print_error("================================================================");
-			}
+	for (const Ref<ScriptBacktrace> &backtrace : ScriptServer::capture_script_backtraces(false)) {
+		if (!backtrace->is_empty()) {
+			print_error(backtrace->format());
+			print_error(vformat("-- END OF %s BACKTRACE --", backtrace->get_language_name().to_upper()));
+			print_error("================================================================");
 		}
 	}
 }


### PR DESCRIPTION
Fixes #107056.

This PR addresses a couple of things:

1. `ScriptServer::capture_script_backtraces` was not locking `languages_mutex` as it probably should have, and in general was calling `ScriptServer` methods through its static interface when it could just have accessed the state directly instead.
2. `ScriptServer::capture_script_backtraces` should rightfully have been checking `ScriptServer::languages_ready` as part of its implementation rather than relying on the caller to call `ScriptServer::are_languages_initialized`, since it doesn't really make much sense to do anything without them being ready anyway, and having the caller do it technically opens you up to a potential race condition.
3. Adds the quick hack for the likely static destruction problem mentioned in [#107056](https://github.com/godotengine/godot/issues/107056).

That last one is very much a hack, and should ideally be fixed properly in short order. However, as mentioned in #107056, it would seem to me that the best way to do so is to convert `ScriptServer` into a proper singleton with a well-defined lifetime instead, which strikes me as a somewhat pervasive/scary change to rush in at the last minute like this.