### PR TITLE
Do not remove `SubViewport` nodes in thumbnail preview scene

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -583,13 +583,6 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 }
 
 void EditorPackedScenePreviewPlugin::_setup_scene_3d(Node *p_node) const {
-	// Do not account any SubViewport at preview scene, as it would not render correctly
-	if (Object::cast_to<SubViewport>(p_node) && p_node->get_parent()) {
-		p_node->get_parent()->remove_child(p_node);
-		callable_mp(p_node, &Node::queue_free).call_deferred();
-		return;
-	}
-
 	// Don't let window to popup
 	Window *window = Object::cast_to<Window>(p_node);
 	if (window) {
@@ -639,13 +632,6 @@ void EditorPackedScenePreviewPlugin::_setup_scene_3d(Node *p_node) const {
 }
 
 void EditorPackedScenePreviewPlugin::_setup_scene_2d(Node *p_node) const {
-	// Do not account any SubViewport at preview scene, as it would not render correctly
-	if (Object::cast_to<SubViewport>(p_node) && p_node->get_parent()) {
-		p_node->get_parent()->remove_child(p_node);
-		callable_mp(p_node, &Node::queue_free).call_deferred();
-		return;
-	}
-
 	// Don't let window to popup
 	Window *window = Object::cast_to<Window>(p_node);
 	if (window) {


### PR DESCRIPTION
Fixes #107667 

In early development of #102313 , we had some problem rendering SubViewport in thumbnails (If I recalled correctly), so we add some code to remove all SubViewport in preview scenes. But overlooked it would cause errors when ViewportTexture is used in scene.

After testing by removing those code now at master 09ed9d4a , the SubViewport texture rendered correctly (via a TextureRect with ViewportTexture), so it should be good to remove those code to get rid of the error mentioned in #107667.

BTW originally it was just a rendering issue, the code this PR addresses should be save to remove.
