### PR TITLE
Add memory amount to output from the Copy System Info editor action

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5386,6 +5386,12 @@ String EditorNode::_get_system_info() const {
 
 	info.push_back(vformat("%s (%d threads)", processor_name, processor_count));
 
+	const int64_t system_ram = OS::get_singleton()->get_memory_info()["physical"];
+	if (system_ram > 0) {
+		// If the memory info is available, display it.
+		info.push_back(vformat("%s memory", String::humanize_size(system_ram)));
+	}
+
 	return String(" - ").join(info);
 }
 


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/75025.

This is useful information to have for out-of-memory issues.

The exact reported amount will vary on a per-system basis, even in systems with the exact same amount of memory installed. If you use integrated graphics, the reported amount will be decreased by the amount reserved by integrated graphics (which is usually configurable in the UEFI).

## Preview

> Godot v4.5.dev (e2a6411ee) - Fedora Linux 42 (KDE Plasma Desktop Edition) on X11 - X11 display driver, Multi-window, 1 monitor - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 5090 (nvidia; 570.153.02) - AMD Ryzen 9 9950X3D 16-Core Processor (32 threads) - 62.33 GiB memory