### PR TITLE
Fix CSV translation not updating after reimport

### DIFF
--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -255,6 +255,20 @@ PackedStringArray TranslationDomain::get_loaded_locales() const {
 	return locales;
 }
 
+// Translation objects that could potentially be used for the given locale.
+HashSet<Ref<Translation>> TranslationDomain::get_potential_translations(const String &p_locale) const {
+	HashSet<Ref<Translation>> res;
+
+	for (const Ref<Translation> &E : translations) {
+		ERR_CONTINUE(E.is_null());
+
+		if (TranslationServer::get_singleton()->compare_locales(p_locale, E->get_locale()) > 0) {
+			res.insert(E);
+		}
+	}
+	return res;
+}
+
 Ref<Translation> TranslationDomain::get_translation_object(const String &p_locale) const {
 	Ref<Translation> res;
 	int best_score = 0;

--- a/core/string/translation_domain.h
+++ b/core/string/translation_domain.h
@@ -71,6 +71,7 @@ public:
 	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_context) const;
 	StringName get_message_from_translations(const String &p_locale, const StringName &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context) const;
 	PackedStringArray get_loaded_locales() const;
+	HashSet<Ref<Translation>> get_potential_translations(const String &p_locale) const;
 
 public:
 	Ref<Translation> get_translation_object(const String &p_locale) const;

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -437,6 +437,21 @@ public:
 		_init_from(p_other);
 	}
 
+	bool operator==(const HashSet &p_other) const {
+		if (num_elements != p_other.num_elements) {
+			return false;
+		}
+		for (uint32_t i = 0; i < num_elements; i++) {
+			if (!p_other.has(keys[i])) {
+				return false;
+			}
+		}
+		return true;
+	}
+	bool operator!=(const HashSet &p_other) const {
+		return !(*this == p_other);
+	}
+
 	HashSet(uint32_t p_initial_capacity) {
 		// Capacity can't be 0.
 		capacity_index = 0;

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2982,6 +2982,13 @@ Error EditorFileSystem::_reimport_file(const String &p_file, const HashMap<Strin
 		fs->files[cpos]->import_valid = fs->files[cpos]->type == "TextFile" ? true : ResourceLoader::is_import_valid(p_file);
 	}
 
+	for (const String &path : gen_files) {
+		Ref<Resource> cached = ResourceCache::get_ref(path);
+		if (cached.is_valid()) {
+			cached->reload_from_file();
+		}
+	}
+
 	if (ResourceUID::get_singleton()->has_id(uid)) {
 		ResourceUID::get_singleton()->set_id(uid, p_file);
 	} else {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -54,6 +54,7 @@ class PanelContainer;
 class RichTextLabel;
 class SubViewport;
 class TextureProgressBar;
+class Translation;
 class Tree;
 class VBoxContainer;
 class VSplitContainer;
@@ -455,6 +456,9 @@ private:
 	bool waiting_for_first_scan = true;
 	bool load_editor_layout_done = false;
 
+	HashSet<Ref<Translation>> tracked_translations;
+	bool pending_translation_notification = false;
+
 	int current_menu_option = 0;
 
 	SubViewport *scene_root = nullptr; // Root of the scene being edited.
@@ -619,6 +623,9 @@ private:
 	void _update_from_settings();
 	void _gdextensions_reloaded();
 	void _update_translations();
+	void _translation_resources_changed();
+	void _queue_translation_notification();
+	void _propagate_translation_notification();
 
 	void _renderer_selected(int);
 	void _update_renderer_color();

--- a/tests/core/templates/test_hash_set.h
+++ b/tests/core/templates/test_hash_set.h
@@ -238,4 +238,20 @@ TEST_CASE("[HashSet] Copy") {
 	}
 }
 
+TEST_CASE("[HashSet] Equality") {
+	// Empty sets.
+	CHECK(HashSet<int>{} == HashSet<int>{});
+	CHECK(HashSet<int>{} != HashSet<int>{ 1, 2, 3 });
+	CHECK(HashSet<int>{ 1, 2, 3 } != HashSet<int>{});
+
+	// Different length.
+	CHECK(HashSet<int>{ 1, 2, 3 } != HashSet<int>{ 1, 2, 3, 4 });
+	CHECK(HashSet<int>{ 1, 2, 3, 4 } != HashSet<int>{ 4, 3, 2 });
+
+	// Same length.
+	CHECK(HashSet<int>{ 1, 2, 3 } == HashSet<int>{ 1, 2, 3 });
+	CHECK(HashSet<int>{ 1, 2, 3 } == HashSet<int>{ 3, 2, 1 });
+	CHECK(HashSet<int>{ 1, 2, 3 } != HashSet<int>{ 1, 2, 8 });
+}
+
 } // namespace TestHashSet


### PR DESCRIPTION
Follow-up to #96921.

One of the known issues is updating CSV translations don't update preview text in the editor.

## Fix updating CSV translation files not updating preview text in the editor

Unlike `.po` files, importing a `.csv` file as translations does not "import" the file as any resource. The `.translation` files are extra files generated during the "import as nothing" process.

A non-imported resource file is only reloaded if the file's last modified time change. I think this logic was only considering external changes to resource files since the editor hooks into the resource saving process, tracking the file's last modified time automatically. So the newly generated `.translation` files won't be reloaded as the file's last modified time is always up-to-date.

~~Fortunately, `Resource` tracks its last modified time too. So we can compare the file's last modified time with the cached resource's last modified time.~~

This PR forces a reload of the resource caches corresponding to the generated files at the end of the import process.

## Only update translation when necessary

Currently, `NOTIFICATION_TRANSLATION_CHANGED` is propagated in the editing scene tree whenever project settings change. This is unnecessary and could make the stuttering worse if the editing scene is very complex.

In this PR, when project settings change, the notification is propagated only if the translation file set of the currently previewing locale is changed.

In order to compare `HashSet` equality, I added `operator{==,!=}` for it and related tests.

## Simplify the preview toggle logic

Originally, the translation preview PR turns translation preview on/off by updating the editing scene root's auto translation mode. Later, this was changed to disabling the entire translation domain for identifier-based translation.

The change made changing auto translation mode unnecessary, but this fact was made less obvious by some optimization logic :(

---

Here is a test project with a demo scene showing translatable texts from PO and CSV files: [test-4.zip](https://github.com/user-attachments/files/20692874/test-4.zip)