### PR TITLE
Clean up numeric EditorProperty `setup()` methods

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1466,18 +1466,18 @@ void EditorPropertyInteger::update_property() {
 #endif
 }
 
-void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_prefer_slider, bool p_hide_control, bool p_allow_greater, bool p_allow_lesser, const String &p_suffix) {
-	spin->set_min(p_min);
-	spin->set_max(p_max);
-	spin->set_step(p_step);
-	if (p_hide_control) {
+void EditorPropertyInteger::setup(const EditorPropertyRangeHint &p_range_hint) {
+	spin->set_min(p_range_hint.min);
+	spin->set_max(p_range_hint.max);
+	spin->set_step(Math::round(p_range_hint.step));
+	if (p_range_hint.hide_control) {
 		spin->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 	} else {
-		spin->set_control_state(p_prefer_slider ? EditorSpinSlider::CONTROL_STATE_PREFER_SLIDER : EditorSpinSlider::CONTROL_STATE_DEFAULT);
+		spin->set_control_state(p_range_hint.prefer_slider ? EditorSpinSlider::CONTROL_STATE_PREFER_SLIDER : EditorSpinSlider::CONTROL_STATE_DEFAULT);
 	}
-	spin->set_allow_greater(p_allow_greater);
-	spin->set_allow_lesser(p_allow_lesser);
-	spin->set_suffix(p_suffix);
+	spin->set_allow_greater(p_range_hint.or_greater);
+	spin->set_allow_lesser(p_range_hint.or_less);
+	spin->set_suffix(p_range_hint.suffix);
 }
 
 EditorPropertyInteger::EditorPropertyInteger() {
@@ -1597,18 +1597,18 @@ void EditorPropertyFloat::update_property() {
 	spin->set_value_no_signal(val);
 }
 
-void EditorPropertyFloat::setup(double p_min, double p_max, double p_step, bool p_hide_control, bool p_exp_range, bool p_greater, bool p_lesser, const String &p_suffix, bool p_radians_as_degrees) {
-	radians_as_degrees = p_radians_as_degrees;
-	spin->set_min(p_min);
-	spin->set_max(p_max);
-	spin->set_step(p_step);
-	if (p_hide_control) {
+void EditorPropertyFloat::setup(const EditorPropertyRangeHint &p_range_hint) {
+	radians_as_degrees = p_range_hint.radians_as_degrees;
+	spin->set_min(p_range_hint.min);
+	spin->set_max(p_range_hint.max);
+	spin->set_step(p_range_hint.step);
+	if (p_range_hint.hide_control) {
 		spin->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 	}
-	spin->set_exp_ratio(p_exp_range);
-	spin->set_allow_greater(p_greater);
-	spin->set_allow_lesser(p_lesser);
-	spin->set_suffix(p_suffix);
+	spin->set_exp_ratio(p_range_hint.exp_range);
+	spin->set_allow_greater(p_range_hint.or_greater);
+	spin->set_allow_lesser(p_range_hint.or_less);
+	spin->set_suffix(p_range_hint.suffix);
 }
 
 EditorPropertyFloat::EditorPropertyFloat() {
@@ -1866,17 +1866,17 @@ void EditorPropertyRect2::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyRect2::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 4; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
-		spin[i]->set_suffix(p_suffix);
+		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
 
@@ -1962,14 +1962,14 @@ void EditorPropertyRect2i::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyRect2i::setup(int p_min, int p_max, const String &p_suffix) {
+void EditorPropertyRect2i::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 4; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
 		spin[i]->set_step(1);
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
-		spin[i]->set_suffix(p_suffix);
+		spin[i]->set_suffix(p_range_hint.suffix);
 		spin[i]->set_editing_integer(true);
 	}
 }
@@ -2056,18 +2056,18 @@ void EditorPropertyPlane::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyPlane::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 4; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 	}
-	spin[3]->set_suffix(p_suffix);
+	spin[3]->set_suffix(p_range_hint.suffix);
 }
 
 EditorPropertyPlane::EditorPropertyPlane(bool p_force_wide) {
@@ -2207,19 +2207,19 @@ void EditorPropertyQuaternion::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyQuaternion::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix, bool p_hide_editor) {
+void EditorPropertyQuaternion::setup(const EditorPropertyRangeHint &p_range_hint, bool p_hide_editor) {
 	for (int i = 0; i < 4; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		// Quaternion is inherently unitless, however someone may want to use it as
 		// a generic way to store 4 values, so we'll still respect the suffix.
-		spin[i]->set_suffix(p_suffix);
+		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 
 	for (int i = 0; i < 3; i++) {
@@ -2354,17 +2354,17 @@ void EditorPropertyAABB::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyAABB::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyAABB::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 6; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
-		spin[i]->set_suffix(p_suffix);
+		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
 
@@ -2434,18 +2434,18 @@ void EditorPropertyTransform2D::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyTransform2D::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyTransform2D::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 6; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		if (i % 3 == 2) {
-			spin[i]->set_suffix(p_suffix);
+			spin[i]->set_suffix(p_range_hint.suffix);
 		}
 	}
 }
@@ -2518,19 +2518,19 @@ void EditorPropertyBasis::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyBasis::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyBasis::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 9; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		// Basis is inherently unitless, however someone may want to use it as
 		// a generic way to store 9 values, so we'll still respect the suffix.
-		spin[i]->set_suffix(p_suffix);
+		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
 
@@ -2609,18 +2609,18 @@ void EditorPropertyTransform3D::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyTransform3D::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyTransform3D::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 12; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		if (i % 4 == 3) {
-			spin[i]->set_suffix(p_suffix);
+			spin[i]->set_suffix(p_range_hint.suffix);
 		}
 	}
 }
@@ -2708,18 +2708,18 @@ void EditorPropertyProjection::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyProjection::setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix) {
+void EditorPropertyProjection::setup(const EditorPropertyRangeHint &p_range_hint) {
 	for (int i = 0; i < 16; i++) {
-		spin[i]->set_min(p_min);
-		spin[i]->set_max(p_max);
-		spin[i]->set_step(p_step);
-		if (p_hide_control) {
+		spin[i]->set_min(p_range_hint.min);
+		spin[i]->set_max(p_range_hint.max);
+		spin[i]->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin[i]->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
 		if (i % 4 == 3) {
-			spin[i]->set_suffix(p_suffix);
+			spin[i]->set_suffix(p_range_hint.suffix);
 		}
 	}
 }
@@ -3621,19 +3621,6 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, const Varian
 	return false;
 }
 
-struct EditorPropertyRangeHint {
-	bool or_greater = true;
-	bool or_less = true;
-	double min = 0.0;
-	double max = 0.0;
-	double step = 1.0;
-	String suffix;
-	bool exp_range = false;
-	bool prefer_slider = false;
-	bool hide_control = true;
-	bool radians_as_degrees = false;
-};
-
 static EditorPropertyRangeHint _parse_range_hint(PropertyHint p_hint, const String &p_hint_text, double p_default_step, bool is_int = false) {
 	EditorPropertyRangeHint hint;
 	hint.step = p_default_step;
@@ -3805,10 +3792,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 			} else {
 				EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
-
-				EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1, true);
-				editor->setup(hint.min, hint.max, hint.step, hint.prefer_slider, hint.hide_control, hint.or_greater, hint.or_less, hint.suffix);
-
+				editor->setup(_parse_range_hint(p_hint, p_hint_text, 1, true));
 				return editor;
 			}
 		} break;
@@ -3833,10 +3817,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 			} else {
 				EditorPropertyFloat *editor = memnew(EditorPropertyFloat);
-
-				EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-				editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.exp_range, hint.or_greater, hint.or_less, hint.suffix, hint.radians_as_degrees);
-
+				editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 				return editor;
 			}
 		} break;
@@ -3890,101 +3871,91 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 
 		case Variant::VECTOR2: {
 			EditorPropertyVector2 *editor = memnew(EditorPropertyVector2(p_wide));
-
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, p_hint == PROPERTY_HINT_LINK, hint.suffix, hint.radians_as_degrees);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step), p_hint == PROPERTY_HINT_LINK);
 			return editor;
 
 		} break;
 		case Variant::VECTOR2I: {
 			EditorPropertyVector2i *editor = memnew(EditorPropertyVector2i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1, true);
-			editor->setup(hint.min, hint.max, 1, false, p_hint == PROPERTY_HINT_LINK, hint.suffix, false, true);
+			hint.step = Math::round(hint.step);
+			editor->setup(hint, p_hint == PROPERTY_HINT_LINK, true);
 			return editor;
 
 		} break;
 		case Variant::RECT2: {
 			EditorPropertyRect2 *editor = memnew(EditorPropertyRect2(p_wide));
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 		} break;
 		case Variant::RECT2I: {
 			EditorPropertyRect2i *editor = memnew(EditorPropertyRect2i(p_wide));
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1, true);
-			editor->setup(hint.min, hint.max, hint.suffix);
-
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, 1, true));
 			return editor;
 		} break;
 		case Variant::VECTOR3: {
 			EditorPropertyVector3 *editor = memnew(EditorPropertyVector3(p_wide));
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, p_hint == PROPERTY_HINT_LINK, hint.suffix, hint.radians_as_degrees);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step), p_hint == PROPERTY_HINT_LINK);
 			return editor;
 
 		} break;
 		case Variant::VECTOR3I: {
 			EditorPropertyVector3i *editor = memnew(EditorPropertyVector3i(p_wide));
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1, true);
-			editor->setup(hint.min, hint.max, 1, false, p_hint == PROPERTY_HINT_LINK, hint.suffix, false, true);
+			hint.step = Math::round(hint.step);
+			editor->setup(hint, p_hint == PROPERTY_HINT_LINK, true);
 			return editor;
 
 		} break;
 		case Variant::VECTOR4: {
 			EditorPropertyVector4 *editor = memnew(EditorPropertyVector4);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, p_hint == PROPERTY_HINT_LINK, hint.suffix, hint.radians_as_degrees);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step), p_hint == PROPERTY_HINT_LINK);
 			return editor;
 
 		} break;
 		case Variant::VECTOR4I: {
 			EditorPropertyVector4i *editor = memnew(EditorPropertyVector4i);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1, true);
-			editor->setup(hint.min, hint.max, 1, false, p_hint == PROPERTY_HINT_LINK, hint.suffix, false, true);
+			hint.step = Math::round(hint.step);
+			editor->setup(hint, p_hint == PROPERTY_HINT_LINK, true);
 			return editor;
 
 		} break;
 		case Variant::TRANSFORM2D: {
 			EditorPropertyTransform2D *editor = memnew(EditorPropertyTransform2D);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 		} break;
 		case Variant::PLANE: {
 			EditorPropertyPlane *editor = memnew(EditorPropertyPlane(p_wide));
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 		} break;
 		case Variant::QUATERNION: {
 			EditorPropertyQuaternion *editor = memnew(EditorPropertyQuaternion);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix, p_hint == PROPERTY_HINT_HIDE_QUATERNION_EDIT);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step), p_hint == PROPERTY_HINT_HIDE_QUATERNION_EDIT);
 			return editor;
 		} break;
 		case Variant::AABB: {
 			EditorPropertyAABB *editor = memnew(EditorPropertyAABB);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 		} break;
 		case Variant::BASIS: {
 			EditorPropertyBasis *editor = memnew(EditorPropertyBasis);
 			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 		} break;
 		case Variant::TRANSFORM3D: {
 			EditorPropertyTransform3D *editor = memnew(EditorPropertyTransform3D);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 
 		} break;
 		case Variant::PROJECTION: {
 			EditorPropertyProjection *editor = memnew(EditorPropertyProjection);
-			EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
-			editor->setup(hint.min, hint.max, hint.step, hint.hide_control, hint.suffix);
+			editor->setup(_parse_range_hint(p_hint, p_hint_text, default_float_step));
 			return editor;
 
 		} break;

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -46,6 +46,19 @@ class SceneTreeDialog;
 class TextEdit;
 class TextureButton;
 
+struct EditorPropertyRangeHint {
+	bool or_greater = true;
+	bool or_less = true;
+	double min = 0.0;
+	double max = 0.0;
+	double step = 1.0;
+	String suffix;
+	bool exp_range = false;
+	bool prefer_slider = false;
+	bool hide_control = true;
+	bool radians_as_degrees = false;
+};
+
 class EditorPropertyNil : public EditorProperty {
 	GDCLASS(EditorPropertyNil, EditorProperty);
 	LineEdit *text = nullptr;
@@ -370,7 +383,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_prefer_slider, bool p_hide_control, bool p_allow_greater, bool p_allow_lesser, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyInteger();
 };
 
@@ -421,7 +434,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, bool p_exp_range, bool p_greater, bool p_lesser, const String &p_suffix = String(), bool p_radians_as_degrees = false);
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyFloat();
 };
 
@@ -477,7 +490,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyRect2(bool p_force_wide = false);
 };
 
@@ -492,7 +505,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(int p_min, int p_max, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyRect2i(bool p_force_wide = false);
 };
 
@@ -507,7 +520,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyPlane(bool p_force_wide = false);
 };
 
@@ -539,7 +552,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String(), bool p_hide_editor = false);
+	void setup(const EditorPropertyRangeHint &p_range_hint, bool p_hide_editor = false);
 	EditorPropertyQuaternion();
 };
 
@@ -554,7 +567,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyAABB();
 };
 
@@ -569,7 +582,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyTransform2D(bool p_include_origin = true);
 };
 
@@ -584,7 +597,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyBasis();
 };
 
@@ -600,7 +613,7 @@ protected:
 public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Transform3D p_transform);
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyTransform3D();
 };
 
@@ -616,7 +629,7 @@ protected:
 public:
 	virtual void update_property() override;
 	virtual void update_using_transform(Projection p_transform);
-	void setup(double p_min, double p_max, double p_step, bool p_hide_control, const String &p_suffix = String());
+	void setup(const EditorPropertyRangeHint &p_range_hint);
 	EditorPropertyProjection();
 };
 

--- a/editor/inspector/editor_properties_vector.cpp
+++ b/editor/inspector/editor_properties_vector.cpp
@@ -153,19 +153,19 @@ void EditorPropertyVectorN::_notification(int p_what) {
 	}
 }
 
-void EditorPropertyVectorN::setup(double p_min, double p_max, double p_step, bool p_hide_control, bool p_link, const String &p_suffix, bool p_radians_as_degrees, bool p_is_int) {
-	radians_as_degrees = p_radians_as_degrees;
+void EditorPropertyVectorN::setup(const EditorPropertyRangeHint &p_range_hint, bool p_link, bool p_is_int) {
+	radians_as_degrees = p_range_hint.radians_as_degrees;
 
 	for (EditorSpinSlider *spin : spin_sliders) {
-		spin->set_min(p_min);
-		spin->set_max(p_max);
-		spin->set_step(p_step);
-		if (p_hide_control) {
+		spin->set_min(p_range_hint.min);
+		spin->set_max(p_range_hint.max);
+		spin->set_step(p_range_hint.step);
+		if (p_range_hint.hide_control) {
 			spin->set_control_state(EditorSpinSlider::CONTROL_STATE_HIDE);
 		}
 		spin->set_allow_greater(true);
 		spin->set_allow_lesser(true);
-		spin->set_suffix(p_suffix);
+		spin->set_suffix(p_range_hint.suffix);
 		spin->set_editing_integer(p_is_int);
 	}
 

--- a/editor/inspector/editor_properties_vector.h
+++ b/editor/inspector/editor_properties_vector.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "editor/inspector/editor_inspector.h"
+#include "editor/inspector/editor_properties.h"
 
 class EditorSpinSlider;
 class TextureButton;
@@ -61,7 +62,7 @@ protected:
 
 public:
 	virtual void update_property() override;
-	void setup(double p_min, double p_max, double p_step = 1.0, bool p_hide_control = true, bool p_link = false, const String &p_suffix = String(), bool p_radians_as_degrees = false, bool p_is_int = false);
+	void setup(const EditorPropertyRangeHint &p_range_hint, bool p_link = false, bool p_is_int = false);
 	EditorPropertyVectorN(Variant::Type p_type, bool p_force_wide, bool p_horizontal);
 };
 

--- a/editor/scene/2d/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/scene/2d/tiles/tile_proxies_manager_dialog.cpp
@@ -390,6 +390,14 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	HBoxContainer *hboxcontainer = memnew(HBoxContainer);
 	vbox_container->add_child(hboxcontainer);
 
+	EditorPropertyRangeHint range_hint;
+	range_hint.min = -1;
+	range_hint.hide_control = false;
+	range_hint.or_less = false;
+
+	EditorPropertyRangeHint coords_property_editor_range_hint;
+	coords_property_editor_range_hint.min = -1;
+
 	// From
 	VBoxContainer *vboxcontainer_from = memnew(VBoxContainer);
 	vboxcontainer_from->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -401,7 +409,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	source_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	source_from_property_editor->set_selectable(false);
 	source_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	source_from_property_editor->setup(-1, 99999, 1, false, false, true, false);
+	source_from_property_editor->setup(range_hint);
 	vboxcontainer_from->add_child(source_from_property_editor);
 
 	coords_from_property_editor = memnew(EditorPropertyVector2i);
@@ -410,7 +418,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	coords_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	coords_from_property_editor->set_selectable(false);
 	coords_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	coords_from_property_editor->setup(-1, 99999, true);
+	coords_from_property_editor->setup(coords_property_editor_range_hint);
 	coords_from_property_editor->hide();
 	vboxcontainer_from->add_child(coords_from_property_editor);
 
@@ -420,7 +428,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	alternative_from_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	alternative_from_property_editor->set_selectable(false);
 	alternative_from_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	alternative_from_property_editor->setup(-1, 99999, 1, false, false, true, false);
+	alternative_from_property_editor->setup(range_hint);
 	alternative_from_property_editor->hide();
 	vboxcontainer_from->add_child(alternative_from_property_editor);
 
@@ -435,7 +443,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	source_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	source_to_property_editor->set_selectable(false);
 	source_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	source_to_property_editor->setup(-1, 99999, 1, false, false, true, false);
+	source_to_property_editor->setup(range_hint);
 	vboxcontainer_to->add_child(source_to_property_editor);
 
 	coords_to_property_editor = memnew(EditorPropertyVector2i);
@@ -444,7 +452,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	coords_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	coords_to_property_editor->set_selectable(false);
 	coords_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	coords_to_property_editor->setup(-1, 99999, true);
+	coords_to_property_editor->setup(coords_property_editor_range_hint);
 	coords_to_property_editor->hide();
 	vboxcontainer_to->add_child(coords_to_property_editor);
 
@@ -454,7 +462,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	alternative_to_property_editor->connect("property_changed", callable_mp(this, &TileProxiesManagerDialog::_property_changed));
 	alternative_to_property_editor->set_selectable(false);
 	alternative_to_property_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	alternative_to_property_editor->setup(-1, 99999, 1, false, false, true, false);
+	alternative_to_property_editor->setup(range_hint);
 	alternative_to_property_editor->hide();
 	vboxcontainer_to->add_child(alternative_to_property_editor);
 

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -63,8 +63,13 @@ void BonePropertiesEditor::create_editors() {
 	section->get_vbox()->add_child(enabled_checkbox);
 
 	// Position property.
+	EditorPropertyRangeHint large_range_hint;
+	large_range_hint.min = -10000;
+	large_range_hint.max = 10000;
+	large_range_hint.step = 0.001;
+
 	position_property = memnew(EditorPropertyVector3());
-	position_property->setup(-10000, 10000, 0.001, true);
+	position_property->setup(large_range_hint);
 	position_property->set_label("Position");
 	position_property->set_selectable(false);
 	position_property->connect("property_changed", callable_mp(this, &BonePropertiesEditor::_value_changed));
@@ -73,7 +78,7 @@ void BonePropertiesEditor::create_editors() {
 
 	// Rotation property.
 	rotation_property = memnew(EditorPropertyQuaternion());
-	rotation_property->setup(-10000, 10000, 0.001, true);
+	rotation_property->setup(large_range_hint);
 	rotation_property->set_label("Rotation");
 	rotation_property->set_selectable(false);
 	rotation_property->connect("property_changed", callable_mp(this, &BonePropertiesEditor::_value_changed));
@@ -82,7 +87,7 @@ void BonePropertiesEditor::create_editors() {
 
 	// Scale property.
 	scale_property = memnew(EditorPropertyVector3());
-	scale_property->setup(-10000, 10000, 0.001, true, true);
+	scale_property->setup(large_range_hint, true);
 	scale_property->set_label("Scale");
 	scale_property->set_selectable(false);
 	scale_property->connect("property_changed", callable_mp(this, &BonePropertiesEditor::_value_changed));
@@ -96,7 +101,7 @@ void BonePropertiesEditor::create_editors() {
 
 	// Transform/Matrix property.
 	rest_matrix = memnew(EditorPropertyTransform3D());
-	rest_matrix->setup(-10000, 10000, 0.001, true);
+	rest_matrix->setup(large_range_hint);
 	rest_matrix->set_label("Transform");
 	rest_matrix->set_selectable(false);
 	rest_section->get_vbox()->add_child(rest_matrix);

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -465,7 +465,12 @@ void EditorPropertyOTVariation::update_property() {
 			Vector3i range = supported.get_value_at_index(i);
 
 			EditorPropertyInteger *prop = memnew(EditorPropertyInteger);
-			prop->setup(range.x, range.y, 1, false, true, false, false);
+			EditorPropertyRangeHint hint;
+			hint.min = range.x;
+			hint.max = range.y;
+			hint.or_greater = false;
+			hint.or_less = false;
+			prop->setup(hint);
 			prop->set_object_and_property(object.ptr(), "keys/" + itos(name_tag));
 
 			String name = TS->tag_to_name(name_tag);
@@ -746,7 +751,13 @@ void EditorPropertyOTFeatures::update_property() {
 					} break;
 					case Variant::INT: {
 						EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
-						editor->setup(0, 255, 1, false, false, false, false);
+						EditorPropertyRangeHint hint;
+						hint.min = 0;
+						hint.max = 255;
+						hint.hide_control = false;
+						hint.or_greater = false;
+						hint.or_less = false;
+						editor->setup(hint);
 						prop = editor;
 					} break;
 					default: {


### PR DESCRIPTION
Currently, the numeric EditorProperty `setup()` methods are somewhat brittle. When these properties are created, they are first bundled into a struct, which is then destructed in the method call. This PR changes the signature of the numeric `setup()` calls to use the struct directly. This has several benefits:

+ If any new functionality is wanted for these properties (like in #105878), this change makes it easy to make these changes without adding any arguments.
+ It removes the use of "magic numbers". In several internal files, EditorPropertyIntegers are created directly (I don't know how much this should be encouraged). Their `setup()` calls have many seemingly arbitrary numbers and booleans that are hard to understand without looking at the `editor_properties.h` file. This change makes it clear within the file what the parameters that the code is changing.

Note: In making this change I found multiple invalid calls to `setup()`, most looking like: `setup(-1, 99999, true);` where there is a boolean in the third argument (which is defined as `double p_step`). I'm not sure what the intention was originally, but making this change will prevent future invalid calls and help catch other invalid calls before they are propagated.