### PR TITLE
[RTL] Revert `get_paragraph_count` behavior.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -189,8 +189,6 @@
 			<return type="int" />
 			<description>
 				Returns the total number of paragraphs (newlines or [code]p[/code] tags in the tag stack's text tags). Considers wrapped text as one paragraph.
-				[b]Note:[/b] Paragraphs hidden by [member visible_characters] are not counted.
-				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>
 		<method name="get_paragraph_offset">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -6248,15 +6248,7 @@ void RichTextLabel::scroll_to_paragraph(int p_paragraph) {
 }
 
 int RichTextLabel::get_paragraph_count() const {
-	int para_count = 0;
-	int to_line = main->first_invalid_line.load();
-	for (int i = 0; i < to_line; i++) {
-		if ((visible_characters >= 0) && main->lines[i].char_offset >= visible_characters) {
-			break;
-		}
-		para_count++;
-	}
-	return para_count;
+	return main->lines.size();
 }
 
 int RichTextLabel::get_visible_paragraph_count() const {


### PR DESCRIPTION
Alternative to https://github.com/godotengine/godot/pull/107321

Fixes https://github.com/godotengine/godot/issues/107320
