### PR TITLE
Simplify `varray`

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -873,25 +873,9 @@ public:
 	}
 };
 
-//typedef Dictionary Dictionary; no
-//typedef Array Array;
-
 template <typename... VarArgs>
 Vector<Variant> varray(VarArgs... p_args) {
-	Vector<Variant> v;
-
-	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
-	uint32_t argc = sizeof...(p_args);
-
-	if (argc > 0) {
-		v.resize(argc);
-		Variant *vw = v.ptrw();
-
-		for (uint32_t i = 0; i < argc; i++) {
-			vw[i] = args[i];
-		}
-	}
-	return v;
+	return Vector<Variant>{ p_args... };
 }
 
 struct VariantHasher {


### PR DESCRIPTION
Reduce complexity of these two functions with initializer list constructor.

`varray` should be ok because it is used together with `sarray`, so not performace critical.

For `vformat` I run both microbenchmark and a test project:
<details>
<summary>code</summary>

```C++
#define ANKERL_NANOBENCH_IMPLEMENT
#include "nanobench.h"
#include "core/templates/list.h"
#include "core/templates/local_vector.h"

class Test
{
public:
    static void bench()
    {
        String fmt = "Test vformat %s %04d-%02d-%02d %02d:%02d:%02d";
        auto bench = ankerl::nanobench::Bench()
            .minEpochIterations(1000);
        bench.run("vformat", [&]{
            for (int i = 0; i < 100; i++) {
                auto r = vformat(fmt, "test", 2023, 10, 5, 12, 30, 45);
            }
        });
    }
};
```
</details>

<details>
<summary>result</summary>


master:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          223,433.91 |            4,475.60 |    0.4% |      2.67 | `vformat`

This PR:
|               ns/op |                op/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|          220,315.97 |            4,538.94 |    0.4% |      2.63 | `vformat`

</details>

<details>
<summary>code</summary>

```GDScript
extends Node2D

func _ready() -> void:
	var times = []
	for i in range(10):
		var start = Time.get_ticks_usec()
		for j in range(100000):
			Time.get_datetime_string_from_unix_time(1751215307)
		var end = Time.get_ticks_usec()
		print((end - start) / 1000.0, " ms")
		times.append((end - start) / 1000.0)
	var avg = 0.0
	for t in times:
		avg += t
	avg /= times.size()
	print("average: ", avg, " ms")
```
</details>
<details>
<summary>result</summary>

master:
175.029 ms
172.557 ms
170.201 ms
172.307 ms
172.757 ms
172.753 ms
172.192 ms
171.617 ms
171.543 ms
173.941 ms
average: 172.4897 ms

This PR:
171.95 ms
170.445 ms
170.952 ms
168.081 ms
169.044 ms
170.402 ms
170.3 ms
171.469 ms
171.817 ms
169.767 ms
average: 170.4227 ms
</details>

both tests show no regressions.
