### PR TITLE
[3.x] `FTI` - Change `SceneTree` global setting to static

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -645,7 +645,7 @@ void CanvasItem::_notification(int p_what) {
 			global_invalid = true;
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated()) {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				VisualServer::get_singleton()->canvas_item_reset_physics_interpolation(canvas_item);
 			}
 		} break;

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -318,7 +318,7 @@ void Light2D::_notification(int p_what) {
 			_update_light_visibility();
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated()) {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				// Explicitly make sure the transform is up to date in VisualServer before
 				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
 				// is normally deferred, and a client change to transform will not always be sent

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -201,7 +201,7 @@ void LightOccluder2D::_notification(int p_what) {
 			VS::get_singleton()->canvas_light_occluder_attach_to_canvas(occluder, RID());
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated()) {
+			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
 				// Explicitly make sure the transform is up to date in VisualServer before
 				// resetting. This is necessary because NOTIFICATION_TRANSFORM_CHANGED
 				// is normally deferred, and a client change to transform will not always be sent

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -63,7 +63,7 @@ void PhysicsBody2D::_bind_methods() {
 String PhysicsBody2D::get_configuration_warning() const {
 	String warning = CollisionObject2D::get_configuration_warning();
 
-	if (!is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && !is_physics_interpolated()) {
 		if (!warning.empty()) {
 			warning += "\n\n";
 		}

--- a/scene/3d/arvr_nodes.cpp
+++ b/scene/3d/arvr_nodes.cpp
@@ -69,7 +69,7 @@ String ARVRCamera::get_configuration_warning() const {
 		warning += TTR("ARVRCamera must have an ARVROrigin node as its parent.");
 	};
 
-	if (is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}
@@ -397,7 +397,7 @@ String ARVRController::get_configuration_warning() const {
 		warning += TTR("The controller ID must not be 0 or this controller won't be bound to an actual controller.");
 	};
 
-	if (is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}
@@ -540,7 +540,7 @@ String ARVRAnchor::get_configuration_warning() const {
 		warning += TTR("The anchor ID must not be 0 or this anchor won't be bound to an actual anchor.");
 	};
 
-	if (is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && is_physics_interpolated()) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}

--- a/scene/3d/physics_body.cpp
+++ b/scene/3d/physics_body.cpp
@@ -101,7 +101,7 @@ void PhysicsBody::_bind_methods() {
 String PhysicsBody::get_configuration_warning() const {
 	String warning = CollisionObject::get_configuration_warning();
 
-	if (!is_physics_interpolated()) {
+	if (SceneTree::is_fti_enabled_in_project() && !is_physics_interpolated()) {
 		if (!warning.empty()) {
 			warning += "\n\n";
 		}

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -461,7 +461,7 @@ public:
 	void set_physics_interpolation_mode(PhysicsInterpolationMode p_mode);
 	PhysicsInterpolationMode get_physics_interpolation_mode() const { return data.physics_interpolation_mode; }
 	_FORCE_INLINE_ bool is_physics_interpolated() const { return data.physics_interpolated; }
-	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && is_physics_interpolated(); }
+	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return SceneTree::is_fti_enabled() && is_physics_interpolated(); }
 	void reset_physics_interpolation();
 
 	uint32_t get_canvas_parent_id() const { return data.canvas_parent_id; }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -108,6 +108,9 @@ SceneTreeTimer::SceneTreeTimer() {
 	process_pause = true;
 }
 
+bool SceneTree::_physics_interpolation_enabled = false;
+bool SceneTree::_physics_interpolation_enabled_in_project = false;
+
 // This should be called once per physics tick, to make sure the transform previous and current
 // is kept up to date on the few spatials that are using client side physics interpolation
 void SceneTree::ClientPhysicsInterpolation::physics_process() {
@@ -527,7 +530,10 @@ void SceneTree::init() {
 }
 
 void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
-	// disallow interpolation in editor
+	// This version is for use in editor.
+	_physics_interpolation_enabled_in_project = p_enabled;
+
+	// We never want interpolation in the editor.
 	if (Engine::get_singleton()->is_editor_hint()) {
 		p_enabled = false;
 	}
@@ -545,10 +551,6 @@ void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
 	if (root) {
 		root->reset_physics_interpolation();
 	}
-}
-
-bool SceneTree::is_physics_interpolation_enabled() const {
-	return _physics_interpolation_enabled;
 }
 
 void SceneTree::client_physics_interpolation_add_spatial(SelfList<Spatial> *p_elem) {
@@ -2334,7 +2336,6 @@ SceneTree::SceneTree() {
 	call_lock = 0;
 	root_lock = 0;
 	node_count = 0;
-	_physics_interpolation_enabled = false;
 
 	//create with mainloop
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -130,7 +130,14 @@ private:
 	bool _quit;
 	bool initialized;
 	bool input_handled;
-	bool _physics_interpolation_enabled;
+
+	// Static so we can get directly instead of via SceneTree pointer.
+	static bool _physics_interpolation_enabled;
+
+	// Note that physics interpolation is hard coded to OFF in the editor,
+	// therefore we have a second bool to enable e.g. configuration warnings
+	// to only take effect when the project is using physics interpolation.
+	static bool _physics_interpolation_enabled_in_project;
 
 	Size2 last_screen_size;
 	StringName tree_changed_name;
@@ -435,7 +442,11 @@ public:
 	bool is_refusing_new_network_connections() const;
 
 	void set_physics_interpolation_enabled(bool p_enabled);
-	bool is_physics_interpolation_enabled() const;
+	bool is_physics_interpolation_enabled() const { return _physics_interpolation_enabled; }
+
+	// Different name to disambiguate fast static versions from the user bound versions.
+	static bool is_fti_enabled() { return _physics_interpolation_enabled; }
+	static bool is_fti_enabled_in_project() { return _physics_interpolation_enabled_in_project; }
 
 	void client_physics_interpolation_add_spatial(SelfList<Spatial> *p_elem);
 	void client_physics_interpolation_remove_spatial(SelfList<Spatial> *p_elem);


### PR DESCRIPTION
Also fixup `FTI` configuration warnings so that they only output when the project is using `FTI`.

Backport of #107886.

@BastiaanOlij noticed that some FTI configuration warnings were firing when FTI was off in the project.
This happened because checking whether FTI was on in the editor was previously unsupported (as it was hard coded to OFF).

I had also been long term intending to swap using a local variable for global on / off in `SceneTree` to a static, the reason being that it would no longer be necessary to check `is_inside_tree()` and access the variable via a pointer, for what is likely to be a bottleneck check (and the global setting hardly ever changes, so a static makes sense here).

So I take the opportunity to swap both the global setting to a static, and add an extra one for checking the on / off setting within the editor (while not actually enabled the FTI functionality).

This enables us to check the project global setting before issuing configuration warnings, without having to use e.g. `GET_GLOBAL_CACHED()`, which isn't a particularly good way of doing this here due to the string duplication.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
