### PR TITLE
[Web] Add notice about issues with setting custom cursor shape every frame

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -724,6 +724,7 @@
 			<description>
 				Sets a custom mouse cursor image for the given [param shape]. This means the user's operating system and mouse cursor theme will no longer influence the mouse cursor's appearance.
 				[param cursor] can be either a [Texture2D] or an [Image], and it should not be larger than 256×256 to display correctly. Optionally, [param hotspot] can be set to offset the image's position relative to the click point. By default, [param hotspot] is set to the top-left corner of the image. See also [method cursor_set_shape].
+				[b]Note:[/b] On Web, calling this method every frame can cause the cursor to flicker.
 			</description>
 		</method>
 		<method name="cursor_set_shape">


### PR DESCRIPTION
This PR adds a note to `DisplayServer.cursor_set_custom_image()` saying that there's some flickering issues with the Web platform if called repeatedly.

Fixes #102403. Kinda.
Supersedes #103304. Also kinda.

Fixing "for real" this issue would need to revisit the API itself. And if the need of an animated cursor arises for the Web platform, a new API would be needed specifically for animated cursors, as I think animated cursors are possible on the Web, but [the animation needs to be delegated to the browser](https://jordaneldredge.com/blog/rendering-animated-ani-cursors-in-the-browser/). (edit: just saw and tested, the technique shown by the link doesn't work on Safari).

(Edit: to answer what I mean by revisiting the API itself, see https://github.com/godotengine/godot/pull/103304#pullrequestreview-2931283589.)