### PR TITLE
[3.x] Change `Node` children to use `LocalVector`

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1156,7 +1156,7 @@ void Node::_validate_child_name(Node *p_child, bool p_force_human_readable) {
 			unique = false;
 		} else {
 			//check if exists
-			Node **children = data.children.ptrw();
+			Node **children = data.children.ptr();
 			int cc = data.children.size();
 
 			for (int i = 0; i < cc; i++) {
@@ -1346,7 +1346,7 @@ void Node::remove_child(Node *p_child) {
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, remove_node() failed. Consider using call_deferred(\"remove_child\", child) instead.");
 
 	int child_count = data.children.size();
-	Node **children = data.children.ptrw();
+	Node **children = data.children.ptr();
 	int idx = -1;
 
 	if (p_child->data.pos >= 0 && p_child->data.pos < child_count) {
@@ -1379,7 +1379,7 @@ void Node::remove_child(Node *p_child) {
 
 	//update pointer and size
 	child_count = data.children.size();
-	children = data.children.ptrw();
+	children = data.children.ptr();
 
 	for (int i = idx; i < child_count; i++) {
 		children[i]->data.pos = i;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -107,7 +107,7 @@ private:
 
 		Node *parent;
 		Node *owner;
-		Vector<Node *> children; // list of children
+		LocalVectori<Node *> children; // list of children
 		HashMap<StringName, Node *> owned_unique_nodes;
 		bool unique_name_in_owner = false;
 


### PR DESCRIPTION
There is no need for COW, it will only slow `Node` down.

### `LocalVectori` (signed) rather than `LocalVector`
One gotcha when changing between `Vector` and `LocalVector` is that the default `size` for `LocalVector` is unsigned, and `Vector` is signed. Usually unsigned makes more sense for counters, but in this case, `children` is used in quite a lot of code in `Node` and in the interests of not introducing any new bugs, I have just changed it to the `signed` variation of `LocalVector`.

If we desire to change to unsigned `LocalVector`, that is probably best as a follow up, then modify the counters etc in `Node.cpp`.

## Notes
* First commit is #107543, as we are using `explicit` `LocalVector` to detect any expensive conversions (there were none).
* Only 4 lines of code needed, may give some speedup as there in no COW machinery needed, and `Node` children are used a lot.
* As with `Spatial` children and `CanvasItem` children, really should have converted these when we created `LocalVector`, but hey, better late than never. :grin: 
* This is 3.x specific, 4.x uses different containers for storing `Node` children.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
