### PR TITLE
[macOS] Restore `gl_HelperInvocation` workaround for Intel macs.

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -234,9 +234,11 @@ void ShaderRD::_build_variant_code(StringBuilder &builder, uint32_t p_variant, c
 					builder.append(String("#define ") + String(E.key) + "_CODE_USED\n");
 				}
 #if (defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED))
+#if defined(__x86_64) || defined(__x86_64__)
 				if (RD::get_singleton()->get_device_capabilities().device_family == RDD::DEVICE_VULKAN) {
 					builder.append("#define MOLTENVK_USED\n");
 				}
+#endif
 				// Image atomics are supported on Metal 3.1 but no support in MoltenVK or SPIRV-Cross yet.
 				builder.append("#define NO_IMAGE_ATOMICS\n");
 #endif

--- a/servers/rendering/renderer_rd/shaders/cluster_render.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_render.glsl
@@ -114,7 +114,11 @@ void main() {
 	uint aux = 0;
 
 	uint cluster_thread_group_index;
+#ifndef MOLTENVK_USED
 	if (!gl_HelperInvocation) {
+#else
+	{
+#endif
 		//https://advances.realtimerendering.com/s2017/2017_Sig_Improved_Culling_final.pdf
 
 		uvec4 mask;
@@ -147,7 +151,11 @@ void main() {
 	uint z_write_offset = cluster_offset + state.cluster_depth_offset + element_index;
 	uint z_write_bit = 1 << z_bit;
 
+#ifndef MOLTENVK_USED
 	if (!gl_HelperInvocation) {
+#else
+	{
+#endif
 		z_write_bit = subgroupOr(z_write_bit); //merge all Zs
 		if (cluster_thread_group_index == 0) {
 			aux = atomicOr(cluster_render.data[z_write_offset], z_write_bit);


### PR DESCRIPTION
Restores workaround removed in https://github.com/godotengine/godot/pull/102552

Fixes https://github.com/godotengine/godot/issues/107753

If I understand correctly, it's not adding any new defines, so should not create additional shader variants for baker and cause any issues.