### PR TITLE
Add link to the main GitHub repo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Official binaries for the Godot editor and the export templates can be found
 
 ### Compiling from source
 
-[See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
+Get the source code from the official [GitHub repository](https://github.com/godotengine/godot). [See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
 for compilation instructions for every supported platform.
 
 ## Community and contributing


### PR DESCRIPTION
It's useful when you're viewing the README in a fork, mirror or locally.