### PR TITLE
[3.x] `LODManager` - Auto-deactivate when no LODs

### DIFF
--- a/scene/3d/lod_manager.h
+++ b/scene/3d/lod_manager.h
@@ -66,6 +66,9 @@ private:
 		Queue queues[NUM_LOD_QUEUES];
 		BinaryMutex mutex;
 		bool saving = false;
+
+		// Used to disable LODManager updates when there are no LODs in use (reduces CPU utilization).
+		int32_t total_lods = 0;
 	} data;
 
 	static bool _enabled;


### PR DESCRIPTION
Just a small tweak as surprisingly I was seeing the `LODManager` in editor profiles even with no LODs active.
Just keep a count of total LODs and do nothing when this number is zero. This should be practically free to do.

## Notes
* Also has a DEV check that the number doesn't out of sync. This isn't crucial but might as well as it might indicate a bug elsewhere.
* Changes to an unordered erase. This is faster with lots of LODs in a queue, even though there is the potential for the moved LOD to have a slight delay to its update (this is unlikely to be a problem).
* `ERR_FAIL` if the erase failed, this would indicate a core bug.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
