### PR TITLE
Improve editor settings override display

### DIFF
--- a/editor/icons/Hierarchy.svg
+++ b/editor/icons/Hierarchy.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="none" stroke="#fff" stroke-linecap="round" stroke-linejoin="round" stroke-opacity=".6" stroke-width="2" d="M 11,11 H 4 V 4"/></svg>

--- a/editor/settings/editor_settings_dialog.h
+++ b/editor/settings/editor_settings_dialog.h
@@ -141,17 +141,19 @@ class EditorSettingsPropertyWrapper : public EditorProperty {
 	GDCLASS(EditorSettingsPropertyWrapper, EditorProperty);
 
 	String property;
+	PropertyHint hint;
+	String hint_text;
+	uint32_t usage;
+
 	EditorProperty *editor_property = nullptr;
 
-	BoxContainer *container = nullptr;
-
-	HBoxContainer *override_info = nullptr;
-	Label *override_label = nullptr;
+	HBoxContainer *override_container = nullptr;
+	TextureRect *override_icon = nullptr;
+	EditorProperty *override_editor_property = nullptr;
 	Button *goto_button = nullptr;
 	Button *remove_button = nullptr;
 
-	bool requires_restart = false;
-
+	void _setup_override_info();
 	void _update_override();
 	void _create_override();
 	void _remove_override();
@@ -163,7 +165,7 @@ public:
 	static inline Callable restart_request_callback;
 
 	virtual void update_property() override;
-	void setup(const String &p_property, EditorProperty *p_editor_property, bool p_requires_restart);
+	void setup(const String &p_property, EditorProperty *p_editor_property, PropertyHint p_hint, const String &p_hint_text, uint32_t p_usage);
 };
 
 class EditorSettingsInspectorPlugin : public EditorInspectorPlugin {


### PR DESCRIPTION
Follow-up to #69012
Changes the layout of override display to better use available space and fixes property hints for override display.

Before:
![image](https://github.com/user-attachments/assets/1c7ba4db-46fa-497b-9d6b-45c1ffee95c8)
After:
![image](https://github.com/user-attachments/assets/85238c02-8a25-4dc2-919d-27fa858524dc)
