### PR TITLE
HeightMapShape3D: Allow data from `L8` image

### DIFF
--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -42,7 +42,7 @@
 			<param index="2" name="height_max" type="float" />
 			<description>
 				Updates [member map_data] with data read from an [Image] reference. Automatically resizes heightmap [member map_width] and [member map_depth] to fit the full image width and height.
-				The image needs to be in either [constant Image.FORMAT_RF] (32 bit), [constant Image.FORMAT_RH] (16 bit), or [constant Image.FORMAT_R8] (8 bit).
+				The image needs to be in either [constant Image.FORMAT_RF] (32 bit), [constant Image.FORMAT_RH] (16 bit), [constant Image.FORMAT_R8] or [constant Image.FORMAT_L8] (8 bit).
 				Each image pixel is read in as a float on the range from [code]0.0[/code] (black pixel) to [code]1.0[/code] (white pixel). This range value gets remapped to [param height_min] and [param height_max] to form the final height value.
 				[b]Note:[/b] Using a heightmap with 16-bit or 32-bit data, stored in EXR or HDR format is recommended. Using 8-bit height data, or a format like PNG that Godot imports as 8-bit, will result in a terraced terrain.
 			</description>

--- a/scene/resources/3d/height_map_shape_3d.cpp
+++ b/scene/resources/3d/height_map_shape_3d.cpp
@@ -245,7 +245,7 @@ real_t HeightMapShape3D::get_max_height() const {
 
 void HeightMapShape3D::update_map_data_from_image(const Ref<Image> &p_image, real_t p_height_min, real_t p_height_max) {
 	ERR_FAIL_COND_MSG(p_image.is_null(), "Heightmap update image requires a valid Image reference.");
-	ERR_FAIL_COND_MSG(p_image->get_format() != Image::FORMAT_RF && p_image->get_format() != Image::FORMAT_RH && p_image->get_format() != Image::FORMAT_R8, "Heightmap update image requires Image in format FORMAT_RF (32 bit), FORMAT_RH (16 bit), or FORMAT_R8 (8 bit).");
+	ERR_FAIL_COND_MSG(p_image->get_format() != Image::FORMAT_RF && p_image->get_format() != Image::FORMAT_RH && p_image->get_format() != Image::FORMAT_R8 && p_image->get_format() != Image::FORMAT_L8, "Heightmap update image requires Image in format FORMAT_RF (32 bit), FORMAT_RH (16 bit), FORMAT_R8 or FORMAT_L8 (8 bit).");
 	ERR_FAIL_COND_MSG(p_image->get_width() < 2, "Heightmap update image requires a minimum Image width of 2.");
 	ERR_FAIL_COND_MSG(p_image->get_height() < 2, "Heightmap update image requires a minimum Image height of 2.");
 	ERR_FAIL_COND_MSG(p_height_min > p_height_max, "Heightmap update image requires height_max to be greater than height_min.");
@@ -307,7 +307,8 @@ void HeightMapShape3D::update_map_data_from_image(const Ref<Image> &p_image, rea
 
 		} break;
 
-		case Image::FORMAT_R8: {
+		case Image::FORMAT_R8:
+		case Image::FORMAT_L8: {
 			const uint8_t *image_data_ptr = (uint8_t *)p_image->get_data().ptr();
 
 			for (int i = 0; i < map_data.size(); i++) {


### PR DESCRIPTION
`HeightMapShape3D.update_map_data_from_image` supports `R8` images but not `L8` images, which is inconvenient. For example `NoiseTexture2D` is `L8` by default, it has to unnecessarily convert from `L8` to `R8`.

( btw `L8`->`R8` isn't free although their data is entirely identical. `R8`->`L8` changes data as it converts to luminance )