### PR TITLE
Fix multimesh memory leak and edge cases when using indirect drawing

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/mesh_storage.cpp
@@ -1572,7 +1572,10 @@ void MeshStorage::_multimesh_allocate_data(RID p_multimesh, int p_instances, RS:
 	multimesh->buffer_set = false;
 
 	multimesh->indirect = p_use_indirect;
-	multimesh->command_buffer = RID();
+	if (multimesh->command_buffer.is_valid()) {
+		RD::get_singleton()->free(multimesh->command_buffer);
+		multimesh->command_buffer = RID();
+	}
 
 	//print_line("allocate, elements: " + itos(p_instances) + " 2D: " + itos(p_transform_format == RS::MULTIMESH_TRANSFORM_2D) + " colors " + itos(multimesh->uses_colors) + " data " + itos(multimesh->uses_custom_data) + " stride " + itos(multimesh->stride_cache) + " total size " + itos(multimesh->stride_cache * multimesh->instances));
 	multimesh->data_cache = Vector<float>();
@@ -1670,19 +1673,20 @@ void MeshStorage::_multimesh_set_mesh(RID p_multimesh, RID p_mesh) {
 				RD::get_singleton()->free(multimesh->command_buffer);
 			}
 
-			Vector<uint8_t> newVector;
-			newVector.resize_initialized(sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE * mesh->surface_count);
+			Vector<uint8_t> command_buffer_arr;
+			command_buffer_arr.resize_initialized(sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE * mesh->surface_count);
+			uint8_t *command_buffer_ptr = command_buffer_arr.ptrw();
 
+			uint32_t instances = multimesh_get_instances_to_draw(p_multimesh);
 			for (uint32_t i = 0; i < mesh->surface_count; i++) {
 				uint32_t count = mesh_surface_get_vertices_drawn_count(mesh->surfaces[i]);
-				newVector.set(i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE, static_cast<uint8_t>(count));
-				newVector.set(i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE + 1, static_cast<uint8_t>(count >> 8));
-				newVector.set(i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE + 2, static_cast<uint8_t>(count >> 16));
-				newVector.set(i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE + 3, static_cast<uint8_t>(count >> 24));
+				uint32_t offset = i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE;
+				memcpy(command_buffer_ptr + offset, &count, sizeof(uint32_t));
+				memcpy(command_buffer_ptr + offset + sizeof(uint32_t), &instances, sizeof(uint32_t));
 			}
 
-			RID newBuffer = RD::get_singleton()->storage_buffer_create(sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE * mesh->surface_count, newVector, RD::STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT);
-			multimesh->command_buffer = newBuffer;
+			RID buffer = RD::get_singleton()->storage_buffer_create(sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE * mesh->surface_count, command_buffer_arr, RD::STORAGE_BUFFER_USAGE_DISPATCH_INDIRECT);
+			multimesh->command_buffer = buffer;
 		}
 	}
 
@@ -2197,8 +2201,9 @@ void MeshStorage::_multimesh_set_visible_instances(RID p_multimesh, int p_visibl
 	if (multimesh->indirect) { //we have to update the command buffer for the instance counts, in each stride this will be the second integer.
 		Mesh *mesh = mesh_owner.get_or_null(multimesh->mesh);
 		if (mesh != nullptr) {
+			int instances = multimesh_get_instances_to_draw(p_multimesh);
 			for (uint32_t i = 0; i < mesh->surface_count; i++) {
-				RD::get_singleton()->buffer_update(multimesh->command_buffer, (i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE) + sizeof(uint32_t), sizeof(uint32_t), &p_visible);
+				RD::get_singleton()->buffer_update(multimesh->command_buffer, (i * sizeof(uint32_t) * INDIRECT_MULTIMESH_COMMAND_STRIDE) + sizeof(uint32_t), sizeof(uint32_t), &instances);
 			}
 		}
 	}

--- a/servers/rendering/storage/mesh_storage.cpp
+++ b/servers/rendering/storage/mesh_storage.cpp
@@ -49,6 +49,7 @@ void RendererMeshStorage::multimesh_free(RID p_rid) {
 }
 
 void RendererMeshStorage::multimesh_allocate_data(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors, bool p_use_custom_data, bool p_use_indirect) {
+	ERR_FAIL_COND(p_instances < 0);
 	MultiMeshInterpolator *mmi = _multimesh_get_interpolator(p_multimesh);
 	if (mmi) {
 		mmi->_transform_format = p_transform_format;


### PR DESCRIPTION
Fixes:
- Indirect draw command buffer memory leak
- GPU out of memory if `use_indirect=true` and `multimesh_set_visible_instances(rid, -1)`
- GPU out of memory if `multimesh_allocate_data(rid, 1)` and then `multimesh_allocate_data(rid, -1)`

And:
- Simplify setting vertex count in the command buffer (follow-up to the 2nd in [99455#comment](https://github.com/godotengine/godot/pull/99455#pullrequestreview-2548874964))
- Follow the visible instance count rather than making all instances invisible, after setting a mesh with indirect drawing
