### PR TITLE
Fix updating project settings after move

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1635,7 +1635,7 @@ void FileSystemDock::_update_project_settings_after_move(const HashMap<String, S
 	// Find all project settings of type FILE and replace them if needed.
 	const HashMap<StringName, PropertyInfo> prop_info = ProjectSettings::get_singleton()->get_custom_property_info();
 	for (const KeyValue<StringName, PropertyInfo> &E : prop_info) {
-		if (E.value.hint == PROPERTY_HINT_FILE_PATH) {
+		if (E.value.hint == PROPERTY_HINT_FILE || E.value.hint == PROPERTY_HINT_FILE_PATH) {
 			String old_path = GLOBAL_GET(E.key);
 			if (p_renames.has(old_path)) {
 				ProjectSettings::get_singleton()->set_setting(E.key, p_renames[old_path]);


### PR DESCRIPTION
Fixes #107927

PROPERTY_HINT_FILE is supposed to store UIDs, but old projects may still have path. Also the default icon path is initialized as path.
https://github.com/godotengine/godot/blob/88b9932ce14412843538b5084d3563ed89dbb308/editor/project_manager/project_dialog.cpp#L547