### PR TITLE
Fix buffer size calculations in lightmapper_rd.cpp to account for element sizes

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -642,21 +642,30 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 	}
 
 	{ //buffers
-		vertex_buffer = rd->storage_buffer_create(vertex_array.size(), vertex_array.span().reinterpret<uint8_t>());
+		vertex_buffer = rd->storage_buffer_create(vertex_array.size() * sizeof(Vertex), vertex_array.span().reinterpret<uint8_t>());
 
-		triangle_buffer = rd->storage_buffer_create(triangles.size(), triangles.span().reinterpret<uint8_t>());
+		triangle_buffer = rd->storage_buffer_create(triangles.size() * sizeof(Triangle), triangles.span().reinterpret<uint8_t>());
 
-		r_triangle_indices_buffer = rd->storage_buffer_create(triangle_indices.size(), triangle_indices.span().reinterpret<uint8_t>());
+		r_triangle_indices_buffer = rd->storage_buffer_create(triangle_indices.size() * sizeof(uint32_t), triangle_indices.span().reinterpret<uint8_t>());
 
-		r_cluster_indices_buffer = rd->storage_buffer_create(cluster_indices.size(), cluster_indices.span().reinterpret<uint8_t>());
+		r_cluster_indices_buffer = rd->storage_buffer_create(cluster_indices.size() * sizeof(uint32_t), cluster_indices.span().reinterpret<uint8_t>());
 
-		r_cluster_aabbs_buffer = rd->storage_buffer_create(cluster_aabbs.size(), cluster_aabbs.span().reinterpret<uint8_t>());
+		r_cluster_aabbs_buffer = rd->storage_buffer_create(cluster_aabbs.size() * sizeof(ClusterAABB), cluster_aabbs.span().reinterpret<uint8_t>());
 
-		lights_buffer = rd->storage_buffer_create(lights.size() * sizeof(Light), lights.span().reinterpret<uint8_t>());
+		// Even when there are no lights, the buffer must exist.
+		static const Light empty_lights[1];
+		Span<uint8_t> lb = (lights.is_empty() ? Span(empty_lights) : lights.span()).reinterpret<uint8_t>();
+		lights_buffer = rd->storage_buffer_create(lb.size(), lb);
 
-		seams_buffer = rd->storage_buffer_create(seam_buffer_vec.size() * sizeof(Vector2i) * 2, seam_buffer_vec.span().reinterpret<uint8_t>());
+		// Even when there are no seams, the buffer must exist.
+		static const Vector2i empty_seams[2];
+		Span<uint8_t> sb = (seam_buffer_vec.is_empty() ? Span(empty_seams) : seam_buffer_vec.span()).reinterpret<uint8_t>();
+		seams_buffer = rd->storage_buffer_create(sb.size(), sb);
 
-		probe_positions_buffer = rd->storage_buffer_create(p_probe_positions.size() * sizeof(Probe), p_probe_positions.span().reinterpret<uint8_t>());
+		// Even when there are no probes, the buffer must exist.
+		static const Probe empty_probes[1];
+		Span<uint8_t> pb = (p_probe_positions.is_empty() ? Span(empty_probes) : p_probe_positions.span()).reinterpret<uint8_t>();
+		probe_positions_buffer = rd->storage_buffer_create(pb.size(), pb);
 	}
 
 	{ //grid


### PR DESCRIPTION
Fixes an issue where the buffer size passed into `storage_buffer_create` didn't equal the actual size of the data.

Fixes #107805

I'm not 100% sure if this is the best way to go about fixing this, but it worked for me at least. Let me know if there's a better way to do this

- Maintainer edit: Fixes regression from https://github.com/godotengine/godot/pull/107486