### PR TITLE
Add `OS::get_command_key()` to get CTRL or META

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -688,6 +688,10 @@ Key OS::find_keycode_from_string(const String &p_code) const {
 	return find_keycode(p_code);
 }
 
+Key OS::get_command_keycode() const {
+	return ::OS::get_singleton()->get_command_keycode();
+}
+
 bool OS::request_permission(const String &p_name) {
 	return ::OS::get_singleton()->request_permission(p_name);
 }
@@ -833,6 +837,8 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_logger", "logger"), &OS::add_logger);
 	ClassDB::bind_method(D_METHOD("remove_logger", "logger"), &OS::remove_logger);
+
+	ClassDB::bind_method(D_METHOD("get_command_keycode"), &OS::get_command_keycode);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -261,6 +261,8 @@ public:
 	bool is_keycode_unicode(char32_t p_unicode) const;
 	Key find_keycode_from_string(const String &p_code) const;
 
+	Key get_command_keycode() const;
+
 	void set_use_file_access_save_and_swap(bool p_enable);
 
 	uint64_t get_static_memory_usage() const;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/io/logger.h"
 #include "core/io/remote_filesystem_client.h"
+#include "core/os/keyboard.h"
 #include "core/os/time_enums.h"
 #include "core/string/ustring.h"
 #include "core/templates/list.h"
@@ -217,6 +218,8 @@ public:
 	virtual List<String> get_cmdline_user_args() const { return _user_args; }
 	virtual List<String> get_cmdline_platform_args() const { return List<String>(); }
 	virtual String get_model_name() const;
+
+	virtual Key get_command_keycode() const { return Key::CTRL; }
 
 	bool is_layered_allowed() const { return _allow_layered; }
 	bool is_hidpi_allowed() const { return _allow_hidpi; }

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -239,6 +239,12 @@
 				To get all passed arguments, use [method get_cmdline_args].
 			</description>
 		</method>
+		<method name="get_command_keycode" qualifiers="const">
+			<return type="int" enum="Key" />
+			<description>
+				Returns the keycode for the command key. On macOS, iOS, visionOS, and Web (on an Apple device), it returns [code]KEY_META[/code]. On other platforms, it returns [code]KEY_CTRL[/code].
+			</description>
+		</method>
 		<method name="get_config_dir" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/drivers/apple_embedded/os_apple_embedded.h
+++ b/drivers/apple_embedded/os_apple_embedded.h
@@ -34,6 +34,7 @@
 
 #import "apple_embedded.h"
 
+#import "core/os/keyboard.h"
 #import "drivers/apple/joypad_apple.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #include "drivers/unix/os_unix.h"
@@ -125,6 +126,8 @@ public:
 	virtual String get_processor_name() const override;
 
 	virtual void vibrate_handheld(int p_duration_ms = 500, float p_amplitude = -1.0) override;
+
+	virtual Key get_command_keycode() const override { return Key::META; }
 
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -33,6 +33,7 @@
 #include "crash_handler_macos.h"
 
 #include "core/input/input.h"
+#include "core/os/keyboard.h"
 #import "drivers/coreaudio/audio_driver_coreaudio.h"
 #import "drivers/coremidi/midi_driver_coremidi.h"
 #include "drivers/unix/os_unix.h"
@@ -125,6 +126,8 @@ public:
 	virtual String get_processor_name() const override;
 
 	virtual String get_model_name() const override;
+
+	virtual Key get_command_keycode() const override { return Key::META; }
 
 	virtual bool is_sandboxed() const override;
 	virtual bool request_permission(const String &p_name) override;

--- a/platform/web/godot_js.h
+++ b/platform/web/godot_js.h
@@ -55,6 +55,7 @@ extern void godot_js_os_shell_open(const char *p_uri);
 extern int godot_js_os_hw_concurrency_get();
 extern int godot_js_os_thread_pool_size_get();
 extern int godot_js_os_has_feature(const char *p_ftr);
+extern char *godot_js_os_get_operating_system();
 extern int godot_js_pwa_cb(void (*p_callback)());
 extern int godot_js_pwa_update();
 

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -268,6 +268,44 @@ const GodotOS = {
 				}, 0);
 			});
 		},
+
+		getOperatingSystem: () => {
+			const userAgent = navigator.userAgent;
+			if (userAgent.indexOf('Macintosh') !== -1) {
+				return 'macOS';
+			}
+			if ((userAgent.indexOf('iPhone') !== -1) || (userAgent.indexOf('iPad') !== -1) || (userAgent.indexOf('iPod') !== -1)) {
+				return 'iOS';
+			}
+			if (userAgent.indexOf('Windows') !== -1) {
+				return 'Windows';
+			}
+			if (userAgent.indexOf('Android') !== -1) {
+				return 'Android';
+			}
+			if (userAgent.indexOf('CrOS') !== -1) {
+				return 'ChromeOS';
+			}
+			if (userAgent.indexOf('FreeBSD') !== -1) {
+				return 'FreeBSD';
+			}
+			if (userAgent.indexOf('NetBSD') !== -1) {
+				return 'NetBSD';
+			}
+			if (userAgent.indexOf('BSD') !== -1) {
+				return '*BSD';
+			}
+			if (userAgent.indexOf('Linux') !== -1) {
+				return 'Linux';
+			}
+			if (userAgent.indexOf('Haiku') !== -1) {
+				return 'Haiku';
+			}
+			if (userAgent.indexOf('X11') !== -1) {
+				return 'X11';
+			}
+			return '';
+		},
 	},
 
 	godot_js_os_finish_async__proxy: 'sync',
@@ -300,26 +338,42 @@ const GodotOS = {
 	},
 
 	godot_js_os_has_feature__proxy: 'sync',
-	godot_js_os_has_feature__sig: 'ii',
+	godot_js_os_has_feature__sig: 'ip',
 	godot_js_os_has_feature: function (p_ftr) {
 		const ftr = GodotRuntime.parseString(p_ftr);
-		const ua = navigator.userAgent;
+
+		const operatingSystem = GodotOS.getOperatingSystem();
 		if (ftr === 'web_macos') {
-			return (ua.indexOf('Mac') !== -1) ? 1 : 0;
-		}
-		if (ftr === 'web_windows') {
-			return (ua.indexOf('Windows') !== -1) ? 1 : 0;
-		}
-		if (ftr === 'web_android') {
-			return (ua.indexOf('Android') !== -1) ? 1 : 0;
+			return Number(operatingSystem === 'macOS');
 		}
 		if (ftr === 'web_ios') {
-			return ((ua.indexOf('iPhone') !== -1) || (ua.indexOf('iPad') !== -1) || (ua.indexOf('iPod') !== -1)) ? 1 : 0;
+			return Number(operatingSystem === 'iOS');
+		}
+		if (ftr === 'web_windows') {
+			return Number(operatingSystem === 'Windows');
+		}
+		if (ftr === 'web_android') {
+			return Number(operatingSystem === 'Android');
 		}
 		if (ftr === 'web_linuxbsd') {
-			return ((ua.indexOf('CrOS') !== -1) || (ua.indexOf('BSD') !== -1) || (ua.indexOf('Linux') !== -1) || (ua.indexOf('X11') !== -1)) ? 1 : 0;
+			return Number(
+				operatingSystem === 'ChromeOS'
+				|| operatingSystem === 'FreeBSD'
+				|| operatingSystem === 'NetBSD'
+				|| operatingSystem === '*BSD'
+				|| operatingSystem === 'Linux'
+				|| operatingSystem === 'X11'
+			);
 		}
+
 		return 0;
+	},
+
+	godot_js_os_get_operating_system__proxy: 'sync',
+	godot_js_os_get_operating_system__sig: 'p',
+	godot_js_os_get_operating_system: function () {
+		// Caller must free the string.
+		GodotRuntime.allocString(GodotOS.getOperatingSystem());
 	},
 
 	godot_js_os_execute__proxy: 'sync',

--- a/platform/web/os_web.cpp
+++ b/platform/web/os_web.cpp
@@ -206,6 +206,24 @@ void OS_Web::vibrate_handheld(int p_duration_ms, float p_amplitude) {
 	godot_js_input_vibrate_handheld(p_duration_ms);
 }
 
+Key OS_Web::get_command_keycode() const {
+	if (command_key != Key::NONE) {
+		return command_key;
+	}
+
+	char *operating_system_ptr = godot_js_os_get_operating_system();
+	String operating_system = String::utf8(operating_system_ptr);
+	memfree(operating_system_ptr);
+
+	if (operating_system == "macOS" || operating_system == "iOS") {
+		command_key = Key::META;
+	} else {
+		command_key = Key::CTRL;
+	}
+
+	return command_key;
+}
+
 String OS_Web::get_user_data_dir(const String &p_user_dir) const {
 	String userfs = "/userfs";
 	return userfs.path_join(p_user_dir).replace_char('\\', '/');

--- a/platform/web/os_web.h
+++ b/platform/web/os_web.h
@@ -52,6 +52,8 @@ class OS_Web : public OS_Unix {
 	bool idb_needs_sync = false;
 	bool pwa_is_waiting = false;
 
+	mutable Key command_key = Key::NONE;
+
 	WASM_EXPORT static void main_loop_callback();
 
 	WASM_EXPORT static void file_access_close_callback(const String &p_file, int p_flags);
@@ -102,6 +104,8 @@ public:
 	void add_frame_delay(bool p_can_draw, bool p_wake_for_events) override;
 
 	void vibrate_handheld(int p_duration_ms, float p_amplitude) override;
+
+	virtual Key get_command_keycode() const override;
 
 	String get_cache_path() const override;
 	String get_config_path() const override;


### PR DESCRIPTION
Fixes godotengine/godot-proposals#12717
Alternative to #108215

I could consider removing `Key.CMD_OR_CTRL` [as suggested](https://github.com/godotengine/godot-proposals/issues/12717#issuecomment-3029123518) by @bruvzg. Or using the `Input` singleton instead of `OS`, but I think it's more related to the operating system than the input system.