### PR TITLE
Enforce GDScript and C# dictionary spacing style guidelines in code samples

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -53,7 +53,7 @@
 		[/codeblock]
 		[b]Note:[/b] [Dictionary] does not support the above due to ambiguity with keys.
 		[codeblock]
-		var dictionary = {"hello": "world"}
+		var dictionary = { "hello": "world" }
 
 		# This will not work, `clear` is treated as a key.
 		tween.tween_callback(dictionary.clear)

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -18,7 +18,7 @@
 			dict_variable_key: dict_variable_value,
 		}
 
-		var points_dict = {"White": 50, "Yellow": 75, "Orange": 100}
+		var points_dict = { "White": 50, "Yellow": 75, "Orange": 100 }
 
 		# Alternative Lua-style syntax.
 		# Doesn't require quotes around keys, but only string constants can be used as key names.
@@ -32,9 +32,9 @@
 		var myDict = new Godot.Collections.Dictionary(); // Creates an empty dictionary.
 		var pointsDict = new Godot.Collections.Dictionary
 		{
-			{"White", 50},
-			{"Yellow", 75},
-			{"Orange", 100}
+			{ "White", 50 },
+			{ "Yellow", 75 },
+			{ "Orange", 100 },
 		};
 		[/csharp]
 		[/codeblocks]
@@ -42,7 +42,7 @@
 		[codeblocks]
 		[gdscript]
 		@export_enum("White", "Yellow", "Orange") var my_color: String
-		var points_dict = {"White": 50, "Yellow": 75, "Orange": 100}
+		var points_dict = { "White": 50, "Yellow": 75, "Orange": 100 }
 		func _ready():
 			# We can't use dot syntax here as `my_color` is a variable.
 			var points = points_dict[my_color]
@@ -52,9 +52,9 @@
 		public string MyColor { get; set; }
 		private Godot.Collections.Dictionary _pointsDict = new Godot.Collections.Dictionary
 		{
-			{"White", 50},
-			{"Yellow", 75},
-			{"Orange", 100}
+			{ "White", 50 },
+			{ "Yellow", 75 },
+			{ "Orange", 100 },
 		};
 
 		public override void _Ready()
@@ -74,22 +74,22 @@
 		[csharp]
 		var myDict = new Godot.Collections.Dictionary
 		{
-			{"First Array", new Godot.Collections.Array{1, 2, 3, 4}}
+			{ "First Array", new Godot.Collections.Array { 1, 2, 3, 4 } }
 		};
 		[/csharp]
 		[/codeblocks]
 		To add a key to an existing dictionary, access it like an existing key and assign to it:
 		[codeblocks]
 		[gdscript]
-		var points_dict = {"White": 50, "Yellow": 75, "Orange": 100}
+		var points_dict = { "White": 50, "Yellow": 75, "Orange": 100 }
 		points_dict["Blue"] = 150 # Add "Blue" as a key and assign 150 as its value.
 		[/gdscript]
 		[csharp]
 		var pointsDict = new Godot.Collections.Dictionary
 		{
-			{"White", 50},
-			{"Yellow", 75},
-			{"Orange", 100}
+			{ "White", 50 },
+			{ "Yellow", 75 },
+			{ "Orange", 100 },
 		};
 		pointsDict["Blue"] = 150; // Add "Blue" as a key and assign 150 as its value.
 		[/csharp]
@@ -104,29 +104,29 @@
 			"String Key": 5,
 			4: [1, 2, 3],
 			7: "Hello",
-			"sub_dict": {"sub_key": "Nested value"},
+			"sub_dict": { "sub_key": "Nested value" },
 		}
 		[/gdscript]
 		[csharp]
 		// This is a valid dictionary.
 		// To access the string "Nested value" below, use `((Godot.Collections.Dictionary)myDict["sub_dict"])["sub_key"]`.
 		var myDict = new Godot.Collections.Dictionary {
-			{"String Key", 5},
-			{4, new Godot.Collections.Array{1,2,3}},
-			{7, "Hello"},
-			{"sub_dict", new Godot.Collections.Dictionary{{"sub_key", "Nested value"}}}
+			{ "String Key", 5 },
+			{ 4, new Godot.Collections.Array { 1, 2, 3 } },
+			{ 7, "Hello" },
+			{ "sub_dict", new Godot.Collections.Dictionary { { "sub_key", "Nested value" } } },
 		};
 		[/csharp]
 		[/codeblocks]
 		The keys of a dictionary can be iterated with the [code]for[/code] keyword:
 		[codeblocks]
 		[gdscript]
-		var groceries = {"Orange": 20, "Apple": 2, "Banana": 4}
+		var groceries = { "Orange": 20, "Apple": 2, "Banana": 4 }
 		for fruit in groceries:
 			var amount = groceries[fruit]
 		[/gdscript]
 		[csharp]
-		var groceries = new Godot.Collections.Dictionary{{"Orange", 20}, {"Apple", 2}, {"Banana", 4}};
+		var groceries = new Godot.Collections.Dictionary { { "Orange", 20 }, { "Apple", 2 }, { "Banana", 4 } };
 		foreach (var (fruit, amount) in groceries)
 		{
 			// `fruit` is the key, `amount` is the value.
@@ -298,7 +298,7 @@
 				[/codeblocks]
 				In GDScript, this is equivalent to the [code]in[/code] operator:
 				[codeblock]
-				if "Godot" in {"Godot": 4}:
+				if "Godot" in { "Godot": 4 }:
 					print("The key is here!") # Will be printed.
 				[/codeblock]
 				[b]Note:[/b] This method returns [code]true[/code] as long as the [param key] exists, even if its corresponding value is [code]null[/code].
@@ -310,7 +310,7 @@
 			<description>
 				Returns [code]true[/code] if the dictionary contains all keys in the given [param keys] array.
 				[codeblock]
-				var data = {"width" : 10, "height" : 20}
+				var data = { "width": 10, "height": 20 }
 				data.has_all(["height", "width"]) # Returns true
 				[/codeblock]
 			</description>
@@ -321,14 +321,14 @@
 				Returns a hashed 32-bit integer value representing the dictionary contents.
 				[codeblocks]
 				[gdscript]
-				var dict1 = {"A": 10, "B": 2}
-				var dict2 = {"A": 10, "B": 2}
+				var dict1 = { "A": 10, "B": 2 }
+				var dict2 = { "A": 10, "B": 2 }
 
 				print(dict1.hash() == dict2.hash()) # Prints true
 				[/gdscript]
 				[csharp]
-				var dict1 = new Godot.Collections.Dictionary{{"A", 10}, {"B", 2}};
-				var dict2 = new Godot.Collections.Dictionary{{"A", 10}, {"B", 2}};
+				var dict1 = new Godot.Collections.Dictionary { { "A", 10 }, { "B", 2 } };
+				var dict2 = new Godot.Collections.Dictionary { { "A", 10 }, { "B", 2 } };
 
 				// Godot.Collections.Dictionary has no Hash() method. Use GD.Hash() instead.
 				GD.Print(GD.Hash(dict1) == GD.Hash(dict2)); // Prints True

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -272,7 +272,7 @@
 				[b]Note:[/b] You must implement [method _get_plugin_name] for the state to be stored and restored correctly.
 				[codeblock]
 				func _get_state():
-					var state = {"zoom": zoom, "preferred_color": my_color}
+					var state = { "zoom": zoom, "preferred_color": my_color }
 					return state
 				[/codeblock]
 			</description>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -58,10 +58,10 @@
 
 				var propertyInfo = new Godot.Collections.Dictionary
 				{
-					{"name", "category/propertyName"},
-					{"type", Variant.Type.Int},
-					{"hint", PropertyHint.Enum},
-					{"hint_string", "one,two,three"}
+					{ "name", "category/propertyName" },
+					{ "type", Variant.Type.Int },
+					{ "hint", PropertyHint.Enum },
+					{ "hint_string", "one,two,three" },
 				};
 
 				settings.AddPropertyInfo(propertyInfo);

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -99,7 +99,7 @@
 				Generates a GET/POST application/x-www-form-urlencoded style query string from a provided dictionary, e.g.:
 				[codeblocks]
 				[gdscript]
-				var fields = {"username": "user", "password": "pass"}
+				var fields = { "username": "user", "password": "pass" }
 				var query_string = http_client.query_string_from_dict(fields)
 				# Returns "username=user&amp;password=pass"
 				[/gdscript]
@@ -112,7 +112,7 @@
 				Furthermore, if a key has a [code]null[/code] value, only the key itself is added, without equal sign and value. If the value is an array, for each value in it a pair with the same key is added.
 				[codeblocks]
 				[gdscript]
-				var fields = {"single": 123, "not_valued": null, "multiple": [22, 33, 44]}
+				var fields = { "single": 123, "not_valued": null, "multiple": [22, 33, 44] }
 				var query_string = http_client.query_string_from_dict(fields)
 				# Returns "single=123&amp;not_valued&amp;multiple=22&amp;multiple=33&amp;multiple=44"
 				[/gdscript]
@@ -148,7 +148,7 @@
 				To create a POST request with query strings to push to the server, do:
 				[codeblocks]
 				[gdscript]
-				var fields = {"username" : "user", "password" : "pass"}
+				var fields = { "username": "user", "password": "pass" }
 				var query_string = http_client.query_string_from_dict(fields)
 				var headers = ["Content-Type: application/x-www-form-urlencoded", "Content-Length: " + str(query_string.length())]
 				var result = http_client.request(http_client.METHOD_POST, "/index.php", headers, query_string)

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -42,10 +42,10 @@
 
 				var propertyInfo = new Godot.Collections.Dictionary
 				{
-					{"name", "category/propertyName"},
-					{"type", (int)Variant.Type.Int},
-					{"hint", (int)PropertyHint.Enum},
-					{"hint_string", "one,two,three"},
+					{ "name", "category/propertyName" },
+					{ "type", (int)Variant.Type.Int },
+					{ "hint", (int)PropertyHint.Enum },
+					{ "hint_string", "one,two,three" },
 				};
 
 				ProjectSettings.AddPropertyInfo(propertyInfo);


### PR DESCRIPTION
Both the [GDScript](https://docs.godotengine.org/en/stable/tutorials/scripting/gdscript/gdscript_styleguide.html#whitespace:~:text=One%20exception%20to%20this%20is%20for%20single%2Dline%20dictionary%20declarations%2C%20where%20a%20space%20should%20be%20added%20after%20the%20opening%20brace%20and%20before%20the%20closing%20brace.) and the [C#](https://docs.godotengine.org/en/stable/tutorials/scripting/c_sharp/c_sharp_style_guide.html#:~:text=After%20the%20opening%20brace%2C%20and%20before%20the%20closing%20brace%20in%20a%20single%20line%20initializer.) style guides state that a space should be added after opening braces and before ending braces in single-line dictionary declarations. This PR enforces that guideline in various code samples.

This PR does _not_ change the style of the following:
- Dictionaries passed to functions (e.g. `foo({"some_key": "bar"})`)
- Single-line dictionary arrays (e.g. `[{"godot": true}]`)