### PR TITLE
Fix crash when inspecting Variant export variable

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -1107,7 +1107,7 @@ void EditorSettingsPropertyWrapper::setup(const String &p_property, EditorProper
 }
 
 bool EditorSettingsInspectorPlugin::can_handle(Object *p_object) {
-	return p_object->is_class("SectionedInspectorFilter") && p_object != current_object;
+	return p_object && p_object->is_class("SectionedInspectorFilter") && p_object != current_object;
 }
 
 bool EditorSettingsInspectorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {


### PR DESCRIPTION
Fixes regression from #69012.

The argument of `can_handle()` could be null when handling `Variant` export variable.

https://github.com/godotengine/godot/blob/978b38797ba8e8757592f21101e32e364d60662d/editor/editor_properties.cpp#L123-L127