### PR TITLE
msdfgen: Update to 1.12.1

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -517,7 +517,7 @@ License: BSD-2-clause
 
 Files: thirdparty/msdfgen/*
 Comment: Multi-channel signed distance field generator
-Copyright: 2014-2024, Viktor Chlumsky
+Copyright: 2014-2025, Viktor Chlumsky
 License: Expat
 
 Files: thirdparty/openxr/*

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -833,7 +833,7 @@ Collection of single-file libraries used in Godot components.
 ## msdfgen
 
 - Upstream: https://github.com/Chlumsky/msdfgen
-- Version: 1.12 (85e8b3d47b3d1a42e4a5ebda0a24fb1cc2e669e0, 2024)
+- Version: 1.12.1 (6574da1310df433c97ca0fddcab7e463c31e58f8, 2025)
 - License: MIT
 
 Files extracted from the upstream source:

--- a/thirdparty/msdfgen/LICENSE.txt
+++ b/thirdparty/msdfgen/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2014 - 2024 Viktor Chlumsky
+Copyright (c) 2014 - 2025 Viktor Chlumsky
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/thirdparty/msdfgen/core/MSDFErrorCorrection.cpp
+++ b/thirdparty/msdfgen/core/MSDFErrorCorrection.cpp
@@ -89,6 +89,8 @@ public:
     bool protectedFlag;
     inline ShapeDistanceChecker(const BitmapConstRef<float, N> &sdf, const Shape &shape, const Projection &projection, DistanceMapping distanceMapping, double minImproveRatio) : distanceFinder(shape), sdf(sdf), distanceMapping(distanceMapping), minImproveRatio(minImproveRatio) {
         texelSize = projection.unprojectVector(Vector2(1));
+        if (shape.inverseYAxis)
+            texelSize.y = -texelSize.y;
     }
     inline ArtifactClassifier classifier(const Vector2 &direction, double span) {
         return ArtifactClassifier(this, direction, span);
@@ -127,10 +129,10 @@ void MSDFErrorCorrection::protectCorners(const Shape &shape) {
                 if (!(commonColor&(commonColor-1))) {
                     // Find the four texels that envelop the corner and mark them as protected.
                     Point2 p = transformation.project((*edge)->point(0));
-                    if (shape.inverseYAxis)
-                        p.y = stencil.height-p.y;
                     int l = (int) floor(p.x-.5);
                     int b = (int) floor(p.y-.5);
+                    if (shape.inverseYAxis)
+                        b = stencil.height-b-2;
                     int r = l+1;
                     int t = b+1;
                     // Check that the positions are within bounds.

--- a/thirdparty/msdfgen/core/msdf-error-correction.cpp
+++ b/thirdparty/msdfgen/core/msdf-error-correction.cpp
@@ -84,6 +84,12 @@ void msdfFastDistanceErrorCorrection(const BitmapRef<float, 3> &sdf, const Proje
 void msdfFastDistanceErrorCorrection(const BitmapRef<float, 4> &sdf, const Projection &projection, Range range, double minDeviationRatio) {
     msdfErrorCorrectionShapeless(sdf, SDFTransformation(projection, range), minDeviationRatio, false);
 }
+void msdfFastDistanceErrorCorrection(const BitmapRef<float, 3> &sdf, Range pxRange, double minDeviationRatio) {
+    msdfErrorCorrectionShapeless(sdf, SDFTransformation(Projection(), pxRange), minDeviationRatio, false);
+}
+void msdfFastDistanceErrorCorrection(const BitmapRef<float, 4> &sdf, Range pxRange, double minDeviationRatio) {
+    msdfErrorCorrectionShapeless(sdf, SDFTransformation(Projection(), pxRange), minDeviationRatio, false);
+}
 
 void msdfFastEdgeErrorCorrection(const BitmapRef<float, 3> &sdf, const SDFTransformation &transformation, double minDeviationRatio) {
     msdfErrorCorrectionShapeless(sdf, transformation, minDeviationRatio, true);
@@ -96,6 +102,12 @@ void msdfFastEdgeErrorCorrection(const BitmapRef<float, 3> &sdf, const Projectio
 }
 void msdfFastEdgeErrorCorrection(const BitmapRef<float, 4> &sdf, const Projection &projection, Range range, double minDeviationRatio) {
     msdfErrorCorrectionShapeless(sdf, SDFTransformation(projection, range), minDeviationRatio, true);
+}
+void msdfFastEdgeErrorCorrection(const BitmapRef<float, 3> &sdf, Range pxRange, double minDeviationRatio) {
+    msdfErrorCorrectionShapeless(sdf, SDFTransformation(Projection(), pxRange), minDeviationRatio, true);
+}
+void msdfFastEdgeErrorCorrection(const BitmapRef<float, 4> &sdf, Range pxRange, double minDeviationRatio) {
+    msdfErrorCorrectionShapeless(sdf, SDFTransformation(Projection(), pxRange), minDeviationRatio, true);
 }
 
 

--- a/thirdparty/msdfgen/core/msdf-error-correction.h
+++ b/thirdparty/msdfgen/core/msdf-error-correction.h
@@ -22,12 +22,16 @@ void msdfFastDistanceErrorCorrection(const BitmapRef<float, 3> &sdf, const SDFTr
 void msdfFastDistanceErrorCorrection(const BitmapRef<float, 4> &sdf, const SDFTransformation &transformation, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 void msdfFastDistanceErrorCorrection(const BitmapRef<float, 3> &sdf, const Projection &projection, Range range, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 void msdfFastDistanceErrorCorrection(const BitmapRef<float, 4> &sdf, const Projection &projection, Range range, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
+void msdfFastDistanceErrorCorrection(const BitmapRef<float, 3> &sdf, Range pxRange, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
+void msdfFastDistanceErrorCorrection(const BitmapRef<float, 4> &sdf, Range pxRange, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 
 /// Applies the simplified error correction to edges only (EDGE_ONLY mode). Does not need shape or translation.
 void msdfFastEdgeErrorCorrection(const BitmapRef<float, 3> &sdf, const SDFTransformation &transformation, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 void msdfFastEdgeErrorCorrection(const BitmapRef<float, 4> &sdf, const SDFTransformation &transformation, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 void msdfFastEdgeErrorCorrection(const BitmapRef<float, 3> &sdf, const Projection &projection, Range range, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 void msdfFastEdgeErrorCorrection(const BitmapRef<float, 4> &sdf, const Projection &projection, Range range, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
+void msdfFastEdgeErrorCorrection(const BitmapRef<float, 3> &sdf, Range pxRange, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
+void msdfFastEdgeErrorCorrection(const BitmapRef<float, 4> &sdf, Range pxRange, double minDeviationRatio = ErrorCorrectionConfig::defaultMinDeviationRatio);
 
 /// The original version of the error correction algorithm.
 void msdfErrorCorrection_legacy(const BitmapRef<float, 3> &output, const Vector2 &threshold);

--- a/thirdparty/msdfgen/core/rasterization.cpp
+++ b/thirdparty/msdfgen/core/rasterization.cpp
@@ -33,7 +33,7 @@ void distanceSignCorrection(const BitmapRef<float, 1> &sdf, const Shape &shape, 
 template <int N>
 static void multiDistanceSignCorrection(const BitmapRef<float, N> &sdf, const Shape &shape, const Projection &projection, FillRule fillRule) {
     int w = sdf.width, h = sdf.height;
-    if (!(w*h))
+    if (!(w && h))
         return;
     Scanline scanline;
     bool ambiguous = false;

--- a/thirdparty/msdfgen/core/save-bmp.cpp
+++ b/thirdparty/msdfgen/core/save-bmp.cpp
@@ -1,5 +1,7 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "save-bmp.h"
 

--- a/thirdparty/msdfgen/core/save-tiff.cpp
+++ b/thirdparty/msdfgen/core/save-tiff.cpp
@@ -1,5 +1,7 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
 
 #include "save-tiff.h"
 

--- a/thirdparty/msdfgen/core/shape-description.cpp
+++ b/thirdparty/msdfgen/core/shape-description.cpp
@@ -1,5 +1,8 @@
 
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "shape-description.h"
 
 #include <cstdlib>

--- a/thirdparty/msdfgen/msdfgen.h
+++ b/thirdparty/msdfgen/msdfgen.h
@@ -4,7 +4,7 @@
 /*
  * MULTI-CHANNEL SIGNED DISTANCE FIELD GENERATOR
  * ---------------------------------------------
- * A utility by Viktor Chlumsky, (c) 2014 - 2024
+ * A utility by Viktor Chlumsky, (c) 2014 - 2025
  *
  * The technique used to generate multi-channel distance fields in this code
  * has been developed by Viktor Chlumsky in 2014 for his master's thesis,


### PR DESCRIPTION
Changes:
```
### Version 1.12.1 (2025-05-31)

- Fixed a bug applying error correction incorrectly if shape's Y-axis is inverted (mainly affected SVG input)
- Fixed error correction not being applied in the standalone executable in MTSDF mode with the `-scanline` option (default in non-Skia builds)
- Minor CMake adjustments and warning fixes
```