### PR TITLE
Prevent scene tabs to scroll when a tab is closed

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -258,8 +258,14 @@
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
+		<member name="is_closing_tab" type="bool" setter="set_is_closing_tab" getter="get_is_closing_tab" default="false">
+			Can be used with [code skip-lint]scroll_on_tab_close[/code] to know if the tab should scroll or not.
+		</member>
 		<member name="max_tab_width" type="int" setter="set_max_tab_width" getter="get_max_tab_width" default="0">
 			Sets the maximum width which all tabs should be limited to. Unlimited if set to [code]0[/code].
+		</member>
+		<member name="scroll_on_tab_close" type="bool" setter="set_scroll_on_tab_close" getter="get_scroll_on_tab_close" default="true">
+			If [code]true[/code], closing a tab will adjust the scroll position to keep the active tab visible. Disable to preserve the current scroll position when closing tabs.
 		</member>
 		<member name="scroll_to_selected" type="bool" setter="set_scroll_to_selected" getter="get_scroll_to_selected" default="true">
 			If [code]true[/code], the tab offset will be changed to keep the currently selected tab visible.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3649,7 +3649,9 @@ void EditorNode::_discard_changes(const String &p_str) {
 			// Don't close tabs when exiting the editor (required for "restore_scenes_on_load" setting).
 			if (!_is_closing_editor()) {
 				_remove_scene(tab_closing_idx);
+				scene_tabs->set_is_closing_tab(true);
 				scene_tabs->update_scene_tabs();
+				scene_tabs->set_is_closing_tab(false);
 			}
 			_proceed_closing_scene_tabs();
 		} break;
@@ -6100,7 +6102,9 @@ void EditorNode::_scene_tab_closed(int p_tab) {
 	}
 
 	save_editor_layout_delayed();
+	scene_tabs->set_is_closing_tab(true);
 	scene_tabs->update_scene_tabs();
+	scene_tabs->set_is_closing_tab(false);
 }
 
 void EditorNode::_cancel_close_scene_tab() {

--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -258,6 +258,10 @@ void EditorSceneTabs::update_scene_tabs() {
 	_update_tab_titles();
 }
 
+void EditorSceneTabs::set_is_closing_tab(bool closing) {
+	scene_tabs->set_is_closing_tab(closing);
+}
+
 void EditorSceneTabs::_update_tab_titles() {
 	bool show_rb = EDITOR_GET("interface/scene_tabs/show_script_button");
 
@@ -418,6 +422,8 @@ EditorSceneTabs::EditorSceneTabs() {
 	scene_tabs->set_drag_to_rearrange_enabled(true);
 	scene_tabs->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	scene_tabs->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	scene_tabs->set_scroll_to_selected(true);
+	scene_tabs->set_scroll_on_tab_close(false);
 	tabbar_container->add_child(scene_tabs);
 
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorSceneTabs::_scene_tab_changed));

--- a/editor/gui/editor_scene_tabs.h
+++ b/editor/gui/editor_scene_tabs.h
@@ -102,6 +102,7 @@ public:
 	int get_current_tab() const;
 
 	void update_scene_tabs();
+	void set_is_closing_tab(bool closing);
 
 	EditorSceneTabs();
 };

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -750,7 +750,7 @@ void TabBar::set_tab_count(int p_count) {
 
 		_update_cache();
 		_ensure_no_over_offset();
-		if (scroll_to_selected) {
+		if (scroll_to_selected && (get_scroll_on_tab_close() || !get_is_closing_tab())) {
 			ensure_tab_visible(current);
 		}
 	}
@@ -795,7 +795,7 @@ void TabBar::set_current_tab(int p_current) {
 	emit_signal(SNAME("tab_selected"), current);
 
 	_update_cache();
-	if (scroll_to_selected) {
+	if (scroll_to_selected && (get_scroll_on_tab_close() || !get_is_closing_tab())) {
 		ensure_tab_visible(current);
 	}
 	queue_accessibility_update();
@@ -889,7 +889,7 @@ void TabBar::set_tab_title(int p_tab, const String &p_title) {
 	_shape(p_tab);
 	_update_cache();
 	_ensure_no_over_offset();
-	if (scroll_to_selected) {
+	if (scroll_to_selected && (get_scroll_on_tab_close() || !get_is_closing_tab())) {
 		ensure_tab_visible(current);
 	}
 	queue_accessibility_update();
@@ -1546,6 +1546,14 @@ void TabBar::_move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_in
 	update_minimum_size();
 }
 
+bool TabBar::get_is_closing_tab() const {
+	return is_closing_tab;
+}
+
+void TabBar::set_is_closing_tab(bool closing) {
+	is_closing_tab = closing;
+}
+
 int TabBar::get_tab_idx_at_point(const Point2 &p_point) const {
 	if (tabs.is_empty()) {
 		return -1;
@@ -1937,6 +1945,14 @@ bool TabBar::get_scroll_to_selected() const {
 	return scroll_to_selected;
 }
 
+void TabBar::set_scroll_on_tab_close(bool p_enabled) {
+	scroll_on_tab_close = p_enabled;
+}
+
+bool TabBar::get_scroll_on_tab_close() const {
+	return scroll_on_tab_close;
+}
+
 void TabBar::set_select_with_rmb(bool p_enabled) {
 	select_with_rmb = p_enabled;
 }
@@ -2013,6 +2029,10 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tabs_rearrange_group"), &TabBar::get_tabs_rearrange_group);
 	ClassDB::bind_method(D_METHOD("set_scroll_to_selected", "enabled"), &TabBar::set_scroll_to_selected);
 	ClassDB::bind_method(D_METHOD("get_scroll_to_selected"), &TabBar::get_scroll_to_selected);
+	ClassDB::bind_method(D_METHOD("set_scroll_on_tab_close", "enabled"), &TabBar::set_scroll_on_tab_close);
+	ClassDB::bind_method(D_METHOD("get_scroll_on_tab_close"), &TabBar::get_scroll_on_tab_close);
+	ClassDB::bind_method(D_METHOD("set_is_closing_tab", "enabled"), &TabBar::set_is_closing_tab);
+	ClassDB::bind_method(D_METHOD("get_is_closing_tab"), &TabBar::get_is_closing_tab);
 	ClassDB::bind_method(D_METHOD("set_select_with_rmb", "enabled"), &TabBar::set_select_with_rmb);
 	ClassDB::bind_method(D_METHOD("get_select_with_rmb"), &TabBar::get_select_with_rmb);
 	ClassDB::bind_method(D_METHOD("set_deselect_enabled", "enabled"), &TabBar::set_deselect_enabled);
@@ -2038,6 +2058,8 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_rearrange_group"), "set_tabs_rearrange_group", "get_tabs_rearrange_group");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_to_selected"), "set_scroll_to_selected", "get_scroll_to_selected");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_on_tab_close"), "set_scroll_on_tab_close", "get_scroll_on_tab_close");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "is_closing_tab"), "set_is_closing_tab", "get_is_closing_tab");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_with_rmb"), "set_select_with_rmb", "get_select_with_rmb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "deselect_enabled"), "set_deselect_enabled", "get_deselect_enabled");
 
@@ -2099,6 +2121,8 @@ TabBar::TabBar() {
 	set_focus_mode(FOCUS_ACCESSIBILITY);
 	set_size(Size2(get_size().width, get_minimum_size().height));
 	set_focus_mode(FOCUS_ALL);
+	set_scroll_on_tab_close(true);
+	set_is_closing_tab(false);
 	connect(SceneStringName(mouse_exited), callable_mp(this, &TabBar::_on_mouse_exited));
 
 	property_helper.setup_for_instance(base_property_helper, this);

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -118,6 +118,8 @@ private:
 	bool drag_to_rearrange_enabled = false;
 	bool dragging_valid_tab = false;
 	bool scroll_to_selected = true;
+	bool scroll_on_tab_close = true;
+	bool is_closing_tab = false;
 	int tabs_rearrange_group = -1;
 
 	static const int CURRENT_TAB_UNINITIALIZED = -2;
@@ -286,6 +288,12 @@ public:
 
 	void set_scroll_to_selected(bool p_enabled);
 	bool get_scroll_to_selected() const;
+
+	void set_scroll_on_tab_close(bool p_enabled);
+	bool get_scroll_on_tab_close() const;
+
+	void set_is_closing_tab(bool closing);
+	bool get_is_closing_tab() const;
 
 	void set_select_with_rmb(bool p_enabled);
 	bool get_select_with_rmb() const;


### PR DESCRIPTION
Prevent scene tabs to scroll when a tab is closed so the user can keep closing other tabs
This is linked to this issue : https://github.com/godotengine/godot/issues/106910

This is my second PR, and first one with "real" code. Thank you for your patience.

* *Bugsquad edit, closes: #106910*