### PR TITLE
Don't put main properties of `AnimatedSprite2D` inside a group

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -669,7 +669,6 @@ void AnimatedSprite2D::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("animation_looped"));
 	ADD_SIGNAL(MethodInfo("animation_finished"));
 
-	ADD_GROUP("Animation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sprite_frames", PROPERTY_HINT_RESOURCE_TYPE, "SpriteFrames"), "set_sprite_frames", "get_sprite_frames");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, ""), "set_animation", "get_animation");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "autoplay", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_autoplay", "get_autoplay");


### PR DESCRIPTION
Inspector when you select an animated sprite node for the first time:

| `AnimatedSprite2D` | `AnimatedSprite3D` |
|----|----|
| ![image](https://github.com/user-attachments/assets/ad1cd0dc-1d68-4c21-8376-eb12cbd1d576) | ![image](https://github.com/user-attachments/assets/7874a1d7-452a-4e92-ba50-07ab5ce9b720) |

Nothing useful is displayed for `AnimatedSprite2D`. Users have to always expand the group in order to set properties.

The four properties hidden inside the Animation group is the same as ones shown directly in `AnimatedSprite3D`.

This PR removes the Animation group:

| Before | After |
|----|----|
| ![image](https://github.com/user-attachments/assets/9a9073ff-b230-4577-8df7-6dd3aee44cf2) | ![image](https://github.com/user-attachments/assets/17d46f80-c746-441c-b24e-560e4b4ccc99) |
