### PR TITLE
Allow using only rgb as args in variant Color parser

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -910,12 +910,16 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return err;
 			}
 
-			if (args.size() != 4) {
-				r_err_str = "Expected 4 arguments for constructor";
+			if (args.size() != 3 and args.size() != 4) {
+				r_err_str = "Expected 3 or 4 arguments for constructor";
 				return ERR_PARSE_ERROR;
 			}
 
-			value = Color(args[0], args[1], args[2], args[3]);
+			if (args.size() == 3) {
+				value = Color(args[0], args[1], args[2]);
+			} else {
+				value = Color(args[0], args[1], args[2], args[3]);
+			}
 		} else if (id == "NodePath") {
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_OPEN) {


### PR DESCRIPTION
This makes it so a Color can be parsed as either rgb or rgba. Currently when using Colors in a ConfigFile all 4 arguments are required which isn't ideal because you don't always care about the alpha.

I had a fun crash bug caused by setting the alpha to 0 (because I didn't care about it so 0 must be a good number...right) for a bunch of colors and then later matched those against the same colors read in from an image but it ended up crashing because reading the same Color from the image had an alpha of 1. The crash was totally my fault for misconfiguring it but it wouldn't have happened if setting Color to rgb was possible.

I tested the changes on my project with both rgb and rgba values and it seems to be working as expected now.