### PR TITLE
Remove dependency of `variant.h` in `print_string.h`

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -341,6 +341,14 @@ bool is_print_verbose_enabled() {
 	return OS::get_singleton()->is_stdout_verbose();
 }
 
-String stringify_variants(const Variant &p_var) {
-	return p_var.operator String();
+String stringify_variants(const Span<Variant> &p_vars) {
+	if (p_vars.is_empty()) {
+		return String();
+	}
+	String result = String(p_vars[0]);
+	for (const Variant &v : Span(p_vars.ptr() + 1, p_vars.size() - 1)) {
+		result += ' ';
+		result += v.operator String();
+	}
+	return result;
 }

--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -30,7 +30,9 @@
 
 #pragma once
 
-#include "core/variant/variant.h"
+#include "core/string/ustring.h"
+
+class Variant;
 
 extern void (*_print_func)(String);
 
@@ -45,12 +47,7 @@ struct PrintHandlerList {
 	PrintHandlerList() {}
 };
 
-String stringify_variants(const Variant &p_var);
-
-template <typename... Args>
-String stringify_variants(const Variant &p_var, Args... p_args) {
-	return p_var.operator String() + " " + stringify_variants(p_args...);
-}
+String stringify_variants(const Span<Variant> &p_vars);
 
 void add_print_handler(PrintHandlerList *p_handler);
 void remove_print_handler(const PrintHandlerList *p_handler);
@@ -69,20 +66,14 @@ extern bool is_print_verbose_enabled();
 		}                                 \
 	}
 
-inline void print_line(const Variant &v) {
-	__print_line(stringify_variants(v));
-}
-
-inline void print_line_rich(const Variant &v) {
-	__print_line_rich(stringify_variants(v));
+template <typename... Args>
+void print_line(Args... p_args) {
+	Variant variants[sizeof...(p_args)] = { p_args... };
+	__print_line(stringify_variants(Span(variants)));
 }
 
 template <typename... Args>
-void print_line(const Variant &p_var, Args... p_args) {
-	__print_line(stringify_variants(p_var, p_args...));
-}
-
-template <typename... Args>
-void print_line_rich(const Variant &p_var, Args... p_args) {
-	__print_line_rich(stringify_variants(p_var, p_args...));
+void print_line_rich(Args... p_args) {
+	Variant variants[sizeof...(p_args)] = { p_args... };
+	__print_line_rich(stringify_variants(Span(variants)));
 }

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -34,8 +34,8 @@
 #include "core/os/mutex.h"
 #include "core/string/print_string.h"
 #include "core/templates/local_vector.h"
-#include "core/templates/rid.h"
 #include "core/templates/safe_refcount.h"
+#include "core/variant/variant.h"
 
 #include <cstdio>
 #include <typeinfo> // IWYU pragma: keep // Used in macro.

--- a/modules/jolt_physics/jolt_globals.cpp
+++ b/modules/jolt_physics/jolt_globals.cpp
@@ -35,8 +35,8 @@
 #include "shapes/jolt_custom_ray_shape.h"
 #include "shapes/jolt_custom_user_data_shape.h"
 
-#include "core/os/memory.h"
 #include "core/string/print_string.h"
+#include "core/variant/variant.h"
 
 #include "Jolt/Jolt.h"
 

--- a/platform/linuxbsd/wayland/detect_prime_egl.cpp
+++ b/platform/linuxbsd/wayland/detect_prime_egl.cpp
@@ -34,7 +34,7 @@
 #include "detect_prime_egl.h"
 
 #include "core/string/print_string.h"
-#include "core/string/ustring.h"
+#include "core/variant/variant.h"
 
 #include <sys/types.h>
 #include <sys/wait.h>

--- a/platform/linuxbsd/x11/detect_prime_x11.cpp
+++ b/platform/linuxbsd/x11/detect_prime_x11.cpp
@@ -33,7 +33,7 @@
 #include "detect_prime_x11.h"
 
 #include "core/string/print_string.h"
-#include "core/string/ustring.h"
+#include "core/variant/variant.h"
 
 #include "thirdparty/glad/glad/gl.h"
 #include "thirdparty/glad/glad/glx.h"


### PR DESCRIPTION
`print_string.h` isn’t the lightweight header its name suggests—concerned only with `String`—but a fairly heavy one, because it includes `variant.h` internally. The only place it actually needs `Variant` is in `stringfy_variants()`. I changed that function to a non-template version and moved it into `print_string.cpp`, so now `print_string.h` only depends on `ustring.h`.

`std::initializer_list` may incur some overhead, but these functions don't seem to be particularly performance-sensitive, so I opted for the most straightforward implementation.


