### PR TITLE
Add missing Color hash function

### DIFF
--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -389,6 +389,13 @@ struct HashMapHasherDefault {
 		h = hash_murmur3_one_real(p_vec.w, h);
 		return hash_fmix32(h);
 	}
+	static _FORCE_INLINE_ uint32_t hash(const Color &p_vec) {
+		uint32_t h = hash_murmur3_one_float(p_vec.r);
+		h = hash_murmur3_one_float(p_vec.g, h);
+		h = hash_murmur3_one_float(p_vec.b, h);
+		h = hash_murmur3_one_float(p_vec.a, h);
+		return hash_fmix32(h);
+	}
 	static _FORCE_INLINE_ uint32_t hash(const Rect2i &p_rect) {
 		uint32_t h = hash_murmur3_one_32(uint32_t(p_rect.position.x));
 		h = hash_murmur3_one_32(uint32_t(p_rect.position.y), h);


### PR DESCRIPTION
The Color type has no hash function in HashMapHasherDefault, it still works right now but it only works because color gets implicitly converted to a String.

I had some code that was insanely slow for no good reason so I ran it through callgrind to figure out what was going on and I saw this in Kcachegrind:

![image](https://github.com/user-attachments/assets/4e22a774-7ee4-46a4-9d52-d995496d1bb3)

40 billion instructions from String allocations when doing Color HashMap lookups didn't really make any sense, Color should have nothing to do with String. So I looked into the HashMap lookup function and sure enough there was no Color hash function, which caused keys of Color type to get implicitly converted to a String and then it called the String hash function.

Just by adding this Color hash function my startup time went from around 5 seconds to about half a second.