### PR TITLE
[3.x] Don't mark the project unsaved when loading editor plugins in initial session

### DIFF
--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -257,6 +257,7 @@ public:
 	EditorFileSystemDirectory *get_filesystem();
 	bool is_scanning() const;
 	bool is_importing() const { return importing; }
+	bool doing_first_scan() const { return first_scan; }
 	float get_scanning_progress() const;
 	void scan();
 	void scan_changes();


### PR DESCRIPTION
Backport of #107884.