### PR TITLE
Add a proper error message when trying to add node to a group with an empty name

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2391,7 +2391,7 @@ bool Node::is_in_group(const StringName &p_identifier) const {
 
 void Node::add_to_group(const StringName &p_identifier, bool p_persistent) {
 	ERR_THREAD_GUARD
-	ERR_FAIL_COND(!p_identifier.operator String().length());
+	ERR_FAIL_COND_MSG(p_identifier.is_empty(), vformat("Cannot add node '%s' to a group with an empty name.", get_name()));
 
 	if (data.grouped.has(p_identifier)) {
 		return;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Right now, if you try to add a node to a group with an empty name, you will get a very unhelpful error
`Condition "!p_identifier.operator String().length()" is true.`

This pull request adds an error message "Tried to add node to a group with an empty name."


Minimal reproduction build: 
[error-message-test.zip](https://github.com/user-attachments/files/20842664/error-message-test.zip)
