### PR TITLE
[3.x] Backport nonexclusive fullscreen mode.

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -403,6 +403,14 @@ bool _OS::is_window_fullscreen() const {
 	return OS::get_singleton()->is_window_fullscreen();
 }
 
+void _OS::set_window_use_nonexclusive_fullscreen(bool p_enabled) {
+	OS::get_singleton()->set_window_use_nonexclusive_fullscreen(p_enabled);
+}
+
+bool _OS::is_window_use_nonexclusive_fullscreen() const {
+	return OS::get_singleton()->is_window_use_nonexclusive_fullscreen();
+}
+
 void _OS::set_window_resizable(bool p_enabled) {
 	OS::get_singleton()->set_window_resizable(p_enabled);
 }
@@ -1371,6 +1379,8 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_display_cutouts"), &_OS::get_display_cutouts);
 	ClassDB::bind_method(D_METHOD("set_window_fullscreen", "enabled"), &_OS::set_window_fullscreen);
 	ClassDB::bind_method(D_METHOD("is_window_fullscreen"), &_OS::is_window_fullscreen);
+	ClassDB::bind_method(D_METHOD("set_window_use_nonexclusive_fullscreen", "enabled"), &_OS::set_window_use_nonexclusive_fullscreen);
+	ClassDB::bind_method(D_METHOD("is_window_use_nonexclusive_fullscreen"), &_OS::is_window_use_nonexclusive_fullscreen);
 	ClassDB::bind_method(D_METHOD("set_window_resizable", "enabled"), &_OS::set_window_resizable);
 	ClassDB::bind_method(D_METHOD("is_window_resizable"), &_OS::is_window_resizable);
 	ClassDB::bind_method(D_METHOD("set_window_minimized", "enabled"), &_OS::set_window_minimized);
@@ -1568,6 +1578,7 @@ void _OS::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_borderless"), "set_borderless_window", "get_borderless_window");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_per_pixel_transparency_enabled"), "set_window_per_pixel_transparency_enabled", "get_window_per_pixel_transparency_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_fullscreen"), "set_window_fullscreen", "is_window_fullscreen");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_use_nonexclusive_fullscreen"), "set_window_use_nonexclusive_fullscreen", "is_window_use_nonexclusive_fullscreen");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_maximized"), "set_window_maximized", "is_window_maximized");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_minimized"), "set_window_minimized", "is_window_minimized");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "window_resizable"), "set_window_resizable", "is_window_resizable");

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -225,6 +225,8 @@ public:
 	virtual void set_window_size(const Size2 &p_size);
 	virtual void set_window_fullscreen(bool p_enabled);
 	virtual bool is_window_fullscreen() const;
+	virtual void set_window_use_nonexclusive_fullscreen(bool p_enabled);
+	virtual bool is_window_use_nonexclusive_fullscreen() const;
 	virtual void set_window_resizable(bool p_enabled);
 	virtual bool is_window_resizable() const;
 	virtual void set_window_minimized(bool p_enabled);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -107,6 +107,7 @@ public:
 	struct VideoMode {
 		int width, height;
 		bool fullscreen;
+		bool non_ex_fs;
 		bool resizable;
 		bool borderless_window;
 		bool maximized;
@@ -126,6 +127,7 @@ public:
 			use_vsync = p_use_vsync;
 			vsync_via_compositor = p_vsync_via_compositor;
 			layered = false;
+			non_ex_fs = false;
 		}
 	};
 
@@ -282,6 +284,8 @@ public:
 	virtual void set_window_size(const Size2 p_size) {}
 	virtual void set_window_fullscreen(bool p_enabled) {}
 	virtual bool is_window_fullscreen() const { return true; }
+	virtual void set_window_use_nonexclusive_fullscreen(bool p_enabled) {}
+	virtual bool is_window_use_nonexclusive_fullscreen() const { return false; }
 	virtual void set_window_resizable(bool p_enabled) {}
 	virtual bool is_window_resizable() const { return false; }
 	virtual void set_window_minimized(bool p_enabled) {}

--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1082,6 +1082,7 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("display/window/size/resizable", true);
 	GLOBAL_DEF("display/window/size/borderless", false);
 	GLOBAL_DEF("display/window/size/fullscreen", false);
+	GLOBAL_DEF("display/window/size/use_nonexclusive_fullscreen", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
 	GLOBAL_DEF("display/window/size/test_width", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/test_width", PropertyInfo(Variant::INT, "display/window/size/test_width", PROPERTY_HINT_RANGE, "0,7680,1,or_greater")); // 8K resolution

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -1211,7 +1211,7 @@
 			[b]Note:[/b] Setting [code]window_borderless[/code] to [code]false[/code] disables per-pixel transparency.
 		</member>
 		<member name="window_fullscreen" type="bool" setter="set_window_fullscreen" getter="is_window_fullscreen" default="false">
-			If [code]true[/code], the window is fullscreen.
+			If [code]true[/code], the window is fullscreen. See also [member window_use_nonexclusive_fullscreen].
 		</member>
 		<member name="window_maximized" type="bool" setter="set_window_maximized" getter="is_window_maximized" default="false">
 			If [code]true[/code], the window is maximized.
@@ -1233,6 +1233,11 @@
 		</member>
 		<member name="window_size" type="Vector2" setter="set_window_size" getter="get_window_size" default="Vector2( 0, 0 )">
 			The size of the window (without counting window manager decorations).
+		</member>
+		<member name="window_use_nonexclusive_fullscreen" type="bool" setter="set_window_use_nonexclusive_fullscreen" getter="is_window_use_nonexclusive_fullscreen" default="false">
+			If [code]true[/code] and [member window_fullscreen] is set, a full screen mode with full multi-window support is used.
+			If [code]false[/code] and [member window_fullscreen] is set, a single window fullscreen mode is used, this mode has less overhead, but only one window can be open on a given screen at a time (opening a application switching will trigger a full screen transition). This mode might not work with screen recording software.
+			[b]Note:[/b] This property is only implemented on Windows.
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -539,8 +539,9 @@
 			[b]Note:[/b] This setting is ignored on iOS, Android, and HTML5.
 		</member>
 		<member name="display/window/size/fullscreen" type="bool" setter="" getter="" default="false">
-			Sets the main window to full screen when the project starts. Note that this is not [i]exclusive[/i] fullscreen. On Windows and Linux, a borderless window is used to emulate fullscreen. On macOS, a new desktop is used to display the running project.
+			Sets the main window to full screen when the project starts. The display's video mode is not changed. See also [member display/window/size/use_nonexclusive_fullscreen].
 			Regardless of the platform, enabling fullscreen will change the window size to match the monitor's size. Therefore, make sure your project supports [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] when enabling fullscreen mode.
+			[b]Note:[/b] On macOS, a new desktop is used to display the running project.
 			[b]Note:[/b] This setting is ignored on iOS, Android, and HTML5.
 		</member>
 		<member name="display/window/size/height" type="int" setter="" getter="" default="600">
@@ -555,6 +556,11 @@
 		</member>
 		<member name="display/window/size/test_width" type="int" setter="" getter="" default="0">
 			If greater than zero, overrides the window width when running the game. Useful for testing stretch modes.
+		</member>
+		<member name="display/window/size/use_nonexclusive_fullscreen" type="bool" setter="" getter="" default="false">
+			If [code]true[/code] and [member display/window/size/fullscreen] is set, a full screen mode with full multi-window support is used.
+			If [code]false[/code] and [member display/window/size/fullscreen] is set, a single window fullscreen mode is used, this mode has less overhead, but only one window can be open on a given screen at a time (opening a application switching will trigger a full screen transition). This mode might not work with screen recording software.
+			[b]Note:[/b] This property is only implemented on Windows.
 		</member>
 		<member name="display/window/size/width" type="int" setter="" getter="" default="1024">
 			Sets the game's main viewport width. On desktop platforms, this is the default window size. Stretch mode settings also use this as a reference when enabled.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -151,6 +151,7 @@ HashMap<Main::CLIScope, Vector<String>> forwardable_cli_arguments;
 static OS::VideoMode video_mode;
 static int init_screen = -1;
 static bool init_fullscreen = false;
+static bool init_non_ex_fs = false;
 static bool init_maximized = false;
 static bool init_windowed = false;
 static bool init_always_on_top = false;
@@ -641,6 +642,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-f" || I->get() == "--fullscreen") { // force fullscreen
 
 			init_fullscreen = true;
+		} else if (I->get() == "--nonexclusive-fullscreen") { // force fullscreen
+
+			init_fullscreen = true;
+			init_non_ex_fs = true;
 		} else if (I->get() == "-m" || I->get() == "--maximized") { // force maximized window
 
 			init_maximized = true;
@@ -1141,6 +1146,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	if (editor || project_manager) {
 		Engine::get_singleton()->set_editor_hint(true);
 		use_custom_res = false;
+		init_non_ex_fs = true;
 		input_map->load_default(); //keys for editor
 	} else {
 		input_map->load_from_globals(); //keys for game
@@ -1192,6 +1198,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		video_mode.resizable = GLOBAL_GET("display/window/size/resizable");
 		video_mode.borderless_window = GLOBAL_GET("display/window/size/borderless");
 		video_mode.fullscreen = GLOBAL_GET("display/window/size/fullscreen");
+		video_mode.non_ex_fs = GLOBAL_GET("display/window/size/use_nonexclusive_fullscreen");
 		video_mode.always_on_top = GLOBAL_GET("display/window/size/always_on_top");
 	}
 
@@ -1486,6 +1493,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	if (init_screen != -1) {
 		OS::get_singleton()->set_current_screen(init_screen);
+	}
+	if (init_non_ex_fs) {
+		OS::get_singleton()->set_window_use_nonexclusive_fullscreen(true);
 	}
 	if (init_windowed) {
 		//do none..

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -344,6 +344,7 @@ class OS_Windows : public OS {
 
 	Size2 window_rect;
 	VideoMode video_mode;
+	bool non_ex_fs = false;
 	bool preserve_window_size = false;
 
 	MainLoop *main_loop;
@@ -486,6 +487,8 @@ public:
 	virtual void set_window_size(const Size2 p_size);
 	virtual void set_window_fullscreen(bool p_enabled);
 	virtual bool is_window_fullscreen() const;
+	virtual void set_window_use_nonexclusive_fullscreen(bool p_enabled);
+	virtual bool is_window_use_nonexclusive_fullscreen() const;
 	virtual void set_window_resizable(bool p_enabled);
 	virtual bool is_window_resizable() const;
 	virtual void set_window_minimized(bool p_enabled);


### PR DESCRIPTION
Adds equivalent of 4.x non-exclusive fullscreen mode, that forces composition to be enabled, allowing multiple windows on the screen and interactions with other apps always work. Mode added as a separate `use_nonexclusive_fullscreen` property that work in conjunction with existing `fullscreen` property (since there's no mode concept in 3.x).

Fixes https://github.com/godotengine/godot/issues/107140