### PR TITLE
Skip killed/invalid subtween

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -875,7 +875,14 @@ void SubtweenTweener::start() {
 
 	// Reset the subtween.
 	subtween->stop();
-	subtween->play();
+
+	// It's possible that a subtween could be killed before it is started;
+	// if so, we just want to skip it entirely.
+	if (subtween->is_valid()) {
+		subtween->play();
+	} else {
+		_finish();
+	}
 }
 
 bool SubtweenTweener::step(double &r_delta) {


### PR DESCRIPTION
Closes #107688 .

This PR adds a check to `SubtweenTweener::start()` so that it checks if the tween it's holding is still valid before starting to play it as a subtween. If not, then it acts as if the subtween has instantly finished, and allows execution to continue to future steps.

Using the same MRP as in the linked issue, but with this code change, the output looks like this. The final step of the tween sequence where the icon moves downwards, which happens after the killed subtween, is able to execute.

https://github.com/user-attachments/assets/5fc9598b-d290-4052-a3df-096bc33e7bb5

