### PR TITLE
Add `HashSet.duplicate()`

### DIFF
--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -255,6 +255,12 @@ public:
 		_size = 0;
 	}
 
+	HashSet duplicate() const {
+		HashSet copy;
+		copy._init_from(*this);
+		return copy;
+	}
+
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
 		uint32_t _idx = 0;
 		return _lookup_key_idx(p_key, _idx);

--- a/modules/gltf/skin_tool.cpp
+++ b/modules/gltf/skin_tool.cpp
@@ -567,11 +567,10 @@ Error SkinTool::_create_skeletons(
 		Vector<Ref<GLTFSkeleton>> &skeletons,
 		HashMap<GLTFNodeIndex, Node *> &scene_nodes,
 		int p_naming_version) {
-	// This is the syntax to duplicate a Godot HashSet.
-	HashSet<String> unique_node_names(unique_names);
+	HashSet<String> unique_node_names = unique_names.duplicate();
 	for (SkinSkeletonIndex skel_i = 0; skel_i < skeletons.size(); ++skel_i) {
 		Ref<GLTFSkeleton> gltf_skeleton = skeletons.write[skel_i];
-		HashSet<String> skel_unique_names(unique_node_names);
+		HashSet<String> skel_unique_names = unique_node_names.duplicate();
 
 		Skeleton3D *skeleton = memnew(Skeleton3D);
 		gltf_skeleton->godot_skeleton = skeleton;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/106537#discussion_r2136667054

HashSet has a copy constructor, but it's not obvious whether the constructor is truly copying the underlying data just from reading the usage. This makes the intent clearer, at the cost of adding a very small function to HashSet. There is already a similar API in `Vector<>` for duplicating those.