### PR TITLE
Fix can't convert to ShaderMaterial in FileSystemDock

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2117,7 +2117,7 @@ Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> select
 }
 
 void FileSystemDock::_tree_rmb_option(int p_option) {
-	if (p_option > FILE_MENU_MAX) {
+	if (p_option > FILE_MENU_MAX && p_option < CONVERT_BASE_ID) {
 		// Extra options don't need paths.
 		_file_option(p_option, {});
 		return;


### PR DESCRIPTION
Fixes #107833

Likely a regression from #106041 according to blame history