### PR TITLE
Add call that allows switch to held clip in InteractivePlayback

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -1021,6 +1021,16 @@ int AudioStreamPlaybackInteractive::get_current_clip_index() const {
 	return playback_current;
 }
 
+int AudioStreamPlaybackInteractive::switch_to_held() {
+	if (return_memory == -1) {
+		return -1;
+	}
+
+	switch_request = return_memory;
+	return_memory = -1;
+	return switch_request;
+}
+
 int AudioStreamPlaybackInteractive::get_loop_count() const {
 	return 0; // Looping not supported
 }
@@ -1036,5 +1046,6 @@ bool AudioStreamPlaybackInteractive::is_playing() const {
 void AudioStreamPlaybackInteractive::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("switch_to_clip_by_name", "clip_name"), &AudioStreamPlaybackInteractive::switch_to_clip_by_name);
 	ClassDB::bind_method(D_METHOD("switch_to_clip", "clip_index"), &AudioStreamPlaybackInteractive::switch_to_clip);
+	ClassDB::bind_method(D_METHOD("switch_to_held"), &AudioStreamPlaybackInteractive::switch_to_held);
 	ClassDB::bind_method(D_METHOD("get_current_clip_index"), &AudioStreamPlaybackInteractive::get_current_clip_index);
 }

--- a/modules/interactive_music/audio_stream_interactive.h
+++ b/modules/interactive_music/audio_stream_interactive.h
@@ -260,6 +260,7 @@ public:
 
 	void switch_to_clip_by_name(const StringName &p_name);
 	void switch_to_clip(int p_index);
+	int switch_to_held();
 	int get_current_clip_index() const;
 
 	virtual void set_parameter(const StringName &p_name, const Variant &p_value) override;

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackInteractive.xml
@@ -35,5 +35,12 @@
 				Switch to a clip (by name).
 			</description>
 		</method>
+		<method name="switch_to_held">
+			<return type="int" />
+			<description>
+				Switch to held clip.
+				Returns the held clip index if successful, or -1 if nothing was held.
+			</description>
+		</method>
 	</methods>
 </class>


### PR DESCRIPTION
The call returns the held clip_index (which can be -1 if no clip is held) to indicate success.

Implements the proposal at https://github.com/godotengine/godot-proposals/issues/12588

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/12588*
