### PR TITLE
Make conversions from `NodePath` to `String` explicit.

### DIFF
--- a/core/string/node_path.h
+++ b/core/string/node_path.h
@@ -78,7 +78,7 @@ public:
 		return data->hash_cache;
 	}
 
-	operator String() const;
+	explicit operator String() const;
 	bool is_empty() const;
 
 	bool operator==(const NodePath &p_path) const;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1642,7 +1642,7 @@ String Variant::stringify(int recursion_count) const {
 		case STRING_NAME:
 			return operator StringName();
 		case NODE_PATH:
-			return operator NodePath();
+			return String(operator NodePath());
 		case COLOR:
 			return String(operator Color());
 		case DICTIONARY: {

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -328,7 +328,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 					continue;
 				}
 
-				String base_path = animation->track_get_path(i);
+				String base_path = String(animation->track_get_path(i));
 				int end = base_path.find_char(':');
 				if (end != -1) {
 					base_path = base_path.substr(0, end + 1);
@@ -405,7 +405,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 
 					int current_track = tracks[i];
 
-					String path = animation->track_get_path(current_track);
+					String path = String(animation->track_get_path(current_track));
 					path = path.replace_first(base_path, "");
 
 					Color cc = color;
@@ -763,7 +763,7 @@ bool AnimationBezierTrackEdit::_is_track_displayed(int p_track_index) {
 	}
 
 	if (is_filtered) {
-		String path = animation->track_get_path(p_track_index);
+		String path = String(animation->track_get_path(p_track_index));
 		if (root && root->has_node(path)) {
 			Node *node = root->get_node(path);
 			if (!node) {
@@ -899,7 +899,7 @@ void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 	if (animation.is_null()) {
 		return;
 	}
-	String base_path = animation->track_get_path(selected_track);
+	String base_path = String(animation->track_get_path(selected_track));
 	if (is_filtered) {
 		if (root && root->has_node(base_path)) {
 			Node *node = root->get_node(base_path);
@@ -909,7 +909,7 @@ void AnimationBezierTrackEdit::set_filtered(bool p_filtered) {
 						continue;
 					}
 
-					base_path = animation->track_get_path(i);
+					base_path = String(animation->track_get_path(i));
 					if (root && root->has_node(base_path)) {
 						node = root->get_node(base_path);
 						if (!node) {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2191,7 +2191,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				} else {
 					icon_cache = key_type_icon;
 
-					text = anim_path;
+					text = String(anim_path);
 				}
 
 				path_cache = text;
@@ -2822,7 +2822,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 
 	// Don't overlap track keys if they start at 0.
 	if (path_rect.has_point(p_pos + Size2(type_icon->get_width(), 0))) {
-		return animation->track_get_path(track);
+		return String(animation->track_get_path(track));
 	}
 
 	if (update_mode_rect.has_point(p_pos)) {
@@ -3230,7 +3230,7 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 			path->connect(SceneStringName(text_submitted), callable_mp(this, &AnimationTrackEdit::_path_submitted));
 		}
 
-		path->set_text(animation->track_get_path(track));
+		path->set_text(String(animation->track_get_path(track)));
 		const Vector2 theme_ofs = path->get_theme_stylebox(CoreStringName(normal), SNAME("LineEdit"))->get_offset();
 
 		moving_selection_attempt = false;
@@ -3462,7 +3462,7 @@ Variant AnimationTrackEdit::get_drag_data(const Point2 &p_point) {
 
 	Dictionary drag_data;
 	drag_data["type"] = "animation_track";
-	String base_path = animation->track_get_path(track);
+	String base_path = String(animation->track_get_path(track));
 	base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 	drag_data["group"] = base_path;
 	drag_data["index"] = track;
@@ -3493,7 +3493,7 @@ bool AnimationTrackEdit::can_drop_data(const Point2 &p_point, const Variant &p_d
 
 	// Don't allow moving tracks outside their groups.
 	if (get_editor()->is_grouping_tracks()) {
-		String base_path = animation->track_get_path(track);
+		String base_path = String(animation->track_get_path(track));
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 		if (d["group"] != base_path) {
 			return false;
@@ -3524,7 +3524,7 @@ void AnimationTrackEdit::drop_data(const Point2 &p_point, const Variant &p_data)
 
 	// Don't allow moving tracks outside their groups.
 	if (get_editor()->is_grouping_tracks()) {
-		String base_path = animation->track_get_path(track);
+		String base_path = String(animation->track_get_path(track));
 		base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 		if (d["group"] != base_path) {
 			return;
@@ -4370,7 +4370,7 @@ void AnimationTrackEditor::insert_transform_key(Node3D *p_node, const String &p_
 	}
 
 	// Let's build a node path.
-	String path = root->get_path_to(p_node, true);
+	String path = String(root->get_path_to(p_node, true));
 	if (!p_sub.is_empty()) {
 		path += ":" + p_sub;
 	}
@@ -4410,7 +4410,7 @@ bool AnimationTrackEditor::has_track(Node3D *p_node, const String &p_sub, const 
 	}
 
 	// Let's build a node path.
-	String path = root->get_path_to(p_node, true);
+	String path = String(root->get_path_to(p_node, true));
 	if (!p_sub.is_empty()) {
 		path += ":" + p_sub;
 	}
@@ -4423,11 +4423,11 @@ bool AnimationTrackEditor::has_track(Node3D *p_node, const String &p_sub, const 
 }
 
 void AnimationTrackEditor::_insert_animation_key(NodePath p_path, const Variant &p_value) {
-	String path = p_path;
+	String path = String(p_path);
 
 	// Animation property is a special case, always creates an animation track.
 	for (int i = 0; i < animation->get_track_count(); i++) {
-		String np = animation->track_get_path(i);
+		String np = String(animation->track_get_path(i));
 
 		if (path == np && animation->track_get_type(i) == Animation::TYPE_ANIMATION) {
 			// Exists.
@@ -4460,7 +4460,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 	ERR_FAIL_NULL(root);
 
 	// Let's build a node path.
-	String path = root->get_path_to(p_node, true);
+	String path = String(root->get_path_to(p_node, true));
 
 	// Get the value from the subpath.
 	Vector<StringName> subpath = NodePath(p_property).get_as_property_path().get_subnames();
@@ -4509,14 +4509,14 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 			inserted = true;
 		} else if (animation->track_get_type(i) == Animation::TYPE_BEZIER) {
 			Variant actual_value;
-			String track_path = animation->track_get_path(i);
-			if (track_path == np) {
+			String track_path = String(animation->track_get_path(i));
+			if (track_path == String(np)) {
 				actual_value = value; // All good.
 			} else {
 				int sep = track_path.rfind_char(':');
 				if (sep != -1) {
 					String base_path = track_path.substr(0, sep);
-					if (base_path == np) {
+					if (base_path == String(np)) {
 						String value_name = track_path.substr(sep + 1);
 						actual_value = value.get(value_name);
 					} else {
@@ -5017,7 +5017,7 @@ void AnimationTrackEditor::_update_tracks() {
 		String filter_text = timeline->filter_track->get_text();
 
 		if (!filter_text.is_empty()) {
-			String target = animation->track_get_path(i);
+			String target = String(animation->track_get_path(i));
 			if (!target.containsn(filter_text)) {
 				continue;
 			}
@@ -5087,7 +5087,7 @@ void AnimationTrackEditor::_update_tracks() {
 		track_edits.push_back(track_edit);
 
 		if (use_grouping) {
-			String base_path = animation->track_get_path(i);
+			String base_path = String(animation->track_get_path(i));
 			base_path = base_path.get_slicec(':', 0); // Remove sub-path.
 
 			if (!group_sort.has(base_path)) {
@@ -5100,7 +5100,7 @@ void AnimationTrackEditor::_update_tracks() {
 					if (n) {
 						icon = EditorNode::get_singleton()->get_object_icon(n, "Node");
 						name = n->get_name();
-						tooltip = root->get_path_to(n);
+						tooltip = String(root->get_path_to(n));
 					}
 				}
 
@@ -6711,7 +6711,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 					path = NodePath(node->get_path().get_names(), path.get_subnames(), true); // Store full path instead for copying.
 				} else {
-					text = path;
+					text = String(path);
 					int sep = text.find_char(':');
 					if (sep != -1) {
 						text = text.substr(sep + 1);

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -413,7 +413,7 @@ Rect2 AnimationTrackEditSpriteFrame::get_key_rect(int p_index, float p_pixels_se
 			animation_name = animations.front()->get();
 		} else {
 			// Go through other track to find if animation is set
-			String animation_path = get_animation()->track_get_path(get_track());
+			String animation_path = String(get_animation()->track_get_path(get_track()));
 			animation_path = animation_path.replace(":frame", ":animation");
 			int animation_track = get_animation()->find_track(animation_path, get_animation()->track_get_type(get_track()));
 			float track_time = get_animation()->track_get_key_time(get_track(), p_index);
@@ -505,7 +505,7 @@ void AnimationTrackEditSpriteFrame::draw_key(int p_index, float p_pixels_sec, in
 			animation_name = animations.front()->get();
 		} else {
 			// Go through other track to find if animation is set
-			String animation_path = get_animation()->track_get_path(get_track());
+			String animation_path = String(get_animation()->track_get_path(get_track()));
 			animation_path = animation_path.replace(":frame", ":animation");
 			int animation_track = get_animation()->find_track(animation_path, get_animation()->track_get_type(get_track()));
 			float track_time = get_animation()->track_get_key_time(get_track(), p_index);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1531,7 +1531,7 @@ void ScriptEditorDebugger::update_live_edit_root() {
 		msg.push_back("");
 	}
 	_put_msg("scene:live_set_root", msg);
-	live_edit_root->set_text(np);
+	live_edit_root->set_text(String(np));
 }
 
 void ScriptEditorDebugger::live_debug_create_node(const NodePath &p_parent, const String &p_type, const String &p_name) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6636,7 +6636,7 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 			// it's a multi-level inheritance scene. We should use
 			NodePath scene_path_to_node = current_edited_scene->get_path_to(original_node);
 			Ref<SceneState> scene_state = current_edited_scene->get_scene_inherited_state();
-			if (scene_path_to_node != "." && scene_state.is_valid() && scene_state->get_path() != instance_modifications.instance_path && scene_state->find_node_by_path(scene_path_to_node) >= 0) {
+			if (String(scene_path_to_node) != "." && scene_state.is_valid() && scene_state->get_path() != instance_modifications.instance_path && scene_state->find_node_by_path(scene_path_to_node) >= 0) {
 				Node *root_node = scene_state->instantiate(SceneState::GenEditState::GEN_EDIT_STATE_INSTANCE);
 				instantiated_node = root_node->get_node(scene_path_to_node);
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2866,7 +2866,7 @@ void EditorPropertyNodePath::_menu_option(int p_idx) {
 		} break;
 
 		case ACTION_COPY: {
-			DisplayServer::get_singleton()->clipboard_set(_get_node_path());
+			DisplayServer::get_singleton()->clipboard_set(String(_get_node_path()));
 		} break;
 
 		case ACTION_EDIT: {
@@ -2874,7 +2874,7 @@ void EditorPropertyNodePath::_menu_option(int p_idx) {
 			menu->hide();
 
 			const NodePath &np = _get_node_path();
-			edit->set_text(np);
+			edit->set_text(String(np));
 			edit->show();
 			callable_mp((Control *)edit, &Control::grab_focus).call_deferred();
 		} break;
@@ -2976,7 +2976,7 @@ bool EditorPropertyNodePath::is_drop_valid(const Dictionary &p_drag_data) const 
 void EditorPropertyNodePath::update_property() {
 	const Node *base_node = get_base_node();
 	const NodePath &p = _get_node_path();
-	assign->set_tooltip_text(p);
+	assign->set_tooltip_text(String(p));
 
 	if (p.is_empty()) {
 		assign->set_button_icon(Ref<Texture2D>());
@@ -2988,7 +2988,7 @@ void EditorPropertyNodePath::update_property() {
 
 	if (!base_node || !base_node->has_node(p)) {
 		assign->set_button_icon(Ref<Texture2D>());
-		assign->set_text(p);
+		assign->set_text(String(p));
 		return;
 	}
 
@@ -2997,7 +2997,7 @@ void EditorPropertyNodePath::update_property() {
 
 	if (String(target_node->get_name()).contains_char('@')) {
 		assign->set_button_icon(Ref<Texture2D>());
-		assign->set_text(p);
+		assign->set_text(String(p));
 		return;
 	}
 

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1565,7 +1565,7 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 		}
 
 		NodeMap &nm = node_map[E];
-		String path = scene->get_path_to(nm.node);
+		String path = String(scene->get_path_to(nm.node));
 
 		if (nm.bone >= 0) {
 			Skeleton3D *sk = static_cast<Skeleton3D *>(nm.node);
@@ -1756,7 +1756,7 @@ void ColladaImport::create_animation(int p_clip, bool p_import_value_tracks) {
 			}
 
 			NodeMap &nm = node_map[at.target];
-			String path = scene->get_path_to(nm.node);
+			String path = String(scene->get_path_to(nm.node));
 
 			animation->add_track(Animation::TYPE_BLEND_SHAPE);
 			int track = animation->get_track_count() - 1;

--- a/editor/import/3d/post_import_plugin_skeleton_renamer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_renamer.cpp
@@ -228,9 +228,9 @@ void PostImportPluginSkeletonRenamer::internal_process(InternalImportCategory p_
 									}
 								} else {
 									if (anim->track_get_path(i).get_subname_count() > 0) {
-										anim->track_set_path(i, UNIQUE_NODE_PREFIX + unique_name + "/" + node->get_path_to(orig_node) + String(":") + anim->track_get_path(i).get_concatenated_subnames());
+										anim->track_set_path(i, UNIQUE_NODE_PREFIX + unique_name + "/" + String(node->get_path_to(orig_node)) + String(":") + anim->track_get_path(i).get_concatenated_subnames());
 									} else {
-										anim->track_set_path(i, UNIQUE_NODE_PREFIX + unique_name + "/" + node->get_path_to(orig_node));
+										anim->track_set_path(i, UNIQUE_NODE_PREFIX + unique_name + "/" + String(node->get_path_to(orig_node)));
 									}
 								}
 								break;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1062,7 +1062,7 @@ Node *ResourceImporterScene::_pre_fix_animations(Node *p_node, Node *p_root, con
 		}
 	}
 
-	String import_id = p_node->get_meta("import_id", "PATH:" + p_root->get_path_to(p_node));
+	String import_id = p_node->get_meta("import_id", "PATH:" + String(p_root->get_path_to(p_node)));
 
 	Dictionary node_settings;
 	if (p_node_data.has(import_id)) {
@@ -1110,7 +1110,7 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 		}
 	}
 
-	String import_id = p_node->get_meta("import_id", "PATH:" + p_root->get_path_to(p_node));
+	String import_id = p_node->get_meta("import_id", "PATH:" + String(p_root->get_path_to(p_node)));
 
 	Dictionary node_settings;
 	if (p_node_data.has(import_id)) {
@@ -1437,7 +1437,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 
 	bool isroot = p_node == p_root;
 
-	String import_id = p_node->get_meta("import_id", "PATH:" + p_root->get_path_to(p_node));
+	String import_id = p_node->get_meta("import_id", "PATH:" + String(p_root->get_path_to(p_node)));
 
 	Dictionary node_settings;
 	if (p_node_data.has(import_id)) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -765,7 +765,7 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 		for (const StringName &E : animation_list) {
 			Ref<Animation> anim = tree->get_animation(E);
 			for (int i = 0; i < anim->get_track_count(); i++) {
-				String track_path = anim->track_get_path(i);
+				String track_path = String(anim->track_get_path(i));
 				paths.insert(track_path);
 
 				String track_type_name;
@@ -890,8 +890,8 @@ bool AnimationNodeBlendTreeEditor::_update_filters(const Ref<AnimationNode> &ano
 			if (ti) {
 				//just a node, not a property track
 				String types_text = "[";
-				if (types.has(path)) {
-					RBSet<String>::Iterator F = types[path].begin();
+				if (types.has(String(path))) {
+					RBSet<String>::Iterator F = types[String(path)].begin();
 					types_text += *F;
 					while (F) {
 						types_text += " / " + *F;

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -809,7 +809,7 @@ void AnimationLibraryEditor::_save_mixer_lib_folding(TreeItem *p_item) {
 	}
 
 	// Get unique identifier for this scene+mixer combination
-	String md = (mixer->get_tree()->get_edited_scene_root()->get_scene_file_path() + mixer->get_path()).md5_text();
+	String md = (mixer->get_tree()->get_edited_scene_root()->get_scene_file_path() + String(mixer->get_path())).md5_text();
 
 	PackedStringArray collapsed_lib_names;
 	PackedStringArray collapsed_lib_ids;
@@ -886,7 +886,7 @@ Vector<uint64_t> AnimationLibraryEditor::_load_mixer_libs_folding() {
 	}
 
 	// Get unique identifier for this scene+mixer combination
-	String md = (mixer->get_tree()->get_edited_scene_root()->get_scene_file_path() + mixer->get_path()).md5_text();
+	String md = (mixer->get_tree()->get_edited_scene_root()->get_scene_file_path() + String(mixer->get_path())).md5_text();
 
 	Vector<uint64_t> collapsed_lib_ids;
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1963,7 +1963,7 @@ bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {
 			for (int j = 0; j < key_len; j++) {
 				Quaternion q;
 				p_anim->rotation_track_get_key(i, j, &q);
-				ERR_BREAK_EDMSG(!q.is_normalized(), "AnimationPlayer: '" + player->get_name() + "', Animation: '" + player->get_current_animation() + "', 3D Rotation Track:  '" + p_anim->track_get_path(i) + "' contains unnormalized Quaternion key.");
+				ERR_BREAK_EDMSG(!q.is_normalized(), "AnimationPlayer: '" + player->get_name() + "', Animation: '" + player->get_current_animation() + "', 3D Rotation Track:  '" + String(p_anim->track_get_path(i)) + "' contains unnormalized Quaternion key.");
 			}
 		} else if (ttype == Animation::TYPE_VALUE) {
 			int key_len = p_anim->track_get_key_count(i);
@@ -1976,7 +1976,7 @@ bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {
 						Quaternion q = Quaternion(p_anim->track_get_key_value(i, j));
 						if (!q.is_normalized()) {
 							is_valid = false;
-							ERR_BREAK_EDMSG(true, "AnimationPlayer: '" + player->get_name() + "', Animation: '" + player->get_current_animation() + "', Value Track:  '" + p_anim->track_get_path(i) + "' contains unnormalized Quaternion key.");
+							ERR_BREAK_EDMSG(true, "AnimationPlayer: '" + player->get_name() + "', Animation: '" + player->get_current_animation() + "', Value Track:  '" + String(p_anim->track_get_path(i)) + "' contains unnormalized Quaternion key.");
 						}
 					}
 				} break;
@@ -1985,7 +1985,7 @@ bool AnimationPlayerEditor::_validate_tracks(const Ref<Animation> p_anim) {
 						Transform3D t = Transform3D(p_anim->track_get_key_value(i, j));
 						if (!t.basis.orthonormalized().is_rotation()) {
 							is_valid = false;
-							ERR_BREAK_EDMSG(true, "AnimationPlayer: '" + player->get_name() + "', Animation: '" + player->get_current_animation() + "', Value Track:  '" + p_anim->track_get_path(i) + "' contains corrupted basis (some axes are too close other axis or scaled by zero) Transform3D key.");
+							ERR_BREAK_EDMSG(true, "AnimationPlayer: '" + player->get_name() + "', Animation: '" + player->get_current_animation() + "', Value Track:  '" + String(p_anim->track_get_path(i)) + "' contains corrupted basis (some axes are too close other axis or scaled by zero) Transform3D key.");
 						}
 					}
 				} break;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2436,7 +2436,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 					CanvasItem *item = selection_results[i].item;
 
 					Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(item, "Node");
-					String node_path = "/" + root_name + "/" + root_path.rel_path_to(item->get_path());
+					String node_path = "/" + root_name + "/" + String(root_path.rel_path_to(item->get_path()));
 
 					int locked = 0;
 					if (_is_node_locked(item)) {
@@ -2503,7 +2503,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				String *paths_write = paths.ptrw();
 
 				for (int i = 0; i < paths.size(); i++) {
-					paths_write[i] = selection_results[i].item->get_path();
+					paths_write[i] = String(selection_results[i].item->get_path());
 				}
 				EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(add_node_menu, EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, paths);
 			}

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -546,7 +546,7 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 	Node *skeleton = node->get_node_or_null(node->get_skeleton_path());
 	if (skeleton && node->get_skin().is_valid()) {
 		mi->set_skin(node->get_skin());
-		mi->set_skeleton_path("../" + node->get_path_to(skeleton));
+		mi->set_skeleton_path("../" + String(node->get_path_to(skeleton)));
 	}
 
 	Node *owner = get_tree()->get_edited_scene_root();

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -222,9 +222,9 @@ void MultiMeshEditor::_browsed(const NodePath &p_path) {
 	NodePath path = node->get_path_to(get_node(p_path));
 
 	if (browsing_source) {
-		mesh_source->set_text(path);
+		mesh_source->set_text(String(path));
 	} else {
-		surface_source->set_text(path);
+		surface_source->set_text(String(path));
 	}
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1631,7 +1631,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 
 			Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(spat, "Node");
 
-			String node_path = "/" + root_name + "/" + root_path.rel_path_to(spat->get_path());
+			String node_path = "/" + root_name + "/" + String(root_path.rel_path_to(spat->get_path()));
 
 			int locked = 0;
 			if (_is_node_locked(spat)) {

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -57,7 +57,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 
 	for (int i = 0; i < state->get_node_count(); i++) {
 		String node_type = state->get_node_type(i);
-		String parent_path = state->get_node_path(i, true);
+		String parent_path = String(state->get_node_path(i, true));
 
 		// Handle instanced scenes.
 		if (node_type.is_empty()) {
@@ -83,7 +83,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 			auto_translate_mode_found = true;
 
 			int idx_last = atr_owners.size() - 1;
-			if (idx_last > 0 && !parent_path.begins_with(atr_owners[idx_last].first)) {
+			if (idx_last > 0 && !parent_path.begins_with(String(atr_owners[idx_last].first))) {
 				// Exit from the current owner nesting into the previous one.
 				atr_owners.remove_at(idx_last);
 			}
@@ -106,7 +106,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 		// If `auto_translate_mode` wasn't found, that means it is set to its default value (`AUTO_TRANSLATE_MODE_INHERIT`).
 		if (!auto_translate_mode_found) {
 			int idx_last = atr_owners.size() - 1;
-			if (idx_last > 0 && parent_path.begins_with(atr_owners[idx_last].first)) {
+			if (idx_last > 0 && parent_path.begins_with(String(atr_owners[idx_last].first))) {
 				auto_translating = atr_owners[idx_last].second;
 			} else {
 				atr_owners.push_back(Pair(state->get_node_path(i), true));
@@ -130,7 +130,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 		}
 
 		if (node_type == "TabContainer") {
-			tabcontainer_paths.push_back(state->get_node_path(i));
+			tabcontainer_paths.push_back(String(state->get_node_path(i)));
 		}
 
 		for (int j = 0; j < state->get_node_property_count(i); j++) {

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -166,7 +166,7 @@ void EditorPropertyRootMotion::_node_clear() {
 
 void EditorPropertyRootMotion::update_property() {
 	NodePath p = get_edited_property_value();
-	assign->set_tooltip_text(p);
+	assign->set_tooltip_text(String(p));
 	if (p == NodePath()) {
 		assign->set_button_icon(Ref<Texture2D>());
 		assign->set_text(TTR("Assign..."));
@@ -175,7 +175,7 @@ void EditorPropertyRootMotion::update_property() {
 	}
 
 	assign->set_button_icon(Ref<Texture2D>());
-	assign->set_text(p);
+	assign->set_text(String(p));
 }
 
 void EditorPropertyRootMotion::setup(const NodePath &p_base_hint) {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -867,8 +867,8 @@ void ScriptTextEditor::_update_warnings() {
 			warnings_panel->push_table(1);
 			for (const Connection &connection : missing_connections) {
 				String base_path = base->get_name();
-				String source_path = base == connection.signal.get_object() ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.signal.get_object()));
-				String target_path = base == connection.callable.get_object() ? base_path : base_path + "/" + base->get_path_to(Object::cast_to<Node>(connection.callable.get_object()));
+				String source_path = base == connection.signal.get_object() ? base_path : base_path + "/" + String(base->get_path_to(Object::cast_to<Node>(connection.signal.get_object())));
+				String target_path = base == connection.callable.get_object() ? base_path : base_path + "/" + String(base->get_path_to(Object::cast_to<Node>(connection.callable.get_object())));
 
 				warnings_panel->push_cell();
 				warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
@@ -2586,7 +2586,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 		}
 	}
 
-	const PackedStringArray paths = { code_editor->get_text_editor()->get_path() };
+	const PackedStringArray paths = { String(code_editor->get_text_editor()->get_path()) };
 	EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE, paths);
 
 	const CodeEdit *tx = code_editor->get_text_editor();

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -441,7 +441,7 @@ void Skeleton3DEditor::insert_keys(const bool p_all_bones) {
 
 	int bone_len = skeleton->get_bone_count();
 	Node *root = EditorNode::get_singleton()->get_tree()->get_root();
-	String path = root->get_path_to(skeleton);
+	String path = String(root->get_path_to(skeleton));
 
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
 	te->make_insert_queue();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1218,7 +1218,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				if (node) {
 					Node *root = EditorNode::get_singleton()->get_edited_scene();
 					NodePath path = root->get_path().rel_path_to(node->get_path());
-					DisplayServer::get_singleton()->clipboard_set(path);
+					DisplayServer::get_singleton()->clipboard_set(String(path));
 				}
 			}
 		} break;
@@ -1998,7 +1998,7 @@ bool SceneTreeDock::_update_node_path(Node *p_root_node, NodePath &r_node_path, 
 	if (found_root_path) {
 		NodePath root_path_new = found_root_path->value;
 		if (!root_path_new.is_empty()) {
-			NodePath old_abs_path = NodePath(String(p_root_node->get_path()).path_join(r_node_path));
+			NodePath old_abs_path = NodePath(String(p_root_node->get_path()).path_join(String(r_node_path)));
 			old_abs_path.simplify();
 			r_node_path = root_path_new.rel_path_to(old_abs_path);
 		}
@@ -2463,7 +2463,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 				NodePath fixed_node_path = NodePath(fixed_new_names, true);
 				path_renames[node] = fixed_node_path;
 			} else {
-				ERR_PRINT("Internal error. Can't find renamed path for node '" + node->get_path() + "'");
+				ERR_PRINT("Internal error. Can't find renamed path for node '" + String(node->get_path()) + "'");
 			}
 		}
 
@@ -3970,7 +3970,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	Vector<String> p_paths;
 	Node *root = EditorNode::get_singleton()->get_edited_scene();
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
-		String node_path = root->get_path().rel_path_to(E->get()->get_path());
+		String node_path = String(root->get_path().rel_path_to(E->get()->get_path()));
 		p_paths.push_back(node_path);
 	}
 	EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_paths);

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1798,7 +1798,7 @@ void FBXDocument::_import_animation(Ref<FBXState> p_state, AnimationPlayer *p_an
 			const Skeleton3D *sk = p_state->skeletons[fbx_node->skeleton]->godot_skeleton;
 			ERR_FAIL_NULL(sk);
 
-			const String path = p_animation_player->get_parent()->get_path_to(sk);
+			const String path = String(p_animation_player->get_parent()->get_path_to(sk));
 			const String bone = fbx_node->get_name();
 			transform_node_path = path + ":" + bone;
 		} else {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -625,7 +625,7 @@ Node *GDScriptWorkspace::_get_owner_scene_node(String p_path) {
 
 	for (const String &owner : owners) {
 		NodePath owner_path = owner;
-		Ref<Resource> owner_res = ResourceLoader::load(owner_path);
+		Ref<Resource> owner_res = ResourceLoader::load(String(owner_path));
 		if (Object::cast_to<PackedScene>(owner_res.ptr())) {
 			Ref<PackedScene> owner_packed_scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*owner_res));
 			owner_scene_node = owner_packed_scene->instantiate();

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -7051,7 +7051,7 @@ Ref<GLTFObjectModelProperty> GLTFDocument::export_object_model_property(Ref<GLTF
 	Ref<GLTFObjectModelProperty> ret;
 	const Object *target_object = p_godot_node;
 	const Vector<StringName> subpath = p_node_path.get_subnames();
-	ERR_FAIL_COND_V_MSG(subpath.is_empty(), ret, "glTF: Cannot export empty property. No property was specified in the NodePath: " + p_node_path);
+	ERR_FAIL_COND_V_MSG(subpath.is_empty(), ret, "glTF: Cannot export empty property. No property was specified in the NodePath: " + String(p_node_path));
 	int target_prop_depth = 0;
 	for (StringName subname : subpath) {
 		Variant target_property = target_object->get(subname);
@@ -7282,7 +7282,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> p_state, AnimationPlayer *p_
 			const Skeleton3D *sk = p_state->skeletons[gltf_node->skeleton]->godot_skeleton;
 			ERR_FAIL_NULL(sk);
 
-			const String path = p_animation_player->get_parent()->get_path_to(sk);
+			const String path = String(p_animation_player->get_parent()->get_path_to(sk));
 			const String bone = gltf_node->get_name();
 			transform_node_path = path + ":" + bone;
 		} else {

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -51,7 +51,7 @@ void _add_nodes_suggestions(const Node *p_base, const Node *p_node, PackedString
 		return;
 	}
 
-	String path_relative_to_orig = p_base->get_path_to(p_node);
+	String path_relative_to_orig = String(p_base->get_path_to(p_node));
 
 	r_suggestions.push_back(quoted(path_relative_to_orig));
 

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -340,7 +340,7 @@ void ReplicationEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		return;
 	}
 
-	String path = root->get_path_to(node);
+	String path = String(root->get_path_to(node));
 	path += ":" + String(d["property"]);
 
 	_add_sync_property(path);
@@ -390,7 +390,7 @@ void ReplicationEditor::_add_pressed() {
 		return;
 	}
 
-	_add_sync_property(path);
+	_add_sync_property(String(path));
 }
 
 void ReplicationEditor::_np_text_submitted(const String &p_newtext) {

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -195,7 +195,7 @@ void MultiplayerDebugger::RPCProfiler::init_node(const ObjectID p_node) {
 	}
 	rpc_node_data.insert(p_node, RPCNodeInfo());
 	rpc_node_data[p_node].node = p_node;
-	rpc_node_data[p_node].node_path = ObjectDB::get_instance<Node>(p_node)->get_path();
+	rpc_node_data[p_node].node_path = String(ObjectDB::get_instance<Node>(p_node)->get_path());
 }
 
 void MultiplayerDebugger::RPCProfiler::toggle(bool p_enable, const Array &p_opts) {

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -116,7 +116,7 @@ void SceneCacheInterface::process_simplify_path(int p_from, const uint8_t *p_pac
 	ERR_FAIL_NULL(node);
 	const bool valid_rpc_checksum = multiplayer->get_rpc_md5(node) == methods_md5;
 	if (valid_rpc_checksum == false) {
-		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + path);
+		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + String(path));
 	}
 
 	peers_info[p_from].recv_nodes.insert(id, RecvNode(node->get_instance_id(), path));
@@ -154,7 +154,7 @@ void SceneCacheInterface::process_confirm_path(int p_from, const uint8_t *p_pack
 	if (valid_rpc_checksum == false) {
 		const Node *node = ObjectDB::get_instance<Node>(*oid);
 		ERR_FAIL_NULL(node); // Bug.
-		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + node->get_path());
+		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + String(node->get_path()));
 	}
 
 	NodeCache *cache = nodes_cache.getptr(*oid);

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -245,7 +245,7 @@ void SceneRPCInterface::_process_rpc(Node *p_node, const uint16_t p_rpc_method_i
 		} break;
 	}
 
-	ERR_FAIL_COND_MSG(!can_call, "RPC '" + String(config.name) + "' is not allowed on node " + p_node->get_path() + " from: " + itos(p_from) + ". Mode is " + itos((int)config.rpc_mode) + ", authority is " + itos(p_node->get_multiplayer_authority()) + ".");
+	ERR_FAIL_COND_MSG(!can_call, "RPC '" + String(config.name) + "' is not allowed on node " + String(p_node->get_path()) + " from: " + itos(p_from) + ". Mode is " + itos((int)config.rpc_mode) + ", authority is " + itos(p_node->get_multiplayer_authority()) + ".");
 
 	int argc = 0;
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1516,7 +1516,7 @@ void LightmapGI::_assign_lightmaps() {
 		NodePath user_path = light_data->get_user_path(i);
 		Node *node = get_node_or_null(user_path);
 		if (!node) {
-			missing_node_paths.push_back(user_path);
+			missing_node_paths.push_back(String(user_path));
 			continue;
 		}
 		int instance_idx = light_data->get_user_sub_instance(i);

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1195,10 +1195,10 @@ void Node3D::_update_visibility_parent(bool p_update_root) {
 			return;
 		}
 		Node *parent = get_node_or_null(visibility_parent_path);
-		ERR_FAIL_NULL_MSG(parent, "Can't find visibility parent node at path: " + visibility_parent_path);
+		ERR_FAIL_NULL_MSG(parent, "Can't find visibility parent node at path: " + String(visibility_parent_path));
 		ERR_FAIL_COND_MSG(parent == this, "The visibility parent can't be the same node.");
 		GeometryInstance3D *gi = Object::cast_to<GeometryInstance3D>(parent);
-		ERR_FAIL_NULL_MSG(gi, "The visibility parent node must be a GeometryInstance3D, at path: " + visibility_parent_path);
+		ERR_FAIL_NULL_MSG(gi, "The visibility parent node must be a GeometryInstance3D, at path: " + String(visibility_parent_path));
 		new_parent = gi ? gi->get_instance() : RID();
 	} else if (data.parent) {
 		new_parent = data.parent->data.visibility_parent;

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -172,9 +172,9 @@ void Area3D::_initialize_wind() {
 	// Overwrite with area-specified info if available
 	if (!wind_source_path.is_empty()) {
 		Node *wind_source_node = get_node_or_null(wind_source_path);
-		ERR_FAIL_NULL_MSG(wind_source_node, "Path to wind source is invalid: '" + wind_source_path + "'.");
+		ERR_FAIL_NULL_MSG(wind_source_node, "Path to wind source is invalid: '" + String(wind_source_path) + "'.");
 		Node3D *wind_source_node3d = Object::cast_to<Node3D>(wind_source_node);
-		ERR_FAIL_NULL_MSG(wind_source_node3d, "Path to wind source does not point to a Node3D: '" + wind_source_path + "'.");
+		ERR_FAIL_NULL_MSG(wind_source_node3d, "Path to wind source does not point to a Node3D: '" + String(wind_source_path) + "'.");
 		Transform3D global_transform = wind_source_node3d->get_transform();
 		wind_direction = -global_transform.basis.get_column(Vector3::AXIS_Z).normalized();
 		wind_source = global_transform.origin;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2381,7 +2381,7 @@ Control *Control::find_next_valid_focus() const {
 	// If the focus property is manually overwritten, attempt to use it.
 	if (!data.focus_next.is_empty()) {
 		Node *n = get_node_or_null(data.focus_next);
-		ERR_FAIL_NULL_V_MSG(n, nullptr, "Next focus node path is invalid: '" + data.focus_next + "'.");
+		ERR_FAIL_NULL_V_MSG(n, nullptr, "Next focus node path is invalid: '" + String(data.focus_next) + "'.");
 		Control *c = Object::cast_to<Control>(n);
 		ERR_FAIL_NULL_V_MSG(c, nullptr, "Next focus node is not a control: '" + n->get_name() + "'.");
 		if (c->_is_focusable()) {
@@ -2485,7 +2485,7 @@ Control *Control::find_prev_valid_focus() const {
 	// If the focus property is manually overwritten, attempt to use it.
 	if (!data.focus_prev.is_empty()) {
 		Node *n = get_node_or_null(data.focus_prev);
-		ERR_FAIL_NULL_V_MSG(n, nullptr, "Previous focus node path is invalid: '" + data.focus_prev + "'.");
+		ERR_FAIL_NULL_V_MSG(n, nullptr, "Previous focus node path is invalid: '" + String(data.focus_prev) + "'.");
 		Control *c = Object::cast_to<Control>(n);
 		ERR_FAIL_NULL_V_MSG(c, nullptr, "Previous focus node is not a control: '" + n->get_name() + "'.");
 		if (c->_is_focusable()) {
@@ -2605,7 +2605,7 @@ Control *Control::_get_focus_neighbor(Side p_side, int p_count) {
 	}
 	if (!data.focus_neighbor[p_side].is_empty()) {
 		Node *n = get_node_or_null(data.focus_neighbor[p_side]);
-		ERR_FAIL_NULL_V_MSG(n, nullptr, "Neighbor focus node path is invalid: '" + data.focus_neighbor[p_side] + "'.");
+		ERR_FAIL_NULL_V_MSG(n, nullptr, "Neighbor focus node path is invalid: '" + String(data.focus_neighbor[p_side]) + "'.");
 		Control *c = Object::cast_to<Control>(n);
 		ERR_FAIL_NULL_V_MSG(c, nullptr, "Neighbor focus node is not a control: '" + n->get_name() + "'.");
 		if (c->_is_focusable()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1455,7 +1455,7 @@ void Node::set_name(const StringName &p_name) {
 String Node::get_description() const {
 	String description;
 	if (is_inside_tree()) {
-		description = get_path();
+		description = String(get_path());
 	} else {
 		description = get_name();
 		if (description.is_empty()) {
@@ -2170,7 +2170,7 @@ void Node::_acquire_unique_name_in_owner() {
 	StringName key = StringName(UNIQUE_NODE_PREFIX + data.name.operator String());
 	Node **which = data.owner->data.owned_unique_nodes.getptr(key);
 	if (which != nullptr && *which != this) {
-		String which_path = is_inside_tree() ? (*which)->get_path() : data.owner->get_path_to(*which);
+		String which_path = String(is_inside_tree() ? (*which)->get_path() : data.owner->get_path_to(*which));
 		WARN_PRINT(vformat("Setting node name '%s' to be unique within scene for '%s', but it's already claimed by '%s'.\n'%s' is no longer set as having a unique name.",
 				get_name(), is_inside_tree() ? get_path() : data.owner->get_path_to(this), which_path, which_path));
 		data.unique_name_in_owner = false;
@@ -3345,7 +3345,7 @@ static void _print_orphan_nodes_routine(Object *p_obj) {
 	if (p == n) {
 		path = n->get_name();
 	} else {
-		path = String(p->get_name()) + "/" + p->get_path_to(n);
+		path = String(p->get_name()) + "/" + String(p->get_path_to(n));
 	}
 
 	String source;
@@ -3434,7 +3434,7 @@ static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<S
 		String n = "%" + p_node->get_name();
 		r_options->push_back(n.quote());
 	}
-	String n = p_base->get_path_to(p_node);
+	String n = String(p_base->get_path_to(p_node));
 	r_options->push_back(n.quote());
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_add_nodes_to_options(p_base, p_node->get_child(i), r_options);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1817,7 +1817,7 @@ void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer, const NodePat
 						break;
 					}
 				}
-				ERR_FAIL_COND_MSG(valid, "Multiplayer is already configured for a parent of this path: '" + p_root_path + "' in '" + E.key + "'.");
+				ERR_FAIL_COND_MSG(valid, "Multiplayer is already configured for a parent of this path: '" + String(p_root_path) + "' in '" + String(E.key) + "'.");
 			}
 		}
 		if (p_multiplayer.is_valid()) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -194,9 +194,9 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 	vp_pending = false;
 
 	Node *vpn = p_loc_scene->get_node_or_null(path);
-	ERR_FAIL_NULL_MSG(vpn, "Path to node is invalid: '" + path + "'.");
+	ERR_FAIL_NULL_MSG(vpn, "Path to node is invalid: '" + String(path) + "'.");
 	vp = Object::cast_to<Viewport>(vpn);
-	ERR_FAIL_NULL_MSG(vp, "Path to node does not point to a viewport: '" + path + "'.");
+	ERR_FAIL_NULL_MSG(vp, "Path to node does not point to a viewport: '" + String(path) + "'.");
 
 	vp->viewport_textures.insert(this);
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1215,7 +1215,7 @@ Vector3 Animation::position_track_interpolate(int p_track, double p_time, bool p
 	Vector3 ret = Vector3(0, 0, 0);
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
 	bool err = try_position_track_interpolate(p_track, p_time, &ret, p_backward);
-	ERR_FAIL_COND_V_MSG(err, ret, "3D Position Track: '" + tracks[p_track]->path + "' is unavailable.");
+	ERR_FAIL_COND_V_MSG(err, ret, "3D Position Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
 }
 
@@ -1295,7 +1295,7 @@ Quaternion Animation::rotation_track_interpolate(int p_track, double p_time, boo
 	Quaternion ret = Quaternion(0, 0, 0, 1);
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
 	bool err = try_rotation_track_interpolate(p_track, p_time, &ret, p_backward);
-	ERR_FAIL_COND_V_MSG(err, ret, "3D Rotation Track: '" + tracks[p_track]->path + "' is unavailable.");
+	ERR_FAIL_COND_V_MSG(err, ret, "3D Rotation Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
 }
 
@@ -1375,7 +1375,7 @@ Vector3 Animation::scale_track_interpolate(int p_track, double p_time, bool p_ba
 	Vector3 ret = Vector3(1, 1, 1);
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
 	bool err = try_scale_track_interpolate(p_track, p_time, &ret, p_backward);
-	ERR_FAIL_COND_V_MSG(err, ret, "3D Scale Track: '" + tracks[p_track]->path + "' is unavailable.");
+	ERR_FAIL_COND_V_MSG(err, ret, "3D Scale Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
 }
 
@@ -1455,7 +1455,7 @@ float Animation::blend_shape_track_interpolate(int p_track, double p_time, bool 
 	float ret = 0;
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), ret);
 	bool err = try_blend_shape_track_interpolate(p_track, p_time, &ret, p_backward);
-	ERR_FAIL_COND_V_MSG(err, ret, "Blend Shape Track: '" + tracks[p_track]->path + "' is unavailable.");
+	ERR_FAIL_COND_V_MSG(err, ret, "Blend Shape Track: '" + String(tracks[p_track]->path) + "' is unavailable.");
 	return ret;
 }
 


### PR DESCRIPTION
- Follow up of https://github.com/godotengine/godot/pull/107379, https://github.com/godotengine/godot/pull/107295, and #107406

Same idea as above - we want to avoid accidentally converting to `String`, because it's expensive.

Some questionable `String` conversions are exposed in this PR. The most egregious are repeated calls for the same conversion in loops, and others are using `NodePath` to verify that a string is path-like, and immediately converting back. If any of these are on hot paths, they should be fixed as a follow-up.

After this PR (and #107406), there are just 2 implicit `String` operator conversions left:

- `Variant` - probably can't fix this now, Variant has all the implicit conversions.
- `StringName` - probably fine for now since it's usually fast (at least on repeated access).

So that concludes the `String` journey for now - but there's tons more implicit conversions elsewhere too 🫣
To be continued...