### PR TITLE
Fix game view window not updating title when translation changes

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -68,7 +68,7 @@ void EditorFileDialog::_native_popup() {
 	}
 	DisplayServer::WindowID wid = w ? w->get_window_id() : DisplayServer::INVALID_WINDOW_ID;
 
-	DisplayServer::get_singleton()->file_dialog_with_options_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), root, file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &EditorFileDialog::_native_dialog_cb), wid);
+	DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(dir->get_text()), root, file->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &EditorFileDialog::_native_dialog_cb), wid);
 }
 
 void EditorFileDialog::popup(const Rect2i &p_rect) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -80,9 +80,9 @@ void FileDialog::_native_popup() {
 	DisplayServer::WindowID wid = w ? w->get_window_id() : DisplayServer::INVALID_WINDOW_ID;
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_DIALOG_FILE_EXTRA)) {
-		DisplayServer::get_singleton()->file_dialog_with_options_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, filename_edit->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options), wid);
+		DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, filename_edit->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options), wid);
 	} else {
-		DisplayServer::get_singleton()->file_dialog_show(get_translated_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), filename_edit->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb), wid);
+		DisplayServer::get_singleton()->file_dialog_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), filename_edit->get_text().get_file(), show_hidden_files, DisplayServer::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb), wid);
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -353,7 +353,7 @@ void Viewport::_sub_window_update(Window *p_window) {
 
 		const real_t title_space = r.size.width - panel->get_minimum_size().x - close_h_ofs;
 		if (title_space > 0) {
-			TextLine title_text = TextLine(p_window->get_translated_title(), title_font, font_size);
+			TextLine title_text = TextLine(p_window->get_displayed_title(), title_font, font_size);
 			title_text.set_width(title_space);
 			title_text.set_direction(p_window->is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 			int x = (r.size.width - title_text.get_size().x) / 2;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -32,7 +32,6 @@
 
 #include "core/config/project_settings.h"
 #include "core/debugger/engine_debugger.h"
-#include "core/input/shortcut.h"
 #include "core/string/translation_server.h"
 #include "scene/gui/control.h"
 #include "scene/theme/theme_db.h"
@@ -305,39 +304,9 @@ void Window::set_title(const String &p_title) {
 	ERR_MAIN_THREAD_GUARD;
 
 	title = p_title;
-	tr_title = atr(p_title);
+	_update_displayed_title();
 
-#ifdef DEBUG_ENABLED
-	if (window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
-		// Append a suffix to the window title to denote that the project is running
-		// from a debug build (including the editor, excluding the project manager).
-		// Since this results in lower performance, this should be clearly presented
-		// to the user.
-		tr_title = vformat("%s (DEBUG)", tr_title);
-	}
-#endif
-
-	if (embedder) {
-		embedder->_sub_window_update(this);
-	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-		DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
-		if (keep_title_visible) {
-			Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(tr_title, window_id);
-			Size2i size_limit = get_clamped_minimum_size();
-			if (title_size.x > size_limit.x || title_size.y > size_limit.y) {
-				_update_window_size();
-			}
-		}
-	}
 	emit_signal("title_changed");
-
-#ifdef DEBUG_ENABLED
-	if (EngineDebugger::get_singleton() && window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
-		Array arr = { tr_title };
-		EngineDebugger::get_singleton()->send_message("window:title", arr);
-	}
-#endif
-	queue_accessibility_update();
 }
 
 String Window::get_title() const {
@@ -345,9 +314,9 @@ String Window::get_title() const {
 	return title;
 }
 
-String Window::get_translated_title() const {
+String Window::get_displayed_title() const {
 	ERR_READ_THREAD_GUARD_V(String());
-	return tr_title;
+	return displayed_title;
 }
 
 void Window::_settings_changed() {
@@ -698,7 +667,7 @@ void Window::_make_window() {
 	DisplayServer::get_singleton()->window_set_max_size(Size2i(), window_id);
 	DisplayServer::get_singleton()->window_set_min_size(Size2i(), window_id);
 	DisplayServer::get_singleton()->window_set_mouse_passthrough(mpath, window_id);
-	DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
+	DisplayServer::get_singleton()->window_set_title(displayed_title, window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 
 	_update_window_size();
@@ -1167,7 +1136,7 @@ Size2i Window::_clamp_window_size(const Size2i &p_size) {
 void Window::_update_window_size() {
 	Size2i size_limit = get_clamped_minimum_size();
 	if (!embedder && window_id != DisplayServer::INVALID_WINDOW_ID && keep_title_visible) {
-		Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(tr_title, window_id);
+		Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(displayed_title, window_id);
 		size_limit = size_limit.max(title_size);
 	}
 
@@ -1437,7 +1406,7 @@ void Window::_notification(int p_what) {
 
 			DisplayServer::get_singleton()->accessibility_update_set_role(ae, DisplayServer::AccessibilityRole::ROLE_WINDOW);
 			if (accessibility_name.is_empty()) {
-				DisplayServer::get_singleton()->accessibility_update_set_name(ae, tr_title);
+				DisplayServer::get_singleton()->accessibility_update_set_name(ae, displayed_title);
 			} else {
 				DisplayServer::get_singleton()->accessibility_update_set_name(ae, accessibility_name);
 			}
@@ -1459,7 +1428,7 @@ void Window::_notification(int p_what) {
 				}
 
 				int w = get_theme_constant(SNAME("title_height"));
-				DisplayServer::get_singleton()->accessibility_update_set_name(accessibility_title_element, tr_title);
+				DisplayServer::get_singleton()->accessibility_update_set_name(accessibility_title_element, displayed_title);
 				DisplayServer::get_singleton()->accessibility_update_set_bounds(accessibility_title_element, Rect2(Vector2(0, -w), Size2(size.x, w)));
 			} else {
 				DisplayServer::get_singleton()->accessibility_update_set_transform(ae, get_final_transform());
@@ -1596,29 +1565,7 @@ void Window::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			_invalidate_theme_cache();
 			_update_theme_item_cache();
-
-			tr_title = atr(title);
-#ifdef DEBUG_ENABLED
-			if (window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
-				// Append a suffix to the window title to denote that the project is running
-				// from a debug build (including the editor, excluding the project manager).
-				// Since this results in lower performance, this should be clearly presented
-				// to the user.
-				tr_title = vformat("%s (DEBUG)", tr_title);
-			}
-#endif
-
-			if (!embedder && window_id != DisplayServer::INVALID_WINDOW_ID) {
-				DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
-				if (keep_title_visible) {
-					Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(tr_title, window_id);
-					Size2i size_limit = get_clamped_minimum_size();
-					if (title_size.x > size_limit.x || title_size.y > size_limit.y) {
-						_update_window_size();
-					}
-				}
-			}
-			queue_accessibility_update();
+			_update_displayed_title();
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -3088,6 +3035,42 @@ void Window::_mouse_leave_viewport() {
 		mouse_in_window = false;
 		_propagate_window_notification(this, NOTIFICATION_WM_MOUSE_EXIT);
 	}
+}
+
+void Window::_update_displayed_title() {
+	displayed_title = atr(title);
+
+#ifdef DEBUG_ENABLED
+	if (window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
+		// Append a suffix to the window title to denote that the project is running
+		// from a debug build (including the editor, excluding the project manager).
+		// Since this results in lower performance, this should be clearly presented
+		// to the user.
+		displayed_title = vformat("%s (DEBUG)", displayed_title);
+	}
+#endif
+
+	if (embedder) {
+		embedder->_sub_window_update(this);
+	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_title(displayed_title, window_id);
+		if (keep_title_visible) {
+			Size2i title_size = DisplayServer::get_singleton()->window_get_title_size(displayed_title, window_id);
+			Size2i size_limit = get_clamped_minimum_size();
+			if (title_size.x > size_limit.x || title_size.y > size_limit.y) {
+				_update_window_size();
+			}
+		}
+	}
+
+#ifdef DEBUG_ENABLED
+	if (EngineDebugger::get_singleton() && window_id == DisplayServer::MAIN_WINDOW_ID && !Engine::get_singleton()->is_project_manager_hint()) {
+		Array arr = { displayed_title };
+		EngineDebugger::get_singleton()->send_message("window:title", arr);
+	}
+#endif
+
+	queue_accessibility_update();
 }
 
 void Window::_bind_methods() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -120,7 +120,7 @@ private:
 	bool initialized = false;
 
 	String title;
-	String tr_title;
+	String displayed_title;
 	mutable int current_screen = 0;
 	mutable Point2i position;
 	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
@@ -252,6 +252,8 @@ private:
 	void _update_mouse_over(Vector2 p_pos) override;
 	void _mouse_leave_viewport() override;
 
+	void _update_displayed_title();
+
 	Ref<Shortcut> debugger_stop_shortcut;
 
 	static int root_layout_direction;
@@ -296,7 +298,7 @@ public:
 
 	void set_title(const String &p_title);
 	String get_title() const;
-	String get_translated_title() const;
+	String get_displayed_title() const;
 
 	void set_initial_position(WindowInitialPosition p_initial_position);
 	WindowInitialPosition get_initial_position() const;


### PR DESCRIPTION
When game embeding is enabled and the game view floats, the floating window's title does not react to translation changes in the editor.

https://github.com/user-attachments/assets/e085b387-8d07-47b7-aa5f-bd4301b2b342

Also renamed the internal `get_translated_title()` to `get_displayed_title()` as the difference between the `title` string and the actual displayed text could be more than translation. e.g., a debug build adds a ` (DEBUG)` suffix.

For easier testing: [window-title-mrp.zip](https://github.com/user-attachments/files/20752836/window-title-mrp.zip)
