### PR TITLE
Fix async resource loading progress on empty `p_original_path`

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -296,7 +296,7 @@ Ref<Resource> ResourceLoader::_load(const String &p_path, const String &p_origin
 		// Avoid double-tracking, for progress reporting, resources that boil down to a remapped path containing the real payload (e.g., imported resources).
 		bool is_remapped_load = original_path == parent_task_path;
 		if (E && !is_remapped_load) {
-			E->value.sub_tasks.insert(p_original_path);
+			E->value.sub_tasks.insert(original_path);
 		}
 	}
 	load_paths_stack.push_back(original_path);


### PR DESCRIPTION
Found while investigating #99128.

Currently, if `p_original_path` is an empty string across multiple resources, the `sub_tasks` will only "track" the single entry with such path, and it will also immediately treat it as loaded in `_dependency_get_progress()`.