### PR TITLE
Fix WorldBoundaryShape2D handle when distance is negative

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -184,7 +184,8 @@ void CollisionShape2DEditor::set_handle(int idx, Point2 &p_point) {
 					Vector2 normal = world_boundary->get_normal();
 					world_boundary->set_distance(p_point.dot(normal) / normal.length_squared());
 				} else {
-					world_boundary->set_normal(p_point.normalized());
+					real_t dir = world_boundary->get_distance() < 0 ? -1 : 1;
+					world_boundary->set_normal(p_point.normalized() * dir);
 				}
 			}
 		} break;


### PR DESCRIPTION
If a `WorldBoundaryShape2D` is set to use a negative distance, dragging the normal vector handle produces a normal vector pointing to the opposite direction.

| Before | After |
|----|----|
| ![before](https://github.com/user-attachments/assets/adb5714d-91d7-4faf-89c0-f1e3b4711fcb) | ![after](https://github.com/user-attachments/assets/97e5d01a-b051-409c-a5b2-91f16588521d) |
