### PR TITLE
[3.x] Optimize hotspots with `Object::derives_from`

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -909,7 +909,7 @@ bool ResourceLoader::add_custom_resource_format_loader(String script_path) {
 
 	Ref<Resource> res = ResourceLoader::load(script_path);
 	ERR_FAIL_COND_V(res.is_null(), false);
-	ERR_FAIL_COND_V(!res->is_class("Script"), false);
+	ERR_FAIL_COND_V(!res->derives_from<Script>(), false);
 
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -203,7 +203,7 @@ bool ResourceSaver::add_custom_resource_format_saver(String script_path) {
 
 	Ref<Resource> res = ResourceLoader::load(script_path);
 	ERR_FAIL_COND_V(res.is_null(), false);
-	ERR_FAIL_COND_V(!res->is_class("Script"), false);
+	ERR_FAIL_COND_V(!res->derives_from<Script>(), false);
 
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();

--- a/core/object.cpp
+++ b/core/object.cpp
@@ -648,7 +648,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 
 	_get_property_listv(p_list, p_reversed);
 
-	if (!is_class("Script")) { // can still be set, but this is for userfriendlyness
+	if (!derives_from<Script>()) { // can still be set, but this is for userfriendlyness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
 	if (!metadata.empty()) {

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2161,7 +2161,7 @@ Variant::Variant(const Object *p_object) {
 
 	memnew_placement(_data._mem, ObjData);
 
-	if (obj && obj->has_ancestry(Object::AncestralClass::REFERENCE)) {
+	if (Object::cast_to<Reference>(obj)) {
 		*reinterpret_cast<Ref<Reference> *>(_get_obj().ref.get_data()) = Ref<Reference>((Reference *)obj);
 		_get_obj().rc = nullptr;
 	} else {

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -77,7 +77,7 @@ PoolVector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_i
 }
 
 bool ResourceSaverPNG::recognize(const RES &p_resource) const {
-	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
+	return (p_resource.is_valid() && p_resource->derives_from<ImageTexture>());
 }
 
 void ResourceSaverPNG::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1330,13 +1330,13 @@ void EditorNode::_save_edited_subresources(Node *scene, Map<RES, bool> &processe
 }
 
 void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
-	if (p_node->is_class("Viewport") || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
+	if (p_node->derives_from<Viewport>() || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
 		return;
 	}
 
-	if (p_node->is_class("CanvasItem")) {
+	if (p_node->derives_from<CanvasItem>()) {
 		count_2d++;
-	} else if (p_node->is_class("Spatial")) {
+	} else if (p_node->derives_from<Spatial>()) {
 		count_3d++;
 	}
 
@@ -2051,8 +2051,8 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	Object *prev_inspected_object = get_inspector()->get_edited_object();
 
 	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding"));
-	bool is_resource = current_obj->is_class("Resource");
-	bool is_node = current_obj->is_class("Node");
+	bool is_resource = current_obj->derives_from<Resource>();
+	bool is_node = current_obj->derives_from<Node>();
 	bool stay_in_script_editor_on_node_selected = bool(EDITOR_GET("text_editor/navigation/stay_in_script_editor_on_node_selected"));
 	bool skip_main_plugin = false;
 
@@ -2113,7 +2113,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		if (current_obj->is_class("ScriptEditorDebuggerInspectedObject")) {
 			editable_warning = TTR("This is a remote object, so changes to it won't be kept.\nPlease read the documentation relevant to debugging to better understand this workflow.");
 			disable_folding = true;
-		} else if (current_obj->is_class("MultiNodeEdit")) {
+		} else if (current_obj->derives_from<MultiNodeEdit>()) {
 			Node *scene = get_edited_scene();
 			if (scene) {
 				MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(current_obj);
@@ -4037,7 +4037,7 @@ StringName EditorNode::get_object_custom_type_name(const Object *p_object) const
 	ERR_FAIL_COND_V(!p_object, StringName());
 
 	Ref<Script> script = p_object->get_script();
-	if (script.is_null() && p_object->is_class("Script")) {
+	if (script.is_null() && p_object->derives_from<Script>()) {
 		script = p_object;
 	}
 
@@ -4103,7 +4103,7 @@ Ref<Texture> EditorNode::get_object_icon(const Object *p_object, const String &p
 	ERR_FAIL_COND_V(!p_object || !gui_base, nullptr);
 
 	Ref<Script> script = p_object->get_script();
-	if (script.is_null() && p_object->is_class("Script")) {
+	if (script.is_null() && p_object->derives_from<Script>()) {
 		script = p_object;
 	}
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -656,7 +656,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 						}
 					}
 				} else if (var.get_type() == Variant::OBJECT) {
-					if (((Object *)var)->is_class("EncodedObjectAsID")) {
+					if (((Object *)var)->derives_from<EncodedObjectAsID>()) {
 						var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();
 						pinfo.type = var.get_type();
 						pinfo.hint = PROPERTY_HINT_OBJECT_ID;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1944,7 +1944,7 @@ bool Main::start() {
 		}
 	}
 
-	if (main_loop->is_class("SceneTree")) {
+	if (main_loop->derives_from<SceneTree>()) {
 		SceneTree *sml = Object::cast_to<SceneTree>(main_loop);
 
 #ifdef DEBUG_ENABLED

--- a/scene/3d/collision_shape.cpp
+++ b/scene/3d/collision_shape.cpp
@@ -121,7 +121,7 @@ String CollisionShape::get_configuration_warning() const {
 		}
 		warning += TTR("A shape must be provided for CollisionShape to function. Please create a shape resource for it.");
 	} else {
-		if (shape->is_class("PlaneShape")) {
+		if (shape->derives_from<PlaneShape>()) {
 			if (warning != String()) {
 				warning += "\n\n";
 			}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -671,7 +671,7 @@ void VisualShader::set_mode(Mode p_mode) {
 				keep = false;
 			} else {
 				Ref<VisualShaderNode> from_node = graph[i].nodes[from].node;
-				if (from_node->is_class("VisualShaderNodeOutput") || from_node->is_class("VisualShaderNodeInput")) {
+				if (from_node->derives_from<VisualShaderNodeOutput>() || from_node->derives_from<VisualShaderNodeInput>()) {
 					keep = false;
 				}
 			}
@@ -680,7 +680,7 @@ void VisualShader::set_mode(Mode p_mode) {
 				keep = false;
 			} else {
 				Ref<VisualShaderNode> to_node = graph[i].nodes[to].node;
-				if (to_node->is_class("VisualShaderNodeOutput") || to_node->is_class("VisualShaderNodeInput")) {
+				if (to_node->derives_from<VisualShaderNodeOutput>() || to_node->derives_from<VisualShaderNodeInput>()) {
 					keep = false;
 				}
 			}


### PR DESCRIPTION
Un-exposes ancestry (so it becomes internal), and instead exposes `Object::_is_class` via a rename to `Object::derives_from`.

Applies in some use cases.

`Object::derives_from()` should be in a lot of cases 1.5x faster in release builds than using `cast_to()` (when a NULL check is not necessary), and will be faster in DEV builds (without optimization). It will also be faster than `Object::is_class(String)` by a huge margin (although we are only worried about hotspots here).

## Notes
* This is something discussed with @Ivorforce , we can now totally totally hide the ancestry system as internal, and use it to accelerate `Object::cast_to` and `Object::derives_from`.
* These functions have the advantage that they will accelerate the classes in `AncestralClass` enum / bitfield, but they will also work with all other classes via the backup `GDSOFTCLASS` system.
* Aim is to do the same in 4.x.
* I haven't converted all the `Object::is_class()` uses.
`Object::is_class()` is still useful for backward compatibility, calling from script (where we don't have an enum of all Object types) and for non-bottleneck areas such as the Editor where we can avoid creating include dependencies.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
