### PR TITLE
SCons: Identify build clearly when using AES256 encryption key

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -185,9 +185,15 @@ gen_hash = env.CommandNoCache(
 env.add_source_files(env.core_sources, gen_hash)
 
 # Generate AES256 script encryption key
+encryption_key = os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")
+if encryption_key:
+    print(
+        "\n*** IMPORTANT: Compiling Godot with custom `SCRIPT_AES256_ENCRYPTION_KEY` set as environment variable."
+        "\n*** Make sure to use templates compiled with this key when exporting a project with encryption.\n"
+    )
 gen_encrypt = env.CommandNoCache(
     "script_encryption_key.gen.cpp",
-    env.Value(os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")),
+    env.Value(encryption_key),
     env.Run(core_builders.encryption_key_builder),
 )
 env.add_source_files(env.core_sources, gen_encrypt)


### PR DESCRIPTION
It seems to be a common pitfall that users try to build custom templates with a key but somehow it doesn't get picked up as they expect it to.

- See #80804.

```
Building for platform "linuxbsd", architecture "x86_64", target "editor".

*** IMPORTANT: Compiling Godot with custom `SCRIPT_AES256_ENCRYPTION_KEY` set as environment variable.
*** Make sure to use templates compiled with this key when exporting a project with encryption.

scons: done reading SConscript files.
```

@Calinou @bruvzg I suggest adding it to the docs so that users know to look for this message in their build logs when troubleshooting.

I also considered whether to print the value of the key so they can confirm it matches their expectations, but chose not to as it might be considered a security issue to print it in clear (e.g. it may be used on CI with a secret).