### PR TITLE
Implement `set_time_left` in Timer node

### DIFF
--- a/doc/classes/Timer.xml
+++ b/doc/classes/Timer.xml
@@ -58,9 +58,9 @@
 		<member name="process_callback" type="int" setter="set_timer_process_callback" getter="get_timer_process_callback" enum="Timer.TimerProcessCallback" default="1">
 			Specifies when the timer is updated during the main loop.
 		</member>
-		<member name="time_left" type="float" setter="" getter="get_time_left">
-			The timer's remaining time in seconds. This is always [code]0[/code] if the timer is stopped.
-			[b]Note:[/b] This property is read-only and cannot be modified. It is based on [member wait_time].
+		<member name="time_left" type="float" setter="set_time_left" getter="get_time_left">
+			The timer's remaining time in seconds. This is always [code]0.0[/code] if the timer is stopped.
+			[b]Note:[/b] It is not possible to set this property while the timer is stopped.
 		</member>
 		<member name="wait_time" type="float" setter="set_wait_time" getter="get_wait_time" default="1.0">
 			The time required for the timer to end, in seconds. This property can also be set every time [method start] is called.

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -68,3 +68,10 @@ GH-110433
 Validate extension JSON: Error: Field 'classes/Performance/methods/add_custom_monitor/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added. Compatibility method registered.
+
+
+GH-107920
+---------
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Timer/properties/time_left': setter
+
+Setter function added.

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -160,6 +160,11 @@ double Timer::get_time_left() const {
 	return time_left > 0 ? time_left : 0;
 }
 
+void Timer::set_time_left(double p_time) {
+	ERR_FAIL_COND_MSG(!processing, "Unable to set time_left when the timer is stopped. Use `start(time_left)` instead.");
+	time_left = p_time;
+}
+
 void Timer::set_timer_process_callback(TimerProcessCallback p_callback) {
 	if (timer_process_callback == p_callback) {
 		return;
@@ -230,6 +235,7 @@ void Timer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_stopped"), &Timer::is_stopped);
 
 	ClassDB::bind_method(D_METHOD("get_time_left"), &Timer::get_time_left);
+	ClassDB::bind_method(D_METHOD("set_time_left", "time_left"), &Timer::set_time_left);
 
 	ClassDB::bind_method(D_METHOD("set_timer_process_callback", "callback"), &Timer::set_timer_process_callback);
 	ClassDB::bind_method(D_METHOD("get_timer_process_callback"), &Timer::get_timer_process_callback);
@@ -242,7 +248,7 @@ void Timer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "autostart"), "set_autostart", "has_autostart");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_paused", "is_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_time_scale"), "set_ignore_time_scale", "is_ignoring_time_scale");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left", PROPERTY_HINT_NONE, "suffix:s", PROPERTY_USAGE_NONE), "", "get_time_left");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_left", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_time_left", "get_time_left");
 
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_PHYSICS);
 	BIND_ENUM_CONSTANT(TIMER_PROCESS_IDLE);

--- a/scene/main/timer.h
+++ b/scene/main/timer.h
@@ -75,6 +75,7 @@ public:
 	bool is_stopped() const;
 
 	double get_time_left() const;
+	void set_time_left(double p_time);
 
 	PackedStringArray get_configuration_warnings() const override;
 


### PR DESCRIPTION
If new time_left is bigger than wait_time, sets wait_time value

Updates
scene\main\timer.cpp
scene\main\timer.h

- Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/12655
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
