### PR TITLE
Provide 'received headers' parameter for websocket server

### DIFF
--- a/misc/extension_api_validation/4.7-stable/GH-107871.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-107871.txt
@@ -1,0 +1,5 @@
+GH-107871
+---------
+Validate extension JSON: Error: Field 'classes/WebSocketPeer/methods/accept_stream/arguments': size changed value in new API, from 1 to 2.
+
+Optional argument removed. Compatibility method registered.

--- a/modules/websocket/doc_classes/WebSocketPeer.xml
+++ b/modules/websocket/doc_classes/WebSocketPeer.xml
@@ -40,8 +40,10 @@
 		<method name="accept_stream">
 			<return type="int" enum="Error" />
 			<param index="0" name="stream" type="StreamPeer" />
+			<param index="1" name="received_headers" type="String" default="&quot;&quot;" />
 			<description>
 				Accepts a peer connection performing the HTTP handshake as a WebSocket server. The [param stream] must be a valid TCP stream retrieved via [method TCPServer.take_connection], or a TLS stream accepted via [method StreamPeerTLS.accept_stream].
+				If the WebSocket headers have already been read from the stream, they can be supplied in [param received_headers] to complete the connection.
 				[b]Note:[/b] Not supported in Web exports due to browsers' restrictions.
 			</description>
 		</method>

--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -117,7 +117,7 @@ Error EMWSPeer::connect_to_url(const String &p_url, const Ref<TLSOptions> &p_tls
 	return OK;
 }
 
-Error EMWSPeer::accept_stream(const Ref<StreamPeer> &p_stream) {
+Error EMWSPeer::accept_stream(const Ref<StreamPeer> &p_stream, String p_received_headers) {
 	WARN_PRINT_ONCE("Acting as WebSocket server is not supported in Web platforms.");
 	return ERR_UNAVAILABLE;
 }

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -87,7 +87,7 @@ public:
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;
 	virtual Error connect_to_url(const String &p_url, const Ref<TLSOptions> &p_tls_client_options) override;
-	virtual Error accept_stream(const Ref<StreamPeer> &p_stream) override;
+	virtual Error accept_stream(const Ref<StreamPeer> &p_stream, String p_received_headers) override;
 	virtual void close(int p_code = 1000, const String &p_reason = "") override;
 	virtual void poll() override;
 

--- a/modules/websocket/websocket_peer.compat.inc
+++ b/modules/websocket/websocket_peer.compat.inc
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  websocket_peer.compat.inc                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "core/object/class_db.h"
+
+Error WebSocketPeer::_accept_stream_bind_compat_107871(const Ref<StreamPeer> &p_stream) {
+	return accept_stream(p_stream, "");
+}
+
+void WebSocketPeer::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("accept_stream", "stream"), &WebSocketPeer::_accept_stream_bind_compat_107871);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/modules/websocket/websocket_peer.cpp
+++ b/modules/websocket/websocket_peer.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "websocket_peer.h"
+#include "websocket_peer.compat.inc"
 
 #include "core/object/class_db.h"
 

--- a/modules/websocket/websocket_peer.cpp
+++ b/modules/websocket/websocket_peer.cpp
@@ -42,7 +42,7 @@ WebSocketPeer::~WebSocketPeer() {
 
 void WebSocketPeer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("connect_to_url", "url", "tls_client_options"), &WebSocketPeer::connect_to_url, DEFVAL(Ref<TLSOptions>()));
-	ClassDB::bind_method(D_METHOD("accept_stream", "stream"), &WebSocketPeer::accept_stream);
+	ClassDB::bind_method(D_METHOD("accept_stream", "stream", "received_headers"), &WebSocketPeer::accept_stream, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("send", "message", "write_mode"), &WebSocketPeer::_send_bind, DEFVAL(WRITE_MODE_BINARY));
 	ClassDB::bind_method(D_METHOD("send_text", "message"), &WebSocketPeer::send_text);
 	ClassDB::bind_method(D_METHOD("was_string_packet"), &WebSocketPeer::was_string_packet);

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -81,7 +81,7 @@ public:
 	}
 
 	virtual Error connect_to_url(const String &p_url, const Ref<TLSOptions> &p_options = Ref<TLSOptions>()) = 0;
-	virtual Error accept_stream(const Ref<StreamPeer> &p_stream) = 0;
+	virtual Error accept_stream(const Ref<StreamPeer> &p_stream, String received_headers = "") = 0;
 
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) = 0;
 	virtual void close(int p_code = 1000, const String &p_reason = "") = 0;

--- a/modules/websocket/websocket_peer.h
+++ b/modules/websocket/websocket_peer.h
@@ -61,6 +61,11 @@ protected:
 
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _accept_stream_bind_compat_107871(const Ref<StreamPeer> &p_stream);
+	static void _bind_compatibility_methods();
+#endif
+
 	Vector<String> supported_protocols;
 	Vector<String> handshake_headers;
 

--- a/modules/websocket/wsl_peer.cpp
+++ b/modules/websocket/wsl_peer.cpp
@@ -130,7 +130,7 @@ void WSLPeer::Resolver::try_next_candidate(const Ref<StreamPeerTCP> &p_tcp) {
 ///
 /// Server functions
 ///
-Error WSLPeer::accept_stream(const Ref<StreamPeer> &p_stream) {
+Error WSLPeer::accept_stream(const Ref<StreamPeer> &p_stream, String p_received_headers) {
 	ERR_FAIL_COND_V(p_stream.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(ready_state != STATE_CLOSED && ready_state != STATE_CLOSING, ERR_ALREADY_IN_USE);
 
@@ -153,6 +153,9 @@ Error WSLPeer::accept_stream(const Ref<StreamPeer> &p_stream) {
 	ready_state = STATE_CONNECTING;
 	handshake_buffer->resize(WSL_MAX_HEADER_SIZE);
 	handshake_buffer->seek(0);
+
+	CharString cs = p_received_headers.utf8();
+	handshake_buffer->put_data((const uint8_t *)cs.get_data(), MIN(cs.length(), WSL_MAX_HEADER_SIZE));
 	return OK;
 }
 
@@ -240,20 +243,8 @@ Error WSLPeer::_do_server_handshake() {
 	if (pending_request) {
 		int read = 0;
 		while (true) {
-			ERR_FAIL_COND_V_MSG(handshake_buffer->get_available_bytes() < 1, ERR_OUT_OF_MEMORY, "WebSocket response headers are too big.");
-			int pos = handshake_buffer->get_position();
-			uint8_t byte;
-			Error err = connection->get_partial_data(&byte, 1, read);
-			if (err != OK) { // Got an error
-				print_verbose(vformat("WebSocket error while getting partial data (StreamPeer error code %d).", err));
-				close(-1);
-				return FAILED;
-			} else if (read != 1) { // Busy, wait next poll
-				return OK;
-			}
-			handshake_buffer->put_u8(byte);
 			const char *r = (const char *)handshake_buffer->get_data_array().ptr();
-			int l = pos;
+			int l = handshake_buffer->get_position() - 1;
 			if (l > 3 && r[l] == '\n' && r[l - 1] == '\r' && r[l - 2] == '\n' && r[l - 3] == '\r') {
 				if (!_parse_client_request()) {
 					close(-1);
@@ -277,6 +268,18 @@ Error WSLPeer::_do_server_handshake() {
 				pending_request = false;
 				break;
 			}
+
+			ERR_FAIL_COND_V_MSG(handshake_buffer->get_available_bytes() < 1, ERR_OUT_OF_MEMORY, "WebSocket response headers are too big.");
+			uint8_t byte;
+			Error err = connection->get_partial_data(&byte, 1, read);
+			if (err != OK) { // Got an error
+				print_verbose(vformat("WebSocket error while getting partial data (StreamPeer error code %d).", err));
+				close(-1);
+				return FAILED;
+			} else if (read != 1) { // Busy, wait next poll
+				return OK;
+			}
+			handshake_buffer->put_u8(byte);
 		}
 	}
 

--- a/modules/websocket/wsl_peer.h
+++ b/modules/websocket/wsl_peer.h
@@ -144,7 +144,7 @@ public:
 	// WebSocketPeer
 	virtual Error send(const uint8_t *p_buffer, int p_buffer_size, WriteMode p_mode) override;
 	virtual Error connect_to_url(const String &p_url, const Ref<TLSOptions> &p_options = Ref<TLSOptions>()) override;
-	virtual Error accept_stream(const Ref<StreamPeer> &p_stream) override;
+	virtual Error accept_stream(const Ref<StreamPeer> &p_stream, String p_received_headers) override;
 	virtual void close(int p_code = 1000, const String &p_reason = "") override;
 	virtual void poll() override;
 


### PR DESCRIPTION
This is a small change that allows http and websockets to be provided through one endpoint.

For example, if you run a tcp server acting as an http endpoint providing two paths:

/index.html -> serves a file through http get
/ws -> opens a websocket connection

At the moment this is not really possible, because you need to read the incoming headers from the tcp stream to find out what the connection is trying to get. However, turning a StreamPeer into a websocket server through `accept_stream` requires that the full http header is sitting in the stream peer. Once you get the bytes out of the stream to examine them, you can no longer use `accept_stream` to let the connection act as a websocket server.

This change allows the received headers to be fed into accept_stream, which are then used to populate the handshake buffer. So, if you have already pulled out the first line, or the entire header, you can supply it when upgrading the connection to a websocket and it will use that.

The code to complete the handshake buffer was rearranged to first check f the buffer is complete, before reading from the connection to fill it.

I have used this change in my game, to reduce it from requiring two separate endpoints (one for http and a separate one for websockets), to only one unified endpoint.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/12756.*