### PR TITLE
Show shader baker related export warnings only if enabled

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -190,7 +190,7 @@ String EditorExportPlatformAppleEmbedded::get_export_option_warning(const Editor
 			if (access == 0) {
 				return TTR("At least one system boot time access reason should be selected.");
 			}
-		} else if (p_name == "shader_baker/enabled") {
+		} else if (p_name == "shader_baker/enabled" && bool(p_preset->get("shader_baker/enabled"))) {
 			String export_renderer = GLOBAL_GET("rendering/renderer/rendering_method.mobile");
 			if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 				return TTR("\"Shader Baker\" doesn't work with the Compatibility renderer.");

--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -66,7 +66,7 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) c
 }
 
 String EditorExportPlatformPC::get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const {
-	if (p_name == "shader_baker/enabled") {
+	if (p_name == "shader_baker/enabled" && bool(p_preset->get("shader_baker/enabled"))) {
 		String export_renderer = GLOBAL_GET("rendering/renderer/rendering_method");
 		if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 			return TTR("\"Shader Baker\" is not supported when using the Compatibility renderer.");

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2067,7 +2067,7 @@ String EditorExportPlatformAndroid::get_export_option_warning(const EditorExport
 			if (!bool(p_preset->get("package/show_in_app_library")) && !gradle_build_enabled) {
 				return TTR("\"Use Gradle Build\" must be enabled to disable \"Show In App Library\".");
 			}
-		} else if (p_name == "shader_baker/enabled") {
+		} else if (p_name == "shader_baker/enabled" && bool(p_preset->get("shader_baker/enabled"))) {
 			String export_renderer = GLOBAL_GET("rendering/renderer/rendering_method.mobile");
 			if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 				return TTR("\"Shader Baker\" is not supported when using the Compatibility renderer.");

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -103,7 +103,7 @@ String EditorExportPlatformMacOS::get_export_option_warning(const EditorExportPr
 			}
 		}
 
-		if (p_name == "shader_baker/enabled") {
+		if (p_name == "shader_baker/enabled" && bool(p_preset->get("shader_baker/enabled"))) {
 			String export_renderer = GLOBAL_GET("rendering/renderer/rendering_method");
 			if (OS::get_singleton()->get_current_rendering_method() == "gl_compatibility") {
 				return TTR("\"Shader Baker\" is not supported when using the Compatibility renderer.");


### PR DESCRIPTION
Currently export window shows the shader baker warnings even if feature itself is disabled. This PR changes that to only show related warnings if shader_baker is `enabled`.
