### PR TITLE
Clarify `_set`/`_get` description

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -35,7 +35,8 @@
 			<param index="0" name="property" type="StringName" />
 			<description>
 				Override this method to customize the behavior of [method get]. Should return the given [param property]'s value, or [code]null[/code] if the [param property] should be handled normally.
-				Combined with [method _set] and [method _get_property_list], this method allows defining custom properties, which is particularly useful for editor plugins. Note that a property must be present in [method get_property_list], otherwise this method will not be called.
+				Combined with [method _set] and [method _get_property_list], this method allows defining custom properties, which is particularly useful for editor plugins.
+				[b]Note:[/b] This method is not called when getting built-in properties of an object, including properties defined with [annotation @GDScript.@export].
 				[codeblocks]
 				[gdscript]
 				func _get(property):
@@ -289,7 +290,8 @@
 			<param index="1" name="value" type="Variant" />
 			<description>
 				Override this method to customize the behavior of [method set]. Should set the [param property] to [param value] and return [code]true[/code], or [code]false[/code] if the [param property] should be handled normally. The [i]exact[/i] way to set the [param property] is up to this method's implementation.
-				Combined with [method _get] and [method _get_property_list], this method allows defining custom properties, which is particularly useful for editor plugins. Note that a property [i]must[/i] be present in [method get_property_list], otherwise this method will not be called.
+				Combined with [method _get] and [method _get_property_list], this method allows defining custom properties, which is particularly useful for editor plugins.
+				[b]Note:[/b] This method is not called when setting built-in properties of an object, including properties defined with [annotation @GDScript.@export].
 				[codeblocks]
 				[gdscript]
 				var internal_data = {}


### PR DESCRIPTION
Closes #70205

> Note that a property must be present in [method get_property_list], otherwise this method will not be called.

So this note is wrong, but _not entirely_.

See, `_set()`/`_get()` are called when calling `set()`/`get()` on an object, with property name that doesn't match any built-in property. So you can do `object.get("this_property_totally_exists_trust_me")`, and `_get()` will be called with this property name.

When `_get_property_list()` matters is when inspecting or serializing the object. The editor/serializer must know that property "exists" and will call `set()`/`get()` on whatever is returned by `get_property_list()`. But if a property is not defined, nothing is stopping you from manually accessing it.

Feel free to suggest how to better convey this information. Or maybe the description is already fine, idk.