### PR TITLE
[SDL] Fix missing header build error on some Linux systems.

### DIFF
--- a/thirdparty/sdl/joystick/SDL_sysjoystick.h
+++ b/thirdparty/sdl/joystick/SDL_sysjoystick.h
@@ -26,6 +26,8 @@
 // This is the system specific header for the SDL joystick API
 #include "SDL_joystick_c.h"
 
+#include <stdlib.h>
+
 // Set up for C function definitions, even when using C++
 #ifdef __cplusplus
 extern "C" {

--- a/thirdparty/sdl/patches/0003-std-include.patch
+++ b/thirdparty/sdl/patches/0003-std-include.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/sdl/joystick/SDL_sysjoystick.h b/thirdparty/sdl/joystick/SDL_sysjoystick.h
+index 041ebc3b50..9b6ea65e9c 100644
+--- a/thirdparty/sdl/joystick/SDL_sysjoystick.h
++++ b/thirdparty/sdl/joystick/SDL_sysjoystick.h
+@@ -26,6 +26,8 @@
+ // This is the system specific header for the SDL joystick API
+ #include "SDL_joystick_c.h"
+ 
++#include <stdlib.h>
++
+ // Set up for C function definitions, even when using C++
+ #ifdef __cplusplus
+ extern "C" {


### PR DESCRIPTION
I'm getting build errors on Asahi Linux (arm64) using GCC 15.1.1, but having `stdlib` included for `free` seems to be a generic C99+ requirement, so it's likely not specific to this config.

```
thirdparty/sdl/joystick/linux/SDL_sysjoystick.c:781:9: error: implicit declaration of function 'free' [-Wimplicit-function-declaration]
  781 |         free(entries[i]); // This should NOT be SDL_free()
      |         ^~~~
thirdparty/sdl/joystick/linux/SDL_sysjoystick.c:126:1: note: include '<stdlib.h>' or provide a declaration of 'free'
  125 | #include "../../core/linux/SDL_udev.h"
```