### PR TITLE
Use create script dialog for script-type resources

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2722,6 +2722,10 @@ void FileSystemDock::_resource_created() {
 		make_shader_dialog->config(fpath.path_join("new_shader"), false, false, type_name);
 		make_shader_dialog->popup_centered();
 		return;
+	} else if (ClassDB::is_parent_class(type_name, "Script")) {
+		make_script_dialog->config("Node", fpath.path_join("new_script"), false, false);
+		make_script_dialog->popup_centered();
+		return;
 	}
 
 	Variant c = new_resource_dialog->instantiate_selected();


### PR DESCRIPTION
While the `FileSystemDock` provides a "Create New -> Script" option, it has been brought to my attention that some of our users are attempting to use the "Create New -> Resource" and then selecting a script type. While this works, it creates an empty script, which is less than desirable because the user isn't taking advantage of choosing a parent type or utilizing any of the templates a language may expose.

This change builds on what we already do if a user selects a shader-based resource type. If the chosen type extends `Script`, the user is redirected to the `CreateScriptDialog` instead. This change enforces the same navigation flow as if the user had selected "Create New -> Script," and it leverages the language-driven script templates and parent type selection process that one would expect when creating script-based resources.
