### PR TITLE
Add a LightmapProbe gizmo size editor setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -518,6 +518,9 @@
 		<member name="editors/3d_gizmos/gizmo_settings/bone_shape" type="int" setter="" getter="">
 			The shape of [Skeleton3D] bone gizmos in the 3D editor. [b]Wire[/b] is a thin line, while [b]Octahedron[/b] is a set of lines that represent a thicker hollow line pointing in a specific direction (similar to most 3D animation software).
 		</member>
+		<member name="editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size" type="float" setter="" getter="">
+			Size of probe gizmos displayed when editing [LightmapGI] and [LightmapProbe] nodes. Setting this to [code]0.0[/code] will hide the probe spheres of [LightmapGI] and wireframes of [LightmapProbe] nodes, but will keep the wireframes linking probes from [LightmapGI] and billboard icons from [LightmapProbe] intact.
+		</member>
 		<member name="editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size" type="float" setter="" getter="">
 			Size of the disk gizmo displayed when editing [Path3D]'s tilt handles.
 		</member>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -847,6 +847,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/3d_gizmos/gizmo_settings/bone_axis_length", (float)0.1);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d_gizmos/gizmo_settings/bone_shape", 1, "Wire,Octahedron");
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size", 0.8, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size", 0.4, "0.0,1.0,0.001,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// If a line is a multiple of this, it uses the primary grid color.
 	// Use a power of 2 value by default as it's more common to use powers of 2 in level design.

--- a/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.cpp
@@ -36,7 +36,10 @@
 #include "scene/3d/lightmap_gi.h"
 
 LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
+	// NOTE: This gizmo only renders solid spheres for previewing indirect lighting on dynamic objects.
+	// The wireframe representation for LightmapProbe nodes is handled in LightmapProbeGizmoPlugin.
 	Color gizmo_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/lightmap_lines");
+	probe_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size");
 
 	gizmo_color.a = 0.1;
 	create_material("lightmap_lines", gizmo_color);
@@ -45,8 +48,8 @@ LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
 	mat->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
 	// Fade out probes when camera gets too close to them.
 	mat->set_distance_fade(StandardMaterial3D::DISTANCE_FADE_PIXEL_DITHER);
-	mat->set_distance_fade_min_distance(0.5);
-	mat->set_distance_fade_max_distance(1.5);
+	mat->set_distance_fade_min_distance(probe_size * 0.5);
+	mat->set_distance_fade_max_distance(probe_size * 1.5);
 	mat->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	mat->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, false);
 	mat->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
@@ -129,91 +132,93 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	LocalVector<Vector3> vertices;
 	LocalVector<Color> colors;
 	LocalVector<int> indices;
-	float radius = 0.3;
+	float radius = probe_size * 0.5f;
 
-	// L2 Spherical Harmonics evaluation and diffuse convolution coefficients.
-	const float sh_coeffs[5] = {
-		static_cast<float>(sqrt(1.0 / (4.0 * Math::PI)) * Math::PI),
-		static_cast<float>(sqrt(3.0 / (4.0 * Math::PI)) * Math::PI * 2.0 / 3.0),
-		static_cast<float>(sqrt(15.0 / (4.0 * Math::PI)) * Math::PI * 1.0 / 4.0),
-		static_cast<float>(sqrt(5.0 / (16.0 * Math::PI)) * Math::PI * 1.0 / 4.0),
-		static_cast<float>(sqrt(15.0 / (16.0 * Math::PI)) * Math::PI * 1.0 / 4.0)
-	};
+	if (!Math::is_zero_approx(radius)) {
+		// L2 Spherical Harmonics evaluation and diffuse convolution coefficients.
+		const float sh_coeffs[5] = {
+			static_cast<float>(sqrt(1.0 / (4.0 * Math::PI)) * Math::PI),
+			static_cast<float>(sqrt(3.0 / (4.0 * Math::PI)) * Math::PI * 2.0 / 3.0),
+			static_cast<float>(sqrt(15.0 / (4.0 * Math::PI)) * Math::PI * 1.0 / 4.0),
+			static_cast<float>(sqrt(5.0 / (16.0 * Math::PI)) * Math::PI * 1.0 / 4.0),
+			static_cast<float>(sqrt(15.0 / (16.0 * Math::PI)) * Math::PI * 1.0 / 4.0)
+		};
 
-	for (int p = 0; p < points.size(); p++) {
-		int vertex_base = vertices.size();
-		Vector3 sh_col[9];
-		for (int i = 0; i < 9; i++) {
-			sh_col[i].x = sh[p * 9 + i].r;
-			sh_col[i].y = sh[p * 9 + i].g;
-			sh_col[i].z = sh[p * 9 + i].b;
-		}
+		for (int p = 0; p < points.size(); p++) {
+			int vertex_base = vertices.size();
+			Vector3 sh_col[9];
+			for (int i = 0; i < 9; i++) {
+				sh_col[i].x = sh[p * 9 + i].r;
+				sh_col[i].y = sh[p * 9 + i].g;
+				sh_col[i].z = sh[p * 9 + i].b;
+			}
 
-		for (int i = 0; i <= stack_count; ++i) {
-			float stack_angle = Math::PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
-			float xy = radius * Math::cos(stack_angle); // r * cos(u)
-			float z = radius * Math::sin(stack_angle); // r * sin(u)
+			for (int i = 0; i <= stack_count; ++i) {
+				float stack_angle = Math::PI / 2 - i * stack_step; // starting from pi/2 to -pi/2
+				float xy = radius * Math::cos(stack_angle); // r * cos(u)
+				float z = radius * Math::sin(stack_angle); // r * sin(u)
 
-			// add (sector_count+1) vertices per stack
-			// the first and last vertices have same position and normal, but different tex coords
-			for (int j = 0; j <= sector_count; ++j) {
-				float sector_angle = j * sector_step; // starting from 0 to 2pi
+				// add (sector_count+1) vertices per stack
+				// the first and last vertices have same position and normal, but different tex coords
+				for (int j = 0; j <= sector_count; ++j) {
+					float sector_angle = j * sector_step; // starting from 0 to 2pi
 
-				// vertex position (x, y, z)
-				float x = xy * Math::cos(sector_angle); // r * cos(u) * cos(v)
-				float y = xy * Math::sin(sector_angle); // r * cos(u) * sin(v)
+					// vertex position (x, y, z)
+					float x = xy * Math::cos(sector_angle); // r * cos(u) * cos(v)
+					float y = xy * Math::sin(sector_angle); // r * cos(u) * sin(v)
 
-				Vector3 n = Vector3(x, z, y);
-				vertices.push_back(points[p] + n);
-				n.normalize();
+					Vector3 n = Vector3(x, z, y);
+					vertices.push_back(points[p] + n);
+					n.normalize();
 
-				const Vector3 light = (sh_coeffs[0] * sh_col[0] +
-						sh_coeffs[1] * sh_col[1] * n.y +
-						sh_coeffs[1] * sh_col[2] * n.z +
-						sh_coeffs[1] * sh_col[3] * n.x +
-						sh_coeffs[2] * sh_col[4] * n.x * n.y +
-						sh_coeffs[2] * sh_col[5] * n.y * n.z +
-						sh_coeffs[3] * sh_col[6] * (3.0 * n.z * n.z - 1.0) +
-						sh_coeffs[2] * sh_col[7] * n.x * n.z +
-						sh_coeffs[4] * sh_col[8] * (n.x * n.x - n.y * n.y));
+					const Vector3 light = (sh_coeffs[0] * sh_col[0] +
+							sh_coeffs[1] * sh_col[1] * n.y +
+							sh_coeffs[1] * sh_col[2] * n.z +
+							sh_coeffs[1] * sh_col[3] * n.x +
+							sh_coeffs[2] * sh_col[4] * n.x * n.y +
+							sh_coeffs[2] * sh_col[5] * n.y * n.z +
+							sh_coeffs[3] * sh_col[6] * (3.0 * n.z * n.z - 1.0) +
+							sh_coeffs[2] * sh_col[7] * n.x * n.z +
+							sh_coeffs[4] * sh_col[8] * (n.x * n.x - n.y * n.y));
 
-				colors.push_back(Color(light.x, light.y, light.z, 1));
+					colors.push_back(Color(light.x, light.y, light.z, 1));
+				}
+			}
+
+			for (int i = 0; i < stack_count; ++i) {
+				int k1 = i * (sector_count + 1); // beginning of current stack
+				int k2 = k1 + sector_count + 1; // beginning of next stack
+
+				for (int j = 0; j < sector_count; ++j, ++k1, ++k2) {
+					// 2 triangles per sector excluding first and last stacks
+					// k1 => k2 => k1+1
+					if (i != 0) {
+						indices.push_back(vertex_base + k1);
+						indices.push_back(vertex_base + k2);
+						indices.push_back(vertex_base + k1 + 1);
+					}
+
+					// k1+1 => k2 => k2+1
+					if (i != (stack_count - 1)) {
+						indices.push_back(vertex_base + k1 + 1);
+						indices.push_back(vertex_base + k2);
+						indices.push_back(vertex_base + k2 + 1);
+					}
+				}
 			}
 		}
 
-		for (int i = 0; i < stack_count; ++i) {
-			int k1 = i * (sector_count + 1); // beginning of current stack
-			int k2 = k1 + sector_count + 1; // beginning of next stack
+		Array array;
+		array.resize(RS::ARRAY_MAX);
+		array[RS::ARRAY_VERTEX] = Vector<Vector3>(vertices);
+		array[RS::ARRAY_INDEX] = Vector<int>(indices);
+		array[RS::ARRAY_COLOR] = Vector<Color>(colors);
 
-			for (int j = 0; j < sector_count; ++j, ++k1, ++k2) {
-				// 2 triangles per sector excluding first and last stacks
-				// k1 => k2 => k1+1
-				if (i != 0) {
-					indices.push_back(vertex_base + k1);
-					indices.push_back(vertex_base + k2);
-					indices.push_back(vertex_base + k1 + 1);
-				}
+		Ref<ArrayMesh> mesh;
+		mesh.instantiate();
+		mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, array, Array(), Dictionary(), 0); //no compression
+		mesh->surface_set_material(0, material_probes);
 
-				// k1+1 => k2 => k2+1
-				if (i != (stack_count - 1)) {
-					indices.push_back(vertex_base + k1 + 1);
-					indices.push_back(vertex_base + k2);
-					indices.push_back(vertex_base + k2 + 1);
-				}
-			}
-		}
+		p_gizmo->add_mesh(mesh);
 	}
-
-	Array array;
-	array.resize(RS::ARRAY_MAX);
-	array[RS::ARRAY_VERTEX] = Vector<Vector3>(vertices);
-	array[RS::ARRAY_INDEX] = Vector<int>(indices);
-	array[RS::ARRAY_COLOR] = Vector<Color>(colors);
-
-	Ref<ArrayMesh> mesh;
-	mesh.instantiate();
-	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, array, Array(), Dictionary(), 0); //no compression
-	mesh->surface_set_material(0, material_probes);
-
-	p_gizmo->add_mesh(mesh);
 }

--- a/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.h
+++ b/editor/plugins/gizmos/lightmap_gi_gizmo_plugin.h
@@ -35,6 +35,8 @@
 class LightmapGIGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(LightmapGIGizmoPlugin, EditorNode3DGizmoPlugin);
 
+	float probe_size = 0.4f;
+
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
 	String get_gizmo_name() const override;

--- a/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.h
+++ b/editor/plugins/gizmos/lightmap_probe_gizmo_plugin.h
@@ -35,6 +35,8 @@
 class LightmapProbeGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(LightmapProbeGizmoPlugin, EditorNode3DGizmoPlugin);
 
+	float probe_size = 0.4f;
+
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
 	String get_gizmo_name() const override;


### PR DESCRIPTION
- Decrease default size of LightmapProbe gizmos to make smaller-scale scenes with dense probes easier to edit.

cc @lander-vr 

## Preview

### Before

![godot_aJtEJ1DOIX](https://github.com/user-attachments/assets/8292f5c5-c125-4380-b9dd-8cb2c8819c10)

### After

![godot windows editor x86_64_fAVSRHVJfh](https://github.com/user-attachments/assets/459985a4-6f95-4836-94ad-654540005652)

### After (probe size set to `0.0` in editor settings)

![godot windows editor x86_64_O1CJFxzBTu](https://github.com/user-attachments/assets/67dea203-0fe7-42b0-be5f-109a5fe832a1)
