### PR TITLE
Fix freelook in 3D when multiple viewports are open

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -560,6 +560,7 @@ public:
 
 	SubViewport *get_viewport_node() { return viewport; }
 	Camera3D *get_camera_3d() { return camera; } // return the default camera object.
+	Control *get_surface() { return surface; }
 
 	Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p_index);
 	~Node3DEditorViewport();
@@ -825,6 +826,8 @@ private:
 
 	Node3D *selected = nullptr;
 
+	Node3DEditorViewport *freelook_viewport = nullptr;
+
 	void _request_gizmo(Object *p_obj);
 	void _request_gizmo_for_id(ObjectID p_id);
 	void _set_subgizmo_selection(Object *p_obj, Ref<Node3DGizmo> p_gizmo, int p_id, Transform3D p_transform = Transform3D());
@@ -1024,6 +1027,9 @@ public:
 		return viewports[p_idx];
 	}
 	Node3DEditorViewport *get_last_used_viewport();
+
+	void set_freelook_viewport(Node3DEditorViewport *p_viewport) { freelook_viewport = p_viewport; }
+	Node3DEditorViewport *get_freelook_viewport() const { return freelook_viewport; }
 
 	void add_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);
 	void remove_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

- Fix https://github.com/godotengine/godot/issues/100720
- Fix https://github.com/godotengine/godot/issues/95073
- Fix https://github.com/godotengine/godot/issues/50051

Supersedes: https://github.com/godotengine/godot/pull/90037, https://github.com/godotengine/godot/pull/103093

The problem was that when the mouse is captured it could be over a UI element that is not the viewport where freelook is active, which prevents the viewport surface from getting inputs. The solution is to redirect the inputs back to the freelook viewport.

 

https://github.com/user-attachments/assets/b944ec5c-f24d-4bf6-9a47-31ad4ca4ae8c


