### PR TITLE
Fix resources wrongly duplicated upon instantiating inherited scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -356,17 +356,17 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 					} else {
 						Variant value = props[nprops[j].value];
 
-						// Making sure that instances of inherited scenes don't share the same
-						// reference between them.
-						if (is_inherited_scene) {
-							value = value.duplicate(true);
-						}
-
 						if (value.get_type() == Variant::OBJECT) {
 							//handle resources that are local to scene by duplicating them if needed
 							Ref<Resource> res = value;
 							if (res.is_valid()) {
 								value = make_local_resource(value, n, resources_local_to_sub_scene, node, snames[nprops[j].name], resources_local_to_scene, i, ret_nodes, p_edit_state);
+							}
+						} else {
+							// Making sure that instances of inherited scenes don't share the same
+							// reference between them.
+							if (is_inherited_scene) {
+								value = value.duplicate(true);
 							}
 						}
 


### PR DESCRIPTION
Since #100673 made `Variant::duplicate()` work on `Resource` objects instead of just returning a reference to the original, part of the work was adapting code calliing it that wanted to keep the former behavior.

This PR does so for one case I missed.

Fixes #107104.
Fixes #107186.
Fixes #107236.

Supersedes #107173.