### PR TITLE
Batch the adding of Jolt Physics bodies

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -80,7 +80,7 @@ void JoltArea3D::_add_to_space() {
 
 	jolt_settings->SetShape(jolt_shape);
 
-	JPH::Body *new_jolt_body = space->add_rigid_body(*this, *jolt_settings, _should_sleep());
+	JPH::Body *new_jolt_body = space->add_object(*this, *jolt_settings, _should_sleep());
 	if (new_jolt_body == nullptr) {
 		return;
 	}
@@ -214,15 +214,11 @@ void JoltArea3D::_remove_all_overlaps() {
 }
 
 void JoltArea3D::_update_sleeping() {
-	if (space == nullptr) {
+	if (!in_space()) {
 		return;
 	}
 
-	if (_should_sleep()) {
-		space->get_body_iface().DeactivateBody(jolt_body->GetID());
-	} else {
-		space->get_body_iface().ActivateBody(jolt_body->GetID());
-	}
+	space->set_is_object_sleeping(jolt_body->GetID(), _should_sleep());
 }
 
 void JoltArea3D::_update_group_filter() {

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -144,7 +144,7 @@ void JoltBody3D::_add_to_space() {
 
 	jolt_settings->SetShape(jolt_shape);
 
-	JPH::Body *new_jolt_body = space->add_rigid_body(*this, *jolt_settings, sleep_initially);
+	JPH::Body *new_jolt_body = space->add_object(*this, *jolt_settings, sleep_initially);
 	if (new_jolt_body == nullptr) {
 		return;
 	}
@@ -706,11 +706,7 @@ void JoltBody3D::set_is_sleeping(bool p_enabled) {
 	if (!in_space()) {
 		sleep_initially = p_enabled;
 	} else {
-		if (p_enabled) {
-			space->get_body_iface().DeactivateBody(jolt_body->GetID());
-		} else {
-			space->get_body_iface().ActivateBody(jolt_body->GetID());
-		}
+		space->set_is_object_sleeping(jolt_body->GetID(), p_enabled);
 	}
 }
 
@@ -1180,7 +1176,7 @@ bool JoltBody3D::is_ccd_enabled() const {
 	if (!in_space()) {
 		return jolt_settings->mMotionQuality == JPH::EMotionQuality::LinearCast;
 	} else {
-		return space->get_body_iface().GetMotionQuality(jolt_body->GetID()) == JPH::EMotionQuality::LinearCast;
+		return !is_static() && jolt_body->GetMotionProperties()->GetMotionQuality() == JPH::EMotionQuality::LinearCast;
 	}
 }
 

--- a/modules/jolt_physics/objects/jolt_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_object_3d.cpp
@@ -41,7 +41,7 @@ void JoltObject3D::_remove_from_space() {
 		return;
 	}
 
-	space->remove_body(jolt_body->GetID());
+	space->remove_object(jolt_body->GetID());
 	jolt_body = nullptr;
 }
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -95,6 +95,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	void _pins_changed();
 	void _vertices_changed();
 	void _exceptions_changed();
+	void _motion_changed();
 
 public:
 	JoltSoftBody3D();

--- a/modules/jolt_physics/spaces/jolt_space_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_space_3d.cpp
@@ -65,6 +65,8 @@ constexpr double SPACE_DEFAULT_SOLVER_ITERATIONS = 8;
 } // namespace
 
 void JoltSpace3D::_pre_step(float p_step) {
+	flush_pending_objects();
+
 	while (needs_optimization_list.first()) {
 		JoltShapedObject3D *object = needs_optimization_list.first()->self();
 		needs_optimization_list.remove(needs_optimization_list.first());
@@ -202,7 +204,6 @@ void JoltSpace3D::step(float p_step) {
 
 	_post_step(p_step);
 
-	bodies_added_since_optimizing = 0;
 	stepping = false;
 }
 
@@ -385,7 +386,7 @@ void JoltSpace3D::set_default_area(JoltArea3D *p_area) {
 	}
 }
 
-JPH::Body *JoltSpace3D::add_rigid_body(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {
+JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping) {
 	JPH::BodyInterface &body_iface = get_body_iface();
 	JPH::Body *jolt_body = body_iface.CreateBody(p_settings);
 	if (unlikely(jolt_body == nullptr)) {
@@ -397,13 +398,16 @@ JPH::Body *JoltSpace3D::add_rigid_body(const JoltObject3D &p_object, const JPH::
 		return nullptr;
 	}
 
-	body_iface.AddBody(jolt_body->GetID(), p_sleeping ? JPH::EActivation::DontActivate : JPH::EActivation::Activate);
-	bodies_added_since_optimizing += 1;
+	if (p_sleeping) {
+		pending_objects_sleeping.push_back(jolt_body->GetID());
+	} else {
+		pending_objects_awake.push_back(jolt_body->GetID());
+	}
 
 	return jolt_body;
 }
 
-JPH::Body *JoltSpace3D::add_soft_body(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping) {
+JPH::Body *JoltSpace3D::add_object(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping) {
 	JPH::BodyInterface &body_iface = get_body_iface();
 	JPH::Body *jolt_body = body_iface.CreateSoftBody(p_settings);
 	if (unlikely(jolt_body == nullptr)) {
@@ -415,33 +419,66 @@ JPH::Body *JoltSpace3D::add_soft_body(const JoltObject3D &p_object, const JPH::S
 		return nullptr;
 	}
 
-	body_iface.AddBody(jolt_body->GetID(), p_sleeping ? JPH::EActivation::DontActivate : JPH::EActivation::Activate);
-	bodies_added_since_optimizing += 1;
+	if (p_sleeping) {
+		pending_objects_sleeping.push_back(jolt_body->GetID());
+	} else {
+		pending_objects_awake.push_back(jolt_body->GetID());
+	}
 
 	return jolt_body;
 }
 
-void JoltSpace3D::remove_body(const JPH::BodyID &p_body_id) {
+void JoltSpace3D::remove_object(const JPH::BodyID &p_jolt_id) {
 	JPH::BodyInterface &body_iface = get_body_iface();
 
-	body_iface.RemoveBody(p_body_id);
-	body_iface.DestroyBody(p_body_id);
+	if (!pending_objects_sleeping.erase_unordered(p_jolt_id) && !pending_objects_awake.erase_unordered(p_jolt_id)) {
+		body_iface.RemoveBody(p_jolt_id);
+	}
+
+	body_iface.DestroyBody(p_jolt_id);
 }
 
-void JoltSpace3D::try_optimize() {
-	// This makes assumptions about the underlying acceleration structure of Jolt's broad-phase, which currently uses a
-	// quadtree, and which gets walked with a fixed-size node stack of 128. This means that when the quadtree is
-	// completely unbalanced, as is the case if we add bodies one-by-one without ever stepping the simulation, like in
-	// the editor viewport, we would exceed this stack size (resulting in an incomplete search) as soon as we perform a
-	// physics query after having added somewhere in the order of 128 * 3 bodies. We leave a hefty margin just in case.
-
-	if (likely(bodies_added_since_optimizing < 128)) {
+void JoltSpace3D::flush_pending_objects() {
+	if (pending_objects_sleeping.is_empty() && pending_objects_awake.is_empty()) {
 		return;
 	}
 
-	physics_system->OptimizeBroadPhase();
+	// We only care about locking within this method, because it's called when performing queries, which aren't covered by `PhysicsServer3DWrapMT`.
+	MutexLock pending_objects_lock(pending_objects_mutex);
 
-	bodies_added_since_optimizing = 0;
+	JPH::BodyInterface &body_iface = get_body_iface();
+
+	if (!pending_objects_sleeping.is_empty()) {
+		JPH::BodyInterface::AddState add_state = body_iface.AddBodiesPrepare(pending_objects_sleeping.ptr(), pending_objects_sleeping.size());
+		body_iface.AddBodiesFinalize(pending_objects_sleeping.ptr(), pending_objects_sleeping.size(), add_state, JPH::EActivation::DontActivate);
+		pending_objects_sleeping.reset();
+	}
+
+	if (!pending_objects_awake.is_empty()) {
+		JPH::BodyInterface::AddState add_state = body_iface.AddBodiesPrepare(pending_objects_awake.ptr(), pending_objects_awake.size());
+		body_iface.AddBodiesFinalize(pending_objects_awake.ptr(), pending_objects_awake.size(), add_state, JPH::EActivation::Activate);
+		pending_objects_awake.reset();
+	}
+}
+
+void JoltSpace3D::set_is_object_sleeping(const JPH::BodyID &p_jolt_id, bool p_enable) {
+	if (p_enable) {
+		if (pending_objects_awake.erase_unordered(p_jolt_id)) {
+			pending_objects_sleeping.push_back(p_jolt_id);
+		} else if (pending_objects_sleeping.has(p_jolt_id)) {
+			// Do nothing.
+		} else {
+			get_body_iface().DeactivateBody(p_jolt_id);
+		}
+	} else {
+		if (pending_objects_sleeping.erase_unordered(p_jolt_id)) {
+			pending_objects_awake.push_back(p_jolt_id);
+		} else if (pending_objects_awake.has(p_jolt_id)) {
+			// Do nothing.
+		} else {
+			get_body_iface().ActivateBody(p_jolt_id);
+		}
+	}
 }
 
 void JoltSpace3D::enqueue_call_queries(SelfList<JoltBody3D> *p_body) {

--- a/modules/jolt_physics/spaces/jolt_space_3d.h
+++ b/modules/jolt_physics/spaces/jolt_space_3d.h
@@ -53,10 +53,15 @@ class JoltShapedObject3D;
 class JoltSoftBody3D;
 
 class JoltSpace3D {
+	Mutex pending_objects_mutex;
+
 	SelfList<JoltBody3D>::List body_call_queries_list;
 	SelfList<JoltArea3D>::List area_call_queries_list;
 	SelfList<JoltShapedObject3D>::List shapes_changed_list;
 	SelfList<JoltShapedObject3D>::List needs_optimization_list;
+
+	LocalVector<JPH::BodyID> pending_objects_sleeping;
+	LocalVector<JPH::BodyID> pending_objects_awake;
 
 	RID rid;
 
@@ -69,8 +74,6 @@ class JoltSpace3D {
 	JoltArea3D *default_area = nullptr;
 
 	float last_step = 0.0f;
-
-	int bodies_added_since_optimizing = 0;
 
 	bool active = false;
 	bool stepping = false;
@@ -125,12 +128,12 @@ public:
 
 	float get_last_step() const { return last_step; }
 
-	JPH::Body *add_rigid_body(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);
-	JPH::Body *add_soft_body(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping = false);
+	JPH::Body *add_object(const JoltObject3D &p_object, const JPH::BodyCreationSettings &p_settings, bool p_sleeping = false);
+	JPH::Body *add_object(const JoltObject3D &p_object, const JPH::SoftBodyCreationSettings &p_settings, bool p_sleeping = false);
+	void remove_object(const JPH::BodyID &p_jolt_id);
+	void flush_pending_objects();
 
-	void remove_body(const JPH::BodyID &p_body_id);
-
-	void try_optimize();
+	void set_is_object_sleeping(const JPH::BodyID &p_jolt_id, bool p_enable);
 
 	void enqueue_call_queries(SelfList<JoltBody3D> *p_body);
 	void enqueue_call_queries(SelfList<JoltArea3D> *p_area);


### PR DESCRIPTION
Fixes #107366.
Supersedes #107396.

This defers the `JPH::BodyInterface::AddBody` call for as long as possible, by batching the `JPH::BodyID`s for any objects that are added to a physics space, until the point where they _must_ be added to the simulation, like when stepping it or performing physics queries against it, at which point we use `JPH::BodyInterface::AddBodiesPrepare` and `JPH::BodyInterface::AddBodiesFinalize` to add all pending objects as a single batch

This means that we (mostly) no longer risk certain problems with Jolt's broad phase, like running out of available nodes or getting a completely unbalanced quadtree, like we do when we add bodies one-by-one, which can cause a number of issues, like the crash seen in #107366.

This replaces the previous `JoltSpace3D::try_optimize` hack, which solved the unbalanced problem, but did so in a fairly crude way.

EDIT: This now also includes a partial cherrypick of jrouwe/JoltPhysics#1675.