### PR TITLE
[RTL] Add support for inserting glyphs by name and font aliases.

### DIFF
--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -137,6 +137,14 @@
 				[b]Note:[/b] Real ascent of the string is context-dependent and can be significantly different from the value returned by this function. Use it only as rough estimate (e.g. as the ascent of empty line).
 			</description>
 		</method>
+		<method name="get_char_from_glyph_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="size" type="int" />
+			<param index="1" name="glyph_index" type="int" />
+			<description>
+				Returns character code associated with [param glyph_index], or [code]0[/code] if [param glyph_index] is invalid. See [method get_glyph_index].
+			</description>
+		</method>
 		<method name="get_char_size" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="char" type="int" />
@@ -188,6 +196,23 @@
 			<return type="int" />
 			<description>
 				Returns weight (boldness) of the font. A value in the [code]100...999[/code] range, normal font weight is [code]400[/code], bold font weight is [code]700[/code].
+			</description>
+		</method>
+		<method name="get_glyph_by_name" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="size" type="int" />
+			<param index="1" name="name" type="String" />
+			<description>
+				Return the glyph index of a glyph with given [param name].
+			</description>
+		</method>
+		<method name="get_glyph_index" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="size" type="int" />
+			<param index="1" name="char" type="int" />
+			<param index="2" name="variation_selector" type="int" />
+			<description>
+				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
 		<method name="get_height" qualifiers="const">

--- a/doc/classes/FontFile.xml
+++ b/doc/classes/FontFile.xml
@@ -116,14 +116,6 @@
 				Returns thickness of the underline in pixels.
 			</description>
 		</method>
-		<method name="get_char_from_glyph_index" qualifiers="const">
-			<return type="int" />
-			<param index="0" name="size" type="int" />
-			<param index="1" name="glyph_index" type="int" />
-			<description>
-				Returns character code associated with [param glyph_index], or [code]0[/code] if [param glyph_index] is invalid. See [method get_glyph_index].
-			</description>
-		</method>
 		<method name="get_embolden" qualifiers="const">
 			<return type="float" />
 			<param index="0" name="cache_index" type="int" />
@@ -161,15 +153,6 @@
 			<description>
 				Returns glyph advance (offset of the next glyph).
 				[b]Note:[/b] Advance for glyphs outlines is the same as the base glyph advance and is not saved.
-			</description>
-		</method>
-		<method name="get_glyph_index" qualifiers="const">
-			<return type="int" />
-			<param index="0" name="size" type="int" />
-			<param index="1" name="char" type="int" />
-			<param index="2" name="variation_selector" type="int" />
-			<description>
-				Returns the glyph index of a [param char], optionally modified by the [param variation_selector].
 			</description>
 		</method>
 		<method name="get_glyph_list" qualifiers="const">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -704,6 +704,9 @@
 			If [code]true[/code], the label's minimum size will be automatically updated to fit its content, matching the behavior of [Label].
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="3" />
+		<member name="font_aliases" type="Dictionary[String, Font]" setter="set_font_aliases" getter="get_font_aliases" default="{}">
+			Dictionary of font aliases that can be used in [code]font[/code] BBCode tag.
+		</member>
 		<member name="hint_underlined" type="bool" setter="set_hint_underline" getter="is_hint_underlined" default="true">
 			If [code]true[/code], the label underlines hint tags such as [code skip-lint][hint=description]{text}[/hint][/code].
 		</member>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -227,6 +227,15 @@
 				[b]Note:[/b] Advance for glyphs outlines is the same as the base glyph advance and is not saved.
 			</description>
 		</method>
+		<method name="font_get_glyph_by_name" qualifiers="const">
+			<return type="int" />
+			<param index="0" name="font_rid" type="RID" />
+			<param index="1" name="size" type="int" />
+			<param index="2" name="name" type="String" />
+			<description>
+				Return the glyph index of a glyph with given [param name].
+			</description>
+		</method>
 		<method name="font_get_glyph_contours" qualifiers="const">
 			<return type="Dictionary" />
 			<param index="0" name="font" type="RID" />

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -215,6 +215,15 @@
 				Returns glyph advance (offset of the next glyph).
 			</description>
 		</method>
+		<method name="_font_get_glyph_by_name" qualifiers="virtual required const">
+			<return type="int" />
+			<param index="0" name="font_rid" type="RID" />
+			<param index="1" name="size" type="int" />
+			<param index="2" name="name" type="String" />
+			<description>
+				Return the glyph index of a glyph with given [param name].
+			</description>
+		</method>
 		<method name="_font_get_glyph_contours" qualifiers="virtual const">
 			<return type="Dictionary" />
 			<param index="0" name="font_rid" type="RID" />

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -329,3 +329,11 @@ Validate extension JSON: API was removed: classes/VisualShader/methods/set_graph
 Validate extension JSON: API was removed: classes/VisualShader/methods/get_graph_offset
 
 The graph_offset property was removed from the resource. This information is now stored in `vs_editor_cache.cfg`.
+
+
+GH-107660
+---------
+Validate extension JSON: API was removed: classes/FontFile/methods/get_char_from_glyph_index
+Validate extension JSON: API was removed: classes/FontFile/methods/get_glyph_index
+
+Method moved to the base Font class.

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -3691,6 +3691,24 @@ Vector2 TextServerAdvanced::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 	return Vector2();
 }
 
+int64_t TextServerAdvanced::_font_get_glyph_by_name(const RID &p_font_rid, int64_t p_size, const String &p_name) const {
+#ifdef MODULE_FREETYPE_ENABLED
+	FontAdvanced *fd = _get_font_data(p_font_rid);
+	ERR_FAIL_NULL_V(fd, 0);
+	ERR_FAIL_COND_V(p_name.is_empty(), 0);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, p_size);
+	FontForSizeAdvanced *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0);
+
+	if (ffsd->face) {
+		return FT_Get_Name_Index(ffsd->face, (const FT_String *)p_name.utf8().get_data());
+	}
+#endif
+	return 0;
+}
+
 int64_t TextServerAdvanced::_font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const {
 	FontAdvanced *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL_V(fd, 0);

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -917,6 +917,7 @@ public:
 	MODBIND4(font_set_kerning, const RID &, int64_t, const Vector2i &, const Vector2 &);
 	MODBIND3RC(Vector2, font_get_kerning, const RID &, int64_t, const Vector2i &);
 
+	MODBIND3RC(int64_t, font_get_glyph_by_name, const RID &, int64_t, const String &);
 	MODBIND4RC(int64_t, font_get_glyph_index, const RID &, int64_t, int64_t, int64_t);
 	MODBIND3RC(int64_t, font_get_char_from_glyph_index, const RID &, int64_t, int64_t);
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -2653,6 +2653,24 @@ Vector2 TextServerFallback::_font_get_kerning(const RID &p_font_rid, int64_t p_s
 	return Vector2();
 }
 
+int64_t TextServerFallback::_font_get_glyph_by_name(const RID &p_font_rid, int64_t p_size, const String &p_name) const {
+#ifdef MODULE_FREETYPE_ENABLED
+	FontFallback *fd = _get_font_data(p_font_rid);
+	ERR_FAIL_NULL_V(fd, 0);
+	ERR_FAIL_COND_V(p_name.is_empty(), 0);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, p_size);
+	FontForSizeFallback *ffsd = nullptr;
+	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), 0);
+
+	if (ffsd->face) {
+		return FT_Get_Name_Index(ffsd->face, (const FT_String *)p_name.utf8().get_data());
+	}
+#endif
+	return 0;
+}
+
 int64_t TextServerFallback::_font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const {
 	ERR_FAIL_COND_V_MSG((p_char >= 0xd800 && p_char <= 0xdfff) || (p_char > 0x10ffff), 0, "Unicode parsing error: Invalid unicode codepoint " + String::num_int64(p_char, 16) + ".");
 	return (int64_t)p_char;

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -772,6 +772,7 @@ public:
 	MODBIND4(font_set_kerning, const RID &, int64_t, const Vector2i &, const Vector2 &);
 	MODBIND3RC(Vector2, font_get_kerning, const RID &, int64_t, const Vector2i &);
 
+	MODBIND3RC(int64_t, font_get_glyph_by_name, const RID &, int64_t, const String &);
 	MODBIND4RC(int64_t, font_get_glyph_index, const RID &, int64_t, int64_t, int64_t);
 	MODBIND3RC(int64_t, font_get_char_from_glyph_index, const RID &, int64_t, int64_t);
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -32,6 +32,7 @@
 
 #include "core/object/worker_thread_pool.h"
 #include "core/templates/rid_owner.h"
+#include "core/variant/typed_dictionary.h"
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/scroll_bar.h"
 #include "scene/resources/image_texture.h"
@@ -613,6 +614,8 @@ private:
 	bool context_menu_enabled = false;
 	bool shortcut_keys_enabled = true;
 
+	TypedDictionary<String, Ref<Font>> aliases;
+
 	// Context menu.
 	PopupMenu *menu = nullptr;
 	void _generate_context_menu();
@@ -962,6 +965,9 @@ public:
 
 	void set_visible_ratio(float p_ratio);
 	float get_visible_ratio() const;
+
+	void set_font_aliases(const TypedDictionary<String, Ref<Font>> &p_aliases);
+	TypedDictionary<String, Ref<Font>> get_font_aliases() const;
 
 	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
 	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -97,6 +97,10 @@ void Font::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_supported_variation_list"), &Font::get_supported_variation_list);
 	ClassDB::bind_method(D_METHOD("get_face_count"), &Font::get_face_count);
 
+	ClassDB::bind_method(D_METHOD("get_glyph_by_name", "size", "name"), &Font::get_glyph_by_name);
+	ClassDB::bind_method(D_METHOD("get_glyph_index", "size", "char", "variation_selector"), &Font::get_glyph_index);
+	ClassDB::bind_method(D_METHOD("get_char_from_glyph_index", "size", "glyph_index"), &Font::get_char_from_glyph_index);
+
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")), "set_fallbacks", "get_fallbacks");
 }
 
@@ -560,6 +564,18 @@ Dictionary Font::get_supported_variation_list() const {
 
 int64_t Font::get_face_count() const {
 	return TS->font_get_face_count(_get_rid());
+}
+
+int64_t Font::get_glyph_by_name(int64_t p_size, const String &p_name) const {
+	return TS->font_get_glyph_by_name(_get_rid(), p_size, p_name);
+}
+
+int32_t Font::get_glyph_index(int p_size, char32_t p_char, char32_t p_variation_selector) const {
+	return TS->font_get_glyph_index(_get_rid(), p_size, p_char, p_variation_selector);
+}
+
+char32_t Font::get_char_from_glyph_index(int p_size, int32_t p_glyph_index) const {
+	return TS->font_get_char_from_glyph_index(_get_rid(), p_size, p_glyph_index);
 }
 
 Font::Font() {
@@ -1037,9 +1053,6 @@ void FontFile::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_opentype_feature_overrides", "overrides"), &FontFile::set_opentype_feature_overrides);
 	ClassDB::bind_method(D_METHOD("get_opentype_feature_overrides"), &FontFile::get_opentype_feature_overrides);
-
-	ClassDB::bind_method(D_METHOD("get_glyph_index", "size", "char", "variation_selector"), &FontFile::get_glyph_index);
-	ClassDB::bind_method(D_METHOD("get_char_from_glyph_index", "size", "glyph_index"), &FontFile::get_char_from_glyph_index);
 
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_data", "get_data");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "generate_mipmaps", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_generate_mipmaps", "get_generate_mipmaps");
@@ -2816,16 +2829,6 @@ void FontFile::set_opentype_feature_overrides(const Dictionary &p_overrides) {
 Dictionary FontFile::get_opentype_feature_overrides() const {
 	_ensure_rid(0);
 	return TS->font_get_opentype_feature_overrides(cache[0]);
-}
-
-int32_t FontFile::get_glyph_index(int p_size, char32_t p_char, char32_t p_variation_selector) const {
-	_ensure_rid(0);
-	return TS->font_get_glyph_index(cache[0], p_size, p_char, p_variation_selector);
-}
-
-char32_t FontFile::get_char_from_glyph_index(int p_size, int32_t p_glyph_index) const {
-	_ensure_rid(0);
-	return TS->font_get_char_from_glyph_index(cache[0], p_size, p_glyph_index);
 }
 
 FontFile::FontFile() {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -172,6 +172,11 @@ public:
 	virtual Dictionary get_supported_variation_list() const;
 	virtual int64_t get_face_count() const;
 
+	// Base font properties.
+	virtual int64_t get_glyph_by_name(int64_t p_size, const String &p_name) const;
+	virtual int32_t get_glyph_index(int p_size, char32_t p_char, char32_t p_variation_selector = 0x0000) const;
+	virtual char32_t get_char_from_glyph_index(int p_size, int32_t p_glyph_index) const;
+
 	Font();
 	~Font();
 };
@@ -392,10 +397,6 @@ public:
 
 	virtual void set_opentype_feature_overrides(const Dictionary &p_overrides);
 	virtual Dictionary get_opentype_feature_overrides() const;
-
-	// Base font properties.
-	virtual int32_t get_glyph_index(int p_size, char32_t p_char, char32_t p_variation_selector = 0x0000) const;
-	virtual char32_t get_char_from_glyph_index(int p_size, int32_t p_glyph_index) const;
 
 	FontFile();
 	~FontFile();

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -84,6 +84,7 @@ public:
 	virtual void font_set_glyph_texture_idx(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph, int64_t p_texture_idx) override {}
 	virtual RID font_get_glyph_texture_rid(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return RID(); }
 	virtual Size2 font_get_glyph_texture_size(const RID &p_font_rid, const Vector2i &p_size, int64_t p_glyph) const override { return Size2(); }
+	virtual int64_t font_get_glyph_by_name(const RID &p_font_rid, int64_t p_size, const String &p_name) const override { return 0; }
 	virtual int64_t font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const override { return 0; }
 	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const override { return 0; }
 	virtual bool font_has_char(const RID &p_font_rid, int64_t p_char) const override { return false; }

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -202,6 +202,7 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_set_kerning, "font_rid", "size", "glyph_pair", "kerning");
 	GDVIRTUAL_BIND(_font_get_kerning, "font_rid", "size", "glyph_pair");
 
+	GDVIRTUAL_BIND(_font_get_glyph_by_name, "font_rid", "size", "name");
 	GDVIRTUAL_BIND(_font_get_glyph_index, "font_rid", "size", "char", "variation_selector");
 	GDVIRTUAL_BIND(_font_get_char_from_glyph_index, "font_rid", "size", "glyph_index");
 
@@ -973,6 +974,12 @@ void TextServerExtension::font_set_kerning(const RID &p_font_rid, int64_t p_size
 Vector2 TextServerExtension::font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const {
 	Vector2 ret;
 	GDVIRTUAL_CALL(_font_get_kerning, p_font_rid, p_size, p_glyph_pair, ret);
+	return ret;
+}
+
+int64_t TextServerExtension::font_get_glyph_by_name(const RID &p_font_rid, int64_t p_size, const String &p_name) const {
+	int64_t ret = 0;
+	GDVIRTUAL_CALL(_font_get_glyph_by_name, p_font_rid, p_size, p_name, ret);
 	return ret;
 }
 

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -330,6 +330,9 @@ public:
 	GDVIRTUAL4(_font_set_kerning, RID, int64_t, const Vector2i &, const Vector2 &);
 	GDVIRTUAL3RC(Vector2, _font_get_kerning, RID, int64_t, const Vector2i &);
 
+	virtual int64_t font_get_glyph_by_name(const RID &p_font_rid, int64_t p_size, const String &p_name) const override;
+	GDVIRTUAL3RC_REQUIRED(int64_t, _font_get_glyph_by_name, RID, int64_t, const String &);
+
 	virtual int64_t font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector = 0) const override;
 	GDVIRTUAL4RC_REQUIRED(int64_t, _font_get_glyph_index, RID, int64_t, int64_t, int64_t);
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -357,6 +357,7 @@ void TextServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("font_set_kerning", "font_rid", "size", "glyph_pair", "kerning"), &TextServer::font_set_kerning);
 	ClassDB::bind_method(D_METHOD("font_get_kerning", "font_rid", "size", "glyph_pair"), &TextServer::font_get_kerning);
 
+	ClassDB::bind_method(D_METHOD("font_get_glyph_by_name", "font_rid", "size", "name"), &TextServer::font_get_glyph_by_name);
 	ClassDB::bind_method(D_METHOD("font_get_glyph_index", "font_rid", "size", "char", "variation_selector"), &TextServer::font_get_glyph_index);
 	ClassDB::bind_method(D_METHOD("font_get_char_from_glyph_index", "font_rid", "size", "glyph_index"), &TextServer::font_get_char_from_glyph_index);
 

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -415,6 +415,7 @@ public:
 	virtual void font_set_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair, const Vector2 &p_kerning) = 0;
 	virtual Vector2 font_get_kerning(const RID &p_font_rid, int64_t p_size, const Vector2i &p_glyph_pair) const = 0;
 
+	virtual int64_t font_get_glyph_by_name(const RID &p_font_rid, int64_t p_size, const String &p_name) const = 0;
 	virtual int64_t font_get_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_char, int64_t p_variation_selector) const = 0;
 	virtual int64_t font_get_char_from_glyph_index(const RID &p_font_rid, int64_t p_size, int64_t p_glyph_index) const = 0;
 


### PR DESCRIPTION
- Makes using icon fonts more convenient by adding support for glyph names in `[char=]` tag.
- Adds font alias dictionary to avoid long `[font=]` tags with full resource path.

<img width="953" alt="Screenshot 2025-06-18 at 11 34 38" src="https://github.com/user-attachments/assets/56063b31-ef3d-4bfd-84fe-c4cae44b1130" />
