### PR TITLE
Expose `exclude_from_capture` for main window.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1581,6 +1581,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
 	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
+	GLOBAL_DEF("display/window/size/exclude_from_capture", false);
 	GLOBAL_DEF("display/window/size/transparent", false);
 	GLOBAL_DEF("display/window/size/extend_to_title", false);
 	GLOBAL_DEF("display/window/size/no_focus", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -980,6 +980,10 @@
 			Forces the main window to be borderless.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and Web.
 		</member>
+		<member name="display/window/size/exclude_from_capture" type="bool" setter="" getter="" default="false">
+			Excludes the main window from screenshots.
+			[b]Note:[/b] This setting is implemented on macOS and Windows.
+		</member>
 		<member name="display/window/size/extend_to_title" type="bool" setter="" getter="" default="false">
 			Main window content is expanded to the full size of the window. Unlike a borderless window, the frame is left intact and can be used to resize the window, and the title bar is transparent, but has minimize/maximize/close buttons.
 			[b]Note:[/b] This setting is implemented only on macOS.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2595,6 +2595,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		if (bool(GLOBAL_GET("display/window/size/always_on_top"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_ALWAYS_ON_TOP_BIT;
 		}
+		if (bool(GLOBAL_GET("display/window/size/exclude_from_capture"))) {
+			window_flags |= DisplayServer::WINDOW_FLAG_EXCLUDE_FROM_CAPTURE_BIT;
+		}
 		if (bool(GLOBAL_GET("display/window/size/transparent"))) {
 			window_flags |= DisplayServer::WINDOW_FLAG_TRANSPARENT_BIT;
 		}


### PR DESCRIPTION
Adds project setting to set main window `exclude_from_capture`, like it is done with other window flags.