### PR TITLE
Fix FileSystemDock signal connection for path navigation text box

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -531,7 +531,7 @@ void FileSystemDock::_notification(int p_what) {
 			button_hist_prev->connect(SceneStringName(pressed), callable_mp(this, &FileSystemDock::_bw_history));
 			file_list_popup->connect(SceneStringName(id_pressed), callable_mp(this, &FileSystemDock::_file_list_rmb_option));
 			tree_popup->connect(SceneStringName(id_pressed), callable_mp(this, &FileSystemDock::_tree_rmb_option));
-			current_path_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FileSystemDock::_navigate_to_path).bind(false));
+			current_path_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &FileSystemDock::_navigate_to_path).bind(false, true));
 
 			always_show_folders = bool(EDITOR_GET("docks/filesystem/always_show_folders"));
 			thumbnail_size_setting = EDITOR_GET("docks/filesystem/thumbnail_size");


### PR DESCRIPTION
In the current master, clicking the filepath textbox and entering a filepath throws an error: `ERROR: Error calling from signal 'text_submitted' to callable: 'FileSystemDock::FileSystemDock::_navigate_to_path': Method expected 3 arguments, but called with 2.`

This was caused because #106049 added another default parameter to the `_navigate_to_path` method, but the signal connection was not updated accordingly. This PR updates the connect call to properly create the callable, so it doesn't throw errors anymore. It chooses the `true` value to give focus to the file that you just navigated to.