### PR TITLE
Expose `ScriptEditor.clear_docs_from_script`

### DIFF
--- a/doc/classes/ScriptEditor.xml
+++ b/doc/classes/ScriptEditor.xml
@@ -10,6 +10,14 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="clear_docs_from_script">
+			<return type="void" />
+			<param index="0" name="script" type="Script" />
+			<description>
+				Removes the documentation for the given [param script].
+				[b]Note:[/b] This should be called whenever the script is changed to keep the open documentation state up to date.
+			</description>
+		</method>
 		<method name="get_breakpoints">
 			<return type="PackedStringArray" />
 			<description>
@@ -103,7 +111,7 @@
 			<return type="void" />
 			<param index="0" name="script" type="Script" />
 			<description>
-				Updates the documentation for the given [param script] if the script's documentation is currently open.
+				Updates the documentation for the given [param script].
 				[b]Note:[/b] This should be called whenever the script is changed to keep the open documentation state up to date.
 			</description>
 		</method>

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -4153,6 +4153,7 @@ void ScriptEditor::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("goto_help", "topic"), &ScriptEditor::goto_help);
 	ClassDB::bind_method(D_METHOD("update_docs_from_script", "script"), &ScriptEditor::update_docs_from_script);
+	ClassDB::bind_method(D_METHOD("clear_docs_from_script", "script"), &ScriptEditor::clear_docs_from_script);
 
 	ADD_SIGNAL(MethodInfo("editor_script_changed", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));


### PR DESCRIPTION
As the `ScriptEditor` presently allows an EditorPlugin to call `update_docs_from_script`, it seems reasonable to also allow plugins to call the sibling method `clear_docs_from_script` to remove documentation tabs if opened.