### PR TITLE
Simplify `TranslationDomain` Workflow

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -30,6 +30,7 @@
 
 #include "object.h"
 
+#include "core/config/project_settings.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/io/resource.h"
 #include "core/object/class_db.h"
@@ -2376,6 +2377,13 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 		} else if (pf == "set_meta" || pf == "get_meta" || pf == "has_meta" || pf == "remove_meta") {
 			for (const KeyValue<StringName, Variant> &K : metadata) {
 				r_options->push_back(String(K.key).quote());
+			}
+		} else if (pf == "set_translation_domain") {
+			if (ProjectSettings::get_singleton()->has_setting("internationalization/locale/translations_domains")) {
+				PackedStringArray domains = GLOBAL_GET("internationalization/locale/translations_domains");
+				for (String &E : domains) {
+					r_options->push_back(E.quote());
+				}
 			}
 		}
 	} else if (p_idx == 2) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -96,6 +96,7 @@ enum PropertyHint {
 	PROPERTY_HINT_GROUP_ENABLE, ///< used to make the property's group checkable. Only use for boolean types. Optional "feature" hint string force hides anything inside when unchecked.
 	PROPERTY_HINT_INPUT_NAME,
 	PROPERTY_HINT_FILE_PATH,
+	PROPERTY_HINT_TRANSLATION_DOMAIN_NAME,
 	PROPERTY_HINT_MAX,
 };
 

--- a/core/string/translation_domain.cpp
+++ b/core/string/translation_domain.cpp
@@ -446,6 +446,7 @@ void TranslationDomain::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_translation", "translation"), &TranslationDomain::add_translation);
 	ClassDB::bind_method(D_METHOD("remove_translation", "translation"), &TranslationDomain::remove_translation);
 	ClassDB::bind_method(D_METHOD("clear"), &TranslationDomain::clear);
+	ClassDB::bind_method(D_METHOD("get_loaded_locales"), &TranslationDomain::get_loaded_locales);
 	ClassDB::bind_method(D_METHOD("translate", "message", "context"), &TranslationDomain::translate, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("translate_plural", "message", "message_plural", "n", "context"), &TranslationDomain::translate_plural, DEFVAL(StringName()));
 	ClassDB::bind_method(D_METHOD("get_locale_override"), &TranslationDomain::get_locale_override);

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -567,6 +567,13 @@ void TranslationServer::get_argument_options(const StringName &p_function, int p
 			target_hash_map = &script_map;
 		} else if (pf == "get_country_name") {
 			target_hash_map = &country_name_map;
+		} else if (pf == "get_or_add_domain") {
+			if (ProjectSettings::get_singleton()->has_setting("internationalization/locale/translations_domains")) {
+				PackedStringArray domains = GLOBAL_GET("internationalization/locale/translations_domains");
+				for (String &E : domains) {
+					r_options->push_back(E.quote());
+				}
+			}
 		}
 
 		if (target_hash_map) {

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -441,6 +441,19 @@ void TranslationServer::remove_domain(const StringName &p_domain) {
 	custom_domains.erase(p_domain);
 }
 
+Vector<String> TranslationServer::get_all_domains(const bool &include_internal) const {
+	Vector<String> domains;
+
+	for (const KeyValue<StringName, Ref<TranslationDomain>> &E : custom_domains) {
+		if (!include_internal && (E.key == "godot.editor" || E.key == "godot.properties" || E.key == "godot.documentation")) {
+			continue; // Skip these internal domains
+		}
+		domains.push_back(E.key);
+	}
+
+	return domains;
+}
+
 void TranslationServer::setup() {
 	String test = GLOBAL_DEF("internationalization/locale/test", "");
 	test = test.strip_edges();
@@ -595,6 +608,7 @@ void TranslationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_domain", "domain"), &TranslationServer::has_domain);
 	ClassDB::bind_method(D_METHOD("get_or_add_domain", "domain"), &TranslationServer::get_or_add_domain);
 	ClassDB::bind_method(D_METHOD("remove_domain", "domain"), &TranslationServer::remove_domain);
+	ClassDB::bind_method(D_METHOD("get_all_domains", "include_internal"), &TranslationServer::get_all_domains, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("clear"), &TranslationServer::clear);
 

--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -391,6 +391,13 @@ PackedStringArray TranslationServer::get_loaded_locales() const {
 
 void TranslationServer::add_translation(const Ref<Translation> &p_translation) {
 	main_domain->add_translation(p_translation);
+
+	if (ProjectSettings::get_singleton()->has_setting("internationalization/locale/translations_domains")) {
+		const Vector<String> &translation_domains = GLOBAL_GET("internationalization/locale/translations_domains");
+		for (String domain_name : translation_domains) {
+			get_or_add_domain(domain_name)->add_translation(p_translation);
+		}
+	}
 }
 
 void TranslationServer::remove_translation(const Ref<Translation> &p_translation) {

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -141,6 +141,7 @@ public:
 	bool has_domain(const StringName &p_domain) const;
 	Ref<TranslationDomain> get_or_add_domain(const StringName &p_domain);
 	void remove_domain(const StringName &p_domain);
+	Vector<String> get_all_domains(const bool &include_internal) const;
 
 	void setup();
 

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1026,6 +1026,19 @@
 				This is the default behavior for all nodes. Calling [method Object.set_translation_domain] disables this behavior.
 			</description>
 		</method>
+		<method name="is_translation_domain_inherited">
+			<return type="bool" />
+			<description>
+				Checks if the current node inherits its translation domain from the parent.
+			</description>
+		</method>
+		<method name="get_translation_domain_explicit" qualifiers="const">
+			<return type="StringName" />
+			<description>
+				Returns the name of the explicitly set translation domain. Always returns an empty string if the translation domain is inherited from the parent.
+				See also [method Object.get_translation_domain].
+			</description>
+		</method>
 		<method name="update_configuration_warnings">
 			<return type="void" />
 			<description>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -92,6 +92,14 @@
 				Returns the translation domain with the specified name. An empty translation domain will be created and added if it does not exist.
 			</description>
 		</method>
+		<method name="get_all_domains" qualifiers="const">
+			<return type="PackedStringArray" />
+			<param index="0" name="include_internal" type="bool" />
+			<description>
+				Returns array of known domains created by [method get_or_add_domain].
+				[b]Note:[/b] It will only return custom domains, excluding the main domain.
+			</description>
+		</method>
 		<method name="get_script_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="script" type="String" />

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3673,6 +3673,21 @@ static EditorProperty *get_input_action_editor(const String &p_hint_text, bool i
 	return editor;
 }
 
+static EditorProperty *get_translation_domain_editor(const String &p_hint_text, bool is_string_name) {
+	EditorPropertyTextEnum *editor = memnew(EditorPropertyTextEnum);
+	Vector<String> options;
+
+	if (ProjectSettings::get_singleton()->has_setting("internationalization/locale/translations_domains")) {
+		PackedStringArray domains = GLOBAL_GET("internationalization/locale/translations_domains");
+		for (String &domain_name : domains) {
+			options.push_back(domain_name);
+		}
+	}
+
+	editor->setup(options, is_string_name, false);
+	return editor;
+}
+
 EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
 	double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
 
@@ -3788,6 +3803,8 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_INPUT_NAME) {
 				return get_input_action_editor(p_hint_text, false);
+			} else if (p_hint == PROPERTY_HINT_TRANSLATION_DOMAIN_NAME) {
+				return get_translation_domain_editor(p_hint_text, false);
 			} else if (p_hint == PROPERTY_HINT_MULTILINE_TEXT) {
 				EditorPropertyMultilineText *editor = memnew(EditorPropertyMultilineText);
 				return editor;
@@ -3943,6 +3960,8 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_INPUT_NAME) {
 				return get_input_action_editor(p_hint_text, true);
+			} else if (p_hint == PROPERTY_HINT_TRANSLATION_DOMAIN_NAME) {
+				return get_translation_domain_editor(p_hint_text, true);
 			} else {
 				EditorPropertyText *editor = memnew(EditorPropertyText);
 				if (p_hint == PROPERTY_HINT_PLACEHOLDER_TEXT) {

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -57,6 +57,9 @@ class LocalizationEditor : public VBoxContainer {
 	EditorFileDialog *pot_generate_dialog = nullptr;
 	Button *pot_generate_button = nullptr;
 
+	Tree *domain_list = nullptr;
+	LineEdit *add_domain_edit = nullptr;
+
 	bool updating_translations = false;
 	String localization_changed;
 
@@ -82,6 +85,10 @@ class LocalizationEditor : public VBoxContainer {
 	void _pot_add_builtin_toggled();
 	void _pot_generate(const String &p_file);
 	void _update_pot_file_extensions();
+
+	void _add_domain_pressed();
+	void _translation_domain_add(const StringName &p_name);
+	void _translation_domain_delete(Object *p_item, int p_column, int p_button, MouseButton p_mouse_button);
 
 	void _filesystem_files_moved(const String &p_old_file, const String &p_new_file);
 	void _filesystem_file_removed(const String &p_file);

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1368,6 +1368,13 @@ StringName Node::get_translation_domain() const {
 	return _translation_domain;
 }
 
+StringName Node::get_translation_domain_explicit() const {
+	if (data.is_translation_domain_inherited) {
+		return "";
+	}
+	return _translation_domain;
+}
+
 void Node::set_translation_domain(const StringName &p_domain) {
 	ERR_THREAD_GUARD
 
@@ -1390,6 +1397,10 @@ void Node::set_translation_domain_inherited() {
 	data.is_translation_domain_inherited = true;
 	data.is_translation_domain_dirty = true;
 	_propagate_translation_domain_dirty();
+}
+
+bool Node::is_translation_domain_inherited() const {
+	return data.is_translation_domain_inherited;
 }
 
 void Node::_propagate_translation_domain_dirty() {
@@ -3794,6 +3805,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_auto_translate_mode"), &Node::get_auto_translate_mode);
 	ClassDB::bind_method(D_METHOD("can_auto_translate"), &Node::can_auto_translate);
 	ClassDB::bind_method(D_METHOD("set_translation_domain_inherited"), &Node::set_translation_domain_inherited);
+	ClassDB::bind_method(D_METHOD("is_translation_domain_inherited"), &Node::is_translation_domain_inherited);
+	ClassDB::bind_method(D_METHOD("get_translation_domain_explicit"), &Node::get_translation_domain_explicit);
 
 	ClassDB::bind_method(D_METHOD("get_window"), &Node::get_window);
 	ClassDB::bind_method(D_METHOD("get_last_exclusive_window"), &Node::get_last_exclusive_window);
@@ -3998,6 +4011,9 @@ void Node::_bind_methods() {
 
 	ADD_GROUP("Auto Translate", "auto_translate_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_auto_translate_mode", "get_auto_translate_mode");
+
+	ADD_GROUP("Translation Domain", "translation_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "translation_custom_domain", PROPERTY_HINT_TRANSLATION_DOMAIN_NAME), "set_translation_domain", "get_translation_domain_explicit");
 
 	ADD_GROUP("Editor Description", "editor_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -779,8 +779,10 @@ public:
 	bool can_auto_translate() const;
 
 	virtual StringName get_translation_domain() const override;
+	StringName get_translation_domain_explicit() const;
 	virtual void set_translation_domain(const StringName &p_domain) override;
 	void set_translation_domain_inherited();
+	bool is_translation_domain_inherited() const;
 
 	_FORCE_INLINE_ String atr(const String &p_message, const StringName &p_context = "") const { return can_auto_translate() ? tr(p_message, p_context) : p_message; }
 	_FORCE_INLINE_ String atr_n(const String &p_message, const StringName &p_message_plural, int p_n, const StringName &p_context = "") const {


### PR DESCRIPTION
This PR introduces the ability to configure `translation_domains` in the project settings and assign a `translation_domain` per Node.

This is useful in scenarios where, for example, a player may prefer different languages for subtitles and voice-over. It simplifies the localization workflow for developers.

You can define translation domains in the Project Settings:
![Bildschirmfoto_2025-06-13_19-53-29](https://github.com/user-attachments/assets/df00eb8d-ee3a-4ab9-9267-2c82c0e934aa)
And assign a custom translation domain per Node:
![Bildschirmfoto_2025-06-13_19-53-57](https://github.com/user-attachments/assets/3924c7fe-3b8e-47d2-91bb-52abd07f415f)
All child nodes will inherit the same translation domain, unless explicitly overridden.

For instance, if you want to use English voice-over with German subtitles, you can set the main language to English and override the subtitles domain to use German.

The changes are split across multiple commits for easier review.

Closes: https://github.com/godotengine/godot-proposals/issues/11610
Closes: https://github.com/godotengine/godot-proposals/issues/6254