### PR TITLE
Fix stencil flag combinations

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -3232,12 +3232,14 @@ void BaseMaterial3D::set_stencil_flags(int p_stencil_flags) {
 		return;
 	}
 
-	if ((p_stencil_flags & STENCIL_FLAG_READ) && (stencil_flags & (STENCIL_FLAG_WRITE | STENCIL_FLAG_WRITE_DEPTH_FAIL))) {
-		p_stencil_flags = p_stencil_flags & STENCIL_FLAG_READ;
-	}
-
-	if ((p_stencil_flags & (STENCIL_FLAG_WRITE | STENCIL_FLAG_WRITE_DEPTH_FAIL)) && (stencil_flags & STENCIL_FLAG_READ)) {
-		p_stencil_flags = p_stencil_flags & (STENCIL_FLAG_WRITE | STENCIL_FLAG_WRITE_DEPTH_FAIL);
+	if (p_stencil_flags & STENCIL_FLAG_READ &&
+			p_stencil_flags & STENCIL_FLAG_WRITE &&
+			p_stencil_flags & STENCIL_FLAG_WRITE_DEPTH_FAIL) {
+		if (!(stencil_flags & STENCIL_FLAG_READ)) {
+			p_stencil_flags = p_stencil_flags & (STENCIL_FLAG_READ | STENCIL_FLAG_WRITE);
+		} else {
+			p_stencil_flags = p_stencil_flags & (STENCIL_FLAG_WRITE | STENCIL_FLAG_WRITE_DEPTH_FAIL);
+		}
 	}
 
 	stencil_flags = p_stencil_flags;


### PR DESCRIPTION
Fix the stencil mask combinations to allow both `Read` and `Write` to be toggled at the same time.

I was using the new outline preset which creates a material with `Read` and `Write` enabled. But when I saved the material and adjusted it, the flags suddenly stopped me from enabling this combination again, instead only enabling `Read`.

With this PR, the flag state can now be set to:
- Each flag individually enabled
- `Read` and `Write`
- `Read` and `Write Depth Fail`
- `Write` and `Write Depth Fail`

I believe my change simply added the `Read` and `Write` combination. And so these should be the valid states of the flag, but please let me know if any of them are invalid!