### PR TITLE
Document limitations of native touch event support (and impact on touch emulation)

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -429,9 +429,11 @@
 	<members>
 		<member name="emulate_mouse_from_touch" type="bool" setter="set_emulate_mouse_from_touch" getter="is_emulating_mouse_from_touch">
 			If [code]true[/code], sends mouse input events when tapping or swiping on the touchscreen. See also [member ProjectSettings.input_devices/pointing/emulate_mouse_from_touch].
+			[b]Note:[/b] This property only affects platforms where Godot supports [i]native[/i] touch events, i.e. Android and iOS. On desktop platforms, changing this setting's value has no effect since the OS will be sending mouse events when the user touches the screen.
 		</member>
 		<member name="emulate_touch_from_mouse" type="bool" setter="set_emulate_touch_from_mouse" getter="is_emulating_touch_from_mouse">
 			If [code]true[/code], sends touch input events when clicking or dragging the mouse. See also [member ProjectSettings.input_devices/pointing/emulate_touch_from_mouse].
+			[b]Note:[/b] Since Godot does not support [i]native[/i] touch events on desktop platforms, you should enable this property when using a touchscreen on a desktop device to test mobile interactions.
 		</member>
 		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
 			Controls the mouse mode.

--- a/doc/classes/InputEventMagnifyGesture.xml
+++ b/doc/classes/InputEventMagnifyGesture.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Stores the factor of a magnifying touch gesture. This is usually performed when the user pinches the touch screen and used for zooming in/out.
+		[b]Note:[/b] This [InputEvent] is only emitted on platforms where Godot supports [i]native[/i] touch events, i.e. Android and iOS. On desktop platforms, this event type is never emitted unless done manually through a script with [method Input.parse_input_event].
 		[b]Note:[/b] On Android, this requires the [member ProjectSettings.input_devices/pointing/android/enable_pan_and_scale_gestures] project setting to be enabled.
 	</description>
 	<tutorials>

--- a/doc/classes/InputEventPanGesture.xml
+++ b/doc/classes/InputEventPanGesture.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Stores information about pan gestures. A pan gesture is performed when the user swipes the touch screen with two fingers. It's typically used for panning/scrolling.
+		[b]Note:[/b] This [InputEvent] is only emitted on platforms where Godot supports [i]native[/i] touch events, i.e. Android and iOS. On desktop platforms, this event type is never emitted unless done manually through a script with [method Input.parse_input_event].
 		[b]Note:[/b] On Android, this requires the [member ProjectSettings.input_devices/pointing/android/enable_pan_and_scale_gestures] project setting to be enabled.
 	</description>
 	<tutorials>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Stores information about screen drag events. See [method Node._input].
+		[b]Note:[/b] This [InputEvent] is only emitted on platforms where Godot supports [i]native[/i] touch events, i.e. Android and iOS. On desktop platforms, this event type is never emitted unless done manually through a script with [method Input.parse_input_event].
 	</description>
 	<tutorials>
 		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Stores information about multi-touch press/release input events. Supports touch press, touch release and [member index] for multi-touch count and order.
+		[b]Note:[/b] This [InputEvent] is only emitted on platforms where Godot supports [i]native[/i] touch events, i.e. Android and iOS. On desktop platforms, this event type is never emitted unless done manually through a script with [method Input.parse_input_event].
 	</description>
 	<tutorials>
 		<link title="Using InputEvent">$DOCS_URL/tutorials/inputs/inputevent.html</link>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1611,9 +1611,11 @@
 		</member>
 		<member name="input_devices/pointing/emulate_mouse_from_touch" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], sends mouse input events when tapping or swiping on the touchscreen.
+			[b]Note:[/b] This setting only affects platforms where Godot supports [i]native[/i] touch events, i.e. Android and iOS. On desktop platforms, changing this setting's value has no effect since the OS will be sending mouse events when the user touches the screen.
 		</member>
 		<member name="input_devices/pointing/emulate_touch_from_mouse" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], sends touch input events when clicking or dragging the mouse.
+			If [code]true[/code], sends touch input events when clicking or dragging the mouse. This is useful to test touch input on desktop platforms.
+			[b]Note:[/b] Since Godot does not support [i]native[/i] touch events on desktop platforms, you should enable this setting when using a touchscreen on a desktop device to test mobile interactions.
 		</member>
 		<member name="input_devices/sensors/enable_accelerometer" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the accelerometer sensor is enabled and [method Input.get_accelerometer] returns valid data.


### PR DESCRIPTION
- This closes #75828.
