### PR TITLE
[3.x] `Spatial` and `CanvasItem` children change to `LocalVector`

### DIFF
--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -186,8 +186,13 @@ private:
 	Color modulate;
 	Color self_modulate;
 
-	List<CanvasItem *> children_items;
-	List<CanvasItem *>::Element *C;
+	struct Data {
+		// An unordered vector of `CanvasItem` children only.
+		// This is a subset of the `Node::children`, purely
+		// an optimization for faster traversal.
+		LocalVector<CanvasItem *> canvas_item_children;
+		uint32_t index_in_parent = UINT32_MAX;
+	} data;
 
 	int light_mask;
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -141,8 +141,12 @@ private:
 
 		int children_lock;
 		Spatial *parent;
-		List<Spatial *> children;
-		List<Spatial *>::Element *C;
+
+		// An unordered vector of `Spatial` children only.
+		// This is a subset of the `Node::children`, purely
+		// an optimization for faster traversal.
+		LocalVector<Spatial *> spatial_children;
+		uint32_t index_in_parent = UINT32_MAX;
 
 		float lod_range = 10.0f;
 		ClientPhysicsInterpolationData *client_physics_interpolation_data;


### PR DESCRIPTION
`Spatial` maintains its own list of `Spatial`-only children (separate from the `Node`), in order to (in theory) make child iteration faster for only spatial children. The same happens with `CanvasItem` and `CanvasItem` children.

The problem is that these lists are stored as a linked list, and there is no reason to require linked list. Linked lists are bad for cache.

## Benchmark
[benchmark_spatial_children.zip](https://github.com/user-attachments/files/20721895/benchmark_spatial_children.zip)
_before:_ 157 fps
_after:_ 280 fps

The benchmark creates a large number of `Spatial` children to the root node, then rotates the root. This stresses the `_propagate_transform_changed()` which utilizes the children list.

## Notes
* This is actually a no brainer, I also tested removing the `Spatial` children list entirely and utilizing the `Node` children list instead with fast casting, but this PR is still faster (because of no need for cast checks).
* Some `NULL` checks in the original were redundant, I don't think these pointers can be `NULL` given the code here. 
* Also applicable in 4.x.
* I may end up being able to use this list for `SceneTreeFTI` now it is faster, instead of `Node` children. Not 100% on this yet, but worth looking into.
* Have done the same for `CanvasItem`, the same applies.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
