### PR TITLE
Fix IME window position not taking into account window transform

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -132,6 +132,8 @@ void LineEdit::_update_ime_window_position() {
 	if (get_window()->get_embedder()) {
 		pos += get_viewport()->get_popup_base_transform().get_origin();
 	}
+	// Take into account the window's transform.
+	pos = get_window()->get_screen_transform().xform(pos);
 	// The window will move to the updated position the next time the IME is updated, not immediately.
 	DisplayServer::get_singleton()->window_set_ime_position(pos, wid);
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3427,6 +3427,8 @@ void TextEdit::_update_ime_window_position() {
 	if (get_window()->get_embedder()) {
 		pos += get_viewport()->get_popup_base_transform().get_origin();
 	}
+	// Take into account the window's transform.
+	pos = get_window()->get_screen_transform().xform(pos);
 	// The window will move to the updated position the next time the IME is updated, not immediately.
 	DisplayServer::get_singleton()->window_set_ime_position(pos, wid);
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107411

**Before**:

https://github.com/user-attachments/assets/3244bdb7-20b3-4644-a7c0-3facd59787a7

**After**:

https://github.com/user-attachments/assets/72d9c530-a1d6-4911-bcef-8003b7ab8823
