### PR TITLE
[3.x] Optimize hotspots with `Object::is_reference()`

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -2961,12 +2961,10 @@ Variant _ClassDB::instance(const StringName &p_class) const {
 		return Variant();
 	}
 
-	Reference *r = Object::cast_to<Reference>(obj);
-	if (r) {
-		return REF(r);
-	} else {
-		return obj;
+	if (obj->is_reference()) {
+		return REF((Reference *)obj);
 	}
+	return obj;
 }
 
 bool _ClassDB::has_signal(StringName p_class, StringName p_signal) const {

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -445,8 +445,8 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 						obj->set(str, value);
 					}
 
-					if (Object::cast_to<Reference>(obj)) {
-						REF ref = REF(Object::cast_to<Reference>(obj));
+					if (obj->is_reference()) {
+						REF ref = REF((Reference *)obj);
 						r_variant = ref;
 					} else {
 						r_variant = obj;

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -743,7 +743,7 @@ static void _test_call_error(const StringName &p_func, const Variant::CallError 
 void Object::call_multilevel(const StringName &p_method, const Variant **p_args, int p_argcount) {
 	if (p_method == CoreStringNames::get_singleton()->_free) {
 #ifdef DEBUG_ENABLED
-		ERR_FAIL_COND_MSG(Object::cast_to<Reference>(this), "Can't 'free' a reference.");
+		ERR_FAIL_COND_MSG(this->is_reference(), "Can't 'free' a reference.");
 
 		ERR_FAIL_COND_MSG(_lock_index.get() > 1, "Object is locked and can't be freed.");
 #endif
@@ -877,7 +877,7 @@ Variant Object::call(const StringName &p_method, const Variant **p_args, int p_a
 			r_error.error = Variant::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 			return Variant();
 		}
-		if (Object::cast_to<Reference>(this)) {
+		if (this->is_reference()) {
 			r_error.argument = 0;
 			r_error.error = Variant::CallError::CALL_ERROR_INVALID_METHOD;
 			ERR_FAIL_V_MSG(Variant(), "Can't 'free' a reference.");

--- a/core/object.h
+++ b/core/object.h
@@ -673,6 +673,9 @@ public:
 	virtual bool is_class(const String &p_class) const { return (p_class == "Object"); }
 	virtual bool is_class_ptr(void *p_ptr) const { return get_class_ptr_static() == p_ptr; }
 
+	// Shortcut for common type.
+	bool is_reference() const { return _has_ancestry(AncestralClass::REFERENCE); }
+
 	template <typename T>
 	bool derives_from() const;
 

--- a/core/reference.cpp
+++ b/core/reference.cpp
@@ -114,9 +114,8 @@ Variant WeakRef::get_ref() const {
 	if (!obj) {
 		return Variant();
 	}
-	Reference *r = cast_to<Reference>(obj);
-	if (r) {
-		return REF(r);
+	if (obj->is_reference()) {
+		return REF((Reference *)obj);
 	}
 
 	return obj;

--- a/core/undo_redo.cpp
+++ b/core/undo_redo.cpp
@@ -107,8 +107,8 @@ void UndoRedo::add_do_method(Object *p_object, const String &p_method, VARIANT_A
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Reference>(p_object)) {
-		do_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
+	if (p_object->is_reference()) {
+		do_op.ref = Ref<Reference>((Reference *)p_object);
 	}
 
 	do_op.type = Operation::TYPE_METHOD;
@@ -133,8 +133,8 @@ void UndoRedo::add_undo_method(Object *p_object, const String &p_method, VARIANT
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Reference>(p_object)) {
-		undo_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
+	if (p_object->is_reference()) {
+		undo_op.ref = Ref<Reference>((Reference *)p_object);
 	}
 
 	undo_op.type = Operation::TYPE_METHOD;
@@ -151,8 +151,8 @@ void UndoRedo::add_do_property(Object *p_object, const String &p_property, const
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Reference>(p_object)) {
-		do_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
+	if (p_object->is_reference()) {
+		do_op.ref = Ref<Reference>((Reference *)p_object);
 	}
 
 	do_op.type = Operation::TYPE_PROPERTY;
@@ -172,8 +172,8 @@ void UndoRedo::add_undo_property(Object *p_object, const String &p_property, con
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Reference>(p_object)) {
-		undo_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
+	if (p_object->is_reference()) {
+		undo_op.ref = Ref<Reference>((Reference *)p_object);
 	}
 
 	undo_op.type = Operation::TYPE_PROPERTY;
@@ -187,8 +187,8 @@ void UndoRedo::add_do_reference(Object *p_object) {
 	ERR_FAIL_COND((current_action + 1) >= actions.size());
 	Operation do_op;
 	do_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Reference>(p_object)) {
-		do_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
+	if (p_object->is_reference()) {
+		do_op.ref = Ref<Reference>((Reference *)p_object);
 	}
 
 	do_op.type = Operation::TYPE_REFERENCE;
@@ -206,8 +206,8 @@ void UndoRedo::add_undo_reference(Object *p_object) {
 
 	Operation undo_op;
 	undo_op.object = p_object->get_instance_id();
-	if (Object::cast_to<Reference>(p_object)) {
-		undo_op.ref = Ref<Reference>(Object::cast_to<Reference>(p_object));
+	if (p_object->is_reference()) {
+		undo_op.ref = Ref<Reference>((Reference *)p_object);
 	}
 
 	undo_op.type = Operation::TYPE_REFERENCE;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -518,9 +518,8 @@ Variant NativeScript::_new(const Variant **p_args, int p_argcount, Variant::Call
 		return Variant();
 	}
 
-	Reference *r = Object::cast_to<Reference>(owner);
-	if (r) {
-		ref = REF(r);
+	if (owner->is_reference()) {
+		ref = REF((Reference *)owner);
 	}
 
 	NativeScriptInstance *instance = (NativeScriptInstance *)instance_create(owner);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -65,9 +65,8 @@ Variant GDScriptNativeClass::_new() {
 	Object *o = instance();
 	ERR_FAIL_COND_V_MSG(!o, Variant(), "Class type: '" + String(name) + "' is not instantiable.");
 
-	Reference *ref = Object::cast_to<Reference>(o);
-	if (ref) {
-		return REF(ref);
+	if (o->is_reference()) {
+		return REF((Reference *)o);
 	} else {
 		return o;
 	}

--- a/modules/mono/mono_gd/gd_mono_marshal.cpp
+++ b/modules/mono/mono_gd/gd_mono_marshal.cpp
@@ -1041,8 +1041,7 @@ Variant mono_object_to_variant_impl(MonoObject *p_obj, const ManagedType &p_type
 			if (CACHED_CLASS(GodotObject)->is_assignable_from(type_class)) {
 				Object *ptr = unbox<Object *>(CACHED_FIELD(GodotObject, ptr)->get_value(p_obj));
 				if (ptr != NULL) {
-					Reference *ref = Object::cast_to<Reference>(ptr);
-					return ref ? Variant(Ref<Reference>(ref)) : Variant(ptr);
+					return ptr->is_reference() ? Variant(Ref<Reference>((Reference *)ptr)) : Variant(ptr);
 				}
 				return Variant();
 			}
@@ -1112,8 +1111,7 @@ Variant mono_object_to_variant_impl(MonoObject *p_obj, const ManagedType &p_type
 			if (CACHED_CLASS(GodotObject)->is_assignable_from(type_class)) {
 				Object *ptr = unbox<Object *>(CACHED_FIELD(GodotObject, ptr)->get_value(p_obj));
 				if (ptr != NULL) {
-					Reference *ref = Object::cast_to<Reference>(ptr);
-					return ref ? Variant(Ref<Reference>(ref)) : Variant(ptr);
+					return ptr->is_reference() ? Variant(Ref<Reference>((Reference *)ptr)) : Variant(ptr);
 				}
 				return Variant();
 			}

--- a/modules/mono/mono_gd/gd_mono_utils.cpp
+++ b/modules/mono/mono_gd/gd_mono_utils.cpp
@@ -106,9 +106,9 @@ MonoObject *unmanaged_get_managed(Object *unmanaged) {
 	gchandle->set_handle(gdmono::MonoGCHandle::new_strong_handle(mono_object), gdmono::MonoGCHandle::STRONG_HANDLE);
 
 	// Tie managed to unmanaged
-	Reference *ref = Object::cast_to<Reference>(unmanaged);
+	if (unmanaged->is_reference()) {
+		Reference *ref = (Reference *)unmanaged;
 
-	if (ref) {
 		// Unsafe refcount increment. The managed instance also counts as a reference.
 		// This way if the unmanaged world has no references to our owner
 		// but the managed instance is alive, the refcount will be 1 instead of 0.


### PR DESCRIPTION
3.x equivalent of `is_ref_counted()` in 4.x.

This is both easier to read, and faster in release (in case where pointer NULL check is not required) by 1.5x, and faster in debug because pointer check won't be optimized out.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
