### PR TITLE
Use one-based line numbers for external text editors

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2503,8 +2503,8 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 		if (flags.size()) {
 			String project_path = ProjectSettings::get_singleton()->get_resource_path();
 
-			flags = flags.replacen("{line}", itos(p_line > 0 ? p_line : 0));
-			flags = flags.replacen("{col}", itos(p_col));
+			flags = flags.replacen("{line}", itos(MAX(p_line + 1, 1)));
+			flags = flags.replacen("{col}", itos(p_col + 1));
 			flags = flags.strip_edges().replace("\\\\", "\\");
 
 			int from = 0;


### PR DESCRIPTION
Closes #107809 . Closes #100832 . Supercedes #107812 .

The table in #107809 notes that all of the external editors mentioned by the Godot Docs expect line numbers to start at 1. Internally, Godot considers line numbers to start at 0. This PR simply adds 1 to an existing line number before passing it to an external editor, so that the editor highlights the correct line.

As noted in the PR's comment, a better long-term solution may be to have Godot adopt one-based line numbering internally. I chose to take a more conservative approach for now, to avoid breaking other parts of the engine or editor while fixing the problem at hand.