### PR TITLE
Documentation: Add clarification to `AudioStream.get_length`

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -91,7 +91,7 @@
 		<method name="get_length" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the length of the audio stream in seconds.
+				Returns the length of the audio stream in seconds. If this stream is an [AudioStreamRandomizer], returns the length of the last played stream. If this stream has an indefinite length (such as for [AudioStreamGenerator] and [AudioStreamMicrophone]), returns [code]0.0[/code].
 			</description>
 		</method>
 		<method name="instantiate_playback">


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/105952

Clarifies some non-straightforward behavior for AudioStream::get_length() when it's not obvious.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
