### PR TITLE
Expose FileDialog callbacks for getting custom icons

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -131,6 +131,34 @@
 				[b]Note:[/b] [FileDialog] will update its internal [ItemList] of favorites when its visibility changes. Be sure to call this method earlier if you want your changes to have effect.
 			</description>
 		</method>
+		<method name="set_get_icon_callback" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<description>
+				Sets the callback used by the [FileDialog] nodes to get a file icon, when [constant DISPLAY_LIST] mode is used. The callback should take a single [String] argument (file path), and return a [Texture2D]. If an invalid texture is returned, the [theme_item file] icon will be used instead.
+			</description>
+		</method>
+		<method name="set_get_thumbnail_callback" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="callback" type="Callable" />
+			<description>
+				Sets the callback used by the [FileDialog] nodes to get a file icon, when [constant DISPLAY_THUMBNAILS] mode is used. The callback should take a single [String] argument (file path), and return a [Texture2D]. If an invalid texture is returned, the [theme_item file_thumbnail] icon will be used instead.
+				Thumbnails are usually more complex and may take a while to load. To avoid stalling the application, you can use [ImageTexture] to asynchronously create the thumbnail.
+				[codeblock]
+				func _ready():
+					FileDialog.set_get_thumbnail_callback(thumbnail_method)
+
+				func thumbnail_method(path):
+					var image_texture = ImageTexture.new()
+					make_thumbnail_async(path, image_texture)
+					return image_texture
+
+				func make_thumbnail_async(path, image_texture):
+					var thumbnail_texture = await generate_thumbnail(path) # Some method that generates a thumbnail.
+					image_texture.set_image(thumbnail_texture.get_image())
+				[/codeblock]
+			</description>
+		</method>
 		<method name="set_option_default">
 			<return type="void" />
 			<param index="0" name="option" type="int" />

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -46,6 +46,7 @@ class ConfirmationDialog;
 class Control;
 class FileDialog;
 class HBoxContainer;
+class ImageTexture;
 class MenuBar;
 class MenuButton;
 class OptionButton;
@@ -512,6 +513,10 @@ private:
 	}
 
 	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);
+	static Ref<Texture2D> _file_dialog_get_thumbnail(const String &p_path);
+	static void _file_dialog_thumbnail_callback(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Ref<ImageTexture> p_texture);
+	Ref<ImageTexture> default_thumbnail;
+
 	static void _file_dialog_register(FileDialog *p_dialog);
 	static void _file_dialog_unregister(FileDialog *p_dialog);
 	static void _editor_file_dialog_register(EditorFileDialog *p_dialog);

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -146,10 +146,11 @@ public:
 		CUSTOMIZATION_MAX
 	};
 
-	typedef Ref<Texture2D> (*GetIconFunc)(const String &);
 	typedef void (*RegisterFunc)(FileDialog *);
 
-	inline static GetIconFunc get_icon_func = nullptr;
+	inline static Callable get_icon_callback;
+	inline static Callable get_thumbnail_callback;
+
 	inline static RegisterFunc register_func = nullptr;
 	inline static RegisterFunc unregister_func = nullptr;
 
@@ -189,6 +190,7 @@ private:
 	String root_prefix;
 	String full_dir;
 
+	Callable thumbnail_callback;
 	bool is_invalidating = false;
 
 	VBoxContainer *main_vbox = nullptr;
@@ -338,6 +340,7 @@ private:
 	void _native_dialog_cb_with_options(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options);
 
 	bool _is_open_should_be_disabled();
+	void _thumbnail_callback(const Ref<Texture2D> &p_texture, const String &p_path);
 
 	TypedArray<Dictionary> _get_options() const;
 	void _update_option_controls();
@@ -429,6 +432,9 @@ public:
 	bool get_show_filename_filter() const;
 
 	static void set_default_show_hidden_files(bool p_show);
+
+	static void set_get_icon_callback(const Callable &p_callback);
+	static void set_get_thumbnail_callback(const Callable &p_callback);
 
 	void invalidate();
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -208,11 +208,20 @@ void ItemList::set_item_icon(int p_idx, const Ref<Texture2D> &p_icon) {
 	}
 	ERR_FAIL_INDEX(p_idx, items.size());
 
-	if (items[p_idx].icon == p_icon) {
+	Item &item = items.write[p_idx];
+	if (item.icon == p_icon) {
 		return;
 	}
 
-	items.write[p_idx].icon = p_icon;
+	const Callable redraw = callable_mp((CanvasItem *)this, &CanvasItem::queue_redraw);
+	if (item.icon.is_valid()) {
+		item.icon->disconnect_changed(redraw);
+	}
+	item.icon = p_icon;
+	if (p_icon.is_valid()) {
+		p_icon->connect_changed(redraw);
+	}
+
 	queue_redraw();
 	shape_changed = true;
 }


### PR DESCRIPTION
Follow-up to #105863

Adds and exposes methods that allow setting up custom icons in FileDialog. Replaces the old `get_icon_func`.