### PR TITLE
[RTL] Restore line breaking behavior in `VC_CHARS_BEFORE_SHAPING` mode.

### DIFF
--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -1371,7 +1371,7 @@
 			<param index="5" name="language" type="String" default="&quot;&quot;" />
 			<param index="6" name="meta" type="Variant" default="null" />
 			<description>
-				Adds text span and font to draw it to the text buffer.
+				Adds text span and font to draw it to the text buffer. If [param text] is empty, a soft line break is added to the buffer.
 			</description>
 		</method>
 		<method name="shaped_text_clear">

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -3715,10 +3715,6 @@ bool TextServerFallback::_shaped_text_add_string(const RID &p_shaped, const Stri
 		ERR_FAIL_NULL_V(_get_font_data(p_fonts[i]), false);
 	}
 
-	if (p_text.is_empty()) {
-		return true;
-	}
-
 	if (sd->parent != RID()) {
 		full_copy(sd);
 	}
@@ -3748,9 +3744,11 @@ bool TextServerFallback::_shaped_text_add_string(const RID &p_shaped, const Stri
 	span.meta = p_meta;
 
 	sd->spans.push_back(span);
-	sd->text = sd->text + p_text;
-	sd->end += p_text.length();
-	invalidate(sd);
+	if (!p_text.is_empty()) {
+		sd->text = sd->text + p_text;
+		sd->end += p_text.length();
+		invalidate(sd);
+	}
 
 	return true;
 }
@@ -4763,6 +4761,15 @@ bool TextServerFallback::_shaped_text_shape(const RID &p_shaped) {
 			} else {
 				gl.advance = sd->objects[span.embedded_key].rect.size.y;
 			}
+			sd->glyphs.push_back(gl);
+		} else if (span.start == span.end) {
+			Glyph gl;
+			gl.count = 1;
+			gl.advance = 0.0;
+			gl.index = 0x0020;
+			gl.font_rid = span.fonts[0];
+			gl.font_size = span.font_size;
+			gl.flags = GRAPHEME_IS_BREAK_SOFT | GRAPHEME_IS_VIRTUAL | GRAPHEME_IS_SPACE;
 			sd->glyphs.push_back(gl);
 		} else {
 			// Text span.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -580,6 +580,7 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 					String first = tx.substr(0, remaining_characters);
 					String second = tx.substr(remaining_characters, -1);
 					l.text_buf->add_string(first, font, font_size, lang, it->rid);
+					l.text_buf->add_string(String(), font, font_size, lang, it->rid); // Force line break.
 					l.text_buf->add_string(second, font, font_size, lang, it->rid);
 				}
 				remaining_characters -= tx.length();


### PR DESCRIPTION
https://github.com/user-attachments/assets/cff89aca-b4fc-4fd8-9e2c-6e3475c87de8

(after shaping vs. before shaping)
