### PR TITLE
GDScript: Replace `abstract` keyword with `@abstract` annotation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -295,6 +295,27 @@
 		</constant>
 	</constants>
 	<annotations>
+		<annotation name="@abstract">
+			<return type="void" />
+			<description>
+				Marks a class or a method as abstract.
+				An abstract class is a class that cannot be instantiated directly. Instead, it is meant to be subclassed by other classes. Attempting to instantiate an abstract class will result in an error.
+				An abstract method is a non-static member function that has no implementation. An abstract function has no body; instead, a newline or semicolon is expected after the function header. An abstract method defines an interface that subclasses must conform to, because the method signature must be compatible when overriding a base class method.
+				If a class has at least one unimplemented abstract method (either its own or inherited), then it must also be declared abstract. However, the reverse is not true; an abstract class may have no abstract methods.
+				[codeblock]
+				@abstract class Shape:
+					@abstract func draw()
+
+				class Circle extends Shape:
+					func draw():
+						print("Drawing a circle.")
+
+				class Square extends Shape:
+					func draw():
+						print("Drawing a square.")
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@export">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2749,7 +2749,6 @@ Vector<String> GDScriptLanguage::get_reserved_words() const {
 		"when",
 		"while",
 		// Declarations.
-		"abstract",
 		"class",
 		"class_name",
 		"const",
@@ -2915,7 +2914,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 		*r_icon_path = c->simplified_icon_path;
 	}
 	if (r_is_abstract) {
-		*r_is_abstract = false;
+		*r_is_abstract = c->is_abstract;
 	}
 	if (r_is_tool) {
 		*r_is_tool = parser.is_tool();

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1540,7 +1540,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 					if (member.function->is_abstract) {
 						if (base_class == p_class) {
 							const String class_name = p_class->identifier == nullptr ? p_class->fqcn.get_file() : String(p_class->identifier->name);
-							push_error(vformat(R"*(Class "%s" is not abstract but contains abstract methods. Mark the class as abstract or remove "abstract" from all methods in this class.)*", class_name), p_class);
+							push_error(vformat(R"*(Class "%s" is not abstract but contains abstract methods. Mark the class as abstract or remove "@abstract" from all methods in this class.)*", class_name), p_class);
 							break;
 						} else if (!implemented_funcs.has(member.function->identifier->name)) {
 							const String class_name = p_class->identifier == nullptr ? p_class->fqcn.get_file() : String(p_class->identifier->name);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1523,7 +1523,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	static const char *_keywords_with_space[] = {
 		"and", "not", "or", "in", "as", "class", "class_name", "extends", "is", "func", "signal", "await",
-		"const", "enum", "abstract", "static", "var", "if", "elif", "else", "for", "match", "when", "while",
+		"const", "enum", "static", "var", "if", "elif", "else", "for", "match", "when", "while",
 		nullptr
 	};
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1506,14 +1506,14 @@ private:
 	ClassNode *parse_class(bool p_is_abstract, bool p_is_static);
 	void parse_class_name();
 	void parse_extends();
-	void parse_class_body(bool p_first_is_abstract, bool p_is_multiline);
+	void parse_class_body(bool p_is_multiline);
 	template <typename T>
-	void parse_class_member(T *(GDScriptParser::*p_parse_function)(bool, bool), AnnotationInfo::TargetKind p_target, const String &p_member_kind, bool p_is_abstract = false, bool p_is_static = false);
+	void parse_class_member(T *(GDScriptParser::*p_parse_function)(bool, bool), AnnotationInfo::TargetKind p_target, const String &p_member_kind, bool p_is_static = false);
 	SignalNode *parse_signal(bool p_is_abstract, bool p_is_static);
 	EnumNode *parse_enum(bool p_is_abstract, bool p_is_static);
 	ParameterNode *parse_parameter();
 	FunctionNode *parse_function(bool p_is_abstract, bool p_is_static);
-	void parse_function_signature(FunctionNode *p_function, SuiteNode *p_body, const String &p_type, int p_signature_start);
+	void parse_function_signature(FunctionNode *p_function, SuiteNode *p_body, bool p_is_abstract, const String &p_type, int p_signature_start);
 	SuiteNode *parse_suite(const String &p_context, SuiteNode *p_suite = nullptr, bool p_for_lambda = false);
 	// Annotations
 	AnnotationNode *parse_annotation(uint32_t p_valid_targets);
@@ -1523,6 +1523,7 @@ private:
 	bool tool_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -101,7 +101,6 @@ static const char *token_names[] = {
 	"match", // MATCH,
 	"when", // WHEN,
 	// Keywords
-	"abstract", // ABSTRACT,
 	"as", // AS,
 	"assert", // ASSERT,
 	"await", // AWAIT,
@@ -200,7 +199,6 @@ bool GDScriptTokenizer::Token::is_identifier() const {
 		case IDENTIFIER:
 		case MATCH: // Used in String.match().
 		case WHEN: // New keyword, avoid breaking existing code.
-		case ABSTRACT:
 		// Allow constants to be treated as regular identifiers.
 		case CONST_PI:
 		case CONST_INF:
@@ -216,7 +214,6 @@ bool GDScriptTokenizer::Token::is_node_name() const {
 	// This is meant to allow keywords with the $ notation, but not as general identifiers.
 	switch (type) {
 		case IDENTIFIER:
-		case ABSTRACT:
 		case AND:
 		case AS:
 		case ASSERT:
@@ -491,7 +488,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::annotation() {
 
 #define KEYWORDS(KEYWORD_GROUP, KEYWORD)     \
 	KEYWORD_GROUP('a')                       \
-	KEYWORD("abstract", Token::ABSTRACT)     \
 	KEYWORD("as", Token::AS)                 \
 	KEYWORD("and", Token::AND)               \
 	KEYWORD("assert", Token::ASSERT)         \

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -106,7 +106,6 @@ public:
 			MATCH,
 			WHEN,
 			// Keywords
-			ABSTRACT,
 			AS,
 			ASSERT,
 			AWAIT,

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.gd
@@ -1,15 +1,15 @@
-abstract class AbstractClass:
-	abstract func some_func()
+@abstract class AbstractClass:
+	@abstract func some_func()
 
 class ImplementedClass extends AbstractClass:
 	func some_func():
 		pass
 
-abstract class AbstractClassAgain extends ImplementedClass:
-	abstract func some_func()
+@abstract class AbstractClassAgain extends ImplementedClass:
+	@abstract func some_func()
 
 class Test1:
-	abstract func some_func()
+	@abstract func some_func()
 
 class Test2 extends AbstractClass:
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.out
@@ -1,5 +1,5 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 11: Class "Test1" is not abstract but contains abstract methods. Mark the class as abstract or remove "abstract" from all methods in this class.
+>> ERROR at line 11: Class "Test1" is not abstract but contains abstract methods. Mark the class as abstract or remove "@abstract" from all methods in this class.
 >> ERROR at line 14: Class "Test2" must implement "AbstractClass.some_func()" and other inherited abstract methods or be marked as abstract.
 >> ERROR at line 17: Class "Test3" must implement "AbstractClassAgain.some_func()" and other inherited abstract methods or be marked as abstract.
 >> ERROR at line 22: Cannot call the parent class' abstract function "some_func()" because it hasn't been defined.

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.gd
@@ -2,7 +2,7 @@ extends RefCounted
 
 const AbstractScript = preload("./construct_abstract_script.notest.gd")
 
-abstract class AbstractClass:
+@abstract class AbstractClass:
 	pass
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.notest.gd
@@ -1,1 +1,1 @@
-abstract class_name AbstractScript
+@abstract class_name AbstractScript

--- a/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
@@ -8,7 +8,7 @@ class B extends A:
 class C extends CanvasItem:
 	pass
 
-abstract class X:
+@abstract class X:
 	pass
 
 class Y extends X:

--- a/modules/gdscript/tests/scripts/completion/common/override_function_abstract.gd
+++ b/modules/gdscript/tests/scripts/completion/common/override_function_abstract.gd
@@ -1,5 +1,5 @@
-abstract class A:
-	abstract func test(x: int) -> void
+@abstract class A:
+	@abstract func test(x: int) -> void
 
 class B extends A:
 	func ➡

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_func_with_body.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_func_with_body.gd
@@ -1,7 +1,7 @@
 extends RefCounted
 
-abstract class A:
-	abstract func f():
+@abstract class A:
+	@abstract func f():
 		pass
 
 func test():

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.gd
@@ -1,8 +1,8 @@
 extends RefCounted
 
-abstract class A:
+@abstract class A:
 	# Currently, an abstract function cannot be static.
-	abstract static func f()
+	@abstract static func f()
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.out
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-Expected "class" or "func" after "abstract".
+A static function cannot be marked as abstract.

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.gd
@@ -1,6 +1,6 @@
 extends RefCounted
 
-abstract abstract class A:
+@abstract @abstract class A:
 	pass
 
 func test():

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.out
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-Expected "class_name", "extends", "class", or "func" after "abstract".
+"@abstract" annotation can only be used once per class.

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.gd
@@ -1,7 +1,7 @@
 extends RefCounted
 
-abstract class A:
-	abstract abstract func f()
+@abstract class A:
+	@abstract @abstract func f()
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.out
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-Expected "class" or "func" after "abstract".
+"@abstract" annotation can only be used once per function.

--- a/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.gd
@@ -1,8 +1,0 @@
-extends RefCounted
-
-abstract class A:
-	# Currently, an abstract function cannot be static.
-	static abstract func f()
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.out
+++ b/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Expected "func" or "var" after "static".

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_methods.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_methods.gd
@@ -1,18 +1,18 @@
-abstract class A:
-	abstract func get_text_1() -> String
-	abstract func get_text_2() -> String
+@abstract class A:
+	@abstract func get_text_1() -> String
+	@abstract func get_text_2() -> String
 
 	# No `UNUSED_PARAMETER` warning.
-	abstract func func_with_param(param: int) -> int
-	abstract func func_with_rest_param(...args: Array) -> int
-	abstract func func_with_semicolon() -> int;
-	abstract func func_1() -> int; abstract func func_2() -> int
-	abstract func func_without_return_type()
+	@abstract func func_with_param(param: int) -> int
+	@abstract func func_with_rest_param(...args: Array) -> int
+	@abstract func func_with_semicolon() -> int;
+	@abstract func func_1() -> int; @abstract func func_2() -> int
+	@abstract func func_without_return_type()
 
 	func print_text_1() -> void:
 		print(get_text_1())
 
-abstract class B extends A:
+@abstract class B extends A:
 	func get_text_1() -> String:
 		return "text_1b"
 
@@ -30,8 +30,8 @@ class C extends B:
 	func func_2() -> int: return 0
 	func func_without_return_type(): pass
 
-abstract class D extends C:
-	abstract func get_text_1() -> String
+@abstract class D extends C:
+	@abstract func get_text_1() -> String
 
 	func get_text_2() -> String:
 		return super() + " text_2d"

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
@@ -2,9 +2,9 @@
 
 @warning_ignore_start("unused_signal")
 
-abstract class A:
-	abstract func test_abstract_func_1()
-	abstract func test_abstract_func_2()
+@abstract class A:
+	@abstract func test_abstract_func_1()
+	@abstract func test_abstract_func_2()
 	func test_override_func_1(): pass
 	func test_override_func_2(): pass
 

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.out
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.out
@@ -32,8 +32,8 @@ func test_override_func_1() -> void
 func test_override_func_2() -> void
 func test_func_b1() -> void
 func test_func_b2() -> void
-abstract func test_abstract_func_1() -> void
-abstract func test_abstract_func_2() -> void
+@abstract func test_abstract_func_1() -> void
+@abstract func test_abstract_func_2() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 --- C ---
@@ -53,8 +53,8 @@ func test_override_func_1() -> void
 func test_override_func_2() -> void
 func test_func_b1() -> void
 func test_func_b2() -> void
-abstract func test_abstract_func_1() -> void
-abstract func test_abstract_func_2() -> void
+@abstract func test_abstract_func_1() -> void
+@abstract func test_abstract_func_2() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 === Signals ===

--- a/modules/gdscript/tests/scripts/utils.notest.gd
+++ b/modules/gdscript/tests/scripts/utils.notest.gd
@@ -101,7 +101,7 @@ static func print_property_extended_info(property: Dictionary, base: Object = nu
 static func get_method_signature(method: Dictionary, is_signal: bool = false) -> String:
 	var result: String = ""
 	if method.flags & METHOD_FLAG_VIRTUAL_REQUIRED:
-		result += "abstract "
+		result += "@abstract "
 	if method.flags & METHOD_FLAG_STATIC:
 		result += "static "
 	result += ("signal " if is_signal else "func ") + method.name + "("


### PR DESCRIPTION
At a GDScript team meeting we came to the conclusion that modifiers should be annotations, not keywords. As for the existing `static`, this requires a separate discussion and PR.