### PR TITLE
Fix Inherited Scenes Lost References

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -382,6 +382,8 @@ Ref<Resource> Resource::_duplicate(const DuplicateParams &p_params) const {
 		r->local_scene = p_params.local_scene;
 	}
 
+	r->path_cache = path_cache;
+
 	// Duplicate script first, so the scripted properties are considered.
 	BEFORE_USER_CODE
 	r->set_script(get_script());


### PR DESCRIPTION
Fix issue #107104 :

When `_duplicate()` the `Resource`, path_cache is now also duplicated with the new `Resource` reference. This variable is used for getting the Resource path with `get_path()`. In my opinion this variable should also be duplicated. However, I dont understand why it is not duplicated by default.

The reason for needing this Resource duplication is stated in this line :
```scene/resources/packed_scene.cpp```
![image](https://github.com/user-attachments/assets/f578d187-4652-4aa4-b9c1-c47760dc7e3a)

Now when opening the mrp, you can see the file path in resources.
```res://some_scene_inherited.tscn```
![image](https://github.com/user-attachments/assets/b14f7421-091d-4c52-8fa9-1e0c7034d8ad)


