### PR TITLE
Apply sun scatter from lights with shadows in compatibility

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1499,6 +1499,9 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 	// Only render the lights without shadows in the base pass.
 	scene_state.data.directional_light_count = p_render_data->directional_light_count - p_render_data->directional_shadow_count;
 
+	// Lights with shadows still need to be applied to fog sun scatter.
+	scene_state.data.directional_shadow_count = p_render_data->directional_shadow_count;
+
 	scene_state.data.z_far = p_render_data->z_far;
 	scene_state.data.z_near = p_render_data->z_near;
 
@@ -3376,6 +3379,10 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 							spec_constants |= SceneShaderGLES3::USE_LIGHTMAP_CAPTURE;
 						} else {
 							spec_constants |= SceneShaderGLES3::DISABLE_LIGHTMAP;
+						}
+
+						if (p_render_data->directional_light_count > 0 && is_environment(p_render_data->environment) && environment_get_fog_sun_scatter(p_render_data->environment) > 0.001) {
+							spec_constants |= SceneShaderGLES3::USE_SUN_SCATTER;
 						}
 					}
 				} else {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -401,7 +401,7 @@ private:
 			float ambient_light_color_energy[4];
 
 			float ambient_color_sky_mix;
-			uint32_t pad2;
+			uint32_t directional_shadow_count;
 			float emissive_exposure_normalization;
 			uint32_t use_ambient_light = 0;
 


### PR DESCRIPTION
Currently sun scatter does not affect scene objects for lights that have shadows in Compatibility because ```directional_light_count``` in ```scene.glsl``` does not include lights with shadows so that they can each be applied in separate passes from each other. This pr passes in the number of lights with shadows so that they can be factored into the sun scatter.

Before:
![image](https://github.com/user-attachments/assets/f1bf6492-cfa9-45ed-9749-4a174b36a2cc)

After:
![image](https://github.com/user-attachments/assets/0384da35-ceb2-4bd4-9f02-d787e71a09bf)

In both images the cube is fully outside the depth end of the fog and should be fully obscured as is the case both without shadows enabled for the light in Compatibility and always in Forward+.