### PR TITLE
SoftBody3D: process set_mesh() changes directly

### DIFF
--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -70,7 +70,7 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
 public:
-	void set_mesh(const Ref<Mesh> &p_mesh);
+	virtual void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
 
 	void set_skin(const Ref<Skin> &p_skin);

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -99,7 +99,6 @@ private:
 
 	DisableMode disable_mode = DISABLE_MODE_REMOVE;
 
-	RID owned_mesh;
 	uint32_t collision_mask = 1;
 	uint32_t collision_layer = 1;
 	NodePath parent_collision_ignore;
@@ -120,7 +119,6 @@ private:
 	void _commit_soft_mesh(real_t p_interpolation_fraction);
 
 	void _prepare_physics_server();
-	void _become_mesh_owner();
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -145,6 +143,8 @@ protected:
 
 public:
 	RID get_physics_rid() const { return physics_rid; }
+
+	virtual void set_mesh(const Ref<Mesh> &p_mesh) override;
 
 	void set_collision_mask(uint32_t p_mask);
 	uint32_t get_collision_mask() const;


### PR DESCRIPTION
This updates `MeshInstance3D::set_mesh()` to be a virtual method, so that `SoftBody3D` can override it.

The `SoftBody3D` code always wants to replace the input mesh with a new unique mesh that is created with the `Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE` flag enabled, allowing it to dynamically modify the mesh and without affecting other users of the original resource.  (However, it does not create a dynamic mesh in the editor, because it does want the original input mesh saved in the scene.)

Previously, `SoftBody3D` did not override `set_mesh()`, and instead simply periodically checked to see if the `mesh` property had been modified and was different from the old value it remembered.  It did this check at various points in time.  Precisely when it would check the mesh depends on the object settings, whether the code is running in the editor or not, and these checks have moved around over time.  In past releases it normally checked in a `frame_pre_draw` callback, but the recent physics interpolation logic changed it to check in `NOTIFICATION_INTERNAL_PHYSICS_PROCESS` instead.

This behavior made it rather confusing to reason about when a `SoftBody3D` object would resync the physics state with the MeshInstance3D mesh, and when it would be out-of-date.  Often in the editor it would not notice changes to the `mesh`, resulting in confusing behavior and bugs.

This commit updates `SoftBody3D` to process `set_mesh()` calls directly, so it can never be in a state where it can no longer be out-of-sync with the parent MeshInstance3D state.

This also fixes the code to check that the mesh is actually supported before allowing it to be set, and to correctly update editor warnings after the mesh is changed.

- Fixes #108036 
- Fixes #108059

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
