### PR TITLE
Add null check on generating thumbnails for PackedScene

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -342,6 +342,11 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 
 	Node *p_scene = pack->instantiate(); // The instantiated preview scene
 
+	if (!p_scene) {
+		print_error(vformat("Failed to generate scene thumbnail for %s : Failed to instantiate scene", p_path));
+		return Ref<Texture2D>();
+	}
+
 	// Prohibit Viewport class as root when generating thumbnails
 	if (Object::cast_to<Viewport>(p_scene)) {
 		p_scene->queue_free();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #107627.

The issue has been reproducible since #102313. It occurs when `EditorPackedScenePreviewPlugin` attempts to instantiate a node to generate a thumbnail. Because `PackedScene.pack` has a chance of returning `null`, there’s a possibility that `null` gets passed to the `_count_node_types` method, leading to a crash.
