### PR TITLE
Add qualifier for multilevel methods

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -30,7 +30,7 @@
 		<link title="Object notifications">$DOCS_URL/tutorials/best_practices/godot_notifications.html</link>
 	</tutorials>
 	<methods>
-		<method name="_get" qualifiers="virtual">
+		<method name="_get" qualifiers="virtual multilevel">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>
@@ -74,7 +74,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="_get_property_list" qualifiers="virtual">
+		<method name="_get_property_list" qualifiers="virtual multilevel">
 			<return type="Dictionary[]" />
 			<description>
 				Override this method to provide a custom list of additional properties to handle by the engine.
@@ -242,7 +242,7 @@
 				Moves the iterator to the next iteration. [param iter] stores the iteration state. Since GDScript does not support passing arguments by reference, a single-element array is used as a wrapper. Returns [code]true[/code] so long as the iterator has not reached the end.
 			</description>
 		</method>
-		<method name="_notification" qualifiers="virtual">
+		<method name="_notification" qualifiers="virtual multilevel">
 			<return type="void" />
 			<param index="0" name="what" type="int" />
 			<description>
@@ -282,7 +282,7 @@
 				[b]Note:[/b] [method _property_can_revert] must also be overridden for this method to be called.
 			</description>
 		</method>
-		<method name="_set" qualifiers="virtual">
+		<method name="_set" qualifiers="virtual multilevel">
 			<return type="bool" />
 			<param index="0" name="property" type="StringName" />
 			<param index="1" name="value" type="Variant" />
@@ -662,7 +662,7 @@
 				[b]Note:[/b] The dictionaries of [code]args[/code] and [code]return[/code] are formatted identically to the results of [method get_property_list], although not all entries are used.
 			</description>
 		</method>
-		<method name="get_property_list" qualifiers="const">
+		<method name="get_property_list" qualifiers="const multilevel">
 			<return type="Dictionary[]" />
 			<description>
 				Returns the object's property list as an [Array] of dictionaries. Each [Dictionary] contains the following entries:
@@ -832,7 +832,7 @@
 				[b]Note:[/b] This method is used by the Inspector dock to display a revert icon. The object must implement [method _property_can_revert] to customize the default value. If [method _property_can_revert] is not implemented, this method returns [code]false[/code].
 			</description>
 		</method>
-		<method name="property_get_revert" qualifiers="const">
+		<method name="property_get_revert" qualifiers="const multilevel">
 			<return type="Variant" />
 			<param index="0" name="property" type="StringName" />
 			<description>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -196,6 +196,11 @@ static void merge_methods(Vector<DocData::MethodDoc> &p_to, const Vector<DocData
 			to.is_experimental = from.is_experimental;
 			to.experimental_message = from.experimental_message;
 			to.keywords = from.keywords;
+
+			if (from.qualifiers.contains("multilevel")) {
+				// Multilevel qualifier is added manually.
+				to.qualifiers += vformat("%s%s", to.qualifiers.is_empty() ? "" : " ", "multilevel");
+			}
 		}
 	}
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -156,6 +156,8 @@ static void _add_qualifiers_to_rt(const String &p_qualifiers, RichTextLabel *p_r
 			hint = TTR("This method does not need an instance to be called.\nIt can be called directly using the class name.");
 		} else if (qualifier == "abstract") {
 			hint = TTR("This method must be implemented to complete the abstract class.");
+		} else if (qualifier == "multilevel") {
+			hint = TTR("This method is called automatically for every script that overrides it.\nThis means that the base implementation should not be called via super in GDScript\nor its equivalents in other languages.");
 		}
 
 		p_rt->add_text(" ");


### PR DESCRIPTION
Alternative to #107564
![image](https://github.com/user-attachments/assets/ba4ee1e8-7527-4ff5-a3ef-27f63c3a3c75)
This adds a hard-coded qualifier that can be used to mark multilevel methods.

It's hard-coded, because the multilevel logic exists only in GDCLASS, AFAIK it's not even a thing in any language. We rarely add multilevel methods (last one was almost 3 years ago), so adding the qualifier manually is fine in this case.

`_property_can_revert()` needs to be double-checked, it is multilevel in core, so it's weird it's not in scripts.
`_validate_property()` is multilevel only in core, which is likely a bug.