### PR TITLE
Split preview generation into 2 steps

### DIFF
--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -85,10 +85,14 @@ class EditorResourcePreview : public Node {
 	};
 
 	List<QueueItem> queue;
+	List<QueueItem> generation_queue;
 
 	Mutex preview_mutex;
+	Mutex generation_mutex;
 	Semaphore preview_sem;
+	Semaphore generation_sem;
 	Thread thread;
+	Thread generation_thread;
 	SafeFlag exiting;
 	SafeFlag exited;
 
@@ -108,9 +112,12 @@ class EditorResourcePreview : public Node {
 	int small_thumbnail_size = -1;
 
 	static void _thread_func(void *ud);
-	void _thread(); // For rendering drivers supporting async texture creation.
+	void _thread();
+	static void _generation_thread_func(void *ud);
+	void _generation_thread(); // For rendering drivers supporting async texture creation.
 	static void _idle_callback(); // For other rendering drivers (i.e., OpenGL).
 	void _iterate();
+	void _iterate_generation();
 
 	void _write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata);
 	void _read_preview_cache(Ref<FileAccess> p_file, int *r_thumbnail_size, bool *r_has_small_texture, uint64_t *r_modified_time, String *r_hash, Dictionary *r_metadata, bool *r_outdated);


### PR DESCRIPTION
Related #107736

Currently when a preview is requested, its put into a queue. Then the queue is processed - it checks if the preview is cached, and generates a new preview if it's not.

This PR adds another queue. If a preview is not cached, it goes into the new queue and then that queue is processed separately. The advantage is that the first queue can be always threaded. With single queue, the cache is processed on the main thread if resource generation can't be threaded (e.g. with Compatibility renderer).

Probably needs testing. I just did a simple test that nothing hangs etc. and it seems to work fine.