### PR TITLE
[Web] Poll controllers only if at least one is detected

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -829,6 +829,12 @@ void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char
 }
 
 void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid) {
+	if (p_connected) {
+		DisplayServerWeb::get_singleton()->gamepad_count += 1;
+	} else {
+		DisplayServerWeb::get_singleton()->gamepad_count -= 1;
+	}
+
 	Input *input = Input::get_singleton();
 	if (p_connected) {
 		input->joy_connection_changed(p_index, true, p_id, p_guid);
@@ -1432,8 +1438,11 @@ DisplayServer::VSyncMode DisplayServerWeb::window_get_vsync_mode(WindowID p_vsyn
 void DisplayServerWeb::process_events() {
 	process_keys();
 	Input::get_singleton()->flush_buffered_events();
-	if (godot_js_input_gamepad_sample() == OK) {
-		process_joypads();
+
+	if (gamepad_count > 0) {
+		if (godot_js_input_gamepad_sample() == OK) {
+			process_joypads();
+		}
 	}
 }
 

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -830,9 +830,6 @@ void DisplayServerWeb::gamepad_callback(int p_index, int p_connected, const char
 
 void DisplayServerWeb::_gamepad_callback(int p_index, int p_connected, const String &p_id, const String &p_guid) {
 	Input *input = Input::get_singleton();
-	DisplayServerWeb *ds = get_singleton();
-	ds->active_gamepad_sample_count = -1; // Invalidate cache
-
 	if (p_connected) {
 		input->joy_connection_changed(p_index, true, p_id, p_guid);
 	} else {
@@ -1435,10 +1432,7 @@ DisplayServer::VSyncMode DisplayServerWeb::window_get_vsync_mode(WindowID p_vsyn
 void DisplayServerWeb::process_events() {
 	process_keys();
 	Input::get_singleton()->flush_buffered_events();
-	if (active_gamepad_sample_count == -1) {
-		active_gamepad_sample_count = godot_js_input_gamepad_sample();
-	}
-	if (active_gamepad_sample_count > 0) {
+	if (godot_js_input_gamepad_sample() == OK) {
 		process_joypads();
 	}
 }

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -104,8 +104,6 @@ private:
 	bool swap_cancel_ok = false;
 	NativeMenu *native_menu = nullptr;
 
-	int active_gamepad_sample_count = -1;
-
 	MouseMode mouse_mode_base = MOUSE_MODE_VISIBLE;
 	MouseMode mouse_mode_override = MOUSE_MODE_VISIBLE;
 	bool mouse_mode_override_enabled = false;

--- a/platform/web/display_server_web.h
+++ b/platform/web/display_server_web.h
@@ -104,6 +104,8 @@ private:
 	bool swap_cancel_ok = false;
 	NativeMenu *native_menu = nullptr;
 
+	int gamepad_count = 0;
+
 	MouseMode mouse_mode_base = MOUSE_MODE_VISIBLE;
 	MouseMode mouse_mode_override = MOUSE_MODE_VISIBLE;
 	bool mouse_mode_override_enabled = false;

--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -205,7 +205,6 @@ const GodotInputGamepads = {
 		sample: function () {
 			const pads = GodotInputGamepads.get_pads();
 			const samples = [];
-			let active = 0;
 			for (let i = 0; i < pads.length; i++) {
 				const pad = pads[i];
 				if (!pad) {
@@ -225,10 +224,8 @@ const GodotInputGamepads = {
 					s.axes.push(pad.axes[a]);
 				}
 				samples.push(s);
-				active++;
 			}
 			GodotInputGamepads.samples = samples;
-			return active;
 		},
 
 		init: function (onchange) {
@@ -662,7 +659,8 @@ const GodotInput = {
 	godot_js_input_gamepad_sample__proxy: 'sync',
 	godot_js_input_gamepad_sample__sig: 'i',
 	godot_js_input_gamepad_sample: function () {
-		return GodotInputGamepads.sample();
+		GodotInputGamepads.sample();
+		return 0;
 	},
 
 	godot_js_input_gamepad_sample_get__proxy: 'sync',


### PR DESCRIPTION
> [!WARNING]
> Follow-up to/depends on #108006.

This PR implements what #105601 wanted to do, without the #107697 regression.

It introduces a simple counter:`DisplayServerWeb::gamepad_count`. It's incremented by one when a gamepad is conntected, decremented by one when a gamepad is disconnected.

I made the logic to poll only the controllers state if `gamepad_count > 0`.

cc. @marcosc90