### PR TITLE
Highlight points on hover in the Polygon2D editor

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.h
+++ b/editor/scene/2d/polygon_2d_editor_plugin.h
@@ -135,6 +135,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	int point_drag_index = -1;
 	bool is_dragging = false;
 	bool is_creating = false;
+	int hovered_point = -1;
 	Vector<int> polygon_create;
 	Action current_action = ACTION_CREATE;
 	Vector2 drag_from;


### PR DESCRIPTION
The Polygon2D editor now highlights a point, if it's near the mouse cursor. It especially useful on touchpads, where it's much harder to aim.
But I was surprised how much it improves the mouse experience as well. And now I don't want to go back to the previuos behavior, because it was awful.
However, the Polygon2D editor is far from perfect and still needs a few improvements.

https://github.com/user-attachments/assets/00cd77a2-8546-4549-b5c9-0636b435e4ee

The downside of this improvement is performance, because now the editor needs to redraw more often and iterate through the array of points on every mouse move. However, it's well optimized, because it redraws only when the highlighted point is changed and avoids looping when is_creating is true, checking only the first point.