### PR TITLE
Ensure macOS shortcut overrides are used for web export on macOS

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -583,6 +583,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::BACKSPACE | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_text_backspace_word.macos", inputs);
+	default_builtin_cache.insert("ui_text_backspace_word.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	default_builtin_cache.insert("ui_text_backspace_all_to_left", inputs);
@@ -590,6 +591,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::BACKSPACE | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_backspace_all_to_left.macos", inputs);
+	default_builtin_cache.insert("ui_text_backspace_all_to_left.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::KEY_DELETE));
@@ -602,6 +604,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::KEY_DELETE | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_text_delete_word.macos", inputs);
+	default_builtin_cache.insert("ui_text_delete_word.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	default_builtin_cache.insert("ui_text_delete_all_to_right", inputs);
@@ -609,6 +612,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::KEY_DELETE | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_delete_all_to_right.macos", inputs);
+	default_builtin_cache.insert("ui_text_delete_all_to_right.web_macos", inputs);
 
 	// Text Caret Movement Left/Right
 
@@ -623,6 +627,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::LEFT | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_text_caret_word_left.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_word_left.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::RIGHT));
@@ -635,6 +640,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::RIGHT | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_text_caret_word_right.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_word_right.web_macos", inputs);
 
 	// Text Caret Movement Up/Down
 
@@ -657,6 +663,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(Key::LEFT | KeyModifierMask::CMD_OR_CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::HOME));
 	default_builtin_cache.insert("ui_text_caret_line_start.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_line_start.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::END));
@@ -667,6 +674,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::END));
 	default_builtin_cache.insert("ui_text_caret_line_end.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_line_end.web_macos", inputs);
 
 	// Text Caret Movement Page Up/Down
 
@@ -688,6 +696,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(Key::UP | KeyModifierMask::CMD_OR_CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::HOME | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_document_start.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_document_start.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::END | KeyModifierMask::CMD_OR_CTRL));
@@ -697,6 +706,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs.push_back(InputEventKey::create_reference(Key::DOWN | KeyModifierMask::CMD_OR_CTRL));
 	inputs.push_back(InputEventKey::create_reference(Key::END | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_document_end.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_document_end.web_macos", inputs);
 
 	// Text Caret Addition Below/Above
 
@@ -707,6 +717,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::L | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_add_below.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_add_below.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::UP | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
@@ -715,6 +726,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::O | KeyModifierMask::SHIFT | KeyModifierMask::CMD_OR_CTRL));
 	default_builtin_cache.insert("ui_text_caret_add_above.macos", inputs);
+	default_builtin_cache.insert("ui_text_caret_add_above.web_macos", inputs);
 
 	// Text Scrolling
 
@@ -725,6 +737,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::UP | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_text_scroll_up.macos", inputs);
+	default_builtin_cache.insert("ui_text_scroll_up.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::DOWN | KeyModifierMask::CMD_OR_CTRL));
@@ -733,6 +746,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::DOWN | KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_text_scroll_down.macos", inputs);
+	default_builtin_cache.insert("ui_text_scroll_down.web_macos", inputs);
 
 	// Text Misc
 
@@ -747,6 +761,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::G | KeyModifierMask::CTRL | KeyModifierMask::META));
 	default_builtin_cache.insert("ui_text_select_word_under_caret.macos", inputs);
+	default_builtin_cache.insert("ui_text_select_word_under_caret.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::D | KeyModifierMask::CMD_OR_CTRL));
@@ -794,6 +809,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::LEFT | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_graph_follow_left.macos", inputs);
+	default_builtin_cache.insert("ui_graph_follow_left.web_macos", inputs);
 
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::RIGHT | KeyModifierMask::CMD_OR_CTRL));
@@ -802,6 +818,7 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 	inputs = List<Ref<InputEvent>>();
 	inputs.push_back(InputEventKey::create_reference(Key::RIGHT | KeyModifierMask::ALT));
 	default_builtin_cache.insert("ui_graph_follow_right.macos", inputs);
+	default_builtin_cache.insert("ui_graph_follow_right.web_macos", inputs);
 
 	// ///// UI File Dialog Shortcuts /////
 	inputs = List<Ref<InputEvent>>();

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -358,40 +358,26 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_text_dedent",                                TTRC("Dedent") },
 	{ "ui_text_backspace",                             TTRC("Backspace") },
 	{ "ui_text_backspace_word",                        TTRC("Backspace Word") },
-	{ "ui_text_backspace_word.macos",                  TTRC("Backspace Word") },
 	{ "ui_text_backspace_all_to_left",                 TTRC("Backspace all to Left") },
-	{ "ui_text_backspace_all_to_left.macos",           TTRC("Backspace all to Left") },
 	{ "ui_text_delete",                                TTRC("Delete") },
 	{ "ui_text_delete_word",                           TTRC("Delete Word") },
-	{ "ui_text_delete_word.macos",                     TTRC("Delete Word") },
 	{ "ui_text_delete_all_to_right",                   TTRC("Delete all to Right") },
-	{ "ui_text_delete_all_to_right.macos",             TTRC("Delete all to Right") },
 	{ "ui_text_caret_left",                            TTRC("Caret Left") },
 	{ "ui_text_caret_word_left",                       TTRC("Caret Word Left") },
-	{ "ui_text_caret_word_left.macos",                 TTRC("Caret Word Left") },
 	{ "ui_text_caret_right",                           TTRC("Caret Right") },
 	{ "ui_text_caret_word_right",                      TTRC("Caret Word Right") },
-	{ "ui_text_caret_word_right.macos",                TTRC("Caret Word Right") },
 	{ "ui_text_caret_up",                              TTRC("Caret Up") },
 	{ "ui_text_caret_down",                            TTRC("Caret Down") },
 	{ "ui_text_caret_line_start",                      TTRC("Caret Line Start") },
-	{ "ui_text_caret_line_start.macos",                TTRC("Caret Line Start") },
 	{ "ui_text_caret_line_end",                        TTRC("Caret Line End") },
-	{ "ui_text_caret_line_end.macos",                  TTRC("Caret Line End") },
 	{ "ui_text_caret_page_up",                         TTRC("Caret Page Up") },
 	{ "ui_text_caret_page_down",                       TTRC("Caret Page Down") },
 	{ "ui_text_caret_document_start",                  TTRC("Caret Document Start") },
-	{ "ui_text_caret_document_start.macos",            TTRC("Caret Document Start") },
 	{ "ui_text_caret_document_end",                    TTRC("Caret Document End") },
-	{ "ui_text_caret_document_end.macos",              TTRC("Caret Document End") },
 	{ "ui_text_caret_add_below",                       TTRC("Caret Add Below") },
-	{ "ui_text_caret_add_below.macos",                 TTRC("Caret Add Below") },
 	{ "ui_text_caret_add_above",                       TTRC("Caret Add Above") },
-	{ "ui_text_caret_add_above.macos",                 TTRC("Caret Add Above") },
 	{ "ui_text_scroll_up",                             TTRC("Scroll Up") },
-	{ "ui_text_scroll_up.macos",                       TTRC("Scroll Up") },
 	{ "ui_text_scroll_down",                           TTRC("Scroll Down") },
-	{ "ui_text_scroll_down.macos",                     TTRC("Scroll Down") },
 	{ "ui_text_select_all",                            TTRC("Select All") },
 	{ "ui_text_select_word_under_caret",               TTRC("Select Word Under Caret") },
 	{ "ui_text_add_selection_for_next_occurrence",     TTRC("Add Selection for Next Occurrence") },
@@ -415,10 +401,11 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 };
 
 String InputMap::get_builtin_display_name(const String &p_name) const {
+	Vector<String> split = p_name.split(".");
+	const String &name = split[0];
 	constexpr int len = std::size(_builtin_action_display_names);
-
 	for (int i = 0; i < len; i++) {
-		if (_builtin_action_display_names[i].name == p_name) {
+		if (_builtin_action_display_names[i].name == name) {
 			return _builtin_action_display_names[i].display_name;
 		}
 	}

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1326,12 +1326,18 @@
 		<member name="input/ui_graph_follow_left.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to follow a [GraphNode] input port connection.
 		</member>
+		<member name="input/ui_graph_follow_left.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to follow a [GraphNode] input port connection.
+		</member>
 		<member name="input/ui_graph_follow_right" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to follow a [GraphNode] output port connection.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_graph_follow_right.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to follow a [GraphNode] output port connection.
+		</member>
+		<member name="input/ui_graph_follow_right.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to follow a [GraphNode] output port connection.
 		</member>
 		<member name="input/ui_home" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to go to the start position of a [Control] (e.g. first item in an [ItemList] or a [Tree]), matching the behavior of [constant KEY_HOME] on typical desktop UI systems.
@@ -1390,6 +1396,9 @@
 		<member name="input/ui_text_backspace_all_to_left.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to delete all text before the text cursor.
 		</member>
+		<member name="input/ui_text_backspace_all_to_left.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to delete all text before the text cursor.
+		</member>
 		<member name="input/ui_text_backspace_word" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to delete all characters before the cursor up until a whitespace or punctuation character.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
@@ -1397,17 +1406,26 @@
 		<member name="input/ui_text_backspace_word.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to delete a word.
 		</member>
+		<member name="input/ui_text_backspace_word.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to delete a word.
+		</member>
 		<member name="input/ui_text_caret_add_above" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to add an additional caret above every caret of a text.
 		</member>
 		<member name="input/ui_text_caret_add_above.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to add a caret above every caret.
 		</member>
+		<member name="input/ui_text_caret_add_above.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to add a caret above every caret.
+		</member>
 		<member name="input/ui_text_caret_add_below" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to add an additional caret below every caret of a text.
 		</member>
 		<member name="input/ui_text_caret_add_below.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to add a caret below every caret.
+		</member>
+		<member name="input/ui_text_caret_add_below.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to add a caret below every caret.
 		</member>
 		<member name="input/ui_text_caret_document_end" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor to the end of the text.
@@ -1416,12 +1434,18 @@
 		<member name="input/ui_text_caret_document_end.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor to the end of the text.
 		</member>
+		<member name="input/ui_text_caret_document_end.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to move the text cursor to the end of the text.
+		</member>
 		<member name="input/ui_text_caret_document_start" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor to the start of the text.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_caret_document_start.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor to the start of the text.
+		</member>
+		<member name="input/ui_text_caret_document_start.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to move the text cursor to the start of the text.
 		</member>
 		<member name="input/ui_text_caret_down" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor down.
@@ -1438,12 +1462,18 @@
 		<member name="input/ui_text_caret_line_end.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor to the end of the line.
 		</member>
+		<member name="input/ui_text_caret_line_end.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to move the text cursor to the end of the line.
+		</member>
 		<member name="input/ui_text_caret_line_start" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor to the start of the line.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_caret_line_start.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor to the start of the line.
+		</member>
+		<member name="input/ui_text_caret_line_start.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to move the text cursor to the start of the line.
 		</member>
 		<member name="input/ui_text_caret_page_down" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor down one page.
@@ -1468,12 +1498,18 @@
 		<member name="input/ui_text_caret_word_left.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor back one word.
 		</member>
+		<member name="input/ui_text_caret_word_left.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to move the text cursor back one word.
+		</member>
 		<member name="input/ui_text_caret_word_right" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to move the text cursor right to the next whitespace or punctuation.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_caret_word_right.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to move the text cursor forward one word.
+		</member>
+		<member name="input/ui_text_caret_word_right.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to move the text cursor forward one word.
 		</member>
 		<member name="input/ui_text_clear_carets_and_selection" type="Dictionary" setter="" getter="">
 			If there's only one caret active and with a selection, clears the selection.
@@ -1507,12 +1543,18 @@
 		<member name="input/ui_text_delete_all_to_right.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to delete all text after the text cursor.
 		</member>
+		<member name="input/ui_text_delete_all_to_right.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to delete all text after the text cursor.
+		</member>
 		<member name="input/ui_text_delete_word" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to delete all characters after the cursor up until a whitespace or punctuation character.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_delete_word.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to delete a word after the text cursor.
+		</member>
+		<member name="input/ui_text_delete_word.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to delete a word after the text cursor.
 		</member>
 		<member name="input/ui_text_indent" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to indent the current line.
@@ -1537,12 +1579,18 @@
 		<member name="input/ui_text_scroll_down.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to scroll down one line.
 		</member>
+		<member name="input/ui_text_scroll_down.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to scroll down one line.
+		</member>
 		<member name="input/ui_text_scroll_up" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to scroll up one line of text.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
 		<member name="input/ui_text_scroll_up.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to scroll up one line.
+		</member>
+		<member name="input/ui_text_scroll_up.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to scroll up one line.
 		</member>
 		<member name="input/ui_text_select_all" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to select all text.
@@ -1554,6 +1602,9 @@
 		</member>
 		<member name="input/ui_text_select_word_under_caret.macos" type="Dictionary" setter="" getter="">
 			macOS specific override for the shortcut to select the word currently under the caret.
+		</member>
+		<member name="input/ui_text_select_word_under_caret.web_macos" type="Dictionary" setter="" getter="">
+			macOS (web) specific override for the shortcut to select the word currently under the caret.
 		</member>
 		<member name="input/ui_text_skip_selection_for_next_occurrence" type="Dictionary" setter="" getter="">
 			If no selection is currently active with the last caret in text fields, searches for the next occurrence of the word currently under the caret and moves the caret to the next occurrence. The action can be performed sequentially for other occurrences of the word under the last caret.


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107371