### PR TITLE
Expose multi_mesh_rid in CPUParticles3D to allow custom rendering via RenderingDevice

### DIFF
--- a/doc/classes/CPUParticles3D.xml
+++ b/doc/classes/CPUParticles3D.xml
@@ -24,6 +24,11 @@
 				Sets this node's properties to match a given [GPUParticles3D] node with an assigned [ParticleProcessMaterial].
 			</description>
 		</method>
+		<method name="get_multimesh_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="get_param_curve" qualifiers="const">
 			<return type="Curve" />
 			<param index="0" name="param" type="int" enum="CPUParticles3D.Parameter" />

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -39,6 +39,10 @@
 #include "scene/resources/gradient_texture.h"
 #include "scene/resources/particle_process_material.h"
 
+RID CPUParticles3D::get_multimesh_rid() const {
+	return multimesh;
+}
+
 AABB CPUParticles3D::get_aabb() const {
 	return AABB();
 }
@@ -1516,6 +1520,7 @@ void CPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &CPUParticles3D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "scale"), &CPUParticles3D::set_speed_scale);
 
+	ClassDB::bind_method(D_METHOD("get_multimesh_rid"), &CPUParticles3D::get_multimesh_rid);
 	ClassDB::bind_method(D_METHOD("is_emitting"), &CPUParticles3D::is_emitting);
 	ClassDB::bind_method(D_METHOD("get_amount"), &CPUParticles3D::get_amount);
 	ClassDB::bind_method(D_METHOD("get_lifetime"), &CPUParticles3D::get_lifetime);

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -215,6 +215,7 @@ protected:
 #endif
 
 public:
+	RID get_multimesh_rid() const;
 	AABB get_aabb() const override;
 
 	void set_emitting(bool p_emitting);


### PR DESCRIPTION
# Description
I’m implementing a custom renderer using the RenderingDevice API. So far, I’ve managed to support both static meshes and skeletal meshes. I would now like to support CPUParticles3D as well.

My approach is to let Godot handle the particle simulation, then use the RenderingServer to fetch the transforms and colors of each instance through:
```gdscript
RenderingServer.multimesh_instance_get_transform(multi_mesh_rid, idx)
RenderingServer.multimesh_instance_get_color(multi_mesh_rid, idx)
```
However, the internal `RID multimesh;` of the `CPUParticles3D` node is currently private, which makes this impossible.

# What this PR does
This PR simply adds a getter for the internal MultiMesh RID (multimesh) and exposes it to scripts using:
```gdscript
ClassDB::bind_method(D_METHOD("get_multimesh_rid"), &CPUParticles3D::get_multimesh_rid);
```
This allows users to integrate `CPUParticles3D` into custom renderers without having to reimplement particle simulation.

# Tests:
- Code compiles and runs correctly.
- Works in a simple POC project

![image](https://github.com/user-attachments/assets/0ba1cad7-6408-45ea-888b-10e5e91c9743)

# Personal Note:
This is my first pull request to the Godot Engine. I’ve read the [Pull Request Workflow](https://docs.godotengine.org/en/stable/contributing/workflow/pr_workflow.html), and while I’m not an advanced Git user, I’m eager to learn and happy to make any requested changes.

Thanks for your time and for maintaining such an awesome engine

