### PR TITLE
Fix miscellaneous oddities around the class reference (part 5)

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -687,7 +687,7 @@
 			[b]Note:[/b] Length is not delimited by the last key, as this one may be before or after the end to ensure correct interpolation and looping.
 		</member>
 		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="Animation.LoopMode" default="0">
-			Determines the behavior of both ends of the animation timeline during animation playback. This is used for correct interpolation of animation cycles, and for hinting the player that it must restart the animation.
+			Determines the behavior of both ends of the animation timeline during animation playback. This indicates whether and how the animation should be restarted, and is also used to correctly interpolate animation cycles.
 		</member>
 		<member name="step" type="float" setter="set_step" getter="get_step" default="0.033333335">
 			The animation step value.

--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -128,7 +128,8 @@
 			<param index="1" name="z_near" type="float" />
 			<param index="2" name="z_far" type="float" />
 			<description>
-				Sets the camera projection to orthogonal mode (see [constant PROJECTION_ORTHOGONAL]), by specifying a [param size], and the [param z_near] and [param z_far] clip planes in world space units. (As a hint, 2D games often use this projection, with values specified in pixels.)
+				Sets the camera projection to orthogonal mode (see [constant PROJECTION_ORTHOGONAL]), by specifying a [param size], and the [param z_near] and [param z_far] clip planes in world space units.
+				As a hint, 3D games that look 2D often use this projection, with [param size] specified in pixels.
 			</description>
 		</method>
 		<method name="set_perspective">

--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -67,10 +67,10 @@
 			<param index="0" name="index" type="int" />
 			<param index="1" name="parameters" type="Dictionary" />
 			<description>
-				Sets the feed format parameters for the given index in the [member formats] array. Returns [code]true[/code] on success. By default YUYV encoded stream is transformed to FEED_RGB. YUYV encoded stream output format can be changed with [param parameters].output value:
-				[code]separate[/code] will result in FEED_YCBCR_SEP
-				[code]grayscale[/code] will result in desaturated FEED_RGB
-				[code]copy[/code] will result in FEED_YCBCR
+				Sets the feed format parameters for the given [param index] in the [member formats] array. Returns [code]true[/code] on success. By default, the YUYV encoded stream is transformed to [constant FEED_RGB]. The YUYV encoded stream output format can be changed by setting [param parameters]'s [code]output[/code] entry to one of the following:
+				- [code]"separate"[/code] will result in [constant FEED_YCBCR_SEP];
+				- [code]"grayscale"[/code] will result in desaturated [constant FEED_RGB];
+				- [code]"copy"[/code] will result in [constant FEED_YCBCR].
 			</description>
 		</method>
 		<method name="set_name">

--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -173,7 +173,7 @@
 			<param index="5" name="pixel_range" type="float" default="4.0" />
 			<param index="6" name="scale" type="float" default="1.0" />
 			<description>
-				Draws a textured rectangle region of the multi-channel signed distance field texture at a given position, optionally modulated by a color. See [member FontFile.multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
+				Draws a textured rectangle region of the multichannel signed distance field texture at a given position, optionally modulated by a color. See [member FontFile.multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
 				If [param outline] is positive, each alpha channel value of pixel in region is set to maximum value of true distance in the [param outline] radius.
 				Value of the [param pixel_range] should the same that was used during distance field texture generation.
 			</description>

--- a/doc/classes/DampedSpringJoint2D.xml
+++ b/doc/classes/DampedSpringJoint2D.xml
@@ -4,7 +4,7 @@
 		A physics joint that connects two 2D physics bodies with a spring-like force.
 	</brief_description>
 	<description>
-		A physics joint that connects two 2D physics bodies with a spring-like force. This resembles a spring that always wants to stretch to a given length.
+		A physics joint that connects two 2D physics bodies with a spring-like force. This behaves like a spring that always wants to stretch to a given length.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -260,19 +260,19 @@
 			Message type for error messages that must be addressed and fail the export.
 		</constant>
 		<constant name="DEBUG_FLAG_DUMB_CLIENT" value="1" enum="DebugFlags" is_bitfield="true">
-			Flag is set if remotely debugged project is expected to use remote file system. If set, [method gen_export_flags] will add [code]--remote-fs[/code] and [code]--remote-fs-password[/code] (if password is set in the editor settings) command line arguments to the list.
+			Flag is set if the remotely debugged project is expected to use the remote file system. If set, [method gen_export_flags] will append [code]--remote-fs[/code] and [code]--remote-fs-password[/code] (if [member EditorSettings.filesystem/file_server/password] is defined) command line arguments to the returned list.
 		</constant>
 		<constant name="DEBUG_FLAG_REMOTE_DEBUG" value="2" enum="DebugFlags" is_bitfield="true">
-			Flag is set if remote debug is enabled. If set, [method gen_export_flags] will add [code]--remote-debug[/code] and [code]--breakpoints[/code] (if breakpoints are selected in the script editor or added by the plugin) command line arguments to the list.
+			Flag is set if remote debug is enabled. If set, [method gen_export_flags] will append [code]--remote-debug[/code] and [code]--breakpoints[/code] (if breakpoints are selected in the script editor or added by the plugin) command line arguments to the returned list.
 		</constant>
 		<constant name="DEBUG_FLAG_REMOTE_DEBUG_LOCALHOST" value="4" enum="DebugFlags" is_bitfield="true">
 			Flag is set if remotely debugged project is running on the localhost. If set, [method gen_export_flags] will use [code]localhost[/code] instead of [member EditorSettings.network/debug/remote_host] as remote debugger host.
 		</constant>
 		<constant name="DEBUG_FLAG_VIEW_COLLISIONS" value="8" enum="DebugFlags" is_bitfield="true">
-			Flag is set if "Visible Collision Shapes" remote debug option is enabled. If set, [method gen_export_flags] will add [code]--debug-collisions[/code] command line arguments to the list.
+			Flag is set if the "Visible Collision Shapes" remote debug option is enabled. If set, [method gen_export_flags] will append the [code]--debug-collisions[/code] command line argument to the returned list.
 		</constant>
 		<constant name="DEBUG_FLAG_VIEW_NAVIGATION" value="16" enum="DebugFlags" is_bitfield="true">
-			Flag is set if Visible Navigation" remote debug option is enabled. If set, [method gen_export_flags] will add [code]--debug-navigation[/code] command line arguments to the list.
+			Flag is set if the "Visible Navigation" remote debug option is enabled. If set, [method gen_export_flags] will append the [code]--debug-navigation[/code] command line argument to the returned list.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/EditorExportPlatformExtension.xml
+++ b/doc/classes/EditorExportPlatformExtension.xml
@@ -139,7 +139,7 @@
 		<method name="_get_logo" qualifiers="virtual required const">
 			<return type="Texture2D" />
 			<description>
-				Returns platform logo displayed in the export dialog, logo should be 32x32 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
+				Returns the platform logo displayed in the export dialog. The logo should be 32×32 pixels, adjusted for the current editor scale (see [method EditorInterface.get_editor_scale]).
 			</description>
 		</method>
 		<method name="_get_name" qualifiers="virtual required const">
@@ -152,7 +152,7 @@
 			<return type="ImageTexture" />
 			<param index="0" name="device" type="int" />
 			<description>
-				Returns one-click deploy menu item icon for the specified [param device], icon should be 16x16 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
+				Returns the item icon for the specified [param device] in the one-click deploy menu. The icon should be 16×16 pixels, adjusted for the current editor scale (see [method EditorInterface.get_editor_scale]).
 			</description>
 		</method>
 		<method name="_get_option_label" qualifiers="virtual const">
@@ -172,7 +172,7 @@
 		<method name="_get_options_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Returns number one-click deploy devices (or other one-click option displayed in the menu).
+				Returns the number of devices (or other options) available in the one-click deploy menu.
 			</description>
 		</method>
 		<method name="_get_options_tooltip" qualifiers="virtual const">
@@ -203,7 +203,7 @@
 		<method name="_get_run_icon" qualifiers="virtual const">
 			<return type="Texture2D" />
 			<description>
-				Returns icon of the one-click deploy menu button, icon should be 16x16 adjusted to the current editor scale, see [method EditorInterface.get_editor_scale].
+				Returns the icon of the one-click deploy menu button. The icon should be 16×16 pixels, adjusted for the current editor scale (see [method EditorInterface.get_editor_scale]).
 			</description>
 		</method>
 		<method name="_has_valid_export_configuration" qualifiers="virtual required const">

--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -230,7 +230,7 @@
 			<return type="bool" />
 			<param index="0" name="platform" type="EditorExportPlatform" />
 			<description>
-				Return [code]true[/code], if the result of [method _get_export_options] has changed and the export options of preset corresponding to [param platform] should be updated.
+				Return [code]true[/code] if the result of [method _get_export_options] has changed and the export options of the preset corresponding to [param platform] should be updated.
 			</description>
 		</method>
 		<method name="_supports_platform" qualifiers="virtual const">

--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -4,7 +4,7 @@
 		Export preset configuration.
 	</brief_description>
 	<description>
-		Export preset configuration. Instances of [EditorExportPreset] by editor UI and intended to be used a read-only configuration passed to the [EditorExportPlatform] methods when exporting the project.
+		Represents the configuration of an export preset, as created by the editor's export dialog. An [EditorExportPreset] instance is intended to be used a read-only configuration passed to the [EditorExportPlatform] methods when exporting the project.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -12,25 +12,25 @@
 		<method name="are_advanced_options_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if "Advanced" toggle is enabled in the export dialog.
+				Returns [code]true[/code] if the "Advanced" toggle is enabled in the export dialog.
 			</description>
 		</method>
 		<method name="get_custom_features" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns string with a comma separated list of custom features.
+				Returns a comma-separated list of custom features added to this preset, as a string. See [url=$DOCS_URL/tutorials/export/feature_tags.html]Feature tags[/url] in the documentation for more information.
 			</description>
 		</method>
 		<method name="get_customized_files" qualifiers="const">
 			<return type="Dictionary" />
 			<description>
-				Returns [Dictionary] of files selected in the "Resources" tab of the export dialog. Dictionary keys are file names and values are export mode - [code]"strip"[/code], [code]"keep"[/code], or [code]"remove"[/code]. See also [method get_file_export_mode].
+				Returns a dictionary of files selected in the "Resources" tab of the export dialog. The dictionary's keys are file paths, and its values are the corresponding export modes: [code]"strip"[/code], [code]"keep"[/code], or [code]"remove"[/code]. See also [method get_file_export_mode].
 			</description>
 		</method>
 		<method name="get_customized_files_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns number of files selected in the "Resources" tab of the export dialog.
+				Returns the number of files selected in the "Resources" tab of the export dialog.
 			</description>
 		</method>
 		<method name="get_encrypt_directory" qualifiers="const">
@@ -118,7 +118,7 @@
 		<method name="get_preset_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns export preset name.
+				Returns this export preset's name.
 			</description>
 		</method>
 		<method name="get_project_setting">
@@ -131,7 +131,7 @@
 		<method name="get_script_export_mode" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns script export mode.
+				Returns the export mode used by GDScript files. [code]0[/code] for "Text", [code]1[/code] for "Binary tokens", and [code]2[/code] for "Compressed binary tokens (smaller files)".
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">
@@ -154,19 +154,19 @@
 			<return type="bool" />
 			<param index="0" name="path" type="String" />
 			<description>
-				Returns [code]true[/code] if specified file is exported.
+				Returns [code]true[/code] if the file at the specified [param path] will be exported.
 			</description>
 		</method>
 		<method name="is_dedicated_server" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if dedicated server export mode is selected in the export dialog.
+				Returns [code]true[/code] if the dedicated server export mode is selected in the export dialog.
 			</description>
 		</method>
 		<method name="is_runnable" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if "Runnable" toggle is enabled in the export dialog.
+				Returns [code]true[/code] if the "Runnable" toggle is enabled in the export dialog.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/EditorFileDialog.xml
+++ b/doc/classes/EditorFileDialog.xml
@@ -15,7 +15,7 @@
 			<param index="0" name="filter" type="String" />
 			<param index="1" name="description" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a comma-delimited file name [param filter] option to the [EditorFileDialog] with an optional [param description], which restricts what files can be picked.
+				Adds a comma-separated file name [param filter] option to the [EditorFileDialog] with an optional [param description], which restricts what files can be picked.
 				A [param filter] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
 				For example, a [param filter] of [code]"*.tscn, *.scn"[/code] and a [param description] of [code]"Scenes"[/code] results in filter text "Scenes (*.tscn, *.scn)".
 			</description>

--- a/doc/classes/EditorScenePostImportPlugin.xml
+++ b/doc/classes/EditorScenePostImportPlugin.xml
@@ -63,15 +63,15 @@
 			<return type="void" />
 			<param index="0" name="scene" type="Node" />
 			<description>
-				Post process the scene. This function is called after the final scene has been configured.
+				Post-process the scene. This function is called after the final scene has been configured.
 			</description>
 		</method>
 		<method name="_pre_process" qualifiers="virtual">
 			<return type="void" />
 			<param index="0" name="scene" type="Node" />
 			<description>
-				Pre Process the scene. This function is called right after the scene format loader loaded the scene and no changes have been made.
-				Pre process may be used to adjust internal import options in the [code]"nodes"[/code], [code]"meshes"[/code], [code]"animations"[/code] or [code]"materials"[/code] keys inside [code]get_option_value("_subresources")[/code].
+				Pre-process the scene. This function is called right after the scene format loader loaded the scene and no changes have been made.
+				Pre-process may be used to adjust internal import options in the [code]"nodes"[/code], [code]"meshes"[/code], [code]"animations"[/code] or [code]"materials"[/code] keys inside [code]get_option_value("_subresources")[/code].
 			</description>
 		</method>
 		<method name="add_import_option">

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -14,7 +14,7 @@
 			<param index="0" name="filter" type="String" />
 			<param index="1" name="description" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a comma-delimited file name [param filter] option to the [FileDialog] with an optional [param description], which restricts what files can be picked.
+				Adds a comma-separated file name [param filter] option to the [FileDialog] with an optional [param description], which restricts what files can be picked.
 				A [param filter] should be of the form [code]"filename.extension"[/code], where filename and extension can be [code]*[/code] to match any string. Filters starting with [code].[/code] (i.e. empty filenames) are not allowed.
 				For example, a [param filter] of [code]"*.png, *.jpg"[/code] and a [param description] of [code]"Images"[/code] results in filter text "Images (*.png, *.jpg)".
 			</description>

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -89,9 +89,9 @@
 			<param index="0" name="event" type="InputEvent" />
 			<param index="1" name="exact_match" type="bool" default="true" />
 			<description>
-				Returns [code]true[/code] if the specified [param event] matches this event. Only valid for action events i.e key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion] or action ([InputEventAction]) events.
-				If [param exact_match] is [code]false[/code], it ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
-				[b]Note:[/b] Only considers the event configuration (such as the keyboard key or joypad axis), not state information like [method is_pressed], [method is_released], [method is_echo], or [method is_canceled].
+				Returns [code]true[/code] if the specified [param event] matches this event. Only valid for action events, which include key ([InputEventKey]), button ([InputEventMouseButton] or [InputEventJoypadButton]), axis [InputEventJoypadMotion], and action ([InputEventAction]) events.
+				If [param exact_match] is [code]false[/code], the check ignores additional input modifiers for [InputEventKey] and [InputEventMouseButton] events, and the direction for [InputEventJoypadMotion] events.
+				[b]Note:[/b] This method only considers the event configuration (such as the keyboard key or the joypad axis), not state information like [method is_pressed], [method is_released], [method is_echo], or [method is_canceled].
 			</description>
 		</method>
 		<method name="is_pressed" qualifiers="const">

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -318,7 +318,7 @@
 		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
 			Maximum number of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 			When a limit is defined, characters that would exceed [member max_length] are truncated. This happens both for existing [member text] contents when setting the max length, or for new text inserted in the [LineEdit], including pasting.
-			If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as parameter:
+			If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as a parameter:
 			[codeblocks]
 			[gdscript]
 			text = "Hello world"
@@ -327,7 +327,7 @@
 			max_length = 10
 			text += " goodbye"
 			# `text` becomes "Hello good".
-			# `text_change_rejected` is emitted with "bye" as parameter.
+			# `text_change_rejected` is emitted with "bye" as a parameter.
 			[/gdscript]
 			[csharp]
 			Text = "Hello world";
@@ -336,7 +336,7 @@
 			MaxLength = 10;
 			Text += " goodbye";
 			// `Text` becomes "Hello good".
-			// `text_change_rejected` is emitted with "bye" as parameter.
+			// `text_change_rejected` is emitted with "bye" as a parameter.
 			[/csharp]
 			[/codeblocks]
 		</member>

--- a/doc/classes/LookAtModifier3D.xml
+++ b/doc/classes/LookAtModifier3D.xml
@@ -120,9 +120,9 @@
 			The transition type of the time-based interpolation. See also [enum Tween.TransitionType].
 		</member>
 		<member name="use_angle_limitation" type="bool" setter="set_use_angle_limitation" getter="is_using_angle_limitation" default="false">
-			If [code]true[/code], limits the degree of rotation. This helps prevent the character's neck from rotating 360 degrees.
+			If [code]true[/code], limits the amount of rotation. For example, this helps to prevent a character's neck from rotating 360 degrees.
 			[b]Note:[/b] As with [AnimationTree] blending, interpolation is provided that favors [method Skeleton3D.get_bone_rest]. This means that interpolation does not select the shortest path in some cases.
-			[b]Note:[/b] Some [member transition_type] may exceed the limitations (e.g. `Back`, `Elastic`, and `Spring`). If interpolation occurs while overshooting the limitations, the result might possibly not respect the bone rest.
+			[b]Note:[/b] Some values for [member transition_type] (such as [constant Tween.TRANS_BACK], [constant Tween.TRANS_ELASTIC], and [constant Tween.TRANS_SPRING]) may exceed the limitations. If interpolation occurs while overshooting the limitations, the result might not respect the bone rest.
 		</member>
 		<member name="use_secondary_rotation" type="bool" setter="set_use_secondary_rotation" getter="is_using_secondary_rotation" default="true">
 			If [code]true[/code], provides rotation by two axes.

--- a/doc/classes/MeshDataTool.xml
+++ b/doc/classes/MeshDataTool.xml
@@ -100,8 +100,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="vertex" type="int" />
 			<description>
-				Returns index of specified vertex connected to given edge.
-				Vertex argument can only be 0 or 1 because edges are comprised of two vertices.
+				Returns the index of the specified [param vertex] connected to the edge at index [param idx].
+				[param vertex] can only be [code]0[/code] or [code]1[/code], as edges are composed of two vertices.
 			</description>
 		</method>
 		<method name="get_face_count" qualifiers="const">
@@ -115,8 +115,8 @@
 			<param index="0" name="idx" type="int" />
 			<param index="1" name="edge" type="int" />
 			<description>
-				Returns specified edge associated with given face.
-				Edge argument must be either 0, 1, or 2 because a face only has three edges.
+				Returns the edge associated with the face at index [param idx].
+				[param edge] argument must be either [code]0[/code], [code]1[/code], or [code]2[/code] because a face only has three edges.
 			</description>
 		</method>
 		<method name="get_face_meta" qualifiers="const">

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -90,7 +90,7 @@
 		<method name="get_navigation_mesh">
 			<return type="NavigationMesh" />
 			<description>
-				Returns the [NavigationMesh] resulting from this navigation polygon. This navigation mesh can be used to update the navigation mesh of a region with the [method NavigationServer3D.region_set_navigation_mesh] API directly (as 2D uses the 3D server behind the scene).
+				Returns the [NavigationMesh] resulting from this navigation polygon. This navigation mesh can be used to update the navigation mesh of a region with the [method NavigationServer3D.region_set_navigation_mesh] API directly.
 			</description>
 		</method>
 		<method name="get_outline" qualifiers="const">

--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -215,7 +215,7 @@
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="paused" type="bool" />
 			<description>
-				If [param paused] is [code]true[/code] the specified [param agent] will not be processed, e.g. calculate avoidance velocities or receive avoidance callbacks.
+				If [param paused] is [code]true[/code] the specified [param agent] will not be processed. For example, it will not calculate avoidance velocities or receive avoidance callbacks.
 			</description>
 		</method>
 		<method name="agent_set_position">
@@ -737,7 +737,7 @@
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="paused" type="bool" />
 			<description>
-				If [param paused] is [code]true[/code] the specified [param obstacle] will not be processed, e.g. affect avoidance velocities.
+				If [param paused] is [code]true[/code] the specified [param obstacle] will not be processed. For example, it will no longer affect avoidance velocities.
 			</description>
 		</method>
 		<method name="obstacle_set_position">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -237,7 +237,7 @@
 			<param index="0" name="agent" type="RID" />
 			<param index="1" name="paused" type="bool" />
 			<description>
-				If [param paused] is [code]true[/code] the specified [param agent] will not be processed, e.g. calculate avoidance velocities or receive avoidance callbacks.
+				If [param paused] is [code]true[/code] the specified [param agent] will not be processed. For example, it will not calculate avoidance velocities or receive avoidance callbacks.
 			</description>
 		</method>
 		<method name="agent_set_position">
@@ -855,7 +855,7 @@
 			<param index="0" name="obstacle" type="RID" />
 			<param index="1" name="paused" type="bool" />
 			<description>
-				If [param paused] is [code]true[/code] the specified [param obstacle] will not be processed, e.g. affect avoidance velocities.
+				If [param paused] is [code]true[/code] the specified [param obstacle] will not be processed. For example, it will no longer affect avoidance velocities.
 			</description>
 		</method>
 		<method name="obstacle_set_position">

--- a/doc/classes/PhysicsServer2DExtension.xml
+++ b/doc/classes/PhysicsServer2DExtension.xml
@@ -1092,7 +1092,7 @@
 			<return type="void" />
 			<param index="0" name="step" type="float" />
 			<description>
-				Called every physics step to process the physics simulation. [param step] is the time elapsed since the last physics step, in seconds. It is usually the same as [method Node.get_physics_process_delta_time].
+				Called every physics step to process the physics simulation. [param step] is the time elapsed since the last physics step, in seconds. It is usually the same as the value returned by [method Node.get_physics_process_delta_time].
 				Overridable version of [PhysicsServer2D]'s internal [code skip-lint]step[/code] method.
 			</description>
 		</method>

--- a/doc/classes/PointMesh.xml
+++ b/doc/classes/PointMesh.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PointMesh" inherits="PrimitiveMesh" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Mesh with a single Point primitive.
+		Mesh with a single point primitive.
 	</brief_description>
 	<description>
-		The PointMesh is made from a single point. Instead of relying on triangles, points are rendered as a single rectangle on the screen with a constant size. They are intended to be used with Particle systems, but can be used as a cheap way to render constant size billboarded sprites (for example in a point cloud).
-		PointMeshes, must be used with a material that has a point size. Point size can be accessed in a shader with [code]POINT_SIZE[/code], or in a [BaseMaterial3D] by setting [member BaseMaterial3D.use_point_size] and the variable [member BaseMaterial3D.point_size].
-		When using PointMeshes, properties that normally alter vertices will be ignored, including billboard mode, grow, and cull face.
+		A [PointMesh] is a primitive mesh composed of a single point. Instead of relying on triangles, points are rendered as a single rectangle on the screen with a constant size. They are intended to be used with particle systems, but can also be used as a cheap way to render billboarded sprites (for example in a point cloud).
+		In order to be displayed, point meshes must be used with a material that has a point size. The point size can be accessed in a shader with the [code]POINT_SIZE[/code] built-in, or in a [BaseMaterial3D] by setting the [member BaseMaterial3D.use_point_size] and [member BaseMaterial3D.point_size] properties.
+		[b]Note:[/b] When using point meshes, properties that normally affect vertices will be ignored, including [member BaseMaterial3D.billboard_mode], [member BaseMaterial3D.grow], and [member BaseMaterial3D.cull_mode].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2683,7 +2683,7 @@
 		</member>
 		<member name="rendering/2d/batching/uniform_set_cache_size" type="int" setter="" getter="" default="4096">
 			Maximum number of uniform sets that will be cached by the 2D renderer when batching draw calls.
-			[b]Note:[/b] A project that uses a large number of unique sprite textures per frame may benefit from increasing this value.
+			[b]Note:[/b] Increasing this value can improve performance if the project renders many unique sprite textures every frame.
 		</member>
 		<member name="rendering/2d/sdf/oversize" type="int" setter="" getter="" default="1">
 			Controls how much of the original viewport size should be covered by the 2D signed distance field. This SDF can be sampled in [CanvasItem] shaders and is used for [GPUParticles2D] collision. Higher values allow portions of occluders located outside the viewport to still be taken into account in the generated signed distance field, at the cost of performance. If you notice particles falling through [LightOccluder2D]s as the occluders leave the viewport, increase this setting.
@@ -2887,15 +2887,15 @@
 			- [code]opengl3_angle[/code], OpenGL ES 3.0 using the ANGLE compatibility layer over native Direct3D 11 drivers. If [member rendering/gl_compatibility/fallback_to_angle] is enabled, this is used as a fallback if OpenGL 3.3 is not supported. By default, ANGLE is used as the default driver for some devices listed in [member rendering/gl_compatibility/force_angle_on_devices].
 		</member>
 		<member name="rendering/gl_compatibility/fallback_to_angle" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the compatibility renderer will fall back to ANGLE if native OpenGL is not supported or the device is listed in [member rendering/gl_compatibility/force_angle_on_devices].
+			If [code]true[/code], the Compatibility renderer will fall back to ANGLE if native OpenGL is not supported or the device is listed in [member rendering/gl_compatibility/force_angle_on_devices].
 			[b]Note:[/b] This setting is implemented only on Windows.
 		</member>
 		<member name="rendering/gl_compatibility/fallback_to_gles" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the compatibility renderer will fall back to OpenGLES if desktop OpenGL is not supported.
+			If [code]true[/code], the Compatibility renderer will fall back to OpenGLES if desktop OpenGL is not supported.
 			[b]Note:[/b] This setting is implemented only on Linux/X11.
 		</member>
 		<member name="rendering/gl_compatibility/fallback_to_native" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the compatibility renderer will fall back to native OpenGL if ANGLE is not supported, or ANGLE dynamic libraries aren't found.
+			If [code]true[/code], the Compatibility renderer will fall back to native OpenGL if ANGLE is not supported, or ANGLE dynamic libraries aren't found.
 			[b]Note:[/b] This setting is implemented on macOS and Windows.
 		</member>
 		<member name="rendering/gl_compatibility/force_angle_on_devices" type="Array" setter="" getter="">
@@ -3011,19 +3011,19 @@
 			Use 16 bits for the omni/spot shadow depth map. Enabling this results in shadows having less precision and may result in shadow acne, but can lead to performance improvements on some devices.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_quadrant_0_subdiv" type="int" setter="" getter="" default="2">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			The subdivision amount of the first quadrant on the shadow atlas. See the [url=$DOCS_URL/tutorials/tutorials/3d/lights_and_shadows.html#shadow-atlas]documentation[/url] for more information.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_quadrant_1_subdiv" type="int" setter="" getter="" default="2">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			The subdivision amount of the second quadrant on the shadow atlas. See the [url=$DOCS_URL/tutorials/tutorials/3d/lights_and_shadows.html#shadow-atlas]documentation[/url] for more information.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_quadrant_2_subdiv" type="int" setter="" getter="" default="3">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			The subdivision amount of the third quadrant on the shadow atlas. See the [url=$DOCS_URL/tutorials/tutorials/3d/lights_and_shadows.html#shadow-atlas]documentation[/url] for more information.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_quadrant_3_subdiv" type="int" setter="" getter="" default="4">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			The subdivision amount of the fourth quadrant on the shadow atlas. See the [url=$DOCS_URL/tutorials/tutorials/3d/lights_and_shadows.html#shadow-atlas]documentation[/url] for more information.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_size" type="int" setter="" getter="" default="4096">
-			Size for shadow atlas (used for OmniLights and SpotLights). See documentation.
+			The size of the shadow atlas used for [OmniLight3D] and [SpotLight3D] nodes. See the [url=$DOCS_URL/tutorials/tutorials/3d/lights_and_shadows.html#shadow-atlas]documentation[/url] for more information.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_size.mobile" type="int" setter="" getter="" default="2048">
 			Lower-end override for [member rendering/lights_and_shadows/positional_shadow/atlas_size] on mobile devices, due to performance concerns or driver support.

--- a/doc/classes/ReferenceRect.xml
+++ b/doc/classes/ReferenceRect.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ReferenceRect" inherits="Control" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A rectangle hint for designing UIs.
+		A rectangular box for designing UIs.
 	</brief_description>
 	<description>
-		A rectangle box that displays only a colored border around its rectangle. It is used to visualize the extents of a [Control].
+		A rectangular box that displays only a colored border around its rectangle (see [method Control.get_rect]). It can be used to visualize the extents of a [Control] node, for testing purposes.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1146,23 +1146,23 @@
 		</constant>
 		<constant name="DRIVER_RESOURCE_LOGICAL_DEVICE" value="0" enum="DriverResource">
 			Specific device object based on a physical device.
-			- Vulkan: Vulkan device driver resource ([code]VkDevice[/code]). ([code]rid[/code] argument doesn't apply.)
+			- Vulkan: Vulkan device driver resource ([code]VkDevice[/code]) ([code]rid[/code] parameter is ignored).
 		</constant>
 		<constant name="DRIVER_RESOURCE_PHYSICAL_DEVICE" value="1" enum="DriverResource">
 			Physical device the specific logical device is based on.
-			- Vulkan: [code]VkDevice[/code]. ([code]rid[/code] argument doesn't apply.)
+			- Vulkan: [code]VkDevice[/code] ([code]rid[/code] parameter is ignored).
 		</constant>
 		<constant name="DRIVER_RESOURCE_TOPMOST_OBJECT" value="2" enum="DriverResource">
 			Top-most graphics API entry object.
-			- Vulkan: [code]VkInstance[/code]. ([code]rid[/code] argument doesn't apply.)
+			- Vulkan: [code]VkInstance[/code] ([code]rid[/code] parameter is ignored).
 		</constant>
 		<constant name="DRIVER_RESOURCE_COMMAND_QUEUE" value="3" enum="DriverResource">
 			The main graphics-compute command queue.
-			- Vulkan: [code]VkQueue[/code]. ([code]rid[/code] argument doesn't apply.)
+			- Vulkan: [code]VkQueue[/code] ([code]rid[/code] parameter is ignored).
 		</constant>
 		<constant name="DRIVER_RESOURCE_QUEUE_FAMILY" value="4" enum="DriverResource">
 			The specific family the main queue belongs to.
-			- Vulkan: the queue family index, an [code]uint32_t[/code]. ([code]rid[/code] argument doesn't apply.)
+			- Vulkan: The queue family index, a [code]uint32_t[/code] ([code]rid[/code] parameter is ignored).
 		</constant>
 		<constant name="DRIVER_RESOURCE_TEXTURE" value="5" enum="DriverResource">
 			- Vulkan: [code]VkImage[/code].

--- a/doc/classes/ResourceImporterImageFont.xml
+++ b/doc/classes/ResourceImporterImageFont.xml
@@ -21,7 +21,7 @@
 			The character ranges to import from the font image. This is an array that maps each position on the image (in tile coordinates, not pixels). The font atlas is traversed from left to right and top to bottom. Characters can be specified with decimal numbers (127), hexadecimal numbers ([code]0x007f[/code], or [code]U+007f[/code]) or between single quotes ([code]'~'[/code]). Ranges can be specified with a hyphen between characters.
 			For example, [code]0-127[/code] represents the full ASCII range. It can also be written as [code]0x0000-0x007f[/code] (or [code]U+0000-U+007f[/code]). As another example, [code]' '-'~'[/code] is equivalent to [code]32-127[/code] and represents the range of printable (visible) ASCII characters.
 			For any range, the character advance and offset can be customized by appending three space-separated integer values (additional advance, x offset, y offset) to the end. For example [code]'a'-'b' 4 5 2[/code] sets the advance to [code]char_width + 4[/code] and offset to [code]Vector2(5, 2)[/code] for both `a` and `b` characters.
-			Make sure [member character_ranges] doesn't exceed the number of [member columns] * [member rows] defined. Otherwise, the font will fail to import.
+			[b]Note:[/b] The overall number of characters must not exceed the number of [member columns] multiplied by [member rows]. Otherwise, the font will fail to import.
 		</member>
 		<member name="columns" type="int" setter="" getter="" default="1">
 			Number of columns in the font image. See also [member rows].

--- a/doc/classes/ResourceImporterScene.xml
+++ b/doc/classes/ResourceImporterScene.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ResourceImporterScene" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		Imports a glTF, FBX, Collada or Blender 3D scene.
+		Imports a glTF, FBX, COLLADA, or Blender 3D scene.
 	</brief_description>
 	<description>
 		See also [ResourceImporterOBJ], which is used for OBJ models that can be imported as an independent [Mesh] or a scene.

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -797,7 +797,7 @@
 			<param index="0" name="key" type="int" />
 			<param index="1" name="with" type="int" />
 			<description>
-				Replaces all occurrences of the Unicode character with code [param key] with the Unicode character with code [param with]. Faster version of [method replace] when the key is only one character long. To get a single character use [code]"X".unicode_at(0)[/code] (note that some strings, like compound letters and emoji, can be made up of multiple unicode codepoints, and will not work with this method, use [method length] to make sure).
+				Replaces all occurrences of the Unicode character with code [param key] with the Unicode character with code [param with]. Faster version of [method replace] when the key is only one character long. To get a single character use [code]"X".unicode_at(0)[/code] (note that some strings, like compound letters and emoji, can be composed of multiple unicode codepoints, and will not work with this method, use [method length] to make sure).
 			</description>
 		</method>
 		<method name="replace_chars" qualifiers="const">

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -705,7 +705,7 @@
 			<param index="0" name="key" type="int" />
 			<param index="1" name="with" type="int" />
 			<description>
-				Replaces all occurrences of the Unicode character with code [param key] with the Unicode character with code [param with]. Faster version of [method replace] when the key is only one character long. To get a single character use [code]"X".unicode_at(0)[/code] (note that some strings, like compound letters and emoji, can be made up of multiple unicode codepoints, and will not work with this method, use [method length] to make sure).
+				Replaces all occurrences of the Unicode character with code [param key] with the Unicode character with code [param with]. Faster version of [method replace] when the key is only one character long. To get a single character use [code]"X".unicode_at(0)[/code] (note that some strings, like compound letters and emoji, can be composed of multiple unicode codepoints, and will not work with this method, use [method length] to make sure).
 			</description>
 		</method>
 		<method name="replace_chars" qualifiers="const">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -2192,10 +2192,10 @@
 			Glyph horizontal position is rounded to one quarter of the pixel size, each glyph is rasterized up to four times.
 		</constant>
 		<constant name="SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE" value="20" enum="SubpixelPositioning">
-			Maximum font size which will use one half of the pixel subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
+			Maximum font size which will use "one half of the pixel" subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
 		</constant>
 		<constant name="SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE" value="16" enum="SubpixelPositioning">
-			Maximum font size which will use one quarter of the pixel subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
+			Maximum font size which will use "one quarter of the pixel" subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
 		</constant>
 		<constant name="FEATURE_SIMPLE_LAYOUT" value="1" enum="Feature">
 			TextServer supports simple text layouts.
@@ -2273,7 +2273,7 @@
 			Font is italic or oblique.
 		</constant>
 		<constant name="FONT_FIXED_WIDTH" value="4" enum="FontStyle" is_bitfield="true">
-			Font have fixed-width characters.
+			Font has fixed-width characters (also known as monospace).
 		</constant>
 		<constant name="STRUCTURED_TEXT_DEFAULT" value="0" enum="StructuredTextParser">
 			Use default Unicode BiDi algorithm.

--- a/modules/enet/doc_classes/ENetPacketPeer.xml
+++ b/modules/enet/doc_classes/ENetPacketPeer.xml
@@ -148,7 +148,7 @@
 			The peer is currently connected and ready to communicate with.
 		</constant>
 		<constant name="STATE_DISCONNECT_LATER" value="6" enum="PeerState">
-			The peer is slated to disconnect after it has no more outgoing packets to send.
+			The peer is expected to disconnect after it has no more outgoing packets to send.
 		</constant>
 		<constant name="STATE_DISCONNECTING" value="7" enum="PeerState">
 			The peer is currently disconnecting.

--- a/modules/noise/doc_classes/FastNoiseLite.xml
+++ b/modules/noise/doc_classes/FastNoiseLite.xml
@@ -30,7 +30,7 @@
 			A low value places more emphasis on the lower frequency base layers, while a high value puts more emphasis on the higher frequency layers.
 		</member>
 		<member name="domain_warp_fractal_lacunarity" type="float" setter="set_domain_warp_fractal_lacunarity" getter="get_domain_warp_fractal_lacunarity" default="6.0">
-			Octave lacunarity of the fractal noise which warps the space. Increasing this value results in higher octaves producing noise with finer details and a rougher appearance.
+			The change in frequency between octaves, also known as "lacunarity", of the fractal noise which warps the space. Increasing this value results in higher octaves, producing noise with finer details and a rougher appearance.
 		</member>
 		<member name="domain_warp_fractal_octaves" type="int" setter="set_domain_warp_fractal_octaves" getter="get_domain_warp_fractal_octaves" default="5">
 			The number of noise layers that are sampled to get the final value for the fractal noise which warps the space.
@@ -81,7 +81,7 @@
 			A lattice of points are assigned random values then interpolated based on neighboring values.
 		</constant>
 		<constant name="TYPE_VALUE_CUBIC" value="4" enum="NoiseType">
-			Similar to Value noise, but slower. Has more variance in peaks and valleys.
+			Similar to value noise ([constant TYPE_VALUE]), but slower. Has more variance in peaks and valleys.
 			Cubic noise can be used to avoid certain artifacts when using value noise to create a bumpmap. In general, you should always use this mode if the value noise is being used for a heightmap or bumpmap.
 		</constant>
 		<constant name="TYPE_PERLIN" value="3" enum="NoiseType">

--- a/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
@@ -115,7 +115,7 @@
 		</constant>
 		<constant name="MIPMAP_MODE_DISABLED" value="0" enum="MipmapMode">
 			Disable mipmapping.
-			[b]Note:[/b] Mipmapping can only be disabled in the compatibility renderer.
+			[b]Note:[/b] Mipmapping can only be disabled in the Compatibility renderer.
 		</constant>
 		<constant name="MIPMAP_MODE_NEAREST" value="1" enum="MipmapMode">
 			Use the mipmap of the nearest resolution.
@@ -137,7 +137,7 @@
 		</constant>
 		<constant name="WRAP_MIRROR_CLAMP_TO_EDGE" value="4" enum="Wrap">
 			Mirror the texture once and then clamp the texture to its edge color.
-			[b]Note:[/b] This wrap mode is not available in the compatibility renderer.
+			[b]Note:[/b] This wrap mode is not available in the Compatibility renderer.
 		</constant>
 		<constant name="SWIZZLE_RED" value="0" enum="Swizzle">
 			Maps a color channel to the value of the red channel.

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -103,7 +103,7 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if OpenXR's foveation extension is supported, the interface must be initialized before this returns a valid value.
-				[b]Note:[/b] This feature is only available on the compatibility renderer and currently only available on some stand alone headsets. For Vulkan set [member Viewport.vrs_mode] to [code]VRS_XR[/code] on desktop.
+				[b]Note:[/b] This feature is only available on the Compatibility renderer and currently only available on some stand alone headsets. For Vulkan set [member Viewport.vrs_mode] to [code]VRS_XR[/code] on desktop.
 			</description>
 		</method>
 		<method name="is_hand_interaction_supported" qualifiers="const">
@@ -157,11 +157,11 @@
 		</member>
 		<member name="foveation_dynamic" type="bool" setter="set_foveation_dynamic" getter="get_foveation_dynamic" default="false">
 			Enable dynamic foveation adjustment, the interface must be initialized before this is accessible. If enabled foveation will automatically adjusted between low and [member foveation_level].
-			[b]Note:[/b] Only works on compatibility renderer.
+			[b]Note:[/b] Only works on the Compatibility renderer.
 		</member>
 		<member name="foveation_level" type="int" setter="set_foveation_level" getter="get_foveation_level" default="0">
 			Set foveation level from 0 (off) to 3 (high), the interface must be initialized before this is accessible.
-			[b]Note:[/b] Only works on compatibility renderer.
+			[b]Note:[/b] Only works on the Compatibility renderer.
 		</member>
 		<member name="render_target_size_multiplier" type="float" setter="set_render_target_size_multiplier" getter="get_render_target_size_multiplier" default="1.0">
 			The render size multiplier for the current HMD. Must be set before the interface has been initialized.

--- a/modules/regex/doc_classes/RegEx.xml
+++ b/modules/regex/doc_classes/RegEx.xml
@@ -17,7 +17,7 @@
 		regex.compile("\\w-(\\d+)")
 		var result = regex.search("abc n-0123")
 		if result:
-			print(result.get_string()) # Would print n-0123
+			print(result.get_string()) # Prints "n-0123"
 		[/codeblock]
 		The results of capturing groups [code]()[/code] can be retrieved by passing the group number to the various methods in [RegExMatch]. Group 0 is the default and will always refer to the entire pattern. In the above example, calling [code]result.get_string(1)[/code] would give you [code]0123[/code].
 		This version of RegEx also supports named capturing groups, and the names can be used to retrieve the results. If two or more groups have the same name, the name would only refer to the first one with a match.
@@ -26,13 +26,13 @@
 		regex.compile("d(?&lt;digit&gt;[0-9]+)|x(?&lt;digit&gt;[0-9a-f]+)")
 		var result = regex.search("the number is x2f")
 		if result:
-			print(result.get_string("digit")) # Would print 2f
+			print(result.get_string("digit")) # Prints "2f"
 		[/codeblock]
 		If you need to process multiple results, [method search_all] generates a list of all non-overlapping results. This can be combined with a [code]for[/code] loop for convenience.
 		[codeblock]
+		# Prints "01 03 0 3f 42"
 		for result in regex.search_all("d01, d03, d0c, x3f and x42"):
 			print(result.get_string("digit"))
-		# Would print 01 03 0 3f 42
 		[/codeblock]
 		[b]Example:[/b] Split a string using a RegEx:
 		[codeblock]
@@ -41,7 +41,7 @@
 		var results = []
 		for result in regex.search_all("One  Two \n\tThree"):
 			results.push_back(result.get_string())
-		# The `results` array now contains "One", "Two", and "Three".
+		print(results) # Prints ["One", "Two", "Three"]
 		[/codeblock]
 		[b]Note:[/b] Godot's regex implementation is based on the [url=https://www.pcre.org/]PCRE2[/url] library. You can view the full pattern reference [url=https://www.pcre.org/current/doc/html/pcre2pattern.html]here[/url].
 		[b]Tip:[/b] You can use [url=https://regexr.com/]Regexr[/url] to test regular expressions online.


### PR DESCRIPTION
Continuation of https://github.com/godotengine/godot/pull/105073

This PR addressed yet yet another huge chunk of class reference oddities I remembered to note down for later while localizing the class reference. Some of these are clear typos, some are inconsistencies, some are just awkward.

Of particular note:
- Link to the existing constants in **CameraFeed**'s `set_format`
- Modify some descriptions of **EditorExportPlatformExtension** and **ReferenceRect** for clarity
- Modify some descriptions of **Animation**, **EditorExportPreset**, **MeshDataTool**, **PointMesh**, and **LookAtModifier3D** substantially
- Removed navigation's "_(as 2D uses the 3D server behind the scene)._"
	- It _should_ be incorrect now. CC @smix8 @AThousandShips
- Be more explicit in some some navigation server methods, instead of "e.g."
	- See [Rocketchat discussion](https://chat.godotengine.org/channel/navigation/thread/HmCe9HG3oZ4cEMZgM)
- Removed a formula in plain text in **ResourceImporterImageFont**
	- We should genuinely avoid expressions like "columns * rows", especially for simple formulas. It's hard to parse
- Link to the documentation in **ProjectSetting**'s shadow atlas descriptions
	- That is, instead of vaguely saying so with "see the documentation"
	- The reworded descriptions are partially taken from **Viewport**'s corresponding properties
- Elaborate more on what "_lacunarity_" is in **FastNoiseLite**'s `domain_warp_fractal_lacunarity`.
	- This term is so niche most languages genuinely don't have a term for it
- Standardize the examples in **RegEx**'s class
- Replace `x` with `×` character in more places
- Replace a few occurrences (_often the only ones_) of "comprise", "constitute", "multi-channel", "resemble", "comma-delimited", "post process", "pre process", "made up", "is slated" with more common alternatives
- Fixed occurrences of "Compatibility renderer" being in lowercase
- Fixed an occurrence of COLLADA not being fully capitalized
- Fixed "parameters" being referred as "arguments" in a few places
- Fixed some missing articles on the way

For some of the descriptions affected, additional tweaks have been made to justify a whole translation string change.