### PR TITLE
[3.x] `FTI` - Clear all when enabling / disabling `SceneTreeFTI`

### DIFF
--- a/scene/main/scene_tree_fti.cpp
+++ b/scene/main/scene_tree_fti.cpp
@@ -87,6 +87,17 @@ void SceneTreeFTI::set_enabled(Node *p_root, bool p_enabled) {
 	data.tick_xform_list[0].clear();
 	data.tick_xform_list[1].clear();
 
+	data.frame_xform_list.clear();
+	data.frame_xform_list_forced.clear();
+
+	data.tick_property_list[0].clear();
+	data.tick_property_list[1].clear();
+
+	data.frame_property_list.clear();
+	data.request_reset_list.clear();
+
+	_clear_depth_lists();
+
 	// Spatial flags must be reset.
 	if (p_root) {
 		_reset_flags(p_root);


### PR DESCRIPTION
Removes any dangling objects when toggling `set_enabled()` for `SceneTreeFTI`.
These could cause crashes / errors if deleted between toggling the setting.

Backport of #108131

## MRP
_(in 4.x, but same bug in 3.x)_
Run https://github.com/godotengine/godot-demo-projects/pull/1223 and keep toggling physics interpolation by pressing `T` while firing.. the `DEV_ASSERT()` will hit.

## Notes
* Sorry my bad, I forgot to clear these completely when adding more lists.
* Should be very safe.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
