### PR TITLE
Android: Fix Android plugins regression

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -204,7 +204,7 @@ class Godot private constructor(val context: Context) {
 	 * @throws IllegalArgumentException exception if the specified expansion pack (if any)
 	 * is invalid.
 	 */
-	fun initEngine(commandLineParams: List<String>, hostPlugins: Set<GodotPlugin>): Boolean {
+	fun initEngine(host: GodotHost?, commandLineParams: List<String>, hostPlugins: Set<GodotPlugin> = Collections.emptySet()): Boolean {
 		if (isNativeInitialized()) {
 			Log.d(TAG, "Engine already initialized")
 			return true
@@ -216,6 +216,8 @@ class Godot private constructor(val context: Context) {
 
 		beginBenchmarkMeasure("Startup", "Godot::initEngine")
 		try {
+			this.primaryHost = host
+
 			Log.v(TAG, "Initializing Godot plugin registry")
 			val runtimePlugins = mutableSetOf<GodotPlugin>(AndroidRuntimePlugin(this))
 			runtimePlugins.addAll(hostPlugins)

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -174,7 +174,7 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 
 	private void performEngineInitialization() {
 		try {
-			if (!godot.initEngine(getCommandLine(), getHostPlugins(godot))) {
+			if (!godot.initEngine(this, getCommandLine(), getHostPlugins(godot))) {
 				throw new IllegalStateException("Unable to initialize Godot engine");
 			}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/service/GodotService.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/service/GodotService.kt
@@ -321,7 +321,7 @@ open class GodotService : Service() {
 		Log.d(TAG, "Performing engine initialization")
 		try {
 			// Initialize the Godot instance
-			if (!godot.initEngine(godotHost.commandLine, godotHost.getHostPlugins(godot))) {
+			if (!godot.initEngine(godotHost, godotHost.commandLine, godotHost.getHostPlugins(godot))) {
 				throw IllegalStateException("Unable to initialize Godot engine layer")
 			}
 


### PR DESCRIPTION
Address a regression introduced in https://github.com/godotengine/godot/pull/102866. 

The proper behavior for Android plugins is to use `getContext` instead of `getActivity`, but since not all plugins follow this pattern, this fix provides backward compat to avoid breaking the plugins that don't.

Fixes https://github.com/godotengine/godot/issues/108193

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
