### PR TITLE
Fix Resource Duplication test errors

### DIFF
--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -384,13 +384,8 @@ TEST_CASE("[Resource] Duplication") {
 			INFO(std::string(String(orig->get_class_name()).utf8().get_data()));
 
 			orig->call("set_defaults");
-
 			const Ref<Resource> &dupe = p_duplicate_fn(orig);
-			if ((p_test_mode == TEST_MODE_RESOURCE_DUPLICATE_DEEP_WITH_MODE || p_test_mode == TEST_MODE_VARIANT_DUPLICATE_DEEP_WITH_MODE) && p_deep_mode == RESOURCE_DEEP_DUPLICATE_MAX) {
-				CHECK(dupe.is_null());
-			} else {
-				dupe->call("verify_duplication", orig, p_test_mode, p_deep_mode);
-			}
+			dupe->call("verify_duplication", orig, p_test_mode, p_deep_mode);
 		}
 	};
 
@@ -414,7 +409,7 @@ TEST_CASE("[Resource] Duplication") {
 
 	SUBCASE("Resource::duplicate_deep()") {
 		static int deep_mode = 0;
-		for (deep_mode = 0; deep_mode <= RESOURCE_DEEP_DUPLICATE_MAX; deep_mode++) {
+		for (deep_mode = 0; deep_mode < RESOURCE_DEEP_DUPLICATE_MAX; deep_mode++) {
 			_run_test(
 					TEST_MODE_RESOURCE_DUPLICATE_DEEP_WITH_MODE,
 					(ResourceDeepDuplicateMode)deep_mode,
@@ -467,7 +462,7 @@ TEST_CASE("[Resource] Duplication") {
 
 	SUBCASE("Variant::duplicate_deep()") {
 		static int deep_mode = 0;
-		for (deep_mode = 0; deep_mode <= RESOURCE_DEEP_DUPLICATE_MAX; deep_mode++) {
+		for (deep_mode = 0; deep_mode < RESOURCE_DEEP_DUPLICATE_MAX; deep_mode++) {
 			_run_test(
 					TEST_MODE_VARIANT_DUPLICATE_DEEP_WITH_MODE,
 					(ResourceDeepDuplicateMode)deep_mode,


### PR DESCRIPTION
Fixes the errors from the resource duplication tests. The test itself doesn't fail, but it prints errors. Ex. on master https://github.com/godotengine/godot/actions/runs/15644773680/job/44081337772#step:13:158
`RESOURCE_DEEP_DUPLICATE_MAX` is not valid for `duplicate_deep()`, so I adjusted the loop bounds.
- related #100673 cc @RandomShaper

```
ERROR: Index p_deep_subresources_mode = 3 is out of bounds (RESOURCE_DEEP_DUPLICATE_MAX = 3).
at: duplicate_deep (core/io/resource.cpp:517)
ERROR: Index p_deep_subresources_mode = 3 is out of bounds (RESOURCE_DEEP_DUPLICATE_MAX = 3).
at: duplicate_deep (core/variant/variant_setget.cpp:1977)
```
