### PR TITLE
Improve performance for shapeless objects when using Jolt Physics

### DIFF
--- a/modules/jolt_physics/objects/jolt_area_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_area_3d.cpp
@@ -57,6 +57,11 @@ JPH::BroadPhaseLayer JoltArea3D::_get_broad_phase_layer() const {
 JPH::ObjectLayer JoltArea3D::_get_object_layer() const {
 	ERR_FAIL_NULL_V(space, 0);
 
+	if (jolt_shape == nullptr || jolt_shape->GetType() == JPH::EShapeType::Empty) {
+		// No point doing collision checks against a shapeless object.
+		return space->map_to_object_layer(_get_broad_phase_layer(), 0, 0);
+	}
+
 	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
 }
 

--- a/modules/jolt_physics/objects/jolt_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_body_3d.cpp
@@ -93,6 +93,11 @@ JPH::BroadPhaseLayer JoltBody3D::_get_broad_phase_layer() const {
 JPH::ObjectLayer JoltBody3D::_get_object_layer() const {
 	ERR_FAIL_NULL_V(space, 0);
 
+	if (jolt_shape == nullptr || jolt_shape->GetType() == JPH::EShapeType::Empty) {
+		// No point doing collision checks against a shapeless object.
+		return space->map_to_object_layer(_get_broad_phase_layer(), 0, 0);
+	}
+
 	return space->map_to_object_layer(_get_broad_phase_layer(), collision_layer, collision_mask);
 }
 

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.cpp
@@ -167,6 +167,9 @@ void JoltShapedObject3D::_dequeue_needs_optimization() {
 
 void JoltShapedObject3D::_shapes_changed() {
 	commit_shapes(false);
+}
+
+void JoltShapedObject3D::_shapes_committed() {
 	_update_object_layer();
 }
 

--- a/modules/jolt_physics/objects/jolt_shaped_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_shaped_object_3d.h
@@ -68,7 +68,7 @@ protected:
 	void _dequeue_needs_optimization();
 
 	virtual void _shapes_changed();
-	virtual void _shapes_committed() {}
+	virtual void _shapes_committed();
 	virtual void _space_changing() override;
 
 public:


### PR DESCRIPTION
This addresses a very minor performance issue when using Jolt Physics and dealing with objects that all have their shapes set to be `disabled`. In such a case, they would get a special "empty" shape type that technically ignores all collisions already, but which will still add overhead during the narrow-phase collision checks.

This is mentioned in [the documentation](https://jrouwe.github.io/JoltPhysics/class_empty_shape.html) for Jolt's `JPH::EmptyShape`:

> Note that, if possible, you should also put your body in an ObjectLayer that doesn't collide with anything. This ensures that collisions will be filtered out at broad phase level instead of at narrow phase level, this is more efficient.

This PR achieves this by simply treating shapeless objects as if they have both `collision_layer` and `collision_mask` set to 0, in which case any collision checks against such an object will be filtered out in `JoltLayers::ShouldCollide(JPH::ObjectLayer, JPH::ObjectLayer)`.

If you want to see the performance gain for yourself, [this very contrived MRP](https://github.com/user-attachments/files/21036993/jolt-shapeless-perf.zip) creates 500 always-awake `RigidBody3D` on top of eachother, that all have their shapes disabled. I see physics processing time go from roughly 3 ms to 0.8 ms.

This should be a very low risk change, so I'll queue it up for 4.5, but it's arguably low reward as well, so I'm happy to punt it to 4.6.