### PR TITLE
Support negative indices in `String::get_slice`

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -908,11 +908,19 @@ String String::get_slice(const String &p_splitter, int p_slice) const {
 		return "";
 	}
 
+	int count = 0;
 	int pos = 0;
 	int prev_pos = 0;
 	//int slices=1;
 	if (p_slice < 0) {
-		return "";
+		while ((pos = text.find(p_splitter, pos)) != std::string::npos) {
+			count++;
+			pos += p_splitter.length();
+		}
+		p_slice = count + p_slice + 1;
+		if (p_slice > count) {
+			return "";
+		}
 	}
 	if (find(p_splitter) == -1) {
 		return *this;


### PR DESCRIPTION
In the get_slice function, the if statement if (p_slice < 0) has been updated to provide negative indexing if the slice value inputted is a negative value. 
For example, if I have a total of 5 (0 through 4) entities and I use index -1, I should be looking at index 4 (last) entity. Also, if I was using index -2 I would be looking at index 3. And index -5 would be index 0.

Below is a run through of the updated code:
Lines 916 - 919 loop through the text to count the amount of total delimiters.
Line 920 converts the negative p_slice into its positive entity.
Lines 921 - 923 will check if the new converted positive value is too high of a slice.

