### PR TITLE
Fix Resource doesn't update when overwritten in editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1585,7 +1585,13 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 		return;
 	}
 
-	((Resource *)p_resource.ptr())->set_path(path);
+	Ref<Resource> prev_resource = ResourceCache::get_ref(p_path);
+	if (prev_resource.is_null() || prev_resource != p_resource) {
+		p_resource->set_path(path, true);
+	}
+	if (prev_resource.is_valid() && prev_resource != p_resource) {
+		replace_resources_in_scenes({ prev_resource }, { p_resource });
+	}
 	saving_resources_in_path.erase(p_resource);
 
 	_resource_saved(p_resource, path);

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -525,15 +525,14 @@ void QuickOpenResultContainer::_use_default_candidates() {
 	if (history) {
 		candidates.append_array(*history);
 	}
-	int count = candidates.size();
 	candidates.resize(MIN(max_total_results, filepaths.size()));
+	int count = candidates.size();
+	int i = 0;
 	for (const String &filepath : filepaths) {
-		if (count >= max_total_results) {
+		if (i >= count) {
 			break;
 		}
-		if (!history || !history_set.has(filepath)) {
-			_setup_candidate(candidates.write[count++], filepath);
-		}
+		_setup_candidate(candidates.write[i++], filepath);
 	}
 }
 


### PR DESCRIPTION
Partially addresses #30302, https://github.com/godotengine/godot/issues/104966#issuecomment-2994111048

After this PR, resources overwritten by `EditorNode::save_resource_in_path` can be updated in scenes, inspector and thumbnails correctly.

Note:
- ~Resources in the scene are still not be updated, but they can be updated by re-assigning the resources or reloading the scene.~ Resolved by `EditorNode::replace_resources_in_scenes`.
- Resources overwritten by tool scripts are still not updated, but this may be resolved by manually calling `Resource.take_over_path` and `EditorFileSystem.update_file`. However it has the above issue unless reloading resources in the scene.