### PR TITLE
Improve NavigationAgent2D debug performance

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -158,8 +158,8 @@
 		<member name="debug_path_custom_color" type="Color" setter="set_debug_path_custom_color" getter="get_debug_path_custom_color" default="Color(1, 1, 1, 1)">
 			If [member debug_use_custom] is [code]true[/code] uses this color for this agent instead of global color.
 		</member>
-		<member name="debug_path_custom_line_width" type="float" setter="set_debug_path_custom_line_width" getter="get_debug_path_custom_line_width" default="-1.0">
-			If [member debug_use_custom] is [code]true[/code] uses this line width for rendering paths for this agent instead of global line width.
+		<member name="debug_path_custom_line_width" type="float" setter="set_debug_path_custom_line_width" getter="get_debug_path_custom_line_width" default="-1.0" deprecated="">
+			This property does nothing.
 		</member>
 		<member name="debug_path_custom_point_size" type="float" setter="set_debug_path_custom_point_size" getter="get_debug_path_custom_point_size" default="4.0">
 			If [member debug_use_custom] is [code]true[/code] uses this rasterized point size for rendering path points for this agent instead of global point size.

--- a/scene/2d/navigation/navigation_agent_2d.h
+++ b/scene/2d/navigation/navigation_agent_2d.h
@@ -102,6 +102,9 @@ class NavigationAgent2D : public Node {
 #ifdef DEBUG_ENABLED
 	// Debug properties internal only
 	bool debug_path_dirty = true;
+	RID debug_path_segments_mesh_rid;
+	RID debug_path_point_mesh_rid;
+	RID debug_path_points_multimesh_rid;
 	RID debug_path_instance;
 #endif // DEBUG_ENABLED
 


### PR DESCRIPTION
Improves NavigationAgent2D debug performance by using static mesh and multimesh.

The old debug used the classic canvas draw functions for line segments and rects. Those are really inefficient for longer paths due to each creating either a new internal throwaway mesh or a new draw command.

This PR changes the agent path debug to a single static mesh for all the line segments, aka a single draw.
All the path points reuse a single rect mesh that is rendered with a multimesh.

Should be a net-gain for all projects but projects with a lot of agents and longer path stability (aka not querying a new path every frame like a madman) will see the biggest performance boost by this change.

Since line width is not supported by mesh line primitives (and never worked great to begin with on a lot of hardware) the option is deprecated and hidden from the inspector.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
