### PR TITLE
Add missing `vpv.push_back(pv);` in `render_target_get_sdf_texture`.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3889,7 +3889,7 @@ RID TextureStorage::render_target_get_sdf_texture(RID p_render_target) {
 		pv.resize(16 * 4);
 		memset(pv.ptrw(), 0, 16 * 4);
 		Vector<Vector<uint8_t>> vpv;
-
+		vpv.push_back(pv);
 		rt->sdf_buffer_read = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 	}
 


### PR DESCRIPTION
From the context, this looks like it was intended.
The alternative would be not creating `pv` or `vpv`, instead defaulting to empty.

I'm not sure what the difference will be; at the very least it should now check for the size requirements.

Code came from https://github.com/godotengine/godot/pull/59984