### PR TITLE
OpenGL: Fix shader compilation failure with `shadow_to_opacity` and `unshaded`

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2273,7 +2273,11 @@ void main() {
 
 #if defined(USE_SHADOW_TO_OPACITY)
 #ifndef MODE_RENDER_DEPTH
+#ifndef MODE_UNSHADED
 	alpha = min(alpha, clamp(length(ambient_light), 0.0, 1.0));
+#else
+	alpha = 0.0;
+#endif
 
 #if defined(ALPHA_SCISSOR_USED)
 #ifdef RENDER_MATERIAL


### PR DESCRIPTION
At the moment, if you make a shader that uses both `shadow_to_opacity` and `unshaded` when using the Compatibility renderer, it will fail to compile with the following error:

```
E 0:00:02:007   _display_error_with_code: SceneShaderGLES3: Fragment shader compilation failed:
ERROR: 0:1817: 'ambient_light' : undeclared identifier
ERROR: 1 compilation errors.  No code generated.
  <C++ Source>  drivers/gles3/shader_gles3.cpp:259 @ _display_error_with_code()
```

This PR fixes that!

This problem doesn't happen with the Forward+ or Mobile renderers, where the result is full transparency (`alpha = 0.0`), even though the scene shaders in those renders don't set it explicitly, like in this PR. I don't know if it'd be worth changing Forward+ and Mobile to do it explicitly too?