### PR TITLE
Tree: Check and clear `popup_pressing_edited_item` when removing TreeItem

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -120,7 +120,7 @@ void TreeItem::_change_tree(Tree *p_tree) {
 			tree->root = nullptr;
 		}
 
-		if (tree->popup_edited_item == this) {
+		if (tree->popup_edited_item == this || tree->popup_pressing_edited_item == this) {
 			tree->popup_edited_item = nullptr;
 			tree->popup_pressing_edited_item = nullptr;
 			tree->pressing_for_editor = false;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/107774

Tested on mac and linux, the crash/use-after-free couldn't be reproduced with this patch. Unclear if this has been a possible crash as long as git blame indicates it has been or if something else uncovered it/opened a path to it.