### PR TITLE
[3.x] Revert "Fix Button not listing `hover_pressed` stylebox"

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -113,9 +113,6 @@
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is being hovered and pressed.
-		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Button].
 		</theme_item>

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -230,7 +230,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("normal", "Button", sb_button_normal);
 	theme->set_stylebox("pressed", "Button", sb_button_pressed);
 	theme->set_stylebox("hover", "Button", sb_button_hover);
-	theme->set_stylebox("hover_pressed", "Button", sb_button_hover);
 	theme->set_stylebox("disabled", "Button", sb_button_disabled);
 	theme->set_stylebox("focus", "Button", sb_button_focus);
 


### PR DESCRIPTION
This reverts commit cc11089786de6fc84a58f4b0af004997131b5b02.

#107659 shows that #98511 breaks compat. It shouldn't be cherrypicked for 3.6.1 at least.

After reverting this commit, I checked and found that the problem that #98511 tried to fix is no longer reproducible, though I'm not sure why. I think we should also revert this on `3.x` in order to avoid creating different behavior than the `master` branch unnecessarily.