### PR TITLE
GDScript: More reliably detect cyclic inheritance in script classes

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -591,7 +591,7 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 
 	if (base_cache.is_valid() && base_cache->is_valid()) {
 		for (int i = 0; i < base_caches.size(); i++) {
-			if (base_caches[i] == base_cache.ptr()) {
+			if (base_caches[i]->get_fully_qualified_name() == base_cache->get_fully_qualified_name()) {
 				if (r_err) {
 					*r_err = true;
 				}
@@ -601,7 +601,15 @@ bool GDScript::_update_exports(bool *r_err, bool p_recursive_call, PlaceHolderSc
 				base_cache.unref();
 				base.unref();
 				_base = nullptr;
-				ERR_FAIL_V_MSG(false, "Cyclic inheritance in script class.");
+
+				String cycle_str;
+				for (int j = i; j < base_caches.size(); j++) {
+					cycle_str += GDScript::debug_get_script_name(base_caches[j]);
+					cycle_str += " -> ";
+				}
+				cycle_str += GDScript::debug_get_script_name(base_caches[i]);
+
+				ERR_FAIL_V_MSG(false, vformat("Cyclic inheritance in script class: %s.", cycle_str));
 			}
 		}
 		if (base_cache->_update_exports(r_err, true)) {


### PR DESCRIPTION
This is my first contribution :) Trying to debug why the editor doesn't display properties for some script base classes and I managed to get this change working. 

Different GDScript instances can refer to the same logical GDScript, so comparing pointer values is not reliable.

This change also includes the inheritance chain as a part of the error message. 

(There seems to be some race at load time. Prior to this change, I only get the error message in ~2/10 editor runs vs 10/10 with a build using these changes)

Error message before this change:
`ERROR: Cyclic inheritance in script class`
After:
`ERROR: Cyclic inheritance in script class: SwitchBase -> Entity -> SwitchBase`