### PR TITLE
Use non-volumetric fog in WorldEnvironment sky reflections

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -717,6 +717,48 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 			RenderingServerDefault::redraw_request();
 		}
 
+		if (environment_get_fog_aerial_perspective(p_render_data->environment) != sky->prev_fog_aerial_perspective) {
+			sky->prev_fog_aerial_perspective = environment_get_fog_aerial_perspective(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (environment_get_fog_light_color(p_render_data->environment) != sky->prev_fog_light_color) {
+			sky->prev_fog_light_color = environment_get_fog_light_color(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (environment_get_fog_sun_scatter(p_render_data->environment) != sky->prev_fog_sun_scatter) {
+			sky->prev_fog_sun_scatter = environment_get_fog_sun_scatter(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (environment_get_fog_enabled(p_render_data->environment) != sky->prev_fog_enabled) {
+			sky->prev_fog_enabled = environment_get_fog_enabled(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (environment_get_fog_density(p_render_data->environment) != sky->prev_fog_density) {
+			sky->prev_fog_density = environment_get_fog_density(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (environment_get_fog_sky_affect(p_render_data->environment) != sky->prev_fog_sky_affect) {
+			sky->prev_fog_sky_affect = environment_get_fog_sky_affect(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (environment_get_fog_light_energy(p_render_data->environment) != sky->prev_fog_light_energy) {
+			sky->prev_fog_light_energy = environment_get_fog_light_energy(p_render_data->environment);
+			sky->reflection_dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
 		if (material_data != sky->prev_material) {
 			sky->prev_material = material_data;
 			sky->reflection_dirty = true;
@@ -966,6 +1008,15 @@ void RasterizerSceneGLES3::_update_sky_radiance(RID p_env, const Projection &p_p
 		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::PROJECTION, cm.columns[2][0], cm.columns[0][0], cm.columns[2][1], cm.columns[1][1], shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
 		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::SKY_ENERGY_MULTIPLIER, p_sky_energy_multiplier, shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
 		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::LUMINANCE_MULTIPLIER, 1.0, shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+
+		Color fog_color = environment_get_fog_light_color(p_env).srgb_to_linear() * environment_get_fog_light_energy(p_env);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_ENABLED, environment_get_fog_enabled(p_env), shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_AERIAL_PERSPECTIVE, environment_get_fog_aerial_perspective(p_env), shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_LIGHT_COLOR, fog_color, shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_SUN_SCATTER, environment_get_fog_sun_scatter(p_env), shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_DENSITY, environment_get_fog_density(p_env), shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_SKY_AFFECT, environment_get_fog_sky_affect(p_env), shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::DIRECTIONAL_LIGHT_COUNT, sky_globals.directional_light_count, shader_data->version, SkyShaderGLES3::MODE_CUBEMAP);
 
 		glBindVertexArray(sky_globals.screen_triangle_array);
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -846,6 +846,13 @@ protected:
 		GLES3::SkyMaterialData *prev_material = nullptr;
 		Vector3 prev_position = Vector3(0.0, 0.0, 0.0);
 		float prev_time = 0.0f;
+		float prev_fog_aerial_perspective = 0.0;
+		Color prev_fog_light_color;
+		float prev_fog_sun_scatter = 0.0;
+		bool prev_fog_enabled = false;
+		float prev_fog_density = 0.0;
+		float prev_fog_sky_affect = 0.0;
+		float prev_fog_light_energy = 0.0;
 	};
 
 	Sky *dirty_sky_list = nullptr;

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -249,7 +249,7 @@ void main() {
 
 	color *= sky_energy_multiplier;
 
-#if !defined(DISABLE_FOG) && !defined(USE_CUBEMAP_PASS)
+#if !defined(DISABLE_FOG)
 
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
 	if (fog_enabled) {

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1043,6 +1043,48 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 			RenderingServerDefault::redraw_request();
 		}
 
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_aerial_perspective(p_render_data->environment) != sky->prev_fog_aerial_perspective) {
+			sky->prev_fog_aerial_perspective = RendererSceneRenderRD::get_singleton()->environment_get_fog_aerial_perspective(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_light_color(p_render_data->environment) != sky->prev_fog_light_color) {
+			sky->prev_fog_light_color = RendererSceneRenderRD::get_singleton()->environment_get_fog_light_color(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_sun_scatter(p_render_data->environment) != sky->prev_fog_sun_scatter) {
+			sky->prev_fog_sun_scatter = RendererSceneRenderRD::get_singleton()->environment_get_fog_sun_scatter(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_enabled(p_render_data->environment) != sky->prev_fog_enabled) {
+			sky->prev_fog_enabled = RendererSceneRenderRD::get_singleton()->environment_get_fog_enabled(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_density(p_render_data->environment) != sky->prev_fog_density) {
+			sky->prev_fog_density = RendererSceneRenderRD::get_singleton()->environment_get_fog_density(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_sky_affect(p_render_data->environment) != sky->prev_fog_sky_affect) {
+			sky->prev_fog_sky_affect = RendererSceneRenderRD::get_singleton()->environment_get_fog_sky_affect(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
+		if (RendererSceneRenderRD::get_singleton()->environment_get_fog_light_energy(p_render_data->environment) != sky->prev_fog_light_energy) {
+			sky->prev_fog_light_energy = RendererSceneRenderRD::get_singleton()->environment_get_fog_light_energy(p_render_data->environment);
+			sky->reflection.dirty = true;
+			RenderingServerDefault::redraw_request();
+		}
+
 		if (material_data != sky->prev_material_data) {
 			sky->prev_material_data = material_data;
 			sky->reflection.dirty = true;

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -287,6 +287,13 @@ public:
 		SkyMaterialData *prev_material_data = nullptr;
 		Vector3 prev_position;
 		float prev_time;
+		float prev_fog_aerial_perspective = 0.0;
+		Color prev_fog_light_color;
+		float prev_fog_sun_scatter = 0.0;
+		bool prev_fog_enabled = false;
+		float prev_fog_density = 0.0;
+		float prev_fog_sky_affect = 0.0;
+		float prev_fog_light_energy = 0.0;
 
 		void free_radiance();
 

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -276,7 +276,7 @@ void main() {
 	// Apply environment 'brightness' setting separately before fog to ensure consistent luminance.
 	frag_color.rgb = frag_color.rgb * params.brightness_multiplier;
 
-#if !defined(DISABLE_FOG) && !defined(USE_CUBEMAP_PASS)
+#if !defined(DISABLE_FOG)
 
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
 	if (sky_scene_data.fog_enabled) {
@@ -284,6 +284,7 @@ void main() {
 		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a * sky_scene_data.fog_sky_affect);
 	}
 
+#if !defined(USE_CUBEMAP_PASS)
 	if (sky_scene_data.volumetric_fog_enabled) {
 		vec4 fog = volumetric_fog_process(uv);
 		if (sky_scene_data.fog_use_legacy_blending) {
@@ -293,6 +294,7 @@ void main() {
 			frag_color.rgb = mix(frag_color.rgb, fog.rgb, sky_scene_data.volumetric_fog_sky_affect);
 		}
 	}
+#endif // USE_CUBEMAP_PASS
 
 	if (custom_fog.a > 0.0) {
 		frag_color.rgb = mix(frag_color.rgb, custom_fog.rgb, custom_fog.a);


### PR DESCRIPTION
Fog is now calculated in sky reflections for the ```WorldEnvironment```, where it previously wasn't.

Screenshots have a default ```ProceduralSkyMaterial``` set in the ```WorldEnvironment```, and the sphere's material has ```metallic == 1.0``` and ```roughness == 0.0```.

__4.5 beta 1__:
![image](https://github.com/user-attachments/assets/2c737ad3-10b8-4e01-8b7f-211b1d66dc38)

__This pr__:
![image](https://github.com/user-attachments/assets/dd81aad6-d07d-4fa7-8dac-3e816007211e)

If you test this in the editor the redraws with the new reflections after updating a fog property don't happen until something else causes a redraw sometimes and I'm not sure why. I couldn't get this to happen in the running project but I'm pretty sure I've had this issue with something not redrawing in the editor previously so I'm not sure it's this pr that is at fault.

Closes #107925.