### PR TITLE
Reduce boilerplate for validated Callable calls

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -380,31 +380,21 @@ int Array::find(const Variant &p_value, int p_from) const {
 }
 
 int Array::find_custom(const Callable &p_callable, int p_from) const {
-	int ret = -1;
-
 	if (p_from < 0 || size() == 0) {
-		return ret;
+		return -1;
 	}
 
-	const Variant *argptrs[1];
-
 	for (int i = p_from; i < size(); i++) {
-		const Variant &val = _p->array[i];
-		argptrs[0] = &val;
 		Variant res;
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, res, ce);
-		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_FAIL_V_MSG(ret, vformat("Error calling method from 'find_custom': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'find_custom'", res, _p->array[i])) {
+			return -1;
 		}
-
-		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, ret, "Error on method from 'find_custom': Return type of callable must be boolean.");
+		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, -1, "Error on method from \"find_custom\": Return type of callable must be boolean.");
 		if (res.operator bool()) {
 			return i;
 		}
 	}
-
-	return ret;
+	return -1;
 }
 
 int Array::rfind(const Variant &p_value, int p_from) const {
@@ -446,18 +436,11 @@ int Array::rfind_custom(const Callable &p_callable, int p_from) const {
 		p_from = _p->array.size() - 1;
 	}
 
-	const Variant *argptrs[1];
-
 	for (int i = p_from; i >= 0; i--) {
-		const Variant &val = _p->array[i];
-		argptrs[0] = &val;
 		Variant res;
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, res, ce);
-		if (unlikely(ce.error != Callable::CallError::CALL_OK)) {
-			ERR_FAIL_V_MSG(-1, vformat("Error calling method from 'rfind_custom': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'rfind_custom'", res, _p->array[i])) {
+			return -1;
 		}
-
 		ERR_FAIL_COND_V_MSG(res.get_type() != Variant::Type::BOOL, -1, "Error on method from 'rfind_custom': Return type of callable must be boolean.");
 		if (res.operator bool()) {
 			return i;
@@ -597,20 +580,15 @@ Array Array::filter(const Callable &p_callable) const {
 	new_arr._p->typed = _p->typed;
 	int accepted_count = 0;
 
-	const Variant *argptrs[1];
 	Variant *write = new_arr._p->array.ptrw();
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
 		Variant result;
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
-		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'filter': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'filter'", result, _p->array[i])) {
+			return Array();
 		}
-
+		ERR_FAIL_COND_V_MSG(result.get_type() != Variant::Type::BOOL, Array(), "Error on method from 'filter': Return type of callable must be boolean.");
 		if (result.operator bool()) {
-			write[accepted_count] = get(i);
+			write[accepted_count] = _p->array[i];
 			accepted_count++;
 		}
 	}
@@ -624,15 +602,10 @@ Array Array::map(const Callable &p_callable) const {
 	Array new_arr;
 	new_arr.resize(size());
 
-	const Variant *argptrs[1];
 	Variant *write = new_arr._p->array.ptrw();
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, write[i], ce);
-		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(Array(), vformat("Error calling method from 'map': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'map'", write[i], _p->array[i])) {
+			return Array();
 		}
 	}
 
@@ -647,16 +620,10 @@ Variant Array::reduce(const Callable &p_callable, const Variant &p_accum) const 
 		start = 1;
 	}
 
-	const Variant *argptrs[2];
 	for (int i = start; i < size(); i++) {
-		argptrs[0] = &ret;
-		argptrs[1] = &get(i);
-
 		Variant result;
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 2, result, ce);
-		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(Variant(), vformat("Error calling method from 'reduce': %s.", Variant::get_callable_error_text(p_callable, argptrs, 2, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'reduce'", result, _p->array[i])) {
+			return Variant();
 		}
 		ret = result;
 	}
@@ -665,16 +632,12 @@ Variant Array::reduce(const Callable &p_callable, const Variant &p_accum) const 
 }
 
 bool Array::any(const Callable &p_callable) const {
-	const Variant *argptrs[1];
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
 		Variant result;
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
-		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(false, vformat("Error calling method from 'any': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'any'", result, _p->array[i])) {
+			return false;
 		}
+		ERR_FAIL_COND_V_MSG(result.get_type() != Variant::Type::BOOL, -1, "Error on method from 'any': Return type of callable must be boolean.");
 
 		if (result.operator bool()) {
 			// Return as early as possible when one of the conditions is `true`.
@@ -687,16 +650,12 @@ bool Array::any(const Callable &p_callable) const {
 }
 
 bool Array::all(const Callable &p_callable) const {
-	const Variant *argptrs[1];
 	for (int i = 0; i < size(); i++) {
-		argptrs[0] = &get(i);
-
 		Variant result;
-		Callable::CallError ce;
-		p_callable.callp(argptrs, 1, result, ce);
-		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(false, vformat("Error calling method from 'all': %s.", Variant::get_callable_error_text(p_callable, argptrs, 1, ce)));
+		if (!p_callable.call_with_error("Error calling method from 'all'", result, _p->array[i])) {
+			return false;
 		}
+		ERR_FAIL_COND_V_MSG(result.get_type() != Variant::Type::BOOL, -1, "Error on method from 'all': Return type of callable must be boolean.");
 
 		if (!(result.operator bool())) {
 			// Return as early as possible when one of the inverted conditions is `false`.

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -69,6 +69,8 @@ public:
 
 	template <typename... VarArgs>
 	Variant call(VarArgs... p_args) const;
+	template <typename... VarArgs>
+	bool call_with_error(const String &p_error_message, Variant &r_return_value, VarArgs... p_args) const;
 	void callp(const Variant **p_arguments, int p_argcount, Variant &r_return_value, CallError &r_call_error) const;
 	void call_deferredp(const Variant **p_arguments, int p_argcount) const;
 	Variant callv(const Array &p_arguments) const;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -954,6 +954,23 @@ Variant Callable::call(VarArgs... p_args) const {
 }
 
 template <typename... VarArgs>
+inline bool Callable::call_with_error(const String &p_error_message, Variant &r_return_value, VarArgs... p_args) const {
+	Variant args[sizeof...(p_args) + 1] = { p_args..., 0 }; // +1 makes sure zero sized arrays are also supported.
+	const Variant *argptrs[sizeof...(p_args) + 1];
+	for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+		argptrs[i] = &args[i];
+	}
+
+	CallError ce;
+	callp(sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args), r_return_value, ce);
+
+	if (unlikely(ce.error != CallError::CALL_OK)) {
+		ERR_FAIL_V_MSG(false, p_error_message + ": " + Variant::get_callable_error_text(*this, argptrs, sizeof...(p_args), ce) + ".");
+	}
+	return true;
+}
+
+template <typename... VarArgs>
 Callable Callable::bind(VarArgs... p_args) const {
 	Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
 	const Variant *argptrs[sizeof...(p_args) + 1];


### PR DESCRIPTION
There is an annoying boilerplate code you have to write if you want to call a Callable with error handling. It comes from `callp()` being very inconvenient to use, and also being the only way to check if the call was successful.

This PR adds a new `call_with_error()` method to Callable, which is similar to `call()` in that it's vararg, but has built-in error handling. Usage is like this:
```C++
Variant ret;
if (!callable.call_with_error("Error message", ret, arg1, arg2) {
	return; // Call failed.
}
```
If the call results in an error, the error message will be printed, along with callable error, so this no longer needs to be handled manually every time. Return value is passed as r-argument, the method instead returns true/false based on whether it failed (since error handling is automatic, the error value is irrelevant).

I applied the new method in Array, which is the heaviest user of `callp()` right now.