### PR TITLE
NavMap2D: check if obstacles have avoidance enabled

### DIFF
--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -444,6 +444,9 @@ void NavMap2D::_update_rvo_obstacles_tree() {
 	// The following block is modified copy from RVO2D::AddObstacle()
 	// Obstacles are linked and depend on all other obstacles.
 	for (NavObstacle2D *obstacle : obstacles) {
+		if (!obstacle->is_avoidance_enabled()) {
+			continue;
+		}
 		const Vector2 &_obstacle_position = obstacle->get_position();
 		const Vector<Vector2> &_obstacle_vertices = obstacle->get_vertices();
 


### PR DESCRIPTION
In NavMap2D::_update_rvo_obstacles_tree() check if the NavObstacle2D has avoidance enabled before adding it to the tree.

This is the 2D fix for #108259

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
