### PR TITLE
SpinBox: Fix `custom_arrow_step` by snapping it to `step`

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -50,7 +50,8 @@
 			Changes the alignment of the underlying [LineEdit].
 		</member>
 		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
-			If not [code]0[/code], [member Range.value] will always be rounded to a multiple of [member custom_arrow_step] when interacting with the arrow buttons of the [SpinBox].
+			If not [code]0[/code], sets the step when interacting with the arrow buttons of the [SpinBox].
+			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member step].
 		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -76,7 +76,6 @@ class SpinBox : public Range {
 	String suffix;
 	String last_text_value;
 	double custom_arrow_step = 0.0;
-	bool use_custom_arrow_step = false;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 


### PR DESCRIPTION
Fixes #108191.

The documentation is correct before #107302. But now when the two steps are inconsistent, `step` takes precedence.

