### PR TITLE
Fix mono builds on Windows

### DIFF
--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -87,7 +87,7 @@ String cwd() {
 	const DWORD expected_size = ::GetCurrentDirectoryW(0, nullptr);
 
 	Char16String buffer;
-	buffer.resize((int)expected_size);
+	buffer.resize_uninitialized((int)expected_size);
 	if (::GetCurrentDirectoryW(expected_size, (wchar_t *)buffer.ptrw()) == 0) {
 		return ".";
 	}
@@ -139,7 +139,7 @@ String realpath(const String &p_path) {
 	}
 
 	Char16String buffer;
-	buffer.resize((int)expected_size);
+	buffer.resize_uninitialized((int)expected_size);
 	::GetFinalPathNameByHandleW(hFile, (wchar_t *)buffer.ptrw(), expected_size, FILE_NAME_NORMALIZED);
 
 	::CloseHandle(hFile);


### PR DESCRIPTION
Master branch broke Windows mono builds with MSVC and MinGW-w64 again, yay...

modules/mono/utils/path_utils.cpp has Windows-specific code that calls the resize function, which was removed/renamed with https://github.com/godotengine/godot/pull/106913, causing Windows builds with module_mono_enabled=yes to fail. Changing it to use the resize_uninitialized function fixes it.

Tested with MSVC on Windows 11 and MinGW-w64 on Ubuntu 22.04, both work fine again.