### PR TITLE
Fix global shader texture uniform

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -872,10 +872,14 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 						E->value = global_textures_pass;
 					}
 
-					if (v->override.get_type() == Variant::RID && ((RID)v->override).is_valid()) {
-						textures.push_back(v->override);
-					} else if (v->value.get_type() == Variant::RID && ((RID)v->value).is_valid()) {
-						textures.push_back(v->value);
+					RID override_rid = v->override;
+					if (override_rid.is_valid()) {
+						textures.push_back(override_rid);
+					} else {
+						RID value_rid = v->value;
+						if (value_rid.is_valid()) {
+							textures.push_back(value_rid);
+						}
 					}
 				}
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -906,10 +906,14 @@ void MaterialStorage::MaterialData::update_textures(const HashMap<StringName, Va
 						E->value = global_textures_pass;
 					}
 
-					if (v->override.get_type() == Variant::RID && ((RID)v->override).is_valid()) {
-						textures.push_back(v->override);
-					} else if (v->value.get_type() == Variant::RID && ((RID)v->value).is_valid()) {
-						textures.push_back(v->value);
+					RID override_rid = v->override;
+					if (override_rid.is_valid()) {
+						textures.push_back(override_rid);
+					} else {
+						RID value_rid = v->value;
+						if (value_rid.is_valid()) {
+							textures.push_back(value_rid);
+						}
 					}
 				}
 


### PR DESCRIPTION
Fixes #107470

`global_shader_parameter_add` can add a `Texture2D` object as a shader parameter, and it is implicitly converted to RID:
https://github.com/godotengine/godot/blob/591e70ff78c665ff11e1f21998d0e52fbc3f23c8/core/variant/variant.cpp#L2017

Additionally we can save the RID before `textures.push_back()` to avoid converting it twice..