### PR TITLE
Remove implicit conversions from math types to `String`, to avoid accidental conversions

### DIFF
--- a/core/math/aabb.cpp
+++ b/core/math/aabb.cpp
@@ -441,5 +441,5 @@ Variant AABB::intersects_ray_bind(const Vector3 &p_from, const Vector3 &p_dir) c
 }
 
 AABB::operator String() const {
-	return "[P: " + position.operator String() + ", S: " + size + "]";
+	return "[P: " + String(position) + ", S: " + String(size) + "]";
 }

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -131,7 +131,7 @@ struct [[nodiscard]] AABB {
 		return position + (size * 0.5f);
 	}
 
-	operator String() const;
+	explicit operator String() const;
 
 	AABB() = default;
 	constexpr AABB(const Vector3 &p_pos, const Vector3 &p_size) :

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -149,7 +149,7 @@ struct [[nodiscard]] Basis {
 	Basis slerp(const Basis &p_to, real_t p_weight) const;
 	void rotate_sh(real_t *p_values);
 
-	operator String() const;
+	explicit operator String() const;
 
 	/* create / set */
 

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -220,7 +220,7 @@ struct [[nodiscard]] Color {
 	static Color from_rgba8(int64_t p_r8, int64_t p_g8, int64_t p_b8, int64_t p_a8 = 255);
 
 	constexpr bool operator<(const Color &p_color) const; // Used in set keys.
-	operator String() const;
+	explicit operator String() const;
 
 	// For the binder.
 	_FORCE_INLINE_ void set_r8(int32_t r8) { r = (CLAMP(r8, 0, 255) / 255.0f); }

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -201,7 +201,7 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 }
 
 Face3::operator String() const {
-	return String() + vertex[0] + ", " + vertex[1] + ", " + vertex[2];
+	return String() + String(vertex[0]) + ", " + String(vertex[1]) + ", " + String(vertex[2]);
 }
 
 void Face3::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -76,7 +76,7 @@ struct [[nodiscard]] Face3 {
 
 	bool intersects_aabb(const AABB &p_aabb) const;
 	_FORCE_INLINE_ bool intersects_aabb2(const AABB &p_aabb) const;
-	operator String() const;
+	explicit operator String() const;
 
 	Face3() = default;
 	constexpr Face3(const Vector3 &p_v1, const Vector3 &p_v2, const Vector3 &p_v3) :

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -78,7 +78,7 @@ struct [[nodiscard]] Plane {
 
 	constexpr bool operator==(const Plane &p_plane) const;
 	constexpr bool operator!=(const Plane &p_plane) const;
-	operator String() const;
+	explicit operator String() const;
 
 	Plane() = default;
 	constexpr Plane(real_t p_a, real_t p_b, real_t p_c, real_t p_d) :

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -127,7 +127,7 @@ struct [[nodiscard]] Projection {
 	Vector4 xform(const Vector4 &p_vec4) const;
 	Vector4 xform_inv(const Vector4 &p_vec4) const;
 
-	operator String() const;
+	explicit operator String() const;
 
 	void scale_translate_to_fit(const AABB &p_aabb);
 	void add_jitter_offset(const Vector2 &p_offset);

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -115,7 +115,7 @@ struct [[nodiscard]] Quaternion {
 	constexpr bool operator==(const Quaternion &p_quaternion) const;
 	constexpr bool operator!=(const Quaternion &p_quaternion) const;
 
-	operator String() const;
+	explicit operator String() const;
 
 	constexpr Quaternion() :
 			x(0), y(0), z(0), w(1) {}

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -358,7 +358,7 @@ struct [[nodiscard]] Rect2 {
 		return position + size;
 	}
 
-	operator String() const;
+	explicit operator String() const;
 	operator Rect2i() const;
 
 	Rect2() = default;

--- a/core/math/rect2i.cpp
+++ b/core/math/rect2i.cpp
@@ -34,7 +34,7 @@
 #include "core/string/ustring.h"
 
 Rect2i::operator String() const {
-	return "[P: " + position.operator String() + ", S: " + size + "]";
+	return "[P: " + String(position) + ", S: " + String(size) + "]";
 }
 
 Rect2i::operator Rect2() const {

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -223,7 +223,7 @@ struct [[nodiscard]] Rect2i {
 		return position + size;
 	}
 
-	operator String() const;
+	explicit operator String() const;
 	operator Rect2() const;
 
 	Rect2i() = default;

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -130,7 +130,7 @@ struct [[nodiscard]] Transform2D {
 	_FORCE_INLINE_ Vector<Vector2> xform(const Vector<Vector2> &p_array) const;
 	_FORCE_INLINE_ Vector<Vector2> xform_inv(const Vector<Vector2> &p_array) const;
 
-	operator String() const;
+	explicit operator String() const;
 
 	constexpr Transform2D(real_t p_xx, real_t p_xy, real_t p_yx, real_t p_yy, real_t p_ox, real_t p_oy) :
 			columns{

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -122,7 +122,7 @@ struct [[nodiscard]] Transform3D {
 		origin.z = p_tz;
 	}
 
-	operator String() const;
+	explicit operator String() const;
 
 	Transform3D() = default;
 	constexpr Transform3D(const Basis &p_basis, const Vector3 &p_origin = Vector3()) :

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -182,7 +182,7 @@ struct [[nodiscard]] Vector2 {
 	Vector2 clampf(real_t p_min, real_t p_max) const;
 	real_t aspect() const { return width / height; }
 
-	operator String() const;
+	explicit operator String() const;
 	operator Vector2i() const;
 
 	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -139,7 +139,7 @@ struct [[nodiscard]] Vector2i {
 	Vector2i snapped(const Vector2i &p_step) const;
 	Vector2i snappedi(int32_t p_step) const;
 
-	operator String() const;
+	explicit operator String() const;
 	operator Vector2() const;
 
 	// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -186,7 +186,7 @@ struct [[nodiscard]] Vector3 {
 	constexpr bool operator>(const Vector3 &p_v) const;
 	constexpr bool operator>=(const Vector3 &p_v) const;
 
-	operator String() const;
+	explicit operator String() const;
 	operator Vector3i() const;
 
 	constexpr Vector3() :

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -130,7 +130,7 @@ struct [[nodiscard]] Vector3i {
 	constexpr bool operator>(const Vector3i &p_v) const;
 	constexpr bool operator>=(const Vector3i &p_v) const;
 
-	operator String() const;
+	explicit operator String() const;
 	operator Vector3() const;
 
 	constexpr Vector3i() :

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -143,7 +143,7 @@ struct [[nodiscard]] Vector4 {
 	constexpr bool operator>=(const Vector4 &p_vec4) const;
 	constexpr bool operator<=(const Vector4 &p_vec4) const;
 
-	operator String() const;
+	explicit operator String() const;
 	operator Vector4i() const;
 
 	constexpr Vector4() :

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -132,7 +132,7 @@ struct [[nodiscard]] Vector4i {
 	constexpr bool operator>(const Vector4i &p_v) const;
 	constexpr bool operator>=(const Vector4i &p_v) const;
 
-	operator String() const;
+	explicit operator String() const;
 	operator Vector4() const;
 
 	constexpr Vector4i() :

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1610,41 +1610,41 @@ String Variant::stringify(int recursion_count) const {
 		case STRING:
 			return *reinterpret_cast<const String *>(_data._mem);
 		case VECTOR2:
-			return operator Vector2();
+			return String(operator Vector2());
 		case VECTOR2I:
-			return operator Vector2i();
+			return String(operator Vector2i());
 		case RECT2:
-			return operator Rect2();
+			return String(operator Rect2());
 		case RECT2I:
-			return operator Rect2i();
+			return String(operator Rect2i());
 		case TRANSFORM2D:
-			return operator Transform2D();
+			return String(operator Transform2D());
 		case VECTOR3:
-			return operator Vector3();
+			return String(operator Vector3());
 		case VECTOR3I:
-			return operator Vector3i();
+			return String(operator Vector3i());
 		case VECTOR4:
-			return operator Vector4();
+			return String(operator Vector4());
 		case VECTOR4I:
-			return operator Vector4i();
+			return String(operator Vector4i());
 		case PLANE:
-			return operator Plane();
+			return String(operator Plane());
 		case AABB:
-			return operator ::AABB();
+			return String(operator ::AABB());
 		case QUATERNION:
-			return operator Quaternion();
+			return String(operator Quaternion());
 		case BASIS:
-			return operator Basis();
+			return String(operator Basis());
 		case TRANSFORM3D:
-			return operator Transform3D();
+			return String(operator Transform3D());
 		case PROJECTION:
-			return operator Projection();
+			return String(operator Projection());
 		case STRING_NAME:
 			return operator StringName();
 		case NODE_PATH:
 			return operator NodePath();
 		case COLOR:
-			return operator Color();
+			return String(operator Color());
 		case DICTIONARY: {
 			ERR_FAIL_COND_V_MSG(recursion_count > MAX_RECURSION, "{ ... }", "Maximum dictionary recursion reached!");
 			recursion_count++;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2928,9 +2928,9 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 					float h = animation->bezier_track_get_key_value(track, key_idx);
 					text += TTR("Value:") + " " + rtos(h) + "\n";
 					Vector2 ih = animation->bezier_track_get_key_in_handle(track, key_idx);
-					text += TTR("In-Handle:") + " " + ih + "\n";
+					text += TTR("In-Handle:") + " " + String(ih) + "\n";
 					Vector2 oh = animation->bezier_track_get_key_out_handle(track, key_idx);
-					text += TTR("Out-Handle:") + " " + oh + "\n";
+					text += TTR("Out-Handle:") + " " + String(oh) + "\n";
 					int hm = animation->bezier_track_get_key_handle_mode(track, key_idx);
 					switch (hm) {
 						case Animation::HANDLE_MODE_FREE: {

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -260,9 +260,9 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			x.type = type_vec2;
 			y.type = type_vec2;
 			origin.type = type_vec2;
-			x.value = transform.columns[0];
-			y.value = transform.columns[1];
-			origin.value = transform.columns[2];
+			x.value = String(transform.columns[0]);
+			y.value = String(transform.columns[1]);
+			origin.value = String(transform.columns[2]);
 			x.variablesReference = parse_variant(transform.columns[0]);
 			y.variablesReference = parse_variant(transform.columns[1]);
 			origin.variablesReference = parse_variant(transform.columns[2]);
@@ -280,7 +280,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			d.type = Variant::get_type_name(Variant::FLOAT);
 			normal.type = Variant::get_type_name(Variant::VECTOR3);
 			d.value = rtos(plane.d);
-			normal.value = plane.normal;
+			normal.value = String(plane.normal);
 			normal.variablesReference = parse_variant(plane.normal);
 
 			Array arr = { d.to_json(), normal.to_json() };
@@ -318,8 +318,8 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			size.name = "size";
 			position.type = type_vec3;
 			size.type = type_vec3;
-			position.value = aabb.position;
-			size.value = aabb.size;
+			position.value = String(aabb.position);
+			size.value = String(aabb.size);
 			position.variablesReference = parse_variant(aabb.position);
 			size.variablesReference = parse_variant(aabb.size);
 
@@ -338,9 +338,9 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			x.type = type_vec3;
 			y.type = type_vec3;
 			z.type = type_vec3;
-			x.value = basis.rows[0];
-			y.value = basis.rows[1];
-			z.value = basis.rows[2];
+			x.value = String(basis.rows[0]);
+			y.value = String(basis.rows[1]);
+			z.value = String(basis.rows[2]);
 			x.variablesReference = parse_variant(basis.rows[0]);
 			y.variablesReference = parse_variant(basis.rows[1]);
 			z.variablesReference = parse_variant(basis.rows[2]);
@@ -357,8 +357,8 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 			origin.name = "origin";
 			basis.type = Variant::get_type_name(Variant::BASIS);
 			origin.type = Variant::get_type_name(Variant::VECTOR3);
-			basis.value = transform.basis;
-			origin.value = transform.origin;
+			basis.value = String(transform.basis);
+			origin.value = String(transform.origin);
 			basis.variablesReference = parse_variant(transform.basis);
 			origin.variablesReference = parse_variant(transform.origin);
 
@@ -560,7 +560,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 				DAP::Variable var;
 				var.name = itos(i);
 				var.type = Variant::get_type_name(Variant::VECTOR2);
-				var.value = array[i];
+				var.value = String(array[i]);
 				var.variablesReference = parse_variant(array[i]);
 				arr.push_back(var.to_json());
 			}
@@ -581,7 +581,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 				DAP::Variable var;
 				var.name = itos(i);
 				var.type = Variant::get_type_name(Variant::VECTOR3);
-				var.value = array[i];
+				var.value = String(array[i]);
 				var.variablesReference = parse_variant(array[i]);
 				arr.push_back(var.to_json());
 			}
@@ -602,7 +602,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 				DAP::Variable var;
 				var.name = itos(i);
 				var.type = Variant::get_type_name(Variant::COLOR);
-				var.value = array[i];
+				var.value = String(array[i]);
 				var.variablesReference = parse_variant(array[i]);
 				arr.push_back(var.to_json());
 			}
@@ -624,7 +624,7 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 				DAP::Variable var;
 				var.name = itos(i);
 				var.type = Variant::get_type_name(Variant::VECTOR4);
-				var.value = array[i];
+				var.value = String(array[i]);
 				var.variablesReference = parse_variant(array[i]);
 				arr.push_back(var.to_json());
 			}

--- a/editor/plugins/tiles/tile_map_layer_editor.cpp
+++ b/editor/plugins/tiles/tile_map_layer_editor.cpp
@@ -54,7 +54,7 @@ TileMapLayer *TileMapLayerSubEditorPlugin::_get_edited_layer() const {
 
 void TileMapLayerSubEditorPlugin::draw_tile_coords_over_viewport(Control *p_overlay, const TileMapLayer *p_edited_layer, Ref<TileSet> p_tile_set, bool p_show_rectangle_size, const Vector2i &p_rectangle_origin) {
 	Point2 msgpos = Point2(20 * EDSCALE, p_overlay->get_size().y - 20 * EDSCALE);
-	String text = p_tile_set->local_to_map(p_edited_layer->get_local_mouse_position());
+	String text = String(p_tile_set->local_to_map(p_edited_layer->get_local_mouse_position()));
 
 	if (p_show_rectangle_size) {
 		Vector2i rect_size = p_tile_set->local_to_map(p_edited_layer->get_local_mouse_position()) - p_tile_set->local_to_map(p_rectangle_origin);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -5226,7 +5226,7 @@ void Animation::compress(uint32_t p_page_size, uint32_t p_fps, float p_split_tol
 				ScaleTrack *st = static_cast<ScaleTrack *>(t);
 				st->scales.clear();
 				st->compressed_track = i;
-				print_line("Scale Bounds " + itos(i) + ": " + track_bounds[i]);
+				print_line("Scale Bounds " + itos(i) + ": " + String(track_bounds[i]));
 			} break;
 			case TYPE_BLEND_SHAPE: {
 				BlendShapeTrack *bst = static_cast<BlendShapeTrack *>(t);


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/107289

We've agreed in a previous core meeting that implicit conversions should be reduced in the codebase. As a costly conversion, implicit conversion to `String` is especially undesirable. This PR makes one small step towards this goal.

As an example, the bug fixed by the above PR (https://github.com/godotengine/godot/pull/107289) was only possible because `Color` had an implicit conversion to `String`. This PR makes this conversion explicit (among others), preventing similar bugs from happening again in the future.
