### PR TITLE
Add search syntax to the editor's Output panel search filter

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -320,9 +320,7 @@ void EditorLog::_rebuild_log() {
 
 bool EditorLog::_check_display_message(LogMessage &p_message) {
 	bool filter_active = type_filter_map[p_message.type]->is_active();
-	String search_text = search_box->get_text();
-	bool search_match = search_text.is_empty() || p_message.text.containsn(search_text);
-	return filter_active && search_match;
+	return filter_active && search_filter->match(p_message.text);
 }
 
 void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
@@ -421,6 +419,7 @@ void EditorLog::_set_search_visible(bool p_visible) {
 }
 
 void EditorLog::_search_changed(const String &p_text) {
+	EditorLogSearchParser(p_text).parse(search_filter);
 	_rebuild_log();
 }
 

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/os/thread.h"
+#include "editor/editor_log_search_filter.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/line_edit.h"
@@ -138,6 +139,7 @@ private:
 
 	Button *show_search_button = nullptr;
 	LineEdit *search_box = nullptr;
+	Ref<EditorLogSearchFilter> search_filter = memnew(EditorLogSearchFilter());
 
 	// Reference to the "Output" button on the toolbar so we can update its icon when warnings or errors are encountered.
 	Button *tool_button = nullptr;

--- a/editor/editor_log_search_filter.cpp
+++ b/editor/editor_log_search_filter.cpp
@@ -1,0 +1,638 @@
+/**************************************************************************/
+/*  editor_log_search_filter.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor/editor_log_search_filter.h"
+
+EditorLogSearchFilter::Node::~Node() {
+}
+
+EditorLogSearchFilter::ContainsNode::ContainsNode(const String &p_contained, bool p_exact) :
+		Node(), contained(p_contained), exact(p_exact) {}
+
+bool EditorLogSearchFilter::ContainsNode::match(const String &p_text) const {
+	if (exact) {
+		return p_text.contains(contained);
+	}
+	return p_text.containsn(contained);
+}
+
+EditorLogSearchFilter::NotNode::NotNode() {}
+
+EditorLogSearchFilter::NotNode::NotNode(Node *p_argument) :
+		Node(), argument(p_argument) {}
+
+EditorLogSearchFilter::NotNode::NotNode(NotNode &&p_other) :
+		Node(), argument(p_other.argument) {
+	p_other.argument = nullptr;
+}
+
+void EditorLogSearchFilter::NotNode::operator=(NotNode &&p_other) {
+	if (this == &p_other) {
+		return;
+	}
+	if (argument) {
+		memdelete(argument);
+	}
+	argument = p_other.argument;
+	p_other.argument = nullptr;
+}
+
+EditorLogSearchFilter::NotNode::~NotNode() {
+	if (argument) {
+		memdelete(argument);
+		argument = nullptr;
+	}
+}
+
+bool EditorLogSearchFilter::NotNode::match(const String &p_text) const {
+	return !argument->match(p_text);
+}
+
+EditorLogSearchFilter::BinaryOpNode::BinaryOpNode() :
+		Node() {}
+
+EditorLogSearchFilter::BinaryOpNode::BinaryOpNode(Node *p_left, Node *p_right) :
+		Node(), left(p_left), right(p_right) {}
+
+EditorLogSearchFilter::BinaryOpNode::BinaryOpNode(BinaryOpNode &&p_other) :
+		Node(), left(p_other.left), right(p_other.right) {
+	p_other.left = nullptr;
+	p_other.right = nullptr;
+}
+
+void EditorLogSearchFilter::BinaryOpNode::operator=(BinaryOpNode &&p_other) {
+	if (this == &p_other) {
+		return;
+	}
+	if (left) {
+		memdelete(left);
+	}
+	if (right) {
+		memdelete(right);
+	}
+	left = p_other.left;
+	right = p_other.right;
+	p_other.left = nullptr;
+	p_other.right = nullptr;
+}
+
+EditorLogSearchFilter::BinaryOpNode::~BinaryOpNode() {
+	if (left) {
+		memdelete(left);
+		left = nullptr;
+	}
+	if (right) {
+		memdelete(right);
+		right = nullptr;
+	}
+}
+
+void EditorLogSearchFilter::BinaryOpNode::set_left(Node *p_left) {
+	if (left && left != p_left) {
+		memdelete(left);
+	}
+	left = p_left;
+}
+
+void EditorLogSearchFilter::BinaryOpNode::set_right(Node *p_right) {
+	if (right && right != p_right) {
+		memdelete(right);
+	}
+	right = p_right;
+}
+
+const EditorLogSearchFilter::Node *EditorLogSearchFilter::BinaryOpNode::get_left() const {
+	return left;
+}
+
+const EditorLogSearchFilter::Node *EditorLogSearchFilter::BinaryOpNode::get_right() const {
+	return right;
+}
+
+EditorLogSearchFilter::AndNode::AndNode() :
+		BinaryOpNode() {}
+
+EditorLogSearchFilter::AndNode::AndNode(Node *p_left, Node *p_right) :
+		BinaryOpNode(p_left, p_right) {}
+
+bool EditorLogSearchFilter::AndNode::match(const String &p_text) const {
+	return get_left()->match(p_text) && get_right()->match(p_text);
+}
+
+EditorLogSearchFilter::OrNode::OrNode() :
+		BinaryOpNode() {}
+
+EditorLogSearchFilter::OrNode::OrNode(Node *p_left, Node *p_right) :
+		BinaryOpNode(p_left, p_right) {}
+
+bool EditorLogSearchFilter::OrNode::match(const String &p_text) const {
+	return get_left()->match(p_text) || get_right()->match(p_text);
+}
+
+EditorLogSearchFilter::EditorLogSearchFilter() :
+		RefCounted() {}
+
+EditorLogSearchFilter::EditorLogSearchFilter(Node *p_filter) :
+		RefCounted(), filter(p_filter) {}
+
+EditorLogSearchFilter::~EditorLogSearchFilter() {
+	if (filter) {
+		memdelete(filter);
+	}
+}
+
+bool EditorLogSearchFilter::match(const String &p_text) const {
+	return !filter || filter->match(p_text);
+}
+
+EditorLogSearchParser::Tokenizer::Token::Token() {}
+
+EditorLogSearchParser::Tokenizer::Token::Token(Type p_type) :
+		type(p_type) {}
+
+EditorLogSearchParser::Tokenizer::Token::Token(Type p_type, const String &p_value) :
+		type(p_type), value(p_value) {}
+
+EditorLogSearchParser::Tokenizer::Token::Type EditorLogSearchParser::Tokenizer::Token::get_type() const {
+	return type;
+}
+
+void EditorLogSearchParser::Tokenizer::Token::set_type(Type p_type) {
+	type = p_type;
+}
+
+const String &EditorLogSearchParser::Tokenizer::Token::get_value() const {
+	return value;
+}
+
+void EditorLogSearchParser::Tokenizer::Token::set_value(const String &p_value) {
+	value = p_value;
+}
+
+void EditorLogSearchParser::Tokenizer::Token::append(const String &p_suffix) {
+	value += p_suffix;
+}
+
+void EditorLogSearchParser::Tokenizer::Token::append(char32_t p_char) {
+	value += p_char;
+}
+
+String EditorLogSearchParser::Tokenizer::Token::get_name(Type p_type) {
+	String name;
+	switch (p_type) {
+		case EMPTY: {
+			name = "";
+			break;
+		}
+
+		case LITERAL: {
+			name = "LITERAL";
+			break;
+		}
+
+		case QUOTED_LITERAL: {
+			name = "QUOTED LITERAL";
+			break;
+		}
+
+		case DOUBLE_PIPE: {
+			name = "||";
+			break;
+		}
+
+		case MINUS: {
+			name = "-";
+			break;
+		}
+
+		case OPEN_PAREN: {
+			name = "(";
+			break;
+		}
+
+		case CLOSE_PAREN: {
+			name = ")";
+			break;
+		}
+
+		case TK_EOF: {
+			name = "EOF";
+			break;
+		}
+
+		case ERROR: {
+			name = "ERROR";
+			break;
+		}
+	}
+	return name;
+}
+
+char32_t EditorLogSearchParser::Tokenizer::_peek(int p_offset) {
+	int idx = position + p_offset;
+	if (idx < 0 || idx >= source.length()) {
+		return '\0';
+	}
+	return source[idx];
+}
+
+char32_t EditorLogSearchParser::Tokenizer::_advance(unsigned int p_offset) {
+	position += p_offset;
+	if (position >= source.length()) {
+		position = source.length() + 1;
+		return '\0';
+	}
+	return source[position++];
+}
+
+char32_t EditorLogSearchParser::Tokenizer::_back(unsigned int p_offset) {
+	position -= p_offset;
+	if (position <= 0) {
+		position = 0;
+		return '\0';
+	}
+	if (position > source.length()) {
+		position = source.length();
+		return '\0';
+	}
+	return source[--position];
+}
+
+bool EditorLogSearchParser::Tokenizer::_is_whitespace(char32_t p_char) {
+	return p_char == ' ';
+}
+
+bool EditorLogSearchParser::Tokenizer::_is_delimiter(char32_t p_char) {
+	switch (p_char) {
+		case '(':
+		case ')':
+		case '"':
+		case '\'':
+		case '\0': {
+			return true;
+		}
+
+		default: {
+			return _is_whitespace(p_char);
+		}
+	}
+}
+
+void EditorLogSearchParser::Tokenizer::_consume_whitespace() {
+	while (true) {
+		if (_is_whitespace(_advance())) {
+			continue;
+		}
+		_back();
+		return;
+	}
+}
+
+/**
+ * Parses a token that starts after a delimiter.
+ * Note that the delimiter itself should have already been consumed before
+ * calling the function.
+ */
+EditorLogSearchParser::Tokenizer::Token EditorLogSearchParser::Tokenizer::_delimiter_start() {
+	char32_t start = _advance();
+	switch (start) {
+		case '-': {
+			return Token(Token::MINUS);
+		}
+
+		case '|': {
+			if (_peek() != '|' || !_is_delimiter(_peek(1))) {
+				break;
+			}
+			_advance();
+			return Token(Token::DOUBLE_PIPE);
+		}
+
+		default: {
+			break;
+		}
+	}
+	_back();
+	return _non_delimiter_start();
+}
+
+/**
+ * Parses a token that doesn't necessarily come after a delimiter (although
+ * the token itself may begin with one).
+ */
+EditorLogSearchParser::Tokenizer::Token EditorLogSearchParser::Tokenizer::_non_delimiter_start() {
+	char32_t start = _advance();
+	Token scanned;
+	switch (start) {
+		case '(': {
+			scanned = Token(Token::OPEN_PAREN);
+			break;
+		}
+
+		case ')': {
+			scanned = Token(Token::CLOSE_PAREN);
+			break;
+		}
+
+		case '\0': {
+			scanned = Token(Token::TK_EOF);
+			break;
+		}
+
+		default: {
+			_back();
+			_parse_literal(scanned);
+			break;
+		}
+	}
+	return scanned;
+}
+
+/**
+ * Parses a literal in the form: <literal>, "<literal>" or '<literal>'.
+ */
+void EditorLogSearchParser::Tokenizer::_parse_literal(Token &r_token) {
+	char32_t start = _peek();
+	bool is_quote = start == '\'' || start == '"';
+	if (_is_delimiter(start) && !is_quote) {
+		r_token.set_type(Token::EMPTY);
+		r_token.set_value("");
+		return;
+	}
+
+	if (!is_quote) {
+		r_token.set_type(Token::LITERAL);
+		while (true) {
+			char32_t c = _advance();
+			if (_is_delimiter(c)) {
+				_back();
+				return;
+			}
+			r_token.append(c);
+		}
+	}
+
+	r_token.set_type(Token::QUOTED_LITERAL);
+	_advance();
+	while (true) {
+		char32_t c = _advance();
+		if (c == start) {
+			return;
+		}
+
+		if (c == '\0') {
+			_back();
+			r_token.set_type(Token::ERROR);
+			r_token.set_value(String("Expected to find closing ") + start);
+			return;
+		}
+
+		if (c == '\\') {
+			c = _advance();
+			if (c == '\0') {
+				_back(1);
+				r_token.set_type(Token::ERROR);
+				r_token.set_value(String("Expected to find closing ") + start);
+				return;
+			}
+			r_token.append(c);
+			continue;
+		}
+
+		r_token.append(c);
+	}
+}
+
+EditorLogSearchParser::Tokenizer::Tokenizer(const String &p_source) :
+		source(p_source) {}
+
+/**
+ * Consumes the next token and returns it.
+ * It's important to note that the '-' token expects a delimiter (i.e. \0, (, ), ", ' or whitespace)
+ * to appear before it and '||' expects delimiters before and after.
+ * This means that the string "--a" will read as "-" "-a", "a||b" as "a||b",
+ * "a|| b" as "a||" "b" and "a || b" as "a" "||" "b".
+ */
+EditorLogSearchParser::Tokenizer::Token EditorLogSearchParser::Tokenizer::next() {
+	if (peeked) {
+		peeked = false;
+		return emitted_last;
+	}
+
+	if (emitted_last.get_type() == Token::ERROR) {
+		return emitted_last;
+	}
+
+	Token scanned = Token();
+	_consume_whitespace();
+	if (_is_delimiter(_peek(-1))) {
+		scanned = _delimiter_start();
+	} else {
+		scanned = _non_delimiter_start();
+	}
+
+	emitted_last = scanned;
+	return scanned;
+}
+
+EditorLogSearchParser::Tokenizer::Token EditorLogSearchParser::Tokenizer::peek() {
+	if (peeked) {
+		return emitted_last;
+	}
+
+	if (emitted_last.get_type() == Token::ERROR) {
+		return emitted_last;
+	}
+
+	next();
+	peeked = true;
+	return emitted_last;
+}
+
+int EditorLogSearchParser::_get_left_precedence(LeftPrecedence p_op) {
+	return 2 * p_op + 1;
+}
+
+int EditorLogSearchParser::_get_right_precedence(RightPrecedence p_op) {
+	return 2 * (p_op + 1);
+}
+
+bool EditorLogSearchParser::_can_begin_expression(const Tokenizer::Token &p_token) {
+	switch (p_token.get_type()) {
+		case Tokenizer::Token::OPEN_PAREN:
+		case Tokenizer::Token::QUOTED_LITERAL:
+		case Tokenizer::Token::LITERAL:
+		case Tokenizer::Token::MINUS: {
+			return true;
+		}
+
+		default: {
+			return false;
+		}
+	}
+}
+
+EditorLogSearchFilter::Node *EditorLogSearchParser::_parse(int p_min_prec) {
+	Tokenizer::Token tlhs = tokenizer.next();
+	EditorLogSearchFilter::Node *lhs = nullptr;
+	switch (tlhs.get_type()) {
+		case Tokenizer::Token::LITERAL: {
+			lhs = memnew(EditorLogSearchFilter::ContainsNode(tlhs.get_value(), false));
+			break;
+		}
+
+		case Tokenizer::Token::QUOTED_LITERAL: {
+			lhs = memnew(EditorLogSearchFilter::ContainsNode(tlhs.get_value(), true));
+			break;
+		}
+
+		case Tokenizer::Token::OPEN_PAREN: {
+			lhs = _parse(0);
+			if (!lhs) {
+				return nullptr;
+			}
+			Tokenizer::Token close_paren = tokenizer.next().get_type();
+			if (close_paren.get_type() != Tokenizer::Token::CLOSE_PAREN) {
+				memdelete(lhs);
+				error_message = vformat("Expected %s token, got %s instead", Tokenizer::Token::get_name(Tokenizer::Token::CLOSE_PAREN), Tokenizer::Token::get_name(close_paren.get_type()));
+				return nullptr;
+			}
+			break;
+		}
+
+		case Tokenizer::Token::MINUS: {
+			EditorLogSearchFilter::Node *arg = _parse(_get_right_precedence(R_NOT));
+			if (!arg) {
+				return nullptr;
+			}
+			lhs = memnew(EditorLogSearchFilter::NotNode(arg));
+			break;
+		}
+
+		case Tokenizer::Token::ERROR: {
+			error_message = tlhs.get_value();
+			return nullptr;
+		}
+
+		default: {
+			error_message = vformat("Found unexpected %s token", Tokenizer::Token::get_name(tlhs.get_type()));
+			return nullptr;
+		}
+	}
+
+	while (true) {
+		int left_prec = 0;
+		int right_prec = 0;
+		bool injected = false;
+		Tokenizer::Token top = tokenizer.peek();
+		EditorLogSearchFilter::BinaryOpNode *op = nullptr;
+
+		switch (top.get_type()) {
+			case Tokenizer::Token::CLOSE_PAREN:
+			case Tokenizer::Token::TK_EOF: {
+				return lhs;
+			}
+
+			case Tokenizer::Token::DOUBLE_PIPE: {
+				op = memnew(EditorLogSearchFilter::OrNode());
+				left_prec = _get_left_precedence(L_OR);
+				right_prec = _get_right_precedence(R_OR);
+				break;
+			}
+
+			default: {
+				if (!_can_begin_expression(top)) {
+					memdelete(lhs);
+					error_message = vformat("Found unexpected \"%s\" token", Tokenizer::Token::get_name(top.get_type()));
+					return nullptr;
+				}
+				op = memnew(EditorLogSearchFilter::AndNode());
+				injected = true;
+				left_prec = _get_left_precedence(L_AND);
+				right_prec = _get_right_precedence(R_AND);
+				break;
+			}
+		}
+
+		if (left_prec < p_min_prec) {
+			memdelete(op);
+			break;
+		}
+		if (!injected) {
+			tokenizer.next();
+		}
+
+		EditorLogSearchFilter::Node *rhs = _parse(right_prec);
+		if (!rhs) {
+			memdelete(lhs);
+			memdelete(op);
+			return nullptr;
+		}
+		op->set_left(lhs);
+		op->set_right(rhs);
+		lhs = op;
+	}
+
+	return lhs;
+}
+
+EditorLogSearchParser::EditorLogSearchParser(const String &p_filter) :
+		tokenizer(p_filter) {}
+
+/**
+ * Parses the source string into a filter.
+ * The available operations are:
+ * 		literal			(message must contain the specified literal, ignoring case)
+ * 		"literal"		(message must contain the specified literal, case matters)
+ * 		'literal'		(same as above)
+ * 		expr || expr	(logical OR);
+ * 		-expr			(logical NOT)
+ * 		(expr)
+ * 		expr expr		(implicitly ANDs both expressions)
+ *
+ * Note that, unless quoted, literals must not contain spaces. For instance,
+ * the string: hello world; will match hello AND world, not hello <space> world.
+ */
+Error EditorLogSearchParser::parse(Ref<EditorLogSearchFilter> &p_filter) {
+	if (tokenizer.peek().get_type() == Tokenizer::Token::TK_EOF) {
+		p_filter = memnew(EditorLogSearchFilter());
+		return OK;
+	}
+	EditorLogSearchFilter::Node *parsed = _parse(0);
+	if (!parsed) {
+		return ERR_PARSE_ERROR;
+	}
+	p_filter = memnew(EditorLogSearchFilter(parsed));
+	return OK;
+}
+
+String EditorLogSearchParser::get_error_message() {
+	return error_message;
+}

--- a/editor/editor_log_search_filter.h
+++ b/editor/editor_log_search_filter.h
@@ -1,0 +1,238 @@
+/**************************************************************************/
+/*  editor_log_search_filter.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/ref_counted.h"
+
+class EditorLogSearchFilter : public RefCounted {
+	GDCLASS(EditorLogSearchFilter, RefCounted);
+
+public:
+	class Node {
+	public:
+		virtual ~Node();
+
+		virtual bool match(const String &p_text) const = 0;
+	};
+
+	class ContainsNode : public Node {
+		String contained;
+		bool exact;
+
+	public:
+		ContainsNode(const String &p_contained, bool p_exact);
+
+		bool match(const String &p_text) const override;
+	};
+
+	class NotNode : public Node {
+		Node *argument = nullptr;
+
+	public:
+		NotNode();
+
+		NotNode(Node *p_argument);
+
+		NotNode(NotNode &&p_other);
+
+		void operator=(NotNode &&p_other);
+
+		~NotNode();
+
+		bool match(const String &p_text) const override;
+
+		NotNode(const NotNode &p_other) = delete;
+
+		void operator=(const NotNode &p_other) = delete;
+	};
+
+	class BinaryOpNode : public Node {
+		Node *left = nullptr;
+		Node *right = nullptr;
+
+	public:
+		BinaryOpNode();
+
+		BinaryOpNode(Node *p_left, Node *p_right);
+
+		BinaryOpNode(BinaryOpNode &&p_other);
+
+		void operator=(BinaryOpNode &&p_other);
+
+		~BinaryOpNode();
+
+		void set_left(Node *p_left);
+
+		void set_right(Node *p_right);
+
+		const Node *get_left() const;
+
+		const Node *get_right() const;
+
+		BinaryOpNode(const BinaryOpNode &p_other) = delete;
+
+		void operator=(const BinaryOpNode &p_other) = delete;
+	};
+
+	class AndNode : public BinaryOpNode {
+	public:
+		AndNode();
+
+		AndNode(Node *p_left, Node *p_right);
+
+		bool match(const String &p_text) const override;
+	};
+
+	class OrNode : public BinaryOpNode {
+	public:
+		OrNode();
+
+		OrNode(Node *p_left, Node *p_right);
+
+		bool match(const String &p_text) const override;
+	};
+
+private:
+	Node *filter = nullptr;
+
+public:
+	EditorLogSearchFilter();
+
+	EditorLogSearchFilter(Node *p_filter);
+
+	~EditorLogSearchFilter();
+
+	bool match(const String &p_text) const;
+};
+
+class EditorLogSearchParser {
+	class Tokenizer {
+	public:
+		struct Token {
+			enum Type {
+				EMPTY,
+				LITERAL,
+				QUOTED_LITERAL,
+				DOUBLE_PIPE,
+				MINUS,
+				OPEN_PAREN,
+				CLOSE_PAREN,
+				TK_EOF,
+				ERROR
+			};
+
+		private:
+			Type type = EMPTY;
+			String value = "";
+
+		public:
+			Token();
+
+			Token(Type p_type);
+
+			Token(Type p_type, const String &p_value);
+
+			Type get_type() const;
+
+			void set_type(Type p_type);
+
+			const String &get_value() const;
+
+			void set_value(const String &p_value);
+
+			void append(const String &p_suffix);
+
+			void append(char32_t p_char);
+
+			static String get_name(Type p_type);
+		};
+
+	private:
+		String source;
+		int position = 0;
+		bool peeked = false;
+		Token emitted_last = Token();
+
+		char32_t _peek(int p_offset = 0);
+
+		char32_t _advance(unsigned int p_offset = 0);
+
+		char32_t _back(unsigned int p_offset = 0);
+
+		bool _is_whitespace(char32_t p_char);
+
+		bool _is_delimiter(char32_t p_char);
+
+		void _consume_whitespace();
+
+		Token _delimiter_start();
+
+		Token _non_delimiter_start();
+
+		void _parse_literal(Token &r_token);
+
+	public:
+		Tokenizer(const String &p_source);
+
+		Token next();
+
+		Token peek();
+	};
+
+	Tokenizer tokenizer;
+	String error_message = "";
+
+	enum LeftPrecedence {
+		L_OR,
+		L_AND
+	};
+
+	enum RightPrecedence {
+		R_OR,
+		R_AND,
+		R_NOT
+	};
+
+	int _get_left_precedence(LeftPrecedence p_op);
+
+	int _get_right_precedence(RightPrecedence p_op);
+
+	bool _can_begin_expression(const Tokenizer::Token &p_token);
+
+	EditorLogSearchFilter::Node *_parse(int p_min_prec);
+
+public:
+	EditorLogSearchParser(const String &p_filter);
+
+	Error parse(Ref<EditorLogSearchFilter> &r_filter);
+
+	String get_error_message();
+};


### PR DESCRIPTION
Currently, you can only filter Godot's panel output logs by their category and whether or not they contain a given substring.

@rafaelgcruz and I implemented a filter that can do boolean operations (AND, OR and NOT) between search terms (this draft PR is a possible implementation of godotengine/godot-proposals#11244).

The syntax is similar to Google and GitHub, with a few differences. You can:

1. match a term, excluding case, by writing it without spaces between each character (i.e. \<Godot\> will match \<Godot\>, \<GODOT\>, \<gODOt\>, etc..., but \<Go dot\> will match \<Go\> AND \<dot\> instead);
2. exactly match a term, including case, by writing <"term"> or <'term'>. This also allows you to match spaces. You can escape nested quotation marks using \\, or by just using a different quotation mark on the outside (i.e. \<"\\"term\\""\>, \<'"term"'\> will both exactly match \<"term"\>);
3. AND two expressions by writing a delimiter (like ", ', (, ), or a space), meaning \<hello world\>, \<hello(world)\>, \<"hello"world\> all match \<hello\> AND \<world\> (with the third example matching hello's case);
4. OR two expressions by typing \<expr || expr\>. Note that || needs a delimiter before and after, otherwise it'll be joined with its neighbouring search term (i.e. \<hello||world\> will literally match \<hello||world\>, \<hello ||world\> will match \<hello\> AND \<||world\>. Only \<hello || world\>, \<"hello"|| world\>, \<'hello'||'world'\> will match \<hello\> OR \<world\>);
5. negate an expression by typing \<-expr\>. The - token needs a delimiter right before it to match, meaning \<hello-world\> will match \<hello-world\> while \<-hello\> will match every log that does not contain \<hello\>. Note that the beginning and end of the input string are also delimiters, meaning you can write - at the beginning of the filter and it will correctly match the NOT operator;
6. use (expr) to group operations (change their associativity).

Consecutive spaces are ignored.

Note: \< and \> are there just to distinguish the PR message and what the user searched for/what the filter is trying to match.

Also, NOT has the highest precedence, followed by AND and lastly OR.

Here are some more examples of how the parser would parse some inputs:

1. \<hello -(world godot)\> will be parsed as (\<hello\> AND (NOT (\<world\> AND \<godot\>)));
2. \<hello -world || godot\> will be parsed as ((\<hello\> AND (NOT \<world\>)) OR \<godot\>);
3. \<'foo "bar" baz'\> will exactly match <foo "bar" baz> (i.e. you can use ' inside " and the other way around);
4. \<---\> will be parsed as NOT \<--\>;
5. \<||(world)\> will be parsed as (OR \<world\>), causing a syntax error;
6. <> (the empty filter) will match every log.

Naturally, we're open to discussing and changing the syntax. We encourage everyone to try out the feature for themselves and give feedback on what to improve.

We also hope you can give us pointers on how to better adapt our design to match Godot's.

Finally, regarding the code itself, we essentially made two classes: EditorLogSearchFilter and EditorLogSearchParser (this one has a tokenizer class inside). As the names suggest, the latter parses the search text into an AST we then traverse it to accept/reject each message. The filter itself is just a thin refcounted wrapper over the root node of the AST. It essentially just has two tasks: own the entire tree and provide the empty filter functionality (i.e. accept everything if there are no nodes).

If you have any questions about the feature (i.e. something about the syntax we failed to explain, etc...), you're welcome to ask :smiley: 

See also:
* https://github.com/godotengine/godot/pull/107148