### PR TITLE
Add support for rotating scene tiles in TileMapLayer

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -127,18 +127,7 @@ void TileMapLayerEditorTilesPlugin::_update_transform_buttons() {
 		return;
 	}
 
-	bool has_scene_tile = false;
-	for (const KeyValue<Vector2i, TileMapCell> &E : selection_pattern->get_pattern()) {
-		if (Object::cast_to<TileSetScenesCollectionSource>(tile_set->get_source(E.value.source_id).ptr())) {
-			has_scene_tile = true;
-			break;
-		}
-	}
-
-	if (has_scene_tile) {
-		_set_transform_buttons_state({}, { transform_button_rotate_left, transform_button_rotate_right, transform_button_flip_h, transform_button_flip_v },
-				TTR("Can't transform scene tiles."));
-	} else if (tile_set->get_tile_shape() != TileSet::TILE_SHAPE_SQUARE && selection_pattern->get_size() != Vector2i(1, 1)) {
+	if (tile_set->get_tile_shape() != TileSet::TILE_SHAPE_SQUARE && selection_pattern->get_size() != Vector2i(1, 1)) {
 		_set_transform_buttons_state({ transform_button_flip_h, transform_button_flip_v }, { transform_button_rotate_left, transform_button_rotate_right },
 				TTR("Can't rotate patterns when using non-square tile grid."));
 	} else {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -474,6 +474,7 @@ private:
 #ifdef DEBUG_ENABLED
 	void _scenes_draw_cell_debug(const RID &p_canvas_item, const Vector2 &p_quadrant_pos, const CellData &r_cell_data);
 #endif // DEBUG_ENABLED
+	void _set_scene_transformed_alternative(const int p_alternative_id, Node2D *p_scene);
 
 	// Terrains.
 	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const RBSet<TerrainConstraint> &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -5775,7 +5775,7 @@ int TileSetScenesCollectionSource::get_alternative_tile_id(const Vector2i p_atla
 
 bool TileSetScenesCollectionSource::has_alternative_tile(const Vector2i p_atlas_coords, int p_alternative_tile) const {
 	ERR_FAIL_COND_V(p_atlas_coords != Vector2i(), false);
-	return scenes.has(p_alternative_tile);
+	return scenes.has(TileSetAtlasSource::alternative_no_transform(p_alternative_tile));
 }
 
 int TileSetScenesCollectionSource::create_scene_tile(Ref<PackedScene> p_packed_scene, int p_id_override) {
@@ -5837,8 +5837,9 @@ void TileSetScenesCollectionSource::set_scene_tile_scene(int p_id, Ref<PackedSce
 }
 
 Ref<PackedScene> TileSetScenesCollectionSource::get_scene_tile_scene(int p_id) const {
-	ERR_FAIL_COND_V(!scenes.has(p_id), Ref<PackedScene>());
-	return scenes[p_id].scene;
+	int scene_tile = TileSetAtlasSource::alternative_no_transform(p_id);
+	ERR_FAIL_COND_V(!scenes.has(scene_tile), Ref<PackedScene>());
+	return scenes[scene_tile].scene;
 }
 
 void TileSetScenesCollectionSource::set_scene_tile_display_placeholder(int p_id, bool p_display_placeholder) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12570

https://github.com/user-attachments/assets/0f355445-70b6-4f2e-90e6-cb11342e955a

> [!WARNING]  
> *Bugsquad edit:* Compatibility breaking in case someone was using scene tile ids greater than 4095. Now bits:
> - `1 << 12 == 4096`,
> - `1 << 13 == 8192`,
> - `1 << 14 == 16384`,
>
> are being used as flip_h/flip_v/transpose flags.
> See https://github.com/godotengine/godot/issues/112175#issuecomment-3681780730 and subsequent comments for more info.