### PR TITLE
[3.x] Revert "FTI - Reduce `VisualInstance` xform notifications"

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -168,7 +168,6 @@ void Camera::_update_camera() {
 
 void Camera::_physics_interpolated_changed() {
 	_update_process_mode();
-	Spatial::_physics_interpolated_changed();
 }
 
 void Camera::set_desired_process_modes(bool p_process_internal, bool p_physics_process_internal) {

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -1076,18 +1076,8 @@ Vector3 Spatial::to_global(Vector3 p_local) const {
 	return get_global_transform().xform(p_local);
 }
 
-void Spatial::_physics_interpolated_changed() {
-	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
-}
-
-void Spatial::_set_notify_transform_when_fti_off(bool p_enable) {
-	data.notify_transform_when_fti_off = p_enable;
-	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
-}
-
 void Spatial::set_notify_transform(bool p_enable) {
-	data.notify_transform_requested = p_enable;
-	data.notify_transform = data.notify_transform_requested || (data.notify_transform_when_fti_off && !is_physics_interpolated_and_enabled());
+	data.notify_transform = p_enable;
 }
 
 bool Spatial::is_transform_notification_enabled() const {
@@ -1289,9 +1279,6 @@ Spatial::Spatial() :
 #endif
 	data.notify_local_transform = false;
 	data.notify_transform = false;
-	data.notify_transform_requested = false;
-	data.notify_transform_when_fti_off = false;
-
 	data.parent = nullptr;
 }
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -117,9 +117,6 @@ private:
 		bool notify_local_transform : 1;
 		bool notify_transform : 1;
 
-		bool notify_transform_requested : 1;
-		bool notify_transform_when_fti_off : 1;
-
 		bool visible : 1;
 		bool visible_in_tree : 1;
 		bool disable_scale : 1;
@@ -178,9 +175,6 @@ protected:
 	// or requires an update in terms of interpolation
 	// (e.g. changing Camera zoom even if position hasn't changed).
 	void fti_notify_node_changed(bool p_transform_changed = true);
-
-	void _set_notify_transform_when_fti_off(bool p_enable);
-	virtual void _physics_interpolated_changed();
 
 	// Opportunity after FTI to update the servers
 	// with global_transform_interpolated,

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -102,10 +102,8 @@ void VisualInstance::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			// NOTIFICATION normally turned off for physics interpolated cases (via
-			// `notify_transform_when_fti_off`), however derived classes can still turn this back on,
-			// so always wrap with is_physics_interpolation_enabled().
-			if (is_visible_in_tree() && !(is_inside_tree() && get_tree()->is_physics_interpolation_enabled()) && !_is_using_identity_transform()) {
+			// ToDo : Can we turn off notify transform for physics interpolated cases?
+			if (is_visible_in_tree() && !SceneTree::is_fti_enabled() && !_is_using_identity_transform()) {
 				// Physics interpolation global off, always send.
 				VisualServer::get_singleton()->instance_set_transform(instance, get_global_transform());
 			}
@@ -209,7 +207,7 @@ VisualInstance::VisualInstance() {
 	layers = 1;
 	sorting_offset = 0.0f;
 	sorting_use_aabb_center = true;
-	_set_notify_transform_when_fti_off(true);
+	set_notify_transform(true);
 }
 
 VisualInstance::~VisualInstance() {


### PR DESCRIPTION
This reverts commit 5ec4fd38fa94dd4b01c222de4829a932edca30d1.

Fixes #107829
Fixes #107755

3.x version of #107854

IMPORTANT: I think we should merge this before building 3.7 alpha 1, to avoid regressions seen in 4.5 beta 1.

## Notes
* As with 4.x, I think it would be wise to do this a slightly different way, `SoftBody` in particular relies on this with its current hacky approach.
* I'll revisit this to see if we can reduce these without causing regressions, it's not critical for 3.7 alpha 1.
* As noted on the original PR, this area was experimental and prone to regressions (the reason for separating it into a self-contained PR in the first place).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
