### PR TITLE
Invalidate selection after undoing cut operation in GridMap editor

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -478,6 +478,7 @@ void GridMapEditor::_delete_selection() {
 	}
 	undo_redo->add_do_method(this, "_set_selection", !selection.active, selection.begin, selection.end);
 	undo_redo->add_undo_method(this, "_set_selection", selection.active, selection.begin, selection.end);
+	undo_redo->add_undo_method(this, "_clear_clipboard_data");
 	undo_redo->commit_action();
 }
 
@@ -1299,6 +1300,7 @@ void GridMapEditor::_floor_mouse_exited() {
 void GridMapEditor::_bind_methods() {
 	ClassDB::bind_method("_configure", &GridMapEditor::_configure);
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
+	ClassDB::bind_method("_clear_clipboard_data", &GridMapEditor::_clear_clipboard_data);
 }
 
 GridMapEditor::GridMapEditor() {


### PR DESCRIPTION
Fixes: [Gridmap Moving/Duplicating tool: Undo does not cancel the operation correctly #101430](https://github.com/godotengine/godot/issues/101430)
Simply marks the current selection as not active after undoing a cut operation