### PR TITLE
Create dummy thumbnails for scenes that have no visuals

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -350,7 +350,7 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 	// Prohibit Viewport class as root when generating thumbnails
 	if (Object::cast_to<Viewport>(p_scene)) {
 		p_scene->queue_free();
-		return Ref<Texture2D>();
+		return _create_dummy_thumbnail();
 	}
 
 	int count_2d = 0;
@@ -584,7 +584,7 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 	}
 
 	// Is scene without any visuals (No Node2D, Node3D, Control found)
-	return Ref<Texture2D>();
+	return _create_dummy_thumbnail();
 }
 
 void EditorPackedScenePreviewPlugin::_setup_scene_3d(Node *p_node) const {
@@ -885,6 +885,16 @@ void EditorPackedScenePreviewPlugin::_wait_frame() const {
 		}
 		continue;
 	}
+}
+
+// Used for scene file that is valid but not suitable to generate thumbnails (no visuals),
+// providing a dummy thumbnail ensures the file will not be read again until it's changed.
+Ref<ImageTexture> EditorPackedScenePreviewPlugin::_create_dummy_thumbnail() const {
+	Ref<Image> dummy_img = Image::create_empty(2, 2, false, Image::Format::FORMAT_RGBA8);
+	Color default_clear_color = GLOBAL_GET("rendering/environment/defaults/default_clear_color");
+	dummy_img->fill(default_clear_color);
+	Ref<ImageTexture> dummy_thumbnail = ImageTexture::create_from_image(dummy_img);
+	return dummy_thumbnail;
 }
 
 void EditorPackedScenePreviewPlugin::_calculate_scene_aabb(Node *p_node, AABB &r_aabb) const {

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -81,6 +81,7 @@ protected:
 	void _hide_gui_in_scene(Node *p_node) const;
 	bool _setup_packed_scene(Ref<PackedScene> p_pack) const;
 	void _wait_frame() const;
+	Ref<ImageTexture> _create_dummy_thumbnail() const;
 
 public:
 	virtual void abort() override;


### PR DESCRIPTION
In PR #102313 thumbnail will not be created if either:
1. Scene is using a ```SubViewport``` class as scene root
2. Scene has no nodes derived from ```Node3D```, ```Node2D```, or ```Control```

Not generating thumbnails for those scenes also **prevents md5 checksum to be recorded**. Related code:
```c++
// editor/editor_resource_preview.cpp:237

// Cache the preview in case it's a resource on disk.
if (r_texture.is_valid()) {
        // Wow it generated a preview... save cache.
        ...
```
Some projects could have many scenes that matches those conditions, to stop unnecessary attempts to read the unchanged scene file, we give them a dummy thumbnail instead (so the md5 is stored).

Other part of code that returns a empty ```Ref<Texture2D>()``` is intended, which means the process is either aborted or failed, and retry is needed.

Fixes #107712