### PR TITLE
Fix max dimensions in error message when too large of an image is made.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -1140,8 +1140,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	ERR_FAIL_COND_MSG(p_height <= 0, "Image height must be greater than 0.");
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, vformat("Image width cannot be greater than %d pixels.", MAX_WIDTH));
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, vformat("Image height cannot be greater than %d pixels.", MAX_HEIGHT));
-	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE, MAX_PIXELS));
+	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, vformat("Too many pixels for Image. Maximum is %d pixels.", MAX_PIXELS));
 
 	if (p_width == width && p_height == height) {
 		return;
@@ -2182,8 +2181,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 			vformat("The Image width specified (%d pixels) cannot be greater than %d pixels.", p_width, MAX_WIDTH));
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
 			vformat("The Image height specified (%d pixels) cannot be greater than %d pixels.", p_height, MAX_HEIGHT));
-	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE, MAX_PIXELS));
+	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, vformat("Too many pixels for Image. Maximum is %d pixels.", MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm = 0;
@@ -2208,8 +2206,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 			vformat("The Image width specified (%d pixels) cannot be greater than %d pixels.", p_width, MAX_WIDTH));
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
 			vformat("The Image height specified (%d pixels) cannot be greater than %d pixels.", p_height, MAX_HEIGHT));
-	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE, MAX_PIXELS));
+	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, vformat("Too many pixels for Image. Maximum is %d pixels.", MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm;

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -1140,7 +1140,8 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	ERR_FAIL_COND_MSG(p_height <= 0, "Image height must be greater than 0.");
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, vformat("Image width cannot be greater than %d pixels.", MAX_WIDTH));
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, vformat("Image height cannot be greater than %d pixels.", MAX_HEIGHT));
-	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, vformat("Too many pixels for image, maximum is %d pixels.", MAX_PIXELS));
+	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
+			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE, MAX_PIXELS));
 
 	if (p_width == width && p_height == height) {
 		return;
@@ -2182,7 +2183,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
 			vformat("The Image height specified (%d pixels) cannot be greater than %d pixels.", p_height, MAX_HEIGHT));
 	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_WIDTH, MAX_HEIGHT, MAX_PIXELS));
+			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE, MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm = 0;
@@ -2208,7 +2209,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
 			vformat("The Image height specified (%d pixels) cannot be greater than %d pixels.", p_height, MAX_HEIGHT));
 	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_WIDTH, MAX_HEIGHT, MAX_PIXELS));
+			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_TEXTURE_SIZE, MAX_TEXTURE_SIZE, MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm;

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -68,7 +68,6 @@ public:
 	enum {
 		MAX_WIDTH = (1 << 24), // Force a limit somehow.
 		MAX_HEIGHT = (1 << 24), // Force a limit somehow.
-		MAX_TEXTURE_SIZE = 16384,
 		MAX_PIXELS = 268435456 // 16384 ^ 2
 	};
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -68,6 +68,7 @@ public:
 	enum {
 		MAX_WIDTH = (1 << 24), // Force a limit somehow.
 		MAX_HEIGHT = (1 << 24), // Force a limit somehow.
+		MAX_TEXTURE_SIZE = 16384,
 		MAX_PIXELS = 268435456 // 16384 ^ 2
 	};
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Updating The dimensions in error message when an image is created to match the square root of MAX_PIXELS value.

