### PR TITLE
Propagate `Tween.kill()` to subtweens

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -164,6 +164,7 @@ Ref<SubtweenTweener> Tween::tween_subtween(const Ref<Tween> &p_subtween) {
 	if (tweener->subtween->parent_tree != nullptr) {
 		tweener->subtween->parent_tree->remove_tween(tweener->subtween);
 	}
+	subtweens.push_back(p_subtween);
 	append(tweener);
 	return tweener;
 }
@@ -200,6 +201,11 @@ void Tween::kill() {
 	running = false; // For the sake of is_running().
 	valid = false;
 	dead = true;
+
+	// Kill all subtweens of this tween.
+	for (Ref<Tween> &st : subtweens) {
+		st->kill();
+	}
 }
 
 bool Tween::is_running() {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -112,6 +112,7 @@ private:
 
 	SceneTree *parent_tree = nullptr;
 	LocalVector<List<Ref<Tweener>>> tweeners;
+	LocalVector<Ref<Tween>> subtweens;
 	double total_time = 0;
 	int current_step = -1;
 	int loops = 1;


### PR DESCRIPTION
This PR fixes a problem with tween/subtween logic I noticed while investigating another issue. Previously, when a tween was killed with `kill()`, if it had subtweens in it that hadn't yet been run, those subtweens would never be executed, but would also never be explicitly killed or made invalid. As a result, if user code was monitoring the status of a subtween (say, waiting for it to be killed or finished), they would end up waiting forever.

With this PR, a `kill()` call on a Tween is passed down to all of its subtweens as well, ensuring that they are all marked as dead/invalid.

>[!NOTE]
> Previously this PR also cleared subtweens when `clear()` was called on the parent. As I thought it through more I realized this didn't make sense, so I removed that but kept the `kill()` behavior.