### PR TITLE
Add missing layout_mode into the control.xml

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1,5 +1,5 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<class name="Control" inherits="CanvasItem" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<?xml version='1.0' encoding='utf-8'?>
+<class xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Control" inherits="CanvasItem" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Base class for all GUI controls. Adapts its position and size based on its parent control.
 	</brief_description>
@@ -1156,7 +1156,14 @@
 			[/csharp]
 			[/codeblocks]
 		</member>
-	</members>
+	<member name="layout_mode" type="int" setter="" getter="" enum="Control.LayoutMode" default="0">
+Controls how the control's position and size are interpreted relative to its parent.
+
+- [b]Anchors and Offsets[/b] ([constant LAYOUT_MODE_ANCHORS_AND_OFFSETS] = 0): Uses anchors and offsets for flexible UI layouts.
+- [b]Position and Size[/b] ([constant LAYOUT_MODE_POSITION_AND_SIZE] = 1): Uses absolute position and size like Node2D.
+
+[b]Note:[/b] This property is only settable via the Inspector. It cannot be changed from scripts.
+</member></members>
 	<signals>
 		<signal name="focus_entered">
 			<description>
@@ -1489,4 +1496,4 @@
 			Right-to-left text writing direction.
 		</constant>
 	</constants>
-</class>
+<enum name="LayoutMode"><value name="LAYOUT_MODE_ANCHORS_AND_OFFSETS" value="0" /><value name="LAYOUT_MODE_POSITION_AND_SIZE" value="1" /></enum></class>


### PR DESCRIPTION
Hi, this is my first contribution!

I noticed that the 'layout_mode' property in the Control node shows up in the Inspector but wasn't documented anywhere in the class reference. I found issue godot-docs#11071 mentioning the same problem, so I tried to help by adding it.

In this PR, I added:
- The 'layout_mode' property with an explanation of how it works.
- The 'LayoutMode' enum with its two values.
- A note that it's only editable from the Inspector and not accessible from scripts (based on how it's set up in the engine).

I'm not sure if I formatted everything perfectly since I'm still learning how the docs system works, so feedback is very welcome.

Thank you!