### PR TITLE
[4.4] Implement reading UID resource references in VariantParser

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -566,6 +566,7 @@ Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hi
 
 Ref<ResourceLoader::LoadToken> ResourceLoader::_load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user) {
 	String local_path = _validate_local_path(p_path);
+	ERR_FAIL_COND_V(local_path.is_empty(), Ref<ResourceLoader::LoadToken>());
 
 	bool ignoring_cache = p_cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE || p_cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE_DEEP;
 


### PR DESCRIPTION
This PR backports the reading, but not writing, part of PR #106902 from @lyuma.

This means that files saved in Godot 4.5 or later will be readable in Godot 4.4.2, whenever that releases. I suggest backporting this to all maintained branches.

I tested that this works by creating a scenario with the example use case (making an external bone map and adding the UID) and it works correctly with this PR and does not work without this PR.