### PR TITLE
Allow instantiating scenes without any scripts

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -555,6 +555,9 @@ void GDExtensionSpecialCompatHashes::initialize() {
 		{ "add_item", 3043792800, 2697778442 },
 		{ "add_icon_item", 3944051090, 3781678508 },
 	});
+	mappings.insert("PackedScene", {
+		{ "instantiate", 2628778455, 180049032 },
+	});
 	mappings.insert("PCKPacker", {
 		{ "pck_start", 3232891339, 508410629 },
 	});

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -91,8 +91,10 @@
 		<method name="instantiate" qualifiers="const" keywords="create, make, spawn, new">
 			<return type="Node" />
 			<param index="0" name="edit_state" type="int" enum="PackedScene.GenEditState" default="0" />
+			<param index="1" name="flags" type="int" default="0" />
 			<description>
 				Instantiates the scene's node hierarchy. Triggers child scene instantiation(s). Triggers a [constant Node.NOTIFICATION_SCENE_INSTANTIATED] notification on the root node.
+				The [param flags] parameter can be used to modify the instantiation behavior. For example, [constant INSTANTIATION_NO_SCRIPTS] can be used to instantiate the scene without attaching any scripts. These flags apply to child scenes as well.
 			</description>
 		</method>
 		<method name="pack">
@@ -118,6 +120,12 @@
 		<constant name="GEN_EDIT_STATE_MAIN_INHERITED" value="3" enum="GenEditState">
 			It's similar to [constant GEN_EDIT_STATE_MAIN], but for the case where the scene is being instantiated to be the base of another one.
 			[b]Note:[/b] Only available in editor builds.
+		</constant>
+		<constant name="INSTANTIATION_DEFAULT" value="0" enum="InstantiationFlags">
+			Default instantiation behavior with no special flags.
+		</constant>
+		<constant name="INSTANTIATION_NO_SCRIPTS" value="1" enum="InstantiationFlags">
+			If passed to [method instantiate], the scene will be instantiated without any attached scripts. This applies to child scenes as well.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/SceneState.xml
+++ b/doc/classes/SceneState.xml
@@ -191,5 +191,11 @@
 			If passed to [method PackedScene.instantiate], it's similar to [constant GEN_EDIT_STATE_MAIN], but for the case where the scene is being instantiated to be the base of another one.
 			[b]Note:[/b] Only available in editor builds.
 		</constant>
+		<constant name="INSTANTIATION_DEFAULT" value="0" enum="InstantiationFlags">
+			Default instantiation behavior with no special flags.
+		</constant>
+		<constant name="INSTANTIATION_NO_SCRIPTS" value="1" enum="InstantiationFlags">
+			If passed to [method PackedScene.instantiate], the scene will be instantiated without any attached scripts. This applies to child scenes as well.
+		</constant>
 	</constants>
 </class>

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -329,3 +329,10 @@ Validate extension JSON: API was removed: classes/VisualShader/methods/set_graph
 Validate extension JSON: API was removed: classes/VisualShader/methods/get_graph_offset
 
 The graph_offset property was removed from the resource. This information is now stored in `vs_editor_cache.cfg`.
+
+
+GH-107818
+---------
+Validate extension JSON: Error: Field 'classes/PackedScene/methods/instantiate/arguments': size changed value in new API, from 1 to 2.
+
+Optional argument added. Compatibility method registered.

--- a/scene/resources/packed_scene.compat.inc
+++ b/scene/resources/packed_scene.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  packed_scene.compat.inc                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Node *PackedScene::_instantiate_bind_compat_107818(GenEditState p_edit_state) {
+	return instantiate(p_edit_state, INSTANTIATION_DEFAULT);
+}
+
+void PackedScene::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("instantiate", "edit_state"), &PackedScene::_instantiate_bind_compat_107818, DEFVAL(GEN_EDIT_STATE_DISABLED));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -129,6 +129,11 @@ public:
 		GEN_EDIT_STATE_MAIN_INHERITED,
 	};
 
+	enum InstantiationFlags {
+		INSTANTIATION_DEFAULT = 0,
+		INSTANTIATION_NO_SCRIPTS = 1,
+	};
+
 	struct PackState {
 		Ref<SceneState> state;
 		int node = -1;
@@ -154,7 +159,7 @@ public:
 	Error copy_from(const Ref<SceneState> &p_scene_state);
 
 	bool can_instantiate() const;
-	Node *instantiate(GenEditState p_edit_state) const;
+	Node *instantiate(GenEditState p_edit_state, int p_flags = INSTANTIATION_DEFAULT) const;
 
 	Array setup_resources_in_array(Array &array_to_scan, const SceneState::NodeData &n, HashMap<Ref<Resource>, Ref<Resource>> &resources_local_to_sub_scene, Node *node, const StringName sname, HashMap<Ref<Resource>, Ref<Resource>> &resources_local_to_scene, int i, Node **ret_nodes, SceneState::GenEditState p_edit_state) const;
 	Dictionary setup_resources_in_dictionary(Dictionary &p_dictionary_to_scan, const SceneState::NodeData &p_n, HashMap<Ref<Resource>, Ref<Resource>> &p_resources_local_to_sub_scene, Node *p_node, const StringName p_sname, HashMap<Ref<Resource>, Ref<Resource>> &p_resources_local_to_scene, int p_i, Node **p_ret_nodes, SceneState::GenEditState p_edit_state) const;
@@ -228,6 +233,7 @@ public:
 };
 
 VARIANT_ENUM_CAST(SceneState::GenEditState)
+VARIANT_ENUM_CAST(SceneState::InstantiationFlags)
 
 class PackedScene : public Resource {
 	GDCLASS(PackedScene, Resource);
@@ -251,12 +257,17 @@ public:
 		GEN_EDIT_STATE_MAIN_INHERITED,
 	};
 
+	enum InstantiationFlags {
+		INSTANTIATION_DEFAULT = 0,
+		INSTANTIATION_NO_SCRIPTS = 1,
+	};
+
 	Error pack(Node *p_scene);
 
 	void clear();
 
 	bool can_instantiate() const;
-	Node *instantiate(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED) const;
+	Node *instantiate(GenEditState p_edit_state = GEN_EDIT_STATE_DISABLED, int p_flags = INSTANTIATION_DEFAULT) const;
 
 	void recreate_state();
 	void replace_state(Ref<SceneState> p_by);
@@ -276,7 +287,16 @@ public:
 #endif
 	Ref<SceneState> get_state() const;
 
+#ifndef DISABLE_DEPRECATED
+private:
+	Node *_instantiate_bind_compat_107818(GenEditState p_edit_state);
+	static void _bind_compatibility_methods();
+
+public:
+#endif
+
 	PackedScene();
 };
 
 VARIANT_ENUM_CAST(PackedScene::GenEditState)
+VARIANT_ENUM_CAST(PackedScene::InstantiationFlags)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes: https://github.com/godotengine/godot-proposals/issues/12647

This would be useful when need a scene for purely visual elements such as generating thumbnails or creating decorative versions. 

We already have the ability the include flags to remove scripts when duplicating, so this just removes the extra step in a performant way. 