### PR TITLE
Fix GLES3 stereo output (sRGB + lens distortion)

### DIFF
--- a/drivers/gles3/effects/copy_effects.h
+++ b/drivers/gles3/effects/copy_effects.h
@@ -60,8 +60,9 @@ public:
 	~CopyEffects();
 
 	// These functions assume that a framebuffer and texture are bound already. They only manage the shader, uniforms, and vertex array.
-	void copy_to_rect(const Rect2 &p_rect);
-	void copy_to_rect_3d(const Rect2 &p_rect, float p_layer, int p_type, float p_lod = 0.0f);
+	void copy_to_rect(const Rect2 &p_rect, bool p_linear_to_srgb = false);
+	void copy_to_rect_3d(const Rect2 &p_rect, float p_layer, int p_type, float p_lod = 0.0f, bool p_linear_to_srgb = false);
+	void copy_with_lens_distortion(const Rect2 &p_rect, float p_layer, const Vector2 &p_eye_center, float p_k1, float p_k2, float p_upscale, float p_aspect_ration, bool p_linear_to_srgb = false);
 	void copy_to_and_from_rect(const Rect2 &p_rect);
 	void copy_screen(float p_multiply = 1.0);
 	void copy_cube_to_rect(const Rect2 &p_rect);

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -83,7 +83,7 @@ protected:
 	RasterizerSceneGLES3 *scene = nullptr;
 	static RasterizerGLES3 *singleton;
 
-	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, const Rect2 &p_screen_rect, uint32_t p_layer, bool p_first = true);
+	void _blit_render_target_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen &p_blit, bool p_first = true);
 
 public:
 	RendererUtilities *get_utilities() { return utilities; }


### PR DESCRIPTION
This PR fixes two issues in the compatibility renderer.

First, when using OpenXR we have to use `GL_SRGB8_ALPHA8` buffers to render to. This triggers a hardware sRGB->Linear conversion when we are reading from this buffer with our final blit to screen. We need to revert that conversion to get proper colors.

Fixes #107655

Second, we never copied over our lens distortion shader used by our `MobileVRInterface` implementation. This is thus a long standing regression from Godot 3.6 that stops people from using Godot with cardboard-ish phone VR (which yes, still gets used to this day).

This can be tested with: https://github.com/godotengine/godot-demo-projects/pull/1212