### PR TITLE
Expose a few missing `Mesh` surface methods to gdscript

### DIFF
--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -144,25 +144,11 @@
 				Returns the length in vertices of the vertex array in the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
-		<method name="surface_get_format" qualifiers="const">
-			<return type="int" enum="Mesh.ArrayFormat" is_bitfield="true" />
-			<param index="0" name="surf_idx" type="int" />
-			<description>
-				Returns the format mask of the requested surface (see [method add_surface_from_arrays]).
-			</description>
-		</method>
 		<method name="surface_get_name" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="surf_idx" type="int" />
 			<description>
 				Gets the name assigned to this surface.
-			</description>
-		</method>
-		<method name="surface_get_primitive_type" qualifiers="const">
-			<return type="int" enum="Mesh.PrimitiveType" />
-			<param index="0" name="surf_idx" type="int" />
-			<description>
-				Returns the primitive type of the requested surface (see [method add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_remove">

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -179,12 +179,33 @@
 				Returns the blend shape arrays for the requested surface.
 			</description>
 		</method>
+		<method name="surface_get_format" qualifiers="const">
+			<return type="int" enum="Mesh.ArrayFormat" is_bitfield="true" />
+			<param index="0" name="surf_idx" type="int" />
+			<description>
+				Returns the format mask of the requested surface (see [method ArrayMesh.add_surface_from_arrays]).
+			</description>
+		</method>
+		<method name="surface_get_lods" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="surf_idx" type="int" />
+			<description>
+				Returns the LOD dictionary for the specified surface (see [method ArrayMesh.add_surface_from_arrays]).
+			</description>
+		</method>
 		<method name="surface_get_material" qualifiers="const">
 			<return type="Material" />
 			<param index="0" name="surf_idx" type="int" />
 			<description>
 				Returns a [Material] in a given surface. Surface is rendered using this material.
 				[b]Note:[/b] This returns the material within the [Mesh] resource, not the [Material] associated to the [MeshInstance3D]'s Surface Material Override properties. To get the [Material] associated to the [MeshInstance3D]'s Surface Material Override properties, use [method MeshInstance3D.get_surface_override_material] instead.
+			</description>
+		</method>
+		<method name="surface_get_primitive_type" qualifiers="const">
+			<return type="int" enum="Mesh.PrimitiveType" />
+			<param index="0" name="surf_idx" type="int" />
+			<description>
+				Returns the primitive type of the requested surface (see [method ArrayMesh.add_surface_from_arrays]).
 			</description>
 		</method>
 		<method name="surface_set_material">

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -321,3 +321,11 @@ Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/a
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments': size changed value in new API, from 11 to 12.
 
 Optional argument added. Compatibility methods registered.
+
+
+GH-107952
+--------
+Validate extension JSON: API was removed: classes/ArrayMesh/methods/surface_get_format
+Validate extension JSON: API was removed: classes/ArrayMesh/methods/surface_get_primitive_type
+
+Moved methods from ArrayMesh to its parent Mesh class.  No adjustments should be necessary.

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -810,8 +810,11 @@ void Mesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_surface_count"), &Mesh::get_surface_count);
 	ClassDB::bind_method(D_METHOD("surface_get_arrays", "surf_idx"), &Mesh::surface_get_arrays);
 	ClassDB::bind_method(D_METHOD("surface_get_blend_shape_arrays", "surf_idx"), &Mesh::surface_get_blend_shape_arrays);
+	ClassDB::bind_method(D_METHOD("surface_get_format", "surf_idx"), &Mesh::surface_get_format);
+	ClassDB::bind_method(D_METHOD("surface_get_lods", "surf_idx"), &Mesh::surface_get_lods);
 	ClassDB::bind_method(D_METHOD("surface_set_material", "surf_idx", "material"), &Mesh::surface_set_material);
 	ClassDB::bind_method(D_METHOD("surface_get_material", "surf_idx"), &Mesh::surface_get_material);
+	ClassDB::bind_method(D_METHOD("surface_get_primitive_type", "surf_idx"), &Mesh::surface_get_primitive_type);
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Mesh::create_placeholder);
 
 	BIND_ENUM_CONSTANT(PRIMITIVE_POINTS);
@@ -2295,8 +2298,6 @@ void ArrayMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("surface_update_skin_region", "surf_idx", "offset", "data"), &ArrayMesh::surface_update_skin_region);
 	ClassDB::bind_method(D_METHOD("surface_get_array_len", "surf_idx"), &ArrayMesh::surface_get_array_len);
 	ClassDB::bind_method(D_METHOD("surface_get_array_index_len", "surf_idx"), &ArrayMesh::surface_get_array_index_len);
-	ClassDB::bind_method(D_METHOD("surface_get_format", "surf_idx"), &ArrayMesh::surface_get_format);
-	ClassDB::bind_method(D_METHOD("surface_get_primitive_type", "surf_idx"), &ArrayMesh::surface_get_primitive_type);
 	ClassDB::bind_method(D_METHOD("surface_find_by_name", "name"), &ArrayMesh::surface_find_by_name);
 	ClassDB::bind_method(D_METHOD("surface_set_name", "surf_idx", "name"), &ArrayMesh::surface_set_name);
 	ClassDB::bind_method(D_METHOD("surface_get_name", "surf_idx"), &ArrayMesh::surface_get_name);


### PR DESCRIPTION
This makes the `Mesh::surface_get_primitive_type()`, `surface_get_format()`, and `surface_get_lods()` methods available in gdscript.

These methods exist in C++, but were previously not exposed to gdscript. This omission seems like an oversight, rather than intentional.  The `surface_get_primitive_type()` and `surface_get_format()` methods were exposed to gdscript in the `ArrayMesh` subclass, but not in the base `Mesh` class itself where they are defined in C++.  This meant that gdscript code could not access these methods on other mesh types like `PrimitiveMesh` subclasses.

The fact that these methods were not previously exposed seems like an oversight to me:
* The virtual `_surface_get_primitive_type()`, and `_surface_get_format()`, and `_surface_get_lods()` methods were already exposed for gdscript to override in custom `Mesh` subclasses.
* The `Mesh::surface_get_arrays()` method is exposed to gdscript, but the index data it returns cannot be interpreted properly without knowing the primitive type and format flags.

This fixes godotengine/godot-proposals#6890.
