### PR TITLE
Document disabling custom tooltip when using `set_tooltip_request_func()` in TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1241,7 +1241,7 @@
 			<return type="void" />
 			<param index="0" name="callback" type="Callable" />
 			<description>
-				Provide custom tooltip text. The callback method must take the following args: [code]hovered_word: String[/code].
+				Provide custom tooltip text. The callback method must take the following argument: [code]hovered_word: String[/code]. Return an empty string to disable the tooltip.
 			</description>
 		</method>
 		<method name="skip_selection_for_next_occurrence">


### PR DESCRIPTION
- See https://github.com/godotengine/godot-docs-user-notes/discussions/211#discussioncomment-13513524.
