### PR TITLE
Always apply SpringArm3D margin

### DIFF
--- a/scene/3d/physics/spring_arm_3d.cpp
+++ b/scene/3d/physics/spring_arm_3d.cpp
@@ -138,7 +138,8 @@ void SpringArm3D::process_spring() {
 	Vector3 motion;
 	const Vector3 cast_direction(get_global_transform().basis.xform(Vector3(0, 0, 1)));
 
-	motion = Vector3(cast_direction * (spring_length));
+	real_t motion_length = spring_length + margin;
+	motion = Vector3(cast_direction * motion_length);
 
 	if (shape.is_null()) {
 		Camera3D *camera = nullptr;
@@ -172,9 +173,7 @@ void SpringArm3D::process_spring() {
 			PhysicsDirectSpaceState3D::RayResult r;
 			bool intersected = get_world_3d()->get_direct_space_state()->intersect_ray(ray_params, r);
 			if (intersected) {
-				real_t dist = get_global_transform().origin.distance_to(r.position);
-				dist -= margin;
-				motion_delta = dist / (spring_length);
+				motion_delta = get_global_transform().origin.distance_to(r.position) / motion_length;
 			}
 		}
 	} else {
@@ -188,9 +187,9 @@ void SpringArm3D::process_spring() {
 		get_world_3d()->get_direct_space_state()->cast_motion(shape_params, motion_delta, motion_delta_unsafe);
 	}
 
-	current_spring_length = spring_length * motion_delta;
+	current_spring_length = motion_length * motion_delta - margin;
 	Transform3D child_transform;
-	child_transform.origin = get_global_transform().origin + cast_direction * (spring_length * motion_delta);
+	child_transform.origin = get_global_transform().origin + cast_direction * current_spring_length;
 
 	for (int i = get_child_count() - 1; 0 <= i; --i) {
 		Node3D *child = Object::cast_to<Node3D>(get_child(i));


### PR DESCRIPTION
Previously the margin was only applied if both:
 - No shape is set and the child is not a camera
 - The arm is colliding

This would make the arm immediately jump to the margin position on collision. This pr always factors in the margin when determining the length. The margin also works now in the case that a shape is set or the child is a camera.

Similar to https://github.com/godotengine/godot/pull/89797 this is technically a breaking change because the margin didn't do anything before in some cases and the default value is not 0. On the other hand the default margin is very small (0.01).

__Example setup: ```margin == 1```, csgbox.size == 0.8\*0.8\*0.8__
![2025-06-23_00-24](https://github.com/user-attachments/assets/e1f25b43-e371-4d4c-8399-be8eb117feed)

__Old behaviour__:

https://github.com/user-attachments/assets/2775f180-e2a1-41fd-8d76-5ce6f3334ee3

__New behaviour__:

https://github.com/user-attachments/assets/a2a2c55d-bbaf-4afe-9594-59b5488d0d3b

Supersedes https://github.com/godotengine/godot/pull/89797

Fixes https://github.com/godotengine/godot/issues/76220