### PR TITLE
Fix crash when `save_on_focus_loss` is enabled

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1957,7 +1957,7 @@ void EditorNode::_save_scene_silently() {
 	// when Save on Focus Loss kicks in.
 	Node *scene = editor_data.get_edited_scene_root();
 	if (scene && !scene->get_scene_file_path().is_empty() && DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
-		_save_scene(scene->get_scene_file_path());
+		_save_scene(scene->get_scene_file_path(), -1, false);
 		save_editor_layout_delayed();
 	}
 }
@@ -1985,23 +1985,29 @@ static void _reset_animation_mixers(Node *p_node, List<Pair<AnimationMixer *, Re
 	}
 }
 
-void EditorNode::_save_scene(String p_file, int idx) {
+void EditorNode::_save_scene(String p_file, int idx, bool show_progress) {
 	ERR_FAIL_COND_MSG(!saving_scene.is_empty() && saving_scene == p_file, "Scene saved while already being saved!");
 
 	Node *scene = editor_data.get_edited_scene_root(idx);
 
-	save_scene_progress = memnew(EditorProgress("save", TTR("Saving Scene"), 3));
-	save_scene_progress->step(TTR("Analyzing"), 0);
+	if (show_progress) {
+		save_scene_progress = memnew(EditorProgress("save", TTR("Saving Scene"), 3));
+		save_scene_progress->step(TTR("Analyzing"), 0);
+	}
 
 	if (!scene) {
 		show_accept(TTR("This operation can't be done without a tree root."), TTR("OK"));
-		_close_save_scene_progress();
+		if (show_progress) {
+			_close_save_scene_progress();
+		}
 		return;
 	}
 
 	if (!scene->get_scene_file_path().is_empty() && _validate_scene_recursive(scene->get_scene_file_path(), scene)) {
 		show_accept(TTR("This scene can't be saved because there is a cyclic instance inclusion.\nPlease resolve it and then attempt to save again."), TTR("OK"));
-		_close_save_scene_progress();
+		if (show_progress) {
+			_close_save_scene_progress();
+		}
 		return;
 	}
 
@@ -2013,7 +2019,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	_reset_animation_mixers(scene, &anim_backups);
 	_save_editor_states(p_file, idx);
 
-	save_scene_progress->step(TTR("Packing Scene"), 1);
+	if (show_progress) {
+		save_scene_progress->step(TTR("Packing Scene"), 1);
+	}
 
 	Ref<PackedScene> sdata;
 
@@ -2035,11 +2043,15 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	if (err != OK) {
 		show_accept(TTR("Couldn't save scene. Likely dependencies (instances or inheritance) couldn't be satisfied."), TTR("OK"));
-		_close_save_scene_progress();
+		if (show_progress) {
+			_close_save_scene_progress();
+		}
 		return;
 	}
 
-	save_scene_progress->step(TTR("Saving scene"), 2);
+	if (show_progress) {
+		save_scene_progress->step(TTR("Saving scene"), 2);
+	}
 
 	int flg = 0;
 	if (EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
@@ -2053,7 +2065,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	emit_signal(SNAME("scene_saved"), p_file);
 	editor_data.notify_scene_saved(p_file);
 
-	save_scene_progress->step(TTR("Saving external resources"), 3);
+	if (show_progress) {
+		save_scene_progress->step(TTR("Saving external resources"), 3);
+	}
 
 	_save_external_resources();
 	saving_scene = p_file; // Some editors may save scenes of built-in resources as external data, so avoid saving this scene again.
@@ -2079,7 +2093,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 
 	scene->propagate_notification(NOTIFICATION_EDITOR_POST_SAVE);
 	_update_unsaved_cache();
-	_close_save_scene_progress();
+	if (show_progress) {
+		_close_save_scene_progress();
+	}
 }
 
 void EditorNode::save_all_scenes() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -587,7 +587,7 @@ private:
 	void _set_current_scene(int p_idx);
 	void _set_current_scene_nocheck(int p_idx);
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);
-	void _save_scene(String p_file, int idx = -1);
+	void _save_scene(String p_file, int idx = -1, bool show_progress = true);
 	void _save_all_scenes();
 	int _next_unsaved_scene(bool p_valid_filename, int p_start = 0);
 	void _discard_changes(const String &p_str = String());


### PR DESCRIPTION
Fixes #107363

At 4.4.1, the save scene progress bar will be created when calling ```EditorNode::_save_scene_with_preview()```, which is triggered when Godot is on focus and scene is saved. On the other hand, ```interface/editor/save_on_focus_loss``` will trigger call ```EditorNode::_save_scene()```, which does not create a progress bar.

But after the PR #102313, ```EditorNode::_save_scene_with_preview()``` is removed, and progress bar creation is moved to ```_save_scene()```, which causes a infinite loop when ```interface/editor/save_on_focus_loss``` is true:
1. Editor lost focus
2. ```NOTIFICATION_APPLICATION_FOCUS_OUT``` is emitted
3. ```EditorNode::_save_scene()``` is called
4. ```ProgressDialog::_update_ui()``` is called
5. ```Main::iteration()``` is called and notification is emitted again, back to step 2.

```ProgressDialog::_update_ui()``` calls ```Main::iteration()``` directly, this is the root cause of this infinite loop. I'm not sure why ```NOTIFICATION_APPLICATION_FOCUS_OUT``` isn't a one-shot event, but the debugger shows that it never stops notifying.

This PR creates a new argument ```bool show_progress``` for ```_save_scene()```, and skip creating progress bar if it is False.
