### PR TITLE
Metal: Use correct environment variable to generate labels

### DIFF
--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -45,7 +45,7 @@ RenderingContextDriverMetal::~RenderingContextDriverMetal() {
 }
 
 Error RenderingContextDriverMetal::initialize() {
-	if (OS::get_singleton()->get_environment(U"METAL_DEVICE_WRAPPER_TYPE") == "1") {
+	if (OS::get_singleton()->get_environment("MTL_CAPTURE_ENABLED") == "1") {
 		capture_available = true;
 	}
 


### PR DESCRIPTION
Ensure capture is enabled with correct environment variable, `MTL_CAPTURE_ENABLED`.