### PR TITLE
[3.x] Bump to c++17

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -477,11 +477,11 @@ if selected_platform in platform_list:
         # both GCC and Clang. This mirrors GCC and Clang's current default
         # compile flags if no -std is specified.
         env.Prepend(CFLAGS=["-std=gnu11"])
-        env.Prepend(CXXFLAGS=["-std=gnu++14"])
+        env.Prepend(CXXFLAGS=["-std=gnu++17"])
     else:
         # MSVC doesn't have clear C standard support, /std only covers C++.
         # We apply it to CCFLAGS (both C and C++ code) in case it impacts C features.
-        env.Prepend(CCFLAGS=["/std:c++14"])
+        env.Prepend(CCFLAGS=["/std:c++17"])
 
     # Handle renamed options.
     if "use_lto" in ARGUMENTS or "use_thinlto" in ARGUMENTS:


### PR DESCRIPTION
As discussed, we want to upgrade to c++17 for a few new bits of super useful functionality, especially `if constexpr`.

I have a later PR for adding some of the compiler requirements we have in 4.x (in `SConstruct`) but hopefully this should be okay to get started.

## Notes
* `if constexpr` is particularly useful for compile time branching, may be useful in #107844 and in a number of cases where we are starting to heavily optimize internal core.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
