### PR TITLE
Show "No Translations Configured" message for empty translation preview menu

### DIFF
--- a/editor/translations/editor_translation_preview_menu.cpp
+++ b/editor/translations/editor_translation_preview_menu.cpp
@@ -45,10 +45,16 @@ void EditorTranslationPreviewMenu::_prepare() {
 		set_item_checked(-1, true);
 	}
 
+	add_separator();
+
 	const Vector<String> locales = TranslationServer::get_singleton()->get_loaded_locales();
-	if (!locales.is_empty()) {
-		add_separator();
+	if (locales.is_empty()) {
+		add_item(TTRC("No Translations Configured"));
+		set_item_tooltip(-1, TTRC("You can add translations in the Project Settings."));
+		set_item_disabled(-1, true);
+		return;
 	}
+
 	for (const String &locale : locales) {
 		const String name = TranslationServer::get_singleton()->get_locale_name(locale);
 		add_radio_check_item(name == locale ? name : name + " [" + locale + "]");


### PR DESCRIPTION
When no translations are configured in Project Settings, the preview menu currently only shows the "None" option (for not using any translation).

This PR adds a message to the locale list section so that users not familiar with this feature are less confused about what they should do.

<table>
<tr><th>Before</th><td>

![no-tr-before](https://github.com/user-attachments/assets/dcf1f0f3-f7c5-466e-b1dd-e76a3009ab3b) </td></tr>
<tr><th>After</th><td>

![no-tr-after](https://github.com/user-attachments/assets/ff51080f-505f-4c83-a28b-729acb7431d1) </td></tr>
</table>