### PR TITLE
Fix inherited nested scenes not updating

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -672,7 +672,7 @@ bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, HashSet<Str
 		ss = p_node->get_scene_instance_state();
 	}
 
-	if (ss.is_valid()) {
+	while (ss.is_valid()) {
 		String path = ss->get_path();
 
 		if (!checked_paths.has(path)) {
@@ -683,6 +683,7 @@ bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, HashSet<Str
 
 			checked_paths.insert(path);
 		}
+		ss = ss->get_base_scene_state();
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
@@ -717,6 +718,8 @@ bool EditorData::check_and_update_scene(int p_idx) {
 		ep.step(TTR("Updating scene..."), 1);
 		Node *new_scene = pscene->instantiate(PackedScene::GEN_EDIT_STATE_MAIN);
 		ERR_FAIL_NULL_V(new_scene, false);
+
+		EditorNode::get_singleton()->make_unique_inheritance(new_scene);
 
 		// Transfer selection.
 		List<Node *> new_selection;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4447,6 +4447,8 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	new_scene->set_scene_instance_state(Ref<SceneState>());
+	// Unlink inherited SceneState from its PackedScene to avoid updating its modified time externally.
+	make_unique_inheritance(new_scene);
 
 	set_edited_scene(new_scene);
 
@@ -4847,6 +4849,22 @@ void EditorNode::replace_history_reimported_nodes(Node *p_original_root_node, No
 
 bool EditorNode::has_previous_closed_scenes() const {
 	return !prev_closed_scenes.is_empty();
+}
+
+void EditorNode::make_unique_inheritance(Node *p_node) {
+	Ref<SceneState> state = p_node->get_scene_inherited_state();
+	if (state.is_valid()) {
+		state->make_unique_inheritance();
+	}
+
+	state = p_node->get_scene_instance_state();
+	if (state.is_valid()) {
+		state->make_unique_inheritance();
+	}
+
+	for (int i = 0; i < p_node->get_child_count(false); i++) {
+		make_unique_inheritance(p_node->get_child(i, false));
+	}
 }
 
 void EditorNode::edit_foreign_resource(Ref<Resource> p_resource) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -785,6 +785,7 @@ public:
 	bool has_previous_closed_scenes() const;
 
 	void new_inherited_scene() { _menu_option_confirm(SCENE_NEW_INHERITED_SCENE, false); }
+	void make_unique_inheritance(Node *p_node);
 
 	void update_distraction_free_mode();
 	void set_distraction_free_mode(bool p_enter);

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -1366,6 +1366,22 @@ Ref<SceneState> SceneState::get_base_scene_state() const {
 	return Ref<SceneState>();
 }
 
+void SceneState::make_unique_inheritance() {
+	Ref<SceneState> state(this);
+
+	while (state->base_scene_idx >= 0) {
+		Ref<PackedScene> base_scene = state->variants[state->base_scene_idx];
+		ERR_FAIL_COND(base_scene.is_null());
+		Ref<SceneState> base_state = base_scene->get_state();
+
+		base_scene.instantiate();
+		base_scene->replace_state(base_state);
+		state->variants.write[state->base_scene_idx] = base_scene;
+
+		state = base_state;
+	}
+}
+
 int SceneState::find_node_by_path(const NodePath &p_node) const {
 	ERR_FAIL_COND_V_MSG(node_path_cache.is_empty(), -1, "This operation requires the node cache to have been built.");
 

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -162,8 +162,7 @@ public:
 	bool has_local_resource(const Array &p_array) const;
 
 	Ref<SceneState> get_base_scene_state() const;
-
-	void update_instance_resource(String p_path, Ref<PackedScene> p_packed_scene);
+	void make_unique_inheritance();
 
 	//unbuild API
 


### PR DESCRIPTION
Fixes #7984 and related issues (https://github.com/godotengine/godot/pull/85562#issuecomment-2968471138)

However it's broken XD

The bug is twofold. First is that when checking for scene changes, EditorData only checked one level of inheritance. This was trivial to fix and required just 2 lines of change.

The fun begins here:
https://github.com/godotengine/godot/blob/88b9932ce14412843538b5084d3563ed89dbb308/editor/editor_data.cpp#L680
`ss->get_modified_time()` may return either old time or new time.
It returns old time from a copy of old SceneState in node.
However higher levels of inheritance keep their SceneState in a PackedScene, which sits in ResourceCache. This means that when base scene is updated, its SceneState gets replaced. At the time `_find_updated_instances()` is called, the base scene has the new state, so modified time is the same.

The solution I came up with is discarding base scene path. I just go through the whole inheritance chain and replace SceneState's PackedScene with one that isn't cached, so it doesn't get updated too early. This does work, but in a rather chaotic way. The 2-level inherited scene does refresh properly, but only once. Then you have to reload manually as usual, however the reload may fail or may restore some old state (??). idk what to do about it.

Another related, but probably separate bug, is that root node properties don't get updated to new default values. The method for obtaining default value probably uses wrong state or something.