### PR TITLE
Fix crash when using `VIEW_INDEX` in shader with Vulkan mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -151,6 +151,7 @@ ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
 #else // USE_MULTIVIEW
+#define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
 }
@@ -882,6 +883,7 @@ ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
 #else // USE_MULTIVIEW
+#define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
 	return uv;
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107187