### PR TITLE
[Web] Fix Emscripten for WebXR and update minimum version

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -9,7 +9,7 @@ env:
     tests=no
     debug_symbols=no
     use_closure_compiler=yes
-  EM_VERSION: 3.1.64
+  EM_VERSION: 4.0.11
 
 jobs:
   web-template:

--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 const GodotWebXR = {
-	$GodotWebXR__deps: ['$Browser', '$GL', '$GodotRuntime', '$runtimeKeepalivePush', '$runtimeKeepalivePop'],
+	$GodotWebXR__deps: ['$MainLoop', '$GL', '$GodotRuntime', '$runtimeKeepalivePush', '$runtimeKeepalivePop'],
 	$GodotWebXR: {
 		gl: null,
 
@@ -64,9 +64,9 @@ const GodotWebXR = {
 		},
 		monkeyPatchRequestAnimationFrame: (enable) => {
 			if (GodotWebXR.orig_requestAnimationFrame === null) {
-				GodotWebXR.orig_requestAnimationFrame = Browser.requestAnimationFrame;
+				GodotWebXR.orig_requestAnimationFrame = MainLoop.requestAnimationFrame;
 			}
-			Browser.requestAnimationFrame = enable
+			MainLoop.requestAnimationFrame = enable
 				? GodotWebXR.requestAnimationFrame
 				: GodotWebXR.orig_requestAnimationFrame;
 		},
@@ -76,11 +76,11 @@ const GodotWebXR = {
 			// enabled or disabled. When using the WebXR API Emulator, this
 			// gets picked up automatically, however, in the Oculus Browser
 			// on the Quest, we need to pause and resume the main loop.
-			Browser.mainLoop.pause();
+			MainLoop.pause();
 			runtimeKeepalivePush();
 			window.setTimeout(function () {
 				runtimeKeepalivePop();
-				Browser.mainLoop.resume();
+				MainLoop.resume();
 			}, 0);
 		},
 

--- a/platform/web/eslint.config.cjs
+++ b/platform/web/eslint.config.cjs
@@ -11,7 +11,6 @@ if (process && process.env && process.env.npm_command && !fs.existsSync('./platf
 }
 
 const emscriptenGlobals = {
-	'Browser': true,
 	'ERRNO_CODES': true,
 	'FS': true,
 	'GL': true,
@@ -22,6 +21,7 @@ const emscriptenGlobals = {
 	'HEAPU32': true,
 	'IDBFS': true,
 	'LibraryManager': true,
+	'MainLoop': true,
 	'Module': true,
 	'UTF8ToString': true,
 	'UTF8Decoder': true,


### PR DESCRIPTION
Supersedes #100489.

This fixes Emscripten for WebXR (replacing `Browser` for `MainLoop`).
It also updates the minimum Emscripten version to build Godot to ~~`4.0.10`~~ `4.0.0`.

> [!NOTE]
> By updating the minimum Emscripten version, we completely skip the need for a eslint preprocessor.