### PR TITLE
[Web] Fix build failure on Windows

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -256,7 +256,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(CCFLAGS=["-sUSE_PTHREADS=1"])
         env.Append(LINKFLAGS=["-sUSE_PTHREADS=1"])
         env.Append(LINKFLAGS=["-sDEFAULT_PTHREAD_STACK_SIZE=%sKB" % env["default_pthread_stack_size"]])
-        env.Append(LINKFLAGS=["-sPTHREAD_POOL_SIZE='Module[\"emscriptenPoolSize\"]||8'"])
+        env.Append(LINKFLAGS=["-sPTHREAD_POOL_SIZE=\"Module['emscriptenPoolSize']||8\""])
         env.Append(LINKFLAGS=["-sWASM_MEM_MAX=2048MB"])
         if not env["dlink_enabled"]:
             # Workaround https://github.com/emscripten-core/emscripten/issues/21844#issuecomment-2116936414.


### PR DESCRIPTION
Follow up to:
* https://github.com/godotengine/godot/pull/104458

In PowerShell (at least, haven't tried with other shells) the pipe characters are not interpreted as part of the expression, leading to:
```
[ 67%] em++: error: error parsing "-s" setting "PTHREAD_POOL_SIZE='Module[emscriptenPoolSize]": unclosed quoted string. expected final character to be "'" and length to be greater than 1 in "'"
[ 68%] '8'' is not recognized as an internal or external command, operable program or batch file.
```
Swapping the quote characters solves this issue (though I don't know how to confirm that the result is parsed correctly in either case)
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
