### PR TITLE
Fix GLES3 new batch condition on adding to batch

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1550,7 +1550,7 @@ void RasterizerCanvasGLES3::_render_batch(Light *p_lights, uint32_t p_index, Ren
 void RasterizerCanvasGLES3::_add_to_batch(uint32_t &r_index, bool &r_batch_broken) {
 	state.canvas_instance_batches[state.current_batch_index].instance_count++;
 	r_index++;
-	if (r_index + state.last_item_index >= data.max_instances_per_buffer) {
+	if (r_index + state.last_item_index > data.max_instances_per_buffer) {
 		// Copy over all data needed for rendering right away
 		// then go back to recording item commands.
 		glBindBuffer(GL_ARRAY_BUFFER, state.canvas_instance_data_buffers[state.current_data_buffer_index].instance_buffers[state.current_instance_buffer_index]);


### PR DESCRIPTION
Fixes not #107297.

AFAICT both `r_index` and `state.last_item_index` used in the changed condition are actual item counts (they're one past the last used index; they start at `0`, not `-1`). Meaning `r_index + state.last_item_index` is a valid item count and doesn't need to trigger new buffer creation.

Haven't dived much deeper but seems like this led to some index mismatching elsewhere, as the change fixes the crash for me. Absolutely not very familiar with that batching code so @clayjohn please check thoroughly. 🙂

Update: this seems to actually not fix the issue (https://github.com/godotengine/godot/issues/107297#issuecomment-2970643592), will need to dig deeper.