### PR TITLE
Unify `get_[_visible]paragraph/line_count` behavior.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -102,7 +102,7 @@
 			<return type="int" />
 			<description>
 				Returns the total number of lines in the text. Wrapped text is counted as multiple lines.
-				[b]Note:[/b] If [member visible_characters_behavior] is set to [constant TextServer.VC_CHARS_BEFORE_SHAPING] only visible wrapped lines are counted.
+				[b]Note:[/b] Lines hidden by [member visible_characters] are not counted.
 				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>
@@ -189,6 +189,8 @@
 			<return type="int" />
 			<description>
 				Returns the total number of paragraphs (newlines or [code]p[/code] tags in the tag stack's text tags). Considers wrapped text as one paragraph.
+				[b]Note:[/b] Paragraphs hidden by [member visible_characters] are not counted.
+				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>
 		<method name="get_paragraph_offset">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2471,8 +2471,11 @@ void RichTextLabel::_notification(int p_what) {
 			while (ofs.y < size.height - v_limit && from_line < to_line) {
 				MutexLock lock(main->lines[from_line].text_buf->get_mutex());
 
-				visible_paragraph_count++;
-				visible_line_count += _draw_line(main, from_line, ofs, text_rect.size.x, vsep, theme_cache.default_color, theme_cache.outline_size, theme_cache.font_outline_color, theme_cache.font_shadow_color, theme_cache.shadow_outline_size, shadow_ofs, processed_glyphs);
+				int drawn_lines = _draw_line(main, from_line, ofs, text_rect.size.x, vsep, theme_cache.default_color, theme_cache.outline_size, theme_cache.font_outline_color, theme_cache.font_shadow_color, theme_cache.shadow_outline_size, shadow_ofs, processed_glyphs);
+				visible_line_count += drawn_lines;
+				if (drawn_lines > 0) {
+					visible_paragraph_count++;
+				}
 				ofs.y += main->lines[from_line].text_buf->get_size().y + main->lines[from_line].text_buf->get_line_count() * (theme_cache.line_separation + vsep);
 				from_line++;
 			}
@@ -6199,7 +6202,15 @@ void RichTextLabel::scroll_to_paragraph(int p_paragraph) {
 }
 
 int RichTextLabel::get_paragraph_count() const {
-	return main->lines.size();
+	int para_count = 0;
+	int to_line = main->first_invalid_line.load();
+	for (int i = 0; i < to_line; i++) {
+		if ((visible_characters >= 0) && main->lines[i].char_offset >= visible_characters) {
+			break;
+		}
+		para_count++;
+	}
+	return para_count;
 }
 
 int RichTextLabel::get_visible_paragraph_count() const {
@@ -6274,7 +6285,13 @@ int RichTextLabel::get_line_count() const {
 	int to_line = main->first_invalid_line.load();
 	for (int i = 0; i < to_line; i++) {
 		MutexLock lock(main->lines[i].text_buf->get_mutex());
-		line_count += main->lines[i].text_buf->get_line_count();
+		for (int j = 0; j < main->lines[i].text_buf->get_line_count(); j++) {
+			RID rid = main->lines[i].text_buf->get_line_rid(j);
+			if ((visible_characters >= 0) && main->lines[i].char_offset + TS->shaped_text_get_range(rid).x >= visible_characters) {
+				break;
+			}
+			line_count++;
+		}
 	}
 	return line_count;
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/99654

Makes behavior of these function the same regardless of `visible_characters_behavior`.

### Before this PR: Chars before / Chars after / Glyphs
https://github.com/user-attachments/assets/3ab84b50-5a77-4641-9da9-02f120ed7bdb

### With this PR: Chars before / Chars after / Glyphs
https://github.com/user-attachments/assets/1b57c741-3371-472c-8c63-278a67295175

