### PR TITLE
Restore default empty skeleton path on MeshInstance3D

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -128,7 +128,7 @@
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] resource for the instance.
 		</member>
-		<member name="skeleton" type="NodePath" setter="set_skeleton_path" getter="get_skeleton_path" default="NodePath(&quot;..&quot;)">
+		<member name="skeleton" type="NodePath" setter="set_skeleton_path" getter="get_skeleton_path" default="NodePath(&quot;&quot;)">
 			[NodePath] to the [Skeleton3D] associated with the instance.
 		</member>
 		<member name="skin" type="Skin" setter="set_skin" getter="get_skin">

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -48,7 +48,7 @@ protected:
 	Ref<Skin> skin;
 	Ref<Skin> skin_internal;
 	Ref<SkinReference> skin_ref;
-	NodePath skeleton_path = NodePath("..");
+	NodePath skeleton_path = NodePath();
 
 	LocalVector<float> blend_shape_tracks;
 	HashMap<StringName, int> blend_shape_properties;


### PR DESCRIPTION
Restores default empty skeleton path on MeshInstance3D to avoid unnecessary or faulty NodePath updates.

_**I dont know if there are any additional quirks now that I am not considering. I asked in dev chat but this needs confirmation from the animation/editor people.**_

### How we got to this and why it is a problem

The original `MeshInstance` pre Godot 4 had an empty `NodePath` for `skeleton_path` as default.

This empty nodepath served 2 purposes. Because the NodePath was fully empty it did not try to resolve and get the node. It was also not prone to faulty and wasteful NodePath auto-updates on all reparent actions (an issue of its own) because there was nothing to update.

In Godot 4.0 that empty default was changed with the PR44630 to initalize class variables.

Instead of adding an empty `NodePath()` that PR changed to a relative`NodePath(..)` targeting the parent for reasons yet unknown.

Going further that change would turn the `MeshInstance3D` into a node that would try to resolve its parent node path for a skeleton all the time even if it was never used.

Another problem with the relative nodepath is that now this NodePath also gets auto-updated on reparent by NodePath and editor magic. If that fails you get error spam, lots and lots of error spam. Try finding that offending node with a broken path in a very large SceneTree when every second node you use is a MeshInstance3D with no skeleton seen within miles, good luck.

In the most ridiculous of all situations, if the relative nodepath would target scene `root`, this could try to resolve to `EditorRoot`, creating a new nodepath that spans from america to china causing a beauty of a commit diff because the path from EditorRoot just to the editor 3d viewport alone goes through 101 different Control related gui nodes.

### Compatibility 

~In order to keep compatibility with the current weirdness I made it look at the parent node when the `skeleton_path` is empty. If the parent node is a skeleton it is used as a fallback to simulate the old (..) parent nodepath behavior.~ If you relied on the default to parent path for your skeleton I have bad new for you. Godot does not store defaults, so with this PR that path would turn empty and you need to set the path manually again to fix it.

For existing projects that already have a convoluted path set in that property from a reparent nothing should change in behavior as that path is already stored for the node variable within the scene file. If they want to remove those unnecessary and often long and faulty nodepaths they need to clear them manually.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
