### PR TITLE
Reduce TileMapLayerEditor's undo/redo memory usage

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -52,6 +52,7 @@ class TileMapLayerSubEditorPlugin : public Object {
 protected:
 	ObjectID edited_tile_map_layer_id;
 	TileMapLayer *_get_edited_layer() const;
+	static void _add_to_output_if_tile_changed(HashMap<Vector2i, TileMapCell> &p_output, const TileMapLayer *p_layer, Vector2i p_coords, const TileMapCell &p_cell);
 
 public:
 	struct TabData {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/107853

~~This PR heavily reduces the amount of undo/redo memory used by `TileMapLayerEditor` with two optimizations.~~
- ~~Edits that have no effect (cell is same before and after) are not recorded in `EditorUndoRedoManager`.~~
  - ~~Mostly helps with redundant operations like clicking the bucket tool on the same tile multiple times.~~
- ~~Edits are compressed into rectangular regions (`TileMapLayerEditor::Rect`) before being recorded in `EditorUndoRedoManager`.~~
  - ~~Helps with bucket and rect tools, whose edits tend to cover large, contiguous regions.~~

~~Improvement is immediately obvious with the bucket tool, but other tools can also benefit from this optimization to different degrees.~~

This PR now only eliminates redundant edits.