### PR TITLE
Fix incorrect vectors when sliding against walls in floating mode

### DIFF
--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -310,7 +310,7 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 				motion = Vector2();
 			} else if (first_slide) {
 				Vector2 motion_slide_norm = result.remainder.slide(result.collision_normal).normalized();
-				motion = motion_slide_norm * (motion.length() - result.travel.length());
+				motion = motion_slide_norm * (motion.dot(motion_slide_norm) - result.travel.length());
 			} else {
 				motion = result.remainder.slide(result.collision_normal);
 			}
@@ -325,6 +325,12 @@ void CharacterBody2D::_move_and_slide_floating(double p_delta) {
 		}
 
 		first_slide = false;
+	}
+
+	if (is_on_wall_only()) {
+		if (wall_normal.dot(velocity) < 0) {
+			velocity = velocity.slide(wall_normal);
+		}
 	}
 }
 void CharacterBody2D::apply_floor_snap() {

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -431,7 +431,7 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 				}
 			} else if (first_slide) {
 				Vector3 motion_slide_norm = result.remainder.slide(wall_normal).normalized();
-				motion = motion_slide_norm * (motion.length() - result.travel.length());
+				motion = motion_slide_norm * (motion.dot(motion_slide_norm) - result.travel.length());
 			} else {
 				motion = result.remainder.slide(wall_normal);
 			}
@@ -446,6 +446,12 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 		}
 
 		first_slide = false;
+	}
+
+	if (is_on_wall_only()) {
+		if (wall_normal.dot(velocity) < 0) {
+			velocity = velocity.slide(wall_normal);
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #101052 incorrect sliding motion and fixes #60447 velocity not being updated.
The first issue was using the motion length when multiplying the motion slide norm, making the velocity greater than it should be. The second issue is slightly related since the velocity would not update to be the same as motion vector.

I am unsure what subtracting the result travel length does from the motion slide length, so I left it in.