### PR TITLE
Add POSITION built-in to canvas-item shaders

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -251,6 +251,11 @@ void main() {
 #ifdef USE_WORLD_VERTEX_COORDS
 	vertex = (model_matrix * vec4(vertex, 0.0, 1.0)).xy;
 #endif
+
+#ifdef OVERRIDE_POSITION
+	highp vec4 position;
+#endif
+
 	{
 #CODE : VERTEX
 	}
@@ -277,7 +282,11 @@ void main() {
 	vertex_interp = vertex;
 	uv_interp = uv;
 
+#ifdef OVERRIDE_POSITION
+	gl_Position = position;
+#else
 	gl_Position = screen_transform * vec4(vertex, 0.0, 1.0);
+#endif
 
 #ifdef USE_POINT_SIZE
 	gl_PointSize = point_size;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1148,6 +1148,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["SHADOW_VERTEX"] = "shadow_vertex";
 		actions.renames["UV"] = "uv";
 		actions.renames["POINT_SIZE"] = "point_size";
+		actions.renames["POSITION"] = "position";
 
 		actions.renames["MODEL_MATRIX"] = "model_matrix";
 		actions.renames["CANVAS_MATRIX"] = "canvas_transform";
@@ -1200,6 +1201,7 @@ MaterialStorage::MaterialStorage() {
 		actions.usage_defines["SPECULAR_SHININESS"] = "#define SPECULAR_SHININESS_USED\n";
 		actions.usage_defines["CUSTOM0"] = "#define CUSTOM0_USED\n";
 		actions.usage_defines["CUSTOM1"] = "#define CUSTOM1_USED\n";
+		actions.usage_defines["POSITION"] = "#define OVERRIDE_POSITION\n";
 
 		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 		actions.render_mode_defines["unshaded"] = "#define MODE_UNSHADED\n";

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1764,6 +1764,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.renames["SHADOW_VERTEX"] = "shadow_vertex";
 		actions.renames["UV"] = "uv";
 		actions.renames["POINT_SIZE"] = "point_size";
+		actions.renames["POSITION"] = "position";
 
 		actions.renames["MODEL_MATRIX"] = "model_matrix";
 		actions.renames["CANVAS_MATRIX"] = "canvas_data.canvas_transform";
@@ -1817,6 +1818,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.usage_defines["POINT_SIZE"] = "#define USE_POINT_SIZE\n";
 		actions.usage_defines["CUSTOM0"] = "#define CUSTOM0_USED\n";
 		actions.usage_defines["CUSTOM1"] = "#define CUSTOM1_USED\n";
+		actions.usage_defines["POSITION"] = "#define OVERRIDE_POSITION\n";
 
 		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
 		actions.render_mode_defines["unshaded"] = "#define MODE_UNSHADED\n";

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -195,6 +195,11 @@ void main() {
 #ifdef USE_WORLD_VERTEX_COORDS
 	vertex = (model_matrix * vec4(vertex, 0.0, 1.0)).xy;
 #endif
+
+#ifdef OVERRIDE_POSITION
+	highp vec4 position;
+#endif
+
 	{
 #CODE : VERTEX
 	}
@@ -221,7 +226,11 @@ void main() {
 	vertex_interp = vertex;
 	uv_interp = uv;
 
+#ifdef OVERRIDE_POSITION
+	gl_Position = position;
+#else
 	gl_Position = canvas_data.screen_transform * vec4(vertex, 0.0, 1.0);
+#endif
 
 #ifdef USE_POINT_SIZE
 	gl_PointSize = point_size;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -259,6 +259,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["UV"] = ShaderLanguage::TYPE_VEC2;
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["COLOR"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["POINT_SIZE"] = ShaderLanguage::TYPE_FLOAT;
+	shader_modes[RS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["POSITION"] = ShaderLanguage::TYPE_VEC4;
 
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["MODEL_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["vertex"].built_ins["CANVAS_MATRIX"] = constt(ShaderLanguage::TYPE_MAT4);


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/12558

Allow overriding vertex gl_position through `POSITION` in canvas-item shaders; the same way it is possible in spatial shaders. Needed the feature for 3D text effect (clipping).

Can test with this basic shader:
```glsl
shader_type canvas_item;
render_mode skip_vertex_transform;

mat3 gen_rot_mat(vec3 r) {
	vec3 s = sin(r);
	vec3 c = cos(r);
	return mat3(
		vec3(c.x*c.y, c.x*s.y*s.z - s.x*c.z, c.x*s.y*c.z + s.x*s.z),
		vec3(s.x*c.y, s.x*s.y*s.z + c.x*c.z, s.x*s.y*c.z - c.x*s.z),
		vec3(   -s.y,               c.y*s.z,               c.y*c.z)
	);
}

void vertex() {
	mat4 combined_matrix = SCREEN_MATRIX * CANVAS_MATRIX * MODEL_MATRIX;
	combined_matrix[2][3] = combined_matrix[1][1] * 0.5;
	vec4 clip_coord = combined_matrix * vec4(gen_rot_mat(vec3(0.0, TIME, 0.0)) * vec3(VERTEX, 0.0), 1.0);
	POSITION = vec4(clip_coord.xy, 0.0, clip_coord.w);
}
```
Demo: [test_canvas_position.zip](https://github.com/user-attachments/files/20611083/test_canvas_position.zip)