### PR TITLE
LightmapGI: Limit the texture size based on the total pixel count

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -816,8 +816,9 @@ LightmapGI::BakeError LightmapGI::_save_and_reimport_atlas_textures(const Ref<Li
 	const int slice_count = images.size();
 	const int slice_width = images[0]->get_width();
 	const int slice_height = images[0]->get_height();
+	const int slice_pixels = slice_width * slice_height;
 
-	const int slices_per_texture = Image::MAX_HEIGHT / slice_height;
+	const int slices_per_texture = Image::MAX_PIXELS / slice_pixels;
 	const int texture_count = Math::ceil(slice_count / (float)slices_per_texture);
 	const int last_count = slice_count % slices_per_texture;
 


### PR DESCRIPTION
Fixes #107640 (probably, needs confirmation)

The factor which determined the lightmap texture count was based on how many slices could fit vertically into a texture. The main drawback of this approach is that it didn't account for the width, and as a result the total pixel count would often exceed the maximum.

This PR changes it to instead rely on the pixel count