### PR TITLE
Add annotations to more easily controls what subresources are duplicated in a deep/shallow copy

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -388,7 +388,10 @@ Ref<Resource> Resource::_duplicate(const DuplicateParams &p_params) const {
 	AFTER_USER_CODE
 
 	for (const PropertyInfo &E : plist) {
-		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
+		if (!(E.usage & (PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_ALWAYS_DUPLICATE))) {
+			continue;
+		}
+		if (E.usage & PROPERTY_USAGE_NEVER_DUPLICATE) {
 			continue;
 		}
 		if (E.name == "script") {

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2881,9 +2881,8 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 					}
 					prop_info.hint = export_info.hint;
 					prop_info.hint_string = export_info.hint_string;
-					prop_info.usage = export_info.usage;
 				}
-				prop_info.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
+				prop_info.usage = export_info.usage | PROPERTY_USAGE_SCRIPT_VARIABLE;
 				minfo.property_info = prop_info;
 
 				if (variable->is_static) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -122,6 +122,8 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@export_flags_3d_navigation"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_NAVIGATION, Variant::INT>);
 		register_annotation(MethodInfo("@export_flags_avoidance"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_AVOIDANCE, Variant::INT>);
 		register_annotation(MethodInfo("@export_storage"), AnnotationInfo::VARIABLE, &GDScriptParser::export_storage_annotation);
+		register_annotation(MethodInfo("@always_duplicate"), AnnotationInfo::VARIABLE, &GDScriptParser::always_duplicate_annotation);
+		register_annotation(MethodInfo("@never_duplicate"), AnnotationInfo::VARIABLE, &GDScriptParser::never_duplicate_annotation);
 		register_annotation(MethodInfo("@export_custom", PropertyInfo(Variant::INT, "hint", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_ENUM, "PropertyHint"), PropertyInfo(Variant::STRING, "hint_string"), PropertyInfo(Variant::INT, "usage", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_CLASS_IS_BITFIELD, "PropertyUsageFlags")), AnnotationInfo::VARIABLE, &GDScriptParser::export_custom_annotation, varray(PROPERTY_USAGE_DEFAULT));
 		register_annotation(MethodInfo("@export_tool_button", PropertyInfo(Variant::STRING, "text"), PropertyInfo(Variant::STRING, "icon")), AnnotationInfo::VARIABLE, &GDScriptParser::export_tool_button_annotation, varray(""));
 		// Export grouping annotations.
@@ -4876,8 +4878,54 @@ bool GDScriptParser::export_storage_annotation(AnnotationNode *p_annotation, Nod
 	variable->exported = true;
 
 	// Save the info because the compiler uses export info for overwriting member info.
+	// we keep previous usage in case some annotation like @always_duplicate or @never_duplicate made a change on it
+	uint32_t usage = variable->export_info.usage;
 	variable->export_info = variable->get_datatype().to_property_info(variable->identifier->name);
+	variable->export_info.usage |= usage;
+	variable->export_info.usage &= ~PROPERTY_USAGE_EDITOR;
 	variable->export_info.usage |= PROPERTY_USAGE_STORAGE;
+
+	return true;
+}
+
+bool GDScriptParser::always_duplicate_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+
+	VariableNode *variable = static_cast<VariableNode *>(p_target);
+	if (variable->is_static) {
+		push_error(vformat(R"(Annotation "%s" cannot be applied to a static variable.)", p_annotation->name), p_annotation);
+		return false;
+	}
+	bool is_resource_var = variable->export_info.hint == PROPERTY_HINT_RESOURCE_TYPE;
+	is_resource_var |= ClassDB::is_parent_class(variable->get_datatype().native_type, SNAME("Resource"));
+	if (!is_resource_var) {
+		push_error(vformat(R"(Annotation "%s" can only be applied to Resource variables.)", p_annotation->name), p_annotation);
+		return false;
+	}
+
+	variable->export_info.usage &= ~PROPERTY_USAGE_NEVER_DUPLICATE;
+	variable->export_info.usage |= PROPERTY_USAGE_ALWAYS_DUPLICATE;
+
+	return true;
+}
+
+bool GDScriptParser::never_duplicate_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+
+	VariableNode *variable = static_cast<VariableNode *>(p_target);
+	if (variable->is_static) {
+		push_error(vformat(R"(Annotation "%s" cannot be applied to a static variable.)", p_annotation->name), p_annotation);
+		return false;
+	}
+	bool is_resource_var = variable->export_info.hint == PROPERTY_HINT_RESOURCE_TYPE;
+	is_resource_var |= ClassDB::is_parent_class(variable->get_datatype().native_type, SNAME("Resource"));
+	if (!is_resource_var) {
+		push_error(vformat(R"(Annotation "%s" can only be applied to Resource variables.)", p_annotation->name), p_annotation);
+		return false;
+	}
+
+	variable->export_info.usage &= ~PROPERTY_USAGE_ALWAYS_DUPLICATE;
+	variable->export_info.usage |= PROPERTY_USAGE_NEVER_DUPLICATE;
 
 	return true;
 }

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1528,6 +1528,8 @@ private:
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool always_duplicate_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool never_duplicate_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_custom_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_tool_button_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyUsageFlags t_usage>

--- a/modules/gdscript/tests/scripts/parser/features/duplicate_resources.gd
+++ b/modules/gdscript/tests/scripts/parser/features/duplicate_resources.gd
@@ -1,0 +1,58 @@
+class ResA extends Resource:
+	var a = 1
+
+class ResB extends Resource:
+	@export var exported_automatic_copy: ResA
+	@never_duplicate
+	@export var exported_shared_resource: ResA
+	@always_duplicate
+	@export var exported_unique_resource: ResA
+	var automatic_copy: ResA
+	@never_duplicate
+	var shared_resource: ResA
+	@always_duplicate
+	var unique_resource: ResA
+
+
+
+func test():
+	var res_a := ResA.new()
+	var res_b := ResB.new()
+	res_b.exported_automatic_copy = res_a
+	res_b.exported_shared_resource = res_a
+	res_b.exported_unique_resource = res_a
+	res_b.automatic_copy = res_a
+	res_b.shared_resource = res_a
+	res_b.unique_resource = res_a
+
+	var shallow_copy := res_b.duplicate(false)
+	var with_subresources_copy := res_b.duplicate(true)
+	var copy_all := res_b.duplicate_deep(Resource.DEEP_DUPLICATE_ALL)
+	var copy_internal := res_b.duplicate_deep(Resource.DEEP_DUPLICATE_INTERNAL)
+	var copy_none := res_b.duplicate_deep(Resource.DEEP_DUPLICATE_NONE)
+
+	var to_test = [
+		{
+			name = "shallow_copy",
+			resource = shallow_copy
+		}, {
+			name = "with_subresources_copy",
+			resource = with_subresources_copy
+		}, {
+			name = "copy_all",
+			resource = copy_all
+		}, {
+			name = "copy_internal",
+			resource = copy_internal
+		}, {
+			name = "copy_none",
+			resource = copy_none
+		}
+	]
+	for field in ["exported_automatic_copy", "exported_shared_resource", "exported_unique_resource", "automatic_copy", "shared_resource", "unique_resource"]:
+		for case in to_test:
+			var member = case.name
+			var copy = case.resource
+			var copy_field = copy.get(field)
+			print(member, ".", field, " duplicated ? ", copy_field != res_a)
+		print("---")

--- a/modules/gdscript/tests/scripts/parser/features/duplicate_resources.out
+++ b/modules/gdscript/tests/scripts/parser/features/duplicate_resources.out
@@ -1,0 +1,37 @@
+GDTEST_OK
+shallow_copy.exported_automatic_copy duplicated ? false
+with_subresources_copy.exported_automatic_copy duplicated ? true
+copy_all.exported_automatic_copy duplicated ? true
+copy_internal.exported_automatic_copy duplicated ? true
+copy_none.exported_automatic_copy duplicated ? false
+---
+shallow_copy.exported_shared_resource duplicated ? true
+with_subresources_copy.exported_shared_resource duplicated ? true
+copy_all.exported_shared_resource duplicated ? true
+copy_internal.exported_shared_resource duplicated ? true
+copy_none.exported_shared_resource duplicated ? true
+---
+shallow_copy.exported_unique_resource duplicated ? true
+with_subresources_copy.exported_unique_resource duplicated ? true
+copy_all.exported_unique_resource duplicated ? true
+copy_internal.exported_unique_resource duplicated ? true
+copy_none.exported_unique_resource duplicated ? true
+---
+shallow_copy.automatic_copy duplicated ? false
+with_subresources_copy.automatic_copy duplicated ? true
+copy_all.automatic_copy duplicated ? true
+copy_internal.automatic_copy duplicated ? true
+copy_none.automatic_copy duplicated ? false
+---
+shallow_copy.shared_resource duplicated ? true
+with_subresources_copy.shared_resource duplicated ? true
+copy_all.shared_resource duplicated ? true
+copy_internal.shared_resource duplicated ? true
+copy_none.shared_resource duplicated ? true
+---
+shallow_copy.unique_resource duplicated ? true
+with_subresources_copy.unique_resource duplicated ? true
+copy_all.unique_resource duplicated ? true
+copy_internal.unique_resource duplicated ? true
+copy_none.unique_resource duplicated ? true
+---


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/issues/108220
(does not close it)

The test case is still not working as i intended, i am calling for input here, what is more important? the USAGE flag, or the duplicate/duplicate_deep argument? I expected the flag to always take presedence over the method argument, but seems is not the case

**TODO:** Add documentation of the new annotations

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
