### PR TITLE
Use default SSH public/private key path in editor version control

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1051,8 +1051,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Version control (VersionControlEditorPlugin)
 	_initial_set("version_control/username", "", true);
-	_initial_set("version_control/ssh_public_key_path", "");
-	_initial_set("version_control/ssh_private_key_path", "");
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "version_control/ssh_public_key_path", "", "~/.ssh/id_rsa.pub");
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "version_control/ssh_private_key_path", "", "~/.ssh/id_rsa");
 
 	/* Extra config */
 

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -46,7 +46,25 @@ bool EditorVCSInterface::initialize(const String &p_project_path) {
 }
 
 void EditorVCSInterface::set_credentials(const String &p_username, const String &p_password, const String &p_ssh_public_key, const String &p_ssh_private_key, const String &p_ssh_passphrase) {
-	GDVIRTUAL_CALL(_set_credentials, p_username, p_password, p_ssh_public_key, p_ssh_private_key, p_ssh_passphrase);
+	String ssh_public_key = p_ssh_public_key;
+	if (p_ssh_public_key.is_empty()) {
+#ifdef WINDOWS_ENABLED
+		ssh_public_key = OS::get_singleton()->get_environment("USERPROFILE").path_join(".ssh/id_rsa.pub");
+#else
+		ssh_public_key = OS::get_singleton()->get_environment("HOME").path_join(".ssh/id_rsa.pub");
+#endif
+	}
+
+	String ssh_private_key = p_ssh_private_key;
+	if (ssh_private_key.is_empty()) {
+#ifdef WINDOWS_ENABLED
+		ssh_private_key = OS::get_singleton()->get_environment("USERPROFILE").path_join(".ssh/id_rsa");
+#else
+		ssh_private_key = OS::get_singleton()->get_environment("HOME").path_join(".ssh/id_rsa");
+#endif
+	}
+
+	GDVIRTUAL_CALL(_set_credentials, p_username, p_password, ssh_public_key, ssh_private_key, p_ssh_passphrase);
 }
 
 List<String> EditorVCSInterface::get_remotes() {

--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -1070,6 +1070,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_ssh_public_key_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_ssh_public_key_path->set_accessibility_name(TTRC("SSH Public Key Path"));
 	set_up_ssh_public_key_path->set_text(EDITOR_GET("version_control/ssh_public_key_path"));
+	set_up_ssh_public_key_path->set_placeholder("~/.ssh/id_rsa.pub");
 	set_up_ssh_public_key_path->connect(SceneStringName(text_changed), callable_mp(this, &VersionControlEditorPlugin::_update_set_up_warning));
 	set_up_ssh_public_key_input_hbc->add_child(set_up_ssh_public_key_path);
 
@@ -1104,6 +1105,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	set_up_ssh_private_key_path = memnew(LineEdit);
 	set_up_ssh_private_key_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	set_up_ssh_private_key_path->set_text(EDITOR_GET("version_control/ssh_private_key_path"));
+	set_up_ssh_private_key_path->set_placeholder("~/.ssh/id_rsa");
 	set_up_ssh_private_key_path->connect(SceneStringName(text_changed), callable_mp(this, &VersionControlEditorPlugin::_update_set_up_warning));
 	set_up_ssh_private_key_path->set_accessibility_name(TTRC("SSH Private Key Path"));
 	set_up_ssh_private_key_input_hbc->add_child(set_up_ssh_private_key_path);


### PR DESCRIPTION
This saves the user from having to configure the SSH public/private key path if it's the default. The user now only has to configure the SSH passphrase for SSH authentication to work.

## Preview

![image](https://github.com/user-attachments/assets/fdd5f98f-06bc-4f89-9948-266b08a30dee)

## TODO

- [ ] Fix browse icon in the SSH configuration dialog (see the above screenshot). The issue isn't specific to this PR, but I'd still like to fix it.
