### PR TITLE
Add a smoke test for non-empty `nullptr` `Span`

### DIFF
--- a/core/templates/span.h
+++ b/core/templates/span.h
@@ -51,8 +51,17 @@ public:
 			std::is_same<T, wchar_t>>;
 
 	_FORCE_INLINE_ constexpr Span() = default;
-	_FORCE_INLINE_ constexpr Span(const T *p_ptr, uint64_t p_len) :
-			_ptr(p_ptr), _len(p_len) {}
+
+	_FORCE_INLINE_ Span(const T *p_ptr, uint64_t p_len) :
+			_ptr(p_ptr), _len(p_len) {
+#ifdef DEBUG_ENABLED
+		// TODO In c++20, make this check run only in non-consteval, and make this constructor constexpr.
+		if (_ptr == nullptr && _len > 0) {
+			ERR_PRINT("Internal bug, please report: Span was created from nullptr with size > 0. Recovering by using size = 0.");
+			_len = 0;
+		}
+#endif
+	}
 
 	// Allows creating Span directly from C arrays and string literals.
 	template <size_t N>

--- a/tests/core/templates/test_span.h
+++ b/tests/core/templates/test_span.h
@@ -43,10 +43,10 @@ TEST_CASE("[Span] Constexpr Validators") {
 	static_assert(span_empty.is_empty());
 
 	constexpr static uint16_t value = 5;
-	constexpr Span<uint16_t> span_value(&value, 1);
-	static_assert(span_value.ptr() == &value);
-	static_assert(span_value.size() == 1);
-	static_assert(!span_value.is_empty());
+	Span<uint16_t> span_value(&value, 1);
+	CHECK(span_value.ptr() == &value);
+	CHECK(span_value.size() == 1);
+	CHECK(!span_value.is_empty());
 
 	static constexpr int ints[] = { 0, 1, 2, 3, 4, 5 };
 	constexpr Span<int> span_array = ints;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/issues/107422

The above bug occurred because a `Span` was created from `nullptr` with a `size > 0`. This is incorrect, because it's promising access to a memory region that does not exist.

We can catch this, at least for the `nullptr` case, by adding a smoke test. This should help us catch such bugs early in the future. The above bug could only have occurred in `DEBUG` builds, so it would have been prevented by this test.

The test is pretty cheap, so it shouldn't create performance problems for `DEBUG`. I'd still hesitate to add it to `RELEASE` because correct code should not need it, and in hot loops, it may actually prevent vectorization. Plus, setting `_len = 0` is unlikely to be the correct fix anyway (though it _should_ be better than nothing).

**Note:** Unfortunately, this change requires the function to be non-`constexpr`, because `ERR_PRINT` isn't `constexpr`. This can be fixed in c++20 with `std::is_constant_evaluated`. Fortunately, we do not use this property yet, so for Godot 4.5 we can give it up. In 4.6, we're planning to [upgrade to C++20](https://github.com/godotengine/godot/pull/100749), so we can re-add `constexpr` then.