### PR TITLE
Fix LineEdit's caret desyncing issue when toggling secret mode

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2444,6 +2444,7 @@ void LineEdit::set_secret(bool p_secret) {
 
 	pass = p_secret;
 	_shape();
+	set_caret_column(caret_column); // Update scroll_offset.
 	queue_redraw();
 }
 
@@ -2462,6 +2463,7 @@ void LineEdit::set_secret_character(const String &p_string) {
 	}
 	secret_character = c;
 	_shape();
+	set_caret_column(caret_column); // Update scroll_offset.
 	queue_redraw();
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107124

**Before:**

https://github.com/user-attachments/assets/163414d0-c386-4bb3-8204-4e1f1e31d9a0

**After:**

https://github.com/user-attachments/assets/3714f867-55cd-4754-bb86-9eaad17e13bb

