### PR TITLE
Provide quick access to `Object` ancestry

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -752,7 +752,9 @@ void Resource::_bind_methods() {
 }
 
 Resource::Resource() :
-		remapped_list(this) {}
+		remapped_list(this) {
+	_define_ancestry(AncestralClass::RESOURCE);
+}
 
 Resource::~Resource() {
 	if (unlikely(path_cache.is_empty())) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -2204,8 +2204,19 @@ void Object::reset_internal_extension(ObjectGDExtension *p_extension) {
 #endif
 
 void Object::_construct_object(bool p_reference) {
-	type_is_reference = p_reference;
+	_block_signals = false;
+	_can_translate = true;
+	_emitting = false;
+
+	// ObjectDB::add_instance relies on AncestralClass::REF_COUNTED
+	// being already set in the case of references.
+	_ancestry = p_reference ? (uint32_t)AncestralClass::REF_COUNTED : 0;
+
 	_instance_id = ObjectDB::add_instance(this);
+
+#ifdef TOOLS_ENABLED
+	_edited = false;
+#endif
 
 #ifdef DEBUG_ENABLED
 	_lock_index.init(1);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -587,6 +587,29 @@ public:
 		CONNECT_INHERITED = 32, // Used in editor builds.
 	};
 
+	// Store on each object a bitfield to quickly test whether it is derived from some "key" classes
+	// that are commonly tested in performance sensitive code.
+	// Ensure unsigned to bitpack.
+	enum class AncestralClass : unsigned int {
+		REF_COUNTED = 1 << 0,
+		NODE = 1 << 1,
+		RESOURCE = 1 << 2,
+		SCRIPT = 1 << 3,
+
+		CANVAS_ITEM = 1 << 4,
+		CONTROL = 1 << 5,
+		NODE_2D = 1 << 6,
+		COLLISION_OBJECT_2D = 1 << 7,
+		AREA_2D = 1 << 8,
+
+		NODE_3D = 1 << 9,
+		VISUAL_INSTANCE_3D = 1 << 10,
+		GEOMETRY_INSTANCE_3D = 1 << 11,
+		COLLISION_OBJECT_3D = 1 << 12,
+		PHYSICS_BODY_3D = 1 << 13,
+		MESH_INSTANCE_3D = 1 << 14,
+	};
+
 	struct Connection {
 		::Signal signal;
 		Callable callable;
@@ -628,16 +651,19 @@ private:
 #ifdef DEBUG_ENABLED
 	SafeRefCount _lock_index;
 #endif // DEBUG_ENABLED
-	bool _block_signals = false;
 	int _predelete_ok = 0;
 	ObjectID _instance_id;
 	bool _predelete();
 	void _initialize();
 	void _postinitialize();
-	bool _can_translate = true;
-	bool _emitting = false;
+
+	uint32_t _ancestry : 15;
+
+	bool _block_signals : 1;
+	bool _can_translate : 1;
+	bool _emitting : 1;
 #ifdef TOOLS_ENABLED
-	bool _edited = false;
+	bool _edited : 1;
 	uint32_t _edited_version = 0;
 	HashSet<String> editor_section_folding;
 #endif
@@ -663,7 +689,6 @@ private:
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
 	friend class RefCounted;
-	bool type_is_reference = false;
 
 	BinaryMutex _instance_binding_mutex;
 	struct InstanceBinding {
@@ -769,6 +794,7 @@ protected:
 	static void _get_property_list_from_classdb(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator);
 
 	bool _disconnect(const StringName &p_signal, const Callable &p_callable, bool p_force = false);
+	void _define_ancestry(AncestralClass p_class) { _ancestry |= (uint32_t)p_class; }
 
 	virtual bool _uses_signal_mutex() const;
 
@@ -844,6 +870,8 @@ public:
 		return (p_class == "Object");
 	}
 	virtual bool is_class_ptr(void *p_ptr) const { return get_class_ptr_static() == p_ptr; }
+
+	bool has_ancestry(AncestralClass p_class) const { return _ancestry & (uint32_t)p_class; }
 
 	const StringName &get_class_name() const;
 
@@ -1003,7 +1031,7 @@ public:
 
 	void clear_internal_resource_paths();
 
-	_ALWAYS_INLINE_ bool is_ref_counted() const { return type_is_reference; }
+	_ALWAYS_INLINE_ bool is_ref_counted() const { return has_ancestry(AncestralClass::REF_COUNTED); }
 
 	void cancel_free();
 

--- a/core/object/ref_counted.cpp
+++ b/core/object/ref_counted.cpp
@@ -95,6 +95,7 @@ bool RefCounted::unreference() {
 
 RefCounted::RefCounted() :
 		Object(true) {
+	_define_ancestry(AncestralClass::REF_COUNTED);
 	refcount.init();
 	refcount_init.init();
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -197,7 +197,9 @@ public:
 
 	virtual const Variant get_rpc_config() const = 0;
 
-	Script() {}
+	Script() {
+		_define_ancestry(AncestralClass::SCRIPT);
+	}
 };
 
 class ScriptLanguage : public Object {

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -510,3 +510,7 @@ void Node2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "global_skew", PROPERTY_HINT_NONE, "radians_as_degrees", PROPERTY_USAGE_NONE), "set_global_skew", "get_global_skew");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "global_transform", PROPERTY_HINT_NONE, "suffix:px", PROPERTY_USAGE_NONE), "set_global_transform", "get_global_transform");
 }
+
+Node2D::Node2D() {
+	_define_ancestry(AncestralClass::NODE_2D);
+}

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -115,4 +115,6 @@ public:
 	Transform2D get_relative_transform_to_parent(const Node *p_parent) const;
 
 	Transform2D get_transform() const override;
+
+	Node2D();
 };

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -678,6 +678,8 @@ void Area2D::_bind_methods() {
 
 Area2D::Area2D() :
 		CollisionObject2D(PhysicsServer2D::get_singleton()->area_create(), true) {
+	_define_ancestry(AncestralClass::AREA_2D);
+
 	set_gravity(980);
 	set_gravity_direction(Vector2(0, 1));
 	set_monitoring(true);

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -655,6 +655,8 @@ void CollisionObject2D::_bind_methods() {
 }
 
 CollisionObject2D::CollisionObject2D(RID p_rid, bool p_area) {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_2D);
+
 	rid = p_rid;
 	area = p_area;
 	pickable = true;
@@ -672,6 +674,7 @@ CollisionObject2D::CollisionObject2D(RID p_rid, bool p_area) {
 }
 
 CollisionObject2D::CollisionObject2D() {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_2D);
 	//owner=
 
 	set_notify_transform(true);

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -925,6 +925,7 @@ void MeshInstance3D::_bind_methods() {
 }
 
 MeshInstance3D::MeshInstance3D() {
+	_define_ancestry(AncestralClass::MESH_INSTANCE_3D);
 }
 
 MeshInstance3D::~MeshInstance3D() {

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1529,6 +1529,8 @@ void Node3D::_bind_methods() {
 
 Node3D::Node3D() :
 		xform_change(this), _client_physics_interpolation_node_3d_list(this) {
+	_define_ancestry(AncestralClass::NODE_3D);
+
 	// Default member initializer for bitfield is a C++20 extension, so:
 
 	data.top_level = false;

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -746,6 +746,8 @@ PackedStringArray CollisionObject3D::get_configuration_warnings() const {
 }
 
 CollisionObject3D::CollisionObject3D() {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_3D);
+
 	set_notify_transform(true);
 	//owner=
 
@@ -753,6 +755,8 @@ CollisionObject3D::CollisionObject3D() {
 }
 
 CollisionObject3D::~CollisionObject3D() {
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_3D);
+
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(rid);
 }

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -220,6 +220,10 @@ PackedStringArray PhysicsBody3D::get_configuration_warnings() const {
 	return warnings;
 }
 
+PhysicsBody3D::PhysicsBody3D() {
+	_define_ancestry(AncestralClass::PHYSICS_BODY_3D);
+}
+
 ///////////////////////////////////////
 
 //so, if you pass 45 as limit, avoid numerical precision errors when angle is 45.

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -65,4 +65,6 @@ public:
 	TypedArray<PhysicsBody3D> get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody
 	void remove_collision_exception_with(Node *p_node);
+
+	PhysicsBody3D();
 };

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -204,6 +204,8 @@ RID VisualInstance3D::get_base() const {
 }
 
 VisualInstance3D::VisualInstance3D() {
+	_define_ancestry(AncestralClass::VISUAL_INSTANCE_3D);
+
 	instance = RenderingServer::get_singleton()->instance_create();
 	RenderingServer::get_singleton()->instance_attach_object_instance_id(instance, get_instance_id());
 	_set_notify_transform_when_fti_off(true);
@@ -645,6 +647,7 @@ void GeometryInstance3D::_bind_methods() {
 }
 
 GeometryInstance3D::GeometryInstance3D() {
+	_define_ancestry(AncestralClass::GEOMETRY_INSTANCE_3D);
 }
 
 GeometryInstance3D::~GeometryInstance3D() {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4399,6 +4399,8 @@ void Control::_bind_methods() {
 }
 
 Control::Control() {
+	_define_ancestry(AncestralClass::CONTROL);
+
 	data.theme_owner = memnew(ThemeOwner(this));
 
 	set_physics_interpolation_mode(Node::PHYSICS_INTERPOLATION_MODE_OFF);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1727,6 +1727,8 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() const {
 
 CanvasItem::CanvasItem() :
 		xform_change(this) {
+	_define_ancestry(AncestralClass::CANVAS_ITEM);
+
 	canvas_item = RenderingServer::get_singleton()->canvas_item_create();
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -4031,6 +4031,8 @@ String Node::_get_name_num_separator() {
 }
 
 Node::Node() {
+	_define_ancestry(AncestralClass::NODE);
+
 	orphan_node_count++;
 
 	// Default member initializer for bitfield is a C++20 extension, so:


### PR DESCRIPTION
Forward port of #107462
See that PR for full details.

TLDR this internal functionality should speed up things like object casting by approx 2x in most cases.

## Introduction
Although we have increased `Object::cast_to` performance significantly with #103708 (4.x) and #104825 (3.x) we discussed at the time that for some high performance bottleneck scenarios we may want an even faster way of determining whether an `Object` is one of the key main types.

At the time I trialed using a bitfield to store this info and it worked well, and is likely to be one of the fastest methods, and discussed this with @Ivorforce .

While it involves storing (and retrieving) data from the `Object / Node` (thus cache effects), it avoids overheads with a virtual function approach, and the virtual function requires reading the `vtable` from the object, so there is a read in all cases.

## Benchmarks

#### 2000 node children
_release_
ancestry 175, virtual 297, cast_to 344
_debug_
ancestry 2719, virtual 2804, cast_to 3386

## Usage
Although ancestry can be used directly, the plan is (as with 3.x):
* Use ancestry mostly internally via `Object::cast_to` (no change to existing code).
* We also may rename `Object::_is_class` to `Object::derives_from` for some other use cases (already done in 3.x in #107881), so that ancestry can then be hidden and only used internally.

## Notes
* Only having a single usage so far to keep the PR simple, @Ivorforce can do a follow up to convert `cast_to` to use `Ancestry` for the specific cases covered, so it will invisibly be used everywhere (see #107844 for 3.x version).
* The single case I've used here is replacing the `type_is_reference` flag on `Object`, as that is no longer necessary now we have `AncestralClass::REF_COUNTED`.
* I didn't attempt to get rid of the peculiar arrangement for the `Object` constructor, which seems to be in order to accommodate `RefCounted`. I worked out that this seems to because `add_instance()` requires being able to check whether the object  is a reference during the call. In the long term we should probably see if calling that can be done later in the `RefCounted` constructor, so the `Object` constructor can be kept simple.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
