### PR TITLE
Jolt physics: wake up a soft body when its transform changes

### DIFF
--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -606,6 +606,7 @@ void JoltSoftBody3D::set_transform(const Transform3D &p_transform) {
 		vertex.mPosition = vertex.mPreviousPosition = relative_transform * vertex.mPosition;
 		vertex.mVelocity = JPH::Vec3::sZero();
 	}
+	wake_up();
 }
 
 AABB JoltSoftBody3D::get_bounds() const {


### PR DESCRIPTION
This updates `JoltSoftBody3D::set_transform()` to wake up the soft body after changing the transform.

Previously, if you had a soft body that was sleeping in a steady state on a ground plane, and you then translated it upwards by 1 meter it would just hang in the air.  Now it falls to the ground correctly.

Issue #108090 has some details and an MRP (although that issue is mostly about other problems in SoftBody3D iteself).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
