### PR TITLE
Core: Handle disabled class detection in `ClassDB`

### DIFF
--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -11,7 +11,7 @@ def disabled_class_builder(target, source, env):
     with methods.generated_wrapper(str(target[0])) as file:
         for c in source[0].read():
             if cs := c.strip():
-                file.write(f"#define ClassDB_Disable_{cs} 1\n")
+                file.write(f"class {cs}; template <> struct is_class_enabled<{cs}> : std::false_type {{}};\n")
 
 
 # Generate version info

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -41,6 +41,24 @@
 
 #include <type_traits>
 
+template <typename T, typename = void>
+struct is_class_enabled;
+
+template <>
+struct is_class_enabled<Object> : std::true_type {};
+
+template <typename T>
+struct is_class_enabled<T, std::enable_if_t<std::is_base_of_v<Object, T>>> {
+	static constexpr bool value = is_class_enabled<typename T::super_type>::value;
+};
+
+template <typename T>
+inline constexpr bool is_class_enabled_v = is_class_enabled<T>::value;
+
+#define GD_IS_CLASS_ENABLED(m_class) is_class_enabled_v<m_class>
+
+#include "core/disabled_classes.gen.h"
+
 #define DEFVAL(m_defval) (m_defval)
 #define DEFVAL_ARRAY DEFVAL(ClassDB::default_array_arg)
 
@@ -551,25 +569,24 @@ public:
 
 #endif // DEBUG_ENABLED
 
-#define GDREGISTER_CLASS(m_class)             \
-	if (m_class::_class_is_enabled) {         \
-		::ClassDB::register_class<m_class>(); \
+#define GDREGISTER_CLASS(m_class)                 \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
+		::ClassDB::register_class<m_class>();     \
 	}
 #define GDREGISTER_VIRTUAL_CLASS(m_class)         \
-	if (m_class::_class_is_enabled) {             \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) { \
 		::ClassDB::register_class<m_class>(true); \
 	}
 #define GDREGISTER_ABSTRACT_CLASS(m_class)             \
-	if (m_class::_class_is_enabled) {                  \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) {      \
 		::ClassDB::register_abstract_class<m_class>(); \
 	}
 #define GDREGISTER_INTERNAL_CLASS(m_class)             \
-	if (m_class::_class_is_enabled) {                  \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) {      \
 		::ClassDB::register_internal_class<m_class>(); \
 	}
-
 #define GDREGISTER_RUNTIME_CLASS(m_class)             \
-	if (m_class::_class_is_enabled) {                 \
+	if constexpr (GD_IS_CLASS_ENABLED(m_class)) {     \
 		::ClassDB::register_runtime_class<m_class>(); \
 	}
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/disabled_classes.gen.h"
 #include "core/extension/gdextension_interface.h"
 #include "core/object/message_queue.h"
 #include "core/object/object_id.h"
@@ -134,9 +133,6 @@ enum PropertyUsageFlags {
 	PROPERTY_USAGE_DEFAULT = PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_EDITOR,
 	PROPERTY_USAGE_NO_EDITOR = PROPERTY_USAGE_STORAGE,
 };
-
-// Respective values are defined by disabled_classes.gen.h
-#define GD_IS_CLASS_ENABLED(m_class) m_class::_class_is_enabled
 
 #define ADD_SIGNAL(m_signal) ::ClassDB::add_signal(get_class_static(), m_signal)
 #define ADD_PROPERTY(m_property, m_setter, m_getter) ::ClassDB::add_property(get_class_static(), m_property, StringName(m_setter), StringName(m_getter))
@@ -498,7 +494,6 @@ private:                                                                        
 	friend class ::ClassDB;                                                                                                                 \
                                                                                                                                             \
 public:                                                                                                                                     \
-	static constexpr bool _class_is_enabled = !bool(GD_IS_DEFINED(ClassDB_Disable_##m_class)) && m_inherits::_class_is_enabled;             \
 	virtual const StringName *_get_class_namev() const override {                                                                           \
 		return &get_class_static();                                                                                                         \
 	}                                                                                                                                       \
@@ -786,8 +781,6 @@ public: // Should be protected, but bug in clang++.
 	_FORCE_INLINE_ static void register_custom_data_to_otdb() {}
 
 public:
-	static constexpr bool _class_is_enabled = true;
-
 	void notify_property_list_changed();
 
 	static void *get_class_ptr_static() {

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -140,7 +140,7 @@ void register_core_types() {
 
 	CoreStringNames::create();
 
-	if (GD_IS_CLASS_ENABLED(Translation)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Translation)) {
 		resource_format_po.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_format_po);
 	}
@@ -156,7 +156,7 @@ void register_core_types() {
 	resource_format_importer_saver.instantiate();
 	ResourceSaver::add_resource_format_saver(resource_format_importer_saver);
 
-	if (GD_IS_CLASS_ENABLED(Image)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Image)) {
 		resource_format_image.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_format_image);
 	}
@@ -226,7 +226,7 @@ void register_core_types() {
 	ClassDB::register_custom_instance_class<PacketPeerDTLS>();
 	ClassDB::register_custom_instance_class<DTLSServer>();
 
-	if (GD_IS_CLASS_ENABLED(Crypto)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Crypto)) {
 		resource_format_saver_crypto.instantiate();
 		ResourceSaver::add_resource_format_saver(resource_format_saver_crypto);
 
@@ -234,7 +234,7 @@ void register_core_types() {
 		ResourceLoader::add_resource_format_loader(resource_format_loader_crypto);
 	}
 
-	if (GD_IS_CLASS_ENABLED(JSON)) {
+	if constexpr (GD_IS_CLASS_ENABLED(JSON)) {
 		resource_saver_json.instantiate();
 		ResourceSaver::add_resource_format_saver(resource_saver_json);
 
@@ -292,7 +292,7 @@ void register_core_types() {
 
 	gdextension_manager = memnew(GDExtensionManager);
 
-	if (GD_IS_CLASS_ENABLED(GDExtension)) {
+	if constexpr (GD_IS_CLASS_ENABLED(GDExtension)) {
 		resource_loader_gdextension.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_gdextension);
 	}
@@ -426,7 +426,7 @@ void unregister_core_types() {
 		memdelete(ip);
 	}
 
-	if (GD_IS_CLASS_ENABLED(Image)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Image)) {
 		ResourceLoader::remove_resource_format_loader(resource_format_image);
 		resource_format_image.unref();
 	}
@@ -443,12 +443,12 @@ void unregister_core_types() {
 	ResourceSaver::remove_resource_format_saver(resource_format_importer_saver);
 	resource_format_importer_saver.unref();
 
-	if (GD_IS_CLASS_ENABLED(Translation)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Translation)) {
 		ResourceLoader::remove_resource_format_loader(resource_format_po);
 		resource_format_po.unref();
 	}
 
-	if (GD_IS_CLASS_ENABLED(Crypto)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Crypto)) {
 		ResourceSaver::remove_resource_format_saver(resource_format_saver_crypto);
 		resource_format_saver_crypto.unref();
 
@@ -456,7 +456,7 @@ void unregister_core_types() {
 		resource_format_loader_crypto.unref();
 	}
 
-	if (GD_IS_CLASS_ENABLED(JSON)) {
+	if constexpr (GD_IS_CLASS_ENABLED(JSON)) {
 		ResourceSaver::remove_resource_format_saver(resource_saver_json);
 		resource_saver_json.unref();
 
@@ -464,7 +464,7 @@ void unregister_core_types() {
 		resource_loader_json.unref();
 	}
 
-	if (GD_IS_CLASS_ENABLED(GDExtension)) {
+	if constexpr (GD_IS_CLASS_ENABLED(GDExtension)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_gdextension);
 		resource_loader_gdextension.unref();
 	}

--- a/modules/dds/register_types.cpp
+++ b/modules/dds/register_types.cpp
@@ -45,7 +45,7 @@ void initialize_dds_module(ModuleInitializationLevel p_level) {
 	Image::save_dds_func = save_dds;
 	Image::save_dds_buffer_func = save_dds_buffer;
 
-	if (GD_IS_CLASS_ENABLED(Texture)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Texture)) {
 		resource_loader_dds.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_dds);
 	}
@@ -56,7 +56,7 @@ void uninitialize_dds_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	if (GD_IS_CLASS_ENABLED(Texture)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Texture)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_dds);
 		resource_loader_dds.unref();
 	}

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -70,7 +70,7 @@ static Node *gltf_import(const String &p_file) {
 
 	// Once editor import convert pngs to ctex, we will need to load it as ctex resource.
 	Ref<ResourceFormatLoaderCompressedTexture2D> resource_loader_stream_texture;
-	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+	if constexpr (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
 		resource_loader_stream_texture.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
 	}
@@ -108,7 +108,7 @@ static Node *gltf_import(const String &p_file) {
 
 	ResourceImporterScene::remove_scene_importer(import_gltf);
 	ResourceFormatImporter::get_singleton()->remove_importer(import_texture);
-	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+	if constexpr (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
 		resource_loader_stream_texture.unref();
 	}

--- a/modules/jpg/register_types.cpp
+++ b/modules/jpg/register_types.cpp
@@ -39,7 +39,7 @@ static MovieWriterMJPEG *writer_mjpeg = nullptr;
 void initialize_jpg_module(ModuleInitializationLevel p_level) {
 	switch (p_level) {
 		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
-			if (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {
+			if constexpr (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {
 				writer_mjpeg = memnew(MovieWriterMJPEG);
 				MovieWriter::add_writer(writer_mjpeg);
 			}
@@ -63,7 +63,7 @@ void uninitialize_jpg_module(ModuleInitializationLevel p_level) {
 		} break;
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
-			if (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {
+			if constexpr (GD_IS_CLASS_ENABLED(MovieWriterMJPEG)) {
 				memdelete(writer_mjpeg);
 			}
 		} break;

--- a/modules/ktx/register_types.cpp
+++ b/modules/ktx/register_types.cpp
@@ -41,7 +41,7 @@ void initialize_ktx_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	if (GD_IS_CLASS_ENABLED(ImageTexture)) {
+	if constexpr (GD_IS_CLASS_ENABLED(ImageTexture)) {
 		resource_loader_ktx.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_ktx);
 	}
@@ -52,7 +52,7 @@ void uninitialize_ktx_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-	if (GD_IS_CLASS_ENABLED(ImageTexture)) {
+	if constexpr (GD_IS_CLASS_ENABLED(ImageTexture)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_ktx);
 		resource_loader_ktx.unref();
 	}

--- a/modules/mono/register_types.cpp
+++ b/modules/mono/register_types.cpp
@@ -53,7 +53,7 @@ void initialize_mono_module(ModuleInitializationLevel p_level) {
 	script_language_cs->set_language_index(ScriptServer::get_language_count());
 	ScriptServer::register_language(script_language_cs);
 
-	if (GD_IS_CLASS_ENABLED(CSharpScript)) {
+	if constexpr (GD_IS_CLASS_ENABLED(CSharpScript)) {
 		resource_loader_cs.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_cs);
 		resource_saver_cs.instantiate();
@@ -72,7 +72,7 @@ void uninitialize_mono_module(ModuleInitializationLevel p_level) {
 		memdelete(script_language_cs);
 	}
 
-	if (GD_IS_CLASS_ENABLED(CSharpScript)) {
+	if constexpr (GD_IS_CLASS_ENABLED(CSharpScript)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_cs);
 		resource_loader_cs.unref();
 		ResourceSaver::remove_resource_format_saver(resource_saver_cs);

--- a/modules/multiplayer/register_types.cpp
+++ b/modules/multiplayer/register_types.cpp
@@ -48,7 +48,7 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(MultiplayerSynchronizer);
 		GDREGISTER_CLASS(OfflineMultiplayerPeer);
 		GDREGISTER_CLASS(SceneMultiplayer);
-		if (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
+		if constexpr (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
 			MultiplayerAPI::set_default_interface("SceneMultiplayer");
 			MultiplayerDebugger::initialize();
 		}
@@ -61,7 +61,7 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 }
 
 void uninitialize_multiplayer_module(ModuleInitializationLevel p_level) {
-	if (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
+	if constexpr (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
 		MultiplayerDebugger::deinitialize();
 	}
 }

--- a/modules/theora/register_types.cpp
+++ b/modules/theora/register_types.cpp
@@ -45,7 +45,7 @@ void initialize_theora_module(ModuleInitializationLevel p_level) {
 	switch (p_level) {
 		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
 #ifdef TOOLS_ENABLED
-			if (GD_IS_CLASS_ENABLED(MovieWriterOGV)) {
+			if constexpr (GD_IS_CLASS_ENABLED(MovieWriterOGV)) {
 				writer_ogv = memnew(MovieWriterOGV);
 				MovieWriter::add_writer(writer_ogv);
 			}
@@ -71,7 +71,7 @@ void uninitialize_theora_module(ModuleInitializationLevel p_level) {
 
 		case MODULE_INITIALIZATION_LEVEL_SERVERS: {
 #ifdef TOOLS_ENABLED
-			if (GD_IS_CLASS_ENABLED(MovieWriterOGV)) {
+			if constexpr (GD_IS_CLASS_ENABLED(MovieWriterOGV)) {
 				memdelete(writer_ogv);
 			}
 #endif

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -371,17 +371,17 @@ void register_scene_types() {
 
 	Node::init_node_hrcr();
 
-	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+	if constexpr (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
 		resource_loader_stream_texture.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_stream_texture);
 	}
 
-	if (GD_IS_CLASS_ENABLED(TextureLayered)) {
+	if constexpr (GD_IS_CLASS_ENABLED(TextureLayered)) {
 		resource_loader_texture_layered.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_texture_layered);
 	}
 
-	if (GD_IS_CLASS_ENABLED(Texture3D)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Texture3D)) {
 		resource_loader_texture_3d.instantiate();
 		ResourceLoader::add_resource_format_loader(resource_loader_texture_3d);
 	}
@@ -392,7 +392,7 @@ void register_scene_types() {
 	resource_loader_text.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_loader_text, true);
 
-	if (GD_IS_CLASS_ENABLED(Shader)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Shader)) {
 		resource_saver_shader.instantiate();
 		ResourceSaver::add_resource_format_saver(resource_saver_shader, true);
 
@@ -400,7 +400,7 @@ void register_scene_types() {
 		ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
 	}
 
-	if (GD_IS_CLASS_ENABLED(ShaderInclude)) {
+	if constexpr (GD_IS_CLASS_ENABLED(ShaderInclude)) {
 		resource_saver_shader_include.instantiate();
 		ResourceSaver::add_resource_format_saver(resource_saver_shader_include, true);
 
@@ -1390,17 +1390,17 @@ void unregister_scene_types() {
 
 	SceneDebugger::deinitialize();
 
-	if (GD_IS_CLASS_ENABLED(TextureLayered)) {
+	if constexpr (GD_IS_CLASS_ENABLED(TextureLayered)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);
 		resource_loader_texture_layered.unref();
 	}
 
-	if (GD_IS_CLASS_ENABLED(Texture3D)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Texture3D)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_texture_3d);
 		resource_loader_texture_3d.unref();
 	}
 
-	if (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
+	if constexpr (GD_IS_CLASS_ENABLED(CompressedTexture2D)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_stream_texture);
 		resource_loader_stream_texture.unref();
 	}
@@ -1411,7 +1411,7 @@ void unregister_scene_types() {
 	ResourceLoader::remove_resource_format_loader(resource_loader_text);
 	resource_loader_text.unref();
 
-	if (GD_IS_CLASS_ENABLED(Shader)) {
+	if constexpr (GD_IS_CLASS_ENABLED(Shader)) {
 		ResourceSaver::remove_resource_format_saver(resource_saver_shader);
 		resource_saver_shader.unref();
 
@@ -1419,7 +1419,7 @@ void unregister_scene_types() {
 		resource_loader_shader.unref();
 	}
 
-	if (GD_IS_CLASS_ENABLED(ShaderInclude)) {
+	if constexpr (GD_IS_CLASS_ENABLED(ShaderInclude)) {
 		ResourceSaver::remove_resource_format_saver(resource_saver_shader_include);
 		resource_saver_shader_include.unref();
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -344,7 +344,7 @@ void register_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(XRTracker);
 #endif // XR_DISABLED
 
-	if (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
+	if constexpr (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
 		writer_pngwav = memnew(MovieWriterPNGWAV);
 		MovieWriter::add_writer(writer_pngwav);
 	}
@@ -357,7 +357,7 @@ void unregister_server_types() {
 
 	ServersDebugger::deinitialize();
 	memdelete(shader_types);
-	if (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
+	if constexpr (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
 		memdelete(writer_pngwav);
 	}
 


### PR DESCRIPTION
- Partially reverts #105030

After more experimentation, it turns out that we *can* properly handle disabled class logic in `ClassDB`! The previous implementation that caused the migration to `object.h` was down to the logic being handled entirely in the `Object` class itself, but this can instead be handled externally via type traits. This won't have an immediate benefit, but once headers are cleaned up we'll be able to only have these checks where they're actually relevant: compilation files of bound classes

Additionally, this converts all existing conditionals of disabled classes to `constexpr`