### PR TITLE
[3.x] Add `EditorSettings` `EDITOR_GET_CACHED`

### DIFF
--- a/core/os/input.cpp
+++ b/core/os/input.cpp
@@ -140,7 +140,7 @@ void Input::_bind_methods() {
 void Input::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
 
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 
 	String pf = p_function;
 	if ((p_idx == 0 && (pf == "is_action_pressed" || pf == "action_press" || pf == "action_release" || pf == "is_action_just_pressed" || pf == "is_action_just_released" || pf == "get_action_strength" || pf == "get_action_raw_strength")) ||

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3458,14 +3458,14 @@ void AnimationTrackEditor::_query_insert(const InsertData &p_id) {
 			insert_confirm->popup_centered_minsize();
 			insert_query = true;
 		} else {
-			call_deferred("_insert_delay", reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), all_bezier && EDITOR_GET("editors/animation/default_create_bezier_tracks"));
+			call_deferred("_insert_delay", reset_allowed && EDITOR_GET_CACHED(bool, "editors/animation/default_create_reset_tracks"), all_bezier && EDITOR_GET_CACHED(bool, "editors/animation/default_create_bezier_tracks"));
 			insert_queue = true;
 		}
 
 	} else {
 		if (!insert_query && !insert_queue) {
 			// Create Beziers wouldn't make sense in this case, where no tracks are being created
-			call_deferred("_insert_delay", reset_allowed && EDITOR_GET("editors/animation/default_create_reset_tracks"), false);
+			call_deferred("_insert_delay", reset_allowed && EDITOR_GET_CACHED(bool, "editors/animation/default_create_reset_tracks"), false);
 			insert_queue = true;
 		}
 	}

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1507,17 +1507,17 @@ void CodeTextEditor::_on_settings_change() {
 
 	// Auto brace completion.
 	text_editor->set_auto_brace_completion(
-			EDITOR_GET("text_editor/completion/auto_brace_complete"));
+			EDITOR_GET_CACHED(bool, "text_editor/completion/auto_brace_complete"));
 
 	code_complete_timer->set_wait_time(
-			EDITOR_GET("text_editor/completion/code_complete_delay"));
+			EDITOR_GET_CACHED(float, "text_editor/completion/code_complete_delay"));
 
 	// Call hint settings.
 	text_editor->set_callhint_settings(
-			EDITOR_GET("text_editor/completion/put_callhint_tooltip_below_current_line"),
-			EDITOR_GET("text_editor/completion/callhint_tooltip_offset"));
+			EDITOR_GET_CACHED(bool, "text_editor/completion/put_callhint_tooltip_below_current_line"),
+			EDITOR_GET_CACHED(Vector2, "text_editor/completion/callhint_tooltip_offset"));
 
-	idle->set_wait_time(EDITOR_GET("text_editor/completion/idle_parse_delay"));
+	idle->set_wait_time(EDITOR_GET_CACHED(float, "text_editor/completion/idle_parse_delay"));
 }
 
 void CodeTextEditor::_text_changed_idle_timeout() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -464,7 +464,7 @@ void EditorNode::_notification(int p_what) {
 
 			editor_selection->update();
 
-			scene_root->set_size_override(true, Size2(ProjectSettings::get_singleton()->get("display/window/size/width"), ProjectSettings::get_singleton()->get("display/window/size/height")));
+			scene_root->set_size_override(true, Size2(GLOBAL_GET_CACHED(real_t, "display/window/size/width"), GLOBAL_GET_CACHED(real_t, "display/window/size/height")));
 
 			ResourceImporterTexture::get_singleton()->update_imports();
 		} break;
@@ -532,7 +532,7 @@ void EditorNode::_notification(int p_what) {
 
 		case MainLoop::NOTIFICATION_WM_FOCUS_IN: {
 			// Restore the original FPS cap after focusing back on the editor.
-			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/low_processor_mode_sleep_usec")));
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(EDITOR_GET_CACHED(int, "interface/editor/low_processor_mode_sleep_usec"));
 
 			EditorFileSystem::get_singleton()->scan_changes();
 			_scan_external_changes();
@@ -540,12 +540,12 @@ void EditorNode::_notification(int p_what) {
 
 		case MainLoop::NOTIFICATION_WM_FOCUS_OUT: {
 			// Save on focus loss before applying the FPS limit to avoid slowing down the saving process.
-			if (EDITOR_GET("interface/editor/save_on_focus_loss")) {
+			if (EDITOR_GET_CACHED(bool, "interface/editor/save_on_focus_loss")) {
 				_menu_option_confirm(FILE_SAVE_SCENE, false);
 			}
 
 			// Set a low FPS cap to decrease CPU/GPU usage while the editor is unfocused.
-			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(int(EDITOR_GET("interface/editor/unfocused_low_processor_mode_sleep_usec")));
+			OS::get_singleton()->set_low_processor_usage_mode_sleep_usec(EDITOR_GET_CACHED(int, "interface/editor/unfocused_low_processor_mode_sleep_usec"));
 		} break;
 
 		case MainLoop::NOTIFICATION_WM_ABOUT: {
@@ -2671,7 +2671,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			play_custom_scene_button->set_icon(gui_base->get_icon("PlayCustom", "EditorIcons"));
 			stop_button->set_disabled(true);
 
-			if (bool(EDITOR_GET("run/output/always_close_output_on_stop"))) {
+			if (EDITOR_GET_CACHED(bool, "run/output/always_close_output_on_stop")) {
 				for (int i = 0; i < bottom_panel_items.size(); i++) {
 					if (bottom_panel_items[i].control == log) {
 						_bottom_panel_switch(false, i);
@@ -2695,7 +2695,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case RUN_PLAY_NATIVE: {
-			bool autosave = EDITOR_GET("run/auto_save/save_before_running");
+			bool autosave = EDITOR_GET_CACHED(bool, "run/auto_save/save_before_running");
 			if (autosave) {
 				_menu_option_confirm(FILE_SAVE_ALL_SCENES, false);
 			}
@@ -5006,7 +5006,7 @@ void EditorNode::_scene_tab_closed(int p_tab, int option) {
 }
 
 void EditorNode::_scene_tab_hover(int p_tab) {
-	if (!bool(EDITOR_GET("interface/scene_tabs/show_thumbnail_on_hover"))) {
+	if (!EDITOR_GET_CACHED(bool, "interface/scene_tabs/show_thumbnail_on_hover")) {
 		return;
 	}
 	int current_tab = scene_tabs->get_current_tab();

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1599,7 +1599,7 @@ void EditorPropertyVector2::setup(double p_min, double p_max, double p_step, boo
 }
 
 EditorPropertyVector2::EditorPropertyVector2() {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector2_editing");
+	bool horizontal = EDITOR_GET_CACHED(bool, "interface/inspector/horizontal_vector2_editing");
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1693,7 +1693,7 @@ void EditorPropertyRect2::setup(double p_min, double p_max, double p_step, bool 
 }
 
 EditorPropertyRect2::EditorPropertyRect2() {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = EDITOR_GET_CACHED(bool, "interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
@@ -1830,7 +1830,7 @@ void EditorPropertyVector3::setup(double p_min, double p_max, double p_step, boo
 }
 
 EditorPropertyVector3::EditorPropertyVector3() {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = EDITOR_GET_CACHED(bool, "interface/inspector/horizontal_vector_types_editing");
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1925,7 +1925,7 @@ void EditorPropertyPlane::setup(double p_min, double p_max, double p_step, bool 
 }
 
 EditorPropertyPlane::EditorPropertyPlane() {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = EDITOR_GET_CACHED(bool, "interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
@@ -2007,7 +2007,7 @@ void EditorPropertyQuat::setup(double p_min, double p_max, double p_step, bool p
 }
 
 EditorPropertyQuat::EditorPropertyQuat() {
-	bool horizontal = EDITOR_GET("interface/inspector/horizontal_vector_types_editing");
+	bool horizontal = EDITOR_GET_CACHED(bool, "interface/inspector/horizontal_vector_types_editing");
 
 	BoxContainer *bc;
 
@@ -2373,7 +2373,7 @@ void EditorPropertyColor::_popup_closed() {
 
 void EditorPropertyColor::_picker_created() {
 	// get default color picker mode from editor settings
-	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
+	int default_color_mode = EDITOR_GET_CACHED(int, "interface/inspector/default_color_picker_mode");
 	if (default_color_mode == 1) {
 		picker->get_picker()->set_hsv_mode(true);
 	} else if (default_color_mode == 2) {
@@ -2920,7 +2920,7 @@ void EditorPropertyResource::_bind_methods() {
 }
 
 EditorPropertyResource::EditorPropertyResource() {
-	use_sub_inspector = bool(EDITOR_GET("interface/inspector/open_resources_in_current_inspector"));
+	use_sub_inspector = EDITOR_GET_CACHED(bool, "interface/inspector/open_resources_in_current_inspector");
 
 	add_to_group("_editor_resource_properties");
 }
@@ -2936,7 +2936,7 @@ void EditorInspectorDefaultPlugin::parse_begin(Object *p_object) {
 }
 
 bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, Variant::Type p_type, const String &p_path, PropertyHint p_hint, const String &p_hint_text, int p_usage) {
-	double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
+	double default_float_step = EDITOR_GET_CACHED(double, "interface/inspector/default_float_step");
 
 	switch (p_type) {
 		// atomic types

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -702,7 +702,7 @@ void EditorPropertyArray::_bind_methods() {
 
 EditorPropertyArray::EditorPropertyArray() {
 	object.instance();
-	page_length = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
+	page_length = EDITOR_GET_CACHED(int, "interface/inspector/max_array_dictionary_items_per_page");
 	edit = memnew(Button);
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1190,7 +1190,7 @@ void EditorPropertyDictionary::_bind_methods() {
 
 EditorPropertyDictionary::EditorPropertyDictionary() {
 	object.instance();
-	page_length = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
+	page_length = EDITOR_GET_CACHED(int, "interface/inspector/max_array_dictionary_items_per_page");
 	edit = memnew(Button);
 	edit->set_flat(true);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -35,7 +35,7 @@
 EditorPropertyNameProcessor *EditorPropertyNameProcessor::singleton = nullptr;
 
 EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_default_inspector_style() {
-	const Style style = (Style)EDITOR_GET("interface/inspector/default_property_name_style").operator int();
+	const Style style = (Style)EDITOR_GET_CACHED(int, "interface/inspector/default_property_name_style");
 	if (style == STYLE_LOCALIZED && !is_localization_available()) {
 		return STYLE_CAPITALIZED;
 	}
@@ -43,7 +43,7 @@ EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_default_insp
 }
 
 EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_settings_style() {
-	const bool translate = EDITOR_GET("interface/editor/localize_settings");
+	const bool translate = EDITOR_GET_CACHED(bool, "interface/editor/localize_settings");
 	return translate ? STYLE_LOCALIZED : STYLE_CAPITALIZED;
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -47,6 +47,12 @@
 #include "scene/main/scene_tree.h"
 #include "scene/main/viewport.h"
 
+EditorSettingsQuick::Data EditorSettingsQuick::data = EditorSettingsQuick::Data();
+
+void EditorSettingsQuick::refresh() {
+	data.text_editor_completion_use_single_quotes = EDITOR_GET_CACHED(bool, "text_editor/completion/use_single_quotes");
+}
+
 // PRIVATE METHODS
 
 Ref<EditorSettings> EditorSettings::singleton = nullptr;
@@ -106,6 +112,10 @@ bool EditorSettings::_set_only(const StringName &p_name, const Variant &p_value)
 				changed = true;
 			}
 		}
+	}
+
+	if (changed) {
+		_version++;
 	}
 
 	return changed;
@@ -1155,6 +1165,7 @@ void EditorSettings::set_initial_value(const StringName &p_setting, const Varian
 	}
 	props[p_setting].initial = p_value;
 	props[p_setting].has_default_value = true;
+
 	if (p_update_current) {
 		set(p_setting, p_value);
 	}
@@ -1604,6 +1615,8 @@ Ref<ShortCut> ED_SHORTCUT(const String &p_path, const String &p_name, uint32_t p
 
 void EditorSettings::notify_changes() {
 	_THREAD_SAFE_METHOD_
+
+	EditorSettingsQuick::refresh();
 
 	SceneTree *sml = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -135,7 +135,7 @@ static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color,
 #endif
 
 float get_gizmo_handle_scale(const String &gizmo_handle_name = "") {
-	const float scale_gizmo_handles_for_touch = EDITOR_GET("interface/touchscreen/scale_gizmo_handles");
+	const float scale_gizmo_handles_for_touch = EDITOR_GET_CACHED(float, "interface/touchscreen/scale_gizmo_handles");
 	if (scale_gizmo_handles_for_touch > 1.0f) {
 		// The names of the icons that require custom scaling.
 		static Set<StringName> gizmo_to_scale;
@@ -772,12 +772,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("visibility_xray", "PopupMenu", theme->get_icon("GuiVisibilityXray", "EditorIcons"));
 	theme->set_constant("vseparation", "PopupMenu", (extra_spacing + default_margin_size + 1) * EDSCALE);
 
+	float subresource_hue_tint = EDITOR_GET("docks/property_editor/subresource_hue_tint");
+
 	for (int i = 0; i < 16; i++) {
 		Color si_base_color = accent_color;
 
 		float hue_rotate = (i * 2 % 16) / 16.0;
 		si_base_color.set_hsv(Math::fmod(float(si_base_color.get_h() + hue_rotate), float(1.0)), si_base_color.get_s(), si_base_color.get_v());
-		si_base_color = accent_color.linear_interpolate(si_base_color, float(EDITOR_GET("docks/property_editor/subresource_hue_tint")));
+		si_base_color = accent_color.linear_interpolate(si_base_color, subresource_hue_tint);
 
 		Ref<StyleBoxFlat> sub_inspector_bg;
 

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -402,7 +402,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 					edge_point = PosVertex();
 					return true;
 				} else {
-					const real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
+					const real_t grab_threshold = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 
 					if (!_is_line() && wip.size() > 1 && xform.xform(wip[0]).distance_to(xform.xform(cpoint)) < grab_threshold) {
 						//wip closed
@@ -541,7 +541,7 @@ void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overl
 			offset = _get_offset(j);
 		}
 
-		if (!wip_active && j == edited_point.polygon && EDITOR_GET("editors/poly_editor/show_previous_outline")) {
+		if (!wip_active && j == edited_point.polygon && EDITOR_GET_CACHED(bool, "editors/poly_editor/show_previous_outline")) {
 			const Color col = Color(0.5, 0.5, 0.5); // FIXME polygon->get_outline_color();
 			const int n = pre_move_edit.size();
 			for (int i = 0; i < n - (is_closed ? 0 : 1); i++) {
@@ -666,7 +666,7 @@ AbstractPolygon2DEditor::Vertex AbstractPolygon2DEditor::get_active_point() cons
 }
 
 AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const Vector2 &p_pos) const {
-	const real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 
 	const int n_polygons = _get_polygon_count();
 	const Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_global_transform();
@@ -694,7 +694,7 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const 
 }
 
 AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(const Vector2 &p_pos) const {
-	const real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 	const real_t eps = grab_threshold * 2;
 	const real_t eps2 = eps * eps;
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1440,12 +1440,15 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	int step_off_a = onion.past ? -onion.steps : 0;
 	int step_off_b = onion.future ? onion.steps : 0;
 	int cidx = 0;
-	onion.capture.material->set_shader_param("dir_color", onion.force_white_modulate ? Color(1, 1, 1) : Color(EDITOR_GET("editors/animation/onion_layers_past_color")));
+	onion.capture.material->set_shader_param("dir_color", onion.force_white_modulate ? Color(1, 1, 1) : Color(EDITOR_GET_CACHED(Color, "editors/animation/onion_layers_past_color")));
+
+	Color onion_layers_future_color = EDITOR_GET_CACHED(Color, "editors/animation/onion_layers_future_color");
+
 	for (int step_off = step_off_a; step_off <= step_off_b; step_off++) {
 		if (step_off == 0) {
 			// Skip present step and switch to the color of future.
 			if (!onion.force_white_modulate) {
-				onion.capture.material->set_shader_param("dir_color", EDITOR_GET("editors/animation/onion_layers_future_color"));
+				onion.capture.material->set_shader_param("dir_color", onion_layers_future_color);
 			}
 			continue;
 		}

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -583,7 +583,7 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 		return;
 	}
 
-	const real_t grab_distance = EDITOR_GET("editors/poly_editor/point_grab_radius");
+	const real_t grab_distance = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
 
 	for (int i = p_node->get_child_count() - 1; i >= 0; i--) {

--- a/editor/plugins/collision_polygon_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_editor_plugin.cpp
@@ -136,7 +136,7 @@ bool Polygon3DEditor::forward_spatial_gui_input(Camera *p_camera, const Ref<Inpu
 		Vector<Vector2> poly = node->call("get_polygon");
 
 		//first check if a point is to be added (segment split)
-		real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
+		real_t grab_threshold = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 
 		switch (mode) {
 			case MODE_CREATE: {

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -69,7 +69,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		return false;
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
+	real_t grab_threshold = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -829,7 +829,7 @@ bool ScriptEditor::_test_script_times_on_disk(RES p_for_script) {
 
 	bool need_ask = false;
 	bool need_reload = false;
-	bool use_autoreload = EDITOR_GET("text_editor/files/auto_reload_scripts_on_external_change");
+	bool use_autoreload = EDITOR_GET_CACHED(bool, "text_editor/files/auto_reload_scripts_on_external_change");
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
@@ -2636,7 +2636,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 void ScriptEditor::_input(const Ref<InputEvent> &p_event) {
 	// This feature can be disabled to avoid interfering with other uses of the additional
 	// mouse buttons, such as push-to-talk in a VoIP program.
-	if (EDITOR_GET("text_editor/navigation/mouse_extra_buttons_navigate_history")) {
+	if (EDITOR_GET_CACHED(bool, "text_editor/navigation/mouse_extra_buttons_navigate_history")) {
 		const Ref<InputEventMouseButton> mb = p_event;
 
 		// Navigate the script history using additional mouse buttons present on some mice.

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -169,7 +169,7 @@ void ScriptTextEditor::enable_editor() {
 void ScriptTextEditor::_update_member_keywords() {
 	member_keywords.clear();
 	code_editor->get_text_edit()->clear_member_keywords();
-	Color member_variable_color = EDITOR_GET("text_editor/highlighting/member_variable_color");
+	Color member_variable_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/member_variable_color");
 
 	StringName instance_base = script->get_instance_base_type();
 
@@ -1504,7 +1504,7 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 }
 
 void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 
 	Dictionary d = p_data;
 
@@ -1562,7 +1562,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		String text_to_drop;
 
 		if (Input::get_singleton()->is_key_pressed(KEY_CONTROL)) {
-			bool use_type = EDITOR_GET("text_editor/completion/add_type_hints");
+			bool use_type = EDITOR_GET_CACHED(bool, "text_editor/completion/add_type_hints");
 			for (int i = 0; i < nodes.size(); i++) {
 				NodePath np = nodes[i];
 				Node *node = get_node(np);
@@ -1845,7 +1845,7 @@ void ScriptTextEditor::_enable_code_editor() {
 	color_panel->add_child(color_picker);
 
 	// get default color picker mode from editor settings
-	int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
+	int default_color_mode = EDITOR_GET_CACHED(int, "interface/inspector/default_color_picker_mode");
 	if (default_color_mode == 1) {
 		color_picker->set_hsv_mode(true);
 	} else if (default_color_mode == 2) {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -432,7 +432,7 @@ void ShaderEditor::_check_for_external_edit() {
 		return;
 	}
 
-	bool use_autoreload = EDITOR_GET("text_editor/files/auto_reload_scripts_on_external_change");
+	bool use_autoreload = EDITOR_GET_CACHED(bool, "text_editor/files/auto_reload_scripts_on_external_change");
 	if (shader->get_last_modified_time() != FileAccess::get_modified_time(shader->get_path())) {
 		if (use_autoreload) {
 			_reload_shader_from_disk();

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -480,16 +480,17 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 		//-------
 		// Perform smoothing
 
+		const float orbit_inertia = EDITOR_GET_CACHED(float, "editors/3d/navigation_feel/orbit_inertia");
+
 		if (is_freelook_active()) {
 			// Higher inertia should increase "lag" (lerp with factor between 0 and 1)
 			// Inertia of zero should produce instant movement (lerp with factor of 1) in this case it returns a really high value and gets clamped to 1.
-			const real_t inertia = EDITOR_GET("editors/3d/freelook/freelook_inertia");
+			const real_t inertia = EDITOR_GET_CACHED(real_t, "editors/3d/freelook/freelook_inertia");
 			real_t factor = (1.0 / inertia) * p_interp_delta;
 
 			// We interpolate a different point here, because in freelook mode the focus point (cursor.pos) orbits around eye_pos
 			camera_cursor.eye_pos = old_camera_cursor.eye_pos.linear_interpolate(cursor.eye_pos, CLAMP(factor, 0, 1));
 
-			const float orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 
@@ -504,9 +505,8 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 			camera_cursor.pos = camera_cursor.eye_pos + forward * camera_cursor.distance;
 
 		} else {
-			const float orbit_inertia = EDITOR_GET("editors/3d/navigation_feel/orbit_inertia");
-			const float translation_inertia = EDITOR_GET("editors/3d/navigation_feel/translation_inertia");
-			const float zoom_inertia = EDITOR_GET("editors/3d/navigation_feel/zoom_inertia");
+			const float translation_inertia = EDITOR_GET_CACHED(float, "editors/3d/navigation_feel/translation_inertia");
+			const float zoom_inertia = EDITOR_GET_CACHED(float, "editors/3d/navigation_feel/zoom_inertia");
 
 			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
 			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
@@ -1744,7 +1744,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 				Vector3 ray_pos = _get_ray_pos(m->get_position());
 				Vector3 ray = _get_ray(m->get_position());
-				double snap = EDITOR_GET("interface/inspector/default_float_step");
+				double snap = EDITOR_GET_CACHED(double, "interface/inspector/default_float_step");
 				int snap_step_decimals = Math::range_step_decimals(snap);
 
 				switch (_edit.mode) {
@@ -7530,7 +7530,7 @@ SpatialEditorPlugin::~SpatialEditorPlugin() {
 }
 
 void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color &p_color, bool p_billboard, bool p_on_top, bool p_use_vertex_color) {
-	Color instanced_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/instanced");
+	Color instanced_color = EDITOR_GET_CACHED(Color, "editors/3d_gizmos/gizmo_colors/instanced");
 
 	Vector<Ref<Material3D>> mats;
 
@@ -7571,7 +7571,7 @@ void EditorSpatialGizmoPlugin::create_material(const String &p_name, const Color
 }
 
 void EditorSpatialGizmoPlugin::create_icon_material(const String &p_name, const Ref<Texture> &p_texture, bool p_on_top, const Color &p_albedo) {
-	Color instanced_color = EDITOR_GET("editors/3d_gizmos/gizmo_colors/instanced");
+	Color instanced_color = EDITOR_GET_CACHED(Color, "editors/3d_gizmos/gizmo_colors/instanced");
 
 	Vector<Ref<Material3D>> icons;
 

--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -808,7 +808,7 @@ void TileMapEditor::_erase_selection() {
 }
 
 void TileMapEditor::_draw_grid(Control *p_viewport, const Rect2 &p_rect) const {
-	if (!EDITOR_GET("editors/tile_map/display_grid")) {
+	if (!EDITOR_GET_CACHED(bool, "editors/tile_map/display_grid")) {
 		return;
 	}
 
@@ -821,8 +821,8 @@ void TileMapEditor::_draw_grid(Control *p_viewport, const Rect2 &p_rect) const {
 	if (distance_fade <= 0) {
 		return;
 	}
-	const Color grid_color = Color(EDITOR_GET("editors/tile_map/grid_color")) * Color(1, 1, 1, distance_fade);
-	const Color axis_color = Color(EDITOR_GET("editors/tile_map/axis_color")) * Color(1, 1, 1, distance_fade);
+	const Color grid_color = EDITOR_GET_CACHED(Color, "editors/tile_map/grid_color") * Color(1, 1, 1, distance_fade);
+	const Color axis_color = EDITOR_GET_CACHED(Color, "editors/tile_map/axis_color") * Color(1, 1, 1, distance_fade);
 
 	const int fade = 5;
 	const Rect2i si = p_rect.grow(fade);

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1585,7 +1585,7 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 						shape_anchor.y *= (size.y + spacing);
 					}
 
-					const real_t grab_threshold = EDITOR_GET("editors/poly_editor/point_grab_radius");
+					const real_t grab_threshold = EDITOR_GET_CACHED(real_t, "editors/poly_editor/point_grab_radius");
 					shape_anchor += current_tile_region.position;
 					if (tools[TOOL_SELECT]->is_pressed()) {
 						if (current_shape.size() > 0) {

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -871,12 +871,12 @@ void VisualShaderEditor::_update_graph() {
 			expression_node->set_control(expression_box, 0);
 			node->add_child(expression_box);
 
-			Color background_color = EDITOR_GET("text_editor/highlighting/background_color");
-			Color text_color = EDITOR_GET("text_editor/highlighting/text_color");
-			Color keyword_color = EDITOR_GET("text_editor/highlighting/keyword_color");
-			Color control_flow_keyword_color = EDITOR_GET("text_editor/highlighting/control_flow_keyword_color");
-			Color comment_color = EDITOR_GET("text_editor/highlighting/comment_color");
-			Color symbol_color = EDITOR_GET("text_editor/highlighting/symbol_color");
+			Color background_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/background_color");
+			Color text_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/text_color");
+			Color keyword_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/keyword_color");
+			Color control_flow_keyword_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/control_flow_keyword_color");
+			Color comment_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/comment_color");
+			Color symbol_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/symbol_color");
 
 			expression_box->set_syntax_coloring(true);
 			expression_box->add_color_override("background_color", background_color);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -834,7 +834,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				color_picker->connect("color_changed", this, "_color_changed");
 
 				// get default color picker mode from editor settings
-				int default_color_mode = EDITOR_GET("interface/inspector/default_color_picker_mode");
+				int default_color_mode = EDITOR_GET_CACHED(int, "interface/inspector/default_color_picker_mode");
 				if (default_color_mode == 1) {
 					color_picker->set_hsv_mode(true);
 				} else if (default_color_mode == 2) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1416,7 +1416,8 @@ void SceneTreeDock::_notification(int p_what) {
 			filter->set_clear_button_enabled(true);
 		} break;
 		case NOTIFICATION_PROCESS: {
-			bool show_create_root = bool(EDITOR_GET("interface/editors/show_scene_tree_root_selection")) && get_tree()->get_edited_scene_root() == nullptr;
+			bool show_scene_tree_root_selection = EDITOR_GET_CACHED(bool, "interface/editors/show_scene_tree_root_selection");
+			bool show_create_root = show_scene_tree_root_selection && get_tree()->get_edited_scene_root() == nullptr;
 
 			if (show_create_root != create_root_dialog->is_visible_in_tree() && !remote_tree->is_visible()) {
 				if (show_create_root) {
@@ -3126,7 +3127,7 @@ void SceneTreeDock::attach_script_to_selected(bool p_extend) {
 			ScriptLanguage *l = ScriptServer::get_language(i);
 			if (l->get_type() == existing->get_class()) {
 				String name = l->get_global_class_name(existing->get_path());
-				if (ScriptServer::is_global_class(name) && EDITOR_GET("interface/editors/derive_script_globals_by_name").operator bool()) {
+				if (ScriptServer::is_global_class(name) && EDITOR_GET_CACHED(bool, "interface/editors/derive_script_globals_by_name")) {
 					inherits = name;
 				} else if (l->can_inherit_from_file()) {
 					inherits = "\"" + existing->get_path() + "\"";
@@ -3199,7 +3200,7 @@ void SceneTreeDock::_remote_tree_selected() {
 }
 
 void SceneTreeDock::_local_tree_selected() {
-	if (!bool(EDITOR_GET("interface/editors/show_scene_tree_root_selection")) || get_tree()->get_edited_scene_root() != nullptr) {
+	if (!EDITOR_GET_CACHED(bool, "interface/editors/show_scene_tree_root_selection") || get_tree()->get_edited_scene_root() != nullptr) {
 		scene_tree->show();
 	}
 	if (remote_tree) {

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -828,7 +828,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 			if (!EditorNode::get_log()->is_visible()) {
 				if (EditorNode::get_singleton()->are_bottom_panels_hidden()) {
-					if (EDITOR_GET("run/output/always_open_output_on_play")) {
+					if (EDITOR_GET_CACHED(bool, "run/output/always_open_output_on_play")) {
 						EditorNode::get_singleton()->make_bottom_panel_item_visible(EditorNode::get_log());
 					}
 				}

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2049,6 +2049,8 @@ bool Main::start() {
 		EditorNode *editor_node = nullptr;
 		if (editor) {
 			editor_node = memnew(EditorNode);
+			EditorSettingsQuick::refresh();
+
 			sml->get_root()->add_child(editor_node);
 
 			if (_export_preset != "") {

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -385,9 +385,9 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 				true);
 	}
 
-	function_definition_color = EDITOR_GET("text_editor/highlighting/gdscript/function_definition_color");
-	node_path_color = EDITOR_GET("text_editor/highlighting/gdscript/node_path_color");
-	type_color = EDITOR_GET("text_editor/highlighting/base_type_color");
+	function_definition_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/gdscript/function_definition_color");
+	node_path_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/gdscript/node_path_color");
+	type_color = EDITOR_GET_CACHED(Color, "text_editor/highlighting/base_type_color");
 }
 
 SyntaxHighlighter *GDScriptSyntaxHighlighter::create() {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -493,7 +493,7 @@ struct GDScriptCompletionIdentifier {
 };
 
 static void _get_directory_contents(EditorFileSystemDirectory *p_dir, Map<String, ScriptCodeCompletionOption> &r_list, String p_ends_with = "") {
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 
 	for (int i = 0; i < p_dir->get_file_count(); i++) {
 		ScriptCodeCompletionOption option(p_dir->get_file_path(i), ScriptCodeCompletionOption::KIND_FILE_PATH);
@@ -2242,7 +2242,7 @@ static void _find_call_arguments(const GDScriptCompletionContext &p_context, con
 	Variant base = p_base.value;
 	GDScriptParser::DataType base_type = p_base.type;
 
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 
 #define IS_METHOD_SIGNAL(m_method) (m_method == "connect" || m_method == "disconnect" || m_method == "is_connected" || m_method == "emit_signal")
 
@@ -2411,7 +2411,7 @@ static void _find_call_arguments(const GDScriptCompletionContext &p_context, con
 }
 
 static void _find_call_arguments(GDScriptCompletionContext &p_context, const GDScriptParser::Node *p_node, int p_argidx, Map<String, ScriptCodeCompletionOption> &r_result, bool &r_forced, String &r_arghint) {
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 
 	if (!p_node || p_node->type != GDScriptParser::Node::TYPE_OPERATOR) {
 		return;
@@ -2539,7 +2539,7 @@ static void _find_call_arguments(GDScriptCompletionContext &p_context, const GDS
 }
 
 Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path, Object *p_owner, List<ScriptCodeCompletionOption> *r_options, bool &r_forced, String &r_call_hint) {
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 
 	GDScriptParser parser;
 
@@ -3044,10 +3044,10 @@ Error GDScriptLanguage::complete_code(const String &p_code, const String &p_path
 String GDScriptLanguage::_get_indentation() const {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		bool use_space_indentation = EDITOR_GET("text_editor/indent/type");
+		bool use_space_indentation = EDITOR_GET_CACHED(bool, "text_editor/indent/type");
 
 		if (use_space_indentation) {
-			int indent_size = EDITOR_GET("text_editor/indent/size");
+			int indent_size = EDITOR_GET_CACHED(int, "text_editor/indent/size");
 
 			String space_indent = "";
 			for (int i = 0; i < indent_size; i++) {

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -281,7 +281,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 
 	if (item.kind == lsp::CompletionItemKind::Event) {
 		if (params.context.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter && (params.context.triggerCharacter == "(")) {
-			const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+			const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 			item.insertText = quote_style + item.label + quote_style;
 		}
 	}

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -833,7 +833,7 @@ void GridMapEditor::_icon_size_changed(float p_value) {
 void GridMapEditor::update_palette() {
 	int selected = mesh_library_palette->get_current();
 
-	float min_size = EDITOR_GET("editors/grid_map/preview_size");
+	float min_size = EDITOR_GET_CACHED(float, "editors/grid_map/preview_size");
 	min_size *= EDSCALE;
 
 	mesh_library_palette->clear();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -507,10 +507,10 @@ String CSharpLanguage::make_function(const String &, const String &, const PoolS
 String CSharpLanguage::_get_indentation() const {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		bool use_space_indentation = EDITOR_GET("text_editor/indent/type");
+		bool use_space_indentation = EDITOR_GET_CACHED(bool, "text_editor/indent/type");
 
 		if (use_space_indentation) {
-			int indent_size = EDITOR_GET("text_editor/indent/size");
+			int indent_size = EDITOR_GET_CACHED(int, "text_editor/indent/size");
 
 			String space_indent = "";
 			for (int i = 0; i < indent_size; i++) {

--- a/scene/2d/animated_sprite.cpp
+++ b/scene/2d/animated_sprite.cpp
@@ -672,7 +672,7 @@ String AnimatedSprite::get_configuration_warning() const {
 
 void AnimatedSprite::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1106,7 +1106,7 @@ String AnimatedSprite3D::get_configuration_warning() const {
 
 void AnimatedSprite3D::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1498,7 +1498,7 @@ NodePath AnimationPlayer::get_root() const {
 
 void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2572,7 +2572,7 @@ bool Control::is_visibility_clip_disabled() const {
 
 void Control::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -758,7 +758,7 @@ void LineEdit::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
 				cursor_set_blink_enabled(EditorSettings::get_singleton()->is_caret_blink_active());
-				cursor_set_blink_speed(EDITOR_GET("text_editor/cursor/caret_blink_speed"));
+				cursor_set_blink_speed(EDITOR_GET_CACHED(float, "text_editor/cursor/caret_blink_speed"));
 
 				if (!EditorSettings::get_singleton()->is_connected("settings_changed", this, "_editor_settings_changed")) {
 					EditorSettings::get_singleton()->connect("settings_changed", this, "_editor_settings_changed");

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2973,7 +2973,7 @@ NodePath Node::get_import_path() const {
 
 static void _add_nodes_to_options(const Node *p_base, const Node *p_node, List<String> *r_options) {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -233,7 +233,7 @@ void ShaderMaterial::_bind_methods() {
 
 void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 #ifdef TOOLS_ENABLED
-	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
+	const String quote_style = EditorSettingsQuick::get_text_editor_completion_use_single_quotes() ? "'" : "\"";
 #else
 	const String quote_style = "\"";
 #endif


### PR DESCRIPTION
Adds a cached version of `EDITOR_GET` to match the functionality in `GLOBAL_GET_CACHED`.

We added `GLOBAL_GET_CACHED` in #105910 for 3.x and 4.x, and at the time it was suggested that we should do the same for editor settings.

This is the 3.x version, in spirit the same approach as with `ProjectSettings`.

## EditorSettingsQuick
The only slightly interesting things to note here, is that I noticed that "text_editor/completion/use_single_quotes" was being grabbed from multiple locations, and figured rather than place statics in each and multiple spinlocks, it might be better to have a small system for heavily used editor settings, so added a small class for this.

It is fairly easy to refresh this on `EditorSettings::notify_changes()`. The only exception is the initial settings at startup, where it isn't well defined where to do a refresh. I've done this after the editor node creation, and indeed the only setting used (`use_single_quotes`) seems to be set by this point.


## Notes
* I've converted most of what seem to be the runtime cases.
* In some cases editor settings were grabbed in loops which is very bad, and I moved out of the loop.
* I've not added any thread protection for `EditorSettingsQuick` as yet, but it doesn't really need any for the single bool used so far. If necessary we can put a spinlock on it or something later if we use it for more variables.
* Also applicable in 4.x.


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
