### PR TITLE
Tree: Fix handling of `__focus_rect` with various Select Modes

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2370,7 +2370,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				}
 			}
 
-			if ((select_mode != SELECT_SINGLE && selected_item == p_item) || p_item->cells[i].selected || !p_item->has_meta("__focus_rect")) {
+			if ((select_mode == SELECT_ROW && selected_item == p_item) || (select_mode == SELECT_MULTI && selected_item == p_item && selected_col == i) || p_item->cells[i].selected || !p_item->has_meta("__focus_rect")) {
 				Rect2i r = cell_rect;
 
 				if (select_mode != SELECT_ROW) {


### PR DESCRIPTION
Fix #107661

Under what conditions does the Tree update the meta data "__focus_rect"?

before https://github.com/godotengine/godot/pull/33286 :
| Tree Select Mode | Selected Cells | Selected Row Selected Col Cell | Selected Row Other Cells |
| ------------- | ------------- | ------------- | ------------- |
| Single | √ | √ | √ |
| Row | × | × | × |
| Multi | √ | √ | √ |

After https://github.com/godotengine/godot/pull/33286 :
| Tree Select Mode | Selected Cells | Selected Row Selected Col Cell | Selected Row Other Cells |
| ------------- | ------------- | ------------- | ------------- |
| Single | √ | × | × |
| Row | √ | √ | √ |
| Multi | √ | × | × |

After #106286:
| Tree Select Mode | Selected Cells | Selected Row Selected Col Cell | Selected Row Other Cells |
| ------------- | ------------- | ------------- | ------------- |
| Single | √ | × | × |
| Row | √ | √ | √ |
| Multi | √ | √ | √ |

Now:
| Tree Select Mode | Selected Cells | Selected Row Selected Col Cell | Selected Row Other Cells |
| ------------- | ------------- | ------------- | ------------- |
| Single | √ | × | × |
| Row | √ | √ | √ |
| Multi | √ | √ | × |
