### PR TITLE
Always use base directory in `CONTEXT_SLOT_FILESYSTEM_CREATE`

### DIFF
--- a/doc/classes/EditorContextMenuPlugin.xml
+++ b/doc/classes/EditorContextMenuPlugin.xml
@@ -89,7 +89,14 @@
 			Context menu of Script editor's script tabs. [method _popup_menu] will be called with the path to the currently edited script, while option callback will receive reference to that script.
 		</constant>
 		<constant name="CONTEXT_SLOT_FILESYSTEM_CREATE" value="3" enum="ContextMenuSlot">
-			The "Create..." submenu of FileSystem dock's context menu, or the "New" section of the main context menu when empty space is clicked. [method _popup_menu] and option callback will be called with the path of the currently selected folder, wrapped in a list. When clicking the empty space, the list of paths for popup method will be empty.
+			The "Create..." submenu of FileSystem dock's context menu, or the "New" section of the main context menu when empty space is clicked. [method _popup_menu] and option callback will be called with the path of the currently selected folder. When clicking the empty space, the list of paths for popup method will be empty.
+			[codeblock]
+			func _popup_menu(paths):
+			    if paths.is_empty():
+			        add_context_menu_item("New Image File...", create_image)
+			    else:
+			        add_context_menu_item("Image File...", create_image)
+			[/codeblock]
 		</constant>
 		<constant name="CONTEXT_SLOT_SCRIPT_EDITOR_CODE" value="4" enum="ContextMenuSlot">
 			Context menu of Script editor's code editor. [method _popup_menu] will be called with the path to the [CodeEdit] node. You can fetch it using this code:

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3325,7 +3325,8 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		new_menu->add_icon_item(get_editor_theme_icon(SNAME("Object")), TTRC("Resource..."), FILE_MENU_NEW_RESOURCE);
 		new_menu->add_icon_item(get_editor_theme_icon(SNAME("TextFile")), TTRC("TextFile..."), FILE_MENU_NEW_TEXTFILE);
 
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(new_menu, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, p_paths);
+		const PackedStringArray folder_path = { p_paths[0].get_base_dir() };
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(new_menu, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, folder_path);
 		p_popup->add_separator();
 	}
 
@@ -3726,13 +3727,25 @@ void FileSystemDock::_tree_gui_input(Ref<InputEvent> p_event) {
 		if (option_id > -1) {
 			_tree_rmb_option(option_id);
 		} else {
+			bool create = false;
 			Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM, p_event);
 			if (!custom_callback.is_valid()) {
+				create = true;
 				custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, p_event);
 			}
 
 			if (custom_callback.is_valid()) {
-				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, _tree_get_selected(false));
+				PackedStringArray selected = _tree_get_selected(false);
+				if (create) {
+					if (selected.is_empty()) {
+						selected.append("res://");
+					} else if (selected.size() == 1) {
+						selected.write[0] = selected[0].get_base_dir();
+					} else {
+						return;
+					}
+				}
+				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, selected);
 			} else {
 				return;
 			}


### PR DESCRIPTION
Addresses https://github.com/godotengine/godot/pull/106820#issuecomment-2913017824

I added "breaks compat", because it makes the method receive base directory instead of full file path, but as I mentioned in the comment, it's more consistent and the file path is not needed in this case.

Also fixed a bug where matching a shortcut for Create option would result in wrong path list.