### PR TITLE
Improve logic for delta smoothing and accessibility cmd line options

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1281,18 +1281,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--delta-smoothing") {
 			if (N) {
 				String string = N->get();
-				bool recognized = false;
 				if (string == "enable") {
 					OS::get_singleton()->set_delta_smoothing(true);
 					delta_smoothing_override = true;
-					recognized = true;
-				}
-				if (string == "disable") {
+				} else if (string == "disable") {
 					OS::get_singleton()->set_delta_smoothing(false);
 					delta_smoothing_override = false;
-					recognized = true;
-				}
-				if (!recognized) {
+				} else {
 					OS::get_singleton()->print("Delta-smoothing argument not recognized, aborting.\n");
 					goto error;
 				}
@@ -1307,16 +1302,15 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "--accessibility") {
 			if (N) {
 				String string = N->get();
+				accessibility_mode_set = true;
 				if (string == "auto") {
 					accessibility_mode = DisplayServer::AccessibilityMode::ACCESSIBILITY_AUTO;
-					accessibility_mode_set = true;
 				} else if (string == "always") {
 					accessibility_mode = DisplayServer::AccessibilityMode::ACCESSIBILITY_ALWAYS;
-					accessibility_mode_set = true;
 				} else if (string == "disabled") {
 					accessibility_mode = DisplayServer::AccessibilityMode::ACCESSIBILITY_DISABLED;
-					accessibility_mode_set = true;
 				} else {
+					accessibility_mode_set = false;
 					OS::get_singleton()->print("Accessibility mode argument not recognized, aborting.\n");
 					goto error;
 				}


### PR DESCRIPTION
The delta smoothing command line option used repeated if statments and a "catch" variable rather than a more efficient and traditional if, else if, else block. This left room for errors to sneak in and was slightly less efficient (each if had to be checked regardless of the fact that `string` did not change between if statements).

Accessibility command line option always set `accessibility_mode_set` to true except in the case of an error. This logic was simplified to set the value to true initially and turn it off in case of an error. 

Relevant discussion can be found [here](https://github.com/godotengine/godot-proposals/discussions/12504#discussion-8377032) 