### PR TITLE
AudioStreamWAV: Inline tag remap inside load

### DIFF
--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -124,7 +124,6 @@ private:
 	LocalVector<uint8_t> data;
 	uint32_t data_bytes = 0;
 
-	HashMap<String, String> tag_id_remaps;
 	Dictionary tags;
 
 protected:
@@ -154,8 +153,6 @@ public:
 
 	void set_tags(const Dictionary &p_tags);
 	virtual Dictionary get_tags() const override;
-
-	HashMap<String, String>::ConstIterator remap_tag_id(const String &p_tag_id);
 
 	virtual double get_length() const override; //if supported, otherwise return 0
 
@@ -292,8 +289,6 @@ public:
 			dst_ptr += qoa_encode_frame(data16.ptr(), p_desc, frame_len, dst_ptr);
 		}
 	}
-
-	AudioStreamWAV();
 };
 
 VARIANT_ENUM_CAST(AudioStreamWAV::Format)


### PR DESCRIPTION
Follow up to #99504. Indirectly part of #96545.

When I was rebasing my PR, the fact a class variable and a constructor were made to be solely used by one load function that won't be used often bothered me.

I have modified so it happens fully inside the function body.