### PR TITLE
Fix setting remote properties that take objects not working

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -272,7 +272,15 @@ void ScriptEditorDebugger::request_remote_evaluate(const String &p_expression, i
 }
 
 void ScriptEditorDebugger::update_remote_object(ObjectID p_obj_id, const String &p_prop, const Variant &p_value, const String &p_field) {
-	Array msg = { p_obj_id, p_prop, p_value };
+	Array msg = { p_obj_id, p_prop };
+
+	Ref<Resource> res = p_value;
+	if (res.is_valid() && !res->get_path().is_empty()) {
+		msg.append(res->get_path());
+	} else {
+		msg.append(p_value);
+	}
+
 	if (p_field.is_empty()) {
 		_put_msg("scene:set_object_property", msg);
 	} else {

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -670,13 +670,14 @@ void SceneDebugger::_set_object_property(ObjectID p_id, const String &p_property
 		prop_name = p_property;
 	}
 
-	Variant value;
-	if (p_field.is_empty()) {
-		// Whole value.
-		value = p_value;
-	} else {
-		// Only one field.
-		value = fieldwise_assign(obj->get(prop_name), p_value, p_field);
+	Variant value = p_value;
+	if (p_value.is_string() && (obj->get_static_property_type(prop_name) == Variant::OBJECT || p_property == "script")) {
+		value = ResourceLoader::load(p_value);
+	}
+
+	if (!p_field.is_empty()) {
+		// Only one specific field.
+		value = fieldwise_assign(obj->get(prop_name), value, p_field);
 	}
 
 	obj->set(prop_name, value);
@@ -860,7 +861,7 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 
 void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 	Array send_props;
-	for (SceneDebuggerObject::SceneDebuggerProperty &property : properties) {
+	for (SceneDebuggerProperty &property : properties) {
 		const PropertyInfo &pi = property.first;
 		Variant &var = property.second;
 


### PR DESCRIPTION
This PR enables changing the value of properties from the remote inspector that take objects as their value. Before, the only way to do it would be setting it in the local inspector with live debugging enabled.

I also took the liberty of hiding exported member variables in the remote inspector, to avoid them showing up twice.