### PR TITLE
Doc: Add "required" qualifier to methods

### DIFF
--- a/core/doc_data.cpp
+++ b/core/doc_data.cpp
@@ -127,6 +127,13 @@ void DocData::method_doc_from_methodinfo(DocData::MethodDoc &p_method, const Met
 		p_method.qualifiers = "virtual";
 	}
 
+	if (p_methodinfo.flags & METHOD_FLAG_VIRTUAL_REQUIRED) {
+		if (!p_method.qualifiers.is_empty()) {
+			p_method.qualifiers += " ";
+		}
+		p_method.qualifiers += "required";
+	}
+
 	if (p_methodinfo.flags & METHOD_FLAG_CONST) {
 		if (!p_method.qualifiers.is_empty()) {
 			p_method.qualifiers += " ";

--- a/doc/classes/AnimationNodeExtension.xml
+++ b/doc/classes/AnimationNodeExtension.xml
@@ -9,7 +9,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_process_animation_node" qualifiers="virtual">
+		<method name="_process_animation_node" qualifiers="virtual required">
 			<return type="PackedFloat32Array" />
 			<param index="0" name="playback_info" type="PackedFloat64Array" />
 			<param index="1" name="test_only" type="bool" />

--- a/doc/classes/AudioEffect.xml
+++ b/doc/classes/AudioEffect.xml
@@ -12,7 +12,7 @@
 		<link title="Audio Microphone Record Demo">https://godotengine.org/asset-library/asset/2760</link>
 	</tutorials>
 	<methods>
-		<method name="_instantiate" qualifiers="virtual">
+		<method name="_instantiate" qualifiers="virtual required">
 			<return type="AudioEffectInstance" />
 			<description>
 				Override this method to customize the [AudioEffectInstance] created when this effect is applied on a bus in the editor's Audio panel, or through [method AudioServer.add_bus_effect].

--- a/doc/classes/AudioEffectInstance.xml
+++ b/doc/classes/AudioEffectInstance.xml
@@ -10,7 +10,7 @@
 		<link title="Audio buses">$DOCS_URL/tutorials/audio/audio_buses.html</link>
 	</tutorials>
 	<methods>
-		<method name="_process" qualifiers="virtual">
+		<method name="_process" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="src_buffer" type="const void*" />
 			<param index="1" name="dst_buffer" type="AudioFrame*" />

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -35,7 +35,7 @@
 				Overridable method. Should return [code]true[/code] if this playback is active and playing its audio stream.
 			</description>
 		</method>
-		<method name="_mix" qualifiers="virtual">
+		<method name="_mix" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="buffer" type="AudioFrame*" />
 			<param index="1" name="rate_scale" type="float" />

--- a/doc/classes/AudioStreamPlaybackResampled.xml
+++ b/doc/classes/AudioStreamPlaybackResampled.xml
@@ -7,12 +7,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_stream_sampling_rate" qualifiers="virtual const">
+		<method name="_get_stream_sampling_rate" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_mix_resampled" qualifiers="virtual">
+		<method name="_mix_resampled" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="dst_buffer" type="AudioFrame*" />
 			<param index="1" name="frame_count" type="int" />

--- a/doc/classes/EditorExportPlatformExtension.xml
+++ b/doc/classes/EditorExportPlatformExtension.xml
@@ -15,7 +15,6 @@
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<param index="1" name="debug" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code], if specified [param preset] is valid and can be exported. Use [method set_config_error] and [method set_config_missing_templates] to set error details.
 				Usual implementation can call [method _has_valid_export_configuration] and [method _has_valid_project_configuration] to determine if export is possible.
 			</description>
@@ -23,7 +22,6 @@
 		<method name="_cleanup" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				[b]Optional.[/b]
 				Called by the editor before platform is unregistered.
 			</description>
 		</method>
@@ -34,7 +32,6 @@
 			<param index="2" name="path" type="String" />
 			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Creates a PCK archive at [param path] for the specified [param preset].
 				This method is called when "Export PCK/ZIP" button is pressed in the export dialog, with "Export as Patch" disabled, and PCK is selected as a file type.
 			</description>
@@ -47,20 +44,18 @@
 			<param index="3" name="patches" type="PackedStringArray" />
 			<param index="4" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Creates a patch PCK archive at [param path] for the specified [param preset], containing only the files that have changed since the last patch.
 				This method is called when "Export PCK/ZIP" button is pressed in the export dialog, with "Export as Patch" enabled, and PCK is selected as a file type.
 				[b]Note:[/b] The patches provided in [param patches] have already been loaded when this method is called and are merely provided as context. When empty the patches defined in the export preset have been loaded instead.
 			</description>
 		</method>
-		<method name="_export_project" qualifiers="virtual">
+		<method name="_export_project" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<param index="1" name="debug" type="bool" />
 			<param index="2" name="path" type="String" />
 			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
 			<description>
-				[b]Required.[/b]
 				Creates a full project at [param path] for the specified [param preset].
 				This method is called when "Export" button is pressed in the export dialog.
 				This method implementation can call [method EditorExportPlatform.save_pack] or [method EditorExportPlatform.save_zip] to use default PCK/ZIP export process, or calls [method EditorExportPlatform.export_project_files] and implement custom callback for processing each exported file.
@@ -73,7 +68,6 @@
 			<param index="2" name="path" type="String" />
 			<param index="3" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Create a ZIP archive at [param path] for the specified [param preset].
 				This method is called when "Export PCK/ZIP" button is pressed in the export dialog, with "Export as Patch" disabled, and ZIP is selected as a file type.
 			</description>
@@ -86,24 +80,21 @@
 			<param index="3" name="patches" type="PackedStringArray" />
 			<param index="4" name="flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Create a ZIP archive at [param path] for the specified [param preset], containing only the files that have changed since the last patch.
 				This method is called when "Export PCK/ZIP" button is pressed in the export dialog, with "Export as Patch" enabled, and ZIP is selected as a file type.
 				[b]Note:[/b] The patches provided in [param patches] have already been loaded when this method is called and are merely provided as context. When empty the patches defined in the export preset have been loaded instead.
 			</description>
 		</method>
-		<method name="_get_binary_extensions" qualifiers="virtual const">
+		<method name="_get_binary_extensions" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<description>
-				[b]Required.[/b]
 				Returns array of supported binary extensions for the full project export.
 			</description>
 		</method>
 		<method name="_get_debug_protocol" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns protocol used for remote debugging. Default implementation return [code]tcp://[/code].
 			</description>
 		</method>
@@ -111,7 +102,6 @@
 			<return type="String" />
 			<param index="0" name="device" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns device architecture for one-click deploy.
 			</description>
 		</method>
@@ -120,7 +110,6 @@
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<param index="1" name="option" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Validates [param option] and returns visibility for the specified [param preset]. Default implementation return [code]true[/code] for all options.
 			</description>
 		</method>
@@ -129,14 +118,12 @@
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<param index="1" name="option" type="StringName" />
 			<description>
-				[b]Optional.[/b]
 				Validates [param option] and returns warning message for the specified [param preset]. Default implementation return empty string for all options.
 			</description>
 		</method>
 		<method name="_get_export_options" qualifiers="virtual const">
 			<return type="Dictionary[]" />
 			<description>
-				[b]Optional.[/b]
 				Returns a property list, as an [Array] of dictionaries. Each [Dictionary] must at least contain the [code]name: StringName[/code] and [code]type: Variant.Type[/code] entries.
 				Additionally, the following keys are supported:
 				- [code]hint: PropertyHint[/code]
@@ -149,17 +136,15 @@
 				See also [method Object._get_property_list].
 			</description>
 		</method>
-		<method name="_get_logo" qualifiers="virtual const">
+		<method name="_get_logo" qualifiers="virtual required const">
 			<return type="Texture2D" />
 			<description>
-				[b]Required.[/b]
 				Returns platform logo displayed in the export dialog, logo should be 32x32 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
 			</description>
 		</method>
-		<method name="_get_name" qualifiers="virtual const">
+		<method name="_get_name" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
-				[b]Required.[/b]
 				Returns export platform name.
 			</description>
 		</method>
@@ -167,7 +152,6 @@
 			<return type="ImageTexture" />
 			<param index="0" name="device" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns one-click deploy menu item icon for the specified [param device], icon should be 16x16 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
 			</description>
 		</method>
@@ -175,7 +159,6 @@
 			<return type="String" />
 			<param index="0" name="device" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns one-click deploy menu item label for the specified [param device].
 			</description>
 		</method>
@@ -183,67 +166,58 @@
 			<return type="String" />
 			<param index="0" name="device" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns one-click deploy menu item tooltip for the specified [param device].
 			</description>
 		</method>
 		<method name="_get_options_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns number one-click deploy devices (or other one-click option displayed in the menu).
 			</description>
 		</method>
 		<method name="_get_options_tooltip" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns tooltip of the one-click deploy menu button.
 			</description>
 		</method>
-		<method name="_get_os_name" qualifiers="virtual const">
+		<method name="_get_os_name" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
-				[b]Required.[/b]
 				Returns target OS name.
 			</description>
 		</method>
-		<method name="_get_platform_features" qualifiers="virtual const">
+		<method name="_get_platform_features" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
-				[b]Required.[/b]
 				Returns array of platform specific features.
 			</description>
 		</method>
-		<method name="_get_preset_features" qualifiers="virtual const">
+		<method name="_get_preset_features" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<description>
-				[b]Required.[/b]
 				Returns array of platform specific features for the specified [param preset].
 			</description>
 		</method>
 		<method name="_get_run_icon" qualifiers="virtual const">
 			<return type="Texture2D" />
 			<description>
-				[b]Optional.[/b]
 				Returns icon of the one-click deploy menu button, icon should be 16x16 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
 			</description>
 		</method>
-		<method name="_has_valid_export_configuration" qualifiers="virtual const">
+		<method name="_has_valid_export_configuration" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<param index="1" name="debug" type="bool" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if export configuration is valid.
 			</description>
 		</method>
-		<method name="_has_valid_project_configuration" qualifiers="virtual const">
+		<method name="_has_valid_project_configuration" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="preset" type="EditorExportPreset" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if project configuration is valid.
 			</description>
 		</method>
@@ -251,14 +225,12 @@
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if specified file is a valid executable (native executable or script) for the target platform.
 			</description>
 		</method>
 		<method name="_poll_export" qualifiers="virtual">
 			<return type="bool" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if one-click deploy options are changed and editor interface should be updated.
 			</description>
 		</method>
@@ -268,7 +240,6 @@
 			<param index="1" name="device" type="int" />
 			<param index="2" name="debug_flags" type="int" enum="EditorExportPlatform.DebugFlags" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				This method is called when [param device] one-click deploy menu option is selected.
 				Implementation should export project to a temporary location, upload and run it on the specific [param device], or perform another action associated with the menu item.
 			</description>
@@ -276,7 +247,6 @@
 		<method name="_should_update_export_options" qualifiers="virtual">
 			<return type="bool" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if export options list is changed and presets should be updated.
 			</description>
 		</method>

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -30,7 +30,7 @@
 				[b]Note:[/b] [method _customize_scene] will only be called for scenes that have been modified since the last export.
 			</description>
 		</method>
-		<method name="_customize_resource" qualifiers="virtual">
+		<method name="_customize_resource" qualifiers="virtual required">
 			<return type="Resource" />
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="path" type="String" />
@@ -47,7 +47,7 @@
 				- [CompressedTexture3D]
 			</description>
 		</method>
-		<method name="_customize_scene" qualifiers="virtual">
+		<method name="_customize_scene" qualifiers="virtual required">
 			<return type="Node" />
 			<param index="0" name="scene" type="Node" />
 			<param index="1" name="path" type="String" />
@@ -152,7 +152,7 @@
 				[b]Note:[/b] Only supported on Android and requires [member EditorExportPlatformAndroid.gradle_build/use_gradle_build] to be enabled.
 			</description>
 		</method>
-		<method name="_get_customization_configuration_hash" qualifiers="virtual const">
+		<method name="_get_customization_configuration_hash" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Return a hash based on the configuration passed (for both scenes and resources). This helps keep separate caches for separate export configurations.
@@ -172,7 +172,6 @@
 			<param index="0" name="platform" type="EditorExportPlatform" />
 			<param index="1" name="option" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Validates [param option] and returns the visibility for the specified [param platform]. The default implementation returns [code]true[/code] for all options.
 			</description>
 		</method>
@@ -220,7 +219,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="_get_name" qualifiers="virtual const">
+		<method name="_get_name" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 				Return the name identifier of this plugin (for future identification by the exporter). The plugins are sorted by name before exporting.

--- a/doc/classes/EditorFileSystemImportFormatSupportQuery.xml
+++ b/doc/classes/EditorFileSystemImportFormatSupportQuery.xml
@@ -9,19 +9,19 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_file_extensions" qualifiers="virtual const">
+		<method name="_get_file_extensions" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
 				Return the file extensions supported.
 			</description>
 		</method>
-		<method name="_is_active" qualifiers="virtual const">
+		<method name="_is_active" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Return whether this importer is active.
 			</description>
 		</method>
-		<method name="_query" qualifiers="virtual const">
+		<method name="_query" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Query support. Return [code]false[/code] if import must not continue.

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -35,7 +35,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_run" qualifiers="virtual">
+		<method name="_run" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				This method is executed by the Editor when [b]File &gt; Run[/b] is used.

--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -10,28 +10,28 @@
 		<link title="Version control systems">$DOCS_URL/tutorials/best_practices/version_control_systems.html</link>
 	</tutorials>
 	<methods>
-		<method name="_checkout_branch" qualifiers="virtual">
+		<method name="_checkout_branch" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="branch_name" type="String" />
 			<description>
 				Checks out a [param branch_name] in the VCS.
 			</description>
 		</method>
-		<method name="_commit" qualifiers="virtual">
+		<method name="_commit" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="msg" type="String" />
 			<description>
 				Commits the currently staged changes and applies the commit [param msg] to the resulting commit.
 			</description>
 		</method>
-		<method name="_create_branch" qualifiers="virtual">
+		<method name="_create_branch" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="branch_name" type="String" />
 			<description>
 				Creates a new branch named [param branch_name] in the VCS.
 			</description>
 		</method>
-		<method name="_create_remote" qualifiers="virtual">
+		<method name="_create_remote" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="remote_name" type="String" />
 			<param index="1" name="remote_url" type="String" />
@@ -39,33 +39,33 @@
 				Creates a new remote destination with name [param remote_name] and points it to [param remote_url]. This can be an HTTPS remote or an SSH remote.
 			</description>
 		</method>
-		<method name="_discard_file" qualifiers="virtual">
+		<method name="_discard_file" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="file_path" type="String" />
 			<description>
 				Discards the changes made in a file present at [param file_path].
 			</description>
 		</method>
-		<method name="_fetch" qualifiers="virtual">
+		<method name="_fetch" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="remote" type="String" />
 			<description>
 				Fetches new changes from the [param remote], but doesn't write changes to the current working directory. Equivalent to [code]git fetch[/code].
 			</description>
 		</method>
-		<method name="_get_branch_list" qualifiers="virtual">
+		<method name="_get_branch_list" qualifiers="virtual required">
 			<return type="String[]" />
 			<description>
 				Gets an instance of an [Array] of [String]s containing available branch names in the VCS.
 			</description>
 		</method>
-		<method name="_get_current_branch_name" qualifiers="virtual">
+		<method name="_get_current_branch_name" qualifiers="virtual required">
 			<return type="String" />
 			<description>
 				Gets the current branch name defined in the VCS.
 			</description>
 		</method>
-		<method name="_get_diff" qualifiers="virtual">
+		<method name="_get_diff" qualifiers="virtual required">
 			<return type="Dictionary[]" />
 			<param index="0" name="identifier" type="String" />
 			<param index="1" name="area" type="int" />
@@ -73,7 +73,7 @@
 				Returns an array of [Dictionary] items (see [method create_diff_file], [method create_diff_hunk], [method create_diff_line], [method add_line_diffs_into_diff_hunk] and [method add_diff_hunks_into_diff_file]), each containing information about a diff. If [param identifier] is a file path, returns a file diff, and if it is a commit identifier, then returns a commit diff.
 			</description>
 		</method>
-		<method name="_get_line_diff" qualifiers="virtual">
+		<method name="_get_line_diff" qualifiers="virtual required">
 			<return type="Dictionary[]" />
 			<param index="0" name="file_path" type="String" />
 			<param index="1" name="text" type="String" />
@@ -81,46 +81,46 @@
 				Returns an [Array] of [Dictionary] items (see [method create_diff_hunk]), each containing a line diff between a file at [param file_path] and the [param text] which is passed in.
 			</description>
 		</method>
-		<method name="_get_modified_files_data" qualifiers="virtual">
+		<method name="_get_modified_files_data" qualifiers="virtual required">
 			<return type="Dictionary[]" />
 			<description>
 				Returns an [Array] of [Dictionary] items (see [method create_status_file]), each containing the status data of every modified file in the project folder.
 			</description>
 		</method>
-		<method name="_get_previous_commits" qualifiers="virtual">
+		<method name="_get_previous_commits" qualifiers="virtual required">
 			<return type="Dictionary[]" />
 			<param index="0" name="max_commits" type="int" />
 			<description>
 				Returns an [Array] of [Dictionary] items (see [method create_commit]), each containing the data for a past commit.
 			</description>
 		</method>
-		<method name="_get_remotes" qualifiers="virtual">
+		<method name="_get_remotes" qualifiers="virtual required">
 			<return type="String[]" />
 			<description>
 				Returns an [Array] of [String]s, each containing the name of a remote configured in the VCS.
 			</description>
 		</method>
-		<method name="_get_vcs_name" qualifiers="virtual">
+		<method name="_get_vcs_name" qualifiers="virtual required">
 			<return type="String" />
 			<description>
 				Returns the name of the underlying VCS provider.
 			</description>
 		</method>
-		<method name="_initialize" qualifiers="virtual">
+		<method name="_initialize" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="project_path" type="String" />
 			<description>
 				Initializes the VCS plugin when called from the editor. Returns whether or not the plugin was successfully initialized. A VCS project is initialized at [param project_path].
 			</description>
 		</method>
-		<method name="_pull" qualifiers="virtual">
+		<method name="_pull" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="remote" type="String" />
 			<description>
 				Pulls changes from the remote. This can give rise to merge conflicts.
 			</description>
 		</method>
-		<method name="_push" qualifiers="virtual">
+		<method name="_push" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="remote" type="String" />
 			<param index="1" name="force" type="bool" />
@@ -128,21 +128,21 @@
 				Pushes changes to the [param remote]. If [param force] is [code]true[/code], a force push will override the change history already present on the remote.
 			</description>
 		</method>
-		<method name="_remove_branch" qualifiers="virtual">
+		<method name="_remove_branch" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="branch_name" type="String" />
 			<description>
 				Remove a branch from the local VCS.
 			</description>
 		</method>
-		<method name="_remove_remote" qualifiers="virtual">
+		<method name="_remove_remote" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="remote_name" type="String" />
 			<description>
 				Remove a remote from the local VCS.
 			</description>
 		</method>
-		<method name="_set_credentials" qualifiers="virtual">
+		<method name="_set_credentials" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="username" type="String" />
 			<param index="1" name="password" type="String" />
@@ -153,20 +153,20 @@
 				Set user credentials in the underlying VCS. [param username] and [param password] are used only during HTTPS authentication unless not already mentioned in the remote URL. [param ssh_public_key_path], [param ssh_private_key_path], and [param ssh_passphrase] are only used during SSH authentication.
 			</description>
 		</method>
-		<method name="_shut_down" qualifiers="virtual">
+		<method name="_shut_down" qualifiers="virtual required">
 			<return type="bool" />
 			<description>
 				Shuts down VCS plugin instance. Called when the user either closes the editor or shuts down the VCS plugin through the editor UI.
 			</description>
 		</method>
-		<method name="_stage_file" qualifiers="virtual">
+		<method name="_stage_file" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="file_path" type="String" />
 			<description>
 				Stages the file present at [param file_path] to the staged area.
 			</description>
 		</method>
-		<method name="_unstage_file" qualifiers="virtual">
+		<method name="_unstage_file" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="file_path" type="String" />
 			<description>

--- a/doc/classes/Material.xml
+++ b/doc/classes/Material.xml
@@ -24,13 +24,13 @@
 				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally to determine if [member render_priority] should be shown in the editor or not.
 			</description>
 		</method>
-		<method name="_get_shader_mode" qualifiers="virtual const">
+		<method name="_get_shader_mode" qualifiers="virtual required const">
 			<return type="int" enum="Shader.Mode" />
 			<description>
 				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally by various editor tools.
 			</description>
 		</method>
-		<method name="_get_shader_rid" qualifiers="virtual const">
+		<method name="_get_shader_rid" qualifiers="virtual required const">
 			<return type="RID" />
 			<description>
 				Only exposed for the purpose of overriding. You cannot call this function directly. Used internally by various editor tools. Used to access the RID of the [Material]'s [Shader].

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -13,32 +13,32 @@
 		<link title="Third Person Shooter (TPS) Demo">https://godotengine.org/asset-library/asset/2710</link>
 	</tutorials>
 	<methods>
-		<method name="_get_aabb" qualifiers="virtual const">
+		<method name="_get_aabb" qualifiers="virtual required const">
 			<return type="AABB" />
 			<description>
 				Virtual method to override the [AABB] for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_get_blend_shape_count" qualifiers="virtual const">
+		<method name="_get_blend_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Virtual method to override the number of blend shapes for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_get_blend_shape_name" qualifiers="virtual const">
+		<method name="_get_blend_shape_name" qualifiers="virtual required const">
 			<return type="StringName" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the retrieval of blend shape names for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_get_surface_count" qualifiers="virtual const">
+		<method name="_get_surface_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Virtual method to override the surface count for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_set_blend_shape_name" qualifiers="virtual">
+		<method name="_set_blend_shape_name" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<param index="1" name="name" type="StringName" />
@@ -46,63 +46,63 @@
 				Virtual method to override the names of blend shapes for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_array_index_len" qualifiers="virtual const">
+		<method name="_surface_get_array_index_len" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface array index length for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_array_len" qualifiers="virtual const">
+		<method name="_surface_get_array_len" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface array length for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_arrays" qualifiers="virtual const">
+		<method name="_surface_get_arrays" qualifiers="virtual required const">
 			<return type="Array" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface arrays for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_blend_shape_arrays" qualifiers="virtual const">
+		<method name="_surface_get_blend_shape_arrays" qualifiers="virtual required const">
 			<return type="Array[]" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the blend shape arrays for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_format" qualifiers="virtual const">
+		<method name="_surface_get_format" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface format for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_lods" qualifiers="virtual const">
+		<method name="_surface_get_lods" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface LODs for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_material" qualifiers="virtual const">
+		<method name="_surface_get_material" qualifiers="virtual required const">
 			<return type="Material" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface material for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_get_primitive_type" qualifiers="virtual const">
+		<method name="_surface_get_primitive_type" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="index" type="int" />
 			<description>
 				Virtual method to override the surface primitive type for a custom class extending [Mesh].
 			</description>
 		</method>
-		<method name="_surface_set_material" qualifiers="virtual">
+		<method name="_surface_set_material" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="index" type="int" />
 			<param index="1" name="material" type="Material" />

--- a/doc/classes/MovieWriter.xml
+++ b/doc/classes/MovieWriter.xml
@@ -16,19 +16,19 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_audio_mix_rate" qualifiers="virtual const">
+		<method name="_get_audio_mix_rate" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the audio sample rate used for recording the audio is requested by the engine. The value returned must be specified in Hz. Defaults to 48000 Hz if [method _get_audio_mix_rate] is not overridden.
 			</description>
 		</method>
-		<method name="_get_audio_speaker_mode" qualifiers="virtual const">
+		<method name="_get_audio_speaker_mode" qualifiers="virtual required const">
 			<return type="int" enum="AudioServer.SpeakerMode" />
 			<description>
 				Called when the audio speaker mode used for recording the audio is requested by the engine. This can affect the number of output channels in the resulting audio file/stream. Defaults to [constant AudioServer.SPEAKER_MODE_STEREO] if [method _get_audio_speaker_mode] is not overridden.
 			</description>
 		</method>
-		<method name="_handles_file" qualifiers="virtual const">
+		<method name="_handles_file" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
@@ -41,7 +41,7 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="_write_begin" qualifiers="virtual">
+		<method name="_write_begin" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="movie_size" type="Vector2i" />
 			<param index="1" name="fps" type="int" />
@@ -50,14 +50,14 @@
 				Called once before the engine starts writing video and audio data. [param movie_size] is the width and height of the video to save. [param fps] is the number of frames per second specified in the project settings or using the [code]--fixed-fps &lt;fps&gt;[/code] [url=$DOCS_URL/tutorials/editor/command_line_tutorial.html]command line argument[/url].
 			</description>
 		</method>
-		<method name="_write_end" qualifiers="virtual">
+		<method name="_write_end" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called when the engine finishes writing. This occurs when the engine quits by pressing the window manager's close button, or when [method SceneTree.quit] is called.
 				[b]Note:[/b] Pressing [kbd]Ctrl + C[/kbd] on the terminal running the editor/project does [i]not[/i] result in [method _write_end] being called.
 			</description>
 		</method>
-		<method name="_write_frame" qualifiers="virtual">
+		<method name="_write_frame" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="frame_image" type="Image" />
 			<param index="1" name="audio_frame_block" type="const void*" />

--- a/doc/classes/MultiplayerPeerExtension.xml
+++ b/doc/classes/MultiplayerPeerExtension.xml
@@ -9,13 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_close" qualifiers="virtual">
+		<method name="_close" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called when the multiplayer peer should be immediately closed (see [method MultiplayerPeer.close]).
 			</description>
 		</method>
-		<method name="_disconnect_peer" qualifiers="virtual">
+		<method name="_disconnect_peer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="p_peer" type="int" />
 			<param index="1" name="p_force" type="bool" />
@@ -23,19 +23,19 @@
 				Called when the connected [param p_peer] should be forcibly disconnected (see [method MultiplayerPeer.disconnect_peer]).
 			</description>
 		</method>
-		<method name="_get_available_packet_count" qualifiers="virtual const">
+		<method name="_get_available_packet_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the available packet count is internally requested by the [MultiplayerAPI].
 			</description>
 		</method>
-		<method name="_get_connection_status" qualifiers="virtual const">
+		<method name="_get_connection_status" qualifiers="virtual required const">
 			<return type="int" enum="MultiplayerPeer.ConnectionStatus" />
 			<description>
 				Called when the connection status is requested on the [MultiplayerPeer] (see [method MultiplayerPeer.get_connection_status]).
 			</description>
 		</method>
-		<method name="_get_max_packet_size" qualifiers="virtual const">
+		<method name="_get_max_packet_size" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the maximum allowed packet size (in bytes) is requested by the [MultiplayerAPI].
@@ -49,19 +49,19 @@
 				Called when a packet needs to be received by the [MultiplayerAPI], with [param r_buffer_size] being the size of the binary [param r_buffer] in bytes.
 			</description>
 		</method>
-		<method name="_get_packet_channel" qualifiers="virtual const">
+		<method name="_get_packet_channel" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called to get the channel over which the next available packet was received. See [method MultiplayerPeer.get_packet_channel].
 			</description>
 		</method>
-		<method name="_get_packet_mode" qualifiers="virtual const">
+		<method name="_get_packet_mode" qualifiers="virtual required const">
 			<return type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
 				Called to get the transfer mode the remote peer used to send the next available packet. See [method MultiplayerPeer.get_packet_mode].
 			</description>
 		</method>
-		<method name="_get_packet_peer" qualifiers="virtual const">
+		<method name="_get_packet_peer" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the ID of the [MultiplayerPeer] who sent the most recent packet is requested (see [method MultiplayerPeer.get_packet_peer]).
@@ -73,19 +73,19 @@
 				Called when a packet needs to be received by the [MultiplayerAPI], if [method _get_packet] isn't implemented. Use this when extending this class via GDScript.
 			</description>
 		</method>
-		<method name="_get_transfer_channel" qualifiers="virtual const">
+		<method name="_get_transfer_channel" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the transfer channel to use is read on this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_channel]).
 			</description>
 		</method>
-		<method name="_get_transfer_mode" qualifiers="virtual const">
+		<method name="_get_transfer_mode" qualifiers="virtual required const">
 			<return type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>
 				Called when the transfer mode to use is read on this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_mode]).
 			</description>
 		</method>
-		<method name="_get_unique_id" qualifiers="virtual const">
+		<method name="_get_unique_id" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the unique ID of this [MultiplayerPeer] is requested (see [method MultiplayerPeer.get_unique_id]). The value must be between [code]1[/code] and [code]2147483647[/code].
@@ -97,7 +97,7 @@
 				Called when the "refuse new connections" status is requested on this [MultiplayerPeer] (see [member MultiplayerPeer.refuse_new_connections]).
 			</description>
 		</method>
-		<method name="_is_server" qualifiers="virtual const">
+		<method name="_is_server" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Called when the "is server" status is requested on the [MultiplayerAPI]. See [method MultiplayerAPI.is_server].
@@ -109,7 +109,7 @@
 				Called to check if the server can act as a relay in the current configuration. See [method MultiplayerPeer.is_server_relay_supported].
 			</description>
 		</method>
-		<method name="_poll" qualifiers="virtual">
+		<method name="_poll" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called when the [MultiplayerAPI] is polled. See [method MultiplayerAPI.poll].
@@ -137,21 +137,21 @@
 				Called when the "refuse new connections" status is set on this [MultiplayerPeer] (see [member MultiplayerPeer.refuse_new_connections]).
 			</description>
 		</method>
-		<method name="_set_target_peer" qualifiers="virtual">
+		<method name="_set_target_peer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="p_peer" type="int" />
 			<description>
 				Called when the target peer to use is set for this [MultiplayerPeer] (see [method MultiplayerPeer.set_target_peer]).
 			</description>
 		</method>
-		<method name="_set_transfer_channel" qualifiers="virtual">
+		<method name="_set_transfer_channel" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="p_channel" type="int" />
 			<description>
 				Called when the channel to use is set for this [MultiplayerPeer] (see [member MultiplayerPeer.transfer_channel]).
 			</description>
 		</method>
-		<method name="_set_transfer_mode" qualifiers="virtual">
+		<method name="_set_transfer_mode" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="p_mode" type="int" enum="MultiplayerPeer.TransferMode" />
 			<description>

--- a/doc/classes/PacketPeerExtension.xml
+++ b/doc/classes/PacketPeerExtension.xml
@@ -7,12 +7,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_available_packet_count" qualifiers="virtual const">
+		<method name="_get_available_packet_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_max_packet_size" qualifiers="virtual const">
+		<method name="_get_max_packet_size" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>

--- a/doc/classes/PhysicsDirectBodyState2DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState2DExtension.xml
@@ -10,14 +10,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_add_constant_central_force" qualifiers="virtual">
+		<method name="_add_constant_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.add_constant_central_force].
 			</description>
 		</method>
-		<method name="_add_constant_force" qualifiers="virtual">
+		<method name="_add_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
@@ -25,28 +25,28 @@
 				Overridable version of [method PhysicsDirectBodyState2D.add_constant_force].
 			</description>
 		</method>
-		<method name="_add_constant_torque" qualifiers="virtual">
+		<method name="_add_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="torque" type="float" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.add_constant_torque].
 			</description>
 		</method>
-		<method name="_apply_central_force" qualifiers="virtual">
+		<method name="_apply_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.apply_central_force].
 			</description>
 		</method>
-		<method name="_apply_central_impulse" qualifiers="virtual">
+		<method name="_apply_central_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.apply_central_impulse].
 			</description>
 		</method>
-		<method name="_apply_force" qualifiers="virtual">
+		<method name="_apply_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
@@ -54,7 +54,7 @@
 				Overridable version of [method PhysicsDirectBodyState2D.apply_force].
 			</description>
 		</method>
-		<method name="_apply_impulse" qualifiers="virtual">
+		<method name="_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector2" />
 			<param index="1" name="position" type="Vector2" />
@@ -62,242 +62,242 @@
 				Overridable version of [method PhysicsDirectBodyState2D.apply_impulse].
 			</description>
 		</method>
-		<method name="_apply_torque" qualifiers="virtual">
+		<method name="_apply_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="torque" type="float" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.apply_torque].
 			</description>
 		</method>
-		<method name="_apply_torque_impulse" qualifiers="virtual">
+		<method name="_apply_torque_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="float" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.apply_torque_impulse].
 			</description>
 		</method>
-		<method name="_get_angular_velocity" qualifiers="virtual const">
+		<method name="_get_angular_velocity" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.angular_velocity] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_center_of_mass" qualifiers="virtual const">
+		<method name="_get_center_of_mass" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.center_of_mass] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_center_of_mass_local" qualifiers="virtual const">
+		<method name="_get_center_of_mass_local" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.center_of_mass_local] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_constant_force" qualifiers="virtual const">
+		<method name="_get_constant_force" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_constant_force].
 			</description>
 		</method>
-		<method name="_get_constant_torque" qualifiers="virtual const">
+		<method name="_get_constant_torque" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_constant_torque].
 			</description>
 		</method>
-		<method name="_get_contact_collider" qualifiers="virtual const">
+		<method name="_get_contact_collider" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_collider].
 			</description>
 		</method>
-		<method name="_get_contact_collider_id" qualifiers="virtual const">
+		<method name="_get_contact_collider_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_collider_id].
 			</description>
 		</method>
-		<method name="_get_contact_collider_object" qualifiers="virtual const">
+		<method name="_get_contact_collider_object" qualifiers="virtual required const">
 			<return type="Object" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_collider_object].
 			</description>
 		</method>
-		<method name="_get_contact_collider_position" qualifiers="virtual const">
+		<method name="_get_contact_collider_position" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_collider_position].
 			</description>
 		</method>
-		<method name="_get_contact_collider_shape" qualifiers="virtual const">
+		<method name="_get_contact_collider_shape" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_collider_shape].
 			</description>
 		</method>
-		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual const">
+		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_collider_velocity_at_position].
 			</description>
 		</method>
-		<method name="_get_contact_count" qualifiers="virtual const">
+		<method name="_get_contact_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_count].
 			</description>
 		</method>
-		<method name="_get_contact_impulse" qualifiers="virtual const">
+		<method name="_get_contact_impulse" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_impulse].
 			</description>
 		</method>
-		<method name="_get_contact_local_normal" qualifiers="virtual const">
+		<method name="_get_contact_local_normal" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_local_normal].
 			</description>
 		</method>
-		<method name="_get_contact_local_position" qualifiers="virtual const">
+		<method name="_get_contact_local_position" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_local_position].
 			</description>
 		</method>
-		<method name="_get_contact_local_shape" qualifiers="virtual const">
+		<method name="_get_contact_local_shape" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_local_shape].
 			</description>
 		</method>
-		<method name="_get_contact_local_velocity_at_position" qualifiers="virtual const">
+		<method name="_get_contact_local_velocity_at_position" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_contact_local_velocity_at_position].
 			</description>
 		</method>
-		<method name="_get_inverse_inertia" qualifiers="virtual const">
+		<method name="_get_inverse_inertia" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.inverse_inertia] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_inverse_mass" qualifiers="virtual const">
+		<method name="_get_inverse_mass" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.inverse_mass] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_linear_velocity" qualifiers="virtual const">
+		<method name="_get_linear_velocity" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.linear_velocity] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_space_state" qualifiers="virtual">
+		<method name="_get_space_state" qualifiers="virtual required">
 			<return type="PhysicsDirectSpaceState2D" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_space_state].
 			</description>
 		</method>
-		<method name="_get_step" qualifiers="virtual const">
+		<method name="_get_step" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.step] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_total_angular_damp" qualifiers="virtual const">
+		<method name="_get_total_angular_damp" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.total_angular_damp] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_total_gravity" qualifiers="virtual const">
+		<method name="_get_total_gravity" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.total_gravity] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_total_linear_damp" qualifiers="virtual const">
+		<method name="_get_total_linear_damp" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.total_linear_damp] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_transform" qualifiers="virtual const">
+		<method name="_get_transform" qualifiers="virtual required const">
 			<return type="Transform2D" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.transform] and its respective getter.
 			</description>
 		</method>
-		<method name="_get_velocity_at_local_position" qualifiers="virtual const">
+		<method name="_get_velocity_at_local_position" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="local_position" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.get_velocity_at_local_position].
 			</description>
 		</method>
-		<method name="_integrate_forces" qualifiers="virtual">
+		<method name="_integrate_forces" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.integrate_forces].
 			</description>
 		</method>
-		<method name="_is_sleeping" qualifiers="virtual const">
+		<method name="_is_sleeping" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.sleeping] and its respective getter.
 			</description>
 		</method>
-		<method name="_set_angular_velocity" qualifiers="virtual">
+		<method name="_set_angular_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="velocity" type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.angular_velocity] and its respective setter.
 			</description>
 		</method>
-		<method name="_set_constant_force" qualifiers="virtual">
+		<method name="_set_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector2" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.set_constant_force].
 			</description>
 		</method>
-		<method name="_set_constant_torque" qualifiers="virtual">
+		<method name="_set_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="torque" type="float" />
 			<description>
 				Overridable version of [method PhysicsDirectBodyState2D.set_constant_torque].
 			</description>
 		</method>
-		<method name="_set_linear_velocity" qualifiers="virtual">
+		<method name="_set_linear_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector2" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.linear_velocity] and its respective setter.
 			</description>
 		</method>
-		<method name="_set_sleep_state" qualifiers="virtual">
+		<method name="_set_sleep_state" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.sleeping] and its respective setter.
 			</description>
 		</method>
-		<method name="_set_transform" qualifiers="virtual">
+		<method name="_set_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="transform" type="Transform2D" />
 			<description>

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -10,261 +10,261 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_add_constant_central_force" qualifiers="virtual">
+		<method name="_add_constant_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_add_constant_force" qualifiers="virtual">
+		<method name="_add_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_add_constant_torque" qualifiers="virtual">
+		<method name="_add_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="torque" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_apply_central_force" qualifiers="virtual">
+		<method name="_apply_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_apply_central_impulse" qualifiers="virtual">
+		<method name="_apply_central_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_apply_force" qualifiers="virtual">
+		<method name="_apply_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_apply_impulse" qualifiers="virtual">
+		<method name="_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
 			<param index="1" name="position" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_apply_torque" qualifiers="virtual">
+		<method name="_apply_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="torque" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_apply_torque_impulse" qualifiers="virtual">
+		<method name="_apply_torque_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="impulse" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_angular_velocity" qualifiers="virtual const">
+		<method name="_get_angular_velocity" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_center_of_mass" qualifiers="virtual const">
+		<method name="_get_center_of_mass" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_center_of_mass_local" qualifiers="virtual const">
+		<method name="_get_center_of_mass_local" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_constant_force" qualifiers="virtual const">
+		<method name="_get_constant_force" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_constant_torque" qualifiers="virtual const">
+		<method name="_get_constant_torque" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_collider" qualifiers="virtual const">
+		<method name="_get_contact_collider" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_collider_id" qualifiers="virtual const">
+		<method name="_get_contact_collider_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_collider_object" qualifiers="virtual const">
+		<method name="_get_contact_collider_object" qualifiers="virtual required const">
 			<return type="Object" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_collider_position" qualifiers="virtual const">
+		<method name="_get_contact_collider_position" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_collider_shape" qualifiers="virtual const">
+		<method name="_get_contact_collider_shape" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual const">
+		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_count" qualifiers="virtual const">
+		<method name="_get_contact_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_impulse" qualifiers="virtual const">
+		<method name="_get_contact_impulse" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_local_normal" qualifiers="virtual const">
+		<method name="_get_contact_local_normal" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_local_position" qualifiers="virtual const">
+		<method name="_get_contact_local_position" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_local_shape" qualifiers="virtual const">
+		<method name="_get_contact_local_shape" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_contact_local_velocity_at_position" qualifiers="virtual const">
+		<method name="_get_contact_local_velocity_at_position" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="contact_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_inverse_inertia" qualifiers="virtual const">
+		<method name="_get_inverse_inertia" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_inverse_inertia_tensor" qualifiers="virtual const">
+		<method name="_get_inverse_inertia_tensor" qualifiers="virtual required const">
 			<return type="Basis" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_inverse_mass" qualifiers="virtual const">
+		<method name="_get_inverse_mass" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_linear_velocity" qualifiers="virtual const">
+		<method name="_get_linear_velocity" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_principal_inertia_axes" qualifiers="virtual const">
+		<method name="_get_principal_inertia_axes" qualifiers="virtual required const">
 			<return type="Basis" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_space_state" qualifiers="virtual">
+		<method name="_get_space_state" qualifiers="virtual required">
 			<return type="PhysicsDirectSpaceState3D" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_step" qualifiers="virtual const">
+		<method name="_get_step" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_total_angular_damp" qualifiers="virtual const">
+		<method name="_get_total_angular_damp" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_total_gravity" qualifiers="virtual const">
+		<method name="_get_total_gravity" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_total_linear_damp" qualifiers="virtual const">
+		<method name="_get_total_linear_damp" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_transform" qualifiers="virtual const">
+		<method name="_get_transform" qualifiers="virtual required const">
 			<return type="Transform3D" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_velocity_at_local_position" qualifiers="virtual const">
+		<method name="_get_velocity_at_local_position" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="local_position" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_integrate_forces" qualifiers="virtual">
+		<method name="_integrate_forces" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_sleeping" qualifiers="virtual const">
+		<method name="_is_sleeping" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_angular_velocity" qualifiers="virtual">
+		<method name="_set_angular_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_constant_force" qualifiers="virtual">
+		<method name="_set_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_constant_torque" qualifiers="virtual">
+		<method name="_set_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="torque" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_linear_velocity" qualifiers="virtual">
+		<method name="_set_linear_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_sleep_state" qualifiers="virtual">
+		<method name="_set_sleep_state" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="enabled" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_transform" qualifiers="virtual">
+		<method name="_set_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="transform" type="Transform3D" />
 			<description>

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_cast_motion" qualifiers="virtual">
+		<method name="_cast_motion" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
@@ -24,7 +24,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_collide_shape" qualifiers="virtual">
+		<method name="_collide_shape" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
@@ -39,7 +39,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_point" qualifiers="virtual">
+		<method name="_intersect_point" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2" />
 			<param index="1" name="canvas_instance_id" type="int" />
@@ -51,7 +51,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_ray" qualifiers="virtual">
+		<method name="_intersect_ray" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="from" type="Vector2" />
 			<param index="1" name="to" type="Vector2" />
@@ -63,7 +63,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_shape" qualifiers="virtual">
+		<method name="_intersect_shape" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
@@ -77,7 +77,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_rest_info" qualifiers="virtual">
+		<method name="_rest_info" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_cast_motion" qualifiers="virtual">
+		<method name="_cast_motion" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
@@ -25,7 +25,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_collide_shape" qualifiers="virtual">
+		<method name="_collide_shape" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
@@ -40,14 +40,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_closest_point_to_object_volume" qualifiers="virtual const">
+		<method name="_get_closest_point_to_object_volume" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="object" type="RID" />
 			<param index="1" name="point" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_point" qualifiers="virtual">
+		<method name="_intersect_point" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="position" type="Vector3" />
 			<param index="1" name="collision_mask" type="int" />
@@ -58,7 +58,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_ray" qualifiers="virtual">
+		<method name="_intersect_ray" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="from" type="Vector3" />
 			<param index="1" name="to" type="Vector3" />
@@ -72,7 +72,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_intersect_shape" qualifiers="virtual">
+		<method name="_intersect_shape" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
@@ -86,7 +86,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_rest_info" qualifiers="virtual">
+		<method name="_rest_info" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_rid" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_area_add_shape" qualifiers="virtual">
+		<method name="_area_add_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape" type="RID" />
@@ -20,7 +20,7 @@
 				Overridable version of [method PhysicsServer2D.area_add_shape].
 			</description>
 		</method>
-		<method name="_area_attach_canvas_instance_id" qualifiers="virtual">
+		<method name="_area_attach_canvas_instance_id" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
@@ -28,7 +28,7 @@
 				Overridable version of [method PhysicsServer2D.area_attach_canvas_instance_id].
 			</description>
 		</method>
-		<method name="_area_attach_object_instance_id" qualifiers="virtual">
+		<method name="_area_attach_object_instance_id" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
@@ -36,48 +36,48 @@
 				Overridable version of [method PhysicsServer2D.area_attach_object_instance_id].
 			</description>
 		</method>
-		<method name="_area_clear_shapes" qualifiers="virtual">
+		<method name="_area_clear_shapes" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_clear_shapes].
 			</description>
 		</method>
-		<method name="_area_create" qualifiers="virtual">
+		<method name="_area_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_create].
 			</description>
 		</method>
-		<method name="_area_get_canvas_instance_id" qualifiers="virtual const">
+		<method name="_area_get_canvas_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_canvas_instance_id].
 			</description>
 		</method>
-		<method name="_area_get_collision_layer" qualifiers="virtual const">
+		<method name="_area_get_collision_layer" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_collision_layer].
 			</description>
 		</method>
-		<method name="_area_get_collision_mask" qualifiers="virtual const">
+		<method name="_area_get_collision_mask" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_collision_mask].
 			</description>
 		</method>
-		<method name="_area_get_object_instance_id" qualifiers="virtual const">
+		<method name="_area_get_object_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_object_instance_id].
 			</description>
 		</method>
-		<method name="_area_get_param" qualifiers="virtual const">
+		<method name="_area_get_param" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
@@ -85,7 +85,7 @@
 				Overridable version of [method PhysicsServer2D.area_get_param].
 			</description>
 		</method>
-		<method name="_area_get_shape" qualifiers="virtual const">
+		<method name="_area_get_shape" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -93,14 +93,14 @@
 				Overridable version of [method PhysicsServer2D.area_get_shape].
 			</description>
 		</method>
-		<method name="_area_get_shape_count" qualifiers="virtual const">
+		<method name="_area_get_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_shape_count].
 			</description>
 		</method>
-		<method name="_area_get_shape_transform" qualifiers="virtual const">
+		<method name="_area_get_shape_transform" qualifiers="virtual required const">
 			<return type="Transform2D" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -108,21 +108,21 @@
 				Overridable version of [method PhysicsServer2D.area_get_shape_transform].
 			</description>
 		</method>
-		<method name="_area_get_space" qualifiers="virtual const">
+		<method name="_area_get_space" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_space].
 			</description>
 		</method>
-		<method name="_area_get_transform" qualifiers="virtual const">
+		<method name="_area_get_transform" qualifiers="virtual required const">
 			<return type="Transform2D" />
 			<param index="0" name="area" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.area_get_transform].
 			</description>
 		</method>
-		<method name="_area_remove_shape" qualifiers="virtual">
+		<method name="_area_remove_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -130,7 +130,7 @@
 				Overridable version of [method PhysicsServer2D.area_remove_shape].
 			</description>
 		</method>
-		<method name="_area_set_area_monitor_callback" qualifiers="virtual">
+		<method name="_area_set_area_monitor_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
@@ -138,7 +138,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_area_monitor_callback].
 			</description>
 		</method>
-		<method name="_area_set_collision_layer" qualifiers="virtual">
+		<method name="_area_set_collision_layer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="layer" type="int" />
@@ -146,7 +146,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_collision_layer].
 			</description>
 		</method>
-		<method name="_area_set_collision_mask" qualifiers="virtual">
+		<method name="_area_set_collision_mask" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="mask" type="int" />
@@ -154,7 +154,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_collision_mask].
 			</description>
 		</method>
-		<method name="_area_set_monitor_callback" qualifiers="virtual">
+		<method name="_area_set_monitor_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
@@ -162,7 +162,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_monitor_callback].
 			</description>
 		</method>
-		<method name="_area_set_monitorable" qualifiers="virtual">
+		<method name="_area_set_monitorable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
@@ -170,7 +170,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_monitorable].
 			</description>
 		</method>
-		<method name="_area_set_param" qualifiers="virtual">
+		<method name="_area_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.AreaParameter" />
@@ -179,7 +179,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_param].
 			</description>
 		</method>
-		<method name="_area_set_pickable" qualifiers="virtual">
+		<method name="_area_set_pickable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="pickable" type="bool" />
@@ -188,7 +188,7 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]area_set_pickable[/code] method. Corresponds to [member CollisionObject2D.input_pickable].
 			</description>
 		</method>
-		<method name="_area_set_shape" qualifiers="virtual">
+		<method name="_area_set_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -197,7 +197,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_shape].
 			</description>
 		</method>
-		<method name="_area_set_shape_disabled" qualifiers="virtual">
+		<method name="_area_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -206,7 +206,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_shape_disabled].
 			</description>
 		</method>
-		<method name="_area_set_shape_transform" qualifiers="virtual">
+		<method name="_area_set_shape_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -215,7 +215,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_shape_transform].
 			</description>
 		</method>
-		<method name="_area_set_space" qualifiers="virtual">
+		<method name="_area_set_space" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="space" type="RID" />
@@ -223,7 +223,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_space].
 			</description>
 		</method>
-		<method name="_area_set_transform" qualifiers="virtual">
+		<method name="_area_set_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
@@ -231,7 +231,7 @@
 				Overridable version of [method PhysicsServer2D.area_set_transform].
 			</description>
 		</method>
-		<method name="_body_add_collision_exception" qualifiers="virtual">
+		<method name="_body_add_collision_exception" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
@@ -239,7 +239,7 @@
 				Overridable version of [method PhysicsServer2D.body_add_collision_exception].
 			</description>
 		</method>
-		<method name="_body_add_constant_central_force" qualifiers="virtual">
+		<method name="_body_add_constant_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
@@ -247,7 +247,7 @@
 				Overridable version of [method PhysicsServer2D.body_add_constant_central_force].
 			</description>
 		</method>
-		<method name="_body_add_constant_force" qualifiers="virtual">
+		<method name="_body_add_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
@@ -256,7 +256,7 @@
 				Overridable version of [method PhysicsServer2D.body_add_constant_force].
 			</description>
 		</method>
-		<method name="_body_add_constant_torque" qualifiers="virtual">
+		<method name="_body_add_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
@@ -264,7 +264,7 @@
 				Overridable version of [method PhysicsServer2D.body_add_constant_torque].
 			</description>
 		</method>
-		<method name="_body_add_shape" qualifiers="virtual">
+		<method name="_body_add_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape" type="RID" />
@@ -274,7 +274,7 @@
 				Overridable version of [method PhysicsServer2D.body_add_shape].
 			</description>
 		</method>
-		<method name="_body_apply_central_force" qualifiers="virtual">
+		<method name="_body_apply_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
@@ -282,7 +282,7 @@
 				Overridable version of [method PhysicsServer2D.body_apply_central_force].
 			</description>
 		</method>
-		<method name="_body_apply_central_impulse" qualifiers="virtual">
+		<method name="_body_apply_central_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector2" />
@@ -290,7 +290,7 @@
 				Overridable version of [method PhysicsServer2D.body_apply_central_impulse].
 			</description>
 		</method>
-		<method name="_body_apply_force" qualifiers="virtual">
+		<method name="_body_apply_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
@@ -299,7 +299,7 @@
 				Overridable version of [method PhysicsServer2D.body_apply_force].
 			</description>
 		</method>
-		<method name="_body_apply_impulse" qualifiers="virtual">
+		<method name="_body_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector2" />
@@ -308,7 +308,7 @@
 				Overridable version of [method PhysicsServer2D.body_apply_impulse].
 			</description>
 		</method>
-		<method name="_body_apply_torque" qualifiers="virtual">
+		<method name="_body_apply_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
@@ -316,7 +316,7 @@
 				Overridable version of [method PhysicsServer2D.body_apply_torque].
 			</description>
 		</method>
-		<method name="_body_apply_torque_impulse" qualifiers="virtual">
+		<method name="_body_apply_torque_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="float" />
@@ -324,7 +324,7 @@
 				Overridable version of [method PhysicsServer2D.body_apply_torque_impulse].
 			</description>
 		</method>
-		<method name="_body_attach_canvas_instance_id" qualifiers="virtual">
+		<method name="_body_attach_canvas_instance_id" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
@@ -332,7 +332,7 @@
 				Overridable version of [method PhysicsServer2D.body_attach_canvas_instance_id].
 			</description>
 		</method>
-		<method name="_body_attach_object_instance_id" qualifiers="virtual">
+		<method name="_body_attach_object_instance_id" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
@@ -340,14 +340,14 @@
 				Overridable version of [method PhysicsServer2D.body_attach_object_instance_id].
 			</description>
 		</method>
-		<method name="_body_clear_shapes" qualifiers="virtual">
+		<method name="_body_clear_shapes" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_clear_shapes].
 			</description>
 		</method>
-		<method name="_body_collide_shape" qualifiers="virtual">
+		<method name="_body_collide_shape" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="body_shape" type="int" />
@@ -362,20 +362,20 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]shape_collide[/code] method. Corresponds to [method PhysicsDirectSpaceState2D.collide_shape].
 			</description>
 		</method>
-		<method name="_body_create" qualifiers="virtual">
+		<method name="_body_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_create].
 			</description>
 		</method>
-		<method name="_body_get_canvas_instance_id" qualifiers="virtual const">
+		<method name="_body_get_canvas_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_canvas_instance_id].
 			</description>
 		</method>
-		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
+		<method name="_body_get_collision_exceptions" qualifiers="virtual required const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
 			<description>
@@ -383,42 +383,42 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]body_get_collision_exceptions[/code] method. Corresponds to [method PhysicsBody2D.get_collision_exceptions].
 			</description>
 		</method>
-		<method name="_body_get_collision_layer" qualifiers="virtual const">
+		<method name="_body_get_collision_layer" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_collision_layer].
 			</description>
 		</method>
-		<method name="_body_get_collision_mask" qualifiers="virtual const">
+		<method name="_body_get_collision_mask" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_collision_mask].
 			</description>
 		</method>
-		<method name="_body_get_collision_priority" qualifiers="virtual const">
+		<method name="_body_get_collision_priority" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_collision_priority].
 			</description>
 		</method>
-		<method name="_body_get_constant_force" qualifiers="virtual const">
+		<method name="_body_get_constant_force" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_constant_force].
 			</description>
 		</method>
-		<method name="_body_get_constant_torque" qualifiers="virtual const">
+		<method name="_body_get_constant_torque" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_constant_torque].
 			</description>
 		</method>
-		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
+		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
@@ -426,42 +426,42 @@
 				[b]Note:[/b] This method is currently unused by Godot's default physics implementation.
 			</description>
 		</method>
-		<method name="_body_get_continuous_collision_detection_mode" qualifiers="virtual const">
+		<method name="_body_get_continuous_collision_detection_mode" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer2D.CCDMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_continuous_collision_detection_mode].
 			</description>
 		</method>
-		<method name="_body_get_direct_state" qualifiers="virtual">
+		<method name="_body_get_direct_state" qualifiers="virtual required">
 			<return type="PhysicsDirectBodyState2D" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_direct_state].
 			</description>
 		</method>
-		<method name="_body_get_max_contacts_reported" qualifiers="virtual const">
+		<method name="_body_get_max_contacts_reported" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_max_contacts_reported].
 			</description>
 		</method>
-		<method name="_body_get_mode" qualifiers="virtual const">
+		<method name="_body_get_mode" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer2D.BodyMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_mode].
 			</description>
 		</method>
-		<method name="_body_get_object_instance_id" qualifiers="virtual const">
+		<method name="_body_get_object_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_object_instance_id].
 			</description>
 		</method>
-		<method name="_body_get_param" qualifiers="virtual const">
+		<method name="_body_get_param" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
@@ -469,7 +469,7 @@
 				Overridable version of [method PhysicsServer2D.body_get_param].
 			</description>
 		</method>
-		<method name="_body_get_shape" qualifiers="virtual const">
+		<method name="_body_get_shape" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -477,14 +477,14 @@
 				Overridable version of [method PhysicsServer2D.body_get_shape].
 			</description>
 		</method>
-		<method name="_body_get_shape_count" qualifiers="virtual const">
+		<method name="_body_get_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_shape_count].
 			</description>
 		</method>
-		<method name="_body_get_shape_transform" qualifiers="virtual const">
+		<method name="_body_get_shape_transform" qualifiers="virtual required const">
 			<return type="Transform2D" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -492,14 +492,14 @@
 				Overridable version of [method PhysicsServer2D.body_get_shape_transform].
 			</description>
 		</method>
-		<method name="_body_get_space" qualifiers="virtual const">
+		<method name="_body_get_space" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_get_space].
 			</description>
 		</method>
-		<method name="_body_get_state" qualifiers="virtual const">
+		<method name="_body_get_state" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
@@ -507,14 +507,14 @@
 				Overridable version of [method PhysicsServer2D.body_get_state].
 			</description>
 		</method>
-		<method name="_body_is_omitting_force_integration" qualifiers="virtual const">
+		<method name="_body_is_omitting_force_integration" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_is_omitting_force_integration].
 			</description>
 		</method>
-		<method name="_body_remove_collision_exception" qualifiers="virtual">
+		<method name="_body_remove_collision_exception" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
@@ -522,7 +522,7 @@
 				Overridable version of [method PhysicsServer2D.body_remove_collision_exception].
 			</description>
 		</method>
-		<method name="_body_remove_shape" qualifiers="virtual">
+		<method name="_body_remove_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -530,14 +530,14 @@
 				Overridable version of [method PhysicsServer2D.body_remove_shape].
 			</description>
 		</method>
-		<method name="_body_reset_mass_properties" qualifiers="virtual">
+		<method name="_body_reset_mass_properties" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.body_reset_mass_properties].
 			</description>
 		</method>
-		<method name="_body_set_axis_velocity" qualifiers="virtual">
+		<method name="_body_set_axis_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis_velocity" type="Vector2" />
@@ -545,7 +545,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_axis_velocity].
 			</description>
 		</method>
-		<method name="_body_set_collision_layer" qualifiers="virtual">
+		<method name="_body_set_collision_layer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
@@ -553,7 +553,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_collision_layer].
 			</description>
 		</method>
-		<method name="_body_set_collision_mask" qualifiers="virtual">
+		<method name="_body_set_collision_mask" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
@@ -561,7 +561,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_collision_mask].
 			</description>
 		</method>
-		<method name="_body_set_collision_priority" qualifiers="virtual">
+		<method name="_body_set_collision_priority" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="priority" type="float" />
@@ -569,7 +569,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_collision_priority].
 			</description>
 		</method>
-		<method name="_body_set_constant_force" qualifiers="virtual">
+		<method name="_body_set_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector2" />
@@ -577,7 +577,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_constant_force].
 			</description>
 		</method>
-		<method name="_body_set_constant_torque" qualifiers="virtual">
+		<method name="_body_set_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="float" />
@@ -585,7 +585,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_constant_torque].
 			</description>
 		</method>
-		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
+		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="threshold" type="float" />
@@ -594,7 +594,7 @@
 				[b]Note:[/b] This method is currently unused by Godot's default physics implementation.
 			</description>
 		</method>
-		<method name="_body_set_continuous_collision_detection_mode" qualifiers="virtual">
+		<method name="_body_set_continuous_collision_detection_mode" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.CCDMode" />
@@ -602,7 +602,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_continuous_collision_detection_mode].
 			</description>
 		</method>
-		<method name="_body_set_force_integration_callback" qualifiers="virtual">
+		<method name="_body_set_force_integration_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
@@ -611,7 +611,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_force_integration_callback].
 			</description>
 		</method>
-		<method name="_body_set_max_contacts_reported" qualifiers="virtual">
+		<method name="_body_set_max_contacts_reported" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="amount" type="int" />
@@ -619,7 +619,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_max_contacts_reported].
 			</description>
 		</method>
-		<method name="_body_set_mode" qualifiers="virtual">
+		<method name="_body_set_mode" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer2D.BodyMode" />
@@ -627,7 +627,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_mode].
 			</description>
 		</method>
-		<method name="_body_set_omit_force_integration" qualifiers="virtual">
+		<method name="_body_set_omit_force_integration" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
@@ -635,7 +635,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_omit_force_integration].
 			</description>
 		</method>
-		<method name="_body_set_param" qualifiers="virtual">
+		<method name="_body_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.BodyParameter" />
@@ -644,7 +644,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_param].
 			</description>
 		</method>
-		<method name="_body_set_pickable" qualifiers="virtual">
+		<method name="_body_set_pickable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="pickable" type="bool" />
@@ -653,7 +653,7 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]body_set_pickable[/code] method. Corresponds to [member CollisionObject2D.input_pickable].
 			</description>
 		</method>
-		<method name="_body_set_shape" qualifiers="virtual">
+		<method name="_body_set_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -662,7 +662,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_shape].
 			</description>
 		</method>
-		<method name="_body_set_shape_as_one_way_collision" qualifiers="virtual">
+		<method name="_body_set_shape_as_one_way_collision" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -672,7 +672,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_shape_as_one_way_collision].
 			</description>
 		</method>
-		<method name="_body_set_shape_disabled" qualifiers="virtual">
+		<method name="_body_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -681,7 +681,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_shape_disabled].
 			</description>
 		</method>
-		<method name="_body_set_shape_transform" qualifiers="virtual">
+		<method name="_body_set_shape_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -690,7 +690,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_shape_transform].
 			</description>
 		</method>
-		<method name="_body_set_space" qualifiers="virtual">
+		<method name="_body_set_space" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
@@ -698,7 +698,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_space].
 			</description>
 		</method>
-		<method name="_body_set_state" qualifiers="virtual">
+		<method name="_body_set_state" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer2D.BodyState" />
@@ -707,7 +707,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_state].
 			</description>
 		</method>
-		<method name="_body_set_state_sync_callback" qualifiers="virtual">
+		<method name="_body_set_state_sync_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
@@ -716,7 +716,7 @@
 				Overridable version of [method PhysicsServer2D.body_set_state_sync_callback].
 			</description>
 		</method>
-		<method name="_body_test_motion" qualifiers="virtual const">
+		<method name="_body_test_motion" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="from" type="Transform2D" />
@@ -729,31 +729,31 @@
 				Overridable version of [method PhysicsServer2D.body_test_motion]. Unlike the exposed implementation, this method does not receive all of the arguments inside a [PhysicsTestMotionParameters2D].
 			</description>
 		</method>
-		<method name="_capsule_shape_create" qualifiers="virtual">
+		<method name="_capsule_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.capsule_shape_create].
 			</description>
 		</method>
-		<method name="_circle_shape_create" qualifiers="virtual">
+		<method name="_circle_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.circle_shape_create].
 			</description>
 		</method>
-		<method name="_concave_polygon_shape_create" qualifiers="virtual">
+		<method name="_concave_polygon_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.concave_polygon_shape_create].
 			</description>
 		</method>
-		<method name="_convex_polygon_shape_create" qualifiers="virtual">
+		<method name="_convex_polygon_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.convex_polygon_shape_create].
 			</description>
 		</method>
-		<method name="_damped_spring_joint_get_param" qualifiers="virtual const">
+		<method name="_damped_spring_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
@@ -761,7 +761,7 @@
 				Overridable version of [method PhysicsServer2D.damped_spring_joint_get_param].
 			</description>
 		</method>
-		<method name="_damped_spring_joint_set_param" qualifiers="virtual">
+		<method name="_damped_spring_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.DampedSpringParam" />
@@ -770,69 +770,69 @@
 				Overridable version of [method PhysicsServer2D.damped_spring_joint_set_param].
 			</description>
 		</method>
-		<method name="_end_sync" qualifiers="virtual">
+		<method name="_end_sync" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called to indicate that the physics server has stopped synchronizing. It is in the loop's iteration/physics phase, and can access physics objects even if running on a separate thread. See also [method _sync].
 				Overridable version of [PhysicsServer2D]'s internal [code]end_sync[/code] method.
 			</description>
 		</method>
-		<method name="_finish" qualifiers="virtual">
+		<method name="_finish" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called when the main loop finalizes to shut down the physics server. See also [method MainLoop._finalize] and [method _init].
 				Overridable version of [PhysicsServer2D]'s internal [code]finish[/code] method.
 			</description>
 		</method>
-		<method name="_flush_queries" qualifiers="virtual">
+		<method name="_flush_queries" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called every physics step before [method _step] to process all remaining queries.
 				Overridable version of [PhysicsServer2D]'s internal [code]flush_queries[/code] method.
 			</description>
 		</method>
-		<method name="_free_rid" qualifiers="virtual">
+		<method name="_free_rid" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.free_rid].
 			</description>
 		</method>
-		<method name="_get_process_info" qualifiers="virtual">
+		<method name="_get_process_info" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer2D.ProcessInfo" />
 			<description>
 				Overridable version of [method PhysicsServer2D.get_process_info].
 			</description>
 		</method>
-		<method name="_init" qualifiers="virtual">
+		<method name="_init" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called when the main loop is initialized and creates a new instance of this physics server. See also [method MainLoop._initialize] and [method _finish].
 				Overridable version of [PhysicsServer2D]'s internal [code]init[/code] method.
 			</description>
 		</method>
-		<method name="_is_flushing_queries" qualifiers="virtual const">
+		<method name="_is_flushing_queries" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Overridable method that should return [code]true[/code] when the physics server is processing queries. See also [method _flush_queries].
 				Overridable version of [PhysicsServer2D]'s internal [code]is_flushing_queries[/code] method.
 			</description>
 		</method>
-		<method name="_joint_clear" qualifiers="virtual">
+		<method name="_joint_clear" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_clear].
 			</description>
 		</method>
-		<method name="_joint_create" qualifiers="virtual">
+		<method name="_joint_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_create].
 			</description>
 		</method>
-		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual">
+		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="disable" type="bool" />
@@ -840,7 +840,7 @@
 				Overridable version of [method PhysicsServer2D.joint_disable_collisions_between_bodies].
 			</description>
 		</method>
-		<method name="_joint_get_param" qualifiers="virtual const">
+		<method name="_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
@@ -848,21 +848,21 @@
 				Overridable version of [method PhysicsServer2D.joint_get_param].
 			</description>
 		</method>
-		<method name="_joint_get_type" qualifiers="virtual const">
+		<method name="_joint_get_type" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer2D.JointType" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_get_type].
 			</description>
 		</method>
-		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual const">
+		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.joint_is_disabled_collisions_between_bodies].
 			</description>
 		</method>
-		<method name="_joint_make_damped_spring" qualifiers="virtual">
+		<method name="_joint_make_damped_spring" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="anchor_a" type="Vector2" />
@@ -873,7 +873,7 @@
 				Overridable version of [method PhysicsServer2D.joint_make_damped_spring].
 			</description>
 		</method>
-		<method name="_joint_make_groove" qualifiers="virtual">
+		<method name="_joint_make_groove" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="a_groove1" type="Vector2" />
@@ -885,7 +885,7 @@
 				Overridable version of [method PhysicsServer2D.joint_make_groove].
 			</description>
 		</method>
-		<method name="_joint_make_pin" qualifiers="virtual">
+		<method name="_joint_make_pin" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="anchor" type="Vector2" />
@@ -895,7 +895,7 @@
 				Overridable version of [method PhysicsServer2D.joint_make_pin].
 			</description>
 		</method>
-		<method name="_joint_set_param" qualifiers="virtual">
+		<method name="_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.JointParam" />
@@ -904,7 +904,7 @@
 				Overridable version of [method PhysicsServer2D.joint_set_param].
 			</description>
 		</method>
-		<method name="_pin_joint_get_flag" qualifiers="virtual const">
+		<method name="_pin_joint_get_flag" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer2D.PinJointFlag" />
@@ -912,7 +912,7 @@
 				Overridable version of [method PhysicsServer2D.pin_joint_get_flag].
 			</description>
 		</method>
-		<method name="_pin_joint_get_param" qualifiers="virtual const">
+		<method name="_pin_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
@@ -920,7 +920,7 @@
 				Overridable version of [method PhysicsServer2D.pin_joint_get_param].
 			</description>
 		</method>
-		<method name="_pin_joint_set_flag" qualifiers="virtual">
+		<method name="_pin_joint_set_flag" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer2D.PinJointFlag" />
@@ -929,7 +929,7 @@
 				Overridable version of [method PhysicsServer2D.pin_joint_set_flag].
 			</description>
 		</method>
-		<method name="_pin_joint_set_param" qualifiers="virtual">
+		<method name="_pin_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.PinJointParam" />
@@ -938,32 +938,32 @@
 				Overridable version of [method PhysicsServer2D.pin_joint_set_param].
 			</description>
 		</method>
-		<method name="_rectangle_shape_create" qualifiers="virtual">
+		<method name="_rectangle_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.rectangle_shape_create].
 			</description>
 		</method>
-		<method name="_segment_shape_create" qualifiers="virtual">
+		<method name="_segment_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.segment_shape_create].
 			</description>
 		</method>
-		<method name="_separation_ray_shape_create" qualifiers="virtual">
+		<method name="_separation_ray_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.separation_ray_shape_create].
 			</description>
 		</method>
-		<method name="_set_active" qualifiers="virtual">
+		<method name="_set_active" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
 			<description>
 				Overridable version of [method PhysicsServer2D.set_active].
 			</description>
 		</method>
-		<method name="_shape_collide" qualifiers="virtual">
+		<method name="_shape_collide" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shape_A" type="RID" />
 			<param index="1" name="xform_A" type="Transform2D" />
@@ -979,7 +979,7 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]shape_collide[/code] method. Corresponds to [method PhysicsDirectSpaceState2D.collide_shape].
 			</description>
 		</method>
-		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
+		<method name="_shape_get_custom_solver_bias" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
 			<description>
@@ -987,21 +987,21 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]shape_get_custom_solver_bias[/code] method. Corresponds to [member Shape2D.custom_solver_bias].
 			</description>
 		</method>
-		<method name="_shape_get_data" qualifiers="virtual const">
+		<method name="_shape_get_data" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.shape_get_data].
 			</description>
 		</method>
-		<method name="_shape_get_type" qualifiers="virtual const">
+		<method name="_shape_get_type" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer2D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.shape_get_type].
 			</description>
 		</method>
-		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
+		<method name="_shape_set_custom_solver_bias" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="bias" type="float" />
@@ -1010,7 +1010,7 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]shape_get_custom_solver_bias[/code] method. Corresponds to [member Shape2D.custom_solver_bias].
 			</description>
 		</method>
-		<method name="_shape_set_data" qualifiers="virtual">
+		<method name="_shape_set_data" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
@@ -1018,13 +1018,13 @@
 				Overridable version of [method PhysicsServer2D.shape_set_data].
 			</description>
 		</method>
-		<method name="_space_create" qualifiers="virtual">
+		<method name="_space_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.space_create].
 			</description>
 		</method>
-		<method name="_space_get_contact_count" qualifiers="virtual const">
+		<method name="_space_get_contact_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
 			<description>
@@ -1032,7 +1032,7 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]space_get_contact_count[/code] method.
 			</description>
 		</method>
-		<method name="_space_get_contacts" qualifiers="virtual const">
+		<method name="_space_get_contacts" qualifiers="virtual required const">
 			<return type="PackedVector2Array" />
 			<param index="0" name="space" type="RID" />
 			<description>
@@ -1040,14 +1040,14 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]space_get_contacts[/code] method.
 			</description>
 		</method>
-		<method name="_space_get_direct_state" qualifiers="virtual">
+		<method name="_space_get_direct_state" qualifiers="virtual required">
 			<return type="PhysicsDirectSpaceState2D" />
 			<param index="0" name="space" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.space_get_direct_state].
 			</description>
 		</method>
-		<method name="_space_get_param" qualifiers="virtual const">
+		<method name="_space_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
@@ -1055,14 +1055,14 @@
 				Overridable version of [method PhysicsServer2D.space_get_param].
 			</description>
 		</method>
-		<method name="_space_is_active" qualifiers="virtual const">
+		<method name="_space_is_active" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="space" type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.space_is_active].
 			</description>
 		</method>
-		<method name="_space_set_active" qualifiers="virtual">
+		<method name="_space_set_active" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
@@ -1070,7 +1070,7 @@
 				Overridable version of [method PhysicsServer2D.space_set_active].
 			</description>
 		</method>
-		<method name="_space_set_debug_contacts" qualifiers="virtual">
+		<method name="_space_set_debug_contacts" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="max_contacts" type="int" />
@@ -1079,7 +1079,7 @@
 				Overridable version of [PhysicsServer2D]'s internal [code]space_set_debug_contacts[/code] method.
 			</description>
 		</method>
-		<method name="_space_set_param" qualifiers="virtual">
+		<method name="_space_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer2D.SpaceParameter" />
@@ -1088,7 +1088,7 @@
 				Overridable version of [method PhysicsServer2D.space_set_param].
 			</description>
 		</method>
-		<method name="_step" qualifiers="virtual">
+		<method name="_step" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="step" type="float" />
 			<description>
@@ -1096,14 +1096,14 @@
 				Overridable version of [PhysicsServer2D]'s internal [code skip-lint]step[/code] method.
 			</description>
 		</method>
-		<method name="_sync" qualifiers="virtual">
+		<method name="_sync" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Called to indicate that the physics server is synchronizing and cannot access physics states if running on a separate thread. See also [method _end_sync].
 				Overridable version of [PhysicsServer2D]'s internal [code]sync[/code] method.
 			</description>
 		</method>
-		<method name="_world_boundary_shape_create" qualifiers="virtual">
+		<method name="_world_boundary_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 				Overridable version of [method PhysicsServer2D.world_boundary_shape_create].

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_area_add_shape" qualifiers="virtual">
+		<method name="_area_add_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape" type="RID" />
@@ -19,124 +19,124 @@
 			<description>
 			</description>
 		</method>
-		<method name="_area_attach_object_instance_id" qualifiers="virtual">
+		<method name="_area_attach_object_instance_id" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_clear_shapes" qualifiers="virtual">
+		<method name="_area_clear_shapes" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_create" qualifiers="virtual">
+		<method name="_area_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_collision_layer" qualifiers="virtual const">
+		<method name="_area_get_collision_layer" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_collision_mask" qualifiers="virtual const">
+		<method name="_area_get_collision_mask" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_object_instance_id" qualifiers="virtual const">
+		<method name="_area_get_object_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_param" qualifiers="virtual const">
+		<method name="_area_get_param" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.AreaParameter" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_shape" qualifiers="virtual const">
+		<method name="_area_get_shape" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_shape_count" qualifiers="virtual const">
+		<method name="_area_get_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_shape_transform" qualifiers="virtual const">
+		<method name="_area_get_shape_transform" qualifiers="virtual required const">
 			<return type="Transform3D" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_space" qualifiers="virtual const">
+		<method name="_area_get_space" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_get_transform" qualifiers="virtual const">
+		<method name="_area_get_transform" qualifiers="virtual required const">
 			<return type="Transform3D" />
 			<param index="0" name="area" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_remove_shape" qualifiers="virtual">
+		<method name="_area_remove_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_area_monitor_callback" qualifiers="virtual">
+		<method name="_area_set_area_monitor_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_collision_layer" qualifiers="virtual">
+		<method name="_area_set_collision_layer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_collision_mask" qualifiers="virtual">
+		<method name="_area_set_collision_mask" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_monitor_callback" qualifiers="virtual">
+		<method name="_area_set_monitor_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="callback" type="Callable" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_monitorable" qualifiers="virtual">
+		<method name="_area_set_monitorable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="monitorable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_param" qualifiers="virtual">
+		<method name="_area_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.AreaParameter" />
@@ -144,14 +144,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_ray_pickable" qualifiers="virtual">
+		<method name="_area_set_ray_pickable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_shape" qualifiers="virtual">
+		<method name="_area_set_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -159,7 +159,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_shape_disabled" qualifiers="virtual">
+		<method name="_area_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -167,7 +167,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_shape_transform" qualifiers="virtual">
+		<method name="_area_set_shape_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -175,35 +175,35 @@
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_space" qualifiers="virtual">
+		<method name="_area_set_space" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_area_set_transform" qualifiers="virtual">
+		<method name="_area_set_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="area" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_add_collision_exception" qualifiers="virtual">
+		<method name="_body_add_collision_exception" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_add_constant_central_force" qualifiers="virtual">
+		<method name="_body_add_constant_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_add_constant_force" qualifiers="virtual">
+		<method name="_body_add_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
@@ -211,14 +211,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_add_constant_torque" qualifiers="virtual">
+		<method name="_body_add_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_add_shape" qualifiers="virtual">
+		<method name="_body_add_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape" type="RID" />
@@ -227,21 +227,21 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_apply_central_force" qualifiers="virtual">
+		<method name="_body_apply_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_apply_central_impulse" qualifiers="virtual">
+		<method name="_body_apply_central_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_apply_force" qualifiers="virtual">
+		<method name="_body_apply_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
@@ -249,7 +249,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_apply_impulse" qualifiers="virtual">
+		<method name="_body_apply_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
@@ -257,190 +257,190 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_apply_torque" qualifiers="virtual">
+		<method name="_body_apply_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_apply_torque_impulse" qualifiers="virtual">
+		<method name="_body_apply_torque_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_attach_object_instance_id" qualifiers="virtual">
+		<method name="_body_attach_object_instance_id" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="id" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_clear_shapes" qualifiers="virtual">
+		<method name="_body_clear_shapes" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_create" qualifiers="virtual">
+		<method name="_body_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_collision_exceptions" qualifiers="virtual const">
+		<method name="_body_get_collision_exceptions" qualifiers="virtual required const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_collision_layer" qualifiers="virtual const">
+		<method name="_body_get_collision_layer" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_collision_mask" qualifiers="virtual const">
+		<method name="_body_get_collision_mask" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_collision_priority" qualifiers="virtual const">
+		<method name="_body_get_collision_priority" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_constant_force" qualifiers="virtual const">
+		<method name="_body_get_constant_force" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_constant_torque" qualifiers="virtual const">
+		<method name="_body_get_constant_torque" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual const">
+		<method name="_body_get_contacts_reported_depth_threshold" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_direct_state" qualifiers="virtual">
+		<method name="_body_get_direct_state" qualifiers="virtual required">
 			<return type="PhysicsDirectBodyState3D" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_max_contacts_reported" qualifiers="virtual const">
+		<method name="_body_get_max_contacts_reported" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_mode" qualifiers="virtual const">
+		<method name="_body_get_mode" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer3D.BodyMode" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_object_instance_id" qualifiers="virtual const">
+		<method name="_body_get_object_instance_id" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_param" qualifiers="virtual const">
+		<method name="_body_get_param" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.BodyParameter" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_shape" qualifiers="virtual const">
+		<method name="_body_get_shape" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_shape_count" qualifiers="virtual const">
+		<method name="_body_get_shape_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_shape_transform" qualifiers="virtual const">
+		<method name="_body_get_shape_transform" qualifiers="virtual required const">
 			<return type="Transform3D" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_space" qualifiers="virtual const">
+		<method name="_body_get_space" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_state" qualifiers="virtual const">
+		<method name="_body_get_state" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_get_user_flags" qualifiers="virtual const">
+		<method name="_body_get_user_flags" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_is_axis_locked" qualifiers="virtual const">
+		<method name="_body_is_axis_locked" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_is_continuous_collision_detection_enabled" qualifiers="virtual const">
+		<method name="_body_is_continuous_collision_detection_enabled" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_is_omitting_force_integration" qualifiers="virtual const">
+		<method name="_body_is_omitting_force_integration" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_remove_collision_exception" qualifiers="virtual">
+		<method name="_body_remove_collision_exception" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="excepted_body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_remove_shape" qualifiers="virtual">
+		<method name="_body_remove_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_reset_mass_properties" qualifiers="virtual">
+		<method name="_body_reset_mass_properties" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_axis_lock" qualifiers="virtual">
+		<method name="_body_set_axis_lock" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
@@ -448,63 +448,63 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_axis_velocity" qualifiers="virtual">
+		<method name="_body_set_axis_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="axis_velocity" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_collision_layer" qualifiers="virtual">
+		<method name="_body_set_collision_layer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_collision_mask" qualifiers="virtual">
+		<method name="_body_set_collision_mask" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_collision_priority" qualifiers="virtual">
+		<method name="_body_set_collision_priority" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="priority" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_constant_force" qualifiers="virtual">
+		<method name="_body_set_constant_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_constant_torque" qualifiers="virtual">
+		<method name="_body_set_constant_torque" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="torque" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual">
+		<method name="_body_set_contacts_reported_depth_threshold" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="threshold" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_enable_continuous_collision_detection" qualifiers="virtual">
+		<method name="_body_set_enable_continuous_collision_detection" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_force_integration_callback" qualifiers="virtual">
+		<method name="_body_set_force_integration_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
@@ -512,28 +512,28 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_max_contacts_reported" qualifiers="virtual">
+		<method name="_body_set_max_contacts_reported" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="amount" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_mode" qualifiers="virtual">
+		<method name="_body_set_mode" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mode" type="int" enum="PhysicsServer3D.BodyMode" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_omit_force_integration" qualifiers="virtual">
+		<method name="_body_set_omit_force_integration" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_param" qualifiers="virtual">
+		<method name="_body_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.BodyParameter" />
@@ -541,14 +541,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_ray_pickable" qualifiers="virtual">
+		<method name="_body_set_ray_pickable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_shape" qualifiers="virtual">
+		<method name="_body_set_shape" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -556,7 +556,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_shape_disabled" qualifiers="virtual">
+		<method name="_body_set_shape_disabled" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -564,7 +564,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_shape_transform" qualifiers="virtual">
+		<method name="_body_set_shape_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shape_idx" type="int" />
@@ -572,14 +572,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_space" qualifiers="virtual">
+		<method name="_body_set_space" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_state" qualifiers="virtual">
+		<method name="_body_set_state" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
@@ -587,21 +587,21 @@
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_state_sync_callback" qualifiers="virtual">
+		<method name="_body_set_state_sync_callback" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="callable" type="Callable" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_set_user_flags" qualifiers="virtual">
+		<method name="_body_set_user_flags" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="flags" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_body_test_motion" qualifiers="virtual const">
+		<method name="_body_test_motion" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="from" type="Transform3D" />
@@ -614,29 +614,29 @@
 			<description>
 			</description>
 		</method>
-		<method name="_box_shape_create" qualifiers="virtual">
+		<method name="_box_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_capsule_shape_create" qualifiers="virtual">
+		<method name="_capsule_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_concave_polygon_shape_create" qualifiers="virtual">
+		<method name="_concave_polygon_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_cone_twist_joint_get_param" qualifiers="virtual const">
+		<method name="_cone_twist_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
 			<description>
 			</description>
 		</method>
-		<method name="_cone_twist_joint_set_param" qualifiers="virtual">
+		<method name="_cone_twist_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
@@ -644,43 +644,43 @@
 			<description>
 			</description>
 		</method>
-		<method name="_convex_polygon_shape_create" qualifiers="virtual">
+		<method name="_convex_polygon_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_custom_shape_create" qualifiers="virtual">
+		<method name="_custom_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_cylinder_shape_create" qualifiers="virtual">
+		<method name="_cylinder_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_end_sync" qualifiers="virtual">
+		<method name="_end_sync" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_finish" qualifiers="virtual">
+		<method name="_finish" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_flush_queries" qualifiers="virtual">
+		<method name="_flush_queries" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_free_rid" qualifiers="virtual">
+		<method name="_free_rid" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_generic_6dof_joint_get_flag" qualifiers="virtual const">
+		<method name="_generic_6dof_joint_get_flag" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
@@ -688,7 +688,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_generic_6dof_joint_get_param" qualifiers="virtual const">
+		<method name="_generic_6dof_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
@@ -696,7 +696,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_generic_6dof_joint_set_flag" qualifiers="virtual">
+		<method name="_generic_6dof_joint_set_flag" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
@@ -705,7 +705,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_generic_6dof_joint_set_param" qualifiers="virtual">
+		<method name="_generic_6dof_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="axis" type="int" enum="Vector3.Axis" />
@@ -714,32 +714,32 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_process_info" qualifiers="virtual">
+		<method name="_get_process_info" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="process_info" type="int" enum="PhysicsServer3D.ProcessInfo" />
 			<description>
 			</description>
 		</method>
-		<method name="_heightmap_shape_create" qualifiers="virtual">
+		<method name="_heightmap_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_hinge_joint_get_flag" qualifiers="virtual const">
+		<method name="_hinge_joint_get_flag" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
 			<description>
 			</description>
 		</method>
-		<method name="_hinge_joint_get_param" qualifiers="virtual const">
+		<method name="_hinge_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
 			<description>
 			</description>
 		</method>
-		<method name="_hinge_joint_set_flag" qualifiers="virtual">
+		<method name="_hinge_joint_set_flag" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
@@ -747,7 +747,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_hinge_joint_set_param" qualifiers="virtual">
+		<method name="_hinge_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
@@ -755,53 +755,53 @@
 			<description>
 			</description>
 		</method>
-		<method name="_init" qualifiers="virtual">
+		<method name="_init" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_flushing_queries" qualifiers="virtual const">
+		<method name="_is_flushing_queries" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_clear" qualifiers="virtual">
+		<method name="_joint_clear" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_create" qualifiers="virtual">
+		<method name="_joint_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual">
+		<method name="_joint_disable_collisions_between_bodies" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="disable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_get_solver_priority" qualifiers="virtual const">
+		<method name="_joint_get_solver_priority" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_get_type" qualifiers="virtual const">
+		<method name="_joint_get_type" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer3D.JointType" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual const">
+		<method name="_joint_is_disabled_collisions_between_bodies" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_joint_make_cone_twist" qualifiers="virtual">
+		<method name="_joint_make_cone_twist" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="body_A" type="RID" />
@@ -811,7 +811,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_joint_make_generic_6dof" qualifiers="virtual">
+		<method name="_joint_make_generic_6dof" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="body_A" type="RID" />
@@ -821,7 +821,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_joint_make_hinge" qualifiers="virtual">
+		<method name="_joint_make_hinge" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="body_A" type="RID" />
@@ -831,7 +831,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_joint_make_hinge_simple" qualifiers="virtual">
+		<method name="_joint_make_hinge_simple" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="body_A" type="RID" />
@@ -843,7 +843,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_joint_make_pin" qualifiers="virtual">
+		<method name="_joint_make_pin" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="body_A" type="RID" />
@@ -853,7 +853,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_joint_make_slider" qualifiers="virtual">
+		<method name="_joint_make_slider" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="body_A" type="RID" />
@@ -863,47 +863,47 @@
 			<description>
 			</description>
 		</method>
-		<method name="_joint_set_solver_priority" qualifiers="virtual">
+		<method name="_joint_set_solver_priority" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="priority" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_get_local_a" qualifiers="virtual const">
+		<method name="_pin_joint_get_local_a" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_get_local_b" qualifiers="virtual const">
+		<method name="_pin_joint_get_local_b" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="joint" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_get_param" qualifiers="virtual const">
+		<method name="_pin_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_set_local_a" qualifiers="virtual">
+		<method name="_pin_joint_set_local_a" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="local_A" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_set_local_b" qualifiers="virtual">
+		<method name="_pin_joint_set_local_b" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="local_B" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_pin_joint_set_param" qualifiers="virtual">
+		<method name="_pin_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
@@ -911,70 +911,70 @@
 			<description>
 			</description>
 		</method>
-		<method name="_separation_ray_shape_create" qualifiers="virtual">
+		<method name="_separation_ray_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_active" qualifiers="virtual">
+		<method name="_set_active" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="active" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_get_custom_solver_bias" qualifiers="virtual const">
+		<method name="_shape_get_custom_solver_bias" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_get_data" qualifiers="virtual const">
+		<method name="_shape_get_data" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_get_margin" qualifiers="virtual const">
+		<method name="_shape_get_margin" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_get_type" qualifiers="virtual const">
+		<method name="_shape_get_type" qualifiers="virtual required const">
 			<return type="int" enum="PhysicsServer3D.ShapeType" />
 			<param index="0" name="shape" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_set_custom_solver_bias" qualifiers="virtual">
+		<method name="_shape_set_custom_solver_bias" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="bias" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_set_data" qualifiers="virtual">
+		<method name="_shape_set_data" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="data" type="Variant" />
 			<description>
 			</description>
 		</method>
-		<method name="_shape_set_margin" qualifiers="virtual">
+		<method name="_shape_set_margin" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shape" type="RID" />
 			<param index="1" name="margin" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_slider_joint_get_param" qualifiers="virtual const">
+		<method name="_slider_joint_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
 			<description>
 			</description>
 		</method>
-		<method name="_slider_joint_set_param" qualifiers="virtual">
+		<method name="_slider_joint_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="joint" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
@@ -982,28 +982,28 @@
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_add_collision_exception" qualifiers="virtual">
+		<method name="_soft_body_add_collision_exception" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="body_b" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_apply_central_force" qualifiers="virtual">
+		<method name="_soft_body_apply_central_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="force" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_apply_central_impulse" qualifiers="virtual">
+		<method name="_soft_body_apply_central_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="impulse" type="Vector3" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_apply_point_force" qualifiers="virtual">
+		<method name="_soft_body_apply_point_force" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
@@ -1011,7 +1011,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_apply_point_impulse" qualifiers="virtual">
+		<method name="_soft_body_apply_point_impulse" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
@@ -1019,105 +1019,105 @@
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_create" qualifiers="virtual">
+		<method name="_soft_body_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_bounds" qualifiers="virtual const">
+		<method name="_soft_body_get_bounds" qualifiers="virtual required const">
 			<return type="AABB" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_collision_exceptions" qualifiers="virtual const">
+		<method name="_soft_body_get_collision_exceptions" qualifiers="virtual required const">
 			<return type="RID[]" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_collision_layer" qualifiers="virtual const">
+		<method name="_soft_body_get_collision_layer" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_collision_mask" qualifiers="virtual const">
+		<method name="_soft_body_get_collision_mask" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_damping_coefficient" qualifiers="virtual const">
+		<method name="_soft_body_get_damping_coefficient" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_drag_coefficient" qualifiers="virtual const">
+		<method name="_soft_body_get_drag_coefficient" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_linear_stiffness" qualifiers="virtual const">
+		<method name="_soft_body_get_linear_stiffness" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_point_global_position" qualifiers="virtual const">
+		<method name="_soft_body_get_point_global_position" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_pressure_coefficient" qualifiers="virtual const">
+		<method name="_soft_body_get_pressure_coefficient" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_shrinking_factor" qualifiers="virtual const">
+		<method name="_soft_body_get_shrinking_factor" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_simulation_precision" qualifiers="virtual const">
+		<method name="_soft_body_get_simulation_precision" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_space" qualifiers="virtual const">
+		<method name="_soft_body_get_space" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_state" qualifiers="virtual const">
+		<method name="_soft_body_get_state" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_get_total_mass" qualifiers="virtual const">
+		<method name="_soft_body_get_total_mass" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_is_point_pinned" qualifiers="virtual const">
+		<method name="_soft_body_is_point_pinned" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_move_point" qualifiers="virtual">
+		<method name="_soft_body_move_point" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
@@ -1125,7 +1125,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_pin_point" qualifiers="virtual">
+		<method name="_soft_body_pin_point" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="point_index" type="int" />
@@ -1133,97 +1133,97 @@
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_remove_all_pinned_points" qualifiers="virtual">
+		<method name="_soft_body_remove_all_pinned_points" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_remove_collision_exception" qualifiers="virtual">
+		<method name="_soft_body_remove_collision_exception" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="body_b" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_collision_layer" qualifiers="virtual">
+		<method name="_soft_body_set_collision_layer" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="layer" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_collision_mask" qualifiers="virtual">
+		<method name="_soft_body_set_collision_mask" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mask" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_damping_coefficient" qualifiers="virtual">
+		<method name="_soft_body_set_damping_coefficient" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="damping_coefficient" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_drag_coefficient" qualifiers="virtual">
+		<method name="_soft_body_set_drag_coefficient" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="drag_coefficient" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_linear_stiffness" qualifiers="virtual">
+		<method name="_soft_body_set_linear_stiffness" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="linear_stiffness" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_mesh" qualifiers="virtual">
+		<method name="_soft_body_set_mesh" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="mesh" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_pressure_coefficient" qualifiers="virtual">
+		<method name="_soft_body_set_pressure_coefficient" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="pressure_coefficient" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_ray_pickable" qualifiers="virtual">
+		<method name="_soft_body_set_ray_pickable" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="enable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_shrinking_factor" qualifiers="virtual">
+		<method name="_soft_body_set_shrinking_factor" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="shrinking_factor" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_simulation_precision" qualifiers="virtual">
+		<method name="_soft_body_set_simulation_precision" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="simulation_precision" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_space" qualifiers="virtual">
+		<method name="_soft_body_set_space" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_state" qualifiers="virtual">
+		<method name="_soft_body_set_state" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
@@ -1231,78 +1231,78 @@
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_total_mass" qualifiers="virtual">
+		<method name="_soft_body_set_total_mass" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="total_mass" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_set_transform" qualifiers="virtual">
+		<method name="_soft_body_set_transform" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="transform" type="Transform3D" />
 			<description>
 			</description>
 		</method>
-		<method name="_soft_body_update_rendering_server" qualifiers="virtual">
+		<method name="_soft_body_update_rendering_server" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="body" type="RID" />
 			<param index="1" name="rendering_server_handler" type="PhysicsServer3DRenderingServerHandler" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_create" qualifiers="virtual">
+		<method name="_space_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_get_contact_count" qualifiers="virtual const">
+		<method name="_space_get_contact_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_get_contacts" qualifiers="virtual const">
+		<method name="_space_get_contacts" qualifiers="virtual required const">
 			<return type="PackedVector3Array" />
 			<param index="0" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_get_direct_state" qualifiers="virtual">
+		<method name="_space_get_direct_state" qualifiers="virtual required">
 			<return type="PhysicsDirectSpaceState3D" />
 			<param index="0" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_get_param" qualifiers="virtual const">
+		<method name="_space_get_param" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_is_active" qualifiers="virtual const">
+		<method name="_space_is_active" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="space" type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_set_active" qualifiers="virtual">
+		<method name="_space_set_active" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="active" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_set_debug_contacts" qualifiers="virtual">
+		<method name="_space_set_debug_contacts" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="max_contacts" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_space_set_param" qualifiers="virtual">
+		<method name="_space_set_param" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="space" type="RID" />
 			<param index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
@@ -1310,23 +1310,23 @@
 			<description>
 			</description>
 		</method>
-		<method name="_sphere_shape_create" qualifiers="virtual">
+		<method name="_sphere_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>
 		</method>
-		<method name="_step" qualifiers="virtual">
+		<method name="_step" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="step" type="float" />
 			<description>
 			</description>
 		</method>
-		<method name="_sync" qualifiers="virtual">
+		<method name="_sync" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_world_boundary_shape_create" qualifiers="virtual">
+		<method name="_world_boundary_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
 			</description>

--- a/doc/classes/PhysicsServer3DRenderingServerHandler.xml
+++ b/doc/classes/PhysicsServer3DRenderingServerHandler.xml
@@ -8,14 +8,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_set_aabb" qualifiers="virtual">
+		<method name="_set_aabb" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="aabb" type="AABB" />
 			<description>
 				Called by the [PhysicsServer3D] to set the bounding box for the [SoftBody3D].
 			</description>
 		</method>
-		<method name="_set_normal" qualifiers="virtual">
+		<method name="_set_normal" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="vertex_id" type="int" />
 			<param index="1" name="normal" type="Vector3" />
@@ -24,7 +24,7 @@
 				[b]Note:[/b] The [param normal] parameter used to be of type [code]const void*[/code] prior to Godot 4.2.
 			</description>
 		</method>
-		<method name="_set_vertex" qualifiers="virtual">
+		<method name="_set_vertex" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="vertex_id" type="int" />
 			<param index="1" name="vertex" type="Vector3" />

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -7,17 +7,17 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_can_instantiate" qualifiers="virtual const">
+		<method name="_can_instantiate" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_editor_can_reload_from_file" qualifiers="virtual">
+		<method name="_editor_can_reload_from_file" qualifiers="virtual required">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_base_script" qualifiers="virtual const">
+		<method name="_get_base_script" qualifiers="virtual required const">
 			<return type="Script" />
 			<description>
 			</description>
@@ -27,60 +27,60 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_constants" qualifiers="virtual const">
+		<method name="_get_constants" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_doc_class_name" qualifiers="virtual const">
+		<method name="_get_doc_class_name" qualifiers="virtual required const">
 			<return type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_documentation" qualifiers="virtual const">
+		<method name="_get_documentation" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_global_name" qualifiers="virtual const">
+		<method name="_get_global_name" qualifiers="virtual required const">
 			<return type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_instance_base_type" qualifiers="virtual const">
+		<method name="_get_instance_base_type" qualifiers="virtual required const">
 			<return type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_language" qualifiers="virtual const">
+		<method name="_get_language" qualifiers="virtual required const">
 			<return type="ScriptLanguage" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_member_line" qualifiers="virtual const">
+		<method name="_get_member_line" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="member" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_members" qualifiers="virtual const">
+		<method name="_get_members" qualifiers="virtual required const">
 			<return type="StringName[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_method_info" qualifiers="virtual const">
+		<method name="_get_method_info" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<param index="0" name="method" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_property_default_value" qualifiers="virtual const">
+		<method name="_get_property_default_value" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_rpc_config" qualifiers="virtual const">
+		<method name="_get_rpc_config" qualifiers="virtual required const">
 			<return type="Variant" />
 			<description>
 			</description>
@@ -92,68 +92,68 @@
 				Return the expected argument count for the given [param method], or [code]null[/code] if it can't be determined (which will then fall back to the default behavior).
 			</description>
 		</method>
-		<method name="_get_script_method_list" qualifiers="virtual const">
+		<method name="_get_script_method_list" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_script_property_list" qualifiers="virtual const">
+		<method name="_get_script_property_list" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_script_signal_list" qualifiers="virtual const">
+		<method name="_get_script_signal_list" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_source_code" qualifiers="virtual const">
+		<method name="_get_source_code" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_has_method" qualifiers="virtual const">
+		<method name="_has_method" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="method" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_has_property_default_value" qualifiers="virtual const">
+		<method name="_has_property_default_value" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="property" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_has_script_signal" qualifiers="virtual const">
+		<method name="_has_script_signal" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="signal" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_has_source_code" qualifiers="virtual const">
+		<method name="_has_source_code" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_has_static_method" qualifiers="virtual const">
+		<method name="_has_static_method" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="method" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_inherits_script" qualifiers="virtual const">
+		<method name="_inherits_script" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="script" type="Script" />
 			<description>
 			</description>
 		</method>
-		<method name="_instance_create" qualifiers="virtual const">
+		<method name="_instance_create" qualifiers="virtual required const">
 			<return type="void*" />
 			<param index="0" name="for_object" type="Object" />
 			<description>
 			</description>
 		</method>
-		<method name="_instance_has" qualifiers="virtual const">
+		<method name="_instance_has" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="object" type="Object" />
 			<description>
@@ -165,17 +165,17 @@
 				Returns [code]true[/code] if the script is an abstract script. Abstract scripts cannot be instantiated directly, instead other scripts should inherit them. Abstract scripts will be either unselectable or hidden in the Create New Node dialog (unselectable if there are non-abstract classes inheriting it, otherwise hidden).
 			</description>
 		</method>
-		<method name="_is_placeholder_fallback_enabled" qualifiers="virtual const">
+		<method name="_is_placeholder_fallback_enabled" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_tool" qualifiers="virtual const">
+		<method name="_is_tool" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_valid" qualifiers="virtual const">
+		<method name="_is_valid" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
@@ -186,25 +186,25 @@
 			<description>
 			</description>
 		</method>
-		<method name="_placeholder_instance_create" qualifiers="virtual const">
+		<method name="_placeholder_instance_create" qualifiers="virtual required const">
 			<return type="void*" />
 			<param index="0" name="for_object" type="Object" />
 			<description>
 			</description>
 		</method>
-		<method name="_reload" qualifiers="virtual">
+		<method name="_reload" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="keep_state" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_source_code" qualifiers="virtual">
+		<method name="_set_source_code" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="code" type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_update_exports" qualifiers="virtual">
+		<method name="_update_exports" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -7,21 +7,21 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_add_global_constant" qualifiers="virtual">
+		<method name="_add_global_constant" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
 			</description>
 		</method>
-		<method name="_add_named_global_constant" qualifiers="virtual">
+		<method name="_add_named_global_constant" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<param index="1" name="value" type="Variant" />
 			<description>
 			</description>
 		</method>
-		<method name="_auto_indent_code" qualifiers="virtual const">
+		<method name="_auto_indent_code" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="code" type="String" />
 			<param index="1" name="from_line" type="int" />
@@ -29,17 +29,17 @@
 			<description>
 			</description>
 		</method>
-		<method name="_can_inherit_from_file" qualifiers="virtual const">
+		<method name="_can_inherit_from_file" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_can_make_function" qualifiers="virtual const">
+		<method name="_can_make_function" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_complete_code" qualifiers="virtual const">
+		<method name="_complete_code" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<param index="0" name="code" type="String" />
 			<param index="1" name="path" type="String" />
@@ -47,52 +47,52 @@
 			<description>
 			</description>
 		</method>
-		<method name="_create_script" qualifiers="virtual const">
+		<method name="_create_script" qualifiers="virtual required const">
 			<return type="Object" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_current_stack_info" qualifiers="virtual">
+		<method name="_debug_get_current_stack_info" qualifiers="virtual required">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_error" qualifiers="virtual const">
+		<method name="_debug_get_error" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_globals" qualifiers="virtual">
+		<method name="_debug_get_globals" qualifiers="virtual required">
 			<return type="Dictionary" />
 			<param index="0" name="max_subitems" type="int" />
 			<param index="1" name="max_depth" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_count" qualifiers="virtual const">
+		<method name="_debug_get_stack_level_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_function" qualifiers="virtual const">
+		<method name="_debug_get_stack_level_function" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="level" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_instance" qualifiers="virtual">
+		<method name="_debug_get_stack_level_instance" qualifiers="virtual required">
 			<return type="void*" />
 			<param index="0" name="level" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_line" qualifiers="virtual const">
+		<method name="_debug_get_stack_level_line" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="level" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_locals" qualifiers="virtual">
+		<method name="_debug_get_stack_level_locals" qualifiers="virtual required">
 			<return type="Dictionary" />
 			<param index="0" name="level" type="int" />
 			<param index="1" name="max_subitems" type="int" />
@@ -100,7 +100,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_members" qualifiers="virtual">
+		<method name="_debug_get_stack_level_members" qualifiers="virtual required">
 			<return type="Dictionary" />
 			<param index="0" name="level" type="int" />
 			<param index="1" name="max_subitems" type="int" />
@@ -108,14 +108,14 @@
 			<description>
 			</description>
 		</method>
-		<method name="_debug_get_stack_level_source" qualifiers="virtual const">
+		<method name="_debug_get_stack_level_source" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="level" type="int" />
 			<description>
 				Returns the source associated with a given debug stack position.
 			</description>
 		</method>
-		<method name="_debug_parse_stack_level_expression" qualifiers="virtual">
+		<method name="_debug_parse_stack_level_expression" qualifiers="virtual required">
 			<return type="String" />
 			<param index="0" name="level" type="int" />
 			<param index="1" name="expression" type="String" />
@@ -124,7 +124,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_find_function" qualifiers="virtual const">
+		<method name="_find_function" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="function" type="String" />
 			<param index="1" name="code" type="String" />
@@ -132,23 +132,23 @@
 				Returns the line where the function is defined in the code, or [code]-1[/code] if the function is not present.
 			</description>
 		</method>
-		<method name="_finish" qualifiers="virtual">
+		<method name="_finish" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_frame" qualifiers="virtual">
+		<method name="_frame" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_built_in_templates" qualifiers="virtual const">
+		<method name="_get_built_in_templates" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<param index="0" name="object" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_comment_delimiters" qualifiers="virtual const">
+		<method name="_get_comment_delimiters" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
 			</description>
@@ -158,85 +158,85 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_extension" qualifiers="virtual const">
+		<method name="_get_extension" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_global_class_name" qualifiers="virtual const">
+		<method name="_get_global_class_name" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<param index="0" name="path" type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_name" qualifiers="virtual const">
+		<method name="_get_name" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_public_annotations" qualifiers="virtual const">
+		<method name="_get_public_annotations" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_public_constants" qualifiers="virtual const">
+		<method name="_get_public_constants" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_public_functions" qualifiers="virtual const">
+		<method name="_get_public_functions" qualifiers="virtual required const">
 			<return type="Dictionary[]" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_recognized_extensions" qualifiers="virtual const">
+		<method name="_get_recognized_extensions" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_reserved_words" qualifiers="virtual const">
+		<method name="_get_reserved_words" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_string_delimiters" qualifiers="virtual const">
+		<method name="_get_string_delimiters" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_type" qualifiers="virtual const">
+		<method name="_get_type" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_handles_global_class_type" qualifiers="virtual const">
+		<method name="_handles_global_class_type" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_has_named_classes" qualifiers="virtual const" deprecated="This method is not called by the engine.">
+		<method name="_has_named_classes" qualifiers="virtual required const" deprecated="This method is not called by the engine.">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_init" qualifiers="virtual">
+		<method name="_init" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_control_flow_keyword" qualifiers="virtual const">
+		<method name="_is_control_flow_keyword" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="keyword" type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_using_templates" qualifiers="virtual">
+		<method name="_is_using_templates" qualifiers="virtual required">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_lookup_code" qualifiers="virtual const">
+		<method name="_lookup_code" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<param index="0" name="code" type="String" />
 			<param index="1" name="symbol" type="String" />
@@ -245,7 +245,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_make_function" qualifiers="virtual const">
+		<method name="_make_function" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="class_name" type="String" />
 			<param index="1" name="function_name" type="String" />
@@ -253,7 +253,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_make_template" qualifiers="virtual const">
+		<method name="_make_template" qualifiers="virtual required const">
 			<return type="Script" />
 			<param index="0" name="template" type="String" />
 			<param index="1" name="class_name" type="String" />
@@ -261,7 +261,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_open_in_external_editor" qualifiers="virtual">
+		<method name="_open_in_external_editor" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="script" type="Script" />
 			<param index="1" name="line" type="int" />
@@ -269,7 +269,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_overrides_external_editor" qualifiers="virtual">
+		<method name="_overrides_external_editor" qualifiers="virtual required">
 			<return type="bool" />
 			<description>
 			</description>
@@ -279,82 +279,82 @@
 			<description>
 			</description>
 		</method>
-		<method name="_profiling_get_accumulated_data" qualifiers="virtual">
+		<method name="_profiling_get_accumulated_data" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="info_array" type="ScriptLanguageExtensionProfilingInfo*" />
 			<param index="1" name="info_max" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_profiling_get_frame_data" qualifiers="virtual">
+		<method name="_profiling_get_frame_data" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="info_array" type="ScriptLanguageExtensionProfilingInfo*" />
 			<param index="1" name="info_max" type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_profiling_set_save_native_calls" qualifiers="virtual">
+		<method name="_profiling_set_save_native_calls" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="enable" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_profiling_start" qualifiers="virtual">
+		<method name="_profiling_start" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_profiling_stop" qualifiers="virtual">
+		<method name="_profiling_stop" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_reload_all_scripts" qualifiers="virtual">
+		<method name="_reload_all_scripts" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_reload_scripts" qualifiers="virtual">
+		<method name="_reload_scripts" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="scripts" type="Array" />
 			<param index="1" name="soft_reload" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_reload_tool_script" qualifiers="virtual">
+		<method name="_reload_tool_script" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="script" type="Script" />
 			<param index="1" name="soft_reload" type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_remove_named_global_constant" qualifiers="virtual">
+		<method name="_remove_named_global_constant" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="_supports_builtin_mode" qualifiers="virtual const">
+		<method name="_supports_builtin_mode" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_supports_documentation" qualifiers="virtual const">
+		<method name="_supports_documentation" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_thread_enter" qualifiers="virtual">
+		<method name="_thread_enter" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_thread_exit" qualifiers="virtual">
+		<method name="_thread_exit" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_validate" qualifiers="virtual const">
+		<method name="_validate" qualifiers="virtual required const">
 			<return type="Dictionary" />
 			<param index="0" name="script" type="String" />
 			<param index="1" name="path" type="String" />
@@ -365,7 +365,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_validate_path" qualifiers="virtual const">
+		<method name="_validate_path" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="path" type="String" />
 			<description>

--- a/doc/classes/StreamPeerExtension.xml
+++ b/doc/classes/StreamPeerExtension.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_available_bytes" qualifiers="virtual const">
+		<method name="_get_available_bytes" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_draw" qualifiers="virtual const">
+		<method name="_draw" qualifiers="virtual required const">
 			<return type="void" />
 			<param index="0" name="to_canvas_item" type="RID" />
 			<param index="1" name="rect" type="Rect2" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -12,14 +12,12 @@
 		<method name="_cleanup" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				[b]Optional.[/b]
 				This method is called before text server is unregistered.
 			</description>
 		</method>
-		<method name="_create_font" qualifiers="virtual">
+		<method name="_create_font" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
-				[b]Required.[/b]
 				Creates a new, empty font cache entry resource.
 			</description>
 		</method>
@@ -31,12 +29,11 @@
 				Creates a new variation existing font which is reusing the same glyph cache and font data.
 			</description>
 		</method>
-		<method name="_create_shaped_text" qualifiers="virtual">
+		<method name="_create_shaped_text" qualifiers="virtual required">
 			<return type="RID" />
 			<param index="0" name="direction" type="int" enum="TextServer.Direction" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
 			<description>
-				[b]Required.[/b]
 				Creates a new buffer for complex text layout, with the given [param direction] and [param orientation].
 			</description>
 		</method>
@@ -48,16 +45,14 @@
 			<param index="3" name="index" type="int" />
 			<param index="4" name="color" type="Color" />
 			<description>
-				[b]Optional.[/b]
 				Draws box displaying character hexadecimal code.
 			</description>
 		</method>
-		<method name="_font_clear_glyphs" qualifiers="virtual">
+		<method name="_font_clear_glyphs" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				[b]Required.[/b]
 				Removes all rendered glyph information from the cache entry.
 			</description>
 		</method>
@@ -66,35 +61,31 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Removes all kerning overrides.
 			</description>
 		</method>
-		<method name="_font_clear_size_cache" qualifiers="virtual">
+		<method name="_font_clear_size_cache" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Removes all font sizes from the cache entry.
 			</description>
 		</method>
 		<method name="_font_clear_system_fallback_cache" qualifiers="virtual">
 			<return type="void" />
 			<description>
-				[b]Optional.[/b]
 				Frees all automatically loaded system fonts.
 			</description>
 		</method>
-		<method name="_font_clear_textures" qualifiers="virtual">
+		<method name="_font_clear_textures" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				[b]Required.[/b]
 				Removes all textures from font cache entry.
 			</description>
 		</method>
-		<method name="_font_draw_glyph" qualifiers="virtual const">
+		<method name="_font_draw_glyph" qualifiers="virtual required const">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="canvas" type="RID" />
@@ -104,11 +95,10 @@
 			<param index="5" name="color" type="Color" />
 			<param index="6" name="oversampling" type="float" />
 			<description>
-				[b]Required.[/b]
 				Draws single glyph into a canvas item at the position, using [param font_rid] at the size [param size]. If [param oversampling] is greater than zero, it is used as font oversampling factor, otherwise viewport oversampling settings are used.
 			</description>
 		</method>
-		<method name="_font_draw_glyph_outline" qualifiers="virtual const">
+		<method name="_font_draw_glyph_outline" qualifiers="virtual required const">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="canvas" type="RID" />
@@ -119,7 +109,6 @@
 			<param index="6" name="color" type="Color" />
 			<param index="7" name="oversampling" type="float" />
 			<description>
-				[b]Required.[/b]
 				Draws single glyph outline of size [param outline_size] into a canvas item at the position, using [param font_rid] at the size [param size]. If [param oversampling] is greater than zero, it is used as font oversampling factor, otherwise viewport oversampling settings are used.
 			</description>
 		</method>
@@ -127,16 +116,14 @@
 			<return type="int" enum="TextServer.FontAntialiasing" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font anti-aliasing mode.
 			</description>
 		</method>
-		<method name="_font_get_ascent" qualifiers="virtual const">
+		<method name="_font_get_ascent" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
@@ -144,26 +131,23 @@
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns extra baseline offset (as a fraction of font height).
 			</description>
 		</method>
-		<method name="_font_get_char_from_glyph_index" qualifiers="virtual const">
+		<method name="_font_get_char_from_glyph_index" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns character code associated with [param glyph_index], or [code]0[/code] if [param glyph_index] is invalid.
 			</description>
 		</method>
-		<method name="_font_get_descent" qualifiers="virtual const">
+		<method name="_font_get_descent" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the font descent (number of pixels below the baseline).
 			</description>
 		</method>
@@ -171,7 +155,6 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns whether the font's embedded bitmap loading is disabled.
 			</description>
 		</method>
@@ -179,7 +162,6 @@
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font embolden strength.
 			</description>
 		</method>
@@ -187,7 +169,6 @@
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns number of faces in the TrueType / OpenType collection.
 			</description>
 		</method>
@@ -195,23 +176,20 @@
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns an active face index in the TrueType / OpenType collection.
 			</description>
 		</method>
-		<method name="_font_get_fixed_size" qualifiers="virtual const">
+		<method name="_font_get_fixed_size" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns bitmap font fixed size.
 			</description>
 		</method>
-		<method name="_font_get_fixed_size_scale_mode" qualifiers="virtual const">
+		<method name="_font_get_fixed_size_scale_mode" qualifiers="virtual required const">
 			<return type="int" enum="TextServer.FixedSizeScaleMode" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns bitmap font scaling mode.
 			</description>
 		</method>
@@ -219,24 +197,21 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if font texture mipmap generation is enabled.
 			</description>
 		</method>
 		<method name="_font_get_global_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<description>
-				[b]Optional.[/b]
 				Returns the font oversampling factor, shared by all fonts in the TextServer.
 			</description>
 		</method>
-		<method name="_font_get_glyph_advance" qualifiers="virtual const">
+		<method name="_font_get_glyph_advance" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns glyph advance (offset of the next glyph).
 			</description>
 		</method>
@@ -246,87 +221,78 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="index" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns outline contours of the glyph.
 			</description>
 		</method>
-		<method name="_font_get_glyph_index" qualifiers="virtual const">
+		<method name="_font_get_glyph_index" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="char" type="int" />
 			<param index="3" name="variation_selector" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
-		<method name="_font_get_glyph_list" qualifiers="virtual const">
+		<method name="_font_get_glyph_list" qualifiers="virtual required const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				[b]Required.[/b]
 				Returns list of rendered glyphs in the cache entry.
 			</description>
 		</method>
-		<method name="_font_get_glyph_offset" qualifiers="virtual const">
+		<method name="_font_get_glyph_offset" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns glyph offset from the baseline.
 			</description>
 		</method>
-		<method name="_font_get_glyph_size" qualifiers="virtual const">
+		<method name="_font_get_glyph_size" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns size of the glyph.
 			</description>
 		</method>
-		<method name="_font_get_glyph_texture_idx" qualifiers="virtual const">
+		<method name="_font_get_glyph_texture_idx" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns index of the cache texture containing the glyph.
 			</description>
 		</method>
-		<method name="_font_get_glyph_texture_rid" qualifiers="virtual const">
+		<method name="_font_get_glyph_texture_rid" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns resource ID of the cache texture containing the glyph.
 			</description>
 		</method>
-		<method name="_font_get_glyph_texture_size" qualifiers="virtual const">
+		<method name="_font_get_glyph_texture_size" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns size of the cache texture containing the glyph.
 			</description>
 		</method>
-		<method name="_font_get_glyph_uv_rect" qualifiers="virtual const">
+		<method name="_font_get_glyph_uv_rect" qualifiers="virtual required const">
 			<return type="Rect2" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns rectangle in the cache texture containing the glyph.
 			</description>
 		</method>
@@ -334,7 +300,6 @@
 			<return type="int" enum="TextServer.Hinting" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns the font hinting mode. Used by dynamic fonts only.
 			</description>
 		</method>
@@ -342,7 +307,6 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns glyph position rounding behavior. If set to [code]true[/code], when aligning glyphs to the pixel boundaries rounding remainders are accumulated to ensure more uniform glyph distribution. This setting has no effect if subpixel positioning is enabled.
 			</description>
 		</method>
@@ -352,7 +316,6 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<description>
-				[b]Optional.[/b]
 				Returns kerning for the pair of glyphs.
 			</description>
 		</method>
@@ -361,7 +324,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns list of the kerning overrides.
 			</description>
 		</method>
@@ -370,7 +332,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if support override is enabled for the [param language].
 			</description>
 		</method>
@@ -378,7 +339,6 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns list of language support overrides.
 			</description>
 		</method>
@@ -386,7 +346,6 @@
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns the width of the range around the shape between the minimum and maximum representable signed distance.
 			</description>
 		</method>
@@ -394,7 +353,6 @@
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns source font size used to generate MSDF textures.
 			</description>
 		</method>
@@ -402,7 +360,6 @@
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font family name.
 			</description>
 		</method>
@@ -410,7 +367,6 @@
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font OpenType feature set override.
 			</description>
 		</method>
@@ -418,7 +374,6 @@
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [Dictionary] with OpenType font name strings (localized font names, version, description, license information, sample text, etc.).
 			</description>
 		</method>
@@ -426,16 +381,14 @@
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
-		<method name="_font_get_scale" qualifiers="virtual const">
+		<method name="_font_get_scale" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns scaling factor of the color bitmap font.
 			</description>
 		</method>
@@ -444,7 +397,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if support override is enabled for the [param script].
 			</description>
 		</method>
@@ -452,7 +404,6 @@
 			<return type="PackedStringArray" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns list of script support overrides.
 			</description>
 		</method>
@@ -460,15 +411,13 @@
 			<return type="Dictionary[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font cache information, each entry contains the following fields: [code]Vector2i size_px[/code] - font size in pixels, [code]float viewport_oversampling[/code] - viewport oversampling factor, [code]int glyphs[/code] - number of rendered glyphs, [code]int textures[/code] - number of used textures, [code]int textures_size[/code] - size of texture data in bytes.
 			</description>
 		</method>
-		<method name="_font_get_size_cache_list" qualifiers="virtual const">
+		<method name="_font_get_size_cache_list" qualifiers="virtual required const">
 			<return type="Vector2i[]" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns list of the font sizes in the cache. Each size is [Vector2i] with font size and outline size.
 			</description>
 		</method>
@@ -477,7 +426,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
-				[b]Optional.[/b]
 				Returns the spacing for [param spacing] in pixels (not relative to the font size).
 			</description>
 		</method>
@@ -485,7 +433,6 @@
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font stretch amount, compared to a normal width. A percentage value between [code]50%[/code] and [code]200%[/code].
 			</description>
 		</method>
@@ -493,7 +440,6 @@
 			<return type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font style flags.
 			</description>
 		</method>
@@ -501,7 +447,6 @@
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font style name.
 			</description>
 		</method>
@@ -509,42 +454,37 @@
 			<return type="int" enum="TextServer.SubpixelPositioning" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns font subpixel glyph positioning mode.
 			</description>
 		</method>
-		<method name="_font_get_supported_chars" qualifiers="virtual const">
+		<method name="_font_get_supported_chars" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns a string containing all the characters available in the font.
 			</description>
 		</method>
-		<method name="_font_get_supported_glyphs" qualifiers="virtual const">
+		<method name="_font_get_supported_glyphs" qualifiers="virtual required const">
 			<return type="PackedInt32Array" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns an array containing all glyph indices in the font.
 			</description>
 		</method>
-		<method name="_font_get_texture_count" qualifiers="virtual const">
+		<method name="_font_get_texture_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				[b]Required.[/b]
 				Returns number of textures used by font cache entry.
 			</description>
 		</method>
-		<method name="_font_get_texture_image" qualifiers="virtual const">
+		<method name="_font_get_texture_image" qualifiers="virtual required const">
 			<return type="Image" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns font cache texture image data.
 			</description>
 		</method>
@@ -554,7 +494,6 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns array containing glyph packing data.
 			</description>
 		</method>
@@ -562,25 +501,22 @@
 			<return type="Transform2D" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns 2D transform applied to the font outlines.
 			</description>
 		</method>
-		<method name="_font_get_underline_position" qualifiers="virtual const">
+		<method name="_font_get_underline_position" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns pixel offset of the underline below the baseline.
 			</description>
 		</method>
-		<method name="_font_get_underline_thickness" qualifiers="virtual const">
+		<method name="_font_get_underline_thickness" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns thickness of the underline in pixels.
 			</description>
 		</method>
@@ -588,7 +524,6 @@
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns variation coordinates for the specified font cache entry.
 			</description>
 		</method>
@@ -596,16 +531,14 @@
 			<return type="int" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns weight (boldness) of the font. A value in the [code]100...999[/code] range, normal font weight is [code]400[/code], bold font weight is [code]700[/code].
 			</description>
 		</method>
-		<method name="_font_has_char" qualifiers="virtual const">
+		<method name="_font_has_char" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="char" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if a Unicode [param char] is available in the font.
 			</description>
 		</method>
@@ -613,7 +546,6 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if system fonts can be automatically used as fallbacks.
 			</description>
 		</method>
@@ -621,7 +553,6 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if auto-hinting is supported and preferred over font built-in hinting.
 			</description>
 		</method>
@@ -630,7 +561,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code], if font supports given language ([url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
 			</description>
 		</method>
@@ -638,7 +568,6 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code], if color modulation is applied when drawing colored glyphs.
 			</description>
 		</method>
@@ -646,7 +575,6 @@
 			<return type="bool" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
 			</description>
 		</method>
@@ -655,17 +583,15 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code], if font supports given script (ISO 15924 code).
 			</description>
 		</method>
-		<method name="_font_remove_glyph" qualifiers="virtual">
+		<method name="_font_remove_glyph" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<description>
-				[b]Required.[/b]
 				Removes specified rendered glyph information from the cache entry.
 			</description>
 		</method>
@@ -675,7 +601,6 @@
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<description>
-				[b]Optional.[/b]
 				Removes kerning override for the pair of glyphs.
 			</description>
 		</method>
@@ -684,7 +609,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Remove language support override.
 			</description>
 		</method>
@@ -693,26 +617,23 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="script" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Removes script support override.
 			</description>
 		</method>
-		<method name="_font_remove_size_cache" qualifiers="virtual">
+		<method name="_font_remove_size_cache" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<description>
-				[b]Required.[/b]
 				Removes specified font size from the cache entry.
 			</description>
 		</method>
-		<method name="_font_remove_texture" qualifiers="virtual">
+		<method name="_font_remove_texture" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Removes specified texture from the cache entry.
 			</description>
 		</method>
@@ -722,7 +643,6 @@
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="index" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Renders specified glyph to the font cache texture.
 			</description>
 		</method>
@@ -733,7 +653,6 @@
 			<param index="2" name="start" type="int" />
 			<param index="3" name="end" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Renders the range of characters to the font cache texture.
 			</description>
 		</method>
@@ -742,7 +661,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="allow_system_fallback" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code], system fonts can be automatically used as fallbacks.
 			</description>
 		</method>
@@ -751,17 +669,15 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="antialiasing" type="int" enum="TextServer.FontAntialiasing" />
 			<description>
-				[b]Optional.[/b]
 				Sets font anti-aliasing mode.
 			</description>
 		</method>
-		<method name="_font_set_ascent" qualifiers="virtual">
+		<method name="_font_set_ascent" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="ascent" type="float" />
 			<description>
-				[b]Required.[/b]
 				Sets the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
@@ -770,7 +686,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="baseline_offset" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Sets extra baseline offset (as a fraction of font height).
 			</description>
 		</method>
@@ -779,7 +694,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="data" type="PackedByteArray" />
 			<description>
-				[b]Optional.[/b]
 				Sets font source data, e.g contents of the dynamic font source file.
 			</description>
 		</method>
@@ -789,17 +703,15 @@
 			<param index="1" name="data_ptr" type="const uint8_t*" />
 			<param index="2" name="data_size" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets pointer to the font source data, e.g contents of the dynamic font source file.
 			</description>
 		</method>
-		<method name="_font_set_descent" qualifiers="virtual">
+		<method name="_font_set_descent" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="descent" type="float" />
 			<description>
-				[b]Required.[/b]
 				Sets the font descent (number of pixels below the baseline).
 			</description>
 		</method>
@@ -808,7 +720,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="disable_embedded_bitmaps" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code], embedded font bitmap loading is disabled.
 			</description>
 		</method>
@@ -825,25 +736,22 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="face_index" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets an active face index in the TrueType / OpenType collection.
 			</description>
 		</method>
-		<method name="_font_set_fixed_size" qualifiers="virtual">
+		<method name="_font_set_fixed_size" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="fixed_size" type="int" />
 			<description>
-				[b]Required.[/b]
 				Sets bitmap font fixed size. If set to value greater than zero, same cache entry will be used for all font sizes.
 			</description>
 		</method>
-		<method name="_font_set_fixed_size_scale_mode" qualifiers="virtual">
+		<method name="_font_set_fixed_size_scale_mode" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="fixed_size_scale_mode" type="int" enum="TextServer.FixedSizeScaleMode" />
 			<description>
-				[b]Required.[/b]
 				Sets bitmap font scaling mode. This property is used only if [code]fixed_size[/code] is greater than zero.
 			</description>
 		</method>
@@ -852,7 +760,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="force_autohinter" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code] auto-hinting is preferred over font built-in hinting.
 			</description>
 		</method>
@@ -861,7 +768,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="generate_mipmaps" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code] font texture mipmap generation is enabled.
 			</description>
 		</method>
@@ -869,62 +775,56 @@
 			<return type="void" />
 			<param index="0" name="oversampling" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Sets oversampling factor, shared by all font in the TextServer.
 			</description>
 		</method>
-		<method name="_font_set_glyph_advance" qualifiers="virtual">
+		<method name="_font_set_glyph_advance" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="advance" type="Vector2" />
 			<description>
-				[b]Required.[/b]
 				Sets glyph advance (offset of the next glyph).
 			</description>
 		</method>
-		<method name="_font_set_glyph_offset" qualifiers="virtual">
+		<method name="_font_set_glyph_offset" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="offset" type="Vector2" />
 			<description>
-				[b]Required.[/b]
 				Sets glyph offset from the baseline.
 			</description>
 		</method>
-		<method name="_font_set_glyph_size" qualifiers="virtual">
+		<method name="_font_set_glyph_size" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="gl_size" type="Vector2" />
 			<description>
-				[b]Required.[/b]
 				Sets size of the glyph.
 			</description>
 		</method>
-		<method name="_font_set_glyph_texture_idx" qualifiers="virtual">
+		<method name="_font_set_glyph_texture_idx" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="texture_idx" type="int" />
 			<description>
-				[b]Required.[/b]
 				Sets index of the cache texture containing the glyph.
 			</description>
 		</method>
-		<method name="_font_set_glyph_uv_rect" qualifiers="virtual">
+		<method name="_font_set_glyph_uv_rect" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="glyph" type="int" />
 			<param index="3" name="uv_rect" type="Rect2" />
 			<description>
-				[b]Required.[/b]
 				Sets rectangle in the cache texture containing the glyph.
 			</description>
 		</method>
@@ -933,7 +833,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="hinting" type="int" enum="TextServer.Hinting" />
 			<description>
-				[b]Optional.[/b]
 				Sets font hinting mode. Used by dynamic fonts only.
 			</description>
 		</method>
@@ -942,7 +841,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="keep_rounding_remainders" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				Sets glyph position rounding behavior. If set to [code]true[/code], when aligning glyphs to the pixel boundaries rounding remainders are accumulated to ensure more uniform glyph distribution. This setting has no effect if subpixel positioning is enabled.
 			</description>
 		</method>
@@ -953,7 +851,6 @@
 			<param index="2" name="glyph_pair" type="Vector2i" />
 			<param index="3" name="kerning" type="Vector2" />
 			<description>
-				[b]Optional.[/b]
 				Sets kerning for the pair of glyphs.
 			</description>
 		</method>
@@ -963,7 +860,6 @@
 			<param index="1" name="language" type="String" />
 			<param index="2" name="supported" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				Adds override for [method _font_is_language_supported].
 			</description>
 		</method>
@@ -972,7 +868,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="modulate" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code], color modulation is applied when drawing colored glyphs, otherwise it's applied to the monochrome glyphs only.
 			</description>
 		</method>
@@ -981,7 +876,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf_pixel_range" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets the width of the range around the shape between the minimum and maximum representable signed distance.
 			</description>
 		</method>
@@ -990,7 +884,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf_size" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets source font size used to generate MSDF textures.
 			</description>
 		</method>
@@ -999,7 +892,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="msdf" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data. MSDF rendering allows displaying the font at any scaling factor without blurriness, and without incurring a CPU cost when the font size changes (since the font no longer needs to be rasterized on the CPU). As a downside, font hinting is not available with MSDF. The lack of font hinting may result in less crisp and less readable fonts at small sizes.
 			</description>
 		</method>
@@ -1008,7 +900,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="name" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Sets the font family name.
 			</description>
 		</method>
@@ -1017,7 +908,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="overrides" type="Dictionary" />
 			<description>
-				[b]Optional.[/b]
 				Sets font OpenType feature set override.
 			</description>
 		</method>
@@ -1026,17 +916,15 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="oversampling" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Sets font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
-		<method name="_font_set_scale" qualifiers="virtual">
+		<method name="_font_set_scale" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="scale" type="float" />
 			<description>
-				[b]Required.[/b]
 				Sets scaling factor of the color bitmap font.
 			</description>
 		</method>
@@ -1046,7 +934,6 @@
 			<param index="1" name="script" type="String" />
 			<param index="2" name="supported" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				Adds override for [method _font_is_script_supported].
 			</description>
 		</method>
@@ -1056,7 +943,6 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets the spacing for [param spacing] to [param value] in pixels (not relative to the font size).
 			</description>
 		</method>
@@ -1065,7 +951,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="stretch" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets font stretch amount, compared to a normal width. A percentage value between [code]50%[/code] and [code]200%[/code].
 			</description>
 		</method>
@@ -1074,7 +959,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="style" type="int" enum="TextServer.FontStyle" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Sets the font style flags.
 			</description>
 		</method>
@@ -1083,7 +967,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="name_style" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Sets the font style name.
 			</description>
 		</method>
@@ -1092,18 +975,16 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="subpixel_positioning" type="int" enum="TextServer.SubpixelPositioning" />
 			<description>
-				[b]Optional.[/b]
 				Sets font subpixel glyph positioning mode.
 			</description>
 		</method>
-		<method name="_font_set_texture_image" qualifiers="virtual">
+		<method name="_font_set_texture_image" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="Vector2i" />
 			<param index="2" name="texture_index" type="int" />
 			<param index="3" name="image" type="Image" />
 			<description>
-				[b]Required.[/b]
 				Sets font cache texture image data.
 			</description>
 		</method>
@@ -1114,7 +995,6 @@
 			<param index="2" name="texture_index" type="int" />
 			<param index="3" name="offset" type="PackedInt32Array" />
 			<description>
-				[b]Optional.[/b]
 				Sets array containing glyph packing data.
 			</description>
 		</method>
@@ -1123,27 +1003,24 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
-				[b]Optional.[/b]
 				Sets 2D transform, applied to the font outlines, can be used for slanting, flipping, and rotating glyphs.
 			</description>
 		</method>
-		<method name="_font_set_underline_position" qualifiers="virtual">
+		<method name="_font_set_underline_position" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_position" type="float" />
 			<description>
-				[b]Required.[/b]
 				Sets pixel offset of the underline below the baseline.
 			</description>
 		</method>
-		<method name="_font_set_underline_thickness" qualifiers="virtual">
+		<method name="_font_set_underline_thickness" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="size" type="int" />
 			<param index="2" name="underline_thickness" type="float" />
 			<description>
-				[b]Required.[/b]
 				Sets thickness of the underline in pixels.
 			</description>
 		</method>
@@ -1152,7 +1029,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="variation_coordinates" type="Dictionary" />
 			<description>
-				[b]Optional.[/b]
 				Sets variation coordinates for the specified font cache entry.
 			</description>
 		</method>
@@ -1161,7 +1037,6 @@
 			<param index="0" name="font_rid" type="RID" />
 			<param index="1" name="weight" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets weight (boldness) of the font. A value in the [code]100...999[/code] range, normal font weight is [code]400[/code], bold font weight is [code]700[/code].
 			</description>
 		</method>
@@ -1169,7 +1044,6 @@
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns the dictionary of the supported OpenType features.
 			</description>
 		</method>
@@ -1177,7 +1051,6 @@
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns the dictionary of the supported OpenType variation coordinates.
 			</description>
 		</method>
@@ -1186,22 +1059,19 @@
 			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Converts a number from the Western Arabic (0..9) to the numeral systems used in [param language].
 			</description>
 		</method>
-		<method name="_free_rid" qualifiers="virtual">
+		<method name="_free_rid" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Frees an object created by this [TextServer].
 			</description>
 		</method>
-		<method name="_get_features" qualifiers="virtual const">
+		<method name="_get_features" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns text server features, see [enum TextServer.Feature].
 			</description>
 		</method>
@@ -1210,51 +1080,44 @@
 			<param index="0" name="size" type="int" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns size of the replacement character (box with character hexadecimal code that is drawn in place of invalid characters).
 			</description>
 		</method>
-		<method name="_get_name" qualifiers="virtual const">
+		<method name="_get_name" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
-				[b]Required.[/b]
 				Returns the name of the server interface.
 			</description>
 		</method>
 		<method name="_get_support_data" qualifiers="virtual const">
 			<return type="PackedByteArray" />
 			<description>
-				[b]Optional.[/b]
 				Returns default TextServer database (e.g. ICU break iterators and dictionaries).
 			</description>
 		</method>
 		<method name="_get_support_data_filename" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns default TextServer database (e.g. ICU break iterators and dictionaries) filename.
 			</description>
 		</method>
 		<method name="_get_support_data_info" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns TextServer database (e.g. ICU break iterators and dictionaries) description.
 			</description>
 		</method>
-		<method name="_has" qualifiers="virtual">
+		<method name="_has" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="rid" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if [param rid] is valid resource owned by this text server.
 			</description>
 		</method>
-		<method name="_has_feature" qualifiers="virtual const">
+		<method name="_has_feature" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="feature" type="int" enum="TextServer.Feature" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if the server supports a feature.
 			</description>
 		</method>
@@ -1263,7 +1126,6 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="dict" type="PackedStringArray" />
 			<description>
-				[b]Optional.[/b]
 				Returns index of the first string in [param dict] which is visually confusable with the [param string], or [code]-1[/code] if none is found.
 			</description>
 		</method>
@@ -1271,7 +1133,6 @@
 			<return type="bool" />
 			<param index="0" name="locale" type="String" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if locale is right-to-left.
 			</description>
 		</method>
@@ -1279,7 +1140,6 @@
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if [param string] is a valid identifier.
 			</description>
 		</method>
@@ -1293,7 +1153,6 @@
 			<return type="bool" />
 			<param index="0" name="filename" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Loads optional TextServer database (e.g. ICU break iterators and dictionaries).
 			</description>
 		</method>
@@ -1301,7 +1160,6 @@
 			<return type="int" />
 			<param index="0" name="name" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Converts readable feature, variation, script, or language name to OpenType tag.
 			</description>
 		</method>
@@ -1310,7 +1168,6 @@
 			<param index="0" name="number" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Converts [param number] from the numeral systems used in [param language] to Western Arabic (0..9).
 			</description>
 		</method>
@@ -1320,7 +1177,6 @@
 			<param index="1" name="args" type="Array" />
 			<param index="2" name="text" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Default implementation of the BiDi algorithm override function.
 			</description>
 		</method>
@@ -1328,7 +1184,6 @@
 			<return type="String" />
 			<param index="0" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns percent sign used in the [param language].
 			</description>
 		</method>
@@ -1336,7 +1191,6 @@
 			<return type="void" />
 			<param index="0" name="oversampling" type="float" />
 			<description>
-				[b]Required.[/b]
 				Increases the reference count of the specified oversampling level. This method is called by [Viewport], and should not be used directly.
 			</description>
 		</method>
@@ -1344,7 +1198,6 @@
 			<return type="bool" />
 			<param index="0" name="filename" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Saves optional TextServer database (e.g. ICU break iterators and dictionaries) to the file.
 			</description>
 		</method>
@@ -1352,7 +1205,6 @@
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns the number of uniform text runs in the buffer.
 			</description>
 		</method>
@@ -1361,7 +1213,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the direction of the [param index] text run (in visual order).
 			</description>
 		</method>
@@ -1370,7 +1221,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the font RID of the [param index] text run (in visual order).
 			</description>
 		</method>
@@ -1379,7 +1229,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the font size of the [param index] text run (in visual order).
 			</description>
 		</method>
@@ -1388,7 +1237,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the language of the [param index] text run (in visual order).
 			</description>
 		</method>
@@ -1397,7 +1245,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the embedded object of the [param index] text run (in visual order).
 			</description>
 		</method>
@@ -1406,7 +1253,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the source text range of the [param index] text run (in visual order).
 			</description>
 		</method>
@@ -1415,63 +1261,56 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the source text of the [param index] text run (in visual order).
 			</description>
 		</method>
-		<method name="_shaped_get_span_count" qualifiers="virtual const">
+		<method name="_shaped_get_span_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns number of text spans added using [method _shaped_text_add_string] or [method _shaped_text_add_object].
 			</description>
 		</method>
-		<method name="_shaped_get_span_embedded_object" qualifiers="virtual const">
+		<method name="_shaped_get_span_embedded_object" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns text embedded object key.
 			</description>
 		</method>
-		<method name="_shaped_get_span_meta" qualifiers="virtual const">
+		<method name="_shaped_get_span_meta" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns text span metadata.
 			</description>
 		</method>
-		<method name="_shaped_get_span_object" qualifiers="virtual const">
+		<method name="_shaped_get_span_object" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the text span embedded object key.
 			</description>
 		</method>
-		<method name="_shaped_get_span_text" qualifiers="virtual const">
+		<method name="_shaped_get_span_text" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns the text span source text.
 			</description>
 		</method>
-		<method name="_shaped_get_text" qualifiers="virtual const">
+		<method name="_shaped_get_text" qualifiers="virtual required const">
 			<return type="String" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns the text buffer source text, including object replacement characters.
 			</description>
 		</method>
-		<method name="_shaped_set_span_update_font" qualifiers="virtual">
+		<method name="_shaped_set_span_update_font" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="index" type="int" />
@@ -1479,11 +1318,10 @@
 			<param index="3" name="size" type="int" />
 			<param index="4" name="opentype_features" type="Dictionary" />
 			<description>
-				[b]Required.[/b]
 				Changes text span font, font size, and OpenType features, without changing the text.
 			</description>
 		</method>
-		<method name="_shaped_text_add_object" qualifiers="virtual">
+		<method name="_shaped_text_add_object" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
@@ -1492,11 +1330,10 @@
 			<param index="4" name="length" type="int" />
 			<param index="5" name="baseline" type="float" />
 			<description>
-				[b]Required.[/b]
 				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
-		<method name="_shaped_text_add_string" qualifiers="virtual">
+		<method name="_shaped_text_add_string" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="text" type="String" />
@@ -1506,15 +1343,13 @@
 			<param index="5" name="language" type="String" />
 			<param index="6" name="meta" type="Variant" />
 			<description>
-				[b]Required.[/b]
 				Adds text span and font to draw it to the text buffer.
 			</description>
 		</method>
-		<method name="_shaped_text_clear" qualifiers="virtual">
+		<method name="_shaped_text_clear" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Clears text buffer (removes text and inline objects).
 			</description>
 		</method>
@@ -1523,7 +1358,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns composite character position closest to the [param pos].
 			</description>
 		</method>
@@ -1537,7 +1371,6 @@
 			<param index="5" name="color" type="Color" />
 			<param index="6" name="oversampling" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Draw shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout). If [param oversampling] is greater than zero, it is used as font oversampling factor, otherwise viewport oversampling settings are used.
 			</description>
 		</method>
@@ -1552,7 +1385,6 @@
 			<param index="6" name="color" type="Color" />
 			<param index="7" name="oversampling" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Draw the outline of the shaped text into a canvas item at a given position, with [param color]. [param pos] specifies the leftmost point of the baseline (for horizontal layout) or topmost point of the baseline (for vertical layout). If [param oversampling] is greater than zero, it is used as font oversampling factor, otherwise viewport oversampling settings are used.
 			</description>
 		</method>
@@ -1562,15 +1394,13 @@
 			<param index="1" name="width" type="float" />
 			<param index="2" name="justification_flags" type="int" enum="TextServer.JustificationFlag" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Adjusts text width to fit to specified width, returns new text width.
 			</description>
 		</method>
-		<method name="_shaped_text_get_ascent" qualifiers="virtual const">
+		<method name="_shaped_text_get_ascent" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns the text ascent (number of pixels above the baseline for horizontal layout or to the left of baseline for vertical).
 			</description>
 		</method>
@@ -1580,7 +1410,6 @@
 			<param index="1" name="position" type="int" />
 			<param index="2" name="caret" type="CaretInfo*" />
 			<description>
-				[b]Optional.[/b]
 				Returns shapes of the carets corresponding to the character offset [param position] in the text. Returned caret shape is 1 pixel wide rectangle.
 			</description>
 		</method>
@@ -1588,7 +1417,6 @@
 			<return type="PackedInt32Array" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns array of the composite character boundaries.
 			</description>
 		</method>
@@ -1596,7 +1424,6 @@
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns ellipsis character used for text clipping.
 			</description>
 		</method>
@@ -1604,15 +1431,13 @@
 			<return type="String" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns custom punctuation character list, used for word breaking. If set to empty string, server defaults are used.
 			</description>
 		</method>
-		<method name="_shaped_text_get_descent" qualifiers="virtual const">
+		<method name="_shaped_text_get_descent" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns the text descent (number of pixels below the baseline for horizontal layout or to the right of baseline for vertical).
 			</description>
 		</method>
@@ -1620,7 +1445,6 @@
 			<return type="int" enum="TextServer.Direction" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns direction of the text.
 			</description>
 		</method>
@@ -1630,47 +1454,41 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="end" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns dominant direction of in the range of text.
 			</description>
 		</method>
-		<method name="_shaped_text_get_ellipsis_glyph_count" qualifiers="virtual const">
+		<method name="_shaped_text_get_ellipsis_glyph_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns number of glyphs in the ellipsis.
 			</description>
 		</method>
-		<method name="_shaped_text_get_ellipsis_glyphs" qualifiers="virtual const">
+		<method name="_shaped_text_get_ellipsis_glyphs" qualifiers="virtual required const">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns array of the glyphs in the ellipsis.
 			</description>
 		</method>
-		<method name="_shaped_text_get_ellipsis_pos" qualifiers="virtual const">
+		<method name="_shaped_text_get_ellipsis_pos" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns position of the ellipsis.
 			</description>
 		</method>
-		<method name="_shaped_text_get_glyph_count" qualifiers="virtual const">
+		<method name="_shaped_text_get_glyph_count" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns number of glyphs in the buffer.
 			</description>
 		</method>
-		<method name="_shaped_text_get_glyphs" qualifiers="virtual const">
+		<method name="_shaped_text_get_glyphs" qualifiers="virtual required const">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns an array of glyphs in the visual order.
 			</description>
 		</method>
@@ -1679,7 +1497,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns composite character's bounds as offsets from the start of the line.
 			</description>
 		</method>
@@ -1687,7 +1504,6 @@
 			<return type="int" enum="TextServer.Direction" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns direction of the text, inferred by the BiDi algorithm.
 			</description>
 		</method>
@@ -1698,7 +1514,6 @@
 			<param index="2" name="start" type="int" />
 			<param index="3" name="break_flags" type="int" enum="TextServer.LineBreakFlag" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Breaks text to the lines and returns character ranges for each line.
 			</description>
 		</method>
@@ -1710,42 +1525,37 @@
 			<param index="3" name="once" type="bool" />
 			<param index="4" name="break_flags" type="int" enum="TextServer.LineBreakFlag" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Breaks text to the lines and columns. Returns character ranges for each segment.
 			</description>
 		</method>
-		<method name="_shaped_text_get_object_glyph" qualifiers="virtual const">
+		<method name="_shaped_text_get_object_glyph" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
 			<description>
-				[b]Required.[/b]
 				Returns the glyph index of the inline object.
 			</description>
 		</method>
-		<method name="_shaped_text_get_object_range" qualifiers="virtual const">
+		<method name="_shaped_text_get_object_range" qualifiers="virtual required const">
 			<return type="Vector2i" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
 			<description>
-				[b]Required.[/b]
 				Returns the character range of the inline object.
 			</description>
 		</method>
-		<method name="_shaped_text_get_object_rect" qualifiers="virtual const">
+		<method name="_shaped_text_get_object_rect" qualifiers="virtual required const">
 			<return type="Rect2" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
 			<description>
-				[b]Required.[/b]
 				Returns bounding rectangle of the inline object.
 			</description>
 		</method>
-		<method name="_shaped_text_get_objects" qualifiers="virtual const">
+		<method name="_shaped_text_get_objects" qualifiers="virtual required const">
 			<return type="Array" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns array of inline objects.
 			</description>
 		</method>
@@ -1753,15 +1563,13 @@
 			<return type="int" enum="TextServer.Orientation" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns text orientation.
 			</description>
 		</method>
-		<method name="_shaped_text_get_parent" qualifiers="virtual const">
+		<method name="_shaped_text_get_parent" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns the parent buffer from which the substring originates.
 			</description>
 		</method>
@@ -1769,7 +1577,6 @@
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if text buffer is configured to display control characters.
 			</description>
 		</method>
@@ -1777,15 +1584,13 @@
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if text buffer is configured to display hexadecimal codes in place of invalid characters.
 			</description>
 		</method>
-		<method name="_shaped_text_get_range" qualifiers="virtual const">
+		<method name="_shaped_text_get_range" qualifiers="virtual required const">
 			<return type="Vector2i" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns substring buffer character range in the parent buffer.
 			</description>
 		</method>
@@ -1795,15 +1600,13 @@
 			<param index="1" name="start" type="int" />
 			<param index="2" name="end" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns selection rectangles for the specified character range.
 			</description>
 		</method>
-		<method name="_shaped_text_get_size" qualifiers="virtual const">
+		<method name="_shaped_text_get_size" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns size of the text.
 			</description>
 		</method>
@@ -1812,39 +1615,34 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<description>
-				[b]Optional.[/b]
 				Returns extra spacing added between glyphs or lines in pixels.
 			</description>
 		</method>
-		<method name="_shaped_text_get_trim_pos" qualifiers="virtual const">
+		<method name="_shaped_text_get_trim_pos" qualifiers="virtual required const">
 			<return type="int" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns the position of the overrun trim.
 			</description>
 		</method>
-		<method name="_shaped_text_get_underline_position" qualifiers="virtual const">
+		<method name="_shaped_text_get_underline_position" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns pixel offset of the underline below the baseline.
 			</description>
 		</method>
-		<method name="_shaped_text_get_underline_thickness" qualifiers="virtual const">
+		<method name="_shaped_text_get_underline_thickness" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns thickness of the underline.
 			</description>
 		</method>
-		<method name="_shaped_text_get_width" qualifiers="virtual const">
+		<method name="_shaped_text_get_width" qualifiers="virtual required const">
 			<return type="float" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns width (for horizontal layout) or height (for vertical) of the text.
 			</description>
 		</method>
@@ -1854,7 +1652,6 @@
 			<param index="1" name="grapheme_flags" type="int" enum="TextServer.GraphemeFlag" is_bitfield="true" />
 			<param index="2" name="skip_grapheme_flags" type="int" enum="TextServer.GraphemeFlag" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Breaks text into words and returns array of character ranges. Use [param grapheme_flags] to set what characters are used for breaking.
 			</description>
 		</method>
@@ -1863,7 +1660,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="coord" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Returns grapheme index at the specified pixel offset at the baseline, or [code]-1[/code] if none is found.
 			</description>
 		</method>
@@ -1872,15 +1668,13 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="coord" type="float" />
 			<description>
-				[b]Optional.[/b]
 				Returns caret character offset at the specified pixel offset at the baseline. This function always returns a valid position.
 			</description>
 		</method>
-		<method name="_shaped_text_is_ready" qualifiers="virtual const">
+		<method name="_shaped_text_is_ready" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns [code]true[/code] if buffer is successfully shaped.
 			</description>
 		</method>
@@ -1889,7 +1683,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns composite character end position closest to the [param pos].
 			</description>
 		</method>
@@ -1898,7 +1691,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns grapheme end position closest to the [param pos].
 			</description>
 		</method>
@@ -1908,7 +1700,6 @@
 			<param index="1" name="width" type="float" />
 			<param index="2" name="trim_flags" type="int" enum="TextServer.TextOverrunFlag" is_bitfield="true" />
 			<description>
-				[b]Optional.[/b]
 				Trims text if it exceeds the given width.
 			</description>
 		</method>
@@ -1917,7 +1708,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns composite character start position closest to the [param pos].
 			</description>
 		</method>
@@ -1926,11 +1716,10 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="pos" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns grapheme start position closest to the [param pos].
 			</description>
 		</method>
-		<method name="_shaped_text_resize_object" qualifiers="virtual">
+		<method name="_shaped_text_resize_object" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="key" type="Variant" />
@@ -1938,7 +1727,6 @@
 			<param index="3" name="inline_align" type="int" enum="InlineAlignment" />
 			<param index="4" name="baseline" type="float" />
 			<description>
-				[b]Required.[/b]
 				Sets new size and alignment of embedded object.
 			</description>
 		</method>
@@ -1947,7 +1735,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="override" type="Array" />
 			<description>
-				[b]Optional.[/b]
 				Overrides BiDi for the structured text.
 			</description>
 		</method>
@@ -1956,7 +1743,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="char" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets ellipsis character used for text clipping.
 			</description>
 		</method>
@@ -1965,7 +1751,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="punct" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Sets custom punctuation character list, used for word breaking. If set to empty string, server defaults are used.
 			</description>
 		</method>
@@ -1974,7 +1759,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="direction" type="int" enum="TextServer.Direction" />
 			<description>
-				[b]Optional.[/b]
 				Sets desired text direction. If set to [constant TextServer.DIRECTION_AUTO], direction will be detected based on the buffer contents and current locale.
 			</description>
 		</method>
@@ -1983,7 +1767,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="orientation" type="int" enum="TextServer.Orientation" />
 			<description>
-				[b]Optional.[/b]
 				Sets desired text orientation.
 			</description>
 		</method>
@@ -1992,7 +1775,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code] text buffer will display control characters.
 			</description>
 		</method>
@@ -2001,7 +1783,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="enabled" type="bool" />
 			<description>
-				[b]Optional.[/b]
 				If set to [code]true[/code] text buffer will display invalid characters as hexadecimal codes, otherwise nothing is displayed.
 			</description>
 		</method>
@@ -2011,33 +1792,29 @@
 			<param index="1" name="spacing" type="int" enum="TextServer.SpacingType" />
 			<param index="2" name="value" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Sets extra spacing added between glyphs or lines in pixels.
 			</description>
 		</method>
-		<method name="_shaped_text_shape" qualifiers="virtual">
+		<method name="_shaped_text_shape" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Shapes buffer if it's not shaped. Returns [code]true[/code] if the string is shaped successfully.
 			</description>
 		</method>
-		<method name="_shaped_text_sort_logical" qualifiers="virtual">
+		<method name="_shaped_text_sort_logical" qualifiers="virtual required">
 			<return type="const Glyph*" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Required.[/b]
 				Returns text glyphs in the logical order.
 			</description>
 		</method>
-		<method name="_shaped_text_substr" qualifiers="virtual const">
+		<method name="_shaped_text_substr" qualifiers="virtual required const">
 			<return type="RID" />
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="start" type="int" />
 			<param index="2" name="length" type="int" />
 			<description>
-				[b]Required.[/b]
 				Returns text buffer for the substring of the text in the [param shaped] text buffer (including inline objects).
 			</description>
 		</method>
@@ -2046,7 +1823,6 @@
 			<param index="0" name="shaped" type="RID" />
 			<param index="1" name="tab_stops" type="PackedFloat32Array" />
 			<description>
-				[b]Optional.[/b]
 				Aligns shaped text to the given tab-stops.
 			</description>
 		</method>
@@ -2054,7 +1830,6 @@
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Updates break points in the shaped text. This method is called by default implementation of text breaking functions.
 			</description>
 		</method>
@@ -2062,7 +1837,6 @@
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
 			<description>
-				[b]Optional.[/b]
 				Updates justification points in the shaped text. This method is called by default implementation of text justification functions.
 			</description>
 		</method>
@@ -2070,7 +1844,6 @@
 			<return type="bool" />
 			<param index="0" name="string" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns [code]true[/code] if [param string] is likely to be an attempt at confusing the reader.
 			</description>
 		</method>
@@ -2079,7 +1852,6 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns array of the composite character boundaries.
 			</description>
 		</method>
@@ -2089,7 +1861,6 @@
 			<param index="1" name="language" type="String" />
 			<param index="2" name="chars_per_line" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Returns an array of the word break boundaries. Elements in the returned array are the offsets of the start and end of words. Therefore the length of the array is always even.
 			</description>
 		</method>
@@ -2098,7 +1869,6 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns the string converted to lowercase.
 			</description>
 		</method>
@@ -2107,7 +1877,6 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns the string converted to title case.
 			</description>
 		</method>
@@ -2116,7 +1885,6 @@
 			<param index="0" name="string" type="String" />
 			<param index="1" name="language" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Returns the string converted to uppercase.
 			</description>
 		</method>
@@ -2124,7 +1892,6 @@
 			<return type="String" />
 			<param index="0" name="string" type="String" />
 			<description>
-				[b]Optional.[/b]
 				Strips diacritics from the string.
 			</description>
 		</method>
@@ -2132,7 +1899,6 @@
 			<return type="String" />
 			<param index="0" name="tag" type="int" />
 			<description>
-				[b]Optional.[/b]
 				Converts OpenType tag to readable feature, variation, script, or language name.
 			</description>
 		</method>
@@ -2140,7 +1906,6 @@
 			<return type="void" />
 			<param index="0" name="oversampling" type="float" />
 			<description>
-				[b]Required.[/b]
 				Decreases the reference count of the specified oversampling level, and frees the font cache for oversampling level when the reference count reaches zero. This method is called by [Viewport], and should not be used directly.
 			</description>
 		</method>

--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -48,13 +48,13 @@
 				[b]Note:[/b] This is only used in 2D rendering, not 3D.
 			</description>
 		</method>
-		<method name="_get_height" qualifiers="virtual const">
+		<method name="_get_height" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [Texture2D]'s height is queried.
 			</description>
 		</method>
-		<method name="_get_width" qualifiers="virtual const">
+		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [Texture2D]'s width is queried.

--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -11,37 +11,37 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_data" qualifiers="virtual const">
+		<method name="_get_data" qualifiers="virtual required const">
 			<return type="Image[]" />
 			<description>
 				Called when the [Texture3D]'s data is queried.
 			</description>
 		</method>
-		<method name="_get_depth" qualifiers="virtual const">
+		<method name="_get_depth" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [Texture3D]'s depth is queried.
 			</description>
 		</method>
-		<method name="_get_format" qualifiers="virtual const">
+		<method name="_get_format" qualifiers="virtual required const">
 			<return type="int" enum="Image.Format" />
 			<description>
 				Called when the [Texture3D]'s format is queried.
 			</description>
 		</method>
-		<method name="_get_height" qualifiers="virtual const">
+		<method name="_get_height" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [Texture3D]'s height is queried.
 			</description>
 		</method>
-		<method name="_get_width" qualifiers="virtual const">
+		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [Texture3D]'s width is queried.
 			</description>
 		</method>
-		<method name="_has_mipmaps" qualifiers="virtual const">
+		<method name="_has_mipmaps" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Called when the presence of mipmaps in the [Texture3D] is queried.

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -13,44 +13,44 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_format" qualifiers="virtual const">
+		<method name="_get_format" qualifiers="virtual required const">
 			<return type="int" enum="Image.Format" />
 			<description>
 				Called when the [TextureLayered]'s format is queried.
 			</description>
 		</method>
-		<method name="_get_height" qualifiers="virtual const">
+		<method name="_get_height" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [TextureLayered]'s height is queried.
 			</description>
 		</method>
-		<method name="_get_layer_data" qualifiers="virtual const">
+		<method name="_get_layer_data" qualifiers="virtual required const">
 			<return type="Image" />
 			<param index="0" name="layer_index" type="int" />
 			<description>
 				Called when the data for a layer in the [TextureLayered] is queried.
 			</description>
 		</method>
-		<method name="_get_layered_type" qualifiers="virtual const">
+		<method name="_get_layered_type" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the layers' type in the [TextureLayered] is queried.
 			</description>
 		</method>
-		<method name="_get_layers" qualifiers="virtual const">
+		<method name="_get_layers" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the number of layers in the [TextureLayered] is queried.
 			</description>
 		</method>
-		<method name="_get_width" qualifiers="virtual const">
+		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 				Called when the [TextureLayered]'s width queried.
 			</description>
 		</method>
-		<method name="_has_mipmaps" qualifiers="virtual const">
+		<method name="_has_mipmaps" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Called when the presence of mipmaps in the [TextureLayered] is queried.

--- a/doc/classes/VideoStreamPlayback.xml
+++ b/doc/classes/VideoStreamPlayback.xml
@@ -84,7 +84,7 @@
 				Stops playback. May be called multiple times before [method _play], or in response to [method VideoStreamPlayer.stop]. [method _is_playing] should return [code]false[/code] once stopped.
 			</description>
 		</method>
-		<method name="_update" qualifiers="virtual">
+		<method name="_update" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<description>

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -59,6 +59,7 @@ BASE_STRINGS = [
     "value",
     "Getter",
     "This method should typically be overridden by the user to have any effect.",
+    "This method is required to be overridden when extending its base class.",
     "This method has no side effects. It doesn't modify any of the instance's member variables.",
     "This method accepts any number of arguments after the ones described here.",
     "This method is used to construct a type.",
@@ -1663,6 +1664,7 @@ def make_footer() -> str:
     # Generate reusable abbreviation substitutions.
     # This way, we avoid bloating the generated rST with duplicate abbreviations.
     virtual_msg = translate("This method should typically be overridden by the user to have any effect.")
+    required_msg = translate("This method is required to be overridden when extending its base class.")
     const_msg = translate("This method has no side effects. It doesn't modify any of the instance's member variables.")
     vararg_msg = translate("This method accepts any number of arguments after the ones described here.")
     constructor_msg = translate("This method is used to construct a type.")
@@ -1675,6 +1677,7 @@ def make_footer() -> str:
 
     return (
         f".. |virtual| replace:: :abbr:`virtual ({virtual_msg})`\n"
+        f".. |required| replace:: :abbr:`required ({required_msg})`\n"
         f".. |const| replace:: :abbr:`const ({const_msg})`\n"
         f".. |vararg| replace:: :abbr:`vararg ({vararg_msg})`\n"
         f".. |constructor| replace:: :abbr:`constructor ({constructor_msg})`\n"

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -148,6 +148,8 @@ static void _add_qualifiers_to_rt(const String &p_qualifiers, RichTextLabel *p_r
 			hint = TTR("This method supports a variable number of arguments.");
 		} else if (qualifier == "virtual") {
 			hint = TTR("This method is called by the engine.\nIt can be overridden to customize built-in behavior.");
+		} else if (qualifier == "required") {
+			hint = TTR("This method is required to be overridden when extending its base class.");
 		} else if (qualifier == "const") {
 			hint = TTR("This method has no side effects.\nIt does not modify the object in any way.");
 		} else if (qualifier == "static") {

--- a/modules/openxr/doc_classes/OpenXRBindingModifier.xml
+++ b/modules/openxr/doc_classes/OpenXRBindingModifier.xml
@@ -9,13 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_description" qualifiers="virtual const">
+		<method name="_get_description" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 				Return the description of this class that is used for the title bar of the binding modifier editor.
 			</description>
 		</method>
-		<method name="_get_ip_modification" qualifiers="virtual">
+		<method name="_get_ip_modification" qualifiers="virtual required">
 			<return type="PackedByteArray" />
 			<description>
 				Returns the data that is sent to OpenXR when submitting the suggested interacting bindings this modifier is a part of.

--- a/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCDataChannelExtension.xml
@@ -7,42 +7,42 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_close" qualifiers="virtual">
+		<method name="_close" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_available_packet_count" qualifiers="virtual const">
+		<method name="_get_available_packet_count" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_buffered_amount" qualifiers="virtual const">
+		<method name="_get_buffered_amount" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_id" qualifiers="virtual const">
+		<method name="_get_id" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_label" qualifiers="virtual const">
+		<method name="_get_label" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_max_packet_life_time" qualifiers="virtual const">
+		<method name="_get_max_packet_life_time" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_max_packet_size" qualifiers="virtual const">
+		<method name="_get_max_packet_size" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_max_retransmits" qualifiers="virtual const">
+		<method name="_get_max_retransmits" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
 			</description>
@@ -54,32 +54,32 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_protocol" qualifiers="virtual const">
+		<method name="_get_protocol" qualifiers="virtual required const">
 			<return type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_ready_state" qualifiers="virtual const">
+		<method name="_get_ready_state" qualifiers="virtual required const">
 			<return type="int" enum="WebRTCDataChannel.ChannelState" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_write_mode" qualifiers="virtual const">
+		<method name="_get_write_mode" qualifiers="virtual required const">
 			<return type="int" enum="WebRTCDataChannel.WriteMode" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_negotiated" qualifiers="virtual const">
+		<method name="_is_negotiated" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_is_ordered" qualifiers="virtual const">
+		<method name="_is_ordered" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>
 		</method>
-		<method name="_poll" qualifiers="virtual">
+		<method name="_poll" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<description>
 			</description>
@@ -91,13 +91,13 @@
 			<description>
 			</description>
 		</method>
-		<method name="_set_write_mode" qualifiers="virtual">
+		<method name="_set_write_mode" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="p_write_mode" type="int" enum="WebRTCDataChannel.WriteMode" />
 			<description>
 			</description>
 		</method>
-		<method name="_was_string_packet" qualifiers="virtual const">
+		<method name="_was_string_packet" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 			</description>

--- a/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_add_ice_candidate" qualifiers="virtual">
+		<method name="_add_ice_candidate" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_sdp_mid_name" type="String" />
 			<param index="1" name="p_sdp_mline_index" type="int" />
@@ -15,57 +15,57 @@
 			<description>
 			</description>
 		</method>
-		<method name="_close" qualifiers="virtual">
+		<method name="_close" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 			</description>
 		</method>
-		<method name="_create_data_channel" qualifiers="virtual">
+		<method name="_create_data_channel" qualifiers="virtual required">
 			<return type="WebRTCDataChannel" />
 			<param index="0" name="p_label" type="String" />
 			<param index="1" name="p_config" type="Dictionary" />
 			<description>
 			</description>
 		</method>
-		<method name="_create_offer" qualifiers="virtual">
+		<method name="_create_offer" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_connection_state" qualifiers="virtual const">
+		<method name="_get_connection_state" qualifiers="virtual required const">
 			<return type="int" enum="WebRTCPeerConnection.ConnectionState" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_gathering_state" qualifiers="virtual const">
+		<method name="_get_gathering_state" qualifiers="virtual required const">
 			<return type="int" enum="WebRTCPeerConnection.GatheringState" />
 			<description>
 			</description>
 		</method>
-		<method name="_get_signaling_state" qualifiers="virtual const">
+		<method name="_get_signaling_state" qualifiers="virtual required const">
 			<return type="int" enum="WebRTCPeerConnection.SignalingState" />
 			<description>
 			</description>
 		</method>
-		<method name="_initialize" qualifiers="virtual">
+		<method name="_initialize" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_config" type="Dictionary" />
 			<description>
 			</description>
 		</method>
-		<method name="_poll" qualifiers="virtual">
+		<method name="_poll" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_local_description" qualifiers="virtual">
+		<method name="_set_local_description" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_type" type="String" />
 			<param index="1" name="p_sdp" type="String" />
 			<description>
 			</description>
 		</method>
-		<method name="_set_remote_description" qualifiers="virtual">
+		<method name="_set_remote_description" qualifiers="virtual required">
 			<return type="int" enum="Error" />
 			<param index="0" name="p_type" type="String" />
 			<param index="1" name="p_sdp" type="String" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/9824

Whether a virtual method is required has been marked by #93311. This PR:

- Makes editor help & online doc show a `required` qualifier next to `virtual` if the method is required.
- Removes the manually added `[b]Optional.[/b]` and `[b]Required.[/b]` from the descriptions of related methods.