### PR TITLE
macOS: Initialize `CVDisplayLinkRef` member field

### DIFF
--- a/platform/macos/embedded_gl_manager.h
+++ b/platform/macos/embedded_gl_manager.h
@@ -90,7 +90,7 @@ class GLManagerEmbedded {
 	CGLErrorStringPtr CGLErrorString = nullptr;
 
 	uint32_t display_id = INVALID_DISPLAY_ID;
-	CVDisplayLinkRef display_link;
+	CVDisplayLinkRef display_link = nullptr;
 	bool vsync_enabled = false;
 	bool display_link_running = false;
 	dispatch_semaphore_t display_semaphore = nullptr;


### PR DESCRIPTION
Fixes a crash running embedded OpenGL apps in dev builds of the Godot editor