### PR TITLE
Fix Mono build on Windows after `String::resize` rename

### DIFF
--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -87,7 +87,7 @@ String cwd() {
 	const DWORD expected_size = ::GetCurrentDirectoryW(0, nullptr);
 
 	Char16String buffer;
-	buffer.resize((int)expected_size);
+	buffer.resize_uninitialized((int)expected_size);
 	if (::GetCurrentDirectoryW(expected_size, (wchar_t *)buffer.ptrw()) == 0) {
 		return ".";
 	}
@@ -139,7 +139,7 @@ String realpath(const String &p_path) {
 	}
 
 	Char16String buffer;
-	buffer.resize((int)expected_size);
+	buffer.resize_uninitialized((int)expected_size);
 	::GetFinalPathNameByHandleW(hFile, (wchar_t *)buffer.ptrw(), expected_size, FILE_NAME_NORMALIZED);
 
 	::CloseHandle(hFile);


### PR DESCRIPTION
Fixup after #106913. We don't have Windows + Mono builds on CI currently so this wasn't caught.