### PR TITLE
Add .zed/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,6 +219,9 @@ xcuserdata/
 *.xcodeproj/*
 !misc/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
 
+# Zed
+.zed/
+
 ##############################
 ### Visual Studio specific ###
 ##############################


### PR DESCRIPTION
As Zed editor developers finally [introduced the debugging functionality](https://zed.dev/blog/debugger), more people may become interested in using it for working on the Godot codebase.