### PR TITLE
Fix points jumping when dragging starts in the Polygon2D editor

### DIFF
--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -629,9 +629,8 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 				if (current_action == ACTION_EDIT_POINT) {
 					point_drag_index = -1;
 					for (int i = 0; i < editing_points.size(); i++) {
-						Vector2 tuv = mtx.xform(editing_points[i]);
-						if (tuv.distance_to(mb->get_position()) < 8) {
-							drag_from = tuv;
+						if (mtx.xform(editing_points[i]).distance_to(mb->get_position()) < 8) {
+							drag_from = mb->get_position();
 							point_drag_index = i;
 						}
 					}


### PR DESCRIPTION
Currently, when you start dragging a vertex in the Polygon2D editor, it immidiately jumps because it uses the position of the points as the drag_from, instead of the position, where you acutally start dragging. It prevents precise editing when you need to shift a point a little bit.
### Before

https://github.com/user-attachments/assets/b8d7cd53-7cfa-4c47-a071-8e8b9ba08455

This PR fixes it by just using the position of you mouse as the drag_from. Now you can move vertices smoothly:

https://github.com/user-attachments/assets/a47d0ecf-31a5-4e0a-a9eb-18afb3a1aef7