### PR TITLE
Set audiostreamplayer default area_mask to 0 and exit early to reduce performance overhead.

### DIFF
--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -53,7 +53,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="1">
+		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="0">
 			Determines which [Area2D] layers affect the sound for reverb and audio bus effects. Areas can be used to redirect [AudioStream]s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 		</member>
 		<member name="attenuation" type="float" setter="set_attenuation" getter="get_attenuation" default="1.0">

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -53,7 +53,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="1">
+		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="0">
 			Determines which [Area3D] layers affect the sound for reverb and audio bus effects. Areas can be used to redirect [AudioStream]s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 		</member>
 		<member name="attenuation_filter_cutoff_hz" type="float" setter="set_attenuation_filter_cutoff_hz" getter="get_attenuation_filter_cutoff_hz" default="5000.0">

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -82,6 +82,10 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 // Interacts with PhysicsServer2D, so can only be called during _physics_process.
 StringName AudioStreamPlayer2D::_get_actual_bus() {
 #ifndef PHYSICS_2D_DISABLED
+	if (area_mask == 0) {
+		return internal->bus;
+	}
+
 	Vector2 global_pos = get_global_position();
 
 	//check if any area is diverting sound into a bus

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -68,7 +68,7 @@ private:
 
 	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer2D *>(self)->force_update_panning = true; }
 
-	uint32_t area_mask = 1;
+	uint32_t area_mask = 0;
 
 	float max_distance = 2000.0;
 	float attenuation = 1.0;

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -306,6 +306,10 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 #ifndef PHYSICS_3D_DISABLED
 // Interacts with PhysicsServer3D, so can only be called during _physics_process
 Area3D *AudioStreamPlayer3D::_get_overriding_area() {
+	if (area_mask == 0) {
+		return nullptr;
+	}
+
 	//check if any area is diverting sound into a bus
 	Ref<World3D> world_3d = get_world_3d();
 	ERR_FAIL_COND_V(world_3d.is_null(), nullptr);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -100,7 +100,7 @@ private:
 #endif // PHYSICS_3D_DISABLED
 	Vector<AudioFrame> _update_panning();
 
-	uint32_t area_mask = 1;
+	uint32_t area_mask = 0;
 
 	AudioServer::PlaybackType playback_type = AudioServer::PlaybackType::PLAYBACK_TYPE_DEFAULT;
 


### PR DESCRIPTION
Fixes #106751 

Quick summary:
By default AudioStreamPlayers2D/3D do a physics check on their position every frame when running to support the audio_bus_override feature on Area2D/3D. 

From my search this is a feature that is rarely used, but results in a non negligible overhead for all projects, even if the feature is never used.

I propose setting the default area_mask to 0 and exiting early in those scenarios to remove this overhead.

#### Reasons:
 1. Most projects don't use this feature and should thus not be affected by the cost.
 2. A default of 0 (aka. no overlap) more closely aligns with the opt-in nature of the feature. 
 I think the default of 1 (aka. check for overlaps with all default areas) is more likely to cause unexpected behaviour.
3. Most projects using this feature will very likely be using a specific non-1 layer for this effect and will thus be unaffected by the change.

#### Warning:
This PR includes a Behavior Breaking Change:
Projects using the audio_bus_override feature on the default layer will find their overrides not working anymore.
(Though I expect this number to be very low, can do a targeted search if required)
