### PR TITLE
Display AnimationTree editor warnings when the node is disabled

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -595,11 +595,7 @@ void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 
 			String error;
 
-			if (!tree->is_active()) {
-				error = TTR("AnimationTree is inactive.\nActivate to enable playback, check node warnings if activation fails.");
-			} else if (tree->is_state_invalid()) {
-				error = tree->get_invalid_state_reason();
-			}
+			error = tree->get_editor_error_message();
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -818,11 +818,9 @@ void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 
 			String error;
 
-			if (!tree->is_active()) {
-				error = TTR("AnimationTree is inactive.\nActivate to enable playback, check node warnings if activation fails.");
-			} else if (tree->is_state_invalid()) {
-				error = tree->get_invalid_state_reason();
-			} else if (blend_space->get_triangle_count() == 0) {
+			error = tree->get_editor_error_message();
+
+			if (error.is_empty() && blend_space->get_triangle_count() == 0) {
 				error = TTR("No triangles exist, so no blending can take place.");
 			}
 

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -970,11 +970,7 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 
 			String error;
 
-			if (!tree->is_active()) {
-				error = TTR("AnimationTree is inactive.\nActivate to enable playback, check node warnings if activation fails.");
-			} else if (tree->is_state_invalid()) {
-				error = tree->get_invalid_state_reason();
-			}
+			error = tree->get_editor_error_message();
 
 			if (error != error_label->get_text()) {
 				error_label->set_text(error);

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -1395,11 +1395,11 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 			if (error_time > 0) {
 				error = error_text;
 				error_time -= get_process_delta_time();
-			} else if (!tree->is_active()) {
-				error = TTR("AnimationTree is inactive.\nActivate to enable playback, check node warnings if activation fails.");
-			} else if (tree->is_state_invalid()) {
-				error = tree->get_invalid_state_reason();
-			} else if (playback.is_null()) {
+			} else {
+				error = tree->get_editor_error_message();
+			}
+
+			if (error.is_empty() && playback.is_null()) {
 				error = vformat(TTR("No playback resource set at path: %s."), AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 			}
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -982,6 +982,20 @@ real_t AnimationTree::get_connection_activity(const StringName &p_path, int p_co
 	return activity[p_connection].activity;
 }
 
+#ifdef TOOLS_ENABLED
+String AnimationTree::get_editor_error_message() const {
+	if (!is_active()) {
+		return TTR("The AnimationTree is inactive.\nActivate it in the inspector to enable playback; check node warnings if activation fails.");
+	} else if (!is_enabled()) {
+		return TTR("The AnimationTree node (or one of its parents) has its process mode set to Disabled.\nChange the process mode in the inspector to allow playback.");
+	} else if (is_state_invalid()) {
+		return get_invalid_state_reason();
+	}
+
+	return "";
+}
+#endif
+
 void AnimationTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tree_root", "animation_node"), &AnimationTree::set_root_animation_node);
 	ClassDB::bind_method(D_METHOD("get_tree_root"), &AnimationTree::get_root_animation_node);

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -351,6 +351,10 @@ public:
 
 	uint64_t get_last_process_pass() const;
 
+#ifdef TOOLS_ENABLED
+	String get_editor_error_message() const;
+#endif
+
 	AnimationTree();
 	~AnimationTree();
 };


### PR DESCRIPTION
AnimationTree's Active property isn't the only way to control whether an AnimationTree can play animations. Node's Process Mode property also affects it.

## Preview

![image](https://github.com/user-attachments/assets/2df43056-0e83-437c-9480-e8a7a7e8f4b6)