### PR TITLE
Fix crash when disabling `SoftBody3D` while using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -74,7 +74,8 @@ JPH::ObjectLayer JoltSoftBody3D::_get_object_layer() const {
 void JoltSoftBody3D::_space_changing() {
 	JoltObject3D::_space_changing();
 
-	if (in_space()) {
+	// Note that we should not use `in_space()` as the condition here, since we could have cleared the mesh at this point.
+	if (jolt_body != nullptr) {
 		jolt_settings = new JPH::SoftBodyCreationSettings(jolt_body->GetSoftBodyCreationSettings());
 		jolt_settings->mSettings = nullptr;
 	}


### PR DESCRIPTION
Fixes #108030.
Supersedes #108032.

This effectively restores the behavior that was erroneously changed in #105748, along with a comment explaining the discrepancy between `JoltSoftBody3D` and `JoltShapedObject3D`.