### PR TITLE
Expose `RID.is_null()` to scripting

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2449,6 +2449,7 @@ VARIANT_ENUM_CAST(ResourceDeepDuplicateMode);
 static void _register_variant_builtin_methods_misc() {
 	/* RID */
 
+	bind_method(RID, is_null, sarray(), varray());
 	bind_method(RID, is_valid, sarray(), varray());
 	bind_method(RID, get_id, sarray(), varray());
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2403,6 +2403,7 @@ VARIANT_ENUM_CAST(ResourceDeepDuplicateMode);
 static void _register_variant_builtin_methods_misc() {
 	/* RID */
 
+	bind_method(RID, is_null, sarray(), varray());
 	bind_method(RID, is_valid, sarray(), varray());
 	bind_method(RID, get_id, sarray(), varray());
 

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -33,10 +33,16 @@
 				Returns the ID of the referenced low-level resource.
 			</description>
 		</method>
+		<method name="is_null" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the [RID] has the ID [code]0[/code]. This is the inverse of [method is_valid].
+			</description>
+		</method>
 		<method name="is_valid" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the [RID] is not [code]0[/code].
+				Returns [code]true[/code] if the [RID] is not [code]0[/code]. This is the inverse of [method is_null].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
I was working on some C++ code and trying to make it compatible with both in-engine module code and GDExtension C++ godot-cpp, and I found that the code uses `.is_null()` on an RID, which works in-engine (used 390 times), but not in GDExtension because the API is not exposed. This PR exposes it. Regardless of this PR, a workaround that is compatible with the currently released godot-cpp API is to use `!` with `.is_valid()` on an RID instead of `.is_null()`.