### PR TITLE
Add `has_editor_variant` to file cache for editor-use assets

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -37,6 +37,8 @@
 #include "core/io/resource_saver.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
+#include "core/string/ustring.h"
+#include "core/variant/dictionary.h"
 #include "core/variant/variant_parser.h"
 #include "editor/doc/editor_help.h"
 #include "editor/editor_node.h"
@@ -52,7 +54,7 @@ int EditorFileSystem::nb_files_total = 0;
 EditorFileSystem::ScannedDirectory *EditorFileSystem::first_scan_root_dir = nullptr;
 
 //the name is the version, to keep compatibility with different versions of Godot
-#define CACHE_FILE_NAME "filesystem_cache10"
+#define CACHE_FILE_NAME "filesystem_cache11"
 
 int EditorFileSystemDirectory::find_file_index(const String &p_file) const {
 	for (int i = 0; i < files.size(); i++) {
@@ -438,7 +440,7 @@ void EditorFileSystem::_scan_filesystem() {
 
 				} else {
 					// The last section (deps) may contain the same splitter, so limit the maxsplit to 8 to get the complete deps.
-					Vector<String> split = l.split("::", true, 8);
+					Vector<String> split = l.split("::", true, 9);
 					ERR_CONTINUE(split.size() < 9);
 					String name = split[0];
 					String file;
@@ -453,9 +455,10 @@ void EditorFileSystem::_scan_filesystem() {
 					fc.modification_time = split[3].to_int();
 					fc.import_modification_time = split[4].to_int();
 					fc.import_valid = split[5].to_int() != 0;
-					fc.import_group_file = split[6].strip_edges();
+					fc.has_editor_variant = split[6].to_int() != 0;
+					fc.import_group_file = split[7].strip_edges();
 					{
-						const Vector<String> &slices = split[7].split("<>");
+						const Vector<String> &slices = split[8].split("<>");
 						ERR_CONTINUE(slices.size() < 7);
 						fc.class_info.name = slices[0];
 						fc.class_info.extends = slices[1];
@@ -465,7 +468,7 @@ void EditorFileSystem::_scan_filesystem() {
 						fc.import_md5 = slices[5];
 						fc.import_dest_paths = slices[6].split("<*>");
 					}
-					fc.deps = split[8].strip_edges().split("<>");
+					fc.deps = split[9].strip_edges().split("<>");
 
 					file_cache[name] = fc;
 				}
@@ -567,6 +570,7 @@ bool EditorFileSystem::_is_test_for_reimport_needed(const String &p_path, uint64
 			}
 		}
 	}
+
 	return false;
 }
 
@@ -1242,6 +1246,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				fi->import_md5 = fc->import_md5;
 				fi->import_dest_paths = fc->import_dest_paths;
 				fi->import_valid = fc->import_valid;
+				fi->has_editor_variant = fc->has_editor_variant;
 				fi->import_group_file = fc->import_group_file;
 				fi->class_info = fc->class_info;
 
@@ -1257,7 +1262,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				// If something is different, we will queue a test for reimportation that will check
 				// the md5 of all files and import settings and, if necessary, execute a reimportation.
 				if (_is_test_for_reimport_needed(path, fc->modification_time, mt, fc->import_modification_time, import_mt, fi->import_dest_paths) ||
-						(revalidate_import_files && !ResourceFormatImporter::get_singleton()->are_import_settings_valid(path))) {
+						(revalidate_import_files && !ResourceFormatImporter::get_singleton()->are_import_settings_valid(path)) || fi->has_editor_variant) {
 					ItemAction ia;
 					ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
 					ia.dir = p_dir;
@@ -1842,6 +1847,7 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 		cache_string.append(itos(file_info->modified_time));
 		cache_string.append(itos(file_info->import_modified_time));
 		cache_string.append(itos(file_info->import_valid));
+		cache_string.append(itos(file_info->has_editor_variant));
 		cache_string.append(file_info->import_group_file);
 		cache_string.append(String("<>").join({ file_info->class_info.name, file_info->class_info.extends, file_info->class_info.icon_path, itos(file_info->class_info.is_abstract), itos(file_info->class_info.is_tool), file_info->import_md5, String("<*>").join(file_info->import_dest_paths) }));
 		cache_string.append(String("<>").join(file_info->deps));
@@ -2841,6 +2847,7 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 			fs->files[cpos]->deps.clear();
 			fs->files[cpos]->type = "";
 			fs->files[cpos]->import_valid = false;
+			fs->files[cpos]->has_editor_variant = false;
 			EditorResourcePreview::get_singleton()->check_for_invalidation(p_file);
 		}
 		return OK;
@@ -3012,6 +3019,8 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		fs->files[cpos]->type = importer->get_resource_type();
 		fs->files[cpos]->uid = uid;
 		fs->files[cpos]->import_valid = fs->files[cpos]->type == "TextFile" ? true : ResourceLoader::is_import_valid(p_file);
+		// Update if the file has an editor variant.
+		fs->files[cpos]->has_editor_variant = (meta != Variant() && ((Dictionary)meta).has("has_editor_variant"));
 	}
 
 	for (const String &path : gen_files) {

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -62,6 +62,7 @@ class EditorFileSystemDirectory : public Object {
 		String import_md5;
 		Vector<String> import_dest_paths;
 		bool import_valid = false;
+		bool has_editor_variant = false;
 		String import_group_file;
 		Vector<String> deps;
 		bool verified = false; //used for checking changes
@@ -223,6 +224,7 @@ class EditorFileSystem : public Node {
 		Vector<String> import_dest_paths;
 		Vector<String> deps;
 		bool import_valid = false;
+		bool has_editor_variant = false;
 		String import_group_file;
 		ScriptClassInfo class_info;
 	};

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/config_file.h"
 #include "core/io/image_loader.h"
+#include "core/math/math_funcs.h"
 #include "core/version.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_toaster.h"
@@ -982,6 +983,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 
 		if (convert_editor_colors) {
 			editor_meta["editor_dark_theme"] = EditorThemeManager::is_dark_theme();
+			editor_meta["icon_saturation"] = EDITOR_GET("interface/theme/icon_saturation");
 		}
 
 		_save_editor_meta(editor_meta, p_save_path + ".editor.meta");
@@ -1038,6 +1040,10 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path, co
 		Dictionary editor_meta = _load_editor_meta(editor_meta_path);
 
 		if (editor_meta.has("editor_scale") && (float)editor_meta["editor_scale"] != EDSCALE) {
+			return false;
+		}
+
+		if (editor_meta.has("icon_saturation") && !Math::is_equal_approx((float)editor_meta["icon_saturation"], EDITOR_GET("interface/theme/icon_saturation"))) {
 			return false;
 		}
 


### PR DESCRIPTION
Follow #107051.

Custom icons changing with editor theme rely on reimport testing on editor launch. However, this works as expected before #95678. 

#95678 uses import time and last edit time to check if this testing is needed, which lead to skipping checks for editor-use assets with editor settings. Specifically, custom icon's color and saturation is skipped, and will not do auto reimport.

This pr adds a `has_editor_variant` property to editor file cache to make auto-reimporting work again, but this changes the file cache format.  I can try creating a cache file if this approach is not wanted.

https://github.com/user-attachments/assets/fd55e8dc-b25a-4150-b14c-8305129ec393

