### PR TITLE
Create more optimized CSGShape3D baked static mesh

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -36,6 +36,7 @@
 #include "core/math/geometry_2d.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "scene/resources/navigation_mesh.h"
+#include "scene/resources/surface_tool.h"
 #ifndef NAVIGATION_3D_DISABLED
 #include "servers/navigation_server_3d.h"
 #endif // NAVIGATION_3D_DISABLED
@@ -736,7 +737,19 @@ void CSGShape3D::update_shape() {
 Ref<ArrayMesh> CSGShape3D::bake_static_mesh() {
 	Ref<ArrayMesh> baked_mesh;
 	if (is_root_shape() && root_mesh.is_valid()) {
-		baked_mesh = root_mesh;
+		Ref<SurfaceTool> st;
+		st.instantiate();
+
+		int surface_count = root_mesh->get_surface_count();
+		for (int i = 0; i < surface_count; i++) {
+			st->append_from(root_mesh, i, Transform3D());
+		}
+		st->generate_normals();
+		st->generate_tangents();
+		st->index();
+		st->optimize_indices_for_cache();
+
+		baked_mesh = st->commit();
 	}
 	return baked_mesh;
 }


### PR DESCRIPTION
Creates more optimized CSGShape3D baked static mesh by adding indices and cache optimization.

Solves https://github.com/godotengine/godot/issues/104883 part 2.
Part 1 -> https://github.com/godotengine/godot/pull/107506
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
