### PR TITLE
Make `BaseButton`s' shortcut feedback timers internal

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -452,7 +452,7 @@ void BaseButton::shortcut_input(const Ref<InputEvent> &p_event) {
 			if (shortcut_feedback_timer == nullptr) {
 				shortcut_feedback_timer = memnew(Timer);
 				shortcut_feedback_timer->set_one_shot(true);
-				add_child(shortcut_feedback_timer);
+				add_child(shortcut_feedback_timer, false, INTERNAL_MODE_BACK);
 				shortcut_feedback_timer->set_wait_time(GLOBAL_GET_CACHED(double, "gui/timers/button_shortcut_feedback_highlight_time"));
 				shortcut_feedback_timer->connect("timeout", callable_mp(this, &BaseButton::_shortcut_feedback_timeout));
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

When a `BaseButton`'s `shortcut_feedback` property is enabled and it is activated by a shortcut, a `Timer` is added as the button's child. However, this timer is not made internal. This PR makes the timer internal to avoid unexpected behavior when getting a button's children.