### PR TITLE
Add MAKE_NODE_TYPE_HINT helper macro

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -161,6 +161,7 @@ enum PropertyUsageFlags {
 // Helper macro to use with PROPERTY_HINT_ARRAY_TYPE for arrays of specific resources:
 // PropertyInfo(Variant::ARRAY, "fallbacks", PROPERTY_HINT_ARRAY_TYPE, MAKE_RESOURCE_TYPE_HINT("Font")
 #define MAKE_RESOURCE_TYPE_HINT(m_type) vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_RESOURCE_TYPE, m_type)
+#define MAKE_NODE_TYPE_HINT(m_type) vformat("%s/%s:%s", Variant::OBJECT, PROPERTY_HINT_NODE_TYPE, m_type)
 
 struct PropertyInfo {
 	Variant::Type type = Variant::NIL;


### PR DESCRIPTION
While writing https://github.com/godotengine/godot/pull/108099, I found myself wanting an equivalent macro to `MAKE_RESOURCE_TYPE_HINT` for typed arrays of nodes. This implements said macro.