### PR TITLE
Fix `Evaluator`'s format issues caused by special characters in the expression

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -389,7 +389,9 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 	}
 
 	PropertyInfo pinfo;
-	pinfo.name = type + n;
+	// Encode special characters to avoid issues with expressions in Evaluator.
+	// Dots are skipped by uri_encode(), but uri_decode() process them correctly when replaced with "%2E".
+	pinfo.name = type + n.uri_encode().replace(".", "%2E");
 	pinfo.type = v.get_type();
 	pinfo.hint = h;
 	pinfo.hint_string = hs;
@@ -403,7 +405,7 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 		}
 		variables->prop_list.insert_before(current, pinfo);
 	}
-	variables->prop_values[type + n][0] = v;
+	variables->prop_values[pinfo.name][0] = v;
 	variables->update();
 	edit(variables);
 }

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3977,6 +3977,7 @@ void EditorInspector::update_tree() {
 				name_override = name_override.substr(0, dot);
 			}
 		}
+		name_override = name_override.uri_decode();
 
 		// Don't localize script variables.
 		EditorPropertyNameProcessor::Style name_style = property_name_style;


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/98714