### PR TITLE
Fix Game runtime debugging in the Android Editor

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -1275,6 +1275,9 @@ bool GameViewPluginBase::_is_window_wrapper_enabled() const {
 }
 
 GameViewPluginBase::GameViewPluginBase() {
+#ifdef ANDROID_ENABLED
+	debugger.instantiate();
+#endif
 }
 
 GameViewPlugin::GameViewPlugin() :


### PR DESCRIPTION
Issue: Clicking on the game debugger menu items doesn't do anything and it throws `ERROR: Debugger plugin is null.`  on Android editor launch.

---
This was a regression caused by https://github.com/godotengine/godot/pull/105884. That PR enabled game debugging menu for macOS but sneakily disabled it for Android 🥲
The issue was instantiating `debugger` in a method that isn’t defined on Android.

Fixes https://github.com/godotengine/godot/issues/107257