### PR TITLE
CodeEdit: Make close brace skipping dependent on brace balance

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -704,6 +704,20 @@ void CodeEdit::_unhide_carets() {
 
 /* Text manipulation */
 
+void CodeEdit::_count_brace_balance(int p_pair, int p_line, int &r_count) {
+	String line = get_line(p_line);
+	for (int c = 0; c < line.length(); c++) {
+		if (is_in_comment(p_line, c) != -1 || is_in_string(p_line, c) != -1) {
+			continue;
+		}
+		if (line[c] == auto_brace_completion_pairs[p_pair].open_key[0]) {
+			r_count += 1;
+		} else if (line[c] == auto_brace_completion_pairs[p_pair].close_key[0]) {
+			r_count -= 1;
+		}
+	}
+}
+
 // Overridable actions
 void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_caret) {
 	start_action(EditAction::ACTION_TYPING);
@@ -755,7 +769,34 @@ void CodeEdit::_handle_unicode_input_internal(const uint32_t p_unicode, int p_ca
 				} else if (cc < get_line(cl).length() && !is_symbol(get_line(cl)[cc])) {
 					insert_text_at_caret(chr, i);
 				} else if (post_brace_pair != -1 && auto_brace_completion_pairs[post_brace_pair].close_key[0] == chr[0]) {
-					caret_move_offset = auto_brace_completion_pairs[post_brace_pair].close_key.length();
+					// Try to count the brace balance for this pair. Insert closing brace if there are too much open braces, otherwise just move the cursor.
+					int pair_balance = 0;
+					if (auto_brace_completion_pairs[post_brace_pair].close_key.length() == 1 && auto_brace_completion_pairs[post_brace_pair].open_key.length() == 1) {
+						// HACK: We only want to balance in the same scope (or even expression). But scope information is not exposed by the script language so indentation is our best heuristic.
+						int indent_level = get_indent_level(cl);
+
+						for (int balance_line = cl; balance_line >= 0; balance_line--) {
+							if (get_indent_level(balance_line) < indent_level) {
+								// Less indented -> not part of the current scope -> stop searching
+								break;
+							}
+							_count_brace_balance(post_brace_pair, balance_line, pair_balance);
+						}
+
+						for (int balance_line = cl + 1; balance_line < get_line_count(); balance_line++) {
+							if (get_indent_level(balance_line) < indent_level) {
+								// Less indented -> not part of the current scope -> stop searching
+								break;
+							}
+							_count_brace_balance(post_brace_pair, balance_line, pair_balance);
+						}
+					}
+
+					if (pair_balance > 0) {
+						insert_text_at_caret(chr, i);
+					} else {
+						caret_move_offset = auto_brace_completion_pairs[post_brace_pair].close_key.length();
+					}
 				} else if (is_in_comment(cl, cc) != -1 || (is_in_string(cl, cc) != -1 && has_string_delimiter(chr))) {
 					insert_text_at_caret(chr, i);
 				} else {

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -87,6 +87,8 @@ private:
 	int _get_auto_brace_pair_open_at_pos(int p_line, int p_col);
 	int _get_auto_brace_pair_close_at_pos(int p_line, int p_col);
 
+	void _count_brace_balance(int p_pair, int p_line, int &r_count);
+
 	/* Main Gutter */
 	enum MainGutterType {
 		MAIN_GUTTER_BREAKPOINT = 0x01,

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3818,6 +3818,17 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		CHECK(code_edit->get_line(0) == "[]");
 		CHECK(code_edit->get_caret_column() == 2);
 
+		/* If braces are not balanced typing close key should not "skip". */
+		code_edit->clear();
+		code_edit->set_text("[[]");
+		code_edit->set_caret_column(2);
+		SEND_GUI_KEY_EVENT(Key::BRACKETRIGHT);
+		CHECK(code_edit->get_line(0) == "[[]]");
+		CHECK(code_edit->get_caret_column() == 3);
+		SEND_GUI_KEY_EVENT(Key::BRACKETRIGHT);
+		CHECK(code_edit->get_line(0) == "[[]]");
+		CHECK(code_edit->get_caret_column() == 4);
+
 		/* If current is char and inserting a string, do not autocomplete. */
 		code_edit->clear();
 		SEND_GUI_KEY_EVENT(Key::A);


### PR DESCRIPTION
One issue I encounter from time to time with auto brace completion, is that I'm trying to close a brace inside of another brace pair, but instead skip the end of the outer pair. This PR tries to solve this by making the skipping logic dependent on the brace balance. Skipping only happens if there are no braces missing:

https://github.com/user-attachments/assets/eeb2ce35-62f6-4681-a3b5-31c45d2490c5



