### PR TITLE
Add external editor Exec Flags replacement option for a one-based script line number

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1197,7 +1197,7 @@ String EditorSettings::_guess_exec_args_for_extenal_editor(const String &p_path)
 	} else if (editor == "geany" || editor == "kate") {
 		new_exec_flags = "{file} --line {line} --column {col}";
 	} else if (editor == "code" || editor == "visual studio code" || editor == "codium" || editor == "vscodium") {
-		new_exec_flags = "{project} --goto {file}:{line}:{col}";
+		new_exec_flags = "{project} --goto {file}:{lineStart1}:{col}";
 	}
 
 	return new_exec_flags;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2503,7 +2503,9 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		if (flags.size()) {
 			String project_path = ProjectSettings::get_singleton()->get_resource_path();
 
-			flags = flags.replacen("{line}", itos(p_line > 0 ? p_line : 0));
+			int line = p_line > 0 ? p_line : 0;
+			flags = flags.replacen("{line}", itos(line));
+			flags = flags.replacen("{lineStart1}", itos(line + 1));
 			flags = flags.replacen("{col}", itos(p_col));
 			flags = flags.strip_edges().replace("\\\\", "\\");
 


### PR DESCRIPTION
Closes #107809 (sort of).

This is the least potentially-compatibility-breaking solution I could think of for this problem. VS Code seems to expect the first line of a file to be line 1, whereas Godot expects it to be line 0. As such, when Godot's debugger opens VS Code to focus on a line that threw an error, it places the cursor on the line *before* the error.

![CleanShot 2025-06-21 at 09 18 37@2x](https://github.com/user-attachments/assets/9fc5e2a9-8725-4c63-b931-29aed6d03e19)
![CleanShot 2025-06-21 at 09 19 51@2x](https://github.com/user-attachments/assets/b0ebd3b9-7773-4cbb-9b4d-45da062dd448)

This PR adds a new replacement string, `{lineStart1}`, to the potential replacements in the external editor flags. It behaves the same as `{line}`, except that it makes the line numbers start at 1 instead of 0.

Note that this means it *won't* automatically fix this issue. Users will need to change their Exec Flags to
```
{project} --goto {file}:{lineStart1}:{col}
```
so that it uses the correct replacement. (If this approach is accepted, we will also want to update https://github.com/godotengine/godot-vscode-plugin/blob/master/README.md.)

As an alternative to this approach, we could instead update the engine to use one-based line numbers instead of zero-based ones, but I would expect doing so to cause more issues.