### PR TITLE
Describe "Fuzzy Search" in Quick Open tooltip

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -265,7 +265,7 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 		fuzzy_search_toggle = memnew(CheckButton);
 		style_button(fuzzy_search_toggle);
 		fuzzy_search_toggle->set_text(TTR("Fuzzy Search"));
-		fuzzy_search_toggle->set_tooltip_text(TTR("Enable fuzzy matching"));
+		fuzzy_search_toggle->set_tooltip_text(TTRC("Include inexact matches or matches starting in the middle of a filename, instead of only exact matches from the beginning."));
 		fuzzy_search_toggle->connect(SceneStringName(toggled), callable_mp(this, &QuickOpenResultContainer::_toggle_fuzzy_search));
 		bottom_bar->add_child(fuzzy_search_toggle);
 


### PR DESCRIPTION
The old tooltip text for the "Fuzzy Search" toggle simply read "Enable fuzzy matching", which wouldn't really help someone unfamiliar with the term "fuzzy" understand any more what it was doing.

This PR expands it to "Include inexact matches or matches starting in the middle of a filename, instead of only exact matches from the beginning", which is (hopefully) a good and more understandable description.