### PR TITLE
Fix rotated/flipped tiles destination rect calculations

### DIFF
--- a/editor/plugins/tiles/tile_map_layer_editor.h
+++ b/editor/plugins/tiles/tile_map_layer_editor.h
@@ -74,7 +74,7 @@ class TileMapLayerEditorTilesPlugin : public TileMapLayerSubEditorPlugin {
 	GDCLASS(TileMapLayerEditorTilesPlugin, TileMapLayerSubEditorPlugin);
 
 public:
-	enum {
+	enum TileTransformType {
 		TRANSFORM_ROTATE_LEFT,
 		TRANSFORM_ROTATE_RIGHT,
 		TRANSFORM_FLIP_H,
@@ -146,8 +146,8 @@ private:
 	HashMap<Vector2i, TileMapCell> _draw_bucket_fill(Vector2i p_coords, bool p_contiguous, bool p_erase);
 	void _stop_dragging();
 
-	void _apply_transform(int p_type);
-	int _get_transformed_alternative(int p_alternative_id, int p_transform);
+	void _apply_transform(TileTransformType p_type);
+	int _get_transformed_alternative(int p_alternative_id, TileTransformType p_transform);
 
 	///// Selection system. /////
 	RBSet<Vector2i> tile_map_selection;
@@ -423,3 +423,5 @@ public:
 	// Static functions.
 	static Vector<Vector2i> get_line(const TileMapLayer *p_tile_map_layer, Vector2i p_from_cell, Vector2i p_to_cell);
 };
+
+VARIANT_ENUM_CAST(TileMapLayerEditorTilesPlugin::TileTransformType);

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2598,34 +2598,10 @@ void TileMapLayer::draw_tile(RID p_canvas_item, const Vector2 &p_position, const
 		// Get the tile modulation.
 		Color modulate = tile_data->get_modulate();
 
-		// Compute the offset.
-		Vector2 tile_offset = tile_data->get_texture_origin();
-
-		// Get destination rect.
+		// Compute the dest rect.
 		Rect2 dest_rect;
-		dest_rect.size = atlas_source->get_runtime_tile_texture_region(p_atlas_coords).size;
-		dest_rect.size.x += FP_ADJUST;
-		dest_rect.size.y += FP_ADJUST;
-
-		bool transpose = tile_data->get_transpose() ^ bool(p_alternative_tile & TileSetAtlasSource::TRANSFORM_TRANSPOSE);
-		if (transpose) {
-			dest_rect.position = (p_position - Vector2(dest_rect.size.y, dest_rect.size.x) / 2);
-			SWAP(tile_offset.x, tile_offset.y);
-		} else {
-			dest_rect.position = (p_position - dest_rect.size / 2);
-		}
-
-		if (tile_data->get_flip_h() ^ bool(p_alternative_tile & TileSetAtlasSource::TRANSFORM_FLIP_H)) {
-			dest_rect.size.x = -dest_rect.size.x;
-			tile_offset.x = -tile_offset.x;
-		}
-
-		if (tile_data->get_flip_v() ^ bool(p_alternative_tile & TileSetAtlasSource::TRANSFORM_FLIP_V)) {
-			dest_rect.size.y = -dest_rect.size.y;
-			tile_offset.y = -tile_offset.y;
-		}
-
-		dest_rect.position -= tile_offset;
+		bool transpose;
+		compute_transformed_tile_dest_rect(dest_rect, transpose, p_position, atlas_source->get_runtime_tile_texture_region(p_atlas_coords).size, tile_data, p_alternative_tile);
 
 		// Draw the tile.
 		if (p_frame >= 0) {
@@ -2655,6 +2631,56 @@ void TileMapLayer::draw_tile(RID p_canvas_item, const Vector2 &p_position, const
 			RenderingServer::get_singleton()->canvas_item_add_animation_slice(p_canvas_item, 1.0, 0.0, 1.0, 0.0);
 		}
 	}
+}
+
+void TileMapLayer::compute_transformed_tile_dest_rect(Rect2 &r_dest_rect, bool &r_transpose, const Vector2 &p_position, const Vector2 &p_dest_rect_size, const TileData *p_tile_data, int p_alternative_tile) {
+	DEV_ASSERT(p_tile_data);
+	// Conceptually the order of transformations is (starting from the tile centered at the origin):
+	// - Per TileSet-tile transforms (transpose then flips).
+	// - Translation so texture origin is at the origin.
+	// - Per TileMapLayer-cell transforms (transpose then flips).
+	// - Translation to target position.
+
+	const bool tile_transpose = p_tile_data->get_transpose();
+	const bool tile_flip_h = p_tile_data->get_flip_h();
+	const bool tile_flip_v = p_tile_data->get_flip_v();
+
+	const Vector2 texture_origin = p_tile_data->get_texture_origin();
+
+	const bool cell_transpose = bool(p_alternative_tile & TileSetAtlasSource::TRANSFORM_TRANSPOSE);
+	const bool cell_flip_h = bool(p_alternative_tile & TileSetAtlasSource::TRANSFORM_FLIP_H);
+	const bool cell_flip_v = bool(p_alternative_tile & TileSetAtlasSource::TRANSFORM_FLIP_V);
+
+	const bool final_transpose = tile_transpose != cell_transpose;
+	const bool final_flip_h = cell_flip_h != (cell_transpose ? tile_flip_v : tile_flip_h);
+	const bool final_flip_v = cell_flip_v != (cell_transpose ? tile_flip_h : tile_flip_v);
+
+	// Rect draw commands swap the size based on the passed transpose, so the size is left non-tranposed here.
+	// Position calculations need to use transposed size though.
+	Rect2 dest_rect;
+	dest_rect.size = p_dest_rect_size;
+	dest_rect.size.x += FP_ADJUST;
+	dest_rect.size.y += FP_ADJUST;
+	Vector2 transposed_size = final_transpose ? Vector2(dest_rect.size.y, dest_rect.size.x) : dest_rect.size;
+	if (final_flip_h) {
+		dest_rect.size.x = -dest_rect.size.x;
+	}
+	if (final_flip_v) {
+		dest_rect.size.y = -dest_rect.size.y;
+	}
+
+	dest_rect.position = -0.5f * transposed_size;
+	dest_rect.position -= cell_transpose ? Vector2(texture_origin.y, texture_origin.x) : texture_origin;
+	if (cell_flip_h) {
+		dest_rect.position.x = -(dest_rect.position.x + transposed_size.x);
+	}
+	if (cell_flip_v) {
+		dest_rect.position.y = -(dest_rect.position.y + transposed_size.y);
+	}
+	dest_rect.position += p_position;
+
+	r_dest_rect = dest_rect;
+	r_transpose = final_transpose;
 }
 
 void TileMapLayer::set_cell(const Vector2i &p_coords, int p_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile) {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -527,6 +527,7 @@ public:
 	// Not exposed to users.
 	TileMapCell get_cell(const Vector2i &p_coords) const;
 
+	static void compute_transformed_tile_dest_rect(Rect2 &r_dest_rect, bool &r_transpose, const Vector2 &p_position, const Vector2 &p_dest_rect_size, const TileData *p_tile_data, int p_alternative_tile);
 	static void draw_tile(RID p_canvas_item, const Vector2 &p_position, const Ref<TileSet> p_tile_set, int p_atlas_source_id, const Vector2i &p_atlas_coords, int p_alternative_tile, int p_frame = -1, const TileData *p_tile_data_override = nullptr, real_t p_normalized_animation_offset = 0.0);
 
 	////////////// Exposed functions //////////////


### PR DESCRIPTION
Fixes #86655 (AFAICT the collision shapes were being rotated correctly before (tested in v4.4.1.stable.official [49a5bc7b6]) but the rendering could have mismatched the collisions).

Fixes #106842 (regression from #105861).

~~Marking this PR with `cherrypick:4.4` as #105861 is marked as such.~~

---

I've tested all possible per-TileSet-tile and per-TileMapLayer-cell flags combinations (8 * 8 = 64 cases) with a non-symmetrical texture origin and collision shape, all seems to work correctly. But further testing welcomed.

Images below are from modified MRP from #86655: [Godot.rotation.bug_v2.zip](https://github.com/user-attachments/files/20572773/Godot.rotation.bug_v2.zip).
(I've tested #106842 as well, all good.)

Alternative tiles with different flip_h/flip_v/transpose flags:
Texture origins<br>![godot windows editor dev x86_64_OcMqIfEyij](https://github.com/user-attachments/assets/9988c0aa-9f96-44b8-87ad-7c0834975872)|Collision shapes<br>![godot windows editor dev x86_64_C9WsOjfJwj](https://github.com/user-attachments/assets/e07b0343-7896-4fb3-b805-7ae7885a280a)
-|-

For each alternative tile 4 per-cell rotations (right half-plane) and 4 flipped-rotations (left half-plane):
v4.4.1.stable.official [49a5bc7b6]|v4.5.dev.custom_build [e45cc6809]<br>(current `master`)|v4.5.dev.custom_build [4366e5f5d]<br>(this PR)
-|-|-
![Godot_v4 4 1-stable_win64_RnLEfyGSs2](https://github.com/user-attachments/assets/ae33bc0e-c00f-4674-9b94-ce3865b59879)|![godot windows editor dev x86_64_6etuKixlAq](https://github.com/user-attachments/assets/83b22b15-3d4f-4e95-aff6-fa769cd46817)|![godot windows editor dev x86_64_i0VLJAnNXJ](https://github.com/user-attachments/assets/d02cfd78-54cb-48d3-9bec-6288968a5148)


