### PR TITLE
Swap UID and path buttons

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -719,12 +719,6 @@ EditorPropertyPath::EditorPropertyPath() {
 	path->connect(SceneStringName(focus_exited), callable_mp(this, &EditorPropertyPath::_path_focus_exited));
 	path->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	path_edit = memnew(Button);
-	path_edit->set_accessibility_name(TTRC("Edit"));
-	path_hb->add_child(path_edit);
-	add_focusable(path);
-	path_edit->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyPath::_path_pressed));
-
 	toggle_uid = memnew(Button);
 	toggle_uid->set_accessibility_name(TTRC("Toggle Display UID"));
 	toggle_uid->set_tooltip_text(TTRC("Toggles displaying between path and UID.\nThe UID is the actual value of this property."));
@@ -732,6 +726,12 @@ EditorPropertyPath::EditorPropertyPath() {
 	path_hb->add_child(toggle_uid);
 	add_focusable(toggle_uid);
 	toggle_uid->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyPath::_toggle_uid_display));
+
+	path_edit = memnew(Button);
+	path_edit->set_accessibility_name(TTRC("Edit"));
+	path_hb->add_child(path_edit);
+	add_focusable(path);
+	path_edit->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyPath::_path_pressed));
 }
 
 ///////////////////// CLASS NAME /////////////////////////

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -162,12 +162,12 @@ class EditorPropertyPath : public EditorProperty {
 	bool global = false;
 	bool save_mode = false;
 	bool enable_uid = false;
-	bool display_uid = true;
+	bool display_uid = false;
 
 	EditorFileDialog *dialog = nullptr;
 	LineEdit *path = nullptr;
-	Button *path_edit = nullptr;
 	Button *toggle_uid = nullptr;
+	Button *path_edit = nullptr;
 
 	String _get_path_text(bool p_allow_uid = false);
 


### PR DESCRIPTION
Follow-up to #106716

Preserve the previous location of browse button and prevent button jumping when UID button appears.

Before:

https://github.com/user-attachments/assets/1df1c1b0-95d3-4c10-8951-c07a72fd6765

After:

https://github.com/user-attachments/assets/9ca0b3ab-34ad-495f-89ee-d7df4a76933b

EDIT:
Also changed the property to show path by default. It was an oversight.