### PR TITLE
[Web] Fix Webkit leak caused by the position reporting audio worklets

### DIFF
--- a/platform/web/js/libs/audio.position.worklet.js
+++ b/platform/web/js/libs/audio.position.worklet.js
@@ -28,38 +28,29 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-const POST_THRESHOLD_S = 0.1;
-
 class GodotPositionReportingProcessor extends AudioWorkletProcessor {
 	constructor(...args) {
 		super(...args);
-		this.lastPostTime = currentTime;
 		this.position = 0;
-		this.ended = false;
 
 		this.port.onmessage = (event) => {
-			if (event?.data?.type === 'ended') {
-				this.ended = true;
+			switch (event?.data?.type) {
+			case 'reset':
+				this.position = 0;
+				break;
+			default:
+				// Do nothing.
 			}
 		};
 	}
 
 	process(inputs, _outputs, _parameters) {
-		if (this.ended) {
-			return false;
-		}
-
 		if (inputs.length > 0) {
 			const input = inputs[0];
 			if (input.length > 0) {
 				this.position += input[0].length;
+				this.port.postMessage({ type: 'position', data: this.position });
 			}
-		}
-
-		// Posting messages is expensive. Let's limit the number of posts.
-		if (currentTime - this.lastPostTime > POST_THRESHOLD_S) {
-			this.lastPostTime = currentTime;
-			this.port.postMessage({ type: 'position', data: this.position });
 		}
 
 		return true;


### PR DESCRIPTION
This PR reintroduces the pooling of `GodotPositionReportingProcessor` worklets. This is because Webkit doesn't seem to delete processors that return `false` in `process()`, [even if the specs says to do so](https://github.com/godotengine/godot/pull/102163#discussion_r1945897924). That made the memory explode and the Webkit engine reloading the games.

This PR also removes the `postMessage` limit on audio position worklet. [The tests](https://github.com/godotengine/godot/pull/105541#issuecomment-2828568538) made by @PizzaLovers007 seem to indicate that the partial reporting didn't achieve it's goals and was basically useless.

Here's my iPad Pro M3 running a tweaked version of the #107390 MRP for more than 18 minutes straight.

<img width="1376" alt="Audio Test 18m" src="https://github.com/user-attachments/assets/86f5dce8-2568-4b5a-963d-8a6b51a1be49" />

At the 18 minutes mark, nothing seems to indicate that the MRP was taxing for my iPad, memory-wise nor processing-wise.

<img width="1237" alt="Capture d’écran, le 2025-06-24 à 14 31 37" src="https://github.com/user-attachments/assets/d0987180-f94e-46e9-b251-534736482208" />

MRP: [audio-test.zip](https://github.com/user-attachments/files/20889786/audio-test.zip)

Fixes #107390.
Fixes #105397.
Supersedes #105541. (added co-authorship)
Reverts the spirit of #102715.
Doesn't seem to create a regression for #102505.