### PR TITLE
Core: Fix invalid resize after appending

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1946,7 +1946,7 @@ Error String::append_utf8(const char *p_utf8, int p_len, bool p_skip_cr) {
 	}
 
 	(*dst++) = 0;
-	resize_uninitialized(prev_length + dst - ptr());
+	resize_uninitialized(dst - ptr());
 
 	return result;
 }


### PR DESCRIPTION
Fix an issue that the string is incorrectly sized after appending UTF-8 data.