### PR TITLE
Android: Fix the build logic to generate the native debug symbols

### DIFF
--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -97,11 +97,20 @@ if lib_arch_dir != "" and host_subpath != "":
     else:
         lib_tools_dir = ""
 
-    out_dir = "#platform/android/java/lib/libs/" + lib_tools_dir + lib_type_dir + "/" + lib_arch_dir
+    jni_libs_dir = "#platform/android/java/lib/libs/" + lib_tools_dir + lib_type_dir + "/"
+    out_dir = jni_libs_dir + lib_arch_dir
     env_android.CommandNoCache(out_dir + "/libgodot_android.so", lib, Move("$TARGET", "$SOURCE"))
 
     stl_lib_path = f"{env['ANDROID_NDK_ROOT']}/toolchains/llvm/prebuilt/{host_subpath}/sysroot/usr/lib/{triple_target_dir}/libc++_shared.so"
     env_android.CommandNoCache(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))
+
+    if env["debug_symbols"] and env["separate_debug_symbols"]:
+        debug_symbols_zip_file = (
+            ("#bin/android-editor-" if env.editor_build else "#bin/android-template-")
+            + lib_type_dir
+            + "-native-symbols.zip"
+        )
+        env_android.NoCache(Zip(debug_symbols_zip_file, jni_libs_dir, ZIPROOT=Dir(jni_libs_dir)))
 
     if env["generate_android_binaries"]:
         env_android.AlwaysBuild(

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -101,7 +101,7 @@ android {
         }
 
         ndk {
-            debugSymbolLevel 'FULL'
+            debugSymbolLevel 'NONE'
             String[] export_abi_list = getExportEnabledABIs()
             abiFilters export_abi_list
         }
@@ -127,9 +127,11 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
 
-        // 'doNotStrip' is enabled for development within Android Studio
+        // Debug symbols are kept for development within Android Studio.
         if (shouldNotStrip()) {
-            doNotStrip '**/*.so'
+            jniLibs {
+                keepDebugSymbols += '**/*.so'
+            }
         }
 
         // Always select Godot's version of libc++_shared.so in case deps have their own

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -176,10 +176,6 @@ def generateBuildTasks(String flavor = "template", String edition = "standard", 
                         from("app/build/outputs/apk/${edition}/${target}") {
                             include("android_${filenameSuffix}.apk")
                         }
-                        from("app/build/outputs/native-debug-symbols/${edition}${capitalizedTarget}") {
-                            include("native-debug-symbols.zip")
-                            rename ("native-debug-symbols.zip", "android-template-${edition}-${target}-native-debug-symbols.zip")
-                        }
                         into(binDir)
                     }
                 }
@@ -193,10 +189,6 @@ def generateBuildTasks(String flavor = "template", String edition = "standard", 
                         dependsOn ":editor:assemble${capitalizedAndroidDistro}${capitalizedTarget}"
                         from("editor/build/outputs/apk/${androidDistro}/${target}") {
                             include("android_editor-${androidDistro}-${target}*.apk")
-                        }
-                        from("editor/build/outputs/native-debug-symbols/${androidDistro}${capitalizedTarget}") {
-                            include("native-debug-symbols.zip")
-                            rename ("native-debug-symbols.zip", "android-editor-${androidDistro}-${target}-native-debug-symbols.zip")
                         }
                         into(androidEditorBuildsDir)
                     }
@@ -323,17 +315,11 @@ task cleanGodotTemplates(type: Delete) {
 
     // Delete the Godot templates in the Godot bin directory
     delete("$binDir/android_debug.apk")
-    delete("$binDir/android-template-standard-debug-native-debug-symbols.zip")
     delete("$binDir/android_dev.apk")
-    delete("$binDir/android-template-standard-dev-native-debug-symbols.zip")
     delete("$binDir/android_release.apk")
-    delete("$binDir/android-template-standard-release-native-debug-symbols.zip")
     delete("$binDir/android_monoDebug.apk")
-    delete("$binDir/android-template-mono-debug-native-debug-symbols.zip")
     delete("$binDir/android_monoDev.apk")
-    delete("$binDir/android-template-mono-dev-native-debug-symbols.zip")
     delete("$binDir/android_monoRelease.apk")
-    delete("$binDir/android-template-mono-release-native-debug-symbols.zip")
     delete("$binDir/android_source.zip")
     delete("$binDir/godot-lib.template_debug.aar")
     delete("$binDir/godot-lib.template_debug.dev.aar")
@@ -343,4 +329,12 @@ task cleanGodotTemplates(type: Delete) {
     delete("$binDir/godot-lib.debug.aar")
     delete("$binDir/godot-lib.dev.aar")
     delete("$binDir/godot-lib.release.aar")
+
+    // Delete the native debug symbols files.
+    delete("$binDir/android-editor-debug-native-symbols.zip")
+    delete("$binDir/android-editor-dev-native-symbols.zip")
+    delete("$binDir/android-editor-release-native-symbols.zip")
+    delete("$binDir/android-template-debug-native-symbols.zip")
+    delete("$binDir/android-template-dev-native-symbols.zip")
+    delete("$binDir/android-template-release-native-symbols.zip")
 }

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -90,7 +90,7 @@ android {
             editorBuildSuffix: ""
         ]
 
-        ndk { debugSymbolLevel 'FULL' }
+        ndk { debugSymbolLevel 'NONE' }
     }
 
     base {
@@ -141,9 +141,11 @@ android {
     }
 
     packagingOptions {
-        // 'doNotStrip' is enabled for development within Android Studio
+        // Debug symbols are kept for development within Android Studio.
         if (shouldNotStrip()) {
-            doNotStrip '**/*.so'
+            jniLibs {
+                keepDebugSymbols += '**/*.so'
+            }
         }
     }
 

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -67,9 +67,11 @@ android {
         exclude 'META-INF/LICENSE'
         exclude 'META-INF/NOTICE'
 
-        // 'doNotStrip' is enabled for development within Android Studio
+        // Debug symbols are kept for development within Android Studio.
         if (shouldNotStrip()) {
-            doNotStrip '**/*.so'
+            jniLibs {
+                keepDebugSymbols += '**/*.so'
+            }
         }
     }
 

--- a/platform/android/platform_android_builders.py
+++ b/platform/android/platform_android_builders.py
@@ -19,7 +19,10 @@ def generate_android_binaries(target, source, env):
     if env["target"] == "editor":
         gradle_process += ["generateGodotEditor", "generateGodotHorizonOSEditor", "generateGodotPicoOSEditor"]
     else:
-        gradle_process += ["generateGodotTemplates"]
+        if env["module_mono_enabled"]:
+            gradle_process += ["generateGodotMonoTemplates"]
+        else:
+            gradle_process += ["generateGodotTemplates"]
     gradle_process += ["--quiet"]
 
     if env["debug_symbols"] and not env["separate_debug_symbols"]:


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/105605.

The first PR attempted to enable the generation of native debug symbols, and while the symbols are generated, they are invalid and cannot be used to symbolicate the stack traces from the Play store.
This PR addresses that issue by disabling native debug symbols generation from `gradle` and instead using the `.so` files generated by `scons`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
