### PR TITLE
libtheora: Update to 1.2.0

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -574,7 +574,7 @@ Files extracted from upstream source:
 ## libtheora
 
 - Upstream: https://www.theora.org
-- Version: git (7180717276af1ebc7da15c83162d6c5d6203aabf, 2020)
+- Version: 1.2.0 (8e4808736e9c181b971306cc3f05df9e61354004, 2025)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:

--- a/thirdparty/libtheora/analyze.c
+++ b/thirdparty/libtheora/analyze.c
@@ -5,13 +5,12 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function: mode selection code
-  last mod: $Id$
 
  ********************************************************************/
 #include <limits.h>
@@ -2168,14 +2167,14 @@ static void oc_cost_inter(oc_enc_ctx *_enc,oc_mode_choice *_modec,
 
 static void oc_cost_inter_nomv(oc_enc_ctx *_enc,oc_mode_choice *_modec,
  unsigned _mbi,int _mb_mode,const oc_fr_state *_fr,const oc_qii_state *_qs,
- const unsigned _skip_ssd[12],const unsigned _rd_scale[4]){
+ const unsigned _skip_ssd[12],const unsigned _rd_scale[5]){
   oc_cost_inter(_enc,_modec,_mbi,_mb_mode,0,_fr,_qs,_skip_ssd,_rd_scale);
 }
 
 static int oc_cost_inter1mv(oc_enc_ctx *_enc,oc_mode_choice *_modec,
  unsigned _mbi,int _mb_mode,oc_mv _mv,
  const oc_fr_state *_fr,const oc_qii_state *_qs,const unsigned _skip_ssd[12],
- const unsigned _rd_scale[4]){
+ const unsigned _rd_scale[5]){
   int bits0;
   oc_cost_inter(_enc,_modec,_mbi,_mb_mode,_mv,_fr,_qs,_skip_ssd,_rd_scale);
   bits0=OC_MV_BITS[0][OC_MV_X(_mv)+31]+OC_MV_BITS[0][OC_MV_Y(_mv)+31];
@@ -2645,7 +2644,7 @@ int oc_enc_analyze_inter(oc_enc_ctx *_enc,int _allow_keyframe,int _recode){
             fragi=mb_maps[mbi][pli][bi];
             /*If we switched from 4MV mode to INTER_MV mode, then the qii
                values won't have been chosen with the right MV, but it's
-               probaby not worth re-estimating them.*/
+               probably not worth re-estimating them.*/
             frags[fragi].qii=modes[mb_mode].qii[mapii];
             frags[fragi].refi=refi;
             frags[fragi].mb_mode=mb_mode;

--- a/thirdparty/libtheora/apiwrapper.c
+++ b/thirdparty/libtheora/apiwrapper.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/apiwrapper.h
+++ b/thirdparty/libtheora/apiwrapper.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: apiwrapper.h 13596 2007-08-23 20:05:38Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/bitpack.c
+++ b/thirdparty/libtheora/bitpack.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE OggTheora SOURCE CODE IS (C) COPYRIGHT 1994-2009             *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function: packing variable sized words into an octet stream
-  last mod: $Id$
 
  ********************************************************************/
 #include <string.h>

--- a/thirdparty/libtheora/bitpack.h
+++ b/thirdparty/libtheora/bitpack.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE OggTheora SOURCE CODE IS (C) COPYRIGHT 1994-2009             *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function: packing variable sized words into an octet stream
-  last mod: $Id: bitwise.c 7675 2004-09-01 00:34:39Z xiphmont $
 
  ********************************************************************/
 #if !defined(_bitpack_H)

--- a/thirdparty/libtheora/collect.c
+++ b/thirdparty/libtheora/collect.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2011                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function: mode selection code
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdio.h>

--- a/thirdparty/libtheora/collect.h
+++ b/thirdparty/libtheora/collect.h
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function: mode selection code
-  last mod: $Id$
 
  ********************************************************************/
 #if !defined(_collect_H)

--- a/thirdparty/libtheora/dct.h
+++ b/thirdparty/libtheora/dct.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/decapiwrapper.c
+++ b/thirdparty/libtheora/decapiwrapper.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: decapiwrapper.c 13596 2007-08-23 20:05:38Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/decinfo.c
+++ b/thirdparty/libtheora/decinfo.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -134,28 +134,33 @@ static int oc_comment_unpack(oc_pack_buf *_opb,th_comment *_tc){
     _tc->comments=0;
     return TH_EBADHEADER;
   }
-  _tc->comment_lengths=(int *)_ogg_malloc(
-   _tc->comments*sizeof(_tc->comment_lengths[0]));
-  _tc->user_comments=(char **)_ogg_malloc(
-   _tc->comments*sizeof(_tc->user_comments[0]));
-  if(_tc->comment_lengths==NULL||_tc->user_comments==NULL){
-    _tc->comments=0;
-    return TH_EFAULT;
-  }
-  for(i=0;i<_tc->comments;i++){
-    len=oc_unpack_length(_opb);
-    if(len<0||len>oc_pack_bytes_left(_opb)){
-      _tc->comments=i;
-      return TH_EBADHEADER;
-    }
-    _tc->comment_lengths[i]=len;
-    _tc->user_comments[i]=_ogg_malloc((size_t)len+1);
-    if(_tc->user_comments[i]==NULL){
-      _tc->comments=i;
+  if(0<_tc->comments){
+    _tc->comment_lengths=(int *)_ogg_malloc(
+     _tc->comments*sizeof(_tc->comment_lengths[0]));
+    _tc->user_comments=(char **)_ogg_malloc(
+     _tc->comments*sizeof(_tc->user_comments[0]));
+    if(_tc->comment_lengths==NULL||_tc->user_comments==NULL){
+      _tc->comments=0;
       return TH_EFAULT;
     }
-    oc_unpack_octets(_opb,_tc->user_comments[i],len);
-    _tc->user_comments[i][len]='\0';
+    for(i=0;i<_tc->comments;i++){
+      len=oc_unpack_length(_opb);
+      if(len<0||len>oc_pack_bytes_left(_opb)){
+        _tc->comments=i;
+        return TH_EBADHEADER;
+      }
+      _tc->comment_lengths[i]=len;
+      _tc->user_comments[i]=_ogg_malloc((size_t)len+1);
+      if(_tc->user_comments[i]==NULL){
+        _tc->comments=i;
+        return TH_EFAULT;
+      }
+      oc_unpack_octets(_opb,_tc->user_comments[i],len);
+      _tc->user_comments[i][len]='\0';
+    }
+  } else {
+    _tc->comment_lengths=NULL;
+    _tc->user_comments=NULL;
   }
   return oc_pack_bytes_left(_opb)<0?TH_EBADHEADER:0;
 }
@@ -217,7 +222,7 @@ static int oc_dec_headerin(oc_pack_buf *_opb,th_info *_info,
     /*Comment header.*/
     case 0x81:{
       if(_tc==NULL)return TH_EFAULT;
-      /*We shoud have already decoded the info header, and should not yet have
+      /*We should have already decoded the info header, and should not yet have
          decoded the comment header.*/
       if(_info->frame_width==0||_tc->vendor!=NULL)return TH_EBADHEADER;
       ret=oc_comment_unpack(_opb,_tc);

--- a/thirdparty/libtheora/decint.h
+++ b/thirdparty/libtheora/decint.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -86,12 +86,12 @@ struct oc_dec_pipeline_state{
      from buffer overflow.
     We make it fully twice as large so that the second half can serve as the
      reconstruction buffer, which saves passing another parameter to all the
-     acceleration functios.
+     acceleration functions.
     It also solves problems with 16-byte alignment for NEON on ARM.
     gcc (as of 4.2.1) only seems to be able to give stack variables 8-byte
      alignment, and silently produces incorrect results if you ask for 16.
     Finally, keeping it off the stack means there's less likely to be a data
-     hazard beween the NEON co-processor and the regular ARM core, which avoids
+     hazard between the NEON co-processor and the regular ARM core, which avoids
      unnecessary stalls.*/
   OC_ALIGN16(ogg_int16_t dct_coeffs[128]);
   OC_ALIGN16(signed char bounding_values[256]);

--- a/thirdparty/libtheora/decode.c
+++ b/thirdparty/libtheora/decode.c
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -147,7 +147,7 @@ static const unsigned char OC_INTERNAL_DCT_TOKEN_EXTRA_BITS[15]={
  ((_eobs)<<OC_DCT_CW_EOB_SHIFT| \
  (_rlen)<<OC_DCT_CW_RLEN_SHIFT| \
  (_flip)<<OC_DCT_CW_FLIP_BIT| \
- (_mag)-(_flip)<<OC_DCT_CW_MAG_SHIFT)
+ ((_mag)-(_flip))*(1<<OC_DCT_CW_MAG_SHIFT))
 
 /*A special code word value that signals the end of the frame (a long EOB run
    of zero).*/
@@ -1755,13 +1755,13 @@ static void oc_dec_deblock_frag_rows(oc_dec_ctx *_dec,
       flimit=(qstep*3)>>2;
       oc_filter_hedge(dst+x,dst_ystride,src+x-src_ystride,src_ystride,
        qstep,flimit,variance,variance+nhfrags);
-      oc_filter_vedge(dst+x-(dst_ystride<<2)-4,dst_ystride,
+      oc_filter_vedge(dst+x-(dst_ystride*4)-4,dst_ystride,
        qstep,flimit,variance-1);
       variance++;
       dc_qi++;
     }
-    dst+=dst_ystride<<3;
-    src+=src_ystride<<3;
+    dst+=dst_ystride*8;
+    src+=src_ystride*8;
   }
   /*And finally, handle the last row in the frame, if it's in the range.*/
   if(!notdone){
@@ -1777,7 +1777,7 @@ static void oc_dec_deblock_frag_rows(oc_dec_ctx *_dec,
     for(x=8;x<width;x+=8){
       qstep=_dec->pp_dc_scale[*dc_qi++];
       flimit=(qstep*3)>>2;
-      oc_filter_vedge(dst+x-(dst_ystride<<3)-4,dst_ystride,
+      oc_filter_vedge(dst+x-(dst_ystride*8)-4,dst_ystride,
        qstep,flimit,variance++);
     }
   }
@@ -1952,7 +1952,7 @@ static void oc_dec_dering_frag_rows(oc_dec_ctx *_dec,th_img_plane *_img,
       frag++;
       variance++;
     }
-    idata+=ystride<<3;
+    idata+=ystride*8;
   }
 }
 
@@ -2101,7 +2101,7 @@ static void oc_render_telemetry(th_dec_ctx *_dec,th_ycbcr_buffer _ycbcr,
   hdec=!(_dec->state.info.pixel_fmt&1);
   vdec=!(_dec->state.info.pixel_fmt&2);
   /*Lazy data buffer init.
-    We could try to re-use the post-processing buffer, which would save
+    We could try to reuse the post-processing buffer, which would save
      memory, but complicate the allocation logic there.
     I don't think anyone cares about memory usage when using telemetry; it is
      not meant for embedded devices.*/
@@ -2674,10 +2674,10 @@ static void oc_render_telemetry(th_dec_ctx *_dec,th_ycbcr_buffer _ycbcr,
           u_row[x>>1]=OC_CLAMP255(u);
           v_row[x>>1]=OC_CLAMP255(v);
         }
-        y_row+=_ycbcr[0].stride<<1;
+        y_row+=_ycbcr[0].stride*2;
         u_row+=_ycbcr[1].stride;
         v_row+=_ycbcr[2].stride;
-        rgb_row+=cstride<<1;
+        rgb_row+=cstride*2;
       }
     }break;
     case TH_PF_422:{

--- a/thirdparty/libtheora/dequant.c
+++ b/thirdparty/libtheora/dequant.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/dequant.h
+++ b/thirdparty/libtheora/dequant.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/encfrag.c
+++ b/thirdparty/libtheora/encfrag.c
@@ -5,13 +5,12 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdlib.h>
@@ -30,7 +29,7 @@ void oc_enc_frag_sub_c(ogg_int16_t _diff[64],const unsigned char *_src,
   }
 }
 
-void oc_enc_frag_sub_128_c(ogg_int16_t *_diff,
+void oc_enc_frag_sub_128_c(ogg_int16_t _diff[64],
  const unsigned char *_src,int _ystride){
   int i;
   for(i=0;i<8;i++){
@@ -88,7 +87,7 @@ unsigned oc_enc_frag_sad2_thresh_c(const unsigned char *_src,
 
 unsigned oc_enc_frag_intra_sad_c(const unsigned char *_src, int _ystride){
   const unsigned char *src = _src;
-  unsigned dc;
+  int dc;
   unsigned sad;
   int      i;
   dc=0;

--- a/thirdparty/libtheora/encint.h
+++ b/thirdparty/libtheora/encint.h
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #if !defined(_encint_H)
@@ -726,7 +725,7 @@ struct th_enc_ctx{
     These are DCT domain quantizers, and so are scaled by an additional factor
      of 4 from the pixel domain.*/
   ogg_int64_t              log_qavg[2][64];
-  /*The "average" quantizer futher partitioned by color plane.
+  /*The "average" quantizer further partitioned by color plane.
     This is used to parameterize mode decision.
     These are DCT domain quantizers, and so are scaled by an additional factor
      of 4 from the pixel domain.*/

--- a/thirdparty/libtheora/encode.c
+++ b/thirdparty/libtheora/encode.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdlib.h>
@@ -512,7 +511,7 @@ static unsigned oc_enc_partial_sb_flags_pack(oc_enc_ctx *_enc){
 
 /*Writes the coded/not coded flags for each super block that is not partially
    coded.
-  These flags are run-length encoded, with the flag value altenating between
+  These flags are run-length encoded, with the flag value alternating between
    each run.*/
 static void oc_enc_coded_sb_flags_pack(oc_enc_ctx *_enc){
   const oc_sb_flags *sb_flags;
@@ -938,7 +937,7 @@ static void oc_enc_frame_pack(oc_enc_ctx *_enc){
 
 void oc_enc_accel_init_c(oc_enc_ctx *_enc){
   /*The implementations prefixed with oc_enc_ are encoder-specific.
-    The rest we re-use from the decoder.*/
+    The rest we reuse from the decoder.*/
 # if defined(OC_ENC_USE_VTABLE)
   _enc->opt_vtable.frag_sub=oc_enc_frag_sub_c;
   _enc->opt_vtable.frag_sub_128=oc_enc_frag_sub_128_c;

--- a/thirdparty/libtheora/encoder_disabled.c
+++ b/thirdparty/libtheora/encoder_disabled.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include "apiwrapper.h"

--- a/thirdparty/libtheora/enquant.c
+++ b/thirdparty/libtheora/enquant.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdlib.h>

--- a/thirdparty/libtheora/fdct.c
+++ b/thirdparty/libtheora/fdct.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include "encint.h"

--- a/thirdparty/libtheora/fragment.c
+++ b/thirdparty/libtheora/fragment.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 #include <string.h>

--- a/thirdparty/libtheora/huffdec.c
+++ b/thirdparty/libtheora/huffdec.c
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -225,6 +225,7 @@ int oc_huff_tree_unpack(oc_pack_buf *_opb,unsigned char _tokens[256][2]){
         _tokens[ntokens][1]=(unsigned char)(len+neb);
         ntokens++;
       }
+      if(len<=0)break;
       code_bit=0x80000000U>>len-1;
       while(len>0&&(code&code_bit)){
         code^=code_bit;
@@ -436,13 +437,10 @@ static size_t oc_huff_tree_size(const ogg_int16_t *_tree,int _node){
   _src: The array of trees to copy.*/
 int oc_huff_trees_copy(ogg_int16_t *_dst[TH_NHUFFMAN_TABLES],
  const ogg_int16_t *const _src[TH_NHUFFMAN_TABLES]){
-  int total;
   int i;
-  total=0;
   for(i=0;i<TH_NHUFFMAN_TABLES;i++){
     size_t size;
     size=oc_huff_tree_size(_src[i],0);
-    total+=size;
     _dst[i]=(ogg_int16_t *)_ogg_malloc(size*sizeof(*_dst[i]));
     if(_dst[i]==NULL){
       while(i-->0)_ogg_free(_dst[i]);

--- a/thirdparty/libtheora/huffdec.h
+++ b/thirdparty/libtheora/huffdec.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/huffman.h
+++ b/thirdparty/libtheora/huffman.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/idct.c
+++ b/thirdparty/libtheora/idct.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/info.c
+++ b/thirdparty/libtheora/info.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/internal.c
+++ b/thirdparty/libtheora/internal.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/internal.h
+++ b/thirdparty/libtheora/internal.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 #if !defined(_internal_H)
@@ -44,6 +44,10 @@
 # if __GNUC_PREREQ(4,2)
 #  pragma GCC diagnostic ignored "-Wparentheses"
 # endif
+/*Et tu, clang.*/
+# if defined(__clang__)
+#  pragma clang diagnostic ignored "-Wparentheses"
+# endif
 
 /*Some assembly constructs require aligned operands.
   The following macros are _only_ intended for structure member declarations.
@@ -72,7 +76,7 @@
 
 
 /*This library's version.*/
-# define OC_VENDOR_STRING "Xiph.Org libtheora 1.2.0alpha 20100924 (Ptalarbvorm)"
+# define OC_VENDOR_STRING "Xiph.Org libtheora 1.2.0 20250329 (Ptalarbvorm)"
 
 /*Theora bitstream version.*/
 # define TH_VERSION_MAJOR (3)

--- a/thirdparty/libtheora/mathops.c
+++ b/thirdparty/libtheora/mathops.c
@@ -22,7 +22,7 @@ static const unsigned char OC_DEBRUIJN_IDX32[32]={
 
 int oc_ilog32(ogg_uint32_t _v){
 #if defined(OC_CLZ32)
-  return OC_CLZ32_OFFS-OC_CLZ32(_v)&-!!_v;
+  return _v ? (OC_CLZ32_OFFS-OC_CLZ32(_v)) : 0;
 #else
 /*On a Pentium M, this branchless version tested as the fastest version without
    multiplications on 1,000,000,000 random 32-bit integers, edging out a
@@ -62,8 +62,8 @@ int oc_ilog32(ogg_uint32_t _v){
 }
 
 int oc_ilog64(ogg_int64_t _v){
-#if defined(OC_CLZ64)
-  return OC_CLZ64_OFFS-OC_CLZ64(_v)&-!!_v;
+#if defined(CLZ64)
+  return _v ? CLZ64_OFFS-CLZ64(_v) : 0;
 #else
 /*If we don't have a fast 64-bit word implementation, split it into two 32-bit
    halves.*/
@@ -160,7 +160,7 @@ ogg_int64_t oc_bexp64(ogg_int64_t _z){
     /*z is the fractional part of the log in Q62 format.
       We need 1 bit of headroom since the magnitude can get larger than 1
        during the iteration, and a sign bit.*/
-    z<<=5;
+    z*=32;
     /*w is the exponential in Q61 format (since it also needs headroom and can
        get as large as 2.0); we could get another bit if we dropped the sign,
        but we'll recover that bit later anyway.
@@ -175,7 +175,7 @@ ogg_int64_t oc_bexp64(ogg_int64_t _z){
       z-=OC_ATANH_LOG2[i]+mask^mask;
       /*Repeat iteration 4.*/
       if(i>=3)break;
-      z<<=1;
+      z*=2;
     }
     for(;;i++){
       mask=-(z<0);
@@ -183,12 +183,12 @@ ogg_int64_t oc_bexp64(ogg_int64_t _z){
       z-=OC_ATANH_LOG2[i]+mask^mask;
       /*Repeat iteration 13.*/
       if(i>=12)break;
-      z<<=1;
+      z*=2;
     }
     for(;i<32;i++){
       mask=-(z<0);
       w+=(w>>i+1)+mask^mask;
-      z=z-(OC_ATANH_LOG2[i]+mask^mask)<<1;
+      z=(z-(OC_ATANH_LOG2[i]+mask^mask))*2;
     }
     wlo=0;
     /*Skip the remaining iterations unless we really require that much
@@ -207,12 +207,12 @@ ogg_int64_t oc_bexp64(ogg_int64_t _z){
         z-=OC_ATANH_LOG2[31]+mask^mask;
         /*Repeat iteration 40.*/
         if(i>=39)break;
-        z<<=1;
+        z*=2;
       }
       for(;i<61;i++){
         mask=-(z<0);
         wlo+=(w>>i)+mask^mask;
-        z=z-(OC_ATANH_LOG2[31]+mask^mask)<<1;
+        z=(z-(OC_ATANH_LOG2[31]+mask^mask))*2;
       }
     }
     w=(w<<1)+wlo;

--- a/thirdparty/libtheora/mathops.h
+++ b/thirdparty/libtheora/mathops.h
@@ -67,7 +67,7 @@ int oc_ilog64(ogg_int64_t _v);
  * This is the number of bits that would be required to represent _v in two's
  *  complement notation with all of the leading zeros stripped.
  */
-#  define OC_ILOG_32(_v)   (OC_ILOGNZ_32(_v)&-!!(_v))
+#  define OC_ILOG_32(_v)   ((_v)?OC_ILOGNZ_32(_v):0)
 # else
 #  define OC_ILOGNZ_32(_v) (oc_ilog32(_v))
 #  define OC_ILOG_32(_v)   (oc_ilog32(_v))
@@ -90,7 +90,7 @@ int oc_ilog64(ogg_int64_t _v);
  * This is the number of bits that would be required to represent _v in two's
  *  complement notation with all of the leading zeros stripped.
  */
-#  define OC_ILOG_64(_v)   (OC_ILOGNZ_64(_v)&-!!(_v))
+#  define OC_ILOG_64(_v)   ((_v)?OC_ILOGNZ_64(_v):0)
 # else
 #  define OC_ILOGNZ_64(_v) (oc_ilog64(_v))
 #  define OC_ILOG_64(_v)   (oc_ilog64(_v))
@@ -131,7 +131,7 @@ int oc_ilog64(ogg_int64_t _v);
  */
 # define OC_STATIC_ILOG_64(_v) (OC_STATIC_ILOG6((ogg_int64_t)(_v)))
 
-#define OC_Q57(_v) ((ogg_int64_t)(_v)<<57)
+#define OC_Q57(_v) ((_v)*((ogg_int64_t)1<<57))
 #define OC_Q10(_v) ((_v)<<10)
 
 ogg_int64_t oc_bexp64(ogg_int64_t _z);

--- a/thirdparty/libtheora/mcenc.c
+++ b/thirdparty/libtheora/mcenc.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdlib.h>
@@ -270,7 +269,7 @@ void oc_mcenc_search_frame(oc_enc_ctx *_enc,oc_mv _accum,int _mbi,int _frame,
  int _frame_full){
   /*Note: Traditionally this search is done using a rate-distortion objective
      function of the form D+lambda*R.
-    However, xiphmont tested this and found it produced a small degredation,
+    However, xiphmont tested this and found it produced a small degradation,
      while requiring extra computation.
     This is most likely due to Theora's peculiar MV encoding scheme: MVs are
      not coded relative to a predictor, and the only truly cheap way to use a
@@ -278,9 +277,9 @@ void oc_mcenc_search_frame(oc_enc_ctx *_enc,oc_mv _accum,int _mbi,int _frame,
     Therefore if we use the MV found here, it's only because both LAST and
      LAST2 performed poorly, and therefore the MB is not likely to be uniform
      or suffer from the aperture problem.
-    Furthermore we would like to re-use the MV found here for as many MBs as
+    Furthermore we would like to reuse the MV found here for as many MBs as
      possible, so picking a slightly sub-optimal vector to save a bit or two
-     may cause increased degredation in many blocks to come.
+     may cause increased degradation in many blocks to come.
     We could artificially reduce lambda to compensate, but it's faster to just
      disable it entirely, and use D (the distortion) as the sole criterion.*/
   oc_mcenc_ctx         mcenc;

--- a/thirdparty/libtheora/ocintrin.h
+++ b/thirdparty/libtheora/ocintrin.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -34,13 +34,13 @@
    speed difference between the two approaches is not measurable).
   Interestingly, the bit-twiddling method was patented in 2000 (US 6,073,150)
    by Sun Microsystems, despite prior art dating back to at least 1996:
-   http://web.archive.org/web/19961201174141/www.x86.org/ftp/articles/pentopt/PENTOPT.TXT
+   https://web.archive.org/web/19961201174141/www.x86.org/ftp/articles/pentopt/PENTOPT.TXT
   On gcc 3.x, however, our assumption is not true, as abs() is translated to a
    conditional jump, which is horrible on deeply piplined architectures (e.g.,
    all consumer architectures for the past decade or more).
   Also be warned that -C*abs(x) where C is a constant is mis-optimized as
    abs(C*x) on every gcc release before 4.2.3.
-  See bug http://gcc.gnu.org/bugzilla/show_bug.cgi?id=34130 */
+  See bug https://gcc.gnu.org/bugzilla/show_bug.cgi?id=34130 */
 
 /*Modern gcc (4.x) can compile the naive versions of min and max with cmov if
    given an appropriate architecture, but the branchless bit-twiddling versions

--- a/thirdparty/libtheora/quant.c
+++ b/thirdparty/libtheora/quant.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -66,7 +66,7 @@ void oc_dequant_tables_init(ogg_uint16_t *_dequant[64][3][2],
       qi_start=qi;
       if(qri==_qinfo->qi_ranges[qti][pli].nranges)qi_end=qi+1;
       else qi_end=qi+_qinfo->qi_ranges[qti][pli].sizes[qri];
-      /*Iterate over quality indicies in this range.*/
+      /*Iterate over quality indices in this range.*/
       for(;;){
         ogg_uint32_t qfac;
         int          zzi;

--- a/thirdparty/libtheora/quant.h
+++ b/thirdparty/libtheora/quant.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/rate.c
+++ b/thirdparty/libtheora/rate.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdlib.h>
@@ -22,7 +21,7 @@
   The values are Q12 fixed-point and spaced at 5 degree intervals.
   These decisions are somewhat arbitrary, but sufficient for the 2nd order
    Bessel follower below.
-  Values of x larger than 85 degrees are extrapolated from the last inteval,
+  Values of x larger than 85 degrees are extrapolated from the last interval,
    which is way off, but "good enough".*/
 static unsigned short OC_ROUGH_TAN_LOOKUP[18]={
       0,  358,  722, 1098, 1491, 1910,
@@ -49,7 +48,7 @@ static int oc_warp_alpha(int _alpha){
   This does not alter the x/y state, but changes the reaction time of the
    filter.
   Altering the time constant of a reactive filter without alterning internal
-   state is something that has to be done carefuly, but our design operates at
+   state is something that has to be done carefully, but our design operates at
    high enough delays and with small enough time constant changes to make it
    safe.*/
 static void oc_iir_filter_reinit(oc_iir_filter *_f,int _delay){

--- a/thirdparty/libtheora/state.c
+++ b/thirdparty/libtheora/state.c
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -388,7 +388,7 @@ static void oc_state_border_init(oc_theora_state *_state){
         /*Otherwise, check to see if it straddles the border.*/
         else if(x<crop_x0&&crop_x0<x+8||x<crop_xf&&crop_xf<x+8||
          y<crop_y0&&crop_y0<y+8||y<crop_yf&&crop_yf<y+8){
-          ogg_int64_t mask;
+          ogg_uint64_t mask;
           int         npixels;
           int         i;
           mask=npixels=0;
@@ -396,7 +396,7 @@ static void oc_state_border_init(oc_theora_state *_state){
             int j;
             for(j=0;j<8;j++){
               if(x+j>=crop_x0&&x+j<crop_xf&&y+i>=crop_y0&&y+i<crop_yf){
-                mask|=(ogg_int64_t)1<<(i<<3|j);
+                mask|=(ogg_uint64_t)1<<(i<<3|j);
                 npixels++;
               }
             }
@@ -651,7 +651,7 @@ static int oc_state_ref_bufs_init(oc_theora_state *_state,int _nrefs){
         frag_buf_offs[fragi]=hpix-ref_frame_data;
         hpix+=8;
       }
-      vpix+=stride<<3;
+      vpix+=stride*8;
     }
   }
   /*Initialize the reference frame pointers and indices.*/
@@ -1053,7 +1053,7 @@ void oc_loop_filter_init_c(signed char _bv[256],int _flimit){
   _fragy0:    The Y coordinate of the first fragment row to filter.
   _fragy_end: The Y coordinate of the fragment row to stop filtering at.*/
 void oc_state_loop_filter_frag_rows_c(const oc_theora_state *_state,
- signed char *_bv,int _refi,int _pli,int _fragy0,int _fragy_end){
+ signed char _bvarray[256],int _refi,int _pli,int _fragy0,int _fragy_end){
   const oc_fragment_plane *fplane;
   const oc_fragment       *frags;
   const ptrdiff_t         *frag_buf_offs;
@@ -1064,7 +1064,7 @@ void oc_state_loop_filter_frag_rows_c(const oc_theora_state *_state,
   ptrdiff_t                fragi0_end;
   int                      ystride;
   int                      nhfrags;
-  _bv+=127;
+  signed char             *_bv = &_bvarray[127];
   fplane=_state->fplanes+_pli;
   nhfrags=fplane->nhfrags;
   fragi_top=fplane->froffset;
@@ -1095,7 +1095,7 @@ void oc_state_loop_filter_frag_rows_c(const oc_theora_state *_state,
           loop_filter_h(ref+8,ystride,_bv);
         }
         if(fragi+nhfrags<fragi_bot&&!frags[fragi+nhfrags].coded){
-          loop_filter_v(ref+(ystride<<3),ystride,_bv);
+          loop_filter_v(ref+(ystride*8),ystride,_bv);
         }
       }
       fragi++;

--- a/thirdparty/libtheora/state.h
+++ b/thirdparty/libtheora/state.h
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: internal.h 17337 2010-07-19 16:08:54Z tterribe $
 
  ********************************************************************/
 #if !defined(_state_H)
@@ -229,7 +229,7 @@ typedef struct oc_theora_state          oc_theora_state;
 
 
 
-#define OC_MV(_x,_y)         ((oc_mv)((_x)&0xFF|(_y)<<8))
+#define OC_MV(_x,_y)         ((oc_mv)((_x)&0xFF|(_y)*256))
 #define OC_MV_X(_mv)         ((signed char)(_mv))
 #define OC_MV_Y(_mv)         ((_mv)>>8)
 #define OC_MV_ADD(_mv1,_mv2) \
@@ -523,7 +523,7 @@ void oc_idct8x8_c(ogg_int16_t _y[64],ogg_int16_t _x[64],int _last_zzi);
 void oc_state_frag_recon_c(const oc_theora_state *_state,ptrdiff_t _fragi,
  int _pli,ogg_int16_t _dct_coeffs[128],int _last_zzi,ogg_uint16_t _dc_quant);
 void oc_state_loop_filter_frag_rows_c(const oc_theora_state *_state,
- signed char _bv[256],int _refi,int _pli,int _fragy0,int _fragy_end);
+ signed char _bvarray[256],int _refi,int _pli,int _fragy0,int _fragy_end);
 void oc_restore_fpu_c(void);
 
 /*We need a way to call a few encoder functions without introducing a link-time

--- a/thirdparty/libtheora/theora/codec.h
+++ b/thirdparty/libtheora/theora/codec.h
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: theora.h,v 1.8 2004/03/15 22:17:32 derf Exp $
 
  ********************************************************************/
 
@@ -22,13 +21,13 @@
  * This is the documentation for the <tt>libtheora</tt> C API.
  *
  * The \c libtheora package is the current reference
- * implementation for <a href="http://www.theora.org/">Theora</a>, a free,
+ * implementation for <a href="https://www.theora.org/">Theora</a>, a free,
  * patent-unencumbered video codec.
  * Theora is derived from On2's VP3 codec with additional features and
  *  integration with Ogg multimedia formats by
- *  <a href="http://www.xiph.org/">the Xiph.Org Foundation</a>.
+ *  <a href="https://www.xiph.org/">the Xiph.Org Foundation</a>.
  * Complete documentation of the format itself is available in
- * <a href="http://www.theora.org/doc/Theora.pdf">the Theora
+ * <a href="https://www.theora.org/doc/Theora.pdf">the Theora
  *  specification</a>.
  *
  * \section Organization
@@ -47,7 +46,7 @@
  * During initial development, prior to the 1.0 release,
  * \c libtheora exported a different \ref oldfuncs which
  * combined both encode and decode functions.
- * In general, legacy API symbols can be indentified
+ * In general, legacy API symbols can be identified
  * by their \c theora_ or \c OC_ namespace prefixes.
  * The current API uses \c th_ or \c TH_ instead.
  *
@@ -62,8 +61,8 @@
  * The shared <tt>libtheoradec</tt> and <tt>libtheoraenc</tt> C API.
  * You don't need to include this directly.*/
 
-#if !defined(_O_THEORA_CODEC_H_)
-# define _O_THEORA_CODEC_H_ (1)
+#if !defined(OGG_THEORA_CODEC_HEADER)
+# define OGG_THEORA_CODEC_HEADER (1)
 # include <ogg/ogg.h>
 
 #if defined(__cplusplus)
@@ -95,7 +94,7 @@ extern "C" {
 /*@}*/
 
 /**The currently defined color space tags.
- * See <a href="http://www.theora.org/doc/Theora.pdf">the Theora
+ * See <a href="https://www.theora.org/doc/Theora.pdf">the Theora
  *  specification</a>, Chapter 4, for exact details on the meaning
  *  of each of these color spaces.*/
 typedef enum{
@@ -111,7 +110,7 @@ typedef enum{
 }th_colorspace;
 
 /**The currently defined pixel format tags.
- * See <a href="http://www.theora.org/doc/Theora.pdf">the Theora
+ * See <a href="https://www.theora.org/doc/Theora.pdf">the Theora
  *  specification</a>, Section 4.4, for details on the precise sample
  *  locations.*/
 typedef enum{
@@ -195,7 +194,7 @@ typedef th_img_plane th_ycbcr_buffer[3];
  *
  * It is also generally recommended that the offsets and sizes should still be
  *  multiples of 2 to avoid chroma sampling shifts when chroma is sub-sampled.
- * See <a href="http://www.theora.org/doc/Theora.pdf">the Theora
+ * See <a href="https://www.theora.org/doc/Theora.pdf">the Theora
  *  specification</a>, Section 4.4, for more details.
  *
  * Frame rate, in frames per second, is stored as a rational fraction, as is
@@ -314,7 +313,7 @@ typedef struct{
  * A particular tag may occur more than once, and order is significant.
  * The character set encoding for the strings is always UTF-8, but the tag
  *  names are limited to ASCII, and treated as case-insensitive.
- * See <a href="http://www.theora.org/doc/Theora.pdf">the Theora
+ * See <a href="https://www.theora.org/doc/Theora.pdf">the Theora
  *  specification</a>, Section 6.3.3 for details.
  *
  * In filling in this structure, th_decode_headerin() will null-terminate
@@ -603,4 +602,4 @@ extern void th_comment_clear(th_comment *_tc);
 }
 #endif
 
-#endif
+#endif /* OGG_THEORA_CODEC_HEADER */

--- a/thirdparty/libtheora/theora/theora.h
+++ b/thirdparty/libtheora/theora/theora.h
@@ -6,17 +6,16 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: theora.h,v 1.17 2003/12/06 18:06:19 arc Exp $
 
  ********************************************************************/
 
-#ifndef _O_THEORA_H_
-#define _O_THEORA_H_
+#ifndef OGG_THEORA_HEADER
+#define OGG_THEORA_HEADER
 
 #ifdef __cplusplus
 extern "C"
@@ -41,16 +40,16 @@ extern "C"
  * declared in theoradec.h and theoraenc.h.
  *
  * libtheora is the reference implementation for
- * <a href="http://www.theora.org/">Theora</a>, a free video codec.
+ * <a href="https://www.theora.org/">Theora</a>, a free video codec.
  * Theora is derived from On2's VP3 codec with improved integration with
- * Ogg multimedia formats by <a href="http://www.xiph.org/">Xiph.Org</a>.
+ * Ogg multimedia formats by <a href="https://www.xiph.org/">Xiph.Org</a>.
  *
  * \section overview Overview
  *
  * This library will both decode and encode theora packets to/from raw YUV
  * frames.  In either case, the packets will most likely either come from or
  * need to be embedded in an Ogg stream.  Use
- * <a href="http://xiph.org/ogg/">libogg</a> or
+ * <a href="https://www.xiph.org/ogg/">libogg</a> or
  * <a href="http://www.annodex.net/software/liboggz/index.html">liboggz</a>
  * to extract/package these packets.
  *
@@ -260,7 +259,7 @@ typedef struct{
  * the 'comment' header packet.
  *
  * Meta data is stored as a series of (tag, value) pairs, in
- * length-encoded string vectors. The first occurence of the
+ * length-encoded string vectors. The first occurrence of the
  * '=' character delimits the tag and value. A particular tag
  * may occur more than once. The character set encoding for
  * the strings is always UTF-8, but the tag names are limited
@@ -330,7 +329,7 @@ typedef struct theora_comment{
  * Call this after a seek, to update the internal granulepos
  * in the decoder, to insure that subsequent frames are marked
  * properly. If you track timestamps yourself and do not use
- * the granule postion returned by the decoder, then you do
+ * the granule position returned by the decoder, then you do
  * not need to use this control.
  */
 #define TH_DECCTL_SET_GRANPOS (5)
@@ -755,7 +754,7 @@ extern char *theora_comment_query(theora_comment *tc, char *tag, int count);
  *  \param tag The tag to look up
  *  \returns The number on instances of a particular tag.
  *
- *  Call this first when querying for a specific tag and then interate
+ *  Call this first when querying for a specific tag and then iterate
  *  over the number of instances with separate calls to
  *  theora_comment_query() to retrieve all instances in order.
  **/
@@ -783,4 +782,4 @@ extern int theora_control(theora_state *th,int req,void *buf,size_t buf_sz);
 }
 #endif /* __cplusplus */
 
-#endif /* _O_THEORA_H_ */
+#endif /* OGG_THEORA_HEADER */

--- a/thirdparty/libtheora/theora/theoradec.h
+++ b/thirdparty/libtheora/theora/theoradec.h
@@ -6,20 +6,19 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: theora.h,v 1.8 2004/03/15 22:17:32 derf Exp $
 
  ********************************************************************/
 
 /**\file
  * The <tt>libtheoradec</tt> C decoding API.*/
 
-#if !defined(_O_THEORA_THEORADEC_H_)
-# define _O_THEORA_THEORADEC_H_ (1)
+#if !defined(OGG_THEORA_THEORADEC_HEADER)
+# define OGG_THEORA_THEORADEC_HEADER (1)
 # include <stddef.h>
 # include <ogg/ogg.h>
 # include "codec.h"
@@ -330,4 +329,4 @@ extern void th_decode_free(th_dec_ctx *_dec);
 }
 #endif
 
-#endif
+#endif /* OGG_THEORA_THEORADEC_HEADER */

--- a/thirdparty/libtheora/theora/theoraenc.h
+++ b/thirdparty/libtheora/theora/theoraenc.h
@@ -6,20 +6,19 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: theora.h,v 1.8 2004/03/15 22:17:32 derf Exp $
 
  ********************************************************************/
 
 /**\file
  * The <tt>libtheoraenc</tt> C encoding API.*/
 
-#if !defined(_O_THEORA_THEORAENC_H_)
-# define _O_THEORA_THEORAENC_H_ (1)
+#if !defined(OGG_THEORA_THEORAENC_HEADER)
+# define OGG_THEORA_THEORAENC_HEADER (1)
 # include <stddef.h>
 # include <ogg/ogg.h>
 # include "codec.h"
@@ -501,7 +500,7 @@ extern int th_encode_flushheader(th_enc_ctx *_enc,
  *                and their use is generally discouraged, as they will not be
  *                well-supported by players and other media frameworks.
  *               See Section 4.4 of
- *                <a href="http://www.theora.org/doc/Theora.pdf">the Theora
+ *                <a href="https://www.theora.org/doc/Theora.pdf">the Theora
  *                specification</a> for details if you wish to use them anyway.
  * \retval 0         Success.
  * \retval TH_EFAULT \a _enc or \a _ycbcr is <tt>NULL</tt>.
@@ -545,4 +544,4 @@ extern void th_encode_free(th_enc_ctx *_enc);
 }
 #endif
 
-#endif
+#endif /* OGG_THEORA_THEORAENC_HEADER */

--- a/thirdparty/libtheora/tokenize.c
+++ b/thirdparty/libtheora/tokenize.c
@@ -5,13 +5,12 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id$
 
  ********************************************************************/
 #include <stdlib.h>
@@ -487,11 +486,11 @@ int oc_enc_tokenize_ac(oc_enc_ctx *_enc,int _pli,ptrdiff_t _fragi,
   zzj=64;
   for(zzi=OC_MINI(_zzi,63);zzi>0;zzi--){
     ogg_uint32_t best_cost;
-    int          best_bits=best_bits;
-    int          best_next=best_next;
-    int          best_token=best_token;
-    int          best_eb=best_eb;
-    int          best_qc=best_qc;
+    int          best_bits=INT_MAX;
+    int          best_next=INT_MAX;
+    int          best_token=INT_MAX;
+    int          best_eb=INT_MAX;
+    int          best_qc=INT_MAX;
     ogg_uint32_t d2;
     int          dq;
     int          qc_m;
@@ -1091,8 +1090,8 @@ void oc_enc_tokenize_dc_frag_list(oc_enc_ctx *_enc,int _pli,
   int                neobs1;
   int                token;
   int                eb;
-  int                token1=token1;
-  int                eb1=eb1;
+  int                token1=OC_DCT_ZRL_TOKEN;
+  int                eb1=INT_MAX;
   /*Return immediately if there are no coded fragments; otherwise we'd flush
      any trailing EOB run into the AC 1 list and never read it back out.*/
   if(_ncoded_fragis<=0)return;
@@ -1328,7 +1327,7 @@ void oc_enc_tokenize_finish(oc_enc_ctx *_enc){
     int       new_eb;
     int       zzj;
     int       plj;
-    ptrdiff_t ti=ti;
+    ptrdiff_t ti=-1;
     int       run_count;
     /*Make sure this coefficient has tokens at all.*/
     if(_enc->ndct_tokens[pli][zzi]<=0)continue;

--- a/thirdparty/libtheora/x86/mmxencfrag.c
+++ b/thirdparty/libtheora/x86/mmxencfrag.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: dsp_mmx.c 14579 2008-03-12 06:42:40Z xiphmont $
 
  ********************************************************************/
 #include <stddef.h>
@@ -522,7 +521,7 @@ static unsigned oc_int_frag_satd_mmxext(int *_dc,
        and %[ret2] with some of the inputs, since for once we don't write to
        them until after we're done using everything but %[buf].*/
     /*Note that _src_ystride and _ref_ystride must be given non-overlapping
-       constraints, otherewise if gcc can prove they're equal it will allocate
+       constraints, otherwise if gcc can prove they're equal it will allocate
        them to the same register (which is bad); _src and _ref face a similar
        problem, though those are never actually the same.*/
     :[ret]"=d"(ret),[ret2]"=r"(ret2),[dc]"=a"(dc),

--- a/thirdparty/libtheora/x86/mmxfdct.c
+++ b/thirdparty/libtheora/x86/mmxfdct.c
@@ -6,7 +6,7 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 1999-2006                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************/
 /*MMX fDCT implementation for x86_32*/

--- a/thirdparty/libtheora/x86/mmxfrag.c
+++ b/thirdparty/libtheora/x86/mmxfrag.c
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -216,7 +216,7 @@ void oc_frag_recon_intra_mmx(unsigned char *_dst,int _ystride,
     :
     :[residue]"r"(_residue),
      [dst]"r"(_dst),
-     [dst4]"r"(_dst+(_ystride<<2)),
+     [dst4]"r"(_dst+(_ystride*4)),
      [ystride]"r"((ptrdiff_t)_ystride),
      [ystride3]"r"((ptrdiff_t)_ystride*3)
     :"memory"

--- a/thirdparty/libtheora/x86/mmxidct.c
+++ b/thirdparty/libtheora/x86/mmxidct.c
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -312,7 +312,7 @@ static void oc_idct8x8_slow_mmx(ogg_int16_t _y[64],ogg_int16_t _x[64]){
 #undef  OC_J
     :[y]"=m"OC_ARRAY_OPERAND(ogg_int16_t,_y,64)
     :[x]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,_x,64),
-     [c]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,128)
+     [c]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,64)
   );
   __asm__ __volatile__("pxor %%mm0,%%mm0\n\t"::);
   for(i=0;i<4;i++){
@@ -510,7 +510,7 @@ static void oc_idct8x8_10_mmx(ogg_int16_t _y[64],ogg_int16_t _x[64]){
 #undef  OC_J
     :[y]"=m"OC_ARRAY_OPERAND(ogg_int16_t,_y,64)
     :[x]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,_x,64),
-     [c]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,128)
+     [c]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,64)
   );
   __asm__ __volatile__(
     "pxor %%mm0,%%mm0\n\t"

--- a/thirdparty/libtheora/x86/mmxstate.c
+++ b/thirdparty/libtheora/x86/mmxstate.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -147,7 +147,7 @@ void oc_state_loop_filter_frag_rows_mmx(const oc_theora_state *_state,
           OC_LOOP_FILTER_H(OC_LOOP_FILTER8_MMX,ref+8,ystride,ll);
         }
         if(fragi+nhfrags<fragi_bot&&!frags[fragi+nhfrags].coded){
-          OC_LOOP_FILTER_V(OC_LOOP_FILTER8_MMX,ref+(ystride<<3),ystride,ll);
+          OC_LOOP_FILTER_V(OC_LOOP_FILTER8_MMX,ref+(ystride*8),ystride,ll);
         }
       }
       fragi++;
@@ -214,7 +214,7 @@ void oc_state_loop_filter_frag_rows_mmxext(const oc_theora_state *_state,
           OC_LOOP_FILTER_H(OC_LOOP_FILTER8_MMXEXT,ref+8,ystride,_bv);
         }
         if(fragi+nhfrags<fragi_bot&&!frags[fragi+nhfrags].coded){
-          OC_LOOP_FILTER_V(OC_LOOP_FILTER8_MMXEXT,ref+(ystride<<3),ystride,_bv);
+          OC_LOOP_FILTER_V(OC_LOOP_FILTER8_MMXEXT,ref+(ystride*8),ystride,_bv);
         }
       }
       fragi++;

--- a/thirdparty/libtheora/x86/sse2encfrag.c
+++ b/thirdparty/libtheora/x86/sse2encfrag.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: dsp_mmx.c 14579 2008-03-12 06:42:40Z xiphmont $
 
  ********************************************************************/
 #include <stddef.h>
@@ -424,7 +423,7 @@ static unsigned oc_int_frag_satd_sse2(int *_dc,
        and %[dc] with some of the inputs, since for once we don't write to
        them until after we're done using everything but %[buf].*/
     /*Note that _src_ystride and _ref_ystride must be given non-overlapping
-       constraints, otherewise if gcc can prove they're equal it will allocate
+       constraints, otherwise if gcc can prove they're equal it will allocate
        them to the same register (which is bad); _src and _ref face a similar
        problem.
       All four are destructively modified, but if we list them as output

--- a/thirdparty/libtheora/x86/sse2fdct.c
+++ b/thirdparty/libtheora/x86/sse2fdct.c
@@ -6,7 +6,7 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 1999-2006                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************/
 /*SSE2 fDCT implementation for x86_64.*/

--- a/thirdparty/libtheora/x86/sse2idct.c
+++ b/thirdparty/libtheora/x86/sse2idct.c
@@ -5,13 +5,13 @@
  * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
- * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009,2025           *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: mmxidct.c 16503 2009-08-22 18:14:02Z giles $
 
  ********************************************************************/
 
@@ -229,7 +229,7 @@ static void oc_idct8x8_slow_sse2(ogg_int16_t _y[64],ogg_int16_t _x[64]){
     :[buf]"=m"(OC_ARRAY_OPERAND(ogg_int16_t,buf,16)),
      [y]"=m"(OC_ARRAY_OPERAND(ogg_int16_t,_y,64))
     :[x]"m"(OC_CONST_ARRAY_OPERAND(ogg_int16_t,_x,64)),
-     [c]"m"(OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,128))
+     [c]"m"(OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,64))
   );
   __asm__ __volatile__("pxor %%xmm0,%%xmm0\n\t"::);
   /*Clear input data for next block (decoder only).*/
@@ -407,7 +407,7 @@ static void oc_idct8x8_10_sse2(ogg_int16_t _y[64],ogg_int16_t _x[64]){
     :[buf]"=m"(OC_ARRAY_OPERAND(short,buf,16)),
      [y]"=m"(OC_ARRAY_OPERAND(ogg_int16_t,_y,64))
     :[x]"m"OC_CONST_ARRAY_OPERAND(ogg_int16_t,_x,64),
-     [c]"m"(OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,128))
+     [c]"m"(OC_CONST_ARRAY_OPERAND(ogg_int16_t,OC_IDCT_CONSTS,64))
   );
   /*Clear input data for next block (decoder only).*/
   __asm__ __volatile__(

--- a/thirdparty/libtheora/x86/sse2trans.h
+++ b/thirdparty/libtheora/x86/sse2trans.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: sse2trans.h 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86/x86cpu.c
+++ b/thirdparty/libtheora/x86/x86cpu.c
@@ -6,7 +6,8 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
@@ -14,7 +15,6 @@
   Originally written by Rudolf Marek.
 
  function:
-  last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86/x86cpu.h
+++ b/thirdparty/libtheora/x86/x86cpu.h
@@ -6,11 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
  function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86/x86enc.c
+++ b/thirdparty/libtheora/x86/x86enc.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: x86state.c 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 #include "x86enc.h"

--- a/thirdparty/libtheora/x86/x86enc.h
+++ b/thirdparty/libtheora/x86/x86enc.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: x86int.h 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86/x86enquant.c
+++ b/thirdparty/libtheora/x86/x86enquant.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: mmxstate.c 17247 2010-05-28 05:35:32Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86/x86int.h
+++ b/thirdparty/libtheora/x86/x86int.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -63,7 +63,7 @@
 #  define OC_MEM_OFFS(_offs,_name) \
   OC_M2STR(_offs-8+%H[_name])
 # endif
-/*If your gcc version does't support %H, then you get to suffer the warnings.
+/*If your gcc version doesn't support %H, then you get to suffer the warnings.
   Note that Apple's gas breaks on things like _offs+(%esp): it throws away the
    whole offset, instead of substituting in 0 for the missing operand to +.*/
 # if !defined(OC_MEM_OFFS)

--- a/thirdparty/libtheora/x86/x86state.c
+++ b/thirdparty/libtheora/x86/x86state.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86/x86zigzag.h
+++ b/thirdparty/libtheora/x86/x86zigzag.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: sse2trans.h 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/mmxencfrag.c
+++ b/thirdparty/libtheora/x86_vc/mmxencfrag.c
@@ -6,12 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************
 
   function:
-  last mod: $Id: dsp_mmx.c 14579 2008-03-12 06:42:40Z xiphmont $
 
  ********************************************************************/
 #include <stddef.h>

--- a/thirdparty/libtheora/x86_vc/mmxfdct.c
+++ b/thirdparty/libtheora/x86_vc/mmxfdct.c
@@ -6,7 +6,7 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 1999-2006                *
- * by the Xiph.Org Foundation http://www.xiph.org/                  *
+ * by the Xiph.Org Foundation https://www.xiph.org/                 *
  *                                                                  *
  ********************************************************************/ 
  /*MMX fDCT implementation for x86_32*/

--- a/thirdparty/libtheora/x86_vc/mmxfrag.c
+++ b/thirdparty/libtheora/x86_vc/mmxfrag.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/mmxidct.c
+++ b/thirdparty/libtheora/x86_vc/mmxidct.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/mmxstate.c
+++ b/thirdparty/libtheora/x86_vc/mmxstate.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 
@@ -158,7 +158,7 @@ void oc_state_loop_filter_frag_rows_mmx(const oc_theora_state *_state,
           OC_LOOP_FILTER_H_MMX(ref+8,ystride,_bv);
         }
         if(fragi+nhfrags<fragi_bot&&!frags[fragi+nhfrags].coded){
-          OC_LOOP_FILTER_V_MMX(ref+(ystride<<3),ystride,_bv);
+          OC_LOOP_FILTER_V_MMX(ref+(ystride*8),ystride,_bv);
         }
 #undef PIX
 #undef YSTRIDE3

--- a/thirdparty/libtheora/x86_vc/x86cpu.c
+++ b/thirdparty/libtheora/x86_vc/x86cpu.c
@@ -6,7 +6,8 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
@@ -14,7 +15,6 @@
   Originally written by Rudolf Marek.
 
  function:
-  last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/x86cpu.h
+++ b/thirdparty/libtheora/x86_vc/x86cpu.h
@@ -6,11 +6,11 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
  function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/x86enc.c
+++ b/thirdparty/libtheora/x86_vc/x86enc.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: x86state.c 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 #include "x86enc.h"

--- a/thirdparty/libtheora/x86_vc/x86enc.h
+++ b/thirdparty/libtheora/x86_vc/x86enc.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: x86int.h 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/x86int.h
+++ b/thirdparty/libtheora/x86_vc/x86int.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/x86state.c
+++ b/thirdparty/libtheora/x86_vc/x86state.c
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id$
 
  ********************************************************************/
 

--- a/thirdparty/libtheora/x86_vc/x86zigzag.h
+++ b/thirdparty/libtheora/x86_vc/x86zigzag.h
@@ -6,12 +6,12 @@
  * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
  *                                                                  *
  * THE Theora SOURCE CODE IS COPYRIGHT (C) 2002-2009                *
- * by the Xiph.Org Foundation and contributors http://www.xiph.org/ *
+ * by the Xiph.Org Foundation and contributors                      *
+ * https://www.xiph.org/                                            *
  *                                                                  *
  ********************************************************************
 
   function:
-    last mod: $Id: sse2trans.h 15675 2009-02-06 09:43:27Z tterribe $
 
  ********************************************************************/
 


### PR DESCRIPTION
Theora finally has a new release after 15 years :sweat_smile: 
https://github.com/xiph/theora/blob/v1.2.0/CHANGES#L1-L48

I haven't tested the changes, CC @berarma @DeeJayLSP.