### PR TITLE
[macOS] Selectively bake specific shader variants for MoltenVK.

### DIFF
--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -397,8 +397,14 @@ void ShaderBakerExportPlugin::_customize_shader_version(ShaderRD *p_shader, RID 
 
 	for (int64_t i = 0; i < variant_count; i++) {
 		int group = p_shader->get_variant_to_group(i);
-		if (!p_shader->is_variant_enabled(i) || !groups_to_compile.has(group)) {
-			continue;
+		if (p_shader->has_variant_bake_for(i)) {
+			if (!p_shader->get_variant_bake_for(i, shader_cache_platform_name + "_" + shader_cache_renderer_name + "_" + shader_container_driver) || !groups_to_compile.has(group)) {
+				continue;
+			}
+		} else {
+			if (!p_shader->is_variant_enabled(i) || !groups_to_compile.has(group)) {
+				continue;
+			}
 		}
 
 		WorkItem work_item;

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -76,6 +76,8 @@ class ClusterBuilderSharedDataRD {
 		enum ShaderVariant {
 			SHADER_NORMAL,
 			SHADER_USE_ATTACHMENT,
+			SHADER_NORMAL_MOLTENVK,
+			SHADER_USE_ATTACHMENT_MOLTENVK,
 		};
 
 		enum PipelineVersion {

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -235,9 +235,6 @@ void ShaderRD::_build_variant_code(StringBuilder &builder, uint32_t p_variant, c
 				}
 #if (defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED))
 				RenderingDevice *rd = RD::get_singleton();
-				if (rd->get_device_capabilities().device_family == RDD::DEVICE_VULKAN) {
-					builder.append("#define MOLTENVK_USED\n");
-				}
 				if (!rd->has_feature(RD::SUPPORTS_IMAGE_ATOMIC_32_BIT)) {
 					builder.append("#define NO_IMAGE_ATOMICS\n");
 				}
@@ -272,7 +269,7 @@ void ShaderRD::_build_variant_code(StringBuilder &builder, uint32_t p_variant, c
 }
 
 Vector<String> ShaderRD::_build_variant_stage_sources(uint32_t p_variant, CompileData p_data) {
-	if (!variants_enabled[p_variant]) {
+	if (!variants_enabled[p_variant] && !variants_bake_for.has(p_variant)) {
 		return Vector<String>(); // Variant is disabled, return.
 	}
 
@@ -474,7 +471,10 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 		int variant_id = group_to_variant_map[p_group][i];
 		uint32_t variant_size = f->get_32();
 		ERR_FAIL_COND_V(variant_size == 0 && variants_enabled[variant_id], false);
-		if (!variants_enabled[variant_id]) {
+		if (!variants_enabled[variant_id] && !variants_bake_for.has(variant_id)) {
+			continue;
+		}
+		if (variant_size == 0) {
 			continue;
 		}
 		Vector<uint8_t> variant_bytes;
@@ -489,10 +489,11 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 
 	for (uint32_t i = 0; i < variant_count; i++) {
 		int variant_id = group_to_variant_map[p_group][i];
-		if (!variants_enabled[variant_id]) {
+		if ((!variants_enabled[variant_id] && !variants_bake_for.has(variant_id)) || p_version->variant_data[variant_id].is_empty()) {
 			p_version->variants.write[variant_id] = RID();
 			continue;
 		}
+		print_verbose(vformat("Loading cache for shader %s, variant %d", name, i));
 		{
 			RID shader = RD::get_singleton()->shader_create_from_bytecode_with_samplers(p_version->variant_data[variant_id], p_version->variants[variant_id], immutable_samplers);
 			if (shader.is_null()) {
@@ -581,7 +582,7 @@ void ShaderRD::_compile_version_end(Version *p_version, int p_group) {
 	if (!all_valid) {
 		// Clear versions if they exist.
 		for (int i = 0; i < variant_defines.size(); i++) {
-			if (!variants_enabled[i] || !group_enabled[variant_defines[i].group]) {
+			if ((!variants_enabled[i] && !variants_bake_for.has(i)) || !group_enabled[variant_defines[i].group]) {
 				continue; // Disabled.
 			}
 			if (!p_version->variants[i].is_null()) {

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -60,6 +60,8 @@ private:
 	CharString general_defines;
 	Vector<VariantDefine> variant_defines;
 	Vector<bool> variants_enabled;
+	HashMap<int, HashMap<String, bool>> variants_bake_for;
+	HashMap<int, bool> variants_bake_for_def;
 	Vector<uint32_t> variant_to_group;
 	HashMap<int, LocalVector<int>> group_to_variant_map;
 	Vector<bool> group_enabled;
@@ -215,6 +217,25 @@ public:
 	bool is_variant_enabled(int p_variant) const;
 	int64_t get_variant_count() const;
 	int get_variant_to_group(int p_variant) const;
+
+	bool has_variant_bake_for(int p_variant) const {
+		return variants_bake_for.has(p_variant);
+	}
+
+	bool get_variant_bake_for(int p_variant, const String &p_name) const {
+		if (!variants_bake_for.has(p_variant)) {
+			return is_variant_enabled(p_variant);
+		}
+		if (!variants_bake_for[p_variant].has(p_name.to_lower())) {
+			return variants_bake_for_def[p_variant];
+		}
+		return variants_bake_for[p_variant][p_name.to_lower()];
+	}
+
+	void set_variants_bake_for(int p_variant, const String &p_name, bool p_enable, bool p_default) {
+		variants_bake_for[p_variant][p_name.to_lower()] = p_enable;
+		variants_bake_for_def[p_variant] = p_default;
+	}
 
 	// Enable/disable groups for things that might be enabled at run time.
 	void enable_group(int p_group);

--- a/servers/rendering/renderer_rd/shaders/cluster_render.glsl
+++ b/servers/rendering/renderer_rd/shaders/cluster_render.glsl
@@ -114,7 +114,11 @@ void main() {
 	uint aux = 0;
 
 	uint cluster_thread_group_index;
+#ifndef MOLTENVK_USED
 	if (!gl_HelperInvocation) {
+#else
+	{
+#endif
 		//https://advances.realtimerendering.com/s2017/2017_Sig_Improved_Culling_final.pdf
 
 		uvec4 mask;
@@ -147,7 +151,11 @@ void main() {
 	uint z_write_offset = cluster_offset + state.cluster_depth_offset + element_index;
 	uint z_write_bit = 1 << z_bit;
 
+#ifndef MOLTENVK_USED
 	if (!gl_HelperInvocation) {
+#else
+	{
+#endif
 		z_write_bit = subgroupOr(z_write_bit); //merge all Zs
 		if (cluster_thread_group_index == 0) {
 			aux = atomicOr(cluster_render.data[z_write_offset], z_write_bit);


### PR DESCRIPTION
Adds `ClusterRenderShaderRD` variants with restored workaround removed in https://github.com/godotengine/godot/pull/102552 and selectively use and bake these variants on macOS.

Fixes https://github.com/godotengine/godot/issues/107753
Supersede https://github.com/godotengine/godot/pull/107769

Tested baking from macOS to macOS and Windows, and running both exports, both seems to be saving and loading correct variants.