### PR TITLE
[3.x] Remove implicit conversion from `LocalVector` to `Vector`

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -247,7 +247,7 @@ public:
 		insert(i, p_val);
 	}
 
-	operator Vector<T>() const {
+	explicit operator Vector<T>() const {
 		Vector<T> ret;
 		ret.resize(size());
 		T *w = ret.ptrw();

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -309,7 +309,7 @@ MeshInstance *FBXMeshData::create_fbx_mesh(const ImportState &state, const FBXDo
 			triangulate_polygon(
 					surface->surface_tool,
 					*indices,
-					surface->vertices_map,
+					Vector<int>(surface->vertices_map),
 					vertices);
 		}
 	}

--- a/modules/lightmapper_cpu/lightmapper_cpu.cpp
+++ b/modules/lightmapper_cpu/lightmapper_cpu.cpp
@@ -1536,9 +1536,9 @@ LightmapperCPU::BakeError LightmapperCPU::bake(BakeQuality p_quality, bool p_use
 			}
 
 			if (p_generate_atlas) {
-				_blit_lightmap(lightmaps_data[i], mesh_instances[i].size, bake_textures[mesh_instances[i].slice], mesh_instances[i].offset.x, mesh_instances[i].offset.y, true);
+				_blit_lightmap(Vector<Vector3>(lightmaps_data[i]), mesh_instances[i].size, bake_textures[mesh_instances[i].slice], mesh_instances[i].offset.x, mesh_instances[i].offset.y, true);
 			} else {
-				_blit_lightmap(lightmaps_data[i], mesh_instances[i].size, bake_textures[i], 0, 0, false);
+				_blit_lightmap(Vector<Vector3>(lightmaps_data[i]), mesh_instances[i].size, bake_textures[i], 0, 0, false);
 			}
 		}
 	}

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -1470,7 +1470,7 @@ bool RoomManager::_convert_room_hull_preliminary(Room *p_room, const Vector<Vect
 		AABB aabb;
 		aabb.create_from_points(p_room_pts);
 
-		LocalVector<Vector3> pts;
+		Vector<Vector3> pts;
 		Vector3 mins = aabb.position;
 		Vector3 maxs = mins + aabb.size;
 
@@ -1596,7 +1596,7 @@ bool RoomManager::_convert_room_hull_final(Room *p_room, const LocalVector<Porta
 	p_room->_bound_mesh_data = md_simplified;
 
 	// send bound to visual server
-	VisualServer::get_singleton()->room_set_bound(p_room->_room_rid, p_room->get_instance_id(), p_room->_planes, p_room->_aabb, md_simplified.vertices);
+	VisualServer::get_singleton()->room_set_bound(p_room->_room_rid, p_room->get_instance_id(), Vector<Plane>(p_room->_planes), p_room->_aabb, md_simplified.vertices);
 
 	return true;
 }

--- a/scene/resources/merging_tool.cpp
+++ b/scene/resources/merging_tool.cpp
@@ -845,7 +845,7 @@ bool MergingTool::join_mesh_surface(const MeshInstance &p_source_mi, uint32_t p_
 }
 
 // No compat checking, no renaming.
-bool MergingTool::join_meshes(MeshInstance &r_dest_mi, Vector<MeshInstance *> p_list) {
+bool MergingTool::join_meshes(MeshInstance &r_dest_mi, LocalVector<MeshInstance *> p_list) {
 	if (p_list.size() < 1) {
 		// Should not happen but just in case...
 		return false;

--- a/scene/resources/merging_tool.h
+++ b/scene/resources/merging_tool.h
@@ -67,7 +67,7 @@ public:
 	static bool merge_meshes(MeshInstance &r_dest_mi, Vector<MeshInstance *> p_list, bool p_use_global_space, bool p_check_compatibility);
 
 	// Join all surfaces into one ubermesh.
-	static bool join_meshes(MeshInstance &r_dest_mi, Vector<MeshInstance *> p_list);
+	static bool join_meshes(MeshInstance &r_dest_mi, LocalVector<MeshInstance *> p_list);
 
 	// Adds a surface from one mesh to another.
 	static bool join_mesh_surface(const MeshInstance &p_source_mi, uint32_t p_source_surface_id, MeshInstance &r_dest_mi);

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -349,7 +349,7 @@ private:
 
 	bool _override_camera = false;
 	Vector3 _override_camera_pos;
-	LocalVector<Plane, int32_t> _override_camera_planes;
+	Vector<Plane> _override_camera_planes;
 
 public:
 	static String _rid_to_string(RID p_rid);

--- a/servers/visual/portals/portal_types.cpp
+++ b/servers/visual/portals/portal_types.cpp
@@ -136,7 +136,7 @@ bool VSPortal::_is_plane_duplicate(const Plane &p_plane, const LocalVector<Plane
 
 bool VSPortal::_pvs_is_outside_planes(const LocalVector<Plane, int32_t> &p_planes) const {
 	// short version
-	const Vector<Vector3> &pts = _pts_world;
+	const LocalVector<Vector3> &pts = _pts_world;
 	int nPoints = pts.size();
 
 	const real_t epsilon = 0.1;
@@ -180,7 +180,7 @@ bool VSPortal::_test_pvs_plane(const Plane &p_plane, const Vector3 *pts_a, int n
 // add clipping planes to the vector formed by each portal edge and the camera
 void VSPortal::add_planes(const Vector3 &p_cam, LocalVector<Plane> &r_planes, bool p_outgoing) const {
 	// short version
-	const Vector<Vector3> &pts = _pts_world;
+	const LocalVector<Vector3> &pts = _pts_world;
 
 	int nPoints = pts.size();
 	ERR_FAIL_COND(nPoints < 3);


### PR DESCRIPTION
3.x version of #107469

## Notes
* Half of these cases were actually me, and genuine typos, so it does show this was worth doing. :grinning: 
* I've fixed up any bottleneck cases to the most appropriate container, non-bottleneck outside my area I've left as is.
* I'll  do another PR for `LocalVector` to `PoolVector` (which isn't present in 4.x).

## Discussion
This clearly shows why the previous implicit conversions of containers is a bad idea. It's very easy (via typos or just not noticing) to introduce expensive conversions. With explicit conversion required, these cases can be caught at development time.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
