### PR TITLE
Vulkan Mobile: Fix writing vertex color in spatial shader

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -380,10 +380,6 @@ void vertex_shader(in vec3 vertex,
 		model_normal_matrix = model_normal_matrix * mat3(matrix);
 	}
 
-#if defined(COLOR_USED)
-	color_interp = hvec4(color_highp);
-#endif
-
 #ifdef UV_USED
 	uv_interp = uv_attrib;
 #endif
@@ -444,6 +440,10 @@ void vertex_shader(in vec3 vertex,
 	{
 #CODE : VERTEX
 	}
+
+#if defined(COLOR_USED)
+	color_interp = hvec4(color_highp);
+#endif
 
 	half roughness = half(roughness_highp);
 


### PR DESCRIPTION
Regression from #107119. `COLOR` is renamed to `color_highp` in mobile scene shader, but we assigned it to `color_interp` before users' vertex code which causes writing vertex color has no effect. This PR fixes it.