### PR TITLE
Support multiple intersections for ray casting

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,5 @@
 name: 🔗 GHA
-on: [push, pull_request, merge_group, workflow_dispatch]
+on: [push, pull_request, merge_group]
 
 concurrency:
   group: ${{ github.workflow }}|${{ github.ref_name }}

--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,5 @@
 name: 🔗 GHA
-on: [push, pull_request, merge_group]
+on: [push, pull_request, merge_group, workflow_dispatch]
 
 concurrency:
   group: ${{ github.workflow }}|${{ github.ref_name }}

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -72,6 +72,22 @@
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
 			</description>
 		</method>
+		<method name="intersect_ray_multiple">
+			<return type="Dictionary[]" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />
+			<param index="1" name="max_results" type="int" default="32" />
+			<description>
+				Intersects a ray in a given space yielding all intersected objects up to the number specified by the [code skip-lint]max_results[/code] parameter. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
+				[code]collider[/code]: The colliding object.
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters2D.hit_from_inside] is [code]true[/code].
+				[code]position[/code]: The intersection point.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				If the ray did not intersect anything, then an empty array is returned instead.
+				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default 32) to compensate.
+			</description>
+		</method>
 		<method name="intersect_shape">
 			<return type="Dictionary[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters2D" />

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -85,7 +85,8 @@
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
-				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default 32) to compensate.
+				If [code skip-lint]max_results[/code] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
+				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) to compensate. This does not apply to [code]max_results = 1[/code].
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -86,7 +86,7 @@
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
 				If [code skip-lint]max_results[/code] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
-				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) to compensate. This does not apply to [code]max_results = 1[/code].
+				[b]Note:[/b] The results array is not guaranteed to contain all possible (or closest) intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. It is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) if all elements in the raycast are required.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -77,7 +77,7 @@
 			<param index="0" name="parameters" type="PhysicsRayQueryParameters2D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>
-				Intersects a ray in a given space yielding all intersected objects up to the number specified by the [code skip-lint]max_results[/code] parameter. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
+				Intersects a ray in a given space yielding all intersected objects up to the number specified by the [param max_results] parameter. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector2(0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters2D.hit_from_inside] is [code]true[/code].
@@ -85,8 +85,8 @@
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
-				If [code skip-lint]max_results[/code] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
-				[b]Note:[/b] The results array is not guaranteed to contain all possible (or closest) intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. It is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) if all elements in the raycast are required.
+				If [param max_results] is set to [code]1[/code], the method will behave as [method intersect_ray].
+				[b]Note:[/b] The results array is not guaranteed to contain all possible (or closest) intersected objects if the returned array has a size of [param max_results]. It is recommended to increase the size of [param max_results] (default [code]32[/code]) if all elements in the raycast are required.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState2DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState2DExtension.xml
@@ -63,6 +63,19 @@
 			<description>
 			</description>
 		</method>
+		<method name="_intersect_ray_multiple" qualifiers="virtual required">
+			<return type="int" />
+			<param index="0" name="from" type="Vector2" />
+			<param index="1" name="to" type="Vector2" />
+			<param index="2" name="collision_mask" type="int" />
+			<param index="3" name="collide_with_bodies" type="bool" />
+			<param index="4" name="collide_with_areas" type="bool" />
+			<param index="5" name="hit_from_inside" type="bool" />
+			<param index="6" name="result" type="PhysicsServer2DExtensionRayResult*" />
+			<param index="7" name="max_results" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_intersect_shape" qualifiers="virtual required">
 			<return type="int" />
 			<param index="0" name="shape_rid" type="RID" />

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -90,7 +90,8 @@
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
-				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default 32) to compensate.
+				If [code skip-lint]max_results[/code] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
+				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) to compensate. This does not apply to [code]max_results = 1[/code].
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -75,6 +75,24 @@
 				If the ray did not intersect anything, then an empty dictionary is returned instead.
 			</description>
 		</method>
+		<method name="intersect_ray_multiple">
+			<return type="Dictionary[]" />
+			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
+			<param index="1" name="max_results" type="int" default="32" />
+			<description>
+				Intersects a ray in a given space yielding all intersected objects up to the number specified by the [code skip-lint]max_results[/code] parameter. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
+				[code]collider[/code]: The colliding object.
+				[code]collider_id[/code]: The colliding object's ID.
+				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
+				[code]position[/code]: The intersection point.
+				[code]face_index[/code]: The face index at the intersection point.
+				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+				[code]rid[/code]: The intersecting object's [RID].
+				[code]shape[/code]: The shape index of the colliding shape.
+				If the ray did not intersect anything, then an empty array is returned instead.
+				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default 32) to compensate.
+			</description>
+		</method>
 		<method name="intersect_shape">
 			<return type="Dictionary[]" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -91,7 +91,7 @@
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
 				If [code skip-lint]max_results[/code] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
-				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. If all elements are required it is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) to compensate. This does not apply to [code]max_results = 1[/code].
+				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. It is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) if all elements in the raycast are required. Additionally, the godot-physics backend is [i]not[/i] guaranteed to provide the closest [code skip-lint]max_results[/code] hits (unless [code]max_results = 1[/code]), whereas the jolt-physics backend will.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -85,7 +85,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
 				[code]position[/code]: The intersection point.
-				[code]face_index[/code]: The face index at the intersection point. [b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+				[code]face_index[/code]: The face index at the intersection point. Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -85,8 +85,7 @@
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].
 				[code]position[/code]: The intersection point.
-				[code]face_index[/code]: The face index at the intersection point.
-				[b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
+				[code]face_index[/code]: The face index at the intersection point. [b]Note:[/b] Returns a valid number only if the intersected shape is a [ConcavePolygonShape3D]. Otherwise, [code]-1[/code] is returned.
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -91,7 +91,7 @@
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
 				If [param max_results] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
-				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. It is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) if all elements in the raycast are required. Additionally, the godot-physics backend is [i]not[/i] guaranteed to provide the closest [code skip-lint]max_results[/code] hits (unless [code]max_results = 1[/code]), whereas the jolt-physics backend will.
+				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [param max_results]. It is recommended to increase the size of [param max_results] (default [code]32[/code]) if all elements in the raycast are required. Additionally, the Godot Physics backend is [i]not[/i] guaranteed to provide the closest [param max_results] hits (unless [code]max_results = 1[/code]), whereas the Jolt Physics backend will.
 			</description>
 		</method>
 		<method name="intersect_shape">

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -90,7 +90,7 @@
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
-				If [code skip-lint]max_results[/code] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
+				If [param max_results] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
 				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [code skip-lint]max_results[/code]. It is recommended to increase the size of [code skip-lint]max_results[/code] (default [code]32[/code]) if all elements in the raycast are required. Additionally, the godot-physics backend is [i]not[/i] guaranteed to provide the closest [code skip-lint]max_results[/code] hits (unless [code]max_results = 1[/code]), whereas the jolt-physics backend will.
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -80,7 +80,7 @@
 			<param index="0" name="parameters" type="PhysicsRayQueryParameters3D" />
 			<param index="1" name="max_results" type="int" default="32" />
 			<description>
-				Intersects a ray in a given space yielding all intersected objects up to the number specified by the [code skip-lint]max_results[/code] parameter. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
+				Intersects a ray in a given space yielding all intersected objects up to the number specified by [param max_results]. Ray position and other parameters are defined through [PhysicsRayQueryParameters2D]. The returned object is an array of dictionaries with the following fields:
 				[code]collider[/code]: The colliding object.
 				[code]collider_id[/code]: The colliding object's ID.
 				[code]normal[/code]: The object's surface normal at the intersection point, or [code]Vector3(0, 0, 0)[/code] if the ray starts inside the shape and [member PhysicsRayQueryParameters3D.hit_from_inside] is [code]true[/code].

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -89,7 +89,7 @@
 				[code]rid[/code]: The intersecting object's [RID].
 				[code]shape[/code]: The shape index of the colliding shape.
 				If the ray did not intersect anything, then an empty array is returned instead.
-				If [param max_results] is set to [code]1[/code], the method will behave as [code skip-lint]intersect_ray[/code].
+				If [param max_results] is set to [code]1[/code], the method will behave as [method intersect_ray].
 				[b]Note:[/b] The results array is not guaranteed to contain all possible intersected objects if the returned array has a size of [param max_results]. It is recommended to increase the size of [param max_results] (default [code]32[/code]) if all elements in the raycast are required. Additionally, the Godot Physics backend is [i]not[/i] guaranteed to provide the closest [param max_results] hits (unless [code]max_results = 1[/code]), whereas the Jolt Physics backend will.
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -40,7 +40,10 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_closest_point_to_object_volume" qualifiers="virtual required const">
+		<method
+			name="_get_closest_point_to_object_volume"
+			qualifiers="virtual required const"
+		>
 			<return type="Vector3" />
 			<param index="0" name="object" type="RID" />
 			<param index="1" name="point" type="Vector3" />
@@ -69,6 +72,21 @@
 			<param index="6" name="hit_back_faces" type="bool" />
 			<param index="7" name="pick_ray" type="bool" />
 			<param index="8" name="r_result" type="PhysicsServer3DExtensionRayResult*" />
+			<description>
+			</description>
+		</method>
+		<method name="_intersect_ray_multiple" qualifiers="virtual required">
+			<return type="int" />
+			<param index="0" name="from" type="Vector3" />
+			<param index="1" name="to" type="Vector3" />
+			<param index="2" name="collision_mask" type="int" />
+			<param index="3" name="collide_with_bodies" type="bool" />
+			<param index="4" name="collide_with_areas" type="bool" />
+			<param index="5" name="hit_from_inside" type="bool" />
+			<param index="6" name="hit_back_faces" type="bool" />
+			<param index="7" name="pick_ray" type="bool" />
+			<param index="8" name="results" type="PhysicsServer3DExtensionRayResult*" />
+			<param index="9" name="max_results" type="int" />
 			<description>
 			</description>
 		</method>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -40,10 +40,7 @@
 			<description>
 			</description>
 		</method>
-		<method
-			name="_get_closest_point_to_object_volume"
-			qualifiers="virtual required const"
-		>
+		<method name="_get_closest_point_to_object_volume" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<param index="0" name="object" type="RID" />
 			<param index="1" name="point" type="Vector3" />

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -115,7 +115,8 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 	return cc;
 }
 
-bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
+
+int GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
 	ERR_FAIL_COND_V(space->locked, false);
 
 	Vector2 begin, end;
@@ -134,7 +135,15 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 	const GodotCollisionObject2D *res_obj = nullptr;
 	real_t min_d = 1e10;
 
+	int r_idx = 0;
+	bool hit_once = false;
+	bool choose_closest = (p_result_max == 1);
+
 	for (int i = 0; i < amount; i++) {
+		collided = false;
+		if (r_idx >= p_result_max) {
+			break;
+		}
 		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
 			continue;
 		}
@@ -164,45 +173,65 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 				res_shape = shape_idx;
 				res_obj = col_obj;
 				collided = true;
-				break;
 			} else {
 				// Ignore shape when starting inside.
 				continue;
 			}
-		}
-
-		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
+		} else if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
 			Transform2D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 			shape_point = xform.xform(shape_point);
 
-			real_t ld = normal.dot(shape_point);
+			res_point = shape_point;
+			res_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
+			res_shape = shape_idx;
+			res_obj = col_obj;
+			collided = true;
+			
+		}
 
-			if (ld < min_d) {
+		if (collided) {
+			ERR_FAIL_NULL_V(res_obj, 0); // Shouldn't happen but silences warning.
+			if (choose_closest && hit_once) {
+				real_t ld = normal.dot(shape_point);
+				if (ld > min_d) {
+					continue;
+				}
 				min_d = ld;
-				res_point = shape_point;
-				res_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
-				res_shape = shape_idx;
-				res_obj = col_obj;
-				collided = true;
+			}
+
+			if (r_results) {
+				r_results[r_idx].collider_id = res_obj->get_instance_id();
+				if (r_results[r_idx].collider_id.is_valid()) {
+					r_results[r_idx].collider = ObjectDB::get_instance(r_results[r_idx].collider_id);
+				}
+				r_results[r_idx].normal = res_normal;
+				r_results[r_idx].position = res_point;
+				r_results[r_idx].rid = res_obj->get_self();
+				r_results[r_idx].shape = res_shape;
+			}
+
+			hit_once = true;
+			collided = false;
+
+			if (p_result_max > 1) {
+				r_idx += 1;
 			}
 		}
 	}
 
-	if (!collided) {
-		return false;
+	if (choose_closest) {
+		r_idx = 1;
 	}
-	ERR_FAIL_NULL_V(res_obj, false); // Shouldn't happen but silences warning.
 
-	r_result.collider_id = res_obj->get_instance_id();
-	if (r_result.collider_id.is_valid()) {
-		r_result.collider = ObjectDB::get_instance(r_result.collider_id);
-	}
-	r_result.normal = res_normal;
-	r_result.position = res_point;
-	r_result.rid = res_obj->get_self();
-	r_result.shape = res_shape;
+	return r_idx;
+}
 
-	return true;
+bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
+	LocalVector<RayResult> results;
+	results.push_back(r_result);
+
+	int n_collisions = intersect_ray_multiple(p_parameters, results.ptr(), 1);
+	return n_collisions > 0;
 }
 
 int GodotPhysicsDirectSpaceState2D::intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) {

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -115,7 +115,6 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PointParameters &p_par
 	return cc;
 }
 
-
 int GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
 	ERR_FAIL_COND_V(space->locked, false);
 
@@ -186,7 +185,6 @@ int GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &
 			res_shape = shape_idx;
 			res_obj = col_obj;
 			collided = true;
-			
 		}
 
 		if (collided) {

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -230,16 +230,7 @@ int GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &
 
 bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
 	int n_collisions = intersect_ray_multiple(p_parameters, &r_result, 1);
-	bool hit = n_collisions > 0;
-	if (hit) {
-		r_result.collider_id = r_result.collider_id;
-		r_result.collider = r_result.collider;
-		r_result.normal = r_result.normal;
-		r_result.position = r_result.position;
-		r_result.rid = r_result.rid;
-		r_result.shape = r_result.shape;
-	}
-	return hit;
+	return n_collisions > 0;
 }
 
 int GodotPhysicsDirectSpaceState2D::intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) {

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -229,18 +229,15 @@ int GodotPhysicsDirectSpaceState2D::intersect_ray_multiple(const RayParameters &
 }
 
 bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
-	LocalVector<RayResult> results;
-	results.resize(1);
-
-	int n_collisions = intersect_ray_multiple(p_parameters, results.ptr(), 1);
+	int n_collisions = intersect_ray_multiple(p_parameters, &r_result, 1);
 	bool hit = n_collisions > 0;
 	if (hit) {
-		r_result.collider_id = results[0].collider_id;
-		r_result.collider = results[0].collider;
-		r_result.normal = results[0].normal;
-		r_result.position = results[0].position;
-		r_result.rid = results[0].rid;
-		r_result.shape = results[0].shape;
+		r_result.collider_id = r_result.collider_id;
+		r_result.collider = r_result.collider;
+		r_result.normal = r_result.normal;
+		r_result.position = r_result.position;
+		r_result.rid = r_result.rid;
+		r_result.shape = r_result.shape;
 	}
 	return hit;
 }

--- a/modules/godot_physics_2d/godot_space_2d.h
+++ b/modules/godot_physics_2d/godot_space_2d.h
@@ -44,6 +44,7 @@ public:
 	GodotSpace2D *space = nullptr;
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe) override;

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -185,7 +185,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 
 		if (collided) {
 			ERR_FAIL_NULL_V(res_obj, 0); // Shouldn't happen but silences warning.
-			
+
 			// Filter to closest hit if only one return is allowed and we've already hit something
 			if (choose_closest && hit_once) {
 				real_t ld = normal.dot(shape_point);
@@ -194,7 +194,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 				}
 				min_d = ld;
 			}
-			
+
 			if (r_results) {
 				r_results[r_idx].collider_id = res_obj->get_instance_id();
 				if (r_results[r_idx].collider_id.is_valid()) {
@@ -208,7 +208,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 				r_results[r_idx].rid = res_obj->get_self();
 				r_results[r_idx].shape = res_shape;
 			}
-			
+
 			hit_once = true;
 			collided = false;
 

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -216,7 +216,8 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 		}
 	}
 
-	if (choose_closest) {
+	// Indicate a successful return if constricting to closest and a hit was found
+	if (choose_closest && res_obj != nullptr) {
 		r_idx = 1;
 	}
 

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -107,6 +107,97 @@ int GodotPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_par
 	return cc;
 }
 
+int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
+	ERR_FAIL_COND_V(space->locked, false);
+
+	Vector3 begin, end;
+	Vector3 normal;
+	begin = p_parameters.from;
+	end = p_parameters.to;
+	normal = (end - begin).normalized();
+
+	int amount = space->broadphase->cull_segment(begin, end, space->intersection_query_results, GodotSpace3D::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
+
+	//todo, create another array that references results, compute AABBs and check closest point to ray origin, sort, and stop evaluating results when beyond first collision
+	
+	int r_idx = 0;
+	for (int i = 0; i < amount; i++) {
+		if (r_idx >= p_result_max) {
+			break;
+		}
+
+		if (!_can_collide_with(space->intersection_query_results[i], p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas)) {
+			continue;
+		}
+
+		if (p_parameters.pick_ray && !(space->intersection_query_results[i]->is_ray_pickable())) {
+			continue;
+		}
+
+		if (p_parameters.exclude.has(space->intersection_query_results[i]->get_self())) {
+			continue;
+		}
+
+		const GodotCollisionObject3D *col_obj = space->intersection_query_results[i];
+
+		int shape_idx = space->intersection_query_subindex_results[i];
+		Transform3D inv_xform = col_obj->get_shape_inv_transform(shape_idx) * col_obj->get_inv_transform();
+
+		Vector3 local_from = inv_xform.xform(begin);
+		Vector3 local_to = inv_xform.xform(end);
+
+		const GodotShape3D *shape = col_obj->get_shape(shape_idx);
+
+		Vector3 shape_point, shape_normal;
+		int shape_face_index = -1;
+
+		if (shape->intersect_point(local_from)) {
+			if (p_parameters.hit_from_inside) {
+				// Hit shape at starting point.
+				RayResult r_result = r_results[r_idx];
+
+				r_result.collider_id = col_obj->get_instance_id();
+				if (r_result.collider_id.is_valid()) {
+					r_result.collider = ObjectDB::get_instance(r_result.collider_id);
+				} else {
+					r_result.collider = nullptr;
+				}
+				r_result.normal = Vector3();
+				r_result.face_index = shape_face_index;
+				r_result.position = begin;
+				r_result.rid = col_obj->get_self();
+				r_result.shape = shape_idx;
+				r_idx++;
+			} else {
+				// Ignore shape when starting inside.
+				continue;
+			}
+		}
+
+		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal, shape_face_index, p_parameters.hit_back_faces)) {
+			Transform3D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
+			shape_point = xform.xform(shape_point);
+
+			RayResult r_result = r_results[r_idx];
+
+			r_result.collider_id = col_obj->get_instance_id();
+			if (r_result.collider_id.is_valid()) {
+				r_result.collider = ObjectDB::get_instance(r_result.collider_id);
+			} else {
+				r_result.collider = nullptr;
+			}
+			r_result.normal = inv_xform.basis.xform_inv(shape_normal).normalized();
+			r_result.face_index = shape_face_index;
+			r_result.position = shape_point;
+			r_result.rid = col_obj->get_self();
+			r_result.shape = shape_idx;
+			r_idx++;
+		}
+	}
+
+	return r_idx;
+}
+
 bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
 	ERR_FAIL_COND_V(space->locked, false);
 

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -130,7 +130,6 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 	bool hit_once = false;
 	bool choose_closest = (p_result_max == 1);
 	for (int i = 0; i < amount; i++) {
-		collided = false;
 		if (r_idx >= p_result_max) {
 			break;
 		}

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -119,6 +119,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 	int amount = space->broadphase->cull_segment(begin, end, space->intersection_query_results, GodotSpace3D::INTERSECTION_QUERY_MAX, space->intersection_query_subindex_results);
 
 	//todo, create another array that references results, compute AABBs and check closest point to ray origin, sort, and stop evaluating results when beyond first collision
+
 	bool collided = false;
 	Vector3 res_point, res_normal;
 	int res_face_index = -1;
@@ -216,7 +217,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 		}
 	}
 
-	// Indicate a successful return if constricting to closest and a hit was found
+	// Indicate a successful return if restricting to closest and a hit was found
 	if (choose_closest && res_obj != nullptr) {
 		r_idx = 1;
 	}
@@ -229,7 +230,8 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 	results.resize(1);
 
 	int n_collisions = intersect_ray_multiple(p_parameters, results.ptr(), 1);
-	if (n_collisions > 0) {
+	bool hit = n_collisions > 0;
+	if (hit) {
 		r_result.collider_id = results[0].collider_id;
 		r_result.collider = results[0].collider;
 		r_result.normal = results[0].normal;
@@ -238,8 +240,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 		r_result.rid = results[0].rid;
 		r_result.shape = results[0].shape;
 	}
-
-	return n_collisions > 0;
+	return hit;
 }
 
 int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) {

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -127,7 +127,6 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 	real_t min_d = 1e10;
 
 	int r_idx = 0;
-	bool hit_once = false;
 	bool choose_closest = (p_result_max == 1);
 	for (int i = 0; i < amount; i++) {
 		if (r_idx >= p_result_max) {
@@ -186,8 +185,8 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 		if (collided) {
 			ERR_FAIL_NULL_V(res_obj, 0); // Shouldn't happen but silences warning.
 
-			// Filter to closest hit if only one return is allowed and we've already hit something
-			if (choose_closest && hit_once) {
+			// Filter to closest hit if only one return is allowed
+			if (choose_closest) {
 				real_t ld = normal.dot(shape_point);
 				if (ld > min_d) {
 					continue;
@@ -209,7 +208,6 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 				r_results[r_idx].shape = res_shape;
 			}
 
-			hit_once = true;
 			collided = false;
 
 			if (p_result_max > 1) {
@@ -227,9 +225,19 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 
 bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
 	LocalVector<RayResult> results;
-	results.push_back(r_result);
+	results.resize(1);
 
 	int n_collisions = intersect_ray_multiple(p_parameters, results.ptr(), 1);
+	if (n_collisions > 0) {
+		r_result.collider_id = results[0].collider_id;
+		r_result.collider = results[0].collider;
+		r_result.normal = results[0].normal;
+		r_result.face_index = results[0].face_index;
+		r_result.position = results[0].position;
+		r_result.rid = results[0].rid;
+		r_result.shape = results[0].shape;
+	}
+
 	return n_collisions > 0;
 }
 

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -227,17 +227,7 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 
 bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
 	int n_collisions = intersect_ray_multiple(p_parameters, &r_result, 1);
-	bool hit = n_collisions > 0;
-	if (hit) {
-		r_result.collider_id = r_result.collider_id;
-		r_result.collider = r_result.collider;
-		r_result.normal = r_result.normal;
-		r_result.face_index = r_result.face_index;
-		r_result.position = r_result.position;
-		r_result.rid = r_result.rid;
-		r_result.shape = r_result.shape;
-	}
-	return hit;
+	return n_collisions > 0;
 }
 
 int GodotPhysicsDirectSpaceState3D::intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) {

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -226,19 +226,16 @@ int GodotPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &
 }
 
 bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
-	LocalVector<RayResult> results;
-	results.resize(1);
-
-	int n_collisions = intersect_ray_multiple(p_parameters, results.ptr(), 1);
+	int n_collisions = intersect_ray_multiple(p_parameters, &r_result, 1);
 	bool hit = n_collisions > 0;
 	if (hit) {
-		r_result.collider_id = results[0].collider_id;
-		r_result.collider = results[0].collider;
-		r_result.normal = results[0].normal;
-		r_result.face_index = results[0].face_index;
-		r_result.position = results[0].position;
-		r_result.rid = results[0].rid;
-		r_result.shape = results[0].shape;
+		r_result.collider_id = r_result.collider_id;
+		r_result.collider = r_result.collider;
+		r_result.normal = r_result.normal;
+		r_result.face_index = r_result.face_index;
+		r_result.position = r_result.position;
+		r_result.rid = r_result.rid;
+		r_result.shape = r_result.shape;
 	}
 	return hit;
 }

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -45,8 +45,8 @@ public:
 	GodotSpace3D *space = nullptr;
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
-	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
 	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override;
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override;

--- a/modules/godot_physics_3d/godot_space_3d.h
+++ b/modules/godot_physics_3d/godot_space_3d.h
@@ -46,6 +46,7 @@ public:
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;
 	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override;

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -454,12 +454,6 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 	// Parity for godot physics 3d - if a single result is expected then return the closest hit (same as intersect_ray)
 	if (p_result_max == 0) {
 		return 0;
-	} else if (p_result_max == 1) {
-		if (intersect_ray(p_parameters, r_results[0])) {
-			return 1;
-		} else {
-			return 0;
-		}
 	}
 
 	space->flush_pending_objects();
@@ -477,7 +471,7 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 	settings.mTreatConvexAsSolid = p_parameters.hit_from_inside;
 	settings.mBackFaceModeTriangles = back_face_mode;
 
-	JoltQueryCollectorAnyMulti<JPH::CastRayCollector, 32> collector(p_result_max);
+	JoltQueryCollectorClosestMulti<JPH::CastRayCollector, 32> collector(p_result_max);
 	space->get_narrow_phase_query().CastRay(ray, settings, collector, query_filter, query_filter, query_filter);
 
 	const int hit_count = collector.get_hit_count();
@@ -524,66 +518,8 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 }
 
 bool JoltPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
-	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
-
-	space->flush_pending_objects();
-
-	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
-
-	const JPH::RVec3 from = to_jolt_r(p_parameters.from);
-	const JPH::RVec3 to = to_jolt_r(p_parameters.to);
-	const JPH::Vec3 vector = JPH::Vec3(to - from);
-	const JPH::RRayCast ray(from, vector);
-
-	const JPH::EBackFaceMode back_face_mode = p_parameters.hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces : JPH::EBackFaceMode::IgnoreBackFaces;
-
-	JPH::RayCastSettings settings;
-	settings.mTreatConvexAsSolid = p_parameters.hit_from_inside;
-	settings.mBackFaceModeTriangles = back_face_mode;
-
-	JoltQueryCollectorClosest<JPH::CastRayCollector> collector;
-	space->get_narrow_phase_query().CastRay(ray, settings, collector, query_filter, query_filter, query_filter);
-
-	if (!collector.had_hit()) {
-		return false;
-	}
-
-	const JPH::RayCastResult &hit = collector.get_hit();
-
-	const JPH::BodyID &body_id = hit.mBodyID;
-	const JPH::SubShapeID &sub_shape_id = hit.mSubShapeID2;
-
-	const JoltObject3D *object = space->try_get_object(body_id);
-	ERR_FAIL_NULL_V(object, false);
-
-	const JPH::RVec3 position = ray.GetPointOnRay(hit.mFraction);
-
-	JPH::Vec3 normal = JPH::Vec3::sZero();
-
-	if (!p_parameters.hit_from_inside || hit.mFraction > 0.0f) {
-		normal = object->get_jolt_body()->GetWorldSpaceSurfaceNormal(sub_shape_id, position);
-
-		// If we got a back-face normal we need to flip it.
-		if (normal.Dot(vector) > 0) {
-			normal = -normal;
-		}
-	}
-
-	r_result.position = to_godot(position);
-	r_result.normal = to_godot(normal);
-	r_result.rid = object->get_rid();
-	r_result.collider_id = object->get_instance_id();
-	r_result.collider = object->get_instance();
-	r_result.shape = 0;
-
-	if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
-		const int shape_index = shaped_object->find_shape_index(sub_shape_id);
-		ERR_FAIL_COND_V(shape_index == -1, false);
-		r_result.shape = shape_index;
-		r_result.face_index = _try_get_face_index(*object->get_jolt_body(), sub_shape_id);
-	}
-
-	return true;
+	int n_hits = intersect_ray_multiple(p_parameters, &r_result, 1);
+	return n_hits > 0;
 }
 
 int JoltPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) {

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -449,9 +449,8 @@ JoltPhysicsDirectSpaceState3D::JoltPhysicsDirectSpaceState3D(JoltSpace3D *p_spac
 }
 
 int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
-	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
+	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray_multiple must not be called while the physics space is being stepped.");
 
-	// Parity for godot physics 3d - if a single result is expected then return the closest hit (same as intersect_ray)
 	if (p_result_max == 0) {
 		return 0;
 	}

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -462,7 +462,7 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 		}
 	}
 
-	space->try_optimize();
+	space->flush_pending_objects();
 
 	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
 
@@ -483,7 +483,7 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 	const int hit_count = collector.get_hit_count();
 
 	for (int i = 0; i < hit_count; ++i) {
-		const JPH::RayCastResult &hit = collector.get_hit();
+		const JPH::RayCastResult &hit = collector.get_hit(i);
 
 		const JPH::BodyID &body_id = hit.mBodyID;
 		const JPH::SubShapeID &sub_shape_id = hit.mSubShapeID2;
@@ -504,6 +504,7 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 			}
 		}
 
+		RayResult &r_result = *r_results++;
 		r_result.position = to_godot(position);
 		r_result.normal = to_godot(normal);
 		r_result.rid = object->get_rid();
@@ -525,7 +526,7 @@ int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p
 bool JoltPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
 
-	space->try_optimize();
+	space->flush_pending_objects();
 
 	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
 

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -448,10 +448,77 @@ JoltPhysicsDirectSpaceState3D::JoltPhysicsDirectSpaceState3D(JoltSpace3D *p_spac
 		space(p_space) {
 }
 
+int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
+	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
+
+	if (p_result_max == 0) {
+		return 0;
+	}
+
+	space->try_optimize();
+
+	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
+
+	const JPH::RVec3 from = to_jolt_r(p_parameters.from);
+	const JPH::RVec3 to = to_jolt_r(p_parameters.to);
+	const JPH::Vec3 vector = JPH::Vec3(to - from);
+	const JPH::RRayCast ray(from, vector);
+
+	const JPH::EBackFaceMode back_face_mode = p_parameters.hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces : JPH::EBackFaceMode::IgnoreBackFaces;
+
+	JPH::RayCastSettings settings;
+	settings.mTreatConvexAsSolid = p_parameters.hit_from_inside;
+	settings.mBackFaceModeTriangles = back_face_mode;
+
+	JoltQueryCollectorAnyMulti<JPH::CastRayCollector, 32> collector(p_result_max);
+	space->get_narrow_phase_query().CastRay(ray, settings, collector, query_filter, query_filter, query_filter);
+
+	const int hit_count = collector.get_hit_count();
+
+	for (int i = 0; i < hit_count; ++i) {
+		const JPH::RayCastResult &hit = collector.get_hit();
+
+		const JPH::BodyID &body_id = hit.mBodyID;
+		const JPH::SubShapeID &sub_shape_id = hit.mSubShapeID2;
+
+		const JoltObject3D *object = space->try_get_object(body_id);
+		ERR_FAIL_NULL_V(object, false);
+
+		const JPH::RVec3 position = ray.GetPointOnRay(hit.mFraction);
+
+		JPH::Vec3 normal = JPH::Vec3::sZero();
+
+		if (!p_parameters.hit_from_inside || hit.mFraction > 0.0f) {
+			normal = object->get_jolt_body()->GetWorldSpaceSurfaceNormal(sub_shape_id, position);
+
+			// If we got a back-face normal we need to flip it.
+			if (normal.Dot(vector) > 0) {
+				normal = -normal;
+			}
+		}
+
+		r_result.position = to_godot(position);
+		r_result.normal = to_godot(normal);
+		r_result.rid = object->get_rid();
+		r_result.collider_id = object->get_instance_id();
+		r_result.collider = object->get_instance();
+		r_result.shape = 0;
+
+		if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
+			const int shape_index = shaped_object->find_shape_index(sub_shape_id);
+			ERR_FAIL_COND_V(shape_index == -1, false);
+			r_result.shape = shape_index;
+			r_result.face_index = _try_get_face_index(*object->get_jolt_body(), sub_shape_id);
+		}
+	}
+
+	return hit_count;
+}
+
 bool JoltPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parameters, RayResult &r_result) {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
 
-	space->flush_pending_objects();
+	space->try_optimize();
 
 	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
 
@@ -509,76 +576,6 @@ bool JoltPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_paramet
 	}
 
 	return true;
-}
-
-
-int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
-	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
-
-	if (p_result_max == 0) {
-		return 0;
-	}
-
-	space->try_optimize();
-
-	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
-
-	const JPH::RVec3 from = to_jolt_r(p_parameters.from);
-	const JPH::RVec3 to = to_jolt_r(p_parameters.to);
-	const JPH::Vec3 vector = JPH::Vec3(to - from);
-	const JPH::RRayCast ray(from, vector);
-
-	const JPH::EBackFaceMode back_face_mode = p_parameters.hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces : JPH::EBackFaceMode::IgnoreBackFaces;
-
-	JPH::RayCastSettings settings;
-	settings.mTreatConvexAsSolid = p_parameters.hit_from_inside;
-	settings.mBackFaceModeTriangles = back_face_mode;
-
-	JoltQueryCollectorAnyMulti<JPH::CastRayCollector, 32> collector(p_result_max);
-	space->get_narrow_phase_query().CastRay(ray, settings, collector, query_filter, query_filter, query_filter);
-
-	const int hit_count = collector.get_hit_count();
-
-	for (int i = 0; i < hit_count; ++i) {
-		const JPH::RayCastResult &hit = collector.get_hit(i);
-
-		const JPH::BodyID &body_id = hit.mBodyID;
-		const JPH::SubShapeID &sub_shape_id = hit.mSubShapeID2;
-
-		const JoltObject3D *object = space->try_get_object(body_id);
-		ERR_FAIL_NULL_V(object, false);
-
-		const JPH::RVec3 position = ray.GetPointOnRay(hit.mFraction);
-
-		JPH::Vec3 normal = JPH::Vec3::sZero();
-
-		RayResult &result = *r_results++;
-
-		if (!p_parameters.hit_from_inside || hit.mFraction > 0.0f) {
-			normal = object->get_jolt_body()->GetWorldSpaceSurfaceNormal(sub_shape_id, position);
-
-			// If we got a back-face normal we need to flip it.
-			if (normal.Dot(vector) > 0) {
-				normal = -normal;
-			}
-		}
-
-		result.position = to_godot(position);
-		result.normal = to_godot(normal);
-		result.rid = object->get_rid();
-		result.collider_id = object->get_instance_id();
-		result.collider = object->get_instance();
-		result.shape = 0;
-
-		if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
-			const int shape_index = shaped_object->find_shape_index(sub_shape_id);
-			ERR_FAIL_COND_V(shape_index == -1, false);
-			result.shape = shape_index;
-			result.face_index = _try_get_face_index(*object->get_jolt_body(), sub_shape_id);
-		}
-	}
-
-	return hit_count;
 }
 
 int JoltPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) {

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -511,6 +511,76 @@ bool JoltPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_paramet
 	return true;
 }
 
+
+int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
+	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
+
+	if (p_result_max == 0) {
+		return 0;
+	}
+
+	space->try_optimize();
+
+	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude, p_parameters.pick_ray);
+
+	const JPH::RVec3 from = to_jolt_r(p_parameters.from);
+	const JPH::RVec3 to = to_jolt_r(p_parameters.to);
+	const JPH::Vec3 vector = JPH::Vec3(to - from);
+	const JPH::RRayCast ray(from, vector);
+
+	const JPH::EBackFaceMode back_face_mode = p_parameters.hit_back_faces ? JPH::EBackFaceMode::CollideWithBackFaces : JPH::EBackFaceMode::IgnoreBackFaces;
+
+	JPH::RayCastSettings settings;
+	settings.mTreatConvexAsSolid = p_parameters.hit_from_inside;
+	settings.mBackFaceModeTriangles = back_face_mode;
+
+	JoltQueryCollectorAnyMulti<JPH::CastRayCollector, 32> collector(p_result_max);
+	space->get_narrow_phase_query().CastRay(ray, settings, collector, query_filter, query_filter, query_filter);
+
+	const int hit_count = collector.get_hit_count();
+
+	for (int i = 0; i < hit_count; ++i) {
+		const JPH::RayCastResult &hit = collector.get_hit(i);
+
+		const JPH::BodyID &body_id = hit.mBodyID;
+		const JPH::SubShapeID &sub_shape_id = hit.mSubShapeID2;
+
+		const JoltObject3D *object = space->try_get_object(body_id);
+		ERR_FAIL_NULL_V(object, false);
+
+		const JPH::RVec3 position = ray.GetPointOnRay(hit.mFraction);
+
+		JPH::Vec3 normal = JPH::Vec3::sZero();
+
+		RayResult &result = *r_results++;
+
+		if (!p_parameters.hit_from_inside || hit.mFraction > 0.0f) {
+			normal = object->get_jolt_body()->GetWorldSpaceSurfaceNormal(sub_shape_id, position);
+
+			// If we got a back-face normal we need to flip it.
+			if (normal.Dot(vector) > 0) {
+				normal = -normal;
+			}
+		}
+
+		result.position = to_godot(position);
+		result.normal = to_godot(normal);
+		result.rid = object->get_rid();
+		result.collider_id = object->get_instance_id();
+		result.collider = object->get_instance();
+		result.shape = 0;
+
+		if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
+			const int shape_index = shaped_object->find_shape_index(sub_shape_id);
+			ERR_FAIL_COND_V(shape_index == -1, false);
+			result.shape = shape_index;
+			result.face_index = _try_get_face_index(*object->get_jolt_body(), sub_shape_id);
+		}
+	}
+
+	return hit_count;
+}
+
 int JoltPhysicsDirectSpaceState3D::intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_point must not be called while the physics space is being stepped.");
 

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -451,8 +451,15 @@ JoltPhysicsDirectSpaceState3D::JoltPhysicsDirectSpaceState3D(JoltSpace3D *p_spac
 int JoltPhysicsDirectSpaceState3D::intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "intersect_ray must not be called while the physics space is being stepped.");
 
+	// Parity for godot physics 3d - if a single result is expected then return the closest hit (same as intersect_ray)
 	if (p_result_max == 0) {
 		return 0;
+	} else if (p_result_max == 1) {
+		if (intersect_ray(p_parameters, r_results[0])) {
+			return 1;
+		} else {
+			return 0;
+		}
 	}
 
 	space->try_optimize();

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
@@ -71,6 +71,7 @@ public:
 	explicit JoltPhysicsDirectSpaceState3D(JoltSpace3D *p_space);
 
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override;
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &r_closest_safe, real_t &r_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
@@ -70,8 +70,8 @@ public:
 	JoltPhysicsDirectSpaceState3D() = default;
 	explicit JoltPhysicsDirectSpaceState3D(JoltSpace3D *p_space);
 
-	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
 	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override;
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override;
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override;
 	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &r_closest_safe, real_t &r_closest_unsafe, ShapeRestInfo *r_info = nullptr) override;

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -338,6 +338,33 @@ void PhysicsShapeQueryParameters2D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_ray_multiple(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, TypedArray<Dictionary>());
+
+	Vector<RayResult> ret;
+	ret.resize(p_max_results);
+
+	int rc = intersect_ray_multiple(p_ray_query->get_parameters(), ret.ptrw(), ret.size());
+
+	if (rc == 0) {
+		return TypedArray<Dictionary>();
+	}
+
+	TypedArray<Dictionary> r;
+	r.resize(rc);
+	for (int i = 0; i < rc; i++) {
+		Dictionary d;
+		d["position"] = ret[i].position;
+		d["normal"] = ret[i].normal;
+		d["collider_id"] = ret[i].collider_id;
+		d["collider"] = ret[i].collider;
+		d["shape"] = ret[i].shape;
+		d["rid"] = ret[i].rid;
+		r[i] = d;
+	}
+	return r;
+}
+
 Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query) {
 	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, Dictionary());
 
@@ -463,6 +490,7 @@ PhysicsDirectSpaceState2D::PhysicsDirectSpaceState2D() {
 
 void PhysicsDirectSpaceState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_intersect_point, DEFVAL(32));
+	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_intersect_ray_multiple, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState2D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState2D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState2D::_cast_motion);

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -123,6 +123,7 @@ class PhysicsShapeQueryParameters2D;
 class PhysicsDirectSpaceState2D : public Object {
 	GDCLASS(PhysicsDirectSpaceState2D, Object);
 
+	TypedArray<Dictionary> _intersect_ray_multiple(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query, int p_max_results = 32);
 	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query);
 	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters2D> rp_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results = 32);
@@ -155,6 +156,7 @@ public:
 		int shape = 0;
 	};
 
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) = 0;
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 
 	struct ShapeResult {

--- a/servers/physics_2d/physics_server_2d_dummy.h
+++ b/servers/physics_2d/physics_server_2d_dummy.h
@@ -114,6 +114,7 @@ class PhysicsDirectSpaceState2DDummy : public PhysicsDirectSpaceState2D {
 	GDCLASS(PhysicsDirectSpaceState2DDummy, PhysicsDirectSpaceState2D);
 
 public:
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override { return 0; }
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override { return false; }
 
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }

--- a/servers/physics_2d/physics_server_2d_extension.cpp
+++ b/servers/physics_2d/physics_server_2d_extension.cpp
@@ -42,6 +42,7 @@ void PhysicsDirectSpaceState2DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState2DExtension::is_body_excluded_from_query);
 
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "r_result");
+	GDVIRTUAL_BIND(_intersect_ray_multiple, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "result", "max_results");
 	GDVIRTUAL_BIND(_intersect_point, "position", "canvas_instance_id", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_result", "max_results");
 	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_closest_safe", "r_closest_unsafe");

--- a/servers/physics_2d/physics_server_2d_extension.h
+++ b/servers/physics_2d/physics_server_2d_extension.h
@@ -131,6 +131,7 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
+	GDVIRTUAL8R_REQUIRED(int, _intersect_ray_multiple, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>, int)
 	GDVIRTUAL7R_REQUIRED(bool, _intersect_ray, const Vector2 &, const Vector2 &, uint32_t, bool, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionRayResult>)
 	GDVIRTUAL7R_REQUIRED(int, _intersect_point, const Vector2 &, ObjectID, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
 	GDVIRTUAL9R_REQUIRED(int, _intersect_shape, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeResult>, int)
@@ -139,6 +140,13 @@ protected:
 	GDVIRTUAL8R_REQUIRED(bool, _rest_info, RID, const Transform2D &, const Vector2 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer2DExtensionShapeRestInfo>)
 
 public:
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override {
+		exclude = &p_parameters.exclude;
+		int ret = 0;
+		GDVIRTUAL_CALL(_intersect_ray_multiple, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, r_results, p_result_max, ret);
+		exclude = nullptr;
+		return ret;
+	}
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
 		exclude = &p_parameters.exclude;
 		bool ret = false;

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -515,7 +515,7 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
-	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray_multiple, DEFVAL(32));
+	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_ray_multiple, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -515,8 +515,8 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
-	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray_multiple, DEFVAL(32));
+	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -383,6 +383,34 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQue
 	return d;
 }
 
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_ray_multiple(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, TypedArray<Dictionary>());
+
+	Vector<RayResult> ret;
+	ret.resize(p_max_results);
+
+	int rc = intersect_ray_multiple(p_ray_query->get_parameters(), ret.ptrw(), ret.size());
+
+	if (rc == 0) {
+		return TypedArray<Dictionary>();
+	}
+
+	TypedArray<Dictionary> r;
+	r.resize(rc);
+	for (int i = 0; i < rc; i++) {
+		Dictionary d;
+		d["position"] = ret[i].position;
+		d["normal"] = ret[i].normal;
+		d["face_index"] = ret[i].face_index;
+		d["collider_id"] = ret[i].collider_id;
+		d["collider"] = ret[i].collider;
+		d["shape"] = ret[i].shape;
+		d["rid"] = ret[i].rid;
+		r[i] = d;
+	}
+	return r;
+}
+
 TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results) {
 	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
 
@@ -488,6 +516,7 @@ PhysicsDirectSpaceState3D::PhysicsDirectSpaceState3D() {
 void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
+	ClassDB::bind_method(D_METHOD("intersect_ray_multiple", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray_multiple, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -163,9 +163,8 @@ public:
 		int face_index = -1;
 	};
 
-	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
-
 	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) = 0;
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
 
 	struct ShapeResult {
 		RID rid;

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -127,6 +127,7 @@ class PhysicsDirectSpaceState3D : public Object {
 
 private:
 	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query);
+	TypedArray<Dictionary> _intersect_ray_multiple(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
 	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
@@ -163,6 +164,8 @@ public:
 	};
 
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) = 0;
+
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) = 0;
 
 	struct ShapeResult {
 		RID rid;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -116,8 +116,8 @@ class PhysicsDirectSpaceState3DDummy : public PhysicsDirectSpaceState3D {
 	GDCLASS(PhysicsDirectSpaceState3DDummy, PhysicsDirectSpaceState3D);
 
 public:
-	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override { return false; }
 	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override { return 0; }
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override { return false; }
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }
 
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -117,7 +117,7 @@ class PhysicsDirectSpaceState3DDummy : public PhysicsDirectSpaceState3D {
 
 public:
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override { return false; }
-
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override { return 0; }
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }
 
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -117,7 +117,9 @@ class PhysicsDirectSpaceState3DDummy : public PhysicsDirectSpaceState3D {
 
 public:
 	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override { return 0; }
+
 	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override { return false; }
+
 	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }
 
 	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override { return 0; }

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -42,6 +42,7 @@ void PhysicsDirectSpaceState3DExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_body_excluded_from_query", "body"), &PhysicsDirectSpaceState3DExtension::is_body_excluded_from_query);
 
 	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "pick_ray", "r_result");
+	GDVIRTUAL_BIND(_intersect_ray_multiple, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "pick_ray", "results", "max_results");
 	GDVIRTUAL_BIND(_intersect_point, "position", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_results", "max_results");
 	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_result_count", "max_results");
 	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "r_closest_safe", "r_closest_unsafe", "r_info");

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -133,8 +133,8 @@ protected:
 	static void _bind_methods();
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
-	GDVIRTUAL9R_REQUIRED(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
 	GDVIRTUAL10R_REQUIRED(int, _intersect_ray_multiple, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>, int)
+	GDVIRTUAL9R_REQUIRED(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
 	GDVIRTUAL6R_REQUIRED(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
 	GDVIRTUAL9R_REQUIRED(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
 	GDVIRTUAL10R_REQUIRED(bool, _cast_motion, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
@@ -143,17 +143,17 @@ protected:
 	GDVIRTUAL2RC_REQUIRED(Vector3, _get_closest_point_to_object_volume, RID, const Vector3 &)
 
 public:
-	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
-		exclude = &p_parameters.exclude;
-		bool ret = false;
-		GDVIRTUAL_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, &r_result, ret);
-		exclude = nullptr;
-		return ret;
-	}
 	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override {
 		exclude = &p_parameters.exclude;
 		int ret = 0;
 		GDVIRTUAL_CALL(_intersect_ray_multiple, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, r_results, p_result_max, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, &r_result, ret);
 		exclude = nullptr;
 		return ret;
 	}

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -134,6 +134,7 @@ protected:
 	bool is_body_excluded_from_query(const RID &p_body) const;
 
 	GDVIRTUAL9R_REQUIRED(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>)
+	GDVIRTUAL10R_REQUIRED(int, _intersect_ray_multiple, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionRayResult>, int)
 	GDVIRTUAL6R_REQUIRED(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
 	GDVIRTUAL9R_REQUIRED(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<PhysicsServer3DExtensionShapeResult>, int)
 	GDVIRTUAL10R_REQUIRED(bool, _cast_motion, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDExtensionPtr<real_t>, GDExtensionPtr<real_t>, GDExtensionPtr<PhysicsServer3DExtensionShapeRestInfo>)
@@ -146,6 +147,13 @@ public:
 		exclude = &p_parameters.exclude;
 		bool ret = false;
 		GDVIRTUAL_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, &r_result, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual int intersect_ray_multiple(const RayParameters &p_parameters, RayResult *r_results, int p_result_max) override {
+		exclude = &p_parameters.exclude;
+		int ret = 0;
+		GDVIRTUAL_CALL(_intersect_ray_multiple, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, p_parameters.pick_ray, r_results, p_result_max, ret);
 		exclude = nullptr;
 		return ret;
 	}


### PR DESCRIPTION
Largely an update of PR https://github.com/godotengine/godot/pull/91303 (handling https://github.com/godotengine/godot-proposals/issues/9059 and https://github.com/godotengine/godot-proposals/issues/2616) to support Jolt Physics - however there are a few key differences.

This PR is to support multiple collisions for raycasts in 2D and 3D space provided by a new `intersect_ray_multiple` function. This function behaves somewhat similarly to the `intersect_point` methods which are provided a maximum number of allowable collisions. Once that number has been reached, the function will return (potentially not yielding all collisions along the raycast). However, if the maximum number of collisions provided is `1`, then it will behave the same as the current `intersect_ray` method and return only the closest intersection.

The return is an unsorted array of dictionaries with the same parameters as the current intersect_ray methods. One curiosity I have seen between Jolt and Godot Physics is that Godot Physics only provides the closest hit on a convex mesh collision shape whereas Jolt provides all collisions where the normal is opposed to the raycast. 
![image](https://github.com/user-attachments/assets/532e30b4-67e5-47b8-b7e1-27233efa96c9)


I've tried to do a good amount of testing with some simple documentation in the attached pdf. However, I doubt I have tested all possibilities since there are a large number of options for raycasts. I would highly welcome any additional testing.
[Validation.pdf](https://github.com/user-attachments/files/20931646/Validation.pdf)
