### PR TITLE
SoftBody3D: Fix infinite delivery of transform notifications

### DIFF
--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -377,6 +377,11 @@ void SoftBody3D::_notification(int p_what) {
 				return;
 			}
 
+			Transform3D global_transform = get_global_transform();
+			if (global_transform == Transform3D()) {
+				return;
+			}
+
 			PhysicsServer3D::get_singleton()->soft_body_set_transform(physics_rid, get_global_transform());
 
 			// Soft body renders mesh in global space.
@@ -848,6 +853,13 @@ SoftBody3D::SoftBody3D() :
 		physics_rid(PhysicsServer3D::get_singleton()->soft_body_create()) {
 	rendering_server_handler = memnew(SoftBodyRenderingServerHandler);
 	PhysicsServer3D::get_singleton()->body_attach_object_instance_id(physics_rid, get_instance_id());
+
+	// We want to always keep our global transform at (0, 0, 0), so receive notifications if anyone
+	// tries to change this
+	set_notify_transform(true);
+	// Disable _set_notify_transform_when_fti_off() so that we can use set_notify_transform(false)
+	// to stop receiving transform notifications temporarily while we are changing it ourselves.
+	_set_notify_transform_when_fti_off(false);
 }
 
 SoftBody3D::~SoftBody3D() {


### PR DESCRIPTION
PR #105901 changed the behavior of how transform notifications are delivered to `VisualInstance3D` subclasses, which resulted in SoftBody3D receiving an infinite stream of transform notifications.

SoftBody3D attempts to always keep its global transform at (0, 0, 0), and does so by listening for transform notifications and resetting it its transform back to 0 whenever it is changed externally.  It called `set_notify_transform(false)` before making its own change, so that it would not receive new notifications about its own change.  However, after PR #105901, transform notifications were still delivered anyway because `VisualInstance3D` had called
`_set_notify_transform_when_fti_off(true)`.

This updates the `SoftBody3D` constructor to explicitly enable transform notifications, and to call `_set_notify_transform_when_fti_off(false)` so that it can still use `set_notify_transform(false)` to prevent receiving notifications about its own changes.

Additionally, I also changed the `NOTIFICATION_TRANSFORM_CHANGED` processing to ignore the notification if the global transform is already 0.  This should also be sufficient to stop the infinite notification change even if somehow it does receive a notification about its own change.

This fixes #107829.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
