### PR TITLE
Documentation: Add missing required qualifier for various classes

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -174,7 +174,7 @@ Ref<Resource> ResourceFormatLoader::load(const String &p_path, const String &p_o
 		}
 	}
 
-	ERR_FAIL_V_MSG(Ref<Resource>(), vformat("Failed to load resource '%s'. ResourceFormatLoader::load was not implemented for this resource type.", p_path));
+	return Ref<Resource>();
 }
 
 void ResourceFormatLoader::get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types) {

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -70,7 +70,7 @@ protected:
 	GDVIRTUAL2RC(Error, _rename_dependencies, String, Dictionary)
 	GDVIRTUAL1RC(bool, _exists, String)
 
-	GDVIRTUAL4RC(Variant, _load, String, String, bool, int)
+	GDVIRTUAL4RC_REQUIRED(Variant, _load, String, String, bool, int)
 
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);

--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -64,7 +64,7 @@
 				Override this method to return [code]true[/code] if this stream has a loop.
 			</description>
 		</method>
-		<method name="_instantiate_playback" qualifiers="virtual const">
+		<method name="_instantiate_playback" qualifiers="virtual required const">
 			<return type="AudioStreamPlayback" />
 			<description>
 				Override this method to customize the returned value of [method instantiate_playback]. Should return a new [AudioStreamPlayback] created when the stream is played (such as by an [AudioStreamPlayer]).

--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -23,13 +23,13 @@
 				Return the current value of a playback parameter by name (see [method AudioStream._get_parameter_list]).
 			</description>
 		</method>
-		<method name="_get_playback_position" qualifiers="virtual const">
+		<method name="_get_playback_position" qualifiers="virtual required const">
 			<return type="float" />
 			<description>
 				Overridable method. Should return the current progress along the audio stream, in seconds.
 			</description>
 		</method>
-		<method name="_is_playing" qualifiers="virtual const">
+		<method name="_is_playing" qualifiers="virtual required const">
 			<return type="bool" />
 			<description>
 				Overridable method. Should return [code]true[/code] if this playback is active and playing its audio stream.
@@ -60,14 +60,14 @@
 				Set the current value of a playback parameter by name (see [method AudioStream._get_parameter_list]).
 			</description>
 		</method>
-		<method name="_start" qualifiers="virtual">
+		<method name="_start" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="from_pos" type="float" />
 			<description>
 				Override this method to customize what happens when the playback starts at the given position, such as by calling [method AudioStreamPlayer.play].
 			</description>
 		</method>
-		<method name="_stop" qualifiers="virtual">
+		<method name="_stop" qualifiers="virtual required">
 			<return type="void" />
 			<description>
 				Override this method to customize what happens when the playback is stopped, such as by calling [method AudioStreamPlayer.stop].

--- a/doc/classes/EditorResourcePreviewGenerator.xml
+++ b/doc/classes/EditorResourcePreviewGenerator.xml
@@ -16,7 +16,7 @@
 				By default, it returns [code]false[/code].
 			</description>
 		</method>
-		<method name="_generate" qualifiers="virtual const">
+		<method name="_generate" qualifiers="virtual required const">
 			<return type="Texture2D" />
 			<param index="0" name="resource" type="Resource" />
 			<param index="1" name="size" type="Vector2i" />
@@ -47,7 +47,7 @@
 				By default, it returns [code]false[/code].
 			</description>
 		</method>
-		<method name="_handles" qualifiers="virtual const">
+		<method name="_handles" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="type" type="String" />
 			<description>

--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_get_extensions" qualifiers="virtual const">
+		<method name="_get_extensions" qualifiers="virtual required const">
 			<return type="PackedStringArray" />
 			<description>
 				Return supported file extensions for this scene importer.
@@ -34,7 +34,7 @@
 				Should return [code]true[/code] to show the given option, [code]false[/code] to hide the given option, or [code]null[/code] to ignore.
 			</description>
 		</method>
-		<method name="_import_scene" qualifiers="virtual">
+		<method name="_import_scene" qualifiers="virtual required">
 			<return type="Object" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="flags" type="int" />

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -80,7 +80,7 @@
 				[b]Note:[/b] Custom resource types defined by scripts aren't known by the [ClassDB], so you might just handle [code]"Resource"[/code] for them.
 			</description>
 		</method>
-		<method name="_load" qualifiers="virtual const">
+		<method name="_load" qualifiers="virtual required const">
 			<return type="Variant" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="original_path" type="String" />

--- a/doc/classes/VideoStream.xml
+++ b/doc/classes/VideoStream.xml
@@ -11,7 +11,7 @@
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>
 	</tutorials>
 	<methods>
-		<method name="_instantiate_playback" qualifiers="virtual">
+		<method name="_instantiate_playback" qualifiers="virtual required">
 			<return type="VideoStreamPlayback" />
 			<description>
 				Called when the video starts playing, to initialize and return a subclass of [VideoStreamPlayback].

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -59,14 +59,10 @@
 
 void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
 	Vector<String> arr;
-	if (GDVIRTUAL_CALL(_get_extensions, arr)) {
-		for (int i = 0; i < arr.size(); i++) {
-			r_extensions->push_back(arr[i]);
-		}
-		return;
+	GDVIRTUAL_CALL(_get_extensions, arr);
+	for (int i = 0; i < arr.size(); i++) {
+		r_extensions->push_back(arr[i]);
 	}
-
-	ERR_FAIL();
 }
 
 Node *EditorSceneFormatImporter::import_scene(const String &p_path, uint32_t p_flags, const HashMap<StringName, Variant> &p_options, List<String> *r_missing_deps, Error *r_err) {
@@ -75,11 +71,8 @@ Node *EditorSceneFormatImporter::import_scene(const String &p_path, uint32_t p_f
 		options_dict[elem.key] = elem.value;
 	}
 	Object *ret = nullptr;
-	if (GDVIRTUAL_CALL(_import_scene, p_path, p_flags, options_dict, ret)) {
-		return Object::cast_to<Node>(ret);
-	}
-
-	ERR_FAIL_V(nullptr);
+	GDVIRTUAL_CALL(_import_scene, p_path, p_flags, options_dict, ret);
+	return Object::cast_to<Node>(ret);
 }
 
 void EditorSceneFormatImporter::add_import_option(const String &p_name, const Variant &p_default_value) {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -57,8 +57,8 @@ protected:
 	Node *import_scene_wrapper(const String &p_path, uint32_t p_flags, const Dictionary &p_options);
 	Ref<Animation> import_animation_wrapper(const String &p_path, uint32_t p_flags, const Dictionary &p_options);
 
-	GDVIRTUAL0RC(Vector<String>, _get_extensions)
-	GDVIRTUAL3R(Object *, _import_scene, String, uint32_t, Dictionary)
+	GDVIRTUAL0RC_REQUIRED(Vector<String>, _get_extensions)
+	GDVIRTUAL3R_REQUIRED(Object *, _import_scene, String, uint32_t, Dictionary)
 	GDVIRTUAL1(_get_import_options, String)
 	GDVIRTUAL3RC(Variant, _get_option_visibility, String, bool, String)
 

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -46,18 +46,14 @@
 
 bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 	bool success = false;
-	if (GDVIRTUAL_CALL(_handles, p_type, success)) {
-		return success;
-	}
-	ERR_FAIL_V_MSG(false, "EditorResourcePreviewGenerator::_handles needs to be overridden.");
+	GDVIRTUAL_CALL(_handles, p_type, success);
+	return success;
 }
 
 Ref<Texture2D> EditorResourcePreviewGenerator::generate(const Ref<Resource> &p_from, const Size2 &p_size, Dictionary &p_metadata) const {
 	Ref<Texture2D> preview;
-	if (GDVIRTUAL_CALL(_generate, p_from, p_size, p_metadata, preview)) {
-		return preview;
-	}
-	ERR_FAIL_V_MSG(Ref<Texture2D>(), "EditorResourcePreviewGenerator::_generate needs to be overridden.");
+	GDVIRTUAL_CALL(_generate, p_from, p_size, p_metadata, preview);
+	return preview;
 }
 
 Ref<Texture2D> EditorResourcePreviewGenerator::generate_from_path(const String &p_path, const Size2 &p_size, Dictionary &p_metadata) const {

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -44,8 +44,8 @@ class EditorResourcePreviewGenerator : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL1RC(bool, _handles, String)
-	GDVIRTUAL3RC(Ref<Texture2D>, _generate, Ref<Resource>, Vector2i, Dictionary)
+	GDVIRTUAL1RC_REQUIRED(bool, _handles, String)
+	GDVIRTUAL3RC_REQUIRED(Ref<Texture2D>, _generate, Ref<Resource>, Vector2i, Dictionary)
 	GDVIRTUAL3RC(Ref<Texture2D>, _generate_from_path, String, Vector2i, Dictionary)
 	GDVIRTUAL0RC(bool, _generate_small_preview_automatically)
 	GDVIRTUAL0RC(bool, _can_generate_small_preview)

--- a/scene/resources/video_stream.h
+++ b/scene/resources/video_stream.h
@@ -94,7 +94,7 @@ class VideoStream : public Resource {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0R(Ref<VideoStreamPlayback>, _instantiate_playback);
+	GDVIRTUAL0R_REQUIRED(Ref<VideoStreamPlayback>, _instantiate_playback);
 
 	String file;
 	int audio_track = 0;

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -33,23 +33,15 @@
 #include "core/config/project_settings.h"
 
 void AudioStreamPlayback::start(double p_from_pos) {
-	if (GDVIRTUAL_CALL(_start, p_from_pos)) {
-		return;
-	}
-	ERR_FAIL_MSG("AudioStreamPlayback::start unimplemented!");
+	GDVIRTUAL_CALL(_start, p_from_pos);
 }
 void AudioStreamPlayback::stop() {
-	if (GDVIRTUAL_CALL(_stop)) {
-		return;
-	}
-	ERR_FAIL_MSG("AudioStreamPlayback::stop unimplemented!");
+	GDVIRTUAL_CALL(_stop);
 }
 bool AudioStreamPlayback::is_playing() const {
-	bool ret;
-	if (GDVIRTUAL_CALL(_is_playing, ret)) {
-		return ret;
-	}
-	ERR_FAIL_V_MSG(false, "AudioStreamPlayback::is_playing unimplemented!");
+	bool ret = false;
+	GDVIRTUAL_CALL(_is_playing, ret);
+	return ret;
 }
 
 int AudioStreamPlayback::get_loop_count() const {
@@ -59,11 +51,9 @@ int AudioStreamPlayback::get_loop_count() const {
 }
 
 double AudioStreamPlayback::get_playback_position() const {
-	double ret;
-	if (GDVIRTUAL_CALL(_get_playback_position, ret)) {
-		return ret;
-	}
-	ERR_FAIL_V_MSG(0, "AudioStreamPlayback::get_playback_position unimplemented!");
+	double ret = 0.0;
+	GDVIRTUAL_CALL(_get_playback_position, ret);
+	return ret;
 }
 void AudioStreamPlayback::seek(double p_time) {
 	GDVIRTUAL_CALL(_seek, p_time);
@@ -250,10 +240,8 @@ int AudioStreamPlaybackResampled::mix(AudioFrame *p_buffer, float p_rate_scale, 
 
 Ref<AudioStreamPlayback> AudioStream::instantiate_playback() {
 	Ref<AudioStreamPlayback> ret;
-	if (GDVIRTUAL_CALL(_instantiate_playback, ret)) {
-		return ret;
-	}
-	ERR_FAIL_V_MSG(Ref<AudioStreamPlayback>(), "Method must be implemented!");
+	GDVIRTUAL_CALL(_instantiate_playback, ret);
+	return ret;
 }
 String AudioStream::get_stream_name() const {
 	String ret;

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -81,11 +81,11 @@ class AudioStreamPlayback : public RefCounted {
 protected:
 	static void _bind_methods();
 	PackedVector2Array _mix_audio_bind(float p_rate_scale, int p_frames);
-	GDVIRTUAL1(_start, double)
-	GDVIRTUAL0(_stop)
-	GDVIRTUAL0RC(bool, _is_playing)
+	GDVIRTUAL1_REQUIRED(_start, double)
+	GDVIRTUAL0_REQUIRED(_stop)
+	GDVIRTUAL0RC_REQUIRED(bool, _is_playing)
 	GDVIRTUAL0RC(int, _get_loop_count)
-	GDVIRTUAL0RC(double, _get_playback_position)
+	GDVIRTUAL0RC_REQUIRED(double, _get_playback_position)
 	GDVIRTUAL1(_seek, double)
 	GDVIRTUAL3R_REQUIRED(int, _mix, GDExtensionPtr<AudioFrame>, float, int)
 	GDVIRTUAL0(_tag_used_streams)
@@ -170,7 +170,7 @@ class AudioStream : public Resource {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL0RC(Ref<AudioStreamPlayback>, _instantiate_playback)
+	GDVIRTUAL0RC_REQUIRED(Ref<AudioStreamPlayback>, _instantiate_playback)
 	GDVIRTUAL0RC(String, _get_stream_name)
 	GDVIRTUAL0RC(double, _get_length)
 	GDVIRTUAL0RC(bool, _is_monophonic)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
There is now a standard way to document required virtual methods. I added the `required` qualifier to the cases I found by a quick code search where an implementation is required (other than EditorImportPlugin, which is in a separate PR #104740 ).

I checked all cases to ensure that they are still up to date.