### PR TITLE
Implement `use_shared_copy` for Resource

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -682,6 +682,14 @@ String Resource::_to_string() {
 	return (name.is_empty() ? "" : String(name) + " ") + "(" + path_cache + "):" + Object::_to_string();
 }
 
+void Resource::set_use_shared_copy(bool p_enable) {
+	use_shared_copy = p_enable;
+}
+
+bool Resource::get_use_shared_copy() const {
+	return use_shared_copy;
+}
+
 Node *(*Resource::_get_local_scene_func)() = nullptr;
 void (*Resource::_update_configuration_warning)() = nullptr;
 
@@ -738,6 +746,8 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Resource::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Resource::get_name);
 	ClassDB::bind_method(D_METHOD("get_rid"), &Resource::get_rid);
+	ClassDB::bind_method(D_METHOD("set_use_shared_copy", "enable"), &Resource::set_use_shared_copy);
+	ClassDB::bind_method(D_METHOD("get_use_shared_copy"), &Resource::get_use_shared_copy);
 	ClassDB::bind_method(D_METHOD("set_local_to_scene", "enable"), &Resource::set_local_to_scene);
 	ClassDB::bind_method(D_METHOD("is_local_to_scene"), &Resource::is_local_to_scene);
 	ClassDB::bind_method(D_METHOD("get_local_scene"), &Resource::get_local_scene);
@@ -771,6 +781,7 @@ void Resource::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("setup_local_to_scene_requested"));
 
 	ADD_GROUP("Resource", "resource_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resource_shared_copy"), "set_use_shared_copy", "get_use_shared_copy");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "resource_local_to_scene"), "set_local_to_scene", "is_local_to_scene");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_path", "get_path");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_name"), "set_name", "get_name");

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -86,6 +86,7 @@ private:
 	};
 	EmitChangedState emit_changed_state = EMIT_CHANGED_UNBLOCKED;
 	bool local_to_scene = false;
+	bool use_shared_copy = true; // Defaults to true, since there's far less resource should use full copy by default
 	friend class SceneState;
 	Node *local_scene = nullptr;
 
@@ -161,6 +162,9 @@ public:
 	void set_local_to_scene(bool p_enable);
 	bool is_local_to_scene() const;
 	virtual void setup_local_to_scene();
+
+	void set_use_shared_copy(bool p_enable);
+	bool get_use_shared_copy() const;
 
 	Node *get_local_scene() const;
 

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -689,6 +689,7 @@
 		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="Animation.LoopMode" default="0">
 			Determines the behavior of both ends of the animation timeline during animation playback. This indicates whether and how the animation should be restarted, and is also used to correctly interpolate animation cycles.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 		<member name="step" type="float" setter="set_step" getter="get_step" default="0.033333335">
 			The animation step value.
 		</member>

--- a/doc/classes/AnimationLibrary.xml
+++ b/doc/classes/AnimationLibrary.xml
@@ -60,6 +60,9 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
+	</members>
 	<signals>
 		<signal name="animation_added">
 			<param index="0" name="name" type="StringName" />

--- a/doc/classes/CameraAttributes.xml
+++ b/doc/classes/CameraAttributes.xml
@@ -30,5 +30,6 @@
 			If [member auto_exposure_enabled] is [code]true[/code], this can be used as a method of exposure compensation, doubling the value will increase the exposure value (measured in EV100) by 1 stop.
 			[b]Note:[/b] Only available when [member ProjectSettings.rendering/lights_and_shadows/use_physical_light_units] is enabled.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/doc/classes/ConcavePolygonShape3D.xml
+++ b/doc/classes/ConcavePolygonShape3D.xml
@@ -32,5 +32,6 @@
 		<member name="backface_collision" type="bool" setter="set_backface_collision_enabled" getter="is_backface_collision_enabled" default="false">
 			If set to [code]true[/code], collisions occur on both sides of the concave shape faces. Otherwise they occur only along the face normals.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="true" />
 	</members>
 </class>

--- a/doc/classes/ConvexPolygonShape3D.xml
+++ b/doc/classes/ConvexPolygonShape3D.xml
@@ -16,5 +16,6 @@
 		<member name="points" type="PackedVector3Array" setter="set_points" getter="get_points" default="PackedVector3Array()">
 			The list of 3D points forming the convex polygon shape.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="true" />
 	</members>
 </class>

--- a/doc/classes/Curve.xml
+++ b/doc/classes/Curve.xml
@@ -195,6 +195,7 @@
 			The right tangent angle (in degrees) for the point at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 	<signals>
 		<signal name="domain_changed">

--- a/doc/classes/Curve2D.xml
+++ b/doc/classes/Curve2D.xml
@@ -189,5 +189,6 @@
 			The position of for the vertex at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/doc/classes/Curve3D.xml
+++ b/doc/classes/Curve3D.xml
@@ -226,6 +226,7 @@
 			The tilt angle in radians for the point at [code]index[/code].
 			[b]Note:[/b] [code]index[/code] is a value in the [code]0 .. point_count - 1[/code] range.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 		<member name="up_vector_enabled" type="bool" setter="set_up_vector_enabled" getter="is_up_vector_enabled" default="true">
 			If [code]true[/code], the curve will bake up vectors used for orientation. This is used when [member PathFollow3D.rotation_mode] is set to [constant PathFollow3D.ROTATION_ORIENTED]. Changing it forces the cache to be recomputed.
 		</member>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1381,6 +1381,8 @@
 		<member name="project_manager/sorting_order" type="int" setter="" getter="">
 			The sorting order to use in the project manager. When changing the sorting order in the project manager, this setting is set permanently in the editor settings.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy">
+		</member>
 		<member name="run/auto_save/save_before_running" type="bool" setter="" getter="">
 			If [code]true[/code], saves all scenes and scripts automatically before running the project. Setting this to [code]false[/code] prevents the editor from saving if there are no changes which can speed up the project startup slightly, but it makes it possible to run a project that has unsaved changes. (Unsaved changes will not be visible in the running project.)
 		</member>

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -203,6 +203,7 @@
 		<member name="reflected_light_source" type="int" setter="set_reflection_source" getter="get_reflection_source" enum="Environment.ReflectionSource" default="0">
 			The reflected (specular) light source.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 		<member name="sdfgi_bounce_feedback" type="float" setter="set_sdfgi_bounce_feedback" getter="get_sdfgi_bounce_feedback" default="0.5">
 			The energy multiplier applied to light every time it bounces from a surface when using SDFGI. Values greater than [code]0.0[/code] will simulate multiple bounces, resulting in a more realistic appearance. Increasing [member sdfgi_bounce_feedback] generally has no performance impact. See also [member sdfgi_energy].
 			[b]Note:[/b] Values greater than [code]0.5[/code] can cause infinite feedback loops and should be avoided in scenes with bright materials.

--- a/doc/classes/Gradient.xml
+++ b/doc/classes/Gradient.xml
@@ -92,6 +92,7 @@
 			Gradient's offsets as a [PackedFloat32Array].
 			[b]Note:[/b] Setting this property updates all offsets at once. To update any offset individually use [method set_offset].
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 	<constants>
 		<constant name="GRADIENT_INTERPOLATE_LINEAR" value="0" enum="InterpolationMode">

--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -61,5 +61,6 @@
 		<member name="map_width" type="int" setter="set_map_width" getter="get_map_width" default="2">
 			Number of vertices in the width of the heightmap. Changing this will resize the [member map_data].
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="true" />
 	</members>
 </class>

--- a/doc/classes/LabelSettings.xml
+++ b/doc/classes/LabelSettings.xml
@@ -151,6 +151,7 @@
 		<member name="paragraph_spacing" type="float" setter="set_paragraph_spacing" getter="get_paragraph_spacing" default="0.0">
 			Vertical space between paragraphs. Added on top of [member line_spacing].
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 		<member name="shadow_color" type="Color" setter="set_shadow_color" getter="get_shadow_color" default="Color(0, 0, 0, 0)">
 			Color of the shadow effect. If alpha is [code]0[/code], no shadow will be drawn.
 		</member>

--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -139,6 +139,7 @@
 			When using low physics tick rates (typically below 20) or high rates of object rotation, you may get better results from the high quality setting.
 			[b]Note:[/b] Fast quality does not equate to low quality. Except in the special cases mentioned above, the quality should be comparable to high quality.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 		<member name="transform_2d_array" type="PackedVector2Array" setter="_set_transform_2d_array" getter="_get_transform_2d_array" deprecated="Accessing this property is very slow. Use [method set_instance_transform_2d] and [method get_instance_transform_2d] instead.">
 			Array containing each [Transform2D] value used by all instances of this mesh, as a [PackedVector2Array]. Each transform is divided into 3 [Vector2] values corresponding to the transforms' [code]x[/code], [code]y[/code], and [code]origin[/code].
 		</member>

--- a/doc/classes/OccluderPolygon2D.xml
+++ b/doc/classes/OccluderPolygon2D.xml
@@ -18,6 +18,7 @@
 		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
 			A [Vector2] array with the index for polygon's vertices positions.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 	<constants>
 		<constant name="CULL_DISABLED" value="0" enum="CullMode">

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -177,6 +177,14 @@
 			[b]Note:[/b] Setting this property does not emit the [signal changed] signal.
 			[b]Warning:[/b] When setting, the ID must only consist of letters, numbers, and underscores. Otherwise, it will fail and default to a randomly generated ID.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" default="true">
+			Controls how resource is copied to a newly duplicated Node.
+			This option only affects internal resources, external resources (Saved as .tres, .res files, or embedded in other .tscn scene) will still use shared copy.
+			If [code]true[/code], uses a shared copy of the resource.
+			If [code]false[/code], uses a full copy of the resource.
+			[b]Note:[/b] Changing this property afterwards does not affect any resource duplicates before.
+			[b]Note:[/b] To have full copy of resources in instanced scenes, use [code]Local to Scene[/code] instead.
+		</member>
 	</members>
 	<signals>
 		<signal name="changed">

--- a/doc/classes/Shape2D.xml
+++ b/doc/classes/Shape2D.xml
@@ -79,5 +79,6 @@
 			The shape's custom solver bias. Defines how much bodies react to enforce contact separation when this shape is involved.
 			When set to [code]0[/code], the default value from [member ProjectSettings.physics/2d/solver/default_contact_bias] is used.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/doc/classes/Shape3D.xml
+++ b/doc/classes/Shape3D.xml
@@ -28,5 +28,6 @@
 			The collision margin for the shape. This is not used in Godot Physics.
 			Collision margins allow collision detection to be more efficient by adding an extra shell around shapes. Collision algorithms are more expensive when objects overlap by more than their margin, so a higher value for margins is better for performance, at the cost of accuracy around edges as it makes them less sharp.
 		</member>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
 	</members>
 </class>

--- a/modules/noise/doc_classes/Noise.xml
+++ b/modules/noise/doc_classes/Noise.xml
@@ -100,4 +100,7 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="resource_shared_copy" type="bool" setter="set_use_shared_copy" getter="get_use_shared_copy" overrides="Resource" default="false" />
+	</members>
 </class>

--- a/modules/noise/noise.cpp
+++ b/modules/noise/noise.cpp
@@ -199,3 +199,7 @@ void Noise::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_image_3d", "width", "height", "depth", "invert", "normalize"), &Noise::get_image_3d, DEFVAL(false), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_seamless_image_3d", "width", "height", "depth", "invert", "skirt", "normalize"), &Noise::get_seamless_image_3d, DEFVAL(false), DEFVAL(0.1), DEFVAL(true));
 }
+
+Noise::Noise() {
+	set_use_shared_copy(false);
+}

--- a/modules/noise/noise.h
+++ b/modules/noise/noise.h
@@ -278,6 +278,7 @@ protected:
 	static void _bind_methods();
 
 public:
+	Noise();
 	// Virtual destructor so we can delete any Noise derived object when referenced as a Noise*.
 	virtual ~Noise() {}
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -148,6 +148,7 @@ void OccluderPolygon2D::_bind_methods() {
 }
 
 OccluderPolygon2D::OccluderPolygon2D() {
+	set_use_shared_copy(false);
 	occ_polygon = RS::get_singleton()->canvas_occluder_polygon_create();
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -3090,34 +3090,73 @@ void Node::_duplicate_properties(const Node *p_root, const Node *p_original, Nod
 			value = value.duplicate(true);
 		}
 
-		if (E.usage & PROPERTY_USAGE_ALWAYS_DUPLICATE) {
+		// Handle Resources
+		if (Object::cast_to<Resource>(value)) {
 			Resource *res = Object::cast_to<Resource>(value);
-			if (res) { // Duplicate only if it's a resource
-				p_copy->set(name, res->duplicate());
+			p_copy->set(name, _duplicate_resource(res, E.usage & PROPERTY_USAGE_ALWAYS_DUPLICATE));
+			continue;
+		}
+
+		if (value.get_type() == Variant::OBJECT) {
+			Node *property_node = Object::cast_to<Node>(value);
+			Variant out_value = value;
+			if (property_node && (p_root == property_node || p_root->is_ancestor_of(property_node))) {
+				out_value = p_copy->get_node_or_null(p_original->get_path_to(property_node));
 			}
-		} else {
-			if (value.get_type() == Variant::OBJECT) {
-				Node *property_node = Object::cast_to<Node>(value);
-				Variant out_value = value;
-				if (property_node && (p_root == property_node || p_root->is_ancestor_of(property_node))) {
-					out_value = p_copy->get_node_or_null(p_original->get_path_to(property_node));
-				}
-				p_copy->set(name, out_value);
-			} else if (value.get_type() == Variant::ARRAY) {
-				Array arr = value;
-				if (arr.get_typed_builtin() == Variant::OBJECT) {
-					for (int i = 0; i < arr.size(); i++) {
-						Node *property_node = Object::cast_to<Node>(arr[i]);
-						if (property_node && (p_root == property_node || p_root->is_ancestor_of(property_node))) {
-							arr[i] = p_copy->get_node_or_null(p_original->get_path_to(property_node));
-						}
+			p_copy->set(name, out_value);
+			continue;
+		}
+
+		if (value.get_type() == Variant::ARRAY) {
+			Array arr = value;
+			if (arr.get_typed_builtin() == Variant::OBJECT) {
+				for (int i = 0; i < arr.size(); i++) {
+					Node *property_node = Object::cast_to<Node>(arr[i]);
+					if (property_node && (p_root == property_node || p_root->is_ancestor_of(property_node))) {
+						arr[i] = p_copy->get_node_or_null(p_original->get_path_to(property_node));
 					}
 				}
-				p_copy->set(name, arr);
-			} else {
-				p_copy->set(name, value);
 			}
+
+			// Duplicate resources stored in array
+			for (int i = 0; i < arr.size(); i++) {
+				if (arr[i].get_type() != Variant::OBJECT) {
+					continue;
+				}
+				Resource *res = Object::cast_to<Resource>(arr[i]);
+				if (res) {
+					arr[i] = _duplicate_resource(res);
+				}
+			}
+
+			p_copy->set(name, arr);
+			continue;
 		}
+
+		if (value.get_type() == Variant::DICTIONARY) {
+			Dictionary dict = value;
+
+			// Duplicate resources stored in dictionary
+			for (int i = 0; i < dict.size(); i++) {
+				if (dict.keys()[i].get_type() == Variant::OBJECT) {
+					Resource *res = Object::cast_to<Resource>(dict.keys()[i]);
+					if (res) {
+						dict.keys().set(i, _duplicate_resource(res));
+					}
+				}
+
+				if (dict.values()[i].get_type() == Variant::OBJECT) {
+					Resource *res = Object::cast_to<Resource>(dict.values()[i]);
+					if (res) {
+						dict.values().set(i, _duplicate_resource(res));
+					}
+				}
+			}
+			p_copy->set(name, dict);
+			continue;
+		}
+
+		p_copy->set(name, value);
 	}
 
 	for (int i = 0; i < p_original->get_child_count(false); i++) {
@@ -3125,6 +3164,22 @@ void Node::_duplicate_properties(const Node *p_root, const Node *p_original, Nod
 		ERR_FAIL_NULL_MSG(copy_child, "Child node disappeared while duplicating.");
 		_duplicate_properties(p_root, p_original->get_child(i, false), copy_child, p_flags);
 	}
+}
+
+Ref<Resource> Node::_duplicate_resource(const Resource *res, bool force_full_copy) const {
+	if (force_full_copy) {
+		return res->duplicate();
+	}
+
+	bool is_internal_resource = (res->get_path() == "" ||
+			res->get_path().begins_with("uid://") ||
+			res->get_path().contains("::"));
+
+	if (!res->get_use_shared_copy() && is_internal_resource) {
+		return res->duplicate();
+	}
+
+	return Ref<Resource>(res);
 }
 
 // Duplication of signals must happen after all the node descendants have been copied,

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -321,6 +321,7 @@ private:
 
 	void _duplicate_scripts(const Node *p_original, Node *p_copy) const;
 	void _duplicate_properties(const Node *p_root, const Node *p_original, Node *p_copy, int p_flags) const;
+	Ref<Resource> _duplicate_resource(const Resource *res, bool force_full_copy = false) const;
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;
 	Node *_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap = nullptr) const;
 

--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -115,6 +115,7 @@ bool Shape2D::is_collision_outline_enabled() {
 }
 
 Shape2D::Shape2D(const RID &p_rid) {
+	set_use_shared_copy(false);
 	shape = p_rid;
 }
 

--- a/scene/resources/3d/box_shape_3d.cpp
+++ b/scene/resources/3d/box_shape_3d.cpp
@@ -117,5 +117,6 @@ void BoxShape3D::_bind_methods() {
 
 BoxShape3D::BoxShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_BOX)) {
+	set_use_shared_copy(false);
 	set_size(Vector3(1, 1, 1));
 }

--- a/scene/resources/3d/capsule_shape_3d.cpp
+++ b/scene/resources/3d/capsule_shape_3d.cpp
@@ -155,5 +155,6 @@ void CapsuleShape3D::_bind_methods() {
 
 CapsuleShape3D::CapsuleShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_CAPSULE)) {
+	set_use_shared_copy(false);
 	_update_shape();
 }

--- a/scene/resources/3d/cylinder_shape_3d.cpp
+++ b/scene/resources/3d/cylinder_shape_3d.cpp
@@ -126,5 +126,6 @@ void CylinderShape3D::_bind_methods() {
 
 CylinderShape3D::CylinderShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_CYLINDER)) {
+	set_use_shared_copy(false);
 	_update_shape();
 }

--- a/scene/resources/3d/separation_ray_shape_3d.cpp
+++ b/scene/resources/3d/separation_ray_shape_3d.cpp
@@ -93,6 +93,7 @@ void SeparationRayShape3D::_bind_methods() {
 SeparationRayShape3D::SeparationRayShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_SEPARATION_RAY)) {
 	/* Code copied from setters to prevent the use of uninitialized variables */
+	set_use_shared_copy(false);
 	_update_shape();
 	emit_changed();
 }

--- a/scene/resources/3d/sphere_shape_3d.cpp
+++ b/scene/resources/3d/sphere_shape_3d.cpp
@@ -103,5 +103,6 @@ void SphereShape3D::_bind_methods() {
 
 SphereShape3D::SphereShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_SPHERE)) {
+	set_use_shared_copy(false);
 	set_radius(0.5);
 }

--- a/scene/resources/3d/world_boundary_shape_3d.cpp
+++ b/scene/resources/3d/world_boundary_shape_3d.cpp
@@ -134,5 +134,6 @@ void WorldBoundaryShape3D::_bind_methods() {
 
 WorldBoundaryShape3D::WorldBoundaryShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_WORLD_BOUNDARY)) {
+	set_use_shared_copy(false);
 	set_plane(Plane(0, 1, 0, 0));
 }

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -6549,6 +6549,7 @@ bool Animation::inform_variant_array(int &r_min, int &r_max) {
 }
 
 Animation::Animation() {
+	set_use_shared_copy(false);
 }
 
 Animation::~Animation() {

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -178,4 +178,5 @@ void AnimationLibrary::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("animation_changed", PropertyInfo(Variant::STRING_NAME, "name")));
 }
 AnimationLibrary::AnimationLibrary() {
+	set_use_shared_copy(false);
 }

--- a/scene/resources/camera_attributes.cpp
+++ b/scene/resources/camera_attributes.cpp
@@ -137,6 +137,7 @@ void CameraAttributes::_bind_methods() {
 }
 
 CameraAttributes::CameraAttributes() {
+	set_use_shared_copy(false);
 	camera_attributes = RS::get_singleton()->camera_attributes_create();
 }
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -40,6 +40,7 @@ const char *Curve::SIGNAL_DOMAIN_CHANGED = "domain_changed";
 
 Curve::Curve() {
 	property_helper.setup_for_instance(base_property_helper, this);
+	set_use_shared_copy(false);
 }
 
 void Curve::set_point_count(int p_count) {
@@ -1349,6 +1350,7 @@ void Curve2D::_bind_methods() {
 
 Curve2D::Curve2D() {
 	property_helper.setup_for_instance(base_property_helper, this);
+	set_use_shared_copy(false);
 }
 
 /***********************************************************************************/
@@ -2393,4 +2395,5 @@ void Curve3D::_bind_methods() {
 
 Curve3D::Curve3D() {
 	property_helper.setup_for_instance(base_property_helper, this);
+	set_use_shared_copy(false);
 }

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1635,6 +1635,8 @@ void Environment::_bind_methods() {
 }
 
 Environment::Environment() {
+	set_use_shared_copy(false);
+
 	environment = RS::get_singleton()->environment_create();
 
 	set_camera_feed_id(bg_camera_feed_id);

--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -34,6 +34,8 @@
 #include "core/object/class_db.h"
 
 Gradient::Gradient() {
+	set_use_shared_copy(false);
+
 	//Set initial gradient transition from black to white
 	points.resize(2);
 	points[0].color = Color(0, 0, 0, 1);

--- a/scene/resources/label_settings.h
+++ b/scene/resources/label_settings.h
@@ -150,6 +150,7 @@ public:
 	int get_stacked_shadow_outline_size(int p_index) const;
 
 	LabelSettings() {
+		set_use_shared_copy(false);
 		stacked_outline_property_helper.setup_for_instance(stacked_outline_base_property_helper, this);
 		stacked_shadow_property_helper.setup_for_instance(stacked_shadow_base_property_helper, this);
 	}

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -434,6 +434,7 @@ void MultiMesh::_bind_methods() {
 }
 
 MultiMesh::MultiMesh() {
+	set_use_shared_copy(false);
 	multimesh = RenderingServer::get_singleton()->multimesh_create();
 }
 

--- a/tests/core/io/test_json_native.cpp
+++ b/tests/core/io/test_json_native.cpp
@@ -104,7 +104,7 @@ TEST_CASE("[JSON][Native] Conversion between native and JSON formats") {
 	res.instantiate();
 
 	// The properties are stored in an array because the order in which they are assigned may be important during initialization.
-	const String res_repr = R"({"type":"Resource","props":["resource_local_to_scene",false,"resource_name","s:","script",null]})";
+	const String res_repr = R"({"type":"Resource","props":["resource_shared_copy",true,"resource_local_to_scene",false,"resource_name","s:","script",null]})";
 
 	test(res, res_repr, true);
 	ERR_PRINT_OFF;


### PR DESCRIPTION
This PR only affects **internal resources**, external resources (saved to .res, tres, or in .tscn) will stay shared (if ```local_to_scene``` is false).

TL;DR After this PR you can do this in Godot by default:

![pr_vid_1](https://github.com/user-attachments/assets/d27221ab-c86f-4c61-aaf7-c9dbaca9b064)

# Related proposals:
godotengine/godot-proposals#4672
godotengine/godot-proposals#9603
godotengine/godot-proposals#11312

# Keynotes from proposals
* We cannot determine if a resource should use a full copy or shared copy solely by its type. (eg: Material)
* If forcing internal resources to use full copy every time, it might unintentionally cause bloat and performance issues. 
* Adding pop-ups every time a node is duplicated for users adjust the resource copy is not good for UX, and some people is against it.
* The solution needs to provide users the option to determine if a full copy is needed **per resource**, not per class.
* The solution also has to provide **reasonable defaults** that fits most of the use cases, so user don't need to adjust resource copy behavior frequently.

# Solution
## Implement property ```use_shared_copy``` in ```Resource```
So I come up with this PR, acts as a new proposal and proof of concept:

![pr_img_1](https://github.com/user-attachments/assets/d632162b-7109-42d7-b2c7-1ebfdb2e0d4a)

Defaults to true (use shared copy) for most resources, and **defaults to false (use full copy) where reasonable**. If user wants a specific resource to behave differently on copy, they can adjust it freely.

This boolean is only taken into account at ```Node::duplicate()```, it doesn't affect ```Resource::duplicate()```. It's main purpose is to improve UX when using editor duplicate tool.

It also doesn't conflict with ```Resource::local_to_scene```. It only accounts for node duplication in the current local scene.

## Resources that defaults to full copy

Here's the list of resources which default to **full copy** in this PR:
```
// Internal resources that uses full copy by default

Animation
AnimationLibrary

BoxShape3D
CapsuleShape3D
CylinderShape3D
SphereShape3D
SeparationRayShape3D
WorldBoundaryShape3D

Shape2D (+ All derived classes)

CameraAttributes (+ All derived classes)

Curve
Curve2D
Curve3D

Environment

Noise (+ All derived classes)

Gradient

LabelSettings

MultiMesh

OccluderPolygon2D
```

Some resources have very even pros and cons when deciding to make it default to full-copy on node duplication, I'll write my decision down here and open for discussion:

* ```Material``` **(shared copy)**: Very likely to run into draw call performance hit if using full copy every time, and possibly time-consuming to manually set all nodes to use the same Material again.

* ```Animation```, ```AnimationLibrary``` **(full copy)**: The most possible scenario where this will be copied is duplicating a ```AnimationPlayer``` node, and the reason for copy is most likely -- **It's an animation created using Godot, the user wants a full copy of the animation and modify it**. Another common scenario is **The user wants to share animation to multiple similar skeletons**, which is a more advanced usage, I consider the user doing this is more likely to think of sharing resources, and even if they don't, it'll still work. We should make this default to full copy for novice users that only wants to animate something in Godot.

* ```Shape3D```, ```Shape2D``` **(depends on shape)**: Whether to use full copy by default depends on **how likely the shape is going to be tweaked by hand**, and performance costs. Namely ```ConcavePolygonShape3D```, ```ConvexPolygonShape3D```, ```HeightMapShape3D``` will default to use shared copy, the others uses full copy.

