### PR TITLE
Fix use of `class_name` in built-in scripts

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -996,6 +996,10 @@ void GDScriptParser::parse_class_name() {
 		current_class->fqcn = String(current_class->identifier->name);
 	}
 
+	if (script_path.begins_with("res://") && script_path.contains("::")) {
+		push_error(R"("class_name" isn't allowed in built-in scripts.)");
+	}
+
 	make_completion_context(COMPLETION_DECLARATION, current_class);
 
 	if (match(GDScriptTokenizer::Token::EXTENDS)) {


### PR DESCRIPTION
fixes: #107813

fixes a regression issue where you can use `class_name` in built-in script. it was marked as an error in godot 3.6, and `class_name `doesn't work anyway.

I used the same error message and condition handling as `godot 3.6`

thanks to KoBeWi for providing the solution ^-^

![image](https://github.com/user-attachments/assets/8596a83b-fa14-4002-8f43-c73f554648bc)

