### PR TITLE
Fix subinspector for parameter preview in visual shader editor

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3438,8 +3438,10 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_use_doc_hints(true);
 
 				EditorInspector *parent_inspector = get_parent_inspector();
-				ERR_FAIL_NULL(parent_inspector);
-				sub_inspector->set_root_inspector(parent_inspector->get_root_inspector());
+				if (parent_inspector) {
+					sub_inspector->set_root_inspector(parent_inspector->get_root_inspector());
+					sub_inspector->register_text_enter(parent_inspector->search_box);
+				}
 
 				sub_inspector->set_property_name_style(InspectorDock::get_singleton()->get_property_name_style());
 
@@ -3454,7 +3456,6 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_focus_mode(FocusMode::FOCUS_NONE);
 
 				sub_inspector->set_use_filter(use_filter);
-				sub_inspector->register_text_enter(parent_inspector->search_box);
 
 				add_child(sub_inspector);
 				set_bottom_editor(sub_inspector);


### PR DESCRIPTION
Currently, it's impossible to edit a texture preview parameters within visual shader editor. This is a regression from 27b7b433e03114c72c89397633d82fd67e0b0b8c (https://github.com/godotengine/godot/pull/96542)

Before fix:

![test2](https://github.com/user-attachments/assets/4180071c-d6c4-44fa-b09e-2ee9ffee7fe6)

After fix:

![test](https://github.com/user-attachments/assets/2739a500-6f13-4eac-b8d1-bfff15a2bebc)


