### PR TITLE
GDScript: Don't get invalid dictionary key during completion

### DIFF
--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -45,6 +45,116 @@ struct ContainerTypeValidate {
 	Ref<Script> script;
 	const char *where = "container";
 
+private:
+	// Coerces String and StringName into each other and int into float when needed.
+	_FORCE_INLINE_ bool _internal_validate(Variant &inout_variant, const char *p_operation, bool p_output_errors) const {
+		if (type == Variant::NIL) {
+			return true;
+		}
+
+		if (type != inout_variant.get_type()) {
+			if (inout_variant.get_type() == Variant::NIL && type == Variant::OBJECT) {
+				return true;
+			}
+			if (type == Variant::STRING && inout_variant.get_type() == Variant::STRING_NAME) {
+				inout_variant = String(inout_variant);
+				return true;
+			} else if (type == Variant::STRING_NAME && inout_variant.get_type() == Variant::STRING) {
+				inout_variant = StringName(inout_variant);
+				return true;
+			} else if (type == Variant::FLOAT && inout_variant.get_type() == Variant::INT) {
+				inout_variant = (float)inout_variant;
+				return true;
+			}
+
+			if (p_output_errors) {
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of type '%s'.", String(p_operation), Variant::get_type_name(inout_variant.get_type()), where, Variant::get_type_name(type)));
+			} else {
+				return false;
+			}
+		}
+
+		if (type != Variant::OBJECT) {
+			return true;
+		}
+
+		return _internal_validate_object(inout_variant, p_operation, p_output_errors);
+	}
+
+	_FORCE_INLINE_ bool _internal_validate_object(const Variant &p_variant, const char *p_operation, bool p_output_errors) const {
+		ERR_FAIL_COND_V(p_variant.get_type() != Variant::OBJECT, false);
+
+#ifdef DEBUG_ENABLED
+		ObjectID object_id = p_variant;
+		if (object_id == ObjectID()) {
+			return true; // This is fine, it's null.
+		}
+		Object *object = ObjectDB::get_instance(object_id);
+		if (object == nullptr) {
+			if (p_output_errors) {
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an invalid (previously freed?) object instance into a '%s'.", String(p_operation), String(where)));
+			} else {
+				return false;
+			}
+		}
+#else
+		Object *object = p_variant;
+		if (object == nullptr) {
+			return true; //fine
+		}
+#endif
+		if (class_name == StringName()) {
+			return true; // All good, no class type requested.
+		}
+
+		const StringName &obj_class = object->get_class_name();
+		if (obj_class != class_name && !ClassDB::is_parent_class(obj_class, class_name)) {
+			if (p_output_errors) {
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), where, String(class_name)));
+			} else {
+				return false;
+			}
+		}
+
+		if (script.is_null()) {
+			return true; // All good, no script requested.
+		}
+
+		Ref<Script> other_script = object->get_script();
+
+		// Check base script..
+		if (other_script.is_null()) {
+			if (p_output_errors) {
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
+			} else {
+				return false;
+			}
+		}
+		if (!other_script->inherits_script(script)) {
+			if (p_output_errors) {
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
+			} else {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+public:
+	_FORCE_INLINE_ bool validate(Variant &inout_variant, const char *p_operation = "use") const {
+		return _internal_validate(inout_variant, p_operation, true);
+	}
+
+	_FORCE_INLINE_ bool validate_object(const Variant &p_variant, const char *p_operation = "use") const {
+		return _internal_validate_object(p_variant, p_operation, true);
+	}
+
+	_FORCE_INLINE_ bool test_validate(const Variant &p_variant) const {
+		Variant tmp = p_variant;
+		return _internal_validate(tmp, "", false);
+	}
+
 	_FORCE_INLINE_ bool can_reference(const ContainerTypeValidate &p_type) const {
 		if (type != p_type.type) {
 			return false;
@@ -76,74 +186,5 @@ struct ContainerTypeValidate {
 	}
 	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
 		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
-	}
-
-	// Coerces String and StringName into each other and int into float when needed.
-	_FORCE_INLINE_ bool validate(Variant &inout_variant, const char *p_operation = "use") const {
-		if (type == Variant::NIL) {
-			return true;
-		}
-
-		if (type != inout_variant.get_type()) {
-			if (inout_variant.get_type() == Variant::NIL && type == Variant::OBJECT) {
-				return true;
-			}
-			if (type == Variant::STRING && inout_variant.get_type() == Variant::STRING_NAME) {
-				inout_variant = String(inout_variant);
-				return true;
-			} else if (type == Variant::STRING_NAME && inout_variant.get_type() == Variant::STRING) {
-				inout_variant = StringName(inout_variant);
-				return true;
-			} else if (type == Variant::FLOAT && inout_variant.get_type() == Variant::INT) {
-				inout_variant = (float)inout_variant;
-				return true;
-			}
-
-			ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of type '%s'.", String(p_operation), Variant::get_type_name(inout_variant.get_type()), where, Variant::get_type_name(type)));
-		}
-
-		if (type != Variant::OBJECT) {
-			return true;
-		}
-
-		return validate_object(inout_variant, p_operation);
-	}
-
-	_FORCE_INLINE_ bool validate_object(const Variant &p_variant, const char *p_operation = "use") const {
-		ERR_FAIL_COND_V(p_variant.get_type() != Variant::OBJECT, false);
-
-#ifdef DEBUG_ENABLED
-		ObjectID object_id = p_variant;
-		if (object_id == ObjectID()) {
-			return true; // This is fine, it's null.
-		}
-		Object *object = ObjectDB::get_instance(object_id);
-		ERR_FAIL_NULL_V_MSG(object, false, vformat("Attempted to %s an invalid (previously freed?) object instance into a '%s'.", String(p_operation), String(where)));
-#else
-		Object *object = p_variant;
-		if (object == nullptr) {
-			return true; //fine
-		}
-#endif
-		if (class_name == StringName()) {
-			return true; // All good, no class type requested.
-		}
-
-		const StringName &obj_class = object->get_class_name();
-		if (obj_class != class_name) {
-			ERR_FAIL_COND_V_MSG(!ClassDB::is_parent_class(obj_class, class_name), false, vformat("Attempted to %s an object of type '%s' into a %s, which does not inherit from '%s'.", String(p_operation), object->get_class(), where, String(class_name)));
-		}
-
-		if (script.is_null()) {
-			return true; // All good, no script requested.
-		}
-
-		Ref<Script> other_script = object->get_script();
-
-		// Check base script..
-		ERR_FAIL_COND_V_MSG(other_script.is_null(), false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
-		ERR_FAIL_COND_V_MSG(!other_script->inherits_script(script), false, vformat("Attempted to %s an object into a %s, that does not inherit from '%s'.", String(p_operation), String(where), String(script->get_class_name())));
-
-		return true;
 	}
 };

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -722,6 +722,14 @@ Variant Dictionary::get_typed_value_script() const {
 	return _p->typed_value.script;
 }
 
+const ContainerTypeValidate &Dictionary::get_key_validator() const {
+	return _p->typed_key;
+}
+
+const ContainerTypeValidate &Dictionary::get_value_validator() const {
+	return _p->typed_value;
+}
+
 void Dictionary::operator=(const Dictionary &p_dictionary) {
 	if (this == &p_dictionary) {
 		return;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -40,6 +40,7 @@
 class Variant;
 
 struct ContainerType;
+struct ContainerTypeValidate;
 struct DictionaryPrivate;
 struct StringLikeVariantComparator;
 struct VariantHasher;
@@ -121,6 +122,8 @@ public:
 	StringName get_typed_value_class_name() const;
 	Variant get_typed_key_script() const;
 	Variant get_typed_value_script() const;
+	const ContainerTypeValidate &get_key_validator() const;
+	const ContainerTypeValidate &get_value_validator() const;
 
 	void make_read_only();
 	bool is_read_only() const;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -44,6 +44,7 @@
 #include "core/core_constants.h"
 #include "core/io/file_access.h"
 #include "core/math/expression.h"
+#include "core/variant/container_type_validate.h"
 
 #ifdef TOOLS_ENABLED
 #include "core/config/project_settings.h"
@@ -2099,13 +2100,22 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 						break;
 					}
 
-					{
-						bool valid;
-						Variant value = base.value.get(index.value, &valid);
-						if (valid) {
-							r_type = _type_from_variant(value, p_context);
-							found = true;
-							break;
+					if (base.type.is_constant && index.type.is_constant) {
+						if (base.value.get_type() == Variant::DICTIONARY) {
+							Dictionary base_dict = base.value.operator Dictionary();
+							if (base_dict.get_key_validator().test_validate(index.value) && base_dict.has(index.value)) {
+								r_type = _type_from_variant(base_dict[index.value], p_context);
+								found = true;
+								break;
+							}
+						} else {
+							bool valid;
+							Variant value = base.value.get(index.value, &valid);
+							if (valid) {
+								r_type = _type_from_variant(value, p_context);
+								found = true;
+								break;
+							}
 						}
 					}
 

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
@@ -1,5 +1,5 @@
 GDTEST_RUNTIME_ERROR
->> ERROR: Condition "!other_script->inherits_script(script)" is true. Returning: false
+>> ERROR: Method/function failed. Returning: false
 >>   Attempted to assign an object into a TypedArray, that does not inherit from 'GDScript'.
 >> ERROR: Method/function failed.
 >>   Unable to convert array index 0 from "Object" to "Object".

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_wrong_to_typed.out
@@ -1,5 +1,5 @@
 GDTEST_RUNTIME_ERROR
->> ERROR: Condition "!other_script->inherits_script(script)" is true. Returning: false
+>> ERROR: Method/function failed. Returning: false
 >>   Attempted to assign an object into a TypedDictionary.Key, that does not inherit from 'GDScript'.
 >> ERROR: Method/function failed.
 >>   Unable to convert key from "Object" to "Object".


### PR DESCRIPTION
We try to get the value out of a dictionary in order to establish its type for completion purposes. However, if the dictionary or the key is not a constant, we cannot safely get the actual value, so we skip this and just try to infer from static typing.

> [!NOTE]
> ~~This also adds a change in core: it removes type validation from `Dictionary.has()` (and `has_all()`) because it simplifies checking if a given key is valid without having to check its type externally.~~
> This now exposes the `ContainerTypeValidate` object from the dictionary and add a function to it to test a value without generating errors. This way the completion code can check it before trying to get the key.

Fix #102926
Supersedes #104757

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
