### PR TITLE
Expose methods to access FileDialog's favorite/recent lists

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -47,6 +47,12 @@
 				Clear all currently selected items in the dialog.
 			</description>
 		</method>
+		<method name="get_favorite_list" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of favorite directories, which is shared by all [FileDialog] nodes. Useful to store the list of favorites between project sessions. This method can be called only from the main thread.
+			</description>
+		</method>
 		<method name="get_line_edit">
 			<return type="LineEdit" />
 			<description>
@@ -73,6 +79,12 @@
 			<param index="0" name="option" type="int" />
 			<description>
 				Returns an array of values of the [OptionButton] with index [param option].
+			</description>
+		</method>
+		<method name="get_recent_list" qualifiers="static">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of recent directories, which is shared by all [FileDialog] nodes. Useful to store the list of recents between project sessions. This method can be called only from the main thread.
 			</description>
 		</method>
 		<method name="get_selected_options" qualifiers="const">
@@ -111,6 +123,14 @@
 				Toggles the specified customization [param flag], allowing to customize features available in this [FileDialog]. See [enum Customization] for options.
 			</description>
 		</method>
+		<method name="set_favorite_list" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="favorites" type="PackedStringArray" />
+			<description>
+				Sets the list of favorite directories, which is shared by all [FileDialog] nodes. Useful to restore the list of favorites saved with [method get_favorite_list]. This method can be called only from the main thread.
+				[b]Note:[/b] [FileDialog] will update its internal [ItemList] of favorites when its visibility changes. Be sure to call this method earlier if you want your changes to have effect.
+			</description>
+		</method>
 		<method name="set_option_default">
 			<return type="void" />
 			<param index="0" name="option" type="int" />
@@ -133,6 +153,14 @@
 			<param index="1" name="values" type="PackedStringArray" />
 			<description>
 				Sets the option values of the [OptionButton] with index [param option].
+			</description>
+		</method>
+		<method name="set_recent_list" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="recents" type="PackedStringArray" />
+			<description>
+				Sets the list of recent directories, which is shared by all [FileDialog] nodes. Useful to restore the list of recents saved with [method set_recent_list]. This method can be called only from the main thread.
+				[b]Note:[/b] [FileDialog] will update its internal [ItemList] of recent directories when its visibility changes. Be sure to call this method earlier if you want your changes to have effect.
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1335,6 +1335,64 @@ FileDialog::DisplayMode FileDialog::get_display_mode() const {
 	return display_mode;
 }
 
+void FileDialog::set_favorite_list(const PackedStringArray &p_favorites) {
+	ERR_FAIL_COND_MSG(Thread::get_caller_id() != Thread::get_main_id(), "Setting favorite list can only be done on the main thread.");
+
+	global_favorites.clear();
+	global_favorites.reserve(p_favorites.size());
+	for (const String &fav : p_favorites) {
+		if (fav.ends_with("/")) {
+			global_favorites.push_back(fav);
+		} else {
+			global_favorites.push_back(fav + "/");
+		}
+	}
+}
+
+PackedStringArray FileDialog::get_favorite_list() {
+	PackedStringArray ret;
+	ERR_FAIL_COND_V_MSG(Thread::get_caller_id() != Thread::get_main_id(), ret, "Getting favorite list can only be done on the main thread.");
+
+	ret.resize(global_favorites.size());
+
+	String *fav_write = ret.ptrw();
+	int i = 0;
+	for (const String &fav : global_favorites) {
+		fav_write[i] = fav;
+		i++;
+	}
+	return ret;
+}
+
+void FileDialog::set_recent_list(const PackedStringArray &p_recents) {
+	ERR_FAIL_COND_MSG(Thread::get_caller_id() != Thread::get_main_id(), "Setting recent list can only be done on the main thread.");
+
+	global_recents.clear();
+	global_recents.reserve(p_recents.size());
+	for (const String &recent : p_recents) {
+		if (recent.ends_with("/")) {
+			global_recents.push_back(recent);
+		} else {
+			global_recents.push_back(recent + "/");
+		}
+	}
+}
+
+PackedStringArray FileDialog::get_recent_list() {
+	PackedStringArray ret;
+	ERR_FAIL_COND_V_MSG(Thread::get_caller_id() != Thread::get_main_id(), ret, "Getting recent list can only be done on the main thread.");
+
+	ret.resize(global_recents.size());
+
+	String *recent_write = ret.ptrw();
+	int i = 0;
+	for (const String &recent : global_recents) {
+		recent_write[i] = recent;
+		i++;
+	}
+	return ret;
+}
+
 void FileDialog::set_customization_flag_enabled(Customization p_flag, bool p_enabled) {
 	ERR_FAIL_INDEX(p_flag, CUSTOMIZATION_MAX);
 	if (customization_flags[p_flag] == p_enabled) {
@@ -1920,6 +1978,11 @@ void FileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_customization_flag_enabled", "flag", "enabled"), &FileDialog::set_customization_flag_enabled);
 	ClassDB::bind_method(D_METHOD("is_customization_flag_enabled", "flag"), &FileDialog::is_customization_flag_enabled);
 	ClassDB::bind_method(D_METHOD("deselect_all"), &FileDialog::deselect_all);
+
+	ClassDB::bind_static_method("FileDialog", D_METHOD("set_favorite_list", "favorites"), &FileDialog::set_favorite_list);
+	ClassDB::bind_static_method("FileDialog", D_METHOD("get_favorite_list"), &FileDialog::get_favorite_list);
+	ClassDB::bind_static_method("FileDialog", D_METHOD("set_recent_list", "recents"), &FileDialog::set_recent_list);
+	ClassDB::bind_static_method("FileDialog", D_METHOD("get_recent_list"), &FileDialog::get_recent_list);
 
 	ClassDB::bind_method(D_METHOD("invalidate"), &FileDialog::invalidate);
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -408,6 +408,12 @@ public:
 	void set_display_mode(DisplayMode p_mode);
 	DisplayMode get_display_mode() const;
 
+	static void set_favorite_list(const PackedStringArray &p_favorites);
+	static PackedStringArray get_favorite_list();
+
+	static void set_recent_list(const PackedStringArray &p_recents);
+	static PackedStringArray get_recent_list();
+
 	void set_customization_flag_enabled(Customization p_flag, bool p_enabled);
 	bool is_customization_flag_enabled(Customization p_flag) const;
 


### PR DESCRIPTION
Follow-up to #105680

Adds and exposes method for accessing the global favorite and recent directory lists.