### PR TITLE
Fix final blit in OpenGL when stereo rendering is used

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -436,7 +436,13 @@ void RasterizerGLES3::_blit_render_target_to_screen(RID p_render_target, Display
 	glViewport(int(MIN(p1.x, p2.x)), int(MIN(p1.y, p2.y)), Math::abs(size.x), Math::abs(size.y));
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, rt->color);
+	GLenum target = rt->view_count > 1 ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+	glBindTexture(target, rt->color);
+	glTexParameteri(target, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+	glDisable(GL_CULL_FACE);
+
 	glEnable(GL_BLEND);
 	glBlendFunc(GL_ONE, GL_ZERO);
 


### PR DESCRIPTION
Not sure how long this has been broken but stereo rendering with the mobile VR Interface was broken completely.

Couple of things were wrong:
- Incorrect usage of GL_TEXTURE_2D, needs to be GL_TEXTURE_2D_ARRAY when stereo is used
- Texture filtering was not being set correctly causing error spam
- As we're vertically flipped, faces were being culled and we didn't render anything

See https://github.com/godotengine/godot-demo-projects/pull/1212 for a demo project with which to test this.
