### PR TITLE
[3.x] Optimize `Object::cast_to` with ancestral classes when possible

### DIFF
--- a/core/reference.h
+++ b/core/reference.h
@@ -46,6 +46,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::REFERENCE;
+
 	_FORCE_INLINE_ bool is_referenced() const { return refcount_init.get() != 1; }
 	bool init_ref();
 	bool reference(); // returns false if refcount is at zero and didn't get increased

--- a/core/resource.h
+++ b/core/resource.h
@@ -83,6 +83,8 @@ protected:
 	void _take_over_path(const String &p_path);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::RESOURCE;
+
 	static Node *(*_get_local_scene_func)(); //used by editor
 
 	virtual bool editor_can_reload_from_file();

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -115,6 +115,8 @@ protected:
 	Dictionary _get_script_constant_map();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::SCRIPT;
+
 	virtual bool can_instance() const = 0;
 
 	virtual Ref<Script> get_base_script() const = 0; //for script inheritance

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -38,6 +38,8 @@ class Area2D : public CollisionObject2D {
 	GDCLASS(Area2D, CollisionObject2D);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::AREA_2D;
+
 	enum SpaceOverride {
 		SPACE_OVERRIDE_DISABLED,
 		SPACE_OVERRIDE_COMBINE,

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -48,6 +48,8 @@ class CanvasItemMaterial : public Material {
 	GDCLASS(CanvasItemMaterial, Material);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::CANVAS_ITEM;
+
 	enum BlendMode {
 		BLEND_MODE_MIX,
 		BLEND_MODE_ADD,

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -85,6 +85,8 @@ protected:
 	void set_only_update_transform_changes(bool p_enable);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::COLLISION_OBJECT_2D;
+
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;
 

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -54,6 +54,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::NODE_2D;
+
 #ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const;
 	virtual void _edit_set_state(const Dictionary &p_state);

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -97,6 +97,8 @@ protected:
 	void _on_transform_changed();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::COLLISION_OBJECT;
+
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;
 

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -105,6 +105,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::MESH_INSTANCE;
+
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
 

--- a/scene/3d/physics_body.h
+++ b/scene/3d/physics_body.h
@@ -49,6 +49,8 @@ protected:
 	PhysicsBody(PhysicsServer::BodyMode p_mode);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::PHYSICS_BODY;
+
 	virtual String get_configuration_warning() const;
 
 	virtual Vector3 get_linear_velocity() const;

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -56,6 +56,8 @@ class Spatial : public Node {
 	friend class SceneTreeFTITests;
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::SPATIAL;
+
 	enum MergingMode : unsigned int {
 		MERGING_MODE_INHERIT,
 		MERGING_MODE_OFF,

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -58,6 +58,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::VISUAL_INSTANCE;
+
 	enum GetFacesFlags {
 		FACES_SOLID = 1, // solid geometry
 		FACES_ENCLOSING = 2,
@@ -93,6 +95,8 @@ class GeometryInstance : public VisualInstance {
 	GDCLASS(GeometryInstance, VisualInstance);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::GEOMETRY_INSTANCE;
+
 	enum Flags {
 		FLAG_USE_BAKED_LIGHT = VS::INSTANCE_FLAG_USE_BAKED_LIGHT,
 		FLAG_DRAW_NEXT_FRAME_IF_VISIBLE = VS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE,

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -48,6 +48,8 @@ class Control : public CanvasItem {
 	OBJ_CATEGORY("GUI Nodes");
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::CONTROL;
+
 	enum Anchor {
 
 		ANCHOR_BEGIN = 0,

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -48,6 +48,8 @@ class Node : public Object {
 	OBJ_CATEGORY("Nodes");
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::NODE;
+
 	// N.B. Any enum stored as a bitfield should
 	// be specified as UNSIGNED to work around
 	// some compilers trying to store it as signed,


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/107462#issuecomment-2994156473

This implementation should be several times faster than regular `Object::cast_to`, for classes with corresponding ancestral classes (although i have not tested this).

It would be possible to "pre-check" the types that derive from any of the ancestral types (e.g. `object && object.has_ancestry(AncestralClass::SPATIAL) && object.is_class_ptr(SpatialSubclass::get_class_ptr_static())`). But that would only accelerate the unhappy path, and only some of the time. The happy path wants to immediately use `is_class_ptr`, so I decided against this micro optimization.

The `_is_class` function should use `constexpr`, but it's not possible until the upgrade to C++17.

4.x equivalent will follow for 4.6, when `AncestralClass` is forward ported.