### PR TITLE
Add support for global favorite properties

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -182,6 +182,11 @@
 				Emitted when a property was deleted. Used internally.
 			</description>
 		</signal>
+		<signal name="property_favorited">
+			<description>
+				Emit when a property is favorited, making it appear at the top of the inspector.
+			</description>
+		</signal>
 		<signal name="property_favorited_global">
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="favorited" type="bool" />

--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -182,11 +182,18 @@
 				Emitted when a property was deleted. Used internally.
 			</description>
 		</signal>
-		<signal name="property_favorited">
+		<signal name="property_favorited_global">
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="favorited" type="bool" />
 			<description>
-				Emit it if you want to mark a property as favorited, making it appear at the top of the inspector.
+				Emit it if you want to mark a property as favorited globally, making it appear at the top of the inspector.
+			</description>
+		</signal>
+		<signal name="property_favorited_local">
+			<param index="0" name="property" type="StringName" />
+			<param index="1" name="favorited" type="bool" />
+			<description>
+				Emit it if you want to mark a property as favorited locally, making it appear at the top of the inspector.
 			</description>
 		</signal>
 		<signal name="property_keyed">

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1297,15 +1297,18 @@ void EditorProperty::menu_option(int p_option) {
 			DisplayServer::get_singleton()->clipboard_set(property_path);
 		} break;
 		case MENU_UNFAVORITE_BOTH: {
+			emit_signal(SNAME("property_favorited"));
 			emit_signal(SNAME("property_favorited_global"), property, false);
 			emit_signal(SNAME("property_favorited_local"), property, false);
 			queue_redraw();
 		} break;
 		case MENU_FAVORITE_PROPERTY_GLOBAL: {
+			emit_signal(SNAME("property_favorited"));
 			emit_signal(SNAME("property_favorited_global"), property, !favorited);
 			queue_redraw();
 		} break;
 		case MENU_FAVORITE_PROPERTY_LOCAL: {
+			emit_signal(SNAME("property_favorited"));
 			emit_signal(SNAME("property_favorited_local"), property, !favorited);
 			queue_redraw();
 		} break;
@@ -1405,6 +1408,7 @@ void EditorProperty::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("property_deleted", PropertyInfo(Variant::STRING_NAME, "property")));
 	ADD_SIGNAL(MethodInfo("property_keyed_with_value", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT)));
 	ADD_SIGNAL(MethodInfo("property_checked", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "checked")));
+	ADD_SIGNAL(MethodInfo("property_favorited"));
 	ADD_SIGNAL(MethodInfo("property_favorited_local", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "favorited")));
 	ADD_SIGNAL(MethodInfo("property_favorited_global", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "favorited")));
 	ADD_SIGNAL(MethodInfo("property_pinned", PropertyInfo(Variant::STRING_NAME, "property"), PropertyInfo(Variant::BOOL, "pinned")));

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -64,7 +64,9 @@ public:
 		MENU_COPY_VALUE,
 		MENU_PASTE_VALUE,
 		MENU_COPY_PROPERTY_PATH,
-		MENU_FAVORITE_PROPERTY,
+		MENU_UNFAVORITE_BOTH,
+		MENU_FAVORITE_PROPERTY_GLOBAL,
+		MENU_FAVORITE_PROPERTY_LOCAL,
 		MENU_PIN_VALUE,
 		MENU_DELETE,
 		MENU_REVERT_VALUE,
@@ -648,7 +650,8 @@ class EditorInspector : public ScrollContainer {
 	void _object_id_selected(const String &p_path, ObjectID p_id);
 
 	void _update_current_favorites();
-	void _set_property_favorited(const String &p_path, bool p_favorited);
+	void _set_property_favorited_global(const String &p_path, bool p_favorited);
+	void _set_property_favorited_local(const String &p_path, bool p_favorited);
 	void _clear_current_favorites();
 
 	void _node_removed(Node *p_node);

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -100,7 +100,9 @@ private:
 	HashMap<String, List<Ref<InputEvent>>> builtin_action_overrides;
 
 	Vector<String> favorites;
-	HashMap<String, PackedStringArray> favorite_properties;
+	HashMap<String, PackedStringArray> favorite_global_properties;
+	HashMap<String, PackedStringArray> favorite_local_properties;
+
 	Vector<String> recent_dirs;
 
 	bool save_changed_setting = true;
@@ -175,9 +177,11 @@ public:
 	Variant get_project_metadata(const String &p_section, const String &p_key, const Variant &p_default) const;
 
 	void set_favorites(const Vector<String> &p_favorites);
+	void set_favorite_global_properties(const HashMap<String, PackedStringArray> &p_favorite_properties);
+	void set_favorite_local_properties(const HashMap<String, PackedStringArray> &p_favorite_properties);
 	Vector<String> get_favorites() const;
-	void set_favorite_properties(const HashMap<String, PackedStringArray> &p_favorite_properties);
-	HashMap<String, PackedStringArray> get_favorite_properties() const;
+	HashMap<String, PackedStringArray> get_favorite_global_properties() const;
+	HashMap<String, PackedStringArray> get_favorite_local_properties() const;
 	void set_recent_dirs(const Vector<String> &p_recent_dirs);
 	Vector<String> get_recent_dirs() const;
 	void load_favorites_and_recent_dirs();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1701,13 +1701,21 @@ void FileSystemDock::_update_favorites_after_move(const HashMap<String, String> 
 	}
 	EditorSettings::get_singleton()->set_favorites(new_favorite_files);
 
-	HashMap<String, PackedStringArray> favorite_properties = EditorSettings::get_singleton()->get_favorite_properties();
+	HashMap<String, PackedStringArray> favorite_properties = EditorSettings::get_singleton()->get_favorite_local_properties();
 	for (const KeyValue<String, String> &KV : p_files_renames) {
 		if (favorite_properties.has(KV.key)) {
 			favorite_properties.replace_key(KV.key, KV.value);
 		}
 	}
-	EditorSettings::get_singleton()->set_favorite_properties(favorite_properties);
+	EditorSettings::get_singleton()->set_favorite_local_properties(favorite_properties);
+
+	favorite_properties = EditorSettings::get_singleton()->get_favorite_global_properties();
+	for (const KeyValue<String, String> &KV : p_files_renames) {
+		if (favorite_properties.has(KV.key)) {
+			favorite_properties.replace_key(KV.key, KV.value);
+		}
+	}
+	EditorSettings::get_singleton()->set_favorite_global_properties(favorite_properties);
 }
 
 void FileSystemDock::_make_scene_confirm() {


### PR DESCRIPTION
This feature adds two buttons one for adding favorite 
properties to all other projects and only to
the present project being developed.

Co-authored-by: António Delgado <antonio.o.delgado@tecnico.ulisboa.pt>

* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/102944*

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
