### PR TITLE
Spinbox: Fix incorrect step and decimal text when using custom arrow step

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -135,8 +135,12 @@ void Range::set_value(double p_val) {
 }
 
 void Range::_set_value_no_signal(double p_val) {
-	if (shared->step > 0) {
-		p_val = Math::round((p_val - shared->min) / shared->step) * shared->step + shared->min;
+	shared->val = _calc_value(p_val, shared->step);
+}
+
+double Range::_calc_value(double p_val, double p_step) const {
+	if (p_step > 0) {
+		p_val = Math::round((p_val - shared->min) / p_step) * p_step + shared->min;
 	}
 
 	if (_rounded_values) {
@@ -150,12 +154,7 @@ void Range::_set_value_no_signal(double p_val) {
 	if (!shared->allow_lesser && p_val < shared->min) {
 		p_val = shared->min;
 	}
-
-	if (shared->val == p_val) {
-		return;
-	}
-
-	shared->val = p_val;
+	return p_val;
 }
 
 void Range::set_value_no_signal(double p_val) {

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -62,6 +62,7 @@ class Range : public Control {
 	void _set_value_no_signal(double p_val);
 
 protected:
+	double _calc_value(double p_val, double p_step) const;
 	virtual void _value_changed(double p_value);
 	void _notify_shared_value_changed() { shared->emit_value_changed(); }
 	void _notification(int p_what);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -144,7 +144,6 @@ class SpinBox : public Range {
 
 	void _mouse_exited();
 	void _update_buttons_state_for_current_value();
-	void _set_step_no_signal(double p_step);
 
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
Fixes #107271 and makes the value correctly snapped to next step.

[屏幕录像_20250609_131829.webm](https://github.com/user-attachments/assets/524dc2ee-bdb2-4da3-8cf2-fd4f02329c07)