### PR TITLE
EditorPlugin: Add dedicated method for workspace button's text

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -259,8 +259,9 @@
 		<method name="_get_plugin_name" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				Override this method in your plugin to provide the name of the plugin when displayed in the Godot editor.
-				For main screen plugins, this appears at the top of the screen, to the right of the "2D", "3D", "Script", "Game", and "AssetLib" buttons.
+				Override this method in your plugin to provide the name of the plugin.
+				This name should be unique if your plugin is a main screen plugin, or uses [method _get_state] and [method _set_state].
+				[b]Note:[/b] [code]"2D"[/code], [code]"3D"[/code], [code]"Script"[/code], [code]"Game"[/code], and [code]"AssetLib"[/code] are reserved for built-in main screen plugins.
 			</description>
 		</method>
 		<method name="_get_state" qualifiers="virtual const">
@@ -318,6 +319,13 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="_get_workspace_display_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+				Override this method in your main screen plugin to provide the text displayed on the workspace button. Falls back to [method _get_plugin_name] if not overridden.
+				[b]Note:[/b] The workspace button does not auto translate. Instead, this method will be called when the editor's language changes. Translate the display name here if needed.
+			</description>
+		</method>
 		<method name="_handles" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="object" type="Object" />
@@ -331,7 +339,7 @@
 			<description>
 				Returns [code]true[/code] if this is a main screen editor plugin (it goes in the workspace selector together with [b]2D[/b], [b]3D[/b], [b]Script[/b], [b]Game[/b], and [b]AssetLib[/b]).
 				When the plugin's workspace is selected, other main screen plugins will be hidden, but your plugin will not appear automatically. It needs to be added as a child of [method EditorInterface.get_editor_main_screen] and made visible inside [method _make_visible].
-				Use [method _get_plugin_name] and [method _get_plugin_icon] to customize the plugin button's appearance.
+				Use [method _get_workspace_display_name] and [method _get_plugin_icon] to customize the workspace button's appearance.
 				[codeblock]
 				var plugin_control
 
@@ -351,7 +359,11 @@
 
 				func _get_plugin_icon():
 					return EditorInterface.get_editor_theme().get_icon("Node", "EditorIcons")
+
+				func _get_workspace_display_name():
+					return "My Workspace"
 				[/codeblock]
+				[b]Note:[/b] You must implement [method _get_plugin_name] for the main screen plugin to work correctly.
 			</description>
 		</method>
 		<method name="_make_visible" qualifiers="virtual">
@@ -782,9 +794,9 @@
 	</methods>
 	<signals>
 		<signal name="main_screen_changed">
-			<param index="0" name="screen_name" type="String" />
+			<param index="0" name="plugin_name" type="String" />
 			<description>
-				Emitted when user changes the workspace ([b]2D[/b], [b]3D[/b], [b]Script[/b], [b]Game[/b], [b]AssetLib[/b]). Also works with custom screens defined by plugins.
+				Emitted when user changes the workspace. [param plugin_name] is the main screen plugin's name returned by [method _get_plugin_name].
 			</description>
 		</signal>
 		<signal name="project_settings_changed" deprecated="Use [signal ProjectSettings.settings_changed] instead.">

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -337,19 +337,11 @@ void EditorData::set_editor_plugin_states(const Dictionary &p_states) {
 	}
 
 	for (const KeyValue<Variant, Variant> &kv : p_states) {
-		String name = kv.key;
-		int idx = -1;
-		for (int i = 0; i < editor_plugins.size(); i++) {
-			if (editor_plugins[i]->get_plugin_name() == name) {
-				idx = i;
-				break;
-			}
-		}
-
-		if (idx == -1) {
+		EditorPlugin *plugin = get_editor_by_name(kv.key);
+		if (plugin == nullptr) {
 			continue;
 		}
-		editor_plugins[idx]->set_state(kv.value);
+		plugin->set_state(kv.value);
 	}
 }
 

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -338,7 +338,8 @@ class AssetLibraryEditorPlugin : public EditorPlugin {
 public:
 	static bool is_available();
 
-	virtual String get_plugin_name() const override { return TTRC("AssetLib"); }
+	virtual String get_plugin_name() const override { return "AssetLib"; }
+	virtual String get_workspace_display_name() const override { return TTR("AssetLib", "Workspace"); }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override {}
 	virtual bool handles(Object *p_object) const override { return false; }

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -602,7 +602,8 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_plugin_name() const override { return TTRC("2D"); }
+	virtual String get_plugin_name() const override { return "2D"; }
+	virtual String get_workspace_display_name() const override { return TTR("2D", "Workspace"); }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -237,13 +237,13 @@ void EditorPlugin::notify_scene_changed(const Node *scn_root) {
 	emit_signal(SNAME("scene_changed"), scn_root);
 }
 
-void EditorPlugin::notify_main_screen_changed(const String &screen_name) {
-	if (screen_name == last_main_screen_name) {
+void EditorPlugin::notify_main_screen_changed(const String &plugin_name) {
+	if (plugin_name == last_main_screen_plugin_name) {
 		return;
 	}
 
-	emit_signal(SNAME("main_screen_changed"), screen_name);
-	last_main_screen_name = screen_name;
+	emit_signal(SNAME("main_screen_changed"), plugin_name);
+	last_main_screen_plugin_name = plugin_name;
 }
 
 void EditorPlugin::notify_scene_closed(const String &scene_filepath) {
@@ -329,6 +329,14 @@ bool EditorPlugin::has_main_screen() const {
 	bool success = false;
 	GDVIRTUAL_CALL(_has_main_screen, success);
 	return success;
+}
+
+String EditorPlugin::get_workspace_display_name() const {
+	String name;
+	if (GDVIRTUAL_CALL(_get_workspace_display_name, name)) {
+		return name;
+	}
+	return get_plugin_name();
 }
 
 void EditorPlugin::make_visible(bool p_visible) {
@@ -652,6 +660,7 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_get_plugin_name);
 	GDVIRTUAL_BIND(_get_plugin_icon);
 	GDVIRTUAL_BIND(_has_main_screen);
+	GDVIRTUAL_BIND(_get_workspace_display_name);
 	GDVIRTUAL_BIND(_make_visible, "visible");
 	GDVIRTUAL_BIND(_edit, "object");
 	GDVIRTUAL_BIND(_handles, "object");
@@ -670,7 +679,7 @@ void EditorPlugin::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("scene_changed", PropertyInfo(Variant::OBJECT, "scene_root", PROPERTY_HINT_RESOURCE_TYPE, "Node")));
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "filepath")));
-	ADD_SIGNAL(MethodInfo("main_screen_changed", PropertyInfo(Variant::STRING, "screen_name")));
+	ADD_SIGNAL(MethodInfo("main_screen_changed", PropertyInfo(Variant::STRING, "plugin_name")));
 	ADD_SIGNAL(MethodInfo("resource_saved", PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource")));
 	ADD_SIGNAL(MethodInfo("scene_saved", PropertyInfo(Variant::STRING, "filepath")));
 	ADD_SIGNAL(MethodInfo("project_settings_changed"));

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -35,11 +35,8 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/gui/control.h"
 
-class Node3D;
 class Button;
-class PopupMenu;
 class EditorDebuggerPlugin;
-class EditorExport;
 class EditorExportPlugin;
 class EditorExportPlatform;
 class EditorImportPlugin;
@@ -49,9 +46,9 @@ class EditorNode3DGizmoPlugin;
 class EditorResourceConversionPlugin;
 class EditorSceneFormatImporter;
 class EditorScenePostImportPlugin;
-class EditorToolAddons;
 class EditorTranslationParserPlugin;
 class EditorUndoRedoManager;
+class PopupMenu;
 class ScriptCreateDialog;
 
 class EditorPlugin : public Node {
@@ -61,7 +58,7 @@ class EditorPlugin : public Node {
 	bool input_event_forwarding_always_enabled = false;
 	bool force_draw_over_forwarding_enabled = false;
 
-	String last_main_screen_name;
+	String last_main_screen_plugin_name;
 	String plugin_version;
 
 #ifndef DISABLE_DEPRECATED
@@ -120,6 +117,7 @@ protected:
 	GDVIRTUAL0RC(String, _get_plugin_name)
 	GDVIRTUAL0RC(Ref<Texture2D>, _get_plugin_icon)
 	GDVIRTUAL0RC(bool, _has_main_screen)
+	GDVIRTUAL0RC(String, _get_workspace_display_name)
 	GDVIRTUAL1(_make_visible, bool)
 	GDVIRTUAL1(_edit, Object *)
 	GDVIRTUAL1RC(bool, _handles, Object *)
@@ -166,7 +164,7 @@ public:
 	void set_force_draw_over_forwarding_enabled();
 	bool is_force_draw_over_forwarding_enabled() { return force_draw_over_forwarding_enabled; }
 
-	void notify_main_screen_changed(const String &screen_name);
+	void notify_main_screen_changed(const String &plugin_name);
 	void notify_scene_changed(const Node *scn_root);
 	void notify_scene_closed(const String &scene_filepath);
 	void notify_resource_saved(const Ref<Resource> &p_resource);
@@ -185,6 +183,7 @@ public:
 	virtual String get_plugin_version() const;
 	virtual void set_plugin_version(const String &p_version);
 	virtual bool has_main_screen() const;
+	virtual String get_workspace_display_name() const;
 	virtual void make_visible(bool p_visible);
 	virtual void selected_notify() {} //notify that it was raised by the user, not the editor
 	virtual void edit(Object *p_object);

--- a/editor/plugins/game_view_plugin.h
+++ b/editor/plugins/game_view_plugin.h
@@ -243,7 +243,8 @@ protected:
 #endif
 
 public:
-	virtual String get_plugin_name() const override { return TTRC("Game"); }
+	virtual String get_plugin_name() const override { return "Game"; }
+	virtual String get_workspace_display_name() const override { return TTR("Game", "Workspace"); }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override {}
 	virtual bool handles(Object *p_object) const override { return false; }

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -1047,7 +1047,8 @@ class Node3DEditorPlugin : public EditorPlugin {
 
 public:
 	Node3DEditor *get_spatial_editor() { return spatial_editor; }
-	virtual String get_plugin_name() const override { return TTRC("3D"); }
+	virtual String get_plugin_name() const override { return "3D"; }
+	virtual String get_workspace_display_name() const override { return TTR("3D", "Workspace"); }
 	bool has_main_screen() const override { return true; }
 	virtual void make_visible(bool p_visible) override;
 	virtual void edit(Object *p_object) override;

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -648,7 +648,8 @@ protected:
 	void _notification(int p_what);
 
 public:
-	virtual String get_plugin_name() const override { return TTRC("Script"); }
+	virtual String get_plugin_name() const override { return "Script"; }
+	virtual String get_workspace_display_name() const override { return TTR("Script", "Workspace"); }
 	bool has_main_screen() const override { return true; }
 	virtual void edit(Object *p_object) override;
 	virtual bool handles(Object *p_object) const override;


### PR DESCRIPTION
Follow-up to #102101.

- Auto translation may not be sufficient to handle the text of a workspace button, especially for custom plugins. See https://github.com/godotengine/godot/pull/102101#issuecomment-2763020877.
- We can't translate inside `_get_plugin_name()` because the name is used as a unique identifier for the main screen plugin and when serializing/deserializing the plugin's state.

This PR provides an overridable `_get_workspace_display_name()` method for plugin authors. The display name defaults to `_get_plugin_name()` when not overridden.

Also put the built-in workspace names inside the `Workspace` context as they are all single words and usage-specific.