### PR TITLE
Add a fade in to stream playback on start

### DIFF
--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -284,10 +284,11 @@ private:
 		// 4. The playback is removed and deallocated on the main thread using the SafeList maybe_cleanup method.
 		enum PlaybackState {
 			PAUSED = 0, // Paused. Keep this stream playback around though so it can be restarted.
-			PLAYING = 1, // Playing. Fading may still be necessary if volume changes!
-			FADE_OUT_TO_PAUSE = 2, // About to pause.
-			FADE_OUT_TO_DELETION = 3, // About to stop.
-			AWAITING_DELETION = 4,
+			FADE_IN = 1, // Fade in to avoid clipping on play
+			PLAYING = 2, // Playing. Fading may still be necessary if volume changes!
+			FADE_OUT_TO_PAUSE = 3, // About to pause.
+			FADE_OUT_TO_DELETION = 4, // About to stop.
+			AWAITING_DELETION = 5,
 		};
 		// If zero or positive, a place in the stream to seek to during the next mix.
 		SafeNumeric<float> setseek;


### PR DESCRIPTION
This is a simple attempt to fix #107551 

I used the same behaviour used for the fade out mechanism to add a fade in mechanism. This just takes advantage of the cubic interpolation to smooth the start, just like it does for the stop.

Without interpolation on start:

https://github.com/user-attachments/assets/723e2256-9a1b-42ef-a77f-b62ceaf4f2d8

With interpolation on start:

https://github.com/user-attachments/assets/01013054-9079-4395-b8e5-30213c66ca7d


## Problems

This doesn't work well with sounds with a punchy start, and should only be an option you set for streams. A comment below shows why.

## Potential enhancements

Because of the problem above, this could be used only for looping streams, or added as a stream parameter (the playback state would just need to be set to `PLAYING` instead of `FADE_IN` if it's not a looping stream). I'm just not really sure how to do it properly in this case.
