### PR TITLE
[3.x] Fix inability to assign script after clearing

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -30,6 +30,7 @@
 
 #include "editor_properties.h"
 
+#include "core/core_string_names.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/filesystem_dock.h"
 #include "editor/project_settings_editor.h"
@@ -2617,8 +2618,11 @@ void EditorPropertyResource::_resource_selected(const RES &p_resource, bool p_ed
 void EditorPropertyResource::_resource_changed(const RES &p_resource) {
 	// Make visual script the correct type.
 	Ref<Script> s = p_resource;
+
+	// The bool is_script applies only to an object's main script.
+	// Changing the value of Script-type exported variables of the main script should not trigger saving/reloading properties.
 	bool is_script = false;
-	if (get_edited_object() && s.is_valid()) {
+	if (get_edited_object() && s.is_valid() && get_edited_property() == CoreStringNames::get_singleton()->_script) {
 		is_script = true;
 		EditorNode::get_singleton()->get_inspector_dock()->store_script_properties(get_edited_object());
 		s->call("set_instance_base_type", get_edited_object()->get_class());


### PR DESCRIPTION
Fixes #104126
Partial backport of #68354 

Pinging @anvilfolk as I couldn't seem to assign as reviewer.

## Discussion
I've made some investigations and debugging, so now I'm a bit more confident with this fix.

#68384 made two changes:
1) Fixing up `editor_properties.cpp` so that the whole store / reload was not done for non-main scripts
2) Changing `script_language.cpp` such that variant conversions were done for comparisons

It turns out only (1) is needed to fix the reported bug above, and (2) appears to be what introduced a regression (#69361).

I'm not keen to introduce a regression then further fixes as this could end up with a game of whack-a-mole, and I'm not very familiar with this area, so unless hearing otherwise I'm of the opinion for 3.x we should be conservative and just fix this immediate regression, so I've only backported (1) here.

This looks fairly safe and straightforward, it just ensures the new functionality only occurs for the _main script_ and not for additional script properties. This after all seems the purpose for the original changes.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
