### PR TITLE
GLTF: Allow importing files as Mesh or MeshLibrary directly

### DIFF
--- a/modules/gltf/config.py
+++ b/modules/gltf/config.py
@@ -30,6 +30,8 @@ def get_doc_classes():
         "GLTFState",
         "GLTFTexture",
         "GLTFTextureSampler",
+        "ResourceImporterGLTFMeshLibrary",
+        "ResourceImporterGLTFSingleMesh",
     ]
 
 

--- a/modules/gltf/doc_classes/ResourceImporterGLTFMeshLibrary.xml
+++ b/modules/gltf/doc_classes/ResourceImporterGLTFMeshLibrary.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterGLTFMeshLibrary" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Imports glTF files as a [MeshLibrary] resource.
+	</brief_description>
+	<description>
+		ResourceImporterGLTFMeshLibrary is a resource importer for glTF files which outputs a [MeshLibrary] resource containing the meshes from the glTF file converted to [ArrayMesh] resources. Optionally, the meshes can be saved to separate files, which allows them to be used independently of the MeshLibrary. This is useful for glTF files intended to be used as a collection of meshes, rather than a single model or scene.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="save_meshes_to_files" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], each mesh will be saved to a separate file, next to the source file. The mesh library will contain references to these files. This allows using the meshes separately if desired. If [code]false[/code], the meshes will be saved only in the imported mesh library.
+			[b]Note:[/b] Saved meshes will be overwritten every time the source file is imported, and therefore should be considered read-only. Any changes made to the mesh files will be lost when the source file is re-imported. To change the materials, set the surface material overrides in the MeshInstance3D nodes using the meshes.
+		</member>
+		<member name="use_node_names_as_mesh_names" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], the mesh names will be set to the names of the nodes in the glTF file. If [code]false[/code], the mesh names will be set to the names of the meshes in the glTF file. Enabling this is a common work-around when the author of the glTF file did not properly set the mesh names in Blender or other 3D modeling apps. For example, a file may have a node named "Turret" with a mesh named "Cube.002", so enabling this option will set the mesh name to "Turret" instead of "Cube_002".
+		</member>
+	</members>
+</class>

--- a/modules/gltf/doc_classes/ResourceImporterGLTFSingleMesh.xml
+++ b/modules/gltf/doc_classes/ResourceImporterGLTFSingleMesh.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="ResourceImporterGLTFSingleMesh" inherits="ResourceImporter" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Imports glTF files as a single [ArrayMesh] resource.
+	</brief_description>
+	<description>
+		ResourceImporterGLTFSingleMesh is a resource importer for glTF files which outputs an [ArrayMesh] resource containing the meshes from the glTF file. If the glTF file contains only one mesh, that mesh will be saved as-is. If the glTF file contains multiple meshes, the meshes will be merged together. This is useful for simple glTF files intended to only transfer mesh geometry without a scene hierarchy. This approach should be preferred over using the OBJ importer, since glTF is a more modern format and supports more features.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="deduplicate_surfaces" type="bool" setter="" getter="" default="true">
+			If the glTF file contains only one mesh, this option has no effect. If [code]true[/code] and the glTF file contains multiple meshes with the same surface names and formats, the surfaces will be merged together when the meshes are merged. This is useful for reducing the number of surfaces in the resulting mesh, and avoids duplicating materials. If [code]false[/code] and the glTF file contains multiple meshes, the surfaces will always be kept separate.
+		</member>
+	</members>
+</class>

--- a/modules/gltf/editor/resource_importer_gltf_mesh_library.cpp
+++ b/modules/gltf/editor/resource_importer_gltf_mesh_library.cpp
@@ -1,0 +1,110 @@
+/**************************************************************************/
+/*  resource_importer_gltf_mesh_library.cpp                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_gltf_mesh_library.h"
+
+#include "../gltf_document.h"
+
+#include "editor/settings/editor_settings.h"
+#include "scene/resources/3d/mesh_library.h"
+
+void ResourceImporterGLTFMeshLibrary::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("glb");
+	p_extensions->push_back("gltf");
+}
+
+void ResourceImporterGLTFMeshLibrary::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "save_meshes_to_files"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "use_node_names_as_mesh_names"), false));
+}
+
+Error ResourceImporterGLTFMeshLibrary::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+	Ref<GLTFDocument> gltf_document;
+	gltf_document.instantiate();
+	Ref<GLTFState> gltf_state;
+	gltf_state.instantiate();
+	Error err = gltf_document->append_from_file(p_source_file, gltf_state);
+	if (err != OK) {
+		return err;
+	}
+	const Vector<Ref<GLTFMesh>> &gltf_meshes = gltf_state->get_meshes();
+	const int gltf_mesh_count = gltf_meshes.size();
+	const bool use_node_names_as_mesh_names = p_options.has("use_node_names_as_mesh_names") && p_options["use_node_names_as_mesh_names"];
+	if (use_node_names_as_mesh_names) {
+		const Vector<Ref<GLTFNode>> &gltf_nodes = gltf_state->get_nodes();
+		for (int i = 0; i < gltf_nodes.size(); i++) {
+			Ref<GLTFNode> gltf_node = gltf_nodes[i];
+			ERR_CONTINUE_MSG(gltf_node.is_null(), "GLTF node at index " + itos(i) + " was null when importing " + p_source_file);
+			const GLTFMeshIndex mesh_index = gltf_node->get_mesh();
+			if (mesh_index != -1) {
+				ERR_FAIL_INDEX_V_MSG(mesh_index, gltf_mesh_count, ERR_INVALID_DATA, "GLTF node at index " + itos(i) + " references mesh at index " + itos(mesh_index) + ", which is out of bounds of the mesh array size " + itos(gltf_mesh_count) + " when importing " + p_source_file);
+				const String node_name = gltf_node->get_name();
+				Ref<GLTFMesh> gltf_mesh = gltf_meshes[mesh_index];
+				ERR_CONTINUE_MSG(gltf_mesh.is_null(), "GLTF mesh at index " + itos(mesh_index) + " was null when importing " + p_source_file);
+				gltf_mesh->set_name(node_name);
+				Ref<ImporterMesh> importer_mesh = gltf_mesh->get_mesh();
+				ERR_CONTINUE_MSG(importer_mesh.is_null(), "Importer mesh at index " + itos(mesh_index) + " was null when importing " + p_source_file);
+				importer_mesh->set_name(node_name);
+				Ref<ArrayMesh> array_mesh = importer_mesh->get_mesh();
+				ERR_CONTINUE_MSG(array_mesh.is_null(), "Array mesh at index " + itos(mesh_index) + " was null when importing " + p_source_file);
+				array_mesh->set_name(node_name);
+			}
+		}
+	}
+	int flags = 0;
+	if (EditorSettings::get_singleton() && EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	const bool save_meshes_to_files = p_options.has("save_meshes_to_files") && p_options["save_meshes_to_files"];
+	const String source_base_dir = p_source_file.get_base_dir();
+	Ref<MeshLibrary> mesh_library;
+	mesh_library.instantiate();
+	for (int i = 0; i < gltf_mesh_count; i++) {
+		Ref<GLTFMesh> gltf_mesh = gltf_meshes[i];
+		ERR_CONTINUE_MSG(gltf_mesh.is_null(), "GLTF mesh at index " + itos(i) + " was null when importing " + p_source_file);
+		Ref<ImporterMesh> importer_mesh = gltf_mesh->get_mesh();
+		ERR_CONTINUE_MSG(importer_mesh.is_null(), "Importer mesh at index " + itos(i) + " was null when importing " + p_source_file);
+		Ref<ArrayMesh> array_mesh = importer_mesh->get_mesh();
+		ERR_CONTINUE_MSG(array_mesh.is_null(), "Array mesh at index " + itos(i) + " was null when importing " + p_source_file);
+		// The glTF importer guarantees mesh names to be unique and
+		// non-empty, so we can use it safely without fallback.
+		const String mesh_name = array_mesh->get_name();
+		if (save_meshes_to_files) {
+			const String mesh_next_to_source_file_path = source_base_dir.path_join(mesh_name + ".res");
+			array_mesh->set_path(mesh_next_to_source_file_path, true);
+			ResourceSaver::save(array_mesh, mesh_next_to_source_file_path, flags);
+		}
+		const int id = mesh_library->get_last_unused_item_id();
+		mesh_library->create_item(id);
+		mesh_library->set_item_name(id, mesh_name);
+		mesh_library->set_item_mesh(id, array_mesh);
+	}
+	return ResourceSaver::save(mesh_library, p_save_path + ".res", flags);
+}

--- a/modules/gltf/editor/resource_importer_gltf_mesh_library.h
+++ b/modules/gltf/editor/resource_importer_gltf_mesh_library.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_node.h                                                           */
+/*  resource_importer_gltf_mesh_library.h                                 */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,85 +30,23 @@
 
 #pragma once
 
-#include "../gltf_defines.h"
+#include "core/io/resource_importer.h"
 
-#include "core/io/resource.h"
-
-class GLTFNode : public Resource {
-	GDCLASS(GLTFNode, Resource);
-	friend class GLTFDocument;
-	friend class SkinTool;
-	friend class FBXDocument;
-
-private:
-	String original_name;
-	GLTFNodeIndex parent = -1;
-	int height = -1;
-	Transform3D transform;
-	GLTFMeshIndex mesh = -1;
-	GLTFCameraIndex camera = -1;
-	GLTFSkinIndex skin = -1;
-	GLTFSkeletonIndex skeleton = -1;
-	bool joint = false;
-	bool visible = true;
-	Vector<int> children;
-	GLTFLightIndex light = -1;
-	Dictionary additional_data;
-
-protected:
-	static void _bind_methods();
+class ResourceImporterGLTFMeshLibrary : public ResourceImporter {
+	GDCLASS(ResourceImporterGLTFMeshLibrary, ResourceImporter);
 
 public:
-	String get_original_name();
-	void set_original_name(const String &p_name);
+	virtual String get_importer_name() const override { return "gltf_mesh_library"; }
+	virtual String get_visible_name() const override { return "Mesh Library"; }
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual String get_save_extension() const override { return "res"; }
+	virtual String get_resource_type() const override { return "MeshLibrary"; }
 
-	GLTFNodeIndex get_parent();
-	void set_parent(GLTFNodeIndex p_parent);
+	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
+	virtual int get_import_order() const override { return 10; } // Should come after image importers, but before scene importers.
+	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override { return true; }
 
-	int get_height();
-	void set_height(int p_height);
+	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-	Transform3D get_xform();
-	void set_xform(const Transform3D &p_xform);
-
-	Transform3D get_rest_xform();
-	void set_rest_xform(const Transform3D &p_rest_xform);
-
-	GLTFMeshIndex get_mesh();
-	void set_mesh(GLTFMeshIndex p_mesh);
-
-	GLTFCameraIndex get_camera();
-	void set_camera(GLTFCameraIndex p_camera);
-
-	GLTFSkinIndex get_skin();
-	void set_skin(GLTFSkinIndex p_skin);
-
-	GLTFSkeletonIndex get_skeleton();
-	void set_skeleton(GLTFSkeletonIndex p_skeleton);
-
-	Vector3 get_position();
-	void set_position(const Vector3 &p_position);
-
-	Quaternion get_rotation();
-	void set_rotation(const Quaternion &p_rotation);
-
-	Vector3 get_scale();
-	void set_scale(const Vector3 &p_scale);
-
-	Vector<int> get_children();
-	void set_children(const Vector<int> &p_children);
-	void append_child_index(int p_child_index);
-
-	GLTFLightIndex get_light();
-	void set_light(GLTFLightIndex p_light);
-
-	bool get_visible();
-	void set_visible(bool p_visible);
-
-	Variant get_additional_data(const StringName &p_extension_name);
-	bool has_additional_data(const StringName &p_extension_name);
-	void set_additional_data(const StringName &p_extension_name, Variant p_additional_data);
-
-	Transform3D get_global_transform(const Ref<GLTFState> &p_state) const;
-	NodePath get_scene_node_path(Ref<GLTFState> p_state, bool p_handle_skeletons = true);
+	virtual bool can_import_threaded() const override { return true; }
 };

--- a/modules/gltf/editor/resource_importer_gltf_single_mesh.cpp
+++ b/modules/gltf/editor/resource_importer_gltf_single_mesh.cpp
@@ -1,0 +1,99 @@
+/**************************************************************************/
+/*  resource_importer_gltf_single_mesh.cpp                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_gltf_single_mesh.h"
+
+#include "../gltf_document.h"
+
+#include "editor/settings/editor_settings.h"
+
+void ResourceImporterGLTFSingleMesh::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("glb");
+	p_extensions->push_back("gltf");
+}
+
+void ResourceImporterGLTFSingleMesh::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "deduplicate_surfaces"), true));
+}
+
+Error ResourceImporterGLTFSingleMesh::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+	Ref<GLTFDocument> gltf_document;
+	gltf_document.instantiate();
+	Ref<GLTFState> gltf_state;
+	gltf_state.instantiate();
+	Error err = gltf_document->append_from_file(p_source_file, gltf_state);
+	if (err != OK) {
+		return err;
+	}
+	const Vector<Ref<GLTFMesh>> &gltf_meshes = gltf_state->get_meshes();
+	const int gltf_mesh_count = gltf_meshes.size();
+	ERR_FAIL_COND_V_MSG(gltf_mesh_count == 0, ERR_INVALID_DATA, "Cannot import GLTF file " + p_source_file + " as a single mesh, because it contains no meshes.");
+	const String save_file_path = p_save_path + ".res";
+	int flags = 0;
+	if (EditorSettings::get_singleton() && EDITOR_GET("filesystem/on_save/compress_binary_resources")) {
+		flags |= ResourceSaver::FLAG_COMPRESS;
+	}
+	// If there is just one mesh, we can save it directly, preserving that one mesh exactly as it is.
+	if (gltf_mesh_count == 1) {
+		Ref<GLTFMesh> gltf_mesh = gltf_meshes[0];
+		ERR_FAIL_COND_V_MSG(gltf_mesh.is_null(), ERR_INVALID_DATA, "GLTF mesh at index 0 was null when importing " + p_source_file);
+		Ref<ImporterMesh> importer_mesh = gltf_mesh->get_mesh();
+		ERR_FAIL_COND_V_MSG(importer_mesh.is_null(), ERR_INVALID_DATA, "Importer mesh at index 0 was null when importing " + p_source_file);
+		Ref<ArrayMesh> array_mesh = importer_mesh->get_mesh();
+		ERR_FAIL_COND_V_MSG(array_mesh.is_null(), ERR_INVALID_DATA, "Array mesh at index 0 was null when importing " + p_source_file);
+		array_mesh->set_path(save_file_path, true);
+		return ResourceSaver::save(array_mesh, save_file_path, flags);
+	}
+	// If the file contains multiple meshes, we have to merge them
+	// into a single mesh, based on their positions in the scene.
+	const Vector<Ref<GLTFNode>> &gltf_nodes = gltf_state->get_nodes();
+	const int gltf_node_count = gltf_nodes.size();
+	TypedArray<ImporterMesh> mesh_instances;
+	TypedArray<Transform3D> relative_transforms;
+	for (int i = 0; i < gltf_node_count; i++) {
+		Ref<GLTFNode> gltf_node = gltf_nodes[i];
+		ERR_FAIL_COND_V_MSG(gltf_node.is_null(), ERR_INVALID_DATA, "GLTF node at index " + itos(i) + " was null when importing " + p_source_file);
+		const GLTFMeshIndex mesh_index = gltf_node->get_mesh();
+		if (mesh_index == -1) {
+			continue; // No mesh for this node, skip it.
+		}
+		ERR_FAIL_INDEX_V_MSG(mesh_index, gltf_mesh_count, ERR_INVALID_DATA, "GLTF node at index " + itos(i) + " references mesh at index " + itos(mesh_index) + ", which is out of bounds of the mesh array size " + itos(gltf_mesh_count) + " when importing " + p_source_file);
+		Ref<GLTFMesh> gltf_mesh = gltf_meshes[mesh_index];
+		ERR_FAIL_COND_V_MSG(gltf_mesh.is_null(), ERR_INVALID_DATA, "GLTF mesh at index " + itos(mesh_index) + " was null when importing " + p_source_file);
+		Ref<ImporterMesh> importer_mesh = gltf_mesh->get_mesh();
+		ERR_FAIL_COND_V_MSG(importer_mesh.is_null(), ERR_INVALID_DATA, "Importer mesh at index " + itos(mesh_index) + " was null when importing " + p_source_file);
+		const Transform3D global_transform = gltf_node->get_global_transform(gltf_state);
+		mesh_instances.append(importer_mesh);
+		relative_transforms.append(global_transform);
+	}
+	const bool deduplicate_surfaces = p_options.has("deduplicate_surfaces") && p_options["deduplicate_surfaces"];
+	Ref<ImporterMesh> merged_mesh = ImporterMesh::merge_importer_meshes(mesh_instances, relative_transforms, deduplicate_surfaces);
+	return ResourceSaver::save(merged_mesh->get_mesh(), save_file_path, flags);
+}

--- a/modules/gltf/editor/resource_importer_gltf_single_mesh.h
+++ b/modules/gltf/editor/resource_importer_gltf_single_mesh.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  gltf_node.h                                                           */
+/*  resource_importer_gltf_single_mesh.h                                  */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,85 +30,23 @@
 
 #pragma once
 
-#include "../gltf_defines.h"
+#include "core/io/resource_importer.h"
 
-#include "core/io/resource.h"
-
-class GLTFNode : public Resource {
-	GDCLASS(GLTFNode, Resource);
-	friend class GLTFDocument;
-	friend class SkinTool;
-	friend class FBXDocument;
-
-private:
-	String original_name;
-	GLTFNodeIndex parent = -1;
-	int height = -1;
-	Transform3D transform;
-	GLTFMeshIndex mesh = -1;
-	GLTFCameraIndex camera = -1;
-	GLTFSkinIndex skin = -1;
-	GLTFSkeletonIndex skeleton = -1;
-	bool joint = false;
-	bool visible = true;
-	Vector<int> children;
-	GLTFLightIndex light = -1;
-	Dictionary additional_data;
-
-protected:
-	static void _bind_methods();
+class ResourceImporterGLTFSingleMesh : public ResourceImporter {
+	GDCLASS(ResourceImporterGLTFSingleMesh, ResourceImporter);
 
 public:
-	String get_original_name();
-	void set_original_name(const String &p_name);
+	virtual String get_importer_name() const override { return "gltf_single_mesh"; }
+	virtual String get_visible_name() const override { return "Single Mesh"; }
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual String get_save_extension() const override { return "res"; }
+	virtual String get_resource_type() const override { return "ArrayMesh"; }
 
-	GLTFNodeIndex get_parent();
-	void set_parent(GLTFNodeIndex p_parent);
+	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
+	virtual int get_import_order() const override { return 10; } // Should come after image importers, but before scene importers.
+	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override { return true; }
 
-	int get_height();
-	void set_height(int p_height);
+	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 
-	Transform3D get_xform();
-	void set_xform(const Transform3D &p_xform);
-
-	Transform3D get_rest_xform();
-	void set_rest_xform(const Transform3D &p_rest_xform);
-
-	GLTFMeshIndex get_mesh();
-	void set_mesh(GLTFMeshIndex p_mesh);
-
-	GLTFCameraIndex get_camera();
-	void set_camera(GLTFCameraIndex p_camera);
-
-	GLTFSkinIndex get_skin();
-	void set_skin(GLTFSkinIndex p_skin);
-
-	GLTFSkeletonIndex get_skeleton();
-	void set_skeleton(GLTFSkeletonIndex p_skeleton);
-
-	Vector3 get_position();
-	void set_position(const Vector3 &p_position);
-
-	Quaternion get_rotation();
-	void set_rotation(const Quaternion &p_rotation);
-
-	Vector3 get_scale();
-	void set_scale(const Vector3 &p_scale);
-
-	Vector<int> get_children();
-	void set_children(const Vector<int> &p_children);
-	void append_child_index(int p_child_index);
-
-	GLTFLightIndex get_light();
-	void set_light(GLTFLightIndex p_light);
-
-	bool get_visible();
-	void set_visible(bool p_visible);
-
-	Variant get_additional_data(const StringName &p_extension_name);
-	bool has_additional_data(const StringName &p_extension_name);
-	void set_additional_data(const StringName &p_extension_name, Variant p_additional_data);
-
-	Transform3D get_global_transform(const Ref<GLTFState> &p_state) const;
-	NodePath get_scene_node_path(Ref<GLTFState> p_state, bool p_handle_skeletons = true);
+	virtual bool can_import_threaded() const override { return true; }
 };

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -52,6 +52,8 @@
 #include "editor/editor_scene_exporter_gltf_plugin.h"
 #include "editor/editor_scene_importer_blend.h"
 #include "editor/editor_scene_importer_gltf.h"
+#include "editor/resource_importer_gltf_mesh_library.h"
+#include "editor/resource_importer_gltf_single_mesh.h"
 //
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"
@@ -100,6 +102,14 @@ static void _editor_init() {
 	}
 	memnew(EditorImportBlendRunner);
 	EditorNode::get_singleton()->add_child(EditorImportBlendRunner::get_singleton());
+
+	// Non-ResourceImporterScene importers.
+	Ref<ResourceImporterGLTFMeshLibrary> res_imp_gltf_mesh_library;
+	res_imp_gltf_mesh_library.instantiate();
+	ResourceFormatImporter::get_singleton()->add_importer(res_imp_gltf_mesh_library);
+	Ref<ResourceImporterGLTFSingleMesh> res_imp_gltf_single_mesh;
+	res_imp_gltf_single_mesh.instantiate();
+	ResourceFormatImporter::get_singleton()->add_importer(res_imp_gltf_single_mesh);
 }
 #endif // TOOLS_ENABLED
 
@@ -147,6 +157,9 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 
 #ifdef TOOLS_ENABLED
 	if (p_level == MODULE_INITIALIZATION_LEVEL_EDITOR) {
+		// Required to document import options in the class reference.
+		GDREGISTER_CLASS(ResourceImporterGLTFMeshLibrary);
+		GDREGISTER_CLASS(ResourceImporterGLTFSingleMesh);
 		GDREGISTER_CLASS(EditorSceneFormatImporterGLTF);
 		EditorPlugins::add_by_type<SceneExporterGLTFPlugin>();
 

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -211,6 +211,22 @@ void GLTFNode::set_additional_data(const StringName &p_extension_name, Variant p
 	additional_data[p_extension_name] = p_additional_data;
 }
 
+Transform3D GLTFNode::get_global_transform(const Ref<GLTFState> &p_state) const {
+	Transform3D global_transform = transform;
+	const int gltf_node_count = p_state->nodes.size();
+	const GLTFNode *current_gltf_node = this;
+	while (true) {
+		const int parent_index = current_gltf_node->parent;
+		if (parent_index == -1) {
+			break;
+		}
+		ERR_FAIL_INDEX_V(parent_index, gltf_node_count, Transform3D());
+		current_gltf_node = p_state->nodes[parent_index].ptr();
+		global_transform = current_gltf_node->transform * global_transform;
+	}
+	return global_transform;
+}
+
 NodePath GLTFNode::get_scene_node_path(Ref<GLTFState> p_state, bool p_handle_skeletons) {
 	Vector<StringName> path;
 	Vector<StringName> subpath;


### PR DESCRIPTION
Alternative to PR https://github.com/godotengine/godot/pull/107856 (mutually exclusive: only one can be merged, the other must be closed)

Implements https://github.com/godotengine/godot-proposals/issues/7494 for glTF, ArrayMesh, and MeshLibrary.

<img width="500" alt="Screenshot 2025-06-22 at 1 14 53 AM" src="https://github.com/user-attachments/assets/19cb1584-2ecd-43fd-ae41-c6e91c46ff04" />

* The "Mesh Library" import option imports all meshes in the glTF file as items in a `MeshLibrary`, and optionally can save these meshes to a file, and optionally can use node names as mesh names. This is useful for glTF files intended to be used as a collection of meshes, rather than a single model or scene.
* The "Single Mesh" import option imports the glTF file as a single `ArrayMesh`, which is that exact mesh as-is when importing a file with a single mesh, or imports a merged mesh if the file contains multiple meshes.

This PR is marked as a discussion because this ResourceImporter approach is just one of the possible implementations. The other approach is to make a mesh out of a generated Godot scene with ResourceImporterScene: https://github.com/godotengine/godot/pull/107856 I briefly discussed this with @fire on Discord and he said he prefers ResourceImporterScene, but I'm putting both options on the table.

Here's a copy of what I sent on Discord. We basically have 3 options:
- Support importing any 3D model as Mesh or MeshLibrary by disassembling the generated scene in ResourceImporterScene. https://github.com/godotengine/godot/pull/107856
  - Advantages: Supports all 3D model formats at once, including glTF, FBX, Blend, Collada, etc. Keeps using the Advanced Import Settings dialog, so it shows the same dialog as when importing as a scene.
  - Disadvantages: More complex, slower since it involves generating a scene, does not support resource-only glTF files, harder to expose mesh-specific import options, not thread safe because physics may exist.
- Support importing glTF directly as Mesh or MeshLibrary using ResourceImporter. (this PR)
  - Advantages: Simpler, faster to run since it skips scene generation, supports resource-only glTF files (requires [PR #107836](https://github.com/godotengine/godot/pull/107836)), easier to expose mesh-specific import options, should be thread safe and Godot may crash when generating physics objects on a thread.
  - Disadvantages: Only gives us glTF, would need duplicate code for FBX, Blend, etc, if desired there. Does not show the Advanced Import Settings dialog, because it bypasses that system, instead double-clicking on the source file will show the imported Resource in the inspector like with other non-scene files.
- Wait for https://github.com/godotengine/godot-proposals/issues/8750 instead?

Also, @fire mentioned that "It won't support multi meshes" and that mesh merging "is better done in blender since it's pretty tricky", but I managed to support it anyway, so long as we have PR https://github.com/godotengine/godot/pull/107838. I think mesh merging functionality should be supported, regardless of how the importer exposes it.