### PR TITLE
C# - Add remaining disposer optimizations for Variant

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Variant.cs
@@ -72,6 +72,11 @@ public partial struct Variant : IDisposable
             case Type.Quaternion:
             case Type.Color:
             case Type.Rid:
+            case Type.Projection:
+            case Type.Aabb:
+            case Type.Basis:
+            case Type.Transform2D:
+            case Type.Transform3D:
                 _disposer = null;
                 break;
             default:


### PR DESCRIPTION
I'm not sure if I'm missing something, but this seems like it could be an easy optimization for C#.

If you run the following code:
```cs
Variant Vector3Variant = new Vector3();
GD.Print(Vector3Variant.GetType().GetField("_disposer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(Vector3Variant));
Variant BasisVariant = new Basis();
GD.Print(BasisVariant.GetType().GetField("_disposer", System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic)!.GetValue(BasisVariant));
```
It outputs:
```cs
null
Godot.Variant+Disposer
```

Even though `Basis` is a struct implemented directly in C# without a native reference, it is registered for disposing.

It seems like `Basis` is one of five structs (`Projection`, `Aabb`, `Basis`, `Transform2D`, `Transform3D`) that are eligible for bypassing disposing but don't.

Let me know if there's something I'm missing about these structs!