### PR TITLE
`FTI` - Add reset on setting `top_level`

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1028,6 +1028,7 @@ void Node3D::set_as_top_level(bool p_enabled) {
 		}
 	}
 	data.top_level = p_enabled;
+	reset_physics_interpolation();
 }
 
 void Node3D::set_as_top_level_keep_local(bool p_enabled) {
@@ -1037,6 +1038,7 @@ void Node3D::set_as_top_level_keep_local(bool p_enabled) {
 	}
 	data.top_level = p_enabled;
 	_propagate_transform_changed(this);
+	reset_physics_interpolation();
 }
 
 bool Node3D::is_set_as_top_level() const {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -519,6 +519,7 @@ void CanvasItem::set_as_top_level(bool p_top_level) {
 	if (get_viewport()) {
 		get_viewport()->canvas_item_top_level_changed();
 	}
+	reset_physics_interpolation();
 }
 
 void CanvasItem::_top_level_changed() {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -952,7 +952,7 @@ void Node::set_physics_interpolation_mode(PhysicsInterpolationMode p_mode) {
 }
 
 void Node::reset_physics_interpolation() {
-	if (is_inside_tree()) {
+	if (SceneTree::is_fti_enabled() && is_inside_tree()) {
 		propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 
 		// If `reset_physics_interpolation()` is called explicitly by the user


### PR DESCRIPTION
Fixes #108086

I've labelled 4.5, but it's really up to production whether to push this to 4.6 as it is easily get aroundable, and is more an enhancement than bug fix, so feel free to push to 4.6.

## Notes
* Although `reset_physics_interpolation()` will cure this (as with any teleport), I think this should be fine for adding an auto-reset, I can't think of any situation where you'd want to toggle `top_level` and not perform a reset.
* I've taken the opportunity to check the new `SceneTree::is_fti_enabled()` static function to make `reset_physics_interpolation()` super cheap to call when FTI is off.
* Also applicable to 3.x.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
