### PR TITLE
Fix deadlock in `EditorFileSystem::reimport_files`.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -3248,11 +3248,13 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 					int imported_count = 0;
 					while (true) {
-						ep->step(reimport_files[imported_count].path.get_file(), from + imported_count, false);
-						imported_sem.wait();
-						do {
-							imported_count++;
-						} while (imported_sem.try_wait());
+						while (true) {
+							ep->step(reimport_files[imported_count].path.get_file(), from + imported_count, false);
+							if (imported_sem.try_wait()) {
+								imported_count++;
+								break;
+							}
+						}
 						if (imported_count == item_count) {
 							break;
 						}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107495

Ensures `ep->step` (which pumps main thread events) it continuously called while waiting for import thread to post.

Old logic is quite odd, so I'm not sure if it's entirely correct.