### PR TITLE
[3.x] Fix `EditorNode::push_item` using 32 bit for `ObjectID`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1970,7 +1970,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 		return;
 	}
 
-	uint32_t id = p_object->get_instance_id();
+	ObjectID id = p_object->get_instance_id();
 	if (id != editor_history.get_current()) {
 		if (p_inspector_only) {
 			editor_history.add_object_inspector_only(id);


### PR DESCRIPTION
`ObjectID` should be 64 bit.

## Discussion
This was a particularly nasty bug to find. I was writing a new `ObjectDB` using a new template, and I kept getting a bug where it would detect trying to use an invalid `ObjectID`.

The interesting thing is that this invalid `ObjectID` bug did not seem to exhibit with the old `ObjectDB`.

Through a lot of detective work I tracked it down to a particular object, repeatedly.

But the actual reason for the bug become clear because the `instance_id` on the `Object` was not the one passed to `editor_history.add_object()` .. it turned out the function is using a 32 bit intermediate, and `ObjectID` should be 64 bit.

So this is likely due to a historical change where `ObjectID` went from 32 bit to 64 bit, _or_ this bug had existed forever.

## How did it ever work?
The interesting question is how did this ever work? The answer is that old `ObjectIDs` were handed out incrementally from zero. This means that the first 4 billion would likely work fine, but the moment you got over this (due to object churn), the editor would go haywire.

## Notes
* This is a particularly nasty bug and we should try and work out whether there are more cases of 32 bit intermediates.
* I'll try and check whether similar bug is present in 4.x.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
