### PR TITLE
Ignore whitespace when filtering in the visual shader editor create dialog

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2229,7 +2229,8 @@ void VisualShaderEditor::_update_options_menu() {
 	members->clear();
 	TreeItem *root = members->create_item();
 
-	String filter = node_filter->get_text().strip_edges();
+	// Ignore all whitespace in the filter. This allows filter strings like "float constant" to match FloatConstant.
+	String filter = node_filter->get_text().strip_edges().replace(" ", "");
 	bool use_filter = !filter.is_empty();
 
 	bool is_first_item = true;


### PR DESCRIPTION
This allows filter strings like "float constant" to match FloatConstant.

- This partially addresses https://github.com/godotengine/godot-proposals/discussions/12553.

## Preview

![image](https://github.com/user-attachments/assets/92767b4b-3e2d-4b6e-9c90-b135cbbb2800)
