### PR TITLE
Carry editor pseudolocalization CLI option across restarts

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1087,7 +1087,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
 			forwardable_cli_arguments[CLI_SCOPE_PROJECT].push_back(arg);
 		}
-		if (arg == "--single-window") {
+		if (arg == "--single-window" || arg == "--editor-pseudolocalization") {
 			forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
 		}
 		if (arg == "--audio-driver" ||
@@ -1803,6 +1803,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #ifdef TOOLS_ENABLED
 		} else if (arg == "--editor-pseudolocalization") {
 			editor_pseudolocalization = true;
+			main_args.push_back(arg);
 #endif // TOOLS_ENABLED
 		} else if (arg == "--profile-gpu") {
 			profile_gpu = true;


### PR DESCRIPTION
This PR keeps the `--editor-pseudolocalization` option when spawning a new instance:

- Project Manager / Editor restarts after certain editor settings are changed.
- Switching between the Project Manager and the Editor.