### PR TITLE
[3.6] Revert "Fix Button not listing `hover_pressed` stylebox"

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -113,9 +113,6 @@
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
-		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is being hovered and pressed.
-		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Button].
 		</theme_item>

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -230,7 +230,6 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("normal", "Button", sb_button_normal);
 	theme->set_stylebox("pressed", "Button", sb_button_pressed);
 	theme->set_stylebox("hover", "Button", sb_button_hover);
-	theme->set_stylebox("hover_pressed", "Button", sb_button_hover);
 	theme->set_stylebox("disabled", "Button", sb_button_disabled);
 	theme->set_stylebox("focus", "Button", sb_button_focus);
 


### PR DESCRIPTION
This reverts commit cc11089786de6fc84a58f4b0af004997131b5b02.

(cherry picked from commit 62feeaab33d3e753790bc99b3d1a07b9a9c9661b)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
