### PR TITLE
Add `apple_platform` feature to check if running on apple platform

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -621,6 +621,13 @@ bool OS::has_feature(const String &p_feature) {
 	return false;
 }
 
+bool OS::is_apple_platform() {
+	const String os_name = get_name();
+	const bool has_apple_feature = has_feature("web_macos") || has_feature("web_ios") || has_feature("web_visionos");
+
+	return os_name == "macOS" || os_name == "iOS" || os_name == "visionOS" || has_apple_feature;
+}
+
 bool OS::is_sandboxed() const {
 	return false;
 }

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -591,6 +591,14 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #endif
 
+	if (p_feature == "apple_platform") {
+#if defined(MACOS_ENABLED) || defined(IOS_ENABLED) || defined(VISIONOS_ENABLED)
+		return true;
+#else
+		return _check_internal_feature_support("web_macos") || _check_internal_feature_support("web_ios") || _check_internal_feature_support("web_visionos");
+#endif
+	}
+
 	if (p_feature == "threads") {
 #ifdef THREADS_ENABLED
 		return true;
@@ -619,13 +627,6 @@ bool OS::has_feature(const String &p_feature) {
 	}
 
 	return false;
-}
-
-bool OS::is_apple_platform() {
-	const String os_name = get_name();
-	const bool has_apple_feature = has_feature("web_macos") || has_feature("web_ios") || has_feature("web_visionos");
-
-	return os_name == "macOS" || os_name == "iOS" || os_name == "visionOS" || has_apple_feature;
 }
 
 bool OS::is_sandboxed() const {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -331,8 +331,6 @@ public:
 
 	bool has_feature(const String &p_feature);
 
-	bool is_apple_platform();
-
 	virtual bool is_sandboxed() const;
 
 	void set_has_server_feature_callback(HasServerFeatureCallback p_callback);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -331,6 +331,8 @@ public:
 
 	bool has_feature(const String &p_feature);
 
+	bool is_apple_platform();
+
 	virtual bool is_sandboxed() const;
 
 	void set_has_server_feature_callback(HasServerFeatureCallback p_callback);


### PR DESCRIPTION
## What it can do ?

This helps to determine at least about whether the `CTRL` or the `META` should be used for shortcut.

## Motivation

Reduce manually checking like this.

https://github.com/godotengine/godot/blob/efb40c1524e54f2cf52f213e248bd0a7b790975a/core/os/keyboard.cpp#L373

Mentioned also in the comment of https://github.com/godotengine/godot/pull/108034#discussion_r2171159049, which is about the checking logic of whether current platform is apple or not.

## TODO

If it is necessary to do so, I will add also the doc and core-bind.