### PR TITLE
Remove the need to have a display name for built-in action overrides

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -358,40 +358,26 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_text_dedent",                                TTRC("Dedent") },
 	{ "ui_text_backspace",                             TTRC("Backspace") },
 	{ "ui_text_backspace_word",                        TTRC("Backspace Word") },
-	{ "ui_text_backspace_word.macos",                  TTRC("Backspace Word") },
 	{ "ui_text_backspace_all_to_left",                 TTRC("Backspace all to Left") },
-	{ "ui_text_backspace_all_to_left.macos",           TTRC("Backspace all to Left") },
 	{ "ui_text_delete",                                TTRC("Delete") },
 	{ "ui_text_delete_word",                           TTRC("Delete Word") },
-	{ "ui_text_delete_word.macos",                     TTRC("Delete Word") },
 	{ "ui_text_delete_all_to_right",                   TTRC("Delete all to Right") },
-	{ "ui_text_delete_all_to_right.macos",             TTRC("Delete all to Right") },
 	{ "ui_text_caret_left",                            TTRC("Caret Left") },
 	{ "ui_text_caret_word_left",                       TTRC("Caret Word Left") },
-	{ "ui_text_caret_word_left.macos",                 TTRC("Caret Word Left") },
 	{ "ui_text_caret_right",                           TTRC("Caret Right") },
 	{ "ui_text_caret_word_right",                      TTRC("Caret Word Right") },
-	{ "ui_text_caret_word_right.macos",                TTRC("Caret Word Right") },
 	{ "ui_text_caret_up",                              TTRC("Caret Up") },
 	{ "ui_text_caret_down",                            TTRC("Caret Down") },
 	{ "ui_text_caret_line_start",                      TTRC("Caret Line Start") },
-	{ "ui_text_caret_line_start.macos",                TTRC("Caret Line Start") },
 	{ "ui_text_caret_line_end",                        TTRC("Caret Line End") },
-	{ "ui_text_caret_line_end.macos",                  TTRC("Caret Line End") },
 	{ "ui_text_caret_page_up",                         TTRC("Caret Page Up") },
 	{ "ui_text_caret_page_down",                       TTRC("Caret Page Down") },
 	{ "ui_text_caret_document_start",                  TTRC("Caret Document Start") },
-	{ "ui_text_caret_document_start.macos",            TTRC("Caret Document Start") },
 	{ "ui_text_caret_document_end",                    TTRC("Caret Document End") },
-	{ "ui_text_caret_document_end.macos",              TTRC("Caret Document End") },
 	{ "ui_text_caret_add_below",                       TTRC("Caret Add Below") },
-	{ "ui_text_caret_add_below.macos",                 TTRC("Caret Add Below") },
 	{ "ui_text_caret_add_above",                       TTRC("Caret Add Above") },
-	{ "ui_text_caret_add_above.macos",                 TTRC("Caret Add Above") },
 	{ "ui_text_scroll_up",                             TTRC("Scroll Up") },
-	{ "ui_text_scroll_up.macos",                       TTRC("Scroll Up") },
 	{ "ui_text_scroll_down",                           TTRC("Scroll Down") },
-	{ "ui_text_scroll_down.macos",                     TTRC("Scroll Down") },
 	{ "ui_text_select_all",                            TTRC("Select All") },
 	{ "ui_text_select_word_under_caret",               TTRC("Select Word Under Caret") },
 	{ "ui_text_add_selection_for_next_occurrence",     TTRC("Add Selection for Next Occurrence") },
@@ -409,7 +395,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
 	{ "ui_filedialog_find",                            TTRC("Find") },
 	{ "ui_filedialog_focus_path",                      TTRC("Focus Path") },
-	{ "ui_swap_input_direction ",                      TTRC("Swap Input Direction") },
+	{ "ui_swap_input_direction",                       TTRC("Swap Input Direction") },
 	{ "ui_unicode_start",                              TTRC("Start Unicode Character Input") },
 	{ "ui_colorpicker_delete_preset",                  TTRC("ColorPicker: Delete Preset") },
 	{ "ui_accessibility_drag_and_drop",                TTRC("Accessibility: Keyboard Drag and Drop") },
@@ -418,10 +404,10 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 };
 
 String InputMap::get_builtin_display_name(const String &p_name) const {
+	const String name = p_name.get_slicec('.', 0);
 	constexpr int len = std_size(_builtin_action_display_names);
-
 	for (int i = 0; i < len; i++) {
-		if (_builtin_action_display_names[i].name == p_name) {
+		if (_builtin_action_display_names[i].name == name) {
 			return _builtin_action_display_names[i].display_name;
 		}
 	}


### PR DESCRIPTION
This PR
- ~Adds missing built-in action display names~
- Fixes extra space in `"ui_swap_input_direction "`
- Removes the need to add a display name for built-in action overrides