### PR TITLE
Use TightLocalVector for AudioStreamWAV/MP3

### DIFF
--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -94,7 +94,7 @@ class AudioStreamMP3 : public AudioStream {
 
 	friend class AudioStreamPlaybackMP3;
 
-	LocalVector<uint8_t> data;
+	TightLocalVector<uint8_t> data;
 	uint32_t data_len = 0;
 
 	float sample_rate = 1.0;

--- a/scene/resources/audio_stream_wav.h
+++ b/scene/resources/audio_stream_wav.h
@@ -54,7 +54,7 @@ class AudioStreamPlaybackWAV : public AudioStreamPlaybackResampled {
 		qoa_desc desc = {};
 		uint32_t data_ofs = 0;
 		uint32_t frame_len = 0;
-		LocalVector<int16_t> dec;
+		TightLocalVector<int16_t> dec;
 		uint32_t dec_len = 0;
 	} qoa;
 
@@ -121,7 +121,7 @@ private:
 	int loop_begin = 0;
 	int loop_end = 0;
 	int mix_rate = 44100;
-	LocalVector<uint8_t> data;
+	TightLocalVector<uint8_t> data;
 	uint32_t data_bytes = 0;
 
 	Dictionary tags;
@@ -274,7 +274,7 @@ public:
 			p_desc->lms[c].weights[3] = (1 << 14);
 		}
 
-		LocalVector<int16_t> data16;
+		TightLocalVector<int16_t> data16;
 		data16.resize(QOA_FRAME_LEN * p_desc->channels);
 
 		uint8_t *dst_ptr = dst_data.ptrw();


### PR DESCRIPTION
These data vectors are never resized except on instantiation, so we don't need them to be able to grow at a rate.

Not applicable to AudioStreamOggVorbis as it uses `Vector`s that are resized.

> Made this partially in response to a regression from #104522 that has already been addressed. Resize on instantiation shouldn't be different between LocalVector and TightLocalVector. Still keeping it open for future codestyle purposes.