### PR TITLE
Fix Sprite2D error spam in exported project

### DIFF
--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -481,7 +481,9 @@ void Sprite2D::_texture_changed() {
 }
 
 void Sprite2D::_emit_region_rect_enabled() {
-	emit_signal("_editor_region_rect_enabled");
+	if (Engine::get_singleton()->is_editor_hint()) {
+		emit_signal("_editor_region_rect_enabled");
+	}
 }
 
 void Sprite2D::_bind_methods() {
@@ -547,7 +549,7 @@ void Sprite2D::_bind_methods() {
 }
 
 Sprite2D::Sprite2D() {
-#ifdef TOOLS_ENABLED
-	add_user_signal(MethodInfo("_editor_region_rect_enabled"));
-#endif
+	if (Engine::get_singleton()->is_editor_hint()) {
+		add_user_signal(MethodInfo("_editor_region_rect_enabled"));
+	}
 }


### PR DESCRIPTION
Fixes regression from #106553
The signal only exists in editor build, but always gets emitted, resulting in error spam about non-existent signal in exported project.