### PR TITLE
Hide property groups from the "Members" section in the remote inspector

### DIFF
--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -833,6 +833,9 @@ void SceneDebuggerObject::_parse_script_properties(Script *p_script, ScriptInsta
 			if (exported_members.has(E)) {
 				continue; // Exported variables already show up in the inspector.
 			}
+			if (String(E).begins_with("@")) {
+				continue; // Skip groups.
+			}
 
 			Variant m;
 			if (p_instance->get(E, m)) {


### PR DESCRIPTION
The remote inspector doesn't show groups for any property. But shows invalid properties in the "Members" section for custom ones. This PR hides those.

Tackles one of the points (![](https://placehold.co/15x15/ffde00/ffde00.png)) from https://github.com/godotengine/godot-proposals/issues/11736 and also fixes https://github.com/godotengine/godot/issues/101475.