### PR TITLE
Allow TabBar's navigation buttons to switch tabs instead of scrolling

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -261,6 +261,12 @@
 		<member name="max_tab_width" type="int" setter="set_max_tab_width" getter="get_max_tab_width" default="0">
 			Sets the maximum width which all tabs should be limited to. Unlimited if set to [code]0[/code].
 		</member>
+		<member name="navigation_buttons_always_visible" type="bool" setter="set_navigation_buttons_always_visible" getter="get_navigation_buttons_always_visible" default="false">
+			If [code]true[/code], navigation buttons will be visible even when there's enough space for all tabs.
+		</member>
+		<member name="navigation_buttons_switch_tabs" type="bool" setter="set_navigation_buttons_switch_tabs" getter="get_navigation_buttons_switch_tabs" default="false">
+			If [code]true[/code], navigation buttons will switch tabs instead of scrolling through them.
+		</member>
 		<member name="scroll_to_selected" type="bool" setter="set_scroll_to_selected" getter="get_scroll_to_selected" default="true">
 			If [code]true[/code], the tab offset will be changed to keep the currently selected tab visible.
 		</member>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -223,6 +223,12 @@
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
+		<member name="navigation_buttons_always_visible" type="bool" setter="set_navigation_buttons_always_visible" getter="get_navigation_buttons_always_visible" default="false">
+			If [code]true[/code], navigation buttons will be visible even when there's enough space for all tabs.
+		</member>
+		<member name="navigation_buttons_switch_tabs" type="bool" setter="set_navigation_buttons_switch_tabs" getter="get_navigation_buttons_switch_tabs" default="false">
+			If [code]true[/code], navigation buttons will switch tabs instead of scrolling through them.
+		</member>
 		<member name="tab_alignment" type="int" setter="set_tab_alignment" getter="get_tab_alignment" enum="TabBar.AlignmentMode" default="0">
 			The position at which tabs will be placed.
 		</member>

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -100,6 +100,8 @@ private:
 	int previous = -1;
 	AlignmentMode tab_alignment = ALIGNMENT_LEFT;
 	bool clip_tabs = true;
+	bool navigation_buttons_switch_tabs = false;
+	bool navigation_buttons_always_visible = false;
 	int rb_hover = -1;
 	bool rb_pressing = false;
 	bool tab_style_v_flip = false;
@@ -177,6 +179,9 @@ private:
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_index);
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
 
+	void _handle_increment();
+	void _handle_decrement();
+
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
@@ -243,6 +248,12 @@ public:
 
 	void set_clip_tabs(bool p_clip_tabs);
 	bool get_clip_tabs() const;
+
+	void set_navigation_buttons_switch_tabs(bool p_navigation_buttons_switch_tabs);
+	bool get_navigation_buttons_switch_tabs() const;
+
+	void set_navigation_buttons_always_visible(bool p_navigation_buttons_always_visible);
+	bool get_navigation_buttons_always_visible() const;
 
 	void set_tab_style_v_flip(bool p_tab_style_v_flip);
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -790,6 +790,22 @@ bool TabContainer::get_clip_tabs() const {
 	return tab_bar->get_clip_tabs();
 }
 
+void TabContainer::set_navigation_buttons_switch_tabs(bool p_navigation_buttons_switch_tabs) {
+	tab_bar->set_navigation_buttons_switch_tabs(p_navigation_buttons_switch_tabs);
+}
+
+bool TabContainer::get_navigation_buttons_switch_tabs() const {
+	return tab_bar->get_navigation_buttons_switch_tabs();
+}
+
+void TabContainer::set_navigation_buttons_always_visible(bool p_navigation_buttons_always_visible) {
+	tab_bar->set_navigation_buttons_always_visible(p_navigation_buttons_always_visible);
+}
+
+bool TabContainer::get_navigation_buttons_always_visible() const {
+	return tab_bar->get_navigation_buttons_always_visible();
+}
+
 void TabContainer::set_tabs_visible(bool p_visible) {
 	if (p_visible == tabs_visible) {
 		return;
@@ -1073,6 +1089,10 @@ void TabContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_tabs_position"), &TabContainer::get_tabs_position);
 	ClassDB::bind_method(D_METHOD("set_clip_tabs", "clip_tabs"), &TabContainer::set_clip_tabs);
 	ClassDB::bind_method(D_METHOD("get_clip_tabs"), &TabContainer::get_clip_tabs);
+	ClassDB::bind_method(D_METHOD("set_navigation_buttons_switch_tabs", "navigation_buttons_switch_tabs"), &TabContainer::set_navigation_buttons_switch_tabs);
+	ClassDB::bind_method(D_METHOD("get_navigation_buttons_switch_tabs"), &TabContainer::get_navigation_buttons_switch_tabs);
+	ClassDB::bind_method(D_METHOD("set_navigation_buttons_always_visible", "navigation_buttons_always_visible"), &TabContainer::set_navigation_buttons_always_visible);
+	ClassDB::bind_method(D_METHOD("get_navigation_buttons_always_visible"), &TabContainer::get_navigation_buttons_always_visible);
 	ClassDB::bind_method(D_METHOD("set_tabs_visible", "visible"), &TabContainer::set_tabs_visible);
 	ClassDB::bind_method(D_METHOD("are_tabs_visible"), &TabContainer::are_tabs_visible);
 	ClassDB::bind_method(D_METHOD("set_all_tabs_in_front", "is_front"), &TabContainer::set_all_tabs_in_front);
@@ -1120,6 +1140,8 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "current_tab", PROPERTY_HINT_RANGE, "-1,4096,1"), "set_current_tab", "get_current_tab");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_position", PROPERTY_HINT_ENUM, "Top,Bottom"), "set_tabs_position", "get_tabs_position");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "clip_tabs"), "set_clip_tabs", "get_clip_tabs");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "navigation_buttons_switch_tabs"), "set_navigation_buttons_switch_tabs", "get_navigation_buttons_switch_tabs");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "navigation_buttons_always_visible"), "set_navigation_buttons_always_visible", "get_navigation_buttons_always_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tabs_visible"), "set_tabs_visible", "are_tabs_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "all_tabs_in_front"), "set_all_tabs_in_front", "is_all_tabs_in_front");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -151,6 +151,12 @@ public:
 	void set_clip_tabs(bool p_clip_tabs);
 	bool get_clip_tabs() const;
 
+	void set_navigation_buttons_switch_tabs(bool p_navigation_buttons_switch_tabs);
+	bool get_navigation_buttons_switch_tabs() const;
+
+	void set_navigation_buttons_always_visible(bool p_navigation_buttons_always_visible);
+	bool get_navigation_buttons_always_visible() const;
+
 	void set_tabs_visible(bool p_visible);
 	bool are_tabs_visible() const;
 


### PR DESCRIPTION
This PR allows to use TabBar's navigation buttons to switch tabs instead of just scrolling through them. This is especially useful on mobile where it's not very convinient to stretch your fingers to the top of the screen. But with this feature, you can use your right hand to comfortable access all the tabs.

https://github.com/user-attachments/assets/2ffee63b-25db-4f4c-b306-b14054ac9077

To achieve this, the PR introduces two new flags:
* `navigation_buttons_switch_tabs` [default: false]
* `navigation_buttons_always_visible` [default: false]
The second one is needed because if you want to use navigation buttons to switch tabs, you most likely want them to always be visible.
As the video shows, the flags can be changed in runtime just fine. But it triggers `queue_redraw`, so changing them too often can be performance-heavy.
Also, I like this behavior even more than the default one and would like to make it default. But I decided not to do this to avoid breaking compatibility at all.