### PR TITLE
Pre-calculate `is_visible_in_tree()`

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -164,6 +164,7 @@ void Node3D::_notification(int p_what) {
 				data.index_in_parent = UINT32_MAX;
 				ERR_PRINT("Node3D ENTER_TREE detected without EXIT_TREE, recovering.");
 			}
+			_update_visible_in_tree();
 
 			if (data.top_level && !Engine::get_singleton()->is_editor_hint()) {
 				if (data.parent) {
@@ -236,6 +237,7 @@ void Node3D::_notification(int p_what) {
 
 			data.parent = nullptr;
 			_update_visibility_parent(true);
+			_update_visible_in_tree();
 			_disable_client_physics_interpolation();
 		} break;
 
@@ -1079,6 +1081,36 @@ Ref<World3D> Node3D::get_world_3d() const {
 	return data.viewport->find_world_3d();
 }
 
+void Node3D::_update_visible_in_tree() {
+	Node3D *parent = get_parent_node_3d();
+
+	bool propagate_visible = parent ? parent->data.visible_in_tree : true;
+
+	// Only propagate visible when entering tree if we are visible.
+	propagate_visible &= is_visible();
+
+	_propagate_visible_in_tree(propagate_visible);
+}
+
+void Node3D::_propagate_visible_in_tree(bool p_visible_in_tree) {
+	// If any node is invisible, the propagation changes to invisible below.
+	p_visible_in_tree &= is_visible();
+
+	// No change.
+	if (data.visible_in_tree == p_visible_in_tree) {
+		return;
+	}
+
+	data.visible_in_tree = p_visible_in_tree;
+
+	for (Node *node : iterate_children()) {
+		Node3D *s = Object::cast_to<Node3D>(node);
+		if (s) {
+			s->_propagate_visible_in_tree(p_visible_in_tree);
+		}
+	}
+}
+
 void Node3D::_propagate_visibility_changed() {
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
 	emit_signal(SceneStringName(visibility_changed));
@@ -1117,9 +1149,17 @@ void Node3D::set_visible(bool p_visible) {
 
 	data.visible = p_visible;
 
+	Node3D *parent = get_parent_node_3d();
+
+	bool parent_visible = parent ? parent->data.visible_in_tree : true;
+	if (parent_visible) {
+		_propagate_visible_in_tree(p_visible);
+	}
+
 	if (!is_inside_tree()) {
 		return;
 	}
+
 	_propagate_visibility_changed();
 }
 
@@ -1128,7 +1168,7 @@ bool Node3D::is_visible() const {
 	return data.visible;
 }
 
-bool Node3D::is_visible_in_tree() const {
+bool Node3D::_is_visible_in_tree_reference() const {
 	ERR_READ_THREAD_GUARD_V(false); // Since visibility can only be changed from main thread, this is safe to call.
 	const Node3D *s = this;
 
@@ -1553,6 +1593,7 @@ Node3D::Node3D() :
 	data.notify_transform = false;
 
 	data.visible = true;
+	data.visible_in_tree = true;
 	data.disable_scale = false;
 	data.vi_visible = true;
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -137,6 +137,7 @@ private:
 		bool notify_transform : 1;
 
 		bool visible : 1;
+		bool visible_in_tree : 1;
 		bool disable_scale : 1;
 
 		// Scene tree interpolation.
@@ -183,6 +184,9 @@ private:
 	void _notify_dirty();
 	void _propagate_transform_changed(Node3D *p_origin);
 
+	void _update_visible_in_tree();
+	bool _is_visible_in_tree_reference() const;
+	void _propagate_visible_in_tree(bool p_visible_in_tree);
 	void _propagate_visibility_changed();
 
 	void _propagate_visibility_parent();
@@ -346,7 +350,16 @@ public:
 	void show();
 	void hide();
 	bool is_visible() const;
-	bool is_visible_in_tree() const;
+	bool is_visible_in_tree() const {
+		ERR_READ_THREAD_GUARD_V(false); // Since visibility can only be changed from main thread, this is safe to call.
+#if DEV_ENABLED
+		// As this is newly introduced, regression test the old method against the new in DEV builds.
+		// If no regressions, this can be removed after a beta.
+		bool visible = _is_visible_in_tree_reference();
+		ERR_FAIL_COND_V_MSG(data.visible_in_tree != visible, visible, "is_visible_in_tree regression detected, recovering.");
+#endif
+		return data.visible_in_tree;
+	}
 
 	void force_update_transform();
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -135,6 +135,7 @@ private:
 		bool notify_transform : 1;
 
 		bool visible : 1;
+		bool visible_in_tree : 1;
 		bool disable_scale : 1;
 
 		// Scene tree interpolation.
@@ -176,6 +177,9 @@ private:
 	void _notify_dirty();
 	void _propagate_transform_changed(Node3D *p_origin);
 
+	void _update_visible_in_tree();
+	bool _is_visible_in_tree_reference() const;
+	void _propagate_visible_in_tree(bool p_visible_in_tree);
 	void _propagate_visibility_changed();
 
 	void _propagate_visibility_parent();
@@ -339,7 +343,16 @@ public:
 	void show();
 	void hide();
 	bool is_visible() const;
-	bool is_visible_in_tree() const;
+	bool is_visible_in_tree() const {
+		ERR_READ_THREAD_GUARD_V(false); // Since visibility can only be changed from main thread, this is safe to call.
+#if DEV_ENABLED
+		// As this is newly introduced, regression test the old method against the new in DEV builds.
+		// If no regressions, this can be removed after a beta.
+		bool visible = _is_visible_in_tree_reference();
+		ERR_FAIL_COND_V_MSG(data.visible_in_tree != visible, visible, "is_visible_in_tree regression detected, recovering.");
+#endif
+		return data.visible_in_tree;
+	}
 
 	void force_update_transform();
 


### PR DESCRIPTION
Greatly increases the efficiency and performance is the `is_visible_in_tree()` system.
Forward port of #107324

#### Benchmarks
~6x faster in DEBUG and RELEASE with depth 10 scene tree
_(repeated for the same node, so in cache, so likely the change would be faster real world)_
_Has to be benchmarked from c++ as gdscript is too slow to benchmark multiple calls to `is_visible_in_tree()`._

## Background
The 3D code for `is_visible_in_tree()` was added 14 years ago in https://github.com/godotengine/godot/commit/2ee4ac183babedd679e901b0158f5268556deceb 
however I long suspected it was not a good approach, as the runtime check is very expensive - it involves recursing up the chain to look for any invisible nodes. This kind of operation is very bad on modern CPUs, as it has a tendency to cause cache misses (like a linked list is bad).

As with many systems in scene graphs, there is a choice between:
* cheap updating
* cheap getting

In many situations Godot goes for "lazy updating", which is the cheap update, and then the expense is deferred to getting. In most cases the expensive getter is cached. Not so for `is_visible_in_tree()`. Everytime it is called, every frame, tick, it is expensive.

## Solutions
There are two obvious solutions here:
1) Add some machinery to cache the expensive result, and continue to defer the calculation to the getter.
2) The other solution I have added here is to go for the more conventional approach, and actually do the expensive calculation as a one off when adding the node to the tree, or showing or hiding.

I think on balance this second approach makes sense. Adding / removing nodes from the tree is a relatively rare operation, as is showing / hiding, and in most cases the update will be cheap anyway as the `_propagate_visible_in_tree()` call terminates early when no change is detected.

#### `_is_vi_visible()`
This problem has come up before, and I'd already added a partial solution, which was the optimized `_is_vi_visible()` system. The only snag is that this only works for `VisualInstance` derived nodes, and not all `Spatials`, therefore we end up needing rather cumbersome checks for `VisualInstance` cast_to before using it. It would be much better if we could replace this with a generic system for all `Spatials`.

This is what this PR does.

## Rollout
As this has some potential for the odd bug, and might require rebasing a couple of (my) PRs, I figure rollout could be done in three stages:

1) Adding the new `is_visible_in_tree()` machinery for 3D (and optional regression testing code) - _this PR_
2) Remove `_is_vi_visible()` and change callers to use `is_visible_in_tree()` (#107493)
3) Add 2D version

## Notes
* The code involved here is actually relatively simple.
* There is no change to behaviour, including the separation of visibility propagation in 2D and 3D.
* I have no idea why no one (including myself) didn't do this earlier, as the current system was probably (as far as I can see) not the best choice (in retrospect). :facepalm: 
* This should in general speed up the engine, but particularly physics interpolation which does lots of scene tree traversal.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
