### PR TITLE
Stop `FileAccess::fix_path` from emitting errors for invalid UIDs

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -258,7 +258,12 @@ String FileAccess::fix_path(const String &p_path) const {
 		case ACCESS_RESOURCES: {
 			if (ProjectSettings::get_singleton()) {
 				if (r_path.begins_with("uid://")) {
-					r_path = ResourceUID::uid_to_path(r_path);
+					ResourceUID::ID uid = ResourceUID::get_singleton()->text_to_id(r_path);
+					if (ResourceUID::get_singleton()->has_id(uid)) {
+						r_path = ResourceUID::get_singleton()->get_id_path(uid);
+					} else {
+						r_path.clear();
+					}
 				}
 
 				if (r_path.begins_with("res://")) {


### PR DESCRIPTION
Fixes #101962.

This is mostly a quick hack to prompt a discussion about a more proper fix, and maybe serve as a hold-over, but...

This adds a `ResourceUID::has_id` check to `FileAccess::fix_path`, before it tries to call `ResourceUID::text_to_id`, and instead just clears the output string if it's not a known UID, same as what this error check is already doing inadvertently by returning an empty `String` when it can't find the UID:

https://github.com/godotengine/godot/blob/51b0379e5502402d44818a4b6f301f544a5754f3/core/io/resource_uid.cpp#L199

Without this, you could otherwise pass perfectly reasonable (or not) but non-existent `uid://` paths to `FileAccess::fix_path` and it would emit the above mentioned error about `Unrecognized UID`, which is exactly what happens in places like the LSP server, where it runs every string literal in the GDScript file through `FileAccess::file_exists`, which in turn calls `FileAccess::fix_path`, as seen here:

https://github.com/godotengine/godot/blob/51b0379e5502402d44818a4b6f301f544a5754f3/modules/gdscript/language_server/gdscript_extend_parser.cpp#L207-L214

I feel like the proper fix is to change `FileAccess::fix_path` to instead return a `bool`, to indicate a failure to fix/resolve the path, like when trying to fix/resolve a non-existent UID, but since that would/should require changing quite a lot of call sites I settled for this for now.

The fact that the LSP server is running every GDScript string literal through `FileAccess::file_exists` is maybe a bit questionable as well, but that seems like more of a performance concern than anything else. `FileAccess::file_exists` should not throw errors on non-existent UIDs.