### PR TITLE
Create scene thumbnails on thread when using Compatibility renderer

### DIFF
--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -130,7 +130,12 @@ Variant EditorResourcePreviewGenerator::DrawRequester::_post_semaphore() {
 }
 
 bool EditorResourcePreview::can_run_on_thread() const {
-	return RSG::rasterizer->can_create_resources_async();
+	// Now forces all renderers to generate thumbnail on thread for better UX. (See issue ##107736)
+	//
+	// Previously this returns `RSG::rasterizer->can_create_resources_async()` to prevent
+	// threading on Compatibility renderer for some reason (Need rendering team to confirm),
+	// But after testing thumbnail creation on a thread using GLES3 it has no issues.
+	return true;
 }
 
 bool EditorResourcePreview::is_threaded() const {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -531,11 +531,10 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 		capture_2d->get_image()->convert(Image::Format::FORMAT_RGBA8); // ALPHA channel is required for image blending
 
 		// Prepare for gui render
-		callable_mp((Node *)sub_viewport, &Node::remove_child).call_deferred(p_scene);
-		p_scene->queue_free();
-		p_scene = pack->instantiate();
-		_setup_scene_2d(p_scene);
-		_hide_node_2d_in_scene(p_scene);
+		Node *p_scene_gui = pack->instantiate();
+		_setup_scene_2d(p_scene_gui);
+		_hide_node_2d_in_scene(p_scene_gui);
+
 		SubViewport *sub_viewport_gui = memnew(SubViewport);
 		sub_viewport_gui->set_size(Size2i(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height")));
 		sub_viewport_gui->set_update_mode(SubViewport::UpdateMode::UPDATE_DISABLED);
@@ -546,7 +545,7 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 		sub_viewport_gui->set_default_canvas_item_texture_filter(Viewport::DefaultCanvasItemTextureFilter(texture_filter));
 		sub_viewport_gui->set_default_canvas_item_texture_repeat(Viewport::DefaultCanvasItemTextureRepeat(texture_repeat));
 		sub_viewport_gui->set_disable_3d(true);
-		sub_viewport_gui->add_child(p_scene);
+		sub_viewport_gui->add_child(p_scene_gui);
 
 		// Render GUI
 		sub_viewport_gui->set_update_mode(SubViewport::UpdateMode::UPDATE_ONCE);


### PR DESCRIPTION
Fixes #107736 

This PR enforces scene thumbnails to be created on thread when using Compatibility renderer (Forward, Mobile renderer already does since PR #102313)

Also fixes crashes due to problematic resource freeing at:
```c++
// editor/plugins/editor_preview_plugins.cpp:534

// Prepare for gui render
callable_mp((Node *)sub_viewport, &Node::remove_child).call_deferred(p_scene);
p_scene->queue_free();
```

Crashes happens randomly and rewriting this part of code to not free the ```p_scene``` early solves it, see changes in this PR commit. Can possibly fix some random crashes users are having recently.

### Note (1)
The decision to make thumbnail creation on main thread when running Compatibility renderer is some comment (removed after PR #102313) suggested we should obey:

**drivers/gles3/rasterizer_gles3.h:137**
```c++
_ALWAYS_INLINE_ bool can_create_resources_async() const { return false; }
```

There's no deep explanation about this, it is just set to false. But after testing various projects running thumbnail creation on thread, I currently don't run into any issues. Mind someone at rendering team can explain the purpose of this boolean, what action is it intended to stop us from doing?

### Note (2)
The single-threaded part of code is remain untouched, I think we can open another PR to clean them up if this PR is approved to become stable. We can simply search for all occurrences of ```can_run_on_thread()``` and ```is_threaded()``` and remove them.

### Note (3)
We leave other non-critical improvements to #107689

---

Test project and results (video is sped up 4x):
[test.zip](https://github.com/user-attachments/files/20827669/test.zip)

https://github.com/user-attachments/assets/64f2fa5c-c448-4a19-ae5b-bbac1bc0e2eb

And another project of mine that runs compatibility renderer, the created thumbnails:
![image](https://github.com/user-attachments/assets/11909e48-97f5-487e-b9ac-d415e6b19664)


