### PR TITLE
Expose `get_active_node()` in 3D editor

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -56,6 +56,13 @@
 				Edits the given [Script]. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
 			</description>
 		</method>
+		<method name="get_active_node_3d" qualifiers="const">
+			<return type="Node3D" />
+			<description>
+				Returns the active [Node3D] in the 3D editor. The active node is the primary selected node when multiple nodes are selected in the editor. Returns [code]null[/code] if no 3D node is currently active.
+				[b]Note:[/b] This method is useful for editor plugins that need to determine which node to operate on during multi-selection scenarios.
+			</description>
+		</method>
 		<method name="get_base_control" qualifiers="const">
 			<return type="Control" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -422,6 +422,10 @@ SubViewport *EditorInterface::get_editor_viewport_3d(int p_idx) const {
 	return Node3DEditor::get_singleton()->get_editor_viewport(p_idx)->get_viewport_node();
 }
 
+Node3D *EditorInterface::get_active_node_3d() const {
+	return Node3DEditor::get_singleton()->get_active_node();
+}
+
 void EditorInterface::set_main_screen_editor(const String &p_name) {
 	EditorNode::get_singleton()->get_editor_main_screen()->select_by_name(p_name);
 }
@@ -853,6 +857,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_script_editor"), &EditorInterface::get_script_editor);
 	ClassDB::bind_method(D_METHOD("get_editor_viewport_2d"), &EditorInterface::get_editor_viewport_2d);
 	ClassDB::bind_method(D_METHOD("get_editor_viewport_3d", "idx"), &EditorInterface::get_editor_viewport_3d, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_active_node_3d"), &EditorInterface::get_active_node_3d);
 
 	ClassDB::bind_method(D_METHOD("set_main_screen_editor", "name"), &EditorInterface::set_main_screen_editor);
 	ClassDB::bind_method(D_METHOD("set_distraction_free_mode", "enter"), &EditorInterface::set_distraction_free_mode);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -58,6 +58,7 @@ class Texture2D;
 class Theme;
 class VBoxContainer;
 class Window;
+class Node3D;
 
 class EditorInterface : public Object {
 	GDCLASS(EditorInterface, Object);
@@ -108,6 +109,7 @@ public:
 	Ref<EditorSettings> get_editor_settings() const;
 	EditorToaster *get_editor_toaster() const;
 	EditorUndoRedoManager *get_editor_undo_redo() const;
+	Node3D *get_active_node_3d() const;
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -8499,6 +8499,15 @@ void Node3DEditor::_selection_changed() {
 
 	const HashMap<ObjectID, Object *> &selection = editor_selection->get_selection();
 
+	active_node = nullptr;
+	const List<Node *> &top_selection = editor_selection->get_top_selected_node_list();
+	if (!top_selection.is_empty()) {
+		Node3D *last_selected = Object::cast_to<Node3D>(top_selection.back()->get());
+		if (last_selected) {
+			active_node = last_selected;
+		}
+	}
+
 	for (const KeyValue<ObjectID, Object *> &E : selection) {
 		Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
 		if (!sp) {
@@ -8510,7 +8519,7 @@ void Node3DEditor::_selection_changed() {
 			continue;
 		}
 
-		if (sp == editor_selection->get_top_selected_node_list().back()->get()) {
+		if (sp == active_node) {
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance, active_selection_box->get_rid());
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray, active_selection_box_xray->get_rid());
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_offset, active_selection_box->get_rid());

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -850,6 +850,7 @@ private:
 	Ref<Environment> viewport_environment;
 
 	Node3D *selected = nullptr;
+	Node3D *active_node = nullptr;
 
 	Node3DEditorViewport *freelook_viewport = nullptr;
 
@@ -1020,6 +1021,7 @@ public:
 
 	VSplitContainer *get_shader_split();
 
+	Node3D *get_active_node() { return active_node; }
 	Node3D *get_single_selected_node() { return selected; }
 	bool is_current_selected_gizmo(const EditorNode3DGizmo *p_gizmo);
 	bool is_subgizmo_selected(int p_id);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

https://github.com/godotengine/godot/pull/102176 added the ability to select an `active node` that other nodes can use as a reference for various functions.

Copy pasted form the updated doc below:

Returns the active `Node3D` in the 3D editor. The active node is the primary selected node when multiple nodes are selected in the editor. Returns `null` if no 3D node is currently active.

**Note:** This method is useful for editor plugins that need to determine which node to operate on during multi-selection scenarios.

May be used for some kind of snapping plugin, setting up custom gizmos, or other things that need a reference. 


https://github.com/user-attachments/assets/2b372ed5-6eba-4ea9-84ee-6acbeb0bc1f8

