### PR TITLE
Add script pre creation plugin

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -544,6 +544,15 @@
 				If [param first_priority] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
+		<method name="add_script_pre_creation_plugin">
+			<return type="void" />
+			<param index="0" name="script_creation_plugin" type="EditorScriptPreCreationPlugin" />
+			<param index="1" name="first_priority" type="bool" default="false" />
+			<description>
+				Add a [EditorScriptPreCreationPlugin]. These plugins allow customizing the creation process of scripts.
+				If [param first_priority] is [code]true[/code], the new creation plugin is inserted first in the list and takes precedence over pre-existing plugins.
+			</description>
+		</method>
 		<method name="add_tool_menu_item">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
@@ -730,6 +739,13 @@
 			<param index="0" name="scene_import_plugin" type="EditorScenePostImportPlugin" />
 			<description>
 				Remove the [EditorScenePostImportPlugin], added with [method add_scene_post_import_plugin].
+			</description>
+		</method>
+		<method name="remove_script_pre_creation_plugin">
+			<return type="void" />
+			<param index="0" name="script_creation_plugin" type="EditorScriptPreCreationPlugin" />
+			<description>
+				Remove the [EditorScriptPreCreationPlugin], added with [method add_script_pre_creation_plugin].
 			</description>
 		</method>
 		<method name="remove_tool_menu_item">

--- a/doc/classes/EditorScriptPreCreationPlugin.xml
+++ b/doc/classes/EditorScriptPreCreationPlugin.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorScriptPreCreationPlugin" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Plugin to control and modifying the process of creating a script.
+	</brief_description>
+	<description>
+		This plugin type exists to modify the process of creating scripts, allowing to change the source code for more complex post processing.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_pre_creation" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="script" type="Script" />
+			<description>
+				Post process the script. This function is called before the script is created.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8683,6 +8683,7 @@ EditorNode::~EditorNode() {
 	EditorInspector::cleanup_plugins();
 	EditorTranslationParser::get_singleton()->clean_parsers();
 	ResourceImporterScene::clean_up_importer_plugins();
+	ScriptCreateDialog::clean_up_creation_plugins();
 	EditorContextMenuPluginManager::cleanup();
 
 	remove_print_handler(&print_handler);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -487,6 +487,14 @@ void EditorPlugin::remove_scene_post_import_plugin(const Ref<EditorScenePostImpo
 	ResourceImporterScene::remove_post_importer_plugin(p_plugin);
 }
 
+void EditorPlugin::add_script_pre_creation_plugin(const Ref<EditorScriptPreCreationPlugin> &p_plugin, bool p_first_priority) {
+	get_script_create_dialog()->add_pre_creation_plugin(p_plugin, p_first_priority);
+}
+
+void EditorPlugin::remove_script_pre_creation_plugin(const Ref<EditorScriptPreCreationPlugin> &p_plugin) {
+	get_script_create_dialog()->remove_pre_creation_plugin(p_plugin);
+}
+
 void EditorPlugin::add_context_menu_plugin(EditorContextMenuPlugin::ContextMenuSlot p_slot, const Ref<EditorContextMenuPlugin> &p_plugin) {
 	EditorContextMenuPluginManager::get_singleton()->add_plugin(p_slot, p_plugin);
 }
@@ -622,6 +630,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::remove_scene_format_importer_plugin);
 	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin", "first_priority"), &EditorPlugin::add_scene_post_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_post_import_plugin", "scene_import_plugin"), &EditorPlugin::remove_scene_post_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_script_pre_creation_plugin", "script_creation_plugin", "first_priority"), &EditorPlugin::add_script_pre_creation_plugin, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("remove_script_pre_creation_plugin", "script_creation_plugin"), &EditorPlugin::remove_script_pre_creation_plugin);
 	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPlugin::add_export_plugin);
 	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPlugin::remove_export_plugin);
 	ClassDB::bind_method(D_METHOD("add_export_platform", "platform"), &EditorPlugin::add_export_platform);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -49,6 +49,7 @@ class EditorNode3DGizmoPlugin;
 class EditorResourceConversionPlugin;
 class EditorSceneFormatImporter;
 class EditorScenePostImportPlugin;
+class EditorScriptPreCreationPlugin;
 class EditorToolAddons;
 class EditorTranslationParserPlugin;
 class EditorUndoRedoManager;
@@ -239,6 +240,9 @@ public:
 
 	void add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer);
+
+	void add_script_pre_creation_plugin(const Ref<EditorScriptPreCreationPlugin> &p_plugin, bool p_first_priority = false);
+	void remove_script_pre_creation_plugin(const Ref<EditorScriptPreCreationPlugin> &p_plugin);
 
 	void add_autoload_singleton(const String &p_name, const String &p_path);
 	void remove_autoload_singleton(const String &p_name);

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -173,6 +173,7 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorResourceConversionPlugin);
 	GDREGISTER_CLASS(EditorSceneFormatImporter);
 	GDREGISTER_CLASS(EditorScenePostImportPlugin);
+	GDREGISTER_CLASS(EditorScriptPreCreationPlugin);
 	GDREGISTER_CLASS(EditorInspector);
 	GDREGISTER_CLASS(EditorInspectorPlugin);
 	GDREGISTER_CLASS(EditorProperty);

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -41,6 +41,18 @@ class EditorFileDialog;
 class EditorValidationPanel;
 class LineEdit;
 
+class EditorScriptPreCreationPlugin : public RefCounted {
+	GDCLASS(EditorScriptPreCreationPlugin, RefCounted);
+
+protected:
+	GDVIRTUAL1(_pre_creation, Ref<Script>)
+
+	static void _bind_methods();
+
+public:
+	virtual void pre_creation(Ref<Script> p_script);
+};
+
 class ScriptCreateDialog : public ConfirmationDialog {
 	GDCLASS(ScriptCreateDialog, ConfirmationDialog);
 
@@ -50,6 +62,8 @@ class ScriptCreateDialog : public ConfirmationDialog {
 		MSG_ID_BUILT_IN,
 		MSG_ID_TEMPLATE,
 	};
+
+	static Vector<Ref<EditorScriptPreCreationPlugin>> pre_creation_plugins;
 
 	EditorValidationPanel *validation_panel = nullptr;
 	LineEdit *parent_name = nullptr;
@@ -121,6 +135,10 @@ protected:
 	static void _bind_methods();
 
 public:
+	static void add_pre_creation_plugin(const Ref<EditorScriptPreCreationPlugin> &p_plugin, bool p_first_priority = false);
+	static void remove_pre_creation_plugin(const Ref<EditorScriptPreCreationPlugin> &p_plugin);
+	static void clean_up_creation_plugins();
+
 	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true, bool p_load_enabled = true);
 	void set_inheritance_base_type(const String &p_base);
 	ScriptCreateDialog();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Add a plugin to perform a post-processing method on a script before it's created. This allows for more complex changes beyond the [placeholders](https://docs.godotengine.org/en/stable/tutorials/scripting/creating_script_templates.html#list-of-template-placeholders)