### PR TITLE
Move editor naming settings out of project settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -647,6 +647,12 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 	}
 	// Automatically adds overrides for project settings that were changed to editor settings.
 	_handle_editor_setting_compat("editor/script/search_in_file_extensions", "text_editor/behavior/general/find_in_file_extensions");
+	_handle_editor_setting_compat("editor/naming/scene_name_casing", "naming/scene_name_casing");
+	_handle_editor_setting_compat("editor/naming/script_name_casing", "naming/script_name_casing");
+	_handle_editor_setting_compat("editor/naming/node_name_casing", "naming/node_name_casing");
+	_handle_editor_setting_compat("editor/naming/node_name_num_separator", "naming/node_name_num_separator");
+	_handle_editor_setting_compat("editor/naming/default_signal_callback_to_self_name", "naming/default_signal_callback_to_self_name");
+	_handle_editor_setting_compat("editor/naming/default_signal_callback_name", "naming/default_signal_callback_name");
 #endif // DISABLE_DEPRECATED
 }
 
@@ -1358,6 +1364,23 @@ Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p
 	return ret;
 }
 
+Variant _GLOBAL_EDITOR_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
+	return _GLOBAL_EDITOR_DEF(PropertyInfo(p_default.get_type(), p_var), p_default, p_restart_if_changed, p_basic);
+}
+
+Variant _GLOBAL_EDITOR_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	ps->editor_fallbacks[p_info.name] = p_default;
+#ifdef TOOLS_ENABLED
+	if (ps->editor_settings) {
+		return ps->call(SNAME("_define_from_project_setting"), p_info.operator Dictionary(), p_default, p_restart_if_changed, p_basic);
+	} else {
+		ps->pending_editor_settings[p_info.name] = Array{ p_info.operator Dictionary(), p_default, p_restart_if_changed, p_basic };
+	}
+#endif
+	return ps->get_editor_setting(p_info.name);
+}
+
 void ProjectSettings::_add_property_info_bind(const Dictionary &p_info) {
 	ERR_FAIL_COND_MSG(!p_info.has("name"), "Property info is missing \"name\" field.");
 	ERR_FAIL_COND_MSG(!p_info.has("type"), "Property info is missing \"type\" field.");
@@ -1423,6 +1446,27 @@ Variant ProjectSettings::get_setting(const String &p_setting, const Variant &p_d
 	} else {
 		return p_default_value;
 	}
+}
+
+Variant ProjectSettings::get_editor_setting(const String &p_setting, const Variant &p_default_value) const {
+	const String override_name = EDITOR_SETTING_OVERRIDE_PREFIX + p_setting;
+	if (has_setting(override_name)) {
+		return get_setting(override_name);
+	}
+#ifdef TOOLS_ENABLED
+	if (editor_settings) {
+		bool valid;
+		const Variant editor_value = editor_settings->get(p_setting, &valid);
+		if (valid) {
+			return editor_value;
+		}
+	}
+#endif
+	const Variant *fallback = editor_fallbacks.getptr(p_setting);
+	if (fallback) {
+		return *fallback;
+	}
+	return p_default_value;
 }
 
 PackedStringArray ProjectSettings::get_changed_settings() const {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -164,11 +164,15 @@ public:
 	static const int CONFIG_VERSION = 5;
 
 #ifdef TOOLS_ENABLED
+	Object *editor_settings = nullptr;
 	HashMap<String, PropertyInfo> editor_settings_info;
+	HashMap<String, Array> pending_editor_settings;
 #endif
+	HashMap<String, Variant> editor_fallbacks;
 
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
+	Variant get_editor_setting(const String &p_setting, const Variant &p_default_value = Variant()) const;
 	TypedArray<Dictionary> get_global_class_list();
 	void refresh_global_class_list();
 	void store_global_class_list(const Array &p_classes);
@@ -260,12 +264,16 @@ public:
 // Not a macro any longer.
 Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 Variant _GLOBAL_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
+Variant _GLOBAL_EDITOR_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
+Variant _GLOBAL_EDITOR_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
 
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
 #define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
 #define GLOBAL_DEF_RST_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true)
+#define GLOBAL_EDITOR_DEF(m_var, m_value) _GLOBAL_EDITOR_DEF(m_var, m_value)
 #define GLOBAL_GET(m_var) ProjectSettings::get_singleton()->get_setting_with_override(m_var)
+#define GLOBAL_EDITOR_GET(m_var) ProjectSettings::get_singleton()->get_editor_setting(m_var)
 
 #define GLOBAL_DEF_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, true)
 #define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1317,6 +1317,24 @@
 			A touch-friendly panel that provides easy access to common actions such as save, delete, undo, and redo without requiring a keyboard.
 			[b]Note:[/b] Only available in the Android and XR editor.
 		</member>
+		<member name="naming/default_signal_callback_name" type="String" setter="" getter="">
+			The format of the default signal callback name (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
+		</member>
+		<member name="naming/default_signal_callback_to_self_name" type="String" setter="" getter="">
+			The format of the default signal callback name when a signal connects to the same node that emits it (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
+		</member>
+		<member name="naming/node_name_casing" type="int" setter="" getter="">
+			The type of casing to use when creating node names automatically.
+		</member>
+		<member name="naming/node_name_num_separator" type="int" setter="" getter="">
+			What to use to separate node name from number.
+		</member>
+		<member name="naming/scene_name_casing" type="int" setter="" getter="">
+			The type of casing to use when generating scene file names from scene root node.
+		</member>
+		<member name="naming/script_name_casing" type="int" setter="" getter="">
+			The type of casing to use when generating script file names from the selected node.
+		</member>
 		<member name="network/connection/check_for_updates" type="int" setter="" getter="">
 			Specifies how the engine should check for updates.
 			- [b]Disable Update Checks[/b] will block the engine from checking updates (see also [member network/connection/network_mode]).

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1177,24 +1177,6 @@
 		<member name="editor/movie_writer/video_quality" type="float" setter="" getter="" default="0.75">
 			The video encoding quality to use when writing a Theora or AVI (MJPEG) video to a file, between [code]0.0[/code] and [code]1.0[/code] (inclusive). Higher [code]quality[/code] values result in better-looking output at the cost of larger file sizes. Recommended [code]quality[/code] values are between [code]0.75[/code] and [code]0.9[/code]. Even at quality [code]1.0[/code], compression remains lossy.
 		</member>
-		<member name="editor/naming/default_signal_callback_name" type="String" setter="" getter="" default="&quot;_on_{node_name}_{signal_name}&quot;">
-			The format of the default signal callback name (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
-		</member>
-		<member name="editor/naming/default_signal_callback_to_self_name" type="String" setter="" getter="" default="&quot;_on_{signal_name}&quot;">
-			The format of the default signal callback name when a signal connects to the same node that emits it (in the Signal Connection Dialog). The following substitutions are available: [code]{NodeName}[/code], [code]{nodeName}[/code], [code]{node_name}[/code], [code]{SignalName}[/code], [code]{signalName}[/code], and [code]{signal_name}[/code].
-		</member>
-		<member name="editor/naming/node_name_casing" type="int" setter="" getter="" default="0">
-			When creating node names automatically, set the type of casing to use in this project. This is mostly an editor setting.
-		</member>
-		<member name="editor/naming/node_name_num_separator" type="int" setter="" getter="" default="0">
-			What to use to separate node name from number. This is mostly an editor setting.
-		</member>
-		<member name="editor/naming/scene_name_casing" type="int" setter="" getter="" default="2">
-			When generating scene file names from scene root node, set the type of casing to use in this project. This is mostly an editor setting.
-		</member>
-		<member name="editor/naming/script_name_casing" type="int" setter="" getter="" default="0">
-			When generating script file names from the selected node, set the type of casing to use in this project. This is mostly an editor setting.
-		</member>
 		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
 			The command-line arguments to append to Godot's own command line when running the project. This doesn't affect the editor itself.
 			It is possible to make another executable run Godot by using the [code]%command%[/code] placeholder. The placeholder will be replaced with Godot's own command line. Program-specific arguments should be placed [i]before[/i] the placeholder, whereas Godot-specific arguments should be placed [i]after[/i] the placeholder.

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1615,7 +1615,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			add_root_node(new_node);
 
-			if (GLOBAL_GET("editor/naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
+			if (EDITOR_GET("naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
 				new_node->set_name(Node::adjust_name_casing(new_node->get_name()));
 			}
 
@@ -3058,7 +3058,7 @@ Node *SceneTreeDock::_do_create(Node *p_parent) {
 	ERR_FAIL_NULL_V(child, nullptr);
 
 	String new_name = p_parent->validate_child_name(child);
-	if (GLOBAL_GET("editor/naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
+	if (EDITOR_GET("naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
 		new_name = adjust_name_casing(new_name);
 	}
 	child->set_name(new_name);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3997,7 +3997,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 }
 
 String EditorNode::adjust_scene_name_casing(const String &p_root_name) {
-	switch (GLOBAL_GET("editor/naming/scene_name_casing").operator int()) {
+	switch (EDITOR_GET("naming/scene_name_casing").operator int()) {
 		case SCENE_NAME_CASING_AUTO:
 			// Use casing of the root node.
 			break;
@@ -4014,7 +4014,7 @@ String EditorNode::adjust_scene_name_casing(const String &p_root_name) {
 }
 
 String EditorNode::adjust_script_name_casing(const String &p_file_name, ScriptLanguage::ScriptNameCasing p_auto_casing) {
-	int editor_casing = GLOBAL_GET("editor/naming/script_name_casing");
+	int editor_casing = EDITOR_GET("naming/script_name_casing");
 	if (editor_casing == ScriptLanguage::SCRIPT_NAME_CASING_AUTO) {
 		// Use the script language's preferred casing.
 		editor_casing = p_auto_casing;

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -34,7 +34,6 @@
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/class_db.h"
-#include "core/object/script_language.h"
 #include "core/os/os.h"
 #include "editor/animation/animation_tree_editor_plugin.h"
 #include "editor/audio/audio_stream_editor_plugin.h"
@@ -300,11 +299,6 @@ void register_editor_types() {
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/run/main_run_args", PROPERTY_HINT_NONE, "monospace"), "");
 
 	GLOBAL_DEF(PropertyInfo(Variant::STRING, "editor/script/templates_search_path", PROPERTY_HINT_DIR), "res://script_templates");
-
-	GLOBAL_DEF("editor/naming/default_signal_callback_name", "_on_{node_name}_{signal_name}");
-	GLOBAL_DEF("editor/naming/default_signal_callback_to_self_name", "_on_{signal_name}");
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/scene_name_casing", PROPERTY_HINT_ENUM, "Auto,PascalCase,snake_case,kebab-case,camelCase"), EditorNode::SCENE_NAME_CASING_SNAKE_CASE);
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/script_name_casing", PROPERTY_HINT_ENUM, "Auto,PascalCase,snake_case,kebab-case,camelCase"), ScriptLanguage::SCRIPT_NAME_CASING_AUTO);
 
 	GLOBAL_DEF("editor/import/reimport_missing_imported_files", true);
 	GLOBAL_DEF("editor/import/use_multiple_threads", true);

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -30,7 +30,6 @@
 
 #include "connections_dialog.h"
 
-#include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/editor_language.h"
@@ -288,9 +287,9 @@ StringName ConnectDialog::generate_method_callback_name(Object *p_source, const 
 
 	String dst_method;
 	if (p_source == p_target) {
-		dst_method = String(GLOBAL_GET("editor/naming/default_signal_callback_to_self_name")).format(subst);
+		dst_method = String(EDITOR_GET("naming/default_signal_callback_to_self_name")).format(subst);
 	} else {
-		dst_method = String(GLOBAL_GET("editor/naming/default_signal_callback_name")).format(subst);
+		dst_method = String(EDITOR_GET("naming/default_signal_callback_name")).format(subst);
 	}
 
 	return dst_method;

--- a/editor/scene/scene_create_dialog.cpp
+++ b/editor/scene/scene_create_dialog.cpp
@@ -142,7 +142,7 @@ void SceneCreateDialog::update_dialog() {
 		if (root_name.is_empty()) {
 			root_name_edit->set_placeholder(TTR("Leave empty to derive from scene name"));
 		} else {
-			// Respect the desired root node casing from ProjectSettings.
+			// Respect the desired root node casing from EditorSettings.
 			root_name = Node::adjust_name_casing(root_name);
 			root_name_edit->set_placeholder(root_name.validate_node_name());
 		}
@@ -296,7 +296,7 @@ SceneCreateDialog::SceneCreateDialog() {
 
 		root_name_edit = memnew(LineEdit);
 		gc->add_child(root_name_edit);
-		root_name_edit->set_tooltip_text(TTR("When empty, the root node name is derived from the scene name based on the \"editor/naming/node_name_casing\" project setting."));
+		root_name_edit->set_tooltip_text(TTR("When empty, the root node name is derived from the scene name based on the \"naming/node_name_casing\" editor setting."));
 		root_name_edit->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		root_name_edit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		root_name_edit->connect(SceneStringName(text_submitted), callable_mp(this, &SceneCreateDialog::accept_create).unbind(1));

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -31,7 +31,6 @@
 #include "scene_tree_editor.h"
 
 #include "core/config/engine.h"
-#include "core/config/project_settings.h"
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
@@ -1682,7 +1681,7 @@ void SceneTreeEditor::rename_node(Node *p_node, const String &p_name, TreeItem *
 
 	if (new_name.is_empty()) {
 		// If name is still empty, fallback to class name.
-		if (GLOBAL_GET("editor/naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
+		if (EDITOR_GET("naming/node_name_casing").operator int() != NAME_CASING_PASCAL_CASE) {
 			new_name = Node::adjust_name_casing(p_node->get_class());
 		} else {
 			new_name = p_node->get_class();

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -667,6 +667,12 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/multi_window/maximize_window", false, "");
 	set_restart_if_changed("interface/multi_window/enable", true);
 
+	// Naming
+	_initial_set("naming/default_signal_callback_name", "_on_{node_name}_{signal_name}");
+	_initial_set("naming/default_signal_callback_to_self_name", "_on_{signal_name}");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "naming/scene_name_casing", EditorNode::SCENE_NAME_CASING_SNAKE_CASE, "Auto,PascalCase,snake_case,kebab-case,camelCase");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "naming/script_name_casing", ScriptLanguage::SCRIPT_NAME_CASING_AUTO, "Auto,PascalCase,snake_case,kebab-case,camelCase");
+
 	/* Filesystem */
 
 	// External Programs
@@ -1214,6 +1220,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #undef EDITOR_SETTING_BASIC
 #undef EDITOR_SETTING_USAGE
 
+	for (const KeyValue<String, Array> &setting : ProjectSettings::get_singleton()->pending_editor_settings) {
+		define_from_project_setting(setting.value[0], setting.value[1], setting.value[2], setting.value[3]);
+	}
+	ProjectSettings::get_singleton()->pending_editor_settings.clear();
+
 	if (p_extra_config.is_valid()) {
 		if (p_extra_config->has_section("init_projects") && p_extra_config->has_section_key("init_projects", "list")) {
 			Vector<String> list = p_extra_config->get_value("init_projects", "list");
@@ -1448,6 +1459,7 @@ void EditorSettings::create() {
 			config_file_path = get_newest_settings_path();
 			goto fail;
 		}
+		ProjectSettings::get_singleton()->editor_settings = singleton.ptr();
 
 		singleton->set_path(get_newest_settings_path()); // Settings can be loaded from older version file, so make sure it's newest.
 		singleton->save_changed_setting = true;
@@ -1589,16 +1601,43 @@ void EditorSettings::mark_setting_changed(const String &p_setting) {
 	changed_settings.insert(p_setting);
 }
 
+Variant EditorSettings::define_from_project_setting(const Dictionary &p_info, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
+	return define_setting(PropertyInfo::from_dict(p_info), p_default, p_restart_if_changed, p_basic);
+}
+
 void EditorSettings::destroy() {
 	if (!singleton.ptr()) {
 		return;
 	}
 	save();
 	singleton = Ref<EditorSettings>();
+	ProjectSettings::get_singleton()->editor_settings = nullptr;
 }
 
 void EditorSettings::set_optimize_save(bool p_optimize) {
 	optimize_save = p_optimize;
+}
+
+Variant EditorSettings::define_setting(const String &p_setting, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
+	Variant ret = p_default;
+	if (has_setting(p_setting)) {
+		ret = get_setting(p_setting);
+	} else {
+		set_manually(p_setting, p_default);
+	}
+	set_restart_if_changed(p_setting, p_restart_if_changed);
+	set_basic(p_setting, p_basic);
+
+	if (!has_default_value(p_setting)) {
+		set_initial_value(p_setting, p_default);
+	}
+	return ret;
+}
+
+Variant EditorSettings::define_setting(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
+	const Variant ret = define_setting(p_info.name, p_default, p_restart_if_changed, p_basic);
+	add_property_hint(p_info);
+	return ret;
 }
 
 // Properties
@@ -1672,21 +1711,12 @@ void EditorSettings::set_initial_value(const StringName &p_setting, const Varian
 
 Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
 	ERR_FAIL_NULL_V_MSG(EditorSettings::get_singleton(), p_default, "EditorSettings not instantiated yet.");
+	return EditorSettings::get_singleton()->define_setting(p_setting, p_default, p_restart_if_changed, p_basic);
+}
 
-	Variant ret = p_default;
-	if (EditorSettings::get_singleton()->has_setting(p_setting)) {
-		ret = EDITOR_GET(p_setting);
-	} else {
-		EditorSettings::get_singleton()->set_manually(p_setting, p_default);
-	}
-	EditorSettings::get_singleton()->set_restart_if_changed(p_setting, p_restart_if_changed);
-	EditorSettings::get_singleton()->set_basic(p_setting, p_basic);
-
-	if (!EditorSettings::get_singleton()->has_default_value(p_setting)) {
-		EditorSettings::get_singleton()->set_initial_value(p_setting, p_default);
-	}
-
-	return ret;
+Variant _EDITOR_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed, bool p_basic) {
+	ERR_FAIL_NULL_V_MSG(EditorSettings::get_singleton(), p_default, "EditorSettings not instantiated yet.");
+	return EditorSettings::get_singleton()->define_setting(p_info, p_default, p_restart_if_changed, p_basic);
 }
 
 Variant _EDITOR_GET(const String &p_setting) {
@@ -2468,6 +2498,8 @@ void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("check_changed_settings_in_group", "setting_prefix"), &EditorSettings::check_changed_settings_in_group);
 	ClassDB::bind_method(D_METHOD("get_changed_settings"), &EditorSettings::get_changed_settings);
 	ClassDB::bind_method(D_METHOD("mark_setting_changed", "setting"), &EditorSettings::mark_setting_changed);
+
+	ClassDB::bind_method(D_METHOD("_define_from_project_setting"), &EditorSettings::define_from_project_setting);
 
 	ADD_SIGNAL(MethodInfo("settings_changed"));
 	ADD_SIGNAL(MethodInfo("_favorites_changed"));

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -154,6 +154,9 @@ public:
 	static void destroy();
 	void set_optimize_save(bool p_optimize);
 
+	Variant define_setting(const String &p_setting, const Variant &p_default, bool p_restart_if_changed, bool p_basic);
+	Variant define_setting(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed, bool p_basic);
+
 	bool has_default_value(const String &p_setting) const;
 	void set_setting(const String &p_setting, const Variant &p_value);
 	Variant get_setting(const String &p_setting) const;
@@ -174,6 +177,8 @@ public:
 	PackedStringArray get_changed_settings() const;
 	bool check_changed_settings_in_group(const String &p_setting_prefix) const;
 	void mark_setting_changed(const String &p_setting);
+
+	Variant define_from_project_setting(const Dictionary &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
 
 	void set_resource_clipboard(const Ref<Resource> &p_resource) { clipboard = p_resource; }
 	Ref<Resource> get_resource_clipboard() const { return clipboard; }
@@ -228,6 +233,7 @@ public:
 #define EDITOR_DEF_RST(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), true)
 #define EDITOR_DEF_BASIC(m_var, m_val) _EDITOR_DEF(m_var, Variant(m_val), false, true)
 Variant _EDITOR_DEF(const String &p_setting, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
+Variant _EDITOR_DEF(const PropertyInfo &p_info, const Variant &p_default, bool p_restart_if_changed = false, bool p_basic = false);
 
 #define EDITOR_GET(m_var) _EDITOR_GET(m_var)
 Variant _EDITOR_GET(const String &p_setting);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1511,7 +1511,7 @@ String Node::prevalidate_child_name(Node *p_child, StringName p_name) {
 #endif
 
 String Node::adjust_name_casing(const String &p_name) {
-	switch (GLOBAL_GET("editor/naming/node_name_casing").operator int()) {
+	switch (GLOBAL_EDITOR_GET("naming/node_name_casing").operator int()) {
 		case NAME_CASING_PASCAL_CASE:
 			return p_name.to_pascal_case();
 		case NAME_CASING_CAMEL_CASE:
@@ -3783,8 +3783,8 @@ RID Node::get_accessibility_element() const {
 }
 
 void Node::_bind_methods() {
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/node_name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"), 0);
-	GLOBAL_DEF(PropertyInfo(Variant::INT, "editor/naming/node_name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case,kebab-case"), NAME_CASING_PASCAL_CASE);
+	GLOBAL_EDITOR_DEF(PropertyInfo(Variant::INT, "naming/node_name_num_separator", PROPERTY_HINT_ENUM, "None,Space,Underscore,Dash"), 0);
+	GLOBAL_EDITOR_DEF(PropertyInfo(Variant::INT, "naming/node_name_casing", PROPERTY_HINT_ENUM, "PascalCase,camelCase,snake_case,kebab-case"), NAME_CASING_PASCAL_CASE);
 
 	ClassDB::bind_static_method("Node", D_METHOD("print_orphan_nodes"), &Node::print_orphan_nodes);
 	ClassDB::bind_static_method("Node", D_METHOD("get_orphan_node_ids"), &Node::get_orphan_node_ids);
@@ -4106,7 +4106,7 @@ void Node::_bind_methods() {
 }
 
 String Node::_get_name_num_separator() {
-	switch (GLOBAL_GET("editor/naming/node_name_num_separator").operator int()) {
+	switch (GLOBAL_EDITOR_GET("naming/node_name_num_separator").operator int()) {
 		case 0:
 			return "";
 		case 1:


### PR DESCRIPTION
Same as #107156, but instead moves `editor/naming` settings.
I also made setting compatibility more explicit.