### PR TITLE
Fix the editor shortcuts for the game menu on Android

### DIFF
--- a/editor/plugins/game_view_plugin.cpp
+++ b/editor/plugins/game_view_plugin.cpp
@@ -227,6 +227,13 @@ void GameViewDebugger::_bind_methods() {
 
 GameViewDebugger::GameViewDebugger() {
 	EditorFeatureProfileManager::get_singleton()->connect("current_feature_profile_changed", callable_mp(this, &GameViewDebugger::_feature_profile_changed));
+
+	ED_SHORTCUT("editor/suspend_resume_embedded_project", TTRC("Suspend/Resume Embedded Project"), Key::F9);
+	ED_SHORTCUT_OVERRIDE("editor/suspend_resume_embedded_project", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);
+
+	ED_SHORTCUT("editor/next_frame_embedded_project", TTRC("Next Frame"), Key::F10);
+
+	ED_SHORTCUT("spatial_editor/tool_select", TTRC("Select Mode"), Key::Q);
 }
 
 ///////
@@ -984,8 +991,6 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	suspend_button->set_theme_type_variation(SceneStringName(FlatButton));
 	suspend_button->connect(SceneStringName(toggled), callable_mp(this, &GameView::_suspend_button_toggled));
 	suspend_button->set_accessibility_name(TTRC("Suspend"));
-	ED_SHORTCUT("editor/suspend_resume_embedded_project", TTRC("Suspend/Resume Embedded Project"), Key::F9);
-	ED_SHORTCUT_OVERRIDE("editor/suspend_resume_embedded_project", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);
 	suspend_button->set_shortcut(ED_GET_SHORTCUT("editor/suspend_resume_embedded_project"));
 
 	next_frame_button = memnew(Button);
@@ -993,7 +998,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	next_frame_button->set_theme_type_variation(SceneStringName(FlatButton));
 	next_frame_button->connect(SceneStringName(pressed), callable_mp(*debugger, &GameViewDebugger::next_frame));
 	next_frame_button->set_accessibility_name(TTRC("Next Frame"));
-	next_frame_button->set_shortcut(ED_SHORTCUT("editor/next_frame_embedded_project", TTRC("Next Frame"), Key::F10));
+	next_frame_button->set_shortcut(ED_GET_SHORTCUT("editor/next_frame_embedded_project"));
 
 	main_menu_hbox->add_child(memnew(VSeparator));
 
@@ -1041,7 +1046,7 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_pressed(true);
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_theme_type_variation(SceneStringName(FlatButton));
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->connect(SceneStringName(pressed), callable_mp(this, &GameView::_select_mode_pressed).bind(RuntimeNodeSelect::SELECT_MODE_SINGLE));
-	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut(ED_SHORTCUT("spatial_editor/tool_select", TTRC("Select Mode"), Key::Q));
+	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut(ED_GET_SHORTCUT("spatial_editor/tool_select"));
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_shortcut_context(this);
 
 	select_mode_button[RuntimeNodeSelect::SELECT_MODE_LIST] = memnew(Button);


### PR DESCRIPTION
A few editor shortcuts were added to the `GameView` constructor in https://github.com/godotengine/godot/pull/103841. That constructor however is not invoked on Android, causing the shortcuts to be missing.
To address that, the shortcuts were moved to the `GameViewDebugger` constructor, which is invoked on Android.

Fixes the following error logs:
```
22:33:33.577  9300-9330  godot                    E  ERROR: Used ED_GET_SHORTCUT with invalid shortcut: editor/suspend_resume_embedded_project
22:33:33.577  9300-9330  godot                    E     at: ED_GET_SHORTCUT (editor/editor_settings.cpp:1961)
22:33:33.577  9300-9330  godot                    E  ERROR: Condition "p_shortcut.is_null()" is true. Returning: Array()
22:33:33.577  9300-9330  godot                    E     at: serialize_key_shortcut (core/debugger/debugger_marshalls.cpp:148)
22:33:33.577  9300-9330  godot                    E  ERROR: Used ED_GET_SHORTCUT with invalid shortcut: editor/next_frame_embedded_project
22:33:33.577  9300-9330  godot                    E     at: ED_GET_SHORTCUT (editor/editor_settings.cpp:1961)
22:33:33.577  9300-9330  godot                    E  ERROR: Condition "p_shortcut.is_null()" is true. Returning: Array()
22:33:33.577  9300-9330  godot                    E     at: serialize_key_shortcut (core/debugger/debugger_marshalls.cpp:148)
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
