### PR TITLE
Update Tree.create_item() documentation

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -50,6 +50,7 @@
 				Creates an item in the tree and adds it as a child of [param parent], which can be either a valid [TreeItem] or [code]null[/code].
 				If [param parent] is [code]null[/code], the root item will be the parent, or the new item will be the root itself if the tree is empty.
 				The new item will be the [param index]-th child of parent, or it will be the last child if there are not enough siblings.
+				[b]Note:[/b] This method returns [code]null[/code] if the tree is locked for modification, such as during selection-related signal callbacks triggered by mouse input. Use [method Object.call_deferred] or connect signals with [constant Object.CONNECT_DEFERRED] to defer execution in such cases.
 			</description>
 		</method>
 		<method name="deselect_all">


### PR DESCRIPTION
This is a simple addition for the following issue: https://github.com/godotengine/godot/issues/103101

It adds documentation to the Tree.create_item so that users avoid creating items with selected-related signal callbacks triggered by mouse input (e.g., item_selected).