### PR TITLE
Fix image download example code

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -90,7 +90,7 @@
 			http_request.request_completed.connect(self._http_request_completed)
 
 			# Perform the HTTP request. The URL below returns a PNG image as of writing.
-			var error = http_request.request("https://placehold.co/512")
+			var error = http_request.request("https://placehold.co/512.png")
 			if error != OK:
 				push_error("An error occurred in the HTTP request.")
 
@@ -120,7 +120,7 @@
 			httpRequest.RequestCompleted += HttpRequestCompleted;
 
 			// Perform the HTTP request. The URL below returns a PNG image as of writing.
-			Error error = httpRequest.Request("https://placehold.co/512");
+			Error error = httpRequest.Request("https://placehold.co/512.png");
 			if (error != Error.Ok)
 			{
 				GD.PushError("An error occurred in the HTTP request.");


### PR DESCRIPTION
using "https://placehold.co/512" as the url will cause image.load_png_from_buffer(body) to throw ERR_FILE_CORRUPT, need to specify that it's a png file in the url.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
