### PR TITLE
Enhance bindings of deep resource duplication

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -535,6 +535,10 @@ Ref<Resource> Resource::duplicate_deep(ResourceDeepDuplicateMode p_deep_subresou
 	return dupe;
 }
 
+Ref<Resource> Resource::_duplicate_deep_bind(DeepDuplicateMode p_deep_subresources_mode) const {
+	return _duplicate_from_variant(true, (ResourceDeepDuplicateMode)p_deep_subresources_mode, 0);
+}
+
 Ref<Resource> Resource::_duplicate_from_variant(bool p_deep, ResourceDeepDuplicateMode p_deep_subresources_mode, int p_recursion_count) const {
 	// A call without deep duplication would have been early-rejected at Variant::duplicate() unless it's the root call.
 	DEV_ASSERT(!(p_recursion_count > 0 && p_deep_subresources_mode == RESOURCE_DEEP_DUPLICATE_NONE));
@@ -724,12 +728,13 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("emit_changed"), &Resource::emit_changed);
 
 	ClassDB::bind_method(D_METHOD("duplicate", "deep"), &Resource::duplicate, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("duplicate_deep", "deep_subresources_mode"), &Resource::duplicate_deep, DEFVAL(RESOURCE_DEEP_DUPLICATE_INTERNAL));
+	ClassDB::bind_method(D_METHOD("duplicate_deep", "deep_subresources_mode"), &Resource::_duplicate_deep_bind, DEFVAL(RESOURCE_DEEP_DUPLICATE_INTERNAL));
 
 	// For the bindings, it's much more natural to expose this enum from the Variant realm via Resource.
-	ClassDB::bind_integer_constant(get_class_static(), StringName("ResourceDeepDuplicateMode"), "RESOURCE_DEEP_DUPLICATE_NONE", RESOURCE_DEEP_DUPLICATE_NONE);
-	ClassDB::bind_integer_constant(get_class_static(), StringName("ResourceDeepDuplicateMode"), "RESOURCE_DEEP_DUPLICATE_INTERNAL", RESOURCE_DEEP_DUPLICATE_INTERNAL);
-	ClassDB::bind_integer_constant(get_class_static(), StringName("ResourceDeepDuplicateMode"), "RESOURCE_DEEP_DUPLICATE_ALL", RESOURCE_DEEP_DUPLICATE_ALL);
+	// Therefore, we can't use BIND_ENUM_CONSTANT here because we need some customization.
+	ClassDB::bind_integer_constant(get_class_static(), StringName("DeepDuplicateMode"), "DEEP_DUPLICATE_NONE", RESOURCE_DEEP_DUPLICATE_NONE);
+	ClassDB::bind_integer_constant(get_class_static(), StringName("DeepDuplicateMode"), "DEEP_DUPLICATE_INTERNAL", RESOURCE_DEEP_DUPLICATE_INTERNAL);
+	ClassDB::bind_integer_constant(get_class_static(), StringName("DeepDuplicateMode"), "DEEP_DUPLICATE_ALL", RESOURCE_DEEP_DUPLICATE_ALL);
 
 	ADD_SIGNAL(MethodInfo("changed"));
 	ADD_SIGNAL(MethodInfo("setup_local_to_scene_requested"));

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -96,6 +96,11 @@ private:
 	Variant _duplicate_recursive(const Variant &p_variant, const DuplicateParams &p_params, uint32_t p_usage = 0) const;
 	void _find_sub_resources(const Variant &p_variant, HashSet<Ref<Resource>> &p_resources_found);
 
+	// Only for binding the deep duplicate method, so it doesn't need actual members.
+	enum DeepDuplicateMode : int;
+
+	_ALWAYS_INLINE_ Ref<Resource> _duplicate_deep_bind(DeepDuplicateMode p_deep_subresources_mode) const;
+
 protected:
 	virtual void _resource_path_changed();
 	static void _bind_methods();
@@ -183,7 +188,7 @@ public:
 	~Resource();
 };
 
-VARIANT_ENUM_CAST(ResourceDeepDuplicateMode);
+VARIANT_ENUM_CAST(Resource::DeepDuplicateMode);
 
 class ResourceCache {
 	friend class Resource;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2206,6 +2206,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_static_method(Color, from_rgba8, sarray("r8", "g8", "b8", "a8"), varray(255));
 }
 
+VARIANT_ENUM_CAST(ResourceDeepDuplicateMode);
+
 static void _register_variant_builtin_methods_misc() {
 	/* RID */
 

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -341,7 +341,7 @@
 			<param index="0" name="deep_subresources_mode" type="int" default="1" />
 			<description>
 				Duplicates this array, deeply, like [method duplicate][code](true)[/code], with extra control over how subresources are handled.
-				[param deep_subresources_mode] must be one of the values from [enum Resource.ResourceDeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).
+				[param deep_subresources_mode] must be one of the values from [enum Resource.DeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).
 			</description>
 		</method>
 		<method name="erase">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -197,7 +197,7 @@
 			<param index="0" name="deep_subresources_mode" type="int" default="1" />
 			<description>
 				Duplicates this dictionary, deeply, like [method duplicate][code](true)[/code], with extra control over how subresources are handled.
-				[param deep_subresources_mode] must be one of the values from [enum Resource.ResourceDeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).
+				[param deep_subresources_mode] must be one of the values from [enum Resource.DeepDuplicateMode]. By default, only internal resources will be duplicated (recursively).
 			</description>
 		</method>
 		<method name="erase">

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -54,7 +54,7 @@
 			<description>
 				Duplicates this resource, returning a new resource with its [code]export[/code]ed or [constant PROPERTY_USAGE_STORAGE] properties copied from the original.
 				If [param deep] is [code]false[/code], a [b]shallow[/b] copy is returned: nested [Array], [Dictionary], and [Resource] properties are not duplicated and are shared with the original resource.
-				If [param deep] is [code]true[/code], a [b]deep[/b] copy is returned: all nested arrays, dictionaries, and packed arrays are also duplicated (recursively). Any [Resource] found inside will only be duplicated if it's local, like [constant RESOURCE_DEEP_DUPLICATE_INTERNAL] used with [method duplicate_deep].
+				If [param deep] is [code]true[/code], a [b]deep[/b] copy is returned: all nested arrays, dictionaries, and packed arrays are also duplicated (recursively). Any [Resource] found inside will only be duplicated if it's local, like [constant DEEP_DUPLICATE_INTERNAL] used with [method duplicate_deep].
 				The following exceptions apply:
 				- Subresource properties with the [constant PROPERTY_USAGE_ALWAYS_DUPLICATE] flag are always duplicated (recursively or not, depending on [param deep]).
 				- Subresource properties with the [constant PROPERTY_USAGE_NEVER_DUPLICATE] flag are never duplicated.
@@ -64,10 +64,10 @@
 		</method>
 		<method name="duplicate_deep" qualifiers="const">
 			<return type="Resource" />
-			<param index="0" name="deep_subresources_mode" type="int" enum="ResourceDeepDuplicateMode" default="1" />
+			<param index="0" name="deep_subresources_mode" type="int" enum="Resource.DeepDuplicateMode" default="1" />
 			<description>
 				Duplicates this resource, deeply, like [method duplicate][code](true)[/code], with extra control over how subresources are handled.
-				[param deep_subresources_mode] must be one of the values from [enum ResourceDeepDuplicateMode].
+				[param deep_subresources_mode] must be one of the values from [enum DeepDuplicateMode].
 			</description>
 		</method>
 		<method name="emit_changed">
@@ -186,13 +186,13 @@
 		</signal>
 	</signals>
 	<constants>
-		<constant name="RESOURCE_DEEP_DUPLICATE_NONE" value="0" enum="ResourceDeepDuplicateMode">
+		<constant name="DEEP_DUPLICATE_NONE" value="0" enum="DeepDuplicateMode">
 			No subresorces at all are duplicated. This is useful even in a deep duplication to have all the arrays and dictionaries duplicated but still pointing to the original resources.
 		</constant>
-		<constant name="RESOURCE_DEEP_DUPLICATE_INTERNAL" value="1" enum="ResourceDeepDuplicateMode">
+		<constant name="DEEP_DUPLICATE_INTERNAL" value="1" enum="DeepDuplicateMode">
 			Only subresources without a path or with a scene-local path will be duplicated.
 		</constant>
-		<constant name="RESOURCE_DEEP_DUPLICATE_ALL" value="2" enum="ResourceDeepDuplicateMode">
+		<constant name="DEEP_DUPLICATE_ALL" value="2" enum="DeepDuplicateMode">
 			Every subresource found will be duplicated, even if it has a non-local path. In other words, even potentially big resources stored separately will be duplicated.
 		</constant>
 	</constants>


### PR DESCRIPTION
Two changes:
1. `Variant.duplicate_deep()` argument is now told to be of the type `enum::Resource.DeepDuplicateMode`, instead of the wrong seemingly global `enum::Resource.DeepDuplicateMode`. See the excerpt below.
2. A few renames are made in the bindings, to remove the redundant 'resource' word. This is why I marked this PR as compat breaking. However, let's bear in mind this is compat breakage compared to prev 4.5 releases. Renames are these:
   - `Resource.ResourceDeepDuplicateMode` -> `Resource.DeepDuplicateMode`
   - `Resource.RESOURCE_DEEP_DUPLICATE_*` -> `Resource.DEEP_DUPLICATE_*`

---

Now, `Variang::deep_duplicate()` looks like this in the API JSON:
```js
{
	"name": "duplicate_deep",
	// [...]
	"arguments": [
		{
			"name": "deep_subresources_mode",
			"type": "enum::Resource.DeepDuplicateMode", // <-- This is the improvement.
			"default_value": "1"
		}
	]
}
```

Fixes #107138.
