### PR TITLE
Fix shader editor auto-opens on startup

### DIFF
--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -266,7 +266,7 @@ void ShaderEditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 	}
 
 	_update_shader_list();
-	_shader_selected(selected_shader_idx);
+	_shader_selected(selected_shader_idx, false);
 
 	_set_text_shader_zoom_factor(p_layout->get_value("ShaderEditor", "text_shader_zoom_factor", 1.0f));
 }
@@ -370,7 +370,7 @@ void ShaderEditorPlugin::apply_changes() {
 	}
 }
 
-void ShaderEditorPlugin::_shader_selected(int p_index) {
+void ShaderEditorPlugin::_shader_selected(int p_index, bool p_push_item) {
 	if (p_index >= (int)edited_shaders.size()) {
 		return;
 	}
@@ -383,11 +383,13 @@ void ShaderEditorPlugin::_shader_selected(int p_index) {
 	shader_tabs->set_current_tab(p_index);
 	shader_list->select(p_index);
 
-	// Avoid `Shader` being edited when editing `ShaderInclude` due to inspector refreshing.
-	if (edited_shaders[p_index].shader.is_valid()) {
-		EditorNode::get_singleton()->push_item_no_inspector(edited_shaders[p_index].shader.ptr());
-	} else {
-		EditorNode::get_singleton()->push_item_no_inspector(edited_shaders[p_index].shader_inc.ptr());
+	if (p_push_item) {
+		// Avoid `Shader` being edited when editing `ShaderInclude` due to inspector refreshing.
+		if (edited_shaders[p_index].shader.is_valid()) {
+			EditorNode::get_singleton()->push_item_no_inspector(edited_shaders[p_index].shader.ptr());
+		} else {
+			EditorNode::get_singleton()->push_item_no_inspector(edited_shaders[p_index].shader_inc.ptr());
+		}
 	}
 }
 
@@ -929,7 +931,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	shader_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	shader_list->set_theme_type_variation("ItemListSecondary");
 	files_split->add_child(shader_list);
-	shader_list->connect(SceneStringName(item_selected), callable_mp(this, &ShaderEditorPlugin::_shader_selected));
+	shader_list->connect(SceneStringName(item_selected), callable_mp(this, &ShaderEditorPlugin::_shader_selected).bind(true));
 	shader_list->connect("item_clicked", callable_mp(this, &ShaderEditorPlugin::_shader_list_clicked));
 	shader_list->set_allow_rmb_select(true);
 	SET_DRAG_FORWARDING_GCD(shader_list, ShaderEditorPlugin);

--- a/editor/shader/shader_editor_plugin.h
+++ b/editor/shader/shader_editor_plugin.h
@@ -102,7 +102,7 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	Ref<Resource> _get_current_shader();
 	void _update_shader_list();
-	void _shader_selected(int p_index);
+	void _shader_selected(int p_index, bool p_push_item = true);
 	void _shader_list_clicked(int p_item, Vector2 p_local_mouse_pos, MouseButton p_mouse_button_index);
 	void _setup_popup_menu(PopupMenuType p_type, PopupMenu *p_menu);
 	void _make_script_list_context_menu();


### PR DESCRIPTION
Fixes #108282

Simply does not call `push_item_no_inspector` at startup. This should not cause #103159 because if a `ShaderInclude` is edited at startup, the `Shader` is definitely not be edited.