### PR TITLE
Core: Remove implicit conversions from `Callable` and `Signal` to `String`, to avoid accidental conversions

### DIFF
--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -77,7 +77,7 @@ class TranslationServer : public Object {
 					(p_locale.variant == variant);
 		}
 
-		operator String() const;
+		explicit operator String() const;
 
 		Locale(const TranslationServer &p_server, const String &p_locale, bool p_add_defaults);
 	};

--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -55,6 +55,7 @@
 #include "core/templates/pair.h"
 #include "core/templates/rid.h"
 #include "core/typedefs.h"
+#include "core/variant/callable.h"
 
 #ifdef _MSC_VER
 #include <intrin.h> // Needed for `__umulh` below.
@@ -342,6 +343,7 @@ struct HashMapHasherDefault {
 	static _FORCE_INLINE_ uint32_t hash(const StringName &p_string_name) { return p_string_name.hash(); }
 	static _FORCE_INLINE_ uint32_t hash(const NodePath &p_path) { return p_path.hash(); }
 	static _FORCE_INLINE_ uint32_t hash(const ObjectID &p_id) { return hash_one_uint64(p_id); }
+	static _FORCE_INLINE_ uint32_t hash(const Callable &p_callable) { return p_callable.hash(); }
 
 	static _FORCE_INLINE_ uint32_t hash(const uint64_t p_int) { return hash_one_uint64(p_int); }
 	static _FORCE_INLINE_ uint32_t hash(const int64_t p_int) { return hash_one_uint64(uint64_t(p_int)); }

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -123,7 +123,7 @@ public:
 
 	void operator=(const Callable &p_callable);
 
-	operator String() const;
+	explicit operator String() const;
 
 	static Callable create(const Variant &p_variant, const StringName &p_method);
 
@@ -190,7 +190,7 @@ public:
 	bool operator!=(const Signal &p_signal) const;
 	bool operator<(const Signal &p_signal) const;
 
-	operator String() const;
+	explicit operator String() const;
 
 	Error emit(const Variant **p_arguments, int p_argcount) const;
 	Error connect(const Callable &p_callable, uint32_t p_flags = 0);

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -131,7 +131,7 @@ struct PtrToArgStringConvertByReference {
 	// No EncodeT because direct pointer conversion not possible.
 	_FORCE_INLINE_ static void encode(const T &p_vec, void *p_ptr) {
 		String *arr = reinterpret_cast<String *>(p_ptr);
-		*arr = p_vec;
+		*arr = String(p_vec);
 	}
 };
 

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1725,11 +1725,11 @@ String Variant::stringify(int recursion_count) const {
 		}
 		case CALLABLE: {
 			const Callable &c = *reinterpret_cast<const Callable *>(_data._mem);
-			return c;
+			return String(c);
 		}
 		case SIGNAL: {
 			const Signal &s = *reinterpret_cast<const Signal *>(_data._mem);
-			return s;
+			return String(s);
 		}
 		case RID: {
 			const ::RID &s = *reinterpret_cast<const ::RID *>(_data._mem);


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/107295

Same idea as above - we want to avoid accidentally converting to `String`, because it's expensive. 

This also happens to fix _another_ exact same type of bug as https://github.com/godotengine/godot/pull/107289, where `Callable` was accidentally converted to `String` before hashing, making using `Callable` as `HashMap` keys very slow. There is already a dedicated `hash()` function for `Callable` - it just wasn't used. 

After this PR, there are just 4 implicit `String` conversions left:
- `Variant` - probably can't fix this now, `Variant` has _all_ the implicit conversions.
- `StringName` - probably fine for now since it's usually fast (at least on repeated access).
- `NodePath` - there's a lot of accessors, so it needs its own PR.
- `IPAddress` - there's a lot of accessors, so it needs its own PR.
