### PR TITLE
Allow editor plugins to modify run arguments

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -362,6 +362,20 @@
 				Remember that you have to manage the visibility of all your editor controls manually.
 			</description>
 		</method>
+		<method name="_run_scene" qualifiers="virtual const">
+			<return type="PackedStringArray" />
+			<param index="0" name="scene" type="String" />
+			<param index="1" name="args" type="PackedStringArray" />
+			<description>
+				This function is called when an individual scene is about to be played in the editor. [param args] is a list of command line arguments that will be passed to the new Godot instance, which will be replaced by the list returned by this function.
+				[codeblock]
+				func _run_scene(scene, args):
+					args.append("--an-extra-argument")
+					return args
+				[/codeblock]
+				[b]Note:[/b] Text that is printed in this method will not be visible in the editor's Output panel unless [member EditorSettings.run/output/always_clear_output_on_play] is [code]false[/code].
+			</description>
+		</method>
 		<method name="_save_external_data" qualifiers="virtual">
 			<return type="void" />
 			<description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7103,6 +7103,13 @@ bool EditorNode::call_build() {
 	return builds_successful;
 }
 
+void EditorNode::call_run_scene(const String &p_scene, Vector<String> &r_args) {
+	for (int i = 0; i < editor_data.get_editor_plugin_count(); i++) {
+		EditorPlugin *plugin = editor_data.get_editor_plugin(i);
+		plugin->run_scene(p_scene, r_args);
+	}
+}
+
 void EditorNode::_inherit_imported(const String &p_action) {
 	open_imported->hide();
 	load_scene(open_import_request, true, true);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -724,6 +724,7 @@ public:
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
 
 	bool call_build();
+	void call_run_scene(const String &p_scene, Vector<String> &r_args);
 
 	// This is a very naive estimation, but we need something now. Will be reworked later.
 	bool is_editor_ready() const { return is_inside_tree() && !waiting_for_first_scan; }

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -531,6 +531,13 @@ bool EditorPlugin::build() {
 	return success;
 }
 
+void EditorPlugin::run_scene(const String &p_scene, Vector<String> &r_args) {
+	Vector<String> new_args;
+	if (GDVIRTUAL_CALL(_run_scene, p_scene, r_args, new_args)) {
+		r_args = new_args;
+	}
+}
+
 void EditorPlugin::queue_save_layout() {
 	EditorNode::get_singleton()->save_editor_layout_delayed();
 }
@@ -665,6 +672,7 @@ void EditorPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_set_window_layout, "configuration");
 	GDVIRTUAL_BIND(_get_window_layout, "configuration");
 	GDVIRTUAL_BIND(_build);
+	GDVIRTUAL_BIND(_run_scene, "scene", "args");
 	GDVIRTUAL_BIND(_enable_plugin);
 	GDVIRTUAL_BIND(_disable_plugin);
 

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -133,6 +133,7 @@ protected:
 	GDVIRTUAL1(_set_window_layout, Ref<ConfigFile>)
 	GDVIRTUAL1(_get_window_layout, Ref<ConfigFile>)
 	GDVIRTUAL0R(bool, _build)
+	GDVIRTUAL2RC(Vector<String>, _run_scene, String, Vector<String>)
 	GDVIRTUAL0(_enable_plugin)
 	GDVIRTUAL0(_disable_plugin)
 
@@ -202,6 +203,7 @@ public:
 	virtual void get_window_layout(Ref<ConfigFile> p_layout);
 	virtual void edited_scene_changed() {} // if changes are pending in editor, apply them
 	virtual bool build(); // builds with external tools. Returns true if safe to continue running scene.
+	virtual void run_scene(const String &p_scene, Vector<String> &r_args);
 
 	EditorInterface *get_editor_interface();
 	ScriptCreateDialog *get_script_create_dialog();

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -314,13 +314,17 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 	if (!EditorNode::get_singleton()->call_build()) {
 		return;
 	}
+
+	Vector<String> args = p_run_args;
+	EditorNode::get_singleton()->call_run_scene(run_filename, args);
+
 	// Use the existing URI, in case it is overridden by the CLI.
 	String uri = EditorDebuggerNode::get_singleton()->get_server_uri();
 	if (uri.is_empty()) {
 		uri = "tcp://";
 	}
 	EditorDebuggerNode::get_singleton()->start(uri);
-	Error error = editor_run.run(run_filename, write_movie_file, p_run_args);
+	Error error = editor_run.run(run_filename, write_movie_file, args);
 	if (error != OK) {
 		EditorDebuggerNode::get_singleton()->stop();
 		EditorNode::get_singleton()->show_accept(TTR("Could not start subprocess(es)!"), TTR("OK"));


### PR DESCRIPTION
This PR aims to allow editor plugins to control the arguments that are used when launching a project from the editor

The ultimate goal is to allow the [godot_openxr_vendor](https://github.com/GodotVR/godot_openxr_vendors) extension to simulate running a hybrid immersive/flat VR app on desktop, so you don't need to deploy to the headset for testing.

See https://github.com/GodotVR/godot_openxr_vendors/pull/312 for the rest of the implementation of that (also depends on https://github.com/godotengine/godot/pull/108852)

~~This is a DRAFT for now, because I need to do more testing (especially with the new embedded game view on multiple platforms)~~