### PR TITLE
Android: Fix the EOF detection logic

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/AssetData.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/AssetData.kt
@@ -138,7 +138,6 @@ internal class AssetData(context: Context, private val filePath: String, accessF
 				0
 			} else {
 				position += readBytes
-				endOfFile = position() >= size()
 				readBytes
 			}
 		} catch (e: IOException) {

--- a/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/io/file/DataAccess.kt
@@ -216,7 +216,6 @@ internal abstract class DataAccess {
 		override fun seek(position: Long) {
 			try {
 				fileChannel.position(position)
-				endOfFile = position >= fileChannel.size()
 			} catch (e: Exception) {
 				Log.w(TAG, "Exception when seeking file $filePath.", e)
 			}
@@ -260,8 +259,8 @@ internal abstract class DataAccess {
 		override fun read(buffer: ByteBuffer): Int {
 			return try {
 				val readBytes = fileChannel.read(buffer)
-				endOfFile = readBytes == -1 || (fileChannel.position() >= fileChannel.size())
 				if (readBytes == -1) {
+					endOfFile = true
 					0
 				} else {
 					readBytes


### PR DESCRIPTION
The current logic was causing file loading to omit the last character because the EOF flag was triggered too early.

This was mostly unnoticed because most files loaded by the editor terminate with a newline character. The issue can be reproduced however by attempting to load [@passivestar's minimal theme](https://github.com/passivestar/godot-minimal-theme) in the Android editor.
The minimal theme config file does not terminate with a newline character, and so attempting to load it in the current version of the editor (4.5 beta 2 and earlier) fails because the last `)` character is omitted.

This PR fixes that issue.
Following the Java documentation, the EOF flag is now only set when a `read()` operation returns `-1`.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
