### PR TITLE
[3.x] `SceneTreeFTI` - Fix `force_update` flag for invisible nodes

### DIFF
--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -288,7 +288,12 @@ void SceneTreeFTI::_create_depth_lists() {
 			}
 #endif
 
+			// Prevent being added to the dest_list twice when on
+			// the frame_xform_list AND the frame_xform_list_forced.
 			if ((l == 0) && s->data.fti_frame_xform_force_update) {
+#ifdef GODOT_SCENE_TREE_FTI_EXTRA_CHECKS
+				DEV_ASSERT(data.frame_xform_list_forced.find(s) != -1);
+#endif
 				continue;
 			}
 
@@ -563,11 +568,6 @@ void SceneTreeFTI::_update_dirty_spatials(Node *p_node, uint32_t p_current_half_
 		// Upload to VisualServer the interpolated global xform.
 		s->fti_update_servers_xform();
 
-		// Only do this at most for one frame,
-		// it is used to catch objects being removed from the tick lists
-		// that have a deferred frame update.
-		s->data.fti_frame_xform_force_update = false;
-
 		// Ensure branches are only processed once on each traversal.
 		s->data.fti_processed = true;
 
@@ -706,6 +706,17 @@ void SceneTreeFTI::frame_update(Node *p_root, bool p_frame_start) {
 
 #endif //  not GODOT_SCENE_TREE_FTI_VERIFY
 
+	// In theory we could clear the `force_update` flags from the nodes in the traversal.
+	// The problem is that hidden nodes are not recursed into, therefore the flags would
+	// never get cleared and could get out of sync with the forced list.
+	// So instead we are clearing them here manually.
+	// This is not ideal in terms of cache coherence so perhaps another method can be
+	// explored in future.
+	uint32_t forced_list_size = data.frame_xform_list_forced.size();
+	for (uint32_t n = 0; n < forced_list_size; n++) {
+		Spatial *s = data.frame_xform_list_forced[n];
+		s->data.fti_frame_xform_force_update = false;
+	}
 	data.frame_xform_list_forced.clear();
 
 	if (!p_frame_start && data.periodic_debug_log) {


### PR DESCRIPTION
If the `force_update` flag remained set after the node was removed from the update lists, the node would never be updated in future. This could occur with hidden nodes that were moved after hiding.

Fixes #107142
Backport of #107175

## Explanation
The `SceneTreeFTI` relies on node flags being in sync with nodes being on various update lists. This bug occurred for the forced frame update list, because the node flag was being cleared in the tree traversal, _however_ invisible nodes were never having their flag cleared, and once the list was cleared the flag and the list became out of sync.

At further node movements, the logic determined incorrectly that the node was _already_ on the update list.

We fix it by removing the flag manually on every node in the list rather than at traversal time.

## Notes
* It's possible this can be done in a more optimal way at a later stage, but this shouldn't be bad.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
