### PR TITLE
Generate scene ID for created built-in Resources

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -497,7 +497,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 
 			Resource *resp = Object::cast_to<Resource>(obj);
 			ERR_BREAK(!resp);
-			resp->set_path(_get_owner_path() + "::"); // Assign a base path for built-in Resources.
+			resp->set_path(_get_owner_path() + "::" + resp->generate_scene_unique_id()); // Assign a base path for built-in Resources.
 
 			EditorNode::get_editor_data().instantiate_object_properties(obj);
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2562,7 +2562,7 @@ void SceneTreeDock::_script_created(Ref<Script> p_script) {
 	}
 
 	if (p_script->is_built_in()) {
-		p_script->set_path(edited_scene->get_scene_file_path() + "::");
+		p_script->set_path(edited_scene->get_scene_file_path() + "::" + p_script->generate_scene_unique_id());
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -251,7 +251,7 @@ void fog() {
 		if (is_built_in) {
 			Node *edited_scene = get_tree()->get_edited_scene_root();
 			if (likely(edited_scene)) {
-				shader->set_path(edited_scene->get_scene_file_path() + "::");
+				shader->set_path(edited_scene->get_scene_file_path() + "::" + shader->generate_scene_unique_id());
 			}
 		} else {
 			String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());


### PR DESCRIPTION
Currently when creating a built-in script etc., it will get a path like `scene_path.tscn::`, where the part after `::` is supposed to be generated when the scene is being saved.
Turns out there is a convenient method that allows generating the ID immediately.

Fixes #107745