### PR TITLE
Fix `RenderingServer::mesh_surface_get_lods()`

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1731,7 +1731,7 @@ Dictionary RenderingServer::mesh_surface_get_lods(RID p_mesh, int p_surface) con
 			const uint16_t *rptr = (const uint16_t *)r;
 			int *w = lods.ptrw();
 			for (uint32_t j = 0; j < lc; j++) {
-				w[j] = rptr[i];
+				w[j] = rptr[j];
 			}
 		} else {
 			uint32_t lc = sd.lods[i].index_data.size() / 4;
@@ -1740,7 +1740,7 @@ Dictionary RenderingServer::mesh_surface_get_lods(RID p_mesh, int p_surface) con
 			const uint32_t *rptr = (const uint32_t *)r;
 			int *w = lods.ptrw();
 			for (uint32_t j = 0; j < lc; j++) {
-				w[j] = rptr[i];
+				w[j] = rptr[j];
 			}
 		}
 


### PR DESCRIPTION
This function was incorrectly using the surface number to index into the LOD indices vector.  This resulted in just returning the same index over and over again.  In theory if you had a mesh with more surfaces than one of its LOD vectors it could read pass the end of the LOD index array.

The SoftBody3D code creates a new ArrayMesh by duplicating the input mesh, and uses `mesh_surface_get_lods()` to duplicate the LODs.  The broken behavior here results in SoftBody3D creating broken meshes that render nothing due to each LOD just using a single vertex.  This commit fixes SoftBody3D to now work correctly with meshes with LODs.

Fixes #107984.
_bugsquad edit: Fixes https://github.com/godotengine/godot/issues/98915_
