### PR TITLE
Fix `MeshInstance3D::get_active_material()` error on empty mesh or empty surfaces

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -380,17 +380,17 @@ Ref<Material> MeshInstance3D::get_active_material(int p_surface) const {
 		return mat_override;
 	}
 
+	Ref<Mesh> m = get_mesh();
+	if (m.is_null() || m->get_surface_count() == 0) {
+		return Ref<Material>();
+	}
+
 	Ref<Material> surface_material = get_surface_override_material(p_surface);
 	if (surface_material.is_valid()) {
 		return surface_material;
 	}
 
-	Ref<Mesh> m = get_mesh();
-	if (m.is_valid()) {
-		return m->surface_get_material(p_surface);
-	}
-
-	return Ref<Material>();
+	return m->surface_get_material(p_surface);
 }
 
 void MeshInstance3D::_mesh_changed() {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/105580

A `MeshInstance3D` without a `Mesh` resource (or empty surfaces) has also empty surface material arrays.

The `get_active_material()` function tried to access those empty internal material arrays and did run into index errors.

The correct order for checking what material is active is:

- Check if there is a general geometry material override on the inherited `GeometryInstance3D`.
- Check if a `Mesh` even exists and if it has surfaces.
- Check the surface material override slot on the rendering instance.
- Check the surface material slot on the mesh resource.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
