### PR TITLE
SoftBody3D: fix transform getting out of sync with the RenderingServer

### DIFF
--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -371,19 +371,25 @@ void SoftBody3D::_notification(int p_what) {
 				_reset_points_offsets();
 				return;
 			}
+			Transform3D global_transform = get_global_transform();
+			if (global_transform == Transform3D()) {
+				// We want to always keep global transform as the identity transform.
+				// If it is already the identity, we have nothing else to do.  This prevents
+				// us from trying to do work on notifications about our own changes to reset
+				// the transform.
+				return;
+			}
 
 			if (!simulation_started) {
 				// Avoid rendering mesh at the origin before simulation.
 				return;
 			}
 
-			PhysicsServer3D::get_singleton()->soft_body_set_transform(physics_rid, get_global_transform());
+			PhysicsServer3D::get_singleton()->soft_body_set_transform(physics_rid, global_transform);
 
 			// Soft body renders mesh in global space.
-			set_notify_transform(false);
 			set_as_top_level(true);
 			set_transform(Transform3D());
-			set_notify_transform(true);
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
 			if (mesh.is_valid() && rendering_server_handler->is_ready(mesh->get_rid())) {


### PR DESCRIPTION
This is a somewhat minimal fix for issue #108090.

This fixes the code so that `VisualInstance3D` still correctly receives all transform update notifications and can call
`RenderingServer::instance_set_transform()` correctly.

In the long run it seems like it would perhaps be better to fix `SoftBody3D` so that it calls
`VisualInstance3D::set_instance_use_identity_transform(true)` rather than attempting to always reset its global transform back to the identity matrix.  However, doing so is a more complex change that may have somewhat larger side-effects.  I think it is possibly worth doing this in a future commit, but applying this minimal fix seems worthwhile in the interim.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
