### PR TITLE
Ogg: Use LocalVector and do memory optimizations

### DIFF
--- a/modules/ogg/ogg_packet_sequence.h
+++ b/modules/ogg/ogg_packet_sequence.h
@@ -44,10 +44,10 @@ class OggPacketSequence : public Resource {
 	friend class OggPacketSequencePlayback;
 
 	// List of pages, each of which is a list of packets on that page. The innermost PackedByteArrays contain complete ogg packets.
-	Vector<Vector<PackedByteArray>> page_data;
+	LocalVector<LocalVector<PackedByteArray, int64_t>> page_data;
 
 	// List of the granule position for each page.
-	Vector<uint64_t> page_granule_positions;
+	LocalVector<uint64_t, int64_t> page_granule_positions;
 
 	// The page after the current last page. Similar semantics to an end() iterator.
 	int64_t end_page = 0;
@@ -63,7 +63,7 @@ protected:
 public:
 	// Pushes information about all the pages that ended on this page.
 	// This should be called for each page, even for pages that no packets ended on.
-	void push_page(int64_t p_granule_pos, const Vector<PackedByteArray> &p_data);
+	void push_page(int64_t p_granule_pos, const LocalVector<PackedByteArray, int64_t> &p_data);
 
 	void set_packet_data(const TypedArray<Array> &p_data);
 	TypedArray<Array> get_packet_data() const;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -629,7 +629,7 @@ Ref<AudioStreamOggVorbis> AudioStreamOggVorbis::load_from_buffer(const Vector<ui
 		ERR_FAIL_COND_V_MSG(err != 0, Ref<AudioStreamOggVorbis>(), "Ogg stream error " + itos(err));
 		int desync_iters = 0;
 
-		RBMap<uint64_t, Vector<Vector<uint8_t>>> sorted_packets;
+		RBMap<uint64_t, LocalVector<PackedByteArray, int64_t>> sorted_packets;
 		int64_t granule_pos = 0;
 
 		while (true) {
@@ -665,9 +665,10 @@ Ref<AudioStreamOggVorbis> AudioStreamOggVorbis::load_from_buffer(const Vector<ui
 				packet_count++;
 			}
 		}
-		Vector<Vector<uint8_t>> packet_data;
-		for (const KeyValue<uint64_t, Vector<Vector<uint8_t>>> &pair : sorted_packets) {
-			for (const Vector<uint8_t> &packets : pair.value) {
+		LocalVector<PackedByteArray, int64_t> packet_data;
+		for (const KeyValue<uint64_t, LocalVector<PackedByteArray, int64_t>> &pair : sorted_packets) {
+			packet_data.reserve(packet_data.size() + pair.value.size());
+			for (const PackedByteArray &packets : pair.value) {
 				packet_data.push_back(packets);
 			}
 		}


### PR DESCRIPTION
Somewhat the Ogg Vorbis version of #96017 and #97026.

Modifies a few `Vector`s in `OggPacketSequence` and `AudioStreamOggVorbis` to use `LocalVector`s instead.

I also did a few memory optimizations by adding `reserve()` calls or using resize + assign.

The innermost type in `page_data` remains a regular `Vector` as it needs to be compatible with `Variant`. Shouldn't be a problem as only one write operation is done on it.