### PR TITLE
Fix visible ratio when displaying all characters in Label

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -1269,10 +1269,10 @@ String Label::get_text() const {
 void Label::set_visible_characters(int p_amount) {
 	if (visible_chars != p_amount) {
 		visible_chars = p_amount;
-		if (get_total_character_count() > 0) {
-			visible_ratio = (float)p_amount / (float)get_total_character_count();
-		} else {
+		if (p_amount == -1 || get_total_character_count() == 0) {
 			visible_ratio = 1.0;
+		} else {
+			visible_ratio = (float)p_amount / (float)get_total_character_count();
 		}
 		if (visible_chars_behavior == TextServer::VC_CHARS_BEFORE_SHAPING) {
 			text_dirty = true;


### PR DESCRIPTION
When changing the visible characters property of a Label, the visible ratio property updates accordingly. However, when  visible characters is reset to -1 (meaning display all characters) **after** entering some text , the ratio is incorrectly set to 0 (meaning show nothing).

Do note that the editor still displays the text even though visible_ratio is 0. Running the scene gives an empty label, which is rather confusing.

This PR should fix this by setting the ratio to 1 when setting the visible characters to -1.