### PR TITLE
Revert some instances of `Math::INF` back to 1e20

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -862,6 +862,7 @@ Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Plane *p_planes, in
 }
 
 #define square(m_s) ((m_s) * (m_s))
+#define BIG_VAL 1e20
 
 /* dt of 1d function using squared distance */
 static void edt(float *f, int stride, int n) {
@@ -871,8 +872,8 @@ static void edt(float *f, int stride, int n) {
 
 	int k = 0;
 	v[0] = 0;
-	z[0] = -Math::INF;
-	z[1] = +Math::INF;
+	z[0] = -BIG_VAL;
+	z[1] = +BIG_VAL;
 	for (int q = 1; q <= n - 1; q++) {
 		float s = ((f[q * stride] + square(q)) - (f[v[k] * stride] + square(v[k]))) / (2 * q - 2 * v[k]);
 		while (s <= z[k]) {
@@ -883,7 +884,7 @@ static void edt(float *f, int stride, int n) {
 		v[k] = q;
 
 		z[k] = s;
-		z[k + 1] = +Math::INF;
+		z[k + 1] = +BIG_VAL;
 	}
 
 	k = 0;
@@ -908,7 +909,7 @@ Vector<uint32_t> Geometry3D::generate_edf(const Vector<bool> &p_voxels, const Ve
 
 	float *work_memory = memnew_arr(float, float_count);
 	for (uint32_t i = 0; i < float_count; i++) {
-		work_memory[i] = Math::INF;
+		work_memory[i] = BIG_VAL;
 	}
 
 	uint32_t y_mult = p_size.x;
@@ -966,6 +967,8 @@ Vector<uint32_t> Geometry3D::generate_edf(const Vector<bool> &p_voxels, const Ve
 
 	return ret;
 }
+
+#undef BIG_VAL
 
 Vector<int8_t> Geometry3D::generate_sdf8(const Vector<uint32_t> &p_positive, const Vector<uint32_t> &p_negative) {
 	ERR_FAIL_COND_V(p_positive.size() != p_negative.size(), Vector<int8_t>());

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -816,6 +816,7 @@ Vector<int> Voxelizer::get_voxel_gi_level_cell_count() const {
 // https://prideout.net/blog/distance_fields/
 
 #define square(m_s) ((m_s) * (m_s))
+#define BIG_VAL 1e20
 
 /* dt of 1d function using squared distance */
 static void edt(float *f, int stride, int n) {
@@ -825,8 +826,8 @@ static void edt(float *f, int stride, int n) {
 
 	int k = 0;
 	v[0] = 0;
-	z[0] = -Math::INF;
-	z[1] = +Math::INF;
+	z[0] = -BIG_VAL;
+	z[1] = +BIG_VAL;
 	for (int q = 1; q <= n - 1; q++) {
 		float s = ((f[q * stride] + square(q)) - (f[v[k] * stride] + square(v[k]))) / (2 * q - 2 * v[k]);
 		while (s <= z[k]) {
@@ -837,7 +838,7 @@ static void edt(float *f, int stride, int n) {
 		v[k] = q;
 
 		z[k] = s;
-		z[k + 1] = +Math::INF;
+		z[k + 1] = +BIG_VAL;
 	}
 
 	k = 0;
@@ -861,7 +862,7 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 	uint32_t float_count = octree_size.x * octree_size.y * octree_size.z;
 	float *work_memory = memnew_arr(float, float_count);
 	for (uint32_t i = 0; i < float_count; i++) {
-		work_memory[i] = Math::INF;
+		work_memory[i] = BIG_VAL;
 	}
 
 	uint32_t y_mult = octree_size.x;
@@ -943,6 +944,8 @@ Voxelizer::BakeResult Voxelizer::get_sdf_3d_image(Vector<uint8_t> &r_image, Bake
 
 	return BAKE_RESULT_OK;
 }
+
+#undef BIG_VAL
 
 void Voxelizer::_debug_mesh(int p_idx, int p_level, const AABB &p_aabb, Ref<MultiMesh> &p_multimesh, int &idx) {
 	if (p_level == cell_subdiv - 1) {


### PR DESCRIPTION
fixes https://github.com/godotengine/godot/issues/107127
fixes https://github.com/godotengine/godot/issues/107134
reverts a few of the changes from https://github.com/godotengine/godot/pull/105249 that were causing issues