### PR TITLE
Ensure hiding `AcceptDialog` OK button keeps other buttons centered

### DIFF
--- a/scene/gui/dialogs.h
+++ b/scene/gui/dialogs.h
@@ -65,7 +65,7 @@ class AcceptDialog : public Window {
 	} theme_cache;
 
 	void _custom_action(const String &p_action);
-	void _custom_button_visibility_changed(Button *button);
+	void _button_visibility_changed(Button *button);
 	void _update_child_rects();
 	void _update_ok_text();
 


### PR DESCRIPTION
Fixes #107278.

Case from #107278|Before<br>(v4.4.1.stable.official [49a5bc7b6])|After<br>(this PR)
-|-|-
Example 1|![Godot_v4 4 1-stable_win64_ZxXIzjrmaA](https://github.com/user-attachments/assets/d769f920-daac-4110-8113-123b6a4f9832)|![godot windows editor dev x86_64_OJfRF4LyDy](https://github.com/user-attachments/assets/fab2a7c4-2b18-4197-bc73-6ef1a25a8af2)
Example 2|![Godot_v4 4 1-stable_win64_iCUcCUxBvv](https://github.com/user-attachments/assets/26f62e08-59a3-4732-8ec6-56b444dd4145)|![godot windows editor dev x86_64_bSqDxrQa8r](https://github.com/user-attachments/assets/b16d4961-f5f7-4a75-82b1-29d00da74c42)
Example 3|![Godot_v4 4 1-stable_win64_Ezqb71znue](https://github.com/user-attachments/assets/fdb6de7e-09de-408d-9d9f-262e4d9c07f2)|![godot windows editor dev x86_64_sXrjWBQSyB](https://github.com/user-attachments/assets/5a125a3e-2cc0-41bf-a267-e86cb8857ebf)
Example 4|![Godot_v4 4 1-stable_win64_cDF11nwLLo](https://github.com/user-attachments/assets/fdd2170e-d0a3-42c2-a99e-18eac5590068)|![godot windows editor dev x86_64_iiiP2J12bf](https://github.com/user-attachments/assets/686ebc61-90d6-436d-9dc7-9aefd88b5b35)

Only custom buttons had their visibility propagating to a neighbor "spacer" control (unique per button). This PRs makes the same thing for the OK button.
Also renamed the used meta from `"__right_spacer"` to `"__bound_spacer"` because the relevant spacer might be added to the left when adding at the beginning of the buttons (it was me who named it `"__right_spacer"` in the first place 🙃).