### PR TITLE
Editor: Update inspector group toggles visually

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -448,6 +448,7 @@ public:
 	void reset_timer();
 	void set_checkable(const String &p_related_check_property, bool p_hide_feature);
 	void set_checked(bool p_checked);
+	bool is_checked() const { return checked; }
 
 	bool has_revertable_properties() const;
 	void property_can_revert_changed(const String &p_path, bool p_can_revert);
@@ -646,6 +647,8 @@ class EditorInspector : public ScrollContainer {
 	HashMap<StringName, List<EditorProperty *>> editor_property_map;
 	List<EditorInspectorSection *> sections;
 	HashSet<StringName> pending;
+
+	HashMap<StringName, EditorInspectorSection *> _toggle_sections;
 
 	void _clear(bool p_hide_plugins = true);
 	Object *object = nullptr;


### PR DESCRIPTION
Currently, properties using `PROPERTY_HINT_GROUP_ENABLE` for inspector sections do not update their visual state (checkbox and folding) immediately when changed by external scripts (e.g., `@tool` scripts). This is because these properties do not create an EditorProperty instance, thus bypassing the standard update mechanism based on `editor_property_map`.

This commit introduces a new `_toggle_sections` HashMap in `EditorInspector` to specifically track and update these sections. When a property change is requested or during auto-refresh, if the property is a section toggle, its associated `EditorInspectorSection` will now be updated directly.

Fixes: #107826 