### PR TITLE
Allow `tab_rmb_clicked` to always work

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -336,7 +336,7 @@
 		<signal name="tab_rmb_clicked">
 			<param index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is right-clicked. [member select_with_rmb] must be enabled.
+				Emitted when a tab is right-clicked.
 			</description>
 		</signal>
 		<signal name="tab_selected">

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -289,25 +289,16 @@ void EditorDockManager::_dock_split_dragged(int p_offset) {
 	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
 
-void EditorDockManager::_dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container) {
-	Ref<InputEventMouseButton> mb = p_input;
-
-	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-		int tab_id = p_dock_container->get_tab_bar()->get_hovered_tab();
-		if (tab_id < 0) {
-			return;
-		}
-
-		EditorDock *hovered_dock = Object::cast_to<EditorDock>(p_dock_container->get_tab_control(tab_id));
-		if (hovered_dock == nullptr) {
-			return;
-		}
-
-		// Right click context menu.
-		dock_context_popup->set_dock(hovered_dock);
-		dock_context_popup->set_position(p_dock_container->get_tab_bar()->get_screen_position() + mb->get_position());
-		dock_context_popup->popup();
+void EditorDockManager::_dock_container_popup(int p_tab_idx, TabContainer *p_dock_container) {
+	EditorDock *hovered_dock = Object::cast_to<EditorDock>(p_dock_container->get_tab_control(p_tab_idx));
+	if (hovered_dock == nullptr) {
+		return;
 	}
+
+	// Right click context menu.
+	dock_context_popup->set_dock(hovered_dock);
+	dock_context_popup->set_position(p_dock_container->get_tab_bar()->get_screen_position() + p_dock_container->get_local_mouse_position());
+	dock_context_popup->popup();
 }
 
 void EditorDockManager::_dock_container_update_visibility(TabContainer *p_dock_container) {
@@ -981,13 +972,13 @@ void EditorDockManager::register_dock_slot(DockSlot p_dock_slot, TabContainer *p
 	p_tab_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	p_tab_container->set_popup(dock_context_popup);
 	p_tab_container->connect("pre_popup_pressed", callable_mp(dock_context_popup, &DockContextPopup::select_current_dock_in_dock_slot).bind(p_dock_slot));
+	p_tab_container->get_tab_bar()->connect("tab_rmb_clicked", callable_mp(this, &EditorDockManager::_dock_container_popup).bind(p_tab_container));
 	p_tab_container->set_drag_to_rearrange_enabled(true);
 	p_tab_container->set_tabs_rearrange_group(1);
 	p_tab_container->connect("tab_changed", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
 	p_tab_container->connect("active_tab_rearranged", callable_mp(this, &EditorDockManager::_update_layout).unbind(1));
 	p_tab_container->connect("child_order_changed", callable_mp(this, &EditorDockManager::_dock_container_update_visibility).bind(p_tab_container));
 	p_tab_container->set_use_hidden_tabs_for_min_size(true);
-	p_tab_container->get_tab_bar()->connect(SceneStringName(gui_input), callable_mp(this, &EditorDockManager::_dock_container_gui_input).bind(p_tab_container));
 	p_tab_container->hide();
 
 	// Create dock dragging hint.

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -106,7 +106,7 @@ private:
 	EditorDock *_get_dock_tab_dragged();
 	void _dock_drag_stopped();
 	void _dock_split_dragged(int p_offset);
-	void _dock_container_gui_input(const Ref<InputEvent> &p_input, TabContainer *p_dock_container);
+	void _dock_container_popup(int p_tab_idx, TabContainer *p_dock_container);
 	void _dock_container_update_visibility(TabContainer *p_dock_container);
 	void _update_layout();
 

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -199,7 +199,7 @@ void EditorBottomPanel::_on_button_visibility_changed(Button *p_button, Control 
 }
 
 EditorBottomPanel::EditorBottomPanel() {
-	get_tab_bar()->connect(SceneStringName(gui_input), callable_mp(EditorDockManager::get_singleton(), &EditorDockManager::_dock_container_gui_input).bind(this));
+	get_tab_bar()->connect("tab_rmb_clicked", callable_mp(EditorDockManager::get_singleton(), &EditorDockManager::_dock_container_popup).bind(this));
 	get_tab_bar()->connect("tab_changed", callable_mp(this, &EditorBottomPanel::_on_tab_changed));
 	set_tabs_position(TabPosition::POSITION_BOTTOM);
 	set_deselect_enabled(true);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -223,10 +223,11 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		if (mb->is_pressed() && (mb->get_button_index() == MouseButton::LEFT || (select_with_rmb && mb->get_button_index() == MouseButton::RIGHT))) {
+		if (mb->is_pressed()) {
 			Point2 pos = mb->get_position();
+			bool selecting = mb->get_button_index() == MouseButton::LEFT || (select_with_rmb && mb->get_button_index() == MouseButton::RIGHT);
 
-			if (buttons_visible) {
+			if (buttons_visible && selecting) {
 				if (is_layout_rtl()) {
 					if (pos.x < theme_cache.decrement_icon->get_width()) {
 						if (missing_right) {
@@ -268,47 +269,43 @@ void TabBar::gui_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 
-			int found = -1;
-			for (int i = offset; i <= max_drawn_tab; i++) {
-				if (tabs[i].hidden) {
-					continue;
-				}
-
-				if (tabs[i].rb_rect.has_point(pos)) {
-					rb_pressing = true;
-					_update_hover();
-					queue_redraw();
-					return;
-				}
-
-				if (tabs[i].cb_rect.has_point(pos) && (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && i == current))) {
-					cb_pressing = true;
-					_update_hover();
-					queue_redraw();
-					return;
-				}
-
-				if (pos.x >= get_tab_rect(i).position.x && pos.x < get_tab_rect(i).position.x + tabs[i].size_cache) {
-					if (!tabs[i].disabled) {
-						found = i;
-					}
-					break;
-				}
-			}
-
+			int found = get_tab_idx_at_point(pos);
 			if (found != -1) {
-				if (deselect_enabled && get_current_tab() == found) {
-					set_current_tab(-1);
-				} else {
-					set_current_tab(found);
+				// Clicking right button icon.
+				if (tabs[found].rb_rect.has_point(pos)) {
+					if (selecting) {
+						rb_pressing = true;
+						_update_hover();
+						queue_redraw();
+					}
+					return;
 				}
 
+				// Clicking close button.
+				if (tabs[found].cb_rect.has_point(pos) && (cb_displaypolicy == CLOSE_BUTTON_SHOW_ALWAYS || (cb_displaypolicy == CLOSE_BUTTON_SHOW_ACTIVE_ONLY && found == current))) {
+					if (selecting) {
+						cb_pressing = true;
+						_update_hover();
+						queue_redraw();
+					}
+					return;
+				}
+
+				// Selecting a tab.
+				if (selecting) {
+					if (deselect_enabled && get_current_tab() == found) {
+						set_current_tab(-1);
+					} else {
+						set_current_tab(found);
+					}
+
+					emit_signal(SNAME("tab_clicked"), found);
+				}
+
+				// Right mouse button clicked on a tab.
 				if (mb->get_button_index() == MouseButton::RIGHT) {
-					// Right mouse button clicked.
 					emit_signal(SNAME("tab_rmb_clicked"), found);
 				}
-
-				emit_signal(SNAME("tab_clicked"), found);
 			}
 		}
 	}


### PR DESCRIPTION
Currently, the `tab_rmb_clicked` signal only works when `select_with_rmb` is enabled. This is not always wanted however, say if you wanted to use the right-click to show a popup. This PR enables the `tab_rmb_clicked` signal to always be emitted if you right click a tab, even if `select_with_rmb` is disabled.

<details><summary>Old Comment</summary>
<p>
Currently, when users add a popup to a TabContainer, it only adds a small icon on the right that they can click to show the popup. Thus, a common use is to allow right clicks to tabs that also brings up the popup. However, the current method to do this is hacky and requires adding another function. The current method is to connect the tabbar's `gui_input` signal to a new method, in a line like:
https://github.com/godotengine/godot/blob/d9cd011e2fa9fa9a3011371843729f33032cee35/editor/editor_dock_manager.cpp#L997

This PR adds an optional boolean to the popup method that can enable this behavior natively, reducing the amount of extra code and hacky workarounds. It's disabled by default to preserve compatibility.

I don't know how much the maintainers would want to expose this but I do think that it is a good usability enhancement. Worst case if this doesn't get exposed a boolean could be made with new methods so the existing methods don't get changed.
</p>
</details> 