### PR TITLE
Move GDScript warnings to EditorSettings

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -155,11 +155,15 @@ public:
 	static const int CONFIG_VERSION = 5;
 
 #ifdef TOOLS_ENABLED
+	Object *editor_settings = nullptr;
 	HashMap<String, PropertyInfo> editor_settings_info;
+	HashMap<String, Array> pending_editor_settings;
 #endif
+	HashMap<String, Variant> editor_fallbacks;
 
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
+	Variant get_editor_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
 	TypedArray<Dictionary> get_global_class_list();
 	void refresh_global_class_list();
 	void store_global_class_list(const Array &p_classes);
@@ -246,12 +250,15 @@ public:
 // Not a macro any longer.
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
+Variant _GLOBAL_EDITOR_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
+Variant _GLOBAL_EDITOR_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
 
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
 #define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
 #define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get_setting_with_override(m_var)
+#define GLOBAL_EDITOR_GET(m_var) ProjectSettings::get_singleton()->get_editor_setting(m_var)
 
 #define GLOBAL_DEF_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, true)
 #define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)
@@ -274,6 +281,25 @@ if (_ggc_local_version != _ggc_new_version) {\
 	_ggc_spin.lock();\
 	_ggc_local_version = _ggc_new_version;\
 	_ggc_local_var = ProjectSettings::get_singleton()->get_setting_with_override(p_name);\
+	m_type _ggc_temp = _ggc_local_var;\
+	_ggc_spin.unlock();\
+	return _ggc_temp;\
+}\
+_ggc_spin.lock();\
+m_type _ggc_temp2 = _ggc_local_var;\
+_ggc_spin.unlock();\
+return _ggc_temp2; })(m_setting_name)
+
+#define GLOBAL_EDITOR_GET_CACHED(m_type, m_setting_name) ([](const char *p_name) -> m_type {\
+static_assert(std::is_trivially_destructible<m_type>::value, "GLOBAL_EDITOR_GET_CACHED must use a trivial type that allows static lifetime.");\
+static m_type _ggc_local_var;\
+static uint32_t _ggc_local_version = 0;\
+static SpinLock _ggc_spin;\
+uint32_t _ggc_new_version = ProjectSettings::get_singleton()->get_version();\
+if (_ggc_local_version != _ggc_new_version) {\
+	_ggc_spin.lock();\
+	_ggc_local_version = _ggc_new_version;\
+	_ggc_local_var = ProjectSettings::get_singleton()->get_editor_setting(p_name);\
 	m_type _ggc_temp = _ggc_local_var;\
 	_ggc_spin.unlock();\
 	return _ggc_temp;\

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -168,6 +168,8 @@ public:
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 	void mark_setting_changed(const String &p_setting);
 
+	Variant define_from_project_setting(const Dictionary &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
+
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
 
@@ -215,6 +217,7 @@ public:
 #define EDITOR_DEF_RST(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), true)
 #define EDITOR_DEF_BASIC(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), false, true)
 Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
+Variant _EDITOR_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
 
 #define EDITOR_GET(m_var) _EDITOR_GET(m_var)
 Variant _EDITOR_GET(const String &p_setting);

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -859,7 +859,7 @@ void ScriptTextEditor::_update_warnings() {
 
 	bool has_connections_table = false;
 	// Add missing connections.
-	if (GLOBAL_GET("debug/gdscript/warnings/enable")) {
+	if (GLOBAL_EDITOR_GET("debug/gdscript/warnings/enable")) {
 		Node *base = get_tree()->get_edited_scene_root();
 		if (base && missing_connections.size() > 0) {
 			has_connections_table = true;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2952,16 +2952,6 @@ GDScriptLanguage::GDScriptLanguage() {
 #ifdef DEBUG_ENABLED
 	track_call_stack = true;
 	track_locals = track_locals || EngineDebugger::is_active();
-
-	GLOBAL_DEF("debug/gdscript/warnings/enable", true);
-	GLOBAL_DEF("debug/gdscript/warnings/exclude_addons", true);
-	GLOBAL_DEF("debug/gdscript/warnings/renamed_in_godot_4_hint", true);
-	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
-		GDScriptWarning::Code code = (GDScriptWarning::Code)i;
-		Variant default_enabled = GDScriptWarning::get_default_value(code);
-		String path = GDScriptWarning::get_settings_path_from_code(code);
-		GLOBAL_DEF(GDScriptWarning::get_property_info(code), default_enabled);
-	}
 #endif // DEBUG_ENABLED
 }
 

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -135,7 +135,7 @@ GDScriptParser::GDScriptParser() {
 	}
 
 #ifdef DEBUG_ENABLED
-	is_ignoring_warnings = !(bool)GLOBAL_GET("debug/gdscript/warnings/enable");
+	is_ignoring_warnings = !(bool)GLOBAL_EDITOR_GET("debug/gdscript/warnings/enable");
 	for (int i = 0; i < GDScriptWarning::WARNING_MAX; i++) {
 		warning_ignore_start_lines[i] = INT_MAX;
 	}
@@ -196,10 +196,10 @@ void GDScriptParser::push_warning(const Node *p_source, GDScriptWarning::Code p_
 	if (is_ignoring_warnings) {
 		return;
 	}
-	if (GLOBAL_GET_CACHED(bool, "debug/gdscript/warnings/exclude_addons") && script_path.begins_with("res://addons/")) {
+	if (GLOBAL_EDITOR_GET_CACHED(bool, "debug/gdscript/warnings/exclude_addons") && script_path.begins_with("res://addons/")) {
 		return;
 	}
-	GDScriptWarning::WarnLevel warn_level = (GDScriptWarning::WarnLevel)(int)GLOBAL_GET(GDScriptWarning::get_settings_path_from_code(p_code));
+	GDScriptWarning::WarnLevel warn_level = (GDScriptWarning::WarnLevel)(int)GLOBAL_EDITOR_GET(GDScriptWarning::get_settings_path_from_code(p_code));
 	if (warn_level == GDScriptWarning::IGNORE) {
 		return;
 	}

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -152,6 +152,16 @@ void initialize_gdscript_module(ModuleInitializationLevel p_level) {
 		gdscript_cache = memnew(GDScriptCache);
 
 		GDScriptUtilityFunctions::register_functions();
+
+		_GLOBAL_EDITOR_DEF("debug/gdscript/warnings/enable", true);
+		_GLOBAL_EDITOR_DEF("debug/gdscript/warnings/exclude_addons", true);
+		_GLOBAL_EDITOR_DEF("debug/gdscript/warnings/renamed_in_godot_4_hint", true);
+		for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
+			GDScriptWarning::Code code = (GDScriptWarning::Code)i;
+			Variant default_enabled = GDScriptWarning::get_default_value(code);
+			String path = GDScriptWarning::get_settings_path_from_code(code);
+			_GLOBAL_EDITOR_DEF(GDScriptWarning::get_property_info(code), default_enabled);
+		}
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Follow-up to #69012

This moves GDScript warning settings to editor settings, so you can customize them once and forget.

To make this work properly, ProjectSettings can now access EditorSettings (via a plain Object pointer). I added `GLOBAL_EDITOR_DEF` and `GLOBAL_EDITOR_GET`, intended for editor settings that need to be accessed in the project. The caveat is that editor settings are not available at runtime .-. In such case, the project override will be used, if available. If not available, the editor setting's value is ignored and I don't know how to fix that :/

I also added compatibility code that automatically adds project overrides for old settings.