### PR TITLE
NavMap3D: check if obstacles have avoidance enabled

### DIFF
--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -500,6 +500,9 @@ void NavMap3D::_update_rvo_obstacles_tree_2d() {
 	// The following block is modified copy from RVO2D::AddObstacle()
 	// Obstacles are linked and depend on all other obstacles.
 	for (NavObstacle3D *obstacle : obstacles) {
+		if (!obstacle->is_avoidance_enabled()) {
+			continue;
+		}
 		const Vector3 &_obstacle_position = obstacle->get_position();
 		const Vector<Vector3> &_obstacle_vertices = obstacle->get_vertices();
 


### PR DESCRIPTION
In `NavMap3D::_update_rvo_obstacles_tree_2d()` check if the `NavObstacle3D` has avoidance enabled before adding it to the tree.

fixes #108259

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
