### PR TITLE
Add module defines to the per-platform generated props file so VS knows which ones are enabled.

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -1293,6 +1293,11 @@ def generate_vs_project(env, original_args, project_name="godot"):
             )
         output = os.path.join("bin", f"godot{env['PROGSUFFIX']}")
 
+        # The modules_enabled.gen.h header containing the defines is only generated on build, and only for the most recently built
+        # platform, which means VS can't properly render code that's inside module-specific ifdefs. This adds those defines to the
+        # platform-specific VS props file, so that VS knows which defines are enabled for the selected platform.
+        env.Append(VSHINT_DEFINES=[f"MODULE_{module.upper()}_ENABLED" for module in env.module_list])
+
         with open("misc/msvs/props.template", "r", encoding="utf-8") as file:
             props_template = file.read()
 


### PR DESCRIPTION
The `modules_enabled.gen.h` header containing the defines for the enabled modules is only generated on build, not during VS project generation, and it only reflects the list of modules enabled for the target and platform that was built most recently. That means that when you generate a project the first time, any code inside `#ifdef MODULE_XXX_ENABLED` will be shown as disabled, even if that module is actually enabled in the build, since the header doesn't exist yet. Additionally, if you generate the VS project with multiple targets and platforms, code inside `MODULE_XXX_ENABLED` conditions won't show up properly if the selected VS configuration doesn't match the most recent build target+platform combo, since the header only reflects the modules enabled on the latest build configuration.

This adds those defines to the `VSHINT_DEFINES` array, which goes into the `NMakePreprocessorDefinitions` property of per-platform generated props file that the project includes. This way, VS will have a better idea of the defines that are available and wil be able to render more better.

It's not a 100% accurate solution, because the generated header is still loaded and the list in it might not match the currently selected VS configuration. But, at least this guarantees that all modules that are enabled in the currently selected VS configuration will have their defines available to VS, making the code view more accurate.

/cc @akien-mga @Repiteo 