### PR TITLE
Allow per `CanvasItem` oversampling override.

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -633,6 +633,9 @@
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)" keywords="color, colour">
 			The color applied to this [CanvasItem]. This property does affect child [CanvasItem]s, unlike [member self_modulate] which only affects the node itself.
 		</member>
+		<member name="oversampling_override" type="float" setter="set_oversampling_override" getter="get_oversampling_override" default="0.0">
+			If greater than zero, this value is used as the font and [SVGTexture] oversampling factor, otherwise oversampling is controlled by viewport.
+		</member>
 		<member name="self_modulate" type="Color" setter="set_self_modulate" getter="get_self_modulate" default="Color(1, 1, 1, 1)">
 			The color applied to this [CanvasItem]. This property does [b]not[/b] affect child [CanvasItem]s, unlike [member modulate] which affects both the node itself and its children.
 			[b]Note:[/b] Internal children are also not affected by this property (see the [code]include_internal[/code] parameter in [method Node.add_child]). For built-in nodes this includes sliders in [ColorPicker], and the tab bar in [TabContainer].

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -38,6 +38,7 @@
 #include "scene/resources/font.h"
 #include "scene/resources/multimesh.h"
 #include "scene/resources/style_box.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/world_2d.h"
 
 #define ERR_DRAW_GUARD \
@@ -143,7 +144,11 @@ void CanvasItem::_redraw_callback() {
 		drawing = true;
 		Ref<TextServer> ts = TextServerManager::get_singleton()->get_primary_interface();
 		if (ts.is_valid()) {
-			ts->set_current_drawn_item_oversampling(get_viewport()->get_oversampling());
+			if (oversampling_override != 0.0) {
+				ts->set_current_drawn_item_oversampling(oversampling_override);
+			} else {
+				ts->set_current_drawn_item_oversampling(get_viewport()->get_oversampling());
+			}
 		}
 		current_item_drawn = this;
 		notification(NOTIFICATION_DRAW);
@@ -367,6 +372,11 @@ void CanvasItem::_notification(int p_what) {
 				get_parent()->connect(SNAME("child_order_changed"), callable_mp(get_viewport(), &Viewport::canvas_parent_mark_dirty).bind(get_parent()), CONNECT_REFERENCE_COUNTED);
 			}
 
+			if (oversampling_override != 0.0) {
+				TS->reference_oversampling_level(oversampling_override);
+				SVGTexture::reference_scaling_level(oversampling_override);
+			}
+
 			// If using physics interpolation, reset for this node only,
 			// as a helper, as in most cases, users will want items reset when
 			// adding to the tree.
@@ -398,6 +408,11 @@ void CanvasItem::_notification(int p_what) {
 			}
 			_set_global_invalid(true);
 			parent_visible_in_tree = false;
+
+			if (oversampling_override != 0.0) {
+				TS->unreference_oversampling_level(oversampling_override);
+				SVGTexture::unreference_scaling_level(oversampling_override);
+			}
 
 			if (get_viewport()) {
 				get_parent()->disconnect(SNAME("child_order_changed"), callable_mp(get_viewport(), &Viewport::canvas_parent_mark_dirty).bind(get_parent()));
@@ -1424,6 +1439,9 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_repeat", "mode"), &CanvasItem::set_texture_repeat);
 	ClassDB::bind_method(D_METHOD("get_texture_repeat"), &CanvasItem::get_texture_repeat);
 
+	ClassDB::bind_method(D_METHOD("set_oversampling_override", "oversampling"), &CanvasItem::set_oversampling_override);
+	ClassDB::bind_method(D_METHOD("get_oversampling_override"), &CanvasItem::get_oversampling_override);
+
 	ClassDB::bind_method(D_METHOD("set_clip_children_mode", "mode"), &CanvasItem::set_clip_children_mode);
 	ClassDB::bind_method(D_METHOD("get_clip_children_mode"), &CanvasItem::get_clip_children_mode);
 
@@ -1438,6 +1456,7 @@ void CanvasItem::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "clip_children", PROPERTY_HINT_ENUM, "Disabled,Clip Only,Clip + Draw"), "set_clip_children_mode", "get_clip_children_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "light_mask", PROPERTY_HINT_LAYERS_2D_RENDER), "set_light_mask", "get_light_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "visibility_layer", PROPERTY_HINT_LAYERS_2D_RENDER), "set_visibility_layer", "get_visibility_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "oversampling_override"), "set_oversampling_override", "get_oversampling_override");
 
 	ADD_GROUP("Ordering", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index", PROPERTY_HINT_RANGE, itos(RS::CANVAS_ITEM_Z_MIN) + "," + itos(RS::CANVAS_ITEM_Z_MAX) + ",1"), "set_z_index", "get_z_index");
@@ -1711,6 +1730,31 @@ CanvasItem::ClipChildrenMode CanvasItem::get_clip_children_mode() const {
 CanvasItem::TextureRepeat CanvasItem::get_texture_repeat() const {
 	ERR_READ_THREAD_GUARD_V(TEXTURE_REPEAT_DISABLED);
 	return texture_repeat;
+}
+
+void CanvasItem::set_oversampling_override(double p_oversampling) {
+	if (oversampling_override == p_oversampling) {
+		return;
+	}
+
+	if (is_inside_tree()) {
+		if (oversampling_override != 0.0) {
+			TS->unreference_oversampling_level(oversampling_override);
+			SVGTexture::unreference_scaling_level(oversampling_override);
+		}
+		if (p_oversampling != 0.0) {
+			TS->reference_oversampling_level(p_oversampling);
+			SVGTexture::reference_scaling_level(p_oversampling);
+		}
+	}
+	oversampling_override = p_oversampling;
+	queue_redraw();
+}
+
+double CanvasItem::get_oversampling_override() const {
+	ERR_READ_THREAD_GUARD_V(0.0);
+
+	return oversampling_override;
 }
 
 CanvasItem::TextureFilter CanvasItem::get_texture_filter_in_tree() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -88,6 +88,7 @@ private:
 
 	int light_mask = 1;
 	uint32_t visibility_layer = 1;
+	double oversampling_override = 0.0f;
 
 	int z_index = 0;
 	bool z_relative = true;
@@ -394,6 +395,9 @@ public:
 
 	virtual void set_texture_repeat(TextureRepeat p_texture_repeat);
 	TextureRepeat get_texture_repeat() const;
+
+	void set_oversampling_override(double p_oversampling);
+	double get_oversampling_override() const;
 
 	TextureFilter get_texture_filter_in_tree() const;
 	TextureRepeat get_texture_repeat_in_tree() const;

--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -271,9 +271,13 @@ void SVGTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_mod
 	double scale = 1.0;
 	CanvasItem *ci = CanvasItem::get_current_item_drawn();
 	if (ci) {
-		Viewport *vp = ci->get_viewport();
-		if (vp) {
-			scale = vp->get_oversampling();
+		if (ci->get_oversampling_override() != 0.0) {
+			scale = ci->get_oversampling_override();
+		} else {
+			Viewport *vp = ci->get_viewport();
+			if (vp) {
+				scale = vp->get_oversampling();
+			}
 		}
 	}
 	RID rid = _ensure_scale(scale);
@@ -285,9 +289,13 @@ void SVGTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, 
 	double scale = 1.0;
 	CanvasItem *ci = CanvasItem::get_current_item_drawn();
 	if (ci) {
-		Viewport *vp = ci->get_viewport();
-		if (vp) {
-			scale = vp->get_oversampling();
+		if (ci->get_oversampling_override() != 0.0) {
+			scale = ci->get_oversampling_override();
+		} else {
+			Viewport *vp = ci->get_viewport();
+			if (vp) {
+				scale = vp->get_oversampling();
+			}
 		}
 	}
 	RID rid = _ensure_scale(scale);
@@ -299,9 +307,13 @@ void SVGTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const 
 	double scale = 1.0;
 	CanvasItem *ci = CanvasItem::get_current_item_drawn();
 	if (ci) {
-		Viewport *vp = ci->get_viewport();
-		if (vp) {
-			scale = vp->get_oversampling();
+		if (ci->get_oversampling_override() != 0.0) {
+			scale = ci->get_oversampling_override();
+		} else {
+			Viewport *vp = ci->get_viewport();
+			if (vp) {
+				scale = vp->get_oversampling();
+			}
 		}
 	}
 	RID rid = _ensure_scale(scale);


### PR DESCRIPTION
Addition (or alternative?) to https://github.com/godotengine/godot/pull/107708

Adds option to override specific `CanvasItem` oversampling.