### PR TITLE
Clarify `visible_characters`

### DIFF
--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -108,6 +108,7 @@
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
 			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
+			[b]Note:[/b] Characters are counted as Unicode codepoints. A single visible grapheme may contain multiple codepoints (e.g. certain emoji use three codepoints). A single codepoint may contain two UTF-16 characters, which are used in C# strings.
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
 			The clipping behavior when [member visible_characters] or [member visible_ratio] is set.

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -763,6 +763,7 @@
 		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
 			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
 			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
+			[b]Note:[/b] Characters are counted as Unicode codepoints. A single visible grapheme may contain multiple codepoints (e.g. certain emoji use three codepoints). A single codepoint may contain two UTF-16 characters, which are used in C# strings.
 		</member>
 		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
 			The clipping behavior when [member visible_characters] or [member visible_ratio] is set.


### PR DESCRIPTION
See: https://github.com/godotengine/godot-proposals/discussions/12654

This clarifies the behaviour of `Label.visible_characters` and `RichTextLabel.visible_characters` with regards to UNICODE. From my tests and the collaborator response, for all `visible_characters_behavior` options, a character is considered to be a UNICODE code point (A.K.A. a UTF-32 character), which may be inconsistent with the visible graphemes/runes and with C# UTF-16 strings.