### PR TITLE
Add support for alpha hash transparency in the Compatibility renderer

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -665,13 +665,15 @@
 			The color of the object is added to the background and the alpha channel is used to mask out the background. This is effectively a hybrid of the blend mix and add modes, useful for effects like fire where you want the flame to add but the smoke to mix. By default, this works with unshaded materials using premultiplied textures. For shaded materials, use the [code]PREMUL_ALPHA_FACTOR[/code] built-in so that lighting can be modulated as well.
 		</constant>
 		<constant name="ALPHA_ANTIALIASING_OFF" value="0" enum="AlphaAntiAliasing">
-			Disables Alpha AntiAliasing for the material.
+			Disables alpha antialiasing for the material.
 		</constant>
 		<constant name="ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE" value="1" enum="AlphaAntiAliasing">
-			Enables AlphaToCoverage. Alpha values in the material are passed to the AntiAliasing sample mask.
+			Enables MSAA alpha to coverage. Alpha values in the material are passed to the antialiasing sample mask. Requires [member Viewport.msaa_3d] to be set to [constant Viewport.MSAA_2X] or greater to have a noticeable effect.
+			[b]Note:[/b] Due to OpenGL ES limitations, alpha antialiasing is only supported in the Forward+ and Mobile renderers, not Compatibility.
 		</constant>
 		<constant name="ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE" value="2" enum="AlphaAntiAliasing">
-			Enables AlphaToCoverage and forces all non-zero alpha values to [code]1[/code]. Alpha values in the material are passed to the AntiAliasing sample mask.
+			Enables MSAA alpha to coverage and forces all non-zero alpha values to [code]1[/code]. Alpha values in the material are passed to the antialiasing sample mask. Requires [member Viewport.msaa_3d] to be set to [constant Viewport.MSAA_2X] or greater to have a noticeable effect.
+			[b]Note:[/b] Due to OpenGL ES limitations, alpha antialiasing is only supported in the Forward+ and Mobile renderers, not Compatibility.
 		</constant>
 		<constant name="DEPTH_DRAW_OPAQUE_ONLY" value="0" enum="DepthDrawMode">
 			Default depth draw mode. Depth is drawn only for opaque objects during the opaque prepass (if any) and during the opaque pass.

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1782,6 +1782,47 @@ vec4 textureArray_bicubic(sampler2DArray tex, vec3 uv, vec2 texture_size) {
 }
 #endif //LIGHTMAP_BICUBIC_FILTER
 
+#ifdef ALPHA_HASH_USED
+
+float hash_2d(vec2 p) {
+	return fract(1.0e4 * sin(17.0 * p.x + 0.1 * p.y) *
+			(0.1 + abs(sin(13.0 * p.y + p.x))));
+}
+
+float hash_3d(vec3 p) {
+	return hash_2d(vec2(hash_2d(p.xy), p.z));
+}
+
+float compute_alpha_hash_threshold(vec3 pos, float hash_scale) {
+	vec3 dx = dFdx(pos);
+	vec3 dy = dFdy(pos);
+	float delta_max_sqr = max(length(dx), length(dy));
+	float pix_scale = 1.0 / (hash_scale * delta_max_sqr);
+
+	vec2 pix_scales =
+			vec2(exp2(floor(log2(pix_scale))), exp2(ceil(log2(pix_scale))));
+
+	vec2 a_thresh = vec2(hash_3d(floor(pix_scales.x * pos.xyz)),
+			hash_3d(floor(pix_scales.y * pos.xyz)));
+
+	float lerp_factor = fract(log2(pix_scale));
+
+	float a_interp = (1.0 - lerp_factor) * a_thresh.x + lerp_factor * a_thresh.y;
+
+	float min_lerp = min(lerp_factor, 1.0 - lerp_factor);
+
+	vec3 cases = vec3(a_interp * a_interp / (2.0 * min_lerp * (1.0 - min_lerp)),
+			(a_interp - 0.5 * min_lerp) / (1.0 - min_lerp),
+			1.0 - ((1.0 - a_interp) * (1.0 - a_interp) / (2.0 * min_lerp * (1.0 - min_lerp))));
+
+	float alpha_hash_threshold =
+			(a_interp < (1.0 - min_lerp)) ? ((a_interp < min_lerp) ? cases.x : cases.y) : cases.z;
+
+	return clamp(alpha_hash_threshold, 0.00001, 1.0);
+}
+
+#endif // ALPHA_HASH_USED
+
 void main() {
 	//lay out everything, whatever is unused is optimized away anyway
 	vec3 vertex = vertex_interp;
@@ -1920,8 +1961,8 @@ void main() {
 
 #ifndef USE_SHADOW_TO_OPACITY
 
-#if defined(ALPHA_SCISSOR_USED)
-#ifdef RENDER_MATERIAL
+#ifdef ALPHA_SCISSOR_USED
+#ifdef MODE_RENDER_MATERIAL
 	if (alpha < alpha_scissor_threshold) {
 		alpha = 0.0;
 	} else {
@@ -1931,18 +1972,37 @@ void main() {
 	if (alpha < alpha_scissor_threshold) {
 		discard;
 	}
-	alpha = 1.0;
-#endif // RENDER_MATERIAL
-#else
-#ifdef MODE_RENDER_DEPTH
-#ifdef USE_OPAQUE_PREPASS
+#endif // MODE_RENDER_MATERIAL
+#endif // ALPHA_SCISSOR_USED
 
+// alpha hash can be used in unison with alpha antialiasing
+#ifdef ALPHA_HASH_USED
+	vec3 object_pos = (inverse(model_matrix) * scene_data.inv_view_matrix * vec4(vertex, 1.0)).xyz;
+#ifdef MODE_RENDER_MATERIAL
+	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
+		alpha = 0.0;
+	} else {
+		alpha = 1.0;
+	}
+#else
+	if (alpha < compute_alpha_hash_threshold(object_pos, alpha_hash_scale)) {
+		discard;
+	}
+#endif // MODE_RENDER_MATERIAL
+#endif // ALPHA_HASH_USED
+
+// If we are not edge antialiasing, we need to remove the output alpha channel from scissor and hash
+#if (defined(ALPHA_SCISSOR_USED) || defined(ALPHA_HASH_USED)) && !defined(MODE_RENDER_MATERIAL)
+	alpha = 1.0;
+#endif
+
+#ifdef MODE_RENDER_DEPTH
+#if defined(USE_OPAQUE_PREPASS)
 	if (alpha < opaque_prepass_threshold) {
 		discard;
 	}
 #endif // USE_OPAQUE_PREPASS
 #endif // MODE_RENDER_DEPTH
-#endif // !ALPHA_SCISSOR_USED
 
 #endif // !USE_SHADOW_TO_OPACITY
 


### PR DESCRIPTION
Alpha antialiasing is not supported since OpenGL ES 3.0 does not support MSAA alpha-to-coverage (only desktop OpenGL does). This updates the documentation accordingly.

- This closes https://github.com/godotengine/godot/issues/103094.

**Testing project:** [test-alpha-hash.zip](https://github.com/user-attachments/files/20961585/test-alpha-hash.zip)

## Preview

*From left to right: alpha blending, alpha scissor, alpha hash, depth pre-pass.*

![godot windows editor x86_64_NKTMqiSg11](https://github.com/user-attachments/assets/796bd1b6-22cd-4e6f-92bd-2be04d02469c)
