### PR TITLE
[3.x] `FTI` - Fix `MultiMesh` stable behaviour

### DIFF
--- a/servers/visual/rasterizer.cpp
+++ b/servers/visual/rasterizer.cpp
@@ -91,6 +91,9 @@ void RasterizerStorage::update_interpolation_tick(bool p_process) {
 
 			// make sure are updated one more time to ensure the AABBs are correct
 			//_instance_queue_update(instance, true);
+
+			// Update the actual stable buffer to the backend.
+			_multimesh_set_as_bulk_array(rid, mmi->_data_interpolated);
 		}
 
 		if (!mmi) {


### PR DESCRIPTION
Fixes the 3.x relevant part of #108058
Backport of #108109

## Update backend with the current buffer on removing from the tick lists
We actually had the same bug in the `SceneTreeFTI` which was fixed a while ago but `MultiMesh` uses an independent system so needed fixing. When the node / individual instances are detected to no longer be moving on the `MultMesh`, it gets removed from the tick and interpolation lists (as it no longer needs to be processed), however, it is essential to make sure the backend has the final (stable) data (which is the situation where curr and prev values are the same).

This didn't show up for `CPUParticles` because they are continuously updated.

## Notes
* The bug as described in the MRP I don't think can occur in 3.x, as `physics_interpolation` property is loaded before the user has the opportunity to set the instances, whereas in 4.x they can be stored to disk.
* It isn't as straightforward to `fix` the other bug in 3.x, as we don't have a function to retrieve the buffer from the backend (except via the constituent parts, e.g. transform, color, custom etc). But I'm not sure it actually constitutes a valid problem in 3.x.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
