### PR TITLE
Add support for closing dialog windows with Cmd+W on macOS

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -334,6 +334,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_accept",                                     TTRC("Accept") },
 	{ "ui_select",                                     TTRC("Select") },
 	{ "ui_cancel",                                     TTRC("Cancel") },
+	{ "ui_close_dialog",                               TTRC("Close Dialog") },
 	{ "ui_focus_next",                                 TTRC("Focus Next") },
 	{ "ui_focus_prev",                                 TTRC("Focus Prev") },
 	{ "ui_left",                                       TTRC("Left") },
@@ -446,6 +447,15 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::ESCAPE));
 	default_builtin_cache.insert("ui_cancel", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::ESCAPE));
+	default_builtin_cache.insert("ui_close_dialog", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+	inputs.push_back(InputEventKey::create_reference(Key::W | KeyModifierMask::META));
+	inputs.push_back(InputEventKey::create_reference(Key::ESCAPE));
+	default_builtin_cache.insert("ui_close_dialog.macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::TAB));

--- a/doc/classes/AcceptDialog.xml
+++ b/doc/classes/AcceptDialog.xml
@@ -62,7 +62,7 @@
 			Sets autowrapping for the text in the dialog.
 		</member>
 		<member name="dialog_close_on_escape" type="bool" setter="set_close_on_escape" getter="get_close_on_escape" default="true">
-			If [code]true[/code], the dialog will be hidden when the [code]ui_cancel[/code] action is pressed (by default, this action is bound to [constant KEY_ESCAPE]).
+			If [code]true[/code], the dialog will be hidden when the [code]ui_close_dialog[/code] action is pressed (by default, this action is bound to [kbd]Escape[/kbd], or [kbd]Cmd + W[/kbd] on macOS).
 		</member>
 		<member name="dialog_hide_on_ok" type="bool" setter="set_hide_on_ok" getter="get_hide_on_ok" default="true">
 			If [code]true[/code], the dialog is hidden when the OK button is pressed. You can set it to [code]false[/code] if you want to do e.g. input validation when receiving the [signal confirmed] signal, and handle hiding the dialog in your own logic.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1257,6 +1257,13 @@
 			Default [InputEventAction] to discard a modal or pending input.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_close_dialog" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to close a dialog window.
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
+		<member name="input/ui_close_dialog.macos" type="Dictionary" setter="" getter="">
+			macOS specific override for the shortcut to close a dialog window.
+		</member>
 		<member name="input/ui_colorpicker_delete_preset" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to delete a color preset in a [ColorPicker].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -37,7 +37,7 @@
 // AcceptDialog
 
 void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
-	if (close_on_escape && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+	if (close_on_escape && p_event->is_action_pressed(SNAME("ui_close_dialog"), false, true)) {
 		_cancel_pressed();
 	}
 	Window::_input_from_window(p_event);


### PR DESCRIPTION
Adds a new `ui_close_dialog` action to allow support for <kbd>Cmd+W</kbd> on macOS. `dialog_close_on_escape` property is kept unchanged. Closes https://github.com/godotengine/godot-proposals/issues/9311, closes https://github.com/godotengine/godot/issues/86200