### PR TITLE
Fix `scons` compability on enabling C++ 20 module

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -52,6 +52,7 @@ _helper_module("version", "version.py")
 _helper_module("core.core_builders", "core/core_builders.py")
 _helper_module("main.main_builders", "main/main_builders.py")
 _helper_module("misc.utility.color", "misc/utility/color.py")
+_helper_module("misc.utility.compatibility", "misc/utility/compatibility.py")
 
 # Local
 import gles3_builders

--- a/drivers/apple_embedded/SCsub
+++ b/drivers/apple_embedded/SCsub
@@ -1,15 +1,13 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
-from misc.utility.compatibility import try_use_cxx20_module
-
 Import("env")
 
 env_apple_embedded = env.Clone()
 
 # Enable module support
-# env_apple_embedded.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
-try_use_cxx20_module(env_apple_embedded)
+# Need a functional export template here, so not using `try_use_cxx20_module`.
+env_apple_embedded.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
 
 # Use bundled Vulkan headers
 vulkan_dir = "#thirdparty/vulkan"

--- a/drivers/apple_embedded/SCsub
+++ b/drivers/apple_embedded/SCsub
@@ -1,12 +1,14 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+from misc.utility.compatibility import try_use_cxx20_module
 
 Import("env")
 
 env_apple_embedded = env.Clone()
 
 # Enable module support
-env_apple_embedded.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+# env_apple_embedded.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+try_use_cxx20_module(env_apple_embedded)
 
 # Use bundled Vulkan headers
 vulkan_dir = "#thirdparty/vulkan"

--- a/drivers/apple_embedded/SCsub
+++ b/drivers/apple_embedded/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+
 from misc.utility.compatibility import try_use_cxx20_module
 
 Import("env")

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+from misc.utility.compatibility import try_use_cxx20_module
 
 Import("env")
 
@@ -40,7 +41,8 @@ if "-std=gnu++17" in env_metal["CXXFLAGS"]:
 env_metal.Append(CXXFLAGS=["-std=c++20"])
 
 # Enable module support
-env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+# env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+try_use_cxx20_module(env_metal)
 
 # Driver source files
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -42,8 +42,10 @@ if "-std=gnu++17" in env_metal["CXXFLAGS"]:
 env_metal.Append(CXXFLAGS=["-std=c++20"])
 
 # Enable module support
-# env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
-try_use_cxx20_module(env_metal)
+if env["platform"] == "macos":
+    try_use_cxx20_module(env_metal)
+else:
+    env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
 
 # Driver source files
 

--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+
 from misc.utility.compatibility import try_use_cxx20_module
 
 Import("env")

--- a/misc/utility/compatibility.py
+++ b/misc/utility/compatibility.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python
+import methods
+
+import os
+import subprocess
+
+is_able_to_use_module_cache = None
+
+def try_use_cxx20_module(env):
+    """
+    Use C++20's `module` if current compiler supports that.
+    Referencing https://en.cppreference.com/w/cpp/compiler_support/20.
+    """
+    global is_able_to_use_module_cache
+
+    if is_able_to_use_module_cache is not None:
+        return is_able_to_use_module_cache
+    else:
+        is_able_to_use_module_cache = True
+
+        # According to the reference, currently (06/03/2025, mm/dd/yyyy),
+        #  only msvc has full support of module.
+        if env.msvc and is_msvc_support_module(env):
+            env.Append(CCFLAGS=["/experimental:module"])
+        # Apple clang also supports module.
+        elif methods.using_clang(env) and is_clang_support_module():
+            env.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+        else:
+            is_able_to_use_module_cache = False
+
+
+def is_msvc_support_module(env) -> bool:
+    """
+    MSVC supports C++ modules after 19.2.8.
+    """
+    version = methods.get_compiler_version(env)
+
+    return version["major"] > 19 \
+        or (version["major"] == 19 and version["minor"] >= 2) \
+        or (version["major"] == 19 and version["minor"] == 2 and version["patch"] >= 8)
+
+
+def is_clang_support_module() -> bool:
+    """
+    Check if the clang is Apple clang.
+    """
+    env = os.environ.copy()
+    env["LC_ALL"] = "C"
+    version_text: str = subprocess.check_output(
+        ["clang", "--version"], env=env, encoding="utf-8"
+    )
+    return "Apple clang version" in version_text

--- a/misc/utility/compatibility.py
+++ b/misc/utility/compatibility.py
@@ -19,28 +19,11 @@ def try_use_cxx20_module(env):
     else:
         is_able_to_use_module_cache = True
 
-        # According to the reference, currently (06/03/2025, mm/dd/yyyy),
-        #  only msvc has full support of module.
-        if env.msvc and is_msvc_support_module(env):
-            env.Append(CCFLAGS=["/experimental:module"])
-        # Apple clang also supports module.
-        elif methods.using_clang(env) and is_clang_support_module():
+        # Apple clang supports module.
+        if methods.using_clang(env) and is_clang_support_module():
             env.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
         else:
             is_able_to_use_module_cache = False
-
-
-def is_msvc_support_module(env) -> bool:
-    """
-    MSVC supports C++ modules after 19.2.8.
-    """
-    # Only "major", "minor", and "patch" has int type.
-    version = methods.get_compiler_version(env)
-    major: int = version["major"]
-    minor: int = version["minor"]
-    patch: int = version["patch"]
-
-    return major > 19 or (version["major"] == 19 and minor >= 2) or (major == 19 and minor == 2 and patch >= 8)
 
 
 def is_clang_support_module() -> bool:

--- a/misc/utility/compatibility.py
+++ b/misc/utility/compatibility.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
-import os
-import subprocess
 
-import methods
+from methods import is_apple_clang
 
 is_able_to_use_module_cache = None
 
@@ -20,17 +18,7 @@ def try_use_cxx20_module(env):
         is_able_to_use_module_cache = True
 
         # Apple clang supports module.
-        if methods.using_clang(env) and is_clang_support_module():
+        if is_apple_clang(env):
             env.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
         else:
             is_able_to_use_module_cache = False
-
-
-def is_clang_support_module() -> bool:
-    """
-    Check if the clang is Apple clang.
-    """
-    env = os.environ.copy()
-    env["LC_ALL"] = "C"
-    version_text: str = subprocess.check_output(["clang", "--version"], env=env, encoding="utf-8")
-    return "Apple clang version" in version_text

--- a/misc/utility/compatibility.py
+++ b/misc/utility/compatibility.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
-import methods
-
 import os
 import subprocess
 
+import methods
+
 is_able_to_use_module_cache = None
+
 
 def try_use_cxx20_module(env):
     """
@@ -33,11 +34,13 @@ def is_msvc_support_module(env) -> bool:
     """
     MSVC supports C++ modules after 19.2.8.
     """
+    # Only "major", "minor", and "patch" has int type.
     version = methods.get_compiler_version(env)
+    major: int = version["major"]
+    minor: int = version["minor"]
+    patch: int = version["patch"]
 
-    return version["major"] > 19 \
-        or (version["major"] == 19 and version["minor"] >= 2) \
-        or (version["major"] == 19 and version["minor"] == 2 and version["patch"] >= 8)
+    return major > 19 or (version["major"] == 19 and minor >= 2) or (major == 19 and minor == 2 and patch >= 8)
 
 
 def is_clang_support_module() -> bool:
@@ -46,7 +49,5 @@ def is_clang_support_module() -> bool:
     """
     env = os.environ.copy()
     env["LC_ALL"] = "C"
-    version_text: str = subprocess.check_output(
-        ["clang", "--version"], env=env, encoding="utf-8"
-    )
+    version_text: str = subprocess.check_output(["clang", "--version"], env=env, encoding="utf-8")
     return "Apple clang version" in version_text

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
-from misc.utility.compatibility import try_use_cxx20_module
 
 from platform_ios_builders import generate_bundle
 
+from misc.utility.compatibility import try_use_cxx20_module
 from platform_methods import combine_libs_apple_embedded
 
 Import("env")

--- a/platform/ios/SCsub
+++ b/platform/ios/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+from misc.utility.compatibility import try_use_cxx20_module
 
 from platform_ios_builders import generate_bundle
 
@@ -20,7 +21,8 @@ env_ios = env.Clone()
 ios_lib = env_ios.add_library("ios", ios_lib)
 
 # (iOS) Enable module support
-env_ios.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+# env_ios.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+try_use_cxx20_module(env_ios)
 
 combine_command = env_ios.CommandNoCache(
     "#bin/libgodot" + env_ios["LIBSUFFIX"], [ios_lib] + env_ios["LIBS"], env.Run(combine_libs_apple_embedded)

--- a/platform/visionos/SCsub
+++ b/platform/visionos/SCsub
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
-from misc.utility.compatibility import try_use_cxx20_module
 
 from platform_visionos_builders import generate_bundle
 
+from misc.utility.compatibility import try_use_cxx20_module
 from platform_methods import combine_libs_apple_embedded
 
 Import("env")

--- a/platform/visionos/SCsub
+++ b/platform/visionos/SCsub
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
+from misc.utility.compatibility import try_use_cxx20_module
 
 from platform_visionos_builders import generate_bundle
 
@@ -19,7 +20,8 @@ env_visionos = env.Clone()
 visionos_lib = env_visionos.add_library("visionos", visionos_lib)
 
 # Enable module support
-env_visionos.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+# env_visionos.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
+try_use_cxx20_module(env_visionos)
 
 combine_command = env_visionos.Command(
     "#bin/libgodot" + env_visionos["LIBSUFFIX"], [visionos_lib] + env_visionos["LIBS"], combine_libs_apple_embedded


### PR DESCRIPTION
Related to #107199.

Solves the compilation failure problem by adding version-detect logic to check if current compiler can enable `-fmodule` flag.

This PR is not considered fixing the root cause of the #107199 currently. 

----

Edit:
Currently, only `clang` and `msvc` is contained in the detecting logic, so more discussion and feedback from #107199 are needed.