### PR TITLE
Add `STATIC_ASSERT_INCOMPLETE_TYPE` to enforce include minimality.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -634,6 +634,7 @@ if env["strict_checks"]:
 
 # Run SCU file generation script if in a SCU build.
 if env["scu_build"]:
+    env.Append(CPPDEFINES=["SCU_BUILD_ENABLED"])
     max_includes_per_scu = 8
     if env.dev_build:
         max_includes_per_scu = 1024

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -30,6 +30,8 @@
 
 #include "ustring.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
+
 #include "core/crypto/crypto_core.h"
 #include "core/math/color.h"
 #include "core/math/math_funcs.h"

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -439,3 +439,23 @@ inline constexpr bool is_zero_constructible_v = is_zero_constructible<T>::value;
 #define GODOT_MSVC_WARNING_POP
 #define GODOT_MSVC_WARNING_PUSH_AND_IGNORE(m_warning)
 #endif
+
+template <typename T, typename = void>
+struct is_fully_defined : std::false_type {};
+
+template <typename T>
+struct is_fully_defined<T, std::void_t<decltype(sizeof(T))>> : std::true_type {};
+
+template <typename T>
+constexpr bool is_fully_defined_v = is_fully_defined<T>::value;
+
+#ifndef SCU_BUILD_ENABLED
+/// Enforces the requirement that a class is not fully defined.
+/// This can be used to reduce include coupling and keep compile times low.
+/// The check must be made at the top of the corresponding .cpp file of a header.
+#define STATIC_ASSERT_INCOMPLETE_TYPE(m_keyword, m_type) \
+	m_keyword m_type;                                    \
+	static_assert(!is_fully_defined_v<m_type>, #m_type " was unexpectedly fully defined. Please check the include hierarchy of '" __FILE__ "' and remove includes that resolve the " #m_keyword ".");
+#else
+#define STATIC_ASSERT_INCOMPLETE_TYPE(m_keyword, m_type)
+#endif

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -30,6 +30,9 @@
 
 #include "array.h"
 
+STATIC_ASSERT_INCOMPLETE_TYPE(class, Dictionary);
+STATIC_ASSERT_INCOMPLETE_TYPE(class, String);
+
 #include "container_type_validate.h"
 #include "core/math/math_funcs.h"
 #include "core/object/script_language.h"


### PR DESCRIPTION
Cross-includes are our main compile time problem right now. Not only does parsing take long, also every small change to a header file leads to hundreds of recompilations of compile units. It's time to do something.

`STATIC_ASSERT_INCOMPLETE_TYPE` is designed to protect ourselves against unnecessary includes. It lets us enforce certain couplings are not made, such as an include to `dictionary.h` from `ustring.h`. The assertion is made only for release build, to avoid interfering with the development cycle.
(This check was originally made for https://github.com/godotengine/godot/pull/107492, but I split it off to make it easier to discuss it separately).

I enforce 3 assumptions in this PR that already hold (no `Dictionary` include from `String`, and `Dictionary` and `String` from `Array`). There are many others we should be making. This is left to do as follow-up PRs (e.g. https://github.com/godotengine/godot/pull/106434).

