### PR TITLE
Implement `EditorRangeDial` on top of `EditorSpinSlider`

### DIFF
--- a/doc/classes/EditorRangeDial.xml
+++ b/doc/classes/EditorRangeDial.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorRangeDial" inherits="Range" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_zoom_from_mouse_dist">
+			<return type="void" />
+			<param index="0" name="relative" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="scale_diff">
+			<return type="float" />
+			<param index="0" name="diff" type="float" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="highlighting_range" type="bool" setter="set_highlighting_range" getter="is_highlighting_range" default="false">
+		</member>
+		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="1" />
+		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />
+		<member name="zoom" type="float" setter="set_zoom" getter="get_zoom" default="1.0">
+		</member>
+	</members>
+	<signals>
+		<signal name="zoom_changed">
+			<description>
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/EditorRangeDialPopup.xml
+++ b/doc/classes/EditorRangeDialPopup.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorRangeDialPopup" inherits="PopupPanel" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_dial" qualifiers="const">
+			<return type="EditorRangeDial" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1133,8 +1133,14 @@
 		<member name="interface/inspector/integer_drag_speed" type="float" setter="" getter="">
 			Base speed for increasing/decreasing integer values by dragging them in the inspector.
 		</member>
+		<member name="interface/inspector/invert_drag_zoom_y" type="bool" setter="" getter="">
+			If [code]true[/code], inverts the Y axis when dragging numeric values in the inspector to zoom in and out.
+		</member>
 		<member name="interface/inspector/max_array_dictionary_items_per_page" type="int" setter="" getter="">
 			The number of [Array] or [Dictionary] items to display on each "page" in the inspector. Higher values allow viewing more values per page, but take more time to load. This increased load time is noticeable when selecting nodes that have array or dictionary properties in the editor.
+		</member>
+		<member name="interface/inspector/max_drag_zoom_out_value" type="float" setter="" getter="">
+			The maximum value for zooming out when dragging numeric values in the inspector.
 		</member>
 		<member name="interface/inspector/nested_color_mode" type="int" setter="" getter="">
 			Control which property editors are colored when they are opened.
@@ -1150,6 +1156,9 @@
 		</member>
 		<member name="interface/inspector/show_low_level_opentype_features" type="bool" setter="" getter="">
 			If [code]true[/code], display OpenType features marked as [code]hidden[/code] by the font file in the [Font] editor.
+		</member>
+		<member name="interface/inspector/zoom_drag_speed" type="float" setter="" getter="">
+			Base speed for increasing/decreasing zoom levels by dragging in the inspector.
 		</member>
 		<member name="interface/multi_window/enable" type="bool" setter="" getter="">
 			If [code]true[/code], multiple window support in editor is enabled. The following panels can become dedicated windows (i.e. made floating): Docks, Script editor, Shader editor, and Game Workspace.

--- a/editor/gui/editor_range_dial.cpp
+++ b/editor/gui/editor_range_dial.cpp
@@ -1,0 +1,322 @@
+/**************************************************************************/
+/*  editor_range_dial.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_range_dial.h"
+#include "core/object/class_db.h"
+#include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
+#include "editor/themes/editor_scale.h"
+
+void EditorRangeDial::add_zoom_from_mouse_dist(double p_relative) {
+	if (inverted_zoom_y) {
+		p_relative = -p_relative;
+	}
+	double zoom_factor = 1.0 + (p_relative * zoom_speed * 0.001);
+	set_zoom(zoom / zoom_factor);
+}
+
+double EditorRangeDial::scale_diff(double p_diff) {
+	return p_diff / zoom * 0.1;
+}
+
+void EditorRangeDial::set_highlighting_range(bool p_enable) {
+	highlighting_range = p_enable;
+	queue_redraw();
+}
+
+bool EditorRangeDial::is_highlighting_range() const {
+	return highlighting_range;
+}
+
+void EditorRangeDial::set_value_no_step(double p_value, bool p_rounded) {
+	if (!is_greater_allowed() && p_value > get_max() - get_page()) {
+		p_value = get_max() - get_page();
+	}
+	if (!is_lesser_allowed() && p_value < get_min()) {
+		p_value = get_min();
+	}
+
+	value_no_snap = p_value;
+
+	if (p_rounded) {
+		set_value(Math::round(value_no_snap));
+	} else {
+		set_value(value_no_snap);
+	}
+	queue_redraw();
+}
+
+void EditorRangeDial::set_zoom_from_value(double p_value) {
+	if (Math::is_zero_approx(p_value)) {
+		set_zoom(get_rect().size.x / (zoom_speed * 2) / 2);
+		return;
+	}
+
+	double value_abs = Math::abs(p_value);
+
+	if (value_abs < 1.0) {
+		int precision = is_using_rounded_values() ? 0 : MAX(0, -floor(log10(p_value)));
+		set_zoom(Math::pow(10, (double)precision + 2));
+	} else {
+		set_zoom(get_rect().size.x / (MAX(1.0, value_abs) * 2) / 2);
+	}
+}
+
+void EditorRangeDial::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			const StringName &sn_label = SNAME("Label");
+			Ref<Font> font = get_theme_font(SNAME("rulers"), EditorStringName(EditorFonts));
+			Color font_color = get_theme_color(SNAME("font_color"), sn_label);
+			Color accent_color = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+			Color highlight_color = get_theme_color(SNAME("highlight_color"), EditorStringName(Editor));
+			highlight_color.a = 0.05;
+
+			const int font_size = get_theme_font_size(SceneStringName(font_size), sn_label);
+			const int precision = is_using_rounded_values() ? 0 : MAX(0, -floor(log10(get_step())));
+			const String max_value_str(String::num(get_max(), precision));
+			const String min_value_str(String::num(get_min(), precision));
+
+			const double middle = get_rect().size.x / 2 - (value_no_snap * zoom);
+			const double number_x_min = middle + get_min() * zoom;
+			const double number_x_max = middle + get_max() * zoom;
+
+			Color mono_color, mono_color_outside, mono_color_highlight, mono_color_highlight_outside;
+			mono_color = mono_color_outside = mono_color_highlight = mono_color_highlight_outside = get_theme_color(SNAME("mono_color"), EditorStringName(Editor));
+			mono_color_highlight.a = 0.75;
+			mono_color_highlight_outside.a = 0.25;
+
+			bool internal_highlighting_range = highlighting_range;
+
+			if (get_min() == get_max()) {
+				internal_highlighting_range = false;
+			}
+
+			// only draw the background if either not allowing lesser or greater values
+			if (internal_highlighting_range) {
+				const double min_x = MIN(MAX(0, number_x_min), get_rect().size.x);
+				const double max_x = MAX(MIN(get_rect().size.x, number_x_max), 0);
+				draw_rect(Rect2(max_x, 0, min_x - max_x, get_rect().size.y), highlight_color);
+			}
+
+			int min_exp = is_using_rounded_values() ? 0 : -MAX(0, -floor(log10(get_step())));
+			int max_exp;
+
+			double mx = EDITOR_GET("interface/inspector/max_drag_zoom_out_value");
+			double zout = Math::abs(get_min()) + get_max();
+			double zoom_out_range = Math::is_zero_approx(zout) ? mx * 2 : MIN(zout, mx * 2);
+
+			max_exp = int(log10(MAX(zoom_out_range, CMP_EPSILON)));
+
+			for (int i = min_exp; i <= max_exp; i++) {
+				const double level = Math::pow(10.0, i);
+				const double size = level * zoom;
+				if (size < Math::pow(10.0, 1) || size > Math::pow(10.0, 2)) {
+					continue;
+				}
+
+				const double powsize = Math::pow(size / 75.0, 3.0);
+				const double alpha = powsize / (powsize + Math::pow((1 - size / 75.0), 3));
+				const double span = get_rect().size.x / size;
+
+				PackedVector2Array lines, lines_highlight, lines_outside, lines_highlight_outside;
+
+				for (int n = -span; n < span; n++) {
+					const double number_x = get_rect().size.x / 2 - Math::fmod(value_no_snap * zoom, size) + n * size;
+					double n_value = Math::snapped((number_x - middle) / zoom, 1 / (Math::pow(10, (double)precision + 1)));
+					if (Math::abs(n_value) < CMP_EPSILON2) {
+						n_value = 0.0;
+					}
+					String current_value(String::num(n_value, precision));
+					Size2 string_size = font->get_string_size(current_value, HORIZONTAL_ALIGNMENT_CENTER, -1.0f, font_size);
+					Color number_font_color = font_color;
+					if (number_x - string_size.x / 2 > get_rect().size.x || number_x + string_size.x / 2 < 0) {
+						continue;
+					}
+
+					if (internal_highlighting_range) {
+						// fade the text color if it is near the min or max text (number_x_min or number_x_max) in distance 64
+						double distance_to_min = Math::abs(number_x - number_x_min);
+						double distance_to_max = Math::abs(number_x - number_x_max);
+						if (distance_to_min < 64.0 || distance_to_max < 64.0) {
+							if (distance_to_min < distance_to_max) {
+								number_font_color.a *= distance_to_min / 64.0;
+							} else {
+								number_font_color.a *= distance_to_max / 64.0;
+							}
+						}
+					}
+
+					bool outside = false;
+					if (internal_highlighting_range) {
+						if ((!is_lesser_allowed() && (n_value <= get_min() + CMP_EPSILON2)) || (!is_greater_allowed() && (n_value >= get_max() - CMP_EPSILON2))) {
+							continue;
+						} else {
+							if (Math::abs(n_value - get_min()) < CMP_EPSILON2 || Math::abs(n_value - get_max()) < CMP_EPSILON2) {
+								continue;
+							}
+							if ((n_value <= get_min() + CMP_EPSILON2) || (n_value >= get_max() - CMP_EPSILON2)) {
+								number_font_color.a = 0.25;
+								outside = true;
+							}
+						}
+					}
+
+					Vector2 line_start(number_x, 0);
+					Vector2 line_end(number_x, get_rect().size.y - string_size.y);
+
+					if (Math::fmod(Math::abs(n_value), level * 10) < CMP_EPSILON2 || Math::fmod(Math::abs(n_value), level * 10) >= (level * 10) - CMP_EPSILON2) {
+						if (outside) {
+							lines_highlight_outside.push_back(line_start);
+							lines_highlight_outside.push_back(line_end);
+						} else {
+							lines_highlight.push_back(line_start);
+							lines_highlight.push_back(line_end);
+						}
+
+						draw_string(font, Point2(number_x - (string_size.x / 2), get_rect().size.y).floor(), current_value, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, number_font_color);
+					} else {
+						if (outside) {
+							lines_outside.push_back(line_start);
+							lines_outside.push_back(line_end);
+						} else {
+							lines.push_back(line_start);
+							lines.push_back(line_end);
+						}
+						number_font_color.a *= alpha;
+						draw_string(font, Point2(number_x - (string_size.x / 2), get_rect().size.y).floor(), current_value, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, number_font_color);
+					}
+				}
+
+				if (internal_highlighting_range) {
+					const Size2 max_value_string_size = font->get_string_size(max_value_str, HORIZONTAL_ALIGNMENT_CENTER, -1.0f, font_size);
+					const Size2 min_value_string_size = font->get_string_size(min_value_str, HORIZONTAL_ALIGNMENT_CENTER, -1.0f, font_size);
+
+					if (number_x_max - max_value_string_size.x / 2 < get_rect().size.x && number_x_max + max_value_string_size.x / 2 > 0) {
+						draw_line(Point2(number_x_max, 0), Point2(number_x_max, get_rect().size.y - max_value_string_size.y), accent_color);
+						draw_string(font, Point2(number_x_max - (max_value_string_size.x / 2), get_rect().size.y).floor(), max_value_str, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, accent_color);
+					}
+					if (number_x_min + min_value_string_size.x > 0 && number_x_min - min_value_string_size.x < get_rect().size.x) {
+						draw_line(Point2(number_x_min, 0), Point2(number_x_min, get_rect().size.y - max_value_string_size.y), accent_color);
+						draw_string(font, Point2(number_x_min - (min_value_string_size.x / 2), get_rect().size.y).floor(), min_value_str, HORIZONTAL_ALIGNMENT_CENTER, -1, font_size, accent_color);
+					}
+				}
+
+				if (!lines.is_empty()) {
+					mono_color.a = 0.5 * alpha;
+					draw_multiline(lines, mono_color);
+				}
+				if (!lines_outside.is_empty()) {
+					mono_color_outside.a = 0.25 * alpha;
+					draw_multiline(lines_outside, mono_color_outside);
+				}
+				if (!lines_highlight.is_empty()) {
+					draw_multiline(lines_highlight, mono_color_highlight);
+				}
+				if (!lines_highlight_outside.is_empty()) {
+					draw_multiline(lines_highlight_outside, mono_color_highlight_outside);
+				}
+				if (!lines_highlight_outside.is_empty()) {
+					draw_multiline(lines_highlight_outside, mono_color_highlight_outside);
+				}
+			}
+			draw_line(Vector2(get_rect().size.x / 2, 0), Vector2(get_rect().size.x / 2, get_rect().size.y), Color(0.96, 0.2, 0.32));
+		}
+	}
+}
+
+void EditorRangeDial::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_zoom"), &EditorRangeDial::get_zoom);
+	ClassDB::bind_method(D_METHOD("set_zoom", "amount"), &EditorRangeDial::set_zoom);
+
+	ClassDB::bind_method(D_METHOD("add_zoom_from_mouse_dist", "relative"), &EditorRangeDial::add_zoom_from_mouse_dist);
+	ClassDB::bind_method(D_METHOD("scale_diff", "diff"), &EditorRangeDial::scale_diff);
+
+	ClassDB::bind_method(D_METHOD("set_highlighting_range", "enable"), &EditorRangeDial::set_highlighting_range);
+	ClassDB::bind_method(D_METHOD("is_highlighting_range"), &EditorRangeDial::is_highlighting_range);
+
+	ADD_SIGNAL(MethodInfo("zoom_changed"));
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "zoom"), "set_zoom", "get_zoom");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "highlighting_range", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR), "set_highlighting_range", "is_highlighting_range");
+}
+
+void EditorRangeDial::set_zoom(double p_zoom) {
+	double min_zoom;
+
+	double zout = Math::abs(get_min()) + get_max();
+	double mx = EDITOR_GET("interface/inspector/max_drag_zoom_out_value");
+	double zoom_out_range = Math::is_zero_approx(zout) ? mx * 2 : MIN(zout, mx * 2);
+	min_zoom = get_rect().size.x / MAX(zoom_out_range, CMP_EPSILON) / 2;
+
+	int precision = is_using_rounded_values() ? 0 : MAX(0, -floor(log10(get_step())));
+	double max_zoom = Math::pow(10, (double)precision + 2);
+	if (min_zoom > max_zoom) {
+		zoom = max_zoom;
+	} else {
+		zoom = CLAMP(p_zoom, min_zoom, max_zoom);
+	}
+	emit_signal("zoom_changed");
+	queue_redraw();
+}
+
+double EditorRangeDial::get_zoom() const {
+	return zoom;
+}
+
+EditorRangeDial::EditorRangeDial() {
+	zoom = 1;
+	value_no_snap = 0.0;
+
+	zoom_speed = EDITOR_GET("interface/inspector/zoom_drag_speed");
+	inverted_zoom_y = EDITOR_GET("interface/inspector/invert_drag_zoom_y");
+}
+
+void EditorRangeDialPopup::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_dial"), &EditorRangeDialPopup::get_dial);
+}
+
+EditorRangeDial *EditorRangeDialPopup::get_dial() const {
+	return dial;
+}
+
+void EditorRangeDialPopup::_pre_popup() {
+	set_min_size(Vector2(350, 48) * EDSCALE);
+	reset_size();
+	set_flag(Window::FLAG_NO_FOCUS, true);
+	set_flag(Window::FLAG_POPUP, false);
+	set_flag(Window::FLAG_MOUSE_PASSTHROUGH, true);
+	set_wrap_controls(true);
+}
+
+EditorRangeDialPopup::EditorRangeDialPopup() {
+	dial = memnew(EditorRangeDial);
+	dial->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	add_child(dial);
+}

--- a/editor/gui/editor_range_dial.h
+++ b/editor/gui/editor_range_dial.h
@@ -1,0 +1,81 @@
+/**************************************************************************/
+/*  editor_range_dial.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/popup.h"
+#include "scene/gui/range.h"
+
+class EditorRangeDial : public Range {
+	GDCLASS(EditorRangeDial, Range);
+
+	double zoom;
+	double value_no_snap;
+
+	double zoom_speed;
+	bool inverted_zoom_y;
+
+	bool highlighting_range = false;
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_zoom(double p_zoom);
+	double get_zoom() const;
+
+	void add_zoom_from_mouse_dist(double p_relative);
+	double scale_diff(double p_diff);
+
+	void set_highlighting_range(bool p_enable);
+	bool is_highlighting_range() const;
+
+	void set_value_no_step(double p_value, bool p_rounded = false);
+	void set_zoom_from_value(double p_value);
+
+	EditorRangeDial();
+};
+
+class EditorRangeDialPopup : public PopupPanel {
+	GDCLASS(EditorRangeDialPopup, PopupPanel);
+
+	EditorRangeDial *dial;
+
+protected:
+	virtual void _pre_popup() override;
+
+	static void _bind_methods();
+
+public:
+	EditorRangeDial *get_dial() const;
+
+	EditorRangeDialPopup();
+};

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -118,33 +118,71 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 			if (mm->is_shift_pressed() && grabbing_spinner) {
 				diff_x *= 0.1;
 			}
-			grabbing_spinner_dist_cache += diff_x * grabbing_spinner_speed;
+
+			int diff_x_applied_speed = diff_x * grabbing_spinner_speed;
+			grabbing_spinner_dist_cache += diff_x_applied_speed;
 
 			if (!grabbing_spinner && Math::abs(grabbing_spinner_dist_cache) > 4 * grabbing_spinner_speed * EDSCALE) {
 				Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
+
+				_ensure_dial_popup();
+				double digits = ceil(log(fabs(get_value())) / log(10));
+				if (digits < CMP_EPSILON2) {
+					digits = 1;
+				}
+				dial_popup->get_dial()->set_zoom_from_value(get_value());
+
+				Rect2i usable_rect = dial_popup->get_usable_parent_rect();
+				Rect2i cp_rect(Point2i(), dial_popup->get_size());
+				for (int i = 0; i < 4; i++) {
+					if (i > 1) {
+						cp_rect.position.y = get_screen_position().y - cp_rect.size.y;
+					} else {
+						cp_rect.position.y = get_screen_position().y + get_size().height;
+					}
+
+					if (i & 1) {
+						cp_rect.position.x = get_screen_position().x;
+					} else {
+						cp_rect.position.x = get_screen_position().x - MAX(0, (cp_rect.size.x - get_size().x));
+					}
+
+					if (usable_rect.encloses(cp_rect)) {
+						break;
+					}
+				}
+				dial_popup->set_position(cp_rect.position);
+				dial_popup->popup();
+
 				grabbing_spinner = true;
 			}
 
 			if (grabbing_spinner) {
 				// Don't make the user scroll all the way back to 'in range' if they went off the end.
-				if (pre_grab_value < get_min() && !is_lesser_allowed()) {
-					pre_grab_value = get_min();
+				if (!is_lesser_allowed()) {
+					if (pre_grab_value < get_min()) {
+						pre_grab_value = get_min();
+					}
+					if (grabbing_spinner_total_applied < get_min() - pre_grab_value) {
+						grabbing_spinner_total_applied = get_min() - pre_grab_value;
+					}
 				}
-				if (pre_grab_value > get_max() && !is_greater_allowed()) {
-					pre_grab_value = get_max();
+				if (!is_greater_allowed()) {
+					if (pre_grab_value > get_max()) {
+						pre_grab_value = get_max();
+					}
+					if (grabbing_spinner_total_applied > get_max() - pre_grab_value) {
+						grabbing_spinner_total_applied = get_max() - pre_grab_value;
+					}
 				}
 
-				// Prevent dragging properties with very precise steps from being agonizingly slow.
-				const double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
-				const double drag_step = MAX(get_step(), default_float_step);
-				const double new_value = pre_grab_value + drag_step * grabbing_spinner_dist_cache;
+				_ensure_dial_popup();
+				EditorRangeDial *dial = dial_popup->get_dial();
 
-				double val = (mm->is_command_or_control_pressed() && !editing_integer) ? Math::round(new_value) : new_value;
-				if (deferred_drag_mode) {
-					set_value_no_signal(val);
-				} else {
-					set_value(val);
-				}
+				dial->add_zoom_from_mouse_dist(mm->get_relative().y);
+				grabbing_spinner_total_applied += dial->scale_diff(diff_x_applied_speed);
+
+				dial->set_value_no_step(pre_grab_value + grabbing_spinner_total_applied, mm->is_command_or_control_pressed() && !editing_integer);
 			}
 		} else if (updown_offset != -1) {
 			bool new_hover = (!is_layout_rtl() && mm->get_position().x > updown_offset) || (is_layout_rtl() && mm->get_position().x < updown_offset);
@@ -172,6 +210,7 @@ void EditorSpinSlider::gui_input(const Ref<InputEvent> &p_event) {
 void EditorSpinSlider::_grab_start() {
 	grabbing_spinner_attempt = true;
 	grabbing_spinner_dist_cache = 0;
+	grabbing_spinner_total_applied = 0;
 	pre_grab_value = get_value();
 	grabbing_spinner = false;
 	grabbing_spinner_mouse_pos = get_global_mouse_position();
@@ -184,6 +223,7 @@ void EditorSpinSlider::_grab_end() {
 			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_VISIBLE);
 			Input::get_singleton()->warp_mouse(grabbing_spinner_mouse_pos);
 			mouse_over_grabber = true;
+			dial_popup->hide();
 			queue_redraw();
 			grabbing_spinner = false;
 			emit_signal("ungrabbed");
@@ -513,6 +553,10 @@ void EditorSpinSlider::_notification(int p_what) {
 				grabbing_spinner = false;
 				grabbing_spinner_attempt = false;
 			}
+
+			if (dial_popup) {
+				dial_popup->hide();
+			}
 		} break;
 
 		case NOTIFICATION_MOUSE_ENTER: {
@@ -530,6 +574,12 @@ void EditorSpinSlider::_notification(int p_what) {
 				_focus_entered();
 			}
 			value_input_closed_frame = 0;
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (dial_popup && !is_visible_in_tree()) {
+				dial_popup->hide();
+			}
 		} break;
 	}
 }
@@ -798,6 +848,22 @@ void EditorSpinSlider::_ensure_value_input() {
 	if (is_inside_tree()) {
 		_update_value_input_stylebox();
 	}
+}
+
+void EditorSpinSlider::_ensure_dial_popup() {
+	if (dial_popup) {
+		return;
+	}
+
+	dial_popup = memnew(EditorRangeDialPopup);
+	bool slider_visible = !editing_integer;
+	bool has_limit = !is_greater_allowed() || !is_lesser_allowed();
+
+	EditorRangeDial *dial = dial_popup->get_dial();
+	dial->set_highlighting_range(slider_visible || has_limit);
+
+	add_child(dial_popup);
+	share(dial);
 }
 
 EditorSpinSlider::EditorSpinSlider() {

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -34,6 +34,8 @@
 #include "scene/gui/range.h"
 #include "scene/gui/texture_rect.h"
 
+#include "editor/gui/editor_range_dial.h"
+
 class EditorSpinSlider : public Range {
 	GDCLASS(EditorSpinSlider, Range);
 
@@ -57,12 +59,14 @@ class EditorSpinSlider : public Range {
 	bool grabbing_spinner = false;
 
 	bool read_only = false;
-	float grabbing_spinner_dist_cache = 0.0f;
+	double grabbing_spinner_dist_cache = 0.0f;
+	double grabbing_spinner_total_applied = 0.0f;
 	float grabbing_spinner_speed = 0.0f;
 	Vector2 grabbing_spinner_mouse_pos;
 	double pre_grab_value = 0.0;
 
 	LineEdit *value_input = nullptr;
+	EditorRangeDialPopup *dial_popup = nullptr;
 	uint64_t value_input_closed_frame = 0;
 	bool value_input_dirty = false;
 	bool value_input_focus_visible = false;
@@ -93,6 +97,7 @@ private:
 
 	void _update_value_input_stylebox();
 	void _ensure_value_input();
+	void _ensure_dial_popup();
 	void _draw_spin_slider();
 
 	struct ThemeCache {

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -50,6 +50,7 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_range_dial.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/import/3d/resource_importer_obj.h"
@@ -191,6 +192,8 @@ void register_editor_types() {
 	GDREGISTER_CLASS(EditorScriptPicker);
 	GDREGISTER_ABSTRACT_CLASS(EditorUndoRedoManager);
 	GDREGISTER_CLASS(EditorContextMenuPlugin);
+	GDREGISTER_CLASS(EditorRangeDial);
+	GDREGISTER_CLASS(EditorRangeDialPopup);
 
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 	GDREGISTER_VIRTUAL_CLASS(EditorFileSystemImportFormatSupportQuery);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -570,7 +570,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/max_array_dictionary_items_per_page", 20, "10,100,1")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/show_low_level_opentype_features", false, "")
 	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/float_drag_speed", 5.0, "0.1,100,0.01")
-	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/integer_drag_speed", 0.5, "0.1,10,0.01")
+	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/integer_drag_speed", 5.0, "0.1,100,0.01")
+	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/max_drag_zoom_out_value", 100000, "1,10000000,1")
+	EDITOR_SETTING_BASIC(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/inspector/zoom_drag_speed", 5, "0.01,100,0.1")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/invert_drag_zoom_y", false, "")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/nested_color_mode", 0, "Containers & Resources,Resources,External Resources")
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/delimitate_all_container_and_resources", true, "")
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_property_name_style", EditorPropertyNameProcessor::STYLE_CAPITALIZED, "Raw (e.g. \"z_index\"),Capitalized (e.g. \"Z Index\"),Localized (e.g. \"Z Index\")", PROPERTY_USAGE_DEFAULT);


### PR DESCRIPTION
Supersedes #44654.
Closes godotengine/godot-proposals#1506.

https://github.com/user-attachments/assets/e06c51f3-19ae-4be0-820c-c3a724eb25ad

This dial-like ruler allows users to select a number with greater precision or the opposite. Unlike the current version, which allows dragging in the horizontal direction only. This method also utilizes the vertical axis for adjusting the level of precision. Useful for properties that need precision or larger steps (e.g. moving Node3D without gizmo, noise value)

~~This PR is WIP and currently only functions properly in single-window mode.~~
- [x] Fix jaggy snapping when reaching deepest precision
- [x] Make it work with non-single window mode
- [x] (2025.09.09) Some updates around September made the Popup broken :(
- [ ] More tests on other `SpinSlider` in the editor
- [ ] Add docs
