### PR TITLE
Improve `ResourceLoader.get_dependencies()`'s description

### DIFF
--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -28,8 +28,20 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="add_types" type="bool" />
 			<description>
-				If implemented, gets the dependencies of a given resource. If [param add_types] is [code]true[/code], paths should be appended [code]::TypeName[/code], where [code]TypeName[/code] is the class name of the dependency.
-				[b]Note:[/b] Custom resource types defined by scripts aren't known by the [ClassDB], so you might just return [code]"Resource"[/code] for them.
+				Should return the dependencies for the resource at the given [param path]. Each dependency is a string composed of one to three sections separated by [code]::[/code], with trailing empty sections omitted:
+				- The first section should contain the UID if the resource has one. Otherwise, it should contain the file path.
+				- The second section should contain the class name of the dependency if [param add_types] is [code]true[/code]. Otherwise, it should be empty.
+				- The third section should contain the fallback path if the resource has a UID. Otherwise, it should be empty.
+				[codeblock]
+				func _get_dependencies(path, add_types):
+					return [
+						"uid://fqgvuwrkuixh::Script::res://script.gd",
+						"uid://fqgvuwrkuixh::::res://script.gd",
+						"res://script.gd::Script",
+						"res://script.gd",
+					]
+				[/codeblock]
+				[b]Note:[/b] Custom resource types defined by scripts aren't known by the [ClassDB], so [code]"Resource"[/code] can be used for the class name.
 			</description>
 		</method>
 		<method name="_get_recognized_extensions" qualifiers="virtual const">

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -45,11 +45,14 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Returns the dependencies for the resource at the given [param path].
-				[b]Note:[/b] The dependencies are returned with slices separated by [code]::[/code]. You can use [method String.get_slice] to get their components.
+				Each dependency is a string that can be divided into sections by [code]::[/code]. There can be either one section or three sections, with the second section always being empty. When there is one section, it contains the file path. When there are three sections, the first section contains the UID and the third section contains the fallback path.
 				[codeblock]
 				for dependency in ResourceLoader.get_dependencies(path):
-					print(dependency.get_slice("::", 0)) # Prints the UID.
-					print(dependency.get_slice("::", 2)) # Prints the path.
+					if dependency.contains("::"):
+						print(dependency.get_slice("::", 0)) # Prints the UID.
+						print(dependency.get_slice("::", 2)) # Prints the fallback path.
+					else:
+						print(dependency) # Prints the path.
 				[/codeblock]
 			</description>
 		</method>


### PR DESCRIPTION
The example code made me wonder what happened to the second slice, so I looked into the source code and improved the documentation.

The second section is optional. It contains the dependency's type info when `p_add_type` is `true`. But the option is never exposed to scripting, so the second section is always empty.