### PR TITLE
[Web] Revert #105601 (avoid unnecessary gamepad polling)

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -830,9 +830,6 @@ void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char
 
 void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid) {
 	Input *input = Input::get_singleton();
-	DisplayServerWeb *ds = get_singleton();
-	ds->active_gamepad_sample_count = -1; // Invalidate cache
-
 	if (p_connected) {
 		input->joy_connection_changed(p_index, true, p_id, p_guid);
 	} else {
@@ -1435,10 +1432,7 @@ DisplayServer::VSyncMode DisplayServerWeb::window_get_vsync_mode(WindowID p_vsyn
 void DisplayServerWeb::process_events() {
 	process_keys();
 	Input::get_singleton()->flush_buffered_events();
-	if (active_gamepad_sample_count == -1) {
-		active_gamepad_sample_count = godot_js_input_gamepad_sample();
-	}
-	if (active_gamepad_sample_count > 0) {
+	if (godot_js_input_gamepad_sample() == OK) {
 		process_joypads();
 	}
 }

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -104,8 +104,6 @@ private:
 	bool swap_cancel_ok = false;
 	NativeMenu *native_menu = nullptr;
 
-	int active_gamepad_sample_count = -1;
-
 	MouseMode mouse_mode_base = MOUSE_MODE_VISIBLE;
 	MouseMode mouse_mode_override = MOUSE_MODE_VISIBLE;
 	bool mouse_mode_override_enabled = false;

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -205,7 +205,6 @@ const GodotInputGamepads = {
 		sample: function () {
 			const pads = GodotInputGamepads.get_pads();
 			const samples = [];
-			let active = 0;
 			for (let i = 0; i < pads.length; i++) {
 				const pad = pads[i];
 				if (!pad) {
@@ -225,10 +224,8 @@ const GodotInputGamepads = {
 					s.axes.push(pad.axes[a]);
 				}
 				samples.push(s);
-				active++;
 			}
 			GodotInputGamepads.samples = samples;
-			return active;
 		},
 
 		init: function (onchange) {
@@ -662,7 +659,8 @@ const GodotInput = {
 	godot_js_input_gamepad_sample__proxy: 'sync',
 	godot_js_input_gamepad_sample__sig: 'i',
 	godot_js_input_gamepad_sample: function () {
-		return GodotInputGamepads.sample();
+		GodotInputGamepads.sample();
+		return 0;
 	},
 
 	godot_js_input_gamepad_sample_get__proxy: 'sync',


### PR DESCRIPTION
Revert "Web: Avoid unnecessary gamepad polling when no gamepads are connected"

This reverts commit 3e7e09f9152288ced7d404b7f7b79e8de9ad165b.

The logic of the PR was flawed, and I didn't see it at the time when I approved it. `godot_js_input_gamepad_sample()` actually sampled the keys pressed. So if it's not called, it will never sample the new keys pressed, even if the gamepad is correctly detected, which caused #107697.

~~I will try to find a way to keep the spirit of #105601 (avoid unnecessary polling) without the side effect of #107697.~~ See #108007.

Fixes #107697