### PR TITLE
Free nodes from instantiating if it is not a `Control` in the theme editor

### DIFF
--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -510,8 +510,15 @@ bool SceneThemeEditorPreview::set_preview_scene(const String &p_path) {
 	}
 
 	Node *instance = loaded_scene->instantiate();
-	if (!instance || !Object::cast_to<Control>(instance)) {
+
+	if (!instance) {
+		EditorNode::get_singleton()->show_warning(TTR("Invalid PackedScene resource, could not instantiate it."));
+		return false;
+	}
+
+	if (!Object::cast_to<Control>(instance)) {
 		EditorNode::get_singleton()->show_warning(TTR("Invalid PackedScene resource, must have a Control node at its root."));
+		memdelete(instance);
 		return false;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Minor fix on the theme editor preview.

Fix a rarely-happening minor memory leak from not freeing the instantiated node inside the if clause that checks if a node is `Control`. Also added more error messages