### PR TITLE
`SceneTreeFTI` - miscellaneous speedups

### DIFF
--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -459,7 +459,7 @@ void SceneTreeFTI::_update_dirty_nodes(Node *p_node, uint32_t p_current_half_fra
 #endif
 
 	// Don't recurse into hidden branches.
-	if (s && !s->is_visible()) {
+	if (s && !s->data.visible) {
 		// NOTE : If we change from recursing entire tree, we should do an is_visible_in_tree()
 		// check for the first of the branch.
 		return;
@@ -593,7 +593,7 @@ void SceneTreeFTI::_update_dirty_nodes(Node *p_node, uint32_t p_current_half_fra
 
 	// Recurse to children.
 	for (uint32_t n = 0; n < num_children; n++) {
-		_update_dirty_nodes(p_node->get_child(n), p_current_half_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
+		_update_dirty_nodes(children.ptr()[n], p_current_half_frame, p_interpolation_fraction, p_active, s->data.fti_global_xform_interp_set ? &s->data.global_transform_interpolated : &s->data.global_transform, p_depth + 1);
 	}
 }
 


### PR DESCRIPTION
This is just a small PR, in case there is a delay to merging #107369 before the next beta (that PR will change how we fast access children).

This fixes up the second case in `_update_dirty_nodes()` to use fast child access (that @Ivorforce noticed yesterday, I accidentally reverted it in #106244 :blush: ).

Also accesses `data.visible` directly to avoid one thread guard.

## Notes
* There are also numerous unneeded thread guards around e.g. `get_transform()` in the function, but that needs a PR of its own.
* This is purely performance, no change in behaviour.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
