### PR TITLE
Core: Remove implicit conversions from `IPAddress` to `String`, to avoid accidental conversions

### DIFF
--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -259,7 +259,7 @@ PackedStringArray IP::_get_local_addresses() const {
 	List<IPAddress> ip_addresses;
 	get_local_addresses(&ip_addresses);
 	for (const IPAddress &E : ip_addresses) {
-		addresses.push_back(E);
+		addresses.push_back(String(E));
 	}
 
 	return addresses;

--- a/core/io/ip_address.h
+++ b/core/io/ip_address.h
@@ -89,7 +89,7 @@ public:
 	const uint8_t *get_ipv6() const;
 	void set_ipv6(const uint8_t *p_buf);
 
-	operator String() const;
+	explicit operator String() const;
 	IPAddress(const String &p_string);
 	IPAddress(uint32_t p_a, uint32_t p_b, uint32_t p_c, uint32_t p_d, bool is_v6 = false);
 	IPAddress() { clear(); }

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -68,7 +68,7 @@ Error PacketPeerUDP::leave_multicast_group(IPAddress p_multi_address, const Stri
 }
 
 String PacketPeerUDP::_get_packet_ip() const {
-	return get_packet_address();
+	return String(get_packet_address());
 }
 
 Error PacketPeerUDP::_set_dest_address(const String &p_address, int p_port) {

--- a/core/variant/variant_internal.h
+++ b/core/variant/variant_internal.h
@@ -821,7 +821,7 @@ struct VariantInternalAccessor<const T *> {
 template <>
 struct VariantInternalAccessor<IPAddress> {
 	static _FORCE_INLINE_ IPAddress get(const Variant *v) { return IPAddress(*VariantInternal::get_string(v)); }
-	static _FORCE_INLINE_ void set(Variant *v, IPAddress p_value) { *VariantInternal::get_string(v) = p_value; }
+	static _FORCE_INLINE_ void set(Variant *v, IPAddress p_value) { *VariantInternal::get_string(v) = String(p_value); }
 };
 
 template <>

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1386,12 +1386,12 @@ void EditorSettings::setup_network() {
 		}
 		// Select current IP (found)
 		if (ip == current) {
-			selected = ip;
+			selected = String(ip);
 		}
 		if (!hint.is_empty()) {
 			hint += ",";
 		}
-		hint += ip;
+		hint += String(ip);
 	}
 
 	// Add hints with valid IP addresses to remote_host property.


### PR DESCRIPTION
- Follow up of https://github.com/godotengine/godot/pull/107379 and https://github.com/godotengine/godot/pull/107295

Same idea as above - we want to avoid accidentally converting to String, because it's expensive.
I misjudged the number of conversion callers, but at least that makes this PR smaller than expected.

After this PR, there are just 3 implicit `String` operator conversions left:

- `Variant` - probably can't fix this now, Variant has all the implicit conversions.
- `StringName` - probably fine for now since it's usually fast (at least on repeated access).
- `NodePath` - there's a lot of accessors, so it needs its own PR.
