### PR TITLE
GLTF: MultiMeshInstance3D import

### DIFF
--- a/doc/classes/ImporterMeshInstance3D.xml
+++ b/doc/classes/ImporterMeshInstance3D.xml
@@ -13,6 +13,8 @@
 		</member>
 		<member name="mesh" type="ImporterMesh" setter="set_mesh" getter="get_mesh">
 		</member>
+		<member name="multimesh" type="MultiMesh" setter="set_multimesh" getter="get_multimesh">
+		</member>
 		<member name="skeleton_path" type="NodePath" setter="set_skeleton_path" getter="get_skeleton_path" default="NodePath(&quot;&quot;)">
 		</member>
 		<member name="skin" type="Skin" setter="set_skin" getter="get_skin">

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -40,6 +40,7 @@
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/multimesh_instance_3d.h"
 #include "scene/3d/navigation/navigation_region_3d.h"
 #include "scene/3d/occluder_instance_3d.h"
 #include "scene/3d/physics/area_3d.h"
@@ -689,6 +690,29 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 					mat->set_name(_fixstr(mat->get_name(), "vcol"));
 				}
 			}
+		}
+	}
+
+	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
+		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
+
+		if (mi->get_multimesh().is_valid()){
+
+			Ref<MultiMesh> mm = mi->get_multimesh();
+			Ref<ImporterMesh> mesh = mi->get_mesh();
+
+			if (mesh.is_valid()){
+				mm->set_mesh(mesh->get_mesh());
+			}
+
+			MultiMeshInstance3D *mm_node = memnew(MultiMeshInstance3D);
+			mm_node->set_multimesh(mm);
+			mm_node->set_name(name);
+			_copy_meta(p_node, mm_node);
+			p_node->replace_by(mm_node);
+			p_node->set_owner(nullptr);
+			memdelete(p_node);
+			p_node = mm_node;
 		}
 	}
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -697,7 +697,6 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 
 		if (mi->get_multimesh().is_valid()) {
-
 			Ref<MultiMesh> mm = mi->get_multimesh();
 			Ref<ImporterMesh> mesh = mi->get_mesh();
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -696,12 +696,12 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
 
-		if (mi->get_multimesh().is_valid()){
+		if (mi->get_multimesh().is_valid()) {
 
 			Ref<MultiMesh> mm = mi->get_multimesh();
 			Ref<ImporterMesh> mesh = mi->get_mesh();
 
-			if (mesh.is_valid()){
+			if (mesh.is_valid()) {
 				mm->set_mesh(mesh->get_mesh());
 			}
 

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2614,6 +2614,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 
 		MultiMeshInstance3D *mm_node = memnew(MultiMeshInstance3D);
 		mm_node->set_multimesh(mm);
+		mm_node->set_transform(src_mesh_node->get_transform());
 		mm_node->set_name(src_mesh_node->get_name());
 		_copy_meta(p_node, mm_node);
 		p_node->replace_by(mm_node);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -40,6 +40,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
+#include "scene/3d/multimesh_instance_3d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/subviewport_container.h"
 #include "scene/main/timer.h"
@@ -468,6 +469,15 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_fill_scene(p_node->get_child(i), item);
 	}
+
+	MultiMeshInstance3D *multimesh_node = Object::cast_to<MultiMeshInstance3D>(p_node);
+	if (multimesh_node) {
+		Ref<MultiMesh> multimesh = multimesh_node->get_multimesh();
+		if (multimesh.is_valid() && multimesh->get_mesh().is_valid()) {
+			_fill_mesh(scene_tree, multimesh->get_mesh(), item);
+		}
+	}
+
 	MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(p_node);
 	if (mesh_node && mesh_node->get_mesh().is_valid()) {
 		// This controls the display of mesh resources in the import settings dialog tree (the white mesh icon).

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -27,21 +27,6 @@
 				The argument should be the [GLTFDocumentExtension] name (does not have to match the extension name in the glTF file), and the return value can be anything you set. If nothing was set, the return value is [code]null[/code].
 			</description>
 		</method>
-		<method name="get_multimesh_rotation">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="get_multimesh_scale">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="get_multimesh_translation">
-			<return type="int" />
-			<description>
-			</description>
-		</method>
 		<method name="get_scene_node_path">
 			<return type="NodePath" />
 			<param index="0" name="gltf_state" type="GLTFState" />
@@ -60,24 +45,6 @@
 				The first argument should be the [GLTFDocumentExtension] name (does not have to match the extension name in the glTF file), and the second argument can be anything you want.
 			</description>
 		</method>
-		<method name="set_multimesh_rotation">
-			<return type="void" />
-			<param index="0" name="multimesh_rotation" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="set_multimesh_scale">
-			<return type="void" />
-			<param index="0" name="multimesh_scale" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="set_multimesh_translation">
-			<return type="void" />
-			<param index="0" name="multimesh_translation" type="int" />
-			<description>
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="camera" type="int" setter="set_camera" getter="get_camera" default="-1">
@@ -94,6 +61,15 @@
 		</member>
 		<member name="mesh" type="int" setter="set_mesh" getter="get_mesh" default="-1">
 			If this glTF node is a mesh, the index of the [GLTFMesh] in the [GLTFState] that describes the mesh's properties. If -1, this node is not a mesh.
+		</member>
+		<member name="multimesh_rotation" type="int" setter="set_multimesh_rotation" getter="get_multimesh_rotation" default="-1">
+			The index of accessor for multimesh instances rotations. If -1, there is no accessor.
+		</member>
+		<member name="multimesh_scale" type="int" setter="set_multimesh_scale" getter="get_multimesh_scale" default="-1">
+			The index of accessor for multimesh instances scales. If -1, there is no accessor.
+		</member>
+		<member name="multimesh_translation" type="int" setter="set_multimesh_translation" getter="get_multimesh_translation" default="-1">
+			The index of accessor for multimesh instances translations. If -1, there is no accessor.
 		</member>
 		<member name="original_name" type="String" setter="set_original_name" getter="get_original_name" default="&quot;&quot;">
 			The original name of the node.

--- a/modules/gltf/doc_classes/GLTFNode.xml
+++ b/modules/gltf/doc_classes/GLTFNode.xml
@@ -27,6 +27,21 @@
 				The argument should be the [GLTFDocumentExtension] name (does not have to match the extension name in the glTF file), and the return value can be anything you set. If nothing was set, the return value is [code]null[/code].
 			</description>
 		</method>
+		<method name="get_multimesh_rotation">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_multimesh_scale">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_multimesh_translation">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="get_scene_node_path">
 			<return type="NodePath" />
 			<param index="0" name="gltf_state" type="GLTFState" />
@@ -43,6 +58,24 @@
 			<description>
 				Sets additional arbitrary data in this [GLTFNode] instance. This can be used to keep per-node state data in [GLTFDocumentExtension] classes, which is important because they are stateless.
 				The first argument should be the [GLTFDocumentExtension] name (does not have to match the extension name in the glTF file), and the second argument can be anything you want.
+			</description>
+		</method>
+		<method name="set_multimesh_rotation">
+			<return type="void" />
+			<param index="0" name="multimesh_rotation" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="set_multimesh_scale">
+			<return type="void" />
+			<param index="0" name="multimesh_scale" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="set_multimesh_translation">
+			<return type="void" />
+			<param index="0" name="multimesh_translation" type="int" />
+			<description>
 			</description>
 		</method>
 	</methods>

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.cpp
@@ -46,7 +46,6 @@ void GLTFDocumentExtensionConvertImporterMesh::_copy_meta(Object *p_src_object, 
 
 Node3D *GLTFDocumentExtensionConvertImporterMesh::convert_importer_mesh_instance_3d(ImporterMeshInstance3D *p_importer_mesh_instance_3d) {
 	if (p_importer_mesh_instance_3d && p_importer_mesh_instance_3d->get_multimesh().is_valid()) {
-
 		Ref<MultiMesh> mm = p_importer_mesh_instance_3d->get_multimesh();
 		Ref<ImporterMesh> mesh = p_importer_mesh_instance_3d->get_mesh();
 

--- a/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.h
+++ b/modules/gltf/extensions/gltf_document_extension_convert_importer_mesh.h
@@ -41,6 +41,6 @@ protected:
 	static void _copy_meta(Object *p_src_object, Object *p_dst_object);
 
 public:
-	static MeshInstance3D *convert_importer_mesh_instance_3d(ImporterMeshInstance3D *p_importer_mesh_instance_3d);
+	static Node3D *convert_importer_mesh_instance_3d(ImporterMeshInstance3D *p_importer_mesh_instance_3d);
 	Error import_post(Ref<GLTFState> p_state, Node *p_root) override;
 };

--- a/modules/gltf/extensions/gltf_document_extension_mesh_gpu_instancing.cpp
+++ b/modules/gltf/extensions/gltf_document_extension_mesh_gpu_instancing.cpp
@@ -1,0 +1,251 @@
+/**************************************************************************/
+/*  gltf_document_extension_mesh_gpu_instancing.cpp                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gltf_document_extension_mesh_gpu_instancing.h"
+
+#include "../gltf_document.h"
+#include "scene/3d/multimesh_instance_3d.h"
+
+Ref<MultiMesh> GLTFDocumentExtensionMeshGPUInstancing::_generate_multimesh(Ref<GLTFState> p_state, Dictionary &p_extensions) {
+	if (!p_extensions.has("EXT_mesh_gpu_instancing")) {
+		return nullptr;
+	}
+
+	Dictionary mesh_gpu_instancing = p_extensions["EXT_mesh_gpu_instancing"];
+	if (!mesh_gpu_instancing.has("attributes")) {
+		return nullptr;
+	}
+
+	Dictionary instancing_attributes = mesh_gpu_instancing["attributes"];
+
+	int instances_count = 0;
+	PackedVector3Array translations;
+	Vector<Quaternion> rotations;
+	PackedVector3Array scales;
+
+	TypedArray<Ref<GLTFAccessor>> state_accessors = p_state->get_accessors();
+	TypedArray<Ref<GLTFBufferView>> state_buffer_views = p_state->get_buffer_views();
+	TypedArray<PackedByteArray> state_buffers = p_state->get_buffers();
+
+	if (instancing_attributes.has("TRANSLATION")) {
+		int multimesh_translation = instancing_attributes["TRANSLATION"];
+		Ref<GLTFAccessor> accessor = state_accessors[multimesh_translation];
+		if (instances_count && instances_count != accessor->get_count()) {
+			ERR_PRINT(vformat("glTF import: translation instances_count: %i", accessor->get_count()));
+			return nullptr;
+		}
+
+		instances_count = accessor->get_count();
+		translations = accessor->decode_as_vector3s(p_state);
+	}
+
+	if (instancing_attributes.has("ROTATION")) {
+		int multimesh_rotation = instancing_attributes["ROTATION"];
+		Ref<GLTFAccessor> accessor = state_accessors[multimesh_rotation];
+		if (instances_count && instances_count != accessor->get_count()) {
+			ERR_PRINT(vformat("glTF import: rotation instances_count: %i", accessor->get_count()));
+			return nullptr;
+		}
+
+		instances_count = accessor->get_count();
+		rotations = accessor->decode_as_quaternions(p_state);
+	}
+
+	if (instancing_attributes.has("SCALE")) {
+		int multimesh_scale = instancing_attributes["SCALE"];
+		Ref<GLTFAccessor> accessor = state_accessors[multimesh_scale];
+		if (instances_count && instances_count != accessor->get_count()) {
+			ERR_PRINT(vformat("glTF import: scale instances_count: %i", accessor->get_count()));
+			return nullptr;
+		}
+		instances_count = accessor->get_count();
+
+		scales = accessor->decode_as_vector3s(p_state);
+	}
+
+	Ref<MultiMesh> multimesh = memnew(MultiMesh);
+	multimesh->set_instance_count(0);
+	multimesh->set_transform_format(MultiMesh::TRANSFORM_3D);
+	multimesh->set_instance_count(instances_count);
+
+	for (int i = 0; i < instances_count; i++) {
+		Transform3D tr;
+
+		if (translations.size()) {
+			tr = tr.translated(translations[i]);
+		}
+
+		if (rotations.size()) {
+			tr.set_basis(Basis(rotations[i]));
+		}
+
+		if (scales.size()) {
+			tr.scale_basis(scales[i]);
+		}
+
+		multimesh->set_instance_transform(i, tr);
+	}
+
+	return multimesh;
+}
+
+Error GLTFDocumentExtensionMeshGPUInstancing::import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions) {
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	Error err = OK;
+
+	if (p_extensions.has("EXT_mesh_gpu_instancing")) {
+		// TODO ?
+	}
+
+	return err;
+}
+
+Node3D *GLTFDocumentExtensionMeshGPUInstancing::generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent) {
+	ERR_FAIL_COND_V(p_state.is_null(), nullptr);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), nullptr);
+	Node3D *ret_node = nullptr;
+
+	// TODO actual creation?
+
+	return ret_node;
+}
+
+Error GLTFDocumentExtensionMeshGPUInstancing::import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_dict, Node *p_node) {
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
+
+	if (!r_dict.has("extensions")) {
+		return OK;
+	}
+
+	Dictionary extensions = r_dict["extensions"];
+	if (!extensions.has("EXT_mesh_gpu_instancing")) {
+		return OK;
+	}
+
+	ImporterMeshInstance3D *mi = Object::cast_to<ImporterMeshInstance3D>(p_node);
+	if (!mi) {
+		return OK;
+	}
+
+	Ref<MultiMesh> multimesh = _generate_multimesh(p_state, extensions);
+	if (multimesh.is_valid()) {
+		if (mi->get_mesh().is_valid()) {
+			multimesh->set_mesh(mi->get_mesh());
+		}
+
+		mi->set_multimesh(multimesh);
+	}
+
+	Error err = OK;
+	return err;
+}
+
+Error GLTFDocumentExtensionMeshGPUInstancing::export_preflight(Ref<GLTFState> p_state, Node *p_root) {
+	ERR_FAIL_NULL_V(p_root, ERR_INVALID_PARAMETER);
+
+	p_state->set_ignore_multimesh_instances(true);
+
+	return OK;
+}
+
+void GLTFDocumentExtensionMeshGPUInstancing::convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) {
+	ERR_FAIL_COND(p_state.is_null());
+	ERR_FAIL_COND(p_gltf_node.is_null());
+	ERR_FAIL_NULL(p_scene_node);
+
+	MultiMeshInstance3D *multi_mesh_instance = Object::cast_to<MultiMeshInstance3D>(p_scene_node);
+	if (!multi_mesh_instance) {
+		return;
+	}
+
+	GLTFMeshIndex mesh_index = GLTFDocument::_convert_multimesh_to_gltf(p_state, multi_mesh_instance);
+	p_gltf_node->set_mesh(mesh_index);
+
+	Ref<MultiMesh> multi_mesh = multi_mesh_instance->get_multimesh();
+	if (!multi_mesh.is_valid()) {
+		return;
+	}
+
+	// TODO 2D?
+	if (multi_mesh->get_transform_format() != MultiMesh::TRANSFORM_3D) {
+		return;
+	}
+
+	///////////////////////////////////////////////////////////////////////////
+
+	Vector<Vector3> translation;
+	Vector<Quaternion> rotation;
+	Vector<Vector3> scale;
+
+	for (int32_t instance_i = 0; instance_i < multi_mesh->get_instance_count(); instance_i++) {
+		Transform3D transform = multi_mesh->get_instance_transform(instance_i);
+		translation.push_back(transform.get_origin());
+		rotation.push_back(transform.get_basis().get_rotation_quaternion());
+		scale.push_back(transform.get_basis().get_scale());
+	}
+
+	Dictionary instancing_attributes;
+	instancing_attributes["TRANSLATION"] = GLTFAccessor::encode_new_accessor_from_vector3s(p_state, translation, GLTFBufferView::TARGET_ARRAY_BUFFER, false);
+	instancing_attributes["ROTATION"] = GLTFAccessor::encode_new_accessor_from_quaternions(p_state, rotation, GLTFBufferView::TARGET_ARRAY_BUFFER, false);
+	instancing_attributes["SCALE"] = GLTFAccessor::encode_new_accessor_from_vector3s(p_state, scale, GLTFBufferView::TARGET_ARRAY_BUFFER, false);
+
+	Dictionary mesh_gpu_instancing;
+	mesh_gpu_instancing["attributes"] = instancing_attributes;
+
+	///////////////////////////////////////////////////////////////////////////
+
+	p_gltf_node->set_additional_data("EXT_mesh_gpu_instancing", mesh_gpu_instancing);
+}
+
+Error GLTFDocumentExtensionMeshGPUInstancing::export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node) {
+	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
+	ERR_FAIL_COND_V(p_gltf_node.is_null(), ERR_INVALID_PARAMETER);
+
+	MultiMeshInstance3D *multi_mesh_instance = Object::cast_to<MultiMeshInstance3D>(p_node);
+
+	if (!multi_mesh_instance) {
+		return OK;
+	}
+
+	if (p_gltf_node->has_additional_data("EXT_mesh_gpu_instancing")) {
+		Dictionary mesh_gpu_instancing = p_gltf_node->get_additional_data("EXT_mesh_gpu_instancing");
+
+		if (!r_json.has("extensions")) {
+			r_json["extensions"] = Dictionary();
+		}
+		Dictionary extensions = r_json["extensions"];
+		extensions["EXT_mesh_gpu_instancing"] = mesh_gpu_instancing;
+	}
+
+	Error err = OK;
+	return err;
+}

--- a/modules/gltf/extensions/gltf_document_extension_mesh_gpu_instancing.h
+++ b/modules/gltf/extensions/gltf_document_extension_mesh_gpu_instancing.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  gltf_document_extension_mesh_gpu_instancing.h                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "gltf_document_extension.h"
+#include "scene/resources/mesh.h"
+
+class GLTFDocumentExtensionMeshGPUInstancing : public GLTFDocumentExtension {
+	GDCLASS(GLTFDocumentExtensionMeshGPUInstancing, GLTFDocumentExtension);
+
+protected:
+	Ref<MultiMesh> _generate_multimesh(Ref<GLTFState> p_state, Dictionary &p_extensions);
+
+public:
+	Error import_preflight(Ref<GLTFState> p_state, const Vector<String> &p_extensions);
+	Node3D *generate_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_parent);
+	Error import_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node) override;
+
+	Error export_preflight(Ref<GLTFState> p_state, Node *p_root) override;
+	void convert_scene_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Node *p_scene_node) override;
+	Error export_node(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node, Dictionary &r_json, Node *p_node) override;
+};

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -657,23 +657,6 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 				}
 			}
 
-			if (extensions.has("EXT_mesh_gpu_instancing")) {
-				Dictionary mesh_gpu_instancing = extensions["EXT_mesh_gpu_instancing"];
-				if (mesh_gpu_instancing.has("attributes")) {
-					Dictionary instancing_attributes = mesh_gpu_instancing["attributes"];
-
-					if (instancing_attributes.has("TRANSLATION")) {
-						node->multimesh_translation = instancing_attributes["TRANSLATION"];
-					}
-					if (instancing_attributes.has("ROTATION")) {
-						node->multimesh_rotation = instancing_attributes["ROTATION"];
-					}
-					if (instancing_attributes.has("SCALE")) {
-						node->multimesh_scale = instancing_attributes["SCALE"];
-					}
-				}
-			}
-
 			for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 				ERR_CONTINUE(ext.is_null());
 				Error err = ext->parse_node_extensions(p_state, node, extensions);
@@ -4129,6 +4112,44 @@ GLTFMeshIndex GLTFDocument::_convert_mesh_to_gltf(Ref<GLTFState> p_state, MeshIn
 	return mesh_i;
 }
 
+GLTFMeshIndex GLTFDocument::_convert_multimesh_to_gltf(Ref<GLTFState> p_state, MultiMeshInstance3D *p_multi_mesh_instance) {
+	ERR_FAIL_NULL_V(p_multi_mesh_instance, -1);
+	// TODO missing checks
+
+	Ref<MultiMesh> multi_mesh = p_multi_mesh_instance->get_multimesh();
+	Ref<Mesh> mesh_resource = multi_mesh->get_mesh();
+
+	TypedArray<Material> instance_materials;
+	for (int32_t surface_i = 0; surface_i < mesh_resource->get_surface_count(); surface_i++) {
+		// TODO consider override?
+		Ref<Material> mat = mesh_resource->surface_get_material(surface_i);
+
+		instance_materials.append(mat);
+	}
+
+	Ref<ImporterMesh> current_mesh = _mesh_to_importer_mesh(mesh_resource);
+	Vector<float> blend_weights;
+	int32_t blend_count = mesh_resource->get_blend_shape_count();
+	blend_weights.resize(blend_count);
+	for (int32_t blend_i = 0; blend_i < blend_count; blend_i++) {
+		blend_weights.write[blend_i] = 0.0f;
+	}
+
+	Ref<GLTFMesh> gltf_mesh;
+	gltf_mesh.instantiate();
+	if (!mesh_resource->get_name().is_empty()) {
+		gltf_mesh->set_original_name(mesh_resource->get_name());
+		gltf_mesh->set_name(_gen_unique_name_static(p_state->unique_names, mesh_resource->get_name()));
+	}
+	gltf_mesh->set_instance_materials(instance_materials);
+	gltf_mesh->set_mesh(current_mesh);
+	gltf_mesh->set_blend_weights(blend_weights);
+	GLTFMeshIndex mesh_i = p_state->meshes.size();
+	p_state->meshes.push_back(gltf_mesh);
+
+	return mesh_i;
+}
+
 ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index) {
 	Ref<GLTFNode> gltf_node = p_state->nodes[p_node_index];
 
@@ -4136,13 +4157,6 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 
 	ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
 	print_verbose("glTF: Creating mesh for: " + gltf_node->get_name());
-
-	if (gltf_node->multimesh_translation >= 0 || gltf_node->multimesh_rotation >= 0 || gltf_node->multimesh_scale >= 0) {
-		Ref<MultiMesh> multimesh = _generate_multimesh(p_state, gltf_node);
-		if (multimesh.is_valid()) {
-			mi->set_multimesh(multimesh);
-		}
-	}
 
 	p_state->scene_mesh_instances.insert(p_node_index, mi);
 	Ref<GLTFMesh> mesh = p_state->meshes.write[gltf_node->mesh];
@@ -4156,100 +4170,6 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	mi->set_mesh(import_mesh);
 	import_mesh->merge_meta_from(*mesh);
 	return mi;
-}
-
-Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node) {
-	int instances_count = 0;
-	Vector3 *translation_ptr = nullptr;
-	Quaternion *rotation_ptr = nullptr;
-	Vector3 *scale_ptr = nullptr;
-
-	if (p_gltf_node->multimesh_translation >= 0) {
-		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_translation];
-		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
-			ERR_PRINT(vformat("glTF import: Invalid translation accessor_type: %i", accessor->accessor_type));
-			return nullptr;
-		}
-		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
-			ERR_PRINT(vformat("glTF import: Invalid translation component_type: %i", accessor->component_type));
-			return nullptr;
-		}
-		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
-		translation_ptr = (Vector3 *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
-
-		if (instances_count && instances_count != accessor->get_count()) {
-			ERR_PRINT(vformat("glTF import: translation instances_count: %i", accessor->get_count()));
-			return nullptr;
-		}
-		instances_count = accessor->get_count();
-	}
-
-	if (p_gltf_node->multimesh_rotation >= 0) {
-		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_rotation];
-		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC4) {
-			ERR_PRINT(vformat("glTF import: Invalid rotation accessor_type: %i", accessor->accessor_type));
-			return nullptr;
-		}
-		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
-			ERR_PRINT(vformat("glTF import: Invalid rotation component_type: %i", accessor->component_type));
-			return nullptr;
-		}
-
-		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
-		rotation_ptr = (Quaternion *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
-
-		if (instances_count && instances_count != accessor->get_count()) {
-			ERR_PRINT(vformat("glTF import: rotation instances_count: %i", accessor->get_count()));
-			return nullptr;
-		}
-		instances_count = accessor->get_count();
-	}
-
-	if (p_gltf_node->multimesh_scale >= 0) {
-		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_scale];
-		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
-			ERR_PRINT(vformat("glTF import: Invalid scale accessor_type: %i", accessor->accessor_type));
-			return nullptr;
-		}
-		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
-			ERR_PRINT(vformat("glTF import: Invalid scale component_type: %i", accessor->component_type));
-			return nullptr;
-		}
-
-		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
-		scale_ptr = (Vector3 *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
-
-		if (instances_count && instances_count != accessor->get_count()) {
-			ERR_PRINT(vformat("glTF import: scale instances_count: %i", accessor->get_count()));
-			return nullptr;
-		}
-		instances_count = accessor->get_count();
-	}
-
-	Ref<MultiMesh> multimesh = memnew(MultiMesh);
-	multimesh->set_instance_count(0);
-	multimesh->set_transform_format(MultiMesh::TRANSFORM_3D);
-	multimesh->set_instance_count(instances_count);
-
-	for (int i = 0; i < instances_count; i++) {
-		Transform3D tr;
-
-		if (translation_ptr) {
-			tr = tr.translated(translation_ptr[i]);
-		}
-
-		if (rotation_ptr) {
-			tr.set_basis(Basis(rotation_ptr[i]));
-		}
-
-		if (scale_ptr) {
-			tr.scale_basis(scale_ptr[i]);
-		}
-
-		multimesh->set_instance_transform(i, tr);
-	}
-
-	return multimesh;
 }
 
 Light3D *GLTFDocument::_generate_light(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index) {
@@ -4341,7 +4261,7 @@ void GLTFDocument::_convert_scene_node(Ref<GLTFState> p_state, Node *p_current, 
 		_convert_skeleton_to_gltf(skel, p_state, p_gltf_parent, p_gltf_root, gltf_node);
 		// We ignore the Godot Engine node that is the skeleton.
 		return;
-	} else if (Object::cast_to<MultiMeshInstance3D>(p_current)) {
+	} else if (Object::cast_to<MultiMeshInstance3D>(p_current) && !p_state->get_ignore_multimesh_instances()) {
 		MultiMeshInstance3D *multi = Object::cast_to<MultiMeshInstance3D>(p_current);
 		_convert_multi_mesh_instance_to_gltf(multi, p_gltf_parent, p_gltf_root, gltf_node, p_state);
 #ifdef MODULE_CSG_ENABLED

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -657,20 +657,20 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 				}
 			}
 
-            if (extensions.has("EXT_mesh_gpu_instancing")){
-                Dictionary mesh_gpu_instancing = extensions["EXT_mesh_gpu_instancing"];
+			if (extensions.has("EXT_mesh_gpu_instancing")){
+				Dictionary mesh_gpu_instancing = extensions["EXT_mesh_gpu_instancing"];
 				if (mesh_gpu_instancing.has("attributes")){
 					Dictionary instancing_attributes = mesh_gpu_instancing["attributes"];
 
-					if (instancing_attributes.has("TRANSLATION")){
+					if (instancing_attributes.has("TRANSLATION")) {
 						int instancing_translation = instancing_attributes["TRANSLATION"];
 						node->multimesh_translation = instancing_attributes["TRANSLATION"];
 					}
-					if (instancing_attributes.has("ROTATION")){
+					if (instancing_attributes.has("ROTATION")) {
 						int instancing_rotation = instancing_attributes["ROTATION"];
 						node->multimesh_rotation = instancing_attributes["ROTATION"];
 					}
-					if (instancing_attributes.has("SCALE")){
+					if (instancing_attributes.has("SCALE")) {
 						int instancing_scale = instancing_attributes["SCALE"];
 						node->multimesh_scale = instancing_attributes["SCALE"];
 					}
@@ -4140,7 +4140,7 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
 	print_verbose("glTF: Creating mesh for: " + gltf_node->get_name());
 
-	if (gltf_node->multimesh_translation >= 0 || gltf_node->multimesh_rotation >= 0 || gltf_node->multimesh_scale >= 0){
+	if (gltf_node->multimesh_translation >= 0 || gltf_node->multimesh_rotation >= 0 || gltf_node->multimesh_scale >= 0) {
 		Ref<MultiMesh> multimesh = _generate_multimesh(p_state, gltf_node);
 		if (multimesh.is_valid()){
 			mi->set_multimesh(multimesh);
@@ -4161,26 +4161,26 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	return mi;
 }
 
-Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node){
+Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node) {
 	int instances_count = 0;
-	Vector3* translation_ptr = nullptr;
-	Quaternion* rotation_ptr = nullptr;
-	Vector3* scale_ptr = nullptr;
+	Vector3 *translation_ptr = nullptr;
+	Quaternion *rotation_ptr = nullptr;
+	Vector3 *scale_ptr = nullptr;
 
-	if (p_gltf_node->multimesh_translation >= 0){
+	if (p_gltf_node->multimesh_translation >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_translation];
 		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3){
 			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i", accessor->accessor_type));
 			return nullptr;
 		}
-		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT){
+		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
 			ERR_PRINT(vformat("glTF import: Invalid component_type: %i" + accessor->component_type));
 			return nullptr;
 		}
 		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
 		translation_ptr = (Vector3*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
-		if (instances_count && instances_count != accessor->get_count()){
+		if (instances_count && instances_count != accessor->get_count()) {
 			ERR_PRINT(vformat("glTF import: instances_count: %i" + accessor->get_count()));
 			return nullptr;
 		}
@@ -4189,11 +4189,11 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 
 	if (p_gltf_node->multimesh_rotation >= 0){
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_rotation];
-		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC4){
+		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC4) {
 			ERR_PRINT(vformat("glTF import: Invalid accessor_type: " + accessor->accessor_type));
 			return nullptr;
 		}
-		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT){
+		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
 			ERR_PRINT(vformat("glTF import: Invalid component_type: %i", accessor->component_type));
 			return nullptr;
 		}
@@ -4210,11 +4210,11 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 
 	if (p_gltf_node->multimesh_scale >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_scale];
-		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3){
+		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
 			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i",accessor->accessor_type));
 			return nullptr;
 		}
-		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT){
+		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
 			ERR_PRINT(vformat("glTF import: Invalid component_type: %i", accessor->component_type));
 			return nullptr;
 		}
@@ -4237,15 +4237,15 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 	for (int i = 0; i < instances_count; i++) {
 		Transform3D tr;
 
-		if (translation_ptr){
+		if (translation_ptr) {
 			tr = tr.translated(translation_ptr[i]);
 		}
 
-		if (rotation_ptr){
+		if (rotation_ptr) {
 			tr.set_basis(Basis(rotation_ptr[i]));
 		}
 
-		if (scale_ptr){
+		if (scale_ptr) {
 			tr.scale_basis(scale_ptr[i]);
 		}
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -657,9 +657,9 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 				}
 			}
 
-			if (extensions.has("EXT_mesh_gpu_instancing")){
+			if (extensions.has("EXT_mesh_gpu_instancing")) {
 				Dictionary mesh_gpu_instancing = extensions["EXT_mesh_gpu_instancing"];
-				if (mesh_gpu_instancing.has("attributes")){
+				if (mesh_gpu_instancing.has("attributes")) {
 					Dictionary instancing_attributes = mesh_gpu_instancing["attributes"];
 
 					if (instancing_attributes.has("TRANSLATION")) {
@@ -4142,7 +4142,7 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 
 	if (gltf_node->multimesh_translation >= 0 || gltf_node->multimesh_rotation >= 0 || gltf_node->multimesh_scale >= 0) {
 		Ref<MultiMesh> multimesh = _generate_multimesh(p_state, gltf_node);
-		if (multimesh.is_valid()){
+		if (multimesh.is_valid()) {
 			mi->set_multimesh(multimesh);
 		}
 	}
@@ -4169,7 +4169,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 
 	if (p_gltf_node->multimesh_translation >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_translation];
-		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3){
+		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
 			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i", accessor->accessor_type));
 			return nullptr;
 		}
@@ -4178,7 +4178,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 			return nullptr;
 		}
 		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
-		translation_ptr = (Vector3*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
+		translation_ptr = (Vector3 *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
 		if (instances_count && instances_count != accessor->get_count()) {
 			ERR_PRINT(vformat("glTF import: instances_count: %i" + accessor->get_count()));
@@ -4187,7 +4187,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 		instances_count = accessor->get_count();
 	}
 
-	if (p_gltf_node->multimesh_rotation >= 0){
+	if (p_gltf_node->multimesh_rotation >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_rotation];
 		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC4) {
 			ERR_PRINT(vformat("glTF import: Invalid accessor_type: " + accessor->accessor_type));
@@ -4199,7 +4199,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 		}
 
 		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
-		rotation_ptr = (Quaternion*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
+		rotation_ptr = (Quaternion *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
 		if (instances_count && instances_count != accessor->get_count()) {
 			ERR_PRINT(vformat("glTF import: instances_count: %i", accessor->get_count()));
@@ -4211,7 +4211,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 	if (p_gltf_node->multimesh_scale >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_scale];
 		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
-			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i",accessor->accessor_type));
+			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i", accessor->accessor_type));
 			return nullptr;
 		}
 		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
@@ -4220,7 +4220,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 		}
 
 		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
-		scale_ptr = (Vector3*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
+		scale_ptr = (Vector3 *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
 		if (instances_count && instances_count != accessor->get_count()) {
 			ERR_PRINT(vformat("glTF import: instances_count: %i", accessor->get_count()));

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -663,15 +663,12 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 					Dictionary instancing_attributes = mesh_gpu_instancing["attributes"];
 
 					if (instancing_attributes.has("TRANSLATION")) {
-						int instancing_translation = instancing_attributes["TRANSLATION"];
 						node->multimesh_translation = instancing_attributes["TRANSLATION"];
 					}
 					if (instancing_attributes.has("ROTATION")) {
-						int instancing_rotation = instancing_attributes["ROTATION"];
 						node->multimesh_rotation = instancing_attributes["ROTATION"];
 					}
 					if (instancing_attributes.has("SCALE")) {
-						int instancing_scale = instancing_attributes["SCALE"];
 						node->multimesh_scale = instancing_attributes["SCALE"];
 					}
 				}
@@ -4170,18 +4167,18 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 	if (p_gltf_node->multimesh_translation >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_translation];
 		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
-			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i", accessor->accessor_type));
+			ERR_PRINT(vformat("glTF import: Invalid translation accessor_type: %i", accessor->accessor_type));
 			return nullptr;
 		}
 		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
-			ERR_PRINT(vformat("glTF import: Invalid component_type: %i" + accessor->component_type));
+			ERR_PRINT(vformat("glTF import: Invalid translation component_type: %i", accessor->component_type));
 			return nullptr;
 		}
 		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
 		translation_ptr = (Vector3 *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
 		if (instances_count && instances_count != accessor->get_count()) {
-			ERR_PRINT(vformat("glTF import: instances_count: %i" + accessor->get_count()));
+			ERR_PRINT(vformat("glTF import: translation instances_count: %i", accessor->get_count()));
 			return nullptr;
 		}
 		instances_count = accessor->get_count();
@@ -4190,11 +4187,11 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 	if (p_gltf_node->multimesh_rotation >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_rotation];
 		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC4) {
-			ERR_PRINT(vformat("glTF import: Invalid accessor_type: " + accessor->accessor_type));
+			ERR_PRINT(vformat("glTF import: Invalid rotation accessor_type: %i", accessor->accessor_type));
 			return nullptr;
 		}
 		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
-			ERR_PRINT(vformat("glTF import: Invalid component_type: %i", accessor->component_type));
+			ERR_PRINT(vformat("glTF import: Invalid rotation component_type: %i", accessor->component_type));
 			return nullptr;
 		}
 
@@ -4202,7 +4199,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 		rotation_ptr = (Quaternion *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
 		if (instances_count && instances_count != accessor->get_count()) {
-			ERR_PRINT(vformat("glTF import: instances_count: %i", accessor->get_count()));
+			ERR_PRINT(vformat("glTF import: rotation instances_count: %i", accessor->get_count()));
 			return nullptr;
 		}
 		instances_count = accessor->get_count();
@@ -4211,11 +4208,11 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 	if (p_gltf_node->multimesh_scale >= 0) {
 		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_scale];
 		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3) {
-			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i", accessor->accessor_type));
+			ERR_PRINT(vformat("glTF import: Invalid scale accessor_type: %i", accessor->accessor_type));
 			return nullptr;
 		}
 		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT) {
-			ERR_PRINT(vformat("glTF import: Invalid component_type: %i", accessor->component_type));
+			ERR_PRINT(vformat("glTF import: Invalid scale component_type: %i", accessor->component_type));
 			return nullptr;
 		}
 
@@ -4223,7 +4220,7 @@ Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLT
 		scale_ptr = (Vector3 *)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
 
 		if (instances_count && instances_count != accessor->get_count()) {
-			ERR_PRINT(vformat("glTF import: instances_count: %i", accessor->get_count()));
+			ERR_PRINT(vformat("glTF import: scale instances_count: %i", accessor->get_count()));
 			return nullptr;
 		}
 		instances_count = accessor->get_count();

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -656,6 +656,27 @@ Error GLTFDocument::_parse_nodes(Ref<GLTFState> p_state) {
 					node->visible = khr_node_visibility["visible"];
 				}
 			}
+
+            if (extensions.has("EXT_mesh_gpu_instancing")){
+                Dictionary mesh_gpu_instancing = extensions["EXT_mesh_gpu_instancing"];
+				if (mesh_gpu_instancing.has("attributes")){
+					Dictionary instancing_attributes = mesh_gpu_instancing["attributes"];
+
+					if (instancing_attributes.has("TRANSLATION")){
+						int instancing_translation = instancing_attributes["TRANSLATION"];
+						node->multimesh_translation = instancing_attributes["TRANSLATION"];
+					}
+					if (instancing_attributes.has("ROTATION")){
+						int instancing_rotation = instancing_attributes["ROTATION"];
+						node->multimesh_rotation = instancing_attributes["ROTATION"];
+					}
+					if (instancing_attributes.has("SCALE")){
+						int instancing_scale = instancing_attributes["SCALE"];
+						node->multimesh_scale = instancing_attributes["SCALE"];
+					}
+				}
+			}
+
 			for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 				ERR_CONTINUE(ext.is_null());
 				Error err = ext->parse_node_extensions(p_state, node, extensions);
@@ -4119,6 +4140,13 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	ImporterMeshInstance3D *mi = memnew(ImporterMeshInstance3D);
 	print_verbose("glTF: Creating mesh for: " + gltf_node->get_name());
 
+	if (gltf_node->multimesh_translation >= 0 || gltf_node->multimesh_rotation >= 0 || gltf_node->multimesh_scale >= 0){
+		Ref<MultiMesh> multimesh = _generate_multimesh(p_state, gltf_node);
+		if (multimesh.is_valid()){
+			mi->set_multimesh(multimesh);
+		}
+	}
+
 	p_state->scene_mesh_instances.insert(p_node_index, mi);
 	Ref<GLTFMesh> mesh = p_state->meshes.write[gltf_node->mesh];
 	if (mesh.is_null()) {
@@ -4131,6 +4159,100 @@ ImporterMeshInstance3D *GLTFDocument::_generate_mesh_instance(Ref<GLTFState> p_s
 	mi->set_mesh(import_mesh);
 	import_mesh->merge_meta_from(*mesh);
 	return mi;
+}
+
+Ref<MultiMesh> GLTFDocument::_generate_multimesh(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node){
+	int instances_count = 0;
+	Vector3* translation_ptr = nullptr;
+	Quaternion* rotation_ptr = nullptr;
+	Vector3* scale_ptr = nullptr;
+
+	if (p_gltf_node->multimesh_translation >= 0){
+		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_translation];
+		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3){
+			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i", accessor->accessor_type));
+			return nullptr;
+		}
+		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT){
+			ERR_PRINT(vformat("glTF import: Invalid component_type: %i" + accessor->component_type));
+			return nullptr;
+		}
+		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
+		translation_ptr = (Vector3*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
+
+		if (instances_count && instances_count != accessor->get_count()){
+			ERR_PRINT(vformat("glTF import: instances_count: %i" + accessor->get_count()));
+			return nullptr;
+		}
+		instances_count = accessor->get_count();
+	}
+
+	if (p_gltf_node->multimesh_rotation >= 0){
+		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_rotation];
+		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC4){
+			ERR_PRINT(vformat("glTF import: Invalid accessor_type: " + accessor->accessor_type));
+			return nullptr;
+		}
+		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT){
+			ERR_PRINT(vformat("glTF import: Invalid component_type: %i", accessor->component_type));
+			return nullptr;
+		}
+
+		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
+		rotation_ptr = (Quaternion*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
+
+		if (instances_count && instances_count != accessor->get_count()) {
+			ERR_PRINT(vformat("glTF import: instances_count: %i", accessor->get_count()));
+			return nullptr;
+		}
+		instances_count = accessor->get_count();
+	}
+
+	if (p_gltf_node->multimesh_scale >= 0) {
+		Ref<GLTFAccessor> accessor = p_state->accessors[p_gltf_node->multimesh_scale];
+		if (accessor->accessor_type != GLTFAccessor::TYPE_VEC3){
+			ERR_PRINT(vformat("glTF import: Invalid accessor_type: %i",accessor->accessor_type));
+			return nullptr;
+		}
+		if (accessor->component_type != GLTFAccessor::COMPONENT_TYPE_SINGLE_FLOAT){
+			ERR_PRINT(vformat("glTF import: Invalid component_type: %i", accessor->component_type));
+			return nullptr;
+		}
+
+		Ref<GLTFBufferView> buffer_view = p_state->buffer_views[accessor->buffer_view];
+		scale_ptr = (Vector3*)(p_state->buffers[buffer_view->get_buffer()].ptr() + buffer_view->get_byte_offset());
+
+		if (instances_count && instances_count != accessor->get_count()) {
+			ERR_PRINT(vformat("glTF import: instances_count: %i", accessor->get_count()));
+			return nullptr;
+		}
+		instances_count = accessor->get_count();
+	}
+
+	Ref<MultiMesh> multimesh = memnew(MultiMesh);
+	multimesh->set_instance_count(0);
+	multimesh->set_transform_format(MultiMesh::TRANSFORM_3D);
+	multimesh->set_instance_count(instances_count);
+
+	for (int i = 0; i < instances_count; i++) {
+		Transform3D tr;
+
+		if (translation_ptr){
+			tr = tr.translated(translation_ptr[i]);
+		}
+
+		if (rotation_ptr){
+			tr.set_basis(Basis(rotation_ptr[i]));
+		}
+
+		if (scale_ptr){
+			tr.scale_basis(scale_ptr[i]);
+		}
+
+		multimesh->set_instance_transform(i, tr);
+	}
+
+	return multimesh;
 }
 
 Light3D *GLTFDocument::_generate_light(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -174,6 +174,7 @@ private:
 	BoneAttachment3D *_generate_bone_attachment(Skeleton3D *p_godot_skeleton, const Ref<GLTFNode> &p_bone_node);
 	BoneAttachment3D *_generate_bone_attachment_compat_4pt4(Ref<GLTFState> p_state, Skeleton3D *p_skeleton, const GLTFNodeIndex p_node_index, const GLTFNodeIndex p_bone_index);
 	ImporterMeshInstance3D *_generate_mesh_instance(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
+	Ref<MultiMesh> _generate_multimesh(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node);
 	Camera3D *_generate_camera(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
 	Light3D *_generate_light(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
 	Node3D *_generate_spatial(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -174,7 +174,6 @@ private:
 	BoneAttachment3D *_generate_bone_attachment(Skeleton3D *p_godot_skeleton, const Ref<GLTFNode> &p_bone_node);
 	BoneAttachment3D *_generate_bone_attachment_compat_4pt4(Ref<GLTFState> p_state, Skeleton3D *p_skeleton, const GLTFNodeIndex p_node_index, const GLTFNodeIndex p_bone_index);
 	ImporterMeshInstance3D *_generate_mesh_instance(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
-	Ref<MultiMesh> _generate_multimesh(Ref<GLTFState> p_state, Ref<GLTFNode> p_gltf_node);
 	Camera3D *_generate_camera(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
 	Light3D *_generate_light(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
 	Node3D *_generate_spatial(Ref<GLTFState> p_state, const GLTFNodeIndex p_node_index);
@@ -277,6 +276,8 @@ public:
 			Ref<GLTFNode> p_gltf_node);
 	GLTFMeshIndex _convert_mesh_to_gltf(Ref<GLTFState> p_state,
 			MeshInstance3D *p_mesh_instance);
+	static GLTFMeshIndex _convert_multimesh_to_gltf(Ref<GLTFState> p_state,
+			MultiMeshInstance3D *p_multi_mesh_instance);
 
 	GLTFNodeIndex _node_and_or_bone_to_gltf_node_index(Ref<GLTFState> p_state, const Vector<StringName> &p_node_subpath, const Node *p_godot_node);
 	bool _convert_animation_node_track(Ref<GLTFState> p_state,

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -394,6 +394,14 @@ AnimationPlayer *GLTFState::get_animation_player(int idx) {
 	return animation_players[idx];
 }
 
+bool GLTFState::get_ignore_multimesh_instances() {
+	return ignore_multimesh_instances;
+}
+
+void GLTFState::set_ignore_multimesh_instances(bool p_ignore_multimesh_instances) {
+	ignore_multimesh_instances = p_ignore_multimesh_instances;
+}
+
 void GLTFState::set_discard_meshes_and_materials(bool p_discard_meshes_and_materials) {
 	discard_meshes_and_materials = p_discard_meshes_and_materials;
 }

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -73,6 +73,7 @@ protected:
 
 	bool use_named_skin_binds = false;
 	bool use_khr_texture_transform = false;
+	bool ignore_multimesh_instances = false;
 	bool discard_meshes_and_materials = false;
 	bool force_generate_tangents = false;
 	bool create_animations = true;
@@ -175,6 +176,9 @@ public:
 
 	bool get_extract_textures();
 	void set_extract_textures(bool p_extract_textures);
+
+	bool get_ignore_multimesh_instances();
+	void set_ignore_multimesh_instances(bool p_ignore_multimesh_instances);
 
 	bool get_discard_meshes_and_materials();
 	void set_discard_meshes_and_materials(bool p_discard_meshes_and_materials);

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -31,6 +31,7 @@
 #include "register_types.h"
 
 #include "extensions/gltf_document_extension_convert_importer_mesh.h"
+#include "extensions/gltf_document_extension_mesh_gpu_instancing.h"
 #include "extensions/gltf_document_extension_texture_ktx.h"
 #include "extensions/gltf_document_extension_texture_webp.h"
 #include "extensions/gltf_spec_gloss.h"
@@ -113,6 +114,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(GLTFDocument);
 		GDREGISTER_CLASS(GLTFDocumentExtension);
 		GDREGISTER_CLASS(GLTFDocumentExtensionConvertImporterMesh);
+		GDREGISTER_CLASS(GLTFDocumentExtensionMeshGPUInstancing);
 		GDREGISTER_CLASS(GLTFLight);
 		GDREGISTER_CLASS(GLTFMesh);
 		GDREGISTER_CLASS(GLTFNode);
@@ -132,6 +134,7 @@ void initialize_gltf_module(ModuleInitializationLevel p_level) {
 		// Ensure physics is first in this list so that physics nodes are created before other nodes.
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionPhysics);
 #endif // PHYSICS_3D_DISABLED
+		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionMeshGPUInstancing);
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureKTX);
 		GLTF_REGISTER_DOCUMENT_EXTENSION(GLTFDocumentExtensionTextureWebP);
 		bool is_editor = Engine::get_singleton()->is_editor_hint();

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -145,6 +145,31 @@ void GLTFNode::set_skeleton(GLTFSkeletonIndex p_skeleton) {
 	skeleton = p_skeleton;
 }
 
+int GLTFNode::get_multimesh_translation() {
+	return multimesh_translation;
+}
+
+void GLTFNode::set_multimesh_translation(GLTFSkeletonIndex p_multimesh_translation) {
+	multimesh_translation = p_multimesh_translation;
+}
+
+int GLTFNode::get_multimesh_rotation() {
+	return multimesh_rotation;
+}
+
+void GLTFNode::set_multimesh_rotation(GLTFSkeletonIndex p_multimesh_rotation) {
+	multimesh_rotation = p_multimesh_rotation;
+}
+
+int GLTFNode::get_multimesh_scale() {
+	return multimesh_scale;
+}
+
+void GLTFNode::set_multimesh_scale(GLTFSkeletonIndex p_multimesh_scale) {
+	multimesh_scale = p_multimesh_scale;
+}
+
+
 Vector3 GLTFNode::get_position() {
 	return transform.origin;
 }

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -49,16 +49,12 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skin", "skin"), &GLTFNode::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skeleton"), &GLTFNode::get_skeleton);
 	ClassDB::bind_method(D_METHOD("set_skeleton", "skeleton"), &GLTFNode::set_skeleton);
-
 	ClassDB::bind_method(D_METHOD("get_multimesh_translation"), &GLTFNode::get_multimesh_translation);
 	ClassDB::bind_method(D_METHOD("set_multimesh_translation", "multimesh_translation"), &GLTFNode::set_multimesh_translation);
-
 	ClassDB::bind_method(D_METHOD("get_multimesh_rotation"), &GLTFNode::get_multimesh_rotation);
 	ClassDB::bind_method(D_METHOD("set_multimesh_rotation", "multimesh_rotation"), &GLTFNode::set_multimesh_rotation);
-
 	ClassDB::bind_method(D_METHOD("get_multimesh_scale"), &GLTFNode::get_multimesh_scale);
 	ClassDB::bind_method(D_METHOD("set_multimesh_scale", "multimesh_scale"), &GLTFNode::set_multimesh_scale);
-
 	ClassDB::bind_method(D_METHOD("get_position"), &GLTFNode::get_position);
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &GLTFNode::set_position);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &GLTFNode::get_rotation);
@@ -84,12 +80,10 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "camera"), "set_camera", "get_camera"); // GLTFCameraIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skin"), "set_skin", "get_skin"); // GLTFSkinIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skeleton"), "set_skeleton", "get_skeleton"); // GLTFSkeletonIndex
-
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_translation"), "get_multimesh_translation", "set_multimesh_translation"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_rotation"), "get_multimesh_rotation", "set_multimesh_rotation"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_scale"), "get_multimesh_scale", "set_multimesh_scale"); // int
-
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_translation"), "set_multimesh_translation", "get_multimesh_translation"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_rotation"), "set_multimesh_rotation", "get_multimesh_rotation"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_scale"), "set_multimesh_scale", "get_multimesh_scale"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3sco
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "rotation"), "set_rotation", "get_rotation"); // Quaternion
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "children"), "set_children", "get_children"); // Vector<int>

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -83,7 +83,7 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_translation"), "set_multimesh_translation", "get_multimesh_translation"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_rotation"), "set_multimesh_rotation", "get_multimesh_rotation"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_scale"), "set_multimesh_scale", "get_multimesh_scale"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3sco
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "rotation"), "set_rotation", "get_rotation"); // Quaternion
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_INT32_ARRAY, "children"), "set_children", "get_children"); // Vector<int>

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -184,7 +184,6 @@ void GLTFNode::set_multimesh_scale(GLTFSkeletonIndex p_multimesh_scale) {
 	multimesh_scale = p_multimesh_scale;
 }
 
-
 Vector3 GLTFNode::get_position() {
 	return transform.origin;
 }

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -49,12 +49,6 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skin", "skin"), &GLTFNode::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skeleton"), &GLTFNode::get_skeleton);
 	ClassDB::bind_method(D_METHOD("set_skeleton", "skeleton"), &GLTFNode::set_skeleton);
-	ClassDB::bind_method(D_METHOD("get_multimesh_translation"), &GLTFNode::get_multimesh_translation);
-	ClassDB::bind_method(D_METHOD("set_multimesh_translation", "multimesh_translation"), &GLTFNode::set_multimesh_translation);
-	ClassDB::bind_method(D_METHOD("get_multimesh_rotation"), &GLTFNode::get_multimesh_rotation);
-	ClassDB::bind_method(D_METHOD("set_multimesh_rotation", "multimesh_rotation"), &GLTFNode::set_multimesh_rotation);
-	ClassDB::bind_method(D_METHOD("get_multimesh_scale"), &GLTFNode::get_multimesh_scale);
-	ClassDB::bind_method(D_METHOD("set_multimesh_scale", "multimesh_scale"), &GLTFNode::set_multimesh_scale);
 	ClassDB::bind_method(D_METHOD("get_position"), &GLTFNode::get_position);
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &GLTFNode::set_position);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &GLTFNode::get_rotation);
@@ -80,9 +74,6 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "camera"), "set_camera", "get_camera"); // GLTFCameraIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skin"), "set_skin", "get_skin"); // GLTFSkinIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skeleton"), "set_skeleton", "get_skeleton"); // GLTFSkeletonIndex
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_translation"), "set_multimesh_translation", "get_multimesh_translation"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_rotation"), "set_multimesh_rotation", "get_multimesh_rotation"); // int
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_scale"), "set_multimesh_scale", "get_multimesh_scale"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "rotation"), "set_rotation", "get_rotation"); // Quaternion
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3
@@ -152,30 +143,6 @@ GLTFSkeletonIndex GLTFNode::get_skeleton() {
 
 void GLTFNode::set_skeleton(GLTFSkeletonIndex p_skeleton) {
 	skeleton = p_skeleton;
-}
-
-int GLTFNode::get_multimesh_translation() {
-	return multimesh_translation;
-}
-
-void GLTFNode::set_multimesh_translation(GLTFSkeletonIndex p_multimesh_translation) {
-	multimesh_translation = p_multimesh_translation;
-}
-
-int GLTFNode::get_multimesh_rotation() {
-	return multimesh_rotation;
-}
-
-void GLTFNode::set_multimesh_rotation(GLTFSkeletonIndex p_multimesh_rotation) {
-	multimesh_rotation = p_multimesh_rotation;
-}
-
-int GLTFNode::get_multimesh_scale() {
-	return multimesh_scale;
-}
-
-void GLTFNode::set_multimesh_scale(GLTFSkeletonIndex p_multimesh_scale) {
-	multimesh_scale = p_multimesh_scale;
 }
 
 Vector3 GLTFNode::get_position() {

--- a/modules/gltf/structures/gltf_node.cpp
+++ b/modules/gltf/structures/gltf_node.cpp
@@ -49,6 +49,16 @@ void GLTFNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skin", "skin"), &GLTFNode::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skeleton"), &GLTFNode::get_skeleton);
 	ClassDB::bind_method(D_METHOD("set_skeleton", "skeleton"), &GLTFNode::set_skeleton);
+
+	ClassDB::bind_method(D_METHOD("get_multimesh_translation"), &GLTFNode::get_multimesh_translation);
+	ClassDB::bind_method(D_METHOD("set_multimesh_translation", "multimesh_translation"), &GLTFNode::set_multimesh_translation);
+
+	ClassDB::bind_method(D_METHOD("get_multimesh_rotation"), &GLTFNode::get_multimesh_rotation);
+	ClassDB::bind_method(D_METHOD("set_multimesh_rotation", "multimesh_rotation"), &GLTFNode::set_multimesh_rotation);
+
+	ClassDB::bind_method(D_METHOD("get_multimesh_scale"), &GLTFNode::get_multimesh_scale);
+	ClassDB::bind_method(D_METHOD("set_multimesh_scale", "multimesh_scale"), &GLTFNode::set_multimesh_scale);
+
 	ClassDB::bind_method(D_METHOD("get_position"), &GLTFNode::get_position);
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &GLTFNode::set_position);
 	ClassDB::bind_method(D_METHOD("get_rotation"), &GLTFNode::get_rotation);
@@ -74,6 +84,11 @@ void GLTFNode::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "camera"), "set_camera", "get_camera"); // GLTFCameraIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skin"), "set_skin", "get_skin"); // GLTFSkinIndex
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "skeleton"), "set_skeleton", "get_skeleton"); // GLTFSkeletonIndex
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_translation"), "get_multimesh_translation", "set_multimesh_translation"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_rotation"), "get_multimesh_rotation", "set_multimesh_rotation"); // int
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "multimesh_scale"), "get_multimesh_scale", "set_multimesh_scale"); // int
+
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "position"), "set_position", "get_position"); // Vector3
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "rotation"), "set_rotation", "get_rotation"); // Quaternion
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale"), "set_scale", "get_scale"); // Vector3

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -50,7 +50,7 @@ private:
 	GLTFSkinIndex skin = -1;
 	GLTFSkeletonIndex skeleton = -1;
 	int multimesh_translation = -1;
-	int multimesh_rotation= -1;
+	int multimesh_rotation = -1;
 	int multimesh_scale = -1;
 	bool joint = false;
 	bool visible = true;

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -49,6 +49,9 @@ private:
 	GLTFCameraIndex camera = -1;
 	GLTFSkinIndex skin = -1;
 	GLTFSkeletonIndex skeleton = -1;
+    int multimesh_translation = -1;
+    int multimesh_rotation= -1;
+    int multimesh_scale = -1;
 	bool joint = false;
 	bool visible = true;
 	Vector<int> children;
@@ -85,6 +88,15 @@ public:
 
 	GLTFSkeletonIndex get_skeleton();
 	void set_skeleton(GLTFSkeletonIndex p_skeleton);
+
+	int get_multimesh_translation();
+	void set_multimesh_translation(int p_multimesh_translation);
+
+	int get_multimesh_rotation();
+	void set_multimesh_rotation(int p_multimesh_rotation);
+
+	int get_multimesh_scale();
+	void set_multimesh_scale(int p_multimesh_scale);
 
 	Vector3 get_position();
 	void set_position(const Vector3 &p_position);

--- a/modules/gltf/structures/gltf_node.h
+++ b/modules/gltf/structures/gltf_node.h
@@ -49,9 +49,9 @@ private:
 	GLTFCameraIndex camera = -1;
 	GLTFSkinIndex skin = -1;
 	GLTFSkeletonIndex skeleton = -1;
-    int multimesh_translation = -1;
-    int multimesh_rotation= -1;
-    int multimesh_scale = -1;
+	int multimesh_translation = -1;
+	int multimesh_rotation= -1;
+	int multimesh_scale = -1;
 	bool joint = false;
 	bool visible = true;
 	Vector<int> children;

--- a/scene/3d/importer_mesh_instance_3d.cpp
+++ b/scene/3d/importer_mesh_instance_3d.cpp
@@ -46,11 +46,11 @@ Ref<Skin> ImporterMeshInstance3D::get_skin() const {
 	return skin;
 }
 
-void ImporterMeshInstance3D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
-    multimesh = p_multimesh;
-}
 Ref<MultiMesh> ImporterMeshInstance3D::get_multimesh() const {
-    return multimesh;
+	return multimesh;
+}
+void ImporterMeshInstance3D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
+	multimesh = p_multimesh;
 }
 
 void ImporterMeshInstance3D::set_surface_material(int p_idx, const Ref<Material> &p_material) {
@@ -144,8 +144,8 @@ void ImporterMeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skin", "skin"), &ImporterMeshInstance3D::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skin"), &ImporterMeshInstance3D::get_skin);
 
-    ClassDB::bind_method(D_METHOD("set_multimesh", "multimesh"), &ImporterMeshInstance3D::set_multimesh);
-    ClassDB::bind_method(D_METHOD("get_multimesh"), &ImporterMeshInstance3D::get_multimesh);
+	ClassDB::bind_method(D_METHOD("set_multimesh", "multimesh"), &ImporterMeshInstance3D::set_multimesh);
+	ClassDB::bind_method(D_METHOD("get_multimesh"), &ImporterMeshInstance3D::get_multimesh);
 
 	ClassDB::bind_method(D_METHOD("set_skeleton_path", "skeleton_path"), &ImporterMeshInstance3D::set_skeleton_path);
 	ClassDB::bind_method(D_METHOD("get_skeleton_path"), &ImporterMeshInstance3D::get_skeleton_path);
@@ -173,7 +173,7 @@ void ImporterMeshInstance3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "ImporterMesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "skin", PROPERTY_HINT_RESOURCE_TYPE, "Skin"), "set_skin", "get_skin");
-    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multimesh", PROPERTY_HINT_RESOURCE_TYPE, "MultiMesh"), "set_multimesh", "get_multimesh");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multimesh", PROPERTY_HINT_RESOURCE_TYPE, "MultiMesh"), "set_multimesh", "get_multimesh");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "skeleton_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton"), "set_skeleton_path", "get_skeleton_path");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
 

--- a/scene/3d/importer_mesh_instance_3d.cpp
+++ b/scene/3d/importer_mesh_instance_3d.cpp
@@ -46,6 +46,13 @@ Ref<Skin> ImporterMeshInstance3D::get_skin() const {
 	return skin;
 }
 
+void ImporterMeshInstance3D::set_multimesh(const Ref<MultiMesh> &p_multimesh) {
+    multimesh = p_multimesh;
+}
+Ref<MultiMesh> ImporterMeshInstance3D::get_multimesh() const {
+    return multimesh;
+}
+
 void ImporterMeshInstance3D::set_surface_material(int p_idx, const Ref<Material> &p_material) {
 	ERR_FAIL_COND(p_idx < 0);
 	if (p_idx >= surface_materials.size()) {
@@ -137,6 +144,9 @@ void ImporterMeshInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_skin", "skin"), &ImporterMeshInstance3D::set_skin);
 	ClassDB::bind_method(D_METHOD("get_skin"), &ImporterMeshInstance3D::get_skin);
 
+    ClassDB::bind_method(D_METHOD("set_multimesh", "multimesh"), &ImporterMeshInstance3D::set_multimesh);
+    ClassDB::bind_method(D_METHOD("get_multimesh"), &ImporterMeshInstance3D::get_multimesh);
+
 	ClassDB::bind_method(D_METHOD("set_skeleton_path", "skeleton_path"), &ImporterMeshInstance3D::set_skeleton_path);
 	ClassDB::bind_method(D_METHOD("get_skeleton_path"), &ImporterMeshInstance3D::get_skeleton_path);
 
@@ -163,6 +173,7 @@ void ImporterMeshInstance3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh", PROPERTY_HINT_RESOURCE_TYPE, "ImporterMesh"), "set_mesh", "get_mesh");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "skin", PROPERTY_HINT_RESOURCE_TYPE, "Skin"), "set_skin", "get_skin");
+    ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multimesh", PROPERTY_HINT_RESOURCE_TYPE, "MultiMesh"), "set_multimesh", "get_multimesh");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "skeleton_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Skeleton"), "set_skeleton_path", "get_skeleton_path");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "layer_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_layer_mask", "get_layer_mask");
 

--- a/scene/3d/importer_mesh_instance_3d.h
+++ b/scene/3d/importer_mesh_instance_3d.h
@@ -33,6 +33,7 @@
 #include "scene/3d/node_3d.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/3d/skin.h"
+#include "scene/resources/multimesh.h"
 
 class ImporterMesh;
 
@@ -41,6 +42,7 @@ class ImporterMeshInstance3D : public Node3D {
 
 	Ref<ImporterMesh> mesh;
 	Ref<Skin> skin;
+    Ref<MultiMesh> multimesh;
 	NodePath skeleton_path;
 	Vector<Ref<Material>> surface_materials;
 	uint32_t layer_mask = 1;
@@ -60,6 +62,9 @@ public:
 
 	void set_skin(const Ref<Skin> &p_skin);
 	Ref<Skin> get_skin() const;
+
+	void set_multimesh(const Ref<MultiMesh> &p_skin);
+	Ref<MultiMesh> get_multimesh() const;
 
 	void set_surface_material(int p_idx, const Ref<Material> &p_material);
 	Ref<Material> get_surface_material(int p_idx) const;

--- a/scene/3d/importer_mesh_instance_3d.h
+++ b/scene/3d/importer_mesh_instance_3d.h
@@ -42,7 +42,7 @@ class ImporterMeshInstance3D : public Node3D {
 
 	Ref<ImporterMesh> mesh;
 	Ref<Skin> skin;
-    Ref<MultiMesh> multimesh;
+	Ref<MultiMesh> multimesh;
 	NodePath skeleton_path;
 	Vector<Ref<Material>> surface_materials;
 	uint32_t layer_mask = 1;


### PR DESCRIPTION
Allows to import MultiMeshInstance3D objects through EXT_mesh_gpu_instancing GLTF extension: https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Vendor/EXT_mesh_gpu_instancing/README.md

Depends on https://github.com/godotengine/godot/pull/107672 for blender. Will work by itself for pure GLTF files(if exporter option enabled)

*Bugsquad edit:* Depends on https://github.com/godotengine/godot/pull/108853 and https://github.com/godotengine/godot/pull/109103.

Implementation notes:

- Adds 3 fields to GLTFNode - multimesh_translation, multimesh_rotation, multimesh_scale. All of this is referencing accessors indices in Gltf document.

- Adds ImporterMeshInstance3D::multimesh. It is created and filled in GLTFDocument::_generate_mesh_instance - nearby ImporterMeshInstance3D creation. 
(I am not sure about that decision - almost every resource parsed/created separately from nodes(and assigned later), but instances info stored in node description and not in json's root, so maybe its ok)

- Actual MultiMeshInstance3D creation happens in ResourceImporterScene::_pre_fix_node - nearby other nodes creation(and suffix parsing)
Currenly there is no condition to create MultiMeshInstance3D - it just checks whether it has or not valid multimesh. 
I think ideally there should be suffix condition, OR at least code should check other conditions first - like col/colonly - whatever might be more important to have.
(for that reason MultiMeshInstance3D is not created early in GLTFDocument)(there is also some mesh material manipulation which duplication we might want to avoid)
Suffixes might be tricky, however - blender will set name of instance node based on name of main node - not on the name of children node in editor.

- to trigger multimesh creation, code need at least one of three accessors. Since blender creates all of them, i only tested that case.

- On import there is some warnings like "Instance count must be 0 to change the transform format". I think it is related more to copying MultimeshInstance3D and/or scene creation, than to creation code itself. 

- There is also some work on GDScript properties and docs left(if rest is even desirable implementation)
