### PR TITLE
Fix `Input.vibrate_handheld` on Android.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -1011,25 +1011,29 @@ class Godot(private val context: Context) {
 	@Keep
 	private fun vibrate(durationMs: Int, amplitude: Int) {
 		if (durationMs > 0 && requestPermission("VIBRATE")) {
-			if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-				if (amplitude <= -1) {
-					vibratorService.vibrate(
-						VibrationEffect.createOneShot(
-							durationMs.toLong(),
-							VibrationEffect.DEFAULT_AMPLITUDE
+			try {
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+					if (amplitude <= -1) {
+						vibratorService.vibrate(
+							VibrationEffect.createOneShot(
+								durationMs.toLong(),
+								VibrationEffect.DEFAULT_AMPLITUDE
+							)
 						)
-					)
+					} else {
+						vibratorService.vibrate(
+							VibrationEffect.createOneShot(
+								durationMs.toLong(),
+								amplitude
+							)
+						)
+					}
 				} else {
-					vibratorService.vibrate(
-						VibrationEffect.createOneShot(
-							durationMs.toLong(),
-							amplitude
-						)
-					)
+					// deprecated in API 26
+					vibratorService.vibrate(durationMs.toLong())
 				}
-			} else {
-				// deprecated in API 26
-				vibratorService.vibrate(durationMs.toLong())
+			} catch (e: SecurityException) {
+				Log.w(TAG, "SecurityException: VIBRATE permission not found. Make sure it is declared in the manifest or enabled in the export preset.")
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #103496

Catched the crash via `try / catch`.

```kotlin
			try {
                                 ....
                                 vibratorService.vibrate( .... )
                                 ....
			} catch (e: SecurityException) {
				Log.w(TAG, e)
			}

```

<details><summary>logcat</summary>

```java
06-11 02:50:51.881 26791 26927 W Godot   : java.lang.SecurityException: vibrate: Neither user 10717 nor current process has android.permission.VIBRATE.
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.Parcel.createExceptionOrNull(Parcel.java:3023)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.Parcel.createException(Parcel.java:3007)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.Parcel.readException(Parcel.java:2990)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.Parcel.readException(Parcel.java:2932)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.IVibratorManagerService$Stub$Proxy.vibrate(IVibratorManagerService.java:438)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.SystemVibratorManager.vibrate(SystemVibratorManager.java:140)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.SystemVibrator.vibrate(SystemVibrator.java:218)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.Vibrator.vibrate(Vibrator.java:513)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.Vibrator.vibrate(Vibrator.java:464)
06-11 02:50:51.881 26791 26927 W Godot   :      at org.godotengine.godot.Godot.vibrate(Godot.kt:1017)
06-11 02:50:51.881 26791 26927 W Godot   :      at org.godotengine.godot.GodotLib.step(Native Method)
06-11 02:50:51.881 26791 26927 W Godot   :      at org.godotengine.godot.gl.GodotRenderer.onDrawFrame(GodotRenderer.java:61)
06-11 02:50:51.881 26791 26927 W Godot   :      at org.godotengine.godot.gl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1592)
06-11 02:50:51.881 26791 26927 W Godot   :      at org.godotengine.godot.gl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1294)
06-11 02:50:51.881 26791 26927 W Godot   : Caused by: android.os.RemoteException: Remote stack trace:
06-11 02:50:51.881 26791 26927 W Godot   :      at android.app.ContextImpl.enforce(ContextImpl.java:2359)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.app.ContextImpl.enforceCallingOrSelfPermission(ContextImpl.java:2387)
06-11 02:50:51.881 26791 26927 W Godot   :      at com.android.server.vibrator.VibratorManagerService.vibrateInternal(VibratorManagerService.java:447)
06-11 02:50:51.881 26791 26927 W Godot   :      at com.android.server.vibrator.VibratorManagerService.vibrate(VibratorManagerService.java:435)
06-11 02:50:51.881 26791 26927 W Godot   :      at android.os.IVibratorManagerService$Stub.onTransact(IVibratorManagerService.java:252)
06-11 02:50:51.881 26791 26927 W Godot   : 
06-11 02:50:51.881 26791 26927 V Godot   : OnGodotMainLoopStarted
```
</details>



