### PR TITLE
Make occlusion bake handle non-index triangle meshes

### DIFF
--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -521,6 +521,15 @@ void OccluderInstance3D::_bake_surface(const Transform3D &p_transform, Array p_s
 	PackedVector3Array vertices = p_surface_arrays[Mesh::ARRAY_VERTEX];
 	PackedInt32Array indices = p_surface_arrays[Mesh::ARRAY_INDEX];
 
+	if (!vertices.is_empty() && indices.is_empty() && vertices.size() % 3 == 0) {
+		// Mesh surface has no indices but valid triangle vertices so make dummy indices to progress.
+		indices.resize(vertices.size());
+		int *indices_ptrw = indices.ptrw();
+		for (int j = 0; j < vertices.size(); j++) {
+			indices_ptrw[j] = j;
+		}
+	}
+
 	if (vertices.is_empty() || indices.is_empty()) {
 		return;
 	}


### PR DESCRIPTION
Makes occlusion bake handle non-index triangle meshes.

Solves https://github.com/godotengine/godot/issues/104883 part 1.
Part 2 -> https://github.com/godotengine/godot/pull/107507

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
