### PR TITLE
Fix decal atlas clipped when using texture resolution < 32

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3463,7 +3463,8 @@ void TextureStorage::update_decal_atlas() {
 			int *v_offsets = v_offsetsv.ptrw();
 			memset(v_offsets, 0, sizeof(int) * base_size);
 
-			int max_height = 0;
+			// Take border into account for minimum height.
+			int max_height = 2;
 
 			for (int i = 0; i < item_count; i++) {
 				//best fit


### PR DESCRIPTION
This fixes issue #108033.

When a texture's resolution in a decal atlas was < 32, the border margin was no longer taken into account. Resulting in cropped textures in the atlas.

The fix might sound unintuitive, but basically an `atlas_height` of 1 = border size (32).
So, an `atlas_height` of 2 = border size * 2. Which is the minimum size required to insert textures into the atlas.

- *Bugsquad:* fixes #108033