### PR TITLE
Document quirks when using TranslationServer in the Editor

### DIFF
--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -9,16 +9,16 @@
 		[b]Note:[/b] TranslationServer will not load translations in the editor. To avoid internal conflicts, use [method get_or_add_domain] to declare a custom editor domain.
 		[codeblocks]
 		[gdscript]
-		var domain #declare a custom domain to use in this script
+		var domain # Declare a custom domain to use in this script.
 
-		#load the editor domain when in editor scope
+		# Load the editor domain when in editor scope.
 		if OS.is_editor_hint():
 			domain = TranslationServer.get_or_add_domain("editor_domain")
 			domain.add_translation(preload("res://translation.en.translation"))
 		else:
 			domain = TranslationServer.get_or_add_domain("")
 		
-		print( domain.translate("key") ) #use [domain] instead of [TranslationServer]
+		print( domain.translate("key") ) # Use [domain] instead of [TranslationServer].
 		[/gdscript]
 		[/codeblocks]
 	</description>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -6,7 +6,7 @@
 	<description>
 		The translation server is the API backend that manages all language translations.
 		Translations are stored in [TranslationDomain]s, which can be accessed by name. The most commonly used translation domain is the main translation domain. It always exists and can be accessed using an empty [StringName]. The translation server provides wrapper methods for accessing the main translation domain directly, without having to fetch the translation domain first. Custom translation domains are mainly for advanced usages like editor plugins. Names starting with [code]godot.[/code] are reserved for engine internals.
-		[b]Note:[/b] It is not recommended to directly use TranslationServer in [code]@tool[/code] scripts as doing so may cause conflicts with the editor. Instead create a custom domain using [method get_or_add_domain].
+		[b]Note:[/b] [code]tool scripts[/code] can cause conflicts when using methods of [TranslationServer] that access the main domain while it is intended to be in control of the editor. Using a custom domain created with [method get_or_add_domain] instead for translations in editor-scope avoids that.
 	</description>
 	<tutorials>
 		<link title="Internationalizing games">$DOCS_URL/tutorials/i18n/internationalizing_games.html</link>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -6,21 +6,7 @@
 	<description>
 		The translation server is the API backend that manages all language translations.
 		Translations are stored in [TranslationDomain]s, which can be accessed by name. The most commonly used translation domain is the main translation domain. It always exists and can be accessed using an empty [StringName]. The translation server provides wrapper methods for accessing the main translation domain directly, without having to fetch the translation domain first. Custom translation domains are mainly for advanced usages like editor plugins. Names starting with [code]godot.[/code] are reserved for engine internals.
-		[b]Note:[/b] TranslationServer will not load translations in the editor. To avoid internal conflicts, use [method get_or_add_domain] to declare a custom editor domain.
-		[codeblocks]
-		[gdscript]
-		var domain # Declare a custom domain to use in this script.
-
-		# Load the editor domain when in editor scope.
-		if OS.is_editor_hint():
-			domain = TranslationServer.get_or_add_domain("editor_domain")
-			domain.add_translation(preload("res://translation.en.translation"))
-		else:
-			domain = TranslationServer.get_or_add_domain("")
-		
-		print( domain.translate("key") ) # Use [domain] instead of [TranslationServer].
-		[/gdscript]
-		[/codeblocks]
+		[b]Note:[/b] It is not recommended to directly use TranslationServer in [code]@tool[/code] scripts as doing so may cause conflicts with the editor. Instead create a custom domain using [method get_or_add_domain].
 	</description>
 	<tutorials>
 		<link title="Internationalizing games">$DOCS_URL/tutorials/i18n/internationalizing_games.html</link>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -6,6 +6,7 @@
 	<description>
 		The translation server is the API backend that manages all language translations.
 		Translations are stored in [TranslationDomain]s, which can be accessed by name. The most commonly used translation domain is the main translation domain. It always exists and can be accessed using an empty [StringName]. The translation server provides wrapper methods for accessing the main translation domain directly, without having to fetch the translation domain first. Custom translation domains are mainly for advanced usages like editor plugins. Names starting with [code]godot.[/code] are reserved for engine internals.
+		[b]Note:[/b] TranslationServer will not load translations in the editor. To avoid internal conflicts, use [method get_or_add_domain] to declare a custom editor domain.
 	</description>
 	<tutorials>
 		<link title="Internationalizing games">$DOCS_URL/tutorials/i18n/internationalizing_games.html</link>

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -7,6 +7,20 @@
 		The translation server is the API backend that manages all language translations.
 		Translations are stored in [TranslationDomain]s, which can be accessed by name. The most commonly used translation domain is the main translation domain. It always exists and can be accessed using an empty [StringName]. The translation server provides wrapper methods for accessing the main translation domain directly, without having to fetch the translation domain first. Custom translation domains are mainly for advanced usages like editor plugins. Names starting with [code]godot.[/code] are reserved for engine internals.
 		[b]Note:[/b] TranslationServer will not load translations in the editor. To avoid internal conflicts, use [method get_or_add_domain] to declare a custom editor domain.
+		[codeblocks]
+		[gdscript]
+		var domain #declare a custom domain to use in this script
+
+		#load the editor domain when in editor scope
+		if OS.is_editor_hint():
+			domain = TranslationServer.get_or_add_domain("editor_domain")
+			domain.add_translation(preload("res://translation.en.translation"))
+		else:
+			domain = TranslationServer.get_or_add_domain("")
+		
+		print( domain.translate("key") ) #use [domain] instead of [TranslationServer]
+		[/gdscript]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="Internationalizing games">$DOCS_URL/tutorials/i18n/internationalizing_games.html</link>


### PR DESCRIPTION
This is a small enhancement to the TranslationServer documentation mainly aimed at preventing #98935 from being raised again in the future.

Feel free to not use the code example. I think it adds some utility and clairity, but may be better suited for a dedicated tutorial on different tool quirks I am still trying to work on in the background.