### PR TITLE
[iOS] Switch window creation to UIScene.

### DIFF
--- a/drivers/apple_embedded/godot_app_delegate.mm
+++ b/drivers/apple_embedded/godot_app_delegate.mm
@@ -31,6 +31,7 @@
 #import "godot_app_delegate.h"
 
 #import "app_delegate_service.h"
+#import "godot_scene_delegate.h"
 
 @implementation GDTApplicationDelegate
 
@@ -59,15 +60,29 @@ static NSMutableArray<GDTAppDelegateServiceProtocol *> *services = nil;
 - (UIWindow *)window {
 	UIWindow *result = nil;
 
-	for (GDTAppDelegateServiceProtocol *service in services) {
-		if (![service respondsToSelector:_cmd]) {
-			continue;
+	if (@available(iOS 13, tvOS 13, visionOS 1, *)) {
+		for (GDTSceneDelegateServiceProtocol *service in [GDTSceneDelegate services]) {
+			if (![service respondsToSelector:_cmd]) {
+				continue;
+			}
+
+			UIWindow *value = [service window];
+
+			if (value) {
+				result = value;
+			}
 		}
+	} else {
+		for (GDTAppDelegateServiceProtocol *service in services) {
+			if (![service respondsToSelector:_cmd]) {
+				continue;
+			}
 
-		UIWindow *value = [service window];
+			UIWindow *value = [service window];
 
-		if (value) {
-			result = value;
+			if (value) {
+				result = value;
+			}
 		}
 	}
 
@@ -108,15 +123,16 @@ static NSMutableArray<GDTAppDelegateServiceProtocol *> *services = nil;
 	return result;
 }
 
-/* Can be handled by Info.plist. Not yet supported by Godot.
-
 // MARK: Scene
 
-- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options {}
+- (UISceneConfiguration *)application:(UIApplication *)application configurationForConnectingSceneSession:(UISceneSession *)connectingSceneSession options:(UISceneConnectionOptions *)options API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	UISceneConfiguration *config = [[UISceneConfiguration alloc] initWithName:@"Default Configuration" sessionRole:connectingSceneSession.role];
+	config.delegateClass = [GDTSceneDelegate class];
+	return config;
+}
 
-- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions {}
-
-*/
+- (void)application:(UIApplication *)application didDiscardSceneSessions:(NSSet<UISceneSession *> *)sceneSessions API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+}
 
 // MARK: Life-Cycle
 

--- a/drivers/apple_embedded/godot_scene_delegate.h
+++ b/drivers/apple_embedded/godot_scene_delegate.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  app_delegate_service.h                                                */
+/*  godot_scene_delegate.h                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -32,11 +32,13 @@
 
 #import <UIKit/UIKit.h>
 
-@class GDTViewController;
+typedef NSObject<UIWindowSceneDelegate> GDTSceneDelegateServiceProtocol API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0));
 
-@interface GDTAppDelegateService : NSObject <UIApplicationDelegate, UIWindowSceneDelegate>
+API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0))
+@interface GDTSceneDelegate : NSObject <UIWindowSceneDelegate>
 
-@property(strong, nonatomic) UIWindow *window;
-@property(strong, class, readonly, nonatomic) GDTViewController *viewController;
+@property(class, readonly, strong) NSArray<GDTSceneDelegateServiceProtocol *> *services;
+
++ (void)addService:(GDTSceneDelegateServiceProtocol *)service;
 
 @end

--- a/drivers/apple_embedded/godot_scene_delegate.mm
+++ b/drivers/apple_embedded/godot_scene_delegate.mm
@@ -1,0 +1,122 @@
+/**************************************************************************/
+/*  godot_scene_delegate.mm                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#import "godot_scene_delegate.h"
+
+#import "app_delegate_service.h"
+
+@implementation GDTSceneDelegate
+
+API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0))
+static NSMutableArray<GDTSceneDelegateServiceProtocol *> *services = nil;
+
++ (NSArray<GDTSceneDelegateServiceProtocol *> *)services API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	return services;
+}
+
++ (void)load {
+	if (@available(iOS 13, tvOS 13, visionOS 1, *)) {
+		services = [NSMutableArray new];
+		[services addObject:[GDTAppDelegateService new]];
+	}
+}
+
++ (void)addService:(GDTSceneDelegateServiceProtocol *)service API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	if (!services || !service) {
+		return;
+	}
+	[services addObject:service];
+}
+
+// MARK: Scene
+
+- (void)scene:(UIScene *)scene willConnectToSession:(UISceneSession *)session options:(UISceneConnectionOptions *)connectionOptions API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTSceneDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service scene:scene willConnectToSession:session options:connectionOptions];
+	}
+}
+
+// MARK: Life-Cycle
+
+- (void)sceneDidDisconnect:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTSceneDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneDidDisconnect:scene];
+	}
+}
+
+- (void)sceneDidBecomeActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTSceneDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneDidBecomeActive:scene];
+	}
+}
+
+- (void)sceneWillResignActive:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTSceneDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneWillResignActive:scene];
+	}
+}
+
+- (void)sceneDidEnterBackground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTSceneDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneDidEnterBackground:scene];
+	}
+}
+
+- (void)sceneWillEnterForeground:(UIScene *)scene API_AVAILABLE(ios(13.0), tvos(13.0), visionos(1.0)) {
+	for (GDTSceneDelegateServiceProtocol *service in services) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
+		}
+
+		[service sceneWillEnterForeground:scene];
+	}
+}
+
+@end

--- a/misc/dist/apple_embedded_xcode/godot_apple_embedded/godot_apple_embedded-Info.plist
+++ b/misc/dist/apple_embedded_xcode/godot_apple_embedded/godot_apple_embedded-Info.plist
@@ -59,5 +59,19 @@
 	$additional_plist_content
 	$plist_launch_screen_name
 	<key>CADisableMinimumFrameDurationOnPhone</key><true/>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key><false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
- Adds `GDTSceneDelegateServiceProtocol` for plugins (same way it is used for `AppDelegate`.
- Switches iOS 13+ window creation to use `UIScene` (bare minimum implementation, since it will be required for iOS 26, no multi-scene support).