### PR TITLE
Fix some inspector action buttons not updating icon when theme changes

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -57,6 +57,21 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/scene_string_names.h"
 
+void EditorInspectorActionButton::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			set_button_icon(get_editor_theme_icon(icon_name));
+		} break;
+	}
+}
+
+EditorInspectorActionButton::EditorInspectorActionButton(const String &p_text, const StringName &p_icon_name) {
+	icon_name = p_icon_name;
+	set_text(p_text);
+	set_theme_type_variation(SNAME("InspectorActionButton"));
+	set_h_size_flags(SIZE_SHRINK_CENTER);
+}
+
 bool EditorInspector::_property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
 	if (p_property_path.containsn(p_filter)) {
 		return true;
@@ -3164,8 +3179,6 @@ void EditorInspectorArray::_notification(int p_what) {
 					ae.erase->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
 				}
 			}
-
-			add_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
 
 		case NOTIFICATION_DRAG_BEGIN: {
@@ -3256,7 +3269,7 @@ EditorInspectorArray::EditorInspectorArray(bool p_read_only) {
 	elements_vbox->add_theme_constant_override("separation", 0);
 	vbox->add_child(elements_vbox);
 
-	add_button = EditorInspector::create_inspector_action_button(TTR("Add Element"));
+	add_button = memnew(EditorInspectorActionButton(TTRC("Add Element"), SNAME("Add")));
 	add_button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorArray::_add_button_pressed));
 	add_button->set_disabled(read_only);
 	vbox->add_child(add_button);
@@ -3511,14 +3524,6 @@ void EditorInspector::cleanup_plugins() {
 		inspector_plugins[i].unref();
 	}
 	inspector_plugin_count = 0;
-}
-
-Button *EditorInspector::create_inspector_action_button(const String &p_text) {
-	Button *button = memnew(Button);
-	button->set_text(p_text);
-	button->set_theme_type_variation(SNAME("InspectorActionButton"));
-	button->set_h_size_flags(SIZE_SHRINK_CENTER);
-	return button;
 }
 
 bool EditorInspector::is_main_editor_inspector() const {
@@ -4611,8 +4616,7 @@ void EditorInspector::update_tree() {
 		spacer->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
 		main_vbox->add_child(spacer);
 
-		Button *add_md = EditorInspector::create_inspector_action_button(TTR("Add Metadata"));
-		add_md->set_button_icon(theme_cache.icon_add);
+		Button *add_md = memnew(EditorInspectorActionButton(TTRC("Add Metadata"), SNAME("Add")));
 		add_md->connect(SceneStringName(pressed), callable_mp(this, &EditorInspector::_show_add_meta_dialog));
 		main_vbox->add_child(add_md);
 		if (all_read_only) {

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -32,12 +32,12 @@
 
 #include "editor/inspector/editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/scroll_container.h"
 
 class AddMetadataDialog;
 class AcceptDialog;
-class Button;
 class ConfirmationDialog;
 class EditorInspector;
 class EditorValidationPanel;
@@ -55,6 +55,18 @@ class EditorPropertyRevert {
 public:
 	static Variant get_property_revert_value(Object *p_object, const StringName &p_property, bool *r_is_valid);
 	static bool can_property_revert(Object *p_object, const StringName &p_property, const Variant *p_custom_current_value = nullptr);
+};
+
+class EditorInspectorActionButton : public Button {
+	GDCLASS(EditorInspectorActionButton, Button);
+
+	StringName icon_name;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	EditorInspectorActionButton(const String &p_text, const StringName &p_icon_name);
 };
 
 class EditorProperty : public Container {
@@ -765,7 +777,6 @@ public:
 	static void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	static void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	static void cleanup_plugins();
-	static Button *create_inspector_action_button(const String &p_text);
 
 	static EditorProperty *instantiate_property_editor(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
 

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -456,8 +456,7 @@ void EditorPropertyArray::update_property() {
 			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 			vbox->add_child(property_vbox);
 
-			button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Element"));
-			button_add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			button_add_item = memnew(EditorInspectorActionButton(TTRC("Add Element"), SNAME("Add")));
 			button_add_item->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyArray::_add_element));
 			button_add_item->connect(SceneStringName(draw), callable_mp(this, &EditorPropertyArray::_button_add_item_draw));
 			SET_DRAG_FORWARDING_CD(button_add_item, EditorPropertyArray);
@@ -750,12 +749,6 @@ Node *EditorPropertyArray::get_base_node() {
 
 void EditorPropertyArray::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			if (button_add_item) {
-				button_add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			}
-		} break;
-
 		case NOTIFICATION_DRAG_BEGIN: {
 			if (is_visible_in_tree()) {
 				if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
@@ -1305,8 +1298,7 @@ void EditorPropertyDictionary::update_property() {
 			_create_new_property_slot(EditorPropertyDictionaryObject::NEW_KEY_INDEX);
 			_create_new_property_slot(EditorPropertyDictionaryObject::NEW_VALUE_INDEX);
 
-			button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Key/Value Pair"));
-			button_add_item->set_button_icon(get_theme_icon(SNAME("Add"), EditorStringName(EditorIcons)));
+			button_add_item = memnew(EditorInspectorActionButton(TTRC("Add Key/Value Pair"), SNAME("Add")));
 			button_add_item->set_disabled(is_read_only());
 			button_add_item->set_accessibility_name(TTRC("Add"));
 			button_add_item->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyDictionary::_add_key_value));
@@ -1454,7 +1446,6 @@ void EditorPropertyDictionary::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			if (button_add_item) {
-				button_add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 				add_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("DictionaryAddItem")));
 			}
 		} break;
@@ -1661,9 +1652,8 @@ void EditorPropertyLocalizableString::update_property() {
 		}
 
 		if (page_index == max_page) {
-			button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Translation"));
+			button_add_item = memnew(EditorInspectorActionButton(TTRC("Add Translation"), SNAME("Add")));
 			button_add_item->set_accessibility_name(TTRC("Add Translation"));
-			button_add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 			button_add_item->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyLocalizableString::_add_locale_popup));
 			property_vbox->add_child(button_add_item);
 		}
@@ -1682,16 +1672,6 @@ void EditorPropertyLocalizableString::update_property() {
 
 void EditorPropertyLocalizableString::_object_id_selected(const StringName &p_property, ObjectID p_id) {
 	emit_signal(SNAME("object_id_selected"), p_property, p_id);
-}
-
-void EditorPropertyLocalizableString::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			if (button_add_item) {
-				button_add_item->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			}
-		} break;
-	}
 }
 
 void EditorPropertyLocalizableString::_edit_pressed() {

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -295,9 +295,6 @@ class EditorPropertyLocalizableString : public EditorProperty {
 	void _add_locale(const String &p_locale);
 	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
-protected:
-	void _notification(int p_what);
-
 public:
 	virtual void update_property() override;
 	EditorPropertyLocalizableString();

--- a/editor/inspector/input_event_editor_plugin.cpp
+++ b/editor/inspector/input_event_editor_plugin.cpp
@@ -34,14 +34,6 @@
 #include "editor/settings/event_listener_line_edit.h"
 #include "editor/settings/input_event_configuration_dialog.h"
 
-void InputEventConfigContainer::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			open_config_button->set_button_icon(get_editor_theme_icon(SNAME("Edit")));
-		} break;
-	}
-}
-
 void InputEventConfigContainer::_configure_pressed() {
 	config_dialog->popup_and_configure(input_event);
 }
@@ -134,7 +126,7 @@ InputEventConfigContainer::InputEventConfigContainer() {
 	input_event_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	add_child(input_event_text);
 
-	open_config_button = EditorInspector::create_inspector_action_button(TTR("Configure"));
+	EditorInspectorActionButton *open_config_button = memnew(EditorInspectorActionButton(TTRC("Configure"), SNAME("Edit")));
 	open_config_button->connect(SceneStringName(pressed), callable_mp(this, &InputEventConfigContainer::_configure_pressed));
 	add_child(open_config_button);
 

--- a/editor/inspector/input_event_editor_plugin.h
+++ b/editor/inspector/input_event_editor_plugin.h
@@ -38,7 +38,6 @@ class InputEventConfigContainer : public VBoxContainer {
 	GDCLASS(InputEventConfigContainer, VBoxContainer);
 
 	Label *input_event_text = nullptr;
-	Button *open_config_button = nullptr;
 
 	Ref<InputEvent> input_event;
 	InputEventConfigurationDialog *config_dialog = nullptr;
@@ -47,9 +46,6 @@ class InputEventConfigContainer : public VBoxContainer {
 	void _configure_pressed();
 
 	void _event_changed();
-
-protected:
-	void _notification(int p_what);
 
 public:
 	void set_event(const Ref<InputEvent> &p_event);

--- a/editor/inspector/tool_button_editor_plugin.cpp
+++ b/editor/inspector/tool_button_editor_plugin.cpp
@@ -30,12 +30,6 @@
 
 #include "tool_button_editor_plugin.h"
 
-#include "scene/gui/button.h"
-
-void EditorInspectorToolButtonPlugin::_update_action_icon(Button *p_action_button, const String &p_action_icon) {
-	p_action_button->set_button_icon(p_action_button->get_editor_theme_icon(p_action_icon));
-}
-
 void EditorInspectorToolButtonPlugin::_call_action(const Variant &p_object, const StringName &p_property) {
 	Object *object = p_object.get_validated_object();
 	ERR_FAIL_NULL_MSG(object, vformat(R"(Failed to get property "%s" on a previously freed instance.)", p_property));
@@ -65,10 +59,9 @@ bool EditorInspectorToolButtonPlugin::parse_property(Object *p_object, const Var
 	const String &hint_text = splits[0]; // Safe since `splits` cannot be empty.
 	const String &hint_icon = splits.size() > 1 ? splits[1] : "Callable";
 
-	Button *action_button = EditorInspector::create_inspector_action_button(hint_text);
+	EditorInspectorActionButton *action_button = memnew(EditorInspectorActionButton(hint_text, hint_icon));
 	action_button->set_auto_translate_mode(Node::AUTO_TRANSLATE_MODE_DISABLED);
 	action_button->set_disabled(p_usage & PROPERTY_USAGE_READ_ONLY);
-	action_button->connect(SceneStringName(theme_changed), callable_mp(this, &EditorInspectorToolButtonPlugin::_update_action_icon).bind(action_button, hint_icon));
 	action_button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorToolButtonPlugin::_call_action).bind(p_object, p_path));
 
 	add_custom_control(action_button);

--- a/editor/inspector/tool_button_editor_plugin.h
+++ b/editor/inspector/tool_button_editor_plugin.h
@@ -36,7 +36,6 @@
 class EditorInspectorToolButtonPlugin : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorToolButtonPlugin, EditorInspectorPlugin);
 
-	void _update_action_icon(Button *p_action_button, const String &p_action_icon);
 	void _call_action(const Variant &p_object, const StringName &p_property);
 
 public:

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -106,7 +106,7 @@ void BonePropertiesEditor::create_editors() {
 	meta_section->setup("bone_meta", TTR("Bone Metadata"), this, Color(.0f, .0f, .0f), true);
 	section->get_vbox()->add_child(meta_section);
 
-	add_metadata_button = EditorInspector::create_inspector_action_button(TTR("Add Bone Metadata"));
+	EditorInspectorActionButton *add_metadata_button = memnew(EditorInspectorActionButton(TTRC("Add Bone Metadata"), SNAME("Add")));
 	add_metadata_button->connect(SceneStringName(pressed), callable_mp(this, &BonePropertiesEditor::_show_add_meta_dialog));
 	section->get_vbox()->add_child(add_metadata_button);
 
@@ -121,7 +121,6 @@ void BonePropertiesEditor::_notification(int p_what) {
 			const Color section_color = get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor));
 			section->set_bg_color(section_color);
 			rest_section->set_bg_color(section_color);
-			add_metadata_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
 	}
 }

--- a/editor/scene/3d/skeleton_3d_editor_plugin.h
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.h
@@ -65,7 +65,6 @@ class BonePropertiesEditor : public VBoxContainer {
 
 	EditorInspectorSection *meta_section = nullptr;
 	AddMetadataDialog *add_meta_dialog = nullptr;
-	Button *add_metadata_button = nullptr;
 
 	Rect2 background_rects[5];
 

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -144,16 +144,6 @@ bool EditorPropertyFontOTObject::_property_get_revert(const StringName &p_name, 
 /* EditorPropertyFontMetaOverride                                        */
 /*************************************************************************/
 
-void EditorPropertyFontMetaOverride::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			if (button_add) {
-				button_add->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			}
-		} break;
-	}
-}
-
 void EditorPropertyFontMetaOverride::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
@@ -255,7 +245,6 @@ void EditorPropertyFontMetaOverride::update_property() {
 			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
 				property_vbox->get_child(i)->queue_free();
 			}
-			button_add = nullptr;
 		}
 
 		int size = dict.size();
@@ -302,11 +291,17 @@ void EditorPropertyFontMetaOverride::update_property() {
 			prop->update_property();
 		}
 
+		EditorInspectorActionButton *button_add;
 		if (script_editor) {
+			// This property editor is currently only used inside the font import settings dialog.
+			// Usually, the dialog needs to be closed in order to change the editor's language.
+			// So we can ignore the auto-translation here.
+
 			// TRANSLATORS: Script refers to a writing system.
-			button_add = EditorInspector::create_inspector_action_button(TTR("Add Script", "Locale"));
+			button_add = memnew(EditorInspectorActionButton(TTR("Add Script", "Locale"), SNAME("Add")));
+			button_add->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		} else {
-			button_add = EditorInspector::create_inspector_action_button(TTR("Add Locale"));
+			button_add = memnew(EditorInspectorActionButton(TTRC("Add Locale"), SNAME("Add")));
 		}
 		button_add->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyFontMetaOverride::_add_menu));
 		property_vbox->add_child(button_add);
@@ -316,7 +311,6 @@ void EditorPropertyFontMetaOverride::update_property() {
 		if (container) {
 			set_bottom_editor(nullptr);
 			memdelete(container);
-			button_add = nullptr;
 			container = nullptr;
 		}
 	}
@@ -549,16 +543,6 @@ EditorPropertyOTVariation::EditorPropertyOTVariation() {
 /* EditorPropertyOTFeatures                                              */
 /*************************************************************************/
 
-void EditorPropertyOTFeatures::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			if (button_add) {
-				button_add->set_button_icon(get_editor_theme_icon(SNAME("Add")));
-			}
-		} break;
-	}
-}
-
 void EditorPropertyOTFeatures::_property_changed(const String &p_property, const Variant &p_value, const String &p_name, bool p_changing) {
 	if (p_property.begins_with("keys")) {
 		Dictionary dict = object->get_dict();
@@ -630,7 +614,6 @@ void EditorPropertyOTFeatures::update_property() {
 		if (container) {
 			set_bottom_editor(nullptr);
 			memdelete(container);
-			button_add = nullptr;
 			container = nullptr;
 		}
 		return;
@@ -667,7 +650,6 @@ void EditorPropertyOTFeatures::update_property() {
 			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
 				property_vbox->get_child(i)->queue_free();
 			}
-			button_add = nullptr;
 		}
 
 		// Update add menu items.
@@ -799,8 +781,7 @@ void EditorPropertyOTFeatures::update_property() {
 			}
 		}
 
-		button_add = EditorInspector::create_inspector_action_button(TTR("Add Feature"));
-		button_add->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+		EditorInspectorActionButton *button_add = memnew(EditorInspectorActionButton(TTRC("Add Feature"), SNAME("Add")));
 		button_add->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyOTFeatures::_add_menu));
 		property_vbox->add_child(button_add);
 
@@ -809,7 +790,6 @@ void EditorPropertyOTFeatures::update_property() {
 		if (container) {
 			set_bottom_editor(nullptr);
 			memdelete(container);
-			button_add = nullptr;
 			container = nullptr;
 		}
 	}

--- a/editor/scene/gui/font_config_plugin.h
+++ b/editor/scene/gui/font_config_plugin.h
@@ -82,7 +82,6 @@ class EditorPropertyFontMetaOverride : public EditorProperty {
 	MarginContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 
-	Button *button_add = nullptr;
 	Button *edit = nullptr;
 	PopupMenu *menu = nullptr;
 	EditorLocaleDialog *locale_select = nullptr;
@@ -96,9 +95,6 @@ class EditorPropertyFontMetaOverride : public EditorProperty {
 	EditorPaginator *paginator = nullptr;
 
 protected:
-	void _notification(int p_what);
-	static void _bind_methods() {}
-
 	void _edit_pressed();
 	void _page_changed(int p_page);
 	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);
@@ -168,7 +164,6 @@ class EditorPropertyOTFeatures : public EditorProperty {
 	MarginContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 
-	Button *button_add = nullptr;
 	Button *edit = nullptr;
 	PopupMenu *menu = nullptr;
 	PopupMenu *menu_sub[FGRP_MAX];
@@ -180,9 +175,6 @@ class EditorPropertyOTFeatures : public EditorProperty {
 	EditorPaginator *paginator = nullptr;
 
 protected:
-	void _notification(int p_what);
-	static void _bind_methods() {}
-
 	void _edit_pressed();
 	void _page_changed(int p_page);
 	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);

--- a/editor/scene/packed_scene_editor_plugin.cpp
+++ b/editor/scene/packed_scene_editor_plugin.cpp
@@ -31,7 +31,6 @@
 #include "packed_scene_editor_plugin.h"
 
 #include "editor/editor_node.h"
-#include "scene/gui/button.h"
 #include "scene/resources/packed_scene.h"
 
 void PackedSceneEditor::_on_open_scene_pressed() {
@@ -39,18 +38,10 @@ void PackedSceneEditor::_on_open_scene_pressed() {
 	callable_mp(EditorNode::get_singleton(), &EditorNode::load_scene).call_deferred(packed_scene->get_path(), false, false, false, false);
 }
 
-void PackedSceneEditor::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_THEME_CHANGED: {
-			open_scene_button->set_button_icon(get_editor_theme_icon(SNAME("PackedScene")));
-		} break;
-	}
-}
-
 PackedSceneEditor::PackedSceneEditor(Ref<PackedScene> &p_packed_scene) {
 	packed_scene = p_packed_scene;
 
-	open_scene_button = EditorInspector::create_inspector_action_button(TTR("Open Scene"));
+	EditorInspectorActionButton *open_scene_button = memnew(EditorInspectorActionButton(TTRC("Open Scene"), SNAME("PackedScene")));
 	open_scene_button->connect(SceneStringName(pressed), callable_mp(this, &PackedSceneEditor::_on_open_scene_pressed));
 	open_scene_button->set_disabled(!packed_scene->get_path().get_file().is_valid_filename());
 	add_child(open_scene_button);

--- a/editor/scene/packed_scene_editor_plugin.h
+++ b/editor/scene/packed_scene_editor_plugin.h
@@ -38,12 +38,8 @@ class PackedSceneEditor : public VBoxContainer {
 	GDCLASS(PackedSceneEditor, VBoxContainer);
 
 	Ref<PackedScene> packed_scene;
-	Button *open_scene_button;
 
 	void _on_open_scene_pressed();
-
-protected:
-	void _notification(int p_what);
 
 public:
 	PackedSceneEditor(Ref<PackedScene> &p_packed_scene);

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -1297,8 +1297,7 @@ void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
 bool EditorInspectorPluginTextureRegion::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
 	if ((p_type == Variant::RECT2 || p_type == Variant::RECT2I)) {
 		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
-			Button *button = EditorInspector::create_inspector_action_button(TTR("Edit Region"));
-			button->set_button_icon(texture_region_editor->get_editor_theme_icon(SNAME("RegionEdit")));
+			EditorInspectorActionButton *button = memnew(EditorInspectorActionButton(TTRC("Edit Region"), SNAME("RegionEdit")));
 			button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorPluginTextureRegion::_region_edit).bind(p_object));
 			add_property_editor(p_path, button, true);
 		}

--- a/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
+++ b/modules/interactive_music/editor/audio_stream_interactive_editor_plugin.cpp
@@ -402,8 +402,7 @@ void EditorInspectorPluginAudioStreamInteractive::_edit(Object *p_object) {
 
 void EditorInspectorPluginAudioStreamInteractive::parse_end(Object *p_object) {
 	if (Object::cast_to<AudioStreamInteractive>(p_object)) {
-		Button *button = EditorInspector::create_inspector_action_button(TTR("Edit Transitions"));
-		button->set_button_icon(audio_stream_interactive_transition_editor->get_editor_theme_icon(SNAME("Blend")));
+		Button *button = memnew(EditorInspectorActionButton(TTRC("Edit Transitions"), SNAME("Blend")));
 		button->connect(SceneStringName(pressed), callable_mp(this, &EditorInspectorPluginAudioStreamInteractive::_edit).bind(p_object));
 		add_custom_control(button);
 	}


### PR DESCRIPTION
This PR adds a `EditorInspectorActionButton` class to replace `create_inspector_action_button()`. Thus action button users don't have to add icon updating logic on-site.