### PR TITLE
Show description for editor setting overrides

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -49,7 +49,7 @@ class ProjectSettings : public Object {
 public:
 	typedef HashMap<String, Variant> CustomMap;
 	static inline const String PROJECT_DATA_DIR_NAME_SUFFIX = "godot";
-	static inline const String EDITOR_SETTING_OVERRIDE_PREFIX = "editor_overrides/";
+	static inline const String EDITOR_SETTING_OVERRIDE_PREFIX = PNAME("editor_overrides") + String("/");
 
 	// Properties that are not for built in values begin from this value, so builtin ones are displayed first.
 	constexpr static const int32_t NO_BUILTIN_ORDER_BASE = 1 << 16;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4171,10 +4171,10 @@ void EditorInspector::update_tree() {
 		String doc_path;
 		String theme_item_name;
 		String doc_tooltip_text;
-		StringName classname = doc_name;
 
 		// Build the doc hint, to use as tooltip.
 		if (use_doc_hints) {
+			StringName classname = doc_name;
 			if (!object_class.is_empty()) {
 				classname = object_class;
 			} else if (Object::cast_to<MultiNodeEdit>(object)) {
@@ -4197,6 +4197,14 @@ void EditorInspector::update_tree() {
 			}
 
 			StringName propname = property_prefix + p.name;
+			for (const KeyValue<String, String> &E : doc_property_class_remaps) {
+				if (property_prefix.begins_with(E.key)) {
+					propname = property_prefix.trim_prefix(E.key) + p.name;
+					classname = E.value;
+					break;
+				}
+			}
+
 			bool found = false;
 
 			// Small hack for theme_overrides. They are listed under Control, but come from another class.
@@ -4261,12 +4269,12 @@ void EditorInspector::update_tree() {
 				if (p.name.contains("shader_parameter/")) {
 					ShaderMaterial *shader_material = Object::cast_to<ShaderMaterial>(object);
 					if (shader_material) {
-						doc_tooltip_text = "property|" + shader_material->get_shader()->get_path() + "|" + property_prefix + p.name;
+						doc_tooltip_text = "property|" + shader_material->get_shader()->get_path() + "|" + propname;
 					}
 				} else if (p.usage & PROPERTY_USAGE_INTERNAL) {
-					doc_tooltip_text = "internal_property|" + classname + "|" + property_prefix + p.name;
+					doc_tooltip_text = "internal_property|" + classname + "|" + propname;
 				} else {
-					doc_tooltip_text = "property|" + classname + "|" + property_prefix + p.name;
+					doc_tooltip_text = "property|" + classname + "|" + propname;
 				}
 			} else {
 				doc_tooltip_text = "theme_item|" + classname + "|" + theme_item_name;
@@ -5560,6 +5568,10 @@ String EditorInspector::get_custom_property_description(const String &p_property
 		return E->value;
 	}
 	return "";
+}
+
+void EditorInspector::remap_doc_property_class(const String &p_property_prefix, const String &p_class) {
+	doc_property_class_remaps[p_property_prefix] = p_class;
 }
 
 void EditorInspector::set_object_class(const String &p_class) {

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -697,6 +697,7 @@ class EditorInspector : public ScrollContainer {
 	HashMap<StringName, HashMap<StringName, DocCacheInfo>> doc_cache;
 	HashSet<StringName> restart_request_props;
 	HashMap<String, String> custom_property_descriptions;
+	HashMap<String, String> doc_property_class_remaps;
 
 	HashMap<ObjectID, int> scroll_cache;
 
@@ -815,6 +816,8 @@ public:
 
 	void add_custom_property_description(const String &p_class, const String &p_property, const String &p_description);
 	String get_custom_property_description(const String &p_property) const;
+
+	void remap_doc_property_class(const String &p_property_prefix, const String &p_class);
 
 	void set_object_class(const String &p_class);
 	String get_object_class() const;

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -758,6 +758,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_settings_inspector->connect("category_changed", callable_mp(this, &ProjectSettingsEditor::_on_category_changed));
 	general_settings_inspector->get_inspector()->set_use_filter(true);
 	general_settings_inspector->get_inspector()->set_mark_unsaved(false);
+	general_settings_inspector->get_inspector()->remap_doc_property_class(ProjectSettings::EDITOR_SETTING_OVERRIDE_PREFIX, "EditorSettings");
 	general_settings_inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));
 	general_settings_inspector->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_setting_edited));
 	general_settings_inspector->get_inspector()->connect("property_deleted", callable_mp(this, &ProjectSettingsEditor::_on_editor_override_deleted));


### PR DESCRIPTION
#69012 added the ability to override editor settings per project. But the doc tooltip is empty for editor override items in the Project Settings.

Also marked the "Editor Overrides" section name for translation.