### PR TITLE
Match avoidance defaults for NavigationAgent and NavigationServer NavAgent

### DIFF
--- a/modules/navigation_2d/nav_agent_2d.h
+++ b/modules/navigation_2d/nav_agent_2d.h
@@ -34,6 +34,7 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/self_list.h"
+#include "servers/navigation/navigation_globals.h"
 
 #include <Agent2d.h>
 
@@ -44,12 +45,12 @@ class NavAgent2D : public NavRid2D {
 	Vector2 target_position;
 	Vector2 velocity;
 	Vector2 velocity_forced;
-	real_t radius = 1.0;
-	real_t max_speed = 1.0;
-	real_t time_horizon_agents = 1.0;
-	real_t time_horizon_obstacles = 0.0;
-	int max_neighbors = 5;
-	real_t neighbor_distance = 5.0;
+	real_t radius = NavigationDefaults2D::AVOIDANCE_AGENT_RADIUS;
+	real_t max_speed = NavigationDefaults2D::AVOIDANCE_AGENT_MAX_SPEED;
+	real_t time_horizon_agents = NavigationDefaults2D::AVOIDANCE_AGENT_TIME_HORIZON_AGENTS;
+	real_t time_horizon_obstacles = NavigationDefaults2D::AVOIDANCE_AGENT_TIME_HORIZON_OBSTACLES;
+	int max_neighbors = NavigationDefaults2D::AVOIDANCE_AGENT_MAX_NEIGHBORS;
+	real_t neighbor_distance = NavigationDefaults2D::AVOIDANCE_AGENT_NEIGHBOR_DISTANCE;
 	Vector2 safe_velocity;
 	bool clamp_speed = true; // Experimental, clamps velocity to max_speed.
 

--- a/modules/navigation_3d/nav_agent_3d.h
+++ b/modules/navigation_3d/nav_agent_3d.h
@@ -34,6 +34,7 @@
 
 #include "core/object/class_db.h"
 #include "core/templates/self_list.h"
+#include "servers/navigation/navigation_globals.h"
 
 #include <Agent2d.h>
 #include <Agent3d.h>
@@ -45,13 +46,13 @@ class NavAgent3D : public NavRid3D {
 	Vector3 target_position;
 	Vector3 velocity;
 	Vector3 velocity_forced;
-	real_t height = 1.0;
-	real_t radius = 1.0;
-	real_t max_speed = 1.0;
-	real_t time_horizon_agents = 1.0;
-	real_t time_horizon_obstacles = 0.0;
-	int max_neighbors = 5;
-	real_t neighbor_distance = 5.0;
+	real_t height = NavigationDefaults3D::AVOIDANCE_AGENT_HEIGHT;
+	real_t radius = NavigationDefaults3D::AVOIDANCE_AGENT_RADIUS;
+	real_t max_speed = NavigationDefaults3D::AVOIDANCE_AGENT_MAX_SPEED;
+	real_t time_horizon_agents = NavigationDefaults3D::AVOIDANCE_AGENT_TIME_HORIZON_AGENTS;
+	real_t time_horizon_obstacles = NavigationDefaults3D::AVOIDANCE_AGENT_TIME_HORIZON_OBSTACLES;
+	int max_neighbors = NavigationDefaults3D::AVOIDANCE_AGENT_MAX_NEIGHBORS;
+	real_t neighbor_distance = NavigationDefaults3D::AVOIDANCE_AGENT_NEIGHBOR_DISTANCE;
 	Vector3 safe_velocity;
 	bool clamp_speed = true; // Experimental, clamps velocity to max_speed.
 

--- a/scene/2d/navigation/navigation_agent_2d.h
+++ b/scene/2d/navigation/navigation_agent_2d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/main/node.h"
+#include "servers/navigation/navigation_globals.h"
 #include "servers/navigation/navigation_path_query_parameters_2d.h"
 #include "servers/navigation/navigation_path_query_result_2d.h"
 
@@ -55,12 +56,12 @@ class NavigationAgent2D : public Node {
 
 	real_t path_desired_distance = 20.0;
 	real_t target_desired_distance = 10.0;
-	real_t radius = 10.0;
-	real_t neighbor_distance = 500.0;
-	int max_neighbors = 10;
-	real_t time_horizon_agents = 1.0;
-	real_t time_horizon_obstacles = 0.0;
-	real_t max_speed = 100.0;
+	real_t radius = NavigationDefaults2D::AVOIDANCE_AGENT_RADIUS;
+	real_t neighbor_distance = NavigationDefaults2D::AVOIDANCE_AGENT_NEIGHBOR_DISTANCE;
+	int max_neighbors = NavigationDefaults2D::AVOIDANCE_AGENT_MAX_NEIGHBORS;
+	real_t time_horizon_agents = NavigationDefaults2D::AVOIDANCE_AGENT_TIME_HORIZON_AGENTS;
+	real_t time_horizon_obstacles = NavigationDefaults2D::AVOIDANCE_AGENT_TIME_HORIZON_OBSTACLES;
+	real_t max_speed = NavigationDefaults2D::AVOIDANCE_AGENT_MAX_SPEED;
 	real_t path_max_distance = 100.0;
 	bool simplify_path = false;
 	real_t simplify_epsilon = 0.0;

--- a/scene/3d/navigation/navigation_agent_3d.h
+++ b/scene/3d/navigation/navigation_agent_3d.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "scene/main/node.h"
+#include "servers/navigation/navigation_globals.h"
 #include "servers/navigation/navigation_path_query_parameters_3d.h"
 #include "servers/navigation/navigation_path_query_result_3d.h"
 
@@ -56,14 +57,14 @@ class NavigationAgent3D : public Node {
 
 	real_t path_desired_distance = 1.0;
 	real_t target_desired_distance = 1.0;
-	real_t height = 1.0;
-	real_t radius = 0.5;
+	real_t height = NavigationDefaults3D::AVOIDANCE_AGENT_HEIGHT;
+	real_t radius = NavigationDefaults3D::AVOIDANCE_AGENT_RADIUS;
 	real_t path_height_offset = 0.0;
-	real_t neighbor_distance = 50.0;
-	int max_neighbors = 10;
-	real_t time_horizon_agents = 1.0;
-	real_t time_horizon_obstacles = 0.0;
-	real_t max_speed = 10.0;
+	real_t neighbor_distance = NavigationDefaults3D::AVOIDANCE_AGENT_NEIGHBOR_DISTANCE;
+	int max_neighbors = NavigationDefaults3D::AVOIDANCE_AGENT_MAX_NEIGHBORS;
+	real_t time_horizon_agents = NavigationDefaults3D::AVOIDANCE_AGENT_TIME_HORIZON_AGENTS;
+	real_t time_horizon_obstacles = NavigationDefaults3D::AVOIDANCE_AGENT_TIME_HORIZON_OBSTACLES;
+	real_t max_speed = NavigationDefaults3D::AVOIDANCE_AGENT_MAX_SPEED;
 	real_t path_max_distance = 5.0;
 	bool simplify_path = false;
 	real_t simplify_epsilon = 0.0;

--- a/servers/navigation/navigation_globals.h
+++ b/servers/navigation/navigation_globals.h
@@ -46,6 +46,16 @@ constexpr const char *const NAV_MESH_CELL_SIZE_HINT = "0.001,100,0.001,or_greate
 constexpr float EDGE_CONNECTION_MARGIN = 0.25f;
 constexpr float LINK_CONNECTION_RADIUS = 1.0f;
 
+// Agent.
+
+constexpr float AVOIDANCE_AGENT_HEIGHT = 1.0;
+constexpr float AVOIDANCE_AGENT_RADIUS = 0.5;
+constexpr float AVOIDANCE_AGENT_MAX_SPEED = 10.0;
+constexpr float AVOIDANCE_AGENT_TIME_HORIZON_AGENTS = 1.0;
+constexpr float AVOIDANCE_AGENT_TIME_HORIZON_OBSTACLES = 0.0;
+constexpr int AVOIDANCE_AGENT_MAX_NEIGHBORS = 10;
+constexpr float AVOIDANCE_AGENT_NEIGHBOR_DISTANCE = 50.0;
+
 } //namespace NavigationDefaults3D
 
 namespace NavigationDefaults2D {
@@ -61,5 +71,14 @@ constexpr const char *const NAV_MESH_CELL_SIZE_HINT = "0.001,100,0.001,or_greate
 
 constexpr float EDGE_CONNECTION_MARGIN = 1.0f;
 constexpr float LINK_CONNECTION_RADIUS = 4.0f;
+
+// Agent.
+
+constexpr float AVOIDANCE_AGENT_RADIUS = 10.0;
+constexpr float AVOIDANCE_AGENT_MAX_SPEED = 100.0;
+constexpr float AVOIDANCE_AGENT_TIME_HORIZON_AGENTS = 1.0;
+constexpr float AVOIDANCE_AGENT_TIME_HORIZON_OBSTACLES = 0.0;
+constexpr int AVOIDANCE_AGENT_MAX_NEIGHBORS = 10;
+constexpr float AVOIDANCE_AGENT_NEIGHBOR_DISTANCE = 500.0;
 
 } //namespace NavigationDefaults2D


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106250

Matches avoidance defaults for NavigationAgent and NavigationServer NavAgent.

The nodes had different properties than the server agent and the 2d version still used outdate defaults from the 3d version.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
