### PR TITLE
GDScript: Replace `abstract` keyword with `@abstract` annotation

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -295,6 +295,27 @@
 		</constant>
 	</constants>
 	<annotations>
+		<annotation name="@abstract">
+			<return type="void" />
+			<description>
+				Marks a class or a method as abstract.
+				An abstract class is a class that cannot be instantiated directly. Instead, it is meant to be inherited by other classes. Attempting to instantiate an abstract class will result in an error.
+				An abstract method is a method that has no implementation. Therefore, a newline or a semicolon is expected after the function header. This defines a contract that inheriting classes must conform to, because the method signature must be compatible when overriding.
+				Inheriting classes must either provide implementations for all abstract methods, or the inheriting class must be marked as abstract. If a class has at least one abstract method (either its own or an unimplemented inherited one), then it must also be marked as abstract. However, the reverse is not true: an abstract class is allowed to have no abstract methods.
+				[codeblock]
+				@abstract class Shape:
+					@abstract func draw()
+
+				class Circle extends Shape:
+					func draw():
+						print("Drawing a circle.")
+
+				class Square extends Shape:
+					func draw():
+						print("Drawing a square.")
+				[/codeblock]
+			</description>
+		</annotation>
 		<annotation name="@export">
 			<return type="void" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2749,7 +2749,6 @@ Vector<String> GDScriptLanguage::get_reserved_words() const {
 		"when",
 		"while",
 		// Declarations.
-		"abstract",
 		"class",
 		"class_name",
 		"const",
@@ -2915,7 +2914,7 @@ String GDScriptLanguage::get_global_class_name(const String &p_path, String *r_b
 		*r_icon_path = c->simplified_icon_path;
 	}
 	if (r_is_abstract) {
-		*r_is_abstract = false;
+		*r_is_abstract = c->is_abstract;
 	}
 	if (r_is_tool) {
 		*r_is_tool = parser.is_tool();

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1523,7 +1523,7 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 
 	static const char *_keywords_with_space[] = {
 		"and", "not", "or", "in", "as", "class", "class_name", "extends", "is", "func", "signal", "await",
-		"const", "enum", "abstract", "static", "var", "if", "elif", "else", "for", "match", "when", "while",
+		"const", "enum", "static", "var", "if", "elif", "else", "for", "match", "when", "while",
 		nullptr
 	};
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1503,17 +1503,17 @@ private:
 
 	// Main blocks.
 	void parse_program();
-	ClassNode *parse_class(bool p_is_abstract, bool p_is_static);
+	ClassNode *parse_class(bool p_is_static);
 	void parse_class_name();
 	void parse_extends();
-	void parse_class_body(bool p_first_is_abstract, bool p_is_multiline);
+	void parse_class_body(bool p_is_multiline);
 	template <typename T>
-	void parse_class_member(T *(GDScriptParser::*p_parse_function)(bool, bool), AnnotationInfo::TargetKind p_target, const String &p_member_kind, bool p_is_abstract = false, bool p_is_static = false);
-	SignalNode *parse_signal(bool p_is_abstract, bool p_is_static);
-	EnumNode *parse_enum(bool p_is_abstract, bool p_is_static);
+	void parse_class_member(T *(GDScriptParser::*p_parse_function)(bool), AnnotationInfo::TargetKind p_target, const String &p_member_kind, bool p_is_static = false);
+	SignalNode *parse_signal(bool p_is_static);
+	EnumNode *parse_enum(bool p_is_static);
 	ParameterNode *parse_parameter();
-	FunctionNode *parse_function(bool p_is_abstract, bool p_is_static);
-	void parse_function_signature(FunctionNode *p_function, SuiteNode *p_body, const String &p_type, int p_signature_start);
+	FunctionNode *parse_function(bool p_is_static);
+	bool parse_function_signature(FunctionNode *p_function, SuiteNode *p_body, const String &p_type, int p_signature_start);
 	SuiteNode *parse_suite(const String &p_context, SuiteNode *p_suite = nullptr, bool p_for_lambda = false);
 	// Annotations
 	AnnotationNode *parse_annotation(uint32_t p_valid_targets);
@@ -1523,6 +1523,7 @@ private:
 	bool tool_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
@@ -1536,12 +1537,12 @@ private:
 	bool rpc_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	// Statements.
 	Node *parse_statement();
-	VariableNode *parse_variable(bool p_is_abstract, bool p_is_static);
-	VariableNode *parse_variable(bool p_is_abstract, bool p_is_static, bool p_allow_property);
+	VariableNode *parse_variable(bool p_is_static);
+	VariableNode *parse_variable(bool p_is_static, bool p_allow_property);
 	VariableNode *parse_property(VariableNode *p_variable, bool p_need_indent);
 	void parse_property_getter(VariableNode *p_variable);
 	void parse_property_setter(VariableNode *p_variable);
-	ConstantNode *parse_constant(bool p_is_abstract, bool p_is_static);
+	ConstantNode *parse_constant(bool p_is_static);
 	AssertNode *parse_assert();
 	BreakNode *parse_break();
 	ContinueNode *parse_continue();

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -101,7 +101,6 @@ static const char *token_names[] = {
 	"match", // MATCH,
 	"when", // WHEN,
 	// Keywords
-	"abstract", // ABSTRACT,
 	"as", // AS,
 	"assert", // ASSERT,
 	"await", // AWAIT,
@@ -200,7 +199,6 @@ bool GDScriptTokenizer::Token::is_identifier() const {
 		case IDENTIFIER:
 		case MATCH: // Used in String.match().
 		case WHEN: // New keyword, avoid breaking existing code.
-		case ABSTRACT:
 		// Allow constants to be treated as regular identifiers.
 		case CONST_PI:
 		case CONST_INF:
@@ -216,7 +214,6 @@ bool GDScriptTokenizer::Token::is_node_name() const {
 	// This is meant to allow keywords with the $ notation, but not as general identifiers.
 	switch (type) {
 		case IDENTIFIER:
-		case ABSTRACT:
 		case AND:
 		case AS:
 		case ASSERT:
@@ -491,7 +488,6 @@ GDScriptTokenizer::Token GDScriptTokenizerText::annotation() {
 
 #define KEYWORDS(KEYWORD_GROUP, KEYWORD)     \
 	KEYWORD_GROUP('a')                       \
-	KEYWORD("abstract", Token::ABSTRACT)     \
 	KEYWORD("as", Token::AS)                 \
 	KEYWORD("and", Token::AND)               \
 	KEYWORD("assert", Token::ASSERT)         \

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -106,7 +106,6 @@ public:
 			MATCH,
 			WHEN,
 			// Keywords
-			ABSTRACT,
 			AS,
 			ASSERT,
 			AWAIT,

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.gd
@@ -1,15 +1,15 @@
-abstract class AbstractClass:
-	abstract func some_func()
+@abstract class AbstractClass:
+	@abstract func some_func()
 
 class ImplementedClass extends AbstractClass:
 	func some_func():
 		pass
 
-abstract class AbstractClassAgain extends ImplementedClass:
-	abstract func some_func()
+@abstract class AbstractClassAgain extends ImplementedClass:
+	@abstract func some_func()
 
 class Test1:
-	abstract func some_func()
+	@abstract func some_func()
 
 class Test2 extends AbstractClass:
 	pass
@@ -23,6 +23,19 @@ class Test4 extends AbstractClass:
 
 	func other_func():
 		super.some_func()
+
+@abstract class A:
+	@abstract @abstract func abstract_dup()
+
+	# An abstract function cannot have a body.
+	@abstract func abstract_bodyful():
+		pass
+
+	# A static function cannot be marked as `@abstract`.
+	@abstract static func abstract_stat()
+
+@abstract @abstract class DuplicateAbstract:
+	pass
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.out
@@ -1,6 +1,11 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 11: Class "Test1" is not abstract but contains abstract methods. Mark the class as abstract or remove "abstract" from all methods in this class.
->> ERROR at line 14: Class "Test2" must implement "AbstractClass.some_func()" and other inherited abstract methods or be marked as abstract.
->> ERROR at line 17: Class "Test3" must implement "AbstractClassAgain.some_func()" and other inherited abstract methods or be marked as abstract.
+>> ERROR at line 37: "@abstract" annotation can only be used once per class.
+>> ERROR at line 28: "@abstract" annotation can only be used once per function.
+>> ERROR at line 35: "@abstract" annotation cannot be applied to static functions.
+>> ERROR at line 11: Class "Test1" is not abstract but contains abstract methods. Mark the class as "@abstract" or remove "@abstract" from all methods in this class.
+>> ERROR at line 14: Class "Test2" must implement "AbstractClass.some_func()" and other inherited abstract methods or be marked as "@abstract".
+>> ERROR at line 17: Class "Test3" must implement "AbstractClassAgain.some_func()" and other inherited abstract methods or be marked as "@abstract".
 >> ERROR at line 22: Cannot call the parent class' abstract function "some_func()" because it hasn't been defined.
 >> ERROR at line 25: Cannot call the parent class' abstract function "some_func()" because it hasn't been defined.
+>> ERROR at line 32: Abstract function cannot have a body.
+>> ERROR at line 35: A function must either have a ":" followed by a body, or be marked as "@abstract".

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_class.gd
@@ -2,7 +2,7 @@ extends RefCounted
 
 const AbstractScript = preload("./construct_abstract_script.notest.gd")
 
-abstract class AbstractClass:
+@abstract class AbstractClass:
 	pass
 
 func test():

--- a/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/construct_abstract_script.notest.gd
@@ -1,1 +1,1 @@
-abstract class_name AbstractScript
+@abstract class_name AbstractScript

--- a/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/extend_abstract_class.gd
@@ -8,7 +8,7 @@ class B extends A:
 class C extends CanvasItem:
 	pass
 
-abstract class X:
+@abstract class X:
 	pass
 
 class Y extends X:

--- a/modules/gdscript/tests/scripts/completion/common/override_function_abstract.gd
+++ b/modules/gdscript/tests/scripts/completion/common/override_function_abstract.gd
@@ -1,5 +1,5 @@
-abstract class A:
-	abstract func test(x: int) -> void
+@abstract class A:
+	@abstract func test(x: int) -> void
 
 class B extends A:
 	func ➡

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_func_with_body.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_func_with_body.gd
@@ -1,8 +1,0 @@
-extends RefCounted
-
-abstract class A:
-	abstract func f():
-		pass
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_func_with_body.out
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_func_with_body.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Expected end of statement after abstract function declaration, found ":" instead.

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.gd
@@ -1,8 +1,0 @@
-extends RefCounted
-
-abstract class A:
-	# Currently, an abstract function cannot be static.
-	abstract static func f()
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.out
+++ b/modules/gdscript/tests/scripts/parser/errors/abstract_static_func.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Expected "class" or "func" after "abstract".

--- a/modules/gdscript/tests/scripts/parser/errors/brace_syntax.out
+++ b/modules/gdscript/tests/scripts/parser/errors/brace_syntax.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-Expected ":" after function declaration.
+Expected end of statement after bodyless function declaration, found "{" instead.

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.gd
@@ -1,7 +1,0 @@
-extends RefCounted
-
-abstract abstract class A:
-	pass
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.out
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_class.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Expected "class_name", "extends", "class", or "func" after "abstract".

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.gd
@@ -1,7 +1,0 @@
-extends RefCounted
-
-abstract class A:
-	abstract abstract func f()
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.out
+++ b/modules/gdscript/tests/scripts/parser/errors/duplicate_abstract_func.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Expected "class" or "func" after "abstract".

--- a/modules/gdscript/tests/scripts/parser/errors/lambda_without_colon.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/lambda_without_colon.gd
@@ -1,0 +1,3 @@
+#           No colon --v
+var f = func () -> void
+	pass

--- a/modules/gdscript/tests/scripts/parser/errors/lambda_without_colon.out
+++ b/modules/gdscript/tests/scripts/parser/errors/lambda_without_colon.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Expected ":" after lambda declaration.

--- a/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.gd
@@ -1,8 +1,0 @@
-extends RefCounted
-
-abstract class A:
-	# Currently, an abstract function cannot be static.
-	static abstract func f()
-
-func test():
-	pass

--- a/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.out
+++ b/modules/gdscript/tests/scripts/parser/errors/static_abstract_func.out
@@ -1,2 +1,0 @@
-GDTEST_PARSER_ERROR
-Expected "func" or "var" after "static".

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_methods.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_methods.gd
@@ -1,18 +1,18 @@
-abstract class A:
-	abstract func get_text_1() -> String
-	abstract func get_text_2() -> String
+@abstract class A:
+	@abstract func get_text_1() -> String
+	@abstract func get_text_2() -> String
 
 	# No `UNUSED_PARAMETER` warning.
-	abstract func func_with_param(param: int) -> int
-	abstract func func_with_rest_param(...args: Array) -> int
-	abstract func func_with_semicolon() -> int;
-	abstract func func_1() -> int; abstract func func_2() -> int
-	abstract func func_without_return_type()
+	@abstract func func_with_param(param: int) -> int
+	@abstract func func_with_rest_param(...args: Array) -> int
+	@abstract func func_with_semicolon() -> int;
+	@abstract func func_1() -> int; @abstract func func_2() -> int
+	@abstract func func_without_return_type()
 
 	func print_text_1() -> void:
 		print(get_text_1())
 
-abstract class B extends A:
+@abstract class B extends A:
 	func get_text_1() -> String:
 		return "text_1b"
 
@@ -30,8 +30,8 @@ class C extends B:
 	func func_2() -> int: return 0
 	func func_without_return_type(): pass
 
-abstract class D extends C:
-	abstract func get_text_1() -> String
+@abstract class D extends C:
+	@abstract func get_text_1() -> String
 
 	func get_text_2() -> String:
 		return super() + " text_2d"

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
@@ -2,9 +2,9 @@
 
 @warning_ignore_start("unused_signal")
 
-abstract class A:
-	abstract func test_abstract_func_1()
-	abstract func test_abstract_func_2()
+@abstract class A:
+	@abstract func test_abstract_func_1()
+	@abstract func test_abstract_func_2()
 	func test_override_func_1(): pass
 	func test_override_func_2(): pass
 

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.out
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.out
@@ -32,8 +32,8 @@ func test_override_func_1() -> void
 func test_override_func_2() -> void
 func test_func_b1() -> void
 func test_func_b2() -> void
-abstract func test_abstract_func_1() -> void
-abstract func test_abstract_func_2() -> void
+@abstract func test_abstract_func_1() -> void
+@abstract func test_abstract_func_2() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 --- C ---
@@ -53,8 +53,8 @@ func test_override_func_1() -> void
 func test_override_func_2() -> void
 func test_func_b1() -> void
 func test_func_b2() -> void
-abstract func test_abstract_func_1() -> void
-abstract func test_abstract_func_2() -> void
+@abstract func test_abstract_func_1() -> void
+@abstract func test_abstract_func_2() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 === Signals ===

--- a/modules/gdscript/tests/scripts/utils.notest.gd
+++ b/modules/gdscript/tests/scripts/utils.notest.gd
@@ -101,7 +101,7 @@ static func print_property_extended_info(property: Dictionary, base: Object = nu
 static func get_method_signature(method: Dictionary, is_signal: bool = false) -> String:
 	var result: String = ""
 	if method.flags & METHOD_FLAG_VIRTUAL_REQUIRED:
-		result += "abstract "
+		result += "@abstract "
 	if method.flags & METHOD_FLAG_STATIC:
 		result += "static "
 	result += ("signal " if is_signal else "func ") + method.name + "("


### PR DESCRIPTION
* Fixes #107738.

This was requested by @vnen and discussed in the GDScript meeting on 2025-06-17. Meeting notes:

<img width="760" alt="Screenshot 2025-06-19 at 6 37 20 AM" src="https://github.com/user-attachments/assets/cd242bd0-84ff-47c6-b5ef-5c3c1a3fff00" />

This effectively restores the code to an earlier version of PR #67777, except that it includes abstract functions as added by PR #106409.

```gdscript
# Before:
abstract class_name MyBaseClass

# After:
@abstract class_name MyBaseClass
```

## Why?

Disclaimer: I am in favor of this PR, so this list is probably biased.

### Reasons For

* Makes more sense from a language design perspective: `@abstract` is a modifier that modifies a `class`, `class_name`, or `func`. It can't be used by itself.
  * See @dalexeev's comment [here](https://github.com/godotengine/godot/pull/107717#issuecomment-2993006162) for a more detailed explanation of this.
* Arguably makes more sense from the perspective of a user reading GDScript code, since it clearly separates the keywords that declare a thing compared to the keywords that modify declared things.
  * This especially improves readability when considering syntax highlighting.
* Consistency with possible future annotations like `@override` and `@virtual` which go well with `@abstract`.
* Simpler to implement, requires a lot less special case code in the GDScript codebase.
* Similar to some programming languages, like Python.

### Reasons Against

* Different from many languages, such as C#, Java, Kotlin, etc.
  * This may counteract the "Arguably makes more sense ..." part above, because if users are used to `abstract` from other languages, then `abstract` would be less friction. (possibly? only slightly?)
* Some users and engine maintainers have expressed that this "feels" like it should be a keyword.
  * I forget @vnen's exact words but he said something along the lines of that this wasn't good justification and nobody could come with a clear precise reason for why this should be a keyword, while the fact of it being a modifier is an objective easy-to-measure thing.
* Short-term: Inconsistency with `static`.
  * `static` is planned to be replaced with `@static`. Since removing `static` would break compatibility, we might add `@static` before removing `static` so both work for awhile.
* Short-term: Affects projects running the engine's `master` branch and already using `abstract`.
  * We don't support compatibility between different revisions of master, so this is a hard breakage.
* Short-term: Breaks the already-updated GitHub syntax highlighting for GDScript.
  * I would expect this to be resolved in a short timespan.

### Neutral

* For functions, this requires allowing the parser stage to parse bodyless functions.
  * This changes the abstract errors to analyzer errors instead of parser errors.
  * This means that a void function with no body is effectively identical to `: pass` except that abstract functions explicitly cannot have a body and so `: pass` is forbidden there and non-abstract functions must have a body.

Godot isn't a democracy, but you can react with 👍 and 👎 to show your support for or against this change.