### PR TITLE
PCKPacker: Fix first file being written mis-aligned

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -111,6 +111,12 @@ Error PCKPacker::pck_start(const String &p_pck_path, int p_alignment, const Stri
 		file->store_32(0); // Reserved.
 	}
 
+	// Align for first file.
+	int pad = _get_pad(alignment, file->get_position());
+	for (int i = 0; i < pad; i++) {
+		file->store_8(0);
+	}
+
 	file_base = file->get_position();
 	file->seek(file_base_ofs);
 	file->store_64(file_base); // Update files base.

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1966,6 +1966,12 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 		f->store_32(0); // Reserved.
 	}
 
+	// Align for first file.
+	int file_padding = _get_pad(PCK_PADDING, f->get_position());
+	for (int i = 0; i < file_padding; i++) {
+		f->store_8(0);
+	}
+
 	uint64_t file_base = f->get_position();
 	f->seek(file_base_ofs);
 	f->store_64(file_base - pck_start_pos); // Update files base.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

cc @bruvzg 

In #105757 , when we changed the PCK format to have the directory come at the end of the files rather than before, we failed to account for the header size potentially causing misalignment on the first file. The header size is currently 104 bytes, so the default alignment of 32 would be not be respected for the first file. This PR fixes that by padding the header so that the file base starts at an aligned byte.
