### PR TITLE
Fix compiler error: pass `-mpopcnt` when using clang / llvm and targeting x86_64

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -741,7 +741,7 @@ if env["arch"] == "x86_64":
         env.Append(CCFLAGS=["/d2archSSE42"])
     else:
         # `-msse2` is implied when compiling for x86_64.
-        env.Append(CCFLAGS=["-msse4.2"])
+        env.Append(CCFLAGS=["-msse4.2", "-mpopcnt"])
 elif env["arch"] == "x86_32":
     # Be more conservative with instruction sets on 32-bit x86 to improve compatibility.
     # SSE and SSE2 are present on all CPUs that support 64-bit, even if running a 32-bit OS.


### PR DESCRIPTION
Introduced by PR: https://github.com/godotengine/godot/pull/59595

The error occurs when compiling with llvm on linux.  At the very least, with the llvm compiler bundled with zig that we use.

```
In file included from thirdparty/embree/kernels/bvh/bvh_intersector_hybrid4_bvh4.cpp:4:
In file included from thirdparty/embree/kernels/bvh/bvh_intersector_hybrid.cpp:4:
In file included from thirdparty/embree/kernels/bvh/bvh_intersector_hybrid.h:6:
In file included from thirdparty/embree/kernels/bvh/bvh.h:7:
In file included from thirdparty/embree/kernels/bvh/bvh_node_aabb.h:6:
In file included from thirdparty/embree/kernels/bvh/bvh_node_base.h:6:
In file included from thirdparty/embree/kernels/bvh/bvh_node_ref.h:6:
In file included from thirdparty/embree/kernels/bvh/../common/default.h:8:
In file included from thirdparty/embree/kernels/bvh/../common/../../common/sys/thread.h:7:
In file included from thirdparty/embree/kernels/bvh/../common/../../common/sys/mutex.h:7:
thirdparty/embree/kernels/bvh/../common/../../common/sys/intrinsics.h:489:12: error: always_inline function '_mm_popcnt_u64' requires target feature 'popcnt', but would be inlined into function 'popcnt' that is compiled without support for 'popcnt'
  489 |     return _mm_popcnt_u64(in);
      |            ^
1 error generated.l.cpp
scons: *** [bin/obj/thirdparty/embree/kernels/bvh/steambvh_intersector_hybrid4_bvh4.linuxbsd.editor.double.x86_64.llvm.steam.o] Error 1
scons: building terminated because of errors.
INFO: Time elapsed: 00:02:22.99
```

The fix is to pass the ``-mpopcnt`` flag to the compiler so that the function ``_mm_popcnt_u64`` supports ``always_inline``.