### PR TITLE
Add spherical harmonics sky

### DIFF
--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -41,6 +41,7 @@
 #include "servers/rendering/renderer_rd/shaders/effects/cubemap_filter_raster.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/cubemap_roughness.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/cubemap_roughness_raster.glsl.gen.h"
+#include "servers/rendering/renderer_rd/shaders/effects/sh_from_cubemap.glsl.gen.h"
 #include "servers/rendering/renderer_rd/shaders/effects/specular_merge.glsl.gen.h"
 #include "servers/rendering/renderer_scene_render.h"
 
@@ -314,6 +315,13 @@ private:
 
 	} specular_merge;
 
+	struct SHfromCubemap {
+		ShFromCubemapShaderRD shader; // Compute Shader.
+		RID shader_version;
+		RID compute_pipeline;
+		RID uniform_set;
+	} sh_from_cubemap;
+
 	static CopyEffects *singleton;
 
 public:
@@ -354,6 +362,8 @@ public:
 	void cubemap_roughness_raster(RID p_source_rd_texture, RID p_dest_framebuffer, uint32_t p_face_id, uint32_t p_sample_count, float p_roughness, float p_size);
 
 	void merge_specular(RID p_dest_framebuffer, RID p_specular, RID p_base, RID p_reflection, uint32_t p_view_count);
+
+	void calculate_sh_from_cubemap(RID p_src_cubemap_texture, RID p_output_storage_buffer, bool p_compute_l2);
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -209,7 +209,8 @@ public:
 		RID radiance_base_cubemap; //cubemap for first layer, first cubemap
 		RID downsampled_radiance_cubemap;
 		DownsampleLayer downsampled_layer;
-		RID coefficient_buffer;
+
+		RID sh_coeff_buffer; // STORAGE buffer where the shader will store the calculated coefficients.
 
 		bool dirty = true;
 
@@ -298,6 +299,7 @@ public:
 	~SkyRD();
 
 	void setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_size);
+	void copy_spherical_harmonics_to_scene_data(RID p_env, RID p_ubo_to_update);
 	void update_radiance_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, const Vector3 &p_global_pos, double p_time, float p_luminance_multiplier = 1.0, float p_brightness_multiplier = 1.0);
 	void update_res_buffers(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, double p_time, float p_luminance_multiplier = 1.0, float p_brightness_multiplier = 1.0);
 	void draw_sky(RD::DrawListID p_draw_list, Ref<RenderSceneBuffersRD> p_render_buffers, RID p_env, RID p_fb, double p_time, float p_luminance_multiplier = 1.0, float p_brightness_multiplier = 1.0);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -695,6 +695,12 @@ void RenderForwardClustered::_setup_environment(const RenderDataRD *p_render_dat
 	}
 
 	p_render_data->scene_data->update_ubo(scene_state.uniform_buffers[p_index], get_debug_draw_mode(), env, reflection_probe_instance, p_render_data->camera_attributes, p_pancake_shadows, p_screen_size, p_default_bg_color, _render_buffers_get_luminance_multiplier(), p_opaque_render_buffers, p_apply_alpha_multiplier);
+	if (p_index == 0u && p_render_data->environment.is_valid()) {
+		RS::EnvironmentAmbientSource ambient_source = environment_get_ambient_source(p_render_data->environment);
+		if (ambient_source == RS::ENV_AMBIENT_SOURCE_SKY || ambient_source == RS::ENV_AMBIENT_SOURCE_BG) {
+			sky.copy_spherical_harmonics_to_scene_data(p_render_data->environment, scene_state.uniform_buffers[p_index]);
+		}
+	}
 
 	// now do implementation UBO
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2194,6 +2194,12 @@ void RenderForwardMobile::_setup_environment(const RenderDataRD *p_render_data, 
 	}
 
 	p_render_data->scene_data->update_ubo(scene_state.uniform_buffers[p_index], get_debug_draw_mode(), env, reflection_probe_instance, p_render_data->camera_attributes, p_pancake_shadows, p_screen_size, p_default_bg_color, _render_buffers_get_luminance_multiplier(), p_opaque_render_buffers, false);
+	if (p_index == 0u && p_render_data->environment.is_valid()) {
+		RS::EnvironmentAmbientSource ambient_source = environment_get_ambient_source(p_render_data->environment);
+		if (ambient_source == RS::ENV_AMBIENT_SOURCE_SKY || ambient_source == RS::ENV_AMBIENT_SOURCE_BG) {
+			sky.copy_spherical_harmonics_to_scene_data(p_render_data->environment, scene_state.uniform_buffers[p_index]);
+		}
+	}
 }
 
 /// RENDERING ///

--- a/servers/rendering/renderer_rd/shaders/effects/sh_from_cubemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/sh_from_cubemap.glsl
@@ -1,0 +1,475 @@
+#[compute]
+
+#version 450
+
+#VERSION_DEFINES
+
+// Uncomment this to use the slow version, which will compute everything in one thread.
+// This is useful to debug problems when you suspect the issue is in the parallel reduction algorithm.
+// #define SH_DEBUG_MODE
+
+// IMPORTANT: Increasing the sample count beyond 1024 can cause out-of-shared LDS memory on weak hardware.
+// To increase this value beyond 1024, small changes would be required (compute more samples per thread,
+// use multiple compute dispatches, or some clever thread group synchronization.
+// Basically beyond 1024 there are performance tradeoffs to consider).
+#define NUM_THREADS 1024u
+#define SAMPLES_PER_THREAD 1u
+
+#define SAMPLE_COUNT (NUM_THREADS * SAMPLES_PER_THREAD)
+
+#define M_PI 3.14159265359
+
+#ifdef SH_DEBUG_MODE
+layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
+#else
+layout(local_size_x = NUM_THREADS, local_size_y = 1, local_size_z = 1) in;
+#endif
+
+layout(push_constant, std430) uniform Constants {
+	uint compute_geomerics_l1;
+}
+constants;
+
+layout(set = 0, binding = 0) uniform samplerCube source_cubemap;
+layout(set = 0, binding = 1, std430) restrict writeonly buffer SHCoeffs {
+	// Always big enough to cover L2 version, even if using L1.
+	// Reference L1 version needs coeffs[3].
+	// Optimized version, baking as much as possible for evaluate_sh_l1_geomerics() needs coeffs[5].
+	vec4 coeffs[7];
+}
+sh;
+
+// For NUM_THREADS = 1024u, 12KB of memory for L0 + L1 and 16kb for L1.
+// Fits on every GPU model (smallest is 16KB). The data is encoded in 16-bit SNORM to save space.
+shared uint shared_lds[NUM_THREADS / 2u][8u];
+
+// Fibonacci Sphere (Sampling).
+vec3 to_vector(uint sample_idx_uint) {
+	const float sample_idx = float(sample_idx_uint);
+	const float offset = 2.0 / SAMPLE_COUNT;
+	const float increment = 2.39996322972865332223155550663361; // Golden Angle.
+	vec3 dir;
+	dir.y = (sample_idx * offset) - 1.0 + offset * 0.5;
+	const float r = sqrt(1.0 - dir.y * dir.y);
+	const float phi = sample_idx * increment;
+	dir.x = cos(phi) * r;
+	dir.z = sin(phi) * r;
+	return dir;
+}
+
+#define SAVE_TO_LDS_L1(idx)                                       \
+	shared_lds[idx][0] = packSnorm2x16(resl0.xy);                 \
+	shared_lds[idx][1] = packSnorm2x16(vec2(resl0.z, resl1n.x));  \
+	shared_lds[idx][2] = packSnorm2x16(resl1n.yz);                \
+	shared_lds[idx][3] = packSnorm2x16(resl10.xy);                \
+	shared_lds[idx][4] = packSnorm2x16(vec2(resl10.z, resl1p.x)); \
+	shared_lds[idx][5] = packSnorm2x16(resl1p.yz)
+
+#define LOAD_FROM_LDS_L1(idx)                        \
+	vec2 tmp0, tmp1;                                 \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][0]);      \
+	tmp1 = unpackSnorm2x16(shared_lds[idx][1]);      \
+	const vec3 other_resl0 = vec3(tmp0.xy, tmp1.x);  \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][2]);      \
+	const vec3 other_resl1n = vec3(tmp1.y, tmp0.xy); \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][3]);      \
+	tmp1 = unpackSnorm2x16(shared_lds[idx][4]);      \
+	const vec3 other_resl10 = vec3(tmp0.xy, tmp1.x); \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][5]);      \
+	const vec3 other_resl1p = vec3(tmp1.y, tmp0.xy)
+
+// We multiply by 0.5 in every iteration instead of dividing by SAMPLE_COUNT
+// at the end because otherwise, we'd be out of snorm range. And dividing at the
+// beginning would cause serious quantization issues. This is the 'least bad' option.
+#define MERGE_LDS_L1()                      \
+	resl0 = (resl0 + other_resl0) * 0.5;    \
+	resl1n = (resl1n + other_resl1n) * 0.5; \
+	resl10 = (resl10 + other_resl10) * 0.5; \
+	resl1p = (resl1p + other_resl1p) * 0.5
+
+#define SAVE_TO_LDS_L2(idx)                                         \
+	shared_lds[idx][0] = packSnorm2x16(resl2n2.xy);                 \
+	shared_lds[idx][1] = packSnorm2x16(vec2(resl2n2.z, resl2n1.x)); \
+	shared_lds[idx][2] = packSnorm2x16(resl2n1.yz);                 \
+	shared_lds[idx][3] = packSnorm2x16(resl200.xy);                 \
+	shared_lds[idx][4] = packSnorm2x16(vec2(resl200.z, resl2p1.x)); \
+	shared_lds[idx][5] = packSnorm2x16(resl2p1.yz);                 \
+	shared_lds[idx][6] = packSnorm2x16(resl2p2.xy);                 \
+	shared_lds[idx][7] = packSnorm2x16(vec2(resl2p2.z, 0.0));
+
+#define LOAD_FROM_LDS_L2(idx)                         \
+	vec2 tmp0, tmp1;                                  \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][0]);       \
+	tmp1 = unpackSnorm2x16(shared_lds[idx][1]);       \
+	const vec3 other_resl2n2 = vec3(tmp0.xy, tmp1.x); \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][2]);       \
+	const vec3 other_resl2n1 = vec3(tmp1.y, tmp0.xy); \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][3]);       \
+	tmp1 = unpackSnorm2x16(shared_lds[idx][4]);       \
+	const vec3 other_resl200 = vec3(tmp0.xy, tmp1.x); \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][5]);       \
+	const vec3 other_resl2p1 = vec3(tmp1.y, tmp0.xy); \
+	tmp0 = unpackSnorm2x16(shared_lds[idx][6]);       \
+	tmp1 = unpackSnorm2x16(shared_lds[idx][7]);       \
+	const vec3 other_resl2p2 = vec3(tmp0.xy, tmp1.x)
+
+#define MERGE_LDS_L2()                         \
+	resl2n2 = (resl2n2 + other_resl2n2) * 0.5; \
+	resl2n1 = (resl2n1 + other_resl2n1) * 0.5; \
+	resl200 = (resl200 + other_resl200) * 0.5; \
+	resl2p1 = (resl2p1 + other_resl2p1) * 0.5; \
+	resl2p2 = (resl2p2 + other_resl2p2) * 0.5
+
+void store_data_l1(vec3 resl0, vec3 resl1n, vec3 resl10, vec3 resl1p) {
+#ifdef REFERENCE_SH_IMPL
+	// Is this the best encoding? For scalar (Desktop) GPUs it doesn't matter, so this arrangement
+	// makes perfect use of contiguous 48 bytes.
+	//
+	// However VLIW archs (like found on not-so-older Android) could benefit from using
+	// vec4 coeffs[4] and waste coeffs[i].w.
+	sh.coeffs[0].x = resl0.x;
+	sh.coeffs[1].x = resl0.y;
+	sh.coeffs[2].x = resl0.z;
+
+	sh.coeffs[0].y = resl1n.x;
+	sh.coeffs[1].y = resl1n.y;
+	sh.coeffs[2].y = resl1n.z;
+
+	sh.coeffs[0].z = resl10.x;
+	sh.coeffs[1].z = resl10.y;
+	sh.coeffs[2].z = resl10.z;
+
+	sh.coeffs[0].w = resl1p.x;
+	sh.coeffs[1].w = resl1p.y;
+	sh.coeffs[2].w = resl1p.z;
+#else
+	// NOTE: R0 can't be negative (unless input colors are).
+	// R1 can be negative. lenR1 cannot be negative (because it's a length).
+	// We use 1e-6 to prevent divisions by zero. This is handled properly in Desktop GPUs, but mobile
+	// is anyone's guess since full IEEE-754 compliance is not mandated.
+	const vec3 R0 = resl0;
+	const vec3 safe_R0 = max(resl0, vec3(1e-6));
+	vec3 R1[3]; // R1[channel].
+	R1[0] = 0.5 * vec3(resl1p[0], resl1n[0], resl10[0]);
+	R1[1] = 0.5 * vec3(resl1p[1], resl1n[1], resl10[1]);
+	R1[2] = 0.5 * vec3(resl1p[2], resl1n[2], resl10[2]);
+	const vec3 lenR1 = max(vec3(length(R1[0]), length(R1[1]), length(R1[2])), vec3(1e-6));
+	const vec3 p = 1.0 + 2.0 * lenR1 / safe_R0;
+	const vec3 a = (1.0 - lenR1 / safe_R0) / (1.0 + lenR1 / safe_R0);
+
+	R1[0] = R1[0] / lenR1[0];
+	R1[1] = R1[1] / lenR1[1];
+	R1[2] = R1[2] / lenR1[2];
+
+	sh.coeffs[0].xyzw = vec4(R0.xyz, R1[0].x);
+	sh.coeffs[1].xyzw = vec4(R1[0].yz, R1[1].xy);
+	sh.coeffs[2].xyzw = vec4(R1[1].z, R1[2].xyz);
+	sh.coeffs[3].xyzw = vec4(p.xyz, a.x);
+	sh.coeffs[4].xyzw = vec4(a.yz, 0.0, 0.0);
+#endif
+}
+
+void store_data_l2_l1(vec3 resl0, vec3 resl1n, vec3 resl10, vec3 resl1p) {
+	sh.coeffs[0].xyzw = vec4(resl0.xyz, resl1p.x);
+	sh.coeffs[1].xyzw = vec4(resl1n.xyz, resl1p.y);
+	sh.coeffs[2].xyzw = vec4(resl10.xyz, resl1p.z);
+}
+
+void store_data_l2_l2(vec3 resl2n2, vec3 resl2n1, vec3 resl200, vec3 resl2p1, vec3 resl2p2) {
+	sh.coeffs[3].xyzw = vec4(resl2n2.xyz, resl2p1.x);
+	sh.coeffs[4].xyzw = vec4(resl2n1.xyz, resl2p1.y);
+	sh.coeffs[5].xyzw = vec4(resl200.xyz, resl2p1.z);
+	sh.coeffs[6].xyzw = vec4(resl2p2.xyz, 0.0);
+}
+
+void main() {
+	const float MDISABLE = 1.0;
+
+#ifdef SH_DEBUG_MODE
+	vec3 resl0 = vec3(0.0);
+	vec3 resl1n = vec3(0.0);
+	vec3 resl10 = vec3(0.0);
+	vec3 resl1p = vec3(0.0);
+
+	vec3 resl2n2 = vec3(0.0);
+	vec3 resl2n1 = vec3(0.0);
+	vec3 resl200 = vec3(0.0);
+	vec3 resl2p1 = vec3(0.0);
+	vec3 resl2p2 = vec3(0.0);
+
+	// Debug mode processes everything in one thread. It's slow, but easy to debug & understand.
+	for (uint _thread_id = 0u; _thread_id < NUM_THREADS; ++_thread_id) {
+		vec3 tmp_resl0 = vec3(0.0);
+		vec3 tmp_resl1n = vec3(0.0);
+		vec3 tmp_resl10 = vec3(0.0);
+		vec3 tmp_resl1p = vec3(0.0);
+		vec3 tmp_resl2n2 = vec3(0.0);
+		vec3 tmp_resl2n1 = vec3(0.0);
+		vec3 tmp_resl200 = vec3(0.0);
+		vec3 tmp_resl2p1 = vec3(0.0);
+		vec3 tmp_resl2p2 = vec3(0.0);
+
+		for (uint s = 0u; s < SAMPLES_PER_THREAD; ++s) {
+			const uint sample_idx = _thread_id * SAMPLES_PER_THREAD + s;
+			const vec3 dir = to_vector(sample_idx);
+			const vec3 col = textureLod(source_cubemap, dir * vec3(-1.0, -1.0, 1.0), 0.0).xyz;
+			// L0 + L1.
+			tmp_resl0 += col;
+			tmp_resl1n += col * dir.y;
+			tmp_resl10 += col * dir.z;
+			tmp_resl1p += col * dir.x;
+
+			// L2.
+			tmp_resl2n2 += col * dir.x * dir.y * MDISABLE;
+			tmp_resl2n1 += col * dir.y * dir.z * MDISABLE;
+			tmp_resl200 += col * (3.0 * dir.z * dir.z - 1.0) * MDISABLE;
+			tmp_resl2p1 += col * dir.x * dir.z * MDISABLE;
+			tmp_resl2p2 += col * ((dir.x * dir.x) - (dir.y * dir.y)) * MDISABLE;
+		}
+		// L0 + L1.
+		resl0 += tmp_resl0 * (1.0 / SAMPLES_PER_THREAD);
+		resl1n += tmp_resl1n * (1.0 / SAMPLES_PER_THREAD);
+		resl10 += tmp_resl10 * (1.0 / SAMPLES_PER_THREAD);
+		resl1p += tmp_resl1p * (1.0 / SAMPLES_PER_THREAD);
+
+		// L2.
+		resl2n2 += tmp_resl2n2 * (1.0 / SAMPLES_PER_THREAD);
+		resl2n1 += tmp_resl2n1 * (1.0 / SAMPLES_PER_THREAD);
+		resl200 += tmp_resl200 * (1.0 / SAMPLES_PER_THREAD);
+		resl2p1 += tmp_resl2p1 * (1.0 / SAMPLES_PER_THREAD);
+		resl2p2 += tmp_resl2p2 * (1.0 / SAMPLES_PER_THREAD);
+	}
+
+	resl0 *= M_PI / NUM_THREADS * 0.28209479177387814;
+	resl1n *= M_PI / NUM_THREADS * -0.4886025119029199;
+	resl10 *= M_PI / NUM_THREADS * 0.4886025119029199;
+	resl1p *= M_PI / NUM_THREADS * -0.4886025119029199;
+
+	resl2n2 *= M_PI / NUM_THREADS * 1.09254843059208;
+	resl2n1 *= M_PI / NUM_THREADS * -1.09254843059208;
+	resl200 *= M_PI / NUM_THREADS * 0.31539156525252;
+	resl2p1 *= M_PI / NUM_THREADS * -1.09254843059208;
+	resl2p2 *= M_PI / NUM_THREADS * 0.54627421529604;
+
+	if (constants.compute_geomerics_l1 != 0u) {
+		store_data_l1(resl0, resl1n, resl10, resl1p);
+	} else {
+		store_data_l2_l1(resl0, resl1n, resl10, resl1p);
+		store_data_l2_l2(resl2n2, resl2n1, resl200, resl2p1, resl2p2);
+	}
+#else // !SH_DEBUG_MODE
+	// The real implementation works like this:
+	//
+	// GPUs have a limit of 1024 threads per threadgroup (also, we run into shared LDS limits too).
+	// Having that in mind...
+	//
+	// For L0+L1 we launch a threadgroup w/ 1024 threads. Each one processes SAMPLES_PER_THREAD samples.
+	// Then uses parallel-sum to combine all those 1024 results into just 1 value (9 to be exact).
+	//
+	// For L2 we also launch 1024 threads. And perform exactly the same as we did with L0+L1, except
+	// that the results will be written to another region of memory that doesn't overlap (it might
+	// cause false cache sharing if such thing can happen on GPUs, but it's only for the last 2 threads
+	// at the end. It shouldn't be a problem).
+	//
+	// We launch one dispatch with 2 threadgroups. We identify the threadgroup that processes
+	// L0+L1 when gl_WorkGroupID.x == 0 and the one that processes L2 when gl_WorkGroupID.x == 1.
+	//
+	// NOTE: Parallel reduction makes heavy use of barrier(). All threads in the same threadgroup
+	// must hit the barrier or else it's undefined behavior. Be mindful of this when using loops
+	// or branches, they can't diverge.  This is not a problem for L0+L1 vs L2 code paths because all
+	// threadgroups take the same paths.
+
+	const uint thread_idx = gl_LocalInvocationIndex;
+	const bool l2_group = gl_WorkGroupID.x != 0u;
+
+	if (!l2_group) {
+		// L0 + L1.
+		vec3 resl0 = vec3(0.0);
+		vec3 resl1n = vec3(0.0);
+		vec3 resl10 = vec3(0.0);
+		vec3 resl1p = vec3(0.0);
+
+		for (uint s = 0u; s < SAMPLES_PER_THREAD; ++s) {
+			const uint sample_idx = thread_idx * SAMPLES_PER_THREAD + s;
+			const vec3 dir = to_vector(sample_idx);
+			const vec3 col = textureLod(source_cubemap, dir * vec3(1.0, 1.0, 1.0), 0.0).xyz;
+			resl0 += col;
+			resl1n += col * dir.y;
+			resl10 += col * dir.z;
+			resl1p += col * dir.x;
+		}
+
+		// We must keep these values within the SNORM range [-1.0; 1.0] because of our LDS.
+		resl0 *= (1.0 / SAMPLES_PER_THREAD);
+		resl1n *= (1.0 / SAMPLES_PER_THREAD);
+		resl10 *= (1.0 / SAMPLES_PER_THREAD);
+		resl1p *= (1.0 / SAMPLES_PER_THREAD);
+
+		// -----------------------------------
+		// Now perform parallel sum reduction.
+		// -----------------------------------
+
+		// The first iteration must be done by hand because otherwise, shared_lds[]
+		// would need to be twice its size.
+
+		if (thread_idx >= NUM_THREADS / 2u) {
+			const uint dst_idx = thread_idx - NUM_THREADS / 2u;
+			SAVE_TO_LDS_L1(dst_idx);
+		}
+
+		// memoryBarrierShared ensures our write is visible to everyone else (must be done BEFORE the barrier).
+		// barrier ensures every thread's execution reached here.
+		memoryBarrierShared();
+		barrier();
+
+		if (thread_idx < NUM_THREADS / 2u) {
+			const uint src_idx = thread_idx;
+			LOAD_FROM_LDS_L1(src_idx);
+			MERGE_LDS_L1();
+			SAVE_TO_LDS_L1(src_idx);
+		}
+
+		// Repeat the same, generically.
+#pragma unroll
+		for (uint s = NUM_THREADS / 4u; s > 1u; s >>= 1u) {
+			const uint dst_idx = thread_idx;
+			const uint src_idx = thread_idx + s;
+
+			memoryBarrierShared();
+			barrier();
+
+			if (dst_idx < s) {
+				LOAD_FROM_LDS_L1(src_idx);
+				MERGE_LDS_L1();
+				SAVE_TO_LDS_L1(dst_idx);
+			}
+		}
+
+		// The last step is also done by hand to avoid a SAVE_TO_LDS_L1() call.
+		// TODO: We could also improve this by finishing a few steps earlier and use subgroups.
+		//
+		// Using subgroups is dangerous because the multiple if statements may not maximally reconverge
+		// unless explicitly using that feature. We also need to account for the different subgroup sizes
+		// and make sure all data ends up in a contiguous wavefront (which supposedly we already do).
+		{
+			const uint dst_idx = thread_idx;
+			const uint src_idx = thread_idx + 1u;
+
+			memoryBarrierShared();
+			barrier();
+
+			if (dst_idx == 0u) {
+				LOAD_FROM_LDS_L1(src_idx);
+				MERGE_LDS_L1();
+
+				resl0 *= M_PI * 0.28209479177387814;
+				resl1n *= M_PI * 0.4886025119029199;
+				resl10 *= M_PI * 0.4886025119029199;
+				resl1p *= M_PI * 0.4886025119029199;
+
+				if (constants.compute_geomerics_l1 != 0u) {
+					store_data_l1(resl0, resl1n, resl10, resl1p);
+				} else {
+					store_data_l2_l1(resl0, resl1n, resl10, resl1p);
+				}
+			}
+		}
+	} else {
+		// L2.
+		vec3 resl2n2 = vec3(0.0);
+		vec3 resl2n1 = vec3(0.0);
+		vec3 resl200 = vec3(0.0);
+		vec3 resl2p1 = vec3(0.0);
+		vec3 resl2p2 = vec3(0.0);
+
+		for (uint s = 0u; s < SAMPLES_PER_THREAD; ++s) {
+			const uint sample_idx = thread_idx * SAMPLES_PER_THREAD + s;
+			const vec3 dir = to_vector(sample_idx);
+			const vec3 col = textureLod(source_cubemap, dir * vec3(1.0, 1.0, 1.0), 0.0).xyz;
+
+			resl2n2 += col * dir.x * dir.y * MDISABLE;
+			resl2n1 += col * dir.y * dir.z * MDISABLE;
+			resl200 += col * (3.0 * dir.z * dir.z - 1.0) * MDISABLE;
+			resl2p1 += col * dir.x * dir.z * MDISABLE;
+			resl2p2 += col * ((dir.x * dir.x) - (dir.y * dir.y)) * MDISABLE;
+		}
+
+		// We must keep these values within the SNORM range [-1.0; 1.0] because of our LDS.
+		resl2n2 *= (1.0 / SAMPLES_PER_THREAD);
+		resl2n1 *= (1.0 / SAMPLES_PER_THREAD);
+		resl200 *= (1.0 / SAMPLES_PER_THREAD);
+		resl2p1 *= (1.0 / SAMPLES_PER_THREAD);
+		resl2p2 *= (1.0 / SAMPLES_PER_THREAD);
+
+		// resl200 is in range [2; -1]. We need it in SNORM.
+		resl200 = clamp((resl200 - 0.5) * (1.0 / 1.5), -1.0, 1.0);
+
+		// -----------------------------------
+		// Now perform parallel sum reduction.
+		// -----------------------------------
+
+		if (thread_idx >= NUM_THREADS / 2u) {
+			const uint dst_idx = thread_idx - NUM_THREADS / 2u;
+			SAVE_TO_LDS_L2(dst_idx);
+		}
+
+		// memoryBarrierShared ensures our write is visible to everyone else (must be done BEFORE the barrier).
+		// barrier ensures every thread's execution reached here.
+		memoryBarrierShared();
+		barrier();
+
+		if (thread_idx < NUM_THREADS / 2u) {
+			const uint src_idx = thread_idx;
+			LOAD_FROM_LDS_L2(src_idx);
+			MERGE_LDS_L2();
+			SAVE_TO_LDS_L2(src_idx);
+		}
+
+		// Repeat the same, generically.
+#pragma unroll
+		for (uint s = NUM_THREADS / 4u; s > 1u; s >>= 1u) {
+			const uint dst_idx = thread_idx;
+			const uint src_idx = thread_idx + s;
+
+			memoryBarrierShared();
+			barrier();
+
+			if (dst_idx < s) {
+				LOAD_FROM_LDS_L2(src_idx);
+				MERGE_LDS_L2();
+				SAVE_TO_LDS_L2(dst_idx);
+			}
+		}
+
+		// The last step is also done by hand to avoid a SAVE_TO_LDS_L2() call.
+		// TODO: We could also improve this by finishing a few steps earlier and use subgroups.
+		//
+		// Using subgroups is dangerous because the multiple if statements may not maximally reconverge
+		// unless explicitly using that feature. We also need to account for the different subgroup sizes
+		// and make sure all data ends up in a contiguous wavefront (which supposedly we already do).
+		{
+			const uint dst_idx = thread_idx;
+			const uint src_idx = thread_idx + 1u;
+
+			memoryBarrierShared();
+			barrier();
+
+			if (dst_idx == 0u) {
+				LOAD_FROM_LDS_L2(src_idx);
+				MERGE_LDS_L2();
+
+				// Restore resl200 to its range [2; -1].
+				resl200 = resl200 * 1.5 + 0.5;
+
+				resl2n2 *= M_PI * 1.09254843059208;
+				resl2n1 *= M_PI * 1.09254843059208;
+				resl200 *= M_PI * 0.31539156525252;
+				resl2p1 *= M_PI * 1.09254843059208;
+				resl2p2 *= M_PI * 0.54627421529604;
+
+				store_data_l2_l2(resl2n2, resl2n1, resl200, resl2p1, resl2p2);
+			}
+		}
+	}
+#endif
+}

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -987,6 +987,10 @@ layout(location = 0) out vec4 frag_color;
 
 #ifndef MODE_RENDER_DEPTH
 
+#ifndef USE_LIGHTMAP
+#include "../spherical_harmonics_inc.glsl"
+#endif
+
 /*
 	Only supporting normal fog here.
 */
@@ -1559,9 +1563,9 @@ void main() {
 		if (sc_scene_use_ambient_cubemap()) {
 			vec3 ambient_dir = scene_data.radiance_inverse_xform * indirect_normal;
 #ifdef USE_RADIANCE_CUBEMAP_ARRAY
-			hvec3 cubemap_ambient = hvec3(texture(samplerCubeArray(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), vec4(ambient_dir, MAX_ROUGHNESS_LOD)).rgb);
+			hvec3 cubemap_ambient = evaluate_sh_l2(hvec3(ambient_dir), scene_data.ambient_sh_coeffs);
 #else
-			hvec3 cubemap_ambient = hvec3(textureLod(samplerCube(radiance_cubemap, DEFAULT_SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP), ambient_dir, MAX_ROUGHNESS_LOD).rgb);
+			hvec3 cubemap_ambient = evaluate_sh_l1_geomerics(hvec3(ambient_dir), scene_data.ambient_sh_coeffs);
 #endif //USE_RADIANCE_CUBEMAP_ARRAY
 			cubemap_ambient *= sc_luminance_multiplier();
 			cubemap_ambient *= half(scene_data.IBL_exposure_normalization);

--- a/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_data_inc.glsl
@@ -73,4 +73,6 @@ struct SceneData {
 	float IBL_exposure_normalization;
 	uint camera_visible_layers;
 	float pass_alpha_multiplier;
+
+	vec4 ambient_sh_coeffs[7];
 };

--- a/servers/rendering/renderer_rd/shaders/spherical_harmonics_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/spherical_harmonics_inc.glsl
@@ -1,0 +1,110 @@
+#ifdef REFERENCE_SH_IMPL
+// This is standard SH evaluation at L1 order. Not used.
+hvec3 evaluate_sh_l1(hvec3 dir, vec4 sh_coeffs[7]) {
+	return hvec3(sh_coeffs[0][0], sh_coeffs[1][0], sh_coeffs[2][0]) +
+			hvec3(sh_coeffs[0][1], sh_coeffs[1][1], sh_coeffs[2][1]) * dir.y +
+			hvec3(sh_coeffs[0][2], sh_coeffs[1][2], sh_coeffs[2][2]) * dir.z +
+			hvec3(sh_coeffs[0][3], sh_coeffs[1][3], sh_coeffs[2][3]) * dir.x;
+}
+
+// This is a modified SH evaluation at L1 order that fights the math to avoid "ringing" artifacts
+// caused by evaluate_sh_l1() returning negative values for certain inputs while conserving energy
+// i.e. physically correct. This function only handles one channel.
+//
+// 1. lenR1 can be precomputed. But it's not needed (see lenR1 / R0).
+// 2. R1[i] = R1[i] / lenR1[i] can be precomputed into R1[i].
+// 3. lenR1 / R0 can be precomputed.
+// 4. p and a can be precomputed.
+mediump half shEvaluateDiffuseL1Geomerics(hvec3 n, vec4 sh_coeffs[7], int channel) {
+	// https://web.archive.org/web/20160313132301/http://www.geomerics.com/wp-content/uploads/2015/08/CEDEC_Geomerics_ReconstructingDiffuseLighting1.pdf
+	// http://www.geomerics.com/wp-content/uploads/2015/08/CEDEC_Geomerics_ReconstructingDiffuseLighting1.pdf
+	hvec4 sh = hvec4(sh_coeffs[channel][0], sh_coeffs[channel][1], sh_coeffs[channel][2], sh_coeffs[channel][3]);
+
+	half R0 = sh[0];
+
+	hvec3 R1 = half(0.5) * hvec3(sh[3], sh[1], sh[2]);
+	half lenR1 = length(R1);
+	half q = half(0.5) * (half(1.0) + dot(R1 / lenR1, n));
+	half p = half(1.0) + 2.0f * lenR1 / R0;
+	half a = (half(1.0) - lenR1 / R0) / (half(1.0) + lenR1 / R0);
+
+	return R0 * (a + (half(1.0) - a) * (p + half(1.0)) * pow(q, p));
+}
+
+// Performs Geomerics' modified formula on all channels.
+hvec3 evaluate_sh_l1_geomerics(hvec3 n, vec4 sh_coeffs[7]) {
+	return hvec3(shEvaluateDiffuseL1Geomerics(n, sh_coeffs, 0),
+			shEvaluateDiffuseL1Geomerics(n, sh_coeffs, 1),
+			shEvaluateDiffuseL1Geomerics(n, sh_coeffs, 2));
+}
+
+// This is the same as evaluate_sh_l1_geomerics_inlined, but inlined so that RGB is evaluated
+// in the same body. It also contains optimization notes.
+hvec3 evaluate_sh_l1_geomerics_inlined(hvec3 dir, vec4 sh_coeffs[7]) {
+	const hvec3 R0 = hvec3(sh_coeffs[0][0], sh_coeffs[1][0], sh_coeffs[2][0]);
+	hvec3 R1[3];
+	// [Optimization] We can bake the 0.5 into the coeffs in the Compute Shader that calculates sh_coeffs.
+	R1[0] = half(0.5) * hvec3(sh_coeffs[0][3], sh_coeffs[0][1], sh_coeffs[0][2]);
+	R1[1] = half(0.5) * hvec3(sh_coeffs[1][3], sh_coeffs[1][1], sh_coeffs[1][2]);
+	R1[2] = half(0.5) * hvec3(sh_coeffs[2][3], sh_coeffs[2][1], sh_coeffs[2][2]);
+	// [Optimization] lenR1 can be precomputed. But it's not needed (see lenR1 / R0).
+	// [Optimization] R1[i] / lenR1[i] can be precomputed into R1[i].
+	// [Optimization] lenR1 / R0 can be precomputed.But it's not needed (see p & a).
+	// [Optimization] p and a can be precomputed.
+	const hvec3 lenR1 = hvec3(length(R1[0]), length(R1[1]), length(R1[2]));
+	const hvec3 q = half(0.5) * (half(1.0) + hvec3(dot(R1[0] / lenR1[0], dir), // r
+													 dot(R1[1] / lenR1[1], dir), // g
+													 dot(R1[2] / lenR1[2], dir))); // b
+	const hvec3 p = half(1.0) + half(2.0) * lenR1 / R0;
+	const hvec3 a = (half(1.0) - lenR1 / R0) / (half(1.0) + lenR1 / R0);
+
+	return R0 * (a + (half(1.0) - a) * (p + half(1.0)) * hvec3(pow(q.x, p.x), pow(q.y, p.y), pow(q.z, p.z)));
+}
+#else
+
+// See REFERENCE_SH_IMPL version for details.
+// sh_coeffs no longer contains the SH coefficients, but rather prebaked versions to avoid
+// uniform-on-uniform math. See "[Optimization]" in evaluate_sh_l1_geomerics_inlined.
+hvec3 evaluate_sh_l1_geomerics(hvec3 dir, vec4 sh_coeffs[7]) {
+	// Load from uniforms.
+	const hvec3 R0 = hvec3(sh_coeffs[0].xyz);
+	hvec3 R1_div_lenR1[3];
+	R1_div_lenR1[0] = hvec3(sh_coeffs[0].w, sh_coeffs[1].xy);
+	R1_div_lenR1[1] = hvec3(sh_coeffs[1].zw, sh_coeffs[2].x);
+	R1_div_lenR1[2] = hvec3(sh_coeffs[2].yzw);
+	const hvec3 p = hvec3(sh_coeffs[3].xyz);
+	const hvec3 a = hvec3(sh_coeffs[3].w, sh_coeffs[4].xy);
+
+	// Actual math.
+	hvec3 q = half(0.5) * (half(1.0) + hvec3(dot(R1_div_lenR1[0], dir), // r
+											   dot(R1_div_lenR1[1], dir), // g
+											   dot(R1_div_lenR1[2], dir))); // b
+	// q should be in range [0; 1] but due to floating point woes, it may land out of
+	// range as a small dot at the poles. Negative values will produce NaNs.
+	q = clamp(q, hvec3(0.0), hvec3(1.0));
+
+	return R0 * (a + (half(1.0) - a) * (p + half(1.0)) * hvec3(pow(q.x, p.x), pow(q.y, p.y), pow(q.z, p.z)));
+}
+#endif
+
+hvec3 evaluate_sh_l2(hvec3 dir, vec4 sh_coeffs[7]) {
+	const hvec3 resl0 = hvec3(sh_coeffs[0].xyz);
+	const hvec3 resl1n = hvec3(sh_coeffs[1].xyz);
+	const hvec3 resl10 = hvec3(sh_coeffs[2].xyz);
+	const hvec3 resl1p = hvec3(sh_coeffs[0].w, sh_coeffs[1].w, sh_coeffs[2].w);
+	const hvec3 resl2n2 = hvec3(sh_coeffs[3].xyz);
+	const hvec3 resl2n1 = hvec3(sh_coeffs[4].xyz);
+	const hvec3 resl200 = hvec3(sh_coeffs[5].xyz);
+	const hvec3 resl2p1 = hvec3(sh_coeffs[3].w, sh_coeffs[4].w, sh_coeffs[5].w);
+	const hvec3 resl2p2 = hvec3(sh_coeffs[6].xyz);
+
+	return resl0 //
+			+ resl1n * dir.y //
+			+ resl10 * dir.z //
+			+ resl1p * dir.x //
+			+ resl2n2 * dir.x * dir.y //
+			+ resl2n1 * dir.y * dir.z //
+			+ resl200 * (half(3.0) * dir.z * dir.z - half(1.0)) //
+			+ resl2p1 * dir.x * dir.z //
+			+ resl2p2 * (dir.x * dir.x - dir.y * dir.y);
+}

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -94,6 +94,10 @@ public:
 	void update_ubo(RID p_uniform_buffer, RS::ViewportDebugDraw p_debug_mode, RID p_env, RID p_reflection_probe_instance, RID p_camera_attributes, bool p_pancake_shadows, const Size2i &p_screen_size, const Color &p_default_bg_color, float p_luminance_multiplier, bool p_opaque_render_buffers, bool p_apply_alpha_multiplier);
 	virtual RID get_uniform_buffer() const override;
 
+	static uint32_t get_sh_coeffs_offset_bytes() {
+		return offsetof(UBO, ambient_sh_coeffs);
+	}
+
 private:
 	RID uniform_buffer; // loaded into this uniform buffer (supplied externally)
 
@@ -168,6 +172,10 @@ private:
 		float IBL_exposure_normalization; // Adjusts for baked exposure.
 		uint32_t camera_visible_layers;
 		float pass_alpha_multiplier;
+
+		// ambient_sh_coeffs is filled from GPU, not from CPU, via a buffer_copy().
+		// See get_sh_coeffs_offset_bytes(). Always big enough to cover L2 version, even if using L1.
+		float ambient_sh_coeffs[7][4];
 	};
 
 	struct UBODATA {


### PR DESCRIPTION
> [!NOTE]
> We were pressed for time so testing is appreciated (both performance, quality, and stability).

For ambient lighting Godot supports using cubemap arrays vs a single cubemap (controlled by `rendering/reflections/sky_reflections/texture_array_reflections`). The former gives a lot more quality\*, but is expensive. The latter is simply faster and more compatible.

However the "single cubemap" version has two problems:

1. It's too low quality (it's essentially 2x2 cubemap; that is a total of 64 samples).
2. It appeared as a performance issue when benchmarking on the Quest 3.

This PR replaces the use of the "single cubemap" version for L1 Spherical Harmonics in hopes of achieving:

1. Faster performance (claim not challenged / profiled).
2. Considerably higher quality (the SH collects 1024 samples and has no aliasing / filtering issues due to its mathematical nature) than the single cubemap version.

Evaluating performance in all devices is complex. Bandwidth-limited GPUs are going to prefer the SH version, while ALU-limited GPUs will prefer the cubemap version. Furthermore it is to be expected that the cubemap version could win in very high resolutions (e.g. 4k rendering) due to texture cache effects; specially on Desktop GPUs that are able to hide the texture fetch latency.

With @clayjohn we are considering making the SH version the only version available for everything (i.e. get rid of the cubemap array too!) to:

1. Increase look consistency between pipelines (PC vs Mobile settings, Clustered vs Mobile).
2. Decrease maintenance (and shader compilation) complexity.
3. The user should not have to worry about this detail as there are 3 competing solutions (cubemap arrays, single cubemap, SH) to do the same thing.

Cubemaps arrays are not entirely going away though, because they are still used for specular reflections. This only affects "sky" ambient lighting.

> [!NOTE]
> To test this feature you must set `rendering/reflections/sky_reflections/texture_array_reflections` to false

(\*) I'm not exactly sure about quality, because comparing the cubemap array, it's very apparent it's significantly brighter than it should be.

- *Production edit: Related to https://github.com/godotengine/godot-proposals/issues/11530.*