### PR TITLE
Fix thread safety issue in resource changed callbacks during imports

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -968,7 +968,7 @@ void ResourceLoader::resource_changed_emit(Resource *p_source) {
 
 	for (const ThreadLoadTask::ResourceChangedConnection &rcc : curr_load_task->resource_changed_connections) {
 		if (unlikely(rcc.source == p_source)) {
-			rcc.callable.call();
+			rcc.callable.call_deferred();
 		}
 	}
 }


### PR DESCRIPTION

## Summary

Fixes a segmentation fault that occurs when font resources are imported in background threads and emit “changed” signals that trigger thread-unsafe node operations.

## Problem

When importing font files, the ResourceLoader can emit “resource changed” callbacks from background threads. These callbacks may be connected to GUI nodes (for example, RichTextLabel) that perform operations requiring main‐thread access, causing thread‐safety violations and crashes.

The specific error trace is:

```
ERROR: Caller thread can't call this function in this node (/root). Use call_deferred() or call_thread_group() instead.
    at: propagate_notification (scene/main/node.cpp:2523)
```

## Solution

Modify `ResourceLoader::resource_changed_emit()` to use `call_deferred()` instead of a direct `call()` when invoking callbacks. This ensures all “resource changed” signals run on the main thread, preventing thread‐safety violations.
