### PR TITLE
Create an undo/redo action when pinning a SoftBody3D point in the editor

### DIFF
--- a/editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.cpp
@@ -30,6 +30,7 @@
 
 #include "soft_body_3d_gizmo_plugin.h"
 
+#include "editor/editor_undo_redo_manager.h"
 #include "scene/3d/physics/soft_body_3d.h"
 
 SoftBody3DGizmoPlugin::SoftBody3DGizmoPlugin() {
@@ -106,7 +107,13 @@ Variant SoftBody3DGizmoPlugin::get_handle_value(const EditorNode3DGizmo *p_gizmo
 
 void SoftBody3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) {
 	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
-	soft_body->pin_point_toggle(p_id);
+	const bool is_pinned = soft_body->is_point_pinned(p_id);
+
+	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+	undo_redo->create_action(vformat(TTR("%s SoftBody3D pinned point %d."), is_pinned ? "Remove" : "Add", p_id));
+	undo_redo->add_do_method(soft_body, "set_point_pinned", p_id, !is_pinned);
+	undo_redo->add_undo_method(soft_body, "set_point_pinned", p_id, is_pinned);
+	undo_redo->commit_action();
 }
 
 bool SoftBody3DGizmoPlugin::is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {


### PR DESCRIPTION
Previously if you pinned a point by clicking on one of the soft body vertex handles the scene was not marked as modified, and the action could not be undone by hitting Ctrl-Z.

I ran into this in my own development, but I suspect that the scene not getting marked as modified is probably the root cause of issue #106325, so I suspect this change fixes that issue.

_bugsquad edit: fixes #106325_
