### PR TITLE
Move Web export threads options out of variant

### DIFF
--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -349,6 +349,8 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {}
 	virtual String get_debug_protocol() const { return "tcp://"; }
 	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const { return HashMap<String, Variant>(); }
+
+	virtual void export_option_set(const String &p_edited_property) {}
 };
 
 VARIANT_ENUM_CAST(EditorExportPlatform::ExportMessageType)

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -483,6 +483,9 @@ void ProjectExportDialog::_tab_changed(int) {
 }
 
 void ProjectExportDialog::_update_parameters(const String &p_edited_property) {
+	Ref<EditorExportPreset> current = get_current_preset();
+	current->get_platform()->export_option_set(p_edited_property);
+
 	_update_current_preset();
 }
 

--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -79,16 +79,16 @@
 			- [b]Landscape:[/b] Forces a horizontal layout (wider than it is taller).
 			- [b]Portrait:[/b] Forces a vertical layout (taller than it is wider).
 		</member>
-		<member name="variant/emscripten_pool_size" type="int" setter="" getter="">
+		<member name="threads/emscripten_pool_size" type="int" setter="" getter="">
 			The number of threads that emscripten will allocate at startup. A smaller value will allocate fewer threads and consume fewer system resources, but you may run the risk of running out of threads in the pool and needing to allocate more threads at run time which may cause a deadlock.
 			[b]Note:[/b] Some browsers have a hard cap on the number of threads that can be allocated, so it is best to be cautious and keep this number low.
 		</member>
+		<member name="threads/godot_pool_size" type="int" setter="" getter="">
+			Override for the default size of the [WorkerThreadPool]. This setting is used when [member ProjectSettings.threading/worker_pool/max_threads] size is set to -1 (which it is by default). This size must be smaller than [member threads/emscripten_pool_size] otherwise deadlocks may occur.
+			When using threads this size needs to be large enough to accommodate features that rely on having a dedicated thread like [member ProjectSettings.physics/2d/run_on_separate_thread] or [member ProjectSettings.rendering/driver/threads/thread_model]. In general, it is best to ensure that this is at least 4 and is at least 2 or 3 less than [member threads/emscripten_pool_size].
+		</member>
 		<member name="variant/extensions_support" type="bool" setter="" getter="">
 			If [code]true[/code] enables [GDExtension] support for this web build.
-		</member>
-		<member name="variant/godot_pool_size" type="int" setter="" getter="">
-			Override for the default size of the [WorkerThreadPool]. This setting is used when [member ProjectSettings.threading/worker_pool/max_threads] size is set to -1 (which it is by default). This size must be smaller than [member variant/emscripten_pool_size] otherwise deadlocks may occur.
-			When using threads this size needs to be large enough to accommodate features that rely on having a dedicated thread like [member ProjectSettings.physics/2d/run_on_separate_thread] or [member ProjectSettings.rendering/driver/threads/thread_model]. In general, it is best to ensure that this is at least 4 and is at least 2 or 3 less than [member variant/emscripten_pool_size].
 		</member>
 		<member name="variant/thread_support" type="bool" setter="" getter="">
 			If [code]true[/code], the exported game will support threads. It requires [url=https://web.dev/articles/coop-coep]a "cross-origin isolated" website[/url], which may be difficult to set up and is limited for security reasons (such as not being able to communicate with third-party websites).

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -143,13 +143,13 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 	config["canvasResizePolicy"] = p_preset->get("html/canvas_resize_policy");
 	config["experimentalVK"] = p_preset->get("html/experimental_virtual_keyboard");
 	config["focusCanvas"] = p_preset->get("html/focus_canvas_on_start");
-	config["godotPoolSize"] = p_preset->get("variant/godot_pool_size");
 	config["gdextensionLibs"] = libs;
 	config["executable"] = p_name;
 	config["args"] = args;
 	config["fileSizes"] = p_file_sizes;
 	config["ensureCrossOriginIsolationHeaders"] = (bool)p_preset->get("progressive_web_app/ensure_cross_origin_isolation_headers");
-	config["emscriptenPoolSize"] = p_preset->get("variant/emscripten_pool_size");
+	config["godotPoolSize"] = p_preset->get("threads/godot_pool_size");
+	config["emscriptenPoolSize"] = p_preset->get("threads/emscripten_pool_size");
 
 	String head_include;
 	if (p_preset->get("html/export_icon")) {
@@ -367,8 +367,7 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "variant/extensions_support"), false)); // GDExtension support.
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "variant/thread_support"), false)); // Thread support (i.e. run with or without COEP/COOP headers).
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "variant/emscripten_pool_size"), 8));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "variant/godot_pool_size"), 4));
+
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_desktop"), true)); // S3TC
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "vram_texture_compression/for_mobile"), false)); // ETC or ETC2, depending on renderer
 
@@ -378,6 +377,7 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "html/canvas_resize_policy", PROPERTY_HINT_ENUM, "None,Project,Adaptive"), 2));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/focus_canvas_on_start"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "html/experimental_virtual_keyboard"), false));
+
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "progressive_web_app/enabled"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "progressive_web_app/ensure_cross_origin_isolation_headers"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/offline_page", PROPERTY_HINT_FILE, "*.html"), ""));
@@ -387,6 +387,9 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_180x180", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_512x512", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::COLOR, "progressive_web_app/background_color", PROPERTY_HINT_COLOR_NO_ALPHA), Color()));
+
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "threads/emscripten_pool_size"), 8));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "threads/godot_pool_size"), 4));
 }
 
 bool EditorExportPlatformWeb::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
@@ -394,6 +397,9 @@ bool EditorExportPlatformWeb::get_export_option_visibility(const EditorExportPre
 	if (p_option == "custom_template/debug" ||
 			p_option == "custom_template/release") {
 		return advanced_options_enabled;
+	}
+	if (p_option == "threads/godot_pool_size" || p_option == "threads/emscripten_pool_size") {
+		return p_preset->get("variant/thread_support").operator bool();
 	}
 
 	return true;

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -59,6 +59,8 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 
 	Ref<EditorHTTPServer> server;
 
+	bool _should_update_export_options = false;
+
 	String _get_template_name(bool p_extension, bool p_thread_support, bool p_debug) const {
 		String name = "web";
 		if (p_extension) {
@@ -115,10 +117,19 @@ class EditorExportPlatformWeb : public EditorExportPlatform {
 	Error _start_server(const String &p_bind_host, uint16_t p_bind_port, bool p_use_tls);
 	Error _stop_server();
 
+	bool _get_preset_threads_enabled(const Ref<EditorExportPreset> &p_preset) const;
+
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
+	virtual bool should_update_export_options() override {
+		if (!_should_update_export_options) {
+			return false;
+		}
+		_should_update_export_options = false;
+		return true;
+	}
 	virtual bool get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const override;
 
 	virtual String get_name() const override;
@@ -144,6 +155,10 @@ public:
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override {
+	}
+
+	virtual void export_option_set(const String &p_edited_property) override {
+		_should_update_export_options = p_edited_property == "variant/thread_support";
 	}
 
 	String get_debug_protocol() const override { return "ws://"; }


### PR DESCRIPTION
This PR moves the newly added (by #104458) `variant/emscripten_pool_size` and `variant/godot_pool_size` to `threads/emscripten_pool_size` and `threads/godot_pool_size`. It also adds the functionality to make the threads option only appear if threads are enabled. (a future PR will hide more data, i.e. PWA options only if it's enabled)

https://github.com/user-attachments/assets/9f0adb90-f6dc-4a71-90be-8d71c417a858

The issue stems of having 2 options prominently featured only for thread builds. This is bad, as most of Godot exports are expected to be single-threaded.