### PR TITLE
Fix scene reload causing segfaults when non-existent node is currently selected

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2533,7 +2533,7 @@ void EditorNode::edit_item(Object *p_object, Object *p_editing_owner) {
 }
 
 void EditorNode::push_node_item(Node *p_node) {
-	if (p_node || Object::cast_to<Node>(InspectorDock::get_inspector_singleton()->get_edited_object()) || Object::cast_to<MultiNodeEdit>(InspectorDock::get_inspector_singleton()->get_edited_object())) {
+	if (p_node || !InspectorDock::get_inspector_singleton()->get_edited_object() || Object::cast_to<Node>(InspectorDock::get_inspector_singleton()->get_edited_object()) || Object::cast_to<MultiNodeEdit>(InspectorDock::get_inspector_singleton()->get_edited_object())) {
 		// Don't push null if the currently edited object is not a Node.
 		push_item(p_node);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Errors in the way we were handling deselecting nodes were causing segfaults when the currently edited scene was reloaded.

When reloading a scene, the currently selected node may not exist. This is supposed to be handled by EditorSelection::update(), which emits a signal that calls SceneTreeDock::_selection_changed(), which calls SceneTreeDock::_push_item, which calls EditorNode::get_singleton()->push_node_item.

However, the problem is thus:

<img width="613" alt="image" src="https://github.com/user-attachments/assets/ab552312-aa09-4e76-9206-66cbbc3cc5f1" />
<img width="801" alt="image" src="https://github.com/user-attachments/assets/6913f3d2-585e-4588-b7fe-76c8883a5eff" />

`SceneTreeDock::_push_item` always calls `push_node_item` for nullptr objects, but this ends up being useless, because `EditorNode::push_node_item` was checking to see if the currently edited object in the inspector was a Node; if the inspector object is null, then it won't be a node, so nothing happens, and the NodeDock and associated docks don't get their selection updated. 

As a result, interacting with any of the NodeDocks besides the SceneTreeDock after a scene reload with a removed node selected can cause a crash. The easiest way to cause this is by interacting with the Node menu and double clicking on one of the signals.

Checking if the currently edited node in the inspector is null and calling `push_item` if so fixes the issue.