### PR TITLE
Fix alignment calculation for camera rays buffer in RaycastOcclusionCull

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -74,7 +74,8 @@ void RaycastOcclusionCull::RaycastHZBuffer::resize(const Size2i &p_size) {
 
 	const int alignment = 64; // Embree requires ray packets to be 64-aligned
 	camera_rays_unaligned_buffer = (uint8_t *)memalloc(camera_rays_tile_count * sizeof(CameraRayTile) + alignment);
-	camera_rays = (CameraRayTile *)(camera_rays_unaligned_buffer + alignment - (((uint64_t)camera_rays_unaligned_buffer) % alignment));
+	size_t offset = (alignment - ((uintptr_t)camera_rays_unaligned_buffer % alignment)) % alignment;
+	camera_rays = (CameraRayTile *)(camera_rays_unaligned_buffer + offset);
 
 	camera_ray_masks.resize(camera_rays_tile_count * TILE_RAYS);
 	memset(camera_ray_masks.ptr(), ~0, camera_rays_tile_count * TILE_RAYS * sizeof(uint32_t));


### PR DESCRIPTION
This PR fixes a bug in the pointer alignment logic within the raycast-based occlusion culling system.                                                                                                   

The formula used in RaycastOcclusionCull::RaycastHZBuffer::resize to ensure the camera_rays buffer was 64-byte aligned was flawed. If the memory allocated for the buffer was already aligned, the      
calculation would incorrectly add a 64-byte offset to the pointer. This caused the first 64 bytes of the buffer to be skipped, which is wasteful and incorrect.                                         

The change corrects the pointer arithmetic to properly calculate the required alignment offset, which will be zero if the buffer is already aligned. This ensures the buffer is always correctly        
positioned at the first available aligned address within the allocated memory block.                                                                                                                    