### PR TITLE
Add documentation description about `"visionOS"` in `OS::get_name`

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -379,6 +379,7 @@
 				- On BSD-based operating systems, this is [code]"FreeBSD"[/code], [code]"NetBSD"[/code], [code]"OpenBSD"[/code], or [code]"BSD"[/code] as a fallback.
 				- On Android, this is [code]"Android"[/code].
 				- On iOS, this is [code]"iOS"[/code].
+				- On visionOS, this is [code]"visionOS"[/code].
 				- On Web, this is [code]"Web"[/code].
 				[b]Note:[/b] Custom builds of the engine may support additional platforms, such as consoles, possibly returning other names.
 				[codeblocks]
@@ -394,6 +395,8 @@
 						print("Welcome to Android!")
 					"iOS":
 						print("Welcome to iOS!")
+					"visionOS":
+						print("Welcome to visionOS!")
 					"Web":
 						print("Welcome to the Web!")
 				[/gdscript]


### PR DESCRIPTION
Mentioned in another PR of mine https://github.com/godotengine/godot/pull/108034#discussion_r2172103209, copied and rephased comment from there.

Found the doc `doc/classes/OS.xml`, lacks the "visionOS" one.
https://github.com/godotengine/godot/blob/9a3976097f5ac99ab3302193d40a944887206e95/doc/classes/OS.xml#L372-L383
which is implemented already:
https://github.com/godotengine/godot/blob/9a3976097f5ac99ab3302193d40a944887206e95/platform/visionos/os_visionos.mm#L48-L50
