### PR TITLE
Filesystem dock: Fix thumbnail size not updating instantly after changing editor setting

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -534,6 +534,7 @@ void FileSystemDock::_notification(int p_what) {
 			current_path_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FileSystemDock::_navigate_to_path).bind(false));
 
 			always_show_folders = bool(EDITOR_GET("docks/filesystem/always_show_folders"));
+			thumbnail_size_setting = EDITOR_GET("docks/filesystem/thumbnail_size");
 
 			set_file_list_display_mode(FileSystemDock::FILE_LIST_DISPLAY_LIST);
 
@@ -633,6 +634,12 @@ void FileSystemDock::_notification(int p_what) {
 			bool new_always_show_folders = bool(EDITOR_GET("docks/filesystem/always_show_folders"));
 			if (new_always_show_folders != always_show_folders) {
 				always_show_folders = new_always_show_folders;
+				do_redraw = true;
+			}
+
+			int new_thumbnail_size_setting = EDITOR_GET("docks/filesystem/thumbnail_size");
+			if (new_thumbnail_size_setting != thumbnail_size_setting) {
+				thumbnail_size_setting = new_thumbnail_size_setting;
 				do_redraw = true;
 			}
 
@@ -938,8 +945,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	String directory = current_path;
 	String file = "";
 
-	int thumbnail_size = EDITOR_GET("docks/filesystem/thumbnail_size");
-	thumbnail_size *= EDSCALE;
+	int thumbnail_size = thumbnail_size_setting * EDSCALE;
 	Ref<Texture2D> folder_thumbnail;
 	Ref<Texture2D> file_thumbnail;
 	Ref<Texture2D> file_thumbnail_broken;

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -203,6 +203,7 @@ private:
 	CreateDialog *new_resource_dialog = nullptr;
 
 	bool always_show_folders = false;
+	int thumbnail_size_setting = 0;
 
 	bool editor_is_dark_theme = false;
 


### PR DESCRIPTION
Before:

https://github.com/user-attachments/assets/d94a22a6-8b07-4691-9ff0-46515e03f8ef

After:

https://github.com/user-attachments/assets/9802f03c-697a-4539-9a76-81b723581d7f

