### PR TITLE
Prevent ternary expression with a sampler types in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -2003,7 +2003,7 @@ bool ShaderLanguage::_validate_operator(const BlockNode *p_block, const Function
 			DataType nb = p_op->arguments[1]->get_datatype();
 			DataType nc = p_op->arguments[2]->get_datatype();
 
-			valid = na == TYPE_BOOL && (nb == nc);
+			valid = na == TYPE_BOOL && (nb == nc) && !is_sampler_type(nb);
 			ret_type = nb;
 			ret_size = sa;
 		} break;


### PR DESCRIPTION
It seems impossible to using a sampler in ternary expression in shader:

![изображение](https://github.com/user-attachments/assets/83cf9d42-6cef-43e5-9082-065e8ef14fa6)
(Screenshot from ShadeRED).

- Fix https://github.com/godotengine/godot/issues/103268