### PR TITLE
Add reversed zoom settings in "editors/3d/navigation/zoom_style" for maya

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -882,7 +882,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/orbit_mouse_button", 1, "Left Mouse,Middle Mouse,Right Mouse,Mouse Button 4,Mouse Button 5")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/pan_mouse_button", 1, "Left Mouse,Middle Mouse,Right Mouse,Mouse Button 4,Mouse Button 5")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/zoom_mouse_button", 1, "Left Mouse,Middle Mouse,Right Mouse,Mouse Button 4,Mouse Button 5")
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/zoom_style", 0, "Vertical,Horizontal")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d/navigation/zoom_style", 0, "Vertical,Horizontal,Reversed Vertical,Reversed Horizontal")
 
 	_initial_set("editors/3d/navigation/emulate_numpad", true, true);
 	_initial_set("editors/3d/navigation/emulate_3_button_mouse", false, true);

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -92,6 +92,7 @@ void EditorSettingsDialog::update_navigation_preset() {
 	Node3DEditorViewport::ViewportNavMouseButton set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
 	Node3DEditorViewport::ViewportNavMouseButton set_pan_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
 	Node3DEditorViewport::ViewportNavMouseButton set_zoom_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
+	Node3DEditorViewport::NavigationZoomStyle zoom_style = Node3DEditorViewport::NAVIGATION_ZOOM_VERTICAL;
 	bool set_3_button_mouse = false;
 	Ref<InputEventKey> orbit_mod_key_1;
 	Ref<InputEventKey> orbit_mod_key_2;
@@ -125,6 +126,7 @@ void EditorSettingsDialog::update_navigation_preset() {
 		pan_mod_key_2 = InputEventKey::create_reference(Key::NONE);
 		zoom_mod_key_1 = InputEventKey::create_reference(Key::ALT);
 		zoom_mod_key_2 = InputEventKey::create_reference(Key::NONE);
+		zoom_style = Node3DEditorViewport::NAVIGATION_ZOOM_REVERSED_VERTICAL;
 	} else if (nav_scheme == Node3DEditorViewport::NAVIGATION_MODO) {
 		set_preset = true;
 		set_orbit_mouse_button = Node3DEditorViewport::NAVIGATION_LEFT_MOUSE;
@@ -156,6 +158,7 @@ void EditorSettingsDialog::update_navigation_preset() {
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
+		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_style", zoom_style);
 		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1);
 		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2);
 		_set_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2597,17 +2597,19 @@ void Node3DEditorViewport::_nav_zoom(Ref<InputEventWithModifiers> p_event, const
 	}
 
 	NavigationZoomStyle zoom_style = (NavigationZoomStyle)EDITOR_GET("editors/3d/navigation/zoom_style").operator int();
-	if (zoom_style == NAVIGATION_ZOOM_HORIZONTAL) {
-		if (p_relative.x > 0) {
-			scale_cursor_distance(1 - p_relative.x * zoom_speed);
-		} else if (p_relative.x < 0) {
-			scale_cursor_distance(1.0 / (1 + p_relative.x * zoom_speed));
+	if (zoom_style == NAVIGATION_ZOOM_HORIZONTAL || zoom_style == NAVIGATION_ZOOM_REVERSED_HORIZONTAL) {
+		float x = (zoom_style == NAVIGATION_ZOOM_HORIZONTAL) ? p_relative.x : -p_relative.x;
+		if (x > 0) {
+			scale_cursor_distance(1 - x * zoom_speed);
+		} else if (x < 0) {
+			scale_cursor_distance(1.0 / (1 + x * zoom_speed));
 		}
 	} else {
-		if (p_relative.y > 0) {
-			scale_cursor_distance(1 + p_relative.y * zoom_speed);
-		} else if (p_relative.y < 0) {
-			scale_cursor_distance(1.0 / (1 - p_relative.y * zoom_speed));
+		float y = (zoom_style == NAVIGATION_ZOOM_VERTICAL) ? p_relative.y : -p_relative.y;
+		if (y > 0) {
+			scale_cursor_distance(1 + y * zoom_speed);
+		} else if (y < 0) {
+			scale_cursor_distance(1.0 / (1 - y * zoom_speed));
 		}
 	}
 }

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -211,6 +211,13 @@ public:
 		NAVIGATION_MOUSE_5,
 	};
 
+	enum NavigationZoomStyle {
+		NAVIGATION_ZOOM_VERTICAL,
+		NAVIGATION_ZOOM_HORIZONTAL,
+		NAVIGATION_ZOOM_REVERSED_VERTICAL,
+		NAVIGATION_ZOOM_REVERSED_HORIZONTAL,
+	};
+
 private:
 	double cpu_time_history[FRAME_TIME_HISTORY];
 	int cpu_time_history_index;
@@ -334,11 +341,6 @@ private:
 	bool selection_in_progress = false;
 
 	PopupMenu *selection_menu = nullptr;
-
-	enum NavigationZoomStyle {
-		NAVIGATION_ZOOM_VERTICAL,
-		NAVIGATION_ZOOM_HORIZONTAL
-	};
 
 	enum NavigationMode {
 		NAVIGATION_NONE,


### PR DESCRIPTION
I noticed that zoom behavior using Maya Navigation scheme is not same as Maya behavior.

Alt + right-drag toward top of window: 
  Maya: zoom out
  Godot: zoom in
You can check Maya behavior like following video.
https://www.youtube.com/watch?v=SN-aftwFo6Q&t=60s

I added reversed zoom setting in "editors/3d/navigation/zoom_style".
Changing Navigation scheme to Maya, then zoom_style is changed as "Reversed Vertical".

I'm very new to Godot engine. 
If I missed another suitable option, please ignore this request.