### PR TITLE
Improve error message for non-finite transforms

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -988,7 +988,7 @@ void RendererSceneCull::instance_set_transform(RID p_instance, const Transform3D
 
 	for (int i = 0; i < 4; i++) {
 		const Vector3 &v = i < 3 ? p_transform.basis.rows[i] : p_transform.origin;
-		ERR_FAIL_COND(!v.is_finite());
+		ERR_FAIL_COND_MSG(!v.is_finite(), vformat("Transform is non-finite %s", String(v)));
 	}
 
 #endif


### PR DESCRIPTION
Fixes #97708

Moving MeshInstance to an infinite or NaN coordinate causes `Condition "!v.is_finite()" is true.` error.
It's not very obvious what does it mean.

This PR changes error message to  `Transform is non-finite {Vector3}` instead.
This should make it easier for developers to figure out what does the error mean, and printing Vector3 should also hopefully help them identify what could've caused the issue, i.e. if there's an infinity in coordinates, there might be a division by zero somewhere in the code.

![image](https://github.com/user-attachments/assets/6a359df5-75e0-42ec-bde1-d793e299c2d1)

### Steps to reproduce

1. Create a MeshInstance3D
2. Set mesh to Cube
3. Assign a new script to it
```gdscript
extends Node3D


func _ready() -> void:
	self.position.x = NAN
```
