### PR TITLE
Fix usage of class_name in built-in scripts (no longer allowed)

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -936,6 +936,10 @@ void GDScriptParser::parse_class_name() {
 		current_class->fqcn = String(current_class->identifier->name);
 	}
 
+	if (!script_path.is_resource_file()) {
+		push_error(R"("class_name" isn't allowed in built-in scripts.)");
+	}
+
 	if (match(GDScriptTokenizer::Token::EXTENDS)) {
 		// Allow extends on the same line.
 		parse_extends();


### PR DESCRIPTION
fixes: https://github.com/godotengine/godot/issues/107813

fixes the issue that we can use `class_name` in built-in script. which is an error and doesn't work anyway

I used the same error message as godot 3.6

_thanks to KoBeWi for providing the solution 🫠_

![image](https://github.com/user-attachments/assets/e3d9427d-f825-46ad-9f45-f63a2192c9ae)
