### PR TITLE
Allow fixing indirect missing dependencies manually

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -43,6 +43,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/file_system/dependency_editor.h"
 #include "editor/gui/create_dialog.h"
 #include "editor/gui/directory_create_dialog.h"
 #include "editor/gui/editor_dir_dialog.h"

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "editor/file_system/dependency_editor.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/file_info.h"
 #include "editor/script/script_create_dialog.h"
@@ -38,19 +37,22 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/item_list.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 
 class CreateDialog;
+class DependencyEditor;
+class DependencyEditorOwners;
+class DependencyRemoveDialog;
+class DirectoryCreateDialog;
 class EditorDirDialog;
-class ItemList;
+class EditorResourceTooltipPlugin;
 class LineEdit;
 class ProgressBar;
 class SceneCreateDialog;
 class ShaderCreateDialog;
-class DirectoryCreateDialog;
-class EditorResourceTooltipPlugin;
 
 class FileSystemTree : public Tree {
 	virtual Control *make_custom_tooltip(const String &p_text) const;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -63,7 +63,6 @@ class Window;
 class AudioStreamImportSettingsDialog;
 class AudioStreamPreviewGenerator;
 class BackgroundProgress;
-class DependencyEditor;
 class DependencyErrorDialog;
 class DockSplitContainer;
 class DynamicFontImportSettingsDialog;
@@ -421,7 +420,6 @@ private:
 
 	DependencyErrorDialog *dependency_error = nullptr;
 	HashMap<String, HashSet<String>> dependency_errors;
-	DependencyEditor *dependency_fixer = nullptr;
 	OrphanResourcesDialog *orphan_resources = nullptr;
 	ConfirmationDialog *open_imported = nullptr;
 	Button *new_inherited_button = nullptr;
@@ -833,7 +831,6 @@ public:
 	String get_preview_locale() const;
 	void set_preview_locale(const String &p_locale);
 
-	void fix_dependencies(const String &p_for_file);
 	int new_scene();
 	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_silent_change_tab = false);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);

--- a/editor/file_system/dependency_editor.h
+++ b/editor/file_system/dependency_editor.h
@@ -30,13 +30,15 @@
 
 #pragma once
 
-#include "scene/gui/box_container.h"
 #include "scene/gui/dialogs.h"
-#include "scene/gui/item_list.h"
-#include "scene/gui/tree.h"
 
 class EditorFileDialog;
 class EditorFileSystemDirectory;
+class ItemList;
+class PopupMenu;
+class Tree;
+class TreeItem;
+class VBoxContainer;
 
 class DependencyEditor : public AcceptDialog {
 	GDCLASS(DependencyEditor, AcceptDialog);
@@ -135,17 +137,20 @@ public:
 class DependencyErrorDialog : public ConfirmationDialog {
 	GDCLASS(DependencyErrorDialog, ConfirmationDialog);
 
-private:
 	String for_file;
-	Mode mode;
-	Button *fdep = nullptr;
-	Label *text = nullptr;
+
 	Tree *files = nullptr;
+	DependencyEditor *deps_editor = nullptr;
+	bool force_open = false;
+
 	void ok_pressed() override;
-	void custom_action(const String &) override;
+
+	void _on_files_button_clicked(TreeItem *p_item, int p_column, int p_id, MouseButton p_button);
+	void _check_for_resolved();
 
 public:
-	void show(const String &p_for_file, const Vector<String> &report);
+	void show(const String &p_for_file, const HashMap<String, HashSet<String>> &p_report);
+
 	DependencyErrorDialog();
 };
 


### PR DESCRIPTION
Currently, the dependency error dialog is only shown for missing dependencies that are referenced directly by the opening scene. Therefore, if the missing dependency is deeply nested, manually fixing it becomes cumbersome. I guess this is the main reason we devote to improving automatic solutions. However, there are situations where manual fixing is inevitable.

This PR lists all missing items related to the current scene in the Dependency Errors dialog. It also allows the user to open the corresponding dependency editing dialog directly from this dialog, so that they don't have to manually locate them one by one in the file system.

https://github.com/user-attachments/assets/c4e6f8d9-d28d-45da-81bf-5645ecf4e5fb

Note: Ideally, fixing one missing resource should ideally fix all references to it automatically. However, this would involve a complete refactoring of the dependency editing dialog. I think that could be a separate PR.

Test project with several missing dependencies: [deps-mrp.zip](https://github.com/user-attachments/files/20751796/deps-mrp.zip)

Closes https://github.com/godotengine/godot-proposals/issues/12681