### PR TITLE
Updated the String String::get_slice function to include negative indexing

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -912,7 +912,14 @@ String String::get_slice(const String &p_splitter, int p_slice) const {
 	int prev_pos = 0;
 	//int slices=1;
 	if (p_slice < 0) {
-		return "";
+		while ((pos = text.find(p_splitter, pos)) != std::string::npos) {
+			count++;
+			pos += p_splitter.length();
+		}
+		p_slice = count + p_slice + 1;
+		if (p_slice > count) {
+			return "";
+		}
 	}
 	if (find(p_splitter) == -1) {
 		return *this;


### PR DESCRIPTION
In the get_slice function, the if statement if (p_slice < 0) has been updated to provide negative indexing if the slice value inputted is a negative value.
For example, if I have a total of 5 entities and I use index -1, I should be looking at the 5th (last) entity. Also, if I was using index -2 I would be looking at index 4.

Below is a snippet of the code update:

![get_slice_negative_index_code](https://github.com/user-attachments/assets/55248ea4-6fef-4d3b-b598-a76137377a81)

