### PR TITLE
Fix ColorPicker linear mode sliders color

### DIFF
--- a/scene/gui/color_mode.cpp
+++ b/scene/gui/color_mode.cpp
@@ -283,7 +283,7 @@ void ColorModeLinear::slider_draw(int p_which) {
 	Size2 size = slider->get_size();
 	Color left_color;
 	Color right_color;
-	Color color = color_picker->color_normalized.linear_to_srgb();
+	Color color = color_picker->color_normalized;
 	const real_t margin = 16 * color_picker->theme_cache.base_scale;
 
 	left_color = Color(


### PR DESCRIPTION
`color_normalized` is already srgb, it incorrectly does a linear to srgb conversion.

Before:
![屏幕截图_20250706_131024](https://github.com/user-attachments/assets/1b04078a-467f-4f20-98db-00f61d7e8b30)

After:
![屏幕截图_20250706_131109](https://github.com/user-attachments/assets/aa63b849-5016-4ab7-8ce1-a47794c0dcfe)
