### PR TITLE
Improve object handling in UndoRedo

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -38,14 +38,12 @@ void UndoRedo::Operation::delete_reference() {
 	if (type != Operation::TYPE_REFERENCE) {
 		return;
 	}
-	if (ref.is_valid()) {
-		ref.unref();
-	} else {
-		Object *obj = ObjectDB::get_instance(object);
-		if (obj) {
-			memdelete(obj);
-		}
+
+	Object *obj = object.get_validated_object();
+	if (obj && !object.is_ref_counted()) {
+		memdelete(obj);
 	}
+	object = Variant();
 }
 
 void UndoRedo::discard_redo() {
@@ -154,10 +152,7 @@ void UndoRedo::add_do_method(const Callable &p_callable) {
 
 	Operation do_op;
 	do_op.callable = p_callable;
-	do_op.object = object_id;
-	if (Object::cast_to<RefCounted>(object)) {
-		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
-	}
+	do_op.object = object ? Variant(object) : Variant();
 	do_op.type = Operation::TYPE_METHOD;
 	do_op.name = p_callable.get_method();
 	if (do_op.name == StringName()) {
@@ -184,10 +179,7 @@ void UndoRedo::add_undo_method(const Callable &p_callable) {
 
 	Operation undo_op;
 	undo_op.callable = p_callable;
-	undo_op.object = object_id;
-	if (Object::cast_to<RefCounted>(object)) {
-		undo_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(object));
-	}
+	undo_op.object = object ? Variant(object) : Variant();
 	undo_op.type = Operation::TYPE_METHOD;
 	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
 	undo_op.name = p_callable.get_method();
@@ -203,12 +195,9 @@ void UndoRedo::add_do_property(Object *p_object, const StringName &p_property, c
 	ERR_FAIL_NULL(p_object);
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
-	Operation do_op;
-	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<RefCounted>(p_object)) {
-		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(p_object));
-	}
 
+	Operation do_op;
+	do_op.object = p_object;
 	do_op.type = Operation::TYPE_PROPERTY;
 	do_op.name = p_property;
 	do_op.value = p_value;
@@ -226,11 +215,7 @@ void UndoRedo::add_undo_property(Object *p_object, const StringName &p_property,
 	}
 
 	Operation undo_op;
-	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<RefCounted>(p_object)) {
-		undo_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(p_object));
-	}
-
+	undo_op.object = p_object;
 	undo_op.type = Operation::TYPE_PROPERTY;
 	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
 	undo_op.name = p_property;
@@ -242,12 +227,9 @@ void UndoRedo::add_do_reference(Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	ERR_FAIL_COND(action_level <= 0);
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
-	Operation do_op;
-	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<RefCounted>(p_object)) {
-		do_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(p_object));
-	}
 
+	Operation do_op;
+	do_op.object = p_object;
 	do_op.type = Operation::TYPE_REFERENCE;
 	actions.write[current_action + 1].do_ops.push_back(do_op);
 }
@@ -263,11 +245,7 @@ void UndoRedo::add_undo_reference(Object *p_object) {
 	}
 
 	Operation undo_op;
-	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<RefCounted>(p_object)) {
-		undo_op.ref = Ref<RefCounted>(Object::cast_to<RefCounted>(p_object));
-	}
-
+	undo_op.object = p_object;
 	undo_op.type = Operation::TYPE_REFERENCE;
 	undo_op.force_keep_in_merge_ends = force_keep_in_merge_ends;
 	actions.write[current_action + 1].undo_ops.push_back(undo_op);
@@ -352,8 +330,8 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *E, bool p_execu
 	for (; E; E = E->next()) {
 		Operation &op = E->get();
 
-		Object *obj = ObjectDB::get_instance(op.object);
-		if (!obj) { //may have been deleted and this is fine
+		Object *obj = op.object.get_validated_object();
+		if (!obj && op.object.get_type() == Variant::OBJECT) { // May have been deleted and this is fine.
 			continue;
 		}
 

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -58,10 +58,10 @@ private:
 		} type;
 
 		bool force_keep_in_merge_ends = false;
-		Ref<RefCounted> ref;
-		ObjectID object;
-		StringName name;
+
+		Variant object;
 		Callable callable;
+		StringName name;
 		Variant value;
 
 		void delete_reference();


### PR DESCRIPTION
This PR simplifies how UndoRedo stores object reference. Instead of ObjectID and potentially RefCounted, it's now a single Variant.

Fixes #107727