### PR TITLE
Expose OS.disable_default_crash_handler() for extensions

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -739,6 +739,10 @@ void OS::remove_script_loggers(const ScriptLanguage *p_script) {
 	}
 }
 
+void OS::disable_default_crash_handler() {
+	::OS::get_singleton()->disable_crash_handler();
+}
+
 void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_entropy", "size"), &OS::get_entropy);
 	ClassDB::bind_method(D_METHOD("get_system_ca_certificates"), &OS::get_system_ca_certificates);
@@ -846,6 +850,8 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("add_logger", "logger"), &OS::add_logger);
 	ClassDB::bind_method(D_METHOD("remove_logger", "logger"), &OS::remove_logger);
+
+	ClassDB::bind_method(D_METHOD("disable_default_crash_handler"), &OS::disable_default_crash_handler);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -313,6 +313,8 @@ public:
 	void remove_logger(const Ref<Logger> &p_logger);
 	void remove_script_loggers(const ScriptLanguage *p_script);
 
+	void disable_default_crash_handler();
+
 	static OS *get_singleton() { return singleton; }
 
 	OS();

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -92,6 +92,13 @@
 				[b]Note:[/b] When [method delay_usec] is called on the main thread, it will freeze the project and will prevent it from redrawing and registering input until the delay has passed. When using [method delay_usec] as part of an [EditorPlugin] or [EditorScript], it will freeze the editor but won't freeze the project if it is currently running (since the project is an independent child process).
 			</description>
 		</method>
+		<method name="disable_default_crash_handler">
+			<return type="void" />
+			<description>
+				Disables the default crash handler. Useful for extensions that want to register their own crash handlers.
+				[b]Warning:[/b] Only use this method if you understand crash handling and have implemented your own handler in native code. Disabling the default handler without replacement may cause silent failures.
+			</description>
+		</method>
 		<method name="execute">
 			<return type="int" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
Allow disabling crash handler from GDExtension API.

We’ve stumbled upon a bit of a problem in [Sentry SDK](https://github.com/getsentry/sentry-godot). It seems that Linux builds aren’t shutting down properly when they crash. The process gets stuck running indefinitely after the crash. This PR would allow us to unregister Godot's crash handler and use ours instead.

We'd really appreciate if this could be added to version 4.5. It can be a real pain in some scenarios, like dedicated servers not automatically restarted because the process gets stuck. It's a relatively simple change.
