### PR TITLE
Fix using wrong script when getting default values

### DIFF
--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -80,7 +80,7 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 	// This function obeys the way property values are set when an object is instantiated,
 	// which is the following (the latter wins):
 	// 1. Default value from builtin class
-	// 2. Default value from script exported variable (from the topmost script)
+	// 2. Default value from script exported variable
 	// 3. Value overrides from the instantiation/inheritance stack
 
 	if (r_is_class_default) {
@@ -99,8 +99,6 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 		}
 		return ct_scr;
 	}
-
-	Ref<Script> topmost_script;
 
 	if (const Node *node = Object::cast_to<Node>(p_object)) {
 		// Check inheritance/instantiation ancestors
@@ -136,30 +134,19 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 				}
 				return value_in_ancestor;
 			}
-			// Save script for later
-			bool has_script = false;
-			Variant script = ia.state->get_property_value(ia.node, SNAME("script"), has_script, node_deferred);
-			if (has_script) {
-				Ref<Script> scr = script;
-				if (scr.is_valid()) {
-					topmost_script = scr;
-				}
-			}
 		}
 	}
 
-	// Let's see what default is set by the topmost script having a default, if any
-	if (topmost_script.is_null()) {
-		topmost_script = p_object->get_script();
-	}
-	if (topmost_script.is_valid()) {
+	Ref<Script> script = p_object->get_script();
+
+	if (script.is_valid()) {
 		// Should be called in the editor only and not at runtime,
 		// otherwise it can cause problems because of missing instance state support
 		if (p_update_exports && Engine::get_singleton()->is_editor_hint()) {
-			topmost_script->update_exports();
+			script->update_exports();
 		}
 		Variant default_value;
-		if (topmost_script->get_property_default_value(p_property, default_value)) {
+		if (script->get_property_default_value(p_property, default_value)) {
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -979,16 +979,27 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			bool is_valid_default = false;
 			Variant default_value = PropertyUtils::get_property_default_value(p_node, name, &is_valid_default, &states_stack, true);
 
-			if (is_valid_default && !PropertyUtils::is_property_value_different(p_node, value, default_value)) {
-				if (value.get_type() == Variant::ARRAY && has_local_resource(value)) {
-					// Save anyway
-				} else if (value.get_type() == Variant::DICTIONARY) {
-					Dictionary dictionary = value;
-					if (!has_local_resource(dictionary.values()) && !has_local_resource(dictionary.keys())) {
-						continue;
+			if (is_valid_default) {
+				if (PropertyUtils::is_property_value_different(p_node, value, default_value)) {
+					if (value.get_type() == Variant::ARRAY && default_value.get_type() == Variant::ARRAY) {
+						Array arr = value;
+						if (arr.is_empty()) {
+							Array default_array = default_value;
+							// Ensure the type is the same as the default array type.
+							value = Array(arr, default_array.get_typed_builtin(), default_array.get_typed_class_name(), default_array.get_typed_script());
+						}
 					}
 				} else {
-					continue;
+					if (value.get_type() == Variant::ARRAY && has_local_resource(value)) {
+						// Save anyway
+					} else if (value.get_type() == Variant::DICTIONARY) {
+						Dictionary dictionary = value;
+						if (!has_local_resource(dictionary.values()) && !has_local_resource(dictionary.keys())) {
+							continue;
+						}
+					} else {
+						continue;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Use the most recent script attached to the scene, which is the current script.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix partially #81526, #101079.

~~The cases in the MRP attached to the issues are fixed, but the case of overwriting a non-empty array with an empty array is not fixed. Perhaps empty arrays (including typed empty arrays) could be recorded simply as `[]`.~~  Combining this with #72514 will completely fix them.

https://github.com/godotengine/godot/blob/80a4af1cc7c97b41f819ac2ac519a12804a53b1c/scene/resources/packed_scene.cpp#L998

This PR ensures that the `value` can be a typed empty array. The difference in `prop.value` due to the different typing of empty array `value` ​​should be addressed by #72514.

