### PR TITLE
Fix TextServer::shaped_text_get_grapheme_bounds() returning the bounds of the wrong grapheme

### DIFF
--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -1632,7 +1632,7 @@ Vector2 TextServer::shaped_text_get_grapheme_bounds(const RID &p_shaped, int64_t
 	real_t off = 0.0f;
 	for (int i = 0; i < v_size; i++) {
 		if ((glyphs[i].count > 0) && ((glyphs[i].index != 0) || ((glyphs[i].flags & GRAPHEME_IS_SPACE) == GRAPHEME_IS_SPACE))) {
-			if (glyphs[i].start <= p_pos && glyphs[i].end >= p_pos) {
+			if (glyphs[i].start <= p_pos && glyphs[i].end > p_pos) {
 				real_t advance = 0.f;
 				for (int j = 0; j < glyphs[i].count; j++) {
 					advance += glyphs[i + j].advance;


### PR DESCRIPTION
Fixes #108269.

A text of "abc" produces three glyphs with start/end pairs of (0, 1), (1, 2), and (2, 3), so apparently `end` is exclusive. This means that this condition for when the correct position is reached leads to an off-by-one error:

https://github.com/godotengine/godot/blob/9b22b41531c82132732fda0f9818c5709c2587bc/servers/text_server.cpp#L1635

If `p_pos == 1` (we want the bounds of character index 1) and `glyph[0].start == 0` and `glyph[0].end == 1`, then this will already be true for `i == 0` and return the position of the first glyph instead of the second.

This is a rather fundamental change for something that's been like this for four years, so maybe there's quite a bit of code out there that compensates for this behavior and would produce incorrect results if we fix it? Then again, just having it return incorrect values forever doesn't feel quite right either.

*Edit:* Oh, wow, this change fails *all* the test cases. 😳 Maybe it was actually inteded that way and the better route would be to document that this function and functions that use it use 1-based indexing?

```c++
			SEND_GUI_MOUSE_BUTTON_EVENT(text_edit->get_rect_at_line_column(1, 0).get_center(), MouseButton::LEFT, MouseButtonMask::LEFT, Key::NONE);
			// Add (2,0) to bring it past the center point of the grapheme and account for integer division flooring.
			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 5).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
			CHECK(text_edit->has_selection());
			CHECK(text_edit->get_selected_text() == "for s");
```

This test case clicks at the center of character 0, drags a bit past the center of character 5, and expects to then have 5 characters selected. Is that what we want? I'm confused.

```
012345
for se
```


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
