### PR TITLE
Remove ResourceImporterScene singletons in favor of local usage

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7834,11 +7834,13 @@ EditorNode::EditorNode() {
 		import_shader_file.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_shader_file);
 
-		Ref<ResourceImporterScene> import_scene = memnew(ResourceImporterScene("PackedScene", true));
-		ResourceFormatImporter::get_singleton()->add_importer(import_scene);
+		Ref<ResourceImporterScene> import_model_as_scene;
+		import_model_as_scene.instantiate("PackedScene");
+		ResourceFormatImporter::get_singleton()->add_importer(import_model_as_scene);
 
-		Ref<ResourceImporterScene> import_animation = memnew(ResourceImporterScene("AnimationLibrary", true));
-		ResourceFormatImporter::get_singleton()->add_importer(import_animation);
+		Ref<ResourceImporterScene> import_model_as_animation;
+		import_model_as_animation.instantiate("AnimationLibrary");
+		ResourceFormatImporter::get_singleton()->add_importer(import_model_as_animation);
 
 		{
 			Ref<EditorSceneFormatImporterCollada> import_collada;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3367,9 +3367,6 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	return OK;
 }
 
-ResourceImporterScene *ResourceImporterScene::scene_singleton = nullptr;
-ResourceImporterScene *ResourceImporterScene::animation_singleton = nullptr;
-
 Vector<Ref<EditorSceneFormatImporter>> ResourceImporterScene::scene_importers;
 Vector<Ref<EditorScenePostImportPlugin>> ResourceImporterScene::post_importer_plugins;
 
@@ -3381,26 +3378,8 @@ void ResourceImporterScene::show_advanced_options(const String &p_path) {
 	SceneImportSettingsDialog::get_singleton()->open_settings(p_path, _scene_import_type);
 }
 
-ResourceImporterScene::ResourceImporterScene(const String &p_scene_import_type, bool p_singleton) {
-	// This should only be set through the EditorNode.
-	if (p_singleton) {
-		if (p_scene_import_type == "AnimationLibrary") {
-			animation_singleton = this;
-		} else if (p_scene_import_type == "PackedScene") {
-			scene_singleton = this;
-		}
-	}
-
+ResourceImporterScene::ResourceImporterScene(const String &p_scene_import_type) {
 	_scene_import_type = p_scene_import_type;
-}
-
-ResourceImporterScene::~ResourceImporterScene() {
-	if (animation_singleton == this) {
-		animation_singleton = nullptr;
-	}
-	if (scene_singleton == this) {
-		scene_singleton = nullptr;
-	}
 }
 
 void ResourceImporterScene::add_scene_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -157,9 +157,6 @@ class ResourceImporterScene : public ResourceImporter {
 	static Vector<Ref<EditorSceneFormatImporter>> scene_importers;
 	static Vector<Ref<EditorScenePostImportPlugin>> post_importer_plugins;
 
-	static ResourceImporterScene *scene_singleton;
-	static ResourceImporterScene *animation_singleton;
-
 	enum LightBakeMode {
 		LIGHT_BAKE_DISABLED,
 		LIGHT_BAKE_STATIC,
@@ -237,8 +234,6 @@ class ResourceImporterScene : public ResourceImporter {
 
 public:
 	static const String material_extension[3];
-	static ResourceImporterScene *get_scene_singleton() { return scene_singleton; }
-	static ResourceImporterScene *get_animation_singleton() { return animation_singleton; }
 
 	static void add_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority = false);
 	static void remove_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin);
@@ -301,8 +296,7 @@ public:
 	virtual bool has_advanced_options() const override;
 	virtual void show_advanced_options(const String &p_path) override;
 
-	ResourceImporterScene(const String &p_scene_import_type = "PackedScene", bool p_singleton = false);
-	~ResourceImporterScene();
+	ResourceImporterScene(const String &p_scene_import_type = "PackedScene");
 
 	template <typename M>
 	static Vector<Ref<Shape3D>> get_collision_shapes(const Ref<ImporterMesh> &p_mesh, const M &p_options, float p_applied_root_scale);

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -204,6 +204,7 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	HashMap<StringName, Variant> defaults;
 
 	SceneImportSettingsData *scene_import_settings_data = nullptr;
+	ResourceImporterScene *_resource_importer_scene = nullptr;
 
 	void _re_import();
 
@@ -234,7 +235,6 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 
 	void _load_default_subresource_settings(HashMap<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category);
 
-	bool editing_animation = false;
 	bool generate_collider = false;
 
 	Timer *update_view_timer = nullptr;
@@ -244,7 +244,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	bool is_editing_animation() const { return editing_animation; }
+	ResourceImporterScene *get_resource_importer_scene() const { return _resource_importer_scene; }
 	void request_generate_collider();
 	void update_view();
 	void open_settings(const String &p_path, const String &p_scene_import_type = "PackedScene");

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -57,7 +57,7 @@ namespace TestGltf {
 static Node *gltf_import(const String &p_file) {
 	// Setting up importers.
 	Ref<ResourceImporterScene> import_scene;
-	import_scene.instantiate("PackedScene", true);
+	import_scene.instantiate("PackedScene");
 	ResourceFormatImporter::get_singleton()->add_importer(import_scene);
 	Ref<EditorSceneFormatImporterGLTF> import_gltf;
 	import_gltf.instantiate();


### PR DESCRIPTION
This PR continues the work that https://github.com/godotengine/godot/pull/87787 started.

In the current master, `ResourceImporterScene` has two singletons registered, one for importing as Scene and one for importing as AnimationLibrary. These were created by `EditorNode`, which used a boolean to indicate that these should become singletons. The singletons were only ever used in one place, by `SceneImportSettingsDialog`, which had a lot of code duplication for choosing between the singletons. The only other usage of `ResourceImporterScene` is in the tests.

The existing code is quite a mess of spaghetti, and makes it harder for us to add non-scene-or-animation import types. Luckily, the fix is fairly straightforward: Get rid of the singletons, and make `SceneImportSettingsDialog` instead work with its own local copy of `ResourceImporterScene`, configuring it as needed. This was always the goal before I opened https://github.com/godotengine/godot/pull/87787, I just didn't prioritize this before now.