### PR TITLE
Jolt Physics: Fix crash if a soft body is disabled

### DIFF
--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -73,12 +73,6 @@ JPH::ObjectLayer JoltSoftBody3D::_get_object_layer() const {
 
 void JoltSoftBody3D::_space_changing() {
 	JoltObject3D::_space_changing();
-
-	if (in_space()) {
-		jolt_settings = new JPH::SoftBodyCreationSettings(jolt_body->GetSoftBodyCreationSettings());
-		jolt_settings->mSettings = nullptr;
-	}
-
 	_deref_shared_data();
 }
 
@@ -119,6 +113,15 @@ void JoltSoftBody3D::_add_to_space() {
 
 	delete jolt_settings;
 	jolt_settings = nullptr;
+}
+
+void JoltSoftBody3D::_remove_from_space() {
+	if (in_space()) {
+		jolt_settings = new JPH::SoftBodyCreationSettings(jolt_body->GetSoftBodyCreationSettings());
+		jolt_settings->mSettings = nullptr;
+	}
+
+	JoltObject3D::_remove_from_space();
 }
 
 bool JoltSoftBody3D::_ref_shared_data() {
@@ -214,6 +217,11 @@ bool JoltSoftBody3D::_ref_shared_data() {
 void JoltSoftBody3D::_deref_shared_data() {
 	if (unlikely(shared == nullptr)) {
 		return;
+	}
+
+	if (in_space()) {
+		jolt_settings = new JPH::SoftBodyCreationSettings(jolt_body->GetSoftBodyCreationSettings());
+		jolt_settings->mSettings = nullptr;
 	}
 
 	HashMap<RID, Shared>::Iterator iter = mesh_to_shared.find(mesh);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -75,6 +75,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	virtual void _space_changed() override;
 
 	virtual void _add_to_space() override;
+	virtual void _remove_from_space() override;
 
 	bool _ref_shared_data();
 	void _deref_shared_data();


### PR DESCRIPTION
If a `SoftBody3D` object is disabled, its default behavior is to remove itself from the physics server by calling
`PhysicsServer3D::soft_body_set_mesh()` to reset the mesh to an empty RID.

With the Jolt physics server, this causes a crash.

The `JoltSoftBody3D` code generally assumes that the `jolt_settings` member variable is null when the body is actively part of a space (when `in_space()` returns true), and non-null when the body is not part of a space.  However, calling `JoltSoftBody3D::set_mesh()` with a null RID moves the body out of the space, but does not re-allocate the `jolt_settings` member variable.  This causes a crash when the code tries to access it later in the `set_mesh()` call (inside `_space_changed()`, which tries to update pressure in the `jolt_settings` object).

This fixes that problem by ensuring that the `jolt_settings` object is always re-allocated whenever we clear the `shared` member variable.

Fixes #108030.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
