### PR TITLE
Fix `SoftBody` - update rendering server once per frame.

### DIFF
--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -150,6 +150,11 @@
 		<member name="parent_collision_ignore" type="NodePath" setter="set_parent_collision_ignore" getter="get_parent_collision_ignore" default="NodePath(&quot;&quot;)">
 			[NodePath] to a [CollisionObject3D] this SoftBody3D should avoid clipping.
 		</member>
+		<member name="pin_mode_process" type="int" setter="set_pin_mode_process" getter="get_pin_mode_process" enum="SoftBody3D.PinModeProcess" default="1">
+			Sets the processing timing for the pinned points.
+			Points attached to a [Skeleton3D] may work better at [code]Idle[/code] if the skeleton is updated at idle.
+			Points attached to geometry moved on the physics tick may produce better results set to [code]Physics[/code].
+		</member>
 		<member name="pressure_coefficient" type="float" setter="set_pressure_coefficient" getter="get_pressure_coefficient" default="0.0">
 			The pressure coefficient of this soft body. Simulate pressure build-up from inside this body. Higher values increase the strength of this effect.
 		</member>
@@ -174,6 +179,10 @@
 		</constant>
 		<constant name="DISABLE_MODE_KEEP_ACTIVE" value="1" enum="DisableMode">
 			When [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED], do not affect the physics simulation.
+		</constant>
+		<constant name="PIN_MODE_PROCESS_PHYSICS" value="0" enum="PinModeProcess">
+		</constant>
+		<constant name="PIN_MODE_PROCESS_IDLE" value="1" enum="PinModeProcess">
 		</constant>
 	</constants>
 </class>

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -39,6 +39,7 @@ class SoftBodyRenderingServerHandler : public PhysicsServer3DRenderingServerHand
 	friend class SoftBody3D;
 
 	RID mesh;
+	bool rendering_server_dirty = true;
 	int surface = 0;
 	AABB aabb_prev;
 	AABB aabb_curr;
@@ -63,6 +64,7 @@ private:
 	void clear();
 	void open();
 	void close();
+	void fti_teleport();
 	void fti_pump();
 	void commit_changes(real_t p_interpolation_fraction);
 
@@ -79,6 +81,11 @@ public:
 	enum DisableMode {
 		DISABLE_MODE_REMOVE,
 		DISABLE_MODE_KEEP_ACTIVE,
+	};
+
+	enum PinModeProcess {
+		PIN_MODE_PROCESS_PHYSICS,
+		PIN_MODE_PROCESS_IDLE,
 	};
 
 	struct PinnedPoint {
@@ -98,6 +105,7 @@ private:
 	RID physics_rid;
 
 	DisableMode disable_mode = DISABLE_MODE_REMOVE;
+	PinModeProcess pin_mode_process = PIN_MODE_PROCESS_IDLE;
 
 	RID owned_mesh;
 	uint32_t collision_mask = 1;
@@ -115,11 +123,15 @@ private:
 
 	void _update_pickable();
 
-	void _update_physics_server();
-	void _update_soft_mesh();
+	void _update_pinned_points();
 	void _commit_soft_mesh(real_t p_interpolation_fraction);
 
+	bool _ensure_soft_mesh_ready();
+	void _tick_update_soft_mesh();
+	void _draw_soft_mesh();
+
 	void _prepare_physics_server();
+	void _update_process_mode();
 	void _become_mesh_owner();
 
 protected:
@@ -160,6 +172,9 @@ public:
 
 	void set_disable_mode(DisableMode p_mode);
 	DisableMode get_disable_mode() const;
+
+	void set_pin_mode_process(PinModeProcess p_mode);
+	PinModeProcess get_pin_mode_process() const { return pin_mode_process; }
 
 	void set_parent_collision_ignore(const NodePath &p_parent_collision_ignore);
 	const NodePath &get_parent_collision_ignore() const;
@@ -225,3 +240,4 @@ private:
 };
 
 VARIANT_ENUM_CAST(SoftBody3D::DisableMode);
+VARIANT_ENUM_CAST(SoftBody3D::PinModeProcess);


### PR DESCRIPTION
Also add selectable pinned point process mode.

## Discussion
This is some heavily work in progress (i.e. contains `DEV_ASSERT(0)` :grinning: ) stuff for fixing the `SoftBody` problems introduced in #106863 .

Hopefully one of the `SoftBody` interested guys will take this all over as I'm keen to avoid any responsibilities in this area.

## The difference between _USER_ callbacks and engine callbacks.

I.e. `PHYSICS_PROCESS` and `INTERNAL_PHYSICS_PROCESS`, `PROCESS` versus `PRE_FRAME_DRAW`.

Users are restricted to calling things at certain times, _engine developers_ on the other hand can use internal callbacks that can be assured to be _after_ or _before_ all user interactions. This is because a user might for example, move a bone, pin or whatever during a physics tick, or process, and we want to have rendering / physics react to that. (Users can use `process priority`, but the engine itself tends to separate user and internal into different phases).

This is commonly called "order of operations" and can cause a number of bugs, because moving one operation somewhere else can change the relative order, and create regressions elsewhere. This is notorious for causing problems, when a contributor is not aware of knock on effects.

Due to the chicken / egg effect, _sometimes there is no option but to add a frame of delay_.

Key things to note:
* There are some situations where it is better to update on the frame, some on the tick.
* Pinned points that are linked things that move on the tick make more sense to update on the tick (so the physics simulation is correct as possible). Pinned points that are linked to things that move on the frame (i.e. skeleton attachments) are more sensible to move on the frame, _AFTER_ the engine and user has had the opportunity to move the skeleton.
* The rendering server doesn't need to be updated on any occasion except prior to rendering. It doesn't care what state the soft body is in during the physics tick.
* In some situations, two frames will occur with no physics tick in between. In this case, without physics interpolation there is no need to update the rendering server because the data is not dirty. With physics interpolation, you still need an update because the interpolation fraction will be different.

## Notes
* Doesn't solve the existing threaded physics deadlock problem.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
