### PR TITLE
Revert "FTI - Reduce `VisualInstance3D` xform notifications"

### DIFF
--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -164,7 +164,6 @@ void Camera3D::_update_camera() {
 
 void Camera3D::_physics_interpolated_changed() {
 	_update_process_mode();
-	Node3D::_physics_interpolated_changed();
 }
 
 void Camera3D::set_desired_process_modes(bool p_process_internal, bool p_physics_process_internal) {

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1241,21 +1241,9 @@ Vector3 Node3D::to_global(Vector3 p_local) const {
 	return get_global_transform().xform(p_local);
 }
 
-void Node3D::_physics_interpolated_changed() {
-	ERR_THREAD_GUARD;
-	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
-}
-
-void Node3D::_set_notify_transform_when_fti_off(bool p_enable) {
-	ERR_THREAD_GUARD;
-	data.notify_transform_when_fti_off = p_enable;
-	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
-}
-
 void Node3D::set_notify_transform(bool p_enabled) {
 	ERR_THREAD_GUARD;
-	data.notify_transform_requested = p_enabled;
-	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
+	data.notify_transform = p_enabled;
 }
 
 bool Node3D::is_transform_notification_enabled() const {
@@ -1537,8 +1525,6 @@ Node3D::Node3D() :
 	data.ignore_notification = false;
 	data.notify_local_transform = false;
 	data.notify_transform = false;
-	data.notify_transform_requested = false;
-	data.notify_transform_when_fti_off = false;
 
 	data.visible = true;
 	data.disable_scale = false;

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -134,9 +134,6 @@ private:
 		bool notify_local_transform : 1;
 		bool notify_transform : 1;
 
-		bool notify_transform_requested : 1;
-		bool notify_transform_when_fti_off : 1;
-
 		bool visible : 1;
 		bool disable_scale : 1;
 
@@ -201,9 +198,6 @@ protected:
 	// or requires an update in terms of interpolation
 	// (e.g. changing Camera zoom even if position hasn't changed).
 	void fti_notify_node_changed(bool p_transform_changed = true);
-
-	void _set_notify_transform_when_fti_off(bool p_enable);
-	virtual void _physics_interpolated_changed() override;
 
 	// Opportunity after FTI to update the servers
 	// with global_transform_interpolated,

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -88,9 +88,7 @@ void VisualInstance3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			// NOTIFICATION normally turned off for physics interpolated cases (via
-			// `notify_transform_when_fti_off`), however derived classes can still turn this back on,
-			// so always wrap with is_physics_interpolation_enabled().
+			// ToDo : Can we turn off notify transform for physics interpolated cases?
 			if (_is_vi_visible() && !(is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) && !_is_using_identity_transform()) {
 				// Physics interpolation global off, always send.
 				RenderingServer::get_singleton()->instance_set_transform(instance, get_global_transform());
@@ -206,7 +204,7 @@ RID VisualInstance3D::get_base() const {
 VisualInstance3D::VisualInstance3D() {
 	instance = RenderingServer::get_singleton()->instance_create();
 	RenderingServer::get_singleton()->instance_attach_object_instance_id(instance, get_instance_id());
-	_set_notify_transform_when_fti_off(true);
+	set_notify_transform(true);
 }
 
 VisualInstance3D::~VisualInstance3D() {


### PR DESCRIPTION
This reverts commit e10003ce33f8640c560ed1b3dec49e30b9e511b9 / https://github.com/godotengine/godot/pull/105901.

Fixes #107829
Fixes #107755

## Notes
* There appear more cases where `NOTIFICATION_TRANSFORM_CHANGED` inherited from `VisualInstance` are used in 4.x than 3.x (where forward ported from)
* I'll revisit this in 3.x / 4.6 to see if we can reduce these without causing regressions, it's not critical for 4.5.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
