### PR TITLE
[Android] `JavaClassWrapper` bug fixes

### DIFF
--- a/doc/classes/JNISingleton.xml
+++ b/doc/classes/JNISingleton.xml
@@ -9,4 +9,13 @@
 	<tutorials>
 		<link title="Creating Android plugins">$DOCS_URL/tutorials/platform/android/android_plugin.html#doc-android-plugin</link>
 	</tutorials>
+	<methods>
+		<method name="has_java_method" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="method" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the given [param method] name exists in the JNISingleton's Java methods.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/doc/classes/JavaClass.xml
+++ b/doc/classes/JavaClass.xml
@@ -29,5 +29,12 @@
 				Returns a [JavaClass] representing the Java parent class of this class.
 			</description>
 		</method>
+		<method name="has_java_method" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="method" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the given [param method] name exists in the object's Java methods.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/JavaObject.xml
+++ b/doc/classes/JavaObject.xml
@@ -17,5 +17,12 @@
 				Returns the [JavaClass] that this object is an instance of.
 			</description>
 		</method>
+		<method name="has_java_method" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="method" type="StringName" />
+			<description>
+				Returns [code]true[/code] if the given [param method] name exists in the object's Java methods.
+			</description>
+		</method>
 	</methods>
 </class>

--- a/platform/android/api/api.cpp
+++ b/platform/android/api/api.cpp
@@ -62,10 +62,12 @@ void JavaClass::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_java_class_name"), &JavaClass::get_java_class_name);
 	ClassDB::bind_method(D_METHOD("get_java_method_list"), &JavaClass::get_java_method_list);
 	ClassDB::bind_method(D_METHOD("get_java_parent_class"), &JavaClass::get_java_parent_class);
+	ClassDB::bind_method(D_METHOD("has_java_method", "method"), &JavaClass::has_java_method);
 }
 
 void JavaObject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_java_class"), &JavaObject::get_java_class);
+	ClassDB::bind_method(D_METHOD("has_java_method", "method"), &JavaObject::has_java_method);
 }
 
 void JavaClassWrapper::_bind_methods() {
@@ -94,6 +96,10 @@ Ref<JavaClass> JavaClass::get_java_parent_class() const {
 	return Ref<JavaClass>();
 }
 
+bool JavaClass::has_java_method(const StringName &) const {
+	return false;
+}
+
 JavaClass::JavaClass() {
 }
 
@@ -106,6 +112,10 @@ Variant JavaObject::callp(const StringName &, const Variant **, int, Callable::C
 
 Ref<JavaClass> JavaObject::get_java_class() const {
 	return Ref<JavaClass>();
+}
+
+bool JavaObject::has_java_method(const StringName &) const {
+	return false;
 }
 
 JavaClassWrapper *JavaClassWrapper::singleton = nullptr;

--- a/platform/android/api/java_class_wrapper.h
+++ b/platform/android/api/java_class_wrapper.h
@@ -200,6 +200,7 @@ public:
 	String get_java_class_name() const;
 	TypedArray<Dictionary> get_java_method_list() const;
 	Ref<JavaClass> get_java_parent_class() const;
+	bool has_java_method(const StringName &p_method) const;
 
 #ifdef ANDROID_ENABLED
 	virtual String to_string() override;
@@ -226,6 +227,7 @@ public:
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
 	Ref<JavaClass> get_java_class() const;
+	bool has_java_method(const StringName &p_method) const;
 
 #ifdef ANDROID_ENABLED
 	virtual String to_string() override;
@@ -244,7 +246,7 @@ class JavaClassWrapper : public Object {
 #ifdef ANDROID_ENABLED
 	RBMap<String, Ref<JavaClass>> class_cache;
 	friend class JavaClass;
-	jmethodID Class_getDeclaredConstructors;
+	jmethodID Class_getConstructors;
 	jmethodID Class_getDeclaredMethods;
 	jmethodID Class_getFields;
 	jmethodID Class_getName;
@@ -272,7 +274,7 @@ class JavaClassWrapper : public Object {
 
 	Ref<JavaObject> exception;
 
-	Ref<JavaClass> _wrap(const String &p_class, bool p_allow_private_methods_access);
+	Ref<JavaClass> _wrap(const String &p_class, bool p_allow_non_public_methods_access);
 
 	static JavaClassWrapper *singleton;
 

--- a/platform/android/api/jni_singleton.h
+++ b/platform/android/api/jni_singleton.h
@@ -46,33 +46,58 @@ class JNISingleton : public Object {
 	RBMap<StringName, MethodData> method_map;
 	Ref<JavaObject> wrapped_object;
 
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("has_java_method", "method"), &JNISingleton::has_java_method);
+	}
+
 public:
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override {
-		if (wrapped_object.is_valid()) {
-			RBMap<StringName, MethodData>::Element *E = method_map.find(p_method);
-
-			// Check the method we're looking for is in the JNISingleton map and that
-			// the arguments match.
-			bool call_error = !E || E->get().argtypes.size() != p_argcount;
-			if (!call_error) {
-				for (int i = 0; i < p_argcount; i++) {
-					if (!Variant::can_convert(p_args[i]->get_type(), E->get().argtypes[i])) {
-						call_error = true;
-						break;
-					}
-				}
-			}
-
-			if (!call_error) {
-				return wrapped_object->callp(p_method, p_args, p_argcount, r_error);
-			}
+		// Godot methods take precedence.
+		Variant ret = Object::callp(p_method, p_args, p_argcount, r_error);
+		if (r_error.error == Callable::CallError::CALL_OK) {
+			return ret;
 		}
 
-		return Object::callp(p_method, p_args, p_argcount, r_error);
+		// Check the method we're looking for is in the JNISingleton map.
+		RBMap<StringName, MethodData>::Element *E = method_map.find(p_method);
+		if (E) {
+			if (wrapped_object.is_valid()) {
+				// Check that the arguments match.
+				int method_arg_count = E->get().argtypes.size();
+				if (p_argcount < method_arg_count) {
+					r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
+				} else if (p_argcount > method_arg_count) {
+					r_error.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
+				} else {
+					// Check the arguments are valid.
+					bool arguments_valid = true;
+					for (int i = 0; i < p_argcount; i++) {
+						if (!Variant::can_convert(p_args[i]->get_type(), E->get().argtypes[i])) {
+							arguments_valid = false;
+							break;
+						}
+					}
+
+					if (arguments_valid) {
+						return wrapped_object->callp(p_method, p_args, p_argcount, r_error);
+					} else {
+						r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+					}
+				}
+			} else {
+				r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			}
+		}
+		return Variant();
 	}
 
 	Ref<JavaObject> get_wrapped_object() const {
 		return wrapped_object;
+	}
+
+	bool has_java_method(const StringName &p_method) const {
+		return method_map.has(p_method);
 	}
 
 	void add_method(const StringName &p_name, const Vector<Variant::Type> &p_args, Variant::Type p_ret_type) {

--- a/platform/android/java/lib/src/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/plugin/AndroidRuntimePlugin.kt
@@ -51,7 +51,7 @@ class AndroidRuntimePlugin(godot: Godot) : GodotPlugin(godot) {
 	 * Provides access to the host [android.app.Activity] to GDScript
 	 */
 	@UsedByGodot
-	override fun getActivity() = super.getActivity()
+	public override fun getActivity() = super.getActivity()
 
 	/**
 	 * Utility method used to create [Runnable] from Godot [Callable].

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -514,7 +514,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setEditorSetting(JNIE
 }
 
 JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_getEditorProjectMetadata(JNIEnv *env, jclass clazz, jstring p_section, jstring p_key, jobject p_default_value) {
-	jvalret result;
+	jvalue result;
 
 #ifdef TOOLS_ENABLED
 	if (EditorSettings::get_singleton() != nullptr) {
@@ -528,7 +528,7 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_getEditorProjectMe
 	WARN_PRINT("Access to the Editor Settings Project Metadata is only available on Editor builds");
 #endif
 
-	return result.obj;
+	return result.l;
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setEditorProjectMetadata(JNIEnv *env, jclass clazz, jstring p_section, jstring p_key, jobject p_data) {

--- a/platform/android/jni_utils.h
+++ b/platform/android/jni_utils.h
@@ -38,13 +38,7 @@
 
 #include <jni.h>
 
-struct jvalret {
-	jobject obj;
-	jvalue val;
-	jvalret() { obj = nullptr; }
-};
-
-jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_arg, bool force_jobject = false, int p_depth = 0);
+jvalue _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_arg, bool force_jobject = false, int p_depth = 0);
 
 String _get_class_name(JNIEnv *env, jclass cls, bool *array);
 

--- a/platform/android/variant/callable_jni.cpp
+++ b/platform/android/variant/callable_jni.cpp
@@ -91,8 +91,8 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall
 		Callable::CallError err;
 		Variant result;
 		callable.callp(argptrs, count, result, err);
-		jvalret jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
-		ret = jresult.obj;
+		jvalue jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
+		ret = jresult.l;
 	}
 
 	// Manually invoke the destructor to decrease the reference counts for the variant arguments.
@@ -107,8 +107,8 @@ JNIEXPORT jobject JNICALL Java_org_godotengine_godot_variant_Callable_nativeCall
 	Callable callable = _generate_callable(p_env, p_object_id, p_method_name, p_parameters);
 	if (callable.is_valid()) {
 		Variant result = callable.call();
-		jvalret jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
-		return jresult.obj;
+		jvalue jresult = _variant_to_jvalue(p_env, result.get_type(), &result, true);
+		return jresult.l;
 	} else {
 		return nullptr;
 	}


### PR DESCRIPTION
- Adds implementation of `has_java_method(...)` for `JavaClassWrapper` and `JNISingleton`
  - Addresses https://github.com/godotengine/godot/issues/106436
- Catch exceptions thrown during 'wrapping' of the Java class
  - Fixes crash described in https://github.com/godotengine/godot/issues/109667
- Cleaning local references during 'wrapping' of the Java class to prevent local references overflow
  - Fixes https://github.com/godotengine/godot/issues/109671

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
