### PR TITLE
Rename TreeItem's `alt_text` to `description` for consistency with Accessibility API

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -18,9 +18,9 @@
 			<param index="2" name="id" type="int" default="-1" />
 			<param index="3" name="disabled" type="bool" default="false" />
 			<param index="4" name="tooltip_text" type="String" default="&quot;&quot;" />
-			<param index="5" name="alt_text" type="String" default="&quot;&quot;" />
+			<param index="5" name="description" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a button with [Texture2D] [param button] to the end of the cell at column [param column]. The [param id] is used to identify the button in the according [signal Tree.button_clicked] signal and can be different from the buttons index. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [param disabled] and have a [param tooltip_text]. [param alt_text] is used as the button description for assistive apps.
+				Adds a button with [Texture2D] [param button] to the end of the cell at column [param column]. The [param id] is used to identify the button in the according [signal Tree.button_clicked] signal and can be different from the buttons index. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [param disabled] and have a [param tooltip_text]. [param description] is used as the button description for assistive apps.
 			</description>
 		</method>
 		<method name="add_child">
@@ -78,13 +78,6 @@
 			<param index="1" name="button_index" type="int" />
 			<description>
 				Removes the button at index [param button_index] in column [param column].
-			</description>
-		</method>
-		<method name="get_alt_text" qualifiers="const">
-			<return type="String" />
-			<param index="0" name="column" type="int" />
-			<description>
-				Returns the given column's alternative text.
 			</description>
 		</method>
 		<method name="get_auto_translate_mode" qualifiers="const">
@@ -208,6 +201,13 @@
 			<param index="0" name="column" type="int" />
 			<description>
 				Returns custom font size used to draw text in the column [param column].
+			</description>
+		</method>
+		<method name="get_description" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="column" type="int" />
+			<description>
+				Returns the given column's description for assistive apps.
 			</description>
 		</method>
 		<method name="get_expand_right" qualifiers="const">
@@ -514,14 +514,6 @@
 				Selects the given [param column].
 			</description>
 		</method>
-		<method name="set_alt_text">
-			<return type="void" />
-			<param index="0" name="column" type="int" />
-			<param index="1" name="text" type="String" />
-			<description>
-				Sets the given column's alternative (description) text for assistive apps.
-			</description>
-		</method>
 		<method name="set_auto_translate_mode">
 			<return type="void" />
 			<param index="0" name="column" type="int" />
@@ -548,15 +540,6 @@
 				Sets the given column's button [Texture2D] at index [param button_index] to [param button].
 			</description>
 		</method>
-		<method name="set_button_alt_text">
-			<return type="void" />
-			<param index="0" name="column" type="int" />
-			<param index="1" name="button_index" type="int" />
-			<param index="2" name="alt_text" type="String" />
-			<description>
-				Sets the given column's button alternative text (description) at index [param button_index] for assistive apps.
-			</description>
-		</method>
 		<method name="set_button_color">
 			<return type="void" />
 			<param index="0" name="column" type="int" />
@@ -564,6 +547,15 @@
 			<param index="2" name="color" type="Color" />
 			<description>
 				Sets the given column's button color at index [param button_index] to [param color].
+			</description>
+		</method>
+		<method name="set_button_description">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="button_index" type="int" />
+			<param index="2" name="description" type="String" />
+			<description>
+				Sets the given column's button description at index [param button_index] for assistive apps.
 			</description>
 		</method>
 		<method name="set_button_disabled">
@@ -665,6 +657,14 @@
 			<param index="1" name="font_size" type="int" />
 			<description>
 				Sets custom font size used to draw text in the given [param column].
+			</description>
+		</method>
+		<method name="set_description">
+			<return type="void" />
+			<param index="0" name="column" type="int" />
+			<param index="1" name="description" type="String" />
+			<description>
+				Sets the given column's description for assistive apps.
 			</description>
 		</method>
 		<method name="set_edit_multiline">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -400,14 +400,14 @@ String TreeItem::get_text(int p_column) const {
 	return cells[p_column].text;
 }
 
-void TreeItem::set_alt_text(int p_column, String p_text) {
+void TreeItem::set_description(int p_column, String p_text) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 
-	if (cells[p_column].alt_text == p_text) {
+	if (cells[p_column].description == p_text) {
 		return;
 	}
 
-	cells.write[p_column].alt_text = p_text;
+	cells.write[p_column].description = p_text;
 
 	_changed_notify(p_column);
 	if (get_tree()) {
@@ -415,9 +415,9 @@ void TreeItem::set_alt_text(int p_column, String p_text) {
 	}
 }
 
-String TreeItem::get_alt_text(int p_column) const {
+String TreeItem::get_description(int p_column) const {
 	ERR_FAIL_INDEX_V(p_column, cells.size(), "");
-	return cells[p_column].alt_text;
+	return cells[p_column].description;
 }
 
 void TreeItem::set_text_direction(int p_column, Control::TextDirection p_text_direction) {
@@ -1330,7 +1330,7 @@ void TreeItem::clear_buttons() {
 	}
 }
 
-void TreeItem::add_button(int p_column, const Ref<Texture2D> &p_button, int p_id, bool p_disabled, const String &p_tooltip, const String &p_alt_text) {
+void TreeItem::add_button(int p_column, const Ref<Texture2D> &p_button, int p_id, bool p_disabled, const String &p_tooltip, const String &p_description) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_COND(p_button.is_null());
 	TreeItem::Cell::Button button;
@@ -1341,7 +1341,7 @@ void TreeItem::add_button(int p_column, const Ref<Texture2D> &p_button, int p_id
 	button.id = p_id;
 	button.disabled = p_disabled;
 	button.tooltip = p_tooltip;
-	button.alt_text = p_alt_text;
+	button.description = p_description;
 	cells.write[p_column].buttons.push_back(button);
 	cells.write[p_column].cached_minimum_size_dirty = true;
 
@@ -1427,15 +1427,15 @@ void TreeItem::set_button(int p_column, int p_index, const Ref<Texture2D> &p_but
 	_changed_notify(p_column);
 }
 
-void TreeItem::set_button_alt_text(int p_column, int p_index, const String &p_alt_text) {
+void TreeItem::set_button_description(int p_column, int p_index, const String &p_description) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_INDEX(p_index, cells[p_column].buttons.size());
 
-	if (cells[p_column].buttons[p_index].alt_text == p_alt_text) {
+	if (cells[p_column].buttons[p_index].description == p_description) {
 		return;
 	}
 
-	cells.write[p_column].buttons.write[p_index].alt_text = p_alt_text;
+	cells.write[p_column].buttons.write[p_index].description = p_description;
 	_changed_notify(p_column);
 	if (get_tree()) {
 		get_tree()->update_configuration_warnings();
@@ -1775,8 +1775,8 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_text", "column", "text"), &TreeItem::set_text);
 	ClassDB::bind_method(D_METHOD("get_text", "column"), &TreeItem::get_text);
 
-	ClassDB::bind_method(D_METHOD("set_alt_text", "column", "text"), &TreeItem::set_alt_text);
-	ClassDB::bind_method(D_METHOD("get_alt_text", "column"), &TreeItem::get_alt_text);
+	ClassDB::bind_method(D_METHOD("set_description", "column", "description"), &TreeItem::set_description);
+	ClassDB::bind_method(D_METHOD("get_description", "column"), &TreeItem::get_description);
 
 	ClassDB::bind_method(D_METHOD("set_text_direction", "column", "direction"), &TreeItem::set_text_direction);
 	ClassDB::bind_method(D_METHOD("get_text_direction", "column"), &TreeItem::get_text_direction);
@@ -1871,7 +1871,7 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_custom_set_as_button", "column"), &TreeItem::is_custom_set_as_button);
 
 	ClassDB::bind_method(D_METHOD("clear_buttons"), &TreeItem::clear_buttons);
-	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "id", "disabled", "tooltip_text", "alt_text"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "id", "disabled", "tooltip_text", "description"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_button_count", "column"), &TreeItem::get_button_count);
 	ClassDB::bind_method(D_METHOD("get_button_tooltip_text", "column", "button_index"), &TreeItem::get_button_tooltip_text);
 	ClassDB::bind_method(D_METHOD("get_button_id", "column", "button_index"), &TreeItem::get_button_id);
@@ -1881,7 +1881,7 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_tooltip_text", "column", "button_index", "tooltip"), &TreeItem::set_button_tooltip_text);
 	ClassDB::bind_method(D_METHOD("set_button", "column", "button_index", "button"), &TreeItem::set_button);
 	ClassDB::bind_method(D_METHOD("erase_button", "column", "button_index"), &TreeItem::erase_button);
-	ClassDB::bind_method(D_METHOD("set_button_alt_text", "column", "button_index", "alt_text"), &TreeItem::set_button_alt_text);
+	ClassDB::bind_method(D_METHOD("set_button_description", "column", "button_index", "description"), &TreeItem::set_button_description);
 	ClassDB::bind_method(D_METHOD("set_button_disabled", "column", "button_index", "disabled"), &TreeItem::set_button_disabled);
 	ClassDB::bind_method(D_METHOD("set_button_color", "column", "button_index", "color"), &TreeItem::set_button_color);
 	ClassDB::bind_method(D_METHOD("is_button_disabled", "column", "button_index"), &TreeItem::is_button_disabled);
@@ -4538,11 +4538,11 @@ int Tree::_get_title_button_height() const {
 void Tree::_check_item_accessibility(TreeItem *p_item, PackedStringArray &r_warnings, int &r_row) const {
 	for (int i = 0; i < p_item->cells.size(); i++) {
 		const TreeItem::Cell &cell = p_item->cells[i];
-		if (cell.alt_text.strip_edges().is_empty() && cell.text.strip_edges().is_empty()) {
+		if (cell.description.strip_edges().is_empty() && cell.text.strip_edges().is_empty()) {
 			r_warnings.push_back(vformat(RTR("Cell %d x %d: either text or alternative text must not be empty."), r_row, i));
 		}
 		for (int j = 0; j < cell.buttons.size(); j++) {
-			if (cell.buttons[j].alt_text.strip_edges().is_empty()) {
+			if (cell.buttons[j].description.strip_edges().is_empty()) {
 				r_warnings.push_back(vformat(RTR("Button %d in %d x %d: alternative text must not be empty."), j, r_row, i));
 			}
 		}
@@ -4732,10 +4732,10 @@ void Tree::_accessibility_update_item(Point2 &r_ofs, TreeItem *p_item, int &r_ro
 
 				DisplayServer::get_singleton()->accessibility_update_set_table_cell_position(cell.accessibility_cell_element, r_row, i);
 				DisplayServer::get_singleton()->accessibility_update_set_list_item_selected(cell.accessibility_cell_element, cell.selected);
-				if (cell.alt_text.is_empty()) {
+				if (cell.description.is_empty()) {
 					DisplayServer::get_singleton()->accessibility_update_set_name(cell.accessibility_cell_element, cell.xl_text);
 				} else {
-					DisplayServer::get_singleton()->accessibility_update_set_name(cell.accessibility_cell_element, cell.alt_text);
+					DisplayServer::get_singleton()->accessibility_update_set_name(cell.accessibility_cell_element, cell.description);
 				}
 
 				DisplayServer::get_singleton()->accessibility_update_set_text_align(cell.accessibility_cell_element, cell.text_alignment);
@@ -4784,10 +4784,10 @@ void Tree::_accessibility_update_item(Point2 &r_ofs, TreeItem *p_item, int &r_ro
 					DisplayServer::get_singleton()->accessibility_update_add_action(cell.buttons[j].accessibility_button_element, DisplayServer::AccessibilityAction::ACTION_CLICK, callable_mp(this, &Tree::_accessibility_action_button_press).bind(p_item, i, j));
 					DisplayServer::get_singleton()->accessibility_update_set_flag(cell.buttons[j].accessibility_button_element, DisplayServer::AccessibilityFlags::FLAG_DISABLED, cell.buttons[j].disabled);
 					DisplayServer::get_singleton()->accessibility_update_set_tooltip(cell.buttons[j].accessibility_button_element, cell.buttons[j].tooltip);
-					if (cell.buttons[j].alt_text.is_empty()) {
+					if (cell.buttons[j].description.is_empty()) {
 						DisplayServer::get_singleton()->accessibility_update_set_name(cell.buttons[j].accessibility_button_element, cell.buttons[j].tooltip);
 					} else {
-						DisplayServer::get_singleton()->accessibility_update_set_name(cell.buttons[j].accessibility_button_element, cell.buttons[j].alt_text);
+						DisplayServer::get_singleton()->accessibility_update_set_name(cell.buttons[j].accessibility_button_element, cell.buttons[j].description);
 					}
 
 					Ref<Texture2D> b = cell.buttons[j].texture;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -68,7 +68,7 @@ private:
 		String text;
 		String xl_text;
 		Node::AutoTranslateMode auto_translate_mode = Node::AUTO_TRANSLATE_MODE_INHERIT;
-		String alt_text;
+		String description;
 		bool edit_multiline = false;
 		String suffix;
 		Ref<TextParagraph> text_buf;
@@ -115,7 +115,7 @@ private:
 			Ref<Texture2D> texture;
 			Color color = Color(1, 1, 1, 1);
 			String tooltip;
-			String alt_text;
+			String description;
 		};
 
 		Vector<Button> buttons;
@@ -271,8 +271,8 @@ public:
 	void set_text(int p_column, String p_text);
 	String get_text(int p_column) const;
 
-	void set_alt_text(int p_column, String p_text);
-	String get_alt_text(int p_column) const;
+	void set_description(int p_column, String p_text);
+	String get_description(int p_column) const;
 
 	void set_text_direction(int p_column, Control::TextDirection p_text_direction);
 	Control::TextDirection get_text_direction(int p_column) const;
@@ -311,7 +311,7 @@ public:
 	int get_icon_max_width(int p_column) const;
 
 	void clear_buttons();
-	void add_button(int p_column, const Ref<Texture2D> &p_button, int p_id = -1, bool p_disabled = false, const String &p_tooltip = "", const String &p_alt_text = "");
+	void add_button(int p_column, const Ref<Texture2D> &p_button, int p_id = -1, bool p_disabled = false, const String &p_tooltip = "", const String &p_description = "");
 	int get_button_count(int p_column) const;
 	String get_button_tooltip_text(int p_column, int p_index) const;
 	Ref<Texture2D> get_button(int p_column, int p_index) const;
@@ -321,7 +321,7 @@ public:
 	Color get_button_color(int p_column, int p_index) const;
 	void set_button_tooltip_text(int p_column, int p_index, const String &p_tooltip);
 	void set_button(int p_column, int p_index, const Ref<Texture2D> &p_button);
-	void set_button_alt_text(int p_column, int p_index, const String &p_alt_text);
+	void set_button_description(int p_column, int p_index, const String &p_description);
 	void set_button_color(int p_column, int p_index, const Color &p_color);
 	void set_button_disabled(int p_column, int p_index, bool p_disabled);
 	bool is_button_disabled(int p_column, int p_index) const;


### PR DESCRIPTION
So, basically, https://github.com/godotengine/godot/pull/76829 introduced many accessibility methods and properties across many classes, in order to assign a custom summary for assistive applications. Most commonly, this is referred to as "_description_":
- **Control**: `accessibility_description`
- **DisplayServer**: `accessibility_update_set_description` & similar.
- **InputMap**: `get_action_description`
- **Viewport**: `gui_get_drag_description` & `gui_set_drag_description`

In comparison, **TreeItem** is the only one that refers to the same concept as "alternative text" [^1]: 
`set_alt_text`, `get_alt_text`, `set_button_alt_text`. This is inconsistent, and this PR addresses that.

Note that this breaks compatibility, but only with existing dev versions, as https://github.com/godotengine/godot/pull/76829 was merged during `4.5`'s development.

[^1]: **RichTextLabel** actually has an `alt_text` parameter for images, which is entirely appropriate.