### PR TITLE
Fix export fail on Android if `shader_baker` is enabled.

### DIFF
--- a/editor/plugins/shader_baker_export_plugin.cpp
+++ b/editor/plugins/shader_baker_export_plugin.cpp
@@ -244,9 +244,12 @@ void ShaderBakerExportPlugin::_end_customize_resources() {
 		if (cache_list_access.is_valid()) {
 			String cache_list_line;
 			while (cache_list_line = cache_list_access->get_line(), !cache_list_line.is_empty()) {
-				PackedByteArray cache_file_bytes = FileAccess::get_file_as_bytes(shader_cache_export_path.path_join(cache_list_line));
-				if (!cache_file_bytes.is_empty()) {
-					add_file(shader_cache_user_dir.path_join(cache_list_line), cache_file_bytes, false);
+				// Only add if it wasn't already added.
+				if (!shader_paths_processed.has(cache_list_line)) {
+					PackedByteArray cache_file_bytes = FileAccess::get_file_as_bytes(shader_cache_export_path.path_join(cache_list_line));
+					if (!cache_file_bytes.is_empty()) {
+						add_file(shader_cache_user_dir.path_join(cache_list_line), cache_file_bytes, false);
+					}
 				}
 
 				shader_paths_processed.erase(cache_list_line);


### PR DESCRIPTION
According to my understanding, files listed in the `shader_cache` were being re-added even if they were already added in the current export run via `shader_group_items`. This led to duplicate entries in the exported file list, which in turn triggered an `ApkFormatException` during APK signing, as shown in the issue.

This change ensures each file is added only once per export by skipping files already processed in the current run.

Fixes https://github.com/godotengine/godot/issues/107535
