### PR TITLE
Fix `PROPERTY_HINT_GROUP_ENABLE` display on hover

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -384,6 +384,7 @@ class EditorInspectorSection : public Container {
 	bool check_hover = false;
 	Rect2 keying_rect;
 	bool keying_hover = false;
+	bool header_hover = false;
 
 	bool checkbox_only = false;
 


### PR DESCRIPTION
Fixes #108257

This PR fixes a regression by making it so unchecked sections do not show the hovered highlight. This PR syncs the `gui_input()`'s understanding of the hover with the `NOTIFICATION_DRAW`, as there were issues with the hover hint becoming out of sync.