### PR TITLE
libogg: Update to 1.3.6

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -566,7 +566,7 @@ Patches:
 ## libogg
 
 - Upstream: https://www.xiph.org/ogg
-- Version: 1.3.5 (e1774cd77f471443541596e09078e78fdc342e4f, 2021)
+- Version: 1.3.6 (be05b13e98b048f0b5a0f5fa8ce514d56db5f822, 2025)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:

--- a/thirdparty/libogg/bitwise.c
+++ b/thirdparty/libogg/bitwise.c
@@ -39,6 +39,8 @@ static const unsigned int mask8B[]=
 void oggpack_writeinit(oggpack_buffer *b){
   memset(b,0,sizeof(*b));
   b->ptr=b->buffer=_ogg_malloc(BUFFER_INCREMENT);
+  if (!b->buffer)
+    return;
   b->buffer[0]='\0';
   b->storage=BUFFER_INCREMENT;
 }
@@ -284,13 +286,13 @@ long oggpack_look(oggpack_buffer *b,int bits){
 
   ret=b->ptr[0]>>b->endbit;
   if(bits>8){
-    ret|=b->ptr[1]<<(8-b->endbit);
+    ret|=(unsigned long)b->ptr[1]<<(8-b->endbit);
     if(bits>16){
-      ret|=b->ptr[2]<<(16-b->endbit);
+      ret|=(unsigned long)b->ptr[2]<<(16-b->endbit);
       if(bits>24){
-        ret|=b->ptr[3]<<(24-b->endbit);
+        ret|=(unsigned long)b->ptr[3]<<(24-b->endbit);
         if(bits>32 && b->endbit)
-          ret|=b->ptr[4]<<(32-b->endbit);
+          ret|=(unsigned long)b->ptr[4]<<(32-b->endbit);
       }
     }
   }
@@ -313,13 +315,13 @@ long oggpackB_look(oggpack_buffer *b,int bits){
     else if(!bits)return(0L);
   }
 
-  ret=b->ptr[0]<<(24+b->endbit);
+  ret=(unsigned long)b->ptr[0]<<(24+b->endbit);
   if(bits>8){
-    ret|=b->ptr[1]<<(16+b->endbit);
+    ret|=(unsigned long)b->ptr[1]<<(16+b->endbit);
     if(bits>16){
-      ret|=b->ptr[2]<<(8+b->endbit);
+      ret|=(unsigned long)b->ptr[2]<<(8+b->endbit);
       if(bits>24){
-        ret|=b->ptr[3]<<(b->endbit);
+        ret|=(unsigned long)b->ptr[3]<<(b->endbit);
         if(bits>32 && b->endbit)
           ret|=b->ptr[4]>>(8-b->endbit);
       }
@@ -389,13 +391,13 @@ long oggpack_read(oggpack_buffer *b,int bits){
 
   ret=b->ptr[0]>>b->endbit;
   if(bits>8){
-    ret|=b->ptr[1]<<(8-b->endbit);
+    ret|=(unsigned long)b->ptr[1]<<(8-b->endbit);
     if(bits>16){
-      ret|=b->ptr[2]<<(16-b->endbit);
+      ret|=(unsigned long)b->ptr[2]<<(16-b->endbit);
       if(bits>24){
-        ret|=b->ptr[3]<<(24-b->endbit);
+        ret|=(unsigned long)b->ptr[3]<<(24-b->endbit);
         if(bits>32 && b->endbit){
-          ret|=b->ptr[4]<<(32-b->endbit);
+          ret|=(unsigned long)b->ptr[4]<<(32-b->endbit);
         }
       }
     }
@@ -430,13 +432,13 @@ long oggpackB_read(oggpack_buffer *b,int bits){
     else if(!bits)return(0L);
   }
 
-  ret=b->ptr[0]<<(24+b->endbit);
+  ret=(unsigned long)b->ptr[0]<<(24+b->endbit);
   if(bits>8){
-    ret|=b->ptr[1]<<(16+b->endbit);
+    ret|=(unsigned long)b->ptr[1]<<(16+b->endbit);
     if(bits>16){
-      ret|=b->ptr[2]<<(8+b->endbit);
+      ret|=(unsigned long)b->ptr[2]<<(8+b->endbit);
       if(bits>24){
-        ret|=b->ptr[3]<<(b->endbit);
+        ret|=(unsigned long)b->ptr[3]<<(b->endbit);
         if(bits>32 && b->endbit)
           ret|=b->ptr[4]>>(8-b->endbit);
       }
@@ -565,17 +567,17 @@ void cliptest(unsigned long *b,int vals,int bits,int *comp,int compsize){
     int tbit=bits?bits:ilog(b[i]);
     if(oggpack_look(&r,tbit)==-1)
       report("out of data!\n");
-    if(oggpack_look(&r,tbit)!=(b[i]&mask[tbit]))
+    if((unsigned long)oggpack_look(&r,tbit)!=(b[i]&mask[tbit]))
       report("looked at incorrect value!\n");
     if(tbit==1)
-      if(oggpack_look1(&r)!=(b[i]&mask[tbit]))
+      if((unsigned long)oggpack_look1(&r)!=(b[i]&mask[tbit]))
         report("looked at single bit incorrect value!\n");
     if(tbit==1){
-      if(oggpack_read1(&r)!=(b[i]&mask[tbit]))
+      if((unsigned long)oggpack_read1(&r)!=(b[i]&mask[tbit]))
         report("read incorrect single bit value!\n");
     }else{
-    if(oggpack_read(&r,tbit)!=(b[i]&mask[tbit]))
-      report("read incorrect value!\n");
+      if((unsigned long)oggpack_read(&r,tbit)!=(b[i]&mask[tbit]))
+	report("read incorrect value!\n");
     }
   }
   if(oggpack_bytes(&r)!=bytes)report("leftover bytes after read!\n");
@@ -600,16 +602,16 @@ void cliptestB(unsigned long *b,int vals,int bits,int *comp,int compsize){
     int tbit=bits?bits:ilog(b[i]);
     if(oggpackB_look(&r,tbit)==-1)
       report("out of data!\n");
-    if(oggpackB_look(&r,tbit)!=(b[i]&mask[tbit]))
+    if((unsigned long)oggpackB_look(&r,tbit)!=(b[i]&mask[tbit]))
       report("looked at incorrect value!\n");
     if(tbit==1)
-      if(oggpackB_look1(&r)!=(b[i]&mask[tbit]))
+      if((unsigned long)oggpackB_look1(&r)!=(b[i]&mask[tbit]))
         report("looked at single bit incorrect value!\n");
     if(tbit==1){
-      if(oggpackB_read1(&r)!=(b[i]&mask[tbit]))
+      if((unsigned long)oggpackB_read1(&r)!=(b[i]&mask[tbit]))
         report("read incorrect single bit value!\n");
     }else{
-    if(oggpackB_read(&r,tbit)!=(b[i]&mask[tbit]))
+    if((unsigned long)oggpackB_read(&r,tbit)!=(b[i]&mask[tbit]))
       report("read incorrect value!\n");
     }
   }
@@ -888,7 +890,7 @@ int main(void){
   oggpack_readinit(&r,buffer,bytes);
   for(i=0;i<test2size;i++){
     if(oggpack_look(&r,32)==-1)report("out of data. failed!");
-    if(oggpack_look(&r,32)!=large[i]){
+    if((unsigned long)oggpack_look(&r,32)!=large[i]){
       fprintf(stderr,"%ld != %lu (%lx!=%lx):",oggpack_look(&r,32),large[i],
               oggpack_look(&r,32),large[i]);
       report("read incorrect value!\n");
@@ -998,7 +1000,7 @@ int main(void){
   oggpackB_readinit(&r,buffer,bytes);
   for(i=0;i<test2size;i++){
     if(oggpackB_look(&r,32)==-1)report("out of data. failed!");
-    if(oggpackB_look(&r,32)!=large[i]){
+    if((unsigned long)oggpackB_look(&r,32)!=large[i]){
       fprintf(stderr,"%ld != %lu (%lx!=%lx):",oggpackB_look(&r,32),large[i],
               oggpackB_look(&r,32),large[i]);
       report("read incorrect value!\n");

--- a/thirdparty/libogg/framing.c
+++ b/thirdparty/libogg/framing.c
@@ -349,12 +349,13 @@ int ogg_stream_packetin(ogg_stream_state *os,ogg_packet *op){
 static int ogg_stream_flush_i(ogg_stream_state *os,ogg_page *og, int force, int nfill){
   int i;
   int vals=0;
-  int maxvals=(os->lacing_fill>255?255:os->lacing_fill);
+  int maxvals;
   int bytes=0;
   long acc=0;
   ogg_int64_t granule_pos=-1;
 
   if(ogg_stream_check(os)) return(0);
+  maxvals=(os->lacing_fill>255?255:os->lacing_fill);
   if(maxvals==0) return(0);
 
   /* construct a page */
@@ -639,11 +640,14 @@ int ogg_sync_wrote(ogg_sync_state *oy, long bytes){
 */
 
 long ogg_sync_pageseek(ogg_sync_state *oy,ogg_page *og){
-  unsigned char *page=oy->data+oy->returned;
+  unsigned char *page;
   unsigned char *next;
-  long bytes=oy->fill-oy->returned;
+  long bytes;
 
   if(ogg_sync_check(oy))return 0;
+
+  page=oy->data+oy->returned;
+  bytes=oy->fill-oy->returned;
 
   if(oy->headerbytes==0){
     int headerbytes,i;
@@ -1086,11 +1090,11 @@ void print_header(ogg_page *og){
           (int)og->header[4],(int)og->header[5]);
 
   fprintf(stderr,"  granulepos: %d  serialno: %d  pageno: %ld\n",
-          (og->header[9]<<24)|(og->header[8]<<16)|
+          ((unsigned)og->header[9]<<24)|(og->header[8]<<16)|
           (og->header[7]<<8)|og->header[6],
-          (og->header[17]<<24)|(og->header[16]<<16)|
+          ((unsigned)og->header[17]<<24)|(og->header[16]<<16)|
           (og->header[15]<<8)|og->header[14],
-          ((long)(og->header[21])<<24)|(og->header[20]<<16)|
+          ((long)((unsigned)og->header[21])<<24)|(og->header[20]<<16)|
           (og->header[19]<<8)|og->header[18]);
 
   fprintf(stderr,"  checksum: %02x:%02x:%02x:%02x\n  segments: %d (",
@@ -1103,19 +1107,26 @@ void print_header(ogg_page *og){
   fprintf(stderr,")\n\n");
 }
 
-void copy_page(ogg_page *og){
+static int copy_page(ogg_page *og){
   unsigned char *temp=_ogg_malloc(og->header_len);
+  if (!temp)
+    return -1;
   memcpy(temp,og->header,og->header_len);
   og->header=temp;
 
   temp=_ogg_malloc(og->body_len);
+  if (!temp)
+    return -1;
   memcpy(temp,og->body,og->body_len);
   og->body=temp;
+  return 0;
 }
 
-void free_page(ogg_page *og){
+static void free_page(ogg_page *og){
   _ogg_free (og->header);
+  og->header=NULL;
   _ogg_free (og->body);
+  og->body=NULL;
 }
 
 void error(void){
@@ -1498,6 +1509,11 @@ void test_pack(const int *pl, const int **headers, int byteskip,
 
   int byteskipcount=0;
 
+  if (!data) {
+    fprintf(stderr,"unable to allocate requried data buffer!\n");
+    exit(1);
+  }
+
   ogg_stream_reset(&os_en);
   ogg_stream_reset(&os_de);
   ogg_sync_reset(&oy);
@@ -1809,6 +1825,11 @@ int main(void){
     int inptr=0,i,j;
     ogg_page og[5];
 
+    if (!data) {
+      fprintf(stderr,"unable to allocate requried packet data buffer!\n");
+      exit(1);
+    }
+
     ogg_stream_reset(&os_en);
 
     for(i=0;pl[i]!=-1;i++){
@@ -1832,7 +1853,10 @@ int main(void){
         fprintf(stderr,"Too few pages output building sync tests!\n");
         exit(1);
       }
-      copy_page(&og[i]);
+      if (-1 == copy_page(&og[i])) {
+        fprintf(stderr,"unable to copy page building sync tests!\n");
+        exit(1);
+      }
     }
 
     /* Test lost pages on pagein/packetout: no rollback */


### PR DESCRIPTION
https://gitlab.xiph.org/xiph/ogg/-/releases/v1.3.6

Version 1.3.6 (2025 June 16):

- Update minimum cmake version to 3.6
  This fixes incompatibility with cmake >= 4.0
- Fix UBsan issues
- Improve allocation failure handling
- Fix various compiler warnings
- Fix various autotool warnings
- Improve continuous integration testing scripts
