### PR TITLE
Change `PROPERTY_HINT_GROUP_ENABLE` behavior to read_only

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1893,8 +1893,8 @@ void EditorInspectorSection::_notification(int p_what) {
 			Rect2 header_rect = Rect2(Vector2(header_offset_x, 0.0), Vector2(header_width, header_height));
 			Color c = bg_color;
 			c.a *= 0.4;
-			if (foldable && header_rect.has_point(get_local_mouse_position())) {
-				c = c.lightened((can_click_unfold && Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT)) ? -0.05 : 0.2);
+			if (header_hover) {
+				c = c.lightened(Input::get_singleton()->is_mouse_button_pressed(MouseButton::LEFT) ? -0.05 : 0.2);
 			}
 			draw_rect(header_rect, c);
 
@@ -2059,11 +2059,13 @@ void EditorInspectorSection::_notification(int p_what) {
 			queue_redraw();
 		} break;
 
+		case NOTIFICATION_MOUSE_EXIT_SELF:
 		case NOTIFICATION_MOUSE_EXIT: {
 			if (dropping_for_unfold) {
 				dropping_unfold_timer->stop();
 			}
 
+			header_hover = false;
 			check_hover = false;
 			keying_hover = false;
 			queue_redraw();
@@ -2166,11 +2168,11 @@ void EditorInspectorSection::setup(const String &p_section, const String &p_labe
 
 void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
-	bool has_children_to_show = vbox->get_child_count(false) != 0;
+	bool can_click_unfold = vbox->get_child_count(false) != 0 && !(!checkbox_only && checkable && !checked);
 
-	Ref<InputEventMouse> me = p_event;
-	if (me.is_valid()) {
-		Vector2 mpos = me->get_position();
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		Vector2 mpos = mm->get_position();
 
 		bool new_check_hover = check_rect.has_point(mpos);
 		if (new_check_hover != check_hover) {
@@ -2183,11 +2185,17 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 			keying_hover = new_keying_hover;
 			queue_redraw();
 		}
+
+		bool new_header_hover = foldable && can_click_unfold && (get_local_mouse_position().y < _get_header_height());
+		if (new_header_hover != header_hover) {
+			header_hover = new_header_hover;
+			queue_redraw();
+		}
 	}
 
 	Ref<InputEventKey> k = p_event;
 	if (k.is_valid() && k->is_pressed()) {
-		if (foldable && has_children_to_show && !(checkable && !checked && !checkbox_only) && k->is_action("ui_accept", true)) {
+		if (foldable && can_click_unfold && k->is_action("ui_accept", true)) {
 			accept_event();
 
 			bool should_unfold = !object->editor_is_section_unfolded(section);
@@ -2224,7 +2232,7 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 		} else if (keying && keying_rect.has_point(pos)) {
 			emit_signal(SNAME("property_keyed"), related_enable_property, false);
 		} else if (foldable) {
-			bool should_unfold = has_children_to_show && !(checkable && !checked && !checkbox_only) && !object->editor_is_section_unfolded(section);
+			bool should_unfold = can_click_unfold && !object->editor_is_section_unfolded(section);
 			if (should_unfold) {
 				unfold();
 			} else {
@@ -2233,15 +2241,6 @@ void EditorInspectorSection::gui_input(const Ref<InputEvent> &p_event) {
 		}
 	} else if (mb.is_valid() && !mb->is_pressed()) {
 		queue_redraw();
-	}
-
-	Ref<InputEventMouseMotion> mm = p_event;
-	if (mm.is_valid()) {
-		int header_height = _get_header_height();
-		Vector2 previous = mm->get_position() - mm->get_relative();
-		if (has_children_to_show && ((mm->get_position().y >= header_height) != (previous.y >= header_height))) {
-			queue_redraw();
-		}
 	}
 }
 

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -384,6 +384,7 @@ class EditorInspectorSection : public Container {
 	bool check_hover = false;
 	Rect2 keying_rect;
 	bool keying_hover = false;
+	bool header_hover = false;
 
 	bool checkbox_only = false;
 

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -397,7 +397,7 @@ class EditorInspectorSection : public Container {
 	Ref<Texture2D> _get_checkbox();
 
 	EditorInspector *_get_parent_inspector() const;
-	void _update_child_read_only(bool p_setup = false);
+	void _update_child_read_only();
 
 	struct ThemeCache {
 		int horizontal_separation = 0;

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -385,6 +385,7 @@ class EditorInspectorSection : public Container {
 	Rect2 keying_rect;
 	bool keying_hover = false;
 	bool header_hover = false;
+	Vector<bool> default_read_only;
 
 	bool checkbox_only = false;
 
@@ -396,6 +397,7 @@ class EditorInspectorSection : public Container {
 	Ref<Texture2D> _get_checkbox();
 
 	EditorInspector *_get_parent_inspector() const;
+	void _update_child_read_only(bool p_setup = false);
 
 	struct ThemeCache {
 		int horizontal_separation = 0;


### PR DESCRIPTION
This PR follows from the discussion on #108257.

Currently, when Inspector Sections are toggled off, they hide all their children in order to convey that these children have no impact on the current state of the object. However, there is another way to convey this, which is by making all the children `read_only`. This has the benefit of not hiding child properties, while also showing that it makes no sense to edit them.

This PR is meant to be a test of the `read_only` approach, and if it has support, to replace the current method.

TODO:
- [ ] Have the read_only change affect more classes
- [ ] Find a way to deal with external changes to the properties (ideally avoiding an `update_tree()` call each time it is ticked)

Edit: I looked into it more and believe that calling `update_tree` every time something checks that mark is the only "proper" way to do it at the moment, without more sophisticated methods of dealing with read_only