### PR TITLE
Add methods to get chunked tile polygons

### DIFF
--- a/doc/classes/TileMapLayer.xml
+++ b/doc/classes/TileMapLayer.xml
@@ -140,6 +140,26 @@
 				Creates and returns a new [TileMapPattern] from the given array of cells. See also [method set_pattern].
 			</description>
 		</method>
+		<method name="get_physics_quadrant_coord">
+			<return type="Vector2i" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the quadrant coord at a given [param index]. Indexes can be obtained from [method get_physics_quadrant_count].
+			</description>
+		</method>
+		<method name="get_physics_quadrant_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of physics quadrants in the tilemap. Can be used to get the coordinate of each quadrant from [method get_physics_quadrant_coord].
+			</description>
+		</method>
+		<method name="get_physics_quadrant_polygons" qualifiers="const">
+			<return type="PackedVector2Array[]" />
+			<param index="0" name="quadrant_coord" type="Vector2i" />
+			<description>
+				Returns an array of polygons inside of the given physics quadrant.
+			</description>
+		</method>
 		<method name="get_surrounding_cells">
 			<return type="Vector2i[]" />
 			<param index="0" name="coords" type="Vector2i" />

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -2118,6 +2118,9 @@ void TileMapLayer::_bind_methods() {
 	// --- Physics helpers ---
 	ClassDB::bind_method(D_METHOD("has_body_rid", "body"), &TileMapLayer::has_body_rid);
 	ClassDB::bind_method(D_METHOD("get_coords_for_body_rid", "body"), &TileMapLayer::get_coords_for_body_rid);
+	ClassDB::bind_method(D_METHOD("get_physics_quadrant_count"), &TileMapLayer::get_physics_quadrant_count);
+	ClassDB::bind_method(D_METHOD("get_physics_quadrant_coord", "index"), &TileMapLayer::get_physics_quadrant_coord);
+	ClassDB::bind_method(D_METHOD("get_physics_quadrant_polygons", "quadrant_coord"), &TileMapLayer::get_physics_quadrant_polygons);
 #endif // PHYSICS_2D_DISABLED
 
 	// --- Runtime ---
@@ -3030,6 +3033,28 @@ Vector2i TileMapLayer::get_coords_for_body_rid(RID p_physics_body) const {
 	const Vector2i *found = bodies_coords.getptr(p_physics_body);
 	ERR_FAIL_NULL_V(found, Vector2i());
 	return *found;
+}
+
+int TileMapLayer::get_physics_quadrant_count() const {
+	return physics_quadrant_map.size();
+}
+
+Vector2i TileMapLayer::get_physics_quadrant_coord(int p_index) {
+	ERR_FAIL_INDEX_V(p_index, (int)physics_quadrant_map.size(), Vector2i());
+	return physics_quadrant_map.get_by_index((uint32_t)p_index).key;
+}
+
+TypedArray<Vector<Vector2>> TileMapLayer::get_physics_quadrant_polygons(Vector2i p_quadrant_coord) const {
+	TypedArray<Vector<Vector2>> polygons;
+	const Ref<PhysicsQuadrant> *quadrant = physics_quadrant_map.getptr(p_quadrant_coord);
+	ERR_FAIL_NULL_V(quadrant, polygons);
+
+	const LocalVector<Ref<ConvexPolygonShape2D>> &shapes = (*quadrant)->shapes;
+	polygons.resize(shapes.size());
+	for (uint32_t i = 0; i < shapes.size(); i++) {
+		polygons[i] = shapes[i]->get_points();
+	}
+	return polygons;
 }
 #endif // PHYSICS_2D_DISABLED
 

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -443,7 +443,7 @@ private:
 #endif // DEBUG_ENABLED
 
 #ifndef PHYSICS_2D_DISABLED
-	HashMap<Vector2i, Ref<PhysicsQuadrant>> physics_quadrant_map;
+	AHashMap<Vector2i, Ref<PhysicsQuadrant>> physics_quadrant_map;
 	HashMap<RID, Vector2i> bodies_coords; // Mapping for RID to coords.
 	bool _physics_was_cleaned_up = false;
 	void _physics_update(bool p_force_cleanup);
@@ -564,6 +564,9 @@ public:
 	// --- Physics helpers ---
 	bool has_body_rid(RID p_physics_body) const;
 	Vector2i get_coords_for_body_rid(RID p_physics_body) const; // For finding tiles from collision.
+	int get_physics_quadrant_count() const;
+	Vector2i get_physics_quadrant_coord(int p_index);
+	TypedArray<Vector<Vector2>> get_physics_quadrant_polygons(Vector2i p_quadrant_coord) const;
 #endif // PHYSICS_2D_DISABLED
 
 	// --- Runtime ---


### PR DESCRIPTION
#102662 added tilemap physics chunking, merging the excessive number of small polygons into larger ones. However, these shapes are opaque: the user does not have any access to them, meaning it's impossible to use them for any purpose other than built-in physics.

This PR exposes methods to get physics quadrants, and subsequently retrieve an array of shape polygons within a given physics quadrant. A major(?) change was converting the `HashMap` of physics quadrants to a `AHashMap`, to allow access by index as well as key, although it shouldn't affect existing functionality

Example usage:
```gdscript
for i: int in tile_map_layer.get_physics_quadrant_count():
	var coord := tile_map_layer.get_physics_quadrant_coord(i)
	var pologons := tile_map_layer.get_physics_quadrant_polygons(coord)
	nefarious_polygon_activities(pologons)
```

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/12612*