### PR TITLE
Cleanup closed embedded processes on macOS

### DIFF
--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -62,7 +62,6 @@ class EmbeddedProcessMacOS final : public EmbeddedProcessBase {
 		IN_PROGRESS,
 		COMPLETED,
 		FAILED,
-		CLOSED,
 	};
 
 	DisplayServerMacOS *ds = nullptr;

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -128,7 +128,7 @@ void EmbeddedProcessMacOS::request_close() {
 	if (current_process_id != 0 && is_embedding_completed()) {
 		script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_CLOSE_REQUEST });
 	}
-	embedding_state = EmbeddingState::CLOSED;
+	reset();
 }
 
 void EmbeddedProcessMacOS::display_state_changed() {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/107916

Tested by examining the size and contents of `embedded_processes` with and without this fix and verifying that without the fix the size of the map increases with project runs and with the fix the map returns back to size zero each time the project is stopped/closed. I tested running both single instance and multi-instance as well as stopping the project both via closing the window and hitting stop in the editor.

Other possible approach described here https://github.com/godotengine/godot/issues/107066#issuecomment-2994596239