### PR TITLE
Add `CameraServer` `feeds_updated` signal, and document async behavior

### DIFF
--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -49,6 +49,29 @@
 		<member name="monitoring_feeds" type="bool" setter="set_monitoring_feeds" getter="is_monitoring_feeds" default="false">
 			If [code]true[/code], the server is actively monitoring available camera feeds.
 			This has a performance cost, so only set it to [code]true[/code] when you're actively accessing the camera.
+			[b]Note:[/b] After setting it to [code]true[/code], you can receive updated camera feeds through the [signal camera_feeds_updated] signal.
+			[codeblocks]
+			[gdscript]
+			func _ready():
+				CameraServer.camera_feeds_updated.connect(_on_camera_feeds_updated)
+				CameraServer.monitoring_feeds = true
+
+			func _on_camera_feeds_updated():
+				var feeds = CameraServer.feeds()
+			[/gdscript]
+			[csharp]
+			public override void _Ready()
+			{
+				CameraServer.CameraFeedsUpdated += OnCameraFeedsUpdated;
+				CameraServer.MonitoringFeeds = true;
+			}
+
+			void OnCameraFeedsUpdated()
+			{
+				var feeds = CameraServer.Feeds();
+			}
+			[/csharp]
+			[/codeblocks]
 		</member>
 	</members>
 	<signals>
@@ -62,6 +85,11 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Emitted when a [CameraFeed] is removed (e.g. a webcam is unplugged).
+			</description>
+		</signal>
+		<signal name="camera_feeds_updated">
+			<description>
+				Emitted when camera feeds are updated.
 			</description>
 		</signal>
 	</signals>

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -474,6 +474,7 @@ void CameraAndroid::update_feeds() {
 	}
 
 	ACameraManager_deleteCameraIdList(cameraIds);
+	emit_signal(SNAME(CameraServer::feeds_updated_signal_name));
 }
 
 void CameraAndroid::remove_all_feeds() {

--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -80,6 +80,7 @@ void CameraLinux::_update_devices() {
 			free(devices);
 		}
 
+		call_deferred("emit_signal", SNAME(CameraServer::feeds_updated_signal_name));
 		usleep(1000000);
 	}
 }

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -363,6 +363,7 @@ void CameraMacOS::update_feeds() {
 			add_feed(newfeed);
 		};
 	};
+	emit_signal(SNAME(CameraServer::feeds_updated_signal_name));
 }
 
 void CameraMacOS::set_monitoring_feeds(bool p_monitoring_feeds) {

--- a/servers/camera_server.cpp
+++ b/servers/camera_server.cpp
@@ -53,6 +53,7 @@ void CameraServer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("camera_feed_added", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("camera_feed_removed", PropertyInfo(Variant::INT, "id")));
+	ADD_SIGNAL(MethodInfo(feeds_updated_signal_name));
 
 	BIND_ENUM_CONSTANT(FEED_RGBA_IMAGE);
 	BIND_ENUM_CONSTANT(FEED_YCBCR_IMAGE);

--- a/servers/camera_server.h
+++ b/servers/camera_server.h
@@ -59,6 +59,7 @@ public:
 	};
 
 	typedef CameraServer *(*CreateFunc)();
+	static inline constexpr const char feeds_updated_signal_name[] = "camera_feeds_updated";
 
 private:
 protected:


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fixed: #108136

- Add SafeFlag to prevent concurrent camera thread initialization
- Set monitoring_feeds to true only after device enumeration completes
- Document that monitoring_feeds requires waiting a few frames
- Add code examples for GDScript and C# showing proper usage pattern

This ensures camera feeds are properly initialized before being accessed and prevents potential crashes from concurrent thread creation.

