### PR TITLE
Only repath a NavigationAgent with a target position

### DIFF
--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -416,7 +416,9 @@ void NavigationAgent2D::set_navigation_layers(uint32_t p_navigation_layers) {
 
 	navigation_layers = p_navigation_layers;
 
-	_request_repath();
+	if (target_position_submitted) {
+		_request_repath();
+	}
 }
 
 uint32_t NavigationAgent2D::get_navigation_layers() const {
@@ -535,7 +537,9 @@ void NavigationAgent2D::set_navigation_map(RID p_navigation_map) {
 	map_override = p_navigation_map;
 
 	NavigationServer2D::get_singleton()->agent_set_map(agent, map_override);
-	_request_repath();
+	if (target_position_submitted) {
+		_request_repath();
+	}
 }
 
 RID NavigationAgent2D::get_navigation_map() const {

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -453,7 +453,9 @@ void NavigationAgent3D::set_navigation_layers(uint32_t p_navigation_layers) {
 
 	navigation_layers = p_navigation_layers;
 
-	_request_repath();
+	if (target_position_submitted) {
+		_request_repath();
+	}
 }
 
 uint32_t NavigationAgent3D::get_navigation_layers() const {
@@ -572,7 +574,9 @@ void NavigationAgent3D::set_navigation_map(RID p_navigation_map) {
 	map_override = p_navigation_map;
 
 	NavigationServer3D::get_singleton()->agent_set_map(agent, map_override);
-	_request_repath();
+	if (target_position_submitted) {
+		_request_repath();
+	}
 }
 
 RID NavigationAgent3D::get_navigation_map() const {


### PR DESCRIPTION
Only repaths a NavigationAgent with a target position.

Resolves https://github.com/godotengine/godot/issues/101232

It is correct that a repath should happen when the `navigation_layers` or navigation `map` changes as the old path can become invalid with such a change.

However a repath only makes sense while an agent is intended to follow a path already, aka has a `target_position` set.

There shouldn't be a path update without a target_position. The agent can do nothing with such a path. As can be seen by the linked issue all it does is set the wrong internal pathfollowing state.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
