### PR TITLE
Change preview methods to take Callable

### DIFF
--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -345,8 +345,8 @@ private:
 	void _get_drag_target_folder(String &target, bool &target_favorites, const Point2 &p_point, Control *p_from) const;
 
 	void _preview_invalidated(const String &p_path);
-	void _file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
-	void _tree_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
+	void _file_list_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index, const String &p_filename);
+	void _tree_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_update_id, ObjectID p_item);
 
 	void _update_display_mode(bool p_force = false);
 

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -511,7 +511,7 @@ void EditorFileDialog::_post_popup() {
 	set_process_shortcut_input(true);
 }
 
-void EditorFileDialog::_thumbnail_result(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
+void EditorFileDialog::_thumbnail_result(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview) {
 	if (display_mode == DISPLAY_LIST || p_preview.is_null()) {
 		return;
 	}
@@ -526,7 +526,7 @@ void EditorFileDialog::_thumbnail_result(const String &p_path, const Ref<Texture
 	}
 }
 
-void EditorFileDialog::_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
+void EditorFileDialog::_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview) {
 	set_process(false);
 	preview_waiting = false;
 
@@ -552,7 +552,7 @@ void EditorFileDialog::_request_single_thumbnail(const String &p_path) {
 	set_process(true);
 	preview_waiting = true;
 	preview_wheel_timeout = 0;
-	EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, this, "_thumbnail_done", p_path);
+	EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, callable_mp(this, &EditorFileDialog::_thumbnail_done));
 }
 
 void EditorFileDialog::_action_pressed() {
@@ -1173,7 +1173,7 @@ void EditorFileDialog::update_file_list() {
 			item_list->set_item_metadata(-1, d);
 
 			if (display_mode == DISPLAY_THUMBNAILS && previews_enabled) {
-				EditorResourcePreview::get_singleton()->queue_resource_preview(file_info.path, this, "_thumbnail_result", file_info.path);
+				EditorResourcePreview::get_singleton()->queue_resource_preview(file_info.path, callable_mp(this, &EditorFileDialog::_thumbnail_result));
 			}
 
 			if (file->get_text() == file_info.name) {
@@ -2172,10 +2172,8 @@ void EditorFileDialog::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_access"), &EditorFileDialog::get_access);
 	ClassDB::bind_method(D_METHOD("set_show_hidden_files", "show"), &EditorFileDialog::set_show_hidden_files);
 	ClassDB::bind_method(D_METHOD("is_showing_hidden_files"), &EditorFileDialog::is_showing_hidden_files);
-	ClassDB::bind_method(D_METHOD("_thumbnail_done"), &EditorFileDialog::_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("set_display_mode", "mode"), &EditorFileDialog::set_display_mode);
 	ClassDB::bind_method(D_METHOD("get_display_mode"), &EditorFileDialog::get_display_mode);
-	ClassDB::bind_method(D_METHOD("_thumbnail_result"), &EditorFileDialog::_thumbnail_result);
 	ClassDB::bind_method(D_METHOD("set_disable_overwrite_warning", "disable"), &EditorFileDialog::set_disable_overwrite_warning);
 	ClassDB::bind_method(D_METHOD("is_overwrite_warning_disabled"), &EditorFileDialog::is_overwrite_warning_disabled);
 	ClassDB::bind_method(D_METHOD("add_side_menu", "menu", "title"), &EditorFileDialog::add_side_menu, DEFVAL(""));

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -272,8 +272,8 @@ private:
 	void _save_to_recent();
 	// Callback function is callback(String p_path,Ref<Texture2D> preview,Variant udata) preview null if could not load.
 
-	void _thumbnail_result(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
-	void _thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
+	void _thumbnail_result(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview);
+	void _thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview);
 	void _request_single_thumbnail(const String &p_path);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -82,7 +82,7 @@ void EditorResourcePicker::_update_resource() {
 			assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + class_name);
 
 			// Preview will override the above, so called at the end.
-			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, this, "_update_resource_preview", edited_resource->get_instance_id());
+			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, callable_mp(this, &EditorResourcePicker::_update_resource_preview).bind(edited_resource->get_instance_id()));
 		}
 	} else if (edited_resource.is_valid()) {
 		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());
@@ -886,8 +886,6 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 }
 
 void EditorResourcePicker::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_update_resource_preview"), &EditorResourcePicker::_update_resource_preview);
-
 	ClassDB::bind_method(D_METHOD("set_base_type", "base_type"), &EditorResourcePicker::set_base_type);
 	ClassDB::bind_method(D_METHOD("get_base_type"), &EditorResourcePicker::get_base_type);
 	ClassDB::bind_method(D_METHOD("get_allowed_types"), &EditorResourcePicker::get_allowed_types);

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -132,7 +132,7 @@ void EditorResourcePreview::_thread_func(void *ud) {
 	erp->_thread();
 }
 
-void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, ObjectID id, const StringName &p_func, const Variant &p_ud, const Dictionary &p_metadata) {
+void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, const Callable &p_callback, const Dictionary &p_metadata) {
 	{
 		MutexLock lock(preview_mutex);
 
@@ -155,8 +155,7 @@ void EditorResourcePreview::_preview_ready(const String &p_path, int p_hash, con
 
 		cache[p_path] = item;
 	}
-
-	Callable(id, p_func).call_deferred(p_path, p_texture, p_small_texture, p_ud);
+	p_callback.call_deferred(p_path, p_texture, p_small_texture);
 }
 
 void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<ImageTexture> &r_small_texture, const QueueItem &p_item, const String &cache_base, Dictionary &p_metadata) {
@@ -285,7 +284,7 @@ void EditorResourcePreview::_iterate() {
 	if (cache.has(item.path)) {
 		Item cached_item = cache[item.path];
 		// Already has it because someone loaded it, just let it know it's ready.
-		_preview_ready(item.path, cached_item.last_hash, cached_item.preview, cached_item.small_preview, item.id, item.function, item.userdata, cached_item.preview_metadata);
+		_preview_ready(item.path, cached_item.last_hash, cached_item.preview, cached_item.small_preview, item.callback, cached_item.preview_metadata);
 		preview_mutex.unlock();
 		return;
 	}
@@ -300,7 +299,7 @@ void EditorResourcePreview::_iterate() {
 	if (item.resource.is_valid()) {
 		Dictionary preview_metadata;
 		_generate_preview(texture, small_texture, item, String(), preview_metadata);
-		_preview_ready(item.path, item.resource->hash_edited_version_for_preview(), texture, small_texture, item.id, item.function, item.userdata, preview_metadata);
+		_preview_ready(item.path, item.resource->hash_edited_version_for_preview(), texture, small_texture, item.callback, preview_metadata);
 		return;
 	}
 
@@ -388,7 +387,7 @@ void EditorResourcePreview::_iterate() {
 			_generate_preview(texture, small_texture, item, cache_base, preview_metadata);
 		}
 	}
-	_preview_ready(item.path, 0, texture, small_texture, item.id, item.function, item.userdata, preview_metadata);
+	_preview_ready(item.path, 0, texture, small_texture, item.callback, preview_metadata);
 }
 
 void EditorResourcePreview::_write_preview_cache(Ref<FileAccess> p_file, int p_thumbnail_size, bool p_has_small_texture, uint64_t p_modified_time, const String &p_hash, const Dictionary &p_metadata) {
@@ -457,8 +456,12 @@ EditorResourcePreview::PreviewItem EditorResourcePreview::get_resource_preview_i
 	return item;
 }
 
-void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata) {
+void EditorResourcePreview::_queue_edited_resource_preview(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata) {
 	ERR_FAIL_NULL(p_receiver);
+	queue_edited_resource_preview(p_res, Callable(p_receiver, p_receiver_func).bind(p_userdata));
+}
+
+void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p_res, const Callable &p_callback) {
 	ERR_FAIL_COND(p_res.is_null());
 	_update_thumbnail_sizes();
 
@@ -466,44 +469,46 @@ void EditorResourcePreview::queue_edited_resource_preview(const Ref<Resource> &p
 		MutexLock lock(preview_mutex);
 
 		String path_id = "ID:" + itos(p_res->get_instance_id());
+		HashMap<String, EditorResourcePreview::Item>::Iterator I = cache.find(path_id);
 
-		if (cache.has(path_id) && cache[path_id].last_hash == p_res->hash_edited_version_for_preview()) {
-			p_receiver->call(p_receiver_func, path_id, cache[path_id].preview, cache[path_id].small_preview, p_userdata);
+		if (I && I->value.last_hash == p_res->hash_edited_version_for_preview()) {
+			p_callback.call(path_id, I->value.preview, I->value.small_preview);
 			return;
 		}
 
-		cache.erase(path_id); //erase if exists, since it will be regen
+		if (I) {
+			cache.remove(I); // Erase if exists, since it will be regen.
+		}
 
 		QueueItem item;
-		item.function = p_receiver_func;
-		item.id = p_receiver->get_instance_id();
 		item.resource = p_res;
 		item.path = path_id;
-		item.userdata = p_userdata;
-
+		item.callback = p_callback;
 		queue.push_back(item);
 	}
 	preview_sem.post();
 }
 
-void EditorResourcePreview::queue_resource_preview(const String &p_path, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata) {
+void EditorResourcePreview::_queue_resource_preview(const String &p_path, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata) {
 	ERR_FAIL_NULL(p_receiver);
+	queue_resource_preview(p_path, Callable(p_receiver, p_receiver_func).bind(p_userdata));
+}
+
+void EditorResourcePreview::queue_resource_preview(const String &p_path, const Callable &p_callback) {
 	_update_thumbnail_sizes();
 
 	{
 		MutexLock lock(preview_mutex);
 
-		if (cache.has(p_path)) {
-			p_receiver->call(p_receiver_func, p_path, cache[p_path].preview, cache[p_path].small_preview, p_userdata);
+		const Item *cached_item = cache.getptr(p_path);
+		if (cached_item) {
+			p_callback.call(p_path, cached_item->preview, cached_item->small_preview);
 			return;
 		}
 
 		QueueItem item;
-		item.function = p_receiver_func;
-		item.id = p_receiver->get_instance_id();
 		item.path = p_path;
-		item.userdata = p_userdata;
-
+		item.callback = p_callback;
 		queue.push_back(item);
 	}
 	preview_sem.post();
@@ -522,8 +527,8 @@ EditorResourcePreview *EditorResourcePreview::get_singleton() {
 }
 
 void EditorResourcePreview::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("queue_resource_preview", "path", "receiver", "receiver_func", "userdata"), &EditorResourcePreview::queue_resource_preview);
-	ClassDB::bind_method(D_METHOD("queue_edited_resource_preview", "resource", "receiver", "receiver_func", "userdata"), &EditorResourcePreview::queue_edited_resource_preview);
+	ClassDB::bind_method(D_METHOD("queue_resource_preview", "path", "receiver", "receiver_func", "userdata"), &EditorResourcePreview::_queue_resource_preview);
+	ClassDB::bind_method(D_METHOD("queue_edited_resource_preview", "resource", "receiver", "receiver_func", "userdata"), &EditorResourcePreview::_queue_edited_resource_preview);
 	ClassDB::bind_method(D_METHOD("add_preview_generator", "generator"), &EditorResourcePreview::add_preview_generator);
 	ClassDB::bind_method(D_METHOD("remove_preview_generator", "generator"), &EditorResourcePreview::remove_preview_generator);
 	ClassDB::bind_method(D_METHOD("check_for_invalidation", "path"), &EditorResourcePreview::check_for_invalidation);

--- a/editor/inspector/editor_resource_preview.h
+++ b/editor/inspector/editor_resource_preview.h
@@ -79,9 +79,7 @@ class EditorResourcePreview : public Node {
 	struct QueueItem {
 		Ref<Resource> resource;
 		String path;
-		ObjectID id;
-		StringName function;
-		Variant userdata;
+		Callable callback;
 	};
 
 	List<QueueItem> queue;
@@ -102,7 +100,7 @@ class EditorResourcePreview : public Node {
 
 	HashMap<String, Item> cache;
 
-	void _preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, ObjectID id, const StringName &p_func, const Variant &p_ud, const Dictionary &p_metadata);
+	void _preview_ready(const String &p_path, int p_hash, const Ref<Texture2D> &p_texture, const Ref<Texture2D> &p_small_texture, const Callable &p_callback, const Dictionary &p_metadata);
 	void _generate_preview(Ref<ImageTexture> &r_texture, Ref<ImageTexture> &r_small_texture, const QueueItem &p_item, const String &cache_base, Dictionary &p_metadata);
 
 	int small_thumbnail_size = -1;
@@ -119,6 +117,10 @@ class EditorResourcePreview : public Node {
 
 	void _update_thumbnail_sizes();
 
+	// TODO: These should be deprecated and the new methods exposed instead.
+	void _queue_resource_preview(const String &p_path, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
+	void _queue_edited_resource_preview(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -131,10 +133,8 @@ public:
 		Ref<Texture2D> small_preview;
 	};
 
-	// p_receiver_func callback has signature (String p_path, Ref<Texture2D> p_preview, Ref<Texture2D> p_preview_small, Variant p_userdata)
-	// p_preview will be null if there was an error
-	void queue_resource_preview(const String &p_path, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
-	void queue_edited_resource_preview(const Ref<Resource> &p_res, Object *p_receiver, const StringName &p_receiver_func, const Variant &p_userdata);
+	void queue_resource_preview(const String &p_path, const Callable &p_callback);
+	void queue_edited_resource_preview(const Ref<Resource> &p_res, const Callable &p_callback);
 	const Dictionary get_preview_metadata(const String &p_path) const;
 
 	PreviewItem get_resource_preview_if_available(const String &p_path);

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -39,19 +39,14 @@
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
 
-void EditorResourceTooltipPlugin::_thumbnail_ready(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
-	ObjectID trid = p_udata;
-	TextureRect *tr = ObjectDB::get_instance<TextureRect>(trid);
-
-	if (!tr) {
-		return;
+void EditorResourceTooltipPlugin::_thumbnail_ready(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_trect_id) {
+	TextureRect *tr = ObjectDB::get_instance<TextureRect>(p_trect_id);
+	if (tr) {
+		tr->set_texture(p_preview);
 	}
-
-	tr->set_texture(p_preview);
 }
 
 void EditorResourceTooltipPlugin::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_thumbnail_ready"), &EditorResourceTooltipPlugin::_thumbnail_ready);
 	ClassDB::bind_method(D_METHOD("request_thumbnail", "path", "control"), &EditorResourceTooltipPlugin::request_thumbnail);
 
 	GDVIRTUAL_BIND(_handles, "type");
@@ -95,7 +90,7 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 
 void EditorResourceTooltipPlugin::request_thumbnail(const String &p_path, TextureRect *p_for_control) const {
 	ERR_FAIL_NULL(p_for_control);
-	EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, const_cast<EditorResourceTooltipPlugin *>(this), "_thumbnail_ready", p_for_control->get_instance_id());
+	EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, callable_mp(const_cast<EditorResourceTooltipPlugin *>(this), &EditorResourceTooltipPlugin::_thumbnail_ready).bind(p_for_control->get_instance_id()));
 }
 
 bool EditorResourceTooltipPlugin::handles(const String &p_resource_type) const {

--- a/editor/inspector/editor_resource_tooltip_plugins.h
+++ b/editor/inspector/editor_resource_tooltip_plugins.h
@@ -41,7 +41,7 @@ class VBoxContainer;
 class EditorResourceTooltipPlugin : public RefCounted {
 	GDCLASS(EditorResourceTooltipPlugin, RefCounted);
 
-	void _thumbnail_ready(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
+	void _thumbnail_ready(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, ObjectID p_trect_id);
 
 protected:
 	static void _bind_methods();

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -441,8 +441,7 @@ void TileMapLayerEditorTilesPlugin::_update_scenes_collection_view() {
 		int item_index = 0;
 		if (scene.is_valid()) {
 			item_index = scene_tiles_list->add_item(vformat("%s (Path: %s, ID: %d)", scene->get_path().get_file().get_basename(), scene->get_path(), scene_id));
-			Variant udata = i;
-			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, this, "_scene_thumbnail_done", udata);
+			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, callable_mp(this, &TileMapLayerEditorTilesPlugin::_scene_thumbnail_done).bind(i));
 		} else {
 			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), tiles_bottom_panel->get_editor_theme_icon(SNAME("PackedScene")));
 		}
@@ -463,11 +462,9 @@ void TileMapLayerEditorTilesPlugin::_update_scenes_collection_view() {
 	scene_tiles_list->set_fixed_icon_size(Vector2(int_size, int_size));
 }
 
-void TileMapLayerEditorTilesPlugin::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud) {
-	int index = p_ud;
-
-	if (index >= 0 && index < scene_tiles_list->get_item_count()) {
-		scene_tiles_list->set_item_icon(index, p_preview);
+void TileMapLayerEditorTilesPlugin::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index) {
+	if (p_index >= 0 && p_index < scene_tiles_list->get_item_count()) {
+		scene_tiles_list->set_item_icon(p_index, p_preview);
 	}
 }
 
@@ -2112,7 +2109,6 @@ void TileMapLayerEditorTilesPlugin::_set_source_sort(int p_sort) {
 }
 
 void TileMapLayerEditorTilesPlugin::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_scene_thumbnail_done"), &TileMapLayerEditorTilesPlugin::_scene_thumbnail_done);
 	ClassDB::bind_method(D_METHOD("_set_tile_map_selection", "selection"), &TileMapLayerEditorTilesPlugin::_set_tile_map_selection);
 	ClassDB::bind_method(D_METHOD("_get_tile_map_selection"), &TileMapLayerEditorTilesPlugin::_get_tile_map_selection);
 }

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -211,7 +211,7 @@ private:
 	ItemList *scene_tiles_list = nullptr;
 
 	void _update_scenes_collection_view();
-	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud);
+	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_index);
 	void _scenes_list_multi_selected(int p_index, bool p_selected);
 	void _scenes_list_lmb_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -222,11 +222,9 @@ void TileSetScenesCollectionSourceEditor::_tile_set_scenes_collection_source_cha
 	tile_set_scenes_collection_source_changed_needs_update = true;
 }
 
-void TileSetScenesCollectionSourceEditor::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud) {
-	int index = p_ud;
-
-	if (index >= 0 && index < scene_tiles_list->get_item_count()) {
-		scene_tiles_list->set_item_icon(index, p_preview);
+void TileSetScenesCollectionSourceEditor::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_idx) {
+	if (p_idx >= 0 && p_idx < scene_tiles_list->get_item_count()) {
+		scene_tiles_list->set_item_icon(p_idx, p_preview);
 	}
 }
 
@@ -327,8 +325,7 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 		int item_index = 0;
 		if (scene.is_valid()) {
 			item_index = scene_tiles_list->add_item(vformat("%s (path:%s id:%d)", scene->get_path().get_file().get_basename(), scene->get_path(), scene_id));
-			Variant udata = i;
-			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, this, "_scene_thumbnail_done", udata);
+			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(scene, callable_mp(this, &TileSetScenesCollectionSourceEditor::_scene_thumbnail_done).bind(i));
 		} else {
 			item_index = scene_tiles_list->add_item(TTR("Tile with Invalid Scene"), get_editor_theme_icon(SNAME("PackedScene")));
 		}
@@ -503,8 +500,6 @@ bool TileSetScenesCollectionSourceEditor::_can_drop_data_fw(const Point2 &p_poin
 
 void TileSetScenesCollectionSourceEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("source_id_changed", PropertyInfo(Variant::INT, "source_id")));
-
-	ClassDB::bind_method(D_METHOD("_scene_thumbnail_done"), &TileSetScenesCollectionSourceEditor::_scene_thumbnail_done);
 }
 
 TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.h
@@ -118,7 +118,7 @@ private:
 
 	void _tile_set_scenes_collection_source_changed();
 	void _scenes_collection_source_proxy_object_changed(const String &p_what);
-	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud);
+	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_idx);
 	void _scenes_list_item_activated(int p_index);
 
 	void _source_add_pressed();

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -111,7 +111,7 @@ void EditorSceneTabs::_scene_tab_hovered(int p_tab) {
 	} else {
 		String path = EditorNode::get_editor_data().get_scene_path(p_tab);
 		if (!path.is_empty()) {
-			EditorResourcePreview::get_singleton()->queue_resource_preview(path, this, "_tab_preview_done", p_tab);
+			EditorResourcePreview::get_singleton()->queue_resource_preview(path, callable_mp(this, &EditorSceneTabs::_tab_preview_done).bind(p_tab));
 		}
 	}
 }
@@ -338,8 +338,7 @@ void EditorSceneTabs::_scene_tabs_resized() {
 	}
 }
 
-void EditorSceneTabs::_tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata) {
-	int p_tab = p_udata;
+void EditorSceneTabs::_tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_tab) {
 	if (p_preview.is_valid()) {
 		tab_preview->set_texture(p_preview);
 
@@ -396,8 +395,6 @@ int EditorSceneTabs::get_current_tab() const {
 void EditorSceneTabs::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab_index")));
 	ADD_SIGNAL(MethodInfo("tab_closed", PropertyInfo(Variant::INT, "tab_index")));
-
-	ClassDB::bind_method("_tab_preview_done", &EditorSceneTabs::_tab_preview_done);
 }
 
 EditorSceneTabs::EditorSceneTabs() {

--- a/editor/scene/editor_scene_tabs.h
+++ b/editor/scene/editor_scene_tabs.h
@@ -80,7 +80,7 @@ private:
 	void _update_context_menu();
 	void _custom_menu_option(int p_option);
 
-	void _tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_udata);
+	void _tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_tab);
 
 	void _global_menu_scene(const Variant &p_tag);
 	void _global_menu_new_window(const Variant &p_tag);


### PR DESCRIPTION
In Godot 4 most methods moved from "object, method, userdata" combo to just use a single Callable. The only remaining one (I think) are preview methods: `queue_resource_preview` and `queue_edited_resource_preview`.

For now the new methods are unexposed, and only used internally.