### PR TITLE
GDExtension: Always run shutdown callback before deinitializing any levels

### DIFF
--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -815,8 +815,12 @@ typedef void (*GDExtensionMainLoopShutdownCallback)();
 typedef void (*GDExtensionMainLoopFrameCallback)();
 
 typedef struct {
+	// Will be called after Godot is started and is fully initialized.
 	GDExtensionMainLoopStartupCallback startup_func;
+	// Will be called before Godot is shutdown when it is still fully initialized.
 	GDExtensionMainLoopShutdownCallback shutdown_func;
+	// Will be called for each process frame. This will run after all `_process()` methods on Node, and before `ScriptServer::frame()`.
+	// This is intended to be the equivalent of `ScriptLanguage::frame()` for GDExtension language bindings that don't use the script API.
 	GDExtensionMainLoopFrameCallback frame_func;
 } GDExtensionMainLoopCallbacks;
 

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -77,19 +77,19 @@ GDExtensionManager::LoadStatus GDExtensionManager::_unload_extension_internal(co
 	emit_signal("extension_unloading", p_extension);
 #endif
 
-	if (level >= 0) { // Already initialized up to some level.
-		// Deinitialize down from current level.
-		for (int32_t i = level; i >= GDExtension::INITIALIZATION_LEVEL_CORE; i--) {
-			p_extension->deinitialize_library(GDExtension::InitializationLevel(i));
-		}
-	}
-
 	if (!shutdown_callback_called) {
 		// Extension is unloading before the shutdown callback has been called,
 		// which means the engine hasn't shutdown yet but we want to make sure
 		// to call the shutdown callback so it doesn't miss it.
 		if (p_extension->shutdown_callback) {
 			p_extension->shutdown_callback();
+		}
+	}
+
+	if (level >= 0) { // Already initialized up to some level.
+		// Deinitialize down from current level.
+		for (int32_t i = level; i >= GDExtension::INITIALIZATION_LEVEL_CORE; i--) {
+			p_extension->deinitialize_library(GDExtension::InitializationLevel(i));
 		}
 	}
 


### PR DESCRIPTION
This is a small fix to PR https://github.com/godotengine/godot/pull/106030

When normal shutdown occurs, the shutdown callbacks are run _before_ any of the initialization levels are deinitialized. So, when an extension is unloaded before Godot is shutdown, it should also run it before any of the initialization levels are deinitialized, which is what this PR does.

(The diff is a little weird, because it removes and adds code that was already there, not the code added by the referenced PR. But the result is the same: the order of the two things are swapped.)

I also snuck in a couple tiny comments to document these callbacks in `gdextension_interface.h`, which was discussed at the last GDExtension team meeting. If it'd be better to move that to its own PR, I can, but these changes are minor fix ups to the same new feature so I thought it may be OK :-)