### PR TITLE
Add extra options for find bar in docs

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -33,6 +33,7 @@
 #include "core/os/thread.h"
 #include "editor/doc_tools.h"
 #include "editor/plugins/editor_plugin.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/rich_text_label.h"
@@ -48,6 +49,17 @@ class FindBar : public HBoxContainer {
 	Button *find_next = nullptr;
 	Label *matches_label = nullptr;
 	Button *hide_button = nullptr;
+	CheckBox *case_sensitive = nullptr;
+	CheckBox *whole_words = nullptr;
+
+	enum {
+		SEARCH_MATCH_CASE = 1 << 0,
+		SEARCH_WHOLE_WORDS = 1 << 1,
+		SEARCH_BACKWARDS = 1 << 2,
+		SEARCH_CONTINUE = 1 << 3,
+	};
+
+	uint32_t flags = 0;
 
 	RichTextLabel *rich_text_label = nullptr;
 
@@ -58,20 +70,25 @@ class FindBar : public HBoxContainer {
 	virtual void input(const Ref<InputEvent> &p_event) override;
 
 	void _hide_bar();
+	void _search_options_changed(bool p_pressed);
 
 	void _search_text_changed(const String &p_text);
 	void _search_text_submitted(const String &p_text);
 
-	void _update_results_count(bool p_search_previous);
+	void _update_results_count(bool p_search_previous, bool p_search_match_case, bool p_search_whole_words);
 	void _update_matches_label();
+
+	void _update_flags(bool p_direction_backwards, bool p_continue = true);
 
 protected:
 	void _notification(int p_what);
 
-	bool _search(bool p_search_previous = false);
+	bool _search();
 
 public:
 	void set_rich_text_label(RichTextLabel *p_rich_text_label);
+	bool is_case_sensitive() const;
+	bool is_whole_words() const;
 
 	void popup_search();
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -627,8 +627,8 @@ private:
 	void _find_click(ItemFrame *p_frame, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool *r_outside = nullptr, bool p_meta = false);
 
 	String _get_line_text(ItemFrame *p_frame, int p_line, Selection p_sel) const;
-	bool _search_line(ItemFrame *p_frame, int p_line, const String &p_string, int p_char_idx, bool p_reverse_search);
-	bool _search_table(ItemTable *p_table, List<Item *>::Element *p_from, const String &p_string, bool p_reverse_search);
+	bool _search_line(ItemFrame *p_frame, int p_line, const String &p_string, int p_char_idx, bool p_reverse_search, bool p_search_match_case, bool p_search_whole_words);
+	bool _search_table(ItemTable *p_table, List<Item *>::Element *p_from, const String &p_string, bool p_reverse_search, bool p_search_match_case, bool p_search_whole_words);
 
 	float _shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, float p_h, int *r_char_offset);
 	float _resize_line(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size, int p_width, float p_h);
@@ -851,6 +851,7 @@ public:
 	void set_fit_content(bool p_enabled);
 	bool is_fit_content_enabled() const;
 
+	bool search_ex(const String &p_string, bool p_from_selection = false, bool p_search_previous = false, bool p_search_match_case = false, bool p_search_whole_words = false);
 	bool search(const String &p_string, bool p_from_selection = false, bool p_search_previous = false);
 
 	void scroll_to_paragraph(int p_paragraph);


### PR DESCRIPTION
QoL enhancement, which adds a `Match Case` and `Whole Words` check boxes to `FindBar` in editor docs:

![изображение](https://github.com/user-attachments/assets/7e117aea-2dd9-4dd6-965f-fdc3cc3ae864)
