### PR TITLE
Add functionalities to fix invalid cells and clear all cells in `GridMap`

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -28,6 +28,12 @@
 				Clears all baked meshes. See [method make_baked_meshes].
 			</description>
 		</method>
+		<method name="fix_invalid_cells">
+			<return type="void" />
+			<description>
+				Clears cells that do not exist in the grid map.
+			</description>
+		</method>
 		<method name="get_bake_mesh_instance">
 			<return type="RID" />
 			<param index="0" name="idx" type="int" />

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -185,6 +185,12 @@ void GridMapEditor::_menu_option(int p_option) {
 			_fill_selection();
 
 		} break;
+		case MENU_OPTION_CLEAR_ALL_CELLS: {
+			_clear_all_cells();
+		} break;
+		case MENU_OPTION_FIX_INVALID_CELLS: {
+			_fix_invalid_cells();
+		} break;
 		case MENU_OPTION_GRIDMAP_SETTINGS: {
 			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + Size2(50, 50) * EDSCALE);
 		} break;
@@ -499,6 +505,24 @@ void GridMapEditor::_fill_selection() {
 	}
 	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
 	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
+	undo_redo->commit_action();
+}
+
+void GridMapEditor::_clear_all_cells() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Clear All Cells"));
+	undo_redo->add_undo_method(node, "set", "data", node->get("data"));
+	node->clear();
+	undo_redo->add_do_method(node, "set", "data", node->get("data"));
+	undo_redo->commit_action();
+}
+
+void GridMapEditor::_fix_invalid_cells() {
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(TTR("Fix Invalid Cells"));
+	undo_redo->add_undo_method(node, "set", "data", node->get("data"));
+	node->fix_invalid_cells();
+	undo_redo->add_do_method(node, "set", "data", node->get("data"));
 	undo_redo->commit_action();
 }
 
@@ -1322,6 +1346,9 @@ GridMapEditor::GridMapEditor() {
 	options->get_popup()->add_shortcut(ED_GET_SHORTCUT("grid_map/clear_rotation"), MENU_OPTION_CURSOR_CLEAR_ROTATION);
 	options->get_popup()->add_check_shortcut(ED_GET_SHORTCUT("grid_map/keep_selected"), MENU_OPTION_PASTE_SELECTS);
 	options->get_popup()->set_item_checked(options->get_popup()->get_item_index(MENU_OPTION_PASTE_SELECTS), true);
+	options->get_popup()->add_separator();
+	options->get_popup()->add_item(TTR("Clear All Cells"), MENU_OPTION_CLEAR_ALL_CELLS);
+	options->get_popup()->add_item(TTR("Fix Invalid Cells"), MENU_OPTION_FIX_INVALID_CELLS);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_item(TTR("Settings..."), MENU_OPTION_GRIDMAP_SETTINGS);
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -197,6 +197,8 @@ class GridMapEditor : public VBoxContainer {
 		MENU_OPTION_SELECTION_CUT,
 		MENU_OPTION_SELECTION_CLEAR,
 		MENU_OPTION_SELECTION_FILL,
+		MENU_OPTION_CLEAR_ALL_CELLS,
+		MENU_OPTION_FIX_INVALID_CELLS,
 		MENU_OPTION_GRIDMAP_SETTINGS
 
 	};
@@ -247,6 +249,8 @@ class GridMapEditor : public VBoxContainer {
 
 	void _delete_selection();
 	void _fill_selection();
+	void _clear_all_cells();
+	void _fix_invalid_cells();
 
 	bool do_input_action(Camera3D *p_camera, const Point2 &p_point, bool p_click);
 

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -307,6 +307,7 @@ public:
 	void make_baked_meshes(bool p_gen_lightmap_uv = false, float p_lightmap_uv_texel_size = 0.1);
 
 	void clear();
+	void fix_invalid_cells();
 
 	Array get_bake_meshes();
 	RID get_bake_mesh_instance(int p_idx);


### PR DESCRIPTION
Fixes: #37124  (for 4.x)

This PR is partially based on #37136



----------------------

TODO: https://github.com/godotengine/godot/pull/37136#issuecomment-1198307134
> ... it should maybe be synced with how this is handled in the TileMap editor in 4.0 to be consistent (which is also able to display invalid cells in the viewport).


----------------------

Tried `Clear All Cells`, it works so far (also with Undo / Redo)


![image](https://github.com/user-attachments/assets/ac990191-8661-4544-a440-7ebf48a98a5a)

