### PR TITLE
Don't store deprecated `auto_translate` property for `Window`

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -581,7 +581,7 @@
 		<member name="always_on_top" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the window will be on top of all other windows. Does not work if [member transient] is enabled.
 		</member>
-		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" default="true" deprecated="Use [member Node.auto_translate_mode] instead.">
+		<member name="auto_translate" type="bool" setter="set_auto_translate" getter="is_auto_translating" deprecated="Use [member Node.auto_translate_mode] instead.">
 			Toggles if any text should automatically change to its translated version depending on the current locale.
 		</member>
 		<member name="borderless" type="bool" setter="set_flag" getter="get_flag" default="false">

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -3271,7 +3271,7 @@ void Window::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "content_scale_factor", PROPERTY_HINT_RANGE, "0.5,8.0,0.01"), "set_content_scale_factor", "get_content_scale_factor");
 
 #ifndef DISABLE_DEPRECATED
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_auto_translate", "is_auto_translating");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_translate", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_auto_translate", "is_auto_translating");
 #endif
 
 	ADD_GROUP("Theme", "theme_");


### PR DESCRIPTION
Fixes #107272

This PR is the same as #90685, but for `Window`s.

Regression from #96921: This is technically a long-existing issue, but the translation preview PR makes it visible by default :crying_cat_face: As long as the translation preview stays off, nodes using the default auto translation mode (inherit) know that they are not auto translating. Thus `Window`-derived nodes store `auto_translate = false` in the tscn.