### PR TITLE
[macOS] Add `--path` argument when instance is created by project started from editor.

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -825,6 +825,18 @@ Error OS_MacOS::create_instance(const List<String> &p_arguments, ProcessID *r_ch
 	NSString *nsappname = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
 	if (nsappname != nil) {
 		String path = String::utf8([[[NSBundle mainBundle] bundlePath] UTF8String]);
+#ifdef TOOLS_ENABLED
+		if (Engine::get_singleton() && !Engine::get_singleton()->is_project_manager_hint() && !Engine::get_singleton()->is_editor_hint()) {
+			// Project started from the editor, inject "path" argument to set instance working directory.
+			char cwd[PATH_MAX];
+			if (::getcwd(cwd, sizeof(cwd)) != nullptr) {
+				List<String> arguments = p_arguments;
+				arguments.push_back("--path");
+				arguments.push_back(String::utf8(cwd));
+				return create_process(path, arguments, r_child_id, false);
+			}
+		}
+#endif
 		return create_process(path, p_arguments, r_child_id, false);
 	} else {
 		return create_process(get_executable_path(), p_arguments, r_child_id, false);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107414

Bundles do not have CWD set on its own, but it is convenient to be able to use `create_instance` when running project from the editor, so it should have CWD to have access to the unpacked project files.