### PR TITLE
Add `is_exiting` to the `EditorInterface`

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -264,6 +264,12 @@
 				Shows the given property on the given [param object] in the editor's Inspector dock. If [param inspector_only] is [code]true[/code], plugins will not attempt to edit [param object].
 			</description>
 		</method>
+		<method name="is_exiting" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the editor is currently exiting.
+			</description>
+		</method>
 		<method name="is_multi_window_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -72,6 +72,10 @@
 
 EditorInterface *EditorInterface::singleton = nullptr;
 
+bool EditorInterface::is_exiting() const {
+	return EditorNode::get_singleton()->is_exiting();
+}
+
 void EditorInterface::restart_editor(bool p_save) {
 	if (p_save) {
 		EditorNode::get_singleton()->save_all_scenes();
@@ -848,6 +852,7 @@ void EditorInterface::get_argument_options(const StringName &p_function, int p_i
 // Base.
 
 void EditorInterface::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("is_exiting"), &EditorInterface::is_exiting);
 	ClassDB::bind_method(D_METHOD("restart_editor", "save"), &EditorInterface::restart_editor, DEFVAL(true));
 
 	// Editor tools.

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -96,6 +96,7 @@ protected:
 public:
 	static EditorInterface *get_singleton() { return singleton; }
 
+	bool is_exiting() const;
 	void restart_editor(bool p_save = true);
 
 	// Editor tools.


### PR DESCRIPTION
There are some corner cases where an `EditorPlugin` may need to know whether the editor is currently in an exit sequence, and to perform some different behavior in this case. There is currently no reliable way to infer that state without resorting to scene node hacks to check for various things such as "is editor base control dimmed".