### PR TITLE
Don't update script documentation when exporting

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3104,6 +3104,10 @@ void EditorHelp::load_script_doc_cache() {
 		return;
 	}
 
+	if (EditorNode::is_cmdline_mode()) {
+		return;
+	}
+
 	_wait_for_thread();
 
 	if (!ResourceLoader::exists(get_script_doc_cache_full_path())) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6007,6 +6007,11 @@ bool EditorNode::immediate_confirmation_dialog(const String &p_text, const Strin
 	return singleton->immediate_dialog_confirmed;
 }
 
+bool EditorNode::is_cmdline_mode() {
+	ERR_FAIL_NULL_V(singleton, false);
+	return singleton->cmdline_mode;
+}
+
 void EditorNode::cleanup() {
 	_init_callbacks.clear();
 }

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -771,6 +771,7 @@ public:
 
 	static bool immediate_confirmation_dialog(const String &p_text, const String &p_ok_text = TTR("Ok"), const String &p_cancel_text = TTR("Cancel"), uint32_t p_wrap_width = 0);
 
+	static bool is_cmdline_mode();
 	static void cleanup();
 
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2285,8 +2285,10 @@ void EditorFileSystem::_process_update_pending() {
 	_update_script_classes();
 	// Parse documentation second, as it requires the class names to be loaded
 	// because _update_script_documentation loads the scripts completely.
-	_update_script_documentation();
-	_update_pending_scene_groups();
+	if (!EditorNode::is_cmdline_mode()) {
+		_update_script_documentation();
+		_update_pending_scene_groups();
+	}
 }
 
 void EditorFileSystem::_queue_update_script_class(const String &p_path, const ScriptClassInfoUpdate &p_script_update) {


### PR DESCRIPTION
Makes the editor skip updating script documentation and scene groups when exporting or running headless.

Fixes #107407 (please test)
Probably fixes #105327 (I tested and seems fixed, but the crash is random)