### PR TITLE
Fix LSP symbol lookup failing due to skipping a character

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -672,8 +672,10 @@ String ExtendGDScriptParser::get_text_for_lookup_symbol(const LSP::Position &p_c
 			String last_part = line.substr(p_cursor.character, lines[i].length());
 			if (!p_symbol.is_empty()) {
 				String left_cursor_text;
-				for (int c = p_cursor.character - 1; c >= 0; c--) {
-					left_cursor_text = line.substr(c, p_cursor.character - c);
+				int start_offset = MIN(p_cursor.character, line.length() - 1);
+				for (int c = start_offset; c >= 0; c--) {
+					// Consider everything until the cursor position + the character at the cursor itself
+					left_cursor_text = line.substr(c, start_offset - c + 1);
 					if (p_symbol.begins_with(left_cursor_text)) {
 						first_part = line.substr(0, c);
 						first_part += p_symbol;


### PR DESCRIPTION
This bug occurs when resolving a completion item (`completionItem/resolve`) and the cursor position reported by the LSP client is at the start of the completed item.

In that case `get_text_for_lookup_symbol()` will skip the character the cursor is placed on, thus never finds a string matching the given symbol name and causes the lookup to fail. This in turn prevents documentation for the completed symbol from showing up.

This scenario may occur with clients that have completion auto-insertion enabled, i.e. selecting a completion inserts it immediately.
In that scenario, the cursor position is technically at the first character of the completed item until the user starts typing again, implicitly accepting the completion.

It seemed like only functions were affected by this bug. Constants and members seemed to work fine.

Example (cursor position is indicated by `|`):
```gdscript
node.|
# Now the completion list appears and we cycle through and select add_child()

# Visual cursor position is at the end, but reported cursor position is at the beginning
node.a|dd_child(
```
