### PR TITLE
Remove implicit conversions between `LocalVector` and `Vector`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -316,7 +316,7 @@ public:
 		insert(i, p_val);
 	}
 
-	operator Vector<T>() const {
+	explicit operator Vector<T>() const {
 		Vector<T> ret;
 		ret.resize(count);
 		T *w = ret.ptrw();

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1443,8 +1443,8 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 		tex_to->tex_id = 0;
 	}
 
-	Vector<RID> proxies_to_update = tex_to->proxies;
-	Vector<RID> proxies_to_redirect = tex_from->proxies;
+	Vector<RID> proxies_to_update = Vector<RID>(tex_to->proxies);
+	Vector<RID> proxies_to_redirect = Vector<RID>(tex_from->proxies);
 
 	*tex_to = *tex_from;
 

--- a/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -162,15 +162,15 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 					continue;
 				}
 				bones[0] = current_bone;
-				surface_tool->set_bones(bones);
-				surface_tool->set_weights(weights);
+				surface_tool->set_bones(Vector<int>(bones));
+				surface_tool->set_weights(Vector<float>(weights));
 				axis = global_pose.xform(axis * p_simulator->get_end_bone_length(i));
 				draw_line(surface_tool, global_pose.origin, axis, bone_color);
 				draw_sphere(surface_tool, global_pose.basis, axis, p_simulator->get_joint_radius(i, j), bone_color);
 			} else {
 				bones[0] = current_bone;
-				surface_tool->set_bones(bones);
-				surface_tool->set_weights(weights);
+				surface_tool->set_bones(Vector<int>(bones));
+				surface_tool->set_weights(Vector<float>(weights));
 				if (j == 0) {
 					// Draw rotation axis vector if not ROTATION_AXIS_ALL.
 					SpringBoneSimulator3D::RotationAxis rotation_axis = p_simulator->get_joint_rotation_axis(i, j);

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1706,12 +1706,12 @@ Ref<ArrayMesh> Skeleton3DGizmoPlugin::get_bones_mesh(Skeleton3D *p_skeleton, int
 				case 0: { // Wire shape.
 					surface_tool->set_color(current_bone_color);
 					bones[0] = current_bone_idx;
-					surface_tool->set_bones(bones);
-					surface_tool->set_weights(weights);
+					surface_tool->set_bones(Vector<int>(bones));
+					surface_tool->set_weights(Vector<float>(weights));
 					surface_tool->add_vertex(v0);
 					bones[0] = child_bone_idx;
-					surface_tool->set_bones(bones);
-					surface_tool->set_weights(weights);
+					surface_tool->set_bones(Vector<int>(bones));
+					surface_tool->set_weights(Vector<float>(weights));
 					surface_tool->add_vertex(v1);
 				} break;
 
@@ -1737,19 +1737,19 @@ Ref<ArrayMesh> Skeleton3DGizmoPlugin::get_bones_mesh(Skeleton3D *p_skeleton, int
 							point += axis * dist * 0.1;
 
 							bones[0] = current_bone_idx;
-							surface_tool->set_bones(bones);
-							surface_tool->set_weights(weights);
+							surface_tool->set_bones(Vector<int>(bones));
+							surface_tool->set_weights(Vector<float>(weights));
 							surface_tool->add_vertex(v0);
-							surface_tool->set_bones(bones);
-							surface_tool->set_weights(weights);
+							surface_tool->set_bones(Vector<int>(bones));
+							surface_tool->set_weights(Vector<float>(weights));
 							surface_tool->add_vertex(point);
 
-							surface_tool->set_bones(bones);
-							surface_tool->set_weights(weights);
+							surface_tool->set_bones(Vector<int>(bones));
+							surface_tool->set_weights(Vector<float>(weights));
 							surface_tool->add_vertex(point);
 							bones[0] = child_bone_idx;
-							surface_tool->set_bones(bones);
-							surface_tool->set_weights(weights);
+							surface_tool->set_bones(Vector<int>(bones));
+							surface_tool->set_weights(Vector<float>(weights));
 							surface_tool->add_vertex(v1);
 							points[point_idx++] = point;
 						}
@@ -1758,11 +1758,11 @@ Ref<ArrayMesh> Skeleton3DGizmoPlugin::get_bones_mesh(Skeleton3D *p_skeleton, int
 					SWAP(points[1], points[2]);
 					bones[0] = current_bone_idx;
 					for (int j = 0; j < 6; j++) {
-						surface_tool->set_bones(bones);
-						surface_tool->set_weights(weights);
+						surface_tool->set_bones(Vector<int>(bones));
+						surface_tool->set_weights(Vector<float>(weights));
 						surface_tool->add_vertex(points[j]);
-						surface_tool->set_bones(bones);
-						surface_tool->set_weights(weights);
+						surface_tool->set_bones(Vector<int>(bones));
+						surface_tool->set_weights(Vector<float>(weights));
 						surface_tool->add_vertex(points[(j + 1) % 6]);
 					}
 				} break;
@@ -1772,11 +1772,11 @@ Ref<ArrayMesh> Skeleton3DGizmoPlugin::get_bones_mesh(Skeleton3D *p_skeleton, int
 			for (int j = 0; j < 3; j++) {
 				bones[0] = current_bone_idx;
 				surface_tool->set_color(axis_colors[j]);
-				surface_tool->set_bones(bones);
-				surface_tool->set_weights(weights);
+				surface_tool->set_bones(Vector<int>(bones));
+				surface_tool->set_weights(Vector<float>(weights));
 				surface_tool->add_vertex(v0);
-				surface_tool->set_bones(bones);
-				surface_tool->set_weights(weights);
+				surface_tool->set_bones(Vector<int>(bones));
+				surface_tool->set_weights(Vector<float>(weights));
 				surface_tool->add_vertex(v0 + (p_skeleton->get_bone_global_rest(current_bone_idx).basis.inverse())[j].normalized() * dist * bone_axis_length);
 
 				if (j == closest) {
@@ -1789,11 +1789,11 @@ Ref<ArrayMesh> Skeleton3DGizmoPlugin::get_bones_mesh(Skeleton3D *p_skeleton, int
 				for (int j = 0; j < 3; j++) {
 					bones[0] = child_bone_idx;
 					surface_tool->set_color(axis_colors[j]);
-					surface_tool->set_bones(bones);
-					surface_tool->set_weights(weights);
+					surface_tool->set_bones(Vector<int>(bones));
+					surface_tool->set_weights(Vector<float>(weights));
 					surface_tool->add_vertex(v1);
-					surface_tool->set_bones(bones);
-					surface_tool->set_weights(weights);
+					surface_tool->set_bones(Vector<int>(bones));
+					surface_tool->set_weights(Vector<float>(weights));
 					surface_tool->add_vertex(v1 + (p_skeleton->get_bone_global_rest(child_bone_idx).basis.inverse())[j].normalized() * dist * bone_axis_length);
 
 					if (j == closest) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -665,7 +665,7 @@ String GDScriptWorkspace::get_file_uri(const String &p_path) const {
 	}
 
 	// Always return file URI's with authority part (encoding drive letters with leading slash), to maintain compat with RFC-1738 which required it.
-	return "file:///" + String("/").join(encoded_parts);
+	return "file:///" + String("/").join(Vector<String>(encoded_parts));
 }
 
 void GDScriptWorkspace::publish_diagnostics(const String &p_path) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2988,9 +2988,9 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 						}
 					}
 					gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i);
-					attributes[gltf_texcoord_key] = _encode_accessor_as_vec2(p_state, first_channel, true);
+					attributes[gltf_texcoord_key] = _encode_accessor_as_vec2(p_state, Vector<Vector2>(first_channel), true);
 					gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i + 1);
-					attributes[gltf_texcoord_key] = _encode_accessor_as_vec2(p_state, second_channel, true);
+					attributes[gltf_texcoord_key] = _encode_accessor_as_vec2(p_state, Vector<Vector2>(second_channel), true);
 				}
 			}
 			{

--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -239,7 +239,7 @@ void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 }
 
 Vector<uint8_t> AudioStreamMP3::get_data() const {
-	return data;
+	return Vector<uint8_t>(data);
 }
 
 void AudioStreamMP3::set_loop(bool p_enable) {

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -101,7 +101,7 @@ Vector<uint8_t> WaylandThread::_read_fd(int fd) {
 		data.resize(bytes_read + chunk_size);
 	}
 
-	return data;
+	return Vector<uint8_t>(data);
 }
 
 // Based on the wayland book's shared memory boilerplate (PD/CC0).

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -172,7 +172,7 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 	replaces["$GODOT_CONFIG"] = str_config;
 	replaces["$GODOT_SPLASH_COLOR"] = "#" + Color(get_project_setting(p_preset, "application/boot_splash/bg_color")).to_html(false);
 
-	LocalVector<String> godot_splash_classes;
+	Vector<String> godot_splash_classes;
 	godot_splash_classes.push_back("show-image--" + String(get_project_setting(p_preset, "application/boot_splash/show_image")));
 	godot_splash_classes.push_back("fullsize--" + String(get_project_setting(p_preset, "application/boot_splash/fullsize")));
 	godot_splash_classes.push_back("use-filter--" + String(get_project_setting(p_preset, "application/boot_splash/use_filter")));

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -139,7 +139,7 @@ void AnimationNode::get_child_nodes(List<ChildNode> *r_child_nodes) {
 
 void AnimationNode::blend_animation(const StringName &p_animation, AnimationMixer::PlaybackInfo p_playback_info) {
 	ERR_FAIL_NULL(process_state);
-	p_playback_info.track_weights = node_state.track_weights;
+	p_playback_info.track_weights = Vector<real_t>(node_state.track_weights);
 	process_state->tree->make_animation_instance(p_animation, p_playback_info);
 }
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -622,7 +622,7 @@ void SceneDebugger::_send_object_ids(const Vector<ObjectID> &p_ids, bool p_updat
 	}
 
 	if (p_update_selection) {
-		RuntimeNodeSelect::get_singleton()->_set_selected_nodes(nodes);
+		RuntimeNodeSelect::get_singleton()->_set_selected_nodes(Vector<Node *>(nodes));
 	}
 
 	if (objs_missing) {
@@ -2008,7 +2008,7 @@ void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_i
 		EngineDebugger::get_singleton()->send_message("remote_objects_selected", message);
 	}
 
-	_set_selected_nodes(nodes);
+	_set_selected_nodes(Vector<Node *>(nodes));
 }
 
 void RuntimeNodeSelect::_set_selected_nodes(const Vector<Node *> &p_nodes) {

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1615,7 +1615,7 @@ void GraphEdit::_draw_minimap_connection_line(const Vector2 &p_from_graph_positi
 		colors.push_back(p_from_color.lerp(p_to_color, normalized_curve_position));
 	}
 
-	minimap->draw_polyline_colors(points, colors, 0.5, lines_antialiased);
+	minimap->draw_polyline_colors(points, Vector<Color>(colors), 0.5, lines_antialiased);
 }
 
 void GraphEdit::_update_connections() {

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -6424,7 +6424,7 @@ void TileData::set_collision_polygon_points(int p_layer_id, int p_polygon_index,
 Vector<Vector2> TileData::get_collision_polygon_points(int p_layer_id, int p_polygon_index) const {
 	ERR_FAIL_INDEX_V(p_layer_id, physics.size(), Vector<Vector2>());
 	ERR_FAIL_INDEX_V(p_polygon_index, physics[p_layer_id].polygons.size(), Vector<Vector2>());
-	return physics[p_layer_id].polygons[p_polygon_index].polygon;
+	return Vector<Vector2>(physics[p_layer_id].polygons[p_polygon_index].polygon);
 }
 
 void TileData::set_collision_polygon_one_way(int p_layer_id, int p_polygon_index, bool p_one_way) {

--- a/scene/resources/3d/convex_polygon_shape_3d.cpp
+++ b/scene/resources/3d/convex_polygon_shape_3d.cpp
@@ -65,7 +65,7 @@ Ref<ArrayMesh> ConvexPolygonShape3D::get_debug_arraymesh_faces(const Color &p_mo
 		Geometry3D::MeshData md;
 		Error err = ConvexHullComputer::convex_hull(hull_points, md);
 		if (err == OK) {
-			verts = md.vertices;
+			verts = Vector<Vector3>(md.vertices);
 			for (int i = 0; i < verts.size(); i++) {
 				colors.push_back(p_modulate);
 			}

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -886,7 +886,7 @@ Ref<ConvexPolygonShape3D> ImporterMesh::create_convex_shape(bool p_clean, bool p
 		Geometry3D::MeshData md;
 		Error err = ConvexHullComputer::convex_hull(vertices, md);
 		if (err == OK) {
-			shape->set_points(md.vertices);
+			shape->set_points(Vector<Vector3>(md.vertices));
 			return shape;
 		} else {
 			ERR_PRINT("Convex shape cleaning failed, falling back to simpler process.");

--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -525,7 +525,7 @@ void AudioStreamWAV::set_data(const Vector<uint8_t> &p_data) {
 }
 
 Vector<uint8_t> AudioStreamWAV::get_data() const {
-	return data;
+	return Vector<uint8_t>(data);
 }
 
 Error AudioStreamWAV::save_to_wav(const String &p_path) {

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -564,7 +564,7 @@ Ref<ConvexPolygonShape3D> Mesh::create_convex_shape(bool p_clean, bool p_simplif
 		Geometry3D::MeshData md;
 		Error err = ConvexHullComputer::convex_hull(vertices, md);
 		if (err == OK) {
-			shape->set_points(md.vertices);
+			shape->set_points(Vector<Vector3>(md.vertices));
 			return shape;
 		} else {
 			ERR_PRINT("Convex shape cleaning failed, falling back to simpler process.");

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -4426,7 +4426,7 @@ static RD::FramebufferFormatID _get_depth_framebuffer_format_for_pipeline(bool p
 
 	passes.ptrw()[0].depth_attachment = 0;
 
-	return RD::get_singleton()->framebuffer_format_create_multipass(attachments, passes);
+	return RD::get_singleton()->framebuffer_format_create_multipass(Vector<RD::AttachmentFormat>(attachments), passes);
 }
 
 static RD::FramebufferFormatID _get_shadow_cubemap_framebuffer_format_for_pipeline() {
@@ -4438,7 +4438,7 @@ static RD::FramebufferFormatID _get_shadow_cubemap_framebuffer_format_for_pipeli
 	attachment.usage_flags = RendererRD::LightStorage::get_cubemap_depth_usage_bits();
 	attachments.push_back(attachment);
 
-	return RD::get_singleton()->framebuffer_format_create(attachments);
+	return RD::get_singleton()->framebuffer_format_create(Vector<RD::AttachmentFormat>(attachments));
 }
 
 static RD::FramebufferFormatID _get_shadow_atlas_framebuffer_format_for_pipeline(bool p_use_16_bits) {
@@ -4450,7 +4450,7 @@ static RD::FramebufferFormatID _get_shadow_atlas_framebuffer_format_for_pipeline
 	attachment.usage_flags = RendererRD::LightStorage::get_shadow_atlas_depth_usage_bits();
 	attachments.push_back(attachment);
 
-	return RD::get_singleton()->framebuffer_format_create(attachments);
+	return RD::get_singleton()->framebuffer_format_create(Vector<RD::AttachmentFormat>(attachments));
 }
 
 static RD::FramebufferFormatID _get_reflection_probe_depth_framebuffer_format_for_pipeline() {
@@ -4462,7 +4462,7 @@ static RD::FramebufferFormatID _get_reflection_probe_depth_framebuffer_format_fo
 	attachment.usage_flags = RendererRD::LightStorage::get_reflection_probe_depth_usage_bits();
 	attachments.push_back(attachment);
 
-	return RD::get_singleton()->framebuffer_format_create(attachments);
+	return RD::get_singleton()->framebuffer_format_create(Vector<RD::AttachmentFormat>(attachments));
 }
 
 void RenderForwardClustered::_mesh_compile_pipeline_for_surface(SceneShaderForwardClustered::ShaderData *p_shader, void *p_mesh_surface, bool p_ubershader, bool p_instanced_surface, RS::PipelineSource p_source, SceneShaderForwardClustered::ShaderData::PipelineKey &r_pipeline_key, Vector<ShaderPipelinePair> *r_pipeline_pairs) {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -3097,7 +3097,7 @@ static RD::FramebufferFormatID _get_shadow_cubemap_framebuffer_format_for_pipeli
 	attachment.usage_flags = RendererRD::LightStorage::get_cubemap_depth_usage_bits();
 	attachments.push_back(attachment);
 
-	return RD::get_singleton()->framebuffer_format_create(attachments);
+	return RD::get_singleton()->framebuffer_format_create(Vector<RD::AttachmentFormat>(attachments));
 }
 
 static RD::FramebufferFormatID _get_shadow_atlas_framebuffer_format_for_pipeline(bool p_use_16_bits) {
@@ -3109,7 +3109,7 @@ static RD::FramebufferFormatID _get_shadow_atlas_framebuffer_format_for_pipeline
 	attachment.usage_flags = RendererRD::LightStorage::get_shadow_atlas_depth_usage_bits();
 	attachments.push_back(attachment);
 
-	return RD::get_singleton()->framebuffer_format_create(attachments);
+	return RD::get_singleton()->framebuffer_format_create(Vector<RD::AttachmentFormat>(attachments));
 }
 
 void RenderForwardMobile::_mesh_compile_pipeline_for_surface(SceneShaderForwardMobile::ShaderData *p_shader, void *p_mesh_surface, bool p_instanced_surface, RS::PipelineSource p_source, SceneShaderForwardMobile::ShaderData::PipelineKey &r_pipeline_key, Vector<ShaderPipelinePair> *r_pipeline_pairs) {


### PR DESCRIPTION
`Vector` copy-conversion to `LocalVector`, and vice versa, are costly. Conversions are currently implicit, which allows them to happen by accident. This PR changes existing conversions (seems to just be one-way right now) to be explicit instead, preventing accidental performance sinks.

The change exposes current unintended conversions. @godotengine/rendering may want to have a look especially, since there are some conversions that should maybe be addressed.
