### PR TITLE
SoftBody3D: fix a crash if given an unsupported mesh

### DIFF
--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -121,6 +121,8 @@ private:
 
 	void _prepare_physics_server();
 	void _become_mesh_owner();
+	bool _check_mesh_supported();
+	RID _create_dynamic_mesh();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);


### PR DESCRIPTION
The `SoftBody3D` class only uses the first surface of the mesh it is given, and only supports `PRIMITIVE_TRIANGLES` surfaces.  Previously it would crash if given an unsupported mesh: it unconditionally interpreted the mesh indices as triangles regardless of the actual format type.

Additionally, while `SoftBody3D::_become_mesh_owner()` code did check that the mesh contained at least one surface, it would still crash if this check failed, as it would leave the mesh unchanged and would pass the unsupported mesh to `PhysicsServer3D::soft_body_set_mesh()`. This generally caused the PhysicsServer3D to crash, and even if the particular physics server did not crash, the SoftBody3D class left `owned_mesh` unchanged, so that it would repeatedly try and fail to convert the mesh every frame.

This fixes the code to check the mesh surface format, and to call `set_mesh(nullptr)` to clear out the invalid mesh if it is ever configured with an unsupported mesh.

Fixes #108036.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
