### PR TITLE
Clear current path when deselecting files

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3581,6 +3581,11 @@ void FileSystemDock::_tree_empty_click(const Vector2 &p_pos, MouseButton p_butto
 
 void FileSystemDock::_tree_empty_selected() {
 	tree->deselect_all();
+	current_path = "";
+	current_path_line_edit->set_text(current_path);
+	if (file_list_vb->is_visible()) {
+		_update_file_list(false);
+	}
 }
 
 void FileSystemDock::_file_list_item_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {


### PR DESCRIPTION
Fixes #92867

https://github.com/user-attachments/assets/33d9f034-ec49-444d-9492-c7e0e1e24956

This also fixes a problem where you may end up with a random file selected after project restart, which can result in many uncollapsed folders.