### PR TITLE
Add `callable_sp` macro to remove boilerplate in core

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -37,6 +37,7 @@
 // Makes callable_mp readily available in all classes connecting signals.
 // Needs to come after method_bind and object have been included.
 #include "core/object/callable_method_pointer.h"
+#include "core/object/callable_signal_pointer.h"
 #include "core/templates/hash_set.h"
 
 #include <type_traits>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1992,10 +1992,6 @@ void AnimationTimelineEdit::set_hscroll(HScrollBar *p_hscroll) {
 	hscroll = p_hscroll;
 }
 
-void AnimationTimelineEdit::_track_added(int p_track) {
-	emit_signal(SNAME("track_added"), p_track);
-}
-
 void AnimationTimelineEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("zoom_changed"));
 	ADD_SIGNAL(MethodInfo("name_limit_changed"));
@@ -2028,7 +2024,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	filter_track->set_custom_minimum_size(Vector2(120 * EDSCALE, 0));
 	filter_track->set_placeholder(TTR("Filter Tracks"));
 	filter_track->set_tooltip_text(TTR("Filter tracks by entering part of their node name or property."));
-	filter_track->connect(SceneStringName(text_changed), callable_mp((AnimationTrackEditor *)this, &AnimationTrackEditor::_on_filter_updated));
+	filter_track->connect(SceneStringName(text_changed), callable_sp(this, SNAME("filter_changed")).unbind(1));
 	filter_track->set_clear_button_enabled(true);
 	filter_track->hide();
 	add_track_hb->add_child(filter_track);
@@ -2067,7 +2063,7 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 	add_child(len_hb);
 
 	add_track->hide();
-	add_track->get_popup()->connect("index_pressed", callable_mp(this, &AnimationTimelineEdit::_track_added));
+	add_track->get_popup()->connect("index_pressed", callable_sp(this, SNAME("track_added")));
 	len_hb->hide();
 
 	panner.instantiate();
@@ -4945,10 +4941,6 @@ bool AnimationTrackEditor::can_add_reset_key() const {
 	return false;
 }
 
-void AnimationTrackEditor::_on_filter_updated(const String &p_filter) {
-	emit_signal(SNAME("filter_changed"));
-}
-
 void AnimationTrackEditor::_update_tracks() {
 	int selected = _get_track_selected();
 
@@ -5404,10 +5396,6 @@ void AnimationTrackEditor::_update_step(double p_new_step) {
 	undo_redo->commit_action();
 	step->set_block_signals(false);
 	emit_signal(SNAME("animation_step_changed"), step_value);
-}
-
-void AnimationTrackEditor::_update_length(double p_new_len) {
-	emit_signal(SNAME("animation_len_changed"), p_new_len);
 }
 
 void AnimationTrackEditor::_dropped_track(int p_from_track, int p_to_track) {
@@ -7767,7 +7755,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline->connect("name_limit_changed", callable_mp(this, &AnimationTrackEditor::_name_limit_changed));
 	timeline->connect("track_added", callable_mp(this, &AnimationTrackEditor::_add_track));
 	timeline->connect(SceneStringName(value_changed), callable_mp(this, &AnimationTrackEditor::_timeline_value_changed));
-	timeline->connect("length_changed", callable_mp(this, &AnimationTrackEditor::_update_length));
+	timeline->connect("length_changed", callable_sp(this, SNAME("animation_len_changed")));
 	timeline->connect("filter_changed", callable_mp(this, &AnimationTrackEditor::_update_tracks));
 
 	panner.instantiate();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -236,7 +236,6 @@ class AnimationTimelineEdit : public Range {
 	bool zoom_callback_occurred = false;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-	void _track_added(int p_track);
 
 	float _get_zoom_scale(double p_zoom_value) const;
 	void _scroll_to_start();
@@ -652,7 +651,6 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _update_nearest_fps_label();
 	void _update_fps_compat_mode(bool p_enabled);
 	void _update_step(double p_new_step);
-	void _update_length(double p_new_len);
 	void _dropped_track(int p_from_track, int p_to_track);
 
 	void _add_track(int p_type);
@@ -956,7 +954,6 @@ public:
 	bool is_snap_keys_enabled() const;
 	bool is_bezier_editor_active() const;
 	bool can_add_reset_key() const;
-	void _on_filter_updated(const String &p_filter);
 	float get_moving_selection_offset() const;
 	float snap_time(float p_value, bool p_relative = false);
 	float get_snap_unit();

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -104,10 +104,6 @@ AudioStreamPreview::AudioStreamPreview() {
 
 ////
 
-void AudioStreamPreviewGenerator::_update_emit(ObjectID p_id) {
-	emit_signal(SNAME("preview_updated"), p_id);
-}
-
 void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 	Thread::set_name("AudioStreamPreviewGenerator");
 
@@ -160,7 +156,7 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 		}
 
 		frames_todo -= to_read;
-		callable_mp(singleton, &AudioStreamPreviewGenerator::_update_emit).call_deferred(preview->id);
+		callable_sp(singleton, SNAME("preview_updated")).call_deferred(preview->id);
 	}
 
 	preview->preview->version++;

--- a/editor/audio_stream_preview.h
+++ b/editor/audio_stream_preview.h
@@ -90,8 +90,6 @@ class AudioStreamPreviewGenerator : public Node {
 
 	static void _preview_thread(void *p_preview);
 
-	void _update_emit(ObjectID p_id);
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -142,7 +142,7 @@ void EditorDebuggerInspector::_bind_methods() {
 void EditorDebuggerInspector::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
-			connect("object_id_selected", callable_mp(this, &EditorDebuggerInspector::_object_selected));
+			connect("object_id_selected", callable_sp(this, SNAME("object_selected")));
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -150,14 +150,6 @@ void EditorDebuggerInspector::_notification(int p_what) {
 			edit(variables);
 		} break;
 	}
-}
-
-void EditorDebuggerInspector::_objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field) {
-	emit_signal(SNAME("objects_edited"), p_prop, p_values, p_field);
-}
-
-void EditorDebuggerInspector::_object_selected(ObjectID p_object) {
-	emit_signal(SNAME("object_selected"), p_object);
 }
 
 EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p_arr) {
@@ -190,7 +182,7 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 		remote_objects = memnew(EditorDebuggerRemoteObjects);
 		remote_objects->remote_object_ids = ids;
 		remote_objects->remote_object_ids.make_read_only();
-		remote_objects->connect("values_edited", callable_mp(this, &EditorDebuggerInspector::_objects_edited));
+		remote_objects->connect("values_edited", callable_sp(this, SNAME("objects_edited")));
 		remote_objects_list.push_back(remote_objects);
 	}
 

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -76,9 +76,6 @@ private:
 	HashSet<Ref<Resource>> remote_dependencies;
 	EditorDebuggerRemoteObjects *variables = nullptr;
 
-	void _object_selected(ObjectID p_object);
-	void _objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field);
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -146,10 +146,6 @@ protected:
 	void _breakpoint_set_in_tree(Ref<RefCounted> p_script, int p_line, bool p_enabled, int p_debugger);
 	void _breakpoints_cleared_in_tree(int p_debugger);
 
-	void _clear_execution(Ref<RefCounted> p_script) {
-		emit_signal(SNAME("clear_execution"), p_script);
-	}
-
 	void _text_editor_stack_goto(const ScriptEditorDebugger *p_debugger);
 	void _text_editor_stack_clear(const ScriptEditorDebugger *p_debugger);
 	void _stack_frame_selected(int p_debugger);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -297,10 +297,6 @@ void ScriptEditorDebugger::_remote_objects_edited(const String &p_prop, const Ty
 	request_remote_objects(p_values.keys(), false);
 }
 
-void ScriptEditorDebugger::_remote_object_property_updated(ObjectID p_id, const String &p_property) {
-	emit_signal(SNAME("remote_object_property_updated"), p_id, p_property);
-}
-
 void ScriptEditorDebugger::_video_mem_request() {
 	_put_msg("servers:memory", Array());
 }
@@ -2119,7 +2115,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		inspector->set_read_only(true);
 		inspector->connect("object_selected", callable_mp(this, &ScriptEditorDebugger::_remote_object_selected));
 		inspector->connect("objects_edited", callable_mp(this, &ScriptEditorDebugger::_remote_objects_edited));
-		inspector->connect("object_property_updated", callable_mp(this, &ScriptEditorDebugger::_remote_object_property_updated));
+		inspector->connect("object_property_updated", callable_sp(this, SNAME("remote_object_property_updated")));
 		inspector->register_text_enter(search);
 		inspector->set_use_filter(true);
 		inspector_vbox->add_child(inspector);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -235,7 +235,6 @@ private:
 	void _update_buttons_state();
 	void _remote_object_selected(ObjectID p_object);
 	void _remote_objects_edited(const String &p_prop, const TypedDictionary<uint64_t, Variant> &p_values, const String &p_field);
-	void _remote_object_property_updated(ObjectID p_id, const String &p_property);
 
 	void _video_mem_request();
 	void _video_mem_export();

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -130,10 +130,6 @@ Dictionary EditorHelpSearch::_native_search_cb(const String &p_search_string, in
 	return ret;
 }
 
-void EditorHelpSearch::_native_action_cb(const String &p_item_string) {
-	emit_signal(SNAME("go_to_help"), p_item_string);
-}
-
 void EditorHelpSearch::_update_results() {
 	const String term = search_box->get_text().strip_edges();
 
@@ -206,7 +202,7 @@ void EditorHelpSearch::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_HELP)) {
-				DisplayServer::get_singleton()->help_set_search_callbacks(callable_mp(this, &EditorHelpSearch::_native_search_cb), callable_mp(this, &EditorHelpSearch::_native_action_cb));
+				DisplayServer::get_singleton()->help_set_search_callbacks(callable_mp(this, &EditorHelpSearch::_native_search_cb), callable_sp(this, SNAME("go_to_help")));
 			}
 		} break;
 

--- a/editor/editor_help_search.h
+++ b/editor/editor_help_search.h
@@ -89,7 +89,6 @@ class EditorHelpSearch : public ConfirmationDialog {
 	void _match_theme_property_name_and_push_back(const String &p_term, const Vector<String> &p_terms, Vector<DocData::ThemeItemDoc> &p_properties, const String &p_type, const String &p_metatype, const String &p_class_name, Dictionary &r_result) const;
 
 	Dictionary _native_search_cb(const String &p_search_string, int p_result_limit);
-	void _native_action_cb(const String &p_item_string);
 
 protected:
 	void _notification(int p_what);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2364,10 +2364,6 @@ void EditorInspectorArray::_add_button_pressed() {
 	_move_element(-1, -1);
 }
 
-void EditorInspectorArray::_paginator_page_changed(int p_page) {
-	emit_signal("page_change_request", p_page);
-}
-
 void EditorInspectorArray::_rmb_popup_id_pressed(int p_id) {
 	switch (p_id) {
 		case OPTION_MOVE_UP:
@@ -2956,7 +2952,7 @@ void EditorInspectorArray::_setup() {
 	if (max_page > 0) {
 		EditorPaginator *paginator = memnew(EditorPaginator);
 		paginator->update(page, max_page);
-		paginator->connect("page_changed", callable_mp(this, &EditorInspectorArray::_paginator_page_changed));
+		paginator->connect("page_changed", callable_sp(this, SNAME("page_change_request")));
 		vbox->add_child(paginator);
 	}
 }
@@ -3203,10 +3199,6 @@ EditorInspectorArray::EditorInspectorArray(bool p_read_only) {
 ////////////////////////////////////////////////
 ////////////////////////////////////////////////
 
-void EditorPaginator::_first_page_button_pressed() {
-	emit_signal("page_changed", 0);
-}
-
 void EditorPaginator::_prev_page_button_pressed() {
 	emit_signal("page_changed", MAX(0, page - 1));
 }
@@ -3267,7 +3259,7 @@ EditorPaginator::EditorPaginator() {
 	first_page_button = memnew(Button);
 	first_page_button->set_accessibility_name(TTRC("First Page"));
 	first_page_button->set_flat(true);
-	first_page_button->connect(SceneStringName(pressed), callable_mp(this, &EditorPaginator::_first_page_button_pressed));
+	first_page_button->connect(SceneStringName(pressed), callable_sp(this, SNAME("page_changed")).bind(0));
 	add_child(first_page_button);
 
 	prev_page_button = memnew(Button);

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -536,7 +536,6 @@ class EditorInspectorArray : public EditorInspectorSection {
 
 	int _get_array_count();
 	void _add_button_pressed();
-	void _paginator_page_changed(int p_page);
 
 	void _rmb_popup_id_pressed(int p_id);
 
@@ -593,7 +592,6 @@ class EditorPaginator : public HBoxContainer {
 	Button *next_page_button = nullptr;
 	Button *last_page_button = nullptr;
 
-	void _first_page_button_pressed();
 	void _prev_page_button_pressed();
 	void _page_line_edit_text_submitted(const String &p_text);
 	void _next_page_button_pressed();

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -297,10 +297,6 @@ void EditorPropertyArray::_change_type_menu(int p_index) {
 	emit_changed(get_edited_property(), array);
 }
 
-void EditorPropertyArray::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal(SNAME("object_id_selected"), p_property, p_id);
-}
-
 void EditorPropertyArray::_create_new_property_slot() {
 	int idx = slots.size();
 	HBoxContainer *hbox = memnew(HBoxContainer);
@@ -511,7 +507,7 @@ void EditorPropertyArray::update_property() {
 				new_prop->set_selectable(false);
 				new_prop->set_use_folding(is_using_folding());
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyArray::_property_changed));
-				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyArray::_object_id_selected));
+				new_prop->connect(SNAME("object_id_selected"), callable_sp(this, SNAME("object_id_selected")));
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				new_prop->set_read_only(is_read_only());
 				slot.prop->add_sibling(new_prop, false);
@@ -1399,7 +1395,7 @@ void EditorPropertyDictionary::update_property() {
 				new_prop->set_selectable(false);
 				new_prop->set_use_folding(is_using_folding());
 				new_prop->connect(SNAME("property_changed"), callable_mp(this, &EditorPropertyDictionary::_property_changed));
-				new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
+				new_prop->connect(SNAME("object_id_selected"), callable_sp(this, SNAME("object_id_selected")));
 				new_prop->set_h_size_flags(SIZE_EXPAND_FILL);
 				if (slot.index != EditorPropertyDictionaryObject::NEW_KEY_INDEX && slot.index != EditorPropertyDictionaryObject::NEW_VALUE_INDEX) {
 					new_prop->set_draw_label(false);
@@ -1444,10 +1440,6 @@ void EditorPropertyDictionary::_remove_pressed(int p_slot_index) {
 	dict.erase(dict.get_key_at_index(index));
 
 	emit_changed(get_edited_property(), dict);
-}
-
-void EditorPropertyDictionary::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
 void EditorPropertyDictionary::_notification(int p_what) {
@@ -1645,7 +1637,7 @@ void EditorPropertyLocalizableString::update_property() {
 
 			prop->set_selectable(false);
 			prop->connect("property_changed", callable_mp(this, &EditorPropertyLocalizableString::_property_changed));
-			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyLocalizableString::_object_id_selected));
+			prop->connect("object_id_selected", callable_sp(this, SNAME("object_id_selected")));
 
 			HBoxContainer *hbox = memnew(HBoxContainer);
 			property_vbox->add_child(hbox);
@@ -1678,10 +1670,6 @@ void EditorPropertyLocalizableString::update_property() {
 			container = nullptr;
 		}
 	}
-}
-
-void EditorPropertyLocalizableString::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
 void EditorPropertyLocalizableString::_notification(int p_what) {

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -156,7 +156,6 @@ protected:
 	virtual void _change_type(Object *p_button, int p_slot_index);
 	virtual void _change_type_menu(int p_index);
 
-	virtual void _object_id_selected(const StringName &p_property, ObjectID p_id);
 	virtual void _remove_pressed(int p_index);
 
 	virtual void _button_draw();
@@ -247,7 +246,6 @@ class EditorPropertyDictionary : public EditorProperty {
 	void _change_type_menu(int p_index);
 
 	void _add_key_value();
-	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 	void _remove_pressed(int p_slot_index);
 
 	Variant::Type key_subtype;
@@ -293,7 +291,6 @@ class EditorPropertyLocalizableString : public EditorProperty {
 
 	void _add_locale_popup();
 	void _add_locale(const String &p_locale);
-	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
 protected:
 	void _notification(int p_what);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -731,7 +731,7 @@ FindInFilesPanel::FindInFilesPanel() {
 
 		_close_button = memnew(Button);
 		_close_button->set_text(TTR("Close"));
-		_close_button->connect(SceneStringName(pressed), callable_mp(this, &FindInFilesPanel::_on_close_button_clicked));
+		_close_button->connect(SceneStringName(pressed), callable_sp(this, SNAME(SIGNAL_CLOSE_BUTTON_CLICKED)));
 		hbc->add_child(_close_button);
 
 		vbc->add_child(hbc);
@@ -960,10 +960,6 @@ void FindInFilesPanel::_on_refresh_button_clicked() {
 
 void FindInFilesPanel::_on_cancel_button_clicked() {
 	stop_search();
-}
-
-void FindInFilesPanel::_on_close_button_clicked() {
-	emit_signal(SNAME(SIGNAL_CLOSE_BUTTON_CLICKED));
 }
 
 void FindInFilesPanel::_on_result_selected() {

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -194,7 +194,6 @@ private:
 	void _on_finished();
 	void _on_refresh_button_clicked();
 	void _on_cancel_button_clicked();
-	void _on_close_button_clicked();
 	void _on_result_selected();
 	void _on_item_edited();
 	void _on_replace_text_changed(const String &text);

--- a/editor/gui/editor_scene_tabs.cpp
+++ b/editor/gui/editor_scene_tabs.cpp
@@ -88,10 +88,6 @@ void EditorSceneTabs::_scene_tab_script_edited(int p_tab) {
 	}
 }
 
-void EditorSceneTabs::_scene_tab_closed(int p_tab) {
-	emit_signal("tab_closed", p_tab);
-}
-
 void EditorSceneTabs::_scene_tab_hovered(int p_tab) {
 	if (!bool(EDITOR_GET("interface/scene_tabs/show_thumbnail_on_hover"))) {
 		return;
@@ -422,7 +418,7 @@ EditorSceneTabs::EditorSceneTabs() {
 
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorSceneTabs::_scene_tab_changed));
 	scene_tabs->connect("tab_button_pressed", callable_mp(this, &EditorSceneTabs::_scene_tab_script_edited));
-	scene_tabs->connect("tab_close_pressed", callable_mp(this, &EditorSceneTabs::_scene_tab_closed));
+	scene_tabs->connect("tab_close_pressed", callable_sp(this, SNAME("tab_closed")));
 	scene_tabs->connect("tab_hovered", callable_mp(this, &EditorSceneTabs::_scene_tab_hovered));
 	scene_tabs->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorSceneTabs::_scene_tab_exit));
 	scene_tabs->connect(SceneStringName(gui_input), callable_mp(this, &EditorSceneTabs::_scene_tab_input));

--- a/editor/gui/editor_scene_tabs.h
+++ b/editor/gui/editor_scene_tabs.h
@@ -70,7 +70,6 @@ private:
 
 	void _scene_tab_changed(int p_tab);
 	void _scene_tab_script_edited(int p_tab);
-	void _scene_tab_closed(int p_tab);
 	void _scene_tab_hovered(int p_tab);
 	void _scene_tab_exit();
 	void _scene_tab_input(const Ref<InputEvent> &p_input);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -757,7 +757,7 @@ void EditorAssetLibrary::_install_asset() {
 
 	if (templates_only) {
 		download->set_external_install(true);
-		download->connect("install_asset", callable_mp(this, &EditorAssetLibrary::_install_external_asset));
+		download->connect("install_asset", callable_sp(this, SNAME("install_asset")));
 	}
 }
 
@@ -1521,10 +1521,6 @@ EditorAssetLibraryItemDownload *EditorAssetLibrary::_get_asset_in_progress(int p
 	}
 
 	return nullptr;
-}
-
-void EditorAssetLibrary::_install_external_asset(String p_zip_path, String p_title) {
-	emit_signal(SNAME("install_asset"), p_zip_path, p_title);
 }
 
 void EditorAssetLibrary::_update_asset_items_columns() {

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -310,8 +310,6 @@ class EditorAssetLibrary : public PanelContainer {
 	void _repository_changed(int p_repository_id);
 	void _support_toggled(int p_support);
 
-	void _install_external_asset(String p_zip_path, String p_title);
-
 	int asset_items_column_width = 0;
 
 	void _update_asset_items_columns();

--- a/editor/plugins/color_channel_selector.cpp
+++ b/editor/plugins/color_channel_selector.cpp
@@ -134,13 +134,9 @@ void ColorChannelSelector::create_button(unsigned int p_channel_index, const Str
 	// Make it look similar to toolbar buttons.
 	button->set_theme_type_variation(SceneStringName(FlatButton));
 
-	button->connect(SceneStringName(toggled), callable_mp(this, &ColorChannelSelector::on_channel_button_toggled));
+	button->connect(SceneStringName(toggled), callable_sp(this, SNAME("selected_channels_changed")).unbind(1));
 	p_parent->add_child(button);
 	channel_buttons[p_channel_index] = button;
-}
-
-void ColorChannelSelector::on_toggled(bool p_pressed) {
-	panel->set_visible(p_pressed);
 }
 
 void ColorChannelSelector::_bind_methods() {

--- a/editor/plugins/color_channel_selector.h
+++ b/editor/plugins/color_channel_selector.h
@@ -52,7 +52,6 @@ private:
 
 	void on_channel_button_toggled(bool p_unused_pressed);
 	void create_button(unsigned int p_channel_index, const String &p_text, Control *p_parent);
-	void on_toggled(bool p_pressed);
 
 	static void _bind_methods();
 

--- a/editor/plugins/editor_debugger_plugin.cpp
+++ b/editor/plugins/editor_debugger_plugin.cpp
@@ -40,14 +40,6 @@ void EditorDebuggerSession::_breaked(bool p_really_did, bool p_can_debug, const 
 	}
 }
 
-void EditorDebuggerSession::_started() {
-	emit_signal(SNAME("started"));
-}
-
-void EditorDebuggerSession::_stopped() {
-	emit_signal(SNAME("stopped"));
-}
-
 void EditorDebuggerSession::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("send_message", "message", "data"), &EditorDebuggerSession::send_message, DEFVAL(Array()));
 	ClassDB::bind_method(D_METHOD("toggle_profiler", "profiler", "enable", "data"), &EditorDebuggerSession::toggle_profiler, DEFVAL(Array()));
@@ -110,8 +102,8 @@ void EditorDebuggerSession::detach_debugger() {
 	if (!debugger) {
 		return;
 	}
-	debugger->disconnect("started", callable_mp(this, &EditorDebuggerSession::_started));
-	debugger->disconnect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
+	debugger->disconnect("started", callable_sp(this, SNAME("started")));
+	debugger->disconnect("stopped", callable_sp(this, SNAME("stopped")));
 	debugger->disconnect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
 	debugger->disconnect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away));
 	for (Control *tab : tabs) {
@@ -129,8 +121,8 @@ void EditorDebuggerSession::_debugger_gone_away() {
 EditorDebuggerSession::EditorDebuggerSession(ScriptEditorDebugger *p_debugger) {
 	ERR_FAIL_NULL(p_debugger);
 	debugger = p_debugger;
-	debugger->connect("started", callable_mp(this, &EditorDebuggerSession::_started));
-	debugger->connect("stopped", callable_mp(this, &EditorDebuggerSession::_stopped));
+	debugger->connect("started", callable_sp(this, SNAME("started")));
+	debugger->connect("stopped", callable_sp(this, SNAME("stopped")));
 	debugger->connect("breaked", callable_mp(this, &EditorDebuggerSession::_breaked));
 	debugger->connect(SceneStringName(tree_exited), callable_mp(this, &EditorDebuggerSession::_debugger_gone_away), CONNECT_ONE_SHOT);
 }

--- a/editor/plugins/editor_debugger_plugin.h
+++ b/editor/plugins/editor_debugger_plugin.h
@@ -43,8 +43,6 @@ private:
 	ScriptEditorDebugger *debugger = nullptr;
 
 	void _breaked(bool p_really_did, bool p_can_debug, const String &p_message, bool p_has_stackdump);
-	void _started();
-	void _stopped();
 	void _debugger_gone_away();
 
 protected:

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -567,21 +567,15 @@ void EditorPlugin::remove_resource_conversion_plugin(const Ref<EditorResourceCon
 	EditorNode::get_singleton()->remove_resource_conversion_plugin(p_plugin);
 }
 
-#ifndef DISABLE_DEPRECATED
-void EditorPlugin::_editor_project_settings_changed() {
-	emit_signal(SNAME("project_settings_changed"));
-}
-#endif
-
 void EditorPlugin::_notification(int p_what) {
 #ifndef DISABLE_DEPRECATED
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+			ProjectSettings::get_singleton()->connect("settings_changed", callable_sp(this, SNAME("project_settings_changed")));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			ProjectSettings::get_singleton()->disconnect("settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+			ProjectSettings::get_singleton()->disconnect("settings_changed", callable_sp(this, SNAME("project_settings_changed")));
 		} break;
 	}
 #endif

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -64,10 +64,6 @@ class EditorPlugin : public Node {
 	String last_main_screen_name;
 	String plugin_version;
 
-#ifndef DISABLE_DEPRECATED
-	void _editor_project_settings_changed();
-#endif
-
 public:
 	enum CustomControlContainer {
 		CONTAINER_TOOLBAR,

--- a/editor/plugins/font_config_plugin.cpp
+++ b/editor/plugins/font_config_plugin.cpp
@@ -214,10 +214,6 @@ void EditorPropertyFontMetaOverride::_add_lang(const String &p_locale) {
 	update_property();
 }
 
-void EditorPropertyFontMetaOverride::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal(SNAME("object_id_selected"), p_property, p_id);
-}
-
 void EditorPropertyFontMetaOverride::update_property() {
 	Variant updated_val = get_edited_property_value();
 
@@ -287,7 +283,7 @@ void EditorPropertyFontMetaOverride::update_property() {
 			prop->set_selectable(false);
 
 			prop->connect("property_changed", callable_mp(this, &EditorPropertyFontMetaOverride::_property_changed));
-			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyFontMetaOverride::_object_id_selected));
+			prop->connect("object_id_selected", callable_sp(this, SNAME("object_id_selected")));
 
 			HBoxContainer *hbox = memnew(HBoxContainer);
 			property_vbox->add_child(hbox);
@@ -387,10 +383,6 @@ void EditorPropertyOTVariation::_property_changed(const String &p_property, cons
 		dict = dict.duplicate(); // Duplicate, so undo/redo works better.
 		object->set_dict(dict);
 	}
-}
-
-void EditorPropertyOTVariation::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
 void EditorPropertyOTVariation::update_property() {
@@ -494,7 +486,7 @@ void EditorPropertyOTVariation::update_property() {
 			prop->set_selectable(false);
 
 			prop->connect("property_changed", callable_mp(this, &EditorPropertyOTVariation::_property_changed));
-			prop->connect("object_id_selected", callable_mp(this, &EditorPropertyOTVariation::_object_id_selected));
+			prop->connect("object_id_selected", callable_sp(this, SNAME("object_id_selected")));
 
 			property_vbox->add_child(prop);
 
@@ -601,10 +593,6 @@ void EditorPropertyOTFeatures::_add_feature(int p_option) {
 	dict = dict.duplicate(); // Duplicate, so undo/redo works better.
 	object->set_dict(dict);
 	update_property();
-}
-
-void EditorPropertyOTFeatures::_object_id_selected(const StringName &p_property, ObjectID p_id) {
-	emit_signal(SNAME("object_id_selected"), p_property, p_id);
 }
 
 void EditorPropertyOTFeatures::update_property() {
@@ -783,7 +771,7 @@ void EditorPropertyOTFeatures::update_property() {
 				prop->set_selectable(false);
 
 				prop->connect("property_changed", callable_mp(this, &EditorPropertyOTFeatures::_property_changed));
-				prop->connect("object_id_selected", callable_mp(this, &EditorPropertyOTFeatures::_object_id_selected));
+				prop->connect("object_id_selected", callable_sp(this, SNAME("object_id_selected")));
 
 				HBoxContainer *hbox = memnew(HBoxContainer);
 				property_vbox->add_child(hbox);

--- a/editor/plugins/font_config_plugin.h
+++ b/editor/plugins/font_config_plugin.h
@@ -106,7 +106,6 @@ protected:
 	void _add_menu();
 	void _add_script(int p_option);
 	void _add_lang(const String &p_locale);
-	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
 public:
 	virtual void update_property() override;
@@ -137,7 +136,6 @@ protected:
 	void _edit_pressed();
 	void _page_changed(int p_page);
 	void _property_changed(const String &p_property, const Variant &p_value, const String &p_name = "", bool p_changing = false);
-	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
 public:
 	virtual void update_property() override;
@@ -189,7 +187,6 @@ protected:
 	void _remove(Object *p_button, int p_key);
 	void _add_menu();
 	void _add_feature(int p_option);
-	void _object_id_selected(const StringName &p_property, ObjectID p_id);
 
 public:
 	virtual void update_property() override;

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -188,14 +188,6 @@ void ProjectListItemControl::_accessibility_action_blur(const Variant &p_data) {
 	}
 }
 
-void ProjectListItemControl::_favorite_button_pressed() {
-	emit_signal(SNAME("favorite_pressed"));
-}
-
-void ProjectListItemControl::_explore_button_pressed() {
-	emit_signal(SNAME("explore_pressed"));
-}
-
 void ProjectListItemControl::set_project_title(const String &p_title) {
 	project_title->set_text(p_title);
 	project_title->set_accessibility_name(TTRC("Project Name"));
@@ -337,7 +329,7 @@ ProjectListItemControl::ProjectListItemControl() {
 	// This makes the project's "hover" style display correctly when hovering the favorite icon.
 	favorite_button->set_mouse_filter(MOUSE_FILTER_PASS);
 	favorite_box->add_child(favorite_button);
-	favorite_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectListItemControl::_favorite_button_pressed));
+	favorite_button->connect(SceneStringName(pressed), callable_sp(this, SNAME("favorite_pressed")));
 
 	project_icon = memnew(TextureRect);
 	project_icon->set_name("ProjectIcon");
@@ -386,7 +378,7 @@ ProjectListItemControl::ProjectListItemControl() {
 		explore_button->set_accessibility_name(TTRC("Open in file manager"));
 		explore_button->set_flat(true);
 		path_hb->add_child(explore_button);
-		explore_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectListItemControl::_explore_button_pressed));
+		explore_button->connect(SceneStringName(pressed), callable_sp(this, SNAME("explore_pressed")));
 
 		project_path = memnew(Label);
 		project_path->set_name("ProjectPath");

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -62,9 +62,6 @@ class ProjectListItemControl : public HBoxContainer {
 	bool is_selected = false;
 	bool is_hovering = false;
 
-	void _favorite_button_pressed();
-	void _explore_button_pressed();
-
 	ProjectList *get_list() const;
 
 	void _accessibility_action_open(const Variant &p_data);

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -222,13 +222,9 @@ void QuickSettingsDialog::_set_setting_value(const String &p_setting, const Vari
 				ed_swap_cancel_ok = DisplayServer::get_singleton()->get_swap_cancel_ok() ? 2 : 1;
 			}
 			restart_required_button = add_button(TTRC("Restart Now"), ed_swap_cancel_ok != 2);
-			restart_required_button->connect(SceneStringName(pressed), callable_mp(this, &QuickSettingsDialog::_request_restart));
+			restart_required_button->connect(SceneStringName(pressed), callable_sp(this, SNAME("restart_required")));
 		}
 	}
-}
-
-void QuickSettingsDialog::_request_restart() {
-	emit_signal("restart_required");
 }
 
 void QuickSettingsDialog::update_size_limits(const Size2 &p_max_popup_size) {

--- a/editor/project_manager/quick_settings_dialog.h
+++ b/editor/project_manager/quick_settings_dialog.h
@@ -85,8 +85,6 @@ class QuickSettingsDialog : public AcceptDialog {
 	Label *restart_required_label = nullptr;
 	Button *restart_required_button = nullptr;
 
-	void _request_restart();
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/window_wrapper.cpp
+++ b/editor/window_wrapper.cpp
@@ -131,10 +131,6 @@ void WindowWrapper::_set_window_rect(const Rect2 p_rect) {
 	}
 }
 
-void WindowWrapper::_window_size_changed() {
-	emit_signal(SNAME("window_size_changed"));
-}
-
 void WindowWrapper::_window_close_request() {
 	if (override_close_request) {
 		emit_signal("window_close_requested");
@@ -369,7 +365,7 @@ WindowWrapper::WindowWrapper() {
 	window->hide();
 
 	window->connect("close_requested", callable_mp(this, &WindowWrapper::_window_close_request));
-	window->connect("size_changed", callable_mp(this, &WindowWrapper::_window_size_changed));
+	window->connect("size_changed", callable_sp(this, SNAME("window_size_changed")));
 
 	ShortcutBin *capturer = memnew(ShortcutBin);
 	window->add_child(capturer);

--- a/editor/window_wrapper.h
+++ b/editor/window_wrapper.h
@@ -56,7 +56,6 @@ class WindowWrapper : public MarginContainer {
 
 	void _set_window_enabled_with_rect(bool p_visible, const Rect2 p_rect);
 	void _set_window_rect(const Rect2 p_rect);
-	void _window_size_changed();
 	void _window_close_request();
 
 protected:

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -47,10 +47,6 @@ bool MultiplayerEditorDebugger::has_capture(const String &p_capture) const {
 	return p_capture == "multiplayer";
 }
 
-void MultiplayerEditorDebugger::_open_request(const String &p_path) {
-	emit_signal("open_request", p_path);
-}
-
 bool MultiplayerEditorDebugger::capture(const String &p_message, const Array &p_data, int p_session) {
 	ERR_FAIL_COND_V(!profilers.has(p_session), false);
 	EditorNetworkProfiler *profiler = profilers[p_session];
@@ -104,7 +100,7 @@ void MultiplayerEditorDebugger::setup_session(int p_session_id) {
 	ERR_FAIL_COND(session.is_null());
 	EditorNetworkProfiler *profiler = memnew(EditorNetworkProfiler);
 	profiler->connect("enable_profiling", callable_mp(this, &MultiplayerEditorDebugger::_profiler_activate).bind(p_session_id));
-	profiler->connect("open_request", callable_mp(this, &MultiplayerEditorDebugger::_open_request));
+	profiler->connect(SNAME("open_request"), callable_sp(this, SNAME("open_request")));
 	profiler->set_name(TTR("Network Profiler"));
 	session->connect("started", callable_mp(profiler, &EditorNetworkProfiler::started));
 	session->connect("stopped", callable_mp(profiler, &EditorNetworkProfiler::stopped));

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.h
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.h
@@ -40,7 +40,6 @@ class MultiplayerEditorDebugger : public EditorDebuggerPlugin {
 private:
 	HashMap<int, EditorNetworkProfiler *> profilers;
 
-	void _open_request(const String &p_path);
 	void _profiler_activate(bool p_enable, int p_session_id);
 
 protected:

--- a/modules/openxr/editor/openxr_action_editor.cpp
+++ b/modules/openxr/editor/openxr_action_editor.cpp
@@ -121,10 +121,6 @@ void OpenXRActionEditor::_do_set_action_type(OpenXRAction::ActionType p_action_t
 	action_type_button->select(int(action->get_action_type()));
 }
 
-void OpenXRActionEditor::_on_remove_action() {
-	emit_signal("remove", this);
-}
-
 OpenXRActionEditor::OpenXRActionEditor(Ref<OpenXRAction> p_action) {
 	undo_redo = EditorUndoRedoManager::get_singleton();
 	action = p_action;
@@ -166,7 +162,7 @@ OpenXRActionEditor::OpenXRActionEditor(Ref<OpenXRAction> p_action) {
 	rem_action = memnew(Button);
 	rem_action->set_tooltip_text(TTR("Remove action"));
 	rem_action->set_accessibility_name(TTRC("Remove action"));
-	rem_action->connect(SceneStringName(pressed), callable_mp(this, &OpenXRActionEditor::_on_remove_action));
+	rem_action->connect(SceneStringName(pressed), callable_sp(this, SNAME("remove")).bind(this));
 	rem_action->set_flat(true);
 	add_child(rem_action);
 }

--- a/modules/openxr/editor/openxr_action_editor.h
+++ b/modules/openxr/editor/openxr_action_editor.h
@@ -55,7 +55,6 @@ private:
 	void _on_action_name_changed(const String p_new_text);
 	void _on_action_localized_name_changed(const String p_new_text);
 	void _on_item_selected(int p_idx);
-	void _on_remove_action();
 
 protected:
 	static void _bind_methods();

--- a/modules/openxr/editor/openxr_action_set_editor.cpp
+++ b/modules/openxr/editor/openxr_action_set_editor.cpp
@@ -170,10 +170,6 @@ void OpenXRActionSetEditor::_on_add_action() {
 	// TODO handle focus
 }
 
-void OpenXRActionSetEditor::_on_remove_action_set() {
-	emit_signal("remove", this);
-}
-
 void OpenXRActionSetEditor::_on_remove_action(Object *p_action_editor) {
 	OpenXRActionEditor *action_editor = Object::cast_to<OpenXRActionEditor>(p_action_editor);
 	ERR_FAIL_NULL(action_editor);
@@ -285,7 +281,7 @@ OpenXRActionSetEditor::OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, 
 
 	rem_action_set = memnew(Button);
 	rem_action_set->set_tooltip_text(TTR("Remove action set."));
-	rem_action_set->connect(SceneStringName(pressed), callable_mp(this, &OpenXRActionSetEditor::_on_remove_action_set));
+	rem_action_set->connect(SceneStringName(pressed), callable_sp(this, SNAME("remove")).bind(this));
 	rem_action_set->set_accessibility_name(TTRC("Remove"));
 	rem_action_set->set_flat(true);
 	action_set_hb->add_child(rem_action_set);

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -71,7 +71,6 @@ private:
 	void _on_action_set_localized_name_changed(const String p_new_text);
 	void _on_action_set_priority_changed(const double p_new_value);
 	void _on_add_action();
-	void _on_remove_action_set();
 
 	void _on_remove_action(Object *p_action_editor);
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1925,10 +1925,6 @@ void TileMapLayer::_tile_set_changed() {
 	emit_signal(CoreStringName(changed));
 }
 
-void TileMapLayer::_renamed() {
-	emit_signal(CoreStringName(changed));
-}
-
 void TileMapLayer::_update_notify_local_transform() {
 	bool notify = is_using_kinematic_bodies() || is_y_sort_enabled();
 	if (!notify) {
@@ -2044,7 +2040,7 @@ void TileMapLayer::_physics_interpolated_changed() {
 void TileMapLayer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
-			connect(SNAME("renamed"), callable_mp(this, &TileMapLayer::_renamed));
+			connect(SNAME("renamed"), callable_sp(this, CoreStringName(changed)));
 			break;
 		}
 		case NOTIFICATION_ENTER_TREE: {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -482,7 +482,6 @@ private:
 
 	void _tile_set_changed();
 
-	void _renamed();
 	void _update_notify_local_transform();
 
 	// Internal updates.

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -531,45 +531,25 @@ void XRController3D::_bind_tracker() {
 	XRNode3D::_bind_tracker();
 	if (tracker.is_valid()) {
 		// bind to input signals
-		tracker->connect("button_pressed", callable_mp(this, &XRController3D::_button_pressed));
-		tracker->connect("button_released", callable_mp(this, &XRController3D::_button_released));
-		tracker->connect("input_float_changed", callable_mp(this, &XRController3D::_input_float_changed));
-		tracker->connect("input_vector2_changed", callable_mp(this, &XRController3D::_input_vector2_changed));
-		tracker->connect("profile_changed", callable_mp(this, &XRController3D::_profile_changed));
+		tracker->connect(SNAME("button_pressed"), callable_sp(this, SNAME("button_pressed")));
+		tracker->connect(SNAME("input_float_changed"), callable_sp(this, SNAME("input_float_changed")));
+		tracker->connect(SNAME("button_released"), callable_sp(this, SNAME("button_released")));
+		tracker->connect(SNAME("input_vector2_changed"), callable_sp(this, SNAME("input_vector2_changed")));
+		tracker->connect(SNAME("profile_changed"), callable_sp(this, SNAME("profile_changed")));
 	}
 }
 
 void XRController3D::_unbind_tracker() {
 	if (tracker.is_valid()) {
 		// unbind input signals
-		tracker->disconnect("button_pressed", callable_mp(this, &XRController3D::_button_pressed));
-		tracker->disconnect("button_released", callable_mp(this, &XRController3D::_button_released));
-		tracker->disconnect("input_float_changed", callable_mp(this, &XRController3D::_input_float_changed));
-		tracker->disconnect("input_vector2_changed", callable_mp(this, &XRController3D::_input_vector2_changed));
-		tracker->disconnect("profile_changed", callable_mp(this, &XRController3D::_profile_changed));
+		tracker->disconnect(SNAME("button_pressed"), callable_sp(this, SNAME("button_pressed")));
+		tracker->disconnect(SNAME("button_released"), callable_sp(this, SNAME("button_released")));
+		tracker->disconnect(SNAME("input_float_changed"), callable_sp(this, SNAME("input_float_changed")));
+		tracker->disconnect(SNAME("input_vector2_changed"), callable_sp(this, SNAME("input_vector2_changed")));
+		tracker->disconnect(SNAME("profile_changed"), callable_sp(this, SNAME("profile_changed")));
 	}
 
 	XRNode3D::_unbind_tracker();
-}
-
-void XRController3D::_button_pressed(const String &p_name) {
-	emit_signal(SNAME("button_pressed"), p_name);
-}
-
-void XRController3D::_button_released(const String &p_name) {
-	emit_signal(SNAME("button_released"), p_name);
-}
-
-void XRController3D::_input_float_changed(const String &p_name, float p_value) {
-	emit_signal(SNAME("input_float_changed"), p_name, p_value);
-}
-
-void XRController3D::_input_vector2_changed(const String &p_name, Vector2 p_value) {
-	emit_signal(SNAME("input_vector2_changed"), p_name, p_value);
-}
-
-void XRController3D::_profile_changed(const String &p_role) {
-	emit_signal(SNAME("profile_changed"), p_role);
 }
 
 bool XRController3D::is_button_pressed(const StringName &p_name) const {

--- a/scene/3d/xr/xr_nodes.h
+++ b/scene/3d/xr/xr_nodes.h
@@ -138,12 +138,6 @@ protected:
 	virtual void _bind_tracker() override;
 	virtual void _unbind_tracker() override;
 
-	void _button_pressed(const String &p_name);
-	void _button_released(const String &p_name);
-	void _input_float_changed(const String &p_name, float p_value);
-	void _input_vector2_changed(const String &p_name, Vector2 p_value);
-	void _profile_changed(const String &p_role);
-
 public:
 	bool is_button_pressed(const StringName &p_name) const;
 	Variant get_input(const StringName &p_name) const;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -497,14 +497,6 @@ void TabContainer::move_tab_from_tab_container(TabContainer *p_from, int p_from_
 	}
 }
 
-void TabContainer::_on_tab_clicked(int p_tab) {
-	emit_signal(SNAME("tab_clicked"), p_tab);
-}
-
-void TabContainer::_on_tab_hovered(int p_tab) {
-	emit_signal(SNAME("tab_hovered"), p_tab);
-}
-
 void TabContainer::_on_tab_changed(int p_tab) {
 	callable_mp(this, &TabContainer::_repaint).call_deferred();
 	queue_redraw();
@@ -518,14 +510,6 @@ void TabContainer::_on_tab_selected(int p_tab) {
 	}
 
 	emit_signal(SNAME("tab_selected"), p_tab);
-}
-
-void TabContainer::_on_tab_button_pressed(int p_tab) {
-	emit_signal(SNAME("tab_button_pressed"), p_tab);
-}
-
-void TabContainer::_on_active_tab_rearranged(int p_tab) {
-	emit_signal(SNAME("active_tab_rearranged"), p_tab);
 }
 
 void TabContainer::_on_tab_visibility_changed(Control *p_child) {
@@ -1178,11 +1162,11 @@ TabContainer::TabContainer() {
 	tab_bar->set_use_parent_material(true);
 	tab_bar->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
 	tab_bar->connect("tab_changed", callable_mp(this, &TabContainer::_on_tab_changed));
-	tab_bar->connect("tab_clicked", callable_mp(this, &TabContainer::_on_tab_clicked));
-	tab_bar->connect("tab_hovered", callable_mp(this, &TabContainer::_on_tab_hovered));
+	tab_bar->connect("tab_clicked", callable_sp(this, SNAME("tab_clicked")));
+	tab_bar->connect("tab_hovered", callable_sp(this, SNAME("tab_hovered")));
 	tab_bar->connect("tab_selected", callable_mp(this, &TabContainer::_on_tab_selected));
-	tab_bar->connect("tab_button_pressed", callable_mp(this, &TabContainer::_on_tab_button_pressed));
-	tab_bar->connect("active_tab_rearranged", callable_mp(this, &TabContainer::_on_active_tab_rearranged));
+	tab_bar->connect("tab_button_pressed", callable_sp(this, SNAME("tab_button_pressed")));
+	tab_bar->connect("active_tab_rearranged", callable_sp(this, SNAME("active_tab_rearranged")));
 
 	connect(SceneStringName(mouse_exited), callable_mp(this, &TabContainer::_on_mouse_exited));
 }

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -109,11 +109,7 @@ private:
 	void _update_margins();
 	void _on_mouse_exited();
 	void _on_tab_changed(int p_tab);
-	void _on_tab_clicked(int p_tab);
-	void _on_tab_hovered(int p_tab);
 	void _on_tab_selected(int p_tab);
-	void _on_tab_button_pressed(int p_tab);
-	void _on_active_tab_rearranged(int p_tab);
 	void _on_tab_visibility_changed(Control *p_child);
 
 	Variant _get_drag_data_fw(const Point2 &p_point, Control *p_from_control);

--- a/scene/main/status_indicator.cpp
+++ b/scene/main/status_indicator.cpp
@@ -44,7 +44,7 @@ void StatusIndicator::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_STATUS_INDICATOR)) {
 				if (visible && iid == DisplayServer::INVALID_INDICATOR_ID) {
-					iid = DisplayServer::get_singleton()->create_status_indicator(icon, tooltip, callable_mp(this, &StatusIndicator::_callback));
+					iid = DisplayServer::get_singleton()->create_status_indicator(icon, tooltip, callable_sp(this, SceneStringName(pressed)));
 					PopupMenu *pm = Object::cast_to<PopupMenu>(get_node_or_null(menu));
 					if (pm) {
 						RID menu_rid = pm->bind_global_menu();
@@ -88,10 +88,6 @@ void StatusIndicator::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_icon", "get_icon");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "menu", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "PopupMenu"), "set_menu", "get_menu");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "visible"), "set_visible", "is_visible");
-}
-
-void StatusIndicator::_callback(MouseButton p_index, const Point2i &p_pos) {
-	emit_signal(SceneStringName(pressed), p_index, p_pos);
 }
 
 void StatusIndicator::set_icon(const Ref<Texture2D> &p_icon) {
@@ -161,7 +157,7 @@ void StatusIndicator::set_visible(bool p_visible) {
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_STATUS_INDICATOR)) {
 		if (visible && iid == DisplayServer::INVALID_INDICATOR_ID) {
-			iid = DisplayServer::get_singleton()->create_status_indicator(icon, tooltip, callable_mp(this, &StatusIndicator::_callback));
+			iid = DisplayServer::get_singleton()->create_status_indicator(icon, tooltip, callable_sp(this, SceneStringName(pressed)));
 			PopupMenu *pm = Object::cast_to<PopupMenu>(get_node_or_null(menu));
 			if (pm) {
 				RID menu_rid = pm->bind_global_menu();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1325,7 +1325,7 @@ void Window::_update_window_callbacks() {
 	DisplayServer::get_singleton()->window_set_window_event_callback(callable_mp(this, &Window::_event_callback), window_id);
 	DisplayServer::get_singleton()->window_set_input_event_callback(callable_mp(this, &Window::_window_input), window_id);
 	DisplayServer::get_singleton()->window_set_input_text_callback(callable_mp(this, &Window::_window_input_text), window_id);
-	DisplayServer::get_singleton()->window_set_drop_files_callback(callable_mp(this, &Window::_window_drop_files), window_id);
+	DisplayServer::get_singleton()->window_set_drop_files_callback(callable_sp(this, SNAME("files_dropped")), window_id);
 }
 
 void Window::set_force_native(bool p_force_native) {
@@ -1801,10 +1801,6 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 
 void Window::_window_input_text(const String &p_text) {
 	push_text_input(p_text);
-}
-
-void Window::_window_drop_files(const Vector<String> &p_files) {
-	emit_signal(SNAME("files_dropped"), p_files);
 }
 
 Viewport *Window::get_parent_viewport() const {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -243,7 +243,6 @@ private:
 
 	void _window_input(const Ref<InputEvent> &p_ev);
 	void _window_input_text(const String &p_text);
-	void _window_drop_files(const Vector<String> &p_files);
 	void _rect_changed_callback(const Rect2i &p_callback);
 	void _event_callback(DisplayServer::WindowEvent p_event);
 	virtual bool _can_consume_input_events() const override;

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -49,13 +49,13 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
 
 	if (animations.has(p_name)) {
-		animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+		animations.get(p_name)->disconnect_changed(callable_sp(this, SceneStringName(animation_changed)));
 		animations.erase(p_name);
 		emit_signal(SNAME("animation_removed"), p_name);
 	}
 
 	animations.insert(p_name, p_animation);
-	animations.get(p_name)->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_name));
+	animations.get(p_name)->connect_changed(callable_sp(this, SceneStringName(animation_changed)).bind(p_name));
 	emit_signal(SNAME("animation_added"), p_name);
 	notify_property_list_changed();
 	return OK;
@@ -64,7 +64,7 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 void AnimationLibrary::remove_animation(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!animations.has(p_name), vformat("Animation not found: %s.", p_name));
 
-	animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+	animations.get(p_name)->disconnect_changed(callable_sp(this, SceneStringName(animation_changed)));
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_removed"), p_name);
 	notify_property_list_changed();
@@ -75,8 +75,8 @@ void AnimationLibrary::rename_animation(const StringName &p_name, const StringNa
 	ERR_FAIL_COND_MSG(!is_valid_animation_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
 	ERR_FAIL_COND_MSG(animations.has(p_new_name), vformat("Animation name \"%s\" already exists in library.", p_new_name));
 
-	animations.get(p_name)->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
-	animations.get(p_name)->connect_changed(callable_mp(this, &AnimationLibrary::_animation_changed).bind(p_new_name));
+	animations.get(p_name)->disconnect_changed(callable_sp(this, SceneStringName(animation_changed)));
+	animations.get(p_name)->connect_changed(callable_sp(this, SceneStringName(animation_changed)).bind(p_new_name));
 	animations.insert(p_new_name, animations[p_name]);
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_renamed"), p_name, p_new_name);
@@ -102,10 +102,6 @@ TypedArray<StringName> AnimationLibrary::_get_animation_list() const {
 	return ret;
 }
 
-void AnimationLibrary::_animation_changed(const StringName &p_name) {
-	emit_signal(SceneStringName(animation_changed), p_name);
-}
-
 void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const {
 	List<StringName> anims;
 
@@ -126,7 +122,7 @@ int AnimationLibrary::get_animation_list_size() const {
 
 void AnimationLibrary::_set_data(const Dictionary &p_data) {
 	for (KeyValue<StringName, Ref<Animation>> &K : animations) {
-		K.value->disconnect_changed(callable_mp(this, &AnimationLibrary::_animation_changed));
+		K.value->disconnect_changed(callable_sp(this, SceneStringName(animation_changed)));
 	}
 	animations.clear();
 	for (const KeyValue<Variant, Variant> &kv : p_data) {

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -41,8 +41,6 @@ class AnimationLibrary : public Resource {
 
 	TypedArray<StringName> _get_animation_list() const;
 
-	void _animation_changed(const StringName &p_name);
-
 	friend class AnimationMixer; // For faster access.
 	HashMap<StringName, Ref<Animation>> animations;
 


### PR DESCRIPTION
Related: #36393

Currently, in order to connect signals to other signals using C++ code, a dedicated boilerplate method is needed to perform the forwarding. This adds code and makes it harder to read as the method name is not necessarily related to the function of how it re-emits the signal.

This PR introduces the `callable_sp` macro as an alternative to `callable_mp` that is able to bundle the re-emit into callable form, so it is able to be used to connect to other signals and anywhere that a callable is needed in core, like for callbacks. The use of this macro eliminates the need for the helper functions and removes several hundred lines of code in total, while also increasing readability.

Since every object inherits from Object, using this macro does not need to include any casts, objects can be provided as-is.