### PR TITLE
Add MultiMesh physics interpolation for 2D transforms (MultiMeshInstance2D)

### DIFF
--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -42,8 +42,24 @@
 Callable MultiMeshInstance2D::_navmesh_source_geometry_parsing_callback;
 RID MultiMeshInstance2D::_navmesh_source_geometry_parser;
 
+void MultiMeshInstance2D::_refresh_interpolated() {
+	if (is_inside_tree() && multimesh.is_valid()) {
+		bool interpolated = is_physics_interpolated_and_enabled();
+		multimesh->set_physics_interpolated(interpolated);
+	}
+}
+
+void MultiMeshInstance2D::_physics_interpolated_changed() {
+	CanvasItem::_physics_interpolated_changed();
+	_refresh_interpolated();
+}
+
 void MultiMeshInstance2D::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			_refresh_interpolated();
+			break;
+		}
 		case NOTIFICATION_DRAW: {
 			if (multimesh.is_valid()) {
 				draw_multimesh(multimesh, texture);
@@ -75,6 +91,7 @@ void MultiMeshInstance2D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
 	// Connect to the multimesh so the AABB can update when instance transforms are changed.
 	if (multimesh.is_valid()) {
 		multimesh->connect_changed(callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw));
+		_refresh_interpolated();
 	}
 	queue_redraw();
 }

--- a/scene/2d/multimesh_instance_2d.h
+++ b/scene/2d/multimesh_instance_2d.h
@@ -43,7 +43,10 @@ class MultiMeshInstance2D : public Node2D {
 
 	Ref<Texture2D> texture;
 
+	void _refresh_interpolated();
+
 protected:
+	virtual void _physics_interpolated_changed() override;
 	void _notification(int p_what);
 	static void _bind_methods();
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -140,8 +140,6 @@ private:
 
 	void _notify_transform(CanvasItem *p_node);
 
-	virtual void _physics_interpolated_changed() override;
-
 	static CanvasItem *current_item_drawn;
 	friend class Viewport;
 	void _refresh_texture_repeat_cache() const;
@@ -156,6 +154,8 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+
+	virtual void _physics_interpolated_changed() override;
 
 	virtual void _update_self_texture_repeat(RS::CanvasItemTextureRepeat p_texture_repeat);
 	virtual void _update_self_texture_filter(RS::CanvasItemTextureFilter p_texture_filter);


### PR DESCRIPTION
I already discussed this on rocket chat. The docs wrongly state that MultiMeshInstance2D (or rather MultiMesh with 2D Transforms) make use of physics interpolation (https://docs.godotengine.org/en/latest/tutorials/physics/interpolation/2d_and_3d_physics_interpolation.html#other). After some fiddling I discovered that this was not the case.

So here is a hopefully decent implementation I basically replicated MultimeshInstance3D behaviour to MultiMeshInstance2D and added mesh_storage for 2D transforms.

Edit:
Small Testproject: [MultiMesh2D_Interp_Test.zip](https://github.com/user-attachments/files/20795528/MultiMesh2D_Interp_Test.zip)

(Use space bar to toggle physics interpolation for the meshinstance on/off)