### PR TITLE
Add warnings for Viewport not supporting TAA/FSR with transparent background

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2738,6 +2738,7 @@
 			Enables temporal antialiasing for the default screen [Viewport]. TAA works by jittering the camera and accumulating the images of the last rendered frames, motion vector rendering is used to account for camera and object motion. Enabling TAA can make the image blurrier, which is partially counteracted by automatically using a negative mipmap LOD bias (see [member rendering/textures/default_filters/texture_mipmap_bias]).
 			[b]Note:[/b] The implementation is not complete yet. Some visual instances such as particles and skinned meshes may show ghosting artifacts in motion.
 			[b]Note:[/b] TAA is only supported in the Forward+ rendering method, not Mobile or Compatibility.
+			[b]Note:[/b] TAA is not compatible with viewports that use a transparent background. TAA will be disabled if [member rendering/viewport/transparent_background] is [code]true[/code].
 			[b]Note:[/b] This property is only read when the project starts. To set TAA at runtime, set [member Viewport.use_taa] on the root [Viewport] instead, or use [method RenderingServer.viewport_set_use_taa].
 		</member>
 		<member name="rendering/anti_aliasing/screen_space_roughness_limiter/amount" type="float" setter="" getter="" default="0.25">
@@ -3260,8 +3261,10 @@
 			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.
 		</member>
 		<member name="rendering/scaling_3d/mode" type="int" setter="" getter="" default="0">
-			Sets the scaling 3D mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially-aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. On particularly low-end GPUs, the added cost of FSR may not be worth it (compared to using bilinear scaling with a slightly higher resolution scale to match performance).
+			Sets the 3D resolution scaling mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially-aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. On particularly low-end GPUs, the added cost of FSR may not be worth it (compared to using bilinear scaling with a slightly higher resolution scale to match performance).
 			[b]Note:[/b] FSR is only effective when using the Forward+ rendering method, not Mobile or Compatibility. If using an incompatible rendering method, FSR will fall back to bilinear scaling.
+			[b]Note:[/b] Only the bilinear scaling mode is compatible with viewports that use a transparent background. Other scaling modes will fall back to bilinear scaling if [member rendering/viewport/transparent_background] is [code]true[/code].
+			[b]Note:[/b] This property is only read when the project starts. To set the 3D resolution scaling mode at runtime, set [member Viewport.scaling_3d_mode] on the root [Viewport] instead, or use [method RenderingServer.viewport_set_scaling_3d_mode].
 		</member>
 		<member name="rendering/scaling_3d/mode.ios" type="int" setter="" getter="">
 			iOS override for [member rendering/scaling_3d/mode]. This allows selecting the MetalFX spatial and MetalFX temporal scaling modes, which are exclusive to platforms where the Metal rendering driver is used.
@@ -3271,6 +3274,7 @@
 		</member>
 		<member name="rendering/scaling_3d/scale" type="float" setter="" getter="" default="1.0">
 			Scales the 3D render buffer based on the viewport size uses an image filter specified in [member rendering/scaling_3d/mode] to scale the output image to the full viewport size. Values lower than [code]1.0[/code] can be used to speed up 3D rendering at the cost of quality (undersampling). Values greater than [code]1.0[/code] are only valid for bilinear mode and can be used to improve 3D rendering quality at a high performance cost (supersampling). See also [member rendering/anti_aliasing/quality/msaa_3d] for multi-sample antialiasing, which is significantly cheaper but only smooths the edges of polygons.
+			[b]Note:[/b] This property is only read when the project starts. To set the 3D resolution scale at runtime, set [member Viewport.scaling_3d_scale] on the root [Viewport] instead, or use [method RenderingServer.viewport_set_scaling_3d_scale].
 		</member>
 		<member name="rendering/shader_compiler/shader_cache/compress" type="bool" setter="" getter="" default="true">
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -409,8 +409,10 @@
 			[b]Note:[/b] If this is set to [code]0[/code], no positional shadows will be visible at all. This can improve performance significantly on low-end systems by reducing both the CPU and GPU load (as fewer draw calls are needed to draw the scene without shadows).
 		</member>
 		<member name="scaling_3d_mode" type="int" setter="set_scaling_3d_mode" getter="get_scaling_3d_mode" enum="Viewport.Scaling3DMode" default="0">
-			Sets scaling 3D mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. FSR should be used where possible.
+			Sets the 3D resolution scaling mode. Bilinear scaling renders at different resolution to either undersample or supersample the viewport. FidelityFX Super Resolution 1.0, abbreviated to FSR, is an upscaling technology that produces high quality images at fast framerates by using a spatially aware upscaling algorithm. FSR is slightly more expensive than bilinear, but it produces significantly higher image quality. On particularly low-end GPUs, the added cost of FSR may not be worth it (compared to using bilinear scaling with a slightly higher resolution scale to match performance).
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/scaling_3d/mode] project setting.
+			[b]Note:[/b] FSR is only effective when using the Forward+ rendering method, not Mobile or Compatibility. If using an incompatible rendering method, FSR will fall back to bilinear scaling.
+			[b]Note:[/b] Only the bilinear scaling mode is compatible with viewports that use a transparent background. Other scaling modes will fall back to bilinear scaling if [member transparent_bg] is [code]true[/code].
 		</member>
 		<member name="scaling_3d_scale" type="float" setter="set_scaling_3d_scale" getter="get_scaling_3d_scale" default="1.0">
 			Scales the 3D render buffer based on the viewport size uses an image filter specified in [member ProjectSettings.rendering/scaling_3d/mode] to scale the output image to the full viewport size. Values lower than [code]1.0[/code] can be used to speed up 3D rendering at the cost of quality (undersampling). Values greater than [code]1.0[/code] are only valid for bilinear mode and can be used to improve 3D rendering quality at a high performance cost (supersampling). See also [member ProjectSettings.rendering/anti_aliasing/quality/msaa_3d] for multi-sample antialiasing, which is significantly cheaper but only smooths the edges of polygons.
@@ -460,6 +462,7 @@
 		<member name="use_taa" type="bool" setter="set_use_taa" getter="is_using_taa" default="false">
 			Enables temporal antialiasing for this viewport. TAA works by jittering the camera and accumulating the images of the last rendered frames, motion vector rendering is used to account for camera and object motion.
 			[b]Note:[/b] The implementation is not complete yet, some visual instances such as particles and skinned meshes may show artifacts.
+			[b]Note:[/b] TAA is not compatible with viewports that use a transparent background. TAA will be disabled if [member transparent_bg] is [code]true[/code].
 			See also [member ProjectSettings.rendering/anti_aliasing/quality/use_taa] and [method RenderingServer.viewport_set_use_taa].
 		</member>
 		<member name="use_xr" type="bool" setter="set_use_xr" getter="is_using_xr" default="false">

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1266,6 +1266,7 @@ void Viewport::set_transparent_background(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 	transparent_bg = p_enable;
 	RS::get_singleton()->viewport_set_transparent_background(viewport, p_enable);
+	update_configuration_warnings();
 }
 
 bool Viewport::has_transparent_background() const {
@@ -3619,6 +3620,23 @@ PackedStringArray Viewport::get_configuration_warnings() const {
 	if (size.x <= 1 || size.y <= 1) {
 		warnings.push_back(RTR("The Viewport size must be greater than or equal to 2 pixels on both dimensions to render anything."));
 	}
+
+	if (transparent_bg && use_taa) {
+		warnings.push_back(RTR("TAA is not compatible with transparent Viewports. TAA will be disabled."));
+	}
+
+	if (transparent_bg && scaling_3d_mode != Viewport::SCALING_3D_MODE_BILINEAR) {
+		warnings.push_back(RTR("FSR or MetalFX 3D resolution scaling are not compatible with transparent Viewports. Bilinear 3D resolution scaling will be used instead."));
+	}
+
+	if (use_taa && (scaling_3d_mode == Viewport::SCALING_3D_MODE_FSR2 || scaling_3d_mode == Viewport::SCALING_3D_MODE_METALFX_TEMPORAL)) {
+		warnings.push_back(RTR("FSR 2 or MetalFX Temporal is not compatible with TAA. TAA will be disabled."));
+	}
+
+	if (scaling_3d_scale >= (1.0 + CMP_EPSILON) && scaling_3d_mode != Viewport::SCALING_3D_MODE_BILINEAR) {
+		warnings.push_back(RTR("FSR or MetalFX 3D resolution scaling are not designed for downsampling (resolution scale above 1.0). Bilinear 3D resolution scaling will be used instead."));
+	}
+
 	return warnings;
 }
 
@@ -3704,6 +3722,7 @@ void Viewport::set_use_taa(bool p_use_taa) {
 	}
 	use_taa = p_use_taa;
 	RS::get_singleton()->viewport_set_use_taa(viewport, p_use_taa);
+	update_configuration_warnings();
 }
 
 bool Viewport::is_using_taa() const {
@@ -4830,6 +4849,7 @@ void Viewport::set_scaling_3d_mode(Scaling3DMode p_scaling_3d_mode) {
 
 	scaling_3d_mode = p_scaling_3d_mode;
 	RS::get_singleton()->viewport_set_scaling_3d_mode(viewport, (RS::ViewportScaling3DMode)(int)p_scaling_3d_mode);
+	update_configuration_warnings();
 }
 
 Viewport::Scaling3DMode Viewport::get_scaling_3d_mode() const {
@@ -4845,6 +4865,7 @@ void Viewport::set_scaling_3d_scale(float p_scaling_3d_scale) {
 	scaling_3d_scale = CLAMP(p_scaling_3d_scale, 0.1, 2.0);
 
 	RS::get_singleton()->viewport_set_scaling_3d_scale(viewport, scaling_3d_scale);
+	update_configuration_warnings();
 }
 
 float Viewport::get_scaling_3d_scale() const {

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -130,13 +130,12 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 		if (p_viewport->size.width == 0 || p_viewport->size.height == 0) {
 			p_viewport->render_buffers.unref();
 		} else {
-			const float EPSILON = 0.0001;
 			float scaling_3d_scale = p_viewport->scaling_3d_scale;
 			RS::ViewportScaling3DMode scaling_3d_mode = p_viewport->scaling_3d_mode;
 			bool upscaler_available = p_viewport->fsr_enabled;
 			RS::ViewportScaling3DType scaling_type = RS::scaling_3d_mode_type(scaling_3d_mode);
 
-			if ((!upscaler_available || (scaling_type == RS::VIEWPORT_SCALING_3D_TYPE_SPATIAL)) && scaling_3d_scale >= (1.0 - EPSILON) && scaling_3d_scale <= (1.0 + EPSILON)) {
+			if ((!upscaler_available || (scaling_type == RS::VIEWPORT_SCALING_3D_TYPE_SPATIAL)) && scaling_3d_scale >= (1.0 - CMP_EPSILON) && scaling_3d_scale <= (1.0 + CMP_EPSILON)) {
 				// No 3D scaling for spatial modes? Ignore scaling mode, this just introduces overhead.
 				// - Mobile can't perform optimal path
 				// - FSR does an extra pass (or 2 extra passes if 2D-MSAA is enabled)
@@ -181,7 +180,7 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 			bool scaling_3d_is_not_bilinear = scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_OFF && scaling_3d_mode != RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
 			bool use_taa = p_viewport->use_taa;
 
-			if (scaling_3d_is_not_bilinear && (scaling_3d_scale >= (1.0 + EPSILON))) {
+			if (scaling_3d_is_not_bilinear && (scaling_3d_scale >= (1.0 + CMP_EPSILON))) {
 				// FSR and MetalFX is not designed for downsampling.
 				// Fall back to bilinear scaling.
 				WARN_PRINT_ONCE("FSR 3D resolution scaling is not designed for downsampling. Falling back to bilinear 3D resolution scaling.");
@@ -200,6 +199,20 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 				// Turn it off and prefer using the temporal upscaler.
 				WARN_PRINT_ONCE("FSR 2 or MetalFX Temporal is not compatible with TAA. Disabling TAA internally.");
 				use_taa = false;
+			}
+
+			if (use_taa && p_viewport->transparent_bg) {
+				// Transparent background can't be used with TAA.
+				// Turn it off so the transparent background can be used.
+				WARN_PRINT_ONCE("Transparent background is not supported with TAA. Disabling TAA internally.");
+				use_taa = false;
+			}
+
+			if (scaling_3d_is_not_bilinear && p_viewport->transparent_bg) {
+				// Transparent background is not supported with FSR or MetalFX.
+				// Fall back to bilinear scaling.
+				WARN_PRINT_ONCE("Transparent background is not supported with FSR or MetalFX. Falling back to bilinear 3D resolution scaling.");
+				scaling_3d_mode = RS::VIEWPORT_SCALING_3D_MODE_BILINEAR;
 			}
 
 			int target_width;


### PR DESCRIPTION
This also adds node configuration warnings to viewport for other unsupported features, such as TAA + FSR2/MetalFX Temporal or FSR + downsampling.

- This closes https://github.com/godotengine/godot/issues/69492.
- See https://github.com/godotengine/godot/issues/66920 (this one *might* be fixable in the long run, but I can't guarantee it).

## TODO

- [ ] Fix jittery visuals when trying to use FSR2 or MetalFX Temporal on a viewport with **Transparent BG** enabled.
  - This occurs for the same reason as https://github.com/godotengine/godot/pull/106731. However, we can't use the same fix since **Transparent BG** may change at runtime (if you disable it, FSR2/MetalFX Temporal should start working again immediately). @stuartcarnie Any ideas?
