### PR TITLE
Allow numpad comma `,` to be used for 3D Blender-Style Transforms

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2267,27 +2267,36 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		if (_edit.instant) {
 			// In a Blender-style transform, numbers set the magnitude of the transform.
 			// E.g. pressing g4.5x means "translate 4.5 units along the X axis".
-			// Use the Unicode value because we care about the text, not the actual keycode.
-			// This ensures numbers work consistently across different keyboard language layouts.
 			bool processed = true;
-			Key key = k->get_physical_keycode();
-			char32_t unicode = k->get_unicode();
-			if (unicode >= '0' && unicode <= '9') {
-				uint32_t value = uint32_t(unicode - Key::KEY_0);
+			Key keycode = k->get_keycode();
+			Key physical_keycode = k->get_physical_keycode();
+
+			// Use physical keycode for main keyboard numbers (for non-QWERTY layouts like AZERTY)
+			// but regular keycode for numpad numbers.
+			if ((physical_keycode >= Key::KEY_0 && physical_keycode <= Key::KEY_9) || (keycode >= Key::KP_0 && keycode <= Key::KP_9)) {
+				uint32_t value;
+				if (physical_keycode >= Key::KEY_0 && physical_keycode <= Key::KEY_9) {
+					value = uint32_t(physical_keycode - Key::KEY_0);
+				} else {
+					value = uint32_t(keycode - Key::KP_0);
+				}
+
 				if (_edit.numeric_next_decimal < 0) {
 					_edit.numeric_input = _edit.numeric_input + value * Math::pow(10.0, _edit.numeric_next_decimal--);
 				} else {
 					_edit.numeric_input = _edit.numeric_input * 10 + value;
 				}
 				update_transform_numeric();
-			} else if (unicode == '-') {
+			} else if (keycode == Key::MINUS || keycode == Key::KP_SUBTRACT) {
 				_edit.numeric_negate = !_edit.numeric_negate;
 				update_transform_numeric();
-			} else if (unicode == '.') {
+			} else if (keycode == Key::PERIOD || physical_keycode == Key::KP_PERIOD) {
+				// Use physical keycode for KP_PERIOD to ensure numpad period works consistently
+				// across different keyboard layouts (like nordic keyboards).
 				if (_edit.numeric_next_decimal == 0) {
 					_edit.numeric_next_decimal = -1;
 				}
-			} else if (key == Key::ENTER || key == Key::KP_ENTER || key == Key::SPACE) {
+			} else if (keycode == Key::ENTER || keycode == Key::KP_ENTER || keycode == Key::SPACE) {
 				commit_transform();
 			} else {
 				processed = false;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/107432