### PR TITLE
Change `NavigationServer2D` avoidance callbacks from `Vector3` to `Vector2`

### DIFF
--- a/modules/navigation_2d/nav_agent_2d.cpp
+++ b/modules/navigation_2d/nav_agent_2d.cpp
@@ -111,9 +111,9 @@ void NavAgent2D::dispatch_avoidance_callback() {
 		return;
 	}
 
-	Vector3 new_velocity;
+	Vector2 new_velocity;
 
-	new_velocity = Vector3(rvo_agent.velocity_.x(), 0.0, rvo_agent.velocity_.y());
+	new_velocity = Vector2(rvo_agent.velocity_.x(), rvo_agent.velocity_.y());
 
 	if (clamp_speed) {
 		new_velocity = new_velocity.limit_length(max_speed);

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -652,9 +652,8 @@ void NavigationAgent2D::set_velocity(const Vector2 p_velocity) {
 	velocity_submitted = true;
 }
 
-void NavigationAgent2D::_avoidance_done(Vector3 p_new_velocity) {
-	const Vector2 new_safe_velocity = Vector2(p_new_velocity.x, p_new_velocity.z);
-	safe_velocity = new_safe_velocity;
+void NavigationAgent2D::_avoidance_done(Vector2 p_new_velocity) {
+	safe_velocity = p_new_velocity;
 	emit_signal(SNAME("velocity_computed"), safe_velocity);
 }
 

--- a/scene/2d/navigation/navigation_agent_2d.h
+++ b/scene/2d/navigation/navigation_agent_2d.h
@@ -203,7 +203,7 @@ public:
 
 	void set_velocity_forced(const Vector2 p_velocity);
 
-	void _avoidance_done(Vector3 p_new_velocity);
+	void _avoidance_done(Vector2 p_new_velocity);
 
 	PackedStringArray get_configuration_warnings() const override;
 

--- a/tests/servers/test_navigation_server_2d.h
+++ b/tests/servers/test_navigation_server_2d.h
@@ -392,7 +392,7 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 0);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_avoidance_callback_mock.function1_calls, 1);
-		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector3(0, 0, 0));
+		CHECK_NE(agent_avoidance_callback_mock.function1_latest_arg0, Vector2(0, 0));
 
 		navigation_server->free(agent);
 		navigation_server->free(map);
@@ -429,12 +429,12 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 1);
-		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
-		Vector3 agent_2_safe_velocity = agent_2_avoidance_callback_mock.function1_latest_arg0;
+		Vector2 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
+		Vector2 agent_2_safe_velocity = agent_2_avoidance_callback_mock.function1_latest_arg0;
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "agent 1 should move a bit along desired velocity (+X)");
 		CHECK_MESSAGE(agent_2_safe_velocity.x < 0, "agent 2 should move a bit along desired velocity (-X)");
-		CHECK_MESSAGE(agent_1_safe_velocity.z < 0, "agent 1 should move a bit to the side so that it avoids agent 2");
-		CHECK_MESSAGE(agent_2_safe_velocity.z > 0, "agent 2 should move a bit to the side so that it avoids agent 1");
+		CHECK_MESSAGE(agent_1_safe_velocity.y < 0, "agent 1 should move a bit to the side so that it avoids agent 2");
+		CHECK_MESSAGE(agent_2_safe_velocity.y > 0, "agent 2 should move a bit to the side so that it avoids agent 1");
 
 		navigation_server->free(agent_2);
 		navigation_server->free(agent_1);
@@ -466,9 +466,9 @@ TEST_SUITE("[Navigation2D]") {
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 0);
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
-		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
+		Vector2 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "Agent 1 should move a bit along desired velocity (+X).");
-		CHECK_MESSAGE(agent_1_safe_velocity.z < 0, "Agent 1 should move a bit to the side so that it avoids obstacle.");
+		CHECK_MESSAGE(agent_1_safe_velocity.y < 0, "Agent 1 should move a bit to the side so that it avoids obstacle.");
 
 		navigation_server->free(obstacle_1);
 		navigation_server->free(agent_1);
@@ -518,12 +518,12 @@ TEST_SUITE("[Navigation2D]") {
 		navigation_server->physics_process(0.0); // Give server some cycles to commit.
 		CHECK_EQ(agent_1_avoidance_callback_mock.function1_calls, 1);
 		CHECK_EQ(agent_2_avoidance_callback_mock.function1_calls, 1);
-		Vector3 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
-		Vector3 agent_2_safe_velocity = agent_2_avoidance_callback_mock.function1_latest_arg0;
+		Vector2 agent_1_safe_velocity = agent_1_avoidance_callback_mock.function1_latest_arg0;
+		Vector2 agent_2_safe_velocity = agent_2_avoidance_callback_mock.function1_latest_arg0;
 		CHECK_MESSAGE(agent_1_safe_velocity.x > 0, "Agent 1 should move a bit along desired velocity (+X).");
-		CHECK_MESSAGE(agent_1_safe_velocity.z < 0, "Agent 1 should move a bit to the side so that it avoids obstacle.");
+		CHECK_MESSAGE(agent_1_safe_velocity.y < 0, "Agent 1 should move a bit to the side so that it avoids obstacle.");
 		CHECK_MESSAGE(agent_2_safe_velocity.x > 0, "Agent 2 should move a bit along desired velocity (+X).");
-		CHECK_MESSAGE(agent_2_safe_velocity.z == 0, "Agent 2 should not move to the side.");
+		CHECK_MESSAGE(agent_2_safe_velocity.y == 0, "Agent 2 should not move to the side.");
 
 		navigation_server->free(obstacle_1);
 		navigation_server->free(agent_2);


### PR DESCRIPTION
Changes `NavigationServer2D` avoidance callbacks from `Vector3` to `Vector2`.

This was always an oddball close to a bug that no one wanted to change because it would be a (small) compatibility break.

It was the result of the `NavigationServer2D` using the NavigationServer3D behind the scene and no one adding a Vector2 callback to the api for 2d. It caused frequent annoyance for 2d users that tried to use it not expecting a Vector3 from a NavigationServer2D. E.g. raised in issues like https://github.com/godotengine/godot/issues/106250.

Now with the major change of a dedicated NavigationServer2D added in Godot 4.5 it is good time to change this as well.

`NavigationAgent2D` users are not affected as this is just the internals changing.

Projects that use the `NavigationServer2D.agent_set_avoidance_callback()` to create custom callbacks need to change their `Vector3` parameter to `Vector2` to not run into an error after this change.

Navigation documentation has likely script examples with this that need to be updated as well.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
