### PR TITLE
ColorPicker: Fix cursor position in okhsl circle

### DIFF
--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -161,11 +161,11 @@ void ColorPickerShape::draw_cursor(Control *p_control, const Vector2 &p_center, 
 	p_control->draw_texture(color_picker->theme_cache.picker_cursor, position);
 }
 
-void ColorPickerShape::draw_circle_cursor(Control *p_control, float p_hue) {
+void ColorPickerShape::draw_circle_cursor(Control *p_control, float p_hue, float p_saturation) {
 	const Vector2 center = p_control->get_size() * 0.5;
 	const Vector2 cursor_pos(
-			center.x + (center.x * Math::cos(p_hue * Math::TAU) * color_picker->s),
-			center.y + (center.y * Math::sin(p_hue * Math::TAU) * color_picker->s));
+			center.x + (center.x * Math::cos(p_hue * Math::TAU) * p_saturation),
+			center.y + (center.y * Math::sin(p_hue * Math::TAU) * p_saturation));
 
 	draw_cursor(p_control, cursor_pos);
 }
@@ -636,7 +636,7 @@ void ColorPickerShapeVHSCircle::_circle_draw() {
 
 void ColorPickerShapeVHSCircle::_circle_overlay_draw() {
 	draw_focus_circle(circle_overlay);
-	draw_circle_cursor(circle_overlay, color_picker->h);
+	draw_circle_cursor(circle_overlay, color_picker->h, color_picker->s);
 }
 
 void ColorPickerShapeVHSCircle::_value_slider_draw() {
@@ -721,7 +721,7 @@ void ColorPickerShapeOKHSLCircle::_circle_draw() {
 
 void ColorPickerShapeOKHSLCircle::_circle_overlay_draw() {
 	draw_focus_circle(circle_overlay);
-	draw_circle_cursor(circle_overlay, color_picker->ok_hsl_h);
+	draw_circle_cursor(circle_overlay, color_picker->ok_hsl_h, color_picker->ok_hsl_s);
 }
 
 void ColorPickerShapeOKHSLCircle::_value_slider_draw() {

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -52,7 +52,7 @@ protected:
 	void draw_focus_circle(Control *p_control);
 	void draw_sv_square(Control *p_control, const Rect2 &p_square, bool p_draw_focus = true);
 	void draw_cursor(Control *p_control, const Vector2 &p_center, bool p_draw_bg = true);
-	void draw_circle_cursor(Control *p_control, float p_hue);
+	void draw_circle_cursor(Control *p_control, float p_hue, float p_saturation);
 
 	void connect_shape_focus(Control *p_shape);
 	void shape_focus_entered();


### PR DESCRIPTION
Before, the cursor position is incorrectly calculated from hsv_s instead of okhsl_s:

<details>

https://github.com/user-attachments/assets/b7a32ba0-79e5-4ba4-8078-9c36922360a6

</details>

After:

<details>

https://github.com/user-attachments/assets/211e35e9-3dee-4b4a-b072-530dad5872b5

</details>
