### PR TITLE
Android: Don't exclude display cutout in immersive mode

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -342,6 +342,8 @@ class Godot private constructor(val context: Context) {
 	 */
 	@JvmOverloads
 	fun enableEdgeToEdge(enabled: Boolean, override: Boolean = false) {
+		// Note: If modifying edge-to-edge or immersive mode logic, ensure to test with GodotIO.getDisplaySafeArea()
+		// to confirm there are no regressions in safe area calculation.
 		val window = getActivity()?.window ?: return
 
 		if (!isEdgeToEdge.compareAndSet(!enabled, enabled) && !override) {
@@ -354,18 +356,25 @@ class Godot private constructor(val context: Context) {
 			ViewCompat.setOnApplyWindowInsetsListener(rootView, null)
 			rootView.setPadding(0, 0, 0, 0)
 		} else {
-			val insetType = WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
 			if (rootView.rootWindowInsets != null) {
 				val windowInsets = WindowInsetsCompat.toWindowInsetsCompat(rootView.rootWindowInsets)
-				val insets = windowInsets.getInsets(insetType)
+				val insets = windowInsets.getInsets(getInsetType())
 				rootView.setPadding(insets.left, insets.top, insets.right, insets.bottom)
 			}
 
 			ViewCompat.setOnApplyWindowInsetsListener(rootView) { v: View, insets: WindowInsetsCompat ->
-				val windowInsets = insets.getInsets(insetType)
+				val windowInsets = insets.getInsets(getInsetType())
 				v.setPadding(windowInsets.left, windowInsets.top, windowInsets.right, windowInsets.bottom)
 				WindowInsetsCompat.CONSUMED
 			}
+		}
+	}
+
+	private fun getInsetType(): Int {
+		return if (!useImmersive.get() || isEditorBuild()) {
+			WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+		} else {
+			WindowInsetsCompat.Type.systemBars()
 		}
 	}
 
@@ -375,6 +384,8 @@ class Godot private constructor(val context: Context) {
 	 */
 	@JvmOverloads
 	fun enableImmersiveMode(enabled: Boolean, override: Boolean = false) {
+		// Note: If modifying edge-to-edge or immersive mode logic, ensure to test with GodotIO.getDisplaySafeArea()
+		// to confirm there are no regressions in safe area calculation.
 		val activity = getActivity() ?: return
 		val window = activity.window ?: return
 

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -231,11 +231,11 @@ public class GodotIO {
 				WindowInsetsCompat insetsCompat = WindowInsetsCompat.toWindowInsetsCompat(topView.getRootWindowInsets(), topView);
 				Insets insets = insetsCompat.getInsets(insetTypes);
 
-				if (godot.isInEdgeToEdgeMode()) {
+				if (godot.isInEdgeToEdgeMode() || godot.isInImmersiveMode()) {
 					result[0] = insets.left;
 					result[1] = insets.top;
 				} else {
-					// If edge-to-edge mode is disabled, then top and left padding (if required) is already applied.
+					// The top and left padding (if required) is already applied.
 					result[0] = 0;
 					result[1] = 0;
 				}


### PR DESCRIPTION
Regression from https://github.com/godotengine/godot/pull/107742

That PR changed the behavior by excluding the display cutout for exported builds as well. Previously, the cutout was only excluded in the editor, not in exported builds.

However, excluding the display cutout in exported builds breaks compatibility and does not make sense when immersive mode is enabled.

This PR fixes the regression by ensuring the display cutout is not excluded if immersive mode is enabled.