### PR TITLE
Fix: Reset simplify_with_attrib_func in uninitialize_meshoptimizer_module

### DIFF
--- a/modules/meshoptimizer/register_types.cpp
+++ b/modules/meshoptimizer/register_types.cpp
@@ -58,6 +58,7 @@ void uninitialize_meshoptimizer_module(ModuleInitializationLevel p_level) {
 	SurfaceTool::optimize_vertex_fetch_remap_func = nullptr;
 	SurfaceTool::simplify_func = nullptr;
 	SurfaceTool::simplify_scale_func = nullptr;
+	SurfaceTool::simplify_with_attrib_func = nullptr;
 	SurfaceTool::generate_remap_func = nullptr;
 	SurfaceTool::remap_vertex_func = nullptr;
 	SurfaceTool::remap_index_func = nullptr;


### PR DESCRIPTION
This pull request addresses a bug in the `meshoptimizer` module where the `uninitialize_meshoptimizer_module` function did not clear all function pointers set during initialization. Specifically, the `SurfaceTool::simplify_with_attrib_func` was not being reset to `nullptr`, which could lead to a dangling pointer when the module is uninitialized.     