### PR TITLE
Optimize `LRUCache` by removing `List`

### DIFF
--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -395,6 +395,35 @@ public:
 		return true;
 	}
 
+	// Renew the entry with the given key, making it the newest entry in insertion order.
+	// Equals to erase(key) followed by insert(key, value).
+	TValue *renew_key(const TKey &p_key) {
+		// This function is unually not guraded by existence checks, so lookup failures are expected.
+		// Not using ERR_FAIL_COND_V here to prevent errors explosion.
+		uint32_t pos = 0;
+		if (elements == nullptr || num_elements == 0 || !_lookup_pos(p_key, pos)) {
+			return nullptr;
+		}
+		HashMapElement<TKey, TValue> *element = elements[pos];
+		// Move element to the end.
+		if (element != tail_element) {
+			if (element->prev) {
+				element->prev->next = element->next;
+			}
+			if (element->next) {
+				element->next->prev = element->prev;
+			}
+			if (head_element == element) {
+				head_element = element->next;
+			}
+			tail_element->next = element;
+			element->prev = tail_element;
+			element->next = nullptr;
+			tail_element = element;
+		}
+		return &element->data.value;
+	}
+
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2957,7 +2957,7 @@ void RendererCanvasRenderRD::_record_item_commands(const Item *p_item, RenderTar
 	}
 }
 
-void RendererCanvasRenderRD::_before_evict(RendererCanvasRenderRD::RIDSetKey &p_key, RID &p_rid) {
+void RendererCanvasRenderRD::_before_evict(const RendererCanvasRenderRD::RIDSetKey &p_key, RID &p_rid) {
 	RD::get_singleton()->uniform_set_set_invalidation_callback(p_rid, nullptr, nullptr);
 	RD::get_singleton()->free(p_rid);
 }
@@ -3000,8 +3000,8 @@ void RendererCanvasRenderRD::_render_batch(RD::DrawListID p_draw_list, CanvasSha
 			RID rid = RD::get_singleton()->uniform_set_create(state.batch_texture_uniforms, shader.default_version_rd_shader, BATCH_UNIFORM_SET);
 			ERR_FAIL_COND_MSG(rid.is_null(), "Failed to create uniform set for batch.");
 
-			const RIDCache::Pair *iter = rid_set_to_uniform_set.insert(key, rid);
-			uniform_set = &iter->data;
+			const RIDCache::Iterator iter = rid_set_to_uniform_set.insert(key, rid);
+			uniform_set = &iter->value;
 			RD::get_singleton()->uniform_set_set_invalidation_callback(rid, RendererCanvasRenderRD::_uniform_set_invalidation_callback, (void *)&iter->key);
 
 			// If this is a CanvasTexture, it must be tracked so that any changes to the diffuse, normal,

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -483,7 +483,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		}
 	};
 
-	static void _before_evict(RendererCanvasRenderRD::RIDSetKey &p_key, RID &p_rid);
+	static void _before_evict(const RendererCanvasRenderRD::RIDSetKey &p_key, RID &p_rid);
 	static void _uniform_set_invalidation_callback(void *p_userdata);
 	static void _canvas_texture_invalidation_callback(bool p_deleted, void *p_userdata);
 

--- a/tests/core/templates/test_hash_map.h
+++ b/tests/core/templates/test_hash_map.h
@@ -122,6 +122,33 @@ TEST_CASE("[HashMap] Iteration") {
 	}
 }
 
+TEST_CASE("[HashMap] Insertion order") {
+	HashMap<int, int> map;
+	map.insert(42, 84);
+	map.insert(123, 12385);
+	map.insert(0, 12934);
+	map.insert(123485, 1238888);
+	map.insert(123, 111111);
+
+	CHECK(*map.last() == KeyValue<int, int>(123485, 1238888));
+	CHECK(*map.renew_key(0) == 12934);
+	CHECK(*map.last() == KeyValue<int, int>(0, 12934));
+	CHECK(*map.renew_key(42) == 84);
+	CHECK(*map.last() == KeyValue<int, int>(42, 84));
+
+	Vector<Pair<int, int>> expected;
+	expected.push_back(Pair<int, int>(123, 111111));
+	expected.push_back(Pair<int, int>(123485, 1238888));
+	expected.push_back(Pair<int, int>(0, 12934));
+	expected.push_back(Pair<int, int>(42, 84));
+
+	int idx = 0;
+	for (const KeyValue<int, int> &E : map) {
+		CHECK(expected[idx] == Pair<int, int>(E.key, E.value));
+		++idx;
+	}
+}
+
 TEST_CASE("[HashMap] Const iteration") {
 	HashMap<int, int> map;
 	map.insert(42, 84);


### PR DESCRIPTION
According to the documentation, `HashMap` internally maintains the insertion order of key-value pairs using a doubly linked list. We can leverage this list to replace the `List` used in `LRUCache`, thereby reducing the need to maintain an additional list.

To improve performance (avoiding an `erase` followed by an `insert`), a `renew_key()` method was added to `HashMap` to move a key-value pair to the end of the insertion order list.

`LRUCache` is rarely used and it's difficult to construct a benchmark, so I use some micro-benchmarks to evaluate the performance of individual APIs.

<details>
<summary>code</summary>

```C++
#define ANKERL_NANOBENCH_IMPLEMENT
#include "nanobench.h"
#include "core/templates/list.h"
#include "core/templates/local_vector.h"

class Test
{
public:
    void bench_insert()
    {
        LRUCache<int64_t, int64_t> cache;
        for (int i = 0; i < 100000; i++) {
            cache.insert(i, i);
        }
        for (int i = 0; i < 100000; i++) {
            cache.erase(i);
        }
    }

    void bench_get()
    {
        LRUCache<int64_t, int64_t> cache;
        for (int i = 0; i < 10; i++) {
            cache.insert(i, i);
        }
        for (int i = 0; i < 100000; i++) {
            cache.get(i % 10);
        }
    }

    static void bench()
    {
        auto bench = ankerl::nanobench::Bench()
            .title("LRUCache Benchmarks")
            .warmup(10)
            .minEpochIterations(100);
        bench.run("insert and erase", [&]{
            Test test;
            test.bench_insert();
        });
        bench.run("get             ", [&]{
            Test test;
            test.bench_get();
        });
    }
};
```

</details>

Result:

Master:
![屏幕截图 2025-06-06 001828](https://github.com/user-attachments/assets/aefe449e-b376-4a22-8f6e-c1076b9d5a21)

This PR:
![屏幕截图 2025-06-06 010846](https://github.com/user-attachments/assets/4d12f2f5-22d9-4344-ad9f-db149e4911a2)

