### PR TITLE
Improve Camera2D limit editing

### DIFF
--- a/editor/plugins/camera_2d_editor_plugin.h
+++ b/editor/plugins/camera_2d_editor_plugin.h
@@ -51,6 +51,10 @@ class Camera2DEditor : public Control {
 		TOP,
 		RIGHT,
 		BOTTOM,
+		TOP_LEFT,
+		TOP_RIGHT,
+		BOTTOM_LEFT,
+		BOTTOM_RIGHT,
 		CENTER,
 	};
 	Drag drag_type = Drag::NONE;


### PR DESCRIPTION
Follow-up to #104190
- Added diagonal dragging
- Re-enabled center drag when a limit edge is visible on screen

https://github.com/user-attachments/assets/302a0e52-ef53-4487-b6a9-f1c13ef15a7e

