### PR TITLE
Check UID to disable "Set as Main Scene" in FileSystemDock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -3299,7 +3299,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 			if (filenames.size() == 1) {
 				p_popup->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTRC("Open Scene"), FILE_MENU_OPEN);
 				p_popup->add_icon_item(get_editor_theme_icon(SNAME("CreateNewSceneFrom")), TTRC("New Inherited Scene"), FILE_MENU_INHERIT);
-				if (GLOBAL_GET("application/run/main_scene") != filenames[0]) {
+				if (ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene")) != filenames[0]) {
 					p_popup->add_icon_item(get_editor_theme_icon(SNAME("PlayScene")), TTRC("Set as Main Scene"), FILE_MENU_MAIN_SCENE);
 				}
 			} else {


### PR DESCRIPTION
Correctly removes "Set as Main Scene" in FileSystemDock's right-click menu for when main scene was set with a `uid://` path.

At the moment, Set as Main Scene's if statement expects a `res://` path, which means for any way in the editor that a main scene is set after 4.4, the right-click option for "Set as Main Scene" always remains, including when set from the option itself.