### PR TITLE
Avoid manipulating `PackedScene` cache when generating scene preview thumbnails

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -324,7 +324,7 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 	aborted = false;
 
 	Error load_error;
-	Ref<PackedScene> pack = ResourceLoader::load(p_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_IGNORE, &load_error); // no more cache issues?
+	Ref<PackedScene> pack = ResourceLoader::load(p_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_IGNORE_DEEP, &load_error); // no more cache issues?
 	if (load_error != OK) {
 		print_error(vformat("Failed to generate scene thumbnail for %s : Loaded with error code %d", p_path, int(load_error)));
 		return Ref<Texture2D>();


### PR DESCRIPTION
Attempt to fix issue #107494

Should likely be a cache issue with ```ResourceLoader```. Need further testing and MRP.

Edit:
Issue confirmed is related to cache mode, see comments below.

* *Bugsquad edit, fixes: #107494*
