### PR TITLE
Remove angle constraint mention from SkeletonModification2DFABRIK class docs

### DIFF
--- a/doc/classes/SkeletonModification2DFABRIK.xml
+++ b/doc/classes/SkeletonModification2DFABRIK.xml
@@ -6,7 +6,7 @@
 	<description>
 		This [SkeletonModification2D] uses an algorithm called Forward And Backward Reaching Inverse Kinematics, or FABRIK, to rotate a bone chain so that it reaches a target.
 		FABRIK works by knowing the positions and lengths of a series of bones, typically called a "bone chain". It first starts by running a forward pass, which places the final bone at the target's position. Then all other bones are moved towards the tip bone, so they stay at the defined bone length away. Then a backwards pass is performed, where the root/first bone in the FABRIK chain is placed back at the origin. Then all other bones are moved so they stay at the defined bone length away. This positions the bone chain so that it reaches the target when possible, but all of the bones stay the correct length away from each other.
-		Because of how FABRIK works, it often gives more natural results than those seen in [SkeletonModification2DCCDIK]. FABRIK also supports angle constraints, which are fully taken into account when solving.
+		Because of how FABRIK works, it often gives more natural results than those seen in [SkeletonModification2DCCDIK].
 		[b]Note:[/b] The FABRIK modifier has [code]fabrik_joints[/code], which are the data objects that hold the data for each joint in the FABRIK chain. This is different from [Bone2D] nodes! FABRIK joints hold the data needed for each [Bone2D] in the bone chain used by FABRIK.
 		To help control how the FABRIK joints move, a magnet vector can be passed, which can nudge the bones in a certain direction prior to solving, giving a level of control over the final result.
 	</description>


### PR DESCRIPTION
SkeletonModification2DFABRIK does not support angle constraints. As far as I can see, there's no mention of angle constraints in the SkeletonModification2DFabrik class and there are no plans to add it, so the line in the docs saying it supports angle constraints should be removed.

Fixes https://github.com/godotengine/godot-docs/issues/10579