### PR TITLE
Fix `CodeEdit` Array bug in the inspector

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -22,7 +22,7 @@
 			<param index="0" name="candidates" type="Dictionary[]" />
 			<description>
 				Override this method to define what items in [param candidates] should be displayed.
-				Both [param candidates] and the return is a [Array] of [Dictionary], see [method get_code_completion_option] for [Dictionary] content.
+				Both [param candidates] and the return is an [Array] of [Dictionary], see [method get_code_completion_option] for [Dictionary] content.
 			</description>
 		</method>
 		<method name="_request_code_completion" qualifiers="virtual">
@@ -539,13 +539,13 @@
 			If [code]true[/code], the [member ProjectSettings.input/ui_text_completion_query] action requests code completion. To handle it, see [method _request_code_completion] or [signal code_completion_requested].
 		</member>
 		<member name="code_completion_prefixes" type="String[]" setter="set_code_completion_prefixes" getter="get_code_completion_prefixes" default="[]">
-			Sets prefixes that will trigger code completion. [br] If you add a prefixes with the editor, you need to press [kbd] Backspace [/kbd] before editing the value.
+			Sets prefixes that will trigger code completion.
 		</member>
 		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[]">
-			Sets the comment delimiters. All existing comment delimiters will be removed. [br] If you add a comment delimiter with the editor, you need to press [kbd] Backspace [/kbd] before editing the value. If you want to make a end key, you need to write it right next to the first character and then put the space between the two characters.
+			Sets the comment delimiters. All existing comment delimiters will be removed.
 		</member>
 		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[&quot;&apos; &apos;&quot;, &quot;\&quot; \&quot;&quot;]">
-			Sets the string delimiters. All existing string delimiters will be removed. [br] If you add a string delimiter with the editor, you need to press [kbd] Backspace [/kbd] before editing the value. If you want to make a end key, you need to write it right next to the first character and then put the space between the two characters.
+			Sets the string delimiters. All existing string delimiters will be removed.
 		</member>
 		<member name="gutters_draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
 			If [code]true[/code], bookmarks are drawn in the gutter. This gutter is shared with breakpoints and executing lines. See [method set_line_as_bookmarked].
@@ -569,7 +569,7 @@
 			If [code]true[/code], an extra indent is automatically inserted when a new line is added and a prefix in [member indent_automatic_prefixes] is found. If a brace pair opening key is found, the matching closing brace will be moved to another new line (see [member auto_brace_completion_pairs]).
 		</member>
 		<member name="indent_automatic_prefixes" type="String[]" setter="set_auto_indent_prefixes" getter="get_auto_indent_prefixes" default="[&quot;:&quot;, &quot;{&quot;, &quot;[&quot;, &quot;(&quot;]">
-			Prefixes to trigger an automatic indent. Used when [member indent_automatic] is set to [code]true[/code]. [br] If you add a prefixes with the editor, you need to press [kbd] Backspace [/kbd] before editing the value.
+			Prefixes to trigger an automatic indent. Used when [member indent_automatic] is set to [code]true[/code].
 		</member>
 		<member name="indent_size" type="int" setter="set_indent_size" getter="get_indent_size" default="4">
 			Size of the tabulation indent (one [kbd]Tab[/kbd] press) in characters. If [member indent_use_spaces] is enabled the number of spaces to use.

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -539,13 +539,13 @@
 			If [code]true[/code], the [member ProjectSettings.input/ui_text_completion_query] action requests code completion. To handle it, see [method _request_code_completion] or [signal code_completion_requested].
 		</member>
 		<member name="code_completion_prefixes" type="String[]" setter="set_code_completion_prefixes" getter="get_code_completion_prefixes" default="[]">
-			Sets prefixes that will trigger code completion.
+			Sets prefixes that will trigger code completion. [br] If you add a prefixes with the editor, you need to press [kbd] Backspace [/kbd] before editing the value.
 		</member>
 		<member name="delimiter_comments" type="String[]" setter="set_comment_delimiters" getter="get_comment_delimiters" default="[]">
-			Sets the comment delimiters. All existing comment delimiters will be removed.
+			Sets the comment delimiters. All existing comment delimiters will be removed. [br] If you add a comment delimiter with the editor, you need to press [kbd] Backspace [/kbd] before editing the value. If you want to make a end key, you need to write it right next to the first character and then put the space between the two characters.
 		</member>
 		<member name="delimiter_strings" type="String[]" setter="set_string_delimiters" getter="get_string_delimiters" default="[&quot;&apos; &apos;&quot;, &quot;\&quot; \&quot;&quot;]">
-			Sets the string delimiters. All existing string delimiters will be removed.
+			Sets the string delimiters. All existing string delimiters will be removed. [br] If you add a string delimiter with the editor, you need to press [kbd] Backspace [/kbd] before editing the value. If you want to make a end key, you need to write it right next to the first character and then put the space between the two characters.
 		</member>
 		<member name="gutters_draw_bookmarks" type="bool" setter="set_draw_bookmarks_gutter" getter="is_drawing_bookmarks_gutter" default="false">
 			If [code]true[/code], bookmarks are drawn in the gutter. This gutter is shared with breakpoints and executing lines. See [method set_line_as_bookmarked].
@@ -569,7 +569,7 @@
 			If [code]true[/code], an extra indent is automatically inserted when a new line is added and a prefix in [member indent_automatic_prefixes] is found. If a brace pair opening key is found, the matching closing brace will be moved to another new line (see [member auto_brace_completion_pairs]).
 		</member>
 		<member name="indent_automatic_prefixes" type="String[]" setter="set_auto_indent_prefixes" getter="get_auto_indent_prefixes" default="[&quot;:&quot;, &quot;{&quot;, &quot;[&quot;, &quot;(&quot;]">
-			Prefixes to trigger an automatic indent. Used when [member indent_automatic] is set to [code]true[/code].
+			Prefixes to trigger an automatic indent. Used when [member indent_automatic] is set to [code]true[/code]. [br] If you add a prefixes with the editor, you need to press [kbd] Backspace [/kbd] before editing the value.
 		</member>
 		<member name="indent_size" type="int" setter="set_indent_size" getter="get_indent_size" default="4">
 			Size of the tabulation indent (one [kbd]Tab[/kbd] press) in characters. If [member indent_use_spaces] is enabled the number of spaces to use.

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2148,6 +2148,11 @@ void CodeEdit::set_code_completion_prefixes(const TypedArray<String> &p_prefixes
 	for (int i = 0; i < p_prefixes.size(); i++) {
 		String prefix = p_prefixes[i];
 
+		// Hadle case if we add a prefixe with the editor.
+		if (Engine::get_singleton()->is_editor_hint() && prefix.is_empty()) {
+			prefix = " ";
+		}
+
 		code_completion_prefixes.insert(prefix[0]);
 	}
 }
@@ -3345,6 +3350,9 @@ void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key
 		}
 	}
 
+	for (int i = 0; i < delimiters.size(); i++) {
+		ERR_FAIL_COND_MSG(delimiters[i].start_key == p_start_key, "delimiter with start key '" + p_start_key + "' already exists.");
+	}
 
 	int at = delimiters.size();
 
@@ -3416,8 +3424,7 @@ void CodeEdit::_set_delimiters(const TypedArray<String> &p_delimiters, Delimiter
 
 		if (key.is_empty()) {
 			start_key = " ";
-		}
-		else {
+		} else {
 			start_key = key.get_slicec(' ', 0);
 			end_key = key.get_slice_count(" ") > 1 ? key.get_slicec(' ', 1) : String();
 		}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2146,13 +2146,9 @@ bool CodeEdit::is_code_completion_enabled() const {
 void CodeEdit::set_code_completion_prefixes(const TypedArray<String> &p_prefixes) {
 	code_completion_prefixes.clear();
 	for (int i = 0; i < p_prefixes.size(); i++) {
-		String prefix = p_prefixes[i];
+		const String prefix = p_prefixes[i];
 
-		// Hadle case if we add a prefixe with the editor.
-		if (Engine::get_singleton()->is_editor_hint() && prefix.is_empty()) {
-			prefix = " ";
-		}
-
+		ERR_CONTINUE_MSG(prefix.is_empty(), "Code completion prefix cannot be empty.");
 		code_completion_prefixes.insert(prefix[0]);
 	}
 }
@@ -2915,18 +2911,18 @@ void CodeEdit::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gutters_draw_fold_gutter"), "set_draw_fold_gutter", "is_drawing_fold_gutter");
 
 	ADD_GROUP("Delimiters", "delimiter_");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_strings", PROPERTY_HINT_TYPE_STRING, "String"), "set_string_delimiters", "get_string_delimiters");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_comments", PROPERTY_HINT_TYPE_STRING, "String"), "set_comment_delimiters", "get_comment_delimiters");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_strings", PROPERTY_HINT_TYPE_STRING, "String", PROPERTY_USAGE_NO_EDITOR), "set_string_delimiters", "get_string_delimiters");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "delimiter_comments", PROPERTY_HINT_TYPE_STRING, "String", PROPERTY_USAGE_NO_EDITOR), "set_comment_delimiters", "get_comment_delimiters");
 
 	ADD_GROUP("Code Completion", "code_completion_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "code_completion_enabled"), "set_code_completion_enabled", "is_code_completion_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "code_completion_prefixes", PROPERTY_HINT_TYPE_STRING, "String"), "set_code_completion_prefixes", "get_code_completion_prefixes");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "code_completion_prefixes", PROPERTY_HINT_TYPE_STRING, "String", PROPERTY_USAGE_NO_EDITOR), "set_code_completion_prefixes", "get_code_completion_prefixes");
 
 	ADD_GROUP("Indentation", "indent_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "indent_size"), "set_indent_size", "get_indent_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_use_spaces"), "set_indent_using_spaces", "is_indent_using_spaces");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "indent_automatic"), "set_auto_indent_enabled", "is_auto_indent_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "indent_automatic_prefixes", PROPERTY_HINT_TYPE_STRING, "String"), "set_auto_indent_prefixes", "get_auto_indent_prefixes");
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_STRING_ARRAY, "indent_automatic_prefixes", PROPERTY_HINT_TYPE_STRING, "String", PROPERTY_USAGE_NO_EDITOR), "set_auto_indent_prefixes", "get_auto_indent_prefixes");
 
 	ADD_GROUP("Auto Brace Completion", "auto_brace_completion_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_brace_completion_enabled"), "set_auto_brace_completion_enabled", "is_auto_brace_completion_enabled");
@@ -3354,10 +3350,8 @@ void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key
 		ERR_FAIL_COND_MSG(delimiters[i].start_key == p_start_key, "delimiter with start key '" + p_start_key + "' already exists.");
 	}
 
-	int at = delimiters.size();
 
-	// Comment that so the order dont change when you edit a value, maybe create a parameter for it later ?
-	/* int at = 0;
+	int at = 0;
 	for (int i = 0; i < delimiters.size(); i++) {
 		ERR_FAIL_COND_MSG(delimiters[i].start_key == p_start_key, "delimiter with start key '" + p_start_key + "' already exists.");
 		if (p_start_key.length() < delimiters[i].start_key.length()) {
@@ -3365,7 +3359,7 @@ void CodeEdit::_add_delimiter(const String &p_start_key, const String &p_end_key
 		} else {
 			break;
 		}
-	} */
+	}
 
 	Delimiter delimiter;
 	delimiter.type = p_type;
@@ -3419,15 +3413,13 @@ void CodeEdit::_set_delimiters(const TypedArray<String> &p_delimiters, Delimiter
 
 	for (int i = 0; i < p_delimiters.size(); i++) {
 		String key = p_delimiters[i];
-		String start_key;
-		String end_key;
 
 		if (key.is_empty()) {
-			start_key = " ";
-		} else {
-			start_key = key.get_slicec(' ', 0);
-			end_key = key.get_slice_count(" ") > 1 ? key.get_slicec(' ', 1) : String();
+			continue;
 		}
+
+		const String start_key = key.get_slicec(' ', 0);
+		const String end_key = key.get_slice_count(" ") > 1 ? key.get_slicec(' ', 1) : String();
 
 		_add_delimiter(start_key, end_key, end_key.is_empty(), p_type);
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/83896 
Fixes https://github.com/godotengine/godot/issues/95872


- Change the display of `Line Lenght Guidlines`, `Delimiter Strings`, `Delimiter Comments`, `Code Completion Prefixes` and `Indent Automatic Prefixes` so we cant change their types (which would not have worked in all cases and would display an error message) and make easier to delete a value.
- Fix the bug that prevents adding values ​​to `Code Completion Prefixes`,  `Delimiter Strings`, `Delimiter Comments` and `Indent Automatic Prefixes`.
- Make the  `Delimiter Strings` and `Delimiter Comments` list dont change order when you do a litlle changement.
- Make `Line Length Guidlines`value unable to be less to 0.
- Update documentation to help on unclear stuff about Array manipulation.

---
<details open>
<summary> Display Modifications </summary>

| Display Modifications | Old | New |
| ------------- | ------------- | ------------- |
| Line Lenght Guidlines  | ![image](https://github.com/user-attachments/assets/44c17231-99ce-49e8-bf19-db066b8c45ab)  | ![image](https://github.com/user-attachments/assets/52525a55-9ae8-4f9c-90a8-aa4840b76694) |
| Others Arrays  | ![image](https://github.com/user-attachments/assets/405cd10b-ef3a-47f9-92e9-faa81eb3e636)  | ![image](https://github.com/user-attachments/assets/043b4d02-383a-41b9-b6b0-5771f03ba83b) |

</details>

<details open>
<summary> Documentation Modifications </summary>

| Documentation Modifications | Old | New |
| ---------- | ---------- | --------- |
| indent_automatic_prefixes | ![image](https://github.com/user-attachments/assets/94c1c7f2-60ff-4235-932f-c4ffa248c708) | ![image](https://github.com/user-attachments/assets/cd66904e-dc30-460e-893d-d0cb6ac366bb) |
|  Delimiter Strings, Delimiter Comments and Code Completion Prefixes | ![image](https://github.com/user-attachments/assets/aa1ea085-266c-4089-99d0-5db136989e99) | ![image](https://github.com/user-attachments/assets/52850afe-43b6-4e74-92e0-c0e1bb95d9cf) |

</details>

---

> [!WARNING]
> This will not pass the tests.

Since I changed the way `set_code_completion_prefixes` handles new empty entries (from deleting them to modifying them with a space to let the user add them with the inspector), the test

``` h
SUBCASE("[CodeEdit] autocomplete") {
	code_edit->set_code_completion_enabled(true);
	CHECK(code_edit->is_code_completion_enabled());

	/* Set prefixes, single char only, disallow empty. */
	TypedArray<String> completion_prefixes = { "", ".", ".", ",," };

	ERR_PRINT_OFF;
	code_edit->set_code_completion_prefixes(completion_prefixes);
	ERR_PRINT_ON;
	completion_prefixes = code_edit->get_code_completion_prefixes();
	CHECK(completion_prefixes.size() == 2);
	CHECK(completion_prefixes.has("."));
	CHECK(completion_prefixes.has(","));

	code_edit->set_text("test\ntest");
	CHECK(code_edit->get_text_for_code_completion() == String::chr(0xFFFF) + "test\ntest");
}
```

will fail because instead of deleting the entry " ", it will add it as " " so that the user can edit it later in the editor.
Should the `test_code_edit.h` script be modified to expect 3 outputs instead of 2?