### PR TITLE
Add missing JNI variant conversion for generic Array

### DIFF
--- a/platform/android/jni_utils.cpp
+++ b/platform/android/jni_utils.cpp
@@ -199,6 +199,22 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 			v.obj = jdict;
 		} break;
 
+		case Variant::ARRAY: {
+			Array array = *p_arg;
+			jobjectArray arr = env->NewObjectArray(array.size(), env->FindClass("java/lang/Object"), nullptr);
+
+			for (int j = 0; j < array.size(); j++) {
+				Variant var = array[j];
+				jvalret valret = _variant_to_jvalue(env, var.get_type(), &var, true);
+				env->SetObjectArrayElement(arr, j, valret.val.l);
+				if (valret.obj) {
+					env->DeleteLocalRef(valret.obj);
+				}
+			}
+			v.val.l = arr;
+			v.obj = arr;
+		} break;
+
 		case Variant::PACKED_INT32_ARRAY: {
 			Vector<int> array = *p_arg;
 			jintArray arr = env->NewIntArray(array.size());


### PR DESCRIPTION
This PR fixes JNI abstractions not performing variant conversion for basic Array.

The issue is described in detail here: 
- #108018

In short, in the [sentry-godot](https://github.com/getsentry/sentry-godot) extension, we are passing Dictionary arguments to Android Plugin methods, and any basic arrays in a Dictionary are getting lost in the process. This PR fixes the issue by adding the conversion path for `Variant::ARRAY` in the `_variant_to_jvalue()` function inside `jni_utils.cpp`.

### Before this PR
<img width="506" alt="Screenshot 2025-06-26 at 16 34 22" src="https://github.com/user-attachments/assets/9ecb6778-302a-43d8-b6bc-40d1c7beb474" />

### After this PR
<img width="501" alt="Screenshot 2025-06-26 at 16 34 12" src="https://github.com/user-attachments/assets/b70eb7ed-89e6-4b30-8d83-3e7c65d17c93" />
