### PR TITLE
Add example of using `get_connection_list_from_node`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -223,6 +223,25 @@
 					keep_alive: bool
 				}
 				[/codeblock]
+				[b]Example:[/b] Get all connections on a specific port:
+				[codeblock]
+				func get_connection_list_from_port(node, port):
+					var connections = get_connection_list_from_node(node)
+					var result = []
+					for connection in connections:
+						var dict = {}
+						if connection["from_node"] == node and connection["from_port"] == port:
+							dict["node"] = connection["to_node"]
+							dict["port"] = connection["to_port"]
+							dict["type"] = "left"
+							result.push_back(dict)
+						elif connection["to_node"] == node and connection["to_port"] == port:
+							dict["node"] = connection["from_node"]
+							dict["port"] = connection["from_port"]
+							dict["type"] = "right"
+							result.push_back(dict)
+					return result
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_connections_intersecting_with_rect" qualifiers="const">


### PR DESCRIPTION
Adds a useful example to the documentation for getting all connections to a specific port in GraphEdit.
Initially, the get_connection_list_from_node function was planned as a method that should get a list of connections to a specific port, but due to the generalization of this method for wider use, it is not easy for beginners to understand how to do this, which is what I encountered and [godot-proposals/issues/12207](https://github.com/godotengine/godot-proposals/issues/12207)
