### PR TITLE
Improve Texture*RD, RenderData and LightmapperRD class documentation

### DIFF
--- a/doc/classes/FramebufferCacheRD.xml
+++ b/doc/classes/FramebufferCacheRD.xml
@@ -4,7 +4,7 @@
 		Framebuffer cache manager for Rendering Device based renderers.
 	</brief_description>
 	<description>
-		Framebuffer cache manager for Rendering Device based renderers. Provides a way to create a framebuffer and reuse it in subsequent calls for as long as the used textures exists. Framebuffers will automatically be cleaned up when dependent objects are freed.
+		Framebuffer cache manager for [RenderingDevice]-based renderers. Provides a way to create a framebuffer and reuse it in subsequent calls for as long as the used textures exists. Framebuffers will automatically be cleaned up when dependent objects are freed.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/LightmapperRD.xml
+++ b/doc/classes/LightmapperRD.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		LightmapperRD ("RD" stands for [RenderingDevice]) is the built-in GPU-based lightmapper for use with [LightmapGI]. On most dedicated GPUs, it can bake lightmaps much faster than most CPU-based lightmappers. LightmapperRD uses compute shaders to bake lightmaps, so it does not require CUDA or OpenCL libraries to be installed to be usable.
-		[b]Note:[/b] Only usable when using the RenderingDevice backend (Forward+ or Mobile renderers), not Compatibility.
+		[b]Note:[/b] This lightmapper requires the GPU to support the [RenderingDevice] backend (Forward+ and Mobile renderers). When using the Compatibility renderer, baking will use a temporary [RenderingDevice]. Support for [RenderingDevice] is not required to [i]render[/i] lightmaps that were already baked beforehand.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderData.xml
+++ b/doc/classes/RenderData.xml
@@ -4,8 +4,8 @@
 		Abstract render data object, holds frame data related to rendering a single frame of a viewport.
 	</brief_description>
 	<description>
-		Abstract render data object, exists for the duration of rendering a single viewport.
-		[b]Note:[/b] This is an internal rendering server object, do not instantiate this from script.
+		Abstract render data object, exists for the duration of rendering a single viewport. See also [RenderDataRD], [RenderSceneData], and [RenderSceneDataRD].
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderDataRD.xml
+++ b/doc/classes/RenderDataRD.xml
@@ -2,11 +2,10 @@
 <class name="RenderDataRD" inherits="RenderData" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Render data implementation for the RenderingDevice based renderers.
-		[b]Note:[/b] This is an internal rendering server object, do not instantiate this from script.
 	</brief_description>
 	<description>
-		This object manages all render data for the rendering device based renderers.
-		[b]Note:[/b] This is an internal rendering server object only exposed for GDExtension plugins.
+		This object manages all render data for the [RenderingDevice]-based renderers. See also [RenderData], [RenderSceneData], and [RenderSceneDataRD].
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderSceneBuffers.xml
+++ b/doc/classes/RenderSceneBuffers.xml
@@ -4,8 +4,8 @@
 		Abstract scene buffers object, created for each viewport for which 3D rendering is done.
 	</brief_description>
 	<description>
-		Abstract scene buffers object, created for each viewport for which 3D rendering is done. It manages any additional buffers used during rendering and will discard buffers when the viewport is resized.
-		[b]Note:[/b] This is an internal rendering server object, do not instantiate this from script.
+		Abstract scene buffers object, created for each viewport for which 3D rendering is done. It manages any additional buffers used during rendering and will discard buffers when the viewport is resized. See also [RenderSceneBuffersRD].
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderSceneBuffersRD.xml
+++ b/doc/classes/RenderSceneBuffersRD.xml
@@ -4,10 +4,10 @@
 		Render scene buffer implementation for the RenderingDevice based renderers.
 	</brief_description>
 	<description>
-		This object manages all 3D rendering buffers for the rendering device based renderers. An instance of this object is created for every viewport that has 3D rendering enabled.
+		This object manages all 3D rendering buffers for the rendering device based renderers. An instance of this object is created for every viewport that has 3D rendering enabled. See also [RenderSceneBuffers].
 		All buffers are organized in [b]contexts[/b]. The default context is called [b]render_buffers[/b] and can contain amongst others the color buffer, depth buffer, velocity buffers, VRS density map and MSAA variants of these buffers.
 		Buffers are only guaranteed to exist during rendering of the viewport.
-		[b]Note:[/b] This is an internal rendering server object, do not instantiate this from script.
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderSceneData.xml
+++ b/doc/classes/RenderSceneData.xml
@@ -4,8 +4,8 @@
 		Abstract render data object, holds scene data related to rendering a single frame of a viewport.
 	</brief_description>
 	<description>
-		Abstract scene data object, exists for the duration of rendering a single viewport.
-		[b]Note:[/b] This is an internal rendering server object, do not instantiate this from script.
+		Abstract scene data object, exists for the duration of rendering a single viewport. See also [RenderSceneDataRD], [RenderData], and [RenderDataRD].
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/RenderSceneDataRD.xml
+++ b/doc/classes/RenderSceneDataRD.xml
@@ -4,8 +4,8 @@
 		Render scene data implementation for the RenderingDevice based renderers.
 	</brief_description>
 	<description>
-		Object holds scene data related to rendering a single frame of a viewport.
-		[b]Note:[/b] This is an internal rendering server object, do not instantiate this from script.
+		Object holds scene data related to rendering a single frame of a viewport. See also [RenderSceneData], [RenderData], and [RenderDataRD].
+		[b]Note:[/b] This is an internal rendering server object. Do not instantiate this class from a script.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/Texture2DArrayRD.xml
+++ b/doc/classes/Texture2DArrayRD.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		This texture array class allows you to use a 2D array texture created directly on the [RenderingDevice] as a texture for materials, meshes, etc.
+		[b]Note:[/b] [Texture2DArrayRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [Texture2DArray] instead.
 	</description>
 	<tutorials>
+		<link title="Compute Texture demo">https://godotengine.org/asset-library/asset/2764</link>
 	</tutorials>
 </class>

--- a/doc/classes/Texture2DRD.xml
+++ b/doc/classes/Texture2DRD.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		This texture class allows you to use a 2D texture created directly on the [RenderingDevice] as a texture for materials, meshes, etc.
+		[b]Note:[/b] [Texture2DRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [Texture2D] instead.
 	</description>
 	<tutorials>
+		<link title="Compute Texture demo">https://godotengine.org/asset-library/asset/2764</link>
 	</tutorials>
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />

--- a/doc/classes/Texture3DRD.xml
+++ b/doc/classes/Texture3DRD.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		This texture class allows you to use a 3D texture created directly on the [RenderingDevice] as a texture for materials, meshes, etc.
+		[b]Note:[/b] [Texture3DRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [Texture3D] instead.
 	</description>
 	<tutorials>
+		<link title="Compute Texture demo">https://godotengine.org/asset-library/asset/2764</link>
 	</tutorials>
 	<members>
 		<member name="texture_rd_rid" type="RID" setter="set_texture_rd_rid" getter="get_texture_rd_rid">

--- a/doc/classes/TextureCubemapArrayRD.xml
+++ b/doc/classes/TextureCubemapArrayRD.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		This texture class allows you to use a cubemap array texture created directly on the [RenderingDevice] as a texture for materials, meshes, etc.
+		[b]Note:[/b] [TextureCubemapArrayRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [CubemapArray] instead.
 	</description>
 	<tutorials>
+		<link title="Compute Texture demo">https://godotengine.org/asset-library/asset/2764</link>
 	</tutorials>
 </class>

--- a/doc/classes/TextureCubemapRD.xml
+++ b/doc/classes/TextureCubemapRD.xml
@@ -5,7 +5,9 @@
 	</brief_description>
 	<description>
 		This texture class allows you to use a cubemap texture created directly on the [RenderingDevice] as a texture for materials, meshes, etc.
+		[b]Note:[/b] [TextureCubemapRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [Cubemap] instead.
 	</description>
 	<tutorials>
+		<link title="Compute Texture demo">https://godotengine.org/asset-library/asset/2764</link>
 	</tutorials>
 </class>

--- a/doc/classes/TextureLayeredRD.xml
+++ b/doc/classes/TextureLayeredRD.xml
@@ -5,8 +5,10 @@
 	</brief_description>
 	<description>
 		Base class for [Texture2DArrayRD], [TextureCubemapRD] and [TextureCubemapArrayRD]. Cannot be used directly, but contains all the functions necessary for accessing the derived resource types.
+		[b]Note:[/b] [TextureLayeredRD] is intended for low-level usage with [RenderingDevice]. For most use cases, use [TextureLayered] instead.
 	</description>
 	<tutorials>
+		<link title="Compute Texture demo">https://godotengine.org/asset-library/asset/2764</link>
 	</tutorials>
 	<members>
 		<member name="texture_rd_rid" type="RID" setter="set_texture_rd_rid" getter="get_texture_rd_rid">

--- a/doc/classes/UniformSetCacheRD.xml
+++ b/doc/classes/UniformSetCacheRD.xml
@@ -4,7 +4,7 @@
 		Uniform set cache manager for Rendering Device based renderers.
 	</brief_description>
 	<description>
-		Uniform set cache manager for Rendering Device based renderers. Provides a way to create a uniform set and reuse it in subsequent calls for as long as the uniform set exists. Uniform set will automatically be cleaned up when dependent objects are freed.
+		Uniform set cache manager for [RenderingDevice]-based renderers. Provides a way to create a uniform set and reuse it in subsequent calls for as long as the uniform set exists. Uniform set will automatically be cleaned up when dependent objects are freed.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
- Link to compute texture demo in Texture*RD class documentation.
- Link to related classes in RenderData/RenderSceneData/RenderSceneBuffers.
- Clarify requirements for baking lightmaps in LightmapperRD.
