### PR TITLE
clipper2: Update to 1.5.4

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -120,7 +120,7 @@ Files extracted from upstream source:
 ## clipper2
 
 - Upstream: https://github.com/AngusJohnson/Clipper2
-- Version: 1.5.3 (fa165fe8364b7d0e5d5db2182369b8c82348f4ea, 2025)
+- Version: 1.5.4 (ef88ee97c0e759792e43a2b2d8072def6c9244e8, 2025)
 - License: BSL 1.0
 
 Files extracted from upstream source:

--- a/thirdparty/clipper2/include/clipper2/clipper.version.h
+++ b/thirdparty/clipper2/include/clipper2/clipper.version.h
@@ -1,6 +1,6 @@
 #ifndef CLIPPER_VERSION_H
 #define CLIPPER_VERSION_H
 
-constexpr auto CLIPPER2_VERSION = "1.5.3";
+constexpr auto CLIPPER2_VERSION = "1.5.4";
 
 #endif  // CLIPPER_VERSION_H

--- a/thirdparty/clipper2/src/clipper.engine.cpp
+++ b/thirdparty/clipper2/src/clipper.engine.cpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 * Author    :  Angus Johnson                                                   *
-* Date      :  4 May 2025                                                      *
+* Date      :  30 May 2025                                                     *
 * Website   :  https://www.angusj.com                                          *
 * Copyright :  Angus Johnson 2010-2025                                         *
 * Purpose   :  This is the main polygon clipping module                        *
@@ -2119,10 +2119,9 @@ namespace Clipper2Lib {
       e->prev_in_sel = e->prev_in_ael;
       e->next_in_sel = e->next_in_ael;
       e->jump = e->next_in_sel;
-      if (e->join_with == JoinWith::Left)
-        e->curr_x = e->prev_in_ael->curr_x; // also avoids complications
-      else
-        e->curr_x = TopX(*e, top_y);
+      // it is safe to ignore 'joined' edges here because
+      // if necessary they will be split in IntersectEdges()
+      e->curr_x = TopX(*e, top_y);
       e = e->next_in_ael;
     }
   }


### PR DESCRIPTION
[Clipper2 1.5.4](https://github.com/AngusJohnson/Clipper2/releases/tag/Clipper2_1.5.4):

- This release fixes a bug that very occasionally caused an endless loop.
