### PR TITLE
Fix: TabBar/TabContainer can't start with all tabs deselected

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1266,7 +1266,7 @@ void TabBar::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
 	queue_redraw();
 	update_minimum_size();
 
-	if (tabs.size() == 1) {
+	if (!deselect_enabled && tabs.size() == 1) {
 		if (is_inside_tree()) {
 			set_current_tab(0);
 		} else {

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -51,7 +51,8 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_previous_tab() == -1);
 	}
 
-	SUBCASE("[TabBar] add tabs") {
+	SUBCASE("[TabBar] add tabs disallowing deselection") {
+		tab_bar->set_deselect_enabled(false);
 		tab_bar->add_tab("tab0");
 		CHECK(tab_bar->get_tab_count() == 1);
 		CHECK(tab_bar->get_current_tab() == 0);
@@ -90,6 +91,23 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		CHECK(tab_bar->get_tab_text_direction(2) == Control::TEXT_DIRECTION_INHERITED);
 		CHECK_FALSE(tab_bar->is_tab_disabled(2));
 		CHECK_FALSE(tab_bar->is_tab_hidden(2));
+	}
+
+	SUBCASE("[TabBar] add tabs allowing deselection") {
+		tab_bar->set_deselect_enabled(true);
+		tab_bar->add_tab("tab0");
+		CHECK(tab_bar->get_tab_count() == 1);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
+
+		tab_bar->add_tab("tab1");
+		CHECK(tab_bar->get_tab_count() == 2);
+		CHECK(tab_bar->get_current_tab() == -1);
+		CHECK(tab_bar->get_previous_tab() == -1);
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
 	}
 
 	SUBCASE("[TabBar] set tab count") {
@@ -320,7 +338,7 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		SIGNAL_CHECK("tab_selected", { { -1 } });
 		SIGNAL_CHECK("tab_changed", { { -1 } });
 
-		// Adding a tab will still set the current tab to 0.
+		// Adding first tab will NOT change the current tab. (stays deselected)
 		tab_bar->clear_tabs();
 		CHECK(tab_bar->get_current_tab() == -1);
 		CHECK(tab_bar->get_previous_tab() == -1);
@@ -329,10 +347,10 @@ TEST_CASE("[SceneTree][TabBar] tab operations") {
 		tab_bar->add_tab("tab1");
 		tab_bar->add_tab("tab2");
 		CHECK(tab_bar->get_tab_count() == 3);
-		CHECK(tab_bar->get_current_tab() == 0);
+		CHECK(tab_bar->get_current_tab() == -1);
 		CHECK(tab_bar->get_previous_tab() == -1);
-		SIGNAL_CHECK("tab_selected", { { 0 } });
-		SIGNAL_CHECK("tab_changed", { { 0 } });
+		SIGNAL_CHECK_FALSE("tab_selected");
+		SIGNAL_CHECK_FALSE("tab_changed");
 
 		tab_bar->set_current_tab(-1);
 		SIGNAL_DISCARD("tab_selected");


### PR DESCRIPTION
`TabBars` and `TabContainers` were unable to start with no tabs selected, and couldn't properly retain their current tab value of "-1", also across editor restarts. 

### Fix for Issue:
https://github.com/godotengine/godot/issues/108223

### Cause
As the tabs were added to a TabBar (or children to a TabContainer) as the scene was set up, a bug in TabBar would always select tab index 0, even if deselection was enabled.

### Repro (also in linked issue):
![image](https://github.com/user-attachments/assets/a9f3dffa-d837-4ed7-af3a-9ce38c908058)

### Before fix:
![image](https://github.com/user-attachments/assets/994f05e3-ebde-4c5e-8ced-784f85713913)

### Fixed via: 
A missing check for `deselect_enabled` was added in `TabBar.cpp` on the code path when a first tab is added to an empty bar. 

### After fix: 
![image](https://github.com/user-attachments/assets/6477f751-0cdd-41d9-a063-89312cfc2998)

### Tests:
- Modified 2 Test cases in [TabBar].
- Added 1 Test case in [TabBar].

Verified on Windows only via manual testing and  
`./bin/godot.windows.editor.x86_64.console.exe --test --test-case="*[TabBar]*"`

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/108223*