### PR TITLE
Avoid crash when texture layers is greater than 1 and format is not an ARRAY type

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1065,7 +1065,7 @@ RID RenderingDevice::texture_create(const TextureFormat &p_format, const Texture
 #endif
 
 	if (data.size()) {
-		for (uint32_t i = 0; i < p_format.array_layers; i++) {
+		for (uint32_t i = 0; i < format.array_layers; i++) {
 			_texture_initialize(id, i, data[i], immediate_flush);
 		}
 


### PR DESCRIPTION
Fixes crash reported here: https://github.com/godotengine/godot/issues/107078#issuecomment-2934650888


When not using an ARRAY type, we set `format.array_layers` to `1` to sanitize the inputs. 
https://github.com/godotengine/godot/blob/d59994688c9bc6860dff5edffabd29b0c78e295e/servers/rendering/rendering_device.cpp#L902

However, when initializing the texture, we were wrongly using `p_format.array_layers` which wasn't sanitized. 