### PR TITLE
Support explicit parameter functions

### DIFF
--- a/core/func_defs.h
+++ b/core/func_defs.h
@@ -1,0 +1,37 @@
+/**************************************************************************/
+/*  func_defs.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <type_traits>
+
+#define EXPLICIT_PARAM_FUNC(RETURN_TYPE, TYPE, EXTRA) \
+	template <typename T>                             \
+	EXTRA typename std::enable_if<std::is_same<T, TYPE>::value, RETURN_TYPE>::type

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/error/error_macros.h"
+#include "core/func_defs.h"
 #include "core/math/math_defs.h"
 #include "core/typedefs.h"
 
@@ -622,10 +623,12 @@ _ALWAYS_INLINE_ float db_to_linear(float p_db) {
 	return exp(p_db * (float)0.11512925464970228420089957273422);
 }
 
-_ALWAYS_INLINE_ double round(double p_val) {
+EXPLICIT_PARAM_FUNC(double, double, _ALWAYS_INLINE_)
+round(T p_val) {
 	return std::round(p_val);
 }
-_ALWAYS_INLINE_ float round(float p_val) {
+EXPLICIT_PARAM_FUNC(float, float, _ALWAYS_INLINE_)
+round(T p_val) {
 	return std::round(p_val);
 }
 


### PR DESCRIPTION
Prevent implicit parameter conversions for specific functions using a macro.

Implicit conversion can sometimes be an indicator of bugs, we use them quite a bit with the basic types, but we identified a desire in the core meeting today to be able to selectively apply explicit protection for parameters in certain functions.

Just adding a draft here to foster more discussion, I'm sure template / macro fu could be applied to make it "more better". :grin: 

```
float f = round(0.3f); // works
float f = round(3); // compile error
```

## Notes
* I'm sure there are much better ways of doing this but it's kind of fun to get the ball rolling.
* Another alternative is to enable the compiler warning for specific sections of code.
* Another way is adding function versions for disallowed types,  and `deleting` these versions.
* I also tried creating an explicit struct for passing but had no joy (e.g. `explicit_param<float>`) as I couldn't get it to accept `float` input.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
