### PR TITLE
Unhide `one-click deploy` button on Android and XR editor.

### DIFF
--- a/editor/gui/editor_run_bar.cpp
+++ b/editor/gui/editor_run_bar.cpp
@@ -610,9 +610,6 @@ EditorRunBar::EditorRunBar() {
 	run_native = memnew(EditorRunNative);
 	main_hbox->add_child(run_native);
 	run_native->connect("native_run", callable_mp(this, &EditorRunBar::_run_native));
-#ifdef ANDROID_ENABLED
-	run_native->hide();
-#endif
 
 	bool add_play_xr_mode_options = false;
 #ifndef XR_DISABLED


### PR DESCRIPTION
Reverts [#105636](https://github.com/godotengine/godot/pull/105636)

See [this (and following) comments](https://github.com/godotengine/godot/pull/105636#issuecomment-2955819788) for why I think this should be reverted