### PR TITLE
Fix the VRS attachment being incorrectly added to `color_attachments`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -2907,6 +2907,8 @@ RID RenderingDevice::framebuffer_create(const Vector<RID> &p_texture_attachments
 
 		if (texture && texture->usage_flags & TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) {
 			pass.depth_attachment = i;
+		} else if (texture && texture->usage_flags & TEXTURE_USAGE_VRS_ATTACHMENT_BIT) {
+			// Prevent the VRS attachment from being added to the color_attachments.
 		} else {
 			if (texture && texture->is_resolve_buffer) {
 				pass.resolve_attachments.push_back(i);


### PR DESCRIPTION
Fixes #107183.

Regression from #99551. @DarioSamo 

During the refactoring of the aforementioned PR the VRS attachment index was removed as property of the FramebufferPass struct (it was moved to method parameters). In this process an if-else branch setting this struct value was removed ([link](https://github.com/DarioSamo/godot/blob/808c9fbcc54a90e219b6b0139f0b311adc483054/servers/rendering/rendering_device.cpp#L2815-L2816)). This caused the final branch to execute also for the VRS attachment, which then adds the index to the `color_attachments` list. This list gets iterated and marks each attachment as already used in this pass, triggering the assertion of the attachment already being used when it should normally be processed for the fragment shading rate ([link](https://github.com/godotengine/godot/blob/03bd8ba9c23d31f8f658f97093fd3f2e4a0f9031/servers/rendering/rendering_device.cpp#L2629)).

The fix is just reintroducing the (now empty) branch to prevent the VRS attachment texture from being added to `color_attachments`.