### PR TITLE
`FTI` - Change `SceneTree` global setting to static

### DIFF
--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -216,7 +216,7 @@ void Light2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated()) {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				// Explicitly make sure the transform is up to date in RenderingServer before
 				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
 				// is normally deferred, and a client change to transform will not always be sent

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -206,7 +206,7 @@ void LightOccluder2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated()) {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				// Explicitly make sure the transform is up to date in RenderingServer before
 				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
 				// is normally deferred, and a client change to transform will not always be sent

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -173,7 +173,7 @@ void PhysicsBody2D::remove_collision_exception_with(Node *p_node) {
 PackedStringArray PhysicsBody2D::get_configuration_warnings() const {
 	PackedStringArray warnings = CollisionObject2D::get_configuration_warnings();
 
-	if (!is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && !is_physics_interpolated()) {
 		warnings.push_back(RTR("PhysicsBody2D will not work correctly on a non-interpolated branch of the SceneTree.\nCheck the node's inherited physics_interpolation_mode."));
 	}
 

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -239,7 +239,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 		}
 
 		// Update all dirty quadrants.
-		bool needs_set_not_interpolated = is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && !is_physics_interpolated();
+		bool needs_set_not_interpolated = SceneTree::is_fti_enabled() && !is_physics_interpolated();
 		for (SelfList<RenderingQuadrant> *quadrant_list_element = dirty_rendering_quadrant_list.first(); quadrant_list_element;) {
 			SelfList<RenderingQuadrant> *next_quadrant_list_element = quadrant_list_element->next(); // "Hack" to clear the list while iterating.
 
@@ -593,7 +593,7 @@ void TileMapLayer::_rendering_occluders_update_cell(CellData &r_cell_data) {
 				bool transpose = (r_cell_data.cell.alternative_tile & TileSetAtlasSource::TRANSFORM_TRANSPOSE);
 
 				// Create, update or clear occluders.
-				bool needs_set_not_interpolated = is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && !is_physics_interpolated();
+				bool needs_set_not_interpolated = SceneTree::is_fti_enabled() && !is_physics_interpolated();
 				for (uint32_t occlusion_layer_index = 0; occlusion_layer_index < r_cell_data.occluders.size(); occlusion_layer_index++) {
 					LocalVector<RID> &occluders = r_cell_data.occluders[occlusion_layer_index];
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -509,7 +509,7 @@ Transform3D Node3D::get_global_transform_interpolated() {
 	// Pass through if physics interpolation is switched off.
 	// This is a convenience, as it allows you to easy turn off interpolation
 	// without changing any code.
-	if (is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && !Engine::get_singleton()->is_in_physics_frame()) {
+	if (SceneTree::is_fti_enabled() && is_inside_tree() && !Engine::get_singleton()->is_in_physics_frame()) {
 		// Note that with SceneTreeFTI, we may want to calculate interpolated transform for a node
 		// with physics interpolation set to OFF, if it has a parent that is ON.
 

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -213,7 +213,7 @@ real_t PhysicsBody3D::get_inverse_mass() const {
 PackedStringArray PhysicsBody3D::get_configuration_warnings() const {
 	PackedStringArray warnings = CollisionObject3D::get_configuration_warnings();
 
-	if (!is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && !is_physics_interpolated()) {
 		warnings.push_back(RTR("PhysicsBody3D will not work correctly on a non-interpolated branch of the SceneTree.\nCheck the node's inherited physics_interpolation_mode."));
 	}
 

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -92,7 +92,7 @@ PackedStringArray XRCamera3D::get_configuration_warnings() const {
 			warnings.push_back(RTR("XRCamera3D may not function as expected without an XROrigin3D node as its parent."));
 		};
 
-		if (is_physics_interpolated()) {
+		if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
 			warnings.push_back(RTR("XRCamera3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 		}
 	}
@@ -501,7 +501,7 @@ PackedStringArray XRNode3D::get_configuration_warnings() const {
 			warnings.push_back(RTR("No pose is set."));
 		}
 
-		if (is_physics_interpolated()) {
+		if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
 			warnings.push_back(RTR("XRNode3D should have physics_interpolation_mode set to OFF in order to avoid jitter."));
 		}
 	}

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -405,7 +405,7 @@ void CanvasItem::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated()) {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				RenderingServer::get_singleton()->canvas_item_reset_physics_interpolation(canvas_item);
 			}
 		} break;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -711,7 +711,7 @@ public:
 	void set_physics_interpolation_mode(PhysicsInterpolationMode p_mode);
 	PhysicsInterpolationMode get_physics_interpolation_mode() const { return data.physics_interpolation_mode; }
 	_FORCE_INLINE_ bool is_physics_interpolated() const { return data.physics_interpolated; }
-	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && is_physics_interpolated(); }
+	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return SceneTree::is_fti_enabled() && is_physics_interpolated(); }
 	void reset_physics_interpolation();
 
 	bool is_enabled() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -137,6 +137,9 @@ void SceneTree::ClientPhysicsInterpolation::physics_process() {
 }
 #endif // _3D_DISABLED
 
+bool SceneTree::_physics_interpolation_enabled = false;
+bool SceneTree::_physics_interpolation_enabled_in_project = false;
+
 void SceneTree::tree_changed() {
 	emit_signal(tree_changed_name);
 }
@@ -566,6 +569,9 @@ void SceneTree::initialize() {
 }
 
 void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
+	// This version is for use in editor.
+	_physics_interpolation_enabled_in_project = p_enabled;
+
 	// We never want interpolation in the editor.
 	if (Engine::get_singleton()->is_editor_hint()) {
 		p_enabled = false;
@@ -584,10 +590,6 @@ void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
 	if (root) {
 		root->reset_physics_interpolation();
 	}
-}
-
-bool SceneTree::is_physics_interpolation_enabled() const {
-	return _physics_interpolation_enabled;
 }
 
 #ifndef _3D_DISABLED

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -146,7 +146,14 @@ private:
 	HashMap<StringName, Group> group_map;
 	bool _quit = false;
 
-	bool _physics_interpolation_enabled = false;
+	// Static so we can get directly instead of via SceneTree pointer.
+	static bool _physics_interpolation_enabled;
+
+	// Note that physics interpolation is hard coded to OFF in the editor,
+	// therefore we have a second bool to enable e.g. configuration warnings
+	// to only take effect when the project is using physics interpolation.
+	static bool _physics_interpolation_enabled_in_project;
+
 	SceneTreeFTI scene_tree_fti;
 
 	StringName tree_changed_name = "tree_changed";
@@ -446,7 +453,11 @@ public:
 	//default texture settings
 
 	void set_physics_interpolation_enabled(bool p_enabled);
-	bool is_physics_interpolation_enabled() const;
+	bool is_physics_interpolation_enabled() const { return _physics_interpolation_enabled; }
+
+	// Different name to disambiguate fast static versions from the user bound versions.
+	static bool is_fti_enabled() { return _physics_interpolation_enabled; }
+	static bool is_fti_enabled_in_project() { return _physics_interpolation_enabled_in_project; }
 
 #ifndef _3D_DISABLED
 	void client_physics_interpolation_add_node_3d(SelfList<Node3D> *p_elem);


### PR DESCRIPTION
Also fixup FTI configuration warnings so that they only output when the project is using FTI.

@BastiaanOlij noticed that some FTI configuration warnings were firing when FTI was off in the project.
This happened because checking whether FTI was on in the editor was previously unsupported (as it was hard coded to OFF).

I had also been long term intending to swap using a local variable for global on / off in `SceneTree` to a static, the reason being that it would no longer be necessary to check `is_inside_tree()` and access the variable via a pointer, for what is likely to be a bottleneck check (and the global setting hardly ever changes, so a static makes sense here).

So I take the opportunity to swap both the global setting to a static, and add an extra one for checking the on / off setting within the editor (while not actually enabled the FTI functionality).

This enables us to check the project global setting before issuing configuration warnings, without having to use e.g. `GET_GLOBAL_CACHED()`, which isn't a particularly good way of doing this here due to the string duplication.

## Notes
* Also applicable to 3.x.
* I also want to actually get an MRP for the scene tree that caused this warning, just in case there is some pattern used in XR that won't well with the FTI, but that is a separate issue.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
