### PR TITLE
SCons: Enable `lightmapper` and `xatlas_unwrap` modules on Android and iOS editors

### DIFF
--- a/modules/lightmapper_rd/config.py
+++ b/modules/lightmapper_rd/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.editor_build and platform not in ["android", "ios"]
+    return env.editor_build
 
 
 def configure(env):

--- a/modules/xatlas_unwrap/config.py
+++ b/modules/xatlas_unwrap/config.py
@@ -1,5 +1,5 @@
 def can_build(env, platform):
-    return env.editor_build and platform not in ["android", "ios"]
+    return env.editor_build
 
 
 def configure(env):


### PR DESCRIPTION
- Fixes #94297.
- Fixes #107398.

CC @migueldeicaza as you might want to test this on Xogot.

It seems like @Calinou already found this config discrepancy in https://github.com/godotengine/godot/issues/94297#issuecomment-2227501864 and tested it together with @Saul2022 for the Android editor. But somehow it seems we forgot to PR the change.

Needs testing to confirm that both UV unwrapping and the lightmapper are functional on the Android editor (and Xogot, if Miguel or his team can test).