### PR TITLE
Fix removing wrong vertices in the Polygon2D editor when points overlap each other

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -575,14 +575,12 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					}
 
 					int closest = -1;
-					real_t closest_dist = 1e20;
 
-					for (int i = editing_points.size() - internal_vertices; i < editing_points.size(); i++) {
+					for (int i = editing_points.size() - 1; i >= editing_points.size() - internal_vertices; i--) {
 						Vector2 tuv = mtx.xform(previous_polygon[i]);
-						real_t dist = tuv.distance_to(mb->get_position());
-						if (dist < 8 && dist < closest_dist) {
+						if (tuv.distance_to(mb->get_position()) < 8) {
 							closest = i;
-							closest_dist = dist;
+							break;
 						}
 					}
 


### PR DESCRIPTION
When working on my previous PR #107890 I noticed that the editor can sometimes remove a point, that is "behind" the point that you actually point on:

https://github.com/user-attachments/assets/93816dc5-9947-4a71-86c7-fcdca2f699c2

This PR fixes it. Now the remove action uses a more intuitive logic to choose which vertex to remove, and its logic now the same, as the move action uses:

https://github.com/user-attachments/assets/4889e605-6d62-452d-be47-063a2851b1f7

