### PR TITLE
Fix EditorSettings usage in TLSContext

### DIFF
--- a/modules/mbedtls/tls_context_mbedtls.cpp
+++ b/modules/mbedtls/tls_context_mbedtls.cpp
@@ -153,7 +153,7 @@ Error TLSContextMbedTLS::init_server(int p_transport, Ref<TLSOptions> p_options,
 
 #if MBEDTLS_VERSION_MAJOR >= 3
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (EditorSettings::get_singleton()) {
 		if (!EditorSettings::get_singleton()->get_setting("network/tls/enable_tls_v1.3").operator bool()) {
 			mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
 		}
@@ -211,7 +211,7 @@ Error TLSContextMbedTLS::init_client(int p_transport, const String &p_hostname, 
 
 #if MBEDTLS_VERSION_MAJOR >= 3
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
+	if (EditorSettings::get_singleton()) {
 		if (!EditorSettings::get_singleton()->get_setting("network/tls/enable_tls_v1.3").operator bool()) {
 			mbedtls_ssl_conf_max_tls_version(&conf, MBEDTLS_SSL_VERSION_TLS1_2);
 		}


### PR DESCRIPTION
Addresses the "broken" setting in #108048

Project Manager does not set editor hint, so the setting was just not used.