### PR TITLE
Use ScriptExportMode enum in EditorExportPreset

### DIFF
--- a/doc/classes/EditorExportPreset.xml
+++ b/doc/classes/EditorExportPreset.xml
@@ -129,7 +129,7 @@
 			</description>
 		</method>
 		<method name="get_script_export_mode" qualifiers="const">
-			<return type="int" />
+			<return type="int" enum="EditorExportPreset.ScriptExportMode" />
 			<description>
 				Returns the export mode used by GDScript files. [code]0[/code] for "Text", [code]1[/code] for "Binary tokens", and [code]2[/code] for "Compressed binary tokens (smaller files)".
 			</description>

--- a/editor/export/editor_export_preset.compat.inc
+++ b/editor/export/editor_export_preset.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  editor_export_preset.compat.inc                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+int EditorExportPreset::_get_script_export_mode_bind_compat_107167() const {
+	return get_script_export_mode();
+}
+
+void EditorExportPreset::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_script_export_mode"), &EditorExportPreset::_get_script_export_mode_bind_compat_107167);
+}
+
+#endif

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "editor_export_preset.h"
+#include "editor_export_preset.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
@@ -549,12 +550,12 @@ String EditorExportPreset::get_script_encryption_key() const {
 	return script_key;
 }
 
-void EditorExportPreset::set_script_export_mode(int p_mode) {
+void EditorExportPreset::set_script_export_mode(ScriptExportMode p_mode) {
 	script_mode = p_mode;
 	EditorExport::singleton->save_presets();
 }
 
-int EditorExportPreset::get_script_export_mode() const {
+EditorExportPreset::ScriptExportMode EditorExportPreset::get_script_export_mode() const {
 	return script_mode;
 }
 

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -98,7 +98,7 @@ private:
 	uint64_t seed = 0;
 
 	String script_key;
-	int script_mode = MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
+	ScriptExportMode script_mode = MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -108,6 +108,11 @@ protected:
 	String _get_property_warning(const StringName &p_name) const;
 
 	static void _bind_methods();
+
+#ifndef DISABLE_DEPRECATED
+	int _get_script_export_mode_bind_compat_107167() const;
+	static void _bind_compatibility_methods();
+#endif
 
 public:
 	Ref<EditorExportPlatform> get_platform() const;
@@ -199,8 +204,8 @@ public:
 	void set_script_encryption_key(const String &p_key);
 	String get_script_encryption_key() const;
 
-	void set_script_export_mode(int p_mode);
-	int get_script_export_mode() const;
+	void set_script_export_mode(ScriptExportMode p_mode);
+	ScriptExportMode get_script_export_mode() const;
 
 	Variant _get_or_env(const StringName &p_name, const String &p_env_var) const {
 		return get_or_env(p_name, p_env_var);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -433,7 +433,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		script_key_error->hide();
 	}
 
-	int script_export_mode = current->get_script_export_mode();
+	int script_export_mode = int(current->get_script_export_mode());
 	script_mode->select(script_export_mode);
 
 	updating = false;
@@ -703,7 +703,7 @@ bool ProjectExportDialog::_validate_script_encryption_key(const String &p_key) {
 	return is_valid;
 }
 
-void ProjectExportDialog::_script_export_mode_changed(int p_mode) {
+void ProjectExportDialog::_script_export_mode_changed(EditorExportPreset::ScriptExportMode p_mode) {
 	if (updating) {
 		return;
 	}

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -219,7 +219,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _script_encryption_key_visibility_changed(bool p_visible);
 	bool _validate_script_encryption_key(const String &p_key);
 
-	void _script_export_mode_changed(int p_mode);
+	void _script_export_mode_changed(EditorExportPreset::ScriptExportMode p_mode);
 
 	void _open_key_help_link();
 

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -225,3 +225,11 @@ Validate extension JSON: API was removed: classes/EditorFileDialog/properties/op
 Validate extension JSON: API was removed: classes/EditorFileDialog/properties/show_hidden_files
 
 The errors are false-positives. The removed methods are now part of the new parent class.
+
+
+GH-107167
+---------
+Validate extension JSON: Error: Field 'classes/EditorExportPreset/methods/get_script_export_mode': meta was removed.
+Validate extension JSON: Error: Field 'classes/EditorExportPreset/methods/get_script_export_mode/return_value': type changed value in new API, from "int" to "enum::EditorExportPreset.ScriptExportMode".
+
+Change return type from `int` to `EditorExportPreset.ScriptExportMode` enum. Compatibility method registered.

--- a/modules/gdscript/register_types.cpp
+++ b/modules/gdscript/register_types.cpp
@@ -78,8 +78,8 @@ Ref<GDScriptEditorTranslationParserPlugin> gdscript_translation_parser_plugin;
 class EditorExportGDScript : public EditorExportPlugin {
 	GDCLASS(EditorExportGDScript, EditorExportPlugin);
 
-	static constexpr int DEFAULT_SCRIPT_MODE = EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
-	int script_mode = DEFAULT_SCRIPT_MODE;
+	static constexpr EditorExportPreset::ScriptExportMode DEFAULT_SCRIPT_MODE = EditorExportPreset::MODE_SCRIPT_BINARY_TOKENS_COMPRESSED;
+	EditorExportPreset::ScriptExportMode script_mode = DEFAULT_SCRIPT_MODE;
 
 protected:
 	virtual void _export_begin(const HashSet<String> &p_features, bool p_debug, const String &p_path, int p_flags) override {


### PR DESCRIPTION
While making https://github.com/godotengine/godot/pull/107143 I discovered that for some ungodly reason EditorExportPreset's `get_script_export_mode` has been exposed to return an integer, **not** a value from ScriptExportMode, which was **exposed for this exact, singular purpose**. This PR fixes that.

This probably breaks compatibility and I am not sure who can review this. Does it count as a fix or an enhancement?