### PR TITLE
[.NET] Mention MSBuild panel when building fails

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -230,7 +230,7 @@ namespace GodotTools.Build
 
             if (!success)
             {
-                ShowBuildErrorDialog("Failed to build project");
+                ShowBuildErrorDialog("Failed to build project. Check MSBuild panel for details.");
             }
 
             return success;

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -286,7 +286,7 @@ namespace GodotTools.Export
                     if (!BuildManager.PublishProjectBlocking(buildConfig, platform,
                             runtimeIdentifier, publishOutputDir, includeDebugSymbols))
                     {
-                        throw new InvalidOperationException("Failed to build project.");
+                        throw new InvalidOperationException("Failed to build project. Check MSBuild panel for details.");
                     }
 
                     string soExt = ridOS switch


### PR DESCRIPTION
When Godot fails to build a C# project, we show an alert with the message "Failed to build project" and, despite the MSBuild panel automatically opening, I constantly see users miss that they can check for build errors in the MSBuild panel. So I hope guiding them towards the MSBuild panel in the alert's message can help.