### PR TITLE
OptimizedTranslation: Explain message texts are not stored

### DIFF
--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -298,10 +298,24 @@ StringName OptimizedTranslation::get_plural_message(const StringName &p_src_text
 	return get_message(p_src_text, p_context);
 }
 
+Vector<String> OptimizedTranslation::_get_message_list() const {
+	WARN_PRINT_ONCE("OptimizedTranslation does not store the message texts to be translated.");
+	return {};
+}
+
+void OptimizedTranslation::get_message_list(List<StringName> *r_messages) const {
+	WARN_PRINT_ONCE("OptimizedTranslation does not store the message texts to be translated.");
+}
+
+int OptimizedTranslation::get_message_count() const {
+	WARN_PRINT_ONCE("OptimizedTranslation does not store the message texts to be translated.");
+	return 0;
+}
+
 void OptimizedTranslation::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "hash_table"));
-	p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "bucket_table"));
-	p_list->push_back(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "strings"));
+	p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "hash_table", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::PACKED_INT32_ARRAY, "bucket_table", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+	p_list->push_back(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "strings", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
 	p_list->push_back(PropertyInfo(Variant::OBJECT, "load_from", PROPERTY_HINT_RESOURCE_TYPE, "Translation", PROPERTY_USAGE_EDITOR));
 }
 

--- a/core/string/optimized_translation.h
+++ b/core/string/optimized_translation.h
@@ -35,23 +35,35 @@
 class OptimizedTranslation : public Translation {
 	GDCLASS(OptimizedTranslation, Translation);
 
-	//this translation uses a sort of modified perfect hash algorithm
-	//it requires hashing strings twice and then does a binary search,
-	//so it's slower, but at the same time it has an extremely high chance
-	//of catching untranslated strings
+	// This translation uses a sort of modified perfect hash algorithm
+	// it requires hashing strings twice and then does a binary search,
+	// so it's slower, but at the same time it has an extremely high chance
+	// of catching untranslated strings.
 
-	//load/store friendly types
+	// `hash_table[hash(0, text)]` produces a `bucket_table` index or 0xFFFFFFFF if not found.
 	Vector<int> hash_table;
+
+	// Continuous `Bucket`s in a flat layout.
 	Vector<int> bucket_table;
+
+	// Data for translated strings, UTF-8 encoded, either compressed or uncompressed.
 	Vector<uint8_t> strings;
 
 	struct Bucket {
+		// Number of `Elem` objects at `elem`.
 		int size;
+
+		// Use `hash(func, text)` to generate the unique `Elem::key` in this bucket.
 		uint32_t func;
 
 		struct Elem {
+			// Unique key for the text.
 			uint32_t key;
+
+			// Used to index into `strings`.
 			uint32_t str_offset;
+
+			// The string is not compressed if `comp_size` equals `uncomp_size`.
 			uint32_t comp_size;
 			uint32_t uncomp_size;
 		};
@@ -71,6 +83,8 @@ class OptimizedTranslation : public Translation {
 		return d;
 	}
 
+	Vector<String> _get_message_list() const override;
+
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -82,6 +96,9 @@ public:
 	virtual StringName get_plural_message(const StringName &p_src_text, const StringName &p_plural_text, int p_n, const StringName &p_context = "") const override;
 	virtual Vector<String> get_translated_message_list() const override;
 	void generate(const Ref<Translation> &p_from);
+
+	void get_message_list(List<StringName> *r_messages) const override;
+	int get_message_count() const override;
 
 	OptimizedTranslation() {}
 };

--- a/doc/classes/OptimizedTranslation.xml
+++ b/doc/classes/OptimizedTranslation.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		An optimized translation, used by default for CSV Translations. Uses real-time compressed translations, which results in very small dictionaries.
+		This class does not store the untranslated strings for optimization purposes. Therefore, [method Translation.get_message_list] always returns an empty array, and [method Translation.get_message_count] always returns [code]0[/code].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Closes #38862.

- Adds a note in the description.
- Prints a one-time warning when accessing `get_message_count()` and `get_message_list()`.
- Adds comments explaining how `OptimizedTranslation` works.
- Hide `hash_table`, `bucket_table`, and `strings` properties from the inspector. They are not meant for user editing.