### PR TITLE
Fix debugger inspector minimum size

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -417,18 +417,11 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 	variables->prop_values[type + n][0] = v;
 	variables->update();
 	edit(variables);
-
-	// To prevent constantly resizing when using filtering.
-	int size_x = get_size().x;
-	if (size_x > get_custom_minimum_size().x) {
-		set_custom_minimum_size(Size2(size_x, 0));
-	}
 }
 
 void EditorDebuggerInspector::clear_stack_variables() {
 	variables->clear();
 	variables->update();
-	set_custom_minimum_size(Size2(0, 0));
 }
 
 String EditorDebuggerInspector::get_stack_variable(const String &p_var) {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/104535

Setting custom minimum size is no longer necessary, it doesn't change size when filtering.
SplitContainer was changed after it was added to keep the size the same and ignores minimum size.