### PR TITLE
Fix risk of `EditorNode`'s progress dialog being freed inadvertently

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5380,10 +5380,14 @@ void EditorNode::progress_end_task_bg(const String &p_task) {
 }
 
 void EditorNode::_progress_dialog_visibility_changed() {
-	// Open the io errors after the progress dialog is closed.
-	if (load_errors_queued_to_display && !progress_dialog->is_visible()) {
-		EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
-		load_errors_queued_to_display = false;
+	if (!progress_dialog->is_visible()) {
+		// Reset the parent to prevent the dialog from being freed externally.
+		progress_dialog->reparent(this);
+		// Open the io errors after the progress dialog is closed.
+		if (load_errors_queued_to_display) {
+			EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
+			load_errors_queued_to_display = false;
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #108003.

Someone will have to look at whether this makes sense, but here's my thinking:

- `EditorNode` creates a private instance of `ProgressDialog` to use for things like saving scenes:
https://github.com/godotengine/godot/blob/e1b4101e3460dd9c6ba0b7f8d88e9751b8383f5b/editor/editor_node.cpp#L7768-L7771
- When there's progress to be reported, it calls `ProgressDialog::add_task()`, which eventually calls `ProgressDialog::_popup()`, which reparents the dialog to a suitable node in the tree:
https://github.com/godotengine/godot/blob/e1b4101e3460dd9c6ba0b7f8d88e9751b8383f5b/editor/progress_dialog.cpp#L169-L171
- The dialog will stay a child of that node until the next time it pops up and chooses a new parent.
- If the chosen parent node is freed in the meantime, the progress dialog is freed along with it. In the linked issue, this happened with a plugin which eventually freed the `AcceptDialog` the progress dialog had chosen as its parent.
- `EditorNode` does not realize its private dialog has been freed externally and will continue to use its `progress_dialog` pointer, leading to memory corruption and possibly crashes the next time it wants to report progress.

One way to mitigate this might be to detach the progress dialog from its parent node once the progress task is finished and the dialog is hidden. I suppose it makes sense to move it back to the `EditorNode`, where it was originally.
```c++
void EditorNode::_progress_dialog_visibility_changed() {
	if (!progress_dialog->is_visible()) {
		// Reset the parent to avoid the risk of the dialog being freed externally.
		progress_dialog->reparent(this);
		// Open the io errors after the progress dialog is closed.
		if (load_errors_queued_to_display) {
			EditorInterface::get_singleton()->popup_dialog_centered_ratio(singleton->load_error_dialog, 0.5);
			load_errors_queued_to_display = false;
		}
	}
}
```

With this change, the MRP in the issue no longer crashes for me.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
