### PR TITLE
Rework Script Editor editing history

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1421,14 +1421,6 @@ Variant CodeTextEditor::get_edit_state() {
 	return state;
 }
 
-Variant CodeTextEditor::get_previous_state() {
-	return previous_state;
-}
-
-void CodeTextEditor::store_previous_state() {
-	previous_state = get_navigation_state();
-}
-
 bool CodeTextEditor::is_previewing_navigation_change() const {
 	return preview_navigation_change;
 }
@@ -1447,8 +1439,11 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	Dictionary state = p_state;
 
 	/* update the row first as it sets the column to 0 */
+	text_editor->set_block_signals(true);
 	text_editor->set_caret_line(state["row"]);
 	text_editor->set_caret_column(state["column"]);
+	text_editor->set_block_signals(false);
+
 	if (int(state["scroll_position"]) == -1) {
 		// Special case for previous state.
 		text_editor->center_viewport_to_caret();
@@ -1482,10 +1477,6 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 		for (int i = 0; i < bookmarks.size(); i++) {
 			text_editor->set_line_as_bookmarked(bookmarks[i], true);
 		}
-	}
-
-	if (previous_state.is_empty()) {
-		previous_state = p_state;
 	}
 }
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -187,7 +187,6 @@ class CodeTextEditor : public VBoxContainer {
 	int error_column;
 
 	bool preview_navigation_change = false;
-	Dictionary previous_state;
 
 	void _update_text_editor_theme();
 	void _update_font_ligatures();
@@ -264,8 +263,6 @@ public:
 	Variant get_edit_state();
 	void set_edit_state(const Variant &p_state);
 	Variant get_navigation_state();
-	Variant get_previous_state();
-	void store_previous_state();
 
 	bool is_previewing_navigation_change() const;
 	void set_preview_navigation_change(bool p_preview);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -393,7 +393,7 @@ class ScriptEditor : public PanelContainer {
 	};
 
 	Vector<ScriptHistory> history;
-	int history_pos;
+	int history_pos = -1;
 
 	List<String> previous_scripts;
 	List<int> script_close_queue;
@@ -535,9 +535,9 @@ class ScriptEditor : public PanelContainer {
 	bool _help_tab_goto(const String &p_name, const String &p_desc);
 	void _update_history_arrows();
 	void _save_history();
-	void _save_previous_state(Dictionary p_state);
+	void _save_history_state(const Variant &p_state);
 	void _go_to_tab(int p_idx);
-	void _update_history_pos(int p_new_pos);
+	void _update_history_pos();
 	void _update_script_colors();
 	void _update_modified_scripts_for_external_editor(Ref<Script> p_for_script = Ref<Script>());
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -699,14 +699,6 @@ Variant ScriptTextEditor::get_navigation_state() {
 	return code_editor->get_navigation_state();
 }
 
-Variant ScriptTextEditor::get_previous_state() {
-	return code_editor->get_previous_state();
-}
-
-void ScriptTextEditor::store_previous_state() {
-	return code_editor->store_previous_state();
-}
-
 void ScriptTextEditor::_convert_case(CodeTextEditor::CaseStyle p_case) {
 	code_editor->convert_case(p_case);
 }
@@ -1204,7 +1196,6 @@ void ScriptTextEditor::_on_caret_moved() {
 		nav_state["row"] = previous_line;
 		nav_state["scroll_position"] = -1;
 		emit_signal(SNAME("request_save_previous_state"), nav_state);
-		store_previous_state();
 	}
 	previous_line = current_line;
 }

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -297,9 +297,6 @@ public:
 
 	virtual void validate() override;
 
-	Variant get_previous_state();
-	void store_previous_state();
-
 	ScriptTextEditor();
 	~ScriptTextEditor();
 };

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -8193,7 +8193,7 @@ void TextEdit::_caret_changed(int p_caret) {
 		return;
 	}
 
-	if (is_inside_tree()) {
+	if (is_inside_tree() && !is_blocking_signals()) {
 		callable_mp(this, &TextEdit::_emit_caret_changed).call_deferred();
 	}
 	caret_pos_dirty = true;


### PR DESCRIPTION
Supposed to fix #92420

The core of the problem is that Script Editor assumes that actions within the same script will not be stored in the history. So like, you can go back to previous script, move around, go forward to next script and that altered state will be stored in the previous history step. #63515 was added on top of this behavior, which is obviously wrong.

My changes in this PR make any history change always be pushed as the last action. So if you go back to previous script and do something that affects history, you can no longer go back to the next script, because the "redo" is discarded. This is how VS Code behaves for example.

Putting as draft, because I got too tangled in the code and don't feel like touching it anymore right now. Maybe I'll finish it sometime.

Also fun fact, ScriptTextEditor has some methods referring to "previous state", but they are effectively never used. It's some leftover from early versions of #63515.