### PR TITLE
Use ProjectSettings path functions instead of hard-coded folder names in tests

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -65,6 +65,7 @@ String ProjectSettings::get_resource_path() const {
 	return resource_path;
 }
 
+// This returns paths like "res://.godot/imported".
 String ProjectSettings::get_imported_files_path() const {
 	return get_project_data_path().path_join("imported");
 }

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -49,6 +49,7 @@ class ProjectSettings : public Object {
 
 public:
 	typedef HashMap<String, Variant> CustomMap;
+	// This constant is used to make the ".godot" folder and paths like "res://.godot/editor".
 	static inline const String PROJECT_DATA_DIR_NAME_SUFFIX = "godot";
 	static inline const String EDITOR_SETTING_OVERRIDE_PREFIX = PNAME("editor_overrides") + String("/");
 

--- a/doc/classes/EditorPaths.xml
+++ b/doc/classes/EditorPaths.xml
@@ -51,7 +51,7 @@
 		<method name="get_project_settings_dir" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the project-specific editor settings path. Projects all have a unique subdirectory inside the settings path where project-specific editor settings are saved.
+				Returns the relative path to the editor settings for this project. This is usually [code]"res://.godot/editor"[/code]. Projects all have a unique subdirectory inside the settings path where project-specific editor settings are saved.
 			</description>
 		</method>
 		<method name="get_self_contained_file" qualifiers="const">

--- a/editor/file_system/editor_paths.cpp
+++ b/editor/file_system/editor_paths.cpp
@@ -83,6 +83,7 @@ String EditorPaths::get_debug_keystore_path() const {
 #endif
 }
 
+// This returns paths like "res://.godot/editor".
 String EditorPaths::get_project_settings_dir() const {
 	return get_project_data_dir().path_join("editor");
 }

--- a/modules/dds/tests/test_dds.h
+++ b/modules/dds/tests/test_dds.h
@@ -43,20 +43,21 @@ namespace TestDDS {
 String init(const String &p_test, const String &p_copy_target = String()) {
 	String old_resource_path = TestProjectSettingsInternalsAccessor::resource_path();
 	Error err;
-	// Setup project settings since it's needed for the import process.
+	// Setup project settings with `res://` set to a temporary path.
 	String project_folder = TestUtils::get_temp_path(p_test.get_file().get_basename());
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	da->make_dir_recursive(project_folder.path_join(".godot").path_join("imported"));
-	// Initialize res:// to `project_folder`.
 	TestProjectSettingsInternalsAccessor::resource_path() = project_folder;
-	err = ProjectSettings::get_singleton()->setup(project_folder, String(), true);
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	err = ps->setup(project_folder, String(), true);
+
+	// Create the imported files folder as the editor import process expects it to exist.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	da->make_dir_recursive(ps->globalize_path(ps->get_imported_files_path()));
 
 	if (p_copy_target.is_empty()) {
 		return old_resource_path;
 	}
 
 	// Copy all the necessary test data files to the res:// directory.
-	da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String test_data = String("tests/data").path_join(p_test);
 	da = DirAccess::open(test_data);
 	CHECK_MESSAGE(da.is_valid(), "Unable to open folder.");

--- a/modules/gltf/tests/test_gltf.h
+++ b/modules/gltf/tests/test_gltf.h
@@ -134,20 +134,21 @@ static Node *gltf_export_then_import(Node *p_root, const String &p_test_name) {
 void init(const String &p_test, const String &p_copy_target = String()) {
 	Error err;
 
-	// Setup project settings since it's needed for the import process.
+	// Setup project settings with `res://` set to a temporary path.
 	String project_folder = TestUtils::get_temp_path(p_test.get_file().get_basename());
-	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	da->make_dir_recursive(project_folder.path_join(".godot").path_join("imported"));
-	// Initialize res:// to `project_folder`.
 	TestProjectSettingsInternalsAccessor::resource_path() = project_folder;
-	err = ProjectSettings::get_singleton()->setup(project_folder, String(), true);
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	err = ps->setup(project_folder, String(), true);
+
+	// Create the imported files folder as the editor import process expects it to exist.
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	da->make_dir_recursive(ps->globalize_path(ps->get_imported_files_path()));
 
 	if (p_copy_target.is_empty()) {
 		return;
 	}
 
 	// Copy all the necessary test data files to the res:// directory.
-	da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	String test_data = String("modules/gltf/tests/data/").path_join(p_test);
 	da = DirAccess::open(test_data);
 	CHECK_MESSAGE(da.is_valid(), "Unable to open folder.");


### PR DESCRIPTION
I was grepping through the codebase to find where the helper function that returns `res://.godot/editor` was, and didn't find these parts of the codebase when I searched for `".godot"` since the actual constant is `"godot"`. Once I found it, I thought it would be nice to have comments here, so that people can grep for these strings to find it. Then, I realized that my search for `".godot"` led me to two places in the tests where this is hard-coded, so I replaced those.

While making this PR, I also noticed that `DirAccess::make_dir_recursive` doesn't properly handle `res://` paths, so I have to call `ProjectSettings::globalize_path` first, but I wonder if that's a bug and DirAccess should be fixed?