### PR TITLE
Add `@final` annotation for GDScript

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -156,6 +156,8 @@ static void _add_qualifiers_to_rt(const String &p_qualifiers, RichTextLabel *p_r
 			hint = TTR("This method does not need an instance to be called.\nIt can be called directly using the class name.");
 		} else if (qualifier == "abstract") {
 			hint = TTR("This method must be implemented to complete the abstract class.");
+		} else if (qualifier == "final") {
+			hint = TTR("This method cannot be overridden by descendants of the class.");
 		}
 
 		p_rt->add_text(" ");

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -742,13 +742,35 @@
 			<return type="void" />
 			<description>
 				Modifies the following class or method as final. A final class cannot be extended, and a final method cannot be overridden.
+				You can annotate a class as final:
 				[codeblock]
+				# A.gd
+				@final class_name A
 
+				# B.gd
+				class_name B extends A # Error: The base class "A" is marked as final and cannot be extended..
+
+				# C.gd
+				@final extends RefCounted
+
+				class D extends C # Error: The base class "C" is marked as final and cannot be extended.
 				[/codeblock]
+				You can also annotate a method as final:
 				[codeblock]
+				# E.gd
+				class_name E extends Node
 
+				@final func my_final_method():
+				    pass
+
+				# F.gd
+				class_name F extends E
+
+				func my_final_method(): # Error: The method "my_final_method" is marked as final and cannot be overridden.
+				    pass
 				[/codeblock]
 				[b]Note:[/b] The annotation [code skip-lint]@final[/code] is a modifier, meaning that it is syntax-related instead of engine-specific.
+				[b]Note:[/b] You cannot modify an abstract class or method as final, as they are syntactically conflicting with each other and disallow the abstract class to be extended or the method to be overridden.
 			</description>
 		</annotation>
 		<annotation name="@icon">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -738,6 +738,19 @@
 				[b]Note:[/b] Avoid storing lambda callables in member variables of [RefCounted]-based classes (e.g. resources), as this can lead to memory leaks. Use only method callables and optionally [method Callable.bind] or [method Callable.unbind].
 			</description>
 		</annotation>
+		<annotation name="@final">
+			<return type="void" />
+			<description>
+				Modifies the following class or method as final. A final class cannot be extended, and a final method cannot be overridden.
+				[codeblock]
+
+				[/codeblock]
+				[codeblock]
+
+				[/codeblock]
+				[b]Note:[/b] The annotation [code skip-lint]@final[/code] is a modifier, meaning that it is syntax-related instead of engine-specific.
+			</description>
+		</annotation>
 		<annotation name="@icon">
 			<return type="void" />
 			<param index="0" name="icon_path" type="String" />

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -12,6 +12,12 @@
 		<link title="GDScript documentation index">$DOCS_URL/tutorials/scripting/gdscript/index.html</link>
 	</tutorials>
 	<methods>
+		<method name="is_final" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the script is marked as final.
+			</description>
+		</method>
 		<method name="new" qualifiers="vararg">
 			<return type="Variant" />
 			<description>

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -422,6 +422,12 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					}
 					method_doc.qualifiers += "abstract";
 				}
+				if (m_func->is_final) {
+					if (!method_doc.qualifiers.is_empty()) {
+						method_doc.qualifiers += " ";
+					}
+					method_doc.qualifiers += "final";
+				}
 				if (m_func->is_static) {
 					if (!method_doc.qualifiers.is_empty()) {
 						method_doc.qualifiers += " ";

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1073,6 +1073,8 @@ void GDScript::_get_property_list(List<PropertyInfo> *p_properties) const {
 
 void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
+
+	ClassDB::bind_method(D_METHOD("is_final"), &GDScript::is_final);
 }
 
 void GDScript::set_path(const String &p_path, bool p_take_over) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -63,6 +63,7 @@ class GDScript : public Script {
 	bool valid = false;
 	bool reloading = false;
 	bool _is_abstract = false;
+	bool _is_final = false;
 
 	struct MemberInfo {
 		int index = 0;
@@ -281,6 +282,7 @@ public:
 
 	bool is_tool() const override { return tool; }
 	bool is_abstract() const override { return _is_abstract; }
+	bool is_final() const { return _is_final; }
 	Ref<GDScript> get_base() const;
 
 	const HashMap<StringName, MemberInfo> &debug_get_member_indices() const { return member_indices; }

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -624,9 +624,9 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 		E->apply(parser, p_class, p_class->outer);
 	}
 
-	// Final classes are not allowed to be instantiated.
-	if (base_class != nullptr && base_class->is_final) {
-		push_error(vformat(R"(The base class "%s" is a final class and cannot be extended.)", base_class->identifier->name), p_class);
+	// Final classes are not allowed to be inherited.
+	if (result.class_type != nullptr && result.class_type->is_final) {
+		push_error(vformat(R"(The base class "%s" is marked as final and cannot be extended.)", result.class_type->fqcn), p_class);
 		return ERR_PARSE_ERROR;
 	}
 
@@ -1925,7 +1925,7 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 
 				GDScriptParser::FunctionNode *base_function = base_type.class_type->get_member(function_name).function;
 				if (base_function != nullptr && base_function->is_final) {
-					push_error(vformat(R"(Function "%s" is modified as final and cannot be overridden.)", function_name), p_function);
+					push_error(vformat(R"(Function "%s" is marked as final and cannot be overridden.)", function_name), p_function);
 				}
 			}
 

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -624,6 +624,12 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 		E->apply(parser, p_class, p_class->outer);
 	}
 
+	// Final classes are not allowed to be instantiated.
+	if (base_class != nullptr && base_class->is_final) {
+		push_error(vformat(R"(The base class "%s" is a final class and cannot be extended.)", base_class->identifier->name), p_class);
+		return ERR_PARSE_ERROR;
+	}
+
 	parser->current_class = previous_class;
 
 	return OK;
@@ -1915,6 +1921,11 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 					} else {
 						valid = valid && is_type_compatible(current_par_type, parent_par_type);
 					}
+				}
+
+				GDScriptParser::FunctionNode *base_function = base_type.class_type->get_member(function_name).function;
+				if (base_function != nullptr && base_function->is_final) {
+					push_error(vformat(R"(Function "%s" is modified as final and cannot be overridden.)", function_name), p_function);
 				}
 			}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2765,6 +2765,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	p_script->tool = parser->is_tool();
 	p_script->_is_abstract = p_class->is_abstract;
+	p_script->_is_final = p_class->is_final;
 
 	if (p_script->local_name != StringName()) {
 		if (ClassDB::class_exists(p_script->local_name) && ClassDB::is_class_exposed(p_script->local_name)) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2300,7 +2300,6 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	StringName func_name;
 	bool is_abstract = false;
 	bool is_static = false;
-	bool is_final = false;
 	Variant rpc_config;
 	GDScriptDataType return_type;
 	return_type.has_type = true;
@@ -2315,7 +2314,6 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		}
 		is_abstract = p_func->is_abstract;
 		is_static = p_func->is_static;
-		is_final = p_func->is_final;
 		rpc_config = p_func->rpc_config;
 		return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
 	} else {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2300,6 +2300,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	StringName func_name;
 	bool is_abstract = false;
 	bool is_static = false;
+	bool is_final = false;
 	Variant rpc_config;
 	GDScriptDataType return_type;
 	return_type.has_type = true;
@@ -2314,6 +2315,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 		}
 		is_abstract = p_func->is_abstract;
 		is_static = p_func->is_static;
+		is_final = p_func->is_final;
 		rpc_config = p_func->rpc_config;
 		return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
 	} else {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -99,7 +99,7 @@ GDScriptParser::GDScriptParser() {
 		// Onready annotation.
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Final annotation.
-		register_annotation(MethodInfo("@final"), AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::final_annotation);
+		register_annotation(MethodInfo("@final"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::final_annotation);
 		// Export annotations.
 		register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
 		register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::NIL>, varray(), true);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4437,24 +4437,24 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 bool GDScriptParser::final_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::FUNCTION && p_target->type != Node::CLASS, false, R"("@final" annotation can only be applied to classes or functions.)");
 
-	ClassNode *class_node = static_cast<ClassNode *>(p_target);
-	if (class_node != nullptr) {
-		if (class_node->is_final) {
-			push_error(R"("@final" annotation can only be used once per class.)", p_annotation);
-			return false;
-		} else {
-			class_node->is_final = true;
-			return true;
-		}
-	}
-
 	FunctionNode *function = static_cast<FunctionNode *>(p_target);
-	if (function != nullptr) {
+	if (p_target->type == Node::FUNCTION && function != nullptr) {
 		if (function->is_final) {
 			push_error(R"("@final" annotation can only be used once per function.)", p_annotation);
 			return false;
 		} else {
 			function->is_final = true;
+			return true;
+		}
+	}
+
+	ClassNode *class_node = static_cast<ClassNode *>(p_target);
+	if (p_target->type == Node::CLASS && class_node != nullptr) {
+		if (class_node->is_final) {
+			push_error(R"("@final" annotation can only be used once per class.)", p_annotation);
+			return false;
+		} else {
+			class_node->is_final = true;
 			return true;
 		}
 	}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4437,25 +4437,33 @@ bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_ta
 bool GDScriptParser::final_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::FUNCTION && p_target->type != Node::CLASS, false, R"("@final" annotation can only be applied to classes or functions.)");
 
-	FunctionNode *function = static_cast<FunctionNode *>(p_target);
-	if (p_target->type == Node::FUNCTION && function != nullptr) {
-		if (function->is_final) {
-			push_error(R"("@final" annotation can only be used once per function.)", p_annotation);
-			return false;
-		} else {
-			function->is_final = true;
-			return true;
+	{
+		FunctionNode *function = static_cast<FunctionNode *>(p_target);
+		if (p_target->type == Node::FUNCTION && function != nullptr) {
+			if (function->is_abstract) {
+				push_error(R"("@final" annotation cannot be applied to an abstract function.)", p_annotation);
+			} else if (function->is_final) {
+				push_error(R"("@final" annotation can only be used once per function.)", p_annotation);
+				return false;
+			} else {
+				function->is_final = true;
+				return true;
+			}
 		}
 	}
 
-	ClassNode *class_node = static_cast<ClassNode *>(p_target);
-	if (p_target->type == Node::CLASS && class_node != nullptr) {
-		if (class_node->is_final) {
-			push_error(R"("@final" annotation can only be used once per class.)", p_annotation);
-			return false;
-		} else {
-			class_node->is_final = true;
-			return true;
+	{
+		ClassNode *class_node = static_cast<ClassNode *>(p_target);
+		if (p_target->type == Node::CLASS && class_node != nullptr) {
+			if (class_node->is_abstract) {
+				push_error(R"("@final" annotation cannot be applied to an abstract class.)", p_annotation);
+			} else if (class_node->is_final) {
+				push_error(R"("@final" annotation can only be used once per class.)", p_annotation);
+				return false;
+			} else {
+				class_node->is_final = true;
+				return true;
+			}
 		}
 	}
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -748,6 +748,7 @@ public:
 		bool extends_used = false;
 		bool onready_used = false;
 		bool is_abstract = false;
+		bool is_final = false;
 		bool has_static_data = false;
 		bool annotated_static_unload = false;
 		String extends_path;
@@ -856,6 +857,7 @@ public:
 		SuiteNode *body = nullptr;
 		bool is_abstract = false;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
+		bool is_final = false;
 		bool is_coroutine = false;
 		Variant rpc_config;
 		MethodInfo info;
@@ -1524,6 +1526,7 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool final_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_classes.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_classes.gd
@@ -1,0 +1,11 @@
+@final abstract class AbstractFinalClass:
+    pass
+
+@final class A:
+    pass
+
+class B extends A:
+    pass
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_classes.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_classes.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 1: "@final" annotation cannot be applied to an abstract class.
+>> ERROR at line 7: The base class "final_classes.gd::A" is marked as final and cannot be extended.

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_methods.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_methods.gd
@@ -1,0 +1,17 @@
+class A:
+    @final func foo():
+        pass
+
+    @final func bar():
+        pass
+
+class B extends A:
+    func foo():
+        pass
+
+class C extends B:
+    func bar():
+        pass
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_methods.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_methods.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 9: Function "foo" is marked as final and cannot be overridden.
+>> ERROR at line 13: Function "bar" is marked as final and cannot be overridden.


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot-proposals/issues/10500

Added `@final` for gdscript.

```GDScript
@final class A:
    pass

class B extends A: # Error, cannot inherit a final class
    pass

class C:
    @final func a(): pass

class D extends C:
    func a(): pass # Error, cannot override a final method
```

Note: You can annotate an anonymous script with `@final`, but when a script is declared without `extends` and the annotation is at the first line of the script, with a member following it:

```GDScript
@final

func a(): pass
```

In this case, you need to add `extends RefCounted` to avoid ambiguity.

- **An abstract class/method cannot be final, and vice versa.**
- **An virtual method cannot be final.** 

# Why adding `@final` as an annotation instead of a keyword?

See #107713 as a reference.

# Tasks

- [x] Complete basic functions.
- [x] Unit tests.