### PR TITLE
Move some values from `DisplayServer` to `DSTypes` namespace, to reduce includers

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -440,3 +440,20 @@ inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 #define GODOT_MSVC_WARNING_POP
 #define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
 #endif
+
+template <typename T, typename = void>
+struct is_incomplete_type : std::true_type {};
+
+template <typename T>
+struct is_incomplete_type<T, std::void_t<decltype(sizeof(T))>> : std::false_type {};
+
+template <typename T>
+constexpr bool is_incomplete_type_v = is_incomplete_type<T>::value;
+
+#ifndef SCU_BUILD
+#define STATIC_ASSERT_INCOMPLETE_CLASS(m_type) \
+	class m_type;                              \
+	static_assert(is_incomplete_type_v<m_type>, #m_type " was defined when it should not be. Please check include hierarchy of " __FILE__);
+#else
+#define STATIC_ASSERT_INCOMPLETE_CLASS(m_type)
+#endif

--- a/drivers/d3d12/rendering_context_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_context_driver_d3d12.cpp
@@ -257,13 +257,13 @@ void RenderingContextDriverD3D12::surface_set_size(SurfaceID p_surface, uint32_t
 	surface->needs_resize = true;
 }
 
-void RenderingContextDriverD3D12::surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) {
+void RenderingContextDriverD3D12::surface_set_vsync_mode(SurfaceID p_surface, DSTypes::VSyncMode p_vsync_mode) {
 	Surface *surface = (Surface *)(p_surface);
 	surface->vsync_mode = p_vsync_mode;
 	surface->needs_resize = true;
 }
 
-DisplayServer::VSyncMode RenderingContextDriverD3D12::surface_get_vsync_mode(SurfaceID p_surface) const {
+DSTypes::VSyncMode RenderingContextDriverD3D12::surface_get_vsync_mode(SurfaceID p_surface) const {
 	Surface *surface = (Surface *)(p_surface);
 	return surface->vsync_mode;
 }

--- a/drivers/d3d12/rendering_context_driver_d3d12.h
+++ b/drivers/d3d12/rendering_context_driver_d3d12.h
@@ -34,7 +34,7 @@
 #include "core/string/ustring.h"
 #include "core/templates/rid_owner.h"
 #include "rendering_device_driver_d3d12.h"
-#include "servers/display_server.h"
+#include "servers/display/dstypes.h"
 #include "servers/rendering/rendering_context_driver.h"
 
 #if defined(AS)
@@ -73,8 +73,8 @@ public:
 	virtual void driver_free(RenderingDeviceDriver *p_driver) override;
 	virtual SurfaceID surface_create(const void *p_platform_data) override;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
-	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
-	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
+	virtual void surface_set_vsync_mode(SurfaceID p_surface, DSTypes::VSyncMode p_vsync_mode) override;
+	virtual DSTypes::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_width(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_height(SurfaceID p_surface) const override;
 	virtual void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) override;
@@ -92,7 +92,7 @@ public:
 		HWND hwnd = nullptr;
 		uint32_t width = 0;
 		uint32_t height = 0;
-		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
+		DSTypes::VSyncMode vsync_mode = DSTypes::VSYNC_ENABLED;
 		bool needs_resize = false;
 #ifdef DCOMP_ENABLED
 		ComPtr<IDCompositionDevice> composition_device;

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -34,6 +34,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
+#include "servers/display_server.h"
 #include "servers/rendering/rendering_device.h"
 #include "thirdparty/zlib/zlib.h"
 

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -37,6 +37,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/image.h"
 #include "core/os/os.h"
+#include "servers/display_server.h"
 #include "storage/texture_storage.h"
 
 #define _EXT_DEBUG_OUTPUT_SYNCHRONOUS_ARB 0x8242

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -83,7 +83,7 @@ protected:
 	RasterizerSceneGLES3 *scene = nullptr;
 	static RasterizerGLES3 *singleton;
 
-	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, const Rect2 &p_screen_rect, uint32_t p_layer, bool p_first = true);
+	void _blit_render_target_to_screen(RID p_render_target, DSTypes::WindowID p_screen, const Rect2 &p_screen_rect, uint32_t p_layer, bool p_first = true);
 
 public:
 	RendererUtilities *get_utilities() { return utilities; }
@@ -102,7 +102,7 @@ public:
 	void initialize();
 	void begin_frame(double frame_step);
 
-	void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
+	void blit_render_targets_to_screen(DSTypes::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
 
 	bool is_opengl() { return true; }
 	void gl_end_frame(bool p_swap_buffers);

--- a/drivers/metal/rendering_context_driver_metal.h
+++ b/drivers/metal/rendering_context_driver_metal.h
@@ -75,8 +75,8 @@ public:
 	void driver_free(RenderingDeviceDriver *p_driver) final override;
 	SurfaceID surface_create(const void *p_platform_data) final override;
 	void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) final override;
-	void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) final override;
-	DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const final override;
+	void surface_set_vsync_mode(SurfaceID p_surface, DSTypes::VSyncMode p_vsync_mode) final override;
+	DSTypes::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const final override;
 	uint32_t surface_get_width(SurfaceID p_surface) const final override;
 	uint32_t surface_get_height(SurfaceID p_surface) const final override;
 	void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) final override;
@@ -106,7 +106,7 @@ public:
 	public:
 		uint32_t width = 0;
 		uint32_t height = 0;
-		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
+		DSTypes::VSyncMode vsync_mode = DSTypes::VSYNC_ENABLED;
 		bool needs_resize = false;
 		double present_minimum_duration = 0.0;
 

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -124,12 +124,12 @@ public:
 #if TARGET_OS_OSX
 		// Display sync is only supported on macOS.
 		switch (vsync_mode) {
-			case DisplayServer::VSYNC_MAILBOX:
-			case DisplayServer::VSYNC_ADAPTIVE:
-			case DisplayServer::VSYNC_ENABLED:
+			case DSTypes::VSYNC_MAILBOX:
+			case DSTypes::VSYNC_ADAPTIVE:
+			case DSTypes::VSYNC_ENABLED:
 				layer.displaySyncEnabled = YES;
 				break;
-			case DisplayServer::VSYNC_DISABLED:
+			case DSTypes::VSYNC_DISABLED:
 				layer.displaySyncEnabled = NO;
 				break;
 		}
@@ -176,7 +176,7 @@ public:
 		count--;
 		front = (front + 1) % frame_buffers.size();
 
-		if (vsync_mode != DisplayServer::VSYNC_DISABLED) {
+		if (vsync_mode != DSTypes::VSYNC_DISABLED) {
 			[p_cmd_buffer->get_command_buffer() presentDrawable:drawable afterMinimumDuration:present_minimum_duration];
 		} else {
 			[p_cmd_buffer->get_command_buffer() presentDrawable:drawable];
@@ -201,7 +201,7 @@ void RenderingContextDriverMetal::surface_set_size(SurfaceID p_surface, uint32_t
 	surface->needs_resize = true;
 }
 
-void RenderingContextDriverMetal::surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) {
+void RenderingContextDriverMetal::surface_set_vsync_mode(SurfaceID p_surface, DSTypes::VSyncMode p_vsync_mode) {
 	Surface *surface = (Surface *)(p_surface);
 	if (surface->vsync_mode == p_vsync_mode) {
 		return;
@@ -210,7 +210,7 @@ void RenderingContextDriverMetal::surface_set_vsync_mode(SurfaceID p_surface, Di
 	surface->needs_resize = true;
 }
 
-DisplayServer::VSyncMode RenderingContextDriverMetal::surface_get_vsync_mode(SurfaceID p_surface) const {
+DSTypes::VSyncMode RenderingContextDriverMetal::surface_get_vsync_mode(SurfaceID p_surface) const {
 	Surface *surface = (Surface *)(p_surface);
 	return surface->vsync_mode;
 }

--- a/drivers/vulkan/rendering_context_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_context_driver_vulkan.cpp
@@ -36,6 +36,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/version.h"
+#include "servers/display_server.h"
 
 #include "rendering_device_driver_vulkan.h"
 #include "vulkan_hooks.h"

--- a/drivers/vulkan/rendering_context_driver_vulkan.h
+++ b/drivers/vulkan/rendering_context_driver_vulkan.h
@@ -32,6 +32,8 @@
 
 #ifdef VULKAN_ENABLED
 
+#include "core/templates/hash_set.h"
+#include "core/templates/local_vector.h"
 #include "servers/rendering/rendering_context_driver.h"
 
 #if defined(DEBUG_ENABLED) || defined(DEV_ENABLED)
@@ -136,8 +138,8 @@ public:
 	virtual void driver_free(RenderingDeviceDriver *p_driver) override;
 	virtual SurfaceID surface_create(const void *p_platform_data) override;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) override;
-	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) override;
-	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
+	virtual void surface_set_vsync_mode(SurfaceID p_surface, DSTypes::VSyncMode p_vsync_mode) override;
+	virtual DSTypes::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_width(SurfaceID p_surface) const override;
 	virtual uint32_t surface_get_height(SurfaceID p_surface) const override;
 	virtual void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) override;
@@ -150,7 +152,7 @@ public:
 		VkSurfaceKHR vk_surface = VK_NULL_HANDLE;
 		uint32_t width = 0;
 		uint32_t height = 0;
-		DisplayServer::VSyncMode vsync_mode = DisplayServer::VSYNC_ENABLED;
+		DSTypes::VSyncMode vsync_mode = DSTypes::VSYNC_ENABLED;
 		bool needs_resize = false;
 	};
 

--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
+#include "servers/display_server.h"
 #include "vulkan_hooks.h"
 
 #if RENDERING_SHADER_CONTAINER_VULKAN_SMOLV

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -316,7 +316,7 @@ private:
 	bool exiting = false;
 	bool dimmed = false;
 
-	DisplayServer::WindowMode prev_mode = DisplayServer::WINDOW_MODE_MAXIMIZED;
+	DSTypes::WindowMode prev_mode = DSTypes::WINDOW_MODE_MAXIMIZED;
 	int old_split_ofs = 0;
 	VSplitContainer *top_split = nullptr;
 	Control *vp_base = nullptr;

--- a/editor/engine_update_label.cpp
+++ b/editor/engine_update_label.cpp
@@ -184,20 +184,20 @@ void EngineUpdateLabel::_set_status(UpdateStatus p_status) {
 			} else {
 				_set_message(TTR("Update checks disabled."), theme_cache.disabled_color);
 			}
-			set_accessibility_live(DisplayServer::AccessibilityLiveMode::LIVE_OFF);
+			set_accessibility_live(DSTypes::AccessibilityLiveMode::LIVE_OFF);
 			set_tooltip_text("");
 			break;
 		}
 
 		case UpdateStatus::ERROR: {
 			set_disabled(false);
-			set_accessibility_live(DisplayServer::AccessibilityLiveMode::LIVE_POLITE);
+			set_accessibility_live(DSTypes::AccessibilityLiveMode::LIVE_POLITE);
 			set_tooltip_text(TTR("An error has occurred. Click to try again."));
 		} break;
 
 		case UpdateStatus::UPDATE_AVAILABLE: {
 			set_disabled(false);
-			set_accessibility_live(DisplayServer::AccessibilityLiveMode::LIVE_POLITE);
+			set_accessibility_live(DSTypes::AccessibilityLiveMode::LIVE_POLITE);
 			set_tooltip_text(TTR("Click to open download page."));
 		} break;
 

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -37,6 +37,7 @@
 #include "scene/gui/label.h"
 #include "scene/gui/panel_container.h"
 #include "scene/resources/style_box_flat.h"
+#include "servers/display_server.h"
 
 EditorToaster *EditorToaster::singleton = nullptr;
 

--- a/editor/gui/editor_version_button.cpp
+++ b/editor/gui/editor_version_button.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/time.h"
 #include "core/version.h"
+#include "servers/display_server.h"
 
 String _get_version_string(EditorVersionButton::VersionFormat p_format) {
 	String main;

--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -38,6 +38,7 @@
 #include "scene/gui/color_rect.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/resources/style_box_flat.h"
+#include "servers/display_server.h"
 
 void TouchActionsPanel::_notification(int p_what) {
 	switch (p_what) {

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -46,6 +46,7 @@
 #include "scene/resources/style_box_texture.h"
 #include "scene/resources/svg_texture.h"
 #include "scene/resources/texture.h"
+#include "servers/display_server.h"
 
 // Theme configuration.
 

--- a/methods.py
+++ b/methods.py
@@ -69,6 +69,7 @@ def add_source_files_scu(self, sources, files, allow_gen=False):
 
         # Add all the gen.cpp files in the SCU directory
         add_source_files_orig(self, sources, subdir + ".scu/scu_*.gen.cpp", True)
+        self.Append(CPPDEFINES=["SCU_BUILD"])
         return True
     return False
 

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -32,12 +32,14 @@
 
 #ifdef GLES3_ENABLED
 
-#include "../../openxr_util.h"
-
+#include "core/input/input.h"
 #include "drivers/gles3/effects/copy_effects.h"
 #include "drivers/gles3/storage/texture_storage.h"
+#include "servers/display_server.h"
 #include "servers/rendering/rendering_server_globals.h"
 #include "servers/rendering_server.h"
+
+#include "../../openxr_util.h"
 
 // OpenXR requires us to submit sRGB textures so that it recognizes the content
 // as being in sRGB color space. We do fall back on "normal" textures but this

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -36,6 +36,7 @@
 #include "extensions/openxr_eye_gaze_interaction.h"
 #include "extensions/openxr_hand_interaction_extension.h"
 #include "extensions/openxr_performance_settings_extension.h"
+#include "servers/display_server.h"
 #include "servers/rendering/renderer_compositor.h"
 
 #include <openxr/openxr.h>

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -75,7 +75,7 @@ class EmbeddedProcessMacOS final : public EmbeddedProcessBase {
 	// Embedded process state.
 
 	// The last mouse mode sent by the embedded process.
-	DisplayServer::MouseMode mouse_mode = DisplayServer::MOUSE_MODE_VISIBLE;
+	DSTypes::MouseMode mouse_mode = DSTypes::MOUSE_MODE_VISIBLE;
 
 	// Helper functions.
 
@@ -90,7 +90,7 @@ public:
 	// MARK: - Message Handlers
 
 	void set_context_id(uint32_t p_context_id);
-	void mouse_set_mode(DisplayServer::MouseMode p_mode);
+	void mouse_set_mode(DSTypes::MouseMode p_mode);
 
 	uint32_t get_context_id() const { return context_id; }
 	void set_script_debugger(ScriptEditorDebugger *p_debugger) override;
@@ -117,7 +117,7 @@ public:
 	void display_state_changed();
 
 	// MARK: - Embedded process state
-	_FORCE_INLINE_ DisplayServer::MouseMode get_mouse_mode() const { return mouse_mode; }
+	_FORCE_INLINE_ DSTypes::MouseMode get_mouse_mode() const { return mouse_mode; }
 
 	EmbeddedProcessMacOS();
 	~EmbeddedProcessMacOS() override;

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -31,6 +31,7 @@
 #include "animated_sprite_2d.h"
 
 #include "scene/main/viewport.h"
+#include "servers/display_server.h"
 
 #ifdef TOOLS_ENABLED
 Dictionary AnimatedSprite2D::_edit_get_state() const {

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -30,7 +30,10 @@
 
 #include "node_2d.h"
 
+STATIC_ASSERT_INCOMPLETE_CLASS(DisplayServer);
+
 #include "scene/main/viewport.h"
+#include "servers/display_server.h"
 
 #ifdef TOOLS_ENABLED
 Dictionary Node2D::_edit_get_state() const {

--- a/scene/2d/physics/touch_screen_button.cpp
+++ b/scene/2d/physics/touch_screen_button.cpp
@@ -31,6 +31,7 @@
 #include "touch_screen_button.h"
 
 #include "scene/main/viewport.h"
+#include "servers/display_server.h"
 
 void TouchScreenButton::set_texture_normal(const Ref<Texture2D> &p_texture) {
 	if (texture_normal == p_texture) {

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -32,6 +32,7 @@
 
 #include "core/input/input.h"
 #include "scene/main/viewport.h"
+#include "servers/display_server.h"
 
 #ifdef TOOLS_ENABLED
 Dictionary Sprite2D::_edit_get_state() const {

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -40,6 +40,7 @@
 #include "scene/resources/environment.h"
 #include "scene/resources/image_texture.h"
 #include "scene/resources/sky.h"
+#include "servers/display_server.h"
 
 #include "modules/modules_enabled.gen.h" // For lightmapper_rd.
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -30,10 +30,13 @@
 
 #include "node_3d.h"
 
+STATIC_ASSERT_INCOMPLETE_CLASS(DisplayServer);
+
 #include "core/math/transform_interpolator.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/main/viewport.h"
 #include "scene/property_utils.h"
+#include "servers/display_server.h"
 
 /*
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -33,6 +33,7 @@
 
 #include "scene/audio/audio_stream_player_internal.h"
 #include "servers/audio/audio_stream.h"
+#include "servers/display_server.h"
 
 void AudioStreamPlayer::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ACCESSIBILITY_UPDATE) {

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -31,6 +31,7 @@
 #include "check_box.h"
 
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 Size2 CheckBox::get_icon_size() const {
 	Size2 tex_size = Size2(0, 0);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -31,6 +31,7 @@
 #include "check_button.h"
 
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 Size2 CheckButton::get_icon_size() const {
 	Ref<Texture2D> on_tex;

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -30,6 +30,8 @@
 
 #include "container.h"
 
+#include "servers/display_server.h"
+
 void Container::_child_minsize_changed() {
 	update_minimum_size();
 	queue_sort();

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -254,7 +254,7 @@ private:
 
 		String accessibility_name;
 		String accessibility_description;
-		DisplayServer::AccessibilityLiveMode accessibility_live = DisplayServer::AccessibilityLiveMode::LIVE_OFF;
+		DSTypes::AccessibilityLiveMode accessibility_live = DSTypes::AccessibilityLiveMode::LIVE_OFF;
 
 		TypedArray<NodePath> accessibility_controls_nodes;
 		TypedArray<NodePath> accessibility_described_by_nodes;
@@ -619,8 +619,8 @@ public:
 	void set_accessibility_description(const String &p_description);
 	String get_accessibility_description() const;
 
-	void set_accessibility_live(DisplayServer::AccessibilityLiveMode p_mode);
-	DisplayServer::AccessibilityLiveMode get_accessibility_live() const;
+	void set_accessibility_live(DSTypes::AccessibilityLiveMode p_mode);
+	DSTypes::AccessibilityLiveMode get_accessibility_live() const;
 
 	void set_accessibility_controls_nodes(const TypedArray<NodePath> &p_node_path);
 	TypedArray<NodePath> get_accessibility_controls_nodes() const;

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -34,6 +34,7 @@
 #include "scene/gui/graph_edit.h"
 #include "scene/gui/label.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 	String str = p_name;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 void ItemList::_shape_text(int p_idx) {
 	Item &item = items.write[p_idx];

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -32,6 +32,7 @@
 
 #include "scene/gui/container.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 #include "servers/text_server.h"
 
 void Label::set_autowrap_mode(TextServer::AutowrapMode p_mode) {

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -31,6 +31,7 @@
 #include "link_button.h"
 
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 void LinkButton::_shape() {
 	Ref<Font> font = theme_cache.font;

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -30,6 +30,7 @@
 
 #include "panel.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 void Panel::_notification(int p_what) {
 	switch (p_what) {

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -32,6 +32,7 @@
 
 #include "scene/resources/text_line.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 Size2 ProgressBar::get_minimum_size() const {
 	Size2 minimum_size = theme_cache.background_style->get_minimum_size();

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -30,6 +30,8 @@
 
 #include "range.h"
 
+#include "servers/display_server.h"
+
 PackedStringArray Range::get_configuration_warnings() const {
 	PackedStringArray warnings = Control::get_configuration_warnings();
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -31,6 +31,7 @@
 #include "slider.h"
 
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 Size2 Slider::get_minimum_size() const {
 	Size2i ss = theme_cache.slider_style->get_minimum_size();

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -33,6 +33,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 void SplitContainerDragger::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -35,6 +35,7 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/main/viewport.h"
 #include "scene/theme/theme_db.h"
+#include "servers/display_server.h"
 
 Size2 TabBar::get_minimum_size() const {
 	Size2 ms;

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -30,6 +30,8 @@
 
 #include "texture_progress_bar.h"
 
+#include "servers/display_server.h"
+
 void TextureProgressBar::set_under_texture(const Ref<Texture2D> &p_texture) {
 	_set_texture(&under, p_texture);
 }

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -174,42 +174,7 @@ private:
 		}
 	}
 
-	_FORCE_INLINE_ void _unlink_from_tree() {
-		if (accessibility_row_element.is_valid()) {
-			DisplayServer::get_singleton()->accessibility_free_element(accessibility_row_element);
-			accessibility_row_element = RID();
-		}
-		for (Cell &cell : cells) {
-			if (cell.accessibility_cell_element.is_valid()) {
-				DisplayServer::get_singleton()->accessibility_free_element(cell.accessibility_cell_element);
-				cell.accessibility_cell_element = RID();
-			}
-			for (Cell::Button &btn : cell.buttons) {
-				if (btn.accessibility_button_element.is_valid()) {
-					DisplayServer::get_singleton()->accessibility_free_element(btn.accessibility_button_element);
-					btn.accessibility_button_element = RID();
-				}
-			}
-		}
-		TreeItem *p = get_prev();
-		if (p) {
-			p->next = next;
-		}
-		if (next) {
-			next->prev = p;
-		}
-		if (parent) {
-			if (!parent->children_cache.is_empty()) {
-				parent->children_cache.remove_at(get_index());
-			}
-			if (parent->first_child == this) {
-				parent->first_child = next;
-			}
-			if (parent->last_child == this) {
-				parent->last_child = prev;
-			}
-		}
-	}
+	_FORCE_INLINE_ void _unlink_from_tree();
 
 	bool _is_any_collapsed(bool p_only_visible);
 

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -32,6 +32,7 @@
 
 #include "core/os/os.h"
 #include "servers/audio_server.h"
+#include "servers/display_server.h"
 
 int VideoStreamPlayer::sp_get_channel_count() const {
 	if (playback.is_null()) {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -238,7 +238,7 @@ void SceneTree::_accessibility_notify_change(const Node *p_node, bool p_remove) 
 	}
 }
 
-void SceneTree::_process_accessibility_changes(DisplayServer::WindowID p_window_id) {
+void SceneTree::_process_accessibility_changes(DSTypes::WindowID p_window_id) {
 	// Process NOTIFICATION_ACCESSIBILITY_UPDATE.
 	Vector<ObjectID> processed;
 	for (const ObjectID &id : accessibility_change_queue) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -329,7 +329,7 @@ public:
 	void _accessibility_force_update();
 	void _accessibility_notify_change(const Node *p_node, bool p_remove = false);
 	void _flush_accessibility_changes();
-	void _process_accessibility_changes(DisplayServer::WindowID p_window_id);
+	void _process_accessibility_changes(DSTypes::WindowID p_window_id);
 
 	virtual void initialize() override;
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -705,7 +705,7 @@ public:
 	void set_vrs_texture(Ref<Texture2D> p_texture);
 	Ref<Texture2D> get_vrs_texture() const;
 
-	virtual DisplayServer::WindowID get_window_id() const = 0;
+	virtual DSTypes::WindowID get_window_id() const = 0;
 
 	void set_embedding_subwindows(bool p_embed);
 	bool is_embedding_subwindows() const;
@@ -882,7 +882,7 @@ private:
 
 protected:
 	static void _bind_methods();
-	virtual DisplayServer::WindowID get_window_id() const override;
+	virtual DSTypes::WindowID get_window_id() const override;
 	void _notification(int p_what);
 
 public:

--- a/servers/display/dstypes.h
+++ b/servers/display/dstypes.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  color_rect.cpp                                                        */
+/*  dstypes.h                                                             */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,41 +28,55 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "color_rect.h"
+#pragma once
 
-#include "servers/display_server.h"
+#include "core/input/input.h"
 
-void ColorRect::set_color(const Color &p_color) {
-	if (color == p_color) {
-		return;
-	}
-	color = p_color;
-	queue_accessibility_update();
-	queue_redraw();
-}
+/// Constants for DisplayServer.
+/// This file is the 'least common denominator' that can be included without
+/// needing to include complex header hierarchies of the DisplayServer.
+namespace DSTypes {
 
-Color ColorRect::get_color() const {
-	return color;
-}
+using WindowID = int;
 
-void ColorRect::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
-			RID ae = get_accessibility_element();
-			ERR_FAIL_COND(ae.is_null());
+enum {
+	MAIN_WINDOW_ID = 0,
+	INVALID_WINDOW_ID = -1,
+	INVALID_INDICATOR_ID = -1
+};
 
-			DisplayServer::get_singleton()->accessibility_update_set_color_value(ae, color);
-		} break;
+using IndicatorID = int;
 
-		case NOTIFICATION_DRAW: {
-			draw_rect(Rect2(Point2(), get_size()), color);
-		} break;
-	}
-}
+// Keep the VSyncMode enum values in sync with the `display/window/vsync/vsync_mode`
+// project setting hint.
+enum VSyncMode {
+	VSYNC_DISABLED,
+	VSYNC_ENABLED,
+	VSYNC_ADAPTIVE,
+	VSYNC_MAILBOX
+};
 
-void ColorRect::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_color", "color"), &ColorRect::set_color);
-	ClassDB::bind_method(D_METHOD("get_color"), &ColorRect::get_color);
+enum AccessibilityLiveMode {
+	LIVE_OFF,
+	LIVE_POLITE,
+	LIVE_ASSERTIVE,
+};
 
-	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "color"), "set_color", "get_color");
-}
+enum MouseMode {
+	MOUSE_MODE_VISIBLE = Input::MOUSE_MODE_VISIBLE,
+	MOUSE_MODE_HIDDEN = Input::MOUSE_MODE_HIDDEN,
+	MOUSE_MODE_CAPTURED = Input::MOUSE_MODE_CAPTURED,
+	MOUSE_MODE_CONFINED = Input::MOUSE_MODE_CONFINED,
+	MOUSE_MODE_CONFINED_HIDDEN = Input::MOUSE_MODE_CONFINED_HIDDEN,
+	MOUSE_MODE_MAX = Input::MOUSE_MODE_MAX,
+};
+
+enum WindowMode {
+	WINDOW_MODE_WINDOWED,
+	WINDOW_MODE_MINIMIZED,
+	WINDOW_MODE_MAXIMIZED,
+	WINDOW_MODE_FULLSCREEN,
+	WINDOW_MODE_EXCLUSIVE_FULLSCREEN,
+};
+
+} //namespace DSTypes

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -36,6 +36,7 @@
 #include "core/os/os.h"
 #include "core/variant/callable.h"
 
+#include "display/dstypes.h"
 #include "display/native_menu.h"
 
 class Texture2D;
@@ -56,26 +57,42 @@ class DisplayServer : public Object {
 	LocalVector<ObjectID> additional_outputs;
 
 public:
+	using WindowID = DSTypes::WindowID;
+	static constexpr WindowID MAIN_WINDOW_ID = DSTypes::MAIN_WINDOW_ID;
+	static constexpr WindowID INVALID_WINDOW_ID = DSTypes::INVALID_WINDOW_ID;
+	static constexpr WindowID INVALID_INDICATOR_ID = DSTypes::INVALID_INDICATOR_ID;
+
+	using IndicatorID = DSTypes::IndicatorID;
+
+	using VSyncMode = DSTypes::VSyncMode;
+	static constexpr VSyncMode VSYNC_DISABLED = VSyncMode::VSYNC_DISABLED;
+	static constexpr VSyncMode VSYNC_ENABLED = VSyncMode::VSYNC_ENABLED;
+	static constexpr VSyncMode VSYNC_ADAPTIVE = VSyncMode::VSYNC_ADAPTIVE;
+	static constexpr VSyncMode VSYNC_MAILBOX = VSyncMode::VSYNC_MAILBOX;
+
+	using AccessibilityLiveMode = DSTypes::AccessibilityLiveMode;
+	static constexpr AccessibilityLiveMode LIVE_OFF = AccessibilityLiveMode::LIVE_OFF;
+	static constexpr AccessibilityLiveMode LIVE_POLITE = AccessibilityLiveMode::LIVE_POLITE;
+	static constexpr AccessibilityLiveMode LIVE_ASSERTIVE = AccessibilityLiveMode::LIVE_ASSERTIVE;
+
+	using MouseMode = DSTypes::MouseMode;
+	static constexpr MouseMode MOUSE_MODE_VISIBLE = MouseMode::MOUSE_MODE_VISIBLE;
+	static constexpr MouseMode MOUSE_MODE_HIDDEN = MouseMode::MOUSE_MODE_HIDDEN;
+	static constexpr MouseMode MOUSE_MODE_CAPTURED = MouseMode::MOUSE_MODE_CAPTURED;
+	static constexpr MouseMode MOUSE_MODE_CONFINED = MouseMode::MOUSE_MODE_CONFINED;
+	static constexpr MouseMode MOUSE_MODE_CONFINED_HIDDEN = MouseMode::MOUSE_MODE_CONFINED_HIDDEN;
+	static constexpr MouseMode MOUSE_MODE_MAX = MouseMode::MOUSE_MODE_MAX;
+
+	using WindowMode = DSTypes::WindowMode;
+	static constexpr WindowMode WINDOW_MODE_WINDOWED = WindowMode::WINDOW_MODE_WINDOWED;
+	static constexpr WindowMode WINDOW_MODE_MINIMIZED = WindowMode::WINDOW_MODE_MINIMIZED;
+	static constexpr WindowMode WINDOW_MODE_MAXIMIZED = WindowMode::WINDOW_MODE_MAXIMIZED;
+	static constexpr WindowMode WINDOW_MODE_FULLSCREEN = WindowMode::WINDOW_MODE_FULLSCREEN;
+	static constexpr WindowMode WINDOW_MODE_EXCLUSIVE_FULLSCREEN = WindowMode::WINDOW_MODE_EXCLUSIVE_FULLSCREEN;
+
 	_FORCE_INLINE_ static DisplayServer *get_singleton() {
 		return singleton;
 	}
-
-	enum WindowMode {
-		WINDOW_MODE_WINDOWED,
-		WINDOW_MODE_MINIMIZED,
-		WINDOW_MODE_MAXIMIZED,
-		WINDOW_MODE_FULLSCREEN,
-		WINDOW_MODE_EXCLUSIVE_FULLSCREEN,
-	};
-
-	// Keep the VSyncMode enum values in sync with the `display/window/vsync/vsync_mode`
-	// project setting hint.
-	enum VSyncMode {
-		VSYNC_DISABLED,
-		VSYNC_ENABLED,
-		VSYNC_ADAPTIVE,
-		VSYNC_MAILBOX
-	};
 
 	enum HandleType {
 		DISPLAY_HANDLE,
@@ -286,15 +303,6 @@ protected:
 public:
 	static void set_early_window_clear_color_override(bool p_enabled, Color p_color = Color(0, 0, 0, 0));
 
-	enum MouseMode {
-		MOUSE_MODE_VISIBLE = Input::MOUSE_MODE_VISIBLE,
-		MOUSE_MODE_HIDDEN = Input::MOUSE_MODE_HIDDEN,
-		MOUSE_MODE_CAPTURED = Input::MOUSE_MODE_CAPTURED,
-		MOUSE_MODE_CONFINED = Input::MOUSE_MODE_CONFINED,
-		MOUSE_MODE_CONFINED_HIDDEN = Input::MOUSE_MODE_CONFINED_HIDDEN,
-		MOUSE_MODE_MAX = Input::MOUSE_MODE_MAX,
-	};
-
 	virtual void mouse_set_mode(MouseMode p_mode);
 	virtual MouseMode mouse_get_mode() const;
 	virtual void mouse_set_mode_override(MouseMode p_mode);
@@ -388,16 +396,8 @@ public:
 
 	virtual void screen_set_keep_on(bool p_enable); //disable screensaver
 	virtual bool screen_is_kept_on() const;
-	enum {
-		MAIN_WINDOW_ID = 0,
-		INVALID_WINDOW_ID = -1,
-		INVALID_INDICATOR_ID = -1
-	};
 
 public:
-	typedef int WindowID;
-	typedef int IndicatorID;
-
 	virtual Vector<DisplayServer::WindowID> get_window_list() const = 0;
 
 	enum WindowFlags {
@@ -645,12 +645,6 @@ public:
 		ACTION_SET_VALUE,
 		ACTION_SHOW_CONTEXT_MENU,
 		ACTION_CUSTOM,
-	};
-
-	enum AccessibilityLiveMode {
-		LIVE_OFF,
-		LIVE_POLITE,
-		LIVE_ASSERTIVE,
 	};
 
 	static AccessibilityMode accessibility_get_mode() { return accessibility_mode; }

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -92,7 +92,7 @@ public:
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;
 
-	virtual void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount) = 0;
+	virtual void blit_render_targets_to_screen(DSTypes::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount) = 0;
 
 	virtual bool is_opengl() = 0;
 	virtual void gl_end_frame(bool p_swap_buffers) = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 
+#include "servers/display_server.h"
 #include "servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h"
 #include "servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h"
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -122,7 +122,7 @@ public:
 
 	void initialize();
 	void begin_frame(double frame_step);
-	void blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
+	void blit_render_targets_to_screen(DSTypes::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount);
 
 	bool is_opengl() { return false; }
 	void gl_end_frame(bool p_swap_buffers) {}

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -36,6 +36,7 @@
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
 #include "rendering_server_globals.h"
+#include "servers/display_server.h"
 #include "storage/texture_storage.h"
 
 #ifndef XR_DISABLED

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -79,7 +79,7 @@ public:
 		bool use_occlusion_culling = false;
 		bool occlusion_buffer_dirty = false;
 
-		DisplayServer::WindowID viewport_to_screen;
+		DSTypes::WindowID viewport_to_screen;
 		Rect2 viewport_to_screen_rect;
 		bool viewport_render_direct_to_screen;
 
@@ -159,7 +159,7 @@ public:
 			transparent_bg = false;
 			use_hdr_2d = false;
 
-			viewport_to_screen = DisplayServer::INVALID_WINDOW_ID;
+			viewport_to_screen = DSTypes::INVALID_WINDOW_ID;
 			shadow_atlas_size = 0;
 			measure_render_time = false;
 
@@ -220,7 +220,7 @@ public:
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
 
-	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
+	void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID);
 	void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable);
 
 	void viewport_set_active(RID p_viewport, bool p_active);
@@ -295,7 +295,7 @@ public:
 
 	void viewport_set_sdf_oversize_and_scale(RID p_viewport, RS::ViewportSDFOversize p_over_size, RS::ViewportSDFScale p_scale);
 
-	virtual RID viewport_find_from_screen_attachment(DisplayServer::WindowID p_id = DisplayServer::MAIN_WINDOW_ID) const;
+	virtual RID viewport_find_from_screen_attachment(DSTypes::WindowID p_id = DSTypes::MAIN_WINDOW_ID) const;
 
 	void viewport_set_vrs_mode(RID p_viewport, RS::ViewportVRSMode p_mode);
 	void viewport_set_vrs_update_mode(RID p_viewport, RS::ViewportVRSUpdateMode p_mode);
@@ -313,7 +313,7 @@ public:
 	int get_num_viewports_with_motion_vectors() const;
 
 	// Workaround for setting this on thread.
-	void call_set_vsync_mode(DisplayServer::VSyncMode p_mode, DisplayServer::WindowID p_window);
+	void call_set_vsync_mode(DSTypes::VSyncMode p_mode, DSTypes::WindowID p_window);
 
 	RendererViewport();
 	virtual ~RendererViewport() {}

--- a/servers/rendering/rendering_context_driver.cpp
+++ b/servers/rendering/rendering_context_driver.cpp
@@ -33,8 +33,8 @@
 RenderingContextDriver::~RenderingContextDriver() {
 }
 
-RenderingContextDriver::SurfaceID RenderingContextDriver::surface_get_from_window(DisplayServer::WindowID p_window) const {
-	HashMap<DisplayServer::WindowID, SurfaceID>::ConstIterator it = window_surface_map.find(p_window);
+RenderingContextDriver::SurfaceID RenderingContextDriver::surface_get_from_window(DSTypes::WindowID p_window) const {
+	HashMap<DSTypes::WindowID, SurfaceID>::ConstIterator it = window_surface_map.find(p_window);
 	if (it != window_surface_map.end()) {
 		return it->value;
 	} else {
@@ -42,7 +42,7 @@ RenderingContextDriver::SurfaceID RenderingContextDriver::surface_get_from_windo
 	}
 }
 
-Error RenderingContextDriver::window_create(DisplayServer::WindowID p_window, const void *p_platform_data) {
+Error RenderingContextDriver::window_create(DSTypes::WindowID p_window, const void *p_platform_data) {
 	SurfaceID surface = surface_create(p_platform_data);
 	if (surface != 0) {
 		window_surface_map[p_window] = surface;
@@ -52,30 +52,30 @@ Error RenderingContextDriver::window_create(DisplayServer::WindowID p_window, co
 	}
 }
 
-void RenderingContextDriver::window_set_size(DisplayServer::WindowID p_window, uint32_t p_width, uint32_t p_height) {
+void RenderingContextDriver::window_set_size(DSTypes::WindowID p_window, uint32_t p_width, uint32_t p_height) {
 	SurfaceID surface = surface_get_from_window(p_window);
 	if (surface) {
 		surface_set_size(surface, p_width, p_height);
 	}
 }
 
-void RenderingContextDriver::window_set_vsync_mode(DisplayServer::WindowID p_window, DisplayServer::VSyncMode p_vsync_mode) {
+void RenderingContextDriver::window_set_vsync_mode(DSTypes::WindowID p_window, DSTypes::VSyncMode p_vsync_mode) {
 	SurfaceID surface = surface_get_from_window(p_window);
 	if (surface) {
 		surface_set_vsync_mode(surface, p_vsync_mode);
 	}
 }
 
-DisplayServer::VSyncMode RenderingContextDriver::window_get_vsync_mode(DisplayServer::WindowID p_window) const {
+DSTypes::VSyncMode RenderingContextDriver::window_get_vsync_mode(DSTypes::WindowID p_window) const {
 	SurfaceID surface = surface_get_from_window(p_window);
 	if (surface) {
 		return surface_get_vsync_mode(surface);
 	} else {
-		return DisplayServer::VSYNC_DISABLED;
+		return DSTypes::VSYNC_DISABLED;
 	}
 }
 
-void RenderingContextDriver::window_destroy(DisplayServer::WindowID p_window) {
+void RenderingContextDriver::window_destroy(DSTypes::WindowID p_window) {
 	SurfaceID surface = surface_get_from_window(p_window);
 	if (surface) {
 		surface_destroy(surface);

--- a/servers/rendering/rendering_context_driver.h
+++ b/servers/rendering/rendering_context_driver.h
@@ -30,7 +30,8 @@
 
 #pragma once
 
-#include "servers/display_server.h"
+#include "core/templates/hash_map.h"
+#include "servers/display/dstypes.h"
 
 class RenderingDeviceDriver;
 
@@ -39,15 +40,15 @@ public:
 	typedef uint64_t SurfaceID;
 
 private:
-	HashMap<DisplayServer::WindowID, SurfaceID> window_surface_map;
+	HashMap<DSTypes::WindowID, SurfaceID> window_surface_map;
 
 public:
-	SurfaceID surface_get_from_window(DisplayServer::WindowID p_window) const;
-	Error window_create(DisplayServer::WindowID p_window, const void *p_platform_data);
-	void window_set_size(DisplayServer::WindowID p_window, uint32_t p_width, uint32_t p_height);
-	void window_set_vsync_mode(DisplayServer::WindowID p_window, DisplayServer::VSyncMode p_vsync_mode);
-	DisplayServer::VSyncMode window_get_vsync_mode(DisplayServer::WindowID p_window) const;
-	void window_destroy(DisplayServer::WindowID p_window);
+	SurfaceID surface_get_from_window(DSTypes::WindowID p_window) const;
+	Error window_create(DSTypes::WindowID p_window, const void *p_platform_data);
+	void window_set_size(DSTypes::WindowID p_window, uint32_t p_width, uint32_t p_height);
+	void window_set_vsync_mode(DSTypes::WindowID p_window, DSTypes::VSyncMode p_vsync_mode);
+	DSTypes::VSyncMode window_get_vsync_mode(DSTypes::WindowID p_window) const;
+	void window_destroy(DSTypes::WindowID p_window);
 
 public:
 	// Not an enum as these values are matched against values returned by
@@ -95,8 +96,8 @@ public:
 	virtual void driver_free(RenderingDeviceDriver *p_driver) = 0;
 	virtual SurfaceID surface_create(const void *p_platform_data) = 0;
 	virtual void surface_set_size(SurfaceID p_surface, uint32_t p_width, uint32_t p_height) = 0;
-	virtual void surface_set_vsync_mode(SurfaceID p_surface, DisplayServer::VSyncMode p_vsync_mode) = 0;
-	virtual DisplayServer::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const = 0;
+	virtual void surface_set_vsync_mode(SurfaceID p_surface, DSTypes::VSyncMode p_vsync_mode) = 0;
+	virtual DSTypes::VSyncMode surface_get_vsync_mode(SurfaceID p_surface) const = 0;
 	virtual uint32_t surface_get_width(SurfaceID p_surface) const = 0;
 	virtual uint32_t surface_get_height(SurfaceID p_surface) const = 0;
 	virtual void surface_set_needs_resize(SurfaceID p_surface, bool p_needs_resize) = 0;

--- a/servers/rendering/rendering_device.compat.inc
+++ b/servers/rendering/rendering_device.compat.inc
@@ -140,7 +140,7 @@ Error RenderingDevice::_texture_resolve_multisample_bind_compat_84976(RID p_from
 }
 
 RenderingDevice::FramebufferFormatID RenderingDevice::_screen_get_framebuffer_format_bind_compat_87340() const {
-	return screen_get_framebuffer_format(DisplayServer::MAIN_WINDOW_ID);
+	return screen_get_framebuffer_format(DSTypes::MAIN_WINDOW_ID);
 }
 
 RID RenderingDevice::_uniform_buffer_create_bind_compat_101561(uint32_t p_size_bytes, const Vector<uint8_t> &p_data) {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -36,7 +36,6 @@
 #include "core/templates/local_vector.h"
 #include "core/templates/rid_owner.h"
 #include "core/variant/typed_array.h"
-#include "servers/display_server.h"
 #include "servers/rendering/rendering_device_commons.h"
 #include "servers/rendering/rendering_device_driver.h"
 #include "servers/rendering/rendering_device_graph.h"
@@ -1170,19 +1169,19 @@ private:
 	/****************/
 	/**** SCREEN ****/
 	/****************/
-	HashMap<DisplayServer::WindowID, RDD::SwapChainID> screen_swap_chains;
-	HashMap<DisplayServer::WindowID, RDD::FramebufferID> screen_framebuffers;
+	HashMap<DSTypes::WindowID, RDD::SwapChainID> screen_swap_chains;
+	HashMap<DSTypes::WindowID, RDD::FramebufferID> screen_framebuffers;
 
 	uint32_t _get_swap_chain_desired_count() const;
 
 public:
-	Error screen_create(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
-	Error screen_prepare_for_drawing(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
-	int screen_get_width(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
-	int screen_get_height(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
-	int screen_get_pre_rotation_degrees(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
-	FramebufferFormatID screen_get_framebuffer_format(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) const;
-	Error screen_free(DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID);
+	Error screen_create(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID);
+	Error screen_prepare_for_drawing(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID);
+	int screen_get_width(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID) const;
+	int screen_get_height(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID) const;
+	int screen_get_pre_rotation_degrees(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID) const;
+	FramebufferFormatID screen_get_framebuffer_format(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID) const;
+	Error screen_free(DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID);
 
 	/*************************/
 	/**** DRAW LISTS (II) ****/
@@ -1295,7 +1294,7 @@ public:
 		DRAW_IGNORE_ALL = DRAW_IGNORE_COLOR_ALL | DRAW_IGNORE_DEPTH | DRAW_IGNORE_STENCIL
 	};
 
-	DrawListID draw_list_begin_for_screen(DisplayServer::WindowID p_screen = 0, const Color &p_clear_color = Color());
+	DrawListID draw_list_begin_for_screen(DSTypes::WindowID p_screen = 0, const Color &p_clear_color = Color());
 	DrawListID draw_list_begin(RID p_framebuffer, BitField<DrawFlags> p_draw_flags = DRAW_DEFAULT_ALL, VectorView<Color> p_clear_color_values = VectorView<Color>(), float p_clear_depth_value = 1.0f, uint32_t p_clear_stencil_value = 0, const Rect2 &p_region = Rect2(), uint32_t p_breadcrumb = 0);
 	DrawListID _draw_list_begin_bind(RID p_framebuffer, BitField<DrawFlags> p_draw_flags = DRAW_DEFAULT_ALL, const Vector<Color> &p_clear_color_values = Vector<Color>(), float p_clear_depth_value = 1.0f, uint32_t p_clear_stencil_value = 0, const Rect2 &p_region = Rect2(), uint32_t p_breadcrumb = 0);
 
@@ -1580,7 +1579,7 @@ public:
 #endif
 
 public:
-	Error initialize(RenderingContextDriver *p_context, DisplayServer::WindowID p_main_window = DisplayServer::INVALID_WINDOW_ID);
+	Error initialize(RenderingContextDriver *p_context, DSTypes::WindowID p_main_window = DSTypes::INVALID_WINDOW_ID);
 	void finalize();
 
 	void _set_max_fps(int p_max_fps);

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -34,6 +34,7 @@
 #include "renderer_canvas_cull.h"
 #include "renderer_scene_cull.h"
 #include "rendering_server_globals.h"
+#include "servers/display_server.h"
 
 // careful, these may run in different threads than the rendering server
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -37,6 +37,7 @@
 #include "renderer_canvas_cull.h"
 #include "renderer_viewport.h"
 #include "rendering_server_globals.h"
+#include "servers/display/dstypes.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering_server.h"
 #include "servers/server_wrap_mt_common.h"
@@ -756,9 +757,9 @@ public:
 	FUNC2(viewport_set_measure_render_time, RID, bool)
 	FUNC1RC(double, viewport_get_measured_render_time_cpu, RID)
 	FUNC1RC(double, viewport_get_measured_render_time_gpu, RID)
-	FUNC1RC(RID, viewport_find_from_screen_attachment, DisplayServer::WindowID)
+	FUNC1RC(RID, viewport_find_from_screen_attachment, DSTypes::WindowID)
 
-	FUNC2(call_set_vsync_mode, DisplayServer::VSyncMode, DisplayServer::WindowID)
+	FUNC2(call_set_vsync_mode, DSTypes::VSyncMode, DSTypes::WindowID)
 
 	FUNC2(viewport_set_vrs_mode, RID, ViewportVRSMode)
 	FUNC2(viewport_set_vrs_update_mode, RID, ViewportVRSUpdateMode)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -31,6 +31,8 @@
 #include "rendering_server.h"
 #include "rendering_server.compat.inc"
 
+STATIC_ASSERT_INCOMPLETE_CLASS(DisplayServer);
+
 #include "core/config/project_settings.h"
 #include "core/variant/typed_array.h"
 #include "servers/rendering/shader_language.h"
@@ -2825,7 +2827,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);
-	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &RenderingServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(DisplayServer::MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &RenderingServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(DSTypes::MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("viewport_set_render_direct_to_screen", "viewport", "enabled"), &RenderingServer::viewport_set_render_direct_to_screen);
 	ClassDB::bind_method(D_METHOD("viewport_set_canvas_cull_mask", "viewport", "canvas_cull_mask"), &RenderingServer::viewport_set_canvas_cull_mask);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -36,7 +36,7 @@
 #include "core/templates/rid.h"
 #include "core/variant/typed_array.h"
 #include "core/variant/variant.h"
-#include "servers/display_server.h"
+#include "servers/display/dstypes.h"
 #include "servers/rendering/rendering_device.h"
 
 // Helper macros for code outside of the rendering server, but that is
@@ -984,7 +984,7 @@ public:
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
 	virtual void viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_canvas_cull_mask) = 0;
 
-	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DisplayServer::WindowID p_screen = DisplayServer::MAIN_WINDOW_ID) = 0;
+	virtual void viewport_attach_to_screen(RID p_viewport, const Rect2 &p_rect = Rect2(), DSTypes::WindowID p_screen = DSTypes::MAIN_WINDOW_ID) = 0;
 	virtual void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) = 0;
 
 	virtual void viewport_set_scaling_3d_mode(RID p_viewport, ViewportScaling3DMode p_scaling_3d_mode) = 0;
@@ -1154,7 +1154,7 @@ public:
 	virtual double viewport_get_measured_render_time_cpu(RID p_viewport) const = 0;
 	virtual double viewport_get_measured_render_time_gpu(RID p_viewport) const = 0;
 
-	virtual RID viewport_find_from_screen_attachment(DisplayServer::WindowID p_id = DisplayServer::MAIN_WINDOW_ID) const = 0;
+	virtual RID viewport_find_from_screen_attachment(DSTypes::WindowID p_id = DSTypes::MAIN_WINDOW_ID) const = 0;
 
 	enum ViewportVRSMode {
 		VIEWPORT_VRS_DISABLED,
@@ -1852,7 +1852,7 @@ public:
 
 	virtual void set_debug_generate_wireframes(bool p_generate) = 0;
 
-	virtual void call_set_vsync_mode(DisplayServer::VSyncMode p_mode, DisplayServer::WindowID p_window) = 0;
+	virtual void call_set_vsync_mode(DSTypes::VSyncMode p_mode, DSTypes::WindowID p_window) = 0;
 
 	virtual bool is_low_end() const = 0;
 


### PR DESCRIPTION
Cross-includes are our main compile time problem right now. Not only does parsing take long, also every small change to a header file leads to thousands of recompilations. It's time to do something.

With this change, the number of compile units to include `display_server.h` reduces from 326 to 248. That means making changes to it should compile about 30% faster. There should also be a small improvement to clean compile times (but I did not measure this).

I hope that, by incrementally reducing cross-includes, we can reduce the compile time of the engine to a fraction of what it is now, over time.

## Background

This is a test run for improving compile times throughout the codebase.

For one, I created `dstypes.h` to account for files that do need to interface with `DisplayServe` _somewhat_, but only through constants. This is true for most includers.

In addition, I designed `STATIC_ASSERT_INCOMPLETE_TYPE` to protect ourselves against regressions. If someone changes includes, such that e.g. `DisplayServer` is once again accessible from `rendering_server.h`, this will trigger a compile error.
I'm not aware of similar tricks used elsewhere, but it seems to work.
