### PR TITLE
Update CI `ruff` pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.4
+    rev: v0.12.0
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
- `ruff`: 0.11.4 → [0.12.0](https://github.com/astral-sh/ruff/releases/tag/0.12.0)

---

No changes across the repo required, simple version bump.
