### PR TITLE
LightmapGI: Search for shadowmask light index only after sorting the lights

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -88,6 +88,15 @@ class LightmapperRD : public Lightmapper {
 		}
 	};
 
+	struct LightMetadata {
+		String name;
+		uint32_t type = LIGHT_TYPE_DIRECTIONAL;
+
+		bool operator<(const LightMetadata &p_light) const {
+			return type < p_light.type;
+		}
+	};
+
 	struct Vertex {
 		float position[3] = {};
 		float normal_z = 0.0;
@@ -203,7 +212,7 @@ class LightmapperRD : public Lightmapper {
 	Vector<MeshInstance> mesh_instances;
 
 	Vector<Light> lights;
-	Vector<String> light_names;
+	Vector<LightMetadata> light_metadata;
 
 	struct TriangleSort {
 		uint32_t cell_index = 0;


### PR DESCRIPTION
Sometimes, shadowmasks would end up baked fully blank due to the logic for finding the directional light index not accounting for the `sort()` function called when optimizing the acceleration structure.

| master | PR |
|---------|----|
| ![master](https://github.com/user-attachments/assets/d470f91f-a500-4ee7-9fd1-36a03435ac16) | ![pr](https://github.com/user-attachments/assets/caac4646-25c4-4934-857d-6f2fb6cf8488) |

MRP:
[shadowmask-order.zip](https://github.com/user-attachments/files/20614397/shadowmask-order.zip)
