### PR TITLE
[3.x] Pre-calculate `is_visible_in_tree()`

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -157,6 +157,7 @@ void Spatial::_notification(int p_what) {
 			} else {
 				data.C = nullptr;
 			}
+			_update_visible_in_tree();
 
 			if (data.toplevel && !Engine::get_singleton()->is_editor_hint()) {
 				if (data.parent) {
@@ -216,6 +217,8 @@ void Spatial::_notification(int p_what) {
 			data.parent = nullptr;
 			data.C = nullptr;
 			data.toplevel_active = false;
+
+			_update_visible_in_tree();
 			_disable_client_physics_interpolation();
 		} break;
 		case NOTIFICATION_ENTER_WORLD: {
@@ -732,6 +735,36 @@ Ref<World> Spatial::get_world() const {
 	return data.viewport->find_world();
 }
 
+void Spatial::_update_visible_in_tree() {
+	Spatial *parent = get_parent_spatial();
+
+	bool propagate_visible = parent ? parent->data.visible_in_tree : true;
+
+	// Only propagate visible when entering tree if we are visible.
+	propagate_visible &= is_visible();
+
+	_propagate_visible_in_tree(propagate_visible);
+}
+
+void Spatial::_propagate_visible_in_tree(bool p_visible_in_tree) {
+	// If any node is invisible, the propagation changes to invisible below.
+	p_visible_in_tree &= is_visible();
+
+	// No change.
+	if (data.visible_in_tree == p_visible_in_tree) {
+		return;
+	}
+
+	data.visible_in_tree = p_visible_in_tree;
+
+	for (int32_t n = 0; n < get_child_count(); n++) {
+		Spatial *s = Object::cast_to<Spatial>(get_child(n));
+		if (s) {
+			s->_propagate_visible_in_tree(p_visible_in_tree);
+		}
+	}
+}
+
 void Spatial::_propagate_visibility_changed() {
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
 	emit_signal(SceneStringNames::get_singleton()->visibility_changed);
@@ -791,6 +824,10 @@ void Spatial::show() {
 		return;
 	}
 
+	bool parent_visible = get_parent_spatial() ? get_parent_spatial()->data.visible_in_tree : true;
+	if (parent_visible) {
+		_propagate_visible_in_tree(true);
+	}
 	_propagate_visibility_changed();
 }
 
@@ -805,10 +842,14 @@ void Spatial::hide() {
 		return;
 	}
 
+	bool parent_visible = get_parent_spatial() ? get_parent_spatial()->data.visible_in_tree : true;
+	if (parent_visible) {
+		_propagate_visible_in_tree(false);
+	}
 	_propagate_visibility_changed();
 }
 
-bool Spatial::is_visible_in_tree() const {
+bool Spatial::_is_visible_in_tree_reference() const {
 	const Spatial *s = this;
 
 	while (s) {
@@ -1121,6 +1162,7 @@ Spatial::Spatial() :
 	data.viewport = nullptr;
 	data.inside_world = false;
 	data.visible = true;
+	data.visible_in_tree = true;
 	data.disable_scale = false;
 	data.vi_visible = true;
 	data.merging_allowed = true;

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -121,6 +121,7 @@ private:
 		bool notify_transform : 1;
 
 		bool visible : 1;
+		bool visible_in_tree : 1;
 		bool disable_scale : 1;
 
 		// Scene tree interpolation
@@ -155,6 +156,9 @@ private:
 	void _notify_dirty();
 	void _propagate_transform_changed(Spatial *p_origin);
 
+	void _update_visible_in_tree();
+	bool _is_visible_in_tree_reference() const;
+	void _propagate_visible_in_tree(bool p_visible_in_tree);
 	void _propagate_visibility_changed();
 	void _propagate_merging_allowed(bool p_merging_allowed);
 
@@ -293,7 +297,15 @@ public:
 	bool is_visible() const;
 	void show();
 	void hide();
-	bool is_visible_in_tree() const;
+	bool is_visible_in_tree() const {
+#if DEV_ENABLED
+		// As this is newly introduced, regression test the old method against the new in DEV builds.
+		// If no regressions, this can be removed after a beta.
+		bool visible = _is_visible_in_tree_reference();
+		ERR_FAIL_COND_V_MSG(data.visible_in_tree != visible, visible, "is_visible_in_tree regression detected, recovering.");
+#endif
+		return data.visible_in_tree;
+	}
 
 	void force_update_transform();
 


### PR DESCRIPTION
Greatly increases the efficiency and performance is the `is_visible_in_tree()` system.

#### Benchmarks
~6x faster in DEBUG and RELEASE with depth 10 scene tree
_(repeated for the same node, so in cache, so likely the change would be faster real world)_
_Has to be benchmarked from c++ as gdscript is too slow to benchmark multiple calls to `is_visible_in_tree()`._

## Background
The 3D code for `is_visible_in_tree()` was added 14 years ago in https://github.com/godotengine/godot/commit/2ee4ac183babedd679e901b0158f5268556deceb 
however I long suspected it was not a good approach, as the runtime check is very expensive - it involves recursing up the chain to look for any invisible nodes. This kind of operation is very bad on modern CPUs, as it has a tendency to cause cache misses (like a linked list is bad).

As with many systems in scene graphs, there is a choice between:
* cheap updating
* cheap getting

In many situations Godot goes for "lazy updating", which is the cheap update, and then the expense is deferred to getting. In most cases the expensive getter is cached. Not so for `is_visible_in_tree()`. Everytime it is called, every frame, tick, it is expensive.

## Solutions
There are two obvious solutions here:
1) Add some machinery to cache the expensive result, and continue to defer the calculation to the getter.
2) The other solution I have added here is to go for the more conventional approach, and actually do the expensive calculation as a one off when adding the node to the tree, or showing or hiding.

I think on balance this second approach makes sense. Adding / removing nodes from the tree is a relatively rare operation, as is showing / hiding, and in most cases the update will be cheap anyway as the `_propagate_visible_in_tree()` call terminates early when no change is detected.

#### `_is_vi_visible()`
This problem has come up before, and I'd already added a partial solution, which was the optimized `_is_vi_visible()` system. The only snag is that this only works for `VisualInstance` derived nodes, and not all `Spatials`, therefore we end up needing rather cumbersome checks for `VisualInstance` cast_to before using it. It would be much better if we could replace this with a generic system for all `Spatials`.

This is what this PR does.

## Rollout
As this has some potential for the odd bug, and might require rebasing a couple of (my) PRs, I figure rollout could be done in three stages:

1) Adding the new `is_visible_in_tree()` machinery for 3D (and optional regression testing code) - _this PR_
2) Remove `_is_vi_visible()` and change callers to use `is_visible_in_tree()`
3) Add 2D version

## Notes
* The code involved here is actually relatively simple.
* There is no change to behaviour, including the separation of visibility propagation in 2D and 3D.
* I have no idea why no one (including myself) didn't do this earlier, as the current system was probably (as far as I can see) not the best choice (in retrospect). :facepalm: 
* This should in general speed up the engine, but particularly physics interpolation which does lots of scene tree traversal.
* Also applicable in 4.x.

## Further work
I have removed changes to move the `visible_in_tree` flag to `Node` for common 2D / 3D usage, leaving that to a later PR.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
