### PR TITLE
ufbx: Update to 0.20.0

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1026,7 +1026,7 @@ Patches:
 ## ufbx
 
 - Upstream: https://github.com/ufbx/ufbx
-- Version: 0.18.2 (5b5494b9b6c2cdb0fc0ae873bdbf8718cdeb85af, 2025)
+- Version: 0.20.0 (a63ff0a47485328880b3300e7bcdf01413343a45, 2025)
 - License: MIT
 
 Files extracted from upstream source:


### PR DESCRIPTION
https://github.com/ufbx/ufbx/releases/tag/v0.20.0

**Changes from version 0.18.2 to version 0.19.0:**

- Add UFBX_PIVOT_HANDLING_ADJUST_TO_ROTATION_PIVOT
- Fixed parsing empty usemtl in .obj files
- Improved DOM array API
- Blender FullWeights support

**Changes from version 0.19.0 to version 0.20.0:**

- Fix ufbx_pack_version() not working in preprocessor
- Ignore GCC -Warray-bounds warning on pre-GCC-14
