### PR TITLE
Fix various errors in the class reference

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2956,7 +2956,7 @@
 			Hints that a property will be changed on its own after setting, such as [member AudioStreamPlayer.playing] or [member GPUParticles3D.emitting].
 		</constant>
 		<constant name="PROPERTY_HINT_GROUP_ENABLE" value="42" enum="PropertyHint">
-			Hints that a boolean property will enable the feature associated with the group that it occurs in. Only works within a group or subgroup. Use the optional hint string [code]"feature"[/code] when the group only has variables that are meaningful when the feature is enabled.
+			Hints that a boolean property will enable the feature associated with the group that it occurs in. Only works within a group or subgroup. Use the optional hint string [code]"feature"[/code] when the group only has properties that are meaningful when the feature is enabled.
 			[b]Note:[/b] The [code]"feature"[/code] hint string does not modify or reset any values.
 		</constant>
 		<constant name="PROPERTY_HINT_INPUT_NAME" value="43" enum="PropertyHint">

--- a/doc/classes/CPUParticles2D.xml
+++ b/doc/classes/CPUParticles2D.xml
@@ -91,7 +91,7 @@
 			<param index="0" name="particle_flag" type="int" enum="CPUParticles2D.ParticleFlags" />
 			<param index="1" name="enable" type="bool" />
 			<description>
-				Enables or disables the given flag.
+				Enables or disables the given particle flag.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -37,7 +37,7 @@
 			<description>
 				Godot calls this method to test if [param data] from a control's [method _get_drag_data] can be dropped at [param at_position]. [param at_position] is local to this control.
 				This method should only be used to test the data. Process the data in [method _drop_data].
-				[b]Note:[/b] If drag was initiated by keyboard shortcut or [method accessibility_drag], [param at_position] is set to [code]Vector2(INFINITY, INFINITY)[/code] and the currently selected item/text position should be used as drop position.
+				[b]Note:[/b] If the drag was initiated by a keyboard shortcut or [method accessibility_drag], [param at_position] is set to [constant Vector2.INF], and the currently selected item/text position should be used as the drop position.
 				[codeblocks]
 				[gdscript]
 				func _can_drop_data(position, data):
@@ -62,7 +62,7 @@
 			<param index="1" name="data" type="Variant" />
 			<description>
 				Godot calls this method to pass you the [param data] from a control's [method _get_drag_data] result. Godot first calls [method _can_drop_data] to test if [param data] is allowed to drop at [param at_position] where [param at_position] is local to this control.
-				[b]Note:[/b] If drag was initiated by keyboard shortcut or [method accessibility_drag], [param at_position] is set to [code]Vector2(INFINITY, INFINITY)[/code] and the currently selected item/text position should be used as drop position.
+				[b]Note:[/b] If the drag was initiated by a keyboard shortcut or [method accessibility_drag], [param at_position] is set to [constant Vector2.INF], and the currently selected item/text position should be used as the drop position.
 				[codeblocks]
 				[gdscript]
 				func _can_drop_data(position, data):
@@ -98,7 +98,7 @@
 			<description>
 				Godot calls this method to get data that can be dragged and dropped onto controls that expect drop data. Returns [code]null[/code] if there is no data to drag. Controls that want to receive drop data should implement [method _can_drop_data] and [method _drop_data]. [param at_position] is local to this control. Drag may be forced with [method force_drag].
 				A preview that will follow the mouse that should represent the data can be set with [method set_drag_preview]. A good time to set the preview is in this method.
-				[b]Note:[/b] If drag was initiated by keyboard shortcut or [method accessibility_drag], [param at_position] is set to [code]Vector2(INFINITY, INFINITY)[/code] and the currently selected item/text position should be used as drop position.
+				[b]Note:[/b] If the drag was initiated by a keyboard shortcut or [method accessibility_drag], [param at_position] is set to [constant Vector2.INF], and the currently selected item/text position should be used as the drag position.
 				[codeblocks]
 				[gdscript]
 				func _get_drag_data(position):

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2045,7 +2045,7 @@
 			<return type="void" />
 			<description>
 				Stops synthesis in progress and removes all utterances from the queue.
-				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux (X11/Linux), macOS, and Windows.
+				[b]Note:[/b] This method is implemented on Android, iOS, Web, Linux (X11/Wayland), macOS, and Windows.
 			</description>
 		</method>
 		<method name="unregister_additional_output">
@@ -2856,13 +2856,13 @@
 			Set scroll offset action, callback argument is set to [Vector2] with the scroll offset.
 		</constant>
 		<constant name="ACTION_SET_VALUE" value="20" enum="AccessibilityAction">
-			Set value action action, callback argument is set to [String] or number with the new value.
+			Set value action, callback argument is set to [String] or number with the new value.
 		</constant>
 		<constant name="ACTION_SHOW_CONTEXT_MENU" value="21" enum="AccessibilityAction">
 			Show context menu action, callback argument is not set.
 		</constant>
 		<constant name="ACTION_CUSTOM" value="22" enum="AccessibilityAction">
-			Custom action, callback argument is set to the integer action id.
+			Custom action, callback argument is set to the integer action ID.
 		</constant>
 		<constant name="LIVE_OFF" value="0" enum="AccessibilityLiveMode">
 			Indicates that updates to the live region should not be presented.

--- a/doc/classes/FoldableContainer.xml
+++ b/doc/classes/FoldableContainer.xml
@@ -57,10 +57,10 @@
 			The container's title text.
 		</member>
 		<member name="title_alignment" type="int" setter="set_title_alignment" getter="get_title_alignment" enum="HorizontalAlignment" default="0">
-			Title's horizontal text alignment as defined in the [enum HorizontalAlignment] enum.
+			Title's horizontal text alignment.
 		</member>
 		<member name="title_position" type="int" setter="set_title_position" getter="get_title_position" enum="FoldableContainer.TitlePosition" default="0">
-			Title's position as defined in the [enum TitlePosition] enum.
+			Title's position.
 		</member>
 		<member name="title_text_direction" type="int" setter="set_title_text_direction" getter="get_title_text_direction" enum="Control.TextDirection" default="0">
 			Title text writing direction.

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -164,7 +164,7 @@
 			The number of stacked outlines.
 		</member>
 		<member name="stacked_shadow_count" type="int" setter="set_stacked_shadow_count" getter="get_stacked_shadow_count" default="0">
-			Returns the stacked shadow count.
+			The number of stacked shadows.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
Found several errors when translating the class reference:

- Entries displayed in the inspector are properties, not variables.
- The description of `LabelSettings.stacked_shadow_count` is written as if it's a method.
- `Control._get_drag_data()`: we should be considering drag position instead of drop position.
- Typos like `Linux (X11/Linux)`, ID capitalization and duplicated words.
- Unnecessary mention of enum types in `FoldableContainer` properties.
- Unnecessary difference between `CPUParticle{2D,3D}.set_particle_flag()` descriptions.