### PR TITLE
`FTI` - Add `multimesh_instances_reset_physics_interpolation()`

### DIFF
--- a/doc/classes/MultiMesh.xml
+++ b/doc/classes/MultiMesh.xml
@@ -59,6 +59,13 @@
 				This allows you to move instances instantaneously, and should usually be used when initially placing an instance such as a bullet to prevent graphical glitches.
 			</description>
 		</method>
+		<method name="reset_instances_physics_interpolation">
+			<return type="void" />
+			<description>
+				When using [i]physics interpolation[/i], this function allows you to prevent interpolation for all instances in the current physics tick.
+				This allows you to move all instances instantaneously, and should usually be used when initially placing instances to prevent graphical glitches.
+			</description>
+		</method>
 		<method name="set_buffer_interpolated">
 			<return type="void" />
 			<param index="0" name="buffer_curr" type="PackedFloat32Array" />

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2756,6 +2756,14 @@
 				Sets the [Transform2D] for this instance. For use when multimesh is used in 2D. Equivalent to [method MultiMesh.set_instance_transform_2d].
 			</description>
 		</method>
+		<method name="multimesh_instances_reset_physics_interpolation">
+			<return type="void" />
+			<param index="0" name="multimesh" type="RID" />
+			<description>
+				Prevents physics interpolation for all instances during the current physics tick.
+				This is useful when moving all instances to new locations, to give instantaneous changes rather than interpolation from the previous locations.
+			</description>
+		</method>
 		<method name="multimesh_set_buffer">
 			<return type="void" />
 			<param index="0" name="multimesh" type="RID" />

--- a/scene/resources/multimesh.cpp
+++ b/scene/resources/multimesh.cpp
@@ -308,6 +308,10 @@ void MultiMesh::reset_instance_physics_interpolation(int p_instance) {
 	RenderingServer::get_singleton()->multimesh_instance_reset_physics_interpolation(multimesh, p_instance);
 }
 
+void MultiMesh::reset_instances_physics_interpolation() {
+	RenderingServer::get_singleton()->multimesh_instances_reset_physics_interpolation(multimesh);
+}
+
 void MultiMesh::set_physics_interpolated(bool p_interpolated) {
 	RenderingServer::get_singleton()->multimesh_set_physics_interpolated(multimesh, p_interpolated);
 }
@@ -382,6 +386,7 @@ void MultiMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_instance_custom_data", "instance", "custom_data"), &MultiMesh::set_instance_custom_data);
 	ClassDB::bind_method(D_METHOD("get_instance_custom_data", "instance"), &MultiMesh::get_instance_custom_data);
 	ClassDB::bind_method(D_METHOD("reset_instance_physics_interpolation", "instance"), &MultiMesh::reset_instance_physics_interpolation);
+	ClassDB::bind_method(D_METHOD("reset_instances_physics_interpolation"), &MultiMesh::reset_instances_physics_interpolation);
 	ClassDB::bind_method(D_METHOD("set_custom_aabb", "aabb"), &MultiMesh::set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_custom_aabb"), &MultiMesh::get_custom_aabb);
 	ClassDB::bind_method(D_METHOD("get_aabb"), &MultiMesh::get_aabb);

--- a/scene/resources/multimesh.h
+++ b/scene/resources/multimesh.h
@@ -115,6 +115,7 @@ public:
 	Color get_instance_custom_data(int p_instance) const;
 
 	void reset_instance_physics_interpolation(int p_instance);
+	void reset_instances_physics_interpolation();
 
 	void set_physics_interpolated(bool p_interpolated);
 

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2484,6 +2484,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("multimesh_set_physics_interpolated", "multimesh", "interpolated"), &RenderingServer::multimesh_set_physics_interpolated);
 	ClassDB::bind_method(D_METHOD("multimesh_set_physics_interpolation_quality", "multimesh", "quality"), &RenderingServer::multimesh_set_physics_interpolation_quality);
 	ClassDB::bind_method(D_METHOD("multimesh_instance_reset_physics_interpolation", "multimesh", "index"), &RenderingServer::multimesh_instance_reset_physics_interpolation);
+	ClassDB::bind_method(D_METHOD("multimesh_instances_reset_physics_interpolation", "multimesh"), &RenderingServer::multimesh_instances_reset_physics_interpolation);
 
 	BIND_ENUM_CONSTANT(MULTIMESH_TRANSFORM_2D);
 	BIND_ENUM_CONSTANT(MULTIMESH_TRANSFORM_3D);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -512,6 +512,7 @@ public:
 	virtual void multimesh_set_physics_interpolated(RID p_multimesh, bool p_interpolated) = 0;
 	virtual void multimesh_set_physics_interpolation_quality(RID p_multimesh, MultimeshPhysicsInterpolationQuality p_quality) = 0;
 	virtual void multimesh_instance_reset_physics_interpolation(RID p_multimesh, int p_index) = 0;
+	virtual void multimesh_instances_reset_physics_interpolation(RID p_multimesh) = 0;
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) = 0;
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -424,6 +424,7 @@ public:
 	FUNC2(multimesh_set_physics_interpolated, RID, bool)
 	FUNC2(multimesh_set_physics_interpolation_quality, RID, MultimeshPhysicsInterpolationQuality)
 	FUNC2(multimesh_instance_reset_physics_interpolation, RID, int)
+	FUNC1(multimesh_instances_reset_physics_interpolation, RID)
 
 	FUNC2(multimesh_set_visible_instances, RID, int)
 	FUNC1RC(int, multimesh_get_visible_instances, RID)

--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -329,6 +329,17 @@ void RendererMeshStorage::multimesh_instance_reset_physics_interpolation(RID p_m
 	}
 }
 
+void RendererMeshStorage::multimesh_instances_reset_physics_interpolation(RID p_multimesh) {
+	MultiMeshInterpolator *mmi = _multimesh_get_interpolator(p_multimesh);
+	if (mmi && mmi->_data_curr.size()) {
+		// We don't want to invoke COW here, so copy the data directly.
+		ERR_FAIL_COND(mmi->_data_prev.size() != mmi->_data_curr.size());
+		float *w = mmi->_data_prev.ptrw();
+		const float *r = mmi->_data_curr.ptr();
+		memcpy(w, r, sizeof(float) * mmi->_data_curr.size());
+	}
+}
+
 void RendererMeshStorage::multimesh_set_visible_instances(RID p_multimesh, int p_visible) {
 	return _multimesh_set_visible_instances(p_multimesh, p_visible);
 }

--- a/servers/rendering/storage/mesh_storage.h
+++ b/servers/rendering/storage/mesh_storage.h
@@ -152,6 +152,7 @@ public:
 	virtual void multimesh_set_physics_interpolated(RID p_multimesh, bool p_interpolated);
 	virtual void multimesh_set_physics_interpolation_quality(RID p_multimesh, RS::MultimeshPhysicsInterpolationQuality p_quality);
 	virtual void multimesh_instance_reset_physics_interpolation(RID p_multimesh, int p_index);
+	virtual void multimesh_instances_reset_physics_interpolation(RID p_multimesh);
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible);
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const;


### PR DESCRIPTION
Convenience function to allow resetting all instances on a `MultiMesh` at once, rather than calling individually _per instance_.

## Notes
* I had been meaning to add this function for a while, there had been several requests to make things easier for bulk resetting.
* The naming is slightly confusing, as we have `MultiMeshInstance` as a scene node, but the `MultiMesh` resource contains instances themselves (which are reset here), but that naming seems to have been set in stone historically and can't easily be changed now.
* An alternative might be to call the functions `reset_all_instances...` rather than `reset_instances...`, given that the current is very similar to `reset_instance...` used already, am happy to change if this is preferred.
* Also applicable in 3.x.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
