### PR TITLE
[3.x] `FTI` - Add reset on setting `toplevel`

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -724,6 +724,7 @@ void CanvasItem::set_as_toplevel(bool p_toplevel) {
 	_enter_canvas();
 
 	_notify_transform();
+	reset_physics_interpolation();
 }
 
 bool CanvasItem::is_set_as_toplevel() const {

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -817,6 +817,7 @@ void Spatial::set_as_toplevel(bool p_enabled) {
 	} else {
 		data.toplevel = p_enabled;
 	}
+	reset_physics_interpolation();
 }
 
 bool Spatial::is_set_as_toplevel() const {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -899,7 +899,7 @@ void Node::set_physics_interpolation_mode(PhysicsInterpolationMode p_mode) {
 }
 
 void Node::reset_physics_interpolation() {
-	if (is_inside_tree()) {
+	if (SceneTree::is_fti_enabled() && is_inside_tree()) {
 		propagate_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
 
 		// If `reset_physics_interpolation()` is called explicitly by the user


### PR DESCRIPTION
Fixes #108086
Backport of #108112

## Notes
* Although `reset_physics_interpolation()` will cure this (as with any teleport), I think this should be fine for adding an auto-reset, I can't think of any situation where you'd want to toggle `top_level` and not perform a reset.
* I've taken the opportunity to check the new `SceneTree::is_fti_enabled()` static function to make `reset_physics_interpolation()` super cheap to call when FTI is off.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
