### PR TITLE
Add "Use Local Space" option to the 2D editor

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -231,6 +231,7 @@ private:
 	real_t snap_rotation_step = 0.0;
 	real_t snap_rotation_offset = 0.0;
 	real_t snap_scale_step = 0.0;
+	bool use_local_space = true;
 	bool smart_snap_active = false;
 	bool grid_snap_active = false;
 
@@ -323,6 +324,7 @@ private:
 
 	Button *ruler_button = nullptr;
 
+	Button *local_space_button = nullptr;
 	Button *smart_snap_button = nullptr;
 	Button *grid_snap_button = nullptr;
 	MenuButton *snap_config_menu = nullptr;
@@ -515,6 +517,7 @@ private:
 	void _update_zoom(real_t p_zoom);
 	void _shortcut_zoom_set(real_t p_zoom);
 	void _zoom_on_position(real_t p_zoom, Point2 p_position = Point2());
+	void _button_toggle_local_space(bool p_status);
 	void _button_toggle_smart_snap(bool p_status);
 	void _button_toggle_grid_snap(bool p_status);
 	void _button_tool_select(int p_index);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6799.

This adds in a "Use Local Space" button to the 2D editor like the 3D editor currently has. By default, Godot uses local space in the 2D editor anyway, so the actual functionality of this PR comes from turning it off, which allows you to do global space transformations. For global translations, this works exactly as you'd expect. For global scale, I made it so that when you scale along the x-axis, it attempts to preserve the height of the object, and when you scale along the y-axis, it attempts to preserve the width of the object. I personally find it intuitive, but there might be a more obvious way that I'm missing, so I'd really appreciate feedback on this.

Keep in mind that by default, "Use Local Space" is on, so there shouldn't be any immediate difference.