### PR TITLE
Make `LightmapGIData::_set_user_data` a proper setter instead of an additive operation

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -81,9 +81,8 @@ void LightmapGIData::clear_users() {
 }
 
 void LightmapGIData::_set_user_data(const Array &p_data) {
-	ERR_FAIL_COND(p_data.is_empty());
 	ERR_FAIL_COND((p_data.size() % 4) != 0);
-
+	users.clear();
 	for (int i = 0; i < p_data.size(); i += 4) {
 		add_user(p_data[i + 0], p_data[i + 1], p_data[i + 2], p_data[i + 3]);
 	}


### PR DESCRIPTION
`LightmapGIData::_set_user_data`, is supposed to be a setter. Not only is it bound to the `user_data` property as its setter, but its naming suggests that it is such.

However, its implementation is an _additive_ operation. This is not only confusing, but can lead to very nasty bugs. For example, getting the `user_data` property and setting it back actually appends a copy of all the data. If done enough times, this can crash the program.

This PR changes it to clear the user data before setting the new data, and removes the error condition for the user data being empty (appending an empty array of user data is an error, but setting it is not).