### PR TITLE
Improve the cubemap preview

### DIFF
--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -145,12 +145,30 @@ constexpr const char *cubemap_array_shader = R"(
 void TextureLayeredEditor::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
+	if (!use_rotation) {
+		return;
+	}
+
 	Ref<InputEventMouseMotion> mm = p_event;
-	if (mm.is_valid() && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
-		y_rot += -mm->get_relative().x * 0.01;
-		x_rot += -mm->get_relative().y * 0.01;
+	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::RIGHT)) {
+		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
+			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_CAPTURED);
+		}
+
+		y_rot += mm->get_relative().x * 0.01;
+		x_rot = CLAMP(x_rot - mm->get_relative().y * 0.01, -Math::PI * 0.5f, Math::PI * 0.5f);
 
 		_update_material(false);
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::RIGHT) {
+		if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
+			Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
+			Input::get_singleton()->warp_mouse(original_mouse_pos);
+		} else if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_VISIBLE) {
+			original_mouse_pos = mb->get_global_position();
+		}
 	}
 }
 
@@ -270,7 +288,7 @@ void TextureLayeredEditor::_update_material(bool p_texture_changed) {
 	materials[0]->set_shader_parameter("layer", layer->get_value());
 	materials[2]->set_shader_parameter("layer", layer->get_value());
 
-	Vector3 v(1, 1, 1);
+	Vector3 v(-1, -1, -1);
 	v.normalize();
 
 	Basis b;
@@ -283,6 +301,9 @@ void TextureLayeredEditor::_update_material(bool p_texture_changed) {
 	materials[2]->set_shader_parameter("rot", b);
 
 	if (p_texture_changed) {
+		const TextureLayered::LayeredType type = texture->get_layered_type();
+		use_rotation = type == TextureLayered::LAYERED_TYPE_CUBEMAP || type == TextureLayered::LAYERED_TYPE_CUBEMAP_ARRAY;
+
 		materials[texture->get_layered_type()]->set_shader_parameter("tex", texture->get_rid());
 	}
 

--- a/editor/scene/texture/texture_layered_editor_plugin.h
+++ b/editor/scene/texture/texture_layered_editor_plugin.h
@@ -57,6 +57,8 @@ class TextureLayeredEditor : public Control {
 	Control *texture_rect = nullptr;
 
 	bool setting = false;
+	Vector2 original_mouse_pos;
+	bool use_rotation = false;
 
 	ColorChannelSelector *channel_selector = nullptr;
 


### PR DESCRIPTION
Changes how the cubemap preview works in an attempt to make it more intuitive.

Rotating the preview now works the same way as in the 3d editor, using the right mouse button as well as the same orientation. Vertical rotation is also limited from -90 to 90 degrees.

The preview's normal direction is also flipped to display the cubemap with the proper rotation.

| master | PR |
|---------|----|
| ![old](https://github.com/user-attachments/assets/4bd93cc1-194b-4020-97fd-4739eb663862) | ![new](https://github.com/user-attachments/assets/ba62496d-a6ba-4020-a78f-5dcc2f19a878) |

TODO:
- [x] Hide and lock the mouse cursor,
- [x] Show comparison images.