### PR TITLE
Fix `mouse_entered` and `mouse_exited` Signals being emitted too early

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3900,14 +3900,6 @@ void Control::_notification(int p_notification) {
 			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
 		} break;
 
-		case NOTIFICATION_MOUSE_ENTER: {
-			emit_signal(SceneStringName(mouse_entered));
-		} break;
-
-		case NOTIFICATION_MOUSE_EXIT: {
-			emit_signal(SceneStringName(mouse_exited));
-		} break;
-
 		case NOTIFICATION_FOCUS_ENTER: {
 			emit_signal(SceneStringName(focus_entered));
 			queue_redraw();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2610,6 +2610,7 @@ void Viewport::_gui_update_mouse_over() {
 	// Send Mouse Exit notifications.
 	for (int exit_control_index : needs_exit) {
 		gui.mouse_over_hierarchy[exit_control_index]->notification(Control::NOTIFICATION_MOUSE_EXIT);
+		gui.mouse_over_hierarchy[exit_control_index]->emit_signal(SceneStringName(mouse_exited));
 	}
 
 	// Update the mouse over hierarchy.
@@ -2621,6 +2622,7 @@ void Viewport::_gui_update_mouse_over() {
 	// Send Mouse Enter notifications.
 	for (int i = needs_enter.size() - 1; i >= 0; i--) {
 		needs_enter[i]->notification(Control::NOTIFICATION_MOUSE_ENTER);
+		needs_enter[i]->emit_signal(SceneStringName(mouse_entered));
 	}
 
 	gui.sending_mouse_enter_exit_notifications = false;
@@ -3274,6 +3276,7 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 			for (int i = over_ancestors.size() - 1; i >= 0; i--) {
 				gui.mouse_over_hierarchy.push_back(over_ancestors[i]);
 				over_ancestors[i]->notification(Control::NOTIFICATION_MOUSE_ENTER);
+				over_ancestors[i]->emit_signal(SceneStringName(mouse_entered));
 			}
 
 			// Send Mouse Enter Self notification.
@@ -3365,6 +3368,7 @@ void Viewport::_drop_mouse_over(Control *p_until_control) {
 	for (int i = gui.mouse_over_hierarchy.size() - 1; i >= notification_until; i--) {
 		if (gui.mouse_over_hierarchy[i]->is_inside_tree()) {
 			gui.mouse_over_hierarchy[i]->notification(Control::NOTIFICATION_MOUSE_EXIT);
+			gui.mouse_over_hierarchy[i]->emit_signal(SceneStringName(mouse_exited));
 		}
 	}
 	gui.mouse_over_hierarchy.resize(notification_until);


### PR DESCRIPTION
Fixes #106953

Currently, the `mouse_entered` and `mouse_exited` signals are emitted in the `notification` method of `Control`. Since notifications are propagated downward from Control to inherited classes and downwards, this means that the signal will be emitted before any inherited classes have the chance to update their state based on the notification.

For example, in the `Button` class, `is_hovered` will not update before the signal is emitted and therefore any code that checks the state will have out of date values. This PR delays the signal emission until after the `notification()` call is fully propagated in order to give time for the internal classes to update their state.

I suppose if another solution isn't found that there should be discussion on how often users would call `notification(NOTIFICATION_MOUSE_ENTERED)` and expect a signal to be emitted. Ideally this would be called after the other classes, it would work with a deferred call but that should be discussed for latency.