### PR TITLE
Don't rename nodes when tree is invisible

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -184,7 +184,7 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 		if (focus_owner && (Object::cast_to<BaseButton>(focus_owner) || Object::cast_to<Range>(focus_owner))) {
 			return;
 		}
-		if (edit_remote->is_pressed()) {
+		if (!scene_tree->is_visible_in_tree()) {
 			return;
 		}
 		_tool_selected(TOOL_RENAME);


### PR DESCRIPTION
Fixes #87228

It's basically an extension of #106688