### PR TITLE
GDScript: Be lenient with member names shadowing native classes

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -273,11 +273,6 @@ Error GDScriptAnalyzer::check_native_member_name_conflict(const StringName &p_me
 		return ERR_PARSE_ERROR;
 	}
 
-	if (class_exists(p_member_name)) {
-		push_error(vformat(R"(The member "%s" shadows a native class.)", p_member_name), p_member_node);
-		return ERR_PARSE_ERROR;
-	}
-
 	if (GDScriptParser::get_builtin_type(p_member_name) < Variant::VARIANT_MAX) {
 		push_error(vformat(R"(The member "%s" cannot have the same name as a builtin type.)", p_member_name), p_member_node);
 		return ERR_PARSE_ERROR;
@@ -717,6 +712,46 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 		} else {
 			push_error(vformat(R"(Local %s "%s" cannot be used as a type.)", local.get_name(), first), first_id);
 			return bad_type;
+		}
+	}
+
+	if (!type_found && parser->current_class->has_member(first_id->name)) {
+		GDScriptParser::ClassNode::Member member = parser->current_class->get_member(first_id->name);
+		switch (member.type) {
+			case GDScriptParser::ClassNode::Member::CONSTANT: {
+				result = member.constant->get_datatype();
+				if (!result.is_set()) {
+					resolve_constant(member.constant, false);
+					result = member.constant->get_datatype();
+				}
+				if (result.is_meta_type) {
+					type_found = true;
+				} else if (Ref<Script>(member.constant->initializer->reduced_value).is_valid()) {
+					Ref<GDScript> gdscript = member.constant->initializer->reduced_value;
+					if (gdscript.is_valid()) {
+						Ref<GDScriptParserRef> ref = parser->get_depended_parser_for(gdscript->get_script_path());
+						if (ref->raise_status(GDScriptParserRef::INHERITANCE_SOLVED) != OK) {
+							push_error(vformat(R"(Could not parse script from "%s".)", gdscript->get_script_path()), first_id);
+							return bad_type;
+						}
+						result = ref->get_parser()->head->get_datatype();
+					} else {
+						result = make_script_meta_type(member.constant->initializer->reduced_value);
+					}
+					type_found = true;
+				} else {
+					push_error(vformat(R"(Constant "%s" is not a valid type.)", first), first_id);
+					return bad_type;
+				}
+			} break;
+			case GDScriptParser::ClassNode::Member::VARIABLE:
+			case GDScriptParser::ClassNode::Member::FUNCTION:
+			case GDScriptParser::ClassNode::Member::SIGNAL:
+			case GDScriptParser::ClassNode::Member::ENUM_VALUE:
+				push_error(vformat(R"(Member %s "%s" cannot be used as a type.)", member.get_type_name(), first), first_id);
+				return bad_type;
+			default:
+				break;
 		}
 	}
 
@@ -4423,6 +4458,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 		case GDScriptParser::IdentifierNode::UNDEFINED_SOURCE:
 		case GDScriptParser::IdentifierNode::MEMBER_FUNCTION:
 		case GDScriptParser::IdentifierNode::MEMBER_CLASS:
+		case GDScriptParser::IdentifierNode::NATIVE_CLASS:
 			break;
 	}
 
@@ -4493,6 +4529,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 				case GDScriptParser::IdentifierNode::MEMBER_CLASS:
 				case GDScriptParser::IdentifierNode::INHERITED_VARIABLE:
 				case GDScriptParser::IdentifierNode::STATIC_VARIABLE:
+				case GDScriptParser::IdentifierNode::NATIVE_CLASS:
 					return; // No need to capture.
 			}
 
@@ -4525,6 +4562,7 @@ void GDScriptAnalyzer::reduce_identifier(GDScriptParser::IdentifierNode *p_ident
 	}
 
 	if (class_exists(name)) {
+		p_identifier->source = GDScriptParser::IdentifierNode::NATIVE_CLASS;
 		p_identifier->set_datatype(make_native_meta_type(name));
 		return;
 	}
@@ -5976,7 +6014,7 @@ void GDScriptAnalyzer::is_shadowing(GDScriptParser::IdentifierNode *p_identifier
 		if (Variant::has_utility_function(name)) {
 			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "built-in function");
 			return;
-		} else if (ClassDB::class_exists(name)) {
+		} else if (class_exists(name)) {
 			parser->push_warning(p_identifier, GDScriptWarning::SHADOWED_GLOBAL_IDENTIFIER, p_context, name, "native class");
 			return;
 		} else if (ScriptServer::is_global_class(name)) {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -413,6 +413,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				} break;
 
 				// GLOBALS.
+				case GDScriptParser::IdentifierNode::NATIVE_CLASS:
 				case GDScriptParser::IdentifierNode::UNDEFINED_SOURCE: {
 					// Try globals.
 					if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
@@ -673,7 +674,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							if (!call->is_super && subscript->base->type == GDScriptParser::Node::IDENTIFIER && GDScriptParser::get_builtin_type(static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name) < Variant::VARIANT_MAX) {
 								gen->write_call_builtin_type_static(result, GDScriptParser::get_builtin_type(static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name), subscript->attribute->name, arguments);
 							} else if (!call->is_super && subscript->base->type == GDScriptParser::Node::IDENTIFIER && call->function_name != SNAME("new") &&
-									ClassDB::class_exists(static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name) && !Engine::get_singleton()->has_singleton(static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name)) {
+									static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->source == GDScriptParser::IdentifierNode::NATIVE_CLASS && !Engine::get_singleton()->has_singleton(static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name)) {
 								// It's a static native method call.
 								StringName class_name = static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name;
 								MethodBind *method = ClassDB::get_method(class_name, subscript->attribute->name);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -904,6 +904,7 @@ public:
 			MEMBER_CLASS,
 			INHERITED_VARIABLE,
 			STATIC_VARIABLE,
+			NATIVE_CLASS,
 		};
 		Source source = UNDEFINED_SOURCE;
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_override_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_override_type.gd
@@ -1,0 +1,7 @@
+const Node = Custom
+
+func test():
+	var a: Node = Node2D.new()
+
+class Custom extends RefCounted:
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/constant_override_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/constant_override_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 4: Cannot assign a value of type Node2D to variable "a" with specified type Custom.

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_value_as_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_value_as_type.gd
@@ -1,0 +1,6 @@
+enum {
+	Node
+}
+
+func test():
+	var a: Node = Node2D.new()

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_value_as_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_value_as_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 6: Member enum value "Node" cannot be used as a type.

--- a/modules/gdscript/tests/scripts/analyzer/errors/local_constant_override_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/local_constant_override_type.gd
@@ -1,0 +1,6 @@
+func test():
+	const Node = Custom
+	var a: Node = Node2D.new()
+
+class Custom extends RefCounted:
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/local_constant_override_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/local_constant_override_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 3: Cannot assign a value of type Node2D to variable "a" with specified type Custom.

--- a/modules/gdscript/tests/scripts/analyzer/errors/local_variable_as_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/local_variable_as_type.gd
@@ -1,0 +1,6 @@
+func test():
+	var Node = Custom
+	var a: Node = Node2D.new()
+
+class Custom extends RefCounted:
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/local_variable_as_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/local_variable_as_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 3: Local variable "Node" cannot be used as a type.

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_as_type.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_as_type.gd
@@ -1,0 +1,7 @@
+var Node = Custom
+
+func test():
+	var a: Node = Node2D.new()
+
+class Custom extends RefCounted:
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_as_type.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_as_type.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 4: Member variable "Node" cannot be used as a type.

--- a/modules/gdscript/tests/scripts/analyzer/features/override_native_class_with_constant.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_native_class_with_constant.gd
@@ -1,0 +1,10 @@
+const Node2D = preload("override_native_class_with_constant.notest.gd")
+var member_test: Node2D = Node2D.new()
+
+func test() -> void:
+	member_test.do_something("member");
+
+	const Node3D = preload("override_native_class_with_constant.notest.gd")
+	var local_test: Node3D = Node3D.new()
+
+	local_test.do_something("local");

--- a/modules/gdscript/tests/scripts/analyzer/features/override_native_class_with_constant.notest.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_native_class_with_constant.notest.gd
@@ -1,0 +1,4 @@
+extends RefCounted
+
+func do_something(test: String) -> void:
+	prints("Custom type", test)

--- a/modules/gdscript/tests/scripts/analyzer/features/override_native_class_with_constant.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/override_native_class_with_constant.out
@@ -1,0 +1,5 @@
+GDTEST_OK
+~~ WARNING at line 1: (SHADOWED_GLOBAL_IDENTIFIER) The constant "Node2D" has the same name as a native class.
+~~ WARNING at line 7: (SHADOWED_GLOBAL_IDENTIFIER) The constant "Node3D" has the same name as a native class.
+Custom type member
+Custom type local

--- a/modules/gdscript/tests/scripts/runtime/features/variable_shadow_class.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/variable_shadow_class.gd
@@ -1,0 +1,18 @@
+func test():
+	print(FileAccess.file_exists("no file here")); # Original.
+
+	var FileAccess = Shadow.new()
+	print(FileAccess.file_exists("no file here")); # Shadowed by local variable.
+
+	var member_shadow = MemberShadow.new()
+	member_shadow.test()
+
+class Shadow:
+	func file_exists(path: String) -> String:
+		return "Called shadows file_exists with path: " + path
+
+class MemberShadow:
+	var FileAccess = Shadow.new()
+
+	func test():
+		print(FileAccess.file_exists("no file here")); # Shadowed by member variable.

--- a/modules/gdscript/tests/scripts/runtime/features/variable_shadow_class.out
+++ b/modules/gdscript/tests/scripts/runtime/features/variable_shadow_class.out
@@ -1,0 +1,7 @@
+GDTEST_OK
+~~ WARNING at line 2: (CONFUSABLE_LOCAL_USAGE) The identifier "FileAccess" will be shadowed below in the block.
+~~ WARNING at line 4: (SHADOWED_GLOBAL_IDENTIFIER) The variable "FileAccess" has the same name as a native class.
+~~ WARNING at line 15: (SHADOWED_GLOBAL_IDENTIFIER) The variable "FileAccess" has the same name as a native class.
+false
+Called shadows file_exists with path: no file here
+Called shadows file_exists with path: no file here


### PR DESCRIPTION
This improves backward compatibility, since if we introduce a new class that matches an existing member, it will still work.

Also fix an issue where the native class is still considered in the compiler even when shadowed. And prevent non-exposed classes from triggering the warning about shadowing.

Fix  #96743
Fix #105362

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
