### PR TITLE
Support creating new scene autoloads from menu

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -169,6 +169,13 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 	return true;
 }
 
+void EditorAutoloadSettings::_autoload_add_pressed() {
+	if (!autoload_add_path->get_text().is_empty()) {
+		add_autoload->get_popup()->hide();
+		_autoload_add();
+	}
+}
+
 void EditorAutoloadSettings::_autoload_add_index_pressed(int p_index) {
 	switch (p_index) {
 	case 0: // Script
@@ -1001,6 +1008,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 
 	add_autoload = memnew(MenuButton);
 	add_autoload->set_text(TTRC("Add"));
+	add_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_autoload_add_pressed));
 	add_autoload->get_popup()->connect("index_pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_add_index_pressed));
 	//add_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_autoload_add));
 	// The button will be enabled once a valid name is entered (either automatically or manually).

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -194,7 +194,7 @@ void EditorAutoloadSettings::_autoload_add() {
 
 	// Although not ideal to clear this on error, it's necessary to avoid
 	//  the Project Settings getting stuck if "Add" is pressed again.
-	// The proper fix would be to just make it so the error dialogue is always on top.
+	// The proper fix would be to just make it so the error dialog is always on top.
 	autoload_add_name->set_text("");
 	add_autoload->set_disabled(true);
 }

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -178,12 +178,12 @@ void EditorAutoloadSettings::_autoload_add_pressed() {
 
 void EditorAutoloadSettings::_autoload_add_index_pressed(int p_index) {
 	switch (p_index) {
-	case 0: // Script button
-		_autoload_add_script();
-		break;
-	case 1: // Scene button
-		_autoload_add_scene();
-		break;
+		case 0: // Script button
+			_autoload_add_script();
+			break;
+		case 1: // Scene button
+			_autoload_add_scene();
+			break;
 	}
 }
 
@@ -209,14 +209,13 @@ void EditorAutoloadSettings::_autoload_add_script() {
 	dialog->popup_centered();
 }
 
-
 void EditorAutoloadSettings::_autoload_add_scene() {
 	SceneCreateDialog *dialog = FileSystemDock::get_singleton()->get_scene_create_dialog();
 	String fpath = path;
 	if (!fpath.ends_with("/")) {
 		fpath = fpath.get_base_dir();
 	}
-	dialog->config(fpath, vformat("%s", autoload_add_name->get_text()));
+	dialog->config(fpath, vformat("%s", autoload_add_name->get_text()), true);
 	dialog->popup_centered();
 }
 
@@ -659,14 +658,13 @@ void EditorAutoloadSettings::_script_created(Ref<Script> p_script) {
 }
 
 void EditorAutoloadSettings::_scene_created() {
-	SceneCreateDialog* scene_dialog = FileSystemDock::get_singleton()->get_scene_create_dialog();
+	SceneCreateDialog *scene_dialog = FileSystemDock::get_singleton()->get_scene_create_dialog();
 	String file_path = scene_dialog->get_scene_path();
 	path = file_path.get_base_dir();
 	autoload_add_path->set_text(file_path);
 	autoload_add_name->set_text(file_path.get_file().get_basename().to_pascal_case());
 	_autoload_add();
 }
-
 
 LineEdit *EditorAutoloadSettings::get_path_box() const {
 	return autoload_add_path;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -66,6 +66,9 @@ void EditorAutoloadSettings::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			browse_button->set_button_icon(get_editor_theme_icon(SNAME("Folder")));
 			add_autoload->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			add_autoload->get_popup()->clear();
+			add_autoload->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("Script")), TTR("Script..."));
+			add_autoload->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("PackedScene")), TTR("Scene..."));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -84,6 +87,22 @@ void EditorAutoloadSettings::_notification(int p_what) {
 					} else {
 						if (dialog->is_connected(SNAME("script_created"), script_created)) {
 							dialog->disconnect("script_created", script_created);
+						}
+					}
+				}
+
+				SceneCreateDialog *scene_dialog = dock->get_scene_create_dialog();
+
+				if (scene_dialog != nullptr) {
+					Callable scene_created = callable_mp(this, &EditorAutoloadSettings::_scene_created);
+
+					if (is_visible_in_tree()) {
+						if (!scene_dialog->is_connected(SceneStringName(confirmed), scene_created)) {
+							scene_dialog->connect(SceneStringName(confirmed), scene_created);
+						}
+					} else {
+						if (scene_dialog->is_connected(SceneStringName(confirmed), scene_created)) {
+							scene_dialog->disconnect(SceneStringName(confirmed), scene_created);
 						}
 					}
 				}
@@ -150,6 +169,17 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 	return true;
 }
 
+void EditorAutoloadSettings::_autoload_add_index_pressed(int p_index) {
+	switch (p_index) {
+	case 0: // Script
+		_autoload_add();
+		break;
+	case 1: // Node
+		_autoload_add_scene();
+		break;
+	}
+}
+
 void EditorAutoloadSettings::_autoload_add() {
 	if (autoload_add_path->get_text().is_empty()) {
 		ScriptCreateDialog *dialog = FileSystemDock::get_singleton()->get_script_create_dialog();
@@ -158,6 +188,26 @@ void EditorAutoloadSettings::_autoload_add() {
 			fpath = fpath.get_base_dir();
 		}
 		dialog->config("Node", fpath.path_join(vformat("%s.gd", autoload_add_name->get_text())), false, false);
+		dialog->popup_centered();
+	} else {
+		if (autoload_add(autoload_add_name->get_text(), autoload_add_path->get_text())) {
+			autoload_add_path->set_text("");
+		}
+
+		autoload_add_name->set_text("");
+		add_autoload->set_disabled(true);
+	}
+}
+
+
+void EditorAutoloadSettings::_autoload_add_scene() {
+	if (autoload_add_path->get_text().is_empty()) {
+		SceneCreateDialog *dialog = FileSystemDock::get_singleton()->get_scene_create_dialog();
+		String fpath = path;
+		if (!fpath.ends_with("/")) {
+			fpath = fpath.get_base_dir();
+		}
+		dialog->config(fpath, vformat("%s", autoload_add_name->get_text()));
 		dialog->popup_centered();
 	} else {
 		if (autoload_add(autoload_add_name->get_text(), autoload_add_path->get_text())) {
@@ -607,6 +657,16 @@ void EditorAutoloadSettings::_script_created(Ref<Script> p_script) {
 	_autoload_add();
 }
 
+void EditorAutoloadSettings::_scene_created() {
+	SceneCreateDialog* scene_dialog = FileSystemDock::get_singleton()->get_scene_create_dialog();
+	String file_path = scene_dialog->get_scene_path();
+	path = file_path.get_base_dir();
+	autoload_add_path->set_text(file_path);
+	autoload_add_name->set_text(file_path.get_file().get_basename().to_pascal_case());
+	_autoload_add();
+}
+
+
 LineEdit *EditorAutoloadSettings::get_path_box() const {
 	return autoload_add_path;
 }
@@ -910,7 +970,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	autoload_add_path->set_accessibility_name(TTRC("Autoload Path"));
 	autoload_add_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	autoload_add_path->set_clear_button_enabled(true);
-	autoload_add_path->set_placeholder(TTRC("Set path or press \"Add\" to create a script."));
+	autoload_add_path->set_placeholder(TTRC("Script or Scene: Set path or press \"Add\" to create new."));
 	autoload_add_path->connect(SceneStringName(text_changed), callable_mp(this, &EditorAutoloadSettings::_autoload_path_text_changed));
 
 	browse_button = memnew(Button);
@@ -939,9 +999,10 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	autoload_add_name->connect(SceneStringName(text_changed), callable_mp(this, &EditorAutoloadSettings::_autoload_text_changed));
 	hbc->add_child(autoload_add_name);
 
-	add_autoload = memnew(Button);
+	add_autoload = memnew(MenuButton);
 	add_autoload->set_text(TTRC("Add"));
-	add_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_autoload_add));
+	add_autoload->get_popup()->connect("index_pressed", callable_mp(this, &EditorAutoloadSettings::_autoload_add_index_pressed));
+	//add_autoload->connect(SceneStringName(pressed), callable_mp(this, &EditorAutoloadSettings::_autoload_add));
 	// The button will be enabled once a valid name is entered (either automatically or manually).
 	add_autoload->set_disabled(true);
 	hbc->add_child(add_autoload);

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -78,9 +78,11 @@ class EditorAutoloadSettings : public VBoxContainer {
 
 	bool _autoload_name_is_valid(const String &p_name, String *r_error = nullptr);
 
+	void _autoload_add_pressed();
 	void _autoload_add_index_pressed(int p_index);
 	void _autoload_add();
 	void _autoload_add_scene();
+
 	void _autoload_selected();
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -81,6 +81,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	void _autoload_add_pressed();
 	void _autoload_add_index_pressed(int p_index);
 	void _autoload_add();
+	void _autoload_add_script();
 	void _autoload_add_scene();
 
 	void _autoload_selected();

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -32,6 +32,7 @@
 
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/tree.h"
 
 class EditorFileDialog;
@@ -69,7 +70,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 
 	Tree *tree = nullptr;
 	LineEdit *autoload_add_name = nullptr;
-	Button *add_autoload = nullptr;
+	MenuButton *add_autoload = nullptr;
 	LineEdit *autoload_add_path = nullptr;
 	Label *error_message = nullptr;
 	Button *browse_button = nullptr;
@@ -77,7 +78,9 @@ class EditorAutoloadSettings : public VBoxContainer {
 
 	bool _autoload_name_is_valid(const String &p_name, String *r_error = nullptr);
 
+	void _autoload_add_index_pressed(int p_index);
 	void _autoload_add();
+	void _autoload_add_scene();
 	void _autoload_selected();
 	void _autoload_edited();
 	void _autoload_button_pressed(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
@@ -90,6 +93,8 @@ class EditorAutoloadSettings : public VBoxContainer {
 	Node *_create_autoload(const String &p_path);
 
 	void _script_created(Ref<Script> p_script);
+
+	void _scene_created();
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_control);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control) const;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2832,6 +2832,10 @@ ScriptCreateDialog *FileSystemDock::get_script_create_dialog() const {
 	return make_script_dialog;
 }
 
+SceneCreateDialog *FileSystemDock::get_scene_create_dialog() const {
+	return make_scene_dialog;
+}
+
 void FileSystemDock::set_file_list_display_mode(FileListDisplayMode p_mode) {
 	if (p_mode == file_list_display_mode) {
 		return;

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -34,6 +34,7 @@
 #include "editor/editor_file_system.h"
 #include "editor/file_info.h"
 #include "editor/plugins/script_editor_plugin.h"
+#include "editor/scene_create_dialog.h"
 #include "editor/script_create_dialog.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
@@ -47,7 +48,6 @@ class EditorDirDialog;
 class ItemList;
 class LineEdit;
 class ProgressBar;
-class SceneCreateDialog;
 class ShaderCreateDialog;
 class DirectoryCreateDialog;
 class EditorResourceTooltipPlugin;
@@ -398,6 +398,8 @@ public:
 	void create_directory(const String &p_path, const String &p_base_dir);
 
 	ScriptCreateDialog *get_script_create_dialog() const;
+
+	SceneCreateDialog *get_scene_create_dialog() const;
 
 	void fix_dependencies(const String &p_for_file);
 	void update_all();

--- a/editor/scene_create_dialog.cpp
+++ b/editor/scene_create_dialog.cpp
@@ -61,10 +61,10 @@ void SceneCreateDialog::_notification(int p_what) {
 	}
 }
 
-void SceneCreateDialog::config(const String &p_dir) {
+void SceneCreateDialog::config(const String &p_dir, const String &p_name) {
 	directory = p_dir;
 	root_name_edit->set_text("");
-	scene_name_edit->set_text("");
+	scene_name_edit->set_text(p_name);
 	callable_mp((Control *)scene_name_edit, &Control::grab_focus).call_deferred();
 	validation_panel->update();
 }

--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -61,7 +61,6 @@ public:
 	};
 
 private:
-	String directory;
 	String scene_name;
 	String root_name;
 
@@ -75,13 +74,17 @@ private:
 	Button *select_node_button = nullptr;
 	CreateDialog *select_node_dialog = nullptr;
 
+	bool can_edit_directory = false;
 	Label *directory_edit_label = nullptr;
 	LineEdit *directory_edit = nullptr;
+	Button *directory_button = nullptr;
+	HBoxContainer *directory_container = nullptr;
 	LineEdit *scene_name_edit = nullptr;
 	OptionButton *scene_extension_picker = nullptr;
 	LineEdit *root_name_edit = nullptr;
 
 	EditorValidationPanel *validation_panel = nullptr;
+	EditorFileDialog *file_browse = nullptr;
 
 	void accept_create();
 	void browse_types();
@@ -96,6 +99,9 @@ public:
 
 	String get_scene_path() const;
 	Node *create_scene_root();
+
+	void _browse_directory();
+	void _dir_selected(const String &p_file);
 
 	SceneCreateDialog();
 };

--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -89,7 +89,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void config(const String &p_dir);
+	void config(const String &p_dir, const String &p_name = "");
 
 	String get_scene_path() const;
 	Node *create_scene_root();

--- a/editor/scene_create_dialog.h
+++ b/editor/scene_create_dialog.h
@@ -45,6 +45,7 @@ class SceneCreateDialog : public ConfirmationDialog {
 	GDCLASS(SceneCreateDialog, ConfirmationDialog);
 
 	enum {
+		MSG_ID_DIR,
 		MSG_ID_PATH,
 		MSG_ID_ROOT,
 	};
@@ -74,6 +75,8 @@ private:
 	Button *select_node_button = nullptr;
 	CreateDialog *select_node_dialog = nullptr;
 
+	Label *directory_edit_label = nullptr;
+	LineEdit *directory_edit = nullptr;
 	LineEdit *scene_name_edit = nullptr;
 	OptionButton *scene_extension_picker = nullptr;
 	LineEdit *root_name_edit = nullptr;
@@ -89,7 +92,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void config(const String &p_dir, const String &p_name = "");
+	void config(const String &p_dir, const String &p_name = "", bool p_can_edit_dir = false);
 
 	String get_scene_path() const;
 	Node *create_scene_root();


### PR DESCRIPTION
Fixes #107131

Update the test for the file picker to make it clear it supports scripts and scenes
Update the "Add" button to open a drop-down instead of just adding a script
 - The drop-down has options for both "Script" and "Scene"
 - "Scene" opens the usual scene creation popup, but with one change
 - Create scene window updated to allow calling into it from the autoloads section
Create scene window allows editing the directory via a new "Scene Path" field
 - Only allows entering a directory, not the full file path
 - This is a config option, so the regular create scene window (accessed from the File Browser) still functions exactly as it did