### PR TITLE
Implement Resizable Scroll Bar for Animation Player

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1287,61 +1287,63 @@ void AnimationMultiTrackKeyEdit::set_use_fps(bool p_enable) {
 }
 
 void AnimationTimelineEdit::_zoom_changed(double) {
-	double zoom_pivot = 0; // Point on timeline to stay fixed.
-	double zoom_pivot_delta = 0; // Delta seconds from left-most point on timeline to zoom pivot.
+	if (!scroll_zoom_change) {
+		double zoom_pivot = 0; // Point on timeline to stay fixed.
+		double zoom_pivot_delta = 0; // Delta seconds from left-most point on timeline to zoom pivot.
 
-	int timeline_width_pixels = get_size().width - get_buttons_width() - get_name_limit();
-	double timeline_width_seconds = timeline_width_pixels / last_zoom_scale; // Length (in seconds) of visible part of timeline before zoom.
-	double updated_timeline_width_seconds = timeline_width_pixels / get_zoom_scale(); // Length after zoom.
-	double updated_timeline_half_width = updated_timeline_width_seconds / 2.0;
-	bool zooming = updated_timeline_width_seconds < timeline_width_seconds;
+		int timeline_width_pixels = get_size().width - get_buttons_width() - get_name_limit();
+		double timeline_width_seconds = timeline_width_pixels / last_zoom_scale; // Length (in seconds) of visible part of timeline before zoom.
+		double updated_timeline_width_seconds = timeline_width_pixels / get_zoom_scale(); // Length after zoom.
+		double updated_timeline_half_width = updated_timeline_width_seconds / 2.0;
+		bool zooming = updated_timeline_width_seconds < timeline_width_seconds;
 
-	double timeline_left = get_value();
-	double timeline_right = timeline_left + timeline_width_seconds;
-	double timeline_center = timeline_left + timeline_width_seconds / 2.0;
+		double timeline_left = get_value();
+		double timeline_right = timeline_left + timeline_width_seconds;
+		double timeline_center = timeline_left + timeline_width_seconds / 2.0;
 
-	if (zoom_callback_occurred) { // Zooming with scroll wheel will focus on the position of the mouse.
-		double zoom_scroll_origin_norm = (zoom_scroll_origin.x - get_name_limit()) / timeline_width_pixels;
-		zoom_scroll_origin_norm = MAX(zoom_scroll_origin_norm, 0);
-		zoom_pivot = timeline_left + timeline_width_seconds * zoom_scroll_origin_norm;
-		zoom_pivot_delta = updated_timeline_width_seconds * zoom_scroll_origin_norm;
-		zoom_callback_occurred = false;
-	} else { // Zooming with slider will depend on the current play position.
-		// If the play position is not in range, or exactly in the center, zoom in on the center.
-		if (get_play_position() < timeline_left || get_play_position() > timeline_left + timeline_width_seconds || get_play_position() == timeline_center) {
-			zoom_pivot = timeline_center;
-			zoom_pivot_delta = updated_timeline_half_width;
+		if (zoom_callback_occurred) { // Zooming with scroll wheel will focus on the position of the mouse.
+			double zoom_scroll_origin_norm = (zoom_scroll_origin.x - get_name_limit()) / timeline_width_pixels;
+			zoom_scroll_origin_norm = MAX(zoom_scroll_origin_norm, 0);
+			zoom_pivot = timeline_left + timeline_width_seconds * zoom_scroll_origin_norm;
+			zoom_pivot_delta = updated_timeline_width_seconds * zoom_scroll_origin_norm;
+			zoom_callback_occurred = false;
+		} else { // Zooming with slider will depend on the current play position.
+			// If the play position is not in range, or exactly in the center, zoom in on the center.
+			if (get_play_position() < timeline_left || get_play_position() > timeline_left + timeline_width_seconds || get_play_position() == timeline_center) {
+				zoom_pivot = timeline_center;
+				zoom_pivot_delta = updated_timeline_half_width;
+			}
+			// Zoom from right if play position is right of center,
+			// and shrink from right if play position is left of center.
+			else if ((get_play_position() > timeline_center) == zooming) {
+				// If play position crosses to other side of center, center it.
+				bool center_passed = (get_play_position() < timeline_right - updated_timeline_half_width) == zooming;
+				zoom_pivot = center_passed ? get_play_position() : timeline_right;
+				double center_offset = CMP_EPSILON * (zooming ? 1 : -1); // Small offset to prevent crossover.
+				zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : updated_timeline_width_seconds;
+			}
+			// Zoom from left if play position is left of center,
+			// and shrink from left if play position is right of center.
+			else if ((get_play_position() <= timeline_center) == zooming) {
+				// If play position crosses to other side of center, center it.
+				bool center_passed = (get_play_position() > timeline_left + updated_timeline_half_width) == zooming;
+				zoom_pivot = center_passed ? get_play_position() : timeline_left;
+				double center_offset = CMP_EPSILON * (zooming ? -1 : 1); // Small offset to prevent crossover.
+				zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : 0;
+			}
 		}
-		// Zoom from right if play position is right of center,
-		// and shrink from right if play position is left of center.
-		else if ((get_play_position() > timeline_center) == zooming) {
-			// If play position crosses to other side of center, center it.
-			bool center_passed = (get_play_position() < timeline_right - updated_timeline_half_width) == zooming;
-			zoom_pivot = center_passed ? get_play_position() : timeline_right;
-			double center_offset = CMP_EPSILON * (zooming ? 1 : -1); // Small offset to prevent crossover.
-			zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : updated_timeline_width_seconds;
-		}
-		// Zoom from left if play position is left of center,
-		// and shrink from left if play position is right of center.
-		else if ((get_play_position() <= timeline_center) == zooming) {
-			// If play position crosses to other side of center, center it.
-			bool center_passed = (get_play_position() > timeline_left + updated_timeline_half_width) == zooming;
-			zoom_pivot = center_passed ? get_play_position() : timeline_left;
-			double center_offset = CMP_EPSILON * (zooming ? -1 : 1); // Small offset to prevent crossover.
-			zoom_pivot_delta = center_passed ? updated_timeline_half_width + center_offset : 0;
-		}
+
+		double hscroll_pos = zoom_pivot - zoom_pivot_delta;
+		hscroll_pos = CLAMP(hscroll_pos, hscroll->get_min(), hscroll->get_max());
+
+		hscroll->set_value(hscroll_pos);
+		hscroll_on_zoom_buffer = hscroll_pos; // In case of page update.
+		last_zoom_scale = get_zoom_scale();
+
+		queue_redraw();
+		play_position->queue_redraw();
+		emit_signal(SNAME("zoom_changed"));
 	}
-
-	double hscroll_pos = zoom_pivot - zoom_pivot_delta;
-	hscroll_pos = CLAMP(hscroll_pos, hscroll->get_min(), hscroll->get_max());
-
-	hscroll->set_value(hscroll_pos);
-	hscroll_on_zoom_buffer = hscroll_pos; // In case of page update.
-	last_zoom_scale = get_zoom_scale();
-
-	queue_redraw();
-	play_position->queue_redraw();
-	emit_signal(SNAME("zoom_changed"));
 }
 
 float AnimationTimelineEdit::get_zoom_scale() const {
@@ -1575,7 +1577,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 				set_min(time_min);
 				set_max(time_max);
 
-				if (zoomw / scale < (time_max - time_min)) {
+				if (zoomw / scale <= (time_max - time_min)) {
 					hscroll->show();
 
 				} else {
@@ -1584,6 +1586,17 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			}
 
 			set_page(zoomw / scale);
+
+			if (scroll_zoom_change) {
+				if (hscroll->handle_1_scrolling()) {
+					hscroll->set_value(hscroll->get_start_page_at_drag());
+				} else if (hscroll->handle_2_scrolling()) {
+					hscroll->set_value(hscroll->get_start_page());
+				}
+				hscroll->set_min(get_min());
+				hscroll->set_max(get_max());
+				scroll_zoom_change = false;
+			}
 
 			if (hscroll->is_visible() && hscroll_on_zoom_buffer >= 0) {
 				hscroll->set_value(hscroll_on_zoom_buffer);
@@ -1988,8 +2001,59 @@ bool AnimationTimelineEdit::is_using_fps() const {
 	return use_fps;
 }
 
-void AnimationTimelineEdit::set_hscroll(HScrollBar *p_hscroll) {
+void AnimationTimelineEdit::set_hscroll(HResizableScrollBar *p_hscroll) {
 	hscroll = p_hscroll;
+	hscroll->connect(SNAME("change_zoom"), callable_mp(this, &AnimationTimelineEdit::_zoom_changed_scroll));
+}
+
+void AnimationTimelineEdit::_zoom_changed_scroll() {
+	double page;
+	// calculate new page size
+	if (hscroll->handle_1_scrolling()) {
+		if (hscroll->get_end_page() >= get_max()) {
+			float time_max = animation->get_length();
+			for (int i = 0; i < animation->get_track_count(); i++) {
+				if (animation->track_get_key_count(i) > 0) {
+					float end = animation->track_get_key_time(i, animation->track_get_key_count(i) - 1);
+
+					if (end > time_max) {
+						time_max = end;
+					}
+				}
+			}
+			page = (time_max - hscroll->get_start_page_at_drag()) * 2;
+		} else {
+			page = hscroll->get_end_page() - hscroll->get_start_page_at_drag();
+		}
+	} else {
+		page = hscroll->get_end_page_at_drag() - hscroll->get_start_page();
+	}
+	// calculate zoom value to change in the slider
+	if (page > 0) {
+		int key_range = get_size().width - get_buttons_width() - get_name_limit();
+		double scale = key_range / page;
+		double zoom_value;
+		if (scale > _get_zoom_scale(zoom->get_max())) {
+			zoom_value = zoom->get_max();
+		} else {
+			zoom_value = _scale_to_zoom(scale);
+			scroll_zoom_change = true;
+			zoom->set_value(zoom_value);
+		}
+
+		queue_redraw();
+		play_position->queue_redraw();
+		emit_signal(SNAME("zoom_changed"));
+	}
+}
+
+double AnimationTimelineEdit::_scale_to_zoom(double scale) {
+	float val = scale / 100.0f;
+	if (val >= 1.0f) {
+		return pow(val, 1.0f / 8.0f);
+	} else {
+		return 2.0f - pow(1.0f / val, 1.0f / 8.0f);
+	}
 }
 
 void AnimationTimelineEdit::_track_added(int p_track) {
@@ -7840,7 +7904,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	timeline_vbox->set_custom_minimum_size(Size2(0, 150) * EDSCALE);
 
-	hscroll = memnew(HScrollBar);
+	hscroll = memnew(HResizableScrollBar);
 	hscroll->share(timeline);
 	hscroll->hide();
 	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_update_scroll));
@@ -8003,7 +8067,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	zoom_icon->set_v_size_flags(SIZE_SHRINK_CENTER);
 	zoom_hb->add_child(zoom_icon);
 	zoom = memnew(HSlider);
-	zoom->set_step(0.01);
+	zoom->set_step(0.000001);
 	zoom->set_min(0.0);
 	zoom->set_max(2.0);
 	zoom->set_value(1.0);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -36,6 +36,7 @@
 #include "scene/3d/node_3d.h"
 #include "scene/gui/control.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/resizable_scroll_bar.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/animation.h"
@@ -209,9 +210,13 @@ class AnimationTimelineEdit : public Range {
 	MenuButton *add_track = nullptr;
 	LineEdit *filter_track = nullptr;
 	Control *play_position = nullptr; //separate control used to draw so updates for only position changed are much faster
-	HScrollBar *hscroll = nullptr;
+	HResizableScrollBar *hscroll = nullptr;
+
+	bool scroll_zoom_change = false;
 
 	void _zoom_changed(double);
+	void _zoom_changed_scroll();
+	double _scale_to_zoom(double scale);
 	void _anim_length_changed(double p_new_len);
 	void _anim_loop_pressed();
 
@@ -267,7 +272,7 @@ public:
 	void set_use_fps(bool p_use_fps);
 	bool is_using_fps() const;
 
-	void set_hscroll(HScrollBar *p_hscroll);
+	void set_hscroll(HResizableScrollBar *p_hscroll);
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
@@ -597,7 +602,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	MenuButton *edit = nullptr;
 
 	PanelContainer *main_panel = nullptr;
-	HScrollBar *hscroll = nullptr;
+	HResizableScrollBar *hscroll = nullptr;
 	ScrollContainer *scroll = nullptr;
 	VBoxContainer *track_vbox = nullptr;
 	AnimationBezierTrackEdit *bezier_edit = nullptr;

--- a/scene/gui/resizable_scroll_bar.cpp
+++ b/scene/gui/resizable_scroll_bar.cpp
@@ -1,0 +1,466 @@
+/**************************************************************************/
+/*  resizable_scroll_bar.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resizable_scroll_bar.h"
+
+#include "scene/theme/theme_db.h"
+
+void ResizableScrollBar::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseMotion> m = p_event;
+
+	Ref<InputEventMouseButton> b = p_event;
+
+	if (b.is_valid()) {
+		accept_event();
+
+		if (b->get_button_index() == MouseButton::WHEEL_DOWN && b->is_pressed()) {
+			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
+			scroll(MAX(change, get_step()));
+			accept_event();
+		}
+
+		if (b->get_button_index() == MouseButton::WHEEL_UP && b->is_pressed()) {
+			double change = ((get_page() != 0.0) ? get_page() / PAGE_DIVISOR : (get_max() - get_min()) / 16.0) * b->get_factor();
+			scroll(-MAX(change, get_step()));
+			accept_event();
+		}
+
+		if (b->get_button_index() != MouseButton::LEFT) {
+			return;
+		}
+
+		if (b->is_pressed()) {
+			double ofs = orientation == VERTICAL ? b->get_position().y : b->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+			Ref<Texture2D> incr = theme_cache.increment_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
+			double grabber_ofs = get_grabber_offset();
+			double grabber_size = get_grabber_size();
+			double total = orientation == VERTICAL ? get_size().height : get_size().width;
+
+			if (ofs < decr_size) {
+				decr_active = true;
+				scroll(-(custom_step >= 0 ? custom_step : get_step()));
+				queue_redraw();
+				return;
+			}
+
+			if (ofs > total - incr_size) {
+				incr_active = true;
+				scroll(custom_step >= 0 ? custom_step : get_step());
+				queue_redraw();
+				return;
+			}
+
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			if (ofs < grabber_ofs) {
+				if (scrolling) {
+					target_scroll = CLAMP(target_scroll - get_page(), get_min(), get_max() - get_page());
+				} else {
+					double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+					target_scroll = CLAMP(get_value() - change, get_min(), get_max() - get_page());
+				}
+
+				if (smooth_scroll_enabled) {
+					scrolling = true;
+					set_process_internal(true);
+				} else {
+					scroll_to(target_scroll);
+				}
+				return;
+			}
+
+			ofs -= grabber_ofs;
+			if (get_grabber_size() >= get_handle_min_size()) {
+				if (ofs < get_handle_size()) {
+					drag.handle_1_active = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					drag.start_page_at_click = get_value();
+					drag.end_page_at_click = get_value() + get_page();
+					drag.handle_offset = ofs;
+					queue_redraw();
+				} else if (ofs > get_handle_size() && ofs < grabber_size - get_handle_size()) {
+					drag.grabber_active = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					queue_redraw();
+				} else if (ofs > grabber_size - get_handle_size() && ofs < grabber_size) {
+					drag.handle_2_active = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					drag.start_page_at_click = get_value();
+					drag.end_page_at_click = get_value() + get_page();
+					drag.handle_offset = grabber_size - ofs;
+					queue_redraw();
+				} else {
+					if (scrolling) {
+						target_scroll = CLAMP(target_scroll + get_page(), get_min(), get_max() - get_page());
+					} else {
+						double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+						target_scroll = CLAMP(get_value() + change, get_min(), get_max() - get_page());
+					}
+
+					if (smooth_scroll_enabled) {
+						scrolling = true;
+						set_process_internal(true);
+					} else {
+						scroll_to(target_scroll);
+					}
+				}
+			} else {
+				if (ofs < grabber_size) {
+					drag.grabber_active = true;
+					drag.pos_at_click = grabber_ofs + ofs;
+					drag.value_at_click = get_as_ratio();
+					queue_redraw();
+				} else {
+					if (scrolling) {
+						target_scroll = CLAMP(target_scroll + get_page(), get_min(), get_max() - get_page());
+					} else {
+						double change = get_page() != 0.0 ? get_page() : (get_max() - get_min()) / 16.0;
+						target_scroll = CLAMP(get_value() + change, get_min(), get_max() - get_page());
+					}
+
+					if (smooth_scroll_enabled) {
+						scrolling = true;
+						set_process_internal(true);
+					} else {
+						scroll_to(target_scroll);
+					}
+				}
+			}
+		} else {
+			incr_active = false;
+			decr_active = false;
+			drag.grabber_active = false;
+			drag.handle_1_active = false;
+			drag.handle_2_active = false;
+			queue_redraw();
+		}
+	}
+
+	if (m.is_valid()) {
+		accept_event();
+
+		if (drag.grabber_active) {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			double diff = (ofs - drag.pos_at_click) / get_area_size();
+
+			double prev_scroll = get_value();
+
+			set_as_ratio(drag.value_at_click + diff);
+
+			if (!Math::is_equal_approx(prev_scroll, get_value())) {
+				emit_signal(SNAME("scrolling"));
+			}
+		} else if (drag.handle_1_active) {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			if (get_max() < drag.end_page_at_click) {
+				drag.end_page_at_click = get_max();
+			}
+
+			double min_value = get_min();
+			double max_value = drag.end_page_at_click - ratio_to_value((get_handle_min_size()) / get_area_size());
+
+			drag.start_page_at_drag = CLAMP(ratio_to_value((ofs - drag.handle_offset) / get_area_size()), min_value, max_value);
+
+			emit_signal(SNAME("change_zoom"));
+		} else if (drag.handle_2_active) {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			ofs -= decr_size + theme_cache.scroll_style->get_margin(orientation == VERTICAL ? SIDE_TOP : SIDE_LEFT);
+
+			double min_value = drag.start_page_at_click + ratio_to_value((get_handle_min_size()) / get_area_size());
+			double max_value = get_max();
+
+			drag.end_page_at_drag = CLAMP(ratio_to_value((ofs + drag.handle_offset - get_grabber_min_size()) / get_area_size()), min_value, max_value);
+
+			emit_signal(SNAME("change_zoom"));
+		} else {
+			double ofs = orientation == VERTICAL ? m->get_position().y : m->get_position().x;
+			Ref<Texture2D> decr = theme_cache.decrement_icon;
+			Ref<Texture2D> incr = theme_cache.increment_icon;
+
+			double decr_size = orientation == VERTICAL ? decr->get_height() : decr->get_width();
+			double incr_size = orientation == VERTICAL ? incr->get_height() : incr->get_width();
+			double total = orientation == VERTICAL ? get_size().height : get_size().width;
+			double grabber_ofs = get_grabber_offset();
+			double grabber_size = get_grabber_size();
+
+			HighlightStatus new_hilite;
+
+			if (ofs < decr_size) {
+				new_hilite = HIGHLIGHT_DECR;
+
+			} else if (ofs > grabber_ofs && ofs < grabber_ofs + get_handle_size()) {
+				new_hilite = HIGHLIGHT_HANDLE_1;
+
+			} else if (ofs > grabber_ofs + grabber_size - get_handle_size() && ofs < grabber_ofs + grabber_size) {
+				new_hilite = HIGHLIGHT_HANDLE_2;
+
+			} else if (ofs > total - incr_size) {
+				new_hilite = HIGHLIGHT_INCR;
+
+			} else {
+				new_hilite = HIGHLIGHT_RANGE;
+			}
+
+			if (new_hilite != highlight) {
+				highlight = new_hilite;
+				queue_redraw();
+			}
+		}
+	}
+
+	if (p_event->is_pressed()) {
+		if (p_event->is_action("ui_left", true)) {
+			if (orientation != HORIZONTAL) {
+				return;
+			}
+			scroll(-(custom_step >= 0 ? custom_step : get_step()));
+
+		} else if (p_event->is_action("ui_right", true)) {
+			if (orientation != HORIZONTAL) {
+				return;
+			}
+			scroll(custom_step >= 0 ? custom_step : get_step());
+
+		} else if (p_event->is_action("ui_up", true)) {
+			if (orientation != VERTICAL) {
+				return;
+			}
+
+			scroll(-(custom_step >= 0 ? custom_step : get_step()));
+
+		} else if (p_event->is_action("ui_down", true)) {
+			if (orientation != VERTICAL) {
+				return;
+			}
+			scroll(custom_step >= 0 ? custom_step : get_step());
+
+		} else if (p_event->is_action("ui_home", true)) {
+			scroll_to(get_min());
+
+		} else if (p_event->is_action("ui_end", true)) {
+			scroll_to(get_max());
+		}
+	}
+}
+
+void ResizableScrollBar::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
+
+			Ref<Texture2D> decr, incr;
+
+			if (decr_active) {
+				decr = theme_cache.decrement_pressed_icon;
+			} else if (highlight == HIGHLIGHT_DECR) {
+				decr = theme_cache.decrement_hl_icon;
+			} else {
+				decr = theme_cache.decrement_icon;
+			}
+
+			if (incr_active) {
+				incr = theme_cache.increment_pressed_icon;
+			} else if (highlight == HIGHLIGHT_INCR) {
+				incr = theme_cache.increment_hl_icon;
+			} else {
+				incr = theme_cache.increment_icon;
+			}
+
+			Ref<StyleBox> grabber, handle_1, handle_2;
+			if (drag.grabber_active) {
+				grabber = theme_cache.grabber_pressed_style;
+			} else if (highlight == HIGHLIGHT_RANGE) {
+				grabber = theme_cache.grabber_hl_style;
+			} else {
+				grabber = theme_cache.grabber_style;
+			}
+
+			if (drag.handle_1_active) {
+				handle_1 = theme_cache.grabber_pressed_style;
+			} else if (highlight == HIGHLIGHT_HANDLE_1) {
+				handle_1 = theme_cache.grabber_hl_style;
+			} else {
+				handle_1 = theme_cache.grabber_style;
+			}
+
+			if (drag.handle_2_active) {
+				handle_2 = theme_cache.grabber_pressed_style;
+			} else if (highlight == HIGHLIGHT_HANDLE_2) {
+				handle_2 = theme_cache.grabber_hl_style;
+			} else {
+				handle_2 = theme_cache.grabber_style;
+			}
+
+			Point2 ofs;
+
+			decr->draw(ci, Point2());
+
+			if (orientation == HORIZONTAL) {
+				ofs.x += decr->get_width();
+			} else {
+				ofs.y += decr->get_height();
+			}
+
+			Size2 area = get_size();
+
+			if (orientation == HORIZONTAL) {
+				area.width -= incr->get_width() + decr->get_width();
+			} else {
+				area.height -= incr->get_height() + decr->get_height();
+			}
+
+			if (has_focus()) {
+				theme_cache.scroll_focus_style->draw(ci, Rect2(ofs, area));
+			} else {
+				theme_cache.scroll_style->draw(ci, Rect2(ofs, area));
+			}
+
+			if (orientation == HORIZONTAL) {
+				ofs.width += area.width;
+			} else {
+				ofs.height += area.height;
+			}
+
+			incr->draw(ci, ofs);
+			Rect2 grabber_rect, handle_1_rect, handle_2_rect;
+
+			if (orientation == HORIZONTAL) {
+				grabber_rect.size.width = get_grabber_size();
+				grabber_rect.size.height = get_size().height;
+				grabber_rect.position.y = 0;
+				grabber_rect.position.x = get_grabber_offset() + decr->get_width() + theme_cache.scroll_style->get_margin(SIDE_LEFT);
+
+				handle_1_rect.size.width = get_handle_size();
+				handle_1_rect.size.height = get_size().height;
+				handle_1_rect.position.y = 0;
+				handle_1_rect.position.x = get_grabber_offset() + decr->get_width() + theme_cache.scroll_style->get_margin(SIDE_LEFT);
+
+				handle_2_rect.size.width = get_handle_size();
+				handle_2_rect.size.height = get_size().height;
+				handle_2_rect.position.y = 0;
+				handle_2_rect.position.x = get_grabber_offset() + decr->get_width() + theme_cache.scroll_style->get_margin(SIDE_LEFT) + get_grabber_size() - get_handle_size();
+			} else {
+				// Not implemented
+				grabber_rect.size.width = get_size().width;
+				grabber_rect.size.height = get_grabber_size();
+				grabber_rect.position.y = get_grabber_offset() + decr->get_height() + theme_cache.scroll_style->get_margin(SIDE_TOP);
+				grabber_rect.position.x = 0;
+			}
+
+			grabber->draw(ci, grabber_rect);
+			if (get_grabber_size() >= get_handle_min_size()) {
+				handle_1->draw(ci, handle_1_rect);
+				handle_2->draw(ci, handle_2_rect);
+			}
+		} break;
+
+		case NOTIFICATION_ACCESSIBILITY_UPDATE:
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_EXIT_TREE:
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			ScrollBar::_notification(p_what);
+		} break;
+		case NOTIFICATION_MOUSE_EXIT: {
+			highlight = HIGHLIGHT_NONE;
+			queue_redraw();
+		} break;
+	}
+}
+
+bool ResizableScrollBar::handle_1_scrolling() {
+	return drag.handle_1_active;
+}
+
+bool ResizableScrollBar::handle_2_scrolling() {
+	return drag.handle_2_active;
+}
+
+double ResizableScrollBar::get_end_page() {
+	return drag.end_page_at_click;
+}
+
+double ResizableScrollBar::get_start_page() {
+	return drag.start_page_at_click;
+}
+
+double ResizableScrollBar::get_end_page_at_drag() {
+	return drag.end_page_at_drag;
+}
+
+double ResizableScrollBar::get_start_page_at_drag() {
+	return drag.start_page_at_drag;
+}
+
+double ResizableScrollBar::get_handle_size() {
+	return 2.5 * get_grabber_min_size();
+}
+
+double ResizableScrollBar::get_handle_min_size() {
+	return 2.5 * get_handle_size();
+}
+
+double ResizableScrollBar::ratio_to_value(double p_value) {
+	double v;
+	double percent = (get_max() - get_min()) * p_value;
+	v = percent + get_min();
+	v = CLAMP(v, get_min(), get_max());
+	return v;
+}
+
+void ResizableScrollBar::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("change_zoom"));
+}
+
+ResizableScrollBar::ResizableScrollBar(Orientation p_orientation) :
+		ScrollBar(p_orientation) {}
+
+ResizableScrollBar::~ResizableScrollBar() {}

--- a/scene/gui/resizable_scroll_bar.h
+++ b/scene/gui/resizable_scroll_bar.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  scroll_bar.h                                                          */
+/*  resizable_scroll_bar.h                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,118 +30,74 @@
 
 #pragma once
 
-#include "scene/gui/range.h"
+#include "scroll_bar.h"
 
-class ScrollBar : public Range {
-	GDCLASS(ScrollBar, Range);
+class ResizableScrollBar : public ScrollBar {
+	GDCLASS(ResizableScrollBar, ScrollBar);
 
 	enum HighlightStatus {
 		HIGHLIGHT_NONE,
 		HIGHLIGHT_DECR,
 		HIGHLIGHT_RANGE,
 		HIGHLIGHT_INCR,
+		HIGHLIGHT_HANDLE_1,
+		HIGHLIGHT_HANDLE_2,
 	};
 
-	static bool focus_by_default;
-
 	Orientation orientation;
-	Size2 size;
+
+	struct Drag {
+		bool grabber_active = false;
+		bool handle_1_active = false;
+		bool handle_2_active = false;
+		float pos_at_click = 0.0;
+		float value_at_click = 0.0;
+		float end_page_at_click = 0.0;
+		float start_page_at_click = 0.0;
+		float start_page_at_drag = 0.0;
+		float end_page_at_drag = 0.0;
+		float handle_offset = 0.0;
+	} drag;
 
 	HighlightStatus highlight = HIGHLIGHT_NONE;
 
-	struct Drag {
-		bool active = false;
-		float pos_at_click = 0.0;
-		float value_at_click = 0.0;
-	} drag;
-
-	static void set_can_focus_by_default(bool p_can_focus);
-
-	Node *drag_node = nullptr;
-	NodePath drag_node_path;
-	bool drag_node_enabled = true;
-
-	Vector2 drag_node_speed;
-	Vector2 drag_node_accum;
-	Vector2 drag_node_from;
-	Vector2 last_drag_node_accum;
-	float last_drag_node_time = 0.0;
-	float time_since_motion = 0.0;
-	bool drag_node_touching = false;
-	bool drag_node_touching_deaccel = false;
-	bool click_handled = false;
-
-	void _drag_node_exit();
-	void _drag_node_input(const Ref<InputEvent> &p_input);
+	double ratio_to_value(double p_value);
+	double get_handle_size();
 
 protected:
-	bool incr_active = false;
-	bool decr_active = false;
-
-	float custom_step = -1.0;
-
-	bool smooth_scroll_enabled = false;
-	bool scrolling = false;
-	double target_scroll = 0.0;
-
-	struct ThemeCache {
-		Ref<StyleBox> scroll_style;
-		Ref<StyleBox> scroll_focus_style;
-		Ref<StyleBox> scroll_offset_style;
-		Ref<StyleBox> grabber_style;
-		Ref<StyleBox> grabber_hl_style;
-		Ref<StyleBox> grabber_pressed_style;
-
-		Ref<Texture2D> increment_icon;
-		Ref<Texture2D> increment_hl_icon;
-		Ref<Texture2D> increment_pressed_icon;
-		Ref<Texture2D> decrement_icon;
-		Ref<Texture2D> decrement_hl_icon;
-		Ref<Texture2D> decrement_pressed_icon;
-	} theme_cache;
-
-	double get_grabber_size() const;
-	double get_grabber_min_size() const;
-	double get_area_size() const;
-	double get_grabber_offset() const;
-
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	static inline const int PAGE_DIVISOR = 8;
+	double get_end_page();
+	double get_start_page();
+	double get_end_page_at_drag();
+	double get_start_page_at_drag();
 
-	void scroll(double p_amount);
-	void scroll_to(double p_position);
+	double get_handle_min_size();
 
-	void set_custom_step(float p_custom_step);
-	float get_custom_step() const;
+	bool handle_1_scrolling();
+	bool handle_2_scrolling();
 
-	void set_drag_node(const NodePath &p_path);
-	NodePath get_drag_node() const;
-	void set_drag_node_enabled(bool p_enable);
-
-	void set_smooth_scroll_enabled(bool p_enable);
-	bool is_smooth_scroll_enabled() const;
-
-	virtual Size2 get_minimum_size() const override;
-	ScrollBar(Orientation p_orientation = VERTICAL);
-	~ScrollBar();
+	ResizableScrollBar(Orientation p_orientation = HORIZONTAL);
+	~ResizableScrollBar();
 };
 
-class HScrollBar : public ScrollBar {
-	GDCLASS(HScrollBar, ScrollBar);
+class HResizableScrollBar : public ResizableScrollBar {
+	GDCLASS(HResizableScrollBar, ResizableScrollBar);
 
 public:
-	HScrollBar() :
-			ScrollBar(HORIZONTAL) { set_v_size_flags(0); }
+	HResizableScrollBar() :
+			ResizableScrollBar(HORIZONTAL) { set_v_size_flags(0); }
 };
 
-class VScrollBar : public ScrollBar {
-	GDCLASS(VScrollBar, ScrollBar);
+// Vertical Resizable ScrollBar not implemented
+
+class VResizableScrollBar : public ResizableScrollBar {
+	GDCLASS(VResizableScrollBar, ResizableScrollBar);
 
 public:
-	VScrollBar() :
-			ScrollBar(VERTICAL) { set_h_size_flags(0); }
+	VResizableScrollBar() :
+			ResizableScrollBar(VERTICAL) { set_h_size_flags(0); }
 };

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -575,6 +575,36 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	const Ref<StyleBoxFlat> style_slider_grabber = make_flat_stylebox(style_progress_color, 4, 4, 4, 4, 4);
 	const Ref<StyleBoxFlat> style_slider_grabber_highlight = make_flat_stylebox(style_focus_color, 4, 4, 4, 4, 4);
 
+	// HResizableScrollbar
+
+	theme->set_stylebox("scroll", "HResizableScrollBar", style_h_scrollbar);
+	theme->set_stylebox("scroll_focus", "HResizableScrollBar", focus);
+	theme->set_stylebox("grabber", "HResizableScrollBar", style_scrollbar_grabber);
+	theme->set_stylebox("grabber_highlight", "HResizableScrollBar", style_scrollbar_grabber_highlight);
+	theme->set_stylebox("grabber_pressed", "HResizableScrollBar", style_scrollbar_grabber_pressed);
+
+	theme->set_icon("increment", "HResizableScrollBar", empty_icon);
+	theme->set_icon("increment_highlight", "HResizableScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "HResizableScrollBar", empty_icon);
+	theme->set_icon("decrement", "HResizableScrollBar", empty_icon);
+	theme->set_icon("decrement_highlight", "HResizableScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "HResizableScrollBar", empty_icon);
+
+	// VResizableScrollBar
+
+	theme->set_stylebox("scroll", "VResizableScrollBar", style_v_scrollbar);
+	theme->set_stylebox("scroll_focus", "VResizableScrollBar", focus);
+	theme->set_stylebox("grabber", "VResizableScrollBar", style_scrollbar_grabber);
+	theme->set_stylebox("grabber_highlight", "VResizableScrollBar", style_scrollbar_grabber_highlight);
+	theme->set_stylebox("grabber_pressed", "VResizableScrollBar", style_scrollbar_grabber_pressed);
+
+	theme->set_icon("increment", "VResizableScrollBar", empty_icon);
+	theme->set_icon("increment_highlight", "VResizableScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "VResizableScrollBar", empty_icon);
+	theme->set_icon("decrement", "VResizableScrollBar", empty_icon);
+	theme->set_icon("decrement_highlight", "VResizableScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "VResizableScrollBar", empty_icon);
+
 	// HSlider
 
 	theme->set_stylebox("slider", "HSlider", style_slider);


### PR DESCRIPTION
@Chenyang341 and I changed the scroll bar in Animation Player to a resizable scrollbar with draggable handles at the edges.

The location of the handles indicate where the the view in timeline starts and ends. Pulling the handles change the zoom. When one handle is pulled the other one stays in the same value.

This gives a new option to change the zoom of the timeline, facilitating its use. This seeks to close https://github.com/godotengine/godot-proposals/issues/11546

It implements the class HResizableScrollbar and can be used to implement Horizontal Resizable Scroll Bars in other places in the future.


https://github.com/user-attachments/assets/b3fc4cf2-7509-4daf-930b-67d1695a7f9f




