### PR TITLE
Do not generate integer division warning after casting expression to integer

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3086,8 +3086,10 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 	}
 
 #ifdef DEBUG_ENABLED
-	if (p_binary_op->variant_op == Variant::OP_DIVIDE && left_type.builtin_type == Variant::INT && right_type.builtin_type == Variant::INT) {
-		parser->push_warning(p_binary_op, GDScriptWarning::INTEGER_DIVISION);
+	if (!(flags & GDScriptAnalyzerFlags::ANALYZER_FLAG_IGNORE_NUMERIC_CONVERSION)) {
+		if (p_binary_op->variant_op == Variant::OP_DIVIDE && left_type.builtin_type == Variant::INT && right_type.builtin_type == Variant::INT) {
+			parser->push_warning(p_binary_op, GDScriptWarning::INTEGER_DIVISION);
+		}
 	}
 #endif // DEBUG_ENABLED
 
@@ -3205,6 +3207,14 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 	bool all_is_constant = true;
 	HashMap<int, GDScriptParser::ArrayNode *> arrays; // For array literal to potentially type when passing.
 	HashMap<int, GDScriptParser::DictionaryNode *> dictionaries; // Same, but for dictionaries.
+	uint32_t old_flags = flags;
+
+	if (p_call->function_name == "int") {
+		flags |= GDScriptAnalyzerFlags::ANALYZER_FLAG_IGNORE_NUMERIC_CONVERSION;
+	} else {
+		flags &= ~GDScriptAnalyzerFlags::ANALYZER_FLAG_IGNORE_NUMERIC_CONVERSION;
+	}
+
 	for (int i = 0; i < p_call->arguments.size(); i++) {
 		reduce_expression(p_call->arguments[i]);
 		if (p_call->arguments[i]->type == GDScriptParser::Node::ARRAY) {
@@ -3747,6 +3757,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 	}
 
 	p_call->set_datatype(call_type);
+	flags = old_flags;
 }
 
 void GDScriptAnalyzer::reduce_cast(GDScriptParser::CastNode *p_cast) {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -36,6 +36,11 @@
 #include "core/object/object.h"
 #include "core/object/ref_counted.h"
 
+enum GDScriptAnalyzerFlags {
+	ANALYZER_FLAG_NONE = 0,
+	ANALYZER_FLAG_IGNORE_NUMERIC_CONVERSION = 1 << 1,
+};
+
 class GDScriptAnalyzer {
 	GDScriptParser *parser = nullptr;
 
@@ -56,6 +61,7 @@ class GDScriptAnalyzer {
 	List<GDScriptParser::LambdaNode *> pending_body_resolution_lambdas;
 	HashMap<const GDScriptParser::ClassNode *, Ref<GDScriptParserRef>> external_class_parser_cache;
 	bool static_context = false;
+	uint32_t flags = GDScriptAnalyzerFlags::ANALYZER_FLAG_NONE;
 
 	// Tests for detecting invalid overloading of script members
 	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node, const GDScriptParser::Node *p_member);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/42966

I've added new `flags` variable which is needed to store behavior change flags for different purposes while going through AST.  I thought that adding a new method argument, which would span multiple methods, is not ideal for adding one kind of check. And adding something like a context structure seemed too over-engineered.