### PR TITLE
C#: Fix return value of `StringExtensions.GetExtension()`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -430,8 +430,8 @@ namespace Godot
         {
             int pos = instance.RFind(".");
 
-            if (pos < 0)
-                return instance;
+            if (pos < 0 || pos < Math.Max(instance.RFind("/"), instance.RFind("\\")))
+                return string.Empty;
 
             return instance.Substring(pos + 1);
         }


### PR DESCRIPTION
Fixes #108039.

The C# implementation of `StringExtensions.GetExtension()` did not match its documentation/examples and its C++ counterpart `String::get_extension()`:

https://github.com/godotengine/godot/blob/9a3976097f5ac99ab3302193d40a944887206e95/core/string/ustring.cpp#L5304-L5311

Previous C# implementation:
https://github.com/godotengine/godot/blob/9a3976097f5ac99ab3302193d40a944887206e95/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs#L429-L437

New implementation:
```C#
        public static string GetExtension(this string instance)
        {
            int pos = instance.RFind(".");

            if (pos < 0 || pos < Math.Max(instance.RFind("/"), instance.RFind("\\")))
                return string.Empty;

            return instance.Substring(pos + 1);
        }
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
