### PR TITLE
Rename server `free` functions to `free_rid` to match exposed API

### DIFF
--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1699,7 +1699,7 @@ void AnimationPlayerEditor::_allocate_onion_layers() {
 void AnimationPlayerEditor::_free_onion_layers() {
 	for (uint32_t i = 0; i < onion.captures.size(); i++) {
 		if (onion.captures[i].is_valid()) {
-			RS::get_singleton()->free(onion.captures[i]);
+			RS::get_singleton()->free_rid(onion.captures[i]);
 		}
 	}
 	onion.captures.clear();
@@ -2283,8 +2283,8 @@ void fragment() {
 
 AnimationPlayerEditor::~AnimationPlayerEditor() {
 	_free_onion_layers();
-	RS::get_singleton()->free(onion.capture.canvas);
-	RS::get_singleton()->free(onion.capture.canvas_item);
+	RS::get_singleton()->free_rid(onion.capture.canvas);
+	RS::get_singleton()->free_rid(onion.capture.canvas_item);
 	onion.capture = {};
 }
 

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -213,18 +213,18 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 		ERR_CONTINUE(img.is_null() || img->is_empty());
 		Ref<ImageTexture> it = ImageTexture::create_from_image(img);
 
-		RS::get_singleton()->free(inst);
+		RS::get_singleton()->free_rid(inst);
 
 		textures.push_back(it);
 	}
 
-	RS::get_singleton()->free(viewport);
-	RS::get_singleton()->free(light);
-	RS::get_singleton()->free(light_instance);
-	RS::get_singleton()->free(light2);
-	RS::get_singleton()->free(light_instance2);
-	RS::get_singleton()->free(camera);
-	RS::get_singleton()->free(scenario);
+	RS::get_singleton()->free_rid(viewport);
+	RS::get_singleton()->free_rid(light);
+	RS::get_singleton()->free_rid(light_instance);
+	RS::get_singleton()->free_rid(light2);
+	RS::get_singleton()->free_rid(light_instance2);
+	RS::get_singleton()->free_rid(camera);
+	RS::get_singleton()->free_rid(scenario);
 
 	return textures;
 }

--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -467,16 +467,16 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 
 EditorMaterialPreviewPlugin::~EditorMaterialPreviewPlugin() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(sphere);
-	RS::get_singleton()->free(sphere_instance);
-	RS::get_singleton()->free(viewport);
-	RS::get_singleton()->free(light);
-	RS::get_singleton()->free(light_instance);
-	RS::get_singleton()->free(light2);
-	RS::get_singleton()->free(light_instance2);
-	RS::get_singleton()->free(camera);
-	RS::get_singleton()->free(camera_attributes);
-	RS::get_singleton()->free(scenario);
+	RS::get_singleton()->free_rid(sphere);
+	RS::get_singleton()->free_rid(sphere_instance);
+	RS::get_singleton()->free_rid(viewport);
+	RS::get_singleton()->free_rid(light);
+	RS::get_singleton()->free_rid(light_instance);
+	RS::get_singleton()->free_rid(light2);
+	RS::get_singleton()->free_rid(light_instance2);
+	RS::get_singleton()->free_rid(camera);
+	RS::get_singleton()->free_rid(camera_attributes);
+	RS::get_singleton()->free_rid(scenario);
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -811,15 +811,15 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 EditorMeshPreviewPlugin::~EditorMeshPreviewPlugin() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	//RS::get_singleton()->free(sphere);
-	RS::get_singleton()->free(mesh_instance);
-	RS::get_singleton()->free(viewport);
-	RS::get_singleton()->free(light);
-	RS::get_singleton()->free(light_instance);
-	RS::get_singleton()->free(light2);
-	RS::get_singleton()->free(light_instance2);
-	RS::get_singleton()->free(camera);
-	RS::get_singleton()->free(camera_attributes);
-	RS::get_singleton()->free(scenario);
+	RS::get_singleton()->free_rid(mesh_instance);
+	RS::get_singleton()->free_rid(viewport);
+	RS::get_singleton()->free_rid(light);
+	RS::get_singleton()->free_rid(light_instance);
+	RS::get_singleton()->free_rid(light2);
+	RS::get_singleton()->free_rid(light_instance2);
+	RS::get_singleton()->free_rid(camera);
+	RS::get_singleton()->free_rid(camera_attributes);
+	RS::get_singleton()->free_rid(scenario);
 }
 
 ///////////////////////////////////////////////////////////////////////////
@@ -903,9 +903,9 @@ EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
 
 EditorFontPreviewPlugin::~EditorFontPreviewPlugin() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(canvas_item);
-	RS::get_singleton()->free(canvas);
-	RS::get_singleton()->free(viewport);
+	RS::get_singleton()->free_rid(canvas_item);
+	RS::get_singleton()->free_rid(canvas);
+	RS::get_singleton()->free_rid(viewport);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -975,11 +975,11 @@ Path2DEditor::Path2DEditor() {
 
 Path2DEditor::~Path2DEditor() {
 	ERR_FAIL_NULL(RS::get_singleton());
-	RS::get_singleton()->free(debug_mesh_rid);
-	RS::get_singleton()->free(debug_handle_curve_multimesh_rid);
-	RS::get_singleton()->free(debug_handle_sharp_multimesh_rid);
-	RS::get_singleton()->free(debug_handle_smooth_multimesh_rid);
-	RS::get_singleton()->free(debug_handle_mesh_rid);
+	RS::get_singleton()->free_rid(debug_mesh_rid);
+	RS::get_singleton()->free_rid(debug_handle_curve_multimesh_rid);
+	RS::get_singleton()->free_rid(debug_handle_sharp_multimesh_rid);
+	RS::get_singleton()->free_rid(debug_handle_smooth_multimesh_rid);
+	RS::get_singleton()->free_rid(debug_handle_mesh_rid);
 }
 
 void Path2DEditorPlugin::edit(Object *p_object) {

--- a/editor/scene/2d/tiles/tile_atlas_view.cpp
+++ b/editor/scene/2d/tiles/tile_atlas_view.cpp
@@ -316,12 +316,12 @@ RID TileAtlasView::_get_canvas_item_to_draw(const TileData *p_for_data, const Ca
 
 void TileAtlasView::_clear_material_canvas_items() {
 	for (KeyValue<Ref<Material>, RID> kv : material_tiles_draw) {
-		RS::get_singleton()->free(kv.value);
+		RS::get_singleton()->free_rid(kv.value);
 	}
 	material_tiles_draw.clear();
 
 	for (KeyValue<Ref<Material>, RID> kv : material_alternatives_draw) {
-		RS::get_singleton()->free(kv.value);
+		RS::get_singleton()->free_rid(kv.value);
 	}
 	material_alternatives_draw.clear();
 }

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -61,7 +61,7 @@ void EditorNode3DGizmo::clear() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
-			RS::get_singleton()->free(instances[i].instance);
+			RS::get_singleton()->free_rid(instances[i].instance);
 		}
 	}
 
@@ -828,7 +828,7 @@ void EditorNode3DGizmo::free() {
 
 	for (int i = 0; i < instances.size(); i++) {
 		if (instances[i].instance.is_valid()) {
-			RS::get_singleton()->free(instances[i].instance);
+			RS::get_singleton()->free_rid(instances[i].instance);
 		}
 		instances.write[i].instance = RID();
 	}

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4257,15 +4257,15 @@ void Node3DEditorViewport::_init_gizmo_instance(int p_idx) {
 void Node3DEditorViewport::_finish_gizmo_instances() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	for (int i = 0; i < 3; i++) {
-		RS::get_singleton()->free(move_gizmo_instance[i]);
-		RS::get_singleton()->free(move_plane_gizmo_instance[i]);
-		RS::get_singleton()->free(rotate_gizmo_instance[i]);
-		RS::get_singleton()->free(scale_gizmo_instance[i]);
-		RS::get_singleton()->free(scale_plane_gizmo_instance[i]);
-		RS::get_singleton()->free(axis_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(move_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(move_plane_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(rotate_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(scale_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(scale_plane_gizmo_instance[i]);
+		RS::get_singleton()->free_rid(axis_gizmo_instance[i]);
 	}
 	// Rotation white outline
-	RS::get_singleton()->free(rotate_gizmo_instance[3]);
+	RS::get_singleton()->free_rid(rotate_gizmo_instance[3]);
 }
 
 void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
@@ -6574,16 +6574,16 @@ Node3DEditor *Node3DEditor::singleton = nullptr;
 Node3DEditorSelectedItem::~Node3DEditorSelectedItem() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (sbox_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(sbox_instance);
+		RenderingServer::get_singleton()->free_rid(sbox_instance);
 	}
 	if (sbox_instance_offset.is_valid()) {
-		RenderingServer::get_singleton()->free(sbox_instance_offset);
+		RenderingServer::get_singleton()->free_rid(sbox_instance_offset);
 	}
 	if (sbox_instance_xray.is_valid()) {
-		RenderingServer::get_singleton()->free(sbox_instance_xray);
+		RenderingServer::get_singleton()->free_rid(sbox_instance_xray);
 	}
 	if (sbox_instance_xray_offset.is_valid()) {
-		RenderingServer::get_singleton()->free(sbox_instance_xray_offset);
+		RenderingServer::get_singleton()->free_rid(sbox_instance_xray_offset);
 	}
 }
 
@@ -8191,17 +8191,17 @@ void Node3DEditor::_init_grid() {
 }
 
 void Node3DEditor::_finish_indicators() {
-	RenderingServer::get_singleton()->free(origin_instance);
-	RenderingServer::get_singleton()->free(origin_multimesh);
-	RenderingServer::get_singleton()->free(origin_mesh);
+	RenderingServer::get_singleton()->free_rid(origin_instance);
+	RenderingServer::get_singleton()->free_rid(origin_multimesh);
+	RenderingServer::get_singleton()->free_rid(origin_mesh);
 
 	_finish_grid();
 }
 
 void Node3DEditor::_finish_grid() {
 	for (int i = 0; i < 3; i++) {
-		RenderingServer::get_singleton()->free(grid_instance[i]);
-		RenderingServer::get_singleton()->free(grid[i]);
+		RenderingServer::get_singleton()->free_rid(grid_instance[i]);
+		RenderingServer::get_singleton()->free_rid(grid[i]);
 	}
 }
 

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -248,15 +248,15 @@ void BetsyCompressor::_thread_exit() {
 
 	if (compress_rd != nullptr) {
 		if (dxt1_encoding_table_buffer.is_valid()) {
-			compress_rd->free(dxt1_encoding_table_buffer);
+			compress_rd->free_rid(dxt1_encoding_table_buffer);
 		}
 
-		compress_rd->free(src_sampler);
+		compress_rd->free_rid(src_sampler);
 
 		// Clear the shader cache, pipelines will be unreferenced automatically.
 		for (int i = 0; i < BETSY_SHADER_MAX; i++) {
 			if (cached_shaders[i].compiled.is_valid()) {
-				compress_rd->free(cached_shaders[i].compiled);
+				compress_rd->free_rid(cached_shaders[i].compiled);
 			}
 		}
 
@@ -707,8 +707,8 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 
 			dst_texture_rid = dst_texture_combined;
 
-			compress_rd->free(dst_texture_primary);
-			compress_rd->free(dst_texture_alpha);
+			compress_rd->free_rid(dst_texture_primary);
+			compress_rd->free_rid(dst_texture_alpha);
 		}
 
 		// Copy data from the GPU to the buffer.
@@ -718,8 +718,8 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		memcpy(dst_data_ptr + dst_ofs, texture_data.ptr(), texture_data.size());
 
 		// Free the source and dest texture.
-		compress_rd->free(src_texture);
-		compress_rd->free(dst_texture_rid);
+		compress_rd->free_rid(src_texture);
+		compress_rd->free_rid(dst_texture_rid);
 	}
 
 	src_images.clear();

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -106,7 +106,7 @@ void CSGShape3D::set_use_collision(bool p_enable) {
 		set_collision_priority(collision_priority);
 		_make_dirty(); //force update
 	} else {
-		PhysicsServer3D::get_singleton()->free(root_collision_instance);
+		PhysicsServer3D::get_singleton()->free_rid(root_collision_instance);
 		root_collision_instance = RID();
 		root_collision_shape.unref();
 	}
@@ -809,7 +809,7 @@ void CSGShape3D::_update_debug_collision_shape() {
 
 void CSGShape3D::_clear_debug_collision_shape() {
 	if (root_collision_debug_instance.is_valid()) {
-		RS::get_singleton()->free(root_collision_debug_instance);
+		RS::get_singleton()->free_rid(root_collision_debug_instance);
 		root_collision_debug_instance = RID();
 	}
 }
@@ -913,7 +913,7 @@ void CSGShape3D::_notification(int p_what) {
 
 		case NOTIFICATION_EXIT_TREE: {
 			if (use_collision && is_root_shape() && root_collision_instance.is_valid()) {
-				PhysicsServer3D::get_singleton()->free(root_collision_instance);
+				PhysicsServer3D::get_singleton()->free_rid(root_collision_instance);
 				root_collision_instance = RID();
 				root_collision_shape.unref();
 				_clear_debug_collision_shape();

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1219,7 +1219,7 @@ PhysicsServer2D::JointType GodotPhysicsServer2D::joint_get_type(RID p_joint) con
 	return joint->get_type();
 }
 
-void GodotPhysicsServer2D::free(RID p_rid) {
+void GodotPhysicsServer2D::free_rid(RID p_rid) {
 	_update_shapes(); // just in case
 
 	if (shape_owner.owns(p_rid)) {
@@ -1264,7 +1264,7 @@ void GodotPhysicsServer2D::free(RID p_rid) {
 		}
 
 		active_spaces.erase(space);
-		free(space->get_default_area()->get_self());
+		free_rid(space->get_default_area()->get_self());
 		space_owner.free(p_rid);
 		memdelete(space);
 	} else if (joint_owner.owns(p_rid)) {

--- a/modules/godot_physics_2d/godot_physics_server_2d.h
+++ b/modules/godot_physics_2d/godot_physics_server_2d.h
@@ -285,7 +285,7 @@ public:
 
 	/* MISC */
 
-	virtual void free(RID p_rid) override;
+	virtual void free_rid(RID p_rid) override;
 
 	virtual void set_active(bool p_active) override;
 	virtual void init() override;

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1595,7 +1595,7 @@ bool GodotPhysicsServer3D::generic_6dof_joint_get_flag(RID p_joint, Vector3::Axi
 	return generic_6dof_joint->get_flag(p_axis, p_flag);
 }
 
-void GodotPhysicsServer3D::free(RID p_rid) {
+void GodotPhysicsServer3D::free_rid(RID p_rid) {
 	_update_shapes(); //just in case
 
 	if (shape_owner.owns(p_rid)) {
@@ -1646,8 +1646,8 @@ void GodotPhysicsServer3D::free(RID p_rid) {
 		}
 
 		active_spaces.erase(space);
-		free(space->get_default_area()->get_self());
-		free(space->get_static_global_body());
+		free_rid(space->get_default_area()->get_self());
+		free_rid(space->get_static_global_body());
 
 		space_owner.free(p_rid);
 		memdelete(space);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -371,7 +371,7 @@ public:
 
 	/* MISC */
 
-	virtual void free(RID p_rid) override;
+	virtual void free_rid(RID p_rid) override;
 
 	virtual void set_active(bool p_active) override;
 	virtual void init() override;

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -507,7 +507,7 @@ void GridMapEditor::_clear_clipboard_data() {
 		if (E.instance.is_null()) {
 			continue;
 		}
-		RenderingServer::get_singleton()->free(E.instance);
+		RenderingServer::get_singleton()->free_rid(E.instance);
 	}
 
 	clipboard_items.clear();
@@ -1172,16 +1172,16 @@ void GridMapEditor::_notification(int p_what) {
 			_clear_clipboard_data();
 
 			for (int i = 0; i < 3; i++) {
-				RS::get_singleton()->free(grid_instance[i]);
-				RS::get_singleton()->free(grid[i]);
+				RS::get_singleton()->free_rid(grid_instance[i]);
+				RS::get_singleton()->free_rid(grid[i]);
 				grid_instance[i] = RID();
 				grid[i] = RID();
-				RenderingServer::get_singleton()->free(selection_level_instance[i]);
+				RenderingServer::get_singleton()->free_rid(selection_level_instance[i]);
 			}
 
-			RenderingServer::get_singleton()->free(cursor_instance);
-			RenderingServer::get_singleton()->free(selection_instance);
-			RenderingServer::get_singleton()->free(paste_instance);
+			RenderingServer::get_singleton()->free_rid(cursor_instance);
+			RenderingServer::get_singleton()->free_rid(selection_instance);
+			RenderingServer::get_singleton()->free_rid(paste_instance);
 			cursor_instance = RID();
 			selection_instance = RID();
 			paste_instance = RID();
@@ -1233,7 +1233,7 @@ void GridMapEditor::_update_cursor_instance() {
 	}
 
 	if (cursor_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(cursor_instance);
+		RenderingServer::get_singleton()->free_rid(cursor_instance);
 	}
 	cursor_instance = RID();
 
@@ -1721,32 +1721,32 @@ GridMapEditor::~GridMapEditor() {
 
 	for (int i = 0; i < 3; i++) {
 		if (grid[i].is_valid()) {
-			RenderingServer::get_singleton()->free(grid[i]);
+			RenderingServer::get_singleton()->free_rid(grid[i]);
 		}
 		if (grid_instance[i].is_valid()) {
-			RenderingServer::get_singleton()->free(grid_instance[i]);
+			RenderingServer::get_singleton()->free_rid(grid_instance[i]);
 		}
 		if (selection_level_instance[i].is_valid()) {
-			RenderingServer::get_singleton()->free(selection_level_instance[i]);
+			RenderingServer::get_singleton()->free_rid(selection_level_instance[i]);
 		}
 		if (selection_level_mesh[i].is_valid()) {
-			RenderingServer::get_singleton()->free(selection_level_mesh[i]);
+			RenderingServer::get_singleton()->free_rid(selection_level_mesh[i]);
 		}
 	}
 
-	RenderingServer::get_singleton()->free(cursor_mesh);
+	RenderingServer::get_singleton()->free_rid(cursor_mesh);
 	if (cursor_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(cursor_instance);
+		RenderingServer::get_singleton()->free_rid(cursor_instance);
 	}
 
-	RenderingServer::get_singleton()->free(selection_mesh);
+	RenderingServer::get_singleton()->free_rid(selection_mesh);
 	if (selection_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(selection_instance);
+		RenderingServer::get_singleton()->free_rid(selection_instance);
 	}
 
-	RenderingServer::get_singleton()->free(paste_mesh);
+	RenderingServer::get_singleton()->free_rid(paste_mesh);
 	if (paste_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(paste_instance);
+		RenderingServer::get_singleton()->free_rid(paste_instance);
 	}
 }
 

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -618,11 +618,11 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	//erase navigation
 	for (KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
 		if (E.value.region.is_valid()) {
-			NavigationServer3D::get_singleton()->free(E.value.region);
+			NavigationServer3D::get_singleton()->free_rid(E.value.region);
 			E.value.region = RID();
 		}
 		if (E.value.navigation_mesh_debug_instance.is_valid()) {
-			RS::get_singleton()->free(E.value.navigation_mesh_debug_instance);
+			RS::get_singleton()->free_rid(E.value.navigation_mesh_debug_instance);
 			E.value.navigation_mesh_debug_instance = RID();
 		}
 	}
@@ -632,8 +632,8 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	//erase multimeshes
 
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
-		RS::get_singleton()->free(g.multimesh_instances[i].instance);
-		RS::get_singleton()->free(g.multimesh_instances[i].multimesh);
+		RS::get_singleton()->free_rid(g.multimesh_instances[i].instance);
+		RS::get_singleton()->free_rid(g.multimesh_instances[i].multimesh);
 	}
 	g.multimesh_instances.clear();
 
@@ -945,11 +945,11 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 #ifndef NAVIGATION_3D_DISABLED
 	for (KeyValue<IndexKey, Octant::NavigationCell> &F : g.navigation_cell_ids) {
 		if (F.value.region.is_valid()) {
-			NavigationServer3D::get_singleton()->free(F.value.region);
+			NavigationServer3D::get_singleton()->free_rid(F.value.region);
 			F.value.region = RID();
 		}
 		if (F.value.navigation_mesh_debug_instance.is_valid()) {
-			RS::get_singleton()->free(F.value.navigation_mesh_debug_instance);
+			RS::get_singleton()->free_rid(F.value.navigation_mesh_debug_instance);
 			F.value.navigation_mesh_debug_instance = RID();
 		}
 	}
@@ -958,7 +958,7 @@ void GridMap::_octant_exit_world(const OctantKey &p_key) {
 #ifdef DEBUG_ENABLED
 	if (bake_navigation) {
 		if (g.navigation_debug_edge_connections_instance.is_valid()) {
-			RenderingServer::get_singleton()->free(g.navigation_debug_edge_connections_instance);
+			RenderingServer::get_singleton()->free_rid(g.navigation_debug_edge_connections_instance);
 			g.navigation_debug_edge_connections_instance = RID();
 		}
 		if (g.navigation_debug_edge_connections_mesh.is_valid()) {
@@ -982,23 +982,23 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 
 #ifndef PHYSICS_3D_DISABLED
 	if (g.collision_debug.is_valid()) {
-		RS::get_singleton()->free(g.collision_debug);
+		RS::get_singleton()->free_rid(g.collision_debug);
 	}
 	if (g.collision_debug_instance.is_valid()) {
-		RS::get_singleton()->free(g.collision_debug_instance);
+		RS::get_singleton()->free_rid(g.collision_debug_instance);
 	}
 
-	PhysicsServer3D::get_singleton()->free(g.static_body);
+	PhysicsServer3D::get_singleton()->free_rid(g.static_body);
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
 	// Erase navigation
 	for (const KeyValue<IndexKey, Octant::NavigationCell> &E : g.navigation_cell_ids) {
 		if (E.value.region.is_valid()) {
-			NavigationServer3D::get_singleton()->free(E.value.region);
+			NavigationServer3D::get_singleton()->free_rid(E.value.region);
 		}
 		if (E.value.navigation_mesh_debug_instance.is_valid()) {
-			RS::get_singleton()->free(E.value.navigation_mesh_debug_instance);
+			RS::get_singleton()->free_rid(E.value.navigation_mesh_debug_instance);
 		}
 	}
 	g.navigation_cell_ids.clear();
@@ -1007,7 +1007,7 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 #ifdef DEBUG_ENABLED
 	if (bake_navigation) {
 		if (g.navigation_debug_edge_connections_instance.is_valid()) {
-			RenderingServer::get_singleton()->free(g.navigation_debug_edge_connections_instance);
+			RenderingServer::get_singleton()->free_rid(g.navigation_debug_edge_connections_instance);
 			g.navigation_debug_edge_connections_instance = RID();
 		}
 		if (g.navigation_debug_edge_connections_mesh.is_valid()) {
@@ -1019,8 +1019,8 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 	//erase multimeshes
 
 	for (int i = 0; i < g.multimesh_instances.size(); i++) {
-		RS::get_singleton()->free(g.multimesh_instances[i].instance);
-		RS::get_singleton()->free(g.multimesh_instances[i].multimesh);
+		RS::get_singleton()->free_rid(g.multimesh_instances[i].instance);
+		RS::get_singleton()->free_rid(g.multimesh_instances[i].multimesh);
 	}
 	g.multimesh_instances.clear();
 }
@@ -1349,7 +1349,7 @@ Vector3 GridMap::_get_offset() const {
 void GridMap::clear_baked_meshes() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	for (int i = 0; i < baked_meshes.size(); i++) {
-		RS::get_singleton()->free(baked_meshes[i].instance);
+		RS::get_singleton()->free_rid(baked_meshes[i].instance);
 	}
 	baked_meshes.clear();
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1580,7 +1580,7 @@ bool JoltPhysicsServer3D::joint_is_disabled_collisions_between_bodies(RID p_join
 	return joint->is_collision_disabled();
 }
 
-void JoltPhysicsServer3D::free(RID p_rid) {
+void JoltPhysicsServer3D::free_rid(RID p_rid) {
 	if (JoltShape3D *shape = shape_owner.get_or_null(p_rid)) {
 		free_shape(shape);
 	} else if (JoltBody3D *body = body_owner.get_or_null(p_rid)) {

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -411,7 +411,7 @@ public:
 	virtual void joint_disable_collisions_between_bodies(RID p_joint, bool p_disable) override;
 	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override;
 
-	virtual void free(RID p_rid) override;
+	virtual void free_rid(RID p_rid) override;
 
 	virtual void set_active(bool p_active) override;
 

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -804,7 +804,7 @@ LightmapperRD::BakeError LightmapperRD::_dilate(RenderingDevice *rd, Ref<RDShade
 		//no barrier, let them run all together
 	}
 	rd->compute_list_end();
-	rd->free(compute_shader_dilate);
+	rd->free_rid(compute_shader_dilate);
 
 #ifdef DEBUG_TEXTURES
 	for (int i = 0; i < atlas_slices; i++) {
@@ -841,7 +841,7 @@ LightmapperRD::BakeError LightmapperRD::_pack_l1(RenderingDevice *rd, Ref<RDShad
 		//no barrier, let them run all together
 	}
 	rd->compute_list_end();
-	rd->free(compute_shader_pack);
+	rd->free_rid(compute_shader_pack);
 
 	return BAKE_OK;
 }
@@ -1051,8 +1051,8 @@ LightmapperRD::BakeError LightmapperRD::_denoise(RenderingDevice *p_rd, Ref<RDSh
 		}
 	}
 
-	p_rd->free(compute_shader_denoise);
-	p_rd->free(denoise_params_buffer);
+	p_rd->free_rid(compute_shader_denoise);
+	p_rd->free_rid(denoise_params_buffer);
 
 	return BAKE_OK;
 }
@@ -1167,19 +1167,19 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	RID shadowmask_tex;
 	RID shadowmask_tex2;
 
-#define FREE_TEXTURES                \
-	rd->free(albedo_array_tex);      \
-	rd->free(emission_array_tex);    \
-	rd->free(normal_tex);            \
-	rd->free(position_tex);          \
-	rd->free(unocclude_tex);         \
-	rd->free(light_source_tex);      \
-	rd->free(light_accum_tex2);      \
-	rd->free(light_accum_tex);       \
-	rd->free(light_environment_tex); \
-	if (p_bake_shadowmask) {         \
-		rd->free(shadowmask_tex);    \
-		rd->free(shadowmask_tex2);   \
+#define FREE_TEXTURES                    \
+	rd->free_rid(albedo_array_tex);      \
+	rd->free_rid(emission_array_tex);    \
+	rd->free_rid(normal_tex);            \
+	rd->free_rid(position_tex);          \
+	rd->free_rid(unocclude_tex);         \
+	rd->free_rid(light_source_tex);      \
+	rd->free_rid(light_accum_tex2);      \
+	rd->free_rid(light_accum_tex);       \
+	rd->free_rid(light_environment_tex); \
+	if (p_bake_shadowmask) {             \
+		rd->free_rid(shadowmask_tex);    \
+		rd->free_rid(shadowmask_tex2);   \
 	}
 
 	{ // create all textures
@@ -1284,17 +1284,17 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	Vector<int> slice_seam_count;
 
-#define FREE_BUFFERS                   \
-	rd->free(bake_parameters_buffer);  \
-	rd->free(vertex_buffer);           \
-	rd->free(triangle_buffer);         \
-	rd->free(lights_buffer);           \
-	rd->free(triangle_indices_buffer); \
-	rd->free(cluster_indices_buffer);  \
-	rd->free(cluster_aabbs_buffer);    \
-	rd->free(grid_texture);            \
-	rd->free(seams_buffer);            \
-	rd->free(probe_positions_buffer);
+#define FREE_BUFFERS                       \
+	rd->free_rid(bake_parameters_buffer);  \
+	rd->free_rid(vertex_buffer);           \
+	rd->free_rid(triangle_buffer);         \
+	rd->free_rid(lights_buffer);           \
+	rd->free_rid(triangle_indices_buffer); \
+	rd->free_rid(cluster_indices_buffer);  \
+	rd->free_rid(cluster_aabbs_buffer);    \
+	rd->free_rid(grid_texture);            \
+	rd->free_rid(seams_buffer);            \
+	rd->free_rid(probe_positions_buffer);
 
 	const uint32_t cluster_size = 16;
 	_create_acceleration_structures(rd, atlas_size, atlas_slices, bounds, grid_size, cluster_size, probe_positions, p_generate_probes, slice_triangle_count, slice_seam_count, vertex_buffer, triangle_buffer, lights_buffer, triangle_indices_buffer, cluster_indices_buffer, cluster_aabbs_buffer, probe_positions_buffer, grid_texture, seams_buffer, p_step_function, p_bake_userdata);
@@ -1535,10 +1535,10 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 #endif
 
-#define FREE_RASTER_RESOURCES   \
-	rd->free(rasterize_shader); \
-	rd->free(sampler);          \
-	rd->free(raster_depth_buffer);
+#define FREE_RASTER_RESOURCES       \
+	rd->free_rid(rasterize_shader); \
+	rd->free_rid(sampler);          \
+	rd->free_rid(raster_depth_buffer);
 
 	/* Plot direct light */
 
@@ -1596,11 +1596,11 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	RID compute_base_uniform_set = rd->uniform_set_create(base_uniforms, compute_shader_primary, 0);
 
-#define FREE_COMPUTE_RESOURCES          \
-	rd->free(compute_shader_unocclude); \
-	rd->free(compute_shader_primary);   \
-	rd->free(compute_shader_secondary); \
-	rd->free(compute_shader_light_probes);
+#define FREE_COMPUTE_RESOURCES              \
+	rd->free_rid(compute_shader_unocclude); \
+	rd->free_rid(compute_shader_primary);   \
+	rd->free_rid(compute_shader_secondary); \
+	rd->free_rid(compute_shader_light_probes);
 
 	Vector3i group_size(Math::division_round_up(atlas_size.x, 8), Math::division_round_up(atlas_size.y, 8), 1);
 	rd->submit();
@@ -1957,7 +1957,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				FREE_RASTER_RESOURCES
 				FREE_COMPUTE_RESOURCES
 				if (probe_positions.size() > 0) {
-					rd->free(light_probe_buffer);
+					rd->free_rid(light_probe_buffer);
 				}
 				memdelete(rd);
 				if (rcd != nullptr) {
@@ -2038,7 +2038,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 					FREE_RASTER_RESOURCES
 					FREE_COMPUTE_RESOURCES
 					if (probe_positions.size() > 0) {
-						rd->free(light_probe_buffer);
+						rd->free_rid(light_probe_buffer);
 					}
 					memdelete(rd);
 					if (rcd != nullptr) {
@@ -2073,7 +2073,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				FREE_RASTER_RESOURCES
 				FREE_COMPUTE_RESOURCES
 				if (probe_positions.size() > 0) {
-					rd->free(light_probe_buffer);
+					rd->free_rid(light_probe_buffer);
 				}
 				memdelete(rd);
 				if (rcd != nullptr) {
@@ -2169,9 +2169,9 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	ERR_FAIL_COND_V(blendseams_triangle_raster_shader.is_null(), BAKE_ERROR_LIGHTMAP_CANT_PRE_BAKE_MESHES);
 
-#define FREE_BLENDSEAMS_RESOURCES            \
-	rd->free(blendseams_line_raster_shader); \
-	rd->free(blendseams_triangle_raster_shader);
+#define FREE_BLENDSEAMS_RESOURCES                \
+	rd->free_rid(blendseams_line_raster_shader); \
+	rd->free_rid(blendseams_triangle_raster_shader);
 
 	{
 		//pre copy
@@ -2331,7 +2331,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		probe_values.resize(probe_positions.size() * 9);
 		Vector<uint8_t> probe_data = rd->buffer_get_data(light_probe_buffer);
 		memcpy(probe_values.ptrw(), probe_data.ptr(), probe_data.size());
-		rd->free(light_probe_buffer);
+		rd->free_rid(light_probe_buffer);
 
 #ifdef DEBUG_TEXTURES
 		{

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.cpp
@@ -1189,7 +1189,7 @@ void GodotNavigationServer2D::flush_queries() {
 	commands.clear();
 }
 
-COMMAND_1(free, RID, p_object) {
+COMMAND_1(free_rid, RID, p_object) {
 	if (geometry_parser_owner.owns(p_object)) {
 		RWLockWrite write_lock(geometry_parser_rwlock);
 

--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -322,7 +322,7 @@ public:
 
 	virtual void query_path(const Ref<NavigationPathQueryParameters2D> &p_query_parameters, Ref<NavigationPathQueryResult2D> p_query_result, const Callable &p_callback = Callable()) override;
 
-	COMMAND_1(free, RID, p_object);
+	COMMAND_1(free_rid, RID, p_object);
 
 	virtual void set_active(bool p_active) override;
 

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.cpp
@@ -1227,7 +1227,7 @@ String GodotNavigationServer3D::get_baking_navigation_mesh_state_msg(Ref<Navigat
 #endif // _3D_DISABLED
 }
 
-COMMAND_1(free, RID, p_object) {
+COMMAND_1(free_rid, RID, p_object) {
 	if (map_owner.owns(p_object)) {
 		NavMap3D *map = map_owner.get_or_null(p_object);
 

--- a/modules/navigation_3d/3d/godot_navigation_server_3d.h
+++ b/modules/navigation_3d/3d/godot_navigation_server_3d.h
@@ -280,7 +280,7 @@ public:
 	virtual Vector<Vector3> simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) override;
 
 public:
-	COMMAND_1(free, RID, p_object);
+	COMMAND_1(free_rid, RID, p_object);
 
 	virtual void set_active(bool p_active) override;
 

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -882,20 +882,20 @@ NavigationObstacle3DEditorPlugin::~NavigationObstacle3DEditorPlugin() {
 	ERR_FAIL_NULL(rs);
 
 	if (point_lines_instance_rid.is_valid()) {
-		rs->free(point_lines_instance_rid);
+		rs->free_rid(point_lines_instance_rid);
 		point_lines_instance_rid = RID();
 	}
 	if (point_lines_mesh_rid.is_valid()) {
-		rs->free(point_lines_mesh_rid);
+		rs->free_rid(point_lines_mesh_rid);
 		point_lines_mesh_rid = RID();
 	}
 
 	if (point_handles_instance_rid.is_valid()) {
-		rs->free(point_handles_instance_rid);
+		rs->free_rid(point_handles_instance_rid);
 		point_handles_instance_rid = RID();
 	}
 	if (point_handle_mesh_rid.is_valid()) {
-		rs->free(point_handle_mesh_rid);
+		rs->free_rid(point_handle_mesh_rid);
 		point_handle_mesh_rid = RID();
 	}
 }

--- a/modules/noise/noise_texture_2d.cpp
+++ b/modules/noise/noise_texture_2d.cpp
@@ -41,7 +41,7 @@ NoiseTexture2D::NoiseTexture2D() {
 NoiseTexture2D::~NoiseTexture2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (texture.is_valid()) {
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 	if (noise_thread.is_started()) {
 		noise_thread.wait_to_finish();

--- a/modules/noise/noise_texture_3d.cpp
+++ b/modules/noise/noise_texture_3d.cpp
@@ -41,7 +41,7 @@ NoiseTexture3D::NoiseTexture3D() {
 NoiseTexture3D::~NoiseTexture3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (texture.is_valid()) {
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 	if (noise_thread.is_started()) {
 		noise_thread.wait_to_finish();

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -120,19 +120,19 @@ void OpenXRVisibilityMaskExtension::on_session_destroyed() {
 
 	// Free our mesh.
 	if (mesh.is_valid()) {
-		rendering_server->free(mesh);
+		rendering_server->free_rid(mesh);
 		mesh = RID();
 	}
 
 	// Free our material.
 	if (material.is_valid()) {
-		rendering_server->free(material);
+		rendering_server->free_rid(material);
 		material = RID();
 	}
 
 	// Free our shader.
 	if (shader.is_valid()) {
-		rendering_server->free(shader);
+		rendering_server->free_rid(shader);
 		shader = RID();
 	}
 

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
@@ -306,7 +306,7 @@ void OpenXRD3D12Extension::cleanup_swapchain_graphics_data(void **p_swapchain_gr
 
 	for (const RID &texture_rid : data->texture_rids) {
 		// This should clean up our RIDs and associated texture objects but shouldn't destroy the images, they are owned by our XrSwapchain.
-		rendering_device->free(texture_rid);
+		rendering_device->free_rid(texture_rid);
 	}
 	data->texture_rids.clear();
 

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -289,7 +289,7 @@ void OpenXRMetalExtension::cleanup_swapchain_graphics_data(void **p_swapchain_gr
 	ERR_FAIL_NULL(rendering_device);
 
 	for (const RID &texture_rid : data->texture_rids) {
-		rendering_device->free(texture_rid);
+		rendering_device->free_rid(texture_rid);
 	}
 	data->texture_rids.clear();
 

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -459,13 +459,13 @@ void OpenXRVulkanExtension::cleanup_swapchain_graphics_data(void **p_swapchain_g
 
 	for (const RID &texture_rid : data->texture_rids) {
 		// This should clean up our RIDs and associated texture objects but shouldn't destroy the images, they are owned by our XrSwapchain.
-		rendering_device->free(texture_rid);
+		rendering_device->free_rid(texture_rid);
 	}
 	data->texture_rids.clear();
 
 	for (int i = 0; i < data->density_map_rids.size(); i++) {
 		if (data->density_map_rids[i].is_valid()) {
-			rendering_device->free(data->density_map_rids[i]);
+			rendering_device->free_rid(data->density_map_rids[i]);
 		}
 	}
 	data->density_map_rids.clear();

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1696,6 +1696,6 @@ CPUParticles2D::CPUParticles2D() {
 
 CPUParticles2D::~CPUParticles2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(multimesh);
-	RS::get_singleton()->free(mesh);
+	RS::get_singleton()->free_rid(multimesh);
+	RS::get_singleton()->free_rid(mesh);
 }

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -1011,6 +1011,6 @@ GPUParticles2D::GPUParticles2D() {
 
 GPUParticles2D::~GPUParticles2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(particles);
-	RS::get_singleton()->free(mesh);
+	RS::get_singleton()->free_rid(particles);
+	RS::get_singleton()->free_rid(mesh);
 }

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -335,7 +335,7 @@ Light2D::Light2D() {
 
 Light2D::~Light2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(canvas_light);
+	RenderingServer::get_singleton()->free_rid(canvas_light);
 }
 
 //////////////////////////////

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -150,7 +150,7 @@ OccluderPolygon2D::OccluderPolygon2D() {
 
 OccluderPolygon2D::~OccluderPolygon2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(occ_polygon);
+	RS::get_singleton()->free_rid(occ_polygon);
 }
 
 void LightOccluder2D::_poly_changed() {
@@ -310,5 +310,5 @@ LightOccluder2D::LightOccluder2D() {
 LightOccluder2D::~LightOccluder2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 
-	RS::get_singleton()->free(occluder);
+	RS::get_singleton()->free_rid(occluder);
 }

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -349,7 +349,7 @@ NavigationAgent2D::NavigationAgent2D() {
 
 NavigationAgent2D::~NavigationAgent2D() {
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
-	NavigationServer2D::get_singleton()->free(agent);
+	NavigationServer2D::get_singleton()->free_rid(agent);
 	agent = RID(); // Pointless
 
 #ifdef DEBUG_ENABLED
@@ -357,7 +357,7 @@ NavigationAgent2D::~NavigationAgent2D() {
 
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_path_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_path_instance);
+		RenderingServer::get_singleton()->free_rid(debug_path_instance);
 	}
 #endif // DEBUG_ENABLED
 }

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -440,6 +440,6 @@ NavigationLink2D::NavigationLink2D() {
 
 NavigationLink2D::~NavigationLink2D() {
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
-	NavigationServer2D::get_singleton()->free(link);
+	NavigationServer2D::get_singleton()->free_rid(link);
 	link = RID();
 }

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -198,16 +198,16 @@ NavigationObstacle2D::NavigationObstacle2D() {
 NavigationObstacle2D::~NavigationObstacle2D() {
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 
-	NavigationServer2D::get_singleton()->free(obstacle);
+	NavigationServer2D::get_singleton()->free_rid(obstacle);
 	obstacle = RID();
 
 #ifdef DEBUG_ENABLED
 	if (debug_mesh_rid.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_mesh_rid);
+		RenderingServer::get_singleton()->free_rid(debug_mesh_rid);
 		debug_mesh_rid = RID();
 	}
 	if (debug_canvas_item.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_canvas_item);
+		RenderingServer::get_singleton()->free_rid(debug_canvas_item);
 		debug_canvas_item = RID();
 	}
 #endif // DEBUG_ENABLED

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -394,16 +394,16 @@ NavigationRegion2D::NavigationRegion2D() {
 
 NavigationRegion2D::~NavigationRegion2D() {
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
-	NavigationServer2D::get_singleton()->free(region);
+	NavigationServer2D::get_singleton()->free_rid(region);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer2D::get_singleton()->disconnect(SNAME("map_changed"), callable_mp(this, &NavigationRegion2D::_navigation_map_changed));
 	NavigationServer2D::get_singleton()->disconnect(SNAME("navigation_debug_changed"), callable_mp(this, &NavigationRegion2D::_navigation_debug_changed));
 	if (debug_instance_rid.is_valid()) {
-		RS::get_singleton()->free(debug_instance_rid);
+		RS::get_singleton()->free_rid(debug_instance_rid);
 	}
 	if (debug_mesh_rid.is_valid()) {
-		RS::get_singleton()->free(debug_mesh_rid);
+		RS::get_singleton()->free_rid(debug_mesh_rid);
 	}
 #endif // DEBUG_ENABLED
 }

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -127,11 +127,11 @@ void Path2D::_debug_free() {
 	ERR_FAIL_NULL(RS::get_singleton());
 
 	if (debug_instance.is_valid()) {
-		RS::get_singleton()->free(debug_instance);
+		RS::get_singleton()->free_rid(debug_instance);
 		debug_instance = RID();
 	}
 	if (debug_mesh_rid.is_valid()) {
-		RS::get_singleton()->free(debug_mesh_rid);
+		RS::get_singleton()->free_rid(debug_mesh_rid);
 		debug_mesh_rid = RID();
 	}
 }

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -682,5 +682,5 @@ CollisionObject2D::CollisionObject2D() {
 
 CollisionObject2D::~CollisionObject2D() {
 	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
-	PhysicsServer2D::get_singleton()->free(rid);
+	PhysicsServer2D::get_singleton()->free_rid(rid);
 }

--- a/scene/2d/physics/joints/joint_2d.cpp
+++ b/scene/2d/physics/joints/joint_2d.cpp
@@ -253,5 +253,5 @@ Joint2D::Joint2D() {
 
 Joint2D::~Joint2D() {
 	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
-	PhysicsServer2D::get_singleton()->free(joint);
+	PhysicsServer2D::get_singleton()->free_rid(joint);
 }

--- a/scene/2d/polygon_2d.cpp
+++ b/scene/2d/polygon_2d.cpp
@@ -731,5 +731,5 @@ Polygon2D::~Polygon2D() {
 	// This will free the internally-allocated mesh instance, if allocated.
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	RS::get_singleton()->canvas_item_attach_skeleton(get_canvas_item(), RID());
-	RS::get_singleton()->free(mesh);
+	RS::get_singleton()->free_rid(mesh);
 }

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -504,7 +504,7 @@ Bone2D::~Bone2D() {
 #ifdef TOOLS_ENABLED
 	if (!editor_gizmo_rid.is_null()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(editor_gizmo_rid);
+		RenderingServer::get_singleton()->free_rid(editor_gizmo_rid);
 	}
 #endif // TOOLS_ENABLED
 }
@@ -838,5 +838,5 @@ Skeleton2D::Skeleton2D() {
 
 Skeleton2D::~Skeleton2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(skeleton);
+	RS::get_singleton()->free_rid(skeleton);
 }

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -73,10 +73,10 @@ void TileMapLayer::_debug_update(bool p_force_cleanup) {
 			// Free the quadrant.
 			Ref<DebugQuadrant> &debug_quadrant = kv.value;
 			if (debug_quadrant->canvas_item.is_valid()) {
-				rs->free(debug_quadrant->canvas_item);
+				rs->free_rid(debug_quadrant->canvas_item);
 			}
 			if (debug_quadrant->physics_mesh.is_valid()) {
-				rs->free(debug_quadrant->physics_mesh);
+				rs->free_rid(debug_quadrant->physics_mesh);
 			}
 		}
 		debug_quadrant_map.clear();
@@ -192,7 +192,7 @@ void TileMapLayer::_debug_update(bool p_force_cleanup) {
 		if (!debug_quadrant->drawn_to) {
 			// Free the quadrant.
 			if (ci.is_valid()) {
-				rs->free(ci);
+				rs->free_rid(ci);
 			}
 			debug_quadrant_map.erase(quadrant_coords);
 		}
@@ -244,7 +244,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 		for (const KeyValue<Vector2i, Ref<RenderingQuadrant>> &kv : rendering_quadrant_map) {
 			for (const RID &ci : kv.value->canvas_items) {
 				if (ci.is_valid()) {
-					rs->free(ci);
+					rs->free_rid(ci);
 				}
 			}
 			kv.value->cells.clear();
@@ -291,7 +291,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 				// First, clear the quadrant's canvas items.
 				for (RID &ci : rendering_quadrant->canvas_items) {
-					rs->free(ci);
+					rs->free_rid(ci);
 				}
 				rendering_quadrant->canvas_items.clear();
 
@@ -387,7 +387,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 				// Free the quadrant.
 				for (const RID &ci : rendering_quadrant->canvas_items) {
 					if (ci.is_valid()) {
-						rs->free(ci);
+						rs->free_rid(ci);
 					}
 				}
 				rendering_quadrant->cells.clear();
@@ -601,7 +601,7 @@ void TileMapLayer::_rendering_occluders_clear_cell(CellData &r_cell_data) {
 	// Free the occluders.
 	for (const LocalVector<RID> &polygons : r_cell_data.occluders) {
 		for (const RID &rid : polygons) {
-			rs->free(rid);
+			rs->free_rid(rid);
 		}
 	}
 	r_cell_data.occluders.clear();
@@ -614,7 +614,7 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 	for (uint32_t i = tile_set->get_occlusion_layers_count(); i < r_cell_data.occluders.size(); i++) {
 		for (const RID &occluder_id : r_cell_data.occluders[i]) {
 			if (occluder_id.is_valid()) {
-				rs->free(occluder_id);
+				rs->free_rid(occluder_id);
 			}
 		}
 	}
@@ -649,7 +649,7 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 					for (uint32_t i = tile_data->get_occluder_polygons_count(occlusion_layer_index); i < r_cell_data.occluders[occlusion_layer_index].size(); i++) {
 						RID occluder_id = occluders[i];
 						if (occluder_id.is_valid()) {
-							rs->free(occluder_id);
+							rs->free_rid(occluder_id);
 						}
 					}
 					occluders.resize(tile_data->get_occluder_polygons_count(occlusion_layer_index));
@@ -676,7 +676,7 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 						} else {
 							// Clear occluder.
 							if (occluder.is_valid()) {
-								rs->free(occluder);
+								rs->free_rid(occluder);
 								occluder = RID();
 							}
 						}
@@ -764,7 +764,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 			for (KeyValue<PhysicsQuadrant::PhysicsBodyKey, PhysicsQuadrant::PhysicsBodyValue> &kvbody : kv.value->bodies) {
 				if (kvbody.value.body.is_valid()) {
 					bodies_coords.erase(kvbody.value.body);
-					ps->free(kvbody.value.body);
+					ps->free_rid(kvbody.value.body);
 				}
 			}
 			kv.value->bodies.clear();
@@ -817,7 +817,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 					RID &body = kvbody.value.body;
 					if (body.is_valid()) {
 						bodies_coords.erase(body);
-						ps->free(body);
+						ps->free_rid(body);
 						body = RID();
 					}
 				}
@@ -940,7 +940,7 @@ void TileMapLayer::_physics_update(bool p_force_cleanup) {
 					RID &body = kv.value.body;
 					if (body.is_valid()) {
 						bodies_coords.erase(body);
-						ps->free(body);
+						ps->free_rid(body);
 					}
 				}
 				physics_quadrant->bodies.clear();
@@ -1296,7 +1296,7 @@ void TileMapLayer::_navigation_update(bool p_force_cleanup) {
 	if (tile_map_node) {
 		if (forced_cleanup) {
 			if (navigation_map_override.is_valid()) {
-				ns->free(navigation_map_override);
+				ns->free_rid(navigation_map_override);
 				navigation_map_override = RID();
 			}
 		} else {
@@ -1367,7 +1367,7 @@ void TileMapLayer::_navigation_clear_cell(CellData &r_cell_data) {
 		const RID &region = r_cell_data.navigation_regions[i];
 		if (region.is_valid()) {
 			ns->region_set_map(region, RID());
-			ns->free(region);
+			ns->free_rid(region);
 		}
 	}
 	r_cell_data.navigation_regions.clear();
@@ -1406,7 +1406,7 @@ void TileMapLayer::_navigation_update_cell(CellData &r_cell_data) {
 					RID &region = r_cell_data.navigation_regions[i];
 					if (region.is_valid()) {
 						ns->region_set_map(region, RID());
-						ns->free(region);
+						ns->free_rid(region);
 						region = RID();
 					}
 				}
@@ -1434,7 +1434,7 @@ void TileMapLayer::_navigation_update_cell(CellData &r_cell_data) {
 						// Clear region.
 						if (region.is_valid()) {
 							ns->region_set_map(region, RID());
-							ns->free(region);
+							ns->free_rid(region);
 							region = RID();
 						}
 					}

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -867,11 +867,11 @@ Camera3D::Camera3D() {
 
 Camera3D::~Camera3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(camera);
+	RenderingServer::get_singleton()->free_rid(camera);
 #ifndef PHYSICS_3D_DISABLED
 	if (pyramid_shape.is_valid()) {
 		ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
-		PhysicsServer3D::get_singleton()->free(pyramid_shape);
+		PhysicsServer3D::get_singleton()->free_rid(pyramid_shape);
 	}
 #endif // PHYSICS_3D_DISABLED
 }

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1822,5 +1822,5 @@ CPUParticles3D::CPUParticles3D() {
 
 CPUParticles3D::~CPUParticles3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(multimesh);
+	RS::get_singleton()->free_rid(multimesh);
 }

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -288,5 +288,5 @@ Decal::Decal() {
 
 Decal::~Decal() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(decal);
+	RS::get_singleton()->free_rid(decal);
 }

--- a/scene/3d/fog_volume.cpp
+++ b/scene/3d/fog_volume.cpp
@@ -142,5 +142,5 @@ FogVolume::FogVolume() {
 
 FogVolume::~FogVolume() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(volume);
+	RS::get_singleton()->free_rid(volume);
 }

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -904,5 +904,5 @@ GPUParticles3D::GPUParticles3D() {
 
 GPUParticles3D::~GPUParticles3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(particles);
+	RS::get_singleton()->free_rid(particles);
 }

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -59,7 +59,7 @@ GPUParticlesCollision3D::GPUParticlesCollision3D(RS::ParticlesCollisionType p_ty
 
 GPUParticlesCollision3D::~GPUParticlesCollision3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(collision);
+	RS::get_singleton()->free_rid(collision);
 }
 
 /////////////////////////////////
@@ -910,7 +910,7 @@ GPUParticlesAttractor3D::GPUParticlesAttractor3D(RS::ParticlesCollisionType p_ty
 }
 GPUParticlesAttractor3D::~GPUParticlesAttractor3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(collision);
+	RS::get_singleton()->free_rid(collision);
 }
 
 /////////////////////////////////

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -470,7 +470,7 @@ void Label3D::_shape() {
 
 	// Clear materials.
 	for (const KeyValue<SurfaceKey, SurfaceData> &E : surfaces) {
-		RenderingServer::get_singleton()->free(E.value.material);
+		RenderingServer::get_singleton()->free_rid(E.value.material);
 	}
 	surfaces.clear();
 
@@ -1105,9 +1105,9 @@ Label3D::~Label3D() {
 	TS->free_rid(text_rid);
 
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(mesh);
+	RenderingServer::get_singleton()->free_rid(mesh);
 	for (KeyValue<SurfaceKey, SurfaceData> E : surfaces) {
-		RenderingServer::get_singleton()->free(E.value.material);
+		RenderingServer::get_singleton()->free_rid(E.value.material);
 	}
 	surfaces.clear();
 }

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -506,7 +506,7 @@ Light3D::~Light3D() {
 	RS::get_singleton()->instance_set_base(get_instance(), RID());
 
 	if (light.is_valid()) {
-		RenderingServer::get_singleton()->free(light);
+		RenderingServer::get_singleton()->free_rid(light);
 	}
 }
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -365,7 +365,7 @@ LightmapGIData::LightmapGIData() {
 
 LightmapGIData::~LightmapGIData() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(lightmap);
+	RS::get_singleton()->free_rid(lightmap);
 }
 
 ///////////////////////////

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -383,7 +383,7 @@ NavigationAgent3D::NavigationAgent3D() {
 
 NavigationAgent3D::~NavigationAgent3D() {
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
-	NavigationServer3D::get_singleton()->free(agent);
+	NavigationServer3D::get_singleton()->free_rid(agent);
 	agent = RID(); // Pointless
 
 #ifdef DEBUG_ENABLED
@@ -391,10 +391,10 @@ NavigationAgent3D::~NavigationAgent3D() {
 
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_path_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_path_instance);
+		RenderingServer::get_singleton()->free_rid(debug_path_instance);
 	}
 	if (debug_path_mesh.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_path_mesh->get_rid());
+		RenderingServer::get_singleton()->free_rid(debug_path_mesh->get_rid());
 	}
 #endif // DEBUG_ENABLED
 }

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -286,16 +286,16 @@ NavigationLink3D::NavigationLink3D() {
 
 NavigationLink3D::~NavigationLink3D() {
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
-	NavigationServer3D::get_singleton()->free(link);
+	NavigationServer3D::get_singleton()->free_rid(link);
 	link = RID();
 
 #ifdef DEBUG_ENABLED
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_instance);
+		RenderingServer::get_singleton()->free_rid(debug_instance);
 	}
 	if (debug_mesh.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_mesh->get_rid());
+		RenderingServer::get_singleton()->free_rid(debug_mesh->get_rid());
 	}
 #endif // DEBUG_ENABLED
 }

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -232,7 +232,7 @@ NavigationObstacle3D::~NavigationObstacle3D() {
 	NavigationServer3D *ns3d = NavigationServer3D::get_singleton();
 	ERR_FAIL_NULL(ns3d);
 
-	ns3d->free(obstacle);
+	ns3d->free_rid(obstacle);
 	obstacle = RID();
 
 #ifdef DEBUG_ENABLED
@@ -242,19 +242,19 @@ NavigationObstacle3D::~NavigationObstacle3D() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	ERR_FAIL_NULL(rs);
 	if (fake_agent_radius_debug_instance_rid.is_valid()) {
-		rs->free(fake_agent_radius_debug_instance_rid);
+		rs->free_rid(fake_agent_radius_debug_instance_rid);
 		fake_agent_radius_debug_instance_rid = RID();
 	}
 	if (fake_agent_radius_debug_mesh_rid.is_valid()) {
-		rs->free(fake_agent_radius_debug_mesh_rid);
+		rs->free_rid(fake_agent_radius_debug_mesh_rid);
 		fake_agent_radius_debug_mesh_rid = RID();
 	}
 	if (static_obstacle_debug_instance_rid.is_valid()) {
-		rs->free(static_obstacle_debug_instance_rid);
+		rs->free_rid(static_obstacle_debug_instance_rid);
 		static_obstacle_debug_instance_rid = RID();
 	}
 	if (static_obstacle_debug_mesh_rid.is_valid()) {
-		rs->free(static_obstacle_debug_mesh_rid);
+		rs->free_rid(static_obstacle_debug_mesh_rid);
 		static_obstacle_debug_mesh_rid = RID();
 	}
 #endif // DEBUG_ENABLED

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -445,7 +445,7 @@ NavigationRegion3D::~NavigationRegion3D() {
 		navigation_mesh->disconnect_changed(callable_mp(this, &NavigationRegion3D::_navigation_mesh_changed));
 	}
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
-	NavigationServer3D::get_singleton()->free(region);
+	NavigationServer3D::get_singleton()->free_rid(region);
 
 #ifdef DEBUG_ENABLED
 	NavigationServer3D::get_singleton()->disconnect(SNAME("map_changed"), callable_mp(this, &NavigationRegion3D::_navigation_map_changed));
@@ -453,16 +453,16 @@ NavigationRegion3D::~NavigationRegion3D() {
 
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_instance);
+		RenderingServer::get_singleton()->free_rid(debug_instance);
 	}
 	if (debug_mesh.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_mesh->get_rid());
+		RenderingServer::get_singleton()->free_rid(debug_mesh->get_rid());
 	}
 	if (debug_edge_connections_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_edge_connections_instance);
+		RenderingServer::get_singleton()->free_rid(debug_edge_connections_instance);
 	}
 	if (debug_edge_connections_mesh.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_edge_connections_mesh->get_rid());
+		RenderingServer::get_singleton()->free_rid(debug_edge_connections_mesh->get_rid());
 	}
 #endif // DEBUG_ENABLED
 }

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -136,7 +136,7 @@ Occluder3D::Occluder3D() {
 Occluder3D::~Occluder3D() {
 	if (occluder.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(occluder);
+		RS::get_singleton()->free_rid(occluder);
 	}
 }
 

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -42,11 +42,11 @@ Path3D::Path3D() {
 Path3D::~Path3D() {
 	if (debug_instance.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(debug_instance);
+		RS::get_singleton()->free_rid(debug_instance);
 	}
 	if (debug_mesh.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(debug_mesh->get_rid());
+		RS::get_singleton()->free_rid(debug_mesh->get_rid());
 	}
 }
 

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -386,7 +386,7 @@ void CollisionObject3D::_update_debug_shapes() {
 				ShapeData::ShapeBase &s = shape_bases[i];
 				if (s.shape.is_null() || shapedata.disabled) {
 					if (s.debug_shape.is_valid()) {
-						RS::get_singleton()->free(s.debug_shape);
+						RS::get_singleton()->free_rid(s.debug_shape);
 						s.debug_shape = RID();
 						--debug_shapes_count;
 					}
@@ -418,7 +418,7 @@ void CollisionObject3D::_clear_debug_shapes() {
 		for (int i = 0; i < shapedata.shapes.size(); i++) {
 			ShapeData::ShapeBase &s = shape_bases[i];
 			if (s.debug_shape.is_valid()) {
-				RS::get_singleton()->free(s.debug_shape);
+				RS::get_singleton()->free_rid(s.debug_shape);
 				s.debug_shape = RID();
 				if (s.shape.is_valid()) {
 					s.shape->disconnect_changed(callable_mp(this, &CollisionObject3D::_update_shape_data));
@@ -664,7 +664,7 @@ void CollisionObject3D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 	}
 
 	if (s.debug_shape.is_valid()) {
-		RS::get_singleton()->free(s.debug_shape);
+		RS::get_singleton()->free_rid(s.debug_shape);
 		if (s.shape.is_valid()) {
 			s.shape->disconnect_changed(callable_mp(this, &CollisionObject3D::_shape_changed));
 		}
@@ -757,5 +757,5 @@ CollisionObject3D::CollisionObject3D() {
 
 CollisionObject3D::~CollisionObject3D() {
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
-	PhysicsServer3D::get_singleton()->free(rid);
+	PhysicsServer3D::get_singleton()->free_rid(rid);
 }

--- a/scene/3d/physics/joints/joint_3d.cpp
+++ b/scene/3d/physics/joints/joint_3d.cpp
@@ -239,5 +239,5 @@ Joint3D::Joint3D() {
 
 Joint3D::~Joint3D() {
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
-	PhysicsServer3D::get_singleton()->free(joint);
+	PhysicsServer3D::get_singleton()->free_rid(joint);
 }

--- a/scene/3d/physics/physical_bone_3d.cpp
+++ b/scene/3d/physics/physical_bone_3d.cpp
@@ -1287,7 +1287,7 @@ PhysicalBone3D::~PhysicalBone3D() {
 		memdelete(joint_data);
 	}
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
-	PhysicsServer3D::get_singleton()->free(joint);
+	PhysicsServer3D::get_singleton()->free_rid(joint);
 }
 
 void PhysicalBone3D::update_bone_id() {

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -547,11 +547,11 @@ void RayCast3D::_update_debug_shape() {
 void RayCast3D::_clear_debug_shape() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_instance);
+		RenderingServer::get_singleton()->free_rid(debug_instance);
 		debug_instance = RID();
 	}
 	if (debug_mesh.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_mesh->get_rid());
+		RenderingServer::get_singleton()->free_rid(debug_mesh->get_rid());
 		debug_mesh = Ref<ArrayMesh>();
 	}
 }

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -633,11 +633,11 @@ void ShapeCast3D::_update_debug_shape() {
 void ShapeCast3D::_clear_debug_shape() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (debug_instance.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_instance);
+		RenderingServer::get_singleton()->free_rid(debug_instance);
 		debug_instance = RID();
 	}
 	if (debug_mesh.is_valid()) {
-		RenderingServer::get_singleton()->free(debug_mesh->get_rid());
+		RenderingServer::get_singleton()->free_rid(debug_mesh->get_rid());
 		debug_mesh = Ref<ArrayMesh>();
 	}
 }

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -741,7 +741,7 @@ SoftBody3D::SoftBody3D() :
 SoftBody3D::~SoftBody3D() {
 	memdelete(rendering_server_handler);
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
-	PhysicsServer3D::get_singleton()->free(physics_rid);
+	PhysicsServer3D::get_singleton()->free_rid(physics_rid);
 }
 
 void SoftBody3D::_make_cache_dirty() {

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -309,5 +309,5 @@ ReflectionProbe::ReflectionProbe() {
 
 ReflectionProbe::~ReflectionProbe() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(probe);
+	RS::get_singleton()->free_rid(probe);
 }

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -61,7 +61,7 @@ SkinReference::~SkinReference() {
 	if (skeleton_node) {
 		skeleton_node->skin_bindings.erase(this);
 	}
-	RS::get_singleton()->free(skeleton);
+	RS::get_singleton()->free_rid(skeleton);
 }
 
 ///////////////////////////////////////

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -772,8 +772,8 @@ SpriteBase3D::SpriteBase3D() {
 
 SpriteBase3D::~SpriteBase3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(mesh);
-	RenderingServer::get_singleton()->free(material);
+	RenderingServer::get_singleton()->free_rid(mesh);
+	RenderingServer::get_singleton()->free_rid(material);
 }
 
 ///////////////////////////////////////////

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -98,7 +98,7 @@ VisibleOnScreenNotifier3D::~VisibleOnScreenNotifier3D() {
 	RID base_old = get_base();
 	set_base(RID());
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(base_old);
+	RS::get_singleton()->free_rid(base_old);
 }
 
 //////////////////////////////////////

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -205,7 +205,7 @@ VisualInstance3D::VisualInstance3D() {
 
 VisualInstance3D::~VisualInstance3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(instance);
+	RenderingServer::get_singleton()->free_rid(instance);
 }
 
 void GeometryInstance3D::set_material_override(const Ref<Material> &p_material) {

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -260,7 +260,7 @@ VoxelGIData::VoxelGIData() {
 
 VoxelGIData::~VoxelGIData() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(probe);
+	RS::get_singleton()->free_rid(probe);
 }
 
 //////////////////////
@@ -586,5 +586,5 @@ VoxelGI::VoxelGI() {
 
 VoxelGI::~VoxelGI() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(voxel_gi);
+	RS::get_singleton()->free_rid(voxel_gi);
 }

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -1501,9 +1501,9 @@ RuntimeNodeSelect::~RuntimeNodeSelect() {
 	}
 
 	if (draw_canvas.is_valid()) {
-		RS::get_singleton()->free(sel_drag_ci);
-		RS::get_singleton()->free(sbox_2d_ci);
-		RS::get_singleton()->free(draw_canvas);
+		RS::get_singleton()->free_rid(sel_drag_ci);
+		RS::get_singleton()->free_rid(sbox_2d_ci);
+		RS::get_singleton()->free_rid(draw_canvas);
 	}
 }
 

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -355,10 +355,10 @@ private:
 
 		~SelectionBox3D() {
 			if (instance.is_valid()) {
-				RS::get_singleton()->free(instance);
-				RS::get_singleton()->free(instance_ofs);
-				RS::get_singleton()->free(instance_xray);
-				RS::get_singleton()->free(instance_xray_ofs);
+				RS::get_singleton()->free_rid(instance);
+				RS::get_singleton()->free_rid(instance_ofs);
+				RS::get_singleton()->free_rid(instance_xray);
+				RS::get_singleton()->free_rid(instance_xray_ofs);
 			}
 		}
 	};

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -9324,5 +9324,5 @@ TextEdit::TextEdit(const String &p_placeholder) {
 }
 
 TextEdit::~TextEdit() {
-	RS::get_singleton()->free(text_ci);
+	RS::get_singleton()->free_rid(text_ci);
 }

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1780,7 +1780,7 @@ CanvasItem::CanvasItem() :
 
 CanvasItem::~CanvasItem() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(canvas_item);
+	RenderingServer::get_singleton()->free_rid(canvas_item);
 }
 
 ///////////////////////////////////////////////////////////////////
@@ -1962,5 +1962,5 @@ CanvasTexture::CanvasTexture() {
 }
 CanvasTexture::~CanvasTexture() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(canvas_texture);
+	RS::get_singleton()->free_rid(canvas_texture);
 }

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -359,5 +359,5 @@ CanvasLayer::CanvasLayer() {
 
 CanvasLayer::~CanvasLayer() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(canvas);
+	RS::get_singleton()->free_rid(canvas);
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -203,7 +203,7 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (proxy_ph.is_valid()) {
 		RS::get_singleton()->texture_proxy_update(proxy, vp->texture_rid);
-		RS::get_singleton()->free(proxy_ph);
+		RS::get_singleton()->free_rid(proxy_ph);
 		proxy_ph = RID();
 	} else {
 		ERR_FAIL_COND(proxy.is_valid()); // Should be invalid.
@@ -233,10 +233,10 @@ ViewportTexture::~ViewportTexture() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 
 	if (proxy_ph.is_valid()) {
-		RS::get_singleton()->free(proxy_ph);
+		RS::get_singleton()->free_rid(proxy_ph);
 	}
 	if (proxy.is_valid()) {
-		RS::get_singleton()->free(proxy);
+		RS::get_singleton()->free_rid(proxy);
 	}
 }
 
@@ -466,11 +466,11 @@ void Viewport::_sub_window_remove(Window *p_window) {
 		sw.window->_mouse_leave_viewport();
 		gui.subwindow_over = nullptr;
 	}
-	RS::get_singleton()->free(sw.canvas_item);
+	RS::get_singleton()->free_rid(sw.canvas_item);
 	gui.sub_windows.remove_at(index);
 
 	if (gui.sub_windows.is_empty()) {
-		RS::get_singleton()->free(subwindow_canvas);
+		RS::get_singleton()->free_rid(subwindow_canvas);
 		subwindow_canvas = RID();
 	}
 
@@ -633,15 +633,15 @@ void Viewport::_notification(int p_what) {
 			RenderingServer::get_singleton()->viewport_remove_canvas(viewport, current_canvas);
 #ifndef PHYSICS_2D_DISABLED
 			if (contact_2d_debug.is_valid()) {
-				RenderingServer::get_singleton()->free(contact_2d_debug);
+				RenderingServer::get_singleton()->free_rid(contact_2d_debug);
 				contact_2d_debug = RID();
 			}
 #endif // PHYSICS_2D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED
 			if (contact_3d_debug_multimesh.is_valid()) {
-				RenderingServer::get_singleton()->free(contact_3d_debug_multimesh);
-				RenderingServer::get_singleton()->free(contact_3d_debug_instance);
+				RenderingServer::get_singleton()->free_rid(contact_3d_debug_multimesh);
+				RenderingServer::get_singleton()->free_rid(contact_3d_debug_instance);
 				contact_3d_debug_instance = RID();
 				contact_3d_debug_multimesh = RID();
 			}
@@ -5338,7 +5338,7 @@ Viewport::~Viewport() {
 		world_2d->remove_viewport(this);
 	}
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(viewport);
+	RenderingServer::get_singleton()->free_rid(viewport);
 }
 
 /////////////////////////////////

--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -119,5 +119,5 @@ Shape2D::Shape2D(const RID &p_rid) {
 
 Shape2D::~Shape2D() {
 	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
-	PhysicsServer2D::get_singleton()->free(shape);
+	PhysicsServer2D::get_singleton()->free_rid(shape);
 }

--- a/scene/resources/3d/fog_material.cpp
+++ b/scene/resources/3d/fog_material.cpp
@@ -133,7 +133,7 @@ void FogMaterial::_bind_methods() {
 void FogMaterial::cleanup_shader() {
 	if (shader.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(shader);
+		RS::get_singleton()->free_rid(shader);
 	}
 }
 

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -372,7 +372,7 @@ PrimitiveMesh::PrimitiveMesh() {
 
 PrimitiveMesh::~PrimitiveMesh() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(mesh);
+	RenderingServer::get_singleton()->free_rid(mesh);
 
 	ERR_FAIL_NULL(ProjectSettings::get_singleton());
 	ProjectSettings *project_settings = ProjectSettings::get_singleton();

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -165,5 +165,5 @@ Shape3D::Shape3D(RID p_shape) :
 
 Shape3D::~Shape3D() {
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
-	PhysicsServer3D::get_singleton()->free(shape);
+	PhysicsServer3D::get_singleton()->free_rid(shape);
 }

--- a/scene/resources/3d/sky_material.cpp
+++ b/scene/resources/3d/sky_material.cpp
@@ -288,7 +288,7 @@ void ProceduralSkyMaterial::_bind_methods() {
 void ProceduralSkyMaterial::cleanup_shader() {
 	for (int i = 0; i < 4; i++) {
 		if (shader_cache[i].is_valid()) {
-			RS::get_singleton()->free(shader_cache[i]);
+			RS::get_singleton()->free_rid(shader_cache[i]);
 		}
 	}
 }
@@ -478,7 +478,7 @@ RID PanoramaSkyMaterial::shader_cache[2];
 void PanoramaSkyMaterial::cleanup_shader() {
 	for (int i = 0; i < 2; i++) {
 		if (shader_cache[i].is_valid()) {
-			RS::get_singleton()->free(shader_cache[i]);
+			RS::get_singleton()->free_rid(shader_cache[i]);
 		}
 	}
 }
@@ -720,7 +720,7 @@ void PhysicalSkyMaterial::_bind_methods() {
 void PhysicalSkyMaterial::cleanup_shader() {
 	for (int i = 0; i < 4; i++) {
 		if (shader_cache[i].is_valid()) {
-			RS::get_singleton()->free(shader_cache[i]);
+			RS::get_singleton()->free_rid(shader_cache[i]);
 		}
 	}
 }

--- a/scene/resources/3d/world_3d.cpp
+++ b/scene/resources/3d/world_3d.cpp
@@ -194,17 +194,17 @@ World3D::~World3D() {
 	ERR_FAIL_NULL(NavigationServer3D::get_singleton());
 #endif // NAVIGATION_3D_DISABLED
 
-	RenderingServer::get_singleton()->free(scenario);
+	RenderingServer::get_singleton()->free_rid(scenario);
 
 #ifndef PHYSICS_3D_DISABLED
 	if (space.is_valid()) {
-		PhysicsServer3D::get_singleton()->free(space);
+		PhysicsServer3D::get_singleton()->free_rid(space);
 	}
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_3D_DISABLED
 	if (navigation_map.is_valid()) {
-		NavigationServer3D::get_singleton()->free(navigation_map);
+		NavigationServer3D::get_singleton()->free_rid(navigation_map);
 	}
 #endif // NAVIGATION_3D_DISABLED
 }

--- a/scene/resources/animated_texture.cpp
+++ b/scene/resources/animated_texture.cpp
@@ -286,6 +286,6 @@ AnimatedTexture::AnimatedTexture() {
 
 AnimatedTexture::~AnimatedTexture() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(proxy);
-	RS::get_singleton()->free(proxy_ph);
+	RS::get_singleton()->free_rid(proxy);
+	RS::get_singleton()->free_rid(proxy_ph);
 }

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -139,7 +139,7 @@ CameraAttributes::CameraAttributes() {
 
 CameraAttributes::~CameraAttributes() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(camera_attributes);
+	RS::get_singleton()->free_rid(camera_attributes);
 }
 
 //////////////////////////////////////////////////////

--- a/scene/resources/camera_texture.cpp
+++ b/scene/resources/camera_texture.cpp
@@ -152,6 +152,6 @@ CameraTexture::CameraTexture() {
 CameraTexture::~CameraTexture() {
 	if (_texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(_texture);
+		RenderingServer::get_singleton()->free_rid(_texture);
 	}
 }

--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -62,7 +62,7 @@ void CanvasItemMaterial::_update_shader() {
 		shader_map[current_key].users--;
 		if (shader_map[current_key].users == 0) {
 			//deallocate shader, as it's no longer in use
-			RS::get_singleton()->free(shader_map[current_key].shader);
+			RS::get_singleton()->free_rid(shader_map[current_key].shader);
 			shader_map.erase(current_key);
 		}
 	}
@@ -298,7 +298,7 @@ CanvasItemMaterial::~CanvasItemMaterial() {
 		shader_map[current_key].users--;
 		if (shader_map[current_key].users == 0) {
 			//deallocate shader, as it's no longer in use
-			RS::get_singleton()->free(shader_map[current_key].shader);
+			RS::get_singleton()->free_rid(shader_map[current_key].shader);
 			shader_map.erase(current_key);
 		}
 

--- a/scene/resources/compositor.cpp
+++ b/scene/resources/compositor.cpp
@@ -193,7 +193,7 @@ CompositorEffect::CompositorEffect() {
 CompositorEffect::~CompositorEffect() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	if (rs != nullptr && rid.is_valid()) {
-		rs->free(rid);
+		rs->free_rid(rid);
 	}
 }
 
@@ -217,7 +217,7 @@ Compositor::Compositor() {
 Compositor::~Compositor() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	if (rs != nullptr && compositor.is_valid()) {
-		rs->free(compositor);
+		rs->free_rid(compositor);
 	}
 }
 

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -458,7 +458,7 @@ void CompressedTexture2D::_bind_methods() {
 CompressedTexture2D::~CompressedTexture2D() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 
@@ -642,7 +642,7 @@ void CompressedTexture3D::_bind_methods() {
 CompressedTexture3D::~CompressedTexture3D() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 
@@ -835,7 +835,7 @@ CompressedTextureLayered::CompressedTextureLayered(LayeredType p_type) {
 CompressedTextureLayered::~CompressedTextureLayered() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 

--- a/scene/resources/curve_texture.cpp
+++ b/scene/resources/curve_texture.cpp
@@ -166,7 +166,7 @@ RID CurveTexture::get_rid() const {
 CurveTexture::~CurveTexture() {
 	if (_texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(_texture);
+		RS::get_singleton()->free_rid(_texture);
 	}
 }
 
@@ -361,6 +361,6 @@ RID CurveXYZTexture::get_rid() const {
 CurveXYZTexture::~CurveXYZTexture() {
 	if (_texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(_texture);
+		RS::get_singleton()->free_rid(_texture);
 	}
 }

--- a/scene/resources/dpi_texture.cpp
+++ b/scene/resources/dpi_texture.cpp
@@ -155,7 +155,7 @@ void DPITexture::_remove_scale(double p_scale) {
 	RID *rid = texture_cache.getptr(p_scale);
 	if (rid) {
 		if (rid->is_valid()) {
-			RenderingServer::get_singleton()->free(*rid);
+			RenderingServer::get_singleton()->free_rid(*rid);
 		}
 		texture_cache.erase(p_scale);
 	}
@@ -230,12 +230,12 @@ RID DPITexture::_load_at_scale(double p_scale, bool p_set_size) const {
 void DPITexture::_clear() {
 	for (KeyValue<double, RID> &tx : texture_cache) {
 		if (tx.value.is_valid()) {
-			RenderingServer::get_singleton()->free(tx.value);
+			RenderingServer::get_singleton()->free_rid(tx.value);
 		}
 	}
 	texture_cache.clear();
 	if (base_texture.is_valid()) {
-		RenderingServer::get_singleton()->free(base_texture);
+		RenderingServer::get_singleton()->free_rid(base_texture);
 	}
 	base_texture = RID();
 	alpha_cache.unref();

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1596,5 +1596,5 @@ Environment::Environment() {
 
 Environment::~Environment() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(environment);
+	RS::get_singleton()->free_rid(environment);
 }

--- a/scene/resources/external_texture.cpp
+++ b/scene/resources/external_texture.cpp
@@ -105,6 +105,6 @@ ExternalTexture::ExternalTexture() {
 ExternalTexture::~ExternalTexture() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(texture);
+		RenderingServer::get_singleton()->free_rid(texture);
 	}
 }

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -39,7 +39,7 @@ GradientTexture1D::GradientTexture1D() {
 GradientTexture1D::~GradientTexture1D() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 
@@ -194,7 +194,7 @@ GradientTexture2D::GradientTexture2D() {
 GradientTexture2D::~GradientTexture2D() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -243,7 +243,7 @@ void ImageTexture::_bind_methods() {
 ImageTexture::~ImageTexture() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(texture);
+		RenderingServer::get_singleton()->free_rid(texture);
 	}
 }
 
@@ -385,7 +385,7 @@ ImageTextureLayered::ImageTextureLayered(LayeredType p_layered_type) {
 ImageTextureLayered::~ImageTextureLayered() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 
@@ -533,7 +533,7 @@ ImageTexture3D::ImageTexture3D() {
 ImageTexture3D::~ImageTexture3D() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free(texture);
+		RS::get_singleton()->free_rid(texture);
 	}
 }
 

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -420,5 +420,5 @@ ImmediateMesh::ImmediateMesh() {
 }
 ImmediateMesh::~ImmediateMesh() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(mesh);
+	RS::get_singleton()->free_rid(mesh);
 }

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -183,7 +183,7 @@ Material::Material() {
 Material::~Material() {
 	if (material.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(material);
+		RenderingServer::get_singleton()->free_rid(material);
 	}
 }
 
@@ -700,7 +700,7 @@ void BaseMaterial3D::_update_shader() {
 			if (v->users == 0) {
 				// Deallocate shader which is no longer in use.
 				shader_rid = RID();
-				RS::get_singleton()->free(v->shader);
+				RS::get_singleton()->free_rid(v->shader);
 				shader_map.erase(current_key);
 			}
 		}
@@ -2067,7 +2067,7 @@ void fragment() {)";
 	if (unlikely(v)) {
 		// We raced and managed to create the same key concurrently, so we'll free the shader we just created,
 		// given we know it isn't used, and use the winner.
-		RS::get_singleton()->free(new_shader);
+		RS::get_singleton()->free_rid(new_shader);
 	} else {
 		ShaderData shader_data;
 		shader_data.shader = new_shader;
@@ -4004,7 +4004,7 @@ BaseMaterial3D::~BaseMaterial3D() {
 			shader_map[current_key].users--;
 			if (shader_map[current_key].users == 0) {
 				// Deallocate shader which is no longer in use.
-				RS::get_singleton()->free(shader_map[current_key].shader);
+				RS::get_singleton()->free_rid(shader_map[current_key].shader);
 				shader_map.erase(current_key);
 			}
 		}

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -2361,7 +2361,7 @@ ArrayMesh::ArrayMesh() {
 ArrayMesh::~ArrayMesh() {
 	if (mesh.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(mesh);
+		RenderingServer::get_singleton()->free_rid(mesh);
 	}
 }
 ///////////////
@@ -2377,5 +2377,5 @@ PlaceholderMesh::PlaceholderMesh() {
 
 PlaceholderMesh::~PlaceholderMesh() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(rid);
+	RS::get_singleton()->free_rid(rid);
 }

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -433,5 +433,5 @@ MultiMesh::MultiMesh() {
 
 MultiMesh::~MultiMesh() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(multimesh);
+	RenderingServer::get_singleton()->free_rid(multimesh);
 }

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -164,7 +164,7 @@ void ParticleProcessMaterial::_update_shader() {
 			v->users--;
 			if (v->users == 0) {
 				// Deallocate shader, as it's no longer in use.
-				RS::get_singleton()->free(v->shader);
+				RS::get_singleton()->free_rid(v->shader);
 				shader_map.erase(current_key);
 				shader_rid = RID();
 			}
@@ -1199,7 +1199,7 @@ void ParticleProcessMaterial::_update_shader() {
 	if (unlikely(v)) {
 		// We raced and managed to create the same key concurrently, so we'll free the shader we just created,
 		// given we know it isn't used, and use the winner.
-		RS::get_singleton()->free(new_shader);
+		RS::get_singleton()->free_rid(new_shader);
 	} else {
 		ShaderData shader_data;
 		shader_data.shader = new_shader;
@@ -2448,7 +2448,7 @@ ParticleProcessMaterial::~ParticleProcessMaterial() {
 		shader_map[current_key].users--;
 		if (shader_map[current_key].users == 0) {
 			//deallocate shader, as it's no longer in use
-			RS::get_singleton()->free(shader_map[current_key].shader);
+			RS::get_singleton()->free_rid(shader_map[current_key].shader);
 			shader_map.erase(current_key);
 		}
 

--- a/scene/resources/placeholder_textures.cpp
+++ b/scene/resources/placeholder_textures.cpp
@@ -70,7 +70,7 @@ PlaceholderTexture2D::PlaceholderTexture2D() {
 PlaceholderTexture2D::~PlaceholderTexture2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (rid.is_valid()) {
-		RS::get_singleton()->free(rid);
+		RS::get_singleton()->free_rid(rid);
 	}
 }
 
@@ -127,7 +127,7 @@ PlaceholderTexture3D::PlaceholderTexture3D() {
 PlaceholderTexture3D::~PlaceholderTexture3D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (rid.is_valid()) {
-		RS::get_singleton()->free(rid);
+		RS::get_singleton()->free_rid(rid);
 	}
 }
 
@@ -195,6 +195,6 @@ PlaceholderTextureLayered::PlaceholderTextureLayered(LayeredType p_type) {
 PlaceholderTextureLayered::~PlaceholderTextureLayered() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 	if (rid.is_valid()) {
-		RS::get_singleton()->free(rid);
+		RS::get_singleton()->free_rid(rid);
 	}
 }

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -400,6 +400,6 @@ void PortableCompressedTexture2D::_bind_methods() {
 PortableCompressedTexture2D::~PortableCompressedTexture2D() {
 	if (texture.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(texture);
+		RenderingServer::get_singleton()->free_rid(texture);
 	}
 }

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -295,7 +295,7 @@ Shader::Shader() {
 Shader::~Shader() {
 	if (shader_rid.is_valid()) {
 		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RenderingServer::get_singleton()->free(shader_rid);
+		RenderingServer::get_singleton()->free_rid(shader_rid);
 	}
 }
 

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -105,5 +105,5 @@ Sky::Sky() {
 
 Sky::~Sky() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(sky);
+	RS::get_singleton()->free_rid(sky);
 }

--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -76,7 +76,7 @@ void Texture2DRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &Texture2DRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
 	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free(texture_rid);
+		RS::get_singleton()->free_rid(texture_rid);
 		texture_rid = RID();
 		size = Size2i();
 
@@ -120,7 +120,7 @@ Texture2DRD::Texture2DRD() {
 Texture2DRD::~Texture2DRD() {
 	if (texture_rid.is_valid()) {
 		ERR_FAIL_NULL(RS::get_singleton());
-		RS::get_singleton()->free(texture_rid);
+		RS::get_singleton()->free_rid(texture_rid);
 		texture_rid = RID();
 	}
 }
@@ -179,7 +179,7 @@ void TextureLayeredRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &TextureLayeredRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
 	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free(texture_rid);
+		RS::get_singleton()->free_rid(texture_rid);
 		texture_rid = RID();
 		image_format = Image::FORMAT_MAX;
 		size = Size2i();
@@ -251,7 +251,7 @@ TextureLayeredRD::TextureLayeredRD(LayeredType p_layer_type) {
 TextureLayeredRD::~TextureLayeredRD() {
 	if (texture_rid.is_valid()) {
 		ERR_FAIL_NULL(RS::get_singleton());
-		RS::get_singleton()->free(texture_rid);
+		RS::get_singleton()->free_rid(texture_rid);
 		texture_rid = RID();
 	}
 }
@@ -301,7 +301,7 @@ void Texture3DRD::set_texture_rd_rid(RID p_texture_rd_rid) {
 	if (p_texture_rd_rid.is_valid()) {
 		RS::get_singleton()->call_on_render_thread(callable_mp(this, &Texture3DRD::_set_texture_rd_rid).bind(p_texture_rd_rid));
 	} else if (texture_rid.is_valid()) {
-		RS::get_singleton()->free(texture_rid);
+		RS::get_singleton()->free_rid(texture_rid);
 		texture_rid = RID();
 		image_format = Image::FORMAT_MAX;
 		size = Vector3i();
@@ -352,7 +352,7 @@ Texture3DRD::Texture3DRD() {
 Texture3DRD::~Texture3DRD() {
 	if (texture_rid.is_valid()) {
 		ERR_FAIL_NULL(RS::get_singleton());
-		RS::get_singleton()->free(texture_rid);
+		RS::get_singleton()->free_rid(texture_rid);
 		texture_rid = RID();
 	}
 }

--- a/scene/resources/world_2d.cpp
+++ b/scene/resources/world_2d.cpp
@@ -106,19 +106,19 @@ World2D::World2D() {
 
 World2D::~World2D() {
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(canvas);
+	RenderingServer::get_singleton()->free_rid(canvas);
 
 #ifndef NAVIGATION_2D_DISABLED
 	ERR_FAIL_NULL(NavigationServer2D::get_singleton());
 	if (navigation_map.is_valid()) {
-		NavigationServer2D::get_singleton()->free(navigation_map);
+		NavigationServer2D::get_singleton()->free_rid(navigation_map);
 	}
 #endif // NAVIGATION_2D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
 	ERR_FAIL_NULL(PhysicsServer2D::get_singleton());
 	if (space.is_valid()) {
-		PhysicsServer2D::get_singleton()->free(space);
+		PhysicsServer2D::get_singleton()->free_rid(space);
 	}
 #endif // PHYSICS_2D_DISABLED
 }

--- a/servers/camera/camera_feed.cpp
+++ b/servers/camera/camera_feed.cpp
@@ -178,8 +178,8 @@ CameraFeed::CameraFeed(String p_name, FeedPosition p_position) {
 CameraFeed::~CameraFeed() {
 	// Free our textures
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RenderingServer::get_singleton()->free(texture[CameraServer::FEED_Y_IMAGE]);
-	RenderingServer::get_singleton()->free(texture[CameraServer::FEED_CBCR_IMAGE]);
+	RenderingServer::get_singleton()->free_rid(texture[CameraServer::FEED_Y_IMAGE]);
+	RenderingServer::get_singleton()->free_rid(texture[CameraServer::FEED_CBCR_IMAGE]);
 }
 
 void CameraFeed::set_rgb_image(const Ref<Image> &p_rgb_img) {

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -437,7 +437,7 @@ public:
 	/* MISC */
 
 	GDVIRTUAL1_REQUIRED(_free_rid, RID)
-	virtual void free(RID p_rid) override {
+	virtual void free_rid(RID p_rid) override {
 		GDVIRTUAL_CALL(_free_rid, p_rid);
 	}
 

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -533,7 +533,7 @@ public:
 	/* MISC */
 
 	GDVIRTUAL1_REQUIRED(_free_rid, RID)
-	virtual void free(RID p_rid) override {
+	virtual void free_rid(RID p_rid) override {
 		GDVIRTUAL_CALL(_free_rid, p_rid);
 	}
 

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -188,7 +188,7 @@ void NavigationServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("simplify_path", "path", "epsilon"), &NavigationServer2D::simplify_path);
 
-	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free_rid);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &NavigationServer2D::set_active);
 
@@ -289,13 +289,13 @@ RID NavigationServer2D::source_geometry_parser_create() {
 	return rid;
 }
 
-void NavigationServer2D::free(RID p_object) {
-	if (!geometry_parser_owner.owns(p_object)) {
+void NavigationServer2D::free_rid(RID p_rid) {
+	if (!geometry_parser_owner.owns(p_rid)) {
 		return;
 	}
 	RWLockWrite write_lock(geometry_parser_rwlock);
 
-	NavMeshGeometryParser2D *parser = geometry_parser_owner.get_or_null(p_object);
+	NavMeshGeometryParser2D *parser = geometry_parser_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(parser);
 
 	generator_parsers.erase(parser);

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -278,7 +278,10 @@ public:
 	virtual void init() = 0;
 	virtual void sync() = 0;
 	virtual void finish() = 0;
-	virtual void free(RID p_object) = 0;
+	virtual void free_rid(RID p_rid) = 0;
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) { free_rid(p_rid); }
+#endif // DISABLE_DEPRECATED
 
 	NavigationServer2D();
 	~NavigationServer2D() override;

--- a/servers/navigation_server_2d_dummy.h
+++ b/servers/navigation_server_2d_dummy.h
@@ -177,7 +177,7 @@ public:
 
 	int get_process_info(ProcessInfo p_info) const override { return 0; }
 
-	void free(RID p_object) override {}
+	void free_rid(RID p_object) override {}
 
 	void parse_source_geometry_data(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, Node *p_root_node, const Callable &p_callback = Callable()) override {}
 	void bake_from_source_geometry_data(const Ref<NavigationPolygon> &p_navigation_mesh, const Ref<NavigationMeshSourceGeometryData2D> &p_source_geometry_data, const Callable &p_callback = Callable()) override {}

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -210,7 +210,7 @@ void NavigationServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("simplify_path", "path", "epsilon"), &NavigationServer3D::simplify_path);
 
-	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free_rid);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &NavigationServer3D::set_active);
 
@@ -370,13 +370,13 @@ RID NavigationServer3D::source_geometry_parser_create() {
 	return rid;
 }
 
-void NavigationServer3D::free(RID p_object) {
-	if (!geometry_parser_owner.owns(p_object)) {
+void NavigationServer3D::free_rid(RID p_rid) {
+	if (!geometry_parser_owner.owns(p_rid)) {
 		return;
 	}
 	RWLockWrite write_lock(geometry_parser_rwlock);
 
-	NavMeshGeometryParser3D *parser = geometry_parser_owner.get_or_null(p_object);
+	NavMeshGeometryParser3D *parser = geometry_parser_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(parser);
 
 	generator_parsers.erase(parser);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -308,7 +308,12 @@ public:
 	virtual void init() = 0;
 	virtual void sync() = 0;
 	virtual void finish() = 0;
-	virtual void free(RID p_object) = 0;
+	virtual void free_rid(RID p_rid) = 0;
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) {
+		free_rid(p_rid);
+	}
+#endif // DISABLE_DEPRECATED
 
 	NavigationServer3D();
 	~NavigationServer3D() override;

--- a/servers/navigation_server_3d_dummy.h
+++ b/servers/navigation_server_3d_dummy.h
@@ -199,7 +199,7 @@ public:
 
 	Vector<Vector3> simplify_path(const Vector<Vector3> &p_path, real_t p_epsilon) override { return Vector<Vector3>(); }
 
-	void free(RID p_object) override {}
+	void free_rid(RID p_object) override {}
 	void set_active(bool p_active) override {}
 	void process(double p_delta_time) override {}
 	void physics_process(double p_delta_time) override {}

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -796,7 +796,7 @@ void PhysicsServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("joint_get_type", "joint"), &PhysicsServer2D::joint_get_type);
 
-	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer2D::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer2D::free_rid);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer2D::set_active);
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -596,7 +596,12 @@ public:
 
 	/* MISC */
 
-	virtual void free(RID p_rid) = 0;
+	virtual void free_rid(RID p_rid) = 0;
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) {
+		free_rid(p_rid);
+	}
+#endif // DISABLE_DEPRECATED
 
 	virtual void set_active(bool p_active) = 0;
 	virtual void init() = 0;

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -331,7 +331,7 @@ public:
 
 	/* MISC */
 
-	virtual void free(RID p_rid) override {}
+	virtual void free_rid(RID p_rid) override {}
 
 	virtual void set_active(bool p_active) override {}
 	virtual void init() override {

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -310,7 +310,7 @@ public:
 
 	/* MISC */
 
-	FUNC1(free, RID);
+	FUNC1(free_rid, RID);
 	FUNC1(set_active, bool);
 
 	virtual void init() override;

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -1045,7 +1045,7 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_set_flag", "joint", "axis", "flag", "enable"), &PhysicsServer3D::generic_6dof_joint_set_flag);
 	ClassDB::bind_method(D_METHOD("generic_6dof_joint_get_flag", "joint", "axis", "flag"), &PhysicsServer3D::generic_6dof_joint_get_flag);
 
-	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free_rid);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &PhysicsServer3D::set_active);
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -805,7 +805,12 @@ public:
 
 	/* MISC */
 
-	virtual void free(RID p_rid) = 0;
+	virtual void free_rid(RID p_rid) = 0;
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) {
+		free_rid(p_rid);
+	}
+#endif // DISABLE_DEPRECATED
 
 	virtual void set_active(bool p_active) = 0;
 	virtual void init() = 0;

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -425,7 +425,7 @@ public:
 
 	/* MISC */
 
-	virtual void free(RID p_rid) override {}
+	virtual void free_rid(RID p_rid) override {}
 
 	virtual void set_active(bool p_active) override {}
 	virtual void init() override {

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -394,7 +394,7 @@ public:
 
 	/* MISC */
 
-	FUNC1(free, RID);
+	FUNC1(free_rid, RID);
 	FUNC1(set_active, bool);
 
 	virtual void init() override;

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -287,12 +287,12 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 	}
 }
 ClusterBuilderSharedDataRD::~ClusterBuilderSharedDataRD() {
-	RD::get_singleton()->free(sphere_vertex_buffer);
-	RD::get_singleton()->free(sphere_index_buffer);
-	RD::get_singleton()->free(cone_vertex_buffer);
-	RD::get_singleton()->free(cone_index_buffer);
-	RD::get_singleton()->free(box_vertex_buffer);
-	RD::get_singleton()->free(box_index_buffer);
+	RD::get_singleton()->free_rid(sphere_vertex_buffer);
+	RD::get_singleton()->free_rid(sphere_index_buffer);
+	RD::get_singleton()->free_rid(cone_vertex_buffer);
+	RD::get_singleton()->free_rid(cone_index_buffer);
+	RD::get_singleton()->free_rid(box_vertex_buffer);
+	RD::get_singleton()->free_rid(box_index_buffer);
 
 	cluster_render.cluster_render_shader.version_free(cluster_render.shader_version);
 	cluster_store.cluster_store_shader.version_free(cluster_store.shader_version);
@@ -306,9 +306,9 @@ void ClusterBuilderRD::_clear() {
 		return;
 	}
 
-	RD::get_singleton()->free(cluster_buffer);
-	RD::get_singleton()->free(cluster_render_buffer);
-	RD::get_singleton()->free(element_buffer);
+	RD::get_singleton()->free_rid(cluster_buffer);
+	RD::get_singleton()->free_rid(cluster_render_buffer);
+	RD::get_singleton()->free_rid(element_buffer);
 	cluster_buffer = RID();
 	cluster_render_buffer = RID();
 	element_buffer = RID();
@@ -319,7 +319,7 @@ void ClusterBuilderRD::_clear() {
 	render_element_max = 0;
 	render_element_count = 0;
 
-	RD::get_singleton()->free(framebuffer);
+	RD::get_singleton()->free_rid(framebuffer);
 	framebuffer = RID();
 
 	cluster_render_uniform_set = RID();
@@ -636,5 +636,5 @@ ClusterBuilderRD::ClusterBuilderRD() {
 
 ClusterBuilderRD::~ClusterBuilderRD() {
 	_clear();
-	RD::get_singleton()->free(state_uniform);
+	RD::get_singleton()->free_rid(state_uniform);
 }

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -320,14 +320,14 @@ CopyEffects::~CopyEffects() {
 	copy.shader.version_free(copy.shader_version);
 	specular_merge.shader.version_free(specular_merge.shader_version);
 
-	RD::get_singleton()->free(filter.coefficient_buffer);
+	RD::get_singleton()->free_rid(filter.coefficient_buffer);
 
 	if (RD::get_singleton()->uniform_set_is_valid(filter.image_uniform_set)) {
-		RD::get_singleton()->free(filter.image_uniform_set);
+		RD::get_singleton()->free_rid(filter.image_uniform_set);
 	}
 
 	if (RD::get_singleton()->uniform_set_is_valid(filter.uniform_set)) {
-		RD::get_singleton()->free(filter.uniform_set);
+		RD::get_singleton()->free_rid(filter.uniform_set);
 	}
 
 	copy_to_fb.shader.version_free(copy_to_fb.shader_version);
@@ -1117,7 +1117,7 @@ void CopyEffects::cubemap_filter(RID p_source_cubemap, Vector<RID> p_dest_cubema
 		uniforms.push_back(u);
 	}
 	if (RD::get_singleton()->uniform_set_is_valid(filter.image_uniform_set)) {
-		RD::get_singleton()->free(filter.image_uniform_set);
+		RD::get_singleton()->free_rid(filter.image_uniform_set);
 	}
 	filter.image_uniform_set = RD::get_singleton()->uniform_set_create(uniforms, filter.compute_shader.version_get_shader(filter.shader_version, 0), 2);
 

--- a/servers/rendering/renderer_rd/effects/debug_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/debug_effects.cpp
@@ -161,17 +161,17 @@ DebugEffects::~DebugEffects() {
 
 	// Destroy vertex buffer and array.
 	if (frustum.vertex_buffer.is_valid()) {
-		RD::get_singleton()->free(frustum.vertex_buffer); // Array gets freed as dependency.
+		RD::get_singleton()->free_rid(frustum.vertex_buffer); // Array gets freed as dependency.
 	}
 
 	// Destroy index buffer and array,
 	if (frustum.index_buffer.is_valid()) {
-		RD::get_singleton()->free(frustum.index_buffer); // Array gets freed as dependency.
+		RD::get_singleton()->free_rid(frustum.index_buffer); // Array gets freed as dependency.
 	}
 
 	// Destroy lines buffer and array.
 	if (frustum.lines_buffer.is_valid()) {
-		RD::get_singleton()->free(frustum.lines_buffer); // Array gets freed as dependency.
+		RD::get_singleton()->free_rid(frustum.lines_buffer); // Array gets freed as dependency.
 	}
 
 	motion_vectors.shader.version_free(motion_vectors.shader_version);

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -196,7 +196,7 @@ static FfxErrorCode destroy_backend_context_rd(FfxFsr2Interface *p_backend_inter
 	FSR2Context::Scratch &scratch = *reinterpret_cast<FSR2Context::Scratch *>(p_backend_interface->scratchBuffer);
 
 	for (uint32_t i = 0; i < FSR2_UBO_RING_BUFFER_SIZE; i++) {
-		RD::get_singleton()->free(scratch.ubo_ring_buffer[i]);
+		RD::get_singleton()->free_rid(scratch.ubo_ring_buffer[i]);
 	}
 
 	return FFX_OK;
@@ -288,7 +288,7 @@ static FfxErrorCode destroy_resource_rd(FfxFsr2Interface *p_backend_interface, F
 	if (p_resource.internalIndex != -1) {
 		FSR2Context::Scratch &scratch = *reinterpret_cast<FSR2Context::Scratch *>(p_backend_interface->scratchBuffer);
 		if (scratch.resources.rids[p_resource.internalIndex].is_valid()) {
-			RD::get_singleton()->free(scratch.resources.rids[p_resource.internalIndex]);
+			RD::get_singleton()->free_rid(scratch.resources.rids[p_resource.internalIndex]);
 			scratch.resources.remove(p_resource.internalIndex);
 		}
 	}
@@ -792,8 +792,8 @@ FSR2Effect::FSR2Effect() {
 }
 
 FSR2Effect::~FSR2Effect() {
-	RD::get_singleton()->free(device.point_clamp_sampler);
-	RD::get_singleton()->free(device.linear_clamp_sampler);
+	RD::get_singleton()->free_rid(device.point_clamp_sampler);
+	RD::get_singleton()->free_rid(device.linear_clamp_sampler);
 
 	for (uint32_t i = 0; i < FFX_FSR2_PASS_COUNT; i++) {
 		device.passes[i].shader->version_free(device.passes[i].shader_version);

--- a/servers/rendering/renderer_rd/effects/luminance.cpp
+++ b/servers/rendering/renderer_rd/effects/luminance.cpp
@@ -121,12 +121,12 @@ void Luminance::LuminanceBuffers::configure(RenderSceneBuffersRD *p_render_buffe
 
 void Luminance::LuminanceBuffers::free_data() {
 	for (int i = 0; i < reduce.size(); i++) {
-		RD::get_singleton()->free(reduce[i]);
+		RD::get_singleton()->free_rid(reduce[i]);
 	}
 	reduce.clear();
 
 	if (current.is_valid()) {
-		RD::get_singleton()->free(current);
+		RD::get_singleton()->free_rid(current);
 		current = RID();
 	}
 }

--- a/servers/rendering/renderer_rd/effects/smaa.cpp
+++ b/servers/rendering/renderer_rd/effects/smaa.cpp
@@ -138,8 +138,8 @@ SMAA::SMAA() {
 }
 
 SMAA::~SMAA() {
-	RD::get_singleton()->free(smaa.search_tex);
-	RD::get_singleton()->free(smaa.area_tex);
+	RD::get_singleton()->free_rid(smaa.search_tex);
+	RD::get_singleton()->free_rid(smaa.area_tex);
 
 	smaa.edge_shader.version_free(smaa.edge_shader_version);
 	smaa.weight_shader.version_free(smaa.weight_shader_version);

--- a/servers/rendering/renderer_rd/effects/ss_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/ss_effects.cpp
@@ -366,7 +366,7 @@ SSEffects::~SSEffects() {
 		ssr_scale.shader.version_free(ssr_scale.shader_version);
 
 		if (ssr.ubo.is_valid()) {
-			RD::get_singleton()->free(ssr.ubo);
+			RD::get_singleton()->free_rid(ssr.ubo);
 		}
 	}
 
@@ -374,8 +374,8 @@ SSEffects::~SSEffects() {
 		// Cleanup SS downsampler
 		ss_effects.downsample_shader.version_free(ss_effects.downsample_shader_version);
 
-		RD::get_singleton()->free(ss_effects.mirror_sampler);
-		RD::get_singleton()->free(ss_effects.gather_constants_buffer);
+		RD::get_singleton()->free_rid(ss_effects.mirror_sampler);
+		RD::get_singleton()->free_rid(ss_effects.gather_constants_buffer);
 	}
 
 	{
@@ -385,8 +385,8 @@ SSEffects::~SSEffects() {
 		ssil.interleave_shader.version_free(ssil.interleave_shader_version);
 		ssil.importance_map_shader.version_free(ssil.importance_map_shader_version);
 
-		RD::get_singleton()->free(ssil.importance_map_load_counter);
-		RD::get_singleton()->free(ssil.projection_uniform_buffer);
+		RD::get_singleton()->free_rid(ssil.importance_map_load_counter);
+		RD::get_singleton()->free_rid(ssil.projection_uniform_buffer);
 	}
 
 	{
@@ -396,7 +396,7 @@ SSEffects::~SSEffects() {
 		ssao.interleave_shader.version_free(ssao.interleave_shader_version);
 		ssao.importance_map_shader.version_free(ssao.importance_map_shader_version);
 
-		RD::get_singleton()->free(ssao.importance_map_load_counter);
+		RD::get_singleton()->free_rid(ssao.importance_map_load_counter);
 	}
 
 	{

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -338,10 +338,10 @@ void Fog::free_fog_shader() {
 		volumetric_fog.process_shader.version_free(volumetric_fog.process_shader_version);
 	}
 	if (volumetric_fog.volume_ubo.is_valid()) {
-		RD::get_singleton()->free(volumetric_fog.volume_ubo);
+		RD::get_singleton()->free_rid(volumetric_fog.volume_ubo);
 	}
 	if (volumetric_fog.params_ubo.is_valid()) {
-		RD::get_singleton()->free(volumetric_fog.params_ubo);
+		RD::get_singleton()->free_rid(volumetric_fog.params_ubo);
 	}
 	if (volumetric_fog.default_shader.is_valid()) {
 		material_storage->shader_free(volumetric_fog.default_shader);
@@ -439,9 +439,9 @@ bool Fog::VolumetricFog::sync_gi_dependent_sets_validity(bool p_ensure_freed) {
 
 	if (valid) {
 		if (p_ensure_freed) {
-			RD::get_singleton()->free(gi_dependent_sets.process_uniform_set_density);
-			RD::get_singleton()->free(gi_dependent_sets.process_uniform_set);
-			RD::get_singleton()->free(gi_dependent_sets.process_uniform_set2);
+			RD::get_singleton()->free_rid(gi_dependent_sets.process_uniform_set_density);
+			RD::get_singleton()->free_rid(gi_dependent_sets.process_uniform_set);
+			RD::get_singleton()->free_rid(gi_dependent_sets.process_uniform_set2);
 			valid = false;
 		}
 	}
@@ -518,27 +518,27 @@ void Fog::VolumetricFog::init(const Vector3i &fog_size, RID p_sky_shader) {
 }
 
 Fog::VolumetricFog::~VolumetricFog() {
-	RD::get_singleton()->free(prev_light_density_map);
-	RD::get_singleton()->free(light_density_map);
-	RD::get_singleton()->free(fog_map);
-	RD::get_singleton()->free(density_map);
-	RD::get_singleton()->free(light_map);
-	RD::get_singleton()->free(emissive_map);
+	RD::get_singleton()->free_rid(prev_light_density_map);
+	RD::get_singleton()->free_rid(light_density_map);
+	RD::get_singleton()->free_rid(fog_map);
+	RD::get_singleton()->free_rid(density_map);
+	RD::get_singleton()->free_rid(light_map);
+	RD::get_singleton()->free_rid(emissive_map);
 
 	if (fog_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(fog_uniform_set)) {
-		RD::get_singleton()->free(fog_uniform_set);
+		RD::get_singleton()->free_rid(fog_uniform_set);
 	}
 	if (copy_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(copy_uniform_set)) {
-		RD::get_singleton()->free(copy_uniform_set);
+		RD::get_singleton()->free_rid(copy_uniform_set);
 	}
 
 	sync_gi_dependent_sets_validity(true);
 
 	if (sdfgi_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(sdfgi_uniform_set)) {
-		RD::get_singleton()->free(sdfgi_uniform_set);
+		RD::get_singleton()->free_rid(sdfgi_uniform_set);
 	}
 	if (sky_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(sky_uniform_set)) {
-		RD::get_singleton()->free(sky_uniform_set);
+		RD::get_singleton()->free_rid(sky_uniform_set);
 	}
 }
 
@@ -979,7 +979,7 @@ void Fog::volumetric_fog_update(const VolumetricFogSettings &p_settings, const P
 		}
 
 		if (fog->copy_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(fog->copy_uniform_set)) {
-			RD::get_singleton()->free(fog->copy_uniform_set);
+			RD::get_singleton()->free_rid(fog->copy_uniform_set);
 		}
 		fog->copy_uniform_set = RD::get_singleton()->uniform_set_create(copy_uniforms, volumetric_fog.process_shader.version_get_shader(volumetric_fog.process_shader_version, _get_fog_process_variant(VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_COPY)), 0);
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -67,10 +67,10 @@ void GI::voxel_gi_allocate_data(RID p_voxel_gi, const Transform3D &p_to_cell_xfo
 	ERR_FAIL_NULL(voxel_gi);
 
 	if (voxel_gi->octree_buffer.is_valid()) {
-		RD::get_singleton()->free(voxel_gi->octree_buffer);
-		RD::get_singleton()->free(voxel_gi->data_buffer);
+		RD::get_singleton()->free_rid(voxel_gi->octree_buffer);
+		RD::get_singleton()->free_rid(voxel_gi->data_buffer);
 		if (voxel_gi->sdf_texture.is_valid()) {
-			RD::get_singleton()->free(voxel_gi->sdf_texture);
+			RD::get_singleton()->free_rid(voxel_gi->sdf_texture);
 		}
 
 		voxel_gi->sdf_texture = RID();
@@ -1126,56 +1126,56 @@ void GI::SDFGI::free_data() {
 
 GI::SDFGI::~SDFGI() {
 	for (const SDFGI::Cascade &c : cascades) {
-		RD::get_singleton()->free(c.light_data);
-		RD::get_singleton()->free(c.light_aniso_0_tex);
-		RD::get_singleton()->free(c.light_aniso_1_tex);
-		RD::get_singleton()->free(c.sdf_tex);
-		RD::get_singleton()->free(c.solid_cell_dispatch_buffer_storage);
-		RD::get_singleton()->free(c.solid_cell_dispatch_buffer_call);
-		RD::get_singleton()->free(c.solid_cell_buffer);
-		RD::get_singleton()->free(c.lightprobe_history_tex);
-		RD::get_singleton()->free(c.lightprobe_average_tex);
-		RD::get_singleton()->free(c.lights_buffer);
+		RD::get_singleton()->free_rid(c.light_data);
+		RD::get_singleton()->free_rid(c.light_aniso_0_tex);
+		RD::get_singleton()->free_rid(c.light_aniso_1_tex);
+		RD::get_singleton()->free_rid(c.sdf_tex);
+		RD::get_singleton()->free_rid(c.solid_cell_dispatch_buffer_storage);
+		RD::get_singleton()->free_rid(c.solid_cell_dispatch_buffer_call);
+		RD::get_singleton()->free_rid(c.solid_cell_buffer);
+		RD::get_singleton()->free_rid(c.lightprobe_history_tex);
+		RD::get_singleton()->free_rid(c.lightprobe_average_tex);
+		RD::get_singleton()->free_rid(c.lights_buffer);
 	}
 
-	RD::get_singleton()->free(render_albedo);
-	RD::get_singleton()->free(render_emission);
-	RD::get_singleton()->free(render_emission_aniso);
+	RD::get_singleton()->free_rid(render_albedo);
+	RD::get_singleton()->free_rid(render_emission);
+	RD::get_singleton()->free_rid(render_emission_aniso);
 
-	RD::get_singleton()->free(render_sdf[0]);
-	RD::get_singleton()->free(render_sdf[1]);
+	RD::get_singleton()->free_rid(render_sdf[0]);
+	RD::get_singleton()->free_rid(render_sdf[1]);
 
-	RD::get_singleton()->free(render_sdf_half[0]);
-	RD::get_singleton()->free(render_sdf_half[1]);
+	RD::get_singleton()->free_rid(render_sdf_half[0]);
+	RD::get_singleton()->free_rid(render_sdf_half[1]);
 
 	for (int i = 0; i < 8; i++) {
-		RD::get_singleton()->free(render_occlusion[i]);
+		RD::get_singleton()->free_rid(render_occlusion[i]);
 	}
 
-	RD::get_singleton()->free(render_geom_facing);
+	RD::get_singleton()->free_rid(render_geom_facing);
 
-	RD::get_singleton()->free(lightprobe_data);
-	RD::get_singleton()->free(lightprobe_history_scroll);
-	RD::get_singleton()->free(lightprobe_average_scroll);
-	RD::get_singleton()->free(occlusion_data);
-	RD::get_singleton()->free(ambient_texture);
+	RD::get_singleton()->free_rid(lightprobe_data);
+	RD::get_singleton()->free_rid(lightprobe_history_scroll);
+	RD::get_singleton()->free_rid(lightprobe_average_scroll);
+	RD::get_singleton()->free_rid(occlusion_data);
+	RD::get_singleton()->free_rid(ambient_texture);
 
-	RD::get_singleton()->free(cascades_ubo);
+	RD::get_singleton()->free_rid(cascades_ubo);
 
 	for (uint32_t v = 0; v < RendererSceneRender::MAX_RENDER_VIEWS; v++) {
 		if (RD::get_singleton()->uniform_set_is_valid(debug_uniform_set[v])) {
-			RD::get_singleton()->free(debug_uniform_set[v]);
+			RD::get_singleton()->free_rid(debug_uniform_set[v]);
 		}
 		debug_uniform_set[v] = RID();
 	}
 
 	if (RD::get_singleton()->uniform_set_is_valid(debug_probes_uniform_set)) {
-		RD::get_singleton()->free(debug_probes_uniform_set);
+		RD::get_singleton()->free_rid(debug_probes_uniform_set);
 	}
 	debug_probes_uniform_set = RID();
 
 	if (debug_probes_scene_data_ubo.is_valid()) {
-		RD::get_singleton()->free(debug_probes_scene_data_ubo);
+		RD::get_singleton()->free_rid(debug_probes_scene_data_ubo);
 		debug_probes_scene_data_ubo = RID();
 	}
 }
@@ -3254,8 +3254,8 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 
 void GI::VoxelGIInstance::free_resources() {
 	if (texture.is_valid()) {
-		RD::get_singleton()->free(texture);
-		RD::get_singleton()->free(write_buffer);
+		RD::get_singleton()->free_rid(texture);
+		RD::get_singleton()->free_rid(write_buffer);
 
 		texture = RID();
 		write_buffer = RID();
@@ -3263,21 +3263,21 @@ void GI::VoxelGIInstance::free_resources() {
 	}
 
 	for (int i = 0; i < dynamic_maps.size(); i++) {
-		RD::get_singleton()->free(dynamic_maps[i].texture);
-		RD::get_singleton()->free(dynamic_maps[i].depth);
+		RD::get_singleton()->free_rid(dynamic_maps[i].texture);
+		RD::get_singleton()->free_rid(dynamic_maps[i].depth);
 
 		// these only exist on the first level...
 		if (dynamic_maps[i].fb_depth.is_valid()) {
-			RD::get_singleton()->free(dynamic_maps[i].fb_depth);
+			RD::get_singleton()->free_rid(dynamic_maps[i].fb_depth);
 		}
 		if (dynamic_maps[i].albedo.is_valid()) {
-			RD::get_singleton()->free(dynamic_maps[i].albedo);
+			RD::get_singleton()->free_rid(dynamic_maps[i].albedo);
 		}
 		if (dynamic_maps[i].normal.is_valid()) {
-			RD::get_singleton()->free(dynamic_maps[i].normal);
+			RD::get_singleton()->free_rid(dynamic_maps[i].normal);
 		}
 		if (dynamic_maps[i].orm.is_valid()) {
-			RD::get_singleton()->free(dynamic_maps[i].orm);
+			RD::get_singleton()->free_rid(dynamic_maps[i].orm);
 		}
 	}
 	dynamic_maps.clear();
@@ -3313,7 +3313,7 @@ void GI::VoxelGIInstance::debug(RD::DrawListID p_draw_list, RID p_framebuffer, c
 	}
 
 	if (gi->voxel_gi_debug_uniform_set.is_valid()) {
-		RD::get_singleton()->free(gi->voxel_gi_debug_uniform_set);
+		RD::get_singleton()->free_rid(gi->voxel_gi_debug_uniform_set);
 	}
 	Vector<RD::Uniform> uniforms;
 	{
@@ -3643,13 +3643,13 @@ void GI::init(SkyRD *p_sky) {
 
 void GI::free() {
 	if (default_voxel_gi_buffer.is_valid()) {
-		RD::get_singleton()->free(default_voxel_gi_buffer);
+		RD::get_singleton()->free_rid(default_voxel_gi_buffer);
 	}
 	if (voxel_gi_lights_uniform.is_valid()) {
-		RD::get_singleton()->free(voxel_gi_lights_uniform);
+		RD::get_singleton()->free_rid(voxel_gi_lights_uniform);
 	}
 	if (sdfgi_ubo.is_valid()) {
-		RD::get_singleton()->free(sdfgi_ubo);
+		RD::get_singleton()->free_rid(sdfgi_ubo);
 	}
 
 	if (voxel_gi_lights) {
@@ -3749,7 +3749,7 @@ void GI::setup_voxel_gi_instances(RenderDataRD *p_render_data, Ref<RenderSceneBu
 	if (voxel_gi_instances_changed) {
 		for (uint32_t v = 0; v < RendererSceneRender::MAX_RENDER_VIEWS; v++) {
 			if (RD::get_singleton()->uniform_set_is_valid(rbgi->uniform_set[v])) {
-				RD::get_singleton()->free(rbgi->uniform_set[v]);
+				RD::get_singleton()->free_rid(rbgi->uniform_set[v]);
 			}
 			rbgi->uniform_set[v] = RID();
 		}
@@ -3780,18 +3780,18 @@ RID GI::RenderBuffersGI::get_voxel_gi_buffer() {
 void GI::RenderBuffersGI::free_data() {
 	for (uint32_t v = 0; v < RendererSceneRender::MAX_RENDER_VIEWS; v++) {
 		if (RD::get_singleton()->uniform_set_is_valid(uniform_set[v])) {
-			RD::get_singleton()->free(uniform_set[v]);
+			RD::get_singleton()->free_rid(uniform_set[v]);
 		}
 		uniform_set[v] = RID();
 	}
 
 	if (scene_data_ubo.is_valid()) {
-		RD::get_singleton()->free(scene_data_ubo);
+		RD::get_singleton()->free_rid(scene_data_ubo);
 		scene_data_ubo = RID();
 	}
 
 	if (voxel_gi_buffer.is_valid()) {
-		RD::get_singleton()->free(voxel_gi_buffer);
+		RD::get_singleton()->free_rid(voxel_gi_buffer);
 		voxel_gi_buffer = RID();
 	}
 }

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -267,7 +267,7 @@ void SkyRD::ReflectionData::clear_reflection_data() {
 	layers.clear();
 	radiance_base_cubemap = RID();
 	if (downsampled_radiance_cubemap.is_valid()) {
-		RD::get_singleton()->free(downsampled_radiance_cubemap);
+		RD::get_singleton()->free_rid(downsampled_radiance_cubemap);
 	}
 	downsampled_radiance_cubemap = RID();
 	downsampled_layer.mipmaps.clear();
@@ -540,13 +540,13 @@ void SkyRD::ReflectionData::update_reflection_mipmaps(int p_start, int p_end) {
 
 void SkyRD::Sky::free() {
 	if (radiance.is_valid()) {
-		RD::get_singleton()->free(radiance);
+		RD::get_singleton()->free_rid(radiance);
 		radiance = RID();
 	}
 	reflection.clear_reflection_data();
 
 	if (uniform_buffer.is_valid()) {
-		RD::get_singleton()->free(uniform_buffer);
+		RD::get_singleton()->free_rid(uniform_buffer);
 		uniform_buffer = RID();
 	}
 
@@ -629,7 +629,7 @@ bool SkyRD::Sky::set_radiance_size(int p_radiance_size) {
 	}
 
 	if (radiance.is_valid()) {
-		RD::get_singleton()->free(radiance);
+		RD::get_singleton()->free_rid(radiance);
 		radiance = RID();
 	}
 	reflection.clear_reflection_data();
@@ -650,7 +650,7 @@ bool SkyRD::Sky::set_mode(RS::SkyMode p_mode) {
 	}
 
 	if (radiance.is_valid()) {
-		RD::get_singleton()->free(radiance);
+		RD::get_singleton()->free_rid(radiance);
 		radiance = RID();
 	}
 	reflection.clear_reflection_data();
@@ -680,7 +680,7 @@ Ref<Image> SkyRD::Sky::bake_panorama(float p_energy, int p_roughness_layers, con
 		RID rad_tex = RD::get_singleton()->texture_create(tf, RD::TextureView());
 		copy_effects->copy_cubemap_to_panorama(radiance, rad_tex, p_size, p_roughness_layers, reflection.layers.size() > 1);
 		Vector<uint8_t> data = RD::get_singleton()->texture_get_data(rad_tex, 0);
-		RD::get_singleton()->free(rad_tex);
+		RD::get_singleton()->free_rid(rad_tex);
 
 		Ref<Image> img = Image::create_from_data(p_size.width, p_size.height, false, Image::FORMAT_RGBAF, data);
 		for (int i = 0; i < p_size.width; i++) {
@@ -964,8 +964,8 @@ SkyRD::~SkyRD() {
 
 	SkyMaterialData *md = static_cast<SkyMaterialData *>(material_storage->material_get_data(sky_shader.default_material, RendererRD::MaterialStorage::SHADER_TYPE_SKY));
 	sky_shader.shader.version_free(md->shader_data->version);
-	RD::get_singleton()->free(sky_scene_state.directional_light_buffer);
-	RD::get_singleton()->free(sky_scene_state.uniform_buffer);
+	RD::get_singleton()->free_rid(sky_scene_state.directional_light_buffer);
+	RD::get_singleton()->free_rid(sky_scene_state.uniform_buffer);
 	memdelete_arr(sky_scene_state.directional_lights);
 	memdelete_arr(sky_scene_state.last_frame_directional_lights);
 	material_storage->shader_free(sky_shader.default_shader);
@@ -974,15 +974,15 @@ SkyRD::~SkyRD() {
 	material_storage->material_free(sky_scene_state.fog_material);
 
 	if (RD::get_singleton()->uniform_set_is_valid(sky_scene_state.uniform_set)) {
-		RD::get_singleton()->free(sky_scene_state.uniform_set);
+		RD::get_singleton()->free_rid(sky_scene_state.uniform_set);
 	}
 
 	if (RD::get_singleton()->uniform_set_is_valid(sky_scene_state.default_fog_uniform_set)) {
-		RD::get_singleton()->free(sky_scene_state.default_fog_uniform_set);
+		RD::get_singleton()->free_rid(sky_scene_state.default_fog_uniform_set);
 	}
 
 	if (RD::get_singleton()->uniform_set_is_valid(sky_scene_state.fog_only_texture_uniform_set)) {
-		RD::get_singleton()->free(sky_scene_state.fog_only_texture_uniform_set);
+		RD::get_singleton()->free_rid(sky_scene_state.fog_only_texture_uniform_set);
 	}
 }
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -135,7 +135,7 @@ void RenderForwardClustered::RenderBufferDataForwardClustered::free_data() {
 #endif
 
 	if (!render_sdfgi_uniform_set.is_null() && RD::get_singleton()->uniform_set_is_valid(render_sdfgi_uniform_set)) {
-		RD::get_singleton()->free(render_sdfgi_uniform_set);
+		RD::get_singleton()->free_rid(render_sdfgi_uniform_set);
 	}
 }
 
@@ -760,7 +760,7 @@ void RenderForwardClustered::_update_instance_data_buffer(RenderListType p_rende
 	if (scene_state.instance_data[p_render_list].size() > 0) {
 		if (scene_state.instance_buffer[p_render_list] == RID() || scene_state.instance_buffer_size[p_render_list] < scene_state.instance_data[p_render_list].size()) {
 			if (scene_state.instance_buffer[p_render_list] != RID()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[p_render_list]);
+				RD::get_singleton()->free_rid(scene_state.instance_buffer[p_render_list]);
 			}
 			uint32_t new_size = nearest_power_of_2_templated(MAX(uint64_t(INSTANCE_DATA_BUFFER_MIN_SIZE), scene_state.instance_data[p_render_list].size()));
 			scene_state.instance_buffer[p_render_list] = RD::get_singleton()->storage_buffer_create(new_size * sizeof(SceneState::InstanceData));
@@ -3093,7 +3093,7 @@ void RenderForwardClustered::_render_sdfgi(Ref<RenderSceneBuffersRD> p_render_bu
 
 void RenderForwardClustered::base_uniforms_changed() {
 	if (!render_base_uniform_set.is_null() && RD::get_singleton()->uniform_set_is_valid(render_base_uniform_set)) {
-		RD::get_singleton()->free(render_base_uniform_set);
+		RD::get_singleton()->free_rid(render_base_uniform_set);
 	}
 	render_base_uniform_set = RID();
 }
@@ -3103,7 +3103,7 @@ void RenderForwardClustered::_update_render_base_uniform_set() {
 
 	if (render_base_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(render_base_uniform_set) || (lightmap_texture_array_version != light_storage->lightmap_array_get_version())) {
 		if (render_base_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(render_base_uniform_set)) {
-			RD::get_singleton()->free(render_base_uniform_set);
+			RD::get_singleton()->free_rid(render_base_uniform_set);
 		}
 
 		lightmap_texture_array_version = light_storage->lightmap_array_get_version();
@@ -5079,36 +5079,36 @@ RenderForwardClustered::~RenderForwardClustered() {
 	}
 #endif
 
-	RD::get_singleton()->free(shadow_sampler);
+	RD::get_singleton()->free_rid(shadow_sampler);
 	RSG::light_storage->directional_shadow_atlas_set_size(0);
 
-	RD::get_singleton()->free(best_fit_normal.pipeline);
-	RD::get_singleton()->free(best_fit_normal.texture);
+	RD::get_singleton()->free_rid(best_fit_normal.pipeline);
+	RD::get_singleton()->free_rid(best_fit_normal.texture);
 	best_fit_normal.shader.version_free(best_fit_normal.shader_version);
 
-	RD::get_singleton()->free(dfg_lut.pipeline);
-	RD::get_singleton()->free(dfg_lut.texture);
+	RD::get_singleton()->free_rid(dfg_lut.pipeline);
+	RD::get_singleton()->free_rid(dfg_lut.texture);
 	dfg_lut.shader.version_free(dfg_lut.shader_version);
 
 	{
 		for (const RID &rid : scene_state.uniform_buffers) {
-			RD::get_singleton()->free(rid);
+			RD::get_singleton()->free_rid(rid);
 		}
 		for (const RID &rid : scene_state.implementation_uniform_buffers) {
-			RD::get_singleton()->free(rid);
+			RD::get_singleton()->free_rid(rid);
 		}
-		RD::get_singleton()->free(scene_state.lightmap_buffer);
-		RD::get_singleton()->free(scene_state.lightmap_capture_buffer);
+		RD::get_singleton()->free_rid(scene_state.lightmap_buffer);
+		RD::get_singleton()->free_rid(scene_state.lightmap_capture_buffer);
 		for (uint32_t i = 0; i < RENDER_LIST_MAX; i++) {
 			if (scene_state.instance_buffer[i] != RID()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[i]);
+				RD::get_singleton()->free_rid(scene_state.instance_buffer[i]);
 			}
 		}
 		memdelete_arr(scene_state.lightmap_captures);
 	}
 
 	while (sdfgi_framebuffer_size_cache.begin()) {
-		RD::get_singleton()->free(sdfgi_framebuffer_size_cache.begin()->value);
+		RD::get_singleton()->free_rid(sdfgi_framebuffer_size_cache.begin()->value);
 		sdfgi_framebuffer_size_cache.remove(sdfgi_framebuffer_size_cache.begin());
 	}
 }

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -606,8 +606,8 @@ SceneShaderForwardClustered::SceneShaderForwardClustered() {
 SceneShaderForwardClustered::~SceneShaderForwardClustered() {
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
-	RD::get_singleton()->free(default_vec4_xform_buffer);
-	RD::get_singleton()->free(shadow_sampler);
+	RD::get_singleton()->free_rid(default_vec4_xform_buffer);
+	RD::get_singleton()->free_rid(shadow_sampler);
 
 	material_storage->shader_free(overdraw_material_shader);
 	material_storage->shader_free(default_shader);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1778,7 +1778,7 @@ void RenderForwardMobile::_render_particle_collider_heightfield(RID p_fb, const 
 
 void RenderForwardMobile::base_uniforms_changed() {
 	if (!render_base_uniform_set.is_null() && RD::get_singleton()->uniform_set_is_valid(render_base_uniform_set)) {
-		RD::get_singleton()->free(render_base_uniform_set);
+		RD::get_singleton()->free_rid(render_base_uniform_set);
 	}
 	render_base_uniform_set = RID();
 }
@@ -1788,7 +1788,7 @@ void RenderForwardMobile::_update_render_base_uniform_set() {
 
 	if (render_base_uniform_set.is_null() || !RD::get_singleton()->uniform_set_is_valid(render_base_uniform_set) || (lightmap_texture_array_version != light_storage->lightmap_array_get_version())) {
 		if (render_base_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(render_base_uniform_set)) {
-			RD::get_singleton()->free(render_base_uniform_set);
+			RD::get_singleton()->free_rid(render_base_uniform_set);
 		}
 
 		lightmap_texture_array_version = light_storage->lightmap_array_get_version();
@@ -1904,7 +1904,7 @@ void RenderForwardMobile::_update_instance_data_buffer(RenderListType p_render_l
 	if (scene_state.instance_data[p_render_list].size() > 0) {
 		if (scene_state.instance_buffer[p_render_list] == RID() || scene_state.instance_buffer_size[p_render_list] < scene_state.instance_data[p_render_list].size()) {
 			if (scene_state.instance_buffer[p_render_list] != RID()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[p_render_list]);
+				RD::get_singleton()->free_rid(scene_state.instance_buffer[p_render_list]);
 			}
 			uint32_t new_size = nearest_power_of_2_templated(MAX(uint64_t(INSTANCE_DATA_BUFFER_MIN_SIZE), scene_state.instance_data[p_render_list].size()));
 			scene_state.instance_buffer[p_render_list] = RD::get_singleton()->storage_buffer_create(new_size * sizeof(SceneState::InstanceData));
@@ -3393,15 +3393,15 @@ RenderForwardMobile::~RenderForwardMobile() {
 
 	{
 		for (const RID &rid : scene_state.uniform_buffers) {
-			RD::get_singleton()->free(rid);
+			RD::get_singleton()->free_rid(rid);
 		}
 		for (uint32_t i = 0; i < RENDER_LIST_MAX; i++) {
 			if (scene_state.instance_buffer[i].is_valid()) {
-				RD::get_singleton()->free(scene_state.instance_buffer[i]);
+				RD::get_singleton()->free_rid(scene_state.instance_buffer[i]);
 			}
 		}
-		RD::get_singleton()->free(scene_state.lightmap_buffer);
-		RD::get_singleton()->free(scene_state.lightmap_capture_buffer);
+		RD::get_singleton()->free_rid(scene_state.lightmap_buffer);
+		RD::get_singleton()->free_rid(scene_state.lightmap_capture_buffer);
 		memdelete_arr(scene_state.lightmap_captures);
 	}
 }

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -953,8 +953,8 @@ bool SceneShaderForwardMobile::is_multiview_shader_group_enabled() const {
 SceneShaderForwardMobile::~SceneShaderForwardMobile() {
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
-	RD::get_singleton()->free(default_vec4_xform_buffer);
-	RD::get_singleton()->free(shadow_sampler);
+	RD::get_singleton()->free_rid(default_vec4_xform_buffer);
+	RD::get_singleton()->free_rid(shadow_sampler);
 
 	material_storage->shader_free(overdraw_material_shader);
 	material_storage->shader_free(default_shader);

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
@@ -76,7 +76,7 @@ void PipelineCacheRD::_clear() {
 		for (uint32_t i = 0; i < version_count; i++) {
 			//shader may be gone, so this may not be valid
 			if (RD::get_singleton()->render_pipeline_is_valid(versions[i].pipeline)) {
-				RD::get_singleton()->free(versions[i].pipeline);
+				RD::get_singleton()->free_rid(versions[i].pipeline);
 			}
 		}
 		version_count = 0;

--- a/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
@@ -208,7 +208,7 @@ public:
 		_add_new_pipelines_to_map();
 
 		for (KeyValue<uint32_t, RID> entry : hash_map) {
-			RD::get_singleton()->free(entry.value);
+			RD::get_singleton()->free_rid(entry.value);
 		}
 
 		hash_map.clear();

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -337,14 +337,14 @@ void RendererCanvasRenderRD::free_polygon(PolygonID p_polygon) {
 	PolygonBuffers &pb = *pb_ptr;
 
 	if (pb.indices.is_valid()) {
-		RD::get_singleton()->free(pb.indices);
+		RD::get_singleton()->free_rid(pb.indices);
 	}
 	if (pb.index_buffer.is_valid()) {
-		RD::get_singleton()->free(pb.index_buffer);
+		RD::get_singleton()->free_rid(pb.index_buffer);
 	}
 
-	RD::get_singleton()->free(pb.vertex_array);
-	RD::get_singleton()->free(pb.vertex_buffer);
+	RD::get_singleton()->free_rid(pb.vertex_array);
+	RD::get_singleton()->free_rid(pb.vertex_buffer);
 
 	polygon_buffers.polygons.erase(p_polygon);
 }
@@ -956,7 +956,7 @@ void RendererCanvasRenderRD::light_set_use_shadow(RID p_rid, bool p_enable) {
 void RendererCanvasRenderRD::_update_shadow_atlas() {
 	if (state.shadow_fb == RID()) {
 		//ah, we lack the shadow texture..
-		RD::get_singleton()->free(state.shadow_texture); //erase placeholder
+		RD::get_singleton()->free_rid(state.shadow_texture); //erase placeholder
 
 		Vector<RID> fb_textures;
 
@@ -995,7 +995,7 @@ void RendererCanvasRenderRD::_update_occluder_buffer(uint32_t p_size) {
 		needs_update = true;
 		state.shadow_occluder_buffer_size = next_power_of_2(p_size);
 		if (state.shadow_occluder_buffer.is_valid()) {
-			RD::get_singleton()->free(state.shadow_occluder_buffer);
+			RD::get_singleton()->free_rid(state.shadow_occluder_buffer);
 		}
 	}
 
@@ -1301,10 +1301,10 @@ void RendererCanvasRenderRD::occluder_polygon_set_shape(RID p_occluder, const Ve
 	}
 
 	if ((oc->line_point_count != lines.size() || lines.is_empty()) && oc->vertex_array.is_valid()) {
-		RD::get_singleton()->free(oc->vertex_array);
-		RD::get_singleton()->free(oc->vertex_buffer);
-		RD::get_singleton()->free(oc->index_array);
-		RD::get_singleton()->free(oc->index_buffer);
+		RD::get_singleton()->free_rid(oc->vertex_array);
+		RD::get_singleton()->free_rid(oc->vertex_buffer);
+		RD::get_singleton()->free_rid(oc->index_array);
+		RD::get_singleton()->free_rid(oc->index_buffer);
 
 		oc->vertex_array = RID();
 		oc->vertex_buffer = RID();
@@ -1406,10 +1406,10 @@ void RendererCanvasRenderRD::occluder_polygon_set_shape(RID p_occluder, const Ve
 	}
 
 	if (((oc->sdf_index_count != sdf_indices.size() && oc->sdf_point_count != p_points.size()) || p_points.is_empty()) && oc->sdf_vertex_array.is_valid()) {
-		RD::get_singleton()->free(oc->sdf_vertex_array);
-		RD::get_singleton()->free(oc->sdf_vertex_buffer);
-		RD::get_singleton()->free(oc->sdf_index_array);
-		RD::get_singleton()->free(oc->sdf_index_buffer);
+		RD::get_singleton()->free_rid(oc->sdf_vertex_array);
+		RD::get_singleton()->free_rid(oc->sdf_vertex_buffer);
+		RD::get_singleton()->free_rid(oc->sdf_index_array);
+		RD::get_singleton()->free_rid(oc->sdf_index_buffer);
 
 		oc->sdf_vertex_array = RID();
 		oc->sdf_vertex_buffer = RID();
@@ -2090,8 +2090,8 @@ void RendererCanvasRenderRD::set_shadow_texture_size(int p_size) {
 	}
 	state.shadow_texture_size = p_size;
 	if (state.shadow_fb.is_valid()) {
-		RD::get_singleton()->free(state.shadow_texture);
-		RD::get_singleton()->free(state.shadow_depth_texture);
+		RD::get_singleton()->free_rid(state.shadow_texture);
+		RD::get_singleton()->free_rid(state.shadow_depth_texture);
 		state.shadow_fb = RID();
 
 		{
@@ -2959,7 +2959,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 
 void RendererCanvasRenderRD::_before_evict(RendererCanvasRenderRD::RIDSetKey &p_key, RID &p_rid) {
 	RD::get_singleton()->uniform_set_set_invalidation_callback(p_rid, nullptr, nullptr);
-	RD::get_singleton()->free(p_rid);
+	RD::get_singleton()->free_rid(p_rid);
 }
 
 void RendererCanvasRenderRD::_uniform_set_invalidation_callback(void *p_userdata) {
@@ -2972,7 +2972,7 @@ void RendererCanvasRenderRD::_canvas_texture_invalidation_callback(bool p_delete
 	RD *rd = RD::get_singleton();
 	for (RID rid : kv->value) {
 		// The invalidation callback will also take care of clearing rid_set_to_uniform_set cache.
-		rd->free(rid);
+		rd->free_rid(rid);
 	}
 	kv->value.clear();
 	if (p_deleted) {
@@ -3307,40 +3307,40 @@ RendererCanvasRenderRD::~RendererCanvasRenderRD() {
 
 	{
 		if (state.canvas_state_buffer.is_valid()) {
-			RD::get_singleton()->free(state.canvas_state_buffer);
+			RD::get_singleton()->free_rid(state.canvas_state_buffer);
 		}
 
 		memdelete_arr(state.light_uniforms);
-		RD::get_singleton()->free(state.lights_storage_buffer);
+		RD::get_singleton()->free_rid(state.lights_storage_buffer);
 	}
 
 	//shadow rendering
 	{
 		shadow_render.shader.version_free(shadow_render.shader_version);
 		//this will also automatically clear all pipelines
-		RD::get_singleton()->free(state.shadow_sampler);
+		RD::get_singleton()->free_rid(state.shadow_sampler);
 	}
 
 	//buffers
 	{
-		RD::get_singleton()->free(shader.quad_index_array);
-		RD::get_singleton()->free(shader.quad_index_buffer);
+		RD::get_singleton()->free_rid(shader.quad_index_array);
+		RD::get_singleton()->free_rid(shader.quad_index_buffer);
 		//primitives are erase by dependency
 	}
 
 	if (state.shadow_fb.is_valid()) {
-		RD::get_singleton()->free(state.shadow_depth_texture);
+		RD::get_singleton()->free_rid(state.shadow_depth_texture);
 	}
-	RD::get_singleton()->free(state.shadow_texture);
+	RD::get_singleton()->free_rid(state.shadow_texture);
 
 	if (state.shadow_occluder_buffer.is_valid()) {
-		RD::get_singleton()->free(state.shadow_occluder_buffer);
+		RD::get_singleton()->free_rid(state.shadow_occluder_buffer);
 	}
 
 	memdelete_arr(state.instance_data_array);
 	for (uint32_t i = 0; i < BATCH_DATA_BUFFER_COUNT; i++) {
 		for (uint32_t j = 0; j < state.canvas_instance_data_buffers[i].instance_buffers.size(); j++) {
-			RD::get_singleton()->free(state.canvas_instance_data_buffers[i].instance_buffers[j]);
+			RD::get_singleton()->free_rid(state.canvas_instance_data_buffers[i].instance_buffers[j]);
 		}
 	}
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -176,8 +176,8 @@ void RendererCompositorRD::finalize() {
 
 	//only need to erase these, the rest are erased by cascade
 	blit.shader.version_free(blit.shader_version);
-	RD::get_singleton()->free(blit.index_buffer);
-	RD::get_singleton()->free(blit.sampler);
+	RD::get_singleton()->free_rid(blit.index_buffer);
+	RD::get_singleton()->free_rid(blit.sampler);
 }
 
 void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
@@ -263,7 +263,7 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	RD::get_singleton()->swap_buffers(true);
 
 	texture_storage->texture_free(texture);
-	RD::get_singleton()->free(sampler);
+	RD::get_singleton()->free_rid(sampler);
 }
 
 RendererCompositorRD *RendererCompositorRD::singleton = nullptr;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1585,33 +1585,33 @@ TypedArray<Image> RendererSceneRenderRD::bake_render_uv2(RID p_base, const Typed
 	{
 		PackedByteArray data = RD::get_singleton()->texture_get_data(albedo_alpha_tex, 0);
 		Ref<Image> img = Image::create_from_data(p_image_size.width, p_image_size.height, false, Image::FORMAT_RGBA8, data);
-		RD::get_singleton()->free(albedo_alpha_tex);
+		RD::get_singleton()->free_rid(albedo_alpha_tex);
 		ret.push_back(img);
 	}
 
 	{
 		PackedByteArray data = RD::get_singleton()->texture_get_data(normal_tex, 0);
 		Ref<Image> img = Image::create_from_data(p_image_size.width, p_image_size.height, false, Image::FORMAT_RGBA8, data);
-		RD::get_singleton()->free(normal_tex);
+		RD::get_singleton()->free_rid(normal_tex);
 		ret.push_back(img);
 	}
 
 	{
 		PackedByteArray data = RD::get_singleton()->texture_get_data(orm_tex, 0);
 		Ref<Image> img = Image::create_from_data(p_image_size.width, p_image_size.height, false, Image::FORMAT_RGBA8, data);
-		RD::get_singleton()->free(orm_tex);
+		RD::get_singleton()->free_rid(orm_tex);
 		ret.push_back(img);
 	}
 
 	{
 		PackedByteArray data = RD::get_singleton()->texture_get_data(emission_tex, 0);
 		Ref<Image> img = Image::create_from_data(p_image_size.width, p_image_size.height, false, Image::FORMAT_RGBAH, data);
-		RD::get_singleton()->free(emission_tex);
+		RD::get_singleton()->free_rid(emission_tex);
 		ret.push_back(img);
 	}
 
-	RD::get_singleton()->free(depth_write_tex);
-	RD::get_singleton()->free(depth_tex);
+	RD::get_singleton()->free_rid(depth_write_tex);
+	RD::get_singleton()->free_rid(depth_tex);
 
 	return ret;
 }
@@ -1765,7 +1765,7 @@ RendererSceneRenderRD::~RendererSceneRenderRD() {
 	}
 
 	if (sky.sky_scene_state.uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(sky.sky_scene_state.uniform_set)) {
-		RD::get_singleton()->free(sky.sky_scene_state.uniform_set);
+		RD::get_singleton()->free_rid(sky.sky_scene_state.uniform_set);
 	}
 
 	if (is_dynamic_gi_supported()) {

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -209,7 +209,7 @@ void ShaderRD::_clear_version(Version *p_version) {
 	if (!p_version->variants.is_empty()) {
 		for (int i = 0; i < variant_defines.size(); i++) {
 			if (p_version->variants[i].is_valid()) {
-				RD::get_singleton()->free(p_version->variants[i]);
+				RD::get_singleton()->free_rid(p_version->variants[i]);
 			}
 		}
 
@@ -495,7 +495,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 			if (shader.is_null()) {
 				for (uint32_t j = 0; j < i; j++) {
 					int variant_free_id = group_to_variant_map[p_group][j];
-					RD::get_singleton()->free(p_version->variants[variant_free_id]);
+					RD::get_singleton()->free_rid(p_version->variants[variant_free_id]);
 				}
 				ERR_FAIL_COND_V(shader.is_null(), false);
 			}
@@ -584,7 +584,7 @@ void ShaderRD::_compile_version_end(Version *p_version, int p_group) {
 				continue; // Disabled.
 			}
 			if (!p_version->variants[i].is_null()) {
-				RD::get_singleton()->free(p_version->variants[i]);
+				RD::get_singleton()->free_rid(p_version->variants[i]);
 			}
 		}
 

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -78,7 +78,7 @@ LightStorage::~LightStorage() {
 	free_light_data();
 
 	for (const KeyValue<int, ShadowCubemap> &E : shadow_cubemaps) {
-		RD::get_singleton()->free(E.value.cubemap);
+		RD::get_singleton()->free_rid(E.value.cubemap);
 	}
 
 	singleton = nullptr;
@@ -539,17 +539,17 @@ void LightStorage::light_instance_mark_visible(RID p_light_instance) {
 
 void LightStorage::free_light_data() {
 	if (directional_light_buffer.is_valid()) {
-		RD::get_singleton()->free(directional_light_buffer);
+		RD::get_singleton()->free_rid(directional_light_buffer);
 		directional_light_buffer = RID();
 	}
 
 	if (omni_light_buffer.is_valid()) {
-		RD::get_singleton()->free(omni_light_buffer);
+		RD::get_singleton()->free_rid(omni_light_buffer);
 		omni_light_buffer = RID();
 	}
 
 	if (spot_light_buffer.is_valid()) {
-		RD::get_singleton()->free(spot_light_buffer);
+		RD::get_singleton()->free_rid(spot_light_buffer);
 		spot_light_buffer = RID();
 	}
 
@@ -1354,9 +1354,9 @@ void LightStorage::reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_s
 
 	if (ra->reflection.is_valid()) {
 		//clear and invalidate everything
-		RD::get_singleton()->free(ra->reflection);
+		RD::get_singleton()->free_rid(ra->reflection);
 		ra->reflection = RID();
-		RD::get_singleton()->free(ra->depth_buffer);
+		RD::get_singleton()->free_rid(ra->depth_buffer);
 		ra->depth_buffer = RID();
 		for (int i = 0; i < ra->reflections.size(); i++) {
 			ra->reflections.write[i].data.clear_reflection_data();
@@ -1494,7 +1494,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 	const bool real_time_mipmaps_different = update_always && atlas->reflection.is_valid() && atlas->reflections[0].data.layers[0].mipmaps.size() != 8;
 	if (update_mode_changed || real_time_mipmaps_different) {
 		// Invalidate reflection atlas, need to regenerate
-		RD::get_singleton()->free(atlas->reflection);
+		RD::get_singleton()->free_rid(atlas->reflection);
 		atlas->reflection = RID();
 
 		for (int i = 0; i < atlas->reflections.size(); i++) {
@@ -1691,7 +1691,7 @@ ClusterBuilderRD *LightStorage::reflection_probe_instance_get_cluster_builder(RI
 
 void LightStorage::free_reflection_data() {
 	if (reflection_buffer.is_valid()) {
-		RD::get_singleton()->free(reflection_buffer);
+		RD::get_singleton()->free_rid(reflection_buffer);
 		reflection_buffer = RID();
 	}
 
@@ -2134,7 +2134,7 @@ void LightStorage::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits
 
 	// erasing atlas
 	if (shadow_atlas->depth.is_valid()) {
-		RD::get_singleton()->free(shadow_atlas->depth);
+		RD::get_singleton()->free_rid(shadow_atlas->depth);
 		shadow_atlas->depth = RID();
 	}
 	for (int i = 0; i < 4; i++) {
@@ -2533,7 +2533,7 @@ void LightStorage::directional_shadow_atlas_set_size(int p_size, bool p_16_bits)
 	directional_shadow.use_16_bits = p_16_bits;
 
 	if (directional_shadow.depth.is_valid()) {
-		RD::get_singleton()->free(directional_shadow.depth);
+		RD::get_singleton()->free_rid(directional_shadow.depth);
 		directional_shadow.depth = RID();
 		RendererSceneRenderRD::get_singleton()->base_uniforms_changed();
 	}

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -859,7 +859,7 @@ MaterialStorage::MaterialData::~MaterialData() {
 
 	for (int i = 0; i < 2; i++) {
 		if (uniform_buffer[i].is_valid()) {
-			RD::get_singleton()->free(uniform_buffer[i]);
+			RD::get_singleton()->free_rid(uniform_buffer[i]);
 		}
 	}
 }
@@ -1137,7 +1137,7 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 void MaterialStorage::MaterialData::free_parameters_uniform_set(RID p_uniform_set) {
 	if (p_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(p_uniform_set)) {
 		RD::get_singleton()->uniform_set_set_invalidation_callback(p_uniform_set, nullptr, nullptr);
-		RD::get_singleton()->free(p_uniform_set);
+		RD::get_singleton()->free_rid(p_uniform_set);
 	}
 }
 
@@ -1145,7 +1145,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 	if ((uint32_t)ubo_data[p_use_linear_color].size() != p_ubo_size) {
 		p_uniform_dirty = true;
 		if (uniform_buffer[p_use_linear_color].is_valid()) {
-			RD::get_singleton()->free(uniform_buffer[p_use_linear_color]);
+			RD::get_singleton()->free_rid(uniform_buffer[p_use_linear_color]);
 			uniform_buffer[p_use_linear_color] = RID();
 		}
 
@@ -1158,7 +1158,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 		//clear previous uniform set
 		if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
 			RD::get_singleton()->uniform_set_set_invalidation_callback(uniform_set, nullptr, nullptr);
-			RD::get_singleton()->free(uniform_set);
+			RD::get_singleton()->free_rid(uniform_set);
 			uniform_set = RID();
 		}
 	}
@@ -1182,7 +1182,7 @@ bool MaterialStorage::MaterialData::update_parameters_uniform_set(const HashMap<
 		//clear previous uniform set
 		if (uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(uniform_set)) {
 			RD::get_singleton()->uniform_set_set_invalidation_callback(uniform_set, nullptr, nullptr);
-			RD::get_singleton()->free(uniform_set);
+			RD::get_singleton()->free_rid(uniform_set);
 			uniform_set = RID();
 		}
 	}
@@ -1328,11 +1328,11 @@ MaterialStorage::~MaterialStorage() {
 	memdelete_arr(global_shader_uniforms.buffer_values);
 	memdelete_arr(global_shader_uniforms.buffer_usage);
 	memdelete_arr(global_shader_uniforms.buffer_dirty_regions);
-	RD::get_singleton()->free(global_shader_uniforms.buffer);
+	RD::get_singleton()->free_rid(global_shader_uniforms.buffer);
 
 	// buffers
 
-	RD::get_singleton()->free(quad_index_buffer); //array gets freed as dependency
+	RD::get_singleton()->free_rid(quad_index_buffer); //array gets freed as dependency
 
 	//def samplers
 	samplers_rd_free(default_samplers);
@@ -2539,7 +2539,7 @@ void MaterialStorage::samplers_rd_free(Samplers &p_samplers) const {
 	for (int i = 1; i < RS::CANVAS_ITEM_TEXTURE_FILTER_MAX; i++) {
 		for (int j = 1; j < RS::CANVAS_ITEM_TEXTURE_REPEAT_MAX; j++) {
 			if (p_samplers.rids[i][j].is_valid()) {
-				RD::get_singleton()->free(p_samplers.rids[i][j]);
+				RD::get_singleton()->free_rid(p_samplers.rids[i][j]);
 				p_samplers.rids[i][j] = RID();
 			}
 		}

--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -186,12 +186,12 @@ MeshStorage::MeshStorage() {
 MeshStorage::~MeshStorage() {
 	//def buffers
 	for (int i = 0; i < DEFAULT_RD_BUFFER_MAX; i++) {
-		RD::get_singleton()->free(mesh_default_rd_buffers[i]);
+		RD::get_singleton()->free_rid(mesh_default_rd_buffers[i]);
 	}
 
 	skeleton_shader.shader.version_free(skeleton_shader.version);
 
-	RD::get_singleton()->free(default_rd_storage_buffer);
+	RD::get_singleton()->free_rid(default_rd_storage_buffer);
 
 	singleton = nullptr;
 }
@@ -514,31 +514,31 @@ void MeshStorage::_mesh_surface_clear(Mesh *p_mesh, int p_surface) {
 	Mesh::Surface &s = *p_mesh->surfaces[p_surface];
 
 	if (s.vertex_buffer.is_valid()) {
-		RD::get_singleton()->free(s.vertex_buffer); // Clears arrays as dependency automatically, including all versions.
+		RD::get_singleton()->free_rid(s.vertex_buffer); // Clears arrays as dependency automatically, including all versions.
 	}
 	if (s.attribute_buffer.is_valid()) {
-		RD::get_singleton()->free(s.attribute_buffer);
+		RD::get_singleton()->free_rid(s.attribute_buffer);
 	}
 	if (s.skin_buffer.is_valid()) {
-		RD::get_singleton()->free(s.skin_buffer);
+		RD::get_singleton()->free_rid(s.skin_buffer);
 	}
 	if (s.versions) {
 		memfree(s.versions); // reallocs, so free with memfree.
 	}
 
 	if (s.index_buffer.is_valid()) {
-		RD::get_singleton()->free(s.index_buffer);
+		RD::get_singleton()->free_rid(s.index_buffer);
 	}
 
 	if (s.lod_count) {
 		for (uint32_t j = 0; j < s.lod_count; j++) {
-			RD::get_singleton()->free(s.lods[j].index_buffer);
+			RD::get_singleton()->free_rid(s.lods[j].index_buffer);
 		}
 		memdelete_arr(s.lods);
 	}
 
 	if (s.blend_shape_buffer.is_valid()) {
-		RD::get_singleton()->free(s.blend_shape_buffer);
+		RD::get_singleton()->free_rid(s.blend_shape_buffer);
 	}
 
 	memdelete(p_mesh->surfaces[p_surface]);
@@ -1086,13 +1086,13 @@ void MeshStorage::_mesh_instance_remove_surface(MeshInstance *mi, int p_surface)
 
 	if (surface.versions) {
 		for (uint32_t j = 0; j < surface.version_count; j++) {
-			RD::get_singleton()->free(surface.versions[j].vertex_array);
+			RD::get_singleton()->free_rid(surface.versions[j].vertex_array);
 		}
 		memfree(surface.versions);
 	}
 	for (uint32_t i = 0; i < 2; i++) {
 		if (surface.vertex_buffer[i].is_valid()) {
-			RD::get_singleton()->free(surface.vertex_buffer[i]);
+			RD::get_singleton()->free_rid(surface.vertex_buffer[i]);
 		}
 	}
 
@@ -1100,7 +1100,7 @@ void MeshStorage::_mesh_instance_remove_surface(MeshInstance *mi, int p_surface)
 
 	if (mi->surfaces.is_empty()) {
 		if (mi->blend_weights_buffer.is_valid()) {
-			RD::get_singleton()->free(mi->blend_weights_buffer);
+			RD::get_singleton()->free_rid(mi->blend_weights_buffer);
 			mi->blend_weights_buffer = RID();
 		}
 
@@ -1544,7 +1544,7 @@ void MeshStorage::_multimesh_allocate_data(RID p_multimesh, int p_instances, RS:
 	}
 
 	if (multimesh->buffer.is_valid()) {
-		RD::get_singleton()->free(multimesh->buffer);
+		RD::get_singleton()->free_rid(multimesh->buffer);
 		multimesh->buffer = RID();
 		multimesh->uniform_set_2d = RID(); //cleared by dependency
 		multimesh->uniform_set_3d = RID(); //cleared by dependency
@@ -1622,7 +1622,7 @@ void MeshStorage::_multimesh_enable_motion_vectors(MultiMesh *multimesh) {
 	}
 
 	if (multimesh->buffer.is_valid()) {
-		RD::get_singleton()->free(multimesh->buffer);
+		RD::get_singleton()->free_rid(multimesh->buffer);
 	}
 
 	multimesh->buffer = new_buffer;
@@ -1667,7 +1667,7 @@ void MeshStorage::_multimesh_set_mesh(RID p_multimesh, RID p_mesh) {
 		ERR_FAIL_NULL(mesh);
 		if (mesh->surface_count > 0) {
 			if (multimesh->command_buffer.is_valid()) {
-				RD::get_singleton()->free(multimesh->command_buffer);
+				RD::get_singleton()->free_rid(multimesh->command_buffer);
 			}
 
 			Vector<uint8_t> newVector;
@@ -2341,7 +2341,7 @@ void MeshStorage::skeleton_allocate_data(RID p_skeleton, int p_bones, bool p_2d_
 	skeleton->uniform_set_3d = RID();
 
 	if (skeleton->buffer.is_valid()) {
-		RD::get_singleton()->free(skeleton->buffer);
+		RD::get_singleton()->free_rid(skeleton->buffer);
 		skeleton->buffer = RID();
 		skeleton->data.clear();
 		skeleton->uniform_set_mi = RID();

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -265,36 +265,36 @@ bool ParticlesStorage::particles_get_emitting(RID p_particles) {
 
 void ParticlesStorage::_particles_free_data(Particles *particles) {
 	if (particles->particle_buffer.is_valid()) {
-		RD::get_singleton()->free(particles->particle_buffer);
+		RD::get_singleton()->free_rid(particles->particle_buffer);
 		particles->particle_buffer = RID();
-		RD::get_singleton()->free(particles->particle_instance_buffer);
+		RD::get_singleton()->free_rid(particles->particle_instance_buffer);
 		particles->particle_instance_buffer = RID();
 	}
 
 	particles->userdata_count = 0;
 
 	if (particles->frame_params_buffer.is_valid()) {
-		RD::get_singleton()->free(particles->frame_params_buffer);
+		RD::get_singleton()->free_rid(particles->frame_params_buffer);
 		particles->frame_params_buffer = RID();
 	}
 	particles->particles_transforms_buffer_uniform_set = RID();
 
 	if (RD::get_singleton()->uniform_set_is_valid(particles->trail_bind_pose_uniform_set)) {
-		RD::get_singleton()->free(particles->trail_bind_pose_uniform_set);
+		RD::get_singleton()->free_rid(particles->trail_bind_pose_uniform_set);
 	}
 	particles->trail_bind_pose_uniform_set = RID();
 
 	if (particles->trail_bind_pose_buffer.is_valid()) {
-		RD::get_singleton()->free(particles->trail_bind_pose_buffer);
+		RD::get_singleton()->free_rid(particles->trail_bind_pose_buffer);
 		particles->trail_bind_pose_buffer = RID();
 	}
 	if (RD::get_singleton()->uniform_set_is_valid(particles->collision_textures_uniform_set)) {
-		RD::get_singleton()->free(particles->collision_textures_uniform_set);
+		RD::get_singleton()->free_rid(particles->collision_textures_uniform_set);
 	}
 	particles->collision_textures_uniform_set = RID();
 
 	if (particles->particles_sort_buffer.is_valid()) {
-		RD::get_singleton()->free(particles->particles_sort_buffer);
+		RD::get_singleton()->free_rid(particles->particles_sort_buffer);
 		particles->particles_sort_buffer = RID();
 		particles->particles_sort_uniform_set = RID();
 	}
@@ -302,23 +302,23 @@ void ParticlesStorage::_particles_free_data(Particles *particles) {
 	if (particles->emission_buffer != nullptr) {
 		particles->emission_buffer = nullptr;
 		particles->emission_buffer_data.clear();
-		RD::get_singleton()->free(particles->emission_storage_buffer);
+		RD::get_singleton()->free_rid(particles->emission_storage_buffer);
 		particles->emission_storage_buffer = RID();
 	}
 
 	if (particles->unused_emission_storage_buffer.is_valid()) {
-		RD::get_singleton()->free(particles->unused_emission_storage_buffer);
+		RD::get_singleton()->free_rid(particles->unused_emission_storage_buffer);
 		particles->unused_emission_storage_buffer = RID();
 	}
 
 	if (particles->unused_trail_storage_buffer.is_valid()) {
-		RD::get_singleton()->free(particles->unused_trail_storage_buffer);
+		RD::get_singleton()->free_rid(particles->unused_trail_storage_buffer);
 		particles->unused_trail_storage_buffer = RID();
 	}
 
 	if (RD::get_singleton()->uniform_set_is_valid(particles->particles_material_uniform_set)) {
 		//will need to be re-created
-		RD::get_singleton()->free(particles->particles_material_uniform_set);
+		RD::get_singleton()->free_rid(particles->particles_material_uniform_set);
 	}
 	particles->particles_material_uniform_set = RID();
 }
@@ -547,7 +547,7 @@ void ParticlesStorage::_particles_allocate_emission_buffer(Particles *particles)
 
 	if (RD::get_singleton()->uniform_set_is_valid(particles->particles_material_uniform_set)) {
 		//will need to be re-created
-		RD::get_singleton()->free(particles->particles_material_uniform_set);
+		RD::get_singleton()->free_rid(particles->particles_material_uniform_set);
 		particles->particles_material_uniform_set = RID();
 	}
 }
@@ -574,7 +574,7 @@ void ParticlesStorage::particles_set_subemitter(RID p_particles, RID p_subemitte
 	particles->sub_emitter = p_subemitter_particles;
 
 	if (RD::get_singleton()->uniform_set_is_valid(particles->particles_material_uniform_set)) {
-		RD::get_singleton()->free(particles->particles_material_uniform_set);
+		RD::get_singleton()->free_rid(particles->particles_material_uniform_set);
 		particles->particles_material_uniform_set = RID(); //clear and force to re create sub emitting
 	}
 }
@@ -1069,7 +1069,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 
 		if (different || !uniform_set_valid) {
 			if (uniform_set_valid) {
-				RD::get_singleton()->free(p_particles->collision_textures_uniform_set);
+				RD::get_singleton()->free_rid(p_particles->collision_textures_uniform_set);
 			}
 
 			thread_local LocalVector<RD::Uniform> uniforms;
@@ -1349,7 +1349,7 @@ void ParticlesStorage::_particles_update_buffers(Particles *particles) {
 	} else if (enable_motion_vectors) {
 		// Only motion vectors are required, release the transforms buffer and uniform set.
 		if (particles->particle_instance_buffer.is_valid()) {
-			RD::get_singleton()->free(particles->particle_instance_buffer);
+			RD::get_singleton()->free_rid(particles->particle_instance_buffer);
 			particles->particle_instance_buffer = RID();
 		}
 
@@ -1494,7 +1494,7 @@ void ParticlesStorage::update_particles() {
 			if (uint32_t(trail_steps) != particles->trail_params.size() || particles->frame_params_buffer.is_null()) {
 				particles->trail_params.resize(trail_steps);
 				if (particles->frame_params_buffer.is_valid()) {
-					RD::get_singleton()->free(particles->frame_params_buffer);
+					RD::get_singleton()->free_rid(particles->frame_params_buffer);
 				}
 				particles->frame_params_buffer = RD::get_singleton()->storage_buffer_create(sizeof(ParticlesFrameParams) * trail_steps);
 			}
@@ -1793,7 +1793,7 @@ void ParticlesStorage::particles_collision_free(RID p_rid) {
 	ParticlesCollision *particles_collision = particles_collision_owner.get_or_null(p_rid);
 
 	if (particles_collision->heightfield_texture.is_valid()) {
-		RD::get_singleton()->free(particles_collision->heightfield_texture);
+		RD::get_singleton()->free_rid(particles_collision->heightfield_texture);
 	}
 	particles_collision->dependency.deleted_notify(p_rid);
 	particles_collision_owner.free(p_rid);
@@ -1843,7 +1843,7 @@ void ParticlesStorage::particles_collision_set_collision_type(RID p_particles_co
 	}
 
 	if (particles_collision->heightfield_texture.is_valid()) {
-		RD::get_singleton()->free(particles_collision->heightfield_texture);
+		RD::get_singleton()->free_rid(particles_collision->heightfield_texture);
 		particles_collision->heightfield_texture = RID();
 	}
 	particles_collision->type = p_type;
@@ -1937,7 +1937,7 @@ void ParticlesStorage::particles_collision_set_height_field_resolution(RID p_par
 	particles_collision->heightfield_resolution = p_resolution;
 
 	if (particles_collision->heightfield_texture.is_valid()) {
-		RD::get_singleton()->free(particles_collision->heightfield_texture);
+		RD::get_singleton()->free_rid(particles_collision->heightfield_texture);
 		particles_collision->heightfield_texture = RID();
 	}
 }

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -93,7 +93,7 @@ void RenderSceneBuffersRD::update_sizes(NamedTexture &p_named_texture) {
 
 void RenderSceneBuffersRD::free_named_texture(NamedTexture &p_named_texture) {
 	if (p_named_texture.texture.is_valid()) {
-		RD::get_singleton()->free(p_named_texture.texture);
+		RD::get_singleton()->free_rid(p_named_texture.texture);
 	}
 	p_named_texture.texture = RID();
 	p_named_texture.slices.clear(); // slices should be freed automatically as dependents...
@@ -135,7 +135,7 @@ void RenderSceneBuffersRD::cleanup() {
 	// Clear weight_buffer / blur textures.
 	for (WeightBuffers &weight_buffer : weight_buffers) {
 		if (weight_buffer.weight.is_valid()) {
-			RD::get_singleton()->free(weight_buffer.weight);
+			RD::get_singleton()->free_rid(weight_buffer.weight);
 			weight_buffer.weight = RID();
 		}
 	}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -60,10 +60,10 @@ TextureStorage::CanvasTexture::~CanvasTexture() {
 void TextureStorage::Texture::cleanup() {
 	if (RD::get_singleton()->texture_is_valid(rd_texture_srgb)) {
 		//erase this first, as it's a dependency of the one below
-		RD::get_singleton()->free(rd_texture_srgb);
+		RD::get_singleton()->free_rid(rd_texture_srgb);
 	}
 	if (RD::get_singleton()->texture_is_valid(rd_texture)) {
-		RD::get_singleton()->free(rd_texture);
+		RD::get_singleton()->free_rid(rd_texture);
 	}
 	if (canvas_texture) {
 		memdelete(canvas_texture);
@@ -620,13 +620,13 @@ TextureStorage::~TextureStorage() {
 	}
 
 	if (decal_atlas.texture.is_valid()) {
-		RD::get_singleton()->free(decal_atlas.texture);
+		RD::get_singleton()->free_rid(decal_atlas.texture);
 	}
 
 	//def textures
 	for (int i = 0; i < DEFAULT_RD_TEXTURE_MAX; i++) {
 		if (default_rd_textures[i].is_valid()) {
-			RD::get_singleton()->free(default_rd_textures[i]);
+			RD::get_singleton()->free_rid(default_rd_textures[i]);
 		}
 	}
 
@@ -896,7 +896,7 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 		rd_view.format_override = texture.rd_format_srgb;
 		texture.rd_texture_srgb = RD::get_singleton()->texture_create_shared(rd_view, texture.rd_texture);
 		if (texture.rd_texture_srgb.is_null()) {
-			RD::get_singleton()->free(texture.rd_texture);
+			RD::get_singleton()->free_rid(texture.rd_texture);
 			ERR_FAIL_COND(texture.rd_texture_srgb.is_null());
 		}
 	}
@@ -1008,7 +1008,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 		rd_view.format_override = texture.rd_format_srgb;
 		texture.rd_texture_srgb = RD::get_singleton()->texture_create_shared(rd_view, texture.rd_texture);
 		if (texture.rd_texture_srgb.is_null()) {
-			RD::get_singleton()->free(texture.rd_texture);
+			RD::get_singleton()->free_rid(texture.rd_texture);
 			ERR_FAIL_COND(texture.rd_texture_srgb.is_null());
 		}
 	}
@@ -1125,7 +1125,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 		rd_view.format_override = texture.rd_format_srgb;
 		texture.rd_texture_srgb = RD::get_singleton()->texture_create_shared(rd_view, texture.rd_texture);
 		if (texture.rd_texture_srgb.is_null()) {
-			RD::get_singleton()->free(texture.rd_texture);
+			RD::get_singleton()->free_rid(texture.rd_texture);
 			ERR_FAIL_COND(texture.rd_texture_srgb.is_null());
 		}
 	}
@@ -1442,11 +1442,11 @@ void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 	if (tex->proxy_to.is_valid()) {
 		//unlink proxy
 		if (RD::get_singleton()->texture_is_valid(tex->rd_texture)) {
-			RD::get_singleton()->free(tex->rd_texture);
+			RD::get_singleton()->free_rid(tex->rd_texture);
 			tex->rd_texture = RID();
 		}
 		if (RD::get_singleton()->texture_is_valid(tex->rd_texture_srgb)) {
-			RD::get_singleton()->free(tex->rd_texture_srgb);
+			RD::get_singleton()->free_rid(tex->rd_texture_srgb);
 			tex->rd_texture_srgb = RID();
 		}
 		Texture *prev_tex = texture_owner.get_or_null(tex->proxy_to);
@@ -1613,9 +1613,9 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 	}
 
 	if (tex->rd_texture_srgb.is_valid()) {
-		RD::get_singleton()->free(tex->rd_texture_srgb);
+		RD::get_singleton()->free_rid(tex->rd_texture_srgb);
 	}
-	RD::get_singleton()->free(tex->rd_texture);
+	RD::get_singleton()->free_rid(tex->rd_texture);
 
 	if (tex->canvas_texture) {
 		memdelete(tex->canvas_texture);
@@ -3047,7 +3047,7 @@ void TextureStorage::update_decal_atlas() {
 	decal_atlas.dirty = false;
 
 	if (decal_atlas.texture.is_valid()) {
-		RD::get_singleton()->free(decal_atlas.texture);
+		RD::get_singleton()->free_rid(decal_atlas.texture);
 		decal_atlas.texture = RID();
 		decal_atlas.texture_srgb = RID();
 		decal_atlas.texture_mipmaps.clear();
@@ -3291,7 +3291,7 @@ void TextureStorage::decal_instance_set_sorting_offset(RID p_decal_instance, flo
 
 void TextureStorage::free_decal_data() {
 	if (decal_buffer.is_valid()) {
-		RD::get_singleton()->free(decal_buffer);
+		RD::get_singleton()->free_rid(decal_buffer);
 		decal_buffer = RID();
 	}
 
@@ -3517,16 +3517,16 @@ void TextureStorage::_clear_render_target(RenderTarget *rt) {
 	}
 
 	if (rt->color.is_valid()) {
-		RD::get_singleton()->free(rt->color);
+		RD::get_singleton()->free_rid(rt->color);
 	}
 	rt->color_slices.clear(); // these are automatically freed.
 
 	if (rt->color_multisample.is_valid()) {
-		RD::get_singleton()->free(rt->color_multisample);
+		RD::get_singleton()->free_rid(rt->color_multisample);
 	}
 
 	if (rt->backbuffer.is_valid()) {
-		RD::get_singleton()->free(rt->backbuffer);
+		RD::get_singleton()->free_rid(rt->backbuffer);
 		rt->backbuffer = RID();
 		rt->backbuffer_mipmaps.clear();
 		rt->backbuffer_uniform_set = RID(); //chain deleted
@@ -3617,10 +3617,10 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 
 		//free existing textures
 		if (RD::get_singleton()->texture_is_valid(tex->rd_texture)) {
-			RD::get_singleton()->free(tex->rd_texture);
+			RD::get_singleton()->free_rid(tex->rd_texture);
 		}
 		if (RD::get_singleton()->texture_is_valid(tex->rd_texture_srgb)) {
-			RD::get_singleton()->free(tex->rd_texture_srgb);
+			RD::get_singleton()->free_rid(tex->rd_texture_srgb);
 		}
 
 		tex->rd_texture = RID();
@@ -3681,7 +3681,7 @@ void TextureStorage::_create_render_target_backbuffer(RenderTarget *rt) {
 
 	if (rt->framebuffer_uniform_set.is_valid() && RD::get_singleton()->uniform_set_is_valid(rt->framebuffer_uniform_set)) {
 		//the new one will require the backbuffer.
-		RD::get_singleton()->free(rt->framebuffer_uniform_set);
+		RD::get_singleton()->free_rid(rt->framebuffer_uniform_set);
 		rt->framebuffer_uniform_set = RID();
 	}
 	//create mipmaps
@@ -4140,7 +4140,7 @@ RID TextureStorage::render_target_get_sdf_texture(RID p_render_target) {
 void TextureStorage::_render_target_allocate_sdf(RenderTarget *rt) {
 	ERR_FAIL_COND(rt->sdf_buffer_write_fb.is_valid());
 	if (rt->sdf_buffer_read.is_valid()) {
-		RD::get_singleton()->free(rt->sdf_buffer_read);
+		RD::get_singleton()->free_rid(rt->sdf_buffer_read);
 		rt->sdf_buffer_read = RID();
 	}
 
@@ -4236,13 +4236,13 @@ void TextureStorage::_render_target_allocate_sdf(RenderTarget *rt) {
 
 void TextureStorage::_render_target_clear_sdf(RenderTarget *rt) {
 	if (rt->sdf_buffer_read.is_valid()) {
-		RD::get_singleton()->free(rt->sdf_buffer_read);
+		RD::get_singleton()->free_rid(rt->sdf_buffer_read);
 		rt->sdf_buffer_read = RID();
 	}
 	if (rt->sdf_buffer_write_fb.is_valid()) {
-		RD::get_singleton()->free(rt->sdf_buffer_write);
-		RD::get_singleton()->free(rt->sdf_buffer_process[0]);
-		RD::get_singleton()->free(rt->sdf_buffer_process[1]);
+		RD::get_singleton()->free_rid(rt->sdf_buffer_write);
+		RD::get_singleton()->free_rid(rt->sdf_buffer_process[0]);
+		RD::get_singleton()->free_rid(rt->sdf_buffer_process[1]);
 		rt->sdf_buffer_write = RID();
 		rt->sdf_buffer_write_fb = RID();
 		rt->sdf_buffer_process[0] = RID();

--- a/servers/rendering/renderer_scene_occlusion_cull.cpp
+++ b/servers/rendering/renderer_scene_occlusion_cull.cpp
@@ -64,7 +64,7 @@ void RendererSceneOcclusionCull::HZBuffer::clear() {
 	}
 
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
-	RS::get_singleton()->free(debug_texture);
+	RS::get_singleton()->free_rid(debug_texture);
 }
 
 void RendererSceneOcclusionCull::HZBuffer::resize(const Size2i &p_size) {
@@ -122,7 +122,7 @@ void RendererSceneOcclusionCull::HZBuffer::resize(const Size2i &p_size) {
 
 	debug_data.resize(sizes[0].x * sizes[0].y);
 	if (debug_texture.is_valid()) {
-		RS::get_singleton()->free(debug_texture);
+		RS::get_singleton()->free_rid(debug_texture);
 		debug_texture = RID();
 	}
 }

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -168,7 +168,7 @@ void RenderingDevice::_free_dependencies(RID p_id) {
 	HashMap<RID, HashSet<RID>>::Iterator E = dependency_map.find(p_id);
 	if (E) {
 		while (E->value.size()) {
-			free(*E->value.begin());
+			free_rid(*E->value.begin());
 		}
 		dependency_map.remove(E);
 	}
@@ -6043,11 +6043,11 @@ bool RenderingDevice::_dependencies_make_mutable(RID p_id, RDG::ResourceTracker 
 /**** FRAME MANAGEMENT ****/
 /**************************/
 
-void RenderingDevice::free(RID p_id) {
+void RenderingDevice::free_rid(RID p_rid) {
 	ERR_RENDER_THREAD_GUARD();
 
-	_free_dependencies(p_id); // Recursively erase dependencies first, to avoid potential API problems.
-	_free_internal(p_id);
+	_free_dependencies(p_rid); // Recursively erase dependencies first, to avoid potential API problems.
+	_free_internal(p_rid);
 }
 
 void RenderingDevice::_free_internal(RID p_id) {
@@ -6986,7 +6986,7 @@ void RenderingDevice::_free_rids(T &p_owner, const char *p_type) {
 				print_line(String(" - ") + resource_names[rid]);
 			}
 #endif
-			free(rid);
+			free_rid(rid);
 		}
 	}
 }
@@ -7199,7 +7199,7 @@ void RenderingDevice::finalize() {
 						print_line(String(" - ") + resource_names[texture_rid]);
 					}
 #endif
-					free(texture_rid);
+					free_rid(texture_rid);
 				} else {
 					owned_non_shared.push_back(texture_rid);
 				}
@@ -7211,7 +7211,7 @@ void RenderingDevice::finalize() {
 					print_line(String(" - ") + resource_names[texture_rid]);
 				}
 #endif
-				free(texture_rid);
+				free_rid(texture_rid);
 			}
 		}
 	}
@@ -7453,7 +7453,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("compute_list_add_barrier", "compute_list"), &RenderingDevice::compute_list_add_barrier);
 	ClassDB::bind_method(D_METHOD("compute_list_end"), &RenderingDevice::compute_list_end);
 
-	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingDevice::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingDevice::free_rid);
 
 	ClassDB::bind_method(D_METHOD("capture_timestamp", "name"), &RenderingDevice::capture_timestamp);
 	ClassDB::bind_method(D_METHOD("get_captured_timestamps_count"), &RenderingDevice::get_captured_timestamps_count);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1603,7 +1603,12 @@ public:
 
 	void _set_max_fps(int p_max_fps);
 
-	void free(RID p_id);
+	void free_rid(RID p_rid);
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) {
+		free_rid(p_rid);
+	}
+#endif // DISABLE_DEPRECATED
 
 	/****************/
 	/**** Timing ****/

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -237,7 +237,7 @@ void RenderingServerDefault::_init() {
 
 void RenderingServerDefault::_finish() {
 	if (test_cube.is_valid()) {
-		free(test_cube);
+		free_rid(test_cube);
 	}
 
 	RSG::canvas->finalize();

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1140,7 +1140,7 @@ public:
 
 	/* FREE */
 
-	virtual void free(RID p_rid) override {
+	virtual void free_rid(RID p_rid) override {
 		if (Thread::get_caller_id() == server_thread) {
 			command_queue.flush_if_pending();
 			_free(p_rid);

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -147,13 +147,13 @@ RID RenderingServer::get_test_texture() {
 
 void RenderingServer::_free_internal_rids() {
 	if (test_texture.is_valid()) {
-		free(test_texture);
+		free_rid(test_texture);
 	}
 	if (white_texture.is_valid()) {
-		free(white_texture);
+		free_rid(white_texture);
 	}
 	if (test_material.is_valid()) {
-		free(test_material);
+		free_rid(test_material);
 	}
 }
 
@@ -3469,7 +3469,7 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_MAX);
 
 	/* Free */
-	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingServer::free); // Shouldn't conflict with Object::free().
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingServer::free_rid);
 
 	/* Misc */
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1768,7 +1768,12 @@ public:
 
 	/* FREE */
 
-	virtual void free(RID p_rid) = 0; // Free RIDs associated with the rendering server.
+	virtual void free_rid(RID p_rid) = 0; // Free RIDs associated with the rendering server.
+#ifndef DISABLE_DEPRECATED
+	[[deprecated("Use `free_rid()` instead.")]] void free(RID p_rid) {
+		free_rid(p_rid);
+	}
+#endif // DISABLE_DEPRECATED
 
 	/* INTERPOLATION */
 

--- a/servers/xr/xr_vrs.cpp
+++ b/servers/xr/xr_vrs.cpp
@@ -53,7 +53,7 @@ void XRVRS::_bind_methods() {
 XRVRS::~XRVRS() {
 	if (vrs_texture.is_valid()) {
 		ERR_FAIL_NULL(RS::get_singleton());
-		RS::get_singleton()->free(vrs_texture);
+		RS::get_singleton()->free_rid(vrs_texture);
 		vrs_texture = RID();
 	}
 }
@@ -126,7 +126,7 @@ RID XRVRS::make_vrs_texture(const Size2 &p_target_size, const PackedVector2Array
 	if (target_size != vrs_sizei || eye_foci != p_eye_foci || vrs_dirty) {
 		// Out with the old.
 		if (vrs_texture.is_valid()) {
-			RS::get_singleton()->free(vrs_texture);
+			RS::get_singleton()->free_rid(vrs_texture);
 			vrs_texture = RID();
 		}
 

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -124,12 +124,12 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 1);
 			navigation_server->agent_set_map(agent, RID());
-			navigation_server->free(map);
+			navigation_server->free_rid(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_AGENT_COUNT), 0);
 		}
 
-		navigation_server->free(agent);
+		navigation_server->free_rid(agent);
 	}
 
 	TEST_CASE("[NavigationServer2D] Server should manage map properly") {
@@ -198,7 +198,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->agent_set_map(agent, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 1);
-			navigation_server->free(agent);
+			navigation_server->free_rid(agent);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 0);
 		}
@@ -209,7 +209,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->link_set_map(link, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 1);
-			navigation_server->free(link);
+			navigation_server->free_rid(link);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 0);
 		}
@@ -220,7 +220,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->obstacle_set_map(obstacle, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 1);
-			navigation_server->free(obstacle);
+			navigation_server->free_rid(obstacle);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 0);
 		}
@@ -231,7 +231,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->region_set_map(region, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 1);
-			navigation_server->free(region);
+			navigation_server->free_rid(region);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 0);
 		}
@@ -264,7 +264,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		}
 
-		navigation_server->free(map);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to actually remove map.
 		CHECK_EQ(navigation_server->get_maps().size(), 0);
 	}
@@ -307,12 +307,12 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 1);
 			navigation_server->link_set_map(link, RID());
-			navigation_server->free(map);
+			navigation_server->free_rid(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_LINK_COUNT), 0);
 		}
 
-		navigation_server->free(link);
+		navigation_server->free_rid(link);
 	}
 
 	TEST_CASE("[NavigationServer2D] Server should manage obstacles properly") {
@@ -323,7 +323,7 @@ TEST_SUITE("[Navigation2D]") {
 
 		// TODO: Add tests for setters/getters once getters are added.
 
-		navigation_server->free(obstacle);
+		navigation_server->free_rid(obstacle);
 	}
 
 	TEST_CASE("[NavigationServer2D] Server should manage regions properly") {
@@ -360,7 +360,7 @@ TEST_SUITE("[Navigation2D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 1);
 			navigation_server->region_set_map(region, RID());
-			navigation_server->free(map);
+			navigation_server->free_rid(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer2D::INFO_REGION_COUNT), 0);
 		}
@@ -373,7 +373,7 @@ TEST_SUITE("[Navigation2D]") {
 			ERR_PRINT_ON;
 		}
 
-		navigation_server->free(region);
+		navigation_server->free_rid(region);
 	}
 
 	// This test case does not check precise values on purpose - to not be too sensitivte.
@@ -394,8 +394,8 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
 		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector2(0, 0));
 
-		navigation_server->free(agent);
-		navigation_server->free(map);
+		navigation_server->free_rid(agent);
+		navigation_server->free_rid(map);
 	}
 
 	// This test case does not check precise values on purpose - to not be too sensitivte.
@@ -436,9 +436,9 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_MESSAGE(agent_1_safe_velocity.y < 0, "agent 1 should move a bit to the side so that it avoids agent 2");
 		CHECK_MESSAGE(agent_2_safe_velocity.y > 0, "agent 2 should move a bit to the side so that it avoids agent 1");
 
-		navigation_server->free(agent_2);
-		navigation_server->free(agent_1);
-		navigation_server->free(map);
+		navigation_server->free_rid(agent_2);
+		navigation_server->free_rid(agent_1);
+		navigation_server->free_rid(map);
 	}
 
 	TEST_CASE("[NavigationServer2D] Server should make agents avoid dynamic obstacles when avoidance enabled") {
@@ -470,9 +470,9 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "Agent 1 should move a bit along desired velocity (+X).");
 		CHECK_MESSAGE(agent_1_safe_velocity.y < 0, "Agent 1 should move a bit to the side so that it avoids obstacle.");
 
-		navigation_server->free(obstacle_1);
-		navigation_server->free(agent_1);
-		navigation_server->free(map);
+		navigation_server->free_rid(obstacle_1);
+		navigation_server->free_rid(agent_1);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
@@ -525,10 +525,10 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_MESSAGE(agent_2_safe_velocity.x > 0, "Agent 2 should move a bit along desired velocity (+X).");
 		CHECK_MESSAGE(agent_2_safe_velocity.y == 0, "Agent 2 should not move to the side.");
 
-		navigation_server->free(obstacle_1);
-		navigation_server->free(agent_2);
-		navigation_server->free(agent_1);
-		navigation_server->free(map);
+		navigation_server->free_rid(obstacle_1);
+		navigation_server->free_rid(agent_2);
+		navigation_server->free_rid(agent_1);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
@@ -630,8 +630,8 @@ TEST_SUITE("[Navigation2D]") {
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector2(0, 0)), Vector2(0, 0));
 		}
 
-		navigation_server->free(region);
-		navigation_server->free(map);
+		navigation_server->free_rid(region);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 
 		memdelete(polygon);
@@ -736,8 +736,8 @@ TEST_SUITE("[Navigation2D]") {
 			CHECK_EQ(query_result->get_path_owner_ids().size(), 0);
 		}
 
-		navigation_server->free(region);
-		navigation_server->free(map);
+		navigation_server->free_rid(region);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 

--- a/tests/servers/test_navigation_server_3d.h
+++ b/tests/servers/test_navigation_server_3d.h
@@ -95,12 +95,12 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 1);
 			navigation_server->agent_set_map(agent, RID());
-			navigation_server->free(map);
+			navigation_server->free_rid(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_AGENT_COUNT), 0);
 		}
 
-		navigation_server->free(agent);
+		navigation_server->free_rid(agent);
 	}
 
 	TEST_CASE("[NavigationServer3D] Server should manage map properly") {
@@ -172,7 +172,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->agent_set_map(agent, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 1);
-			navigation_server->free(agent);
+			navigation_server->free_rid(agent);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_agents(map).size(), 0);
 		}
@@ -183,7 +183,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->link_set_map(link, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 1);
-			navigation_server->free(link);
+			navigation_server->free_rid(link);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_links(map).size(), 0);
 		}
@@ -194,7 +194,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->obstacle_set_map(obstacle, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 1);
-			navigation_server->free(obstacle);
+			navigation_server->free_rid(obstacle);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_obstacles(map).size(), 0);
 		}
@@ -205,7 +205,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->region_set_map(region, map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 1);
-			navigation_server->free(region);
+			navigation_server->free_rid(region);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->map_get_regions(map).size(), 0);
 		}
@@ -239,7 +239,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		}
 
-		navigation_server->free(map);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to actually remove map.
 		CHECK_EQ(navigation_server->get_maps().size(), 0);
 	}
@@ -282,12 +282,12 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 1);
 			navigation_server->link_set_map(link, RID());
-			navigation_server->free(map);
+			navigation_server->free_rid(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_LINK_COUNT), 0);
 		}
 
-		navigation_server->free(link);
+		navigation_server->free_rid(link);
 	}
 
 	TEST_CASE("[NavigationServer3D] Server should manage obstacles properly") {
@@ -298,7 +298,7 @@ TEST_SUITE("[Navigation3D]") {
 
 		// TODO: Add tests for setters/getters once getters are added.
 
-		navigation_server->free(obstacle);
+		navigation_server->free_rid(obstacle);
 	}
 
 	TEST_CASE("[NavigationServer3D] Server should manage regions properly") {
@@ -335,7 +335,7 @@ TEST_SUITE("[Navigation3D]") {
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 1);
 			navigation_server->region_set_map(region, RID());
-			navigation_server->free(map);
+			navigation_server->free_rid(map);
 			navigation_server->physics_process(0.0); // Give server some cycles to commit.
 			CHECK_EQ(navigation_server->get_process_info(NavigationServer3D::INFO_REGION_COUNT), 0);
 		}
@@ -348,7 +348,7 @@ TEST_SUITE("[Navigation3D]") {
 			ERR_PRINT_ON;
 		}
 
-		navigation_server->free(region);
+		navigation_server->free_rid(region);
 	}
 
 	// This test case does not check precise values on purpose - to not be too sensitivte.
@@ -369,8 +369,8 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
 		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector3(0, 0, 0));
 
-		navigation_server->free(agent);
-		navigation_server->free(map);
+		navigation_server->free_rid(agent);
+		navigation_server->free_rid(map);
 	}
 
 	// This test case does not check precise values on purpose - to not be too sensitivte.
@@ -411,9 +411,9 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_MESSAGE(agent_1_safe_velocity.z < 0, "agent 1 should move a bit to the side so that it avoids agent 2");
 		CHECK_MESSAGE(agent_2_safe_velocity.z > 0, "agent 2 should move a bit to the side so that it avoids agent 1");
 
-		navigation_server->free(agent_2);
-		navigation_server->free(agent_1);
-		navigation_server->free(map);
+		navigation_server->free_rid(agent_2);
+		navigation_server->free_rid(agent_1);
+		navigation_server->free_rid(map);
 	}
 
 	TEST_CASE("[NavigationServer3D] Server should make agents avoid dynamic obstacles when avoidance enabled") {
@@ -445,9 +445,9 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "Agent 1 should move a bit along desired velocity (+X).");
 		CHECK_MESSAGE(agent_1_safe_velocity.z < 0, "Agent 1 should move a bit to the side so that it avoids obstacle.");
 
-		navigation_server->free(obstacle_1);
-		navigation_server->free(agent_1);
-		navigation_server->free(map);
+		navigation_server->free_rid(obstacle_1);
+		navigation_server->free_rid(agent_1);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
@@ -508,10 +508,10 @@ TEST_SUITE("[Navigation3D]") {
 		CHECK_MESSAGE(agent_2_safe_velocity.x > 0, "Agent 2 should move a bit along desired velocity (+X).");
 		CHECK_MESSAGE(agent_2_safe_velocity.z == 0, "Agent 2 should not move to the side.");
 
-		navigation_server->free(obstacle_1);
-		navigation_server->free(agent_2);
-		navigation_server->free(agent_1);
-		navigation_server->free(map);
+		navigation_server->free_rid(obstacle_1);
+		navigation_server->free_rid(agent_2);
+		navigation_server->free_rid(agent_1);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 
@@ -561,8 +561,8 @@ TEST_SUITE("[Navigation3D]") {
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
 		}
 
-		navigation_server->free(region);
-		navigation_server->free(map);
+		navigation_server->free_rid(region);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		memdelete(mesh_instance);
 		memdelete(node_3d);
@@ -658,8 +658,8 @@ TEST_SUITE("[Navigation3D]") {
 			CHECK_NE(navigation_server->map_get_closest_point(map, Vector3(0, 0, 0)), Vector3(0, 0, 0));
 		}
 
-		navigation_server->free(region);
-		navigation_server->free(map);
+		navigation_server->free_rid(region);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		memdelete(mesh_instance);
 		memdelete(node_3d);
@@ -798,8 +798,8 @@ TEST_SUITE("[Navigation3D]") {
 			CHECK_EQ(query_result->get_path().size(), 0);
 		}
 
-		navigation_server->free(region);
-		navigation_server->free(map);
+		navigation_server->free_rid(region);
+		navigation_server->free_rid(map);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 	}
 


### PR DESCRIPTION
In the current master before this PR, the servers had these functions registered with the name `"free_rid"`:

```cpp
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free);
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer2D::free);
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &PhysicsServer3D::free);
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingDevice::free);
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &RenderingServer::free);
ClassDB::bind_method(D_METHOD("free_rid", "rid"), &TextServer::free_rid);
```

I was working on some C++ code that uses RenderingServer and trying to make it compatible with both in-engine module code and GDExtension C++ godot-cpp, and I found that the exposed API is different from the internal API for no reason. The name `free_rid` is clearer and avoids confusion with freeing `Object`s. Furthermore, TextServer already uses the name `free_rid` for its internal function.

This PR renames the internal `free` function on NavigationServer\*D, PhysicsServer\*D, RenderingDevice, and RenderingServer to `free_rid` to match the exposed API in GDScript and GDExtension and match TextServer.

Third-party modules can support multiple Godot versions by using `free_rid` and conditionally having `#define free_rid free` depending on the Godot version in files that use the modified servers.