### PR TITLE
Add short-circuiting logic for `Expression` AND/OR operators

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1267,6 +1267,10 @@ bool Expression::_execute(const Array &p_inputs, Object *p_instance, Expression:
 				return true;
 			}
 
+			if (op->should_short_circuit(a, r_ret)) {
+				return false;
+			}
+
 			Variant b;
 
 			if (op->nodes[1]) {
@@ -1526,4 +1530,16 @@ Expression::~Expression() {
 	if (nodes) {
 		memdelete(nodes);
 	}
+}
+
+bool Expression::OperatorNode::should_short_circuit(const Variant &p_first_value, Variant &r_ret) const {
+	if (op == Variant::Operator::OP_AND && !p_first_value.booleanize()) {
+		r_ret = false;
+		return true;
+	} else if (op == Variant::Operator::OP_OR && p_first_value.booleanize()) {
+		r_ret = true;
+		return true;
+	}
+
+	return false;
 }

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -175,6 +175,8 @@ private:
 		OperatorNode() {
 			type = TYPE_OPERATOR;
 		}
+
+		bool should_short_circuit(const Variant &p_first_value, Variant &r_ret) const;
 	};
 
 	struct SelfNode : public ENode {


### PR DESCRIPTION
Added `OperatorNode::should_short_circuit` method, to use in `Expression::_execute` to return early when possible.

Fixes #107025

Tested with gdscript below:

```gdscript
func _ready() -> void:
	test_expr("true_func() and false_func()")
	test_expr("false_func() && false_func()")
	test_expr("false_func() || false_func()")
	test_expr("true_func() or false_func()")

func true_func() -> bool:
	print("true_func() called")
	return true

func false_func() -> bool:
	print("false_func() called")
	return false
	
func test_expr(p_expr: String):
	var test_name: String = p_expr.replace("_func()", "")
	print("%s\n----------" % [test_name])
	var expr = Expression.new()
	expr.parse(p_expr)
	var result = expr.execute([], self)
	print("Result: %s\n" % [result])
```

old:
```
true and false
----------
true_func() called
false_func() called
Result: false

false && false
----------
false_func() called
false_func() called
Result: false

false || false
----------
false_func() called
false_func() called
Result: false

true or false
----------
true_func() called
false_func() called
Result: true
```

new:
```
true and false
----------
true_func() called
false_func() called
Result: false

false && false
----------
false_func() called
Result: false

false || false
----------
false_func() called
false_func() called
Result: false

true or false
----------
true_func() called
Result: true
```


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
