### PR TITLE
Fix `FLAG_CHANGE_PATH`

### DIFF
--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -117,12 +117,8 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 			continue;
 		}
 
-		String old_path = p_resource->get_path();
-
-		String local_path = ProjectSettings::get_singleton()->localize_path(path);
-
 		if (p_flags & FLAG_CHANGE_PATH) {
-			p_resource->set_path(local_path);
+			p_resource->set_path(ProjectSettings::get_singleton()->localize_path(path));
 		}
 
 		err = saver[i]->save(p_resource, path, p_flags);
@@ -137,10 +133,6 @@ Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path,
 				((Resource *)p_resource.ptr())->set_last_modified_time(mt);
 			}
 #endif
-
-			if (p_flags & FLAG_CHANGE_PATH) {
-				p_resource->set_path(old_path);
-			}
 
 			if (save_callback && path.begins_with("res://")) {
 				save_callback(p_resource, path);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1922,7 +1922,7 @@ Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> ani
 		}
 	}
 	anim->set_path(res_path, true); // Set path to save externally.
-	Error err = ResourceSaver::save(anim, res_path, ResourceSaver::FLAG_CHANGE_PATH);
+	Error err = ResourceSaver::save(anim, res_path);
 
 	ERR_FAIL_COND_V_MSG(err != OK, anim, "Saving of animation failed: " + res_path);
 	if (p_save_to_path.begins_with("uid://")) {

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -172,7 +172,6 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 		// which would be serialized as Base64 if the scene is a `.tscn` file.
 		Ref<VoxelGIData> voxel_gi_data = voxel_gi->get_probe_data();
 		ERR_FAIL_COND(voxel_gi_data.is_null());
-		voxel_gi_data->set_path(p_path);
 		ResourceSaver::save(voxel_gi_data, p_path, ResourceSaver::FLAG_CHANGE_PATH);
 	}
 }

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -383,9 +383,7 @@ void ScriptCreateDialog::_create_new() {
 		// Make sure the script is compiled to make its type recognizable.
 		scr->reload();
 	} else {
-		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
-		scr->set_path(lpath);
-		Error err = ResourceSaver::save(scr, lpath, ResourceSaver::FLAG_CHANGE_PATH);
+		Error err = ResourceSaver::save(scr, file_path->get_text(), ResourceSaver::FLAG_CHANGE_PATH);
 		if (err != OK) {
 			alert->set_text(TTR("Error - Could not create script in filesystem."));
 			alert->popup_centered();

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -236,10 +236,7 @@ void fog() {
 	}
 
 	if (shader.is_null()) {
-		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
-		shader_inc->set_path(lpath);
-
-		Error error = ResourceSaver::save(shader_inc, lpath, ResourceSaver::FLAG_CHANGE_PATH);
+		Error error = ResourceSaver::save(shader_inc, file_path->get_text(), ResourceSaver::FLAG_CHANGE_PATH);
 		if (error != OK) {
 			alert->set_text(TTR("Error - Could not create shader include in filesystem."));
 			alert->popup_centered();
@@ -254,10 +251,7 @@ void fog() {
 				shader->set_path(edited_scene->get_scene_file_path() + "::" + shader->generate_scene_unique_id());
 			}
 		} else {
-			String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
-			shader->set_path(lpath);
-
-			Error error = ResourceSaver::save(shader, lpath, ResourceSaver::FLAG_CHANGE_PATH);
+			Error error = ResourceSaver::save(shader, file_path->get_text(), ResourceSaver::FLAG_CHANGE_PATH);
 			if (error != OK) {
 				alert->set_text(TTR("Error - Could not create shader in filesystem."));
 				alert->popup_centered();


### PR DESCRIPTION
Fixes #42697

The flag was used in surprisingly many places, given it did absolutely nothing.  I took advantage of the fix and simplified some code. `FLAG_CHANGE_PATH` is now equivalent of calling `resource.set_path(ProjectSettings::get_singleton()->localize_path(path), false)` before saving the resource.