### PR TITLE
Fix tests warning line break strictness project setting

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2637,9 +2637,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 	}
 
-	GLOBAL_DEF_BASIC("internationalization/locale/include_text_server_data", false);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "internationalization/locale/line_breaking_strictness", PROPERTY_HINT_ENUM, "Auto,Loose,Normal,Strict"), 0);
-
 	OS::get_singleton()->_allow_hidpi = GLOBAL_DEF("display/window/dpi/allow_hidpi", true);
 	OS::get_singleton()->_allow_layered = GLOBAL_DEF_RST("display/window/per_pixel_transparency/allowed", false);
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -2357,6 +2357,8 @@ TextServer::TextServer() {
 	GLOBAL_DEF_RST("gui/theme/default_font_generate_mipmaps", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/theme/lcd_subpixel_layout", PROPERTY_HINT_ENUM, "Disabled,Horizontal RGB,Horizontal BGR,Vertical RGB,Vertical BGR"), 1);
+	GLOBAL_DEF_BASIC("internationalization/locale/include_text_server_data", false);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "internationalization/locale/line_breaking_strictness", PROPERTY_HINT_ENUM, "Auto,Loose,Normal,Strict"), 0);
 
 	_init_diacritics_map();
 }


### PR DESCRIPTION
When running tests, it shows a warning since it cannot find the project setting `'internationalization/locale/line_breaking_strictness'`. Ex. on master https://github.com/godotengine/godot/actions/runs/15644773680/job/44081337772#step:13:144
This setting is used by the TextServerAdvanced when it is created, so tests need it too and it cannot be defined in the main setup. I moved it to some other settings in TextServer.
- related https://github.com/godotengine/godot/pull/107439 cc @bruvzg 

I haven't been able to test the functionality of the setting itself, so hopefully it is fine.

```
WARNING: Property not found: 'internationalization/locale/line_breaking_strictness'.
     at: get_setting_with_override (core/config/project_settings.cpp:404)
```
