### PR TITLE
Core: Integrate math constants in structs directly

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -41,6 +41,11 @@
 class Variant;
 
 struct [[nodiscard]] AABB {
+	static const AABB ZERO;
+	static const AABB ONE;
+	static const AABB INF;
+	static const AABB NaN;
+
 	Vector3 position;
 	Vector3 size;
 
@@ -139,6 +144,11 @@ struct [[nodiscard]] AABB {
 			size(p_size) {
 	}
 };
+
+inline constexpr AABB AABB::ZERO = { Vector3::ZERO, Vector3::ZERO };
+inline constexpr AABB AABB::ONE = { Vector3::ONE, Vector3::ONE };
+inline constexpr AABB AABB::INF = { Vector3::INF, Vector3::INF };
+inline constexpr AABB AABB::NaN = { Vector3::NaN, Vector3::NaN };
 
 inline bool AABB::intersects(const AABB &p_aabb) const {
 #ifdef MATH_CHECKS

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -34,6 +34,15 @@
 #include "core/math/vector3.h"
 
 struct [[nodiscard]] Basis {
+	static const Basis ZERO;
+	static const Basis ONE;
+	static const Basis INF;
+	static const Basis NaN;
+	static const Basis IDENTITY;
+	static const Basis FLIP_X;
+	static const Basis FLIP_Y;
+	static const Basis FLIP_Z;
+
 	Vector3 rows[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),
@@ -224,7 +233,7 @@ struct [[nodiscard]] Basis {
 
 	operator Quaternion() const { return get_quaternion(); }
 
-	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
+	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 
 	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); }
 	Basis(const Quaternion &p_quaternion, const Vector3 &p_scale) { set_quaternion_scale(p_quaternion, p_scale); }
@@ -246,6 +255,15 @@ private:
 	// Helper method.
 	void _set_diagonal(const Vector3 &p_diag);
 };
+
+inline constexpr Basis Basis::ZERO = { Vector3::ZERO, Vector3::ZERO, Vector3::ZERO };
+inline constexpr Basis Basis::ONE = { Vector3::ONE, Vector3::ONE, Vector3::ONE };
+inline constexpr Basis Basis::INF = { Vector3::INF, Vector3::INF, Vector3::INF };
+inline constexpr Basis Basis::NaN = { Vector3::NaN, Vector3::NaN, Vector3::NaN };
+inline constexpr Basis Basis::IDENTITY = { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };
+inline constexpr Basis Basis::FLIP_X = { { -1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };
+inline constexpr Basis Basis::FLIP_Y = { { 1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } };
+inline constexpr Basis Basis::FLIP_Z = { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, -1 } };
 
 constexpr bool Basis::operator==(const Basis &p_matrix) const {
 	for (int i = 0; i < 3; i++) {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -35,6 +35,14 @@
 class Variant;
 
 struct [[nodiscard]] Plane {
+	static const Plane ZERO;
+	static const Plane ONE;
+	static const Plane INF;
+	static const Plane NaN;
+	static const Plane PLANE_YZ;
+	static const Plane PLANE_XZ;
+	static const Plane PLANE_XY;
+
 	Vector3 normal;
 	real_t d = 0;
 
@@ -89,6 +97,14 @@ struct [[nodiscard]] Plane {
 	_FORCE_INLINE_ Plane(const Vector3 &p_normal, const Vector3 &p_point);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };
+
+inline constexpr Plane Plane::ZERO = { 0, 0, 0, 0 };
+inline constexpr Plane Plane::ONE = { 1, 1, 1, 1 };
+inline constexpr Plane Plane::INF = { (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF };
+inline constexpr Plane Plane::NaN = { (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN };
+inline constexpr Plane Plane::PLANE_YZ = { 1, 0, 0, 0 };
+inline constexpr Plane Plane::PLANE_XZ = { 0, 1, 0, 0 };
+inline constexpr Plane Plane::PLANE_XY = { 0, 0, 1, 0 };
 
 bool Plane::is_point_over(const Vector3 &p_point) const {
 	return (normal.dot(p_point) > d);

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -43,6 +43,12 @@ struct Transform3D;
 struct Vector2;
 
 struct [[nodiscard]] Projection {
+	static const Projection ZERO;
+	static const Projection ONE;
+	static const Projection INF;
+	static const Projection NaN;
+	static const Projection IDENTITY;
+
 	enum Planes {
 		PLANE_NEAR,
 		PLANE_FAR,
@@ -168,6 +174,12 @@ struct [[nodiscard]] Projection {
 			} {}
 	Projection(const Transform3D &p_transform);
 };
+
+inline constexpr Projection Projection::ZERO = { Vector4::ZERO, Vector4::ZERO, Vector4::ZERO, Vector4::ZERO };
+inline constexpr Projection Projection::ONE = { Vector4::ONE, Vector4::ONE, Vector4::ONE, Vector4::ONE };
+inline constexpr Projection Projection::INF = { Vector4::INF, Vector4::INF, Vector4::INF, Vector4::INF };
+inline constexpr Projection Projection::NaN = { Vector4::NaN, Vector4::NaN, Vector4::NaN, Vector4::NaN };
+inline constexpr Projection Projection::IDENTITY = { { 1, 0, 0, 0 }, { 0, 1, 0, 0 }, { 0, 0, 1, 0 }, { 0, 0, 0, 1 } };
 
 constexpr Projection Projection::operator*(const Projection &p_matrix) const {
 	Projection new_matrix;

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -35,6 +35,12 @@
 #include "core/string/ustring.h"
 
 struct [[nodiscard]] Quaternion {
+	static const Quaternion ZERO;
+	static const Quaternion ONE;
+	static const Quaternion INF;
+	static const Quaternion NaN;
+	static const Quaternion IDENTITY;
+
 	union {
 		// NOLINTBEGIN(modernize-use-default-member-init)
 		struct {
@@ -169,6 +175,12 @@ struct [[nodiscard]] Quaternion {
 		normalize();
 	}
 };
+
+inline constexpr Quaternion Quaternion::ZERO = { 0, 0, 0, 0 };
+inline constexpr Quaternion Quaternion::ONE = { 1, 1, 1, 1 };
+inline constexpr Quaternion Quaternion::INF = { (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF };
+inline constexpr Quaternion Quaternion::NaN = { (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN };
+inline constexpr Quaternion Quaternion::IDENTITY = { 0, 0, 0, 1 };
 
 real_t Quaternion::dot(const Quaternion &p_q) const {
 	return x * p_q.x + y * p_q.y + z * p_q.z + w * p_q.w;

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -38,6 +38,11 @@ struct Rect2i;
 struct Transform2D;
 
 struct [[nodiscard]] Rect2 {
+	static const Rect2 ZERO;
+	static const Rect2 ONE;
+	static const Rect2 INF;
+	static const Rect2 NaN;
+
 	Point2 position;
 	Size2 size;
 
@@ -371,6 +376,11 @@ struct [[nodiscard]] Rect2 {
 			size(p_size) {
 	}
 };
+
+inline constexpr Rect2 Rect2::ZERO = { Vector2::ZERO, Vector2::ZERO };
+inline constexpr Rect2 Rect2::ONE = { Vector2::ONE, Vector2::ONE };
+inline constexpr Rect2 Rect2::INF = { Vector2::INF, Vector2::INF };
+inline constexpr Rect2 Rect2::NaN = { Vector2::NaN, Vector2::NaN };
 
 template <>
 struct is_zero_constructible<Rect2> : std::true_type {};

--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -36,7 +36,15 @@
 class String;
 struct Rect2;
 
+#undef MIN
+#undef MAX
+
 struct [[nodiscard]] Rect2i {
+	static const Rect2i ZERO;
+	static const Rect2i ONE;
+	static const Rect2i MIN;
+	static const Rect2i MAX;
+
 	Point2i position;
 	Size2i size;
 
@@ -236,6 +244,11 @@ struct [[nodiscard]] Rect2i {
 			size(p_size) {
 	}
 };
+
+inline constexpr Rect2i Rect2i::ZERO = { Vector2i::ZERO, Vector2i::ZERO };
+inline constexpr Rect2i Rect2i::ONE = { Vector2i::ONE, Vector2i::ONE };
+inline constexpr Rect2i Rect2i::MIN = { Vector2i::MIN, Vector2i::MIN };
+inline constexpr Rect2i Rect2i::MAX = { Vector2i::MAX, Vector2i::MAX };
 
 template <>
 struct is_zero_constructible<Rect2i> : std::true_type {};

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -52,6 +52,14 @@ struct [[nodiscard]] Transform2D {
 	// WARNING: Be aware that unlike 3D code, 2D code uses a left-handed coordinate system:
 	// Y-axis points down, and angle is measure from +X to +Y in a clockwise-fashion.
 
+	static const Transform2D ZERO;
+	static const Transform2D ONE;
+	static const Transform2D INF;
+	static const Transform2D NaN;
+	static const Transform2D IDENTITY;
+	static const Transform2D FLIP_X;
+	static const Transform2D FLIP_Y;
+
 	Vector2 columns[3] = {
 		{ 1, 0 },
 		{ 0, 1 },
@@ -148,6 +156,14 @@ struct [[nodiscard]] Transform2D {
 
 	Transform2D() = default;
 };
+
+inline constexpr Transform2D Transform2D::ZERO = { Vector2::ZERO, Vector2::ZERO, Vector2::ZERO };
+inline constexpr Transform2D Transform2D::ONE = { Vector2::ONE, Vector2::ONE, Vector2::ONE };
+inline constexpr Transform2D Transform2D::INF = { Vector2::INF, Vector2::INF, Vector2::INF };
+inline constexpr Transform2D Transform2D::NaN = { Vector2::NaN, Vector2::NaN, Vector2::NaN };
+inline constexpr Transform2D Transform2D::IDENTITY = { { 1, 0 }, { 0, 1 }, Vector2::ZERO };
+inline constexpr Transform2D Transform2D::FLIP_X = { { -1, 0 }, { 0, 1 }, Vector2::ZERO };
+inline constexpr Transform2D Transform2D::FLIP_Y = { { 1, 0 }, { 0, -1 }, Vector2::ZERO };
 
 constexpr bool Transform2D::operator==(const Transform2D &p_transform) const {
 	for (int i = 0; i < 3; i++) {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -36,6 +36,15 @@
 #include "core/templates/vector.h"
 
 struct [[nodiscard]] Transform3D {
+	static const Transform3D ZERO;
+	static const Transform3D ONE;
+	static const Transform3D INF;
+	static const Transform3D NaN;
+	static const Transform3D IDENTITY;
+	static const Transform3D FLIP_X;
+	static const Transform3D FLIP_Y;
+	static const Transform3D FLIP_Z;
+
 	Basis basis;
 	Vector3 origin;
 
@@ -51,8 +60,8 @@ struct [[nodiscard]] Transform3D {
 	void rotate(const Vector3 &p_axis, real_t p_angle);
 	void rotate_basis(const Vector3 &p_axis, real_t p_angle);
 
-	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
-	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false) const;
+	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
+	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false) const;
 
 	void scale(const Vector3 &p_scale);
 	Transform3D scaled(const Vector3 &p_scale) const;
@@ -135,6 +144,15 @@ struct [[nodiscard]] Transform3D {
 			basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz),
 			origin(p_ox, p_oy, p_oz) {}
 };
+
+inline constexpr Transform3D Transform3D::ZERO = { Basis::ZERO, Vector3::ZERO };
+inline constexpr Transform3D Transform3D::ONE = { Basis::ONE, Vector3::ONE };
+inline constexpr Transform3D Transform3D::INF = { Basis::INF, Vector3::INF };
+inline constexpr Transform3D Transform3D::NaN = { Basis::NaN, Vector3::NaN };
+inline constexpr Transform3D Transform3D::IDENTITY = { Basis::IDENTITY, Vector3::ZERO };
+inline constexpr Transform3D Transform3D::FLIP_X = { Basis::FLIP_X, Vector3::ZERO };
+inline constexpr Transform3D Transform3D::FLIP_Y = { Basis::FLIP_Y, Vector3::ZERO };
+inline constexpr Transform3D Transform3D::FLIP_Z = { Basis::FLIP_Z, Vector3::ZERO };
 
 constexpr bool Transform3D::operator==(const Transform3D &p_transform) const {
 	return (basis == p_transform.basis && origin == p_transform.origin);

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -37,7 +37,16 @@ class String;
 struct Vector2i;
 
 struct [[nodiscard]] Vector2 {
-	static const int AXIS_COUNT = 2;
+	static const Vector2 ZERO;
+	static const Vector2 ONE;
+	static const Vector2 INF;
+	static const Vector2 NaN;
+	static const Vector2 LEFT;
+	static const Vector2 RIGHT;
+	static const Vector2 UP;
+	static const Vector2 DOWN;
+
+	static constexpr int AXIS_COUNT = 2;
 
 	enum Axis {
 		AXIS_X,
@@ -192,6 +201,15 @@ struct [[nodiscard]] Vector2 {
 			x(p_x), y(p_y) {}
 	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
+
+inline constexpr Vector2 Vector2::ZERO = { 0, 0 };
+inline constexpr Vector2 Vector2::ONE = { 1, 1 };
+inline constexpr Vector2 Vector2::INF = { (real_t)Math::INF, (real_t)Math::INF };
+inline constexpr Vector2 Vector2::NaN = { (real_t)Math::NaN, (real_t)Math::NaN };
+inline constexpr Vector2 Vector2::LEFT = { -1, 0 };
+inline constexpr Vector2 Vector2::RIGHT = { 1, 0 };
+inline constexpr Vector2 Vector2::UP = { 0, -1 };
+inline constexpr Vector2 Vector2::DOWN = { 0, 1 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {
 	return p_vec - *this * (dot(p_vec) - p_d);

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -36,8 +36,20 @@
 class String;
 struct Vector2;
 
+#undef MIN
+#undef MAX
+
 struct [[nodiscard]] Vector2i {
-	static const int AXIS_COUNT = 2;
+	static const Vector2i ZERO;
+	static const Vector2i ONE;
+	static const Vector2i MIN;
+	static const Vector2i MAX;
+	static const Vector2i LEFT;
+	static const Vector2i RIGHT;
+	static const Vector2i UP;
+	static const Vector2i DOWN;
+
+	static constexpr int AXIS_COUNT = 2;
 
 	enum Axis {
 		AXIS_X,
@@ -78,19 +90,19 @@ struct [[nodiscard]] Vector2i {
 	}
 
 	Vector2i min(const Vector2i &p_vector2i) const {
-		return Vector2i(MIN(x, p_vector2i.x), MIN(y, p_vector2i.y));
+		return Vector2i(::MIN(x, p_vector2i.x), ::MIN(y, p_vector2i.y));
 	}
 
 	Vector2i mini(int32_t p_scalar) const {
-		return Vector2i(MIN(x, p_scalar), MIN(y, p_scalar));
+		return Vector2i(::MIN(x, p_scalar), ::MIN(y, p_scalar));
 	}
 
 	Vector2i max(const Vector2i &p_vector2i) const {
-		return Vector2i(MAX(x, p_vector2i.x), MAX(y, p_vector2i.y));
+		return Vector2i(::MAX(x, p_vector2i.x), ::MAX(y, p_vector2i.y));
 	}
 
 	Vector2i maxi(int32_t p_scalar) const {
-		return Vector2i(MAX(x, p_scalar), MAX(y, p_scalar));
+		return Vector2i(::MAX(x, p_scalar), ::MAX(y, p_scalar));
 	}
 
 	double distance_to(const Vector2i &p_to) const {
@@ -149,6 +161,15 @@ struct [[nodiscard]] Vector2i {
 			x(p_x), y(p_y) {}
 	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
+
+inline constexpr Vector2i Vector2i::ZERO = { 0, 0 };
+inline constexpr Vector2i Vector2i::ONE = { 1, 1 };
+inline constexpr Vector2i Vector2i::MIN = { INT32_MIN, INT32_MIN };
+inline constexpr Vector2i Vector2i::MAX = { INT32_MAX, INT32_MAX };
+inline constexpr Vector2i Vector2i::LEFT = { -1, 0 };
+inline constexpr Vector2i Vector2i::RIGHT = { 1, 0 };
+inline constexpr Vector2i Vector2i::UP = { 0, -1 };
+inline constexpr Vector2i Vector2i::DOWN = { 0, 1 };
 
 constexpr Vector2i Vector2i::operator+(const Vector2i &p_v) const {
 	return Vector2i(x + p_v.x, y + p_v.y);

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -39,7 +39,24 @@ struct Vector2;
 struct Vector3i;
 
 struct [[nodiscard]] Vector3 {
-	static const int AXIS_COUNT = 3;
+	static const Vector3 ZERO;
+	static const Vector3 ONE;
+	static const Vector3 INF;
+	static const Vector3 NaN;
+	static const Vector3 LEFT;
+	static const Vector3 RIGHT;
+	static const Vector3 UP;
+	static const Vector3 DOWN;
+	static const Vector3 FORWARD;
+	static const Vector3 BACK;
+	static const Vector3 MODEL_LEFT;
+	static const Vector3 MODEL_RIGHT;
+	static const Vector3 MODEL_TOP;
+	static const Vector3 MODEL_BOTTOM;
+	static const Vector3 MODEL_FRONT;
+	static const Vector3 MODEL_REAR;
+
+	static constexpr int AXIS_COUNT = 3;
 
 	enum Axis {
 		AXIS_X,
@@ -194,6 +211,23 @@ struct [[nodiscard]] Vector3 {
 	constexpr Vector3(real_t p_x, real_t p_y, real_t p_z) :
 			x(p_x), y(p_y), z(p_z) {}
 };
+
+inline constexpr Vector3 Vector3::ZERO = { 0, 0, 0 };
+inline constexpr Vector3 Vector3::ONE = { 1, 1, 1 };
+inline constexpr Vector3 Vector3::INF = { (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF };
+inline constexpr Vector3 Vector3::NaN = { (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN };
+inline constexpr Vector3 Vector3::LEFT = { -1, 0, 0 };
+inline constexpr Vector3 Vector3::RIGHT = { 1, 0, 0 };
+inline constexpr Vector3 Vector3::UP = { 0, 1, 0 };
+inline constexpr Vector3 Vector3::DOWN = { 0, -1, 0 };
+inline constexpr Vector3 Vector3::FORWARD = { 0, 0, -1 };
+inline constexpr Vector3 Vector3::BACK = { 0, 0, 1 };
+inline constexpr Vector3 Vector3::MODEL_LEFT = { 1, 0, 0 };
+inline constexpr Vector3 Vector3::MODEL_RIGHT = { -1, 0, 0 };
+inline constexpr Vector3 Vector3::MODEL_TOP = { 0, 1, 0 };
+inline constexpr Vector3 Vector3::MODEL_BOTTOM = { 0, -1, 0 };
+inline constexpr Vector3 Vector3::MODEL_FRONT = { 0, 0, 1 };
+inline constexpr Vector3 Vector3::MODEL_REAR = { 0, 0, -1 };
 
 Vector3 Vector3::cross(const Vector3 &p_with) const {
 	Vector3 ret(

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -36,8 +36,22 @@
 class String;
 struct Vector3;
 
+#undef MIN
+#undef MAX
+
 struct [[nodiscard]] Vector3i {
-	static const int AXIS_COUNT = 3;
+	static const Vector3i ZERO;
+	static const Vector3i ONE;
+	static const Vector3i MIN;
+	static const Vector3i MAX;
+	static const Vector3i LEFT;
+	static const Vector3i RIGHT;
+	static const Vector3i UP;
+	static const Vector3i DOWN;
+	static const Vector3i FORWARD;
+	static const Vector3i BACK;
+
+	static constexpr int AXIS_COUNT = 3;
 
 	enum Axis {
 		AXIS_X,
@@ -71,19 +85,19 @@ struct [[nodiscard]] Vector3i {
 	Vector3i::Axis max_axis_index() const;
 
 	Vector3i min(const Vector3i &p_vector3i) const {
-		return Vector3i(MIN(x, p_vector3i.x), MIN(y, p_vector3i.y), MIN(z, p_vector3i.z));
+		return Vector3i(::MIN(x, p_vector3i.x), ::MIN(y, p_vector3i.y), ::MIN(z, p_vector3i.z));
 	}
 
 	Vector3i mini(int32_t p_scalar) const {
-		return Vector3i(MIN(x, p_scalar), MIN(y, p_scalar), MIN(z, p_scalar));
+		return Vector3i(::MIN(x, p_scalar), ::MIN(y, p_scalar), ::MIN(z, p_scalar));
 	}
 
 	Vector3i max(const Vector3i &p_vector3i) const {
-		return Vector3i(MAX(x, p_vector3i.x), MAX(y, p_vector3i.y), MAX(z, p_vector3i.z));
+		return Vector3i(::MAX(x, p_vector3i.x), ::MAX(y, p_vector3i.y), ::MAX(z, p_vector3i.z));
 	}
 
 	Vector3i maxi(int32_t p_scalar) const {
-		return Vector3i(MAX(x, p_scalar), MAX(y, p_scalar), MAX(z, p_scalar));
+		return Vector3i(::MAX(x, p_scalar), ::MAX(y, p_scalar), ::MAX(z, p_scalar));
 	}
 
 	_FORCE_INLINE_ int64_t length_squared() const;
@@ -138,6 +152,17 @@ struct [[nodiscard]] Vector3i {
 	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :
 			x(p_x), y(p_y), z(p_z) {}
 };
+
+inline constexpr Vector3i Vector3i::ZERO = { 0, 0, 0 };
+inline constexpr Vector3i Vector3i::ONE = { 1, 1, 1 };
+inline constexpr Vector3i Vector3i::MIN = { INT32_MIN, INT32_MIN, INT32_MIN };
+inline constexpr Vector3i Vector3i::MAX = { INT32_MAX, INT32_MAX, INT32_MAX };
+inline constexpr Vector3i Vector3i::LEFT = { -1, 0, 0 };
+inline constexpr Vector3i Vector3i::RIGHT = { 1, 0, 0 };
+inline constexpr Vector3i Vector3i::UP = { 0, 1, 0 };
+inline constexpr Vector3i Vector3i::DOWN = { 0, -1, 0 };
+inline constexpr Vector3i Vector3i::FORWARD = { 0, 0, -1 };
+inline constexpr Vector3i Vector3i::BACK = { 0, 0, 1 };
 
 int64_t Vector3i::length_squared() const {
 	return x * (int64_t)x + y * (int64_t)y + z * (int64_t)z;

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -38,7 +38,12 @@ class String;
 struct Vector4i;
 
 struct [[nodiscard]] Vector4 {
-	static const int AXIS_COUNT = 4;
+	static const Vector4 ZERO;
+	static const Vector4 ONE;
+	static const Vector4 INF;
+	static const Vector4 NaN;
+
+	static constexpr int AXIS_COUNT = 4;
 
 	enum Axis {
 		AXIS_X,
@@ -151,6 +156,11 @@ struct [[nodiscard]] Vector4 {
 	constexpr Vector4(real_t p_x, real_t p_y, real_t p_z, real_t p_w) :
 			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };
+
+inline constexpr Vector4 Vector4::ZERO = { 0, 0, 0, 0 };
+inline constexpr Vector4 Vector4::ONE = { 1, 1, 1, 1 };
+inline constexpr Vector4 Vector4::INF = { (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF, (real_t)Math::INF };
+inline constexpr Vector4 Vector4::NaN = { (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN, (real_t)Math::NaN };
 
 real_t Vector4::dot(const Vector4 &p_vec4) const {
 	return x * p_vec4.x + y * p_vec4.y + z * p_vec4.z + w * p_vec4.w;

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -36,8 +36,16 @@
 class String;
 struct Vector4;
 
+#undef MIN
+#undef MAX
+
 struct [[nodiscard]] Vector4i {
-	static const int AXIS_COUNT = 4;
+	static const Vector4i ZERO;
+	static const Vector4i ONE;
+	static const Vector4i MIN;
+	static const Vector4i MAX;
+
+	static constexpr int AXIS_COUNT = 4;
 
 	enum Axis {
 		AXIS_X,
@@ -73,19 +81,19 @@ struct [[nodiscard]] Vector4i {
 	Vector4i::Axis max_axis_index() const;
 
 	Vector4i min(const Vector4i &p_vector4i) const {
-		return Vector4i(MIN(x, p_vector4i.x), MIN(y, p_vector4i.y), MIN(z, p_vector4i.z), MIN(w, p_vector4i.w));
+		return Vector4i(::MIN(x, p_vector4i.x), ::MIN(y, p_vector4i.y), ::MIN(z, p_vector4i.z), ::MIN(w, p_vector4i.w));
 	}
 
 	Vector4i mini(int32_t p_scalar) const {
-		return Vector4i(MIN(x, p_scalar), MIN(y, p_scalar), MIN(z, p_scalar), MIN(w, p_scalar));
+		return Vector4i(::MIN(x, p_scalar), ::MIN(y, p_scalar), ::MIN(z, p_scalar), ::MIN(w, p_scalar));
 	}
 
 	Vector4i max(const Vector4i &p_vector4i) const {
-		return Vector4i(MAX(x, p_vector4i.x), MAX(y, p_vector4i.y), MAX(z, p_vector4i.z), MAX(w, p_vector4i.w));
+		return Vector4i(::MAX(x, p_vector4i.x), ::MAX(y, p_vector4i.y), ::MAX(z, p_vector4i.z), ::MAX(w, p_vector4i.w));
 	}
 
 	Vector4i maxi(int32_t p_scalar) const {
-		return Vector4i(MAX(x, p_scalar), MAX(y, p_scalar), MAX(z, p_scalar), MAX(w, p_scalar));
+		return Vector4i(::MAX(x, p_scalar), ::MAX(y, p_scalar), ::MAX(z, p_scalar), ::MAX(w, p_scalar));
 	}
 
 	_FORCE_INLINE_ int64_t length_squared() const;
@@ -141,6 +149,11 @@ struct [[nodiscard]] Vector4i {
 	constexpr Vector4i(int32_t p_x, int32_t p_y, int32_t p_z, int32_t p_w) :
 			x(p_x), y(p_y), z(p_z), w(p_w) {}
 };
+
+inline constexpr Vector4i Vector4i::ZERO = { 0, 0, 0, 0 };
+inline constexpr Vector4i Vector4i::ONE = { 1, 1, 1, 1 };
+inline constexpr Vector4i Vector4i::MIN = { INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN };
+inline constexpr Vector4i Vector4i::MAX = { INT32_MAX, INT32_MAX, INT32_MAX, INT32_MAX };
 
 int64_t Vector4i::length_squared() const {
 	return x * (int64_t)x + y * (int64_t)y + z * (int64_t)z + w * (int64_t)w;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2867,31 +2867,31 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_enum_constant(Variant::VECTOR3, "Axis", "AXIS_Y", Vector3::AXIS_Y);
 	_VariantCall::add_enum_constant(Variant::VECTOR3, "Axis", "AXIS_Z", Vector3::AXIS_Z);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(Math::INF, Math::INF, Math::INF));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3::ZERO);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3::ONE);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3::INF);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3::DOWN);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3::FORWARD);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3::BACK);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_LEFT", Vector3(1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_RIGHT", Vector3(-1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_TOP", Vector3(0, 1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_BOTTOM", Vector3(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_FRONT", Vector3(0, 0, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_REAR", Vector3(0, 0, -1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_LEFT", Vector3::MODEL_LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_RIGHT", Vector3::MODEL_RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_TOP", Vector3::MODEL_TOP);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_BOTTOM", Vector3::MODEL_BOTTOM);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_FRONT", Vector3::MODEL_FRONT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_REAR", Vector3::MODEL_REAR);
 
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_X", Vector4::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_Y", Vector4::AXIS_Y);
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_Z", Vector4::AXIS_Z);
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_W", Vector4::AXIS_W);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR4, "ZERO", Vector4(0, 0, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR4, "ONE", Vector4(1, 1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR4, "INF", Vector4(Math::INF, Math::INF, Math::INF, Math::INF));
+	_VariantCall::add_variant_constant(Variant::VECTOR4, "ZERO", Vector4::ZERO);
+	_VariantCall::add_variant_constant(Variant::VECTOR4, "ONE", Vector4::ONE);
+	_VariantCall::add_variant_constant(Variant::VECTOR4, "INF", Vector4::INF);
 
 	_VariantCall::add_enum_constant(Variant::VECTOR3I, "Axis", "AXIS_X", Vector3i::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR3I, "Axis", "AXIS_Y", Vector3i::AXIS_Y);
@@ -2902,21 +2902,21 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_enum_constant(Variant::VECTOR4I, "Axis", "AXIS_Z", Vector4i::AXIS_Z);
 	_VariantCall::add_enum_constant(Variant::VECTOR4I, "Axis", "AXIS_W", Vector4i::AXIS_W);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR4I, "ZERO", Vector4i(0, 0, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR4I, "ONE", Vector4i(1, 1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR4I, "MIN", Vector4i(INT32_MIN, INT32_MIN, INT32_MIN, INT32_MIN));
-	_VariantCall::add_variant_constant(Variant::VECTOR4I, "MAX", Vector4i(INT32_MAX, INT32_MAX, INT32_MAX, INT32_MAX));
+	_VariantCall::add_variant_constant(Variant::VECTOR4I, "ZERO", Vector4i::ZERO);
+	_VariantCall::add_variant_constant(Variant::VECTOR4I, "ONE", Vector4i::ONE);
+	_VariantCall::add_variant_constant(Variant::VECTOR4I, "MIN", Vector4i::MIN);
+	_VariantCall::add_variant_constant(Variant::VECTOR4I, "MAX", Vector4i::MAX);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ZERO", Vector3i(0, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ONE", Vector3i(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MIN", Vector3i(INT32_MIN, INT32_MIN, INT32_MIN));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MAX", Vector3i(INT32_MAX, INT32_MAX, INT32_MAX));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "LEFT", Vector3i(-1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "RIGHT", Vector3i(1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i(0, 1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ZERO", Vector3i::ZERO);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ONE", Vector3i::ONE);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MIN", Vector3i::MIN);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MAX", Vector3i::MAX);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "LEFT", Vector3i::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "RIGHT", Vector3i::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i::DOWN);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i::FORWARD);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i::BACK);
 
 	_VariantCall::add_enum_constant(Variant::VECTOR2, "Axis", "AXIS_X", Vector2::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR2, "Axis", "AXIS_Y", Vector2::AXIS_Y);
@@ -2924,50 +2924,42 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_enum_constant(Variant::VECTOR2I, "Axis", "AXIS_X", Vector2i::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR2I, "Axis", "AXIS_Y", Vector2i::AXIS_Y);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "ZERO", Vector2(0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "ONE", Vector2(1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(Math::INF, Math::INF));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2(-1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2(1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2(0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "DOWN", Vector2(0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "ZERO", Vector2::ZERO);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "ONE", Vector2::ONE);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2::INF);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "DOWN", Vector2::DOWN);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "ZERO", Vector2i(0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "ONE", Vector2i(1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "MIN", Vector2i(INT32_MIN, INT32_MIN));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "MAX", Vector2i(INT32_MAX, INT32_MAX));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "LEFT", Vector2i(-1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "RIGHT", Vector2i(1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "UP", Vector2i(0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "DOWN", Vector2i(0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "ZERO", Vector2i::ZERO);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "ONE", Vector2i::ONE);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "MIN", Vector2i::MIN);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "MAX", Vector2i::MAX);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "LEFT", Vector2i::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "RIGHT", Vector2i::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "UP", Vector2i::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "DOWN", Vector2i::DOWN);
 
-	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "IDENTITY", Transform2D());
-	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_X", Transform2D(-1, 0, 0, 1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_Y", Transform2D(1, 0, 0, -1, 0, 0));
+	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "IDENTITY", Transform2D::IDENTITY);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_X", Transform2D::FLIP_X);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_Y", Transform2D::FLIP_Y);
 
-	Transform3D identity_transform;
-	Transform3D flip_x_transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
-	Transform3D flip_y_transform = Transform3D(1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0);
-	Transform3D flip_z_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "IDENTITY", identity_transform);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_X", flip_x_transform);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Y", flip_y_transform);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Z", flip_z_transform);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "IDENTITY", Transform3D::IDENTITY);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_X", Transform3D::FLIP_X);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Y", Transform3D::FLIP_Y);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Z", Transform3D::FLIP_Z);
 
-	Basis identity_basis;
-	Basis flip_x_basis = Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
-	Basis flip_y_basis = Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
-	Basis flip_z_basis = Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
-	_VariantCall::add_variant_constant(Variant::BASIS, "IDENTITY", identity_basis);
-	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_X", flip_x_basis);
-	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Y", flip_y_basis);
-	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Z", flip_z_basis);
+	_VariantCall::add_variant_constant(Variant::BASIS, "IDENTITY", Basis::IDENTITY);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_X", Basis::FLIP_X);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Y", Basis::FLIP_Y);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Z", Basis::FLIP_Z);
 
-	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_YZ", Plane(Vector3(1, 0, 0), 0));
-	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XZ", Plane(Vector3(0, 1, 0), 0));
-	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XY", Plane(Vector3(0, 0, 1), 0));
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_YZ", Plane::PLANE_YZ);
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XZ", Plane::PLANE_XZ);
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XY", Plane::PLANE_XY);
 
-	_VariantCall::add_variant_constant(Variant::QUATERNION, "IDENTITY", Quaternion(0, 0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::QUATERNION, "IDENTITY", Quaternion::IDENTITY);
 
 	_VariantCall::add_enum_constant(Variant::PROJECTION, "Planes", "PLANE_NEAR", Projection::PLANE_NEAR);
 	_VariantCall::add_enum_constant(Variant::PROJECTION, "Planes", "PLANE_FAR", Projection::PLANE_FAR);
@@ -2976,10 +2968,8 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_enum_constant(Variant::PROJECTION, "Planes", "PLANE_RIGHT", Projection::PLANE_RIGHT);
 	_VariantCall::add_enum_constant(Variant::PROJECTION, "Planes", "PLANE_BOTTOM", Projection::PLANE_BOTTOM);
 
-	Projection p;
-	_VariantCall::add_variant_constant(Variant::PROJECTION, "IDENTITY", p);
-	p.set_zero();
-	_VariantCall::add_variant_constant(Variant::PROJECTION, "ZERO", p);
+	_VariantCall::add_variant_constant(Variant::PROJECTION, "IDENTITY", Projection::IDENTITY);
+	_VariantCall::add_variant_constant(Variant::PROJECTION, "ZERO", Projection::ZERO);
 }
 
 void Variant::_register_variant_methods() {

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -288,7 +288,7 @@ bool ActionMapEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 	TreeItem *source = Object::cast_to<TreeItem>(ObjectDB::get_instance(d["source"].operator ObjectID()));
 	TreeItem *selected = action_tree->get_selected();
 
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? selected : action_tree->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? selected : action_tree->get_item_at_position(p_point);
 	if (!selected || !item || item == source) {
 		return false;
 	}
@@ -312,12 +312,12 @@ void ActionMapEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 	}
 
 	TreeItem *selected = action_tree->get_selected();
-	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? selected : action_tree->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2::INF) ? selected : action_tree->get_item_at_position(p_point);
 	if (!target) {
 		return;
 	}
 
-	bool drop_above = ((p_point == Vector2(Math::INF, Math::INF)) ? action_tree->get_drop_section_at_position(action_tree->get_item_rect(target).position) : action_tree->get_drop_section_at_position(p_point)) == -1;
+	bool drop_above = ((p_point == Vector2::INF) ? action_tree->get_drop_section_at_position(action_tree->get_item_rect(target).position) : action_tree->get_drop_section_at_position(p_point)) == -1;
 
 	Dictionary d = p_data;
 	if (d["input_type"] == "action") {

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -711,7 +711,7 @@ void CreateDialog::_favorite_activated() {
 }
 
 Variant CreateDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2::INF) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
 	if (ti) {
 		Dictionary d;
 		d["type"] = "create_favorite_drag";
@@ -743,13 +743,13 @@ bool CreateDialog::can_drop_data_fw(const Point2 &p_point, const Variant &p_data
 void CreateDialog::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary d = p_data;
 
-	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2::INF) ? favorites->get_selected() : favorites->get_item_at_position(p_point);
 	if (!ti) {
 		return;
 	}
 
 	String drop_at = ti->get_text(0);
-	int ds = (p_point == Vector2(Math::INF, Math::INF)) ? favorites->get_drop_section_at_position(favorites->get_item_rect(ti).position) : favorites->get_drop_section_at_position(p_point);
+	int ds = (p_point == Vector2::INF) ? favorites->get_drop_section_at_position(favorites->get_item_rect(ti).position) : favorites->get_drop_section_at_position(p_point);
 
 	int drop_idx = favorite_list.find(drop_at);
 	if (drop_idx < 0) {

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -635,7 +635,7 @@ Variant EditorAudioBus::get_drag_data(const Point2 &p_point) {
 	p->set_modulate(Color(1, 1, 1, 0.7));
 	p->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("focus"), SNAME("Button")));
 	p->set_size(get_size());
-	p->set_position((p_point == Vector2(Math::INF, Math::INF)) ? Vector2() : -p_point);
+	p->set_position((p_point == Vector2::INF) ? Vector2() : -p_point);
 	set_drag_preview(c);
 	Dictionary d;
 	d["type"] = "move_audio_bus";
@@ -668,7 +668,7 @@ void EditorAudioBus::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Variant EditorAudioBus::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_selected() : effects->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? effects->get_selected() : effects->get_item_at_position(p_point);
 	if (!item) {
 		return Variant();
 	}
@@ -698,7 +698,7 @@ bool EditorAudioBus::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		return false;
 	}
 
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_selected() : effects->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? effects->get_selected() : effects->get_item_at_position(p_point);
 	if (!item) {
 		return false;
 	}
@@ -711,11 +711,11 @@ bool EditorAudioBus::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 void EditorAudioBus::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary d = p_data;
 
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_selected() : effects->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? effects->get_selected() : effects->get_item_at_position(p_point);
 	if (!item) {
 		return;
 	}
-	int pos = (p_point == Vector2(Math::INF, Math::INF)) ? effects->get_drop_section_at_position(effects->get_item_rect(item).position) : effects->get_drop_section_at_position(p_point);
+	int pos = (p_point == Vector2::INF) ? effects->get_drop_section_at_position(effects->get_item_rect(item).position) : effects->get_drop_section_at_position(p_point);
 	Variant md = item->get_metadata(0);
 
 	int paste_at;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -663,13 +663,13 @@ bool EditorAutoloadSettings::can_drop_data_fw(const Point2 &p_point, const Varia
 	}
 
 	if (drop_data.has("type")) {
-		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 
 		if (!ti) {
 			return false;
 		}
 
-		int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		int section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 
 		return section >= -1;
 	}
@@ -678,13 +678,13 @@ bool EditorAutoloadSettings::can_drop_data_fw(const Point2 &p_point, const Varia
 }
 
 void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_control) {
-	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 
 	if (!ti) {
 		return;
 	}
 
-	int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+	int section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 
 	if (section < -1) {
 		return;

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2982,7 +2982,7 @@ void EditorInspectorArray::drop_data_fw(const Point2 &p_point, const Variant &p_
 	Dictionary dict = p_data;
 
 	int to_drop = dict["index"];
-	int drop_position = (p_point == Vector2(Math::INF, Math::INF)) ? selected : _drop_position();
+	int drop_position = (p_point == Vector2::INF) ? selected : _drop_position();
 	if (drop_position < 0) {
 		return;
 	}
@@ -3000,7 +3000,7 @@ bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant
 		return false;
 	}
 	Dictionary dict = p_data;
-	int drop_position = (p_point == Vector2(Math::INF, Math::INF)) ? selected : _drop_position();
+	int drop_position = (p_point == Vector2::INF) ? selected : _drop_position();
 	if (!dict.has("type") || dict["type"] != "property_array_element" || String(dict["property_array_prefix"]) != array_element_prefix || drop_position < 0) {
 		return false;
 	}

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -752,7 +752,7 @@ Variant EditorSettingsDialog::get_drag_data_fw(const Point2 &p_point, Control *p
 
 bool EditorSettingsDialog::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
 	TreeItem *selected = shortcuts->get_selected();
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
 	if (!selected || !item || item == selected || (String)item->get_meta("type", "") != "event") {
 		return false;
 	}
@@ -771,7 +771,7 @@ void EditorSettingsDialog::drop_data_fw(const Point2 &p_point, const Variant &p_
 	}
 
 	TreeItem *selected = shortcuts->get_selected();
-	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2::INF) ? shortcuts->get_selected() : shortcuts->get_item_at_position(p_point);
 
 	if (!target) {
 		return;

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -750,7 +750,7 @@ void ProjectExportDialog::_delete_preset_confirm() {
 Variant ProjectExportDialog::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
 	if (p_from == presets) {
 		int pos = -1;
-		if (p_point == Vector2(Math::INF, Math::INF)) {
+		if (p_point == Vector2::INF) {
 			if (presets->is_anything_selected()) {
 				pos = presets->get_selected_items()[0];
 			}
@@ -778,7 +778,7 @@ Variant ProjectExportDialog::get_drag_data_fw(const Point2 &p_point, Control *p_
 			return d;
 		}
 	} else if (p_from == patches) {
-		TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? patches->get_selected() : patches->get_item_at_position(p_point);
+		TreeItem *item = (p_point == Vector2::INF) ? patches->get_selected() : patches->get_item_at_position(p_point);
 
 		if (item) {
 			int item_metadata = item->get_metadata(0);
@@ -806,7 +806,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 
 		int pos = -1;
 		bool end = true;
-		if (p_point == Vector2(Math::INF, Math::INF)) {
+		if (p_point == Vector2::INF) {
 			if (presets->is_anything_selected()) {
 				pos = presets->get_selected_items()[0];
 			}
@@ -824,7 +824,7 @@ bool ProjectExportDialog::can_drop_data_fw(const Point2 &p_point, const Variant 
 			return false;
 		}
 
-		TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? patches->get_selected() : patches->get_item_at_position(p_point);
+		TreeItem *item = (p_point == Vector2::INF) ? patches->get_selected() : patches->get_item_at_position(p_point);
 		if (!item) {
 			return false;
 		}
@@ -844,7 +844,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 
 		int pos = -1;
 		bool end = true;
-		if (p_point == Vector2(Math::INF, Math::INF)) {
+		if (p_point == Vector2::INF) {
 			if (presets->is_anything_selected()) {
 				pos = presets->get_selected_items()[0];
 			}
@@ -881,7 +881,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 		Dictionary d = p_data;
 		int from_pos = d["patch"];
 
-		TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? patches->get_selected() : patches->get_item_at_position(p_point);
+		TreeItem *item = (p_point == Vector2::INF) ? patches->get_selected() : patches->get_item_at_position(p_point);
 		if (!item) {
 			return;
 		}
@@ -889,7 +889,7 @@ void ProjectExportDialog::drop_data_fw(const Point2 &p_point, const Variant &p_d
 		int to_pos = item->get_metadata(0);
 
 		int pos = -1;
-		if (p_point == Vector2(Math::INF, Math::INF)) {
+		if (p_point == Vector2::INF) {
 			pos = patches->get_drop_section_at_position(patches->get_item_rect(item).position);
 		} else {
 			pos = patches->get_drop_section_at_position(p_point);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2953,12 +2953,12 @@ bool FileSystemDock::can_drop_data_fw(const Point2 &p_point, const Variant &p_da
 		}
 
 		// Moving favorite around.
-		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 		if (!ti) {
 			return false;
 		}
 
-		int drop_section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		int drop_section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 		if (ti == favorites_item) {
 			return (drop_section == 1); // The parent, first fav.
 		}
@@ -3031,11 +3031,11 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			return;
 		}
 		// Moving favorite around.
-		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 		if (!ti) {
 			return;
 		}
-		int drop_section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		int drop_section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 
 		int drop_position;
 		Vector<String> drag_files = drag_data["files"];
@@ -3155,7 +3155,7 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 
 	// In the file list.
 	if (p_from == files) {
-		int pos = (p_point == Vector2(Math::INF, Math::INF)) ? -1 : files->get_item_at_position(p_point, true);
+		int pos = (p_point == Vector2::INF) ? -1 : files->get_item_at_position(p_point, true);
 		if (pos == -1) {
 			target = get_current_directory();
 			return;
@@ -3168,8 +3168,8 @@ void FileSystemDock::_get_drag_target_folder(String &target, bool &target_favori
 
 	// In the tree.
 	if (p_from == tree) {
-		TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
-		int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
+		TreeItem *ti = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
+		int section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(ti).position) : tree->get_drop_section_at_position(p_point);
 		if (ti) {
 			// Check the favorites first.
 			if (ti == tree->get_root()->get_first_child() && section >= 0) {

--- a/editor/gui/scene_tree_editor.cpp
+++ b/editor/gui/scene_tree_editor.cpp
@@ -1882,12 +1882,12 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return false;
 	}
 
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 	if (!item) {
 		return false;
 	}
 
-	int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
+	int section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
 	if (section < -1 || (section == -1 && !item->get_parent())) {
 		return false;
 	}
@@ -1971,11 +1971,11 @@ void SceneTreeEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data,
 		return;
 	}
 
-	TreeItem *item = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *item = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 	if (!item) {
 		return;
 	}
-	int section = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
+	int section = (p_point == Vector2::INF) ? tree->get_drop_section_at_position(tree->get_item_rect(item).position) : tree->get_drop_section_at_position(p_point);
 	if (section < -1) {
 		return;
 	}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4291,8 +4291,8 @@ void CanvasItemEditor::_selection_changed() {
 	}
 	selected_from_canvas = false;
 
-	if (temp_pivot != Vector2(Math::INF, Math::INF)) {
-		temp_pivot = Vector2(Math::INF, Math::INF);
+	if (temp_pivot != Vector2::INF) {
+		temp_pivot = Vector2::INF;
 		viewport->queue_redraw();
 	}
 }
@@ -6218,7 +6218,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 }
 
 bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		return false;
 	}
 	Dictionary d = p_data;
@@ -6352,7 +6352,7 @@ bool CanvasItemEditorViewport::_is_any_texture_selected() const {
 }
 
 void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p_data) {
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		return;
 	}
 	bool is_shift = Input::get_singleton()->is_key_pressed(Key::SHIFT);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -252,7 +252,7 @@ private:
 	bool key_scale = false;
 
 	bool pan_pressed = false;
-	Vector2 temp_pivot = Vector2(Math::INF, Math::INF);
+	Vector2 temp_pivot = Vector2::INF;
 
 	bool ruler_tool_active = false;
 	Point2 ruler_tool_origin;

--- a/editor/plugins/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/plugins/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -192,29 +192,26 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 }
 
 void SpringBoneSimulator3DGizmoPlugin::draw_sphere(Ref<SurfaceTool> &p_surface_tool, const Basis &p_basis, const Vector3 &p_center, float p_radius, const Color &p_color) {
-	static const Vector3 VECTOR3_RIGHT = Vector3(1, 0, 0);
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
-	static const int STEP = 16;
-	static const float SPPI = Math::TAU / (float)STEP;
+	static constexpr int STEP = 16;
+	static constexpr float SPPI = Math::TAU / (float)STEP;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_UP * p_radius)).rotated(p_basis.xform(VECTOR3_RIGHT), SPPI * ((i - 1) % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::UP * p_radius)).rotated(p_basis.xform(Vector3::RIGHT), SPPI * ((i - 1) % STEP))));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_UP * p_radius)).rotated(p_basis.xform(VECTOR3_RIGHT), SPPI * (i % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::UP * p_radius)).rotated(p_basis.xform(Vector3::RIGHT), SPPI * (i % STEP))));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_RIGHT * p_radius)).rotated(p_basis.xform(VECTOR3_FORWARD), SPPI * ((i - 1) % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::RIGHT * p_radius)).rotated(p_basis.xform(Vector3::FORWARD), SPPI * ((i - 1) % STEP))));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_RIGHT * p_radius)).rotated(p_basis.xform(VECTOR3_FORWARD), SPPI * (i % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::RIGHT * p_radius)).rotated(p_basis.xform(Vector3::FORWARD), SPPI * (i % STEP))));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_FORWARD * p_radius)).rotated(p_basis.xform(VECTOR3_UP), SPPI * ((i - 1) % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::FORWARD * p_radius)).rotated(p_basis.xform(Vector3::UP), SPPI * ((i - 1) % STEP))));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_FORWARD * p_radius)).rotated(p_basis.xform(VECTOR3_UP), SPPI * (i % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::FORWARD * p_radius)).rotated(p_basis.xform(Vector3::UP), SPPI * (i % STEP))));
 	}
 }
 
@@ -323,74 +320,68 @@ Ref<ArrayMesh> SpringBoneCollision3DGizmoPlugin::get_collision_mesh(SpringBoneCo
 }
 
 void SpringBoneCollision3DGizmoPlugin::draw_sphere(Ref<SurfaceTool> &p_surface_tool, float p_radius, const Color &p_color) {
-	static const Vector3 VECTOR3_RIGHT = Vector3(1, 0, 0);
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
-	static const int STEP = 16;
-	static const float SPPI = Math::TAU / (float)STEP;
+	static constexpr int STEP = 16;
+	static constexpr float SPPI = Math::TAU / (float)STEP;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((Vector3::UP * p_radius).rotated(Vector3::RIGHT, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((Vector3::UP * p_radius).rotated(Vector3::RIGHT, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * (i % STEP)));
 	}
 }
 
 void SpringBoneCollision3DGizmoPlugin::draw_capsule(Ref<SurfaceTool> &p_surface_tool, float p_radius, float p_height, const Color &p_color) {
-	static const Vector3 VECTOR3_RIGHT = Vector3(1, 0, 0);
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
-	static const int STEP = 16;
-	static const int HALF_STEP = 8;
-	static const float SPPI = Math::TAU / (float)STEP;
-	static const float HALF_PI = Math::PI * 0.5;
+	static constexpr int STEP = 16;
+	static constexpr int HALF_STEP = 8;
+	static constexpr float SPPI = Math::TAU / (float)STEP;
+	static constexpr float HALF_PI = Math::PI * 0.5;
 
-	Vector3 top = VECTOR3_UP * (p_height * 0.5 - p_radius);
+	Vector3 top = Vector3::UP * (p_height * 0.5 - p_radius);
 	Vector3 bottom = -top;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, -HALF_PI + SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::UP * p_radius).rotated(Vector3::RIGHT, -HALF_PI + SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, -HALF_PI + SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::UP * p_radius).rotated(Vector3::RIGHT, -HALF_PI + SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(top + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex(top + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(top + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex(top + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(bottom + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex(bottom + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(bottom + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex(bottom + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * (i % STEP)));
 	}
 	LocalVector<Vector3> directions;
 	directions.resize(4);
-	directions[0] = VECTOR3_RIGHT;
-	directions[1] = -VECTOR3_RIGHT;
-	directions[2] = VECTOR3_FORWARD;
-	directions[3] = -VECTOR3_FORWARD;
+	directions[0] = Vector3::RIGHT;
+	directions[1] = -Vector3::RIGHT;
+	directions[2] = Vector3::FORWARD;
+	directions[3] = -Vector3::FORWARD;
 	for (int i = 0; i < 4; i++) {
 		Vector3 dir = directions[i] * p_radius;
 		p_surface_tool->set_color(p_color);
@@ -400,16 +391,15 @@ void SpringBoneCollision3DGizmoPlugin::draw_capsule(Ref<SurfaceTool> &p_surface_
 }
 
 void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_tool, const Color &p_color) {
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const float HALF_PI = Math::PI * 0.5;
-	static const float ARROW_LENGTH = 0.3;
-	static const float ARROW_HALF_WIDTH = 0.05;
-	static const float ARROW_TOP_HALF_WIDTH = 0.1;
-	static const float ARROW_TOP = 0.5;
-	static const float RECT_SIZE = 1.0;
-	static const int RECT_STEP_COUNT = 9;
-	static const float RECT_HALF_SIZE = RECT_SIZE * 0.5;
-	static const float RECT_STEP = RECT_SIZE / (float)RECT_STEP_COUNT;
+	static constexpr float HALF_PI = Math::PI * 0.5;
+	static constexpr float ARROW_LENGTH = 0.3;
+	static constexpr float ARROW_HALF_WIDTH = 0.05;
+	static constexpr float ARROW_TOP_HALF_WIDTH = 0.1;
+	static constexpr float ARROW_TOP = 0.5;
+	static constexpr float RECT_SIZE = 1.0;
+	static constexpr int RECT_STEP_COUNT = 9;
+	static constexpr float RECT_HALF_SIZE = RECT_SIZE * 0.5;
+	static constexpr float RECT_STEP = RECT_SIZE / (float)RECT_STEP_COUNT;
 
 	p_surface_tool->set_color(p_color);
 
@@ -424,7 +414,7 @@ void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_to
 	arrow[5] = Vector3(ARROW_HALF_WIDTH, ARROW_LENGTH, 0);
 	arrow[6] = Vector3(ARROW_TOP_HALF_WIDTH, ARROW_LENGTH, 0);
 	for (int i = 0; i < 2; i++) {
-		Basis ma(VECTOR3_UP, HALF_PI * i);
+		Basis ma(Vector3::UP, HALF_PI * i);
 		for (uint32_t j = 0; j < arrow.size(); j++) {
 			Vector3 v1 = arrow[j];
 			Vector3 v2 = arrow[(j + 1) % arrow.size()];
@@ -435,7 +425,7 @@ void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_to
 
 	// Draw dashed line of the rect.
 	for (int i = 0; i < 4; i++) {
-		Basis ma(VECTOR3_UP, HALF_PI * i);
+		Basis ma(Vector3::UP, HALF_PI * i);
 		for (int j = 0; j < RECT_STEP_COUNT; j++) {
 			if (j % 2 == 1) {
 				continue;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4969,7 +4969,7 @@ void Node3DEditorViewport::_perform_drop_data() {
 }
 
 bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		return false;
 	}
 	preview_node_viewport_pos = p_point;

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -252,7 +252,7 @@ void ResourcePreloaderEditor::edit(ResourcePreloader *p_preloader) {
 }
 
 Variant ResourcePreloaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	TreeItem *ti = (p_point == Vector2(Math::INF, Math::INF)) ? tree->get_selected() : tree->get_item_at_position(p_point);
+	TreeItem *ti = (p_point == Vector2::INF) ? tree->get_selected() : tree->get_item_at_position(p_point);
 	if (!ti) {
 		return Variant();
 	}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3278,7 +3278,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 			int new_index = 0;
 			if (script_list->get_item_count() > 0) {
 				int pos = 0;
-				if (p_point == Vector2(Math::INF, Math::INF)) {
+				if (p_point == Vector2::INF) {
 					if (script_list->is_anything_selected()) {
 						pos = script_list->get_selected_items()[0];
 					}
@@ -3306,7 +3306,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 			int new_index = 0;
 			if (script_list->get_item_count() > 0) {
 				int pos = 0;
-				if (p_point == Vector2(Math::INF, Math::INF)) {
+				if (p_point == Vector2::INF) {
 					if (script_list->is_anything_selected()) {
 						pos = script_list->get_selected_items()[0];
 					}
@@ -3327,7 +3327,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 		int new_index = 0;
 		if (script_list->get_item_count() > 0) {
 			int pos = 0;
-			if (p_point == Vector2(Math::INF, Math::INF)) {
+			if (p_point == Vector2::INF) {
 				if (script_list->is_anything_selected()) {
 					pos = script_list->get_selected_items()[0];
 				}

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -2203,7 +2203,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	Dictionary d = p_data;
 
 	CodeEdit *te = code_editor->get_text_editor();
-	Point2i pos = (p_point == Vector2(Math::INF, Math::INF)) ? Point2i(te->get_caret_line(0), te->get_caret_column(0)) : te->get_line_column_at_pos(p_point);
+	Point2i pos = (p_point == Vector2::INF) ? Point2i(te->get_caret_line(0), te->get_caret_column(0)) : te->get_line_column_at_pos(p_point);
 	int drop_at_line = pos.y;
 	int drop_at_column = pos.x;
 	int selection_index = te->get_selection_at_line_column(drop_at_line, drop_at_column);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -661,7 +661,7 @@ Variant ShaderEditorPlugin::get_drag_data_fw(const Point2 &p_point, Control *p_f
 	}
 
 	int idx = 0;
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		if (shader_list->is_anything_selected()) {
 			idx = shader_list->get_selected_items()[0];
 		}
@@ -745,7 +745,7 @@ void ShaderEditorPlugin::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	if (String(d["type"]) == "shader_list_element") {
 		int idx = d["shader_list_element"];
 		int new_idx = 0;
-		if (p_point == Vector2(Math::INF, Math::INF)) {
+		if (p_point == Vector2::INF) {
 			if (shader_list->is_anything_selected()) {
 				new_idx = shader_list->get_selected_items()[0];
 			}

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -701,7 +701,7 @@ Variant Skeleton3DEditor::get_drag_data_fw(const Point2 &p_point, Control *p_fro
 }
 
 bool Skeleton3DEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2::INF) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
 	if (!target) {
 		return false;
 	}
@@ -729,7 +729,7 @@ void Skeleton3DEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		return;
 	}
 
-	TreeItem *target = (p_point == Vector2(Math::INF, Math::INF)) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
+	TreeItem *target = (p_point == Vector2::INF) ? joint_tree->get_selected() : joint_tree->get_item_at_position(p_point);
 	TreeItem *selected = Object::cast_to<TreeItem>(Dictionary(p_data)["node"]);
 
 	const BoneId target_boneidx = String(target->get_metadata(0)).get_slicec('/', 1).to_int();

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1662,7 +1662,7 @@ Variant SpriteFramesEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 	}
 
 	int idx = -1;
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		if (frame_list->is_anything_selected()) {
 			idx = frame_list->get_selected_items()[0];
 		}
@@ -1744,7 +1744,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	}
 
 	int at_pos = -1;
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		if (frame_list->is_anything_selected()) {
 			at_pos = frame_list->get_selected_items()[0];
 		}

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6166,7 +6166,7 @@ void VisualShaderEditor::_connection_menu_id_pressed(int p_idx) {
 }
 
 Variant VisualShaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from) {
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		return Variant();
 	}
 
@@ -6196,7 +6196,7 @@ Variant VisualShaderEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 }
 
 bool VisualShaderEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		return false;
 	}
 
@@ -6215,7 +6215,7 @@ bool VisualShaderEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 }
 
 void VisualShaderEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		return;
 	}
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -326,8 +326,8 @@ public:
 	void global_scale(const Vector3 &p_scale);
 	void global_translate(const Vector3 &p_offset);
 
-	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
-	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
+	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
+	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;

--- a/scene/3d/spring_bone_collision_capsule_3d.cpp
+++ b/scene/3d/spring_bone_collision_capsule_3d.cpp
@@ -84,10 +84,8 @@ bool SpringBoneCollisionCapsule3D::is_inside() const {
 }
 
 Pair<Vector3, Vector3> SpringBoneCollisionCapsule3D::get_head_and_tail(const Transform3D &p_center) const {
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_DOWN = Vector3(0, -1, 0);
 	Transform3D tr = get_transform_from_skeleton(p_center);
-	return Pair<Vector3, Vector3>(tr.origin + tr.basis.xform(VECTOR3_UP * (height * 0.5 - radius)), tr.origin + tr.basis.xform(VECTOR3_DOWN * (height * 0.5 - radius)));
+	return Pair<Vector3, Vector3>(tr.origin + tr.basis.xform(Vector3::UP * (height * 0.5 - radius)), tr.origin + tr.basis.xform(Vector3::DOWN * (height * 0.5 - radius)));
 }
 
 void SpringBoneCollisionCapsule3D::_bind_methods() {

--- a/scene/3d/spring_bone_collision_plane_3d.cpp
+++ b/scene/3d/spring_bone_collision_plane_3d.cpp
@@ -31,10 +31,9 @@
 #include "spring_bone_collision_plane_3d.h"
 
 Vector3 SpringBoneCollisionPlane3D::_collide(const Transform3D &p_center, float p_bone_radius, float p_bone_length, const Vector3 &p_current) const {
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
 	Transform3D tr = get_transform_from_skeleton(p_center);
 	Vector3 pos = tr.origin;
-	Vector3 normal = tr.basis.get_rotation_quaternion().xform(VECTOR3_UP);
+	Vector3 normal = tr.basis.get_rotation_quaternion().xform(Vector3::UP);
 	Vector3 to_vec = p_current - pos;
 	float distance = to_vec.dot(normal) - p_bone_radius;
 	if (distance > 0) {

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -1821,7 +1821,7 @@ void RuntimeNodeSelect::_physics_frame() {
 
 	switch (selection_drag_state) {
 		case SELECTION_DRAG_END: {
-			selection_position = Point2(Math::INF, Math::INF);
+			selection_position = Point2::INF;
 			selection_drag_state = SELECTION_DRAG_NONE;
 
 			if (selection_drag_area.get_area() > SELECTION_MIN_AREA) {
@@ -1877,11 +1877,11 @@ void RuntimeNodeSelect::_physics_frame() {
 	}
 
 	if (items.is_empty()) {
-		selection_position = Point2(Math::INF, Math::INF);
+		selection_position = Point2::INF;
 		return;
 	}
 	if ((!list_shortcut_pressed && node_select_mode == SELECT_MODE_SINGLE) || items.size() == 1) {
-		selection_position = Point2(Math::INF, Math::INF);
+		selection_position = Point2::INF;
 
 		Vector<Node *> node;
 		node.append(items[0].item);
@@ -1894,7 +1894,7 @@ void RuntimeNodeSelect::_physics_frame() {
 		_open_selection_list(items, selection_position);
 	}
 
-	selection_position = Point2(Math::INF, Math::INF);
+	selection_position = Point2::INF;
 }
 
 void RuntimeNodeSelect::_send_ids(const Vector<Node *> &p_picked_nodes, bool p_invert_new_selections) {

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -267,7 +267,7 @@ private:
 
 	bool has_selection = false;
 	int max_selection = 1;
-	Point2 selection_position = Point2(Math::INF, Math::INF);
+	Point2 selection_position = Point2::INF;
 	Rect2 selection_drag_area;
 	PopupMenu *selection_list = nullptr;
 	Color selection_area_fill;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2098,7 +2098,7 @@ void Control::accessibility_drag() {
 	Viewport *vp = get_viewport();
 
 	vp->_gui_force_drag_start();
-	Variant dnd_data = get_drag_data(Vector2(Math::INF, Math::INF));
+	Variant dnd_data = get_drag_data(Vector2::INF);
 	if (dnd_data.get_type() != Variant::NIL) {
 		Window *w = Window::get_from_id(get_window()->get_window_id());
 		if (w) {
@@ -2116,7 +2116,7 @@ void Control::accessibility_drop() {
 	ERR_FAIL_COND(!is_inside_tree());
 	ERR_FAIL_COND(!get_viewport()->gui_is_dragging());
 
-	get_viewport()->gui_perform_drop_at(Vector2(Math::INF, Math::INF), this);
+	get_viewport()->gui_perform_drop_at(Vector2::INF, this);
 
 	queue_accessibility_update();
 }
@@ -3722,7 +3722,7 @@ void Control::_notification(int p_notification) {
 			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_HIDE_TOOLTIP, callable_mp(this, &Control::_accessibility_action_hide_tooltip));
 			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_SCROLL_INTO_VIEW, callable_mp(this, &Control::_accessibility_action_scroll_into_view));
 			if (is_inside_tree() && get_viewport()->gui_is_dragging()) {
-				if (can_drop_data(Vector2(Math::INF, Math::INF), get_viewport()->gui_get_drag_data())) {
+				if (can_drop_data(Vector2::INF, get_viewport()->gui_get_drag_data())) {
 					DisplayServer::get_singleton()->accessibility_update_set_extra_info(ae, vformat(RTR("%s can be dropped here. Use %s to drop, use %s to cancel."), get_viewport()->gui_get_drag_description(), InputMap::get_singleton()->get_action_description("ui_accessibility_drag_and_drop"), InputMap::get_singleton()->get_action_description("ui_cancel")));
 				} else {
 					DisplayServer::get_singleton()->accessibility_update_set_extra_info(ae, vformat(RTR("%s can not be dropped here. Use %s to cancel."), get_viewport()->gui_get_drag_description(), InputMap::get_singleton()->get_action_description("ui_cancel")));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1073,7 +1073,7 @@ void LineEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	if (p_data.is_string() && is_editable()) {
 		apply_ime();
 
-		if (p_point != Vector2(Math::INF, Math::INF)) {
+		if (p_point != Vector2::INF) {
 			set_caret_at_pixel_pos(p_point.x);
 		}
 		int caret_column_tmp = caret_column;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1398,7 +1398,7 @@ void TabBar::drop_data(const Point2 &p_point, const Variant &p_data) {
 }
 
 Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_point) {
-	int tab_over = (p_point == Vector2(Math::INF, Math::INF)) ? current : get_tab_idx_at_point(p_point);
+	int tab_over = (p_point == Vector2::INF) ? current : get_tab_idx_at_point(p_point);
 	if (tab_over < 0) {
 		return Variant();
 	}
@@ -1463,7 +1463,7 @@ void TabBar::_handle_drop_data(const String &p_type, const Point2 &p_point, cons
 
 	if (String(d["type"]) == p_type) {
 		int tab_from_id = d["tab_index"];
-		int hover_now = (p_point == Vector2(Math::INF, Math::INF)) ? current : get_closest_tab_idx_to_point(p_point);
+		int hover_now = (p_point == Vector2::INF) ? current : get_closest_tab_idx_to_point(p_point);
 		NodePath from_path = d["from_path"];
 		NodePath to_path = get_path();
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3525,7 +3525,7 @@ bool TextEdit::can_drop_data(const Point2 &p_point, const Variant &p_data) const
 void TextEdit::drop_data(const Point2 &p_point, const Variant &p_data) {
 	Control::drop_data(p_point, p_data);
 
-	if (p_point == Vector2(Math::INF, Math::INF)) {
+	if (p_point == Vector2::INF) {
 		insert_text_at_caret(p_data);
 	} else if (p_data.is_string() && is_editable()) {
 		Point2i pos = get_line_column_at_pos(get_local_mouse_pos());

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -6322,7 +6322,7 @@ int Tree::get_button_id_at_position(const Point2 &p_pos) const {
 		return -1;
 	}
 
-	if (p_pos == Vector2(Math::INF, Math::INF)) {
+	if (p_pos == Vector2::INF) {
 		if (selected_item && selected_button >= 0) {
 			return selected_item->cells[selected_col].buttons[selected_button].id;
 		}

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -3328,8 +3328,8 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 	Vector<Vector2> uvs;
 	Vector<int32_t> indices;
 
-	Vector2 min_p = Vector2(Math::INF, Math::INF);
-	Vector2 max_p = Vector2(-Math::INF, -Math::INF);
+	Vector2 min_p = Vector2::INF;
+	Vector2 max_p = -Vector2::INF;
 
 	int32_t p_size = 0;
 	int32_t i_size = 0;

--- a/scene/resources/3d/primitive_meshes.h
+++ b/scene/resources/3d/primitive_meshes.h
@@ -567,8 +567,8 @@ private:
 		Vector<Vector2> triangles;
 		Vector<Vector<ContourPoint>> contours;
 		Vector<ContourInfo> contours_info;
-		Vector2 min_p = Vector2(Math::INF, Math::INF);
-		Vector2 max_p = Vector2(-Math::INF, -Math::INF);
+		Vector2 min_p = Vector2::INF;
+		Vector2 max_p = -Vector2::INF;
 	};
 	mutable HashMap<GlyphMeshKey, GlyphMeshData, GlyphMeshKeyHasher> cache;
 

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -460,22 +460,19 @@ TEST_CASE("[AABB] Expanding") {
 }
 
 TEST_CASE("[AABB] Finite number checks") {
-	constexpr Vector3 x(0, 1, 2);
-	constexpr Vector3 infinite(Math::NaN, Math::NaN, Math::NaN);
-
 	CHECK_MESSAGE(
-			AABB(x, x).is_finite(),
+			AABB(Vector3::ZERO, Vector3::ZERO).is_finite(),
 			"AABB with all components finite should be finite");
 
 	CHECK_FALSE_MESSAGE(
-			AABB(infinite, x).is_finite(),
+			AABB(Vector3::INF, Vector3::ZERO).is_finite(),
 			"AABB with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			AABB(x, infinite).is_finite(),
+			AABB(Vector3::ZERO, Vector3::INF).is_finite(),
 			"AABB with one component infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			AABB(infinite, infinite).is_finite(),
+			AABB(Vector3::INF, Vector3::INF).is_finite(),
 			"AABB with two components infinite should not be finite.");
 }
 

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -269,35 +269,32 @@ TEST_CASE("[Basis] Set axis angle") {
 }
 
 TEST_CASE("[Basis] Finite number checks") {
-	constexpr Vector3 x(0, 1, 2);
-	constexpr Vector3 infinite(Math::NaN, Math::NaN, Math::NaN);
-
 	CHECK_MESSAGE(
-			Basis(x, x, x).is_finite(),
+			Basis(Vector3::ZERO, Vector3::ZERO, Vector3::ZERO).is_finite(),
 			"Basis with all components finite should be finite");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(infinite, x, x).is_finite(),
+			Basis(Vector3::INF, Vector3::ZERO, Vector3::ZERO).is_finite(),
 			"Basis with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Basis(x, infinite, x).is_finite(),
+			Basis(Vector3::ZERO, Vector3::INF, Vector3::ZERO).is_finite(),
 			"Basis with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Basis(x, x, infinite).is_finite(),
+			Basis(Vector3::ZERO, Vector3::ZERO, Vector3::INF).is_finite(),
 			"Basis with one component infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(infinite, infinite, x).is_finite(),
+			Basis(Vector3::INF, Vector3::INF, Vector3::ZERO).is_finite(),
 			"Basis with two components infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Basis(infinite, x, infinite).is_finite(),
+			Basis(Vector3::INF, Vector3::ZERO, Vector3::INF).is_finite(),
 			"Basis with two components infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Basis(x, infinite, infinite).is_finite(),
+			Basis(Vector3::ZERO, Vector3::INF, Vector3::INF).is_finite(),
 			"Basis with two components infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Basis(infinite, infinite, infinite).is_finite(),
+			Basis(Vector3::INF, Vector3::INF, Vector3::INF).is_finite(),
 			"Basis with three components infinite should not be finite.");
 }
 

--- a/tests/core/math/test_plane.h
+++ b/tests/core/math/test_plane.h
@@ -168,24 +168,19 @@ TEST_CASE("[Plane] Intersection") {
 }
 
 TEST_CASE("[Plane] Finite number checks") {
-	constexpr Vector3 x(0, 1, 2);
-	constexpr Vector3 infinite_vec(Math::NaN, Math::NaN, Math::NaN);
-	constexpr real_t y = 0;
-	constexpr real_t infinite_y = Math::NaN;
-
 	CHECK_MESSAGE(
-			Plane(x, y).is_finite(),
+			Plane(Vector3::ZERO, 0).is_finite(),
 			"Plane with all components finite should be finite");
 
 	CHECK_FALSE_MESSAGE(
-			Plane(x, infinite_y).is_finite(),
+			Plane(Vector3::ZERO, Math::NaN).is_finite(),
 			"Plane with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Plane(infinite_vec, y).is_finite(),
+			Plane(Vector3::INF, 0).is_finite(),
 			"Plane with one component infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Plane(infinite_vec, infinite_y).is_finite(),
+			Plane(Vector3::INF, Math::NaN).is_finite(),
 			"Plane with two components infinite should not be finite.");
 }
 

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -323,22 +323,19 @@ TEST_CASE("[Rect2] Merging") {
 }
 
 TEST_CASE("[Rect2] Finite number checks") {
-	constexpr Vector2 x(0, 1);
-	constexpr Vector2 infinite(Math::NaN, Math::NaN);
-
 	CHECK_MESSAGE(
-			Rect2(x, x).is_finite(),
+			Rect2(Vector2::ZERO, Vector2::ZERO).is_finite(),
 			"Rect2 with all components finite should be finite");
 
 	CHECK_FALSE_MESSAGE(
-			Rect2(infinite, x).is_finite(),
+			Rect2(Vector2::INF, Vector2::ZERO).is_finite(),
 			"Rect2 with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Rect2(x, infinite).is_finite(),
+			Rect2(Vector2::ZERO, Vector2::INF).is_finite(),
 			"Rect2 with one component infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Rect2(infinite, infinite).is_finite(),
+			Rect2(Vector2::INF, Vector2::INF).is_finite(),
 			"Rect2 with two components infinite should not be finite.");
 }
 

--- a/tests/core/math/test_transform_2d.h
+++ b/tests/core/math/test_transform_2d.h
@@ -181,35 +181,32 @@ TEST_CASE("[Transform2D] Interpolation") {
 }
 
 TEST_CASE("[Transform2D] Finite number checks") {
-	constexpr Vector2 x = Vector2(0, 1);
-	constexpr Vector2 infinite = Vector2(Math::NaN, Math::NaN);
-
 	CHECK_MESSAGE(
-			Transform2D(x, x, x).is_finite(),
+			Transform2D(Vector2::ZERO, Vector2::ZERO, Vector2::ZERO).is_finite(),
 			"Transform2D with all components finite should be finite");
 
 	CHECK_FALSE_MESSAGE(
-			Transform2D(infinite, x, x).is_finite(),
+			Transform2D(Vector2::INF, Vector2::ZERO, Vector2::ZERO).is_finite(),
 			"Transform2D with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Transform2D(x, infinite, x).is_finite(),
+			Transform2D(Vector2::ZERO, Vector2::INF, Vector2::ZERO).is_finite(),
 			"Transform2D with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Transform2D(x, x, infinite).is_finite(),
+			Transform2D(Vector2::ZERO, Vector2::ZERO, Vector2::INF).is_finite(),
 			"Transform2D with one component infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Transform2D(infinite, infinite, x).is_finite(),
+			Transform2D(Vector2::INF, Vector2::INF, Vector2::ZERO).is_finite(),
 			"Transform2D with two components infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Transform2D(infinite, x, infinite).is_finite(),
+			Transform2D(Vector2::INF, Vector2::ZERO, Vector2::INF).is_finite(),
 			"Transform2D with two components infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Transform2D(x, infinite, infinite).is_finite(),
+			Transform2D(Vector2::ZERO, Vector2::INF, Vector2::INF).is_finite(),
 			"Transform2D with two components infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Transform2D(infinite, infinite, infinite).is_finite(),
+			Transform2D(Vector2::INF, Vector2::INF, Vector2::INF).is_finite(),
 			"Transform2D with three components infinite should not be finite.");
 }
 

--- a/tests/core/math/test_transform_3d.h
+++ b/tests/core/math/test_transform_3d.h
@@ -85,24 +85,19 @@ TEST_CASE("[Transform3D] rotation") {
 }
 
 TEST_CASE("[Transform3D] Finite number checks") {
-	constexpr Vector3 y(0, 1, 2);
-	constexpr Vector3 infinite_vec(Math::NaN, Math::NaN, Math::NaN);
-	constexpr Basis x(y, y, y);
-	constexpr Basis infinite_basis(infinite_vec, infinite_vec, infinite_vec);
-
 	CHECK_MESSAGE(
-			Transform3D(x, y).is_finite(),
+			Transform3D(Basis::ZERO, Vector3::ZERO).is_finite(),
 			"Transform3D with all components finite should be finite");
 
 	CHECK_FALSE_MESSAGE(
-			Transform3D(x, infinite_vec).is_finite(),
+			Transform3D(Basis::ZERO, Vector3::INF).is_finite(),
 			"Transform3D with one component infinite should not be finite.");
 	CHECK_FALSE_MESSAGE(
-			Transform3D(infinite_basis, y).is_finite(),
+			Transform3D(Basis::INF, Vector3::ZERO).is_finite(),
 			"Transform3D with one component infinite should not be finite.");
 
 	CHECK_FALSE_MESSAGE(
-			Transform3D(infinite_basis, infinite_vec).is_finite(),
+			Transform3D(Basis::INF, Vector3::INF).is_finite(),
 			"Transform3D with two components infinite should not be finite.");
 }
 


### PR DESCRIPTION
Extends our defined math constants to the mathmatical structs directly. This has the benefit of reducing redundancy across the codebase with a singular variable, as well as making developer intent much clearer on whether an arbitrary struct value is a magic number or referencing one of our constants. For usability, this implements the constants `ZERO`/`ONE` for all structs, `INF`/`NAN` for float structs, and `MAX`/`MIN` for integral structs; no additional bindings were made.