### PR TITLE
[3.x] Provide quick access to `Object` ancestry

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1937,6 +1937,7 @@ Object::Object() {
 	_can_translate = true;
 	_is_queued_for_deletion = false;
 	_emitting = false;
+	_ancestry = 0;
 	memset(_script_instance_bindings, 0, sizeof(void *) * MAX_SCRIPT_INSTANCE_BINDINGS);
 	script_instance = nullptr;
 	_rc.store(nullptr, std::memory_order_release);

--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -97,6 +97,7 @@ bool Reference::unreference() {
 }
 
 Reference::Reference() {
+	_define_ancestry(AncestralClass::REFERENCE);
 	refcount.init();
 	refcount_init.init();
 }

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -381,6 +381,7 @@ void Resource::_bind_methods() {
 
 Resource::Resource() :
 		remapped_list(this) {
+	_define_ancestry(AncestralClass::RESOURCE);
 #ifdef TOOLS_ENABLED
 	last_modified_time = 0;
 	import_last_modified_time = 0;

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -155,7 +155,9 @@ public:
 
 	virtual bool is_placeholder_fallback_enabled() const { return false; }
 
-	Script() {}
+	Script() {
+		_define_ancestry(AncestralClass::SCRIPT);
+	}
 };
 
 class ScriptInstance {

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2160,9 +2160,9 @@ Variant::Variant(const Object *p_object) {
 	Object *obj = const_cast<Object *>(p_object);
 
 	memnew_placement(_data._mem, ObjData);
-	Reference *ref = Object::cast_to<Reference>(obj);
-	if (unlikely(ref)) {
-		*reinterpret_cast<Ref<Reference> *>(_get_obj().ref.get_data()) = Ref<Reference>(ref);
+
+	if (obj && obj->has_ancestry(Object::AncestralClass::REFERENCE)) {
+		*reinterpret_cast<Ref<Reference> *>(_get_obj().ref.get_data()) = Ref<Reference>((Reference *)obj);
 		_get_obj().rc = nullptr;
 	} else {
 		_get_obj().rc = likely(obj) ? obj->_use_rc() : nullptr;

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -571,6 +571,8 @@ void Area2D::_bind_methods() {
 
 Area2D::Area2D() :
 		CollisionObject2D(RID_PRIME(Physics2DServer::get_singleton()->area_create()), true) {
+	_define_ancestry(AncestralClass::AREA_2D);
+
 	space_override = SPACE_OVERRIDE_DISABLED;
 	set_gravity(98);
 	set_gravity_vector(Vector2(0, 1));

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1367,6 +1367,8 @@ int CanvasItem::get_canvas_layer() const {
 
 CanvasItem::CanvasItem() :
 		xform_change(this) {
+	_define_ancestry(AncestralClass::CANVAS_ITEM);
+
 	canvas_item = RID_PRIME(VisualServer::get_singleton()->canvas_item_create());
 	visible = true;
 	pending_update = false;

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -479,6 +479,8 @@ void CollisionObject2D::_bind_methods() {
 }
 
 CollisionObject2D::CollisionObject2D(RID p_rid, bool p_area) {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_2D);
+
 	rid = p_rid;
 	area = p_area;
 	pickable = true;
@@ -494,6 +496,7 @@ CollisionObject2D::CollisionObject2D(RID p_rid, bool p_area) {
 }
 
 CollisionObject2D::CollisionObject2D() {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_2D);
 	//owner=
 
 	set_notify_transform(true);

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -452,6 +452,8 @@ StringName Node2D::get_property_store_alias(const StringName &p_property) const 
 #endif
 
 Node2D::Node2D() {
+	_define_ancestry(AncestralClass::NODE_2D);
+
 	angle = 0;
 	_scale = Vector2(1, 1);
 	_xform_dirty = false;

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -541,6 +541,8 @@ uint32_t CollisionObject::shape_find_owner(int p_shape_index) const {
 }
 
 CollisionObject::CollisionObject(RID p_rid, bool p_area) {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT);
+
 	rid = p_rid;
 	area = p_area;
 	capture_input_on_drag = false;
@@ -578,6 +580,8 @@ String CollisionObject::get_configuration_warning() const {
 }
 
 CollisionObject::CollisionObject() {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT);
+
 	capture_input_on_drag = false;
 	ray_pickable = true;
 	set_notify_transform(true);

--- a/scene/3d/mesh_instance.cpp
+++ b/scene/3d/mesh_instance.cpp
@@ -913,6 +913,8 @@ void MeshInstance::_bind_methods() {
 }
 
 MeshInstance::MeshInstance() {
+	_define_ancestry(AncestralClass::MESH_INSTANCE);
+
 	skeleton_path = NodePath("..");
 	software_skinning = nullptr;
 	software_skinning_flags = SoftwareSkinning::FLAG_TRANSFORM_NORMALS;

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -113,6 +113,7 @@ String PhysicsBody::get_configuration_warning() const {
 
 PhysicsBody::PhysicsBody(PhysicsServer::BodyMode p_mode) :
 		CollisionObject(RID_PRIME(PhysicsServer::get_singleton()->body_create(p_mode)), false) {
+	_define_ancestry(AncestralClass::PHYSICS_BODY);
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -1268,6 +1268,8 @@ void Spatial::_bind_methods() {
 
 Spatial::Spatial() :
 		xform_change(this), _client_physics_interpolation_spatials_list(this) {
+	_define_ancestry(AncestralClass::SPATIAL);
+
 	data.dirty = DIRTY_NONE;
 	data.children_lock = 0;
 

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -208,6 +208,8 @@ RID VisualInstance::get_base() const {
 }
 
 VisualInstance::VisualInstance() {
+	_define_ancestry(AncestralClass::VISUAL_INSTANCE);
+
 	instance = RID_PRIME(VisualServer::get_singleton()->instance_create());
 	VisualServer::get_singleton()->instance_attach_object_instance_id(instance, get_instance_id());
 	layers = 1;
@@ -357,6 +359,8 @@ void GeometryInstance::_bind_methods() {
 }
 
 GeometryInstance::GeometryInstance() {
+	_define_ancestry(AncestralClass::GEOMETRY_INSTANCE);
+
 	for (int i = 0; i < FLAG_MAX; i++) {
 		flags[i] = false;
 	}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2959,6 +2959,8 @@ void Control::_bind_methods() {
 }
 
 Control::Control() {
+	_define_ancestry(AncestralClass::CONTROL);
+
 	data.parent = nullptr;
 
 	data.mouse_filter = MOUSE_FILTER_STOP;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3291,6 +3291,8 @@ String Node::_get_name_num_separator() {
 }
 
 Node::Node() {
+	_define_ancestry(AncestralClass::NODE);
+
 	data.pos = -1;
 	data.depth = -1;
 	data.blocked = 0;


### PR DESCRIPTION
Although we have increased `Object::cast_to` performance significantly with #103708 (4.x) and #104825 (3.x) we discussed at the time that for some high performance bottleneck scenarios we may want an even faster way of determining whether an `Object` is one of the key main types.

At the time I trialed using a bitfield to store this info and it worked well, and is likely to be one of the fastest methods, and discussed this with @Ivorforce .

While it involves storing (and retrieving) data from the `Object / Node` (thus cache effects), it avoids overheads with a virtual function approach, and the virtual function requires reading the `vtable` from the object, so there is a read in all cases I think.

## Benchmarks
In order to compare the different approaches, I benchmarked between:
* ancestry (this PR currently)
* virtual function (e.g. `virtual bool is_spatial()`)
* `Object::cast_to<Spatial>`

I wrote gdscript to create a node with 200,000 children, alternating `Node` and `Spatial`. The reason for alternating and the count is to ensure that the optimizer doesn't optimize out the benchmark (although the alternating may make things easier for branch predictor compared to random).

Created a `benchmark` c++ function:

<details>

```
void Node::benchmark_ancestry() {
	int num_children = get_child_count();
	uint32_t num_iterations = 100;
	uint32_t count = 0;
	
	// Heat cache
	for (uint32_t iter = 0; iter < 1; iter++) {
		for (int n = 0; n < num_children; n++) {
			Node *child = get_child(n);
			if (child->test_ancestry(AncestralClass::ANCESTRAL_CLASS_SPATIAL)) {
				count++;
			}
		}
	}
	
	
	uint64_t before = OS::get_singleton()->get_ticks_usec();
	for (uint32_t iter = 0; iter < num_iterations; iter++) {
		for (int n = 0; n < num_children; n++) {
			Node *child = get_child(n);
			if (child->test_ancestry(AncestralClass::ANCESTRAL_CLASS_SPATIAL)) {
				count++;
			}
		}
	}
	uint64_t after = OS::get_singleton()->get_ticks_usec();
	uint64_t ancestry_time = after - before;
	
	
	before = OS::get_singleton()->get_ticks_usec();
	for (uint32_t iter = 0; iter < num_iterations; iter++) {
		for (int n = 0; n < num_children; n++) {
			Node *child = get_child(n);
			if (child->virtual_is_spatial()) {
				count++;
			}
		}
	}
	after = OS::get_singleton()->get_ticks_usec();
	uint64_t virtual_time = after - before;

	before = OS::get_singleton()->get_ticks_usec();
	for (uint32_t iter = 0; iter < num_iterations; iter++) {
		for (int n = 0; n < num_children; n++) {
			Node *child = get_child(n);
			if (Object::cast_to<Spatial>(child)) {
				count++;
			}
		}
	}
	after = OS::get_singleton()->get_ticks_usec();
	uint64_t cast_time = after - before;

	print_line("ancestry " + itos(ancestry_time) + ", virtual " + itos(virtual_time) + ", cast " + itos(cast_time));
	print_line("count " + itos(count));
}

```

</details>

### Results

_Godot Engine v3.7.dev.custom_build [57304c0ce] - X11 - 2 monitors - GLES2 - Mesa Intel(R) Graphics (RPL-S) - 13th Gen Intel(R) Core(TM) i7-13700T (24 threads)_

#### 200,000 node children
_release_
ancestry 85793, virtual 86305, cast 103659
_debug_
ancestry 350618, virtual 249225, cast 308729

#### 2000 node children
_release_
ancestry 175, virtual 297, cast 344
_debug_
ancestry 2719, virtual 2804, cast 3386

## Discussion
Well, as I suspected, this is a turnup for the books. I did question whether the cache slowdown of actually reading the data would compare to the overhead of a virtual function, and it turns out to be closer than we thought.

In release, with large numbers of children, storing the type on the object (ancestry) and virtual seem to be neck and neck, with `cast_to` not _that_ much slower.

With a smaller number of children, the results seem to flip, and everything is more likely to be in cache, so the costs of reading the object are lower, and the ancestry approach clearly wins. So with large numbers of nodes, memory read speed may be the bottleneck, and with smaller numbers of nodes, the processing itself may be more a bottleneck.

So the question at the moment is which approach is likely to be faster _in the wild_, and by how much. At the moment it looks like ancestry is fastest in all cases, but possibly not by a huge margin once we have a really large number of nodes, or cache is cold. We also have to bear in mind this might be hardware dependent as memory read speed / cache versus virtual overhead may vary e.g. on mobile.

Also I have realized that we need to read from the memory in both cases. Even for virtual function, we need to read the `vtable` pointer from the object in RAM, so there should in theory *always* be more work for the virtual approach (though it uses no memory on the object itself).

## Power use on mobile
I also considered power use on mobile, and asked Grok:
> For 200,000 objects, virtual calls could consume 2–5x more power, depending on cache hit rates and branch prediction success.

## Notes
* Only having a single usage so far to keep the PR simple, and @Ivorforce can do a follow up to convert `cast_to` to use `Ancestry` for the specific cases covered, so it will invisibly be used everywhere.
* I'm not absolutely sure yet on using the name "ancestry", as we also tend to use this to refer to ancestors in the scene tree (parents of parent), rather than in terms of inheritance. But the principle should stand whichever name we go for, if we did go with this approach.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
