### PR TITLE
`FTI` - Fix `MultiMesh` init and stable behavior

### DIFF
--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -258,7 +258,20 @@ void RendererMeshStorage::multimesh_set_buffer_interpolated(RID p_multimesh, con
 void RendererMeshStorage::multimesh_set_physics_interpolated(RID p_multimesh, bool p_interpolated) {
 	MultiMeshInterpolator *mmi = _multimesh_get_interpolator(p_multimesh);
 	if (mmi) {
+		if (p_interpolated == mmi->interpolated) {
+			return;
+		}
+
 		mmi->interpolated = p_interpolated;
+
+		// If we are turning on physics interpolation, as a convenience,
+		// we want to get the current buffer data from the backend,
+		// and reset all the instances.
+		if (p_interpolated) {
+			mmi->_data_curr = _multimesh_get_buffer(p_multimesh);
+			mmi->_data_prev = mmi->_data_curr;
+			mmi->_data_interpolated = mmi->_data_curr;
+		}
 	}
 }
 
@@ -337,6 +350,9 @@ void RendererMeshStorage::update_interpolation_tick(bool p_process) {
 
 			// ... and that both prev and current are the same, just in case of any interpolations.
 			mmi->_data_prev = mmi->_data_curr;
+
+			// Update the actual stable buffer to the backend.
+			_multimesh_set_buffer(rid, mmi->_data_interpolated);
 		}
 
 		if (!mmi) {


### PR DESCRIPTION
Fixes #108058 

There's actually a couple of bugs fixed here, both a result of how this functionality was originally added - for `CPUParticles` in 3.x:

## Update backend with the current buffer on removing from the tick lists
We actually had the same bug in the `SceneTreeFTI` which was fixed a while ago but `MultiMesh` uses an independent system so needed fixing. When the node / individual instances are detected to no longer be moving on the `MultMesh`, it gets removed from the tick and interpolation lists (as it no longer needs to be processed), however, it is essential to make sure the backend has the final (stable) data (which is the situation where curr and prev values are the same).

This didn't show up for `CPUParticles` because they are continuously updated.

## Prefill interpolated buffers when setting physics interpolation to `on`
This one is quite subtle, and I'm not sure whether it can occur in 3.x. In 3.x you can't seem to store the buffer and save to disk (as far as I can make out so far), you have to set the instances in script, and this typically happens _after_ the scene is loaded and physics interpolation has been set to ON for the `MultiMesh`.

In 4.x, in the MRP, it appears that you can set the data directly in the resource and load from disk. The problem comes because the buffer is loaded from disk _before_ the physics interpolation property is set to ON. When setting to ON, any data inside the buffers is ignored (it is blank), and expects to be set afterward.

The simple solution I've used here is to retrieve the current buffer from the backend, and use it to set the interpolated buffers. This works, but it would be nice to change to a different paradigm in the longterm, because this has the potential to cause a stall when such a `MultiMesh` is loaded. It isn't as bad as every frame, but it still has the potential to cause a glitch on load.

The obvious solution would be to get the scene side to resend the buffer _after_ setting physics interpolation to ON (each time this is done), but unfortunately the buffer is not stored scene side. The only "master copy" is in the server.

We *could* store the buffer via the wrapper in the `MMI` every time the buffer is changed, _just in case_ the user was going to later switch on physics interpolation. However, this would be a needless extra cost for users that are not using physics interpolation at all.

There is probably some solution to prevent the stall, but it will take a little more time to formulate, and this version will probably do for closing this bug for 4.5.

## Notes
* Also applicable to 3.x (although the second bug is less likely to happen except in contrived circumstances).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
