### PR TITLE
Vulkan Mobile: Fix crash from shader compilation with `USE_RADIANCE_CUBEMAP_ARRAY`

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1577,7 +1577,7 @@ void main() {
 		float lod;
 		half blend = half(modf(roughness_lod, lod));
 		hvec3 clearcoat_sample_a = hvec3(texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod)).rgb);
-		hvec3 clearcoat_sample_b = hvec3(texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP)), vec4(ref_vec, lod + 1)).rgb);
+		hvec3 clearcoat_sample_b = hvec3(texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ref_vec, lod + 1)).rgb);
 		hvec3 clearcoat_light = mix(clearcoat_sample_a, clearcoat_sample_b, blend);
 
 #else


### PR DESCRIPTION
Opening the [GDQuest TPS demo](https://github.com/gdquest-demos/godot-4-3d-third-person-controller) in the editor is currently crashing for me with the following errors:

<details>
<summary>Error output</summary>

```
ERROR: Error compiling Fragment shader.
   at: compile_stages (servers/rendering/renderer_rd/shader_rd.cpp:986)
ERROR: Failed parse:
WARNING: 0:575: '' : all default precisions are highp; use precision statements to quiet warning, e.g.:
         "precision mediump int; precision highp float;"
ERROR: 0:2525: 'texture' : no matching overloaded function found
ERROR: 0:2525: '' : missing #endif
ERROR: 0:2525: '' : compilation terminated
ERROR: 3 compilation errors.  No code generated.
ERROR: code: [shader code]
   at: compile_stages (servers/rendering/renderer_rd/shader_rd.cpp:990)
ERROR: Condition "variant_stages.is_empty()" is true.
   at: _compile_variant (servers/rendering/renderer_rd/shader_rd.cpp:312)
ERROR: Parameter "shader" is null.
   at: uniform_set_create (servers/rendering/rendering_device.cpp:3540)
ERROR: Parameter "us" is null.
   at: uniform_set_set_invalidation_callback (servers/rendering/rendering_device.cpp:3944)
ERROR: Parameter "shader" is null.
   at: uniform_set_create (servers/rendering/rendering_device.cpp:3540)

  ================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.5.dev.custom_build (ca1e4785b20beea056c7ba4b6a3079c9bb7cc518)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x42520) [0x71033a242520] (??:0)
[2] CowData<RID>::get(long) const (/home/dsnopek/Sync/Projects/default/godot-4/core/templates/cowdata.h:187 (discriminator 7))
[3] Vector<RID>::operator[](long) const (/home/dsnopek/Sync/Projects/default/godot-4/core/templates/vector.h:122)
[4] ShaderRD::_compile_version_end(ShaderRD::Version*, int) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/shader_rd.cpp:573)
[5] ShaderRD::_compile_ensure_finished(ShaderRD::Version*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/shader_rd.cpp:605 (discriminator 3))
[6] ShaderRD::version_is_valid(RID) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/shader_rd.cpp:703)
[7] RendererSceneRenderImplementation::SceneShaderForwardMobile::ShaderData::is_valid() const (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp:410)
[8] RendererSceneRenderImplementation::RenderForwardMobile::_geometry_instance_add_surface(RendererSceneRenderImplementation::RenderForwardMobile::GeometryInstanceForwardMobile*, unsigned int, RID, RID) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp:2786 (discriminator 2))
[9] RendererSceneRenderImplementation::RenderForwardMobile::_geometry_instance_update(RenderGeometryInstance*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp:2840 (discriminator 6))
[10] RendererSceneRenderImplementation::RenderForwardMobile::_update_dirty_geometry_instances() (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp:3200)
[11] RendererSceneRenderImplementation::RenderForwardMobile::_fill_render_list(RendererSceneRenderImplementation::RenderForwardMobile::RenderListType, RenderDataRD const*, RendererSceneRenderImplementation::RenderForwardMobile::PassMode, bool) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp:2002)
[12] RendererSceneRenderImplementation::RenderForwardMobile::_render_scene(RenderDataRD*, Color const&) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp:887)
[13] RendererSceneRenderRD::render_scene(Ref<RenderSceneBuffers> const&, RendererSceneRender::CameraData const*, RendererSceneRender::CameraData const*, PagedArray<RenderGeometryInstance*> const&, PagedArray<RID> const&, PagedArray<RID> const&, PagedArray<RID> const&, PagedArray<RID> const&, PagedArray<RID> const&, PagedArray<RID> const&, RID, RID, RID, RID, RID, RID, RID, int, float, RendererSceneRender::RenderShadowData const*, int, RendererSceneRender::RenderSDFGIData const*, int, RendererSceneRender::RenderSDFGIUpdateData const*, RenderingMethod::RenderInfo*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp:1338)
[14] RendererSceneCull::_render_scene(RendererSceneRender::CameraData const*, Ref<RenderSceneBuffers> const&, RID, RID, RID, unsigned int, RID, RID, RID, RID, int, float, bool, RenderingMethod::RenderInfo*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_scene_cull.cpp:3486 (discriminator 4))
[15] RendererSceneCull::render_camera(Ref<RenderSceneBuffers> const&, RID, RID, RID, Vector2, unsigned int, float, RID, Ref<XRInterface>&, RenderingMethod::RenderInfo*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_scene_cull.cpp:2707)
[16] RendererViewport::_draw_3d(RendererViewport::Viewport*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_viewport.cpp:309)
[17] RendererViewport::_draw_viewport(RendererViewport::Viewport*) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_viewport.cpp:378)
[18] RendererViewport::draw_viewports(bool) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/renderer_viewport.cpp:881)
[19] RenderingServerDefault::_draw(bool, double) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/rendering_server_default.cpp:95)
[20] RenderingServerDefault::draw(bool, double) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/rendering_server_default.cpp:425)
[21] Main::iteration() (/home/dsnopek/Sync/Projects/default/godot-4/main/main.cpp:4780)
[22] OS_LinuxBSD::run() (/home/dsnopek/Sync/Projects/default/godot-4/platform/linuxbsd/os_linuxbsd.cpp:979)
[23] /home/dsnopek/prj/default/godot-4/bin/godot.linuxbsd.editor.dev.x86_64(main+0x190) [0x5c7621a59c69] (/home/dsnopek/Sync/Projects/default/godot-4/platform/linuxbsd/godot_linuxbsd.cpp:85)
[24] /lib/x86_64-linux-gnu/libc.so.6(+0x29d90) [0x71033a229d90] (??:0)
[25] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x80) [0x71033a229e40] (??:0)
[26] /home/dsnopek/prj/default/godot-4/bin/godot.linuxbsd.editor.dev.x86_64(_start+0x25) [0x5c7621a59a15] (??:?)
-- END OF C++ BACKTRACE --
================================================================
```
</details>

Appears to be one too many parens! This PR fixes the issue for me