### PR TITLE
Partially revert 107110, process all lines in `VC_CHARS_BEFORE_SHAPING` mode to return correct line count.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -102,7 +102,6 @@
 			<return type="int" />
 			<description>
 				Returns the total number of lines in the text. Wrapped text is counted as multiple lines.
-				[b]Note:[/b] Lines hidden by [member visible_characters] are not counted.
 				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>
@@ -189,8 +188,6 @@
 			<return type="int" />
 			<description>
 				Returns the total number of paragraphs (newlines or [code]p[/code] tags in the tag stack's text tags). Considers wrapped text as one paragraph.
-				[b]Note:[/b] Paragraphs hidden by [member visible_characters] are not counted.
-				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>
 		</method>
 		<method name="get_paragraph_offset">


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107320 seems like a lot of stuff was using old behavior.

Partially reverts https://github.com/godotengine/godot/pull/107110 and fixes https://github.com/godotengine/godot/issues/99654 differently, by processing all lines regardless of `visible_character_behavior`.