### PR TITLE
Clear cache when setting Mesh's surfaces

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1679,6 +1679,7 @@ void ArrayMesh::_set_surfaces(const Array &p_surfaces) {
 	}
 
 	surfaces.clear();
+	clear_cache();
 
 	aabb = AABB();
 	for (int i = 0; i < surface_data.size(); i++) {


### PR DESCRIPTION
Fixes #104003

Might be useful to find what exactly caused the regression (I didn't test if it's a regression).