### PR TITLE
Add `RETURN_IF_ERR` macro, propagating an error upwards

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -818,9 +818,7 @@ bool ProjectSettings::has_setting(const String &p_var) const {
 Error ProjectSettings::_load_settings_binary(const String &p_path) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	uint8_t hdr[4];
 	f->get_buffer(hdr, 4);

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -125,6 +125,19 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
  * issues when expanded e.g. after an `if (cond) ERR_FAIL();` without braces.
  */
 
+/**
+ * If the return value of the expression is not OK, returns it as an error.
+ * This is similar to the
+ */
+#define RETURN_IF_ERR(m_error)  \
+	if (true) {                 \
+		Error _error = m_error; \
+		if (unlikely(_error)) { \
+			return _error;      \
+		}                       \
+	} else                      \
+		((void)0)
+
 // Index out of bounds error macros.
 // These macros should be used instead of `ERR_FAIL_COND` for bounds checking.
 

--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -127,7 +127,6 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 
 /**
  * If the return value of the expression is not OK, returns it as an error.
- * This is similar to the
  */
 #define RETURN_IF_ERR(m_error)  \
 	if (true) {                 \
@@ -136,6 +135,19 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 			return _error;      \
 		}                       \
 	} else                      \
+		((void)0)
+
+/**
+ * If the return value of the expression is not OK, returns it as an error.
+ */
+#define RETURN_IF_ERR_MSG(m_error, m_msg)                                                                                                  \
+	if (true) {                                                                                                                            \
+		Error _error = m_error;                                                                                                            \
+		if (unlikely(_error)) {                                                                                                            \
+			_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "Expression \"" _STR(m_cond) "\" resulted in an error. Returning.", m_msg); \
+			return _error;                                                                                                                 \
+		}                                                                                                                                  \
+	} else                                                                                                                                 \
 		((void)0)
 
 // Index out of bounds error macros.

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -174,10 +174,7 @@ String GDExtensionLibraryLoader::find_extension_library(const String &p_path, Re
 }
 
 Error GDExtensionLibraryLoader::open_library(const String &p_path) {
-	Error err = parse_gdextension_file(p_path);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(parse_gdextension_file(p_path));
 
 	String abs_path = ProjectSettings::get_singleton()->globalize_path(library_path);
 
@@ -195,12 +192,7 @@ Error GDExtensionLibraryLoader::open_library(const String &p_path) {
 		&abs_dependencies_paths, // library_dependencies
 	};
 
-	err = OS::get_singleton()->open_dynamic_library(is_static_library ? String() : abs_path, library, &data);
-	if (err != OK) {
-		return err;
-	}
-
-	return OK;
+	return OS::get_singleton()->open_dynamic_library(is_static_library ? String() : abs_path, library, &data);
 }
 
 Error GDExtensionLibraryLoader::initialize(GDExtensionInterfaceGetProcAddress p_get_proc_address, const Ref<GDExtension> &p_extension, GDExtensionInitialization *r_initialization) {

--- a/core/io/config_file.cpp
+++ b/core/io/config_file.cpp
@@ -144,10 +144,7 @@ String ConfigFile::encode_to_text() const {
 Error ConfigFile::save(const String &p_path) {
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	return _internal_save(file);
 }
@@ -155,34 +152,22 @@ Error ConfigFile::save(const String &p_path) {
 Error ConfigFile::save_encrypted(const String &p_path, const Vector<uint8_t> &p_key) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	Ref<FileAccessEncrypted> fae;
 	fae.instantiate();
-	err = fae->open_and_parse(f, p_key, FileAccessEncrypted::MODE_WRITE_AES256);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(fae->open_and_parse(f, p_key, FileAccessEncrypted::MODE_WRITE_AES256));
 	return _internal_save(fae);
 }
 
 Error ConfigFile::save_encrypted_pass(const String &p_path, const String &p_pass) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	Ref<FileAccessEncrypted> fae;
 	fae.instantiate();
-	err = fae->open_and_parse_password(f, p_pass, FileAccessEncrypted::MODE_WRITE_AES256);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(fae->open_and_parse_password(f, p_pass, FileAccessEncrypted::MODE_WRITE_AES256));
 
 	return _internal_save(fae);
 }
@@ -223,34 +208,22 @@ Error ConfigFile::load(const String &p_path) {
 Error ConfigFile::load_encrypted(const String &p_path, const Vector<uint8_t> &p_key) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
-
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	Ref<FileAccessEncrypted> fae;
 	fae.instantiate();
-	err = fae->open_and_parse(f, p_key, FileAccessEncrypted::MODE_READ);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(fae->open_and_parse(f, p_key, FileAccessEncrypted::MODE_READ));
 	return _internal_load(p_path, fae);
 }
 
 Error ConfigFile::load_encrypted_pass(const String &p_path, const String &p_pass) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
-
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	Ref<FileAccessEncrypted> fae;
 	fae.instantiate();
-	err = fae->open_and_parse_password(f, p_pass, FileAccessEncrypted::MODE_READ);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(fae->open_and_parse_password(f, p_pass, FileAccessEncrypted::MODE_READ));
 
 	return _internal_load(p_path, fae);
 }

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -95,31 +95,18 @@ static Error _erase_recursive(DirAccess *da) {
 	da->list_dir_end();
 
 	for (const String &E : dirs) {
-		Error err = da->change_dir(E);
-		if (err == OK) {
-			err = _erase_recursive(da);
-			if (err) {
-				da->change_dir("..");
-				return err;
-			}
-			err = da->change_dir("..");
-			if (err) {
-				return err;
-			}
-			err = da->remove(da->get_current_dir().path_join(E));
-			if (err) {
-				return err;
-			}
-		} else {
+		RETURN_IF_ERR(da->change_dir(E));
+		Error err = _erase_recursive(da);
+		if (err) {
+			da->change_dir("..");
 			return err;
 		}
+		RETURN_IF_ERR(da->change_dir(".."));
+		RETURN_IF_ERR(da->remove(da->get_current_dir().path_join(E)));
 	}
 
 	for (const String &E : files) {
-		Error err = da->remove(da->get_current_dir().path_join(E));
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(da->remove(da->get_current_dir().path_join(E)));
 	}
 
 	return OK;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -153,10 +153,7 @@ Error HTTPClientTCP::request(Method p_method, const String &p_url, const Vector<
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(connection.is_null(), ERR_INVALID_DATA);
 
-	Error err = verify_headers(p_headers);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(verify_headers(p_headers));
 
 	String uri = p_url;
 	if (tls_options.is_null() && http_proxy_port != -1) {

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -402,17 +402,11 @@ Error JSON::_parse_value(Variant &value, Token &token, const char32_t *p_str, in
 
 	if (token.type == TK_CURLY_BRACKET_OPEN) {
 		Dictionary d;
-		Error err = _parse_object(d, p_str, index, p_len, line, p_depth + 1, r_err_str);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_object(d, p_str, index, p_len, line, p_depth + 1, r_err_str));
 		value = d;
 	} else if (token.type == TK_BRACKET_OPEN) {
 		Array a;
-		Error err = _parse_array(a, p_str, index, p_len, line, p_depth + 1, r_err_str);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_array(a, p_str, index, p_len, line, p_depth + 1, r_err_str));
 		value = a;
 	} else if (token.type == TK_IDENTIFIER) {
 		String id = token.value;
@@ -443,10 +437,7 @@ Error JSON::_parse_array(Array &array, const char32_t *p_str, int &index, int p_
 	bool need_comma = false;
 
 	while (index < p_len) {
-		Error err = _get_token(p_str, index, p_len, token, line, r_err_str);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_get_token(p_str, index, p_len, token, line, r_err_str));
 
 		if (token.type == TK_BRACKET_CLOSE) {
 			return OK;
@@ -463,10 +454,7 @@ Error JSON::_parse_array(Array &array, const char32_t *p_str, int &index, int p_
 		}
 
 		Variant v;
-		err = _parse_value(v, token, p_str, index, p_len, line, p_depth, r_err_str);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_value(v, token, p_str, index, p_len, line, p_depth, r_err_str));
 
 		array.push_back(v);
 		need_comma = true;
@@ -484,10 +472,7 @@ Error JSON::_parse_object(Dictionary &object, const char32_t *p_str, int &index,
 
 	while (index < p_len) {
 		if (at_key) {
-			Error err = _get_token(p_str, index, p_len, token, line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_get_token(p_str, index, p_len, token, line, r_err_str));
 
 			if (token.type == TK_CURLY_BRACKET_CLOSE) {
 				return OK;
@@ -509,26 +494,17 @@ Error JSON::_parse_object(Dictionary &object, const char32_t *p_str, int &index,
 			}
 
 			key = token.value;
-			err = _get_token(p_str, index, p_len, token, line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_get_token(p_str, index, p_len, token, line, r_err_str));
 			if (token.type != TK_COLON) {
 				r_err_str = "Expected ':'";
 				return ERR_PARSE_ERROR;
 			}
 			at_key = false;
 		} else {
-			Error err = _get_token(p_str, index, p_len, token, line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_get_token(p_str, index, p_len, token, line, r_err_str));
 
 			Variant v;
-			err = _parse_value(v, token, p_str, index, p_len, line, p_depth, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_value(v, token, p_str, index, p_len, line, p_depth, r_err_str));
 			object[key] = v;
 			need_comma = true;
 			at_key = true;
@@ -552,12 +528,9 @@ Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_st
 	r_err_line = 0;
 	String aux_key;
 
-	Error err = _get_token(str, idx, len, token, r_err_line, r_err_str);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(_get_token(str, idx, len, token, r_err_line, r_err_str));
 
-	err = _parse_value(r_ret, token, str, idx, len, r_err_line, 0, r_err_str);
+	Error err = _parse_value(r_ret, token, str, idx, len, r_err_line, 0, r_err_str);
 
 	// Check if EOF is reached
 	// or it's a type of the next token.

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1554,7 +1554,7 @@ Error ResourceFormatSaverJSON::save(const Ref<Resource> &p_resource, const Strin
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
-	ERR_FAIL_COND_V_MSG(err, err, vformat("Cannot save json '%s'.", p_path));
+	RETURN_IF_ERR_MSG(err, vformat("Cannot save json '%s'.", p_path));
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -147,10 +147,7 @@ static Error _decode_container_type(const uint8_t *&buf, int &len, int *r_len, b
 		} break;
 		case CONTAINER_TYPE_KIND_CLASS_NAME: {
 			String str;
-			Error err = _decode_string(buf, len, r_len, str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 
 			r_type.builtin_type = Variant::OBJECT;
 			if (p_allow_objects) {
@@ -162,10 +159,7 @@ static Error _decode_container_type(const uint8_t *&buf, int &len, int *r_len, b
 		} break;
 		case CONTAINER_TYPE_KIND_SCRIPT: {
 			String path;
-			Error err = _decode_string(buf, len, r_len, path);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_decode_string(buf, len, r_len, path));
 
 			r_type.builtin_type = Variant::OBJECT;
 			if (p_allow_objects) {
@@ -253,10 +247,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 		} break;
 		case Variant::STRING: {
 			String str;
-			Error err = _decode_string(buf, len, r_len, str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 			r_variant = str;
 
 		} break;
@@ -629,10 +620,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 		} break;
 		case Variant::STRING_NAME: {
 			String str;
-			Error err = _decode_string(buf, len, r_len, str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 			r_variant = StringName(str);
 
 		} break;
@@ -666,10 +654,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 				for (uint32_t i = 0; i < total; i++) {
 					String str;
-					Error err = _decode_string(buf, len, r_len, str);
-					if (err) {
-						return err;
-					}
+					RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 
 					if (i < namecount) {
 						names.push_back(str);
@@ -717,10 +702,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 				ERR_FAIL_COND_V(!p_allow_objects, ERR_UNAUTHORIZED);
 
 				String str;
-				Error err = _decode_string(buf, len, r_len, str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 
 				if (str.is_empty()) {
 					r_variant = (Object *)nullptr;
@@ -750,17 +732,11 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 					for (int i = 0; i < count; i++) {
 						str = String();
-						err = _decode_string(buf, len, r_len, str);
-						if (err) {
-							return err;
-						}
+						RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 
 						Variant value;
 						int used;
-						err = decode_variant(value, buf, len, &used, p_allow_objects, p_depth + 1);
-						if (err) {
-							return err;
-						}
+						RETURN_IF_ERR(decode_variant(value, buf, len, &used, p_allow_objects, p_depth + 1));
 
 						buf += used;
 						len -= used;
@@ -790,10 +766,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 		} break;
 		case Variant::SIGNAL: {
 			String name;
-			Error err = _decode_string(buf, len, r_len, name);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_decode_string(buf, len, r_len, name));
 
 			ERR_FAIL_COND_V(len < 8, ERR_INVALID_DATA);
 			ObjectID id = ObjectID(decode_uint64(buf));
@@ -808,20 +781,14 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			{
 				ContainerTypeKind key_type_kind = GET_CONTAINER_TYPE_KIND(header, TYPED_DICTIONARY_KEY);
-				Error err = _decode_container_type(buf, len, r_len, p_allow_objects, key_type_kind, key_type);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_decode_container_type(buf, len, r_len, p_allow_objects, key_type_kind, key_type));
 			}
 
 			ContainerType value_type;
 
 			{
 				ContainerTypeKind value_type_kind = GET_CONTAINER_TYPE_KIND(header, TYPED_DICTIONARY_VALUE);
-				Error err = _decode_container_type(buf, len, r_len, p_allow_objects, value_type_kind, value_type);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_decode_container_type(buf, len, r_len, p_allow_objects, value_type_kind, value_type));
 			}
 
 			ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
@@ -875,10 +842,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			{
 				ContainerTypeKind type_kind = GET_CONTAINER_TYPE_KIND(header, TYPED_ARRAY);
-				Error err = _decode_container_type(buf, len, r_len, p_allow_objects, type_kind, type);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_decode_container_type(buf, len, r_len, p_allow_objects, type_kind, type));
 			}
 
 			ERR_FAIL_COND_V(len < 4, ERR_INVALID_DATA);
@@ -1055,10 +1019,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			for (int32_t i = 0; i < count; i++) {
 				String str;
-				Error err = _decode_string(buf, len, r_len, str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_decode_string(buf, len, r_len, str));
 
 				strings.push_back(str);
 			}
@@ -1830,17 +1791,11 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			const Dictionary dict = p_variant;
 
 			{
-				Error err = _encode_container_type(dict.get_key_type(), buf, r_len, p_full_objects);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_encode_container_type(dict.get_key_type(), buf, r_len, p_full_objects));
 			}
 
 			{
-				Error err = _encode_container_type(dict.get_value_type(), buf, r_len, p_full_objects);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_encode_container_type(dict.get_value_type(), buf, r_len, p_full_objects));
 			}
 
 			if (buf) {
@@ -1872,10 +1827,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 			const Array array = p_variant;
 
 			{
-				Error err = _encode_container_type(array.get_element_type(), buf, r_len, p_full_objects);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_encode_container_type(array.get_element_type(), buf, r_len, p_full_objects));
 			}
 
 			if (buf) {

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1751,8 +1751,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 						}
 
 						int len;
-						Error err = encode_variant(value, buf, len, p_full_objects, p_depth + 1);
-						ERR_FAIL_COND_V(err, err);
+						RETURN_IF_ERR(encode_variant(value, buf, len, p_full_objects, p_depth + 1));
 						ERR_FAIL_COND_V(len % 4, ERR_BUG);
 						r_len += len;
 						if (buf) {
@@ -1806,15 +1805,13 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 
 			for (const KeyValue<Variant, Variant> &kv : dict) {
 				int len;
-				Error err = encode_variant(kv.key, buf, len, p_full_objects, p_depth + 1);
-				ERR_FAIL_COND_V(err, err);
+				RETURN_IF_ERR(encode_variant(kv.key, buf, len, p_full_objects, p_depth + 1));
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				r_len += len;
 				if (buf) {
 					buf += len;
 				}
-				err = encode_variant(kv.value, buf, len, p_full_objects, p_depth + 1);
-				ERR_FAIL_COND_V(err, err);
+				RETURN_IF_ERR(encode_variant(kv.value, buf, len, p_full_objects, p_depth + 1));
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				r_len += len;
 				if (buf) {
@@ -1838,8 +1835,7 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 
 			for (const Variant &elem : array) {
 				int len;
-				Error err = encode_variant(elem, buf, len, p_full_objects, p_depth + 1);
-				ERR_FAIL_COND_V(err, err);
+				RETURN_IF_ERR(encode_variant(elem, buf, len, p_full_objects, p_depth + 1));
 				ERR_FAIL_COND_V(len % 4, ERR_BUG);
 				if (buf) {
 					buf += len;

--- a/core/io/packet_peer_udp.cpp
+++ b/core/io/packet_peer_udp.cpp
@@ -97,10 +97,7 @@ int PacketPeerUDP::get_available_packet_count() const {
 }
 
 Error PacketPeerUDP::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
-	Error err = _poll();
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_poll());
 	if (queue_count == 0) {
 		return ERR_UNAVAILABLE;
 	}

--- a/core/io/remote_filesystem_client.cpp
+++ b/core/io/remote_filesystem_client.cpp
@@ -98,10 +98,7 @@ Error RemoteFilesystemClient::_store_file(const String &p_path, const LocalVecto
 	Ref<FileAccess> f = FileAccess::open(full_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_FILE_CANT_OPEN, vformat("Unable to open file for writing to remote filesystem cache: '%s'.", p_path));
 	f->store_buffer(p_file.ptr(), p_file.size());
-	Error err = f->get_error();
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(f->get_error());
 	f.unref(); // Unref to ensure file is not locked and modified time can be obtained.
 
 	modified_time = FileAccess::get_modified_time(full_path);

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -679,9 +679,7 @@ Ref<Resource> ResourceLoaderBinary::get_resource() {
 }
 
 Error ResourceLoaderBinary::load() {
-	if (error != OK) {
-		return error;
-	}
+	RETURN_IF_ERR(error);
 
 	for (int i = 0; i < external_resources.size(); i++) {
 		String path = external_resources[i].path;
@@ -825,10 +823,7 @@ Error ResourceLoaderBinary::load() {
 
 			Variant value;
 
-			error = parse_variant(value);
-			if (error) {
-				return error;
-			}
+			RETURN_IF_ERR(parse_variant(value));
 
 			bool set_valid = true;
 			if (value.get_type() == Variant::OBJECT && missing_resource == nullptr && ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -590,10 +590,7 @@ void ResourceImporter::_bind_methods() {
 Error ResourceFormatImporterSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	Ref<ConfigFile> cf;
 	cf.instantiate();
-	Error err = cf->load(p_path + ".import");
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(cf->load(p_path + ".import"));
 	cf->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(p_uid));
 	cf->save(p_path + ".import");
 

--- a/core/io/stream_peer_gzip.cpp
+++ b/core/io/stream_peer_gzip.cpp
@@ -124,10 +124,7 @@ Error StreamPeerGZIP::_process(uint8_t *p_dst, int p_dst_size, const uint8_t *p_
 
 Error StreamPeerGZIP::put_data(const uint8_t *p_data, int p_bytes) {
 	int wrote = 0;
-	Error err = put_partial_data(p_data, p_bytes, wrote);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(put_partial_data(p_data, p_bytes, wrote));
 	ERR_FAIL_COND_V(p_bytes != wrote, ERR_OUT_OF_MEMORY);
 	return OK;
 }
@@ -146,10 +143,7 @@ Error StreamPeerGZIP::put_partial_data(const uint8_t *p_data, int p_bytes, int &
 		int sent = 0;
 		int to_write = 0;
 		// Compress or decompress
-		Error err = _process(buffer.ptrw(), MIN(buffer.size(), rb.space_left()), p_data + r_sent, p_bytes - r_sent, sent, to_write);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_process(buffer.ptrw(), MIN(buffer.size(), rb.space_left()), p_data + r_sent, p_bytes - r_sent, sent, to_write));
 		// When decompressing, we might need to do another round.
 		r_sent += sent;
 
@@ -168,10 +162,7 @@ Error StreamPeerGZIP::put_partial_data(const uint8_t *p_data, int p_bytes, int &
 
 Error StreamPeerGZIP::get_data(uint8_t *p_buffer, int p_bytes) {
 	int received = 0;
-	Error err = get_partial_data(p_buffer, p_bytes, received);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(get_partial_data(p_buffer, p_bytes, received));
 	ERR_FAIL_COND_V(p_bytes != received, ERR_UNAVAILABLE);
 	return OK;
 }
@@ -200,10 +191,7 @@ Error StreamPeerGZIP::finish() {
 	}
 	int consumed = 0;
 	int to_write = 0;
-	Error err = _process(buffer.ptrw(), buffer.size(), nullptr, 0, consumed, to_write, true); // compress
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_process(buffer.ptrw(), buffer.size(), nullptr, 0, consumed, to_write, true)); // compress
 	int wrote = rb.write(buffer.ptr(), to_write);
 	ERR_FAIL_COND_V(wrote != to_write, ERR_OUT_OF_MEMORY);
 	return OK;

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -97,10 +97,7 @@ Error StreamPeerTCP::bind(int p_port, const IPAddress &p_host) {
 	if (p_host.is_wildcard()) {
 		ip_type = IP::TYPE_ANY;
 	}
-	Error err = _sock->open(NetSocket::TYPE_TCP, ip_type);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_sock->open(NetSocket::TYPE_TCP, ip_type));
 	_sock->set_blocking_enabled(false);
 	return _sock->bind(p_host, p_port);
 }
@@ -113,10 +110,7 @@ Error StreamPeerTCP::connect_to_host(const IPAddress &p_host, int p_port) {
 
 	if (!_sock->is_open()) {
 		IP::Type ip_type = p_host.is_ipv4() ? IP::TYPE_IPV4 : IP::TYPE_IPV6;
-		Error err = _sock->open(NetSocket::TYPE_TCP, ip_type);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_sock->open(NetSocket::TYPE_TCP, ip_type));
 		_sock->set_blocking_enabled(false);
 	}
 

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -206,8 +206,7 @@ public:
 	Error insert(Size p_pos, const T &p_val) {
 		Size new_size = size() + 1;
 		ERR_FAIL_INDEX_V(p_pos, new_size, ERR_INVALID_PARAMETER);
-		Error err = resize(new_size);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(resize(new_size));
 		T *p = ptrw();
 		for (Size i = new_size - 1; i > p_pos; i--) {
 			p[i] = std::move(p[i - 1]);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -286,10 +286,7 @@ Error CowData<T>::_fork_allocate(USize p_size) {
 
 	if (!_ptr) {
 		// We had no data before; just allocate a new array.
-		const Error error = _alloc(alloc_size);
-		if (error) {
-			return error;
-		}
+		RETURN_IF_ERR(_alloc(alloc_size));
 	} else if (_get_refcount()->get() == 1) {
 		// Resize in-place.
 		// NOTE: This case is not just an optimization, but required, as some callers depend on
@@ -362,10 +359,7 @@ Error CowData<T>::resize(Size p_size) {
 		return OK;
 	}
 
-	const Error error = _fork_allocate(p_size);
-	if (error) {
-		return error;
-	}
+	RETURN_IF_ERR(_fork_allocate(p_size));
 
 	if constexpr (p_initialize) {
 		if (p_size > prev_size) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -676,18 +676,12 @@ Error VariantParser::_parse_byte_array(Stream *p_stream, Vector<uint8_t> &r_cons
 Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream, int &line, String &r_err_str, ResourceParser *p_res_parser) {
 	if (token.type == TK_CURLY_BRACKET_OPEN) {
 		Dictionary d;
-		Error err = _parse_dictionary(d, p_stream, line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_dictionary(d, p_stream, line, r_err_str, p_res_parser));
 		value = d;
 		return OK;
 	} else if (token.type == TK_BRACKET_OPEN) {
 		Array a;
-		Error err = _parse_array(a, p_stream, line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_array(a, p_stream, line, r_err_str, p_res_parser));
 		value = a;
 		return OK;
 	} else if (token.type == TK_IDENTIFIER) {
@@ -707,10 +701,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Math::NaN;
 		} else if (id == "Vector2") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 2) {
 				r_err_str = "Expected 2 arguments for constructor";
@@ -720,10 +711,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Vector2(args[0], args[1]);
 		} else if (id == "Vector2i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<int32_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 2) {
 				r_err_str = "Expected 2 arguments for constructor";
@@ -733,10 +721,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Vector2i(args[0], args[1]);
 		} else if (id == "Rect2") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -746,10 +731,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Rect2(args[0], args[1], args[2], args[3]);
 		} else if (id == "Rect2i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<int32_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -759,10 +741,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Rect2i(args[0], args[1], args[2], args[3]);
 		} else if (id == "Vector3") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 3) {
 				r_err_str = "Expected 3 arguments for constructor";
@@ -772,10 +751,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Vector3(args[0], args[1], args[2]);
 		} else if (id == "Vector3i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<int32_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 3) {
 				r_err_str = "Expected 3 arguments for constructor";
@@ -785,10 +761,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Vector3i(args[0], args[1], args[2]);
 		} else if (id == "Vector4") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -798,10 +771,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Vector4(args[0], args[1], args[2], args[3]);
 		} else if (id == "Vector4i") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<int32_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -811,10 +781,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Vector4i(args[0], args[1], args[2], args[3]);
 		} else if (id == "Transform2D" || id == "Matrix32") { //compatibility
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 6) {
 				r_err_str = "Expected 6 arguments for constructor";
@@ -828,10 +795,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = m;
 		} else if (id == "Plane") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -841,10 +805,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Plane(args[0], args[1], args[2], args[3]);
 		} else if (id == "Quaternion" || id == "Quat") { // "Quat" kept for compatibility
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -854,10 +815,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Quaternion(args[0], args[1], args[2], args[3]);
 		} else if (id == "AABB" || id == "Rect3") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 6) {
 				r_err_str = "Expected 6 arguments for constructor";
@@ -867,10 +825,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = AABB(Vector3(args[0], args[1], args[2]), Vector3(args[3], args[4], args[5]));
 		} else if (id == "Basis" || id == "Matrix3") { //compatibility
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 9) {
 				r_err_str = "Expected 9 arguments for constructor";
@@ -880,10 +835,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Basis(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]);
 		} else if (id == "Transform3D" || id == "Transform") { // "Transform" kept for compatibility with Godot <4.
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 12) {
 				r_err_str = "Expected 12 arguments for constructor";
@@ -893,10 +845,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Transform3D(Basis(args[0], args[1], args[2], args[3], args[4], args[5], args[6], args[7], args[8]), Vector3(args[9], args[10], args[11]));
 		} else if (id == "Projection") { // "Transform" kept for compatibility with Godot <4.
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 16) {
 				r_err_str = "Expected 16 arguments for constructor";
@@ -906,10 +855,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Projection(Vector4(args[0], args[1], args[2], args[3]), Vector4(args[4], args[5], args[6], args[7]), Vector4(args[8], args[9], args[10], args[11]), Vector4(args[12], args[13], args[14], args[15]));
 		} else if (id == "Color") {
 			Vector<float> args;
-			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<float>(p_stream, args, line, r_err_str));
 
 			if (args.size() != 4) {
 				r_err_str = "Expected 4 arguments for constructor";
@@ -1033,10 +979,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				}
 
 				if (at_key) {
-					Error err = get_token(p_stream, token, line, r_err_str);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 
 					if (token.type == TK_PARENTHESIS_CLOSE) {
 						value = ref.is_valid() ? Variant(ref) : Variant(obj);
@@ -1060,27 +1003,17 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 					key = token.value;
 
-					err = get_token(p_stream, token, line, r_err_str);
-
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 					if (token.type != TK_COLON) {
 						r_err_str = "Expected ':'";
 						return ERR_PARSE_ERROR;
 					}
 					at_key = false;
 				} else {
-					Error err = get_token(p_stream, token, line, r_err_str);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 
 					Variant v;
-					err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
-					if (err) {
-						return err;
-					}
+					RETURN_IF_ERR(parse_value(token, v, p_stream, line, r_err_str, p_res_parser));
 					obj->set(key, v);
 					need_comma = true;
 					at_key = true;
@@ -1095,10 +1028,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 			if (p_res_parser && id == "Resource" && p_res_parser->func) {
 				Ref<Resource> res;
-				Error err = p_res_parser->func(p_res_parser->userdata, p_stream, res, line, r_err_str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(p_res_parser->func(p_res_parser->userdata, p_stream, res, line, r_err_str));
 
 				value = res;
 			} else if (p_res_parser && id == "ExtResource" && p_res_parser->ext_func) {
@@ -1114,10 +1044,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				value = res;
 			} else if (p_res_parser && id == "SubResource" && p_res_parser->sub_func) {
 				Ref<Resource> res;
-				Error err = p_res_parser->sub_func(p_res_parser->userdata, p_stream, res, line, r_err_str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(p_res_parser->sub_func(p_res_parser->userdata, p_stream, res, line, r_err_str));
 
 				value = res;
 			} else {
@@ -1310,10 +1237,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			Dictionary values;
-			err = _parse_dictionary(values, p_stream, line, r_err_str, p_res_parser);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_dictionary(values, p_stream, line, r_err_str, p_res_parser));
 
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_CLOSE) {
@@ -1393,10 +1317,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			Array values;
-			err = _parse_array(values, p_stream, line, r_err_str, p_res_parser);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_array(values, p_stream, line, r_err_str, p_res_parser));
 
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_PARENTHESIS_CLOSE) {
@@ -1409,10 +1330,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = array;
 		} else if (id == "PackedByteArray" || id == "PoolByteArray" || id == "ByteArray") {
 			Vector<uint8_t> args;
-			Error err = _parse_byte_array(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_byte_array(p_stream, args, line, r_err_str));
 
 			Vector<uint8_t> arr;
 			{
@@ -1427,10 +1345,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedInt32Array" || id == "PackedIntArray" || id == "PoolIntArray" || id == "IntArray") {
 			Vector<int32_t> args;
-			Error err = _parse_construct<int32_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<int32_t>(p_stream, args, line, r_err_str));
 
 			Vector<int32_t> arr;
 			{
@@ -1445,10 +1360,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedInt64Array") {
 			Vector<int64_t> args;
-			Error err = _parse_construct<int64_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<int64_t>(p_stream, args, line, r_err_str));
 
 			Vector<int64_t> arr;
 			{
@@ -1463,10 +1375,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedFloat32Array" || id == "PackedRealArray" || id == "PoolRealArray" || id == "FloatArray") {
 			Vector<float> args;
-			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<float>(p_stream, args, line, r_err_str));
 
 			Vector<float> arr;
 			{
@@ -1481,10 +1390,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedFloat64Array") {
 			Vector<double> args;
-			Error err = _parse_construct<double>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<double>(p_stream, args, line, r_err_str));
 
 			Vector<double> arr;
 			{
@@ -1545,10 +1451,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedVector2Array" || id == "PoolVector2Array" || id == "Vector2Array") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			Vector<Vector2> arr;
 			{
@@ -1563,10 +1466,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedVector3Array" || id == "PoolVector3Array" || id == "Vector3Array") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			Vector<Vector3> arr;
 			{
@@ -1581,10 +1481,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedVector4Array" || id == "PoolVector4Array" || id == "Vector4Array") {
 			Vector<real_t> args;
-			Error err = _parse_construct<real_t>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<real_t>(p_stream, args, line, r_err_str));
 
 			Vector<Vector4> arr;
 			{
@@ -1599,10 +1496,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = arr;
 		} else if (id == "PackedColorArray" || id == "PoolColorArray" || id == "ColorArray") {
 			Vector<float> args;
-			Error err = _parse_construct<float>(p_stream, args, line, r_err_str);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_construct<float>(p_stream, args, line, r_err_str));
 
 			Vector<Color> arr;
 			{
@@ -1650,10 +1544,7 @@ Error VariantParser::_parse_array(Array &array, Stream *p_stream, int &line, Str
 			return ERR_FILE_CORRUPT;
 		}
 
-		Error err = get_token(p_stream, token, line, r_err_str);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 
 		if (token.type == TK_BRACKET_CLOSE) {
 			return OK;
@@ -1670,10 +1561,7 @@ Error VariantParser::_parse_array(Array &array, Stream *p_stream, int &line, Str
 		}
 
 		Variant v;
-		err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(parse_value(token, v, p_stream, line, r_err_str, p_res_parser));
 
 		array.push_back(v);
 		need_comma = true;
@@ -1693,10 +1581,7 @@ Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int
 		}
 
 		if (at_key) {
-			Error err = get_token(p_stream, token, line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 
 			if (token.type == TK_CURLY_BRACKET_CLOSE) {
 				return OK;
@@ -1712,30 +1597,19 @@ Error VariantParser::_parse_dictionary(Dictionary &object, Stream *p_stream, int
 				}
 			}
 
-			err = parse_value(token, key, p_stream, line, r_err_str, p_res_parser);
+			RETURN_IF_ERR(parse_value(token, key, p_stream, line, r_err_str, p_res_parser));
+			RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 
-			if (err) {
-				return err;
-			}
-
-			err = get_token(p_stream, token, line, r_err_str);
-
-			if (err != OK) {
-				return err;
-			}
 			if (token.type != TK_COLON) {
 				r_err_str = "Expected ':'";
 				return ERR_PARSE_ERROR;
 			}
 			at_key = false;
 		} else {
-			Error err = get_token(p_stream, token, line, r_err_str);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(get_token(p_stream, token, line, r_err_str));
 
 			Variant v;
-			err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
+			Error err = parse_value(token, v, p_stream, line, r_err_str, p_res_parser);
 			if (err && err != ERR_FILE_MISSING_DEPENDENCIES) {
 				return err;
 			}
@@ -1860,10 +1734,7 @@ Error VariantParser::_parse_tag(Token &token, Stream *p_stream, int &line, Strin
 
 		get_token(p_stream, token, line, r_err_str);
 		Variant value;
-		Error err = parse_value(token, value, p_stream, line, r_err_str, p_res_parser);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(parse_value(token, value, p_stream, line, r_err_str, p_res_parser));
 
 		r_tag.fields[id] = value;
 	}
@@ -1933,10 +1804,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 			if (c == '"') { //quoted
 				p_stream->saved = '"';
 				Token tk;
-				Error err = get_token(p_stream, tk, line, r_err_str);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(get_token(p_stream, tk, line, r_err_str));
 				if (tk.type != TK_STRING) {
 					r_err_str = "Error reading quoted string";
 					return ERR_INVALID_DATA;
@@ -1961,10 +1829,7 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &line, String &r
 
 Error VariantParser::parse(Stream *p_stream, Variant &r_ret, String &r_err_str, int &r_err_line, ResourceParser *p_res_parser) {
 	Token token;
-	Error err = get_token(p_stream, token, r_err_line, r_err_str);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(get_token(p_stream, token, r_err_line, r_err_str));
 
 	if (token.type == TK_EOF) {
 		return ERR_FILE_EOF;

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -35,10 +35,7 @@
 Error ImageLoaderPNG::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) {
 	const uint64_t buffer_size = f->get_length();
 	Vector<uint8_t> file_buffer;
-	Error err = file_buffer.resize(buffer_size);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(file_buffer.resize(buffer_size));
 	{
 		uint8_t *writer = file_buffer.ptrw();
 		f->get_buffer(writer, buffer_size);

--- a/drivers/png/png_driver_common.cpp
+++ b/drivers/png/png_driver_common.cpp
@@ -173,8 +173,7 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	size_t compressed_size = png_size_estimate;
 	int success = 0;
 	{ // scope writer lifetime
-		Error err = p_buffer.resize(buffer_offset + png_size_estimate);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(p_buffer.resize(buffer_offset + png_size_estimate));
 
 		uint8_t *writer = p_buffer.ptrw();
 		success = png_image_write_to_memory(&png_img, &writer[buffer_offset],
@@ -186,8 +185,7 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 		ERR_FAIL_COND_V(compressed_size <= png_size_estimate, FAILED);
 
 		// write failed due to buffer size, resize and retry
-		Error err = p_buffer.resize(buffer_offset + compressed_size);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(p_buffer.resize(buffer_offset + compressed_size));
 
 		uint8_t *writer = p_buffer.ptrw();
 		success = png_image_write_to_memory(&png_img, &writer[buffer_offset],
@@ -197,8 +195,7 @@ Error image_to_png(const Ref<Image> &p_image, Vector<uint8_t> &p_buffer) {
 	}
 
 	// trim buffer size to content
-	Error err = p_buffer.resize(buffer_offset + compressed_size);
-	ERR_FAIL_COND_V(err, err);
+	RETURN_IF_ERR(p_buffer.resize(buffer_offset + compressed_size));
 
 	return OK;
 }

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -51,9 +51,9 @@ Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_pa
 Error ResourceSaverPNG::save_image(const String &p_path, const Ref<Image> &p_img) {
 	Vector<uint8_t> buffer;
 	Error err = PNGDriverCommon::image_to_png(p_img, buffer);
-	ERR_FAIL_COND_V_MSG(err, err, "Can't convert image to PNG.");
+	RETURN_IF_ERR_MSG(err, "Can't convert image to PNG.");
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save PNG at path: '%s'.", p_path));
+	RETURN_IF_ERR_MSG(err, vformat("Can't save PNG at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();
 

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -415,11 +415,7 @@ Error DirAccessUnix::rename(String p_path, String p_new_path) {
 
 	int res = ::rename(p_path.utf8().get_data(), p_new_path.utf8().get_data());
 	if (res != 0 && errno == EXDEV) { // Cross-device move, use copy and remove.
-		Error err = OK;
-		err = copy(p_path, p_new_path);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(copy(p_path, p_new_path));
 		return remove(p_path);
 	} else {
 		return (res == 0) ? OK : FAILED;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -121,10 +121,7 @@ Error DAPeer::send_data() {
 		int data_sent = 0;
 		while (data_sent < formatted_data.size()) {
 			int curr_sent = 0;
-			Error err = connection->put_partial_data(formatted_data.ptr() + data_sent, formatted_data.size() - data_sent, curr_sent);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(connection->put_partial_data(formatted_data.ptr() + data_sent, formatted_data.size() - data_sent, curr_sent));
 			data_sent += curr_sent;
 		}
 		res_queue.pop_front();

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -279,10 +279,7 @@ Error EditorDebuggerNode::start(const String &p_uri) {
 	current_uri = p_uri;
 
 	server = Ref<EditorDebuggerServer>(EditorDebuggerServer::create(p_uri.substr(0, p_uri.find("://") + 3)));
-	const Error err = server->start(p_uri);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(server->start(p_uri));
 	set_process(true);
 	EditorNode::get_log()->add_message("--- Debugging process started ---", EditorLog::MSG_TYPE_EDITOR);
 	return OK;

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1230,10 +1230,7 @@ Error DocTools::load_classes(const String &p_dir) {
 	while (!path.is_empty()) {
 		if (!da->current_is_dir() && path.ends_with("xml")) {
 			Ref<XMLParser> parser = memnew(XMLParser);
-			Error err2 = parser->open(p_dir.path_join(path));
-			if (err2) {
-				return err2;
-			}
+			RETURN_IF_ERR(parser->open(p_dir.path_join(path)));
 
 			_load(parser);
 		}
@@ -1806,10 +1803,7 @@ Error DocTools::load_compressed(const uint8_t *p_data, int64_t p_compressed_size
 	class_list.clear();
 
 	Ref<XMLParser> parser = memnew(XMLParser);
-	Error err = parser->open_buffer(data);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(parser->open_buffer(data));
 
 	_load(parser);
 
@@ -1818,10 +1812,7 @@ Error DocTools::load_compressed(const uint8_t *p_data, int64_t p_compressed_size
 
 Error DocTools::load_xml(const uint8_t *p_data, int64_t p_size) {
 	Ref<XMLParser> parser = memnew(XMLParser);
-	Error err = parser->_open_buffer(p_data, p_size);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(parser->_open_buffer(p_data, p_size));
 
 	_load(parser);
 

--- a/editor/editor_build_profile.cpp
+++ b/editor/editor_build_profile.cpp
@@ -522,9 +522,7 @@ Error EditorBuildProfile::save_to_file(const String &p_path) {
 Error EditorBuildProfile::load_from_file(const String &p_path) {
 	Error err;
 	String text = FileAccess::get_file_as_string(p_path, &err);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	JSON json;
 	err = json.parse(text);

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -220,9 +220,7 @@ Error EditorFeatureProfile::save_to_file(const String &p_path) {
 Error EditorFeatureProfile::load_from_file(const String &p_path) {
 	Error err;
 	String text = FileAccess::get_file_as_string(p_path, &err);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	JSON json;
 	err = json.parse(text);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -3040,10 +3040,7 @@ void EditorFileSystem::reimport_file_with_custom_parameters(const String &p_file
 Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (FileAccess::exists(p_from + ".import")) {
-		Error err = da->copy(p_from, p_to);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(da->copy(p_from, p_to));
 
 		// Roll a new uid for this copied .import file to avoid conflict.
 		ResourceUID::ID res_uid = ResourceUID::get_singleton()->create_id();
@@ -3053,28 +3050,19 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 		cfg.instantiate();
 		cfg->load(p_from + ".import");
 		cfg->set_value("remap", "uid", ResourceUID::get_singleton()->id_to_text(res_uid));
-		err = cfg->save(p_to + ".import");
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(cfg->save(p_to + ".import"));
 
 		// Make sure it's immediately added to the map so we can remap dependencies if we want to after this.
 		ResourceUID::get_singleton()->add_id(res_uid, p_to);
 	} else if (ResourceLoader::get_resource_uid(p_from) == ResourceUID::INVALID_ID) {
 		// Files which do not use an uid can just be copied.
-		Error err = da->copy(p_from, p_to);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(da->copy(p_from, p_to));
 	} else {
 		// Load the resource and save it again in the new location (this generates a new UID).
 		Error err;
 		Ref<Resource> res = ResourceLoader::load(p_from, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 		if (err == OK && res.is_valid()) {
-			err = ResourceSaver::save(res, p_to, ResourceSaver::FLAG_COMPRESS);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(ResourceSaver::save(res, p_to, ResourceSaver::FLAG_COMPRESS));
 		} else if (err != OK) {
 			// When loading files like text files the error is OK but the resource is still null.
 			// We can ignore such files.
@@ -3453,10 +3441,7 @@ Error EditorFileSystem::make_dir_recursive(const String &p_path, const String &p
 		return ERR_ALREADY_EXISTS;
 	}
 
-	err = da->make_dir_recursive(p_path);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(da->make_dir_recursive(p_path));
 
 	const String path = da->get_current_dir();
 	EditorFileSystemDirectory *parent = get_filesystem_path(path);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -174,8 +174,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 		}
 
 		OS::ProcessID pid = 0;
-		Error err = OS::get_singleton()->create_instance(instance_args, &pid);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(OS::get_singleton()->create_instance(instance_args, &pid));
 		if (pid != 0) {
 			pids.push_back(pid);
 		}

--- a/editor/export/codesign.cpp
+++ b/editor/export/codesign.cpp
@@ -1351,8 +1351,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 		CryptoCore::RandomGenerator rng;
 		ERR_FAIL_COND_V_MSG(rng.init(), FAILED, "Failed to initialize random number generator.");
 		uint8_t uuid[16];
-		Error err = rng.get_random_bytes(uuid, 16);
-		ERR_FAIL_COND_V_MSG(err, err, "Failed to generate UUID.");
+		RETURN_IF_ERR_MSG(rng.get_random_bytes(uuid, 16), "Failed to generate UUID.");
 		id = (String("a-55554944") /*a-UUID*/ + String::hex_encode_buffer(uuid, 16));
 	}
 	CharString uuid_str = id.utf8();

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -906,9 +906,7 @@ Error EditorExportPlatformAppleEmbedded::_walk_dir_recursive(Ref<DirAccess> &p_d
 		p_da->change_dir(dirs[i]);
 		Error err = _walk_dir_recursive(p_da, p_handler, p_userdata);
 		p_da->change_dir("..");
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(err);
 	}
 
 	return OK;
@@ -1052,10 +1050,7 @@ Error EditorExportPlatformAppleEmbedded::_convert_to_framework(const String &p_s
 	}
 
 	if (!filesystem_da->dir_exists(p_destination)) {
-		Error make_dir_err = filesystem_da->make_dir_recursive(p_destination);
-		if (make_dir_err) {
-			return make_dir_err;
-		}
+		RETURN_IF_ERR(filesystem_da->make_dir_recursive(p_destination));
 	}
 
 	String asset = p_source.ends_with("/") ? p_source.left(-1) : p_source;
@@ -1318,10 +1313,7 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 		destination = destination_dir;
 
 		// Convert to framework and copy.
-		Error err = _convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier"));
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier")));
 	} else if (p_is_framework && asset.ends_with(".xcframework")) {
 		// For Apple Embedded platforms we need to turn .dylib inside .xcframework
 		// into .framework to be able to send application to AppStore
@@ -1347,22 +1339,13 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 
 		if (dylibs > 0) {
 			// Convert to framework and copy.
-			Error err = _convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier"));
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier")));
 		} else {
 			// Copy as is.
 			if (!filesystem_da->dir_exists(destination_dir)) {
-				Error make_dir_err = filesystem_da->make_dir_recursive(destination_dir);
-				if (make_dir_err) {
-					return make_dir_err;
-				}
+				RETURN_IF_ERR(filesystem_da->make_dir_recursive(destination_dir));
 			}
-			Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination));
 		}
 	} else if (p_is_framework && asset.ends_with(".framework")) {
 		// Framework.
@@ -1387,10 +1370,7 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 				return make_dir_err;
 			}
 		}
-		Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination));
 	} else {
 		// Unknown resource.
 		asset_path = base_dir;
@@ -1409,15 +1389,9 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 
 		// Copy as is.
 		if (!filesystem_da->dir_exists(destination_dir)) {
-			Error make_dir_err = filesystem_da->make_dir_recursive(destination_dir);
-			if (make_dir_err) {
-				return make_dir_err;
-			}
+			RETURN_IF_ERR(filesystem_da->make_dir_recursive(destination_dir));
 		}
-		Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination));
 	}
 
 	if (asset_path.ends_with("/")) {
@@ -2079,11 +2053,8 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 		return err;
 	}
 
-	err = _export_icons(p_preset, iconset_dir);
-	if (err != OK) {
-		// Message is supplied by the subroutine method.
-		return err;
-	}
+	// Message is supplied by the subroutine method.
+	RETURN_IF_ERR(_export_icons(p_preset, iconset_dir));
 
 	{
 		String splash_image_path = binary_dir + "/Images.xcassets/SplashImage.imageset/";
@@ -2102,9 +2073,7 @@ Error EditorExportPlatformAppleEmbedded::_export_project_helper(const Ref<Editor
 		}
 	}
 
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	print_line("Exporting additional assets");
 	_export_additional_assets(p_preset, binary_dir, libraries, assets);

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -1426,31 +1426,26 @@ Error EditorExportPlatformAppleEmbedded::_export_additional_assets(const Ref<Edi
 	Vector<Ref<EditorExportPlugin>> export_plugins = EditorExport::get_singleton()->get_export_plugins();
 	for (int i = 0; i < export_plugins.size(); i++) {
 		Vector<String> linked_frameworks = export_plugins[i]->get_apple_embedded_platform_frameworks();
-		Error err = _export_additional_assets(p_preset, p_out_dir, linked_frameworks, true, false, r_exported_assets);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(_export_additional_assets(p_preset, p_out_dir, linked_frameworks, true, false, r_exported_assets));
 
 		Vector<String> embedded_frameworks = export_plugins[i]->get_apple_embedded_platform_embedded_frameworks();
-		err = _export_additional_assets(p_preset, p_out_dir, embedded_frameworks, true, true, r_exported_assets);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(_export_additional_assets(p_preset, p_out_dir, embedded_frameworks, true, true, r_exported_assets));
 
 		Vector<String> project_static_libs = export_plugins[i]->get_apple_embedded_platform_project_static_libs();
 		for (int j = 0; j < project_static_libs.size(); j++) {
 			project_static_libs.write[j] = project_static_libs[j].get_file(); // Only the file name as it's copied to the project
 		}
-		err = _export_additional_assets(p_preset, p_out_dir, project_static_libs, true, false, r_exported_assets);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(_export_additional_assets(p_preset, p_out_dir, project_static_libs, true, false, r_exported_assets));
 
 		Vector<String> apple_embedded_platform_bundle_files = export_plugins[i]->get_apple_embedded_platform_bundle_files();
-		err = _export_additional_assets(p_preset, p_out_dir, apple_embedded_platform_bundle_files, false, false, r_exported_assets);
-		ERR_FAIL_COND_V(err, err);
+		RETURN_IF_ERR(_export_additional_assets(p_preset, p_out_dir, apple_embedded_platform_bundle_files, false, false, r_exported_assets));
 	}
 
 	Vector<String> library_paths;
 	for (int i = 0; i < p_libraries.size(); ++i) {
 		library_paths.push_back(p_libraries[i].path);
 	}
-	Error err = _export_additional_assets(p_preset, p_out_dir, library_paths, true, true, r_exported_assets);
-	ERR_FAIL_COND_V(err, err);
+	RETURN_IF_ERR(_export_additional_assets(p_preset, p_out_dir, library_paths, true, true, r_exported_assets));
 
 	return OK;
 }

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -296,10 +296,7 @@ Error EditorExportPlatformExtension::export_zip(const Ref<EditorExportPreset> &p
 Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	Error err = _load_patches(p_patches.is_empty() ? p_preset->get_patches() : p_patches);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_load_patches(p_patches.is_empty() ? p_preset->get_patches() : p_patches));
 
 	Error ret = FAILED;
 	if (GDVIRTUAL_CALL(_export_pack_patch, p_preset, p_debug, p_path, p_patches, p_flags, ret)) {
@@ -307,7 +304,7 @@ Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPre
 		return ret;
 	}
 
-	err = save_pack_patch(p_preset, p_debug, p_path);
+	Error err = save_pack_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
 }
@@ -315,10 +312,7 @@ Error EditorExportPlatformExtension::export_pack_patch(const Ref<EditorExportPre
 Error EditorExportPlatformExtension::export_zip_patch(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, const Vector<String> &p_patches, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
-	Error err = _load_patches(p_patches.is_empty() ? p_preset->get_patches() : p_patches);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_load_patches(p_patches.is_empty() ? p_preset->get_patches() : p_patches));
 
 	Error ret = FAILED;
 	if (GDVIRTUAL_CALL(_export_zip_patch, p_preset, p_debug, p_path, p_patches, p_flags, ret)) {
@@ -326,7 +320,7 @@ Error EditorExportPlatformExtension::export_zip_patch(const Ref<EditorExportPres
 		return ret;
 	}
 
-	err = save_zip_patch(p_preset, p_debug, p_path);
+	Error err = save_zip_patch(p_preset, p_debug, p_path);
 	_unload_patches();
 	return err;
 }

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -2323,8 +2323,7 @@ int Collada::get_uv_channel(const String &p_name) {
 Error Collada::load(const String &p_path, int p_flags) {
 	Ref<XMLParser> parserr = memnew(XMLParser);
 	XMLParser &parser = *parserr.ptr();
-	Error err = parser.open(p_path);
-	ERR_FAIL_COND_V_MSG(err, err, "Cannot open Collada file '" + p_path + "'.");
+	RETURN_IF_ERR_MSG(parser.open(p_path), "Cannot open Collada file '" + p_path + "'.");
 
 	state.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	state.import_flags = p_flags;

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -135,10 +135,7 @@ Error ColladaImport::_populate_skeleton(Skeleton3D *p_skeleton, Collada::Node *p
 
 	int id = r_bone++;
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _populate_skeleton(p_skeleton, p_node->children[i], r_bone, id);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_populate_skeleton(p_skeleton, p_node->children[i], r_bone, id));
 	}
 
 	return OK;
@@ -176,10 +173,7 @@ Error ColladaImport::_create_scene_skeletons(Collada::Node *p_node) {
 	}
 
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _create_scene_skeletons(p_node->children[i]);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_create_scene_skeletons(p_node->children[i]));
 	}
 	return OK;
 }
@@ -319,10 +313,7 @@ Error ColladaImport::_create_scene(Collada::Node *p_node, Node3D *p_parent) {
 	}
 
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _create_scene(p_node->children[i], node);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_create_scene(p_node->children[i], node));
 	}
 	return OK;
 }
@@ -1319,10 +1310,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 	}
 
 	for (int i = 0; i < p_node->children.size(); i++) {
-		Error err = _create_resources(p_node->children[i], p_use_compression);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_create_resources(p_node->children[i], p_use_compression));
 	}
 	return OK;
 }

--- a/editor/import/3d/editor_import_collada.cpp
+++ b/editor/import/3d/editor_import_collada.cpp
@@ -1220,8 +1220,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 									Ref<ImporterMesh> mesh = Ref<ImporterMesh>(memnew(ImporterMesh));
 									const Collada::MeshData &meshdata = collada.state.mesh_data_map[meshid2];
 									mesh->set_name(meshdata.name);
-									Error err = _create_mesh_surfaces(false, mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, nullptr, Vector<Ref<ImporterMesh>>(), false);
-									ERR_FAIL_COND_V(err, err);
+									RETURN_IF_ERR(_create_mesh_surfaces(false, mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, nullptr, Vector<Ref<ImporterMesh>>(), false));
 
 									morphs.push_back(mesh);
 								} else {
@@ -1269,8 +1268,9 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 					mesh_unique_names.insert(name);
 
 					mesh->set_name(name);
-					Error err = _create_mesh_surfaces(morphs.is_empty(), mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, morph, morphs, p_use_compression, use_mesh_builtin_materials);
-					ERR_FAIL_COND_V_MSG(err, err, "Cannot create mesh surface.");
+					RETURN_IF_ERR_MSG(
+						_create_mesh_surfaces(morphs.is_empty(), mesh, ng2->material_map, meshdata, apply_xform, bone_remap, skin, morph, morphs, p_use_compression, use_mesh_builtin_materials),
+						"Cannot create mesh surface.");
 
 					mesh_cache[meshid] = mesh;
 				} else {
@@ -1316,8 +1316,7 @@ Error ColladaImport::_create_resources(Collada::Node *p_node, bool p_use_compres
 }
 
 Error ColladaImport::load(const String &p_path, int p_flags, bool p_force_make_tangents, bool p_use_compression) {
-	Error err = collada.load(p_path, p_flags);
-	ERR_FAIL_COND_V_MSG(err, err, "Cannot load file '" + p_path + "'.");
+	RETURN_IF_ERR_MSG(collada.load(p_path, p_flags), "Cannot load file '" + p_path + "'.");
 
 	force_make_tangents = p_force_make_tangents;
 	ERR_FAIL_COND_V(!collada.state.visual_scene_map.has(collada.state.root_visual_scene), ERR_INVALID_DATA);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3328,14 +3328,16 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		}
 
 		print_verbose("Saving animation to: " + p_save_path + ".res");
-		err = ResourceSaver::save(library, p_save_path + ".res", flags); //do not take over, let the changed files reload themselves
-		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save animation to file '" + p_save_path + ".res'.");
+		RETURN_IF_ERR_MSG(
+				ResourceSaver::save(library, p_save_path + ".res", flags), //do not take over, let the changed files reload themselves
+				"Cannot save animation to file '" + p_save_path + ".res'.");
 	} else if (_scene_import_type == "PackedScene") {
 		Ref<PackedScene> packer = memnew(PackedScene);
 		packer->pack(scene);
 		print_verbose("Saving scene to: " + p_save_path + ".scn");
-		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
-		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
+		RETURN_IF_ERR_MSG(
+				ResourceSaver::save(packer, p_save_path + ".scn", flags);, //do not take over, let the changed files reload themselves
+				"Cannot save scene to file '" + p_save_path + ".scn'.");
 	} else {
 		ERR_FAIL_V_MSG(ERR_FILE_UNRECOGNIZED, "Unknown scene import type: " + _scene_import_type);
 	}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3121,17 +3121,11 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	// Check whether any of the meshes or animations have nonexistent save paths
 	// and if they do, fail the import immediately.
 	if (subresources.has("meshes")) {
-		err = _check_resource_save_paths(p_source_id, "m", subresources["meshes"]);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_check_resource_save_paths(p_source_id, "m", subresources["meshes"]));
 	}
 
 	if (subresources.has("animations")) {
-		err = _check_resource_save_paths(p_source_id, "a", subresources["animations"]);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_check_resource_save_paths(p_source_id, "a", subresources["animations"]));
 	}
 
 	List<String> missing_deps; // for now, not much will be done with this

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -77,10 +77,7 @@ Error ResourceImporterBitMap::import(ResourceUID::ID p_source_id, const String &
 	float threshold = p_options["threshold"];
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(ImageLoader::load_image(p_source_file, image));
 
 	int w = image->get_width();
 	int h = image->get_height();

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -340,10 +340,7 @@ Error ResourceImporterLayeredTexture::import(ResourceUID::ID p_source_id, const 
 
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(ImageLoader::load_image(p_source_file, image));
 
 	if (compress_mode == COMPRESS_VRAM_COMPRESSED) {
 		//if using video ram, optimize

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -787,10 +787,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 	// Load the main image.
 	Ref<Image> image;
 	image.instantiate();
-	Error err = ImageLoader::load_image(p_source_file, image, nullptr, loader_flags, scale);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(ImageLoader::load_image(p_source_file, image, nullptr, loader_flags, scale));
 	images_imported.push_back(image);
 
 	// Load the editor-only image.
@@ -805,7 +802,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 		}
 
 		editor_image.instantiate();
-		err = ImageLoader::load_image(p_source_file, editor_image, nullptr, editor_loader_flags, editor_scale);
+		Error err = ImageLoader::load_image(p_source_file, editor_image, nullptr, editor_loader_flags, editor_scale);
 
 		if (err != OK) {
 			WARN_PRINT(vformat("Failed to import an image resource for editor use from '%s'.", p_source_file));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2447,7 +2447,7 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 	{
 		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
-		ERR_FAIL_COND_V_MSG(err, err, "Cannot save text file '" + p_path + "'.");
+		RETURN_IF_ERR_MSG(err, "Cannot save text file '" + p_path + "'.");
 
 		file->store_string(source);
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -411,11 +411,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		src_texture_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 	}
 
-	err = get_src_texture_format(r_img, src_texture_format.format);
-
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(get_src_texture_format(r_img, src_texture_format.format));
 
 	// For the destination format just copy the source format and change the usage bits.
 	RD::TextureFormat dst_texture_format = src_texture_format;

--- a/modules/enet/enet_multiplayer_peer.cpp
+++ b/modules/enet/enet_multiplayer_peer.cpp
@@ -62,10 +62,7 @@ Error ENetMultiplayerPeer::create_server(int p_port, int p_max_clients, int p_ma
 	set_refuse_new_connections(false);
 	Ref<ENetConnection> host;
 	host.instantiate();
-	Error err = host->create_host_bound(bind_ip, p_port, p_max_clients, 0, p_max_channels > 0 ? p_max_channels + SYSCH_MAX : 0, p_out_bandwidth);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(host->create_host_bound(bind_ip, p_port, p_max_clients, 0, p_max_channels > 0 ? p_max_channels + SYSCH_MAX : 0, p_out_bandwidth));
 
 	active_mode = MODE_SERVER;
 	unique_id = 1;
@@ -79,14 +76,10 @@ Error ENetMultiplayerPeer::create_client(const String &p_address, int p_port, in
 	set_refuse_new_connections(false);
 	Ref<ENetConnection> host;
 	host.instantiate();
-	Error err;
 	if (p_local_port) {
-		err = host->create_host_bound(bind_ip, p_local_port, 1, 0, p_in_bandwidth, p_out_bandwidth);
+		RETURN_IF_ERR(host->create_host_bound(bind_ip, p_local_port, 1, 0, p_in_bandwidth, p_out_bandwidth));
 	} else {
-		err = host->create_host(1, 0, p_in_bandwidth, p_out_bandwidth);
-	}
-	if (err != OK) {
-		return err;
+		RETURN_IF_ERR(host->create_host(1, 0, p_in_bandwidth, p_out_bandwidth));
 	}
 
 	unique_id = generate_unique_id();

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -2449,16 +2449,13 @@ Error FBXDocument::_parse_skins(Ref<FBXState> p_state) {
 		}
 	}
 	p_state->original_skin_indices = p_state->skin_indices.duplicate();
-	Error err = SkinTool::_asset_parse_skins(
+	RETURN_IF_ERR(SkinTool::_asset_parse_skins(
 			p_state->original_skin_indices,
 			p_state->skins.duplicate(),
 			p_state->nodes.duplicate(),
 			p_state->skin_indices,
 			p_state->skins,
-			joint_mapping);
-	if (err != OK) {
-		return err;
-	}
+			joint_mapping));
 	for (int i = 0; i < p_state->skins.size(); ++i) {
 		Ref<GLTFSkin> skin = p_state->skins.write[i];
 		ERR_FAIL_COND_V(skin.is_null(), ERR_PARSE_ERROR);

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -47,7 +47,7 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 
 	Error err;
 	Ref<Resource> loaded_res = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
-	ERR_FAIL_COND_V_MSG(err, err, "Failed to load " + p_path);
+	RETURN_IF_ERR_MSG(err, "Failed to load " + p_path);
 
 	translations = r_translations;
 
@@ -55,12 +55,14 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 	String source_code = gdscript->get_source_code();
 
 	GDScriptParser parser;
-	err = parser.parse(source_code, p_path, false);
-	ERR_FAIL_COND_V_MSG(err, err, "Failed to parse GDScript with GDScriptParser.");
+	RETURN_IF_ERR_MSG(
+		parser.parse(source_code, p_path, false),
+		"Failed to parse GDScript with GDScriptParser.");
 
 	GDScriptAnalyzer analyzer(&parser);
-	err = analyzer.analyze();
-	ERR_FAIL_COND_V_MSG(err, err, "Failed to analyze GDScript with GDScriptAnalyzer.");
+	RETURN_IF_ERR_MSG(
+		analyzer.analyze(),
+		"Failed to analyze GDScript with GDScriptAnalyzer.");
 
 	comment_data = &parser.comment_data;
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -3127,8 +3127,7 @@ Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const S
 	{
 		Error err;
 		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-
-		ERR_FAIL_COND_V_MSG(err, err, "Cannot save GDScript file '" + p_path + "'.");
+		RETURN_IF_ERR_MSG(err, "Cannot save GDScript file '" + p_path + "'.");
 
 		file->store_string(source);
 		if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -883,10 +883,7 @@ Error GDScript::reload(bool p_keep_state) {
 #endif
 
 	if (can_run) {
-		err = _static_init();
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_static_init());
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -532,10 +532,7 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 				for (GDScriptParser::ClassNode *look_class : script_classes) {
 					if (look_class->identifier && look_class->identifier->name == name) {
 						if (!look_class->get_datatype().is_set()) {
-							Error err = resolve_class_inheritance(look_class, id);
-							if (err) {
-								return err;
-							}
+							RETURN_IF_ERR(resolve_class_inheritance(look_class, id));
 						}
 						base = look_class->get_datatype();
 						found = true;
@@ -630,18 +627,12 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 }
 
 Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive) {
-	Error err = resolve_class_inheritance(p_class);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(resolve_class_inheritance(p_class));
 
 	if (p_recursive) {
 		for (int i = 0; i < p_class->members.size(); i++) {
 			if (p_class->members[i].type == GDScriptParser::ClassNode::Member::CLASS) {
-				err = resolve_class_inheritance(p_class->members[i].m_class, true);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(resolve_class_inheritance(p_class->members[i].m_class, true));
 			}
 		}
 	}
@@ -6422,16 +6413,9 @@ Error GDScriptAnalyzer::resolve_dependencies() {
 Error GDScriptAnalyzer::analyze() {
 	parser->errors.clear();
 
-	Error err = resolve_inheritance();
-	if (err) {
-		return err;
-	}
-
+	RETURN_IF_ERR(resolve_inheritance());
 	resolve_interface();
-	err = resolve_body();
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(resolve_body());
 
 	return resolve_dependencies();
 }

--- a/modules/gdscript/gdscript_tokenizer_buffer.cpp
+++ b/modules/gdscript/gdscript_tokenizer_buffer.cpp
@@ -190,10 +190,7 @@ Error GDScriptTokenizerBuffer::set_code_buffer(const Vector<uint8_t> &p_buffer) 
 	for (uint32_t i = 0; i < constant_count; i++) {
 		Variant v;
 		int len;
-		Error err = decode_variant(v, b, total_len, &len, false);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(decode_variant(v, b, total_len, &len, false));
 		b += len;
 		total_len -= len;
 		constants.write[i] = v;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -106,10 +106,7 @@ Error GDScriptLanguageProtocol::LSPeer::send_data() {
 	while (!res_queue.is_empty()) {
 		CharString c_res = res_queue[0];
 		if (res_sent < c_res.size()) {
-			Error err = connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(connection->put_partial_data((const uint8_t *)c_res.get_data() + res_sent, c_res.size() - res_sent - 1, sent));
 			res_sent += sent;
 		}
 		// Response sent

--- a/modules/gltf/editor/editor_import_blend_runner.cpp
+++ b/modules/gltf/editor/editor_import_blend_runner.cpp
@@ -339,11 +339,7 @@ bool EditorImportBlendRunner::_extract_error_message_xml(const Vector<uint8_t> &
 Error EditorImportBlendRunner::do_import_direct(const Dictionary &p_options) {
 	// Export glTF directly.
 	String python = vformat(PYTHON_SCRIPT_DIRECT, dict_to_python(p_options));
-	Error err = start_blender(python, true);
-	if (err != OK) {
-		return err;
-	}
-
+	RETURN_IF_ERR(start_blender(python, true));
 	return OK;
 }
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -8284,10 +8284,7 @@ Error GLTFDocument::_parse(Ref<GLTFState> p_state, String p_path, Ref<FileAccess
 	if (magic == 0x46546C67) {
 		// Binary file.
 		p_file->seek(0);
-		err = _parse_glb(p_file, p_state);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_glb(p_file, p_state));
 	} else {
 		// Text file.
 		p_file->seek(0);
@@ -8795,11 +8792,8 @@ Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_
 	ERR_FAIL_COND_V(state.is_null(), ERR_INVALID_PARAMETER);
 	state->set_base_path(p_path.get_base_dir());
 	state->filename = p_path.get_file();
-	Error err = _serialize(state);
-	if (err != OK) {
-		return err;
-	}
-	err = _serialize_file(state, p_path);
+	RETURN_IF_ERR(_serialize(state));
+	Error err = _serialize_file(state, p_path);
 	if (err != OK) {
 		return Error::FAILED;
 	}

--- a/modules/jpg/image_loader_libjpeg_turbo.cpp
+++ b/modules/jpg/image_loader_libjpeg_turbo.cpp
@@ -173,7 +173,7 @@ static Vector<uint8_t> _jpeg_turbo_buffer_save_func(const Ref<Image> &p_img, flo
 static Error _jpeg_turbo_save_func(const String &p_path, const Ref<Image> &p_img, float p_quality) {
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save JPG at path: '%s'.", p_path));
+	RETURN_IF_ERR_MSG(err, vformat("Can't save JPG at path: '%s'.", p_path));
 
 	Vector<uint8_t> data = _jpeg_turbo_buffer_save_func(p_img, p_quality);
 	ERR_FAIL_COND_V(data.size() == 0, FAILED);

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -862,7 +862,7 @@ Error LightmapperRD::_store_pfm(RenderingDevice *p_rd, RID p_atlas_tex, int p_in
 
 	Error err = OK;
 	Ref<FileAccess> file = FileAccess::open(p_name, FileAccess::WRITE, &err);
-	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save PFN at path: '%s'.", p_name));
+	RETURN_IF_ERR_MSG(err, vformat("Can't save PFN at path: '%s'.", p_name));
 	file->store_line("PF");
 	file->store_line(vformat("%d %d", img->get_width(), img->get_height()));
 #ifdef BIG_ENDIAN_ENABLED

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -139,16 +139,9 @@ Error StreamPeerMbedTLS::accept_stream(Ref<StreamPeer> p_base, Ref<TLSOptions> p
 Error StreamPeerMbedTLS::put_data(const uint8_t *p_data, int p_bytes) {
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_UNCONFIGURED);
 
-	Error err;
 	int sent = 0;
-
 	while (p_bytes > 0) {
-		err = put_partial_data(p_data, p_bytes, sent);
-
-		if (err != OK) {
-			return err;
-		}
-
+		RETURN_IF_ERR(put_partial_data(p_data, p_bytes, sent));
 		p_data += sent;
 		p_bytes -= sent;
 	}
@@ -189,15 +182,9 @@ Error StreamPeerMbedTLS::put_partial_data(const uint8_t *p_data, int p_bytes, in
 Error StreamPeerMbedTLS::get_data(uint8_t *p_buffer, int p_bytes) {
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_UNCONFIGURED);
 
-	Error err;
-
 	int got = 0;
 	while (p_bytes > 0) {
-		err = get_partial_data(p_buffer, p_bytes, got);
-
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(get_partial_data(p_buffer, p_bytes, got));
 
 		p_buffer += got;
 		p_bytes -= got;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -1751,10 +1751,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		StringBuilder constants_source;
 		_generate_global_constants(constants_source);
 		String output_file = Path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_constants.cs");
-		Error save_err = _save_file(output_file, constants_source);
-		if (save_err != OK) {
-			return save_err;
-		}
+		RETURN_IF_ERR(_save_file(output_file, constants_source));
 
 		compile_items.push_back(output_file);
 	}
@@ -1764,10 +1761,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		StringBuilder extensions_source;
 		_generate_array_extensions(extensions_source);
 		String output_file = Path::join(base_gen_dir, BINDINGS_GLOBAL_SCOPE_CLASS "_extensions.cs");
-		Error save_err = _save_file(output_file, extensions_source);
-		if (save_err != OK) {
-			return save_err;
-		}
+		RETURN_IF_ERR(_save_file(output_file, extensions_source));
 
 		compile_items.push_back(output_file);
 	}
@@ -1786,9 +1780,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 			continue;
 		}
 
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(err);
 
 		compile_items.push_back(output_file);
 	}
@@ -1849,9 +1841,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		String constructors_file = Path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR ".cs");
 		Error err = _save_file(constructors_file, cs_built_in_ctors_content);
 
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(err);
 
 		compile_items.push_back(constructors_file);
 	}
@@ -1881,20 +1871,14 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 		if (icall.editor_only) {
 			continue;
 		}
-		Error err = _generate_cs_native_calls(icall, cs_icalls_content);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_generate_cs_native_calls(icall, cs_icalls_content));
 	}
 
 	cs_icalls_content.append(CLOSE_BLOCK);
 
 	String internal_methods_file = Path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS ".cs");
 
-	Error err = _save_file(internal_methods_file, cs_icalls_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_save_file(internal_methods_file, cs_icalls_content));
 
 	compile_items.push_back(internal_methods_file);
 
@@ -1914,10 +1898,7 @@ Error BindingsGenerator::generate_cs_core_project(const String &p_proj_dir) {
 
 	String includes_props_file = Path::join(base_gen_dir, "GeneratedIncludes.props");
 
-	err = _save_file(includes_props_file, includes_props_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_save_file(includes_props_file, includes_props_content));
 
 	return OK;
 }
@@ -1956,9 +1937,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 			continue;
 		}
 
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(err);
 
 		compile_items.push_back(output_file);
 	}
@@ -2005,11 +1984,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		cs_built_in_ctors_content.append(CLOSE_BLOCK);
 
 		String constructors_file = Path::join(base_gen_dir, BINDINGS_CLASS_CONSTRUCTOR_EDITOR ".cs");
-		Error err = _save_file(constructors_file, cs_built_in_ctors_content);
-
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_save_file(constructors_file, cs_built_in_ctors_content));
 
 		compile_items.push_back(constructors_file);
 	}
@@ -2041,20 +2016,14 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 		if (!icall.editor_only) {
 			continue;
 		}
-		Error err = _generate_cs_native_calls(icall, cs_icalls_content);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(_generate_cs_native_calls(icall, cs_icalls_content));
 	}
 
 	cs_icalls_content.append(CLOSE_BLOCK);
 
 	String internal_methods_file = Path::join(base_gen_dir, BINDINGS_CLASS_NATIVECALLS_EDITOR ".cs");
 
-	Error err = _save_file(internal_methods_file, cs_icalls_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_save_file(internal_methods_file, cs_icalls_content));
 
 	compile_items.push_back(internal_methods_file);
 
@@ -2074,10 +2043,7 @@ Error BindingsGenerator::generate_cs_editor_project(const String &p_proj_dir) {
 
 	String includes_props_file = Path::join(base_gen_dir, "GeneratedIncludes.props");
 
-	err = _save_file(includes_props_file, includes_props_content);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_save_file(includes_props_file, includes_props_content));
 
 	return OK;
 }

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -161,20 +161,15 @@ Error ImageLoaderSVG::load_image(Ref<Image> p_image, Ref<FileAccess> p_fileacces
 	p_fileaccess->get_buffer(buffer.ptrw(), buffer.size());
 
 	String svg;
-	Error err = svg.append_utf8((const char *)buffer.ptr(), buffer.size());
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(svg.append_utf8((const char *)buffer.ptr(), buffer.size()));
 
 	if (p_flags & FLAG_CONVERT_COLORS) {
-		err = create_image_from_string(p_image, svg, p_scale, false, forced_color_map);
+		RETURN_IF_ERR(create_image_from_string(p_image, svg, p_scale, false, forced_color_map));
 	} else {
-		err = create_image_from_string(p_image, svg, p_scale, false, HashMap<Color, Color>());
+		RETURN_IF_ERR(create_image_from_string(p_image, svg, p_scale, false, HashMap<Color, Color>()));
 	}
 
-	if (err != OK) {
-		return err;
-	} else if (p_image->is_empty()) {
+	if (p_image->is_empty()) {
 		return ERR_INVALID_DATA;
 	}
 

--- a/modules/tga/image_loader_tga.cpp
+++ b/modules/tga/image_loader_tga.cpp
@@ -35,13 +35,8 @@
 #include "core/io/image.h"
 
 Error ImageLoaderTGA::decode_tga_rle(const uint8_t *p_compressed_buffer, size_t p_pixel_size, uint8_t *p_uncompressed_buffer, size_t p_output_size, size_t p_input_size) {
-	Error error;
-
 	Vector<uint8_t> pixels;
-	error = pixels.resize(p_pixel_size);
-	if (error != OK) {
-		return error;
-	}
+	RETURN_IF_ERR(pixels.resize(p_pixel_size));
 
 	uint8_t *pixels_w = pixels.ptrw();
 

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -53,7 +53,7 @@ Error ResourceSaverWebP::save_image(const String &p_path, const Ref<Image> &p_im
 	Vector<uint8_t> buffer = save_image_to_buffer(p_img, p_lossy, p_quality);
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
-	ERR_FAIL_COND_V_MSG(err, err, vformat("Can't save WebP at path: '%s'.", p_path));
+	RETURN_IF_ERR_MSG(err, vformat("Can't save WebP at path: '%s'.", p_path));
 
 	const uint8_t *reader = buffer.ptr();
 

--- a/modules/websocket/websocket_multiplayer_peer.cpp
+++ b/modules/websocket/websocket_multiplayer_peer.cpp
@@ -199,10 +199,7 @@ Error WebSocketMultiplayerPeer::create_client(const String &p_url, Ref<TLSOption
 	ERR_FAIL_COND_V(p_options.is_valid() && p_options->is_server(), ERR_INVALID_PARAMETER);
 	_clear();
 	Ref<WebSocketPeer> peer = _create_peer();
-	Error err = peer->connect_to_url(p_url, p_options);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(peer->connect_to_url(p_url, p_options));
 	PendingPeer pending;
 	pending.time = OS::get_singleton()->get_ticks_msec();
 	pending_peers[1] = pending;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -837,8 +837,9 @@ Error EditorExportPlatformAndroid::copy_gradle_so(void *p_userdata, const Shared
 			String dst_path = export_data->libs_directory.path_join(type).path_join(abi).path_join(filename);
 			Vector<uint8_t> data = FileAccess::get_file_as_bytes(p_so.path);
 			print_verbose("Copying .so file from " + p_so.path + " to " + dst_path);
-			Error err = store_file_at_path(dst_path, data);
-			ERR_FAIL_COND_V_MSG(err, err, "Failed to copy .so file from " + p_so.path + " to " + dst_path);
+			RETURN_IF_ERR_MSG(
+				store_file_at_path(dst_path, data),
+				"Failed to copy .so file from " + p_so.path + " to " + dst_path);
 			export_data->libs.push_back(dst_path);
 		}
 	}

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -137,10 +137,7 @@ Error create_directory(const String &p_dir) {
 // Note: this will overwrite the file at p_path if it already exists.
 Error store_file_at_path(const String &p_path, const Vector<uint8_t> &p_data) {
 	String dir = p_path.get_base_dir();
-	Error err = create_directory(dir);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(create_directory(dir));
 	Ref<FileAccess> fa = FileAccess::open(p_path, FileAccess::WRITE);
 	ERR_FAIL_COND_V_MSG(fa.is_null(), ERR_CANT_CREATE, "Cannot create file '" + p_path + "'.");
 	fa->store_buffer(p_data.ptr(), p_data.size());

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -96,10 +96,7 @@ void NetSocketAndroid::close() {
 }
 
 Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
-	Error err = NetSocketUnix::set_broadcasting_enabled(p_enabled);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(NetSocketUnix::set_broadcasting_enabled(p_enabled));
 
 	if (p_enabled != wants_broadcast) {
 		if (p_enabled) {
@@ -115,10 +112,7 @@ Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
 }
 
 Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
-	Error err = NetSocketUnix::join_multicast_group(p_multi_address, p_if_name);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(NetSocketUnix::join_multicast_group(p_multi_address, p_if_name));
 
 	if (!multicast_groups) {
 		multicast_lock_acquire();
@@ -129,10 +123,7 @@ Error NetSocketAndroid::join_multicast_group(const IPAddress &p_multi_address, c
 }
 
 Error NetSocketAndroid::leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) {
-	Error err = NetSocketUnix::leave_multicast_group(p_multi_address, p_if_name);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(NetSocketUnix::leave_multicast_group(p_multi_address, p_if_name));
 
 	ERR_FAIL_COND_V(multicast_groups == 0, ERR_BUG);
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -754,15 +754,9 @@ Error OS_Android::move_to_trash(const String &p_path) {
 
 	// Check if it's a directory
 	if (da_ref->dir_exists(p_path)) {
-		Error err = da_ref->change_dir(p_path);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(da_ref->change_dir(p_path));
 		// This is directory, let's erase its contents
-		err = da_ref->erase_contents_recursive();
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(da_ref->erase_contents_recursive());
 		// Remove the top directory
 		return da_ref->remove(p_path);
 	} else if (da_ref->file_exists(p_path)) {

--- a/platform/web/audio_driver_web.cpp
+++ b/platform/web/audio_driver_web.cpp
@@ -130,10 +130,7 @@ Error AudioDriverWeb::init() {
 	mix_rate = audio_context.mix_rate;
 	channel_count = audio_context.channel_count;
 	buffer_length = closest_power_of_2(uint32_t(latency * mix_rate / 1000));
-	Error err = create(buffer_length, channel_count);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(create(buffer_length, channel_count));
 	if (output_rb) {
 		memdelete_arr(output_rb);
 	}

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -786,23 +786,14 @@ Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int 
 			switch (p_option) {
 				// Run in Browser.
 				case 0: {
-					Error err = _export_project(p_preset, p_debug_flags);
-					if (err != OK) {
-						return err;
-					}
-					err = _start_server(bind_host, bind_port, use_tls);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERR(_export_project(p_preset, p_debug_flags));
+					RETURN_IF_ERR(_start_server(bind_host, bind_port, use_tls));
 					return _launch_browser(bind_host, bind_port, use_tls);
 				} break;
 
 				// Start HTTP Server.
 				case 1: {
-					Error err = _export_project(p_preset, p_debug_flags);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERR(_export_project(p_preset, p_debug_flags));
 					return _start_server(bind_host, bind_port, use_tls);
 				} break;
 
@@ -816,10 +807,7 @@ Error EditorExportPlatformWeb::run(const Ref<EditorExportPreset> &p_preset, int 
 			switch (p_option) {
 				// Run in Browser.
 				case 0: {
-					Error err = _export_project(p_preset, p_debug_flags);
-					if (err != OK) {
-						return err;
-					}
+					RETURN_IF_ERR(_export_project(p_preset, p_debug_flags));
 					return _launch_browser(bind_host, bind_port, use_tls);
 				} break;
 

--- a/platform/web/http_client_web.cpp
+++ b/platform/web/http_client_web.cpp
@@ -87,10 +87,7 @@ Error HTTPClientWeb::request(Method p_method, const String &p_url, const Vector<
 	ERR_FAIL_COND_V(port < 0, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(!p_url.begins_with("/"), ERR_INVALID_PARAMETER);
 
-	Error err = verify_headers(p_headers);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(verify_headers(p_headers));
 
 	String url = (use_tls ? "https://" : "http://") + host + ":" + itos(port) + p_url;
 	Vector<CharString> keeper;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -82,9 +82,7 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 
 	if (p_src_path.get_extension() == "ico") {
 		Ref<FileAccess> f = FileAccess::open(p_src_path, FileAccess::READ, &err);
-		if (err != OK) {
-			return err;
-		}
+		RETURN_IF_ERR(err);
 
 		// Read ICONDIR.
 		f->get_16(); // Reserved.
@@ -142,9 +140,7 @@ Error EditorExportPlatformWindows::_process_icon(const Ref<EditorExportPreset> &
 	ERR_FAIL_COND_V(valid_icon_count == 0, ERR_CANT_OPEN);
 
 	Ref<FileAccess> fw = FileAccess::open(p_dst_path, FileAccess::WRITE, &err);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(err);
 
 	// Write ICONDIR.
 	fw->store_16(0); // Reserved.

--- a/platform/windows/gl_manager_windows_native.cpp
+++ b/platform/windows/gl_manager_windows_native.cpp
@@ -350,10 +350,7 @@ PFNWGLDELETECONTEXT gd_wglDeleteContext;
 PFNWGLGETPROCADDRESS gd_wglGetProcAddress;
 
 Error GLManagerNative_Windows::_create_context(GLWindow &win, GLDisplay &gl_display) {
-	Error err = _configure_pixel_format(win.hDC);
-	if (err != OK) {
-		return err;
-	}
+	RETURN_IF_ERR(_configure_pixel_format(win.hDC));
 
 	HMODULE module = LoadLibraryW(L"opengl32.dll");
 	if (!module) {
@@ -432,10 +429,7 @@ Error GLManagerNative_Windows::window_create(DisplayServer::WindowID p_window_id
 	}
 
 	// configure the HDC to use a compatible pixel format
-	Error result = _configure_pixel_format(hDC);
-	if (result != OK) {
-		return result;
-	}
+	RETURN_IF_ERR(_configure_pixel_format(hDC));
 
 	GLWindow win;
 	win.hwnd = p_hwnd;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -125,10 +125,7 @@ Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_cust
 
 	method = p_method;
 
-	Error err = _parse_url(p_url);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(_parse_url(p_url));
 
 	headers = p_custom_headers;
 
@@ -150,7 +147,7 @@ Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_cust
 		thread.start(_thread_func, this);
 	} else {
 		client->set_blocking_mode(false);
-		err = _request();
+		Error err = _request();
 		if (err != OK) {
 			_defer_done(RESULT_CANT_CONNECT, 0, PackedStringArray(), PackedByteArray());
 			return ERR_CANT_CONNECT;

--- a/scene/main/multiplayer_api.cpp
+++ b/scene/main/multiplayer_api.cpp
@@ -122,10 +122,7 @@ Error MultiplayerAPI::encode_and_compress_variant(const Variant &p_variant, uint
 		} break;
 		default:
 			// Any other case is not yet compressed.
-			Error err = encode_variant(p_variant, r_buffer, r_len, p_allow_object_decoding);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(encode_variant(p_variant, r_buffer, r_len, p_allow_object_decoding));
 			if (r_buffer) {
 				// The first byte is not used by the marshaling, so store the type
 				// so we know how to decompress and decode this variant.
@@ -195,10 +192,7 @@ Error MultiplayerAPI::decode_and_decompress_variant(Variant &r_variant, const ui
 			}
 		} break;
 		default:
-			Error err = decode_variant(r_variant, p_buffer, p_len, r_len, p_allow_object_decoding);
-			if (err != OK) {
-				return err;
-			}
+			return decode_variant(r_variant, p_buffer, p_len, r_len, p_allow_object_decoding);
 	}
 
 	return OK;

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -135,10 +135,7 @@ Error CompressedTexture2D::load(const String &p_path) {
 	bool request_roughness;
 	int mipmap_limit;
 
-	Error err = _load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(_load_data(p_path, lw, lh, image, request_3d, request_normal, request_roughness, mipmap_limit));
 
 	if (texture.is_valid()) {
 		RID new_texture = RS::get_singleton()->texture_2d_create(image);
@@ -551,10 +548,7 @@ Error CompressedTexture3D::load(const String &p_path) {
 	Image::Format tfmt;
 	bool tmm;
 
-	Error err = _load_data(p_path, data, tfmt, tw, th, td, tmm);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(_load_data(p_path, data, tfmt, tw, th, td, tmm));
 
 	if (texture.is_valid()) {
 		RID new_texture = RS::get_singleton()->texture_3d_create(tfmt, tw, th, td, tmm, data);
@@ -735,10 +729,7 @@ Error CompressedTextureLayered::load(const String &p_path) {
 
 	int mipmap_limit;
 
-	Error err = _load_data(p_path, images, mipmap_limit);
-	if (err) {
-		return err;
-	}
+	RETURN_IF_ERR(_load_data(p_path, images, mipmap_limit));
 
 	if (texture.is_valid()) {
 		RID new_texture = RS::get_singleton()->texture_2d_layered_create(images, RS::TextureLayeredType(layered_type));

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1027,10 +1027,7 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *c = p_node->get_child(i);
-		Error err = _parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_node(p_owner, c, parent_node, name_map, variant_map, node_map, nodepath_map));
 	}
 
 	return OK;
@@ -1234,10 +1231,7 @@ Error SceneState::_parse_connections(Node *p_owner, Node *p_node, HashMap<String
 	// Recursively parse child connections.
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		Node *child = p_node->get_child(i);
-		Error err = _parse_connections(p_owner, child, name_map, variant_map, node_map, nodepath_map);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_parse_connections(p_owner, child, name_map, variant_map, node_map, nodepath_map));
 	}
 
 	return OK;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -401,9 +401,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 }
 
 Error ResourceLoaderText::load() {
-	if (error != OK) {
-		return error;
-	}
+	RETURN_IF_ERR(error);
 
 	while (true) {
 		if (next_tag.name != "ext_resource") {
@@ -1148,9 +1146,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 }
 
 Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
-	if (error) {
-		return error;
-	}
+	RETURN_IF_ERR(error);
 
 	ignore_resource_parsing = true;
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -354,7 +354,7 @@ Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const Str
 	Error err;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
-	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
+	RETURN_IF_ERR_MSG(err, "Cannot save shader '" + p_path + "'.");
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -138,7 +138,7 @@ Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, co
 	Error error;
 	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &error);
 
-	ERR_FAIL_COND_V_MSG(error, error, "Cannot save shader include '" + p_path + "'.");
+	RETURN_IF_ERR_MSG(error, "Cannot save shader include '" + p_path + "'.");
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -53,7 +53,7 @@ Error TextFile::load_text(const String &p_path) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 
-	ERR_FAIL_COND_V_MSG(err, err, "Cannot open TextFile '" + p_path + "'.");
+	RETURN_IF_ERR_MSG(err, "Cannot open TextFile '" + p_path + "'.");
 
 	uint64_t len = f->get_length();
 	sourcef.resize(len + 1);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2084,10 +2084,7 @@ Error VisualShader::_write_node(Type type, StringBuilder *p_global_code, StringB
 				continue;
 			}
 
-			Error err = _write_node(type, p_global_code, p_global_code_per_node, p_global_code_per_func, r_code, r_def_tex_params, p_input_connections, from_node, r_processed, p_for_preview, r_classes);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_write_node(type, p_global_code, p_global_code_per_node, p_global_code_per_func, r_code, r_def_tex_params, p_input_connections, from_node, r_processed, p_for_preview, r_classes));
 		}
 	}
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -320,10 +320,7 @@ Error RenderingDevice::_staging_buffer_allocate(StagingBuffers &p_staging_buffer
 					// Guess we did.. ok, let's see if we can insert a new block.
 					if ((uint64_t)p_staging_buffers.blocks.size() * p_staging_buffers.block_size < p_staging_buffers.max_size) {
 						// We can, so we are safe.
-						Error err = _insert_staging_block(p_staging_buffers);
-						if (err) {
-							return err;
-						}
+						RETURN_IF_ERR(_insert_staging_block(p_staging_buffers));
 						// Claim for this frame.
 						p_staging_buffers.blocks.write[p_staging_buffers.current].frame_used = frames_drawn;
 					} else {
@@ -348,10 +345,7 @@ Error RenderingDevice::_staging_buffer_allocate(StagingBuffers &p_staging_buffer
 			// This block may still be in use, let's not touch it unless we have to, so.. can we create a new one?
 			if ((uint64_t)p_staging_buffers.blocks.size() * p_staging_buffers.block_size < p_staging_buffers.max_size) {
 				// We are still allowed to create a new block, so let's do that and insert it for current pos.
-				Error err = _insert_staging_block(p_staging_buffers);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_insert_staging_block(p_staging_buffers));
 				// Claim for this frame.
 				p_staging_buffers.blocks.write[p_staging_buffers.current].frame_used = frames_drawn;
 			} else {
@@ -482,10 +476,7 @@ Error RenderingDevice::buffer_update(RID p_buffer, uint32_t p_offset, uint32_t p
 		uint32_t block_write_amount;
 		StagingRequiredAction required_action;
 
-		Error err = _staging_buffer_allocate(upload_staging_buffers, MIN(to_submit, upload_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_staging_buffer_allocate(upload_staging_buffers, MIN(to_submit, upload_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action));
 
 		if (!command_buffer_copies_vector.is_empty() && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL) {
 			if (_buffer_make_mutable(buffer, p_buffer)) {
@@ -715,10 +706,7 @@ Error RenderingDevice::buffer_get_data_async(RID p_buffer, const Callable &p_cal
 	uint32_t to_submit = p_size;
 	uint32_t submit_from = 0;
 	while (to_submit > 0) {
-		Error err = _staging_buffer_allocate(download_staging_buffers, MIN(to_submit, download_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action);
-		if (err) {
-			return err;
-		}
+		RETURN_IF_ERR(_staging_buffer_allocate(download_staging_buffers, MIN(to_submit, download_staging_buffers.block_size), required_align, block_write_offset, block_write_amount, required_action));
 
 		const bool flush_frames = (get_data_request.frame_local_count > 0) && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL;
 		if (flush_frames) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8043,10 +8043,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 					}
 
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(p_block, p_function_info, false, &decl.size_expression, &array_size, &unknown_size);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERR(_parse_array_size(p_block, p_function_info, false, &decl.size_expression, &array_size, &unknown_size));
 						decl.size = array_size;
 
 						fixed_array_size = true;
@@ -8103,10 +8100,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				tk = _get_token();
 
 				if (tk.type == TK_BRACKET_OPEN) {
-					Error error = _parse_array_size(p_block, p_function_info, false, &decl.size_expression, &var.array_size, &unknown_size);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERR(_parse_array_size(p_block, p_function_info, false, &decl.size_expression, &var.array_size, &unknown_size));
 
 					decl.size = var.array_size;
 					array_size = var.array_size;
@@ -8189,10 +8183,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 								tk = _get_token();
 								if (tk.type == TK_BRACKET_OPEN) {
 									bool is_unknown_size = false;
-									Error error = _parse_array_size(p_block, p_function_info, false, nullptr, &array_size2, &is_unknown_size);
-									if (error != OK) {
-										return error;
-									}
+									RETURN_IF_ERR(_parse_array_size(p_block, p_function_info, false, nullptr, &array_size2, &is_unknown_size));
 									if (is_unknown_size) {
 										array_size2 = var.array_size;
 									}
@@ -8412,10 +8403,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			cf->blocks.push_back(block);
 			p_block->statements.push_back(cf);
 
-			Error err = _parse_block(block, p_function_info, true, p_can_break, p_can_continue);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(block, p_function_info, true, p_can_break, p_can_continue));
 
 			pos = _get_tkpos();
 			tk = _get_token();
@@ -8423,10 +8411,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				block = alloc_node<BlockNode>();
 				block->parent_block = p_block;
 				cf->blocks.push_back(block);
-				err = _parse_block(block, p_function_info, true, p_can_break, p_can_continue);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_parse_block(block, p_function_info, true, p_can_break, p_can_continue));
 			} else {
 				_set_tkpos(pos); //rollback
 			}
@@ -8623,10 +8608,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			cf->blocks.push_back(case_block);
 			p_block->statements.push_back(cf);
 
-			Error err = _parse_block(case_block, p_function_info, false, true, false);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(case_block, p_function_info, false, true, false));
 
 			return OK;
 
@@ -8657,10 +8639,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			cf->blocks.push_back(default_block);
 			p_block->statements.push_back(cf);
 
-			Error err = _parse_block(default_block, p_function_info, false, true, false);
-			if (err) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(default_block, p_function_info, false, true, false));
 
 			return OK;
 
@@ -8674,10 +8653,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				do_block = alloc_node<BlockNode>();
 				do_block->parent_block = p_block;
 
-				Error err = _parse_block(do_block, p_function_info, true, true, true);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_parse_block(do_block, p_function_info, true, true, true));
 
 				tk = _get_token();
 				if (tk.type != TK_CF_WHILE) {
@@ -8715,10 +8691,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 				cf->blocks.push_back(block);
 				p_block->statements.push_back(cf);
 
-				Error err = _parse_block(block, p_function_info, true, true, true);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_parse_block(block, p_function_info, true, true, true));
 			} else {
 				cf->expressions.push_back(n);
 				cf->blocks.push_back(do_block);
@@ -8750,10 +8723,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 #ifdef DEBUG_ENABLED
 			keyword_completion_context = CF_DATATYPE;
 #endif // DEBUG_ENABLED
-			Error err = _parse_block(init_block, p_function_info, true, false, false);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(init_block, p_function_info, true, false, false));
 #ifdef DEBUG_ENABLED
 			keyword_completion_context = CF_UNSPECIFIED;
 #endif // DEBUG_ENABLED
@@ -8764,10 +8734,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			condition_block->single_statement = true;
 			condition_block->use_comma_between_statements = true;
 			cf->blocks.push_back(condition_block);
-			err = _parse_block(condition_block, p_function_info, true, false, false);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(condition_block, p_function_info, true, false, false));
 
 			BlockNode *expression_block = alloc_node<BlockNode>();
 			expression_block->block_type = BlockNode::BLOCK_TYPE_FOR_EXPRESSION;
@@ -8775,10 +8742,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 			expression_block->single_statement = true;
 			expression_block->use_comma_between_statements = true;
 			cf->blocks.push_back(expression_block);
-			err = _parse_block(expression_block, p_function_info, true, false, false);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(expression_block, p_function_info, true, false, false));
 
 			BlockNode *block = alloc_node<BlockNode>();
 			block->parent_block = init_block;
@@ -8788,10 +8752,7 @@ Error ShaderLanguage::_parse_block(BlockNode *p_block, const FunctionInfo &p_fun
 #ifdef DEBUG_ENABLED
 			keyword_completion_context = CF_BLOCK;
 #endif // DEBUG_ENABLED
-			err = _parse_block(block, p_function_info, true, true, true);
-			if (err != OK) {
-				return err;
-			}
+			RETURN_IF_ERR(_parse_block(block, p_function_info, true, true, true));
 
 		} else if (tk.type == TK_CF_RETURN) {
 			//check return type
@@ -9184,10 +9145,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				keyword_completion_context = CF_UNSPECIFIED;
 #endif // DEBUG_ENABLED
 				while (true) {
-					Error error = _parse_shader_mode(false, p_render_modes, defined_render_modes);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERR(_parse_shader_mode(false, p_render_modes, defined_render_modes));
 
 					tk = _get_token();
 
@@ -9234,10 +9192,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					} else {
 						_set_tkpos(pos);
 
-						Error error = _parse_shader_mode(true, p_stencil_modes, defined_stencil_modes);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERR(_parse_shader_mode(true, p_stencil_modes, defined_stencil_modes));
 					}
 
 					tk = _get_token();
@@ -9354,10 +9309,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 								}
 
 								if (tk.type == TK_BRACKET_OPEN) {
-									Error error = _parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr);
-									if (error != OK) {
-										return error;
-									}
+									RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr));
 									fixed_array_size = true;
 									tk = _get_token();
 								}
@@ -9383,10 +9335,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							tk = _get_token();
 
 							if (tk.type == TK_BRACKET_OPEN) {
-								Error error = _parse_array_size(nullptr, constants, true, nullptr, &member->array_size, nullptr);
-								if (error != OK) {
-									return error;
-								}
+								RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &member->array_size, nullptr));
 								tk = _get_token();
 							}
 
@@ -9614,10 +9563,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				}
 
 				if (tk.type == TK_BRACKET_OPEN) {
-					Error error = _parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &array_size, nullptr));
 					tk = _get_token();
 				}
 
@@ -9664,10 +9610,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 					tk = _get_token();
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &uniform.array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &uniform.array_size, nullptr));
 						tk = _get_token();
 					}
 
@@ -10138,10 +10081,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					}
 
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &varying.array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &varying.array_size, nullptr));
 						tk = _get_token();
 					}
 
@@ -10266,10 +10206,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				bool fixed_array_size = false;
 
 				if (tk.type == TK_BRACKET_OPEN) {
-					Error error = _parse_array_size(nullptr, constants, !is_constant, nullptr, &array_size, &unknown_size);
-					if (error != OK) {
-						return error;
-					}
+					RETURN_IF_ERR(_parse_array_size(nullptr, constants, !is_constant, nullptr, &array_size, &unknown_size));
 					fixed_array_size = true;
 					prev_pos = _get_tkpos();
 				}
@@ -10312,10 +10249,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						is_const_decl = true;
 
 						if (tk.type == TK_BRACKET_OPEN) {
-							Error error = _parse_array_size(nullptr, constants, false, nullptr, &constant.array_size, &unknown_size);
-							if (error != OK) {
-								return error;
-							}
+							RETURN_IF_ERR(_parse_array_size(nullptr, constants, false, nullptr, &constant.array_size, &unknown_size));
 							tk = _get_token();
 						}
 
@@ -10371,10 +10305,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 									if (tk.type == TK_BRACKET_OPEN) {
 										bool is_unknown_size = false;
-										Error error = _parse_array_size(nullptr, constants, false, nullptr, &array_size2, &is_unknown_size);
-										if (error != OK) {
-											return error;
-										}
+										RETURN_IF_ERR(_parse_array_size(nullptr, constants, false, nullptr, &array_size2, &is_unknown_size));
 										if (is_unknown_size) {
 											array_size2 = constant.array_size;
 										}
@@ -10804,10 +10735,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					tk = _get_token();
 
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr));
 						tk = _get_token();
 					}
 					if (tk.type != TK_IDENTIFIER) {
@@ -10843,10 +10771,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 					tk = _get_token();
 					if (tk.type == TK_BRACKET_OPEN) {
-						Error error = _parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr);
-						if (error != OK) {
-							return error;
-						}
+						RETURN_IF_ERR(_parse_array_size(nullptr, constants, true, nullptr, &arg_array_size, nullptr));
 						tk = _get_token();
 					}
 
@@ -10946,10 +10871,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 #ifdef DEBUG_ENABLED
 				keyword_completion_context = CF_BLOCK;
 #endif // DEBUG_ENABLED
-				Error err = _parse_block(func_node->body, builtins);
-				if (err) {
-					return err;
-				}
+				RETURN_IF_ERR(_parse_block(func_node->body, builtins));
 #ifdef DEBUG_ENABLED
 				keyword_completion_context = CF_GLOBAL_SPACE;
 #endif // DEBUG_ENABLED
@@ -11321,10 +11243,7 @@ Error ShaderLanguage::compile(const String &p_code, const ShaderCompileInfo &p_i
 	}
 #endif // DEBUG_ENABLED
 
-	if (err != OK) {
-		return err;
-	}
-	return OK;
+	return err;
 }
 
 Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_info, List<ScriptLanguage::CodeCompletionOption> *r_options, String &r_call_hint) {


### PR DESCRIPTION
Godot does not use exceptions. This often results in patterns where errors are _propagated upwards_:

```c++
Error error = expression();
if (error) {
	return error;
}
```

I propose to support this paradigm with a dedicated macro:

```c++
RETURN_IF_ERROR(expression());
```

The benefit of this is threefold:
- Error propagation is encouraged (through the 'syntactic sugar').
- Existing code is (arguably) easier to read than before.
- The code is standardized, and if desired, could be improved (e.g. by adding more printing).

An arguable downside is that it's 'another godot-thing' to remember about the code base. I personally think the naming makes it clear enough what the macro does, though.

## Relations

The idea of this macro may be familiar to Rust programmers. Rust embraces exception-free coding so much it made this concept into a core part of its grammar, with the [question mark ? operator](https://doc.rust-lang.org/rust-by-example/std/result/question_mark.html).
It [has been proposed](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2022/p2561r0.html) to add this operator to C++ too, for exception-free projects like Godot, but it's unlikely it will make it into the standard anytime soon.