### PR TITLE
Revert "Add support for exporting to Google Play Instant"

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -61,11 +61,6 @@
 		<member name="gradle_build/export_format" type="int" setter="" getter="">
 			Application export format (*.apk or *.aab).
 		</member>
-		<member name="gradle_build/google_play_instant" type="bool" setter="" getter="">
-			If [code]true[/code], configures the exported project for Play Instant Build.
-			Use this option when targeting Play Instant to allow users to launch the app without installation. See [url=https://developer.android.com/topic/google-play-instant/overview]Google Play Instant[/url].
-			[b]Note:[/b] Instant play games also need to be optimized for size. See [url=https://docs.godotengine.org/en/stable/contributing/development/compiling/optimizing_for_size.html]Optimizing a build for size[/url].
-		</member>
 		<member name="gradle_build/gradle_build_directory" type="String" setter="" getter="">
 			Path to the Gradle build directory. If left empty, then [code]res://android[/code] will be used.
 		</member>

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -315,8 +315,6 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 	int app_category_index = (int)(p_preset->get("package/app_category"));
 	bool is_game = app_category_index == APP_CATEGORY_GAME;
 
-	bool google_play_instant_build = (bool)p_preset->get("gradle_build/google_play_instant");
-
 	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"
@@ -336,10 +334,6 @@ String _get_application_tag(const Ref<EditorExportPlatform> &p_export_platform, 
 		manifest_application_text += "        tools:replace=\"android:allowBackup,android:isGame,android:hasFragileUserData,android:requestLegacyExternalStorage\"\n";
 	}
 	manifest_application_text += "        tools:ignore=\"GoogleAppIndexingWarning\">\n\n";
-
-	if (google_play_instant_build) {
-		manifest_application_text += "        <dist:module dist:instant=\"true\" />\n";
-	}
 
 	for (int i = 0; i < p_metadata.size(); i++) {
 		manifest_application_text += vformat("        <meta-data tools:node=\"replace\" android:name=\"%s\" android:value=\"%s\" />\n", p_metadata[i].name, p_metadata[i].value);

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -37,10 +37,6 @@ dependencies {
     implementation "androidx.fragment:fragment:$versions.fragmentVersion"
     implementation "androidx.core:core-splashscreen:$versions.splashscreenVersion"
 
-    if (isInstantApp()) {
-        implementation "com.google.android.gms:play-services-instantapps:$versions.instantAppsVersion"
-    }
-
     if (rootProject.findProject(":lib")) {
         implementation project(":lib")
     } else if (rootProject.findProject(":godot:lib")) {
@@ -94,7 +90,7 @@ android {
         jvmTarget = versions.javaVersion
     }
 
-    assetPacks = isInstantApp() ? [] : [":assetPackInstallTime"]
+    assetPacks = [":assetPackInstallTime"]
 
     namespace = 'com.godot.game'
 

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -15,8 +15,7 @@ ext.versions = [
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '28.1.13356709',
     splashscreenVersion: '1.0.1',
-    openxrVendorsVersion: '4.0.0-stable',
-    instantAppsVersion: '17.0.0'
+    openxrVendorsVersion: '4.0.0-stable'
 
 ]
 
@@ -379,9 +378,4 @@ ext.shouldNotStrip = { ->
 ext.getAddonsDirectory = { ->
     String addonsDirectory = project.hasProperty("addons_directory") ? project.property("addons_directory") : ""
     return addonsDirectory
-}
-
-ext.isInstantApp = { ->
-    String instantApp = project.hasProperty("play_instant_app") ? project.property("play_instant_app") : ""
-    return Boolean.parseBoolean(instantApp)
 }


### PR DESCRIPTION
This PR reverts the recently added support for Google Play Instant (https://github.com/godotengine/godot/pull/106447).

Shortly after the feature was merged, we received news that Google will shut down Instant Apps in December 2025. Since this feature is being discontinued soon, there’s no value in keeping it for just a few months.

![image](https://github.com/user-attachments/assets/3012350b-4762-43f3-942e-98f5283ab65b)
