### PR TITLE
[TextServer] Check if "gui/theme/lcd_subpixel_layout" is set.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -8075,7 +8075,9 @@ bool TextServerAdvanced::_is_valid_letter(uint64_t p_unicode) const {
 }
 
 void TextServerAdvanced::_update_settings() {
-	lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+	if (ProjectSettings::get_singleton()->has_setting("gui/theme/lcd_subpixel_layout")) {
+		lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+	}
 	lb_strictness = (LineBreakStrictness)(int)GLOBAL_GET("internationalization/locale/line_breaking_strictness");
 }
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -5186,11 +5186,14 @@ PackedInt32Array TextServerFallback::_string_get_word_breaks(const String &p_str
 }
 
 void TextServerFallback::_update_settings() {
-	lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+	if (ProjectSettings::get_singleton()->has_setting("gui/theme/lcd_subpixel_layout")) {
+		lcd_subpixel_layout.set((TextServer::FontLCDSubpixelLayout)(int)GLOBAL_GET("gui/theme/lcd_subpixel_layout"));
+	}
 }
 
 TextServerFallback::TextServerFallback() {
 	_insert_feature_sets();
+	_update_settings();
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerFallback::_update_settings));
 }
 


### PR DESCRIPTION
Fixes `Property not found: 'gui/theme/lcd_subpixel_layout'.` error on start.