### PR TITLE
ShaderCompiler: Optimize compilation error printing

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -1520,6 +1520,17 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 
 		// Print the files.
 		for (const KeyValue<String, Vector<String>> &E : includes) {
+			int err_line = -1;
+			for (const ShaderLanguage::FilePosition &include_position : include_positions) {
+				if (include_position.file == E.key) {
+					err_line = include_position.line;
+				}
+			}
+			if (err_line < 0) {
+				// Skip files that don't contain errors.
+				continue;
+			}
+
 			if (E.key.is_empty()) {
 				if (p_path == "") {
 					print_line("--Main Shader--");
@@ -1529,19 +1540,14 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 			} else {
 				print_line("--" + E.key + "--");
 			}
-			int err_line = -1;
-			for (int i = 0; i < include_positions.size(); i++) {
-				if (include_positions[i].file == E.key) {
-					err_line = include_positions[i].line;
-				}
-			}
 			const Vector<String> &V = E.value;
 			for (int i = 0; i < V.size(); i++) {
 				if (i == err_line - 1) {
 					// Mark the error line to be visible without having to look at
 					// the trace at the end.
 					print_line(vformat("E%4d-> %s", i + 1, V[i]));
-				} else {
+				} else if ((i == err_line - 3) || (i == err_line - 2) || (i == err_line) || (i == err_line + 1)) {
+					// Print 4 lines around the error line.
 					print_line(vformat("%5d | %s", i + 1, V[i]));
 				}
 			}


### PR DESCRIPTION
Background:
I included https://github.com/Auburn/FastNoiseLite/blob/master/GLSL/FastNoiseLite.glsl in gdshader. Whenever I modify the gdshader file, the editor freezes for ~10 secs  and prints out ~12,000 lines of output.

This also happends in issue #107403 where the core shader fails to compile and causes the editor to freeze and prints a large amount of log.

After testing I found that most of the time is spent on `RichTextLabel` operations during console printing:

![屏幕截图_20250615_031128](https://github.com/user-attachments/assets/9f6780a8-50d3-4341-a437-1432dd0f11af)

After this PR the editor's freezing time is reduced from ~10 secs to nearly instantaneous. This will significantly improve the performance when editing large shader files that contain many gdshaderinc. And the main cause of compilation failure will still be printed as errors.

This changes to only print 5 lines around the error line. And changes `ShaderRD` to print in verbose mode.
Example log: 
```
--res://shader/fast_noise.gdshader--
    1 | shader_type spatial;
    2 | 
E   3-> #include "res://shader/include/thirdparty/FastNoiseLite.gdshaderinc"
    4 | 
    5 | 
--res://shader/include/thirdparty/FastNoiseLite.gdshaderinc--
  111 |  
  112 |  
E 113->  fnl_noise_typ noise_type;
  114 | 
  115 |  
  ERROR: res://shader/include/thirdparty/FastNoiseLite.gdshaderinc:113 - Expected data type.
  ERROR: Shader compilation failed.

```

- Fixes #103109
- Related #103894