### PR TITLE
Gridmap editor: Avoid extra mesh instantiation when setting clipboard data

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -535,7 +535,6 @@ void GridMapEditor::_set_clipboard_data() {
 				item.cell_item = itm;
 				item.grid_offset = Vector3(selected) - selection.begin;
 				item.orientation = node->get_cell_item_orientation(selected);
-				item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);
 
 				if (mesh.is_valid()) {
 					item.instance = RenderingServer::get_singleton()->instance_create2(mesh->get_rid(), scenario);


### PR DESCRIPTION
This should fix: https://github.com/godotengine/godot/issues/107996
When storing meshes in the clipboard, the selected mesh is instanced twice in a row, overwriting item.instance and leaving an extra mesh at the origin of the scene, since we lose the reference to it and it's never set to follow the selection cursor