### PR TITLE
Fix crash in C# bindings generator with bad enum documentation XML

### DIFF
--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -964,7 +964,7 @@ void BindingsGenerator::_append_text_enum(StringBuilder &p_output, const TypeInt
 		p_output.append(target_enum_itype.proxy_name); // Includes nesting class if any
 		p_output.append("'");
 	} else {
-		if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+		if (p_target_itype == nullptr || !p_target_itype->is_intentionally_ignored(p_link_target)) {
 			ERR_PRINT("Cannot resolve enum reference in documentation: '" + p_link_target + "'.");
 		}
 
@@ -1258,7 +1258,7 @@ void BindingsGenerator::_append_xml_enum(StringBuilder &p_xml_output, const Type
 			p_xml_output.append("\"/>");
 		}
 	} else {
-		if (!p_target_itype->is_intentionally_ignored(p_link_target)) {
+		if (p_target_itype == nullptr || !p_target_itype->is_intentionally_ignored(p_link_target)) {
 			ERR_PRINT("Cannot resolve enum reference in documentation: '" + p_link_target + "'.");
 		}
 


### PR DESCRIPTION
I had a bad `[enum ...]` in my documentation XML. This was crashing the C# bindings generator, because the code was running `p_target_itype->is_intentionally_ignored` without checking if `p_target_itype` is null or not.

Note that these functions have code paths for dealing with a null `p_target_itype`, so it seems to not be a case where we can simply have guard clauses. In most of the functions calling `is_intentionally_ignored` the code already checked for a null `p_target_itype` and used a different code path, but this was missing only for the error case of enums.

I've marked this as cherrypick for 4.3 and 4.4. The bug seems to also exist in 4.2 and earlier but the code is a bit different so the cherrypick can't be done automatically, and I don't know if it's worth the effort for such an old branch.