### PR TITLE
Simplify Node Filter's placeholder in Scene dock

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4760,7 +4760,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	// The "Filter Nodes" text input above the Scene Tree Editor.
 	filter = memnew(LineEdit);
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
-	filter->set_placeholder(TTRC("Filter: name, t:type, g:group"));
+	filter->set_placeholder(TTRC("Filter Nodes"));
 	filter->set_accessibility_name(TTRC("Filter Nodes"));
 	filter->set_tooltip_text(TTRC("Filter nodes by entering a part of their name, type (if prefixed with \"type:\" or \"t:\")\nor group (if prefixed with \"group:\" or \"g:\"). Filtering is case-insensitive."));
 	filter_hbc->add_child(filter);


### PR DESCRIPTION
Partially reverts https://github.com/godotengine/godot/pull/81675
See also https://github.com/godotengine/godot/pull/107656#discussion_r2158620905

I'm going to try to make it brief (_sure did, buddy_). I believe https://github.com/godotengine/godot/pull/81675 changing the placeholder to `"Filter: name, t:type, g:group"` was an overcorrection:
- There's already plenty of ways to discover the filtering options as highlighted in https://github.com/godotengine/godot/pull/65932
- The placeholder tries really hard to explain something, but with so few words it's somewhat meaningless, _unless_ the user has already discovered this feature already
	- This information is better suited for a tooltip, which _has_ been implemented by https://github.com/godotengine/godot/pull/81675
- The placeholder is not future-proof
- The placeholder is excessively long, even for the default layout
- Due of its syntax, it's comparatively busy and "unprofessional" compared to the rest of the interface upon starting the Godot Editor

