### PR TITLE
Add --generate-pot option

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5246,7 +5246,7 @@ static int progress_total_steps = 0;
 void EditorNode::progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel) {
 	if (!singleton) {
 		return;
-	} else if (singleton->cmdline_mode) {
+	} else if (Main::is_cmdline_tool()) {
 		print_line_rich(vformat("[   0%% ] [color=gray][b]%s[/b] | Started %s (%d steps)[/color]", p_task, p_label, p_steps));
 		progress_total_steps = p_steps;
 	} else if (singleton->progress_dialog) {
@@ -5257,7 +5257,7 @@ void EditorNode::progress_add_task(const String &p_task, const String &p_label, 
 bool EditorNode::progress_task_step(const String &p_task, const String &p_state, int p_step, bool p_force_refresh) {
 	if (!singleton) {
 		return false;
-	} else if (singleton->cmdline_mode) {
+	} else if (Main::is_cmdline_tool()) {
 		const int percent = (p_step / float(progress_total_steps + 1)) * 100;
 		print_line_rich(vformat("[%4d%% ] [color=gray][b]%s[/b] | %s[/color]", percent, p_task, p_state));
 		return false;
@@ -5271,7 +5271,7 @@ bool EditorNode::progress_task_step(const String &p_task, const String &p_state,
 void EditorNode::progress_end_task(const String &p_task) {
 	if (!singleton) {
 		return;
-	} else if (singleton->cmdline_mode) {
+	} else if (Main::is_cmdline_tool()) {
 		print_line_rich(vformat("[color=green][ DONE ][/color] [b]%s[/b]\n", p_task));
 	} else if (singleton->progress_dialog) {
 		singleton->progress_dialog->end_task(p_task);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -117,6 +117,7 @@
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
 #include "editor/editor_translation.h"
+#include "editor/pot_generator.h"
 #include "editor/progress_dialog.h"
 #include "editor/project_manager.h"
 #include "editor/register_editor_types.h"
@@ -217,6 +218,7 @@ static bool found_project = false;
 static bool recovery_mode = false;
 static bool auto_build_solutions = false;
 static String debug_server_uri;
+static String generate_pot_path;
 static bool wait_for_import = false;
 static bool restore_editor_window_layout = true;
 #ifndef DISABLE_DEPRECATED
@@ -695,6 +697,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("", "If incompatibilities or errors are detected, the exit code will be non-zero.\n");
 	print_help_option("--benchmark", "Benchmark the run time and print it to console.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 	print_help_option("--benchmark-file <path>", "Benchmark the run time and save it to a given file in JSON format. The path should be absolute.\n", CLI_OPTION_AVAILABILITY_EDITOR);
+	print_help_option("--generate-pot <path>", "Generate POT file for use with gettext translations, and then quit.\n", CLI_OPTION_AVAILABILITY_EDITOR);
 #endif // TOOLS_ENABLED
 #ifdef TESTS_ENABLED
 	print_help_option("--test [--help]", "Run unit tests. Use --test --help for more information.\n");
@@ -1633,6 +1636,26 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 #endif // MODULE_GDSCRIPT_ENABLED
+		} else if (arg == "--generate-pot") {
+					editor = true;
+					cmdline_tool = true;
+					wait_for_import = true;
+					quit_after = 1;
+
+					if (N) {
+						// Will be handled in start()
+						main_args.push_back(arg);
+						main_args.push_back(N->get());
+						N = N->next();
+					} else {
+						OS::get_singleton()->print("Missing POT file path after --generate-pot, aborting.\n");
+						goto error;
+					}
+
+					// `--generate-pot` implies `--headless` to avoid spawning an unnecessary window
+					// and speed up class reference generation.
+					audio_driver = NULL_AUDIO_DRIVER;
+					display_driver = NULL_DISPLAY_DRIVER;
 #endif // TOOLS_ENABLED
 		} else if (arg == "--path") { // set path of project to start or edit
 
@@ -3946,6 +3969,10 @@ int Main::start() {
 				export_patch = true;
 			} else if (E->get() == "--patches") {
 				patches = E->next()->get().split(",", false);
+			} else if (E->get() == "--generate-pot") {
+				ERR_FAIL_COND_V_MSG(!editor && !found_project, EXIT_FAILURE, "Please provide a valid project path when generating POT file, aborting.");
+				editor = true;
+				generate_pot_path = E->next()->get();
 #endif
 			} else {
 				// The parameter does not match anything known, don't skip the next argument
@@ -4891,6 +4918,11 @@ bool Main::iteration() {
 			ERR_FAIL_V_MSG(true,
 					"Command line option --build-solutions was passed, but the build callback failed. Aborting.");
 		}
+	}
+
+	if (!generate_pot_path.is_empty()) {
+		print_line("Generating POT file " + generate_pot_path);
+		POTGenerator::get_singleton()->generate_pot(generate_pot_path);
 	}
 #endif
 

--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -168,6 +168,9 @@ Generate GDExtension header file 'gdextension_interface.h' in the current folder
 \fB\-\-dump\-extension\-api\fR
 Generate JSON dump of the Godot API for GDExtension bindings named 'extension_api.json' in the current folder.
 .TP
+\fB\-\-generate\-pot\fR <path>
+Generate POT file for use with gettext translations, and then quit.
+.TP
 \fB\-\-test\fR <test>
 Run a unit test ('string', 'math', 'physics', 'physics_2d', 'render', 'oa_hash_map', 'gui', 'shaderlang', 'gd_tokenizer', 'gd_parser', 'gd_compiler', 'gd_bytecode', 'ordered_hash_map', 'astar').
 .SH FILES

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -93,4 +93,5 @@ _arguments \
   '--dump-extension-api[generate JSON dump of the Godot API for GDExtension bindings named "extension_api.json" in the current folder]' \
   '--benchmark[benchmark the run time and print it to console]' \
   '--benchmark-file[benchmark the run time and save it to a given file in JSON format]:path to output JSON file' \
+  '--generate-pot[generate POT file for use with gettext translations, and then quit]:path to POT file' \
   '--test[run all unit tests; run with "--test --help" for more information]'

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -96,6 +96,7 @@ _complete_godot_options() {
 --dump-extension-api
 --benchmark
 --benchmark-file
+--generate-pot
 --test
 " -- "$1"))
 }
@@ -145,6 +146,10 @@ _complete_godot_bash() {
     local IFS=$'\n\t'
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -f -X "!*.gd" -- "$cur"))
+  elif [[ $prev == "--generate-pot" ]]; then
+    local IFS=$'\n\t'
+    # shellcheck disable=SC2207
+    COMPREPLY=($(compgen -f -- "$cur"))
   fi
 }
 

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -114,4 +114,5 @@ complete -c godot -l dump-gdextension-interface -d "Generate GDExtension header 
 complete -c godot -l dump-extension-api -d "Generate JSON dump of the Godot API for GDExtension bindings named 'extension_api.json' in the current folder"
 complete -c godot -l benchmark -d "Benchmark the run time and print it to console"
 complete -c godot -l benchmark-file -d "Benchmark the run time and save it to a given file in JSON format" -x
+complete -c godot -l generate-pot -d "Generate POT file for use with gettext translations, and then quit" -x
 complete -c godot -l test -d "Run all unit tests; run with '--test --help' for more information" -x


### PR DESCRIPTION
POT file generation is the only part of the Gettext translation pipeline that can't be automated. Add a --generate-pot option to run POTGenerator without opening the editor. The editor needs to be fully initialized so that EditorTranslationParserPlugin have been enabled.

See godotengine/godot-proposals#10986 for background.

