### PR TITLE
Fix some menu bar items unresponsive after language change

### DIFF
--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -320,11 +320,17 @@ void MenuBar::_notification(int p_what) {
 					}
 				}
 			}
+			if (!is_global) {
+				update_minimum_size();
+			}
 		} break;
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < menu_cache.size(); i++) {
 				shape(menu_cache.write[i]);
+			}
+			if (global_menu_tag.is_empty()) {
+				update_minimum_size();
 			}
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
To reproduce the problem, try changing the editor's language so that the menu bar is wider.

In this demo, after changing from `zh_CN` to `ja`, the last two menu items can't be focused because the control's effective size is not changed.

https://github.com/user-attachments/assets/86ea030b-f35e-4f1b-829c-2b5cb943e66f

