### PR TITLE
Use `reserve` in `LocalVector::resize`, to restore expected growth behavior

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -59,11 +59,7 @@ private:
 			}
 			count = p_size;
 		} else if (p_size > count) {
-			if (unlikely(p_size > capacity)) {
-				capacity = tight ? p_size : nearest_power_of_2_templated(p_size);
-				data = (T *)memrealloc(data, capacity * sizeof(T));
-				CRASH_COND_MSG(!data, "Out of memory");
-			}
+			reserve(p_size);
 			if constexpr (p_init) {
 				memnew_arr_placement(data + count, p_size - count);
 			} else {


### PR DESCRIPTION
- Fixes [regression](https://github.com/godotengine/godot/pull/104522#discussion_r2159835297) from https://github.com/godotengine/godot/pull/104522 (rebase loss)

We introduced 1.5x growth factor for `LocalVector` in 4.5 with https://github.com/godotengine/godot/pull/100944.
3 months later, this regressed for `resize` with https://github.com/godotengine/godot/pull/104522 (sorry!).

This makes the current `LocalVector` growth inconsistent, with 2x for `resize` and `1.5x` for other operations.

There are no actual problems associated with this change (i think), so It's not super risky to merge for 4.5 still — but it's also not a super important bug to fix. 4.6 would also be an OK target for this PR.