### PR TITLE
Add default parameter for AnimationNode as super class

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -52,6 +52,9 @@ void AnimationNode::get_parameter_list(List<PropertyInfo> *r_list) const {
 
 Variant AnimationNode::get_parameter_default_value(const StringName &p_parameter) const {
 	Variant ret;
+	if (p_parameter == current_length || p_parameter == current_position || p_parameter == current_delta) {
+		return 0.0;
+	}
 	GDVIRTUAL_CALL(_get_parameter_default_value, p_parameter, ret);
 	return ret;
 }


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/107005

As commented in https://github.com/godotengine/godot/pull/107005#issuecomment-2944956592, AnimationNode itself has parameters as a superclass, but the default values are missing and errors are spammed.

The causes is type matching to always fail for extended classes of AnimationNode that are not float at the end of the if block with the default type. Fixed.