### PR TITLE
LightmapGI: Limit the number of lights computed per direct pass

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2955,6 +2955,10 @@
 			The VoxelGI quality to use. High quality leads to more precise lighting and better reflections, but is slower to render. This setting does not affect the baked data and doesn't require baking the [VoxelGI] again to apply.
 			[b]Note:[/b] This property is only read when the project starts. To control VoxelGI quality at runtime, call [method RenderingServer.voxel_gi_set_quality] instead.
 		</member>
+		<member name="rendering/lightmapping/bake_performance/max_lights_per_pass" type="int" setter="" getter="" default="8">
+			The maximum number of lights that can be computed per pass when baking lightmaps with [LightmapGI]. Depending on the scene, adjusting this value may result in higher GPU utilization when baking lightmaps, leading to faster bake times.
+			[b]Note:[/b] Using a value that is too high for your system can cause crashes due to the GPU being unresponsive for long periods of time, and the graphics driver being reset by the OS.
+		</member>
 		<member name="rendering/lightmapping/bake_performance/max_rays_per_pass" type="int" setter="" getter="" default="4">
 			The maximum number of rays that can be thrown per pass when baking lightmaps with [LightmapGI]. Depending on the scene, adjusting this value may result in higher GPU utilization when baking lightmaps, leading to faster bake times.
 			[b]Note:[/b] Using a value that is too high for your system can cause crashes due to the GPU being unresponsive for long periods of time, and the graphics driver being reset by the OS.

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1685,6 +1685,9 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	const int x_regions = Math::division_round_up(atlas_size.width, max_region_size);
 	const int y_regions = Math::division_round_up(atlas_size.height, max_region_size);
 
+	const int lights_per_pass = int(GLOBAL_GET("rendering/lightmapping/bake_performance/max_lights_per_pass"));
+	const int light_pass_count = Math::division_round_up(int(lights.size()), lights_per_pass);
+
 	// Set ray count to the quality used for direct light and bounces.
 	switch (p_quality) {
 		case BAKE_QUALITY_LOW: {
@@ -1760,41 +1763,46 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 			for (int i = 0; i < x_regions; i++) {
 				for (int j = 0; j < y_regions; j++) {
-					int x = i * max_region_size;
-					int y = j * max_region_size;
-					int w = MIN((i + 1) * max_region_size, atlas_size.width) - x;
-					int h = MIN((j + 1) * max_region_size, atlas_size.height) - y;
+					for (int l = 0; l < light_pass_count; l++) {
+						int x = i * max_region_size;
+						int y = j * max_region_size;
+						int w = MIN((i + 1) * max_region_size, atlas_size.width) - x;
+						int h = MIN((j + 1) * max_region_size, atlas_size.height) - y;
 
-					push_constant.region_ofs[0] = x;
-					push_constant.region_ofs[1] = y;
+						push_constant.region_ofs[0] = x;
+						push_constant.region_ofs[1] = y;
 
-					group_size = Vector3i(Math::division_round_up(w, 8), Math::division_round_up(h, 8), 1);
-					RD::ComputeListID compute_list = rd->compute_list_begin();
-					rd->compute_list_bind_compute_pipeline(compute_list, compute_shader_primary_pipeline);
-					rd->compute_list_bind_uniform_set(compute_list, compute_base_uniform_set, 0);
-					rd->compute_list_bind_uniform_set(compute_list, light_uniform_set, 1);
-					rd->compute_list_set_push_constant(compute_list, &push_constant, sizeof(PushConstant));
-					rd->compute_list_dispatch(compute_list, group_size.x, group_size.y, group_size.z);
-					rd->compute_list_end();
+						push_constant.light_from = l * lights_per_pass;
+						push_constant.light_to = MIN((l + 1) * lights_per_pass, int(lights.size()));
 
-					rd->submit();
-					rd->sync();
+						group_size = Vector3i(Math::division_round_up(w, 8), Math::division_round_up(h, 8), 1);
+						RD::ComputeListID compute_list = rd->compute_list_begin();
+						rd->compute_list_bind_compute_pipeline(compute_list, compute_shader_primary_pipeline);
+						rd->compute_list_bind_uniform_set(compute_list, compute_base_uniform_set, 0);
+						rd->compute_list_bind_uniform_set(compute_list, light_uniform_set, 1);
+						rd->compute_list_set_push_constant(compute_list, &push_constant, sizeof(PushConstant));
+						rd->compute_list_dispatch(compute_list, group_size.x, group_size.y, group_size.z);
+						rd->compute_list_end();
 
-					count++;
-					if (p_step_function) {
-						int total = (atlas_slices * x_regions * y_regions);
-						int percent = count * 100 / total;
-						float p = float(count) / total * 0.1;
-						if (p_step_function(0.5 + p, vformat(RTR("Plot direct lighting %d%%"), percent), p_bake_userdata, false)) {
-							FREE_TEXTURES
-							FREE_BUFFERS
-							FREE_RASTER_RESOURCES
-							FREE_COMPUTE_RESOURCES
-							memdelete(rd);
-							if (rcd != nullptr) {
-								memdelete(rcd);
+						rd->submit();
+						rd->sync();
+
+						count++;
+						if (p_step_function) {
+							int total = (atlas_slices * x_regions * y_regions * lights.size());
+							int percent = count * 100 / total;
+							float p = float(count) / total * 0.1;
+							if (p_step_function(0.5 + p, vformat(RTR("Plot direct lighting %d%%"), percent), p_bake_userdata, false)) {
+								FREE_TEXTURES
+								FREE_BUFFERS
+								FREE_RASTER_RESOURCES
+								FREE_COMPUTE_RESOURCES
+								memdelete(rd);
+								if (rcd != nullptr) {
+									memdelete(rcd);
+								}
+								return BAKE_ERROR_USER_ABORTED;
 							}
-							return BAKE_ERROR_USER_ABORTED;
 						}
 					}
 				}

--- a/modules/lightmapper_rd/lightmapper_rd.h
+++ b/modules/lightmapper_rd/lightmapper_rd.h
@@ -259,9 +259,12 @@ class LightmapperRD : public Lightmapper {
 		uint32_t ray_count = 0;
 		uint32_t ray_from = 0;
 		uint32_t ray_to = 0;
+		uint32_t light_from = 0;
+		uint32_t light_to = 0;
 		uint32_t region_ofs[2] = {};
 		uint32_t probe_count = 0;
 		uint32_t denoiser_range = 0;
+		uint32_t pad[2] = {};
 	};
 
 	Vector<Ref<Image>> lightmap_textures;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -52,7 +52,12 @@ layout(rgba32f, set = 1, binding = 1) uniform restrict image2DArray unocclude;
 
 #if defined(MODE_DIRECT_LIGHT) || defined(MODE_BOUNCE_LIGHT)
 
+#if defined(MODE_DIRECT_LIGHT)
+layout(rgba16f, set = 1, binding = 0) uniform restrict image2DArray dest_light;
+#else
 layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2DArray dest_light;
+#endif
+
 layout(set = 1, binding = 1) uniform texture2DArray source_light;
 layout(set = 1, binding = 2) uniform texture2DArray source_position;
 layout(set = 1, binding = 3) uniform texture2DArray source_normal;
@@ -61,7 +66,7 @@ layout(rgba16f, set = 1, binding = 4) uniform restrict image2DArray accum_light;
 #endif
 
 #if defined(MODE_DIRECT_LIGHT) && defined(USE_SHADOWMASK)
-layout(rgba8, set = 1, binding = 5) uniform restrict writeonly image2DArray shadowmask;
+layout(rgba8, set = 1, binding = 5) uniform restrict image2DArray shadowmask;
 #elif defined(MODE_BOUNCE_LIGHT)
 layout(set = 1, binding = 5) uniform texture2D environment;
 #endif
@@ -91,6 +96,9 @@ layout(push_constant, std430) uniform Params {
 	uint ray_count;
 	uint ray_from;
 	uint ray_to;
+
+	uint light_from;
+	uint light_to;
 
 	ivec2 region_ofs;
 	uint probe_count;
@@ -836,32 +844,31 @@ void main() {
 	}
 	float texel_size_world_space = distance(position, neighbor_position.xyz) * bake_params.supersampling_factor;
 
-	vec3 light_for_texture = vec3(0.0);
-	vec3 light_for_bounces = vec3(0.0);
-
-#ifdef USE_SHADOWMASK
-	float shadowmask_value = 0.0f;
-#endif
+	vec3 light_for_bounces = imageLoad(dest_light, ivec3(atlas_pos, params.atlas_slice)).rgb;
 
 #ifdef USE_SH_LIGHTMAPS
 	vec4 sh_accum[4] = vec4[](
-			vec4(0.0, 0.0, 0.0, 1.0),
-			vec4(0.0, 0.0, 0.0, 1.0),
-			vec4(0.0, 0.0, 0.0, 1.0),
-			vec4(0.0, 0.0, 0.0, 1.0));
+			imageLoad(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 0)),
+			imageLoad(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 1)),
+			imageLoad(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 2)),
+			imageLoad(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 3)));
+#else
+	vec3 light_for_texture = imageLoad(accum_light, ivec3(atlas_pos, params.atlas_slice)).rgb;
+#endif
+
+#ifdef USE_SHADOWMASK
+	float shadowmask_value = imageLoad(shadowmask, ivec3(atlas_pos, params.atlas_slice)).r;
 #endif
 
 	// Use atlas position and a prime number as the seed.
 	uint noise = random_seed(ivec3(atlas_pos, 43573547));
-	for (uint i = 0; i < bake_params.light_count; i++) {
+	for (uint i = params.light_from; i < params.light_to; i++) {
 		vec3 light;
 		vec3 light_dir;
 		float shadow;
 		trace_direct_light(position, normal, i, true, light, light_dir, noise, texel_size_world_space, shadow);
 
 		if (lights.data[i].static_bake) {
-			light_for_texture += light;
-
 #ifdef USE_SH_LIGHTMAPS
 			// For L0, light needs to be attenuated by dot(normal, light_dir) else it is oversaturated when sampled later.
 			// For L1, light can't be attenuated by dot(normal, light_dir) since when sampling later, the dot product is done.
@@ -894,10 +901,12 @@ void main() {
 			for (uint j = 0; j < 4; j++) {
 				sh_accum[j].rgb += light * c[j] * bake_params.exposure_normalization;
 			}
+#else
+			light_for_texture += light * bake_params.exposure_normalization;
 #endif
 		}
 
-		light_for_bounces += light * lights.data[i].indirect_energy;
+		light_for_bounces += light * lights.data[i].indirect_energy * bake_params.exposure_normalization;
 
 #ifdef USE_SHADOWMASK
 		if (lights.data[i].type == LIGHT_TYPE_DIRECTIONAL && i == bake_params.shadowmask_light_idx) {
@@ -906,22 +915,20 @@ void main() {
 #endif
 	}
 
-	light_for_bounces *= bake_params.exposure_normalization;
 	imageStore(dest_light, ivec3(atlas_pos, params.atlas_slice), vec4(light_for_bounces, 1.0));
 
 #ifdef USE_SH_LIGHTMAPS
 	// Keep for adding at the end.
-	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 0), sh_accum[0]);
-	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 1), sh_accum[1]);
-	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 2), sh_accum[2]);
-	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 3), sh_accum[3]);
+	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 0), vec4(sh_accum[0].rgb, 1.0));
+	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 1), vec4(sh_accum[1].rgb, 1.0));
+	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 2), vec4(sh_accum[2].rgb, 1.0));
+	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice * 4 + 3), vec4(sh_accum[3].rgb, 1.0));
 #else
-	light_for_texture *= bake_params.exposure_normalization;
 	imageStore(accum_light, ivec3(atlas_pos, params.atlas_slice), vec4(light_for_texture, 1.0));
 #endif
 
 #ifdef USE_SHADOWMASK
-	imageStore(shadowmask, ivec3(atlas_pos, params.atlas_slice), vec4(shadowmask_value, shadowmask_value, shadowmask_value, 1.0));
+	imageStore(shadowmask, ivec3(atlas_pos, params.atlas_slice), vec4(shadowmask_value, 1.0, 1.0, 1.0));
 #endif
 
 #endif

--- a/modules/lightmapper_rd/register_types.cpp
+++ b/modules/lightmapper_rd/register_types.cpp
@@ -60,6 +60,8 @@ void initialize_lightmapper_rd_module(ModuleInitializationLevel p_level) {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 2048);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_performance/max_rays_per_probe_pass", PROPERTY_HINT_RANGE, "1,256,1,or_greater"), 64);
 
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/bake_performance/max_lights_per_pass", PROPERTY_HINT_RANGE, "1,128,1,or_greater"), 8);
+
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/lightmapping/denoising/denoiser", PROPERTY_HINT_ENUM, "JNLM,OIDN"), 0);
 #ifndef _3D_DISABLED
 	GDREGISTER_CLASS(LightmapperRD);


### PR DESCRIPTION
An attempt to fix #106975

Limits the amount of lights that can be computed during a single pass.