### PR TITLE
Deduplicate `MethodBind::_gen_argument_type`

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -67,7 +67,7 @@ class GDExtensionMethodBind : public MethodBind {
 #endif
 
 protected:
-	virtual Variant::Type _gen_argument_type(int p_arg) const override {
+	virtual Variant::Type _get_argument_type(int p_arg) const override {
 		if (p_arg < 0) {
 			return return_value_info.type;
 		} else {

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -102,10 +102,10 @@ void MethodBind::_generate_argument_types(int p_count) {
 	set_argument_count(p_count);
 
 	Variant::Type *argt = memnew_arr(Variant::Type, p_count + 1);
-	argt[0] = _gen_argument_type(-1); // return type
+	argt[0] = _get_argument_type(-1); // return type
 
 	for (int i = 0; i < p_count; i++) {
-		argt[i + 1] = _gen_argument_type(i);
+		argt[i + 1] = _get_argument_type(i);
 	}
 
 	argument_types = argt;
@@ -117,7 +117,7 @@ MethodBind::MethodBind() {
 }
 
 MethodBind::~MethodBind() {
-	if (argument_types) {
+	if (argument_types && _argument_types_dynamic_allocated) {
 		memdelete_arr(argument_types);
 	}
 }


### PR DESCRIPTION
Deduplicate `_gen_argument_type()` in `MethodBindT/TC/TR/TRC/TS/TRS`, they all share simillar logic.

Use the static `_argument_types` array in each variation to specify arguments types. This array is passed to parent class during construction, reusing the previously unused `MethodBind::argument_types`.

Add a flag `_argument_types_dynamic_allocated` to prevent static array from being freed. It is inserted in padding bytes so `sizeof MethodBind` remains the same.

With `scons production=yes scu_build=yes` the binary size decrease from 146,477,568 bytes to 146,365,952 bytes.

Update:

I revisited this old PR and found that `_gen_argument_type()` is actually a dead method. It is private so no extern user, internally it is used by GDExtension and vaargs method bind, I inlined former one and latter caller is itself deadcode, so we can completely remove this method.

With `scons production=yes scu_build=yes` the binary size decreased from 181,523,456 bytes to 181,274,624 bytes. (-200KB)

