### PR TITLE
SpinBox: Add a property to set whether `custom_arrow_step` rounds value

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -49,6 +49,9 @@
 		<member name="alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
 			Changes the alignment of the underlying [LineEdit].
 		</member>
+		<member name="custom_arrow_round" type="bool" setter="set_custom_arrow_round" getter="is_custom_arrow_rounding" default="false">
+			If [code]true[/code], the value will be rounded to a multiple of [member custom_arrow_step] when interacting with the arrow buttons. Otherwise, increments the value by [member custom_arrow_step] and then rounds it according to [member Range.step].
+		</member>
 		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
 			If not [code]0[/code], sets the step when interacting with the arrow buttons of the [SpinBox].
 			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member Range.step].

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2170,6 +2170,7 @@ ColorPicker::ColorPicker() {
 	intensity_slider->set_step(0.001);
 	intensity_value->set_allow_greater(true);
 	intensity_value->set_custom_arrow_step(1);
+	intensity_value->set_custom_arrow_round(true);
 
 	hex_hbc = memnew(HBoxContainer);
 	hex_hbc->set_alignment(ALIGNMENT_BEGIN);

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -67,6 +67,7 @@ class SpinBox : public Range {
 	Timer *range_click_timer = nullptr;
 	void _range_click_timeout();
 	void _release_mouse_from_drag_mode();
+	void _arrow_clicked(bool p_up);
 
 	void _update_text(bool p_only_update_if_value_changed = false);
 	void _text_submitted(const String &p_string);
@@ -76,6 +77,7 @@ class SpinBox : public Range {
 	String suffix;
 	String last_text_value;
 	double custom_arrow_step = 0.0;
+	bool custom_arrow_round = false;
 
 	void _line_edit_input(const Ref<InputEvent> &p_event);
 
@@ -179,6 +181,9 @@ public:
 	void apply();
 	void set_custom_arrow_step(const double p_custom_arrow_step);
 	double get_custom_arrow_step() const;
+
+	void set_custom_arrow_round(bool p_round);
+	bool is_custom_arrow_rounding() const;
 
 	SpinBox();
 };


### PR DESCRIPTION
Adds a property to set whether `custom_arrow_step` rounds value, to restore the behavior in 4.3. It is useful to avoid breadking original value when clicking the arrow.
