### PR TITLE
Improvements to multiple layer support

### DIFF
--- a/doc/classes/RenderSceneBuffersConfiguration.xml
+++ b/doc/classes/RenderSceneBuffersConfiguration.xml
@@ -37,7 +37,7 @@
 			Bias applied to mipmaps.
 		</member>
 		<member name="view_count" type="int" setter="set_view_count" getter="get_view_count" default="1">
-			The number of views we're rendering.
+			The number of views we're rendering. If larger than [code]1[/code] this will enable multiview rendering for stereoscopic or multiscopic views.
 		</member>
 	</members>
 </class>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3915,15 +3915,17 @@
 		<method name="viewport_get_render_target" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="layer" type="int" default="0" />
 			<description>
-				Returns the render target for the viewport.
+				Returns the render target for the [param layer] of the viewport.
 			</description>
 		</method>
 		<method name="viewport_get_texture" qualifiers="const">
 			<return type="RID" />
 			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="layer" type="int" default="0" />
 			<description>
-				Returns the viewport's last rendered frame.
+				Returns the viewport's last rendered frame for a [param layer].
 			</description>
 		</method>
 		<method name="viewport_get_update_mode" qualifiers="const">
@@ -4062,6 +4064,15 @@
 				Sets the viewport's global transformation matrix.
 			</description>
 		</method>
+		<method name="viewport_set_layer_count">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="layer_count" type="int" />
+			<description>
+				Sets the number of layers for this viewport. Each layer will be rendered separately.
+				[b]Note:[/b] This is an XR feature only, in other use cases the output of additional layers is discarded.
+			</description>
+		</method>
 		<method name="viewport_set_measure_render_time">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
@@ -4180,10 +4191,12 @@
 		<method name="viewport_set_size">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
-			<param index="1" name="width" type="int" />
-			<param index="2" name="height" type="int" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="width" type="int" />
+			<param index="3" name="height" type="int" />
+			<param index="4" name="view_count" type="int" />
 			<description>
-				Sets the viewport's width and height in pixels.
+				Sets the viewport's [param width], [param height] in pixels and the [param view_count] for the specified [param layer].
 			</description>
 		</method>
 		<method name="viewport_set_snap_2d_transforms_to_pixel">

--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -36,6 +36,9 @@
 		<member name="size_2d_override_stretch" type="bool" setter="set_size_2d_override_stretch" getter="is_size_2d_override_stretch_enabled" default="false">
 			If [code]true[/code], the 2D size override affects stretch as well.
 		</member>
+		<member name="view_count" type="int" setter="set_view_count" getter="get_view_count" default="1">
+			The number of views we're rendering. If larger than [code]1[/code] this will enable multiview rendering for stereoscopic or multiscopic views.
+		</member>
 	</members>
 	<constants>
 		<constant name="CLEAR_MODE_ALWAYS" value="0" enum="ClearMode">

--- a/doc/classes/XRInterface.xml
+++ b/doc/classes/XRInterface.xml
@@ -23,6 +23,12 @@
 				Returns a combination of [enum Capabilities] flags providing information about the capabilities of this interface.
 			</description>
 		</method>
+		<method name="get_layer_count">
+			<return type="int" />
+			<description>
+				Returns the number of layers we require for rendering. Each layer may have different resolution, view count and camera data.
+			</description>
+		</method>
 		<method name="get_name" qualifiers="const">
 			<return type="StringName" />
 			<description>
@@ -37,16 +43,18 @@
 		</method>
 		<method name="get_projection_for_view">
 			<return type="Projection" />
-			<param index="0" name="view" type="int" />
-			<param index="1" name="aspect" type="float" />
-			<param index="2" name="near" type="float" />
-			<param index="3" name="far" type="float" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="view" type="int" />
+			<param index="2" name="aspect" type="float" />
+			<param index="3" name="near" type="float" />
+			<param index="4" name="far" type="float" />
 			<description>
 				Returns the projection matrix for a view/eye.
 			</description>
 		</method>
 		<method name="get_render_target_size">
 			<return type="Vector2" />
+			<param index="0" name="layer" type="int" default="0" />
 			<description>
 				Returns the resolution at which we should render our intermediate results before things like lens distortion are applied by the VR platform.
 			</description>
@@ -72,8 +80,9 @@
 		</method>
 		<method name="get_transform_for_view">
 			<return type="Transform3D" />
-			<param index="0" name="view" type="int" />
-			<param index="1" name="cam_transform" type="Transform3D" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="view" type="int" />
+			<param index="2" name="cam_transform" type="Transform3D" />
 			<description>
 				Returns the transform for a view/eye.
 				[param view] is the view/eye index.
@@ -82,6 +91,7 @@
 		</method>
 		<method name="get_view_count">
 			<return type="int" />
+			<param index="0" name="layer" type="int" default="0" />
 			<description>
 				Returns the number of views that need to be rendered for this device. 1 for Monoscopic, 2 for Stereoscopic.
 			</description>

--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -46,10 +46,27 @@
 				Return color texture into which to render (if applicable).
 			</description>
 		</method>
+		<method name="_get_color_texture2" qualifiers="virtual">
+			<return type="RID" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_depth_texture" qualifiers="virtual">
 			<return type="RID" />
 			<description>
 				Return depth texture into which to render (if applicable).
+			</description>
+		</method>
+		<method name="_get_depth_texture2" qualifiers="virtual">
+			<return type="RID" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_layer_count" qualifiers="virtual">
+			<return type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="_get_name" qualifiers="virtual const">
@@ -84,6 +101,12 @@
 			<return type="Vector2" />
 			<description>
 				Returns the size of our render target for this interface, this overrides the size of the [Viewport] marked as the xr viewport.
+			</description>
+		</method>
+		<method name="_get_render_target_size2" qualifiers="virtual">
+			<return type="Vector2" />
+			<param index="0" name="layer" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="_get_suggested_pose_names" qualifiers="virtual const">
@@ -125,10 +148,22 @@
 				Return velocity texture into which to render (if applicable).
 			</description>
 		</method>
+		<method name="_get_velocity_texture2" qualifiers="virtual">
+			<return type="RID" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_view_count" qualifiers="virtual">
 			<return type="int" />
 			<description>
 				Returns the number of views this interface requires, 1 for mono, 2 for stereoscopic.
+			</description>
+		</method>
+		<method name="_get_view_count2" qualifiers="virtual">
+			<return type="int" />
+			<param index="0" name="layer" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="_get_vrs_texture" qualifiers="virtual">
@@ -239,11 +274,13 @@
 		</method>
 		<method name="get_color_texture">
 			<return type="RID" />
+			<param index="0" name="layer" type="int" default="0" />
 			<description>
 			</description>
 		</method>
 		<method name="get_depth_texture">
 			<return type="RID" />
+			<param index="0" name="layer" type="int" default="0" />
 			<description>
 			</description>
 		</method>
@@ -256,6 +293,7 @@
 		</method>
 		<method name="get_velocity_texture">
 			<return type="RID" />
+			<param index="0" name="layer" type="int" default="0" />
 			<description>
 			</description>
 		</method>

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2548,7 +2548,7 @@ Size2i TextureStorage::render_target_get_size(RID p_render_target) const {
 	return rt->size;
 }
 
-void TextureStorage::render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) {
+void TextureStorage::render_target_set_override(RID p_render_target, int p_index, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);
 	ERR_FAIL_COND(rt->direct_to_screen);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -691,7 +691,7 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const override { return RID(); }
 
-	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) override;
+	virtual void render_target_set_override(RID p_render_target, int p_index, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) override;
 	virtual RID render_target_get_override_color(RID p_render_target) const override;
 	virtual RID render_target_get_override_depth(RID p_render_target) const override;
 	virtual RID render_target_get_override_velocity(RID p_render_target) const override;

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1683,7 +1683,7 @@ void AnimationPlayerEditor::_allocate_onion_layers() {
 		// Each capture is a viewport with a canvas item attached that renders a full-size rect with the contents of the main viewport.
 		onion.captures[i] = RS::get_singleton()->viewport_create();
 
-		RS::get_singleton()->viewport_set_size(onion.captures[i], capture_size.width, capture_size.height);
+		RS::get_singleton()->viewport_set_size(onion.captures[i], 0, capture_size.width, capture_size.height, 1);
 		RS::get_singleton()->viewport_set_update_mode(onion.captures[i], RS::VIEWPORT_UPDATE_ALWAYS);
 		RS::get_singleton()->viewport_set_transparent_background(onion.captures[i], !is_present);
 		RS::get_singleton()->viewport_attach_canvas(onion.captures[i], onion.capture.canvas);

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -148,7 +148,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 	RID viewport = RS::get_singleton()->viewport_create();
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_ALWAYS);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, size, size);
+	RS::get_singleton()->viewport_set_size(viewport, 0, size, size, 1);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	RID viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);

--- a/editor/inspector/editor_preview_plugins.cpp
+++ b/editor/inspector/editor_preview_plugins.cpp
@@ -360,7 +360,7 @@ EditorMaterialPreviewPlugin::EditorMaterialPreviewPlugin() {
 	viewport = RS::get_singleton()->viewport_create();
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	RS::get_singleton()->viewport_set_size(viewport, 0, 128, 128, 1);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
@@ -775,7 +775,7 @@ EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
 	viewport = RS::get_singleton()->viewport_create();
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
 	RS::get_singleton()->viewport_set_scenario(viewport, scenario);
-	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	RS::get_singleton()->viewport_set_size(viewport, 0, 128, 128, 1);
 	RS::get_singleton()->viewport_set_transparent_background(viewport, true);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
@@ -890,7 +890,7 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate(const Ref<Resource> &p_from, co
 EditorFontPreviewPlugin::EditorFontPreviewPlugin() {
 	viewport = RS::get_singleton()->viewport_create();
 	RS::get_singleton()->viewport_set_update_mode(viewport, RS::VIEWPORT_UPDATE_DISABLED);
-	RS::get_singleton()->viewport_set_size(viewport, 128, 128);
+	RS::get_singleton()->viewport_set_size(viewport, 0, 128, 128, 1);
 	RS::get_singleton()->viewport_set_active(viewport, true);
 	viewport_texture = RS::get_singleton()->viewport_get_texture(viewport);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2756,7 +2756,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF_RST_BASIC("xr/openxr/enabled", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "xr/openxr/default_action_map", PROPERTY_HINT_FILE, "*.tres"), "res://openxr_action_map.tres");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/form_factor", PROPERTY_HINT_ENUM, "Head Mounted,Handheld"), "0");
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/view_configuration", PROPERTY_HINT_ENUM, "Mono,Stereo"), "1"); // "Mono,Stereo,Quad,Observer"
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/view_configuration", PROPERTY_HINT_ENUM, "Mono,Stereo,Quad,Observer"), "1");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/reference_space", PROPERTY_HINT_ENUM, "Local,Stage,Local Floor"), "1");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/environment_blend_mode", PROPERTY_HINT_ENUM, "Opaque,Additive,Alpha"), "0");
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "xr/openxr/foveation_level", PROPERTY_HINT_ENUM, "Off,Low,Medium,High"), "0");

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -341,7 +341,7 @@ void MobileVRInterface::set_vrs_strength(float p_vrs_strength) {
 	xr_vrs.set_vrs_strength(p_vrs_strength);
 }
 
-uint32_t MobileVRInterface::get_view_count() {
+uint32_t MobileVRInterface::get_view_count(uint32_t p_layer) {
 	// needs stereo...
 	return 2;
 }
@@ -431,8 +431,10 @@ bool MobileVRInterface::set_play_area_mode(XRInterface::PlayAreaMode p_mode) {
 	return p_mode == XR_PLAY_AREA_3DOF;
 }
 
-Size2 MobileVRInterface::get_render_target_size() {
+Size2 MobileVRInterface::get_render_target_size(uint32_t p_layer) {
 	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND_V(p_layer > 0, Size2());
 
 	// we use half our window size
 	Size2 target_size = DisplayServer::get_singleton()->window_get_size();
@@ -464,8 +466,9 @@ Transform3D MobileVRInterface::get_camera_transform() {
 	return transform_for_eye;
 }
 
-Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
+Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) {
 	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND_V(p_layer > 0, Transform3D());
 
 	Transform3D transform_for_eye;
 
@@ -498,8 +501,9 @@ Transform3D MobileVRInterface::get_transform_for_view(uint32_t p_view, const Tra
 	return transform_for_eye;
 }
 
-Projection MobileVRInterface::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
+Projection MobileVRInterface::get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	_THREAD_SAFE_METHOD_
+	ERR_FAIL_COND_V(p_layer > 0, Projection());
 
 	Projection eye;
 
@@ -580,7 +584,7 @@ RID MobileVRInterface::get_vrs_texture() {
 	uint32_t view_count = get_view_count();
 
 	for (uint32_t v = 0; v < view_count; v++) {
-		Projection cm = get_projection_for_view(v, aspect_ratio, 0.1, 1000.0);
+		Projection cm = get_projection_for_view(0, v, aspect_ratio, 0.1, 1000.0);
 		Vector3 center = cm.xform(Vector3(0.0, 0.0, 999.0));
 
 		eye_foci.push_back(Vector2(center.x, center.y));

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -160,11 +160,11 @@ public:
 	virtual XRInterface::PlayAreaMode get_play_area_mode() const override;
 	virtual bool set_play_area_mode(XRInterface::PlayAreaMode p_mode) override;
 
-	virtual Size2 get_render_target_size() override;
-	virtual uint32_t get_view_count() override;
+	virtual Size2 get_render_target_size(uint32_t p_layer = 0) override;
+	virtual uint32_t get_view_count(uint32_t p_layer = 0) override;
 	virtual Transform3D get_camera_transform() override;
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual Transform3D get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) override;
+	virtual Projection get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -211,7 +211,7 @@ void OpenXRViewportCompositionLayerProvider::set_viewport(RID p_viewport, Size2i
 	if (subviewport.viewport != p_viewport) {
 		if (subviewport.viewport.is_valid()) {
 			RID rt = rs->viewport_get_render_target(subviewport.viewport);
-			RSG::texture_storage->render_target_set_override(rt, RID(), RID(), RID(), RID());
+			RSG::texture_storage->render_target_set_override(rt, 0, RID(), RID(), RID(), RID());
 		}
 
 		subviewport.viewport = p_viewport;
@@ -333,7 +333,7 @@ void OpenXRViewportCompositionLayerProvider::on_pre_render() {
 			if (update_and_acquire_swapchain(update_mode == RS::VIEWPORT_UPDATE_ONCE)) {
 				// Render to our XR swapchain image.
 				RID rt = rs->viewport_get_render_target(subviewport.viewport);
-				RSG::texture_storage->render_target_set_override(rt, get_current_swapchain_texture(), RID(), RID(), RID());
+				RSG::texture_storage->render_target_set_override(rt, 0, get_current_swapchain_texture(), RID(), RID(), RID());
 			}
 		}
 	}

--- a/modules/openxr/extensions/openxr_varjo_quad_view_extension.cpp
+++ b/modules/openxr/extensions/openxr_varjo_quad_view_extension.cpp
@@ -1,0 +1,40 @@
+/**************************************************************************/
+/*  openxr_varjo_quad_view_extension.cpp                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "openxr_varjo_quad_view_extension.h"
+
+HashMap<String, bool *> OpenXRVarjoQuadViewExtension::get_requested_extensions() {
+	HashMap<String, bool *> request_extensions;
+
+	// Once we support OpenXR 1.1, we should only include this if we're initialising OpenXR 1.0
+	request_extensions[XR_VARJO_QUAD_VIEWS_EXTENSION_NAME] = &available;
+
+	return request_extensions;
+}

--- a/modules/openxr/extensions/openxr_varjo_quad_view_extension.h
+++ b/modules/openxr/extensions/openxr_varjo_quad_view_extension.h
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  openxr_varjo_quad_view_extension.h                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "openxr_extension_wrapper.h"
+
+// In OpenXR 1.0 XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET
+// was a Varjo only extension.
+// We enable it as a fallback if supported.
+
+class OpenXRVarjoQuadViewExtension : public OpenXRExtensionWrapper {
+	GDCLASS(OpenXRVarjoQuadViewExtension, OpenXRExtensionWrapper);
+
+protected:
+	static void _bind_methods() {}
+
+public:
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+
+private:
+	bool available = false;
+};

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1225,10 +1225,11 @@ bool OpenXRAPI::obtain_swapchain_formats() {
 	return true;
 }
 
-bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
+bool OpenXRAPI::create_main_swapchains(uint32_t p_layer, Size2i p_size) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 	ERR_FAIL_NULL_V(graphics_extension, false);
 	ERR_FAIL_COND_V(session == XR_NULL_HANDLE, false);
+	ERR_FAIL_COND_V(p_layer >= MIN(get_layer_count(), (uint32_t)OPENXR_LAYER_MAX), false);
 
 	/*
 		TODO: We need to improve on this, for now we're taking our old approach of creating our main swapchains and substituting
@@ -1245,16 +1246,17 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 		as we render 3D content into internal buffers that are copied into the swapchain, we do now have (basic) VRS support
 	*/
 
-	render_state.main_swapchain_size = p_size;
+	render_state.main_swapchain_size[p_layer] = p_size;
 	uint32_t sample_count = 1;
+	uint32_t view_count = get_view_count(p_layer);
 
 	// We start with our color swapchain...
 	if (color_swapchain_format != 0) {
-		if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, color_swapchain_format, render_state.main_swapchain_size.width, render_state.main_swapchain_size.height, sample_count, view_configuration_views.size())) {
+		if (!render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_COLOR].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, color_swapchain_format, render_state.main_swapchain_size[p_layer].width, render_state.main_swapchain_size[p_layer].height, sample_count, view_count)) {
 			return false;
 		}
 
-		set_object_name(XR_OBJECT_TYPE_SWAPCHAIN, uint64_t(render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain()), "Main color swapchain");
+		set_object_name(XR_OBJECT_TYPE_SWAPCHAIN, uint64_t(render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_COLOR].get_swapchain()), "Primary color swapchain");
 	}
 
 	// We create our depth swapchain if:
@@ -1262,11 +1264,11 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 	// - we support our depth layer extension
 	// - we have our spacewarp extension (not yet implemented)
 	if (depth_swapchain_format != 0 && submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available()) {
-		if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, depth_swapchain_format, render_state.main_swapchain_size.width, render_state.main_swapchain_size.height, sample_count, view_configuration_views.size())) {
+		if (!render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_DEPTH].create(0, XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, depth_swapchain_format, render_state.main_swapchain_size[p_layer].width, render_state.main_swapchain_size[p_layer].height, sample_count, view_count)) {
 			return false;
 		}
 
-		set_object_name(XR_OBJECT_TYPE_SWAPCHAIN, uint64_t(render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_swapchain()), "Main depth swapchain");
+		set_object_name(XR_OBJECT_TYPE_SWAPCHAIN, uint64_t(render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_DEPTH].get_swapchain()), "Primary depth swapchain");
 	}
 
 	// We create our velocity swapchain if:
@@ -1275,30 +1277,32 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 		// TBD
 	}
 
-	for (uint32_t i = 0; i < render_state.views.size(); i++) {
+	uint32_t view_offset = get_view_offset(p_layer);
+	ERR_FAIL_COND_V(view_offset + view_count > render_state.views.size(), false);
+	for (uint32_t i = view_offset; i < view_offset + view_count; i++) {
 		render_state.views[i].type = XR_TYPE_VIEW;
 		render_state.views[i].next = nullptr;
 
 		render_state.projection_views[i].type = XR_TYPE_COMPOSITION_LAYER_PROJECTION_VIEW;
 		render_state.projection_views[i].next = nullptr;
-		render_state.projection_views[i].subImage.swapchain = render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
-		render_state.projection_views[i].subImage.imageArrayIndex = i;
+		render_state.projection_views[i].subImage.swapchain = render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_COLOR].get_swapchain();
+		render_state.projection_views[i].subImage.imageArrayIndex = i - view_offset;
 		render_state.projection_views[i].subImage.imageRect.offset.x = 0;
 		render_state.projection_views[i].subImage.imageRect.offset.y = 0;
-		render_state.projection_views[i].subImage.imageRect.extent.width = render_state.main_swapchain_size.width;
-		render_state.projection_views[i].subImage.imageRect.extent.height = render_state.main_swapchain_size.height;
+		render_state.projection_views[i].subImage.imageRect.extent.width = render_state.main_swapchain_size[p_layer].width;
+		render_state.projection_views[i].subImage.imageRect.extent.height = render_state.main_swapchain_size[p_layer].height;
 
 		if (render_state.submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available() && !render_state.depth_views.is_empty()) {
 			render_state.projection_views[i].next = &render_state.depth_views[i];
 
 			render_state.depth_views[i].type = XR_TYPE_COMPOSITION_LAYER_DEPTH_INFO_KHR;
 			render_state.depth_views[i].next = nullptr;
-			render_state.depth_views[i].subImage.swapchain = render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_swapchain();
-			render_state.depth_views[i].subImage.imageArrayIndex = i;
+			render_state.depth_views[i].subImage.swapchain = render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_DEPTH].get_swapchain();
+			render_state.depth_views[i].subImage.imageArrayIndex = i - view_offset;
 			render_state.depth_views[i].subImage.imageRect.offset.x = 0;
 			render_state.depth_views[i].subImage.imageRect.offset.y = 0;
-			render_state.depth_views[i].subImage.imageRect.extent.width = render_state.main_swapchain_size.width;
-			render_state.depth_views[i].subImage.imageRect.extent.height = render_state.main_swapchain_size.height;
+			render_state.depth_views[i].subImage.imageRect.extent.width = render_state.main_swapchain_size[p_layer].width;
+			render_state.depth_views[i].subImage.imageRect.extent.height = render_state.main_swapchain_size[p_layer].height;
 			// OpenXR spec says that: minDepth < maxDepth.
 			render_state.depth_views[i].minDepth = 0.0;
 			render_state.depth_views[i].maxDepth = 1.0;
@@ -1307,10 +1311,6 @@ bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
 			render_state.depth_views[i].farZ = 0.01;
 		}
 	};
-
-	for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
-		wrapper->on_main_swapchains_created();
-	}
 
 	return true;
 }
@@ -1334,7 +1334,9 @@ void OpenXRAPI::destroy_session() {
 	render_state.projection_views.clear();
 	render_state.depth_views.clear();
 
-	free_main_swapchains();
+	for (uint32_t layer = 0; layer < OPENXR_LAYER_MAX; layer++) {
+		free_main_swapchains(layer);
+	}
 	OpenXRSwapChainInfo::free_queued();
 
 	supported_swapchain_formats.clear();
@@ -1516,8 +1518,52 @@ void OpenXRAPI::set_form_factor(XrFormFactor p_form_factor) {
 	form_factor = p_form_factor;
 }
 
-uint32_t OpenXRAPI::get_view_count() {
-	return view_configuration_views.size();
+uint32_t OpenXRAPI::get_layer_count() {
+	switch (view_configuration) {
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO:
+			return 1;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO:
+			return 1;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET: // Note: This is Varjo QuadView in OpenXR 1.0
+			return 2;
+		case XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT:
+			return 2;
+		default:
+			return 1;
+	}
+}
+
+uint32_t OpenXRAPI::get_view_offset(uint32_t p_layer) {
+	// Returns the index for our first entry in our view/projection_views/depth_views buffers
+	switch (view_configuration) {
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO:
+			return 0;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO:
+			return 0;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET: // Note: This is Varjo QuadView in OpenXR 1.0
+			return p_layer == 1 ? 2 : 0;
+		case XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT:
+			ERR_FAIL_COND_V(p_layer > 1, 0);
+			return p_layer == 1 ? 2 : 0; // First layer is stereo, second layer is mono
+		default:
+			return 0;
+	}
+}
+
+uint32_t OpenXRAPI::get_view_count(uint32_t p_layer) {
+	switch (view_configuration) {
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_MONO:
+			return p_layer == 0 ? 1 : 0;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO:
+			return p_layer == 0 ? 2 : 0;
+		case XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO_WITH_FOVEATED_INSET: // Note: This is Varjo QuadView in OpenXR 1.0
+			return p_layer <= 1 ? 2 : 0; // Both layers are stereo
+		case XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT:
+			return p_layer == 0 ? 2 : (p_layer == 1 ? 1 : 0); // First layer is stereo, second layer is mono
+		default:
+			// Unsupported, assume stereo..
+			return p_layer == 0 ? 2 : 0;
+	}
 }
 
 void OpenXRAPI::set_view_configuration(XrViewConfigurationType p_view_configuration) {
@@ -1830,18 +1876,19 @@ XrHandTrackerEXT OpenXRAPI::get_hand_tracker(int p_hand_index) {
 	return hand_tracking->get_hand_tracker(hand)->hand_tracker;
 }
 
-Size2 OpenXRAPI::get_recommended_target_size() {
+Size2 OpenXRAPI::get_recommended_target_size(uint32_t p_layer) {
 	RenderingServer *rendering_server = RenderingServer::get_singleton();
 	ERR_FAIL_COND_V(view_configuration_views.is_empty(), Size2());
 
 	Size2 target_size;
+	uint32_t view_offset = get_view_offset(p_layer);
 
 	if (rendering_server && rendering_server->is_on_render_thread()) {
-		target_size.width = view_configuration_views[0].recommendedImageRectWidth * render_state.render_target_size_multiplier;
-		target_size.height = view_configuration_views[0].recommendedImageRectHeight * render_state.render_target_size_multiplier;
+		target_size.width = view_configuration_views[view_offset].recommendedImageRectWidth * render_state.render_target_size_multiplier;
+		target_size.height = view_configuration_views[view_offset].recommendedImageRectHeight * render_state.render_target_size_multiplier;
 	} else {
-		target_size.width = view_configuration_views[0].recommendedImageRectWidth * render_target_size_multiplier;
-		target_size.height = view_configuration_views[0].recommendedImageRectHeight * render_target_size_multiplier;
+		target_size.width = view_configuration_views[view_offset].recommendedImageRectWidth * render_target_size_multiplier;
+		target_size.height = view_configuration_views[view_offset].recommendedImageRectHeight * render_target_size_multiplier;
 	}
 
 	return target_size;
@@ -1902,7 +1949,7 @@ XRPose::TrackingConfidence OpenXRAPI::get_head_center(Transform3D &r_transform, 
 	return confidence;
 }
 
-bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
+bool OpenXRAPI::get_view_transform(uint32_t p_layers, uint32_t p_view, Transform3D &r_transform) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 
 	if (!render_state.running) {
@@ -1915,12 +1962,17 @@ bool OpenXRAPI::get_view_transform(uint32_t p_view, Transform3D &r_transform) {
 	}
 
 	// Note, the timing of this is set right before rendering, which is what we need here.
-	r_transform = transform_from_pose(render_state.views[p_view].pose);
+	int32_t v = get_view_offset(p_layers) + p_view;
+	if (v < render_state.views.size()) {
+		r_transform = transform_from_pose(render_state.views[v].pose);
 
-	return true;
+		return true;
+	}
+
+	return false;
 }
 
-bool OpenXRAPI::get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix) {
+bool OpenXRAPI::get_view_projection(uint32_t p_layers, uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 	ERR_FAIL_NULL_V(graphics_extension, false);
 
@@ -1933,7 +1985,10 @@ bool OpenXRAPI::get_view_projection(uint32_t p_view, double p_z_near, double p_z
 		return false;
 	}
 
-	// if we're using depth views, make sure we update our near and far there...
+	// Note, our near and far come from our camera so we can trust them to be
+	// the same for all layers and views.
+
+	// If we're using depth views, make sure we update our near and far there...
 	if (!render_state.depth_views.is_empty()) {
 		for (XrCompositionLayerDepthInfoKHR &depth_view : render_state.depth_views) {
 			// As we are using reverse-Z these need to be flipped.
@@ -1945,8 +2000,13 @@ bool OpenXRAPI::get_view_projection(uint32_t p_view, double p_z_near, double p_z
 	render_state.z_near = p_z_near;
 	render_state.z_far = p_z_far;
 
-	// now update our projection
-	return graphics_extension->create_projection_fov(render_state.views[p_view].fov, p_z_near, p_z_far, p_camera_matrix);
+	int32_t v = get_view_offset(p_layers) + p_view;
+	if (v < render_state.views.size()) {
+		// now update our projection
+		return graphics_extension->create_projection_fov(render_state.views[v].fov, p_z_near, p_z_far, p_camera_matrix);
+	}
+
+	return false;
 }
 
 Vector2 OpenXRAPI::get_eye_focus(uint32_t p_view, float p_aspect) {
@@ -2231,9 +2291,9 @@ bool OpenXRAPI::process() {
 	return true;
 }
 
-void OpenXRAPI::free_main_swapchains() {
+void OpenXRAPI::free_main_swapchains(uint32_t p_layer) {
 	for (int i = 0; i < OPENXR_SWAPCHAIN_MAX; i++) {
-		render_state.main_swapchains[i].queue_free();
+		render_state.main_swapchains[p_layer][i].queue_free();
 	}
 }
 
@@ -2250,13 +2310,24 @@ void OpenXRAPI::pre_render() {
 	// Process any swapchains that were queued to be freed
 	OpenXRSwapChainInfo::free_queued();
 
-	Size2i swapchain_size = get_recommended_target_size();
-	if (swapchain_size != render_state.main_swapchain_size) {
-		// Out with the old.
-		free_main_swapchains();
+	bool swapchains_updated = false;
+	for (uint32_t layer = 0; layer < get_layer_count(); layer++) {
+		Size2i swapchain_size = get_recommended_target_size(layer);
+		if (swapchain_size != render_state.main_swapchain_size[layer]) {
+			// Out with the old.
+			free_main_swapchains(layer);
 
-		// In with the new.
-		create_main_swapchains(swapchain_size);
+			// In with the new.
+			create_main_swapchains(layer, swapchain_size);
+
+			swapchains_updated = true;
+		}
+	}
+
+	if (swapchains_updated) {
+		for (OpenXRExtensionWrapper *wrapper : registered_extension_wrappers) {
+			wrapper->on_main_swapchains_created();
+		}
 	}
 
 	void *view_locate_info_next_pointer = nullptr;
@@ -2347,10 +2418,12 @@ bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 	}
 
 	// Acquire our images
-	for (int i = 0; i < OPENXR_SWAPCHAIN_MAX; i++) {
-		if (!render_state.main_swapchains[i].is_image_acquired() && render_state.main_swapchains[i].get_swapchain() != XR_NULL_HANDLE) {
-			if (!render_state.main_swapchains[i].acquire(render_state.should_render)) {
-				return false;
+	for (uint32_t l = 0; l < OPENXR_LAYER_MAX; l++) {
+		for (int i = 0; i < OPENXR_SWAPCHAIN_MAX; i++) {
+			if (!render_state.main_swapchains[l][i].is_image_acquired() && render_state.main_swapchains[l][i].get_swapchain() != XR_NULL_HANDLE) {
+				if (!render_state.main_swapchains[l][i].acquire(render_state.should_render)) {
+					return false;
+				}
 			}
 		}
 	}
@@ -2362,24 +2435,27 @@ bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 	return true;
 }
 
-XrSwapchain OpenXRAPI::get_color_swapchain() {
+XrSwapchain OpenXRAPI::get_color_swapchain(uint32_t p_layer) {
 	ERR_NOT_ON_RENDER_THREAD_V(XR_NULL_HANDLE);
+	ERR_FAIL_COND_V(p_layer >= OPENXR_LAYER_MAX, XR_NULL_HANDLE);
 
-	return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_swapchain();
+	return render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_COLOR].get_swapchain();
 }
 
-RID OpenXRAPI::get_color_texture() {
+RID OpenXRAPI::get_color_texture(uint32_t p_layer) {
 	ERR_NOT_ON_RENDER_THREAD_V(RID());
+	ERR_FAIL_COND_V(p_layer >= OPENXR_LAYER_MAX, RID());
 
-	return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_image();
+	return render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_COLOR].get_image();
 }
 
-RID OpenXRAPI::get_depth_texture() {
+RID OpenXRAPI::get_depth_texture(uint32_t p_layer) {
 	ERR_NOT_ON_RENDER_THREAD_V(RID());
+	ERR_FAIL_COND_V(p_layer >= OPENXR_LAYER_MAX, RID());
 
 	// Note, image will not be acquired if we didn't have a suitable swap chain format.
-	if (render_state.submit_depth_buffer && render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].is_image_acquired()) {
-		return render_state.main_swapchains[OPENXR_SWAPCHAIN_DEPTH].get_image();
+	if (render_state.submit_depth_buffer && render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_DEPTH].is_image_acquired()) {
+		return render_state.main_swapchains[p_layer][OPENXR_SWAPCHAIN_DEPTH].get_image();
 	} else {
 		return RID();
 	}
@@ -2390,7 +2466,8 @@ RID OpenXRAPI::get_density_map_texture() {
 
 	OpenXRFBFoveationExtension *fov_ext = OpenXRFBFoveationExtension::get_singleton();
 	if (fov_ext && fov_ext->is_enabled()) {
-		return render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].get_density_map();
+		// For now only supported on the first layer.
+		return render_state.main_swapchains[0][OPENXR_SWAPCHAIN_COLOR].get_density_map();
 	}
 
 	return RID();
@@ -2454,25 +2531,33 @@ void OpenXRAPI::end_frame() {
 	if (render_state.should_render && render_state.view_pose_valid) {
 		if (!render_state.has_xr_viewport) {
 			print_line("OpenXR: No viewport was marked with use_xr, there is no rendered output!");
-		} else if (!render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].is_image_acquired()) {
+		} else if (!render_state.main_swapchains[0][OPENXR_SWAPCHAIN_COLOR].is_image_acquired()) {
 			print_line("OpenXR: No swapchain could be acquired to render to!");
 		}
 	}
 
-	Rect2i new_render_region = (render_state.render_region != Rect2i()) ? render_state.render_region : Rect2i(Point2i(0, 0), render_state.main_swapchain_size);
+	for (uint32_t layer = 0; layer < get_layer_count(); layer++) {
+		// Render region is nonly done on the first layer, doesn't make sense for our insets.
+		Rect2i new_render_region = (layer == 0 && render_state.render_region != Rect2i()) ? render_state.render_region : Rect2i(Point2i(0, 0), render_state.main_swapchain_size[layer]);
 
-	for (XrCompositionLayerProjectionView &projection_view : render_state.projection_views) {
-		projection_view.subImage.imageRect.offset.x = new_render_region.position.x;
-		projection_view.subImage.imageRect.offset.y = new_render_region.position.y;
-		projection_view.subImage.imageRect.extent.width = new_render_region.size.width;
-		projection_view.subImage.imageRect.extent.height = new_render_region.size.height;
-	}
-	if (render_state.submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available() && !render_state.depth_views.is_empty()) {
-		for (XrCompositionLayerDepthInfoKHR &depth_view : render_state.depth_views) {
-			depth_view.subImage.imageRect.offset.x = new_render_region.position.x;
-			depth_view.subImage.imageRect.offset.y = new_render_region.position.y;
-			depth_view.subImage.imageRect.extent.width = new_render_region.size.width;
-			depth_view.subImage.imageRect.extent.height = new_render_region.size.height;
+		uint32_t view_offset = get_view_offset(layer);
+		uint32_t view_count = get_view_count(layer);
+		for (uint32_t i = view_offset; i < view_offset + view_count; i++) {
+			if (i < render_state.projection_views.size()) {
+				XrCompositionLayerProjectionView &projection_view = render_state.projection_views[i];
+				projection_view.subImage.imageRect.offset.x = new_render_region.position.x;
+				projection_view.subImage.imageRect.offset.y = new_render_region.position.y;
+				projection_view.subImage.imageRect.extent.width = new_render_region.size.width;
+				projection_view.subImage.imageRect.extent.height = new_render_region.size.height;
+			}
+
+			if (render_state.submit_depth_buffer && OpenXRCompositionLayerDepthExtension::get_singleton()->is_available() && i < render_state.depth_views.size()) {
+				XrCompositionLayerDepthInfoKHR &depth_view = render_state.depth_views[i];
+				depth_view.subImage.imageRect.offset.x = new_render_region.position.x;
+				depth_view.subImage.imageRect.offset.y = new_render_region.position.y;
+				depth_view.subImage.imageRect.extent.width = new_render_region.size.width;
+				depth_view.subImage.imageRect.extent.height = new_render_region.size.height;
+			}
 		}
 	}
 
@@ -2480,7 +2565,7 @@ void OpenXRAPI::end_frame() {
 	// - should_render set to true
 	// - a valid view pose for projection_views[eye].pose to submit layer
 	// - an image to render
-	if (!render_state.should_render || !render_state.view_pose_valid || !render_state.main_swapchains[OPENXR_SWAPCHAIN_COLOR].is_image_acquired()) {
+	if (!render_state.should_render || !render_state.view_pose_valid || !render_state.main_swapchains[0][OPENXR_SWAPCHAIN_COLOR].is_image_acquired()) {
 		// submit 0 layers when we shouldn't render
 		XrFrameEndInfo frame_end_info = {
 			XR_TYPE_FRAME_END_INFO, // type
@@ -2502,10 +2587,12 @@ void OpenXRAPI::end_frame() {
 		return;
 	}
 
-	// release our swapchain image if we acquired it
-	for (int i = 0; i < OPENXR_SWAPCHAIN_MAX; i++) {
-		if (render_state.main_swapchains[i].is_image_acquired()) {
-			render_state.main_swapchains[i].release();
+	// release our swapchain images if we acquired them
+	for (uint32_t l = 0; l < OPENXR_LAYER_MAX; l++) {
+		for (int i = 0; i < OPENXR_SWAPCHAIN_MAX; i++) {
+			if (render_state.main_swapchains[l][i].is_image_acquired()) {
+				render_state.main_swapchains[l][i].release();
+			}
 		}
 	}
 
@@ -2737,14 +2824,12 @@ OpenXRAPI::OpenXRAPI() {
 			case 1: {
 				view_configuration = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_STEREO;
 			} break;
-			/* we don't support quad and observer configurations (yet)
 			case 2: {
 				view_configuration = XR_VIEW_CONFIGURATION_TYPE_PRIMARY_QUAD_VARJO;
 			} break;
 			case 3: {
 				view_configuration = XR_VIEW_CONFIGURATION_TYPE_SECONDARY_MONO_FIRST_PERSON_OBSERVER_MSFT;
 			} break;
-			*/
 			default:
 				break;
 		}

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -146,6 +146,12 @@ private:
 
 	LocalVector<XrViewConfigurationView> view_configuration_views;
 
+	enum OpenXRLayers {
+		OPENXR_LAYER_PRIMARY,
+		OPENXR_LAYER_SECONDARY,
+		OPENXR_LAYER_MAX
+	};
+
 	enum OpenXRSwapChainTypes {
 		OPENXR_SWAPCHAIN_COLOR,
 		OPENXR_SWAPCHAIN_DEPTH,
@@ -260,8 +266,8 @@ private:
 	bool load_supported_swapchain_formats();
 	bool is_swapchain_format_supported(int64_t p_swapchain_format);
 	bool obtain_swapchain_formats();
-	bool create_main_swapchains(Size2i p_size);
-	void free_main_swapchains();
+	bool create_main_swapchains(uint32_t p_layer, Size2i p_size);
+	void free_main_swapchains(uint32_t p_layer);
 	void destroy_session();
 
 	// action map
@@ -359,8 +365,8 @@ private:
 			nullptr // views
 		};
 
-		Size2i main_swapchain_size;
-		OpenXRSwapChainInfo main_swapchains[OPENXR_SWAPCHAIN_MAX];
+		Size2i main_swapchain_size[OPENXR_LAYER_MAX];
+		OpenXRSwapChainInfo main_swapchains[OPENXR_LAYER_MAX][OPENXR_SWAPCHAIN_MAX];
 	} render_state;
 
 	static void _allocate_view_buffers(uint32_t p_view_count, bool p_submit_depth_buffer);
@@ -466,7 +472,10 @@ public:
 	void set_form_factor(XrFormFactor p_form_factor);
 	XrFormFactor get_form_factor() const { return form_factor; }
 
-	uint32_t get_view_count();
+	uint32_t get_layer_count();
+	uint32_t get_view_offset(uint32_t p_layer = 0);
+	uint32_t get_view_count(uint32_t p_layer = 0);
+
 	void set_view_configuration(XrViewConfigurationType p_view_configuration);
 	XrViewConfigurationType get_view_configuration() const { return view_configuration; }
 
@@ -493,18 +502,18 @@ public:
 
 	XrHandTrackerEXT get_hand_tracker(int p_hand_index);
 
-	Size2 get_recommended_target_size();
+	Size2 get_recommended_target_size(uint32_t p_layer);
 	XRPose::TrackingConfidence get_head_center(Transform3D &r_transform, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
-	bool get_view_transform(uint32_t p_view, Transform3D &r_transform);
-	bool get_view_projection(uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix);
+	bool get_view_transform(uint32_t p_layers, uint32_t p_view, Transform3D &r_transform);
+	bool get_view_projection(uint32_t p_layers, uint32_t p_view, double p_z_near, double p_z_far, Projection &p_camera_matrix);
 	Vector2 get_eye_focus(uint32_t p_view, float p_aspect);
 	bool process();
 
 	void pre_render();
 	bool pre_draw_viewport(RID p_render_target);
-	XrSwapchain get_color_swapchain();
-	RID get_color_texture();
-	RID get_depth_texture();
+	XrSwapchain get_color_swapchain(uint32_t p_layer = 0);
+	RID get_color_texture(uint32_t p_layer = 0);
+	RID get_depth_texture(uint32_t p_layer = 0);
 	RID get_density_map_texture();
 	void set_velocity_texture(RID p_render_target);
 	RID get_velocity_texture();

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -78,7 +78,7 @@ private:
 	Vector3 head_linear_velocity;
 	Vector3 head_angular_velocity;
 	XRPose::TrackingConfidence head_confidence;
-	Transform3D transform_for_view[2]; // We currently assume 2, but could be 4 for VARJO which we do not support yet
+	Transform3D transform_for_view[2][2];
 
 	XRVRS xr_vrs;
 
@@ -176,18 +176,19 @@ public:
 	float get_vrs_strength() const;
 	void set_vrs_strength(float p_vrs_strength);
 
-	virtual Size2 get_render_target_size() override;
-	virtual uint32_t get_view_count() override;
+	virtual uint32_t get_layer_count() override;
+	virtual Size2 get_render_target_size(uint32_t p_layer = 0) override;
+	virtual uint32_t get_view_count(uint32_t p_layer = 0) override;
 	virtual Transform3D get_camera_transform() override;
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual Transform3D get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) override;
+	virtual Projection get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
 
 	virtual Rect2i get_render_region() override;
 
-	virtual RID get_color_texture() override;
-	virtual RID get_depth_texture() override;
-	virtual RID get_velocity_texture() override;
-	virtual RID get_velocity_depth_texture() override;
+	virtual RID get_color_texture(uint32_t p_layer = 0) override;
+	virtual RID get_depth_texture(uint32_t p_layer = 0) override;
+	virtual RID get_velocity_texture(uint32_t p_layer = 0) override;
+	virtual RID get_velocity_depth_texture(uint32_t p_layer = 0) override;
 	virtual Size2i get_velocity_target_size() override;
 
 	virtual void process() override;

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -73,6 +73,7 @@
 #include "extensions/openxr_pico_controller_extension.h"
 #include "extensions/openxr_render_model_extension.h"
 #include "extensions/openxr_valve_analog_threshold_extension.h"
+#include "extensions/openxr_varjo_quad_view_extension.h"
 #include "extensions/openxr_visibility_mask_extension.h"
 #include "extensions/openxr_wmr_controller_extension.h"
 
@@ -157,6 +158,7 @@ void initialize_openxr_module(ModuleInitializationLevel p_level) {
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRMxInkExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVisibilityMaskExtension));
 			OpenXRAPI::register_extension_wrapper(memnew(OpenXRPerformanceSettingsExtension));
+			OpenXRAPI::register_extension_wrapper(memnew(OpenXRVarjoQuadViewExtension));
 
 			// Futures extension has to be registered as a singleton so extensions can access it.
 			OpenXRFutureExtension *future_extension = memnew(OpenXRFutureExtension);

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -277,7 +277,9 @@ uint32_t WebXRInterfaceJS::get_capabilities() const {
 	return XRInterface::XR_STEREO | XRInterface::XR_MONO | XRInterface::XR_VR | XRInterface::XR_AR;
 }
 
-uint32_t WebXRInterfaceJS::get_view_count() {
+uint32_t WebXRInterfaceJS::get_view_count(uint32_t p_layer) {
+	ERR_FAIL_COND_V(p_layer > 0, 0);
+
 	return godot_webxr_get_view_count();
 }
 
@@ -416,7 +418,9 @@ Transform3D WebXRInterfaceJS::_js_matrix_to_transform(float *p_js_matrix) {
 	return transform;
 }
 
-Size2 WebXRInterfaceJS::get_render_target_size() {
+Size2 WebXRInterfaceJS::get_render_target_size(uint32_t p_layer) {
+	ERR_FAIL_COND_V(p_layer > 0, Size2());
+
 	if (render_targetsize.width != 0 && render_targetsize.height != 0) {
 		return render_targetsize;
 	}
@@ -454,10 +458,11 @@ Transform3D WebXRInterfaceJS::get_camera_transform() {
 	return camera_transform;
 }
 
-Transform3D WebXRInterfaceJS::get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) {
+Transform3D WebXRInterfaceJS::get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) {
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, p_cam_transform);
 	ERR_FAIL_COND_V(!initialized, p_cam_transform);
+	ERR_FAIL_COND_V(p_layer > 0, p_cam_transform);
 
 	float js_matrix[16];
 	bool has_transform = godot_webxr_get_transform_for_view(p_view, js_matrix);
@@ -473,10 +478,11 @@ Transform3D WebXRInterfaceJS::get_transform_for_view(uint32_t p_view, const Tran
 	return p_cam_transform * xr_server->get_reference_frame() * transform_for_view;
 }
 
-Projection WebXRInterfaceJS::get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
+Projection WebXRInterfaceJS::get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) {
 	Projection view;
 
 	ERR_FAIL_COND_V(!initialized, view);
+	ERR_FAIL_COND_V(p_layer > 0, view);
 
 	float js_matrix[16];
 	bool has_projection = godot_webxr_get_projection_for_view(p_view, js_matrix);
@@ -582,15 +588,18 @@ RID WebXRInterfaceJS::_get_texture(unsigned int p_texture_id) {
 	return texture;
 }
 
-RID WebXRInterfaceJS::get_color_texture() {
+RID WebXRInterfaceJS::get_color_texture(uint32_t p_layer) {
+	ERR_FAIL_COND_V(p_layer > 0, RID());
 	return color_texture;
 }
 
-RID WebXRInterfaceJS::get_depth_texture() {
+RID WebXRInterfaceJS::get_depth_texture(uint32_t p_layer) {
+	ERR_FAIL_COND_V(p_layer > 0, RID());
 	return depth_texture;
 }
 
-RID WebXRInterfaceJS::get_velocity_texture() {
+RID WebXRInterfaceJS::get_velocity_texture(uint32_t p_layer) {
+	ERR_FAIL_COND_V(p_layer > 0, RID());
 	unsigned int texture_id = godot_webxr_get_velocity_texture();
 	if (texture_id == 0) {
 		return RID();

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -126,16 +126,16 @@ public:
 	virtual void uninitialize() override;
 	virtual Dictionary get_system_info() override;
 
-	virtual Size2 get_render_target_size() override;
-	virtual uint32_t get_view_count() override;
+	virtual Size2 get_render_target_size(uint32_t p_layer = 0) override;
+	virtual uint32_t get_view_count(uint32_t p_layer = 0) override;
 	virtual Transform3D get_camera_transform() override;
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual Transform3D get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) override;
+	virtual Projection get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
 	virtual bool pre_draw_viewport(RID p_render_target) override;
 	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
-	virtual RID get_color_texture() override;
-	virtual RID get_depth_texture() override;
-	virtual RID get_velocity_texture() override;
+	virtual RID get_color_texture(uint32_t p_layer = 0) override;
+	virtual RID get_depth_texture(uint32_t p_layer = 0) override;
+	virtual RID get_velocity_texture(uint32_t p_layer = 0) override;
 
 	virtual void process() override;
 

--- a/scene/3d/xr/xr_nodes.cpp
+++ b/scene/3d/xr/xr_nodes.cpp
@@ -118,7 +118,7 @@ Vector3 XRCamera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	Vector3 ray;
 
 	// Just use the first view, if multiple views are supported this function has no good result
-	Projection cm = xr_interface->get_projection_for_view(0, viewport_size.aspect(), get_near(), get_far());
+	Projection cm = xr_interface->get_projection_for_view(0, 0, viewport_size.aspect(), get_near(), get_far());
 	Vector2 screen_he = cm.get_viewport_half_extents();
 	ray = Vector3(((cpos.x / viewport_size.width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (cpos.y / viewport_size.height)) * 2.0 - 1.0) * screen_he.y, -get_near()).normalized();
 
@@ -141,7 +141,7 @@ Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
 	// Just use the first view, if multiple views are supported this function has no good result
-	Projection cm = xr_interface->get_projection_for_view(0, viewport_size.aspect(), get_near(), get_far());
+	Projection cm = xr_interface->get_projection_for_view(0, 0, viewport_size.aspect(), get_near(), get_far());
 
 	Plane p(get_camera_transform().xform_inv(p_pos), 1.0);
 
@@ -171,7 +171,7 @@ Vector3 XRCamera3D::project_position(const Point2 &p_point, real_t p_z_depth) co
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 
 	// Just use the first view, if multiple views are supported this function has no good result
-	Projection cm = xr_interface->get_projection_for_view(0, viewport_size.aspect(), get_near(), get_far());
+	Projection cm = xr_interface->get_projection_for_view(0, 0, viewport_size.aspect(), get_near(), get_far());
 
 	Vector2 vp_he = cm.get_viewport_half_extents();
 
@@ -200,7 +200,7 @@ Vector<Plane> XRCamera3D::get_frustum() const {
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
 	// TODO Just use the first view for now, this is mostly for debugging so we may look into using our combined projection here.
-	Projection cm = xr_interface->get_projection_for_view(0, viewport_size.aspect(), get_near(), get_far());
+	Projection cm = xr_interface->get_projection_for_view(0, 0, viewport_size.aspect(), get_near(), get_far());
 	return cm.get_projection_planes(get_camera_transform());
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -638,6 +638,14 @@ void Viewport::_notification(int p_what) {
 			RenderingServer::get_singleton()->viewport_set_parent_viewport(viewport, RID());
 		} break;
 
+#ifndef XR_DISABLED
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (use_xr) {
+				_check_xr_size();
+			}
+		} break;
+#endif // XR_DISABLED
+
 		case NOTIFICATION_PATH_RENAMED: {
 			_update_viewport_path();
 		} break;
@@ -1039,7 +1047,7 @@ void Viewport::set_use_oversampling(bool p_oversampling) {
 		return;
 	}
 	use_font_oversampling = p_oversampling;
-	_set_size(_get_size(), _get_size_2d_override(), _is_size_allocated());
+	_set_size(_get_size(), view_count, _get_size_2d_override(), _is_size_allocated());
 }
 
 bool Viewport::is_using_oversampling() const {
@@ -1053,7 +1061,7 @@ void Viewport::set_oversampling_override(float p_oversampling) {
 		return;
 	}
 	font_oversampling_override = p_oversampling;
-	_set_size(_get_size(), _get_size_2d_override(), _is_size_allocated());
+	_set_size(_get_size(), view_count, _get_size_2d_override(), _is_size_allocated());
 }
 
 float Viewport::get_oversampling_override() const {
@@ -1061,7 +1069,7 @@ float Viewport::get_oversampling_override() const {
 	return font_oversampling_override;
 }
 
-bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, bool p_allocated) {
+bool Viewport::_set_size(const Size2i &p_size, const int p_view_count, const Size2 &p_size_2d_override, bool p_allocated) {
 	Transform2D stretch_transform_new = Transform2D();
 	float new_font_oversampling = 1.0;
 	if (is_size_2d_override_stretch_enabled() && p_size_2d_override.width > 0 && p_size_2d_override.height > 0) {
@@ -1082,7 +1090,7 @@ bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, 
 	}
 
 	Size2i new_size = p_size.maxi(2);
-	if (size == new_size && size_allocated == p_allocated && stretch_transform == stretch_transform_new && p_size_2d_override == size_2d_override && new_font_oversampling == font_oversampling) {
+	if (size == new_size && view_count == p_view_count && size_allocated == p_allocated && stretch_transform == stretch_transform_new && p_size_2d_override == size_2d_override && new_font_oversampling == font_oversampling) {
 		return false;
 	}
 
@@ -1095,24 +1103,17 @@ bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, 
 	}
 
 	size = new_size;
+	view_count = p_view_count;
 	size_allocated = p_allocated;
 	size_2d_override = p_size_2d_override;
 	stretch_transform = stretch_transform_new;
 	font_oversampling = new_font_oversampling;
 
-#ifndef _3D_DISABLED
-	if (!use_xr) {
-#endif
-
-		if (p_allocated) {
-			RS::get_singleton()->viewport_set_size(viewport, size.width, size.height);
-		} else {
-			RS::get_singleton()->viewport_set_size(viewport, 0, 0);
-		}
-
-#ifndef _3D_DISABLED
-	} // if (!use_xr)
-#endif
+	if (p_allocated) {
+		RS::get_singleton()->viewport_set_size(viewport, 0, size.width, size.height, view_count);
+	} else {
+		RS::get_singleton()->viewport_set_size(viewport, 0, 0, 0, 0);
+	}
 
 	_update_global_transform();
 	update_configuration_warnings();
@@ -1138,25 +1139,46 @@ bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, 
 	return true;
 }
 
-Size2i Viewport::_get_size() const {
-#ifndef XR_DISABLED
-	if (use_xr) {
-		if (XRServer::get_singleton() != nullptr) {
-			Ref<XRInterface> xr_interface = XRServer::get_singleton()->get_primary_interface();
-			if (xr_interface.is_valid() && xr_interface->is_initialized()) {
-				Size2 xr_size = xr_interface->get_render_target_size();
-				return (Size2i)xr_size;
-			}
-		}
-		return Size2i();
-	}
-#endif // XR_DISABLED
+void Viewport::_check_xr_size() {
+	// If our viewport has the use_xr flag set, our size and layout is managed by the XRServer.
+	if (use_xr && XRServer::get_singleton() != nullptr) {
+		Ref<XRInterface> xr_interface = XRServer::get_singleton()->get_primary_interface();
+		if (xr_interface.is_valid() && xr_interface->is_initialized()) {
+			uint32_t layer_count = xr_interface->get_layer_count();
+			RS::get_singleton()->viewport_set_layer_count(viewport, layer_count);
 
+			for (uint32_t layer = 0; layer < layer_count; layer++) {
+				Size2 xr_size = xr_interface->get_render_target_size(layer);
+				int xr_view_count = xr_interface->get_view_count(layer);
+
+				if (layer == 0) {
+					// We set our first view checking all our other properties.
+					// Q: Should we check for changes here and skip if there are none?
+					_set_size((Size2i)xr_size, xr_view_count, Size2i(0, 0), true);
+				} else {
+					// Set additional layer.
+					// Q: Should we check for changes here and skip if there are none?
+					RS::get_singleton()->viewport_set_size(viewport, layer, (int)xr_size.width, (int)xr_size.height, xr_view_count);
+				}
+			}
+		} else {
+			// Set to default and prevent rendering for now (unless in editor, so we get a preview).
+			RS::get_singleton()->viewport_set_layer_count(viewport, 1);
+			_set_size(Engine::get_singleton()->is_editor_hint() ? Size2i(512, 512) : Size2i(0, 0), 1, Size2i(0, 0), false);
+		}
+	}
+}
+
+Size2i Viewport::_get_size() const {
 	return size;
 }
 
 Size2 Viewport::_get_size_2d_override() const {
 	return size_2d_override;
+}
+
+int Viewport::_get_view_count() const {
+	return view_count;
 }
 
 bool Viewport::_is_size_allocated() const {
@@ -4807,22 +4829,49 @@ void Viewport::set_use_xr(bool p_use_xr) {
 
 		RS::get_singleton()->viewport_set_use_xr(viewport, use_xr);
 
-		if (!use_xr) {
-			// Set viewport to previous size when exiting XR.
-			if (size_allocated) {
-				RS::get_singleton()->viewport_set_size(viewport, size.width, size.height);
-			} else {
-				RS::get_singleton()->viewport_set_size(viewport, 0, 0);
-			}
+#ifndef XR_DISABLED
+		if (use_xr) {
+			// Note: use_xr is ONLY used for the primary XR viewport.
+			// Any additional (sub)viewports for composition layers and
+			// other purposes should not have use_xr set.
+			_check_xr_size();
+
+			// Enable internal process as we need to check for recommended size changes each frame
+			// (though size changes should only happen sporadically).
+			set_process_internal(true);
+		} else
+#endif // XR_DISABLED
+		{
+			// No longer check for recommended size changes in internal process.
+			set_process_internal(false);
+
+			// Change the layer count back to 1, however it is possible to add
+			// layers later on to our viewport even if we're not dealing with
+			// and XR viewport!
+			RS::get_singleton()->viewport_set_layer_count(viewport, 1);
 
 			// Reset render target override textures.
 			RID rt = RS::get_singleton()->viewport_get_render_target(viewport);
-			RSG::texture_storage->render_target_set_override(rt, RID(), RID(), RID(), RID());
+			RSG::texture_storage->render_target_set_override(rt, 0, RID(), RID(), RID(), RID());
+
+			// Q: Now that we properly set the size even when using XR,
+			// this wouldn't do anything meaningful.
+			// Do we want to set the size back to some default,
+			// and espectially set the view_count back to 1?
+			// Is there even a use case where someone turns XR off and
+			// continues?
+			//if (size_allocated) {
+			//	RS::get_singleton()->viewport_set_size(viewport, 0, size.width, size.height, view_count);
+			//} else {
+			//	RS::get_singleton()->viewport_set_size(viewport, 0, 0, 0, 0);
+			//}
 		}
+
+		notify_property_list_changed();
 	}
 }
 
-bool Viewport::is_using_xr() {
+bool Viewport::is_using_xr() const {
 	ERR_READ_THREAD_GUARD_V(false);
 	return use_xr;
 }
@@ -5377,17 +5426,17 @@ Viewport::~Viewport() {
 
 void SubViewport::set_size(const Size2i &p_size) {
 	ERR_MAIN_THREAD_GUARD;
-	_internal_set_size(p_size);
+	_internal_set_size(p_size, _get_view_count());
 }
 
 void SubViewport::set_size_force(const Size2i &p_size) {
 	ERR_MAIN_THREAD_GUARD;
 	// Use only for setting the size from the parent SubViewportContainer with enabled stretch mode.
 	// Don't expose function to scripting.
-	_internal_set_size(p_size, true);
+	_internal_set_size(p_size, _get_view_count(), true);
 }
 
-void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
+void SubViewport::_internal_set_size(const Size2i &p_size, const int p_view_count, bool p_force) {
 	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());
 	if (!p_force && c && c->is_stretch_enabled()) {
 #ifdef DEBUG_ENABLED
@@ -5396,7 +5445,7 @@ void SubViewport::_internal_set_size(const Size2i &p_size, bool p_force) {
 		return;
 	}
 
-	_set_size(p_size, _get_size_2d_override(), true);
+	_set_size(p_size, p_view_count, _get_size_2d_override(), true);
 
 	if (c) {
 		c->update_minimum_size();
@@ -5409,9 +5458,21 @@ Size2i SubViewport::get_size() const {
 	return _get_size();
 }
 
+void SubViewport::set_view_count(const int p_view_count) {
+	ERR_MAIN_THREAD_GUARD;
+
+	_internal_set_size(_get_size(), p_view_count);
+}
+
+int SubViewport::get_view_count() const {
+	ERR_READ_THREAD_GUARD_V(1);
+
+	return _get_view_count();
+}
+
 void SubViewport::set_size_2d_override(const Size2i &p_size) {
 	ERR_MAIN_THREAD_GUARD;
-	_set_size(_get_size(), p_size, true);
+	_set_size(_get_size(), _get_view_count(), p_size, true);
 }
 
 Size2i SubViewport::get_size_2d_override() const {
@@ -5429,7 +5490,7 @@ void SubViewport::set_size_2d_override_stretch(bool p_enable) {
 	}
 
 	size_2d_override_stretch = p_enable;
-	_set_size(_get_size(), _get_size_2d_override(), true);
+	_set_size(_get_size(), _get_view_count(), _get_size_2d_override(), true);
 }
 
 bool SubViewport::is_size_2d_override_stretch_enabled() const {
@@ -5535,6 +5596,9 @@ void SubViewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_size_2d_override_stretch", "enable"), &SubViewport::set_size_2d_override_stretch);
 	ClassDB::bind_method(D_METHOD("is_size_2d_override_stretch_enabled"), &SubViewport::is_size_2d_override_stretch_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_view_count", "view_count"), &SubViewport::set_view_count);
+	ClassDB::bind_method(D_METHOD("get_view_count"), &SubViewport::get_view_count);
+
 	ClassDB::bind_method(D_METHOD("set_update_mode", "mode"), &SubViewport::set_update_mode);
 	ClassDB::bind_method(D_METHOD("get_update_mode"), &SubViewport::get_update_mode);
 
@@ -5544,6 +5608,7 @@ void SubViewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size", PROPERTY_HINT_NONE, "suffix:px"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "size_2d_override", PROPERTY_HINT_NONE, "suffix:px"), "set_size_2d_override", "get_size_2d_override");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "size_2d_override_stretch"), "set_size_2d_override_stretch", "is_size_2d_override_stretch_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "view_count"), "set_view_count", "get_view_count");
 	ADD_GROUP("Render Target", "render_target_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_target_clear_mode", PROPERTY_HINT_ENUM, "Always,Never,Next Frame"), "set_clear_mode", "get_clear_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_target_update_mode", PROPERTY_HINT_ENUM, "Disabled,Once,When Visible,When Parent Visible,Always"), "set_update_mode", "get_update_mode");
@@ -5563,7 +5628,9 @@ void SubViewport::_validate_property(PropertyInfo &p_property) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		return;
 	}
-	if (p_property.name == "size") {
+	if (is_using_xr() && (p_property.name == "size" || p_property.name == "size_2d_override" || p_property.name == "size_2d_override_stretch" || p_property.name == "view_count")) {
+		p_property.usage = PROPERTY_USAGE_NONE; // Managed by XR
+	} else if (p_property.name == "size") {
 		SubViewportContainer *parent_svc = Object::cast_to<SubViewportContainer>(get_parent());
 		if (parent_svc && parent_svc->is_stretch_enabled()) {
 			p_property.usage = PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY;
@@ -5574,5 +5641,5 @@ void SubViewport::_validate_property(PropertyInfo &p_property) const {
 }
 
 SubViewport::SubViewport() {
-	RS::get_singleton()->viewport_set_size(get_viewport_rid(), get_size().width, get_size().height);
+	RS::get_singleton()->viewport_set_size(get_viewport_rid(), 0, get_size().width, get_size().height, 1);
 }

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -256,6 +256,7 @@ private:
 	Transform2D stretch_transform;
 
 	Size2i size = Size2i(512, 512);
+	int view_count = 1;
 	Size2 size_2d_override;
 	bool size_allocated = false;
 
@@ -502,10 +503,12 @@ private:
 	void _window_start_resize(SubWindowResize p_edge, Window *p_window);
 
 protected:
-	bool _set_size(const Size2i &p_size, const Size2 &p_size_2d_override, bool p_allocated);
+	bool _set_size(const Size2i &p_size, const int p_view_count, const Size2 &p_size_2d_override, bool p_allocated);
+	void _check_xr_size();
 
 	Size2i _get_size() const;
 	Size2 _get_size_2d_override() const;
+	int _get_view_count() const;
 	bool _is_size_allocated() const;
 
 	void _notification(int p_what);
@@ -849,7 +852,7 @@ public:
 	bool is_using_own_world_3d() const;
 
 	void set_use_xr(bool p_use_xr);
-	bool is_using_xr();
+	bool is_using_xr() const;
 #endif // _3D_DISABLED
 
 	Viewport();
@@ -879,7 +882,7 @@ private:
 	ClearMode clear_mode = CLEAR_MODE_ALWAYS;
 	bool size_2d_override_stretch = false;
 
-	void _internal_set_size(const Size2i &p_size, bool p_force = false);
+	void _internal_set_size(const Size2i &p_size, const int p_view_count, bool p_force = false);
 
 protected:
 	static void _bind_methods();
@@ -890,6 +893,9 @@ public:
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;
 	void set_size_force(const Size2i &p_size);
+
+	void set_view_count(const int p_view_count);
+	int get_view_count() const;
 
 	void set_size_2d_override(const Size2i &p_size);
 	Size2i get_size_2d_override() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1299,13 +1299,21 @@ void Window::_update_viewport_size() {
 		}
 	}
 
-	bool allocate = is_inside_tree() && visible && (window_id != DisplayServer::INVALID_WINDOW_ID || embedder != nullptr);
-	_set_size(final_size, final_size_override, allocate);
+	// If `use_xr` set, we should skip this logic.
+#ifndef XR_DISABLED
+	if (is_using_xr()) {
+		return;
+	} else
+#endif // XR_DISABLED
+	{
+		bool allocate = is_inside_tree() && visible && (window_id != DisplayServer::INVALID_WINDOW_ID || embedder != nullptr);
+		_set_size(final_size, 1, final_size_override, allocate);
 
-	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), attach_to_screen_rect, window_id);
-	} else if (!is_embedded()) {
-		RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), Rect2i(), DisplayServer::INVALID_WINDOW_ID);
+		if (window_id != DisplayServer::INVALID_WINDOW_ID) {
+			RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), attach_to_screen_rect, window_id);
+		} else if (!is_embedded()) {
+			RenderingServer::get_singleton()->viewport_attach_to_screen(get_viewport_rid(), Rect2i(), DisplayServer::INVALID_WINDOW_ID);
+		}
 	}
 
 	notification(NOTIFICATION_WM_SIZE_CHANGED);
@@ -1315,7 +1323,7 @@ void Window::_update_viewport_size() {
 		Viewport::set_oversampling_override(scale);
 		Size2 s = Size2(final_size.width * scale, final_size.height * scale).ceil();
 		RS::get_singleton()->viewport_set_global_canvas_transform(get_viewport_rid(), global_canvas_transform * scale * content_scale_factor);
-		RS::get_singleton()->viewport_set_size(get_viewport_rid(), s.width, s.height);
+		RS::get_singleton()->viewport_set_size(get_viewport_rid(), 0, s.width, s.height, 1);
 		embedder->_sub_window_update(this);
 	}
 }

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -200,7 +200,7 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) override {}
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const override { return RID(); }
 
-	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) override {}
+	virtual void render_target_set_override(RID p_render_target, int p_index, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) override {}
 	virtual RID render_target_get_override_color(RID p_render_target) const override { return RID(); }
 	virtual RID render_target_get_override_depth(RID p_render_target) const override { return RID(); }
 	virtual RID render_target_get_override_velocity(RID p_render_target) const override { return RID(); }

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3524,7 +3524,7 @@ RID TextureStorage::render_target_get_texture(RID p_render_target) {
 	return rt->texture;
 }
 
-void TextureStorage::render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) {
+void TextureStorage::render_target_set_override(RID p_render_target, int p_index, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -789,7 +789,7 @@ public:
 	virtual void render_target_set_vrs_texture(RID p_render_target, RID p_texture) override;
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const override;
 
-	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) override;
+	virtual void render_target_set_override(RID p_render_target, int p_index, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) override;
 	virtual RID render_target_get_override_color(RID p_render_target) const override;
 	virtual RID render_target_get_override_depth(RID p_render_target) const override;
 	RID render_target_get_override_depth_slice(RID p_render_target, const uint32_t p_layer) const;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1156,7 +1156,7 @@ public:
 	void _render_scene(const RendererSceneRender::CameraData *p_camera_data, const Ref<RenderSceneBuffers> &p_render_buffers, RID p_environment, RID p_force_camera_attributes, RID p_compositor, uint32_t p_visible_layers, RID p_scenario, RID p_viewport, RID p_shadow_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, bool p_using_shadows = true, RenderInfo *r_render_info = nullptr);
 	void render_empty_scene(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_scenario, RID p_shadow_atlas);
 
-	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, RenderingMethod::RenderInfo *r_render_info = nullptr);
+	void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_screen_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, uint32_t p_viewport_layer = 0, uint32_t p_first_view = 0, uint32_t p_view_count = 1, RenderingMethod::RenderInfo *r_render_info = nullptr);
 	void update_dirty_instances() const;
 
 	void render_particle_colliders();

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -346,7 +346,7 @@ public:
 		int info[RS::VIEWPORT_RENDER_INFO_TYPE_MAX][RS::VIEWPORT_RENDER_INFO_MAX] = {};
 	};
 
-	virtual void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, RenderInfo *r_render_info = nullptr) = 0;
+	virtual void render_camera(const Ref<RenderSceneBuffers> &p_render_buffers, RID p_camera, RID p_scenario, RID p_viewport, Size2 p_viewport_size, uint32_t p_jitter_phase_count, float p_mesh_lod_threshold, RID p_shadow_atlas, Ref<XRInterface> &p_xr_interface, uint32_t p_viewport_layer = 0, uint32_t p_first_view = 0, uint32_t p_view_count = 1, RenderInfo *r_render_info = nullptr) = 0;
 
 	virtual void update() = 0;
 	virtual void render_probes() = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -691,7 +691,8 @@ public:
 	FUNCRIDSPLIT(viewport)
 
 	FUNC2(viewport_set_use_xr, RID, bool)
-	FUNC3(viewport_set_size, RID, int, int)
+	FUNC2(viewport_set_layer_count, RID, uint32_t)
+	FUNC5(viewport_set_size, RID, uint32_t, int, int, int)
 
 	FUNC2(viewport_set_active, RID, bool)
 	FUNC2(viewport_set_parent_viewport, RID, RID)
@@ -710,8 +711,8 @@ public:
 	FUNC2(viewport_set_update_mode, RID, ViewportUpdateMode)
 	FUNC1RC(ViewportUpdateMode, viewport_get_update_mode, RID)
 
-	FUNC1RC(RID, viewport_get_render_target, RID)
-	FUNC1RC(RID, viewport_get_texture, RID)
+	FUNC2RC(RID, viewport_get_render_target, RID, uint32_t)
+	FUNC2RC(RID, viewport_get_texture, RID, uint32_t)
 
 	FUNC2(viewport_set_disable_2d, RID, bool)
 	FUNC2(viewport_set_environment_mode, RID, ViewportEnvironmentMode)

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -179,7 +179,7 @@ public:
 	virtual RID render_target_get_vrs_texture(RID p_render_target) const = 0;
 
 	// override color, depth and velocity buffers (depth and velocity only for 3D)
-	virtual void render_target_set_override(RID p_render_target, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) = 0;
+	virtual void render_target_set_override(RID p_render_target, int p_index, RID p_color_texture, RID p_depth_texture, RID p_velocity_texture, RID p_velocity_depth_texture) = 0;
 	virtual RID render_target_get_override_color(RID p_render_target) const = 0;
 	virtual RID render_target_get_override_depth(RID p_render_target) const = 0;
 	virtual RID render_target_get_override_velocity(RID p_render_target) const = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2822,7 +2822,8 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("viewport_create"), &RenderingServer::viewport_create);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_xr", "viewport", "use_xr"), &RenderingServer::viewport_set_use_xr);
-	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
+	ClassDB::bind_method(D_METHOD("viewport_set_layer_count", "viewport", "layer_count"), &RenderingServer::viewport_set_layer_count);
+	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "layer", "width", "height", "view_count"), &RenderingServer::viewport_set_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);
 	ClassDB::bind_method(D_METHOD("viewport_attach_to_screen", "viewport", "rect", "screen"), &RenderingServer::viewport_attach_to_screen, DEFVAL(Rect2()), DEFVAL(DisplayServer::MAIN_WINDOW_ID));
@@ -2837,8 +2838,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_update_mode", "viewport", "update_mode"), &RenderingServer::viewport_set_update_mode);
 	ClassDB::bind_method(D_METHOD("viewport_get_update_mode", "viewport"), &RenderingServer::viewport_get_update_mode);
 	ClassDB::bind_method(D_METHOD("viewport_set_clear_mode", "viewport", "clear_mode"), &RenderingServer::viewport_set_clear_mode);
-	ClassDB::bind_method(D_METHOD("viewport_get_render_target", "viewport"), &RenderingServer::viewport_get_render_target);
-	ClassDB::bind_method(D_METHOD("viewport_get_texture", "viewport"), &RenderingServer::viewport_get_texture);
+	ClassDB::bind_method(D_METHOD("viewport_get_render_target", "viewport", "layer"), &RenderingServer::viewport_get_render_target, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("viewport_get_texture", "viewport", "layer"), &RenderingServer::viewport_get_texture, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("viewport_set_disable_3d", "viewport", "disable"), &RenderingServer::viewport_set_disable_3d);
 	ClassDB::bind_method(D_METHOD("viewport_set_disable_2d", "viewport", "disable"), &RenderingServer::viewport_set_disable_2d);
 	ClassDB::bind_method(D_METHOD("viewport_set_environment_mode", "viewport", "mode"), &RenderingServer::viewport_set_environment_mode);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -979,7 +979,8 @@ public:
 	}
 
 	virtual void viewport_set_use_xr(RID p_viewport, bool p_use_xr) = 0;
-	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height) = 0;
+	virtual void viewport_set_layer_count(RID p_viewport, uint32_t p_layer_count) = 0;
+	virtual void viewport_set_size(RID p_viewport, uint32_t p_layer, int p_width, int p_height, int p_view_count) = 0;
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;
 	virtual void viewport_set_canvas_cull_mask(RID p_viewport, uint32_t p_canvas_cull_mask) = 0;
@@ -1012,8 +1013,8 @@ public:
 
 	virtual void viewport_set_clear_mode(RID p_viewport, ViewportClearMode p_clear_mode) = 0;
 
-	virtual RID viewport_get_render_target(RID p_viewport) const = 0;
-	virtual RID viewport_get_texture(RID p_viewport) const = 0;
+	virtual RID viewport_get_render_target(RID p_viewport, uint32_t p_layer = 0) const = 0;
+	virtual RID viewport_get_texture(RID p_viewport, uint32_t p_layer = 0) const = 0;
 
 	enum ViewportEnvironmentMode {
 		VIEWPORT_ENVIRONMENT_DISABLED,

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -46,8 +46,9 @@ void XRInterface::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_tracking_status"), &XRInterface::get_tracking_status);
 
-	ClassDB::bind_method(D_METHOD("get_render_target_size"), &XRInterface::get_render_target_size);
-	ClassDB::bind_method(D_METHOD("get_view_count"), &XRInterface::get_view_count);
+	ClassDB::bind_method(D_METHOD("get_layer_count"), &XRInterface::get_layer_count);
+	ClassDB::bind_method(D_METHOD("get_render_target_size", "layer"), &XRInterface::get_render_target_size, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("get_view_count", "layer"), &XRInterface::get_view_count, DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("trigger_haptic_pulse", "action_name", "tracker_name", "frequency", "amplitude", "duration_sec", "delay_sec"), &XRInterface::trigger_haptic_pulse);
 
@@ -72,8 +73,8 @@ void XRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_passthrough_enabled"), &XRInterface::is_passthrough_enabled);
 	ClassDB::bind_method(D_METHOD("start_passthrough"), &XRInterface::start_passthrough);
 	ClassDB::bind_method(D_METHOD("stop_passthrough"), &XRInterface::stop_passthrough);
-	ClassDB::bind_method(D_METHOD("get_transform_for_view", "view", "cam_transform"), &XRInterface::get_transform_for_view);
-	ClassDB::bind_method(D_METHOD("get_projection_for_view", "view", "aspect", "near", "far"), &XRInterface::get_projection_for_view);
+	ClassDB::bind_method(D_METHOD("get_transform_for_view", "layer", "view", "cam_transform"), &XRInterface::get_transform_for_view);
+	ClassDB::bind_method(D_METHOD("get_projection_for_view", "layer", "view", "aspect", "near", "far"), &XRInterface::get_projection_for_view);
 
 	/** environment blend mode. */
 	ClassDB::bind_method(D_METHOD("get_supported_environment_blend_modes"), &XRInterface::get_supported_environment_blend_modes);
@@ -179,19 +180,19 @@ RID XRInterface::get_vrs_texture() {
 
 /** these are optional, so we want dummies **/
 
-RID XRInterface::get_color_texture() {
+RID XRInterface::get_color_texture(uint32_t p_layer) {
 	return RID();
 }
 
-RID XRInterface::get_depth_texture() {
+RID XRInterface::get_depth_texture(uint32_t p_layer) {
 	return RID();
 }
 
-RID XRInterface::get_velocity_texture() {
+RID XRInterface::get_velocity_texture(uint32_t p_layer) {
 	return RID();
 }
 
-RID XRInterface::get_velocity_depth_texture() {
+RID XRInterface::get_velocity_depth_texture(uint32_t p_layer) {
 	return RID();
 }
 

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -134,16 +134,17 @@ public:
 	virtual void process() = 0;
 
 	// These methods can be called from both main and render thread.
-	virtual Size2 get_render_target_size() = 0; /* returns the recommended render target size per eye for this device */
-	virtual uint32_t get_view_count() = 0; /* returns the view count we need (1 is monoscopic, 2 is stereoscopic but can be more) */
+	virtual uint32_t get_layer_count() { return 1; } /* Returns the number of layers we need. */
+	virtual Size2 get_render_target_size(uint32_t p_layer = 0) = 0; /* returns the recommended render target size per eye for this device */
+	virtual uint32_t get_view_count(uint32_t p_layer = 0) = 0; /* returns the view count we need (1 is monoscopic, 2 is stereoscopic but can be more) */
 
 	// These methods are called from the rendering thread.
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) = 0; /* get each views transform */
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) = 0; /* get each view projection matrix */
-	virtual RID get_color_texture(); /* obtain color output texture (if applicable) */
-	virtual RID get_depth_texture(); /* obtain depth output texture (if applicable, used for reprojection) */
-	virtual RID get_velocity_texture(); /* obtain velocity output texture (if applicable, used for spacewarp) */
-	virtual RID get_velocity_depth_texture();
+	virtual Transform3D get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) = 0; /* get each views transform */
+	virtual Projection get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) = 0; /* get each view projection matrix */
+	virtual RID get_color_texture(uint32_t p_layer = 0); /* obtain color output texture (if applicable) */
+	virtual RID get_depth_texture(uint32_t p_layer = 0); /* obtain depth output texture (if applicable, used for reprojection) */
+	virtual RID get_velocity_texture(uint32_t p_layer = 0); /* obtain velocity output texture (if applicable, used for spacewarp) */
+	virtual RID get_velocity_depth_texture(uint32_t p_layer = 0);
 	virtual Size2i get_velocity_target_size();
 	virtual Rect2i get_render_region();
 	virtual void pre_render() {}

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -97,27 +97,39 @@ public:
 
 	/** rendering and internal **/
 
-	virtual Size2 get_render_target_size() override;
-	virtual uint32_t get_view_count() override;
+	virtual uint32_t get_layer_count() override;
+	virtual Size2 get_render_target_size(uint32_t p_layer = 0) override;
+	virtual uint32_t get_view_count(uint32_t p_layer = 0) override;
 	virtual Transform3D get_camera_transform() override;
-	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
-	virtual Projection get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
+	virtual Transform3D get_transform_for_view(uint32_t p_layer, uint32_t p_view, const Transform3D &p_cam_transform) override;
+	virtual Projection get_projection_for_view(uint32_t p_layer, uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
 	virtual RID get_vrs_texture() override;
 	virtual VRSTextureFormat get_vrs_texture_format() override;
-	virtual RID get_color_texture() override;
-	virtual RID get_depth_texture() override;
-	virtual RID get_velocity_texture() override;
+	virtual RID get_color_texture(uint32_t p_layer = 0) override;
+	virtual RID get_depth_texture(uint32_t p_layer = 0) override;
+	virtual RID get_velocity_texture(uint32_t p_layer = 0) override;
 
-	GDVIRTUAL0R(Size2, _get_render_target_size);
-	GDVIRTUAL0R(uint32_t, _get_view_count);
+	GDVIRTUAL0R(uint32_t, _get_layer_count);
+	GDVIRTUAL1R(Size2, _get_render_target_size2, uint32_t);
+	GDVIRTUAL1R(uint32_t, _get_view_count2, uint32_t);
 	GDVIRTUAL0R(Transform3D, _get_camera_transform);
-	GDVIRTUAL2R(Transform3D, _get_transform_for_view, uint32_t, const Transform3D &);
-	GDVIRTUAL4R(PackedFloat64Array, _get_projection_for_view, uint32_t, double, double, double);
+	GDVIRTUAL3R(Transform3D, _get_transform_for_view2, uint32_t, uint32_t, const Transform3D &);
+	GDVIRTUAL5R(PackedFloat64Array, _get_projection_for_view2, uint32_t, uint32_t, double, double, double);
 	GDVIRTUAL0R(RID, _get_vrs_texture);
 	GDVIRTUAL0R(VRSTextureFormat, _get_vrs_texture_format);
+	GDVIRTUAL1R(RID, _get_color_texture2, uint32_t);
+	GDVIRTUAL1R(RID, _get_depth_texture2, uint32_t);
+	GDVIRTUAL1R(RID, _get_velocity_texture2, uint32_t);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0R(Size2, _get_render_target_size);
+	GDVIRTUAL0R(uint32_t, _get_view_count);
+	GDVIRTUAL2R(Transform3D, _get_transform_for_view, uint32_t, const Transform3D &);
+	GDVIRTUAL4R(PackedFloat64Array, _get_projection_for_view, uint32_t, double, double, double);
 	GDVIRTUAL0R(RID, _get_color_texture);
 	GDVIRTUAL0R(RID, _get_depth_texture);
 	GDVIRTUAL0R(RID, _get_velocity_texture);
+#endif
 
 	void add_blit(RID p_render_target, Rect2 p_src_rect, Rect2i p_dst_rect, bool p_use_layer = false, uint32_t p_layer = 0, bool p_apply_lens_distortion = false, Vector2 p_eye_center = Vector2(), double p_k1 = 0.0, double p_k2 = 0.0, double p_upscale = 1.0, double p_aspect_ratio = 1.0);
 


### PR DESCRIPTION
**Introduction**

For advanced XR headsets we're required to render more than a single stereoscopic result. This approach has now been added as a standard to OpenXR for use by multiple headset vendors and support for it is growing. The Khronos Group is funding work for us to implement this.

This primary use case is well described in [Varjo's documentation on the subject](https://varjo.com/vr-lab/make-the-best-out-of-your-varjo-experience-update-on-varjo-quad-view-eye-tracked-foveation-and-varjo-base-settings/).
Here we are rendering two stereoscopic buffers of different resolutions and with different camera positions and projection settings.  

This PR makes changes to the rendering engine in support of this. 

**Alternatives**

Before settling on this approach we trailed two alternative solutions for this:

1. Increasing the number of layers we support for multiview from 2 to 4. This is the quickest and least intrusive option but does not cater for the requirement of different resolutions and introduces an increased memory footprint even when the feature is not used.
2. Using a separate viewport for the extra rendering, while promising as a solution and possibly worth exploring further, this approach ultimately added complexity to the viewport system that is unwieldy for the end user.

**Bonus objectives**

The approach in this PR solves more than the ability to render multiple sets of views in a viewport. It also:

1. Moves some of the XR logic out of the rendering core and into the viewport allow us to setup multiview viewports outside of an XR use case. Once we also perform needed camera improvements this will enable a number features closed off to us such as stereo mirrors and stereo portals.
2. Introduces the ability to increase the number of views beyond the two we support for multiview and loop through them in pairs. This both results in finally having a fallback (which has been requested many times for webXR) when multiview is not supported, and allows us to render for multiscopic displays such as for [looking glass](https://lookingglassfactory.com/).

**TODO**

This is still a work in progress:
- [x] complete OpenXRInterface changes for quad view support.
- [ ] complete fallback logic including adding a check for asymmetry in projection matrices and correct use of view count.
- [ ] cleanup `_check_xr_size` logic in viewport.
- [ ] test if turning `use_xr` on/off behaves correctly
- [ ] add in compatibility functions so the API remains backwards compatible!!!! <-- must have, very important.
- [ ] ...

Implements: https://github.com/godotengine/godot-proposals/issues/12572

**Contributed by Khronos Group through the Godot Integration Project**