### PR TITLE
[3.x] Remove implicit conversion from `LocalVector` to `PoolVector`

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -255,7 +255,7 @@ public:
 		return ret;
 	}
 
-	operator PoolVector<T>() const {
+	explicit operator PoolVector<T>() const {
 		PoolVector<T> pl;
 		if (size()) {
 			pl.resize(size());

--- a/core/math/vertex_cache_optimizer.cpp
+++ b/core/math/vertex_cache_optimizer.cpp
@@ -281,7 +281,7 @@ bool VertexCacheOptimizer::reorder_indices_pool(PoolVector<int> &r_indices, uint
 	LocalVector<int> temp;
 	temp = r_indices;
 	if (reorder_indices(temp, p_num_triangles, p_num_verts)) {
-		r_indices = temp;
+		r_indices = PoolVector<int>(temp);
 		return true;
 	}
 	return false;

--- a/scene/resources/merging_tool.cpp
+++ b/scene/resources/merging_tool.cpp
@@ -505,7 +505,7 @@ int MergingTool::_clean_mesh_surface(const String &p_source_name, const Transfor
 	return 0;
 }
 
-bool MergingTool::_ensure_indices_valid(LocalVector<int> &r_indices, const PoolVector<Vector3> &p_verts) {
+bool MergingTool::_ensure_indices_valid(LocalVector<int> &r_indices, const LocalVector<Vector3> &p_verts) {
 	// No indices? create some.
 	if (!r_indices.size()) {
 #ifdef TOOLS_ENABLED
@@ -535,7 +535,7 @@ bool MergingTool::_ensure_indices_valid(LocalVector<int> &r_indices, const PoolV
 }
 
 // Check for invalid tris, or make a list of the valid triangles, depending on whether r_inds is set.
-bool MergingTool::_check_for_valid_indices(const LocalVector<int> &p_inds, const PoolVector<Vector3> &p_verts, LocalVector<int> *r_inds) {
+bool MergingTool::_check_for_valid_indices(const LocalVector<int> &p_inds, const LocalVector<Vector3> &p_verts, LocalVector<int> *r_inds) {
 	int nTris = p_inds.size();
 	nTris /= 3;
 	int indCount = 0;

--- a/scene/resources/merging_tool.h
+++ b/scene/resources/merging_tool.h
@@ -109,8 +109,8 @@ private:
 	static bool _is_mergeable_with_common(const MeshInstance &p_mi, const MeshInstance &p_other);
 	static bool _is_shadow_mergeable(const MeshInstance &p_mi);
 	static bool _is_material_opaque(const Ref<Material> &p_mat);
-	static bool _ensure_indices_valid(LocalVector<int> &r_indices, const PoolVector<Vector3> &p_verts);
-	static bool _check_for_valid_indices(const LocalVector<int> &p_inds, const PoolVector<Vector3> &p_verts, LocalVector<int> *r_inds);
+	static bool _ensure_indices_valid(LocalVector<int> &r_indices, const LocalVector<Vector3> &p_verts);
+	static bool _check_for_valid_indices(const LocalVector<int> &p_inds, const LocalVector<Vector3> &p_verts, LocalVector<int> *r_inds);
 	static bool _triangle_is_degenerate(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, real_t p_epsilon);
 	static int _clean_mesh_surface(const String &p_source_name, const Transform &p_xform, Ref<Mesh> &p_rmesh, int p_surface_id, Ref<ArrayMesh> r_dest_mesh);
 	static void _copy_geometry_instance_settings(const GeometryInstance &p_source, MeshInstance &r_dest, bool p_copy_transform);


### PR DESCRIPTION
Reveals more cases where we can avoid conversions.

## Notes
* This should be better in all cases as less conversions.
* Similar idea to #107543.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
