### PR TITLE
Expose `Image::get_format_name`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3520,6 +3520,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_size"), &Image::get_size);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Image::has_mipmaps);
 	ClassDB::bind_method(D_METHOD("get_format"), &Image::get_format);
+	ClassDB::bind_static_method("Image", D_METHOD("get_format_name", "format"), &Image::get_format_name);
 	ClassDB::bind_method(D_METHOD("get_data"), &Image::get_data);
 	ClassDB::bind_method(D_METHOD("get_data_size"), &Image::get_data_size);
 

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -237,6 +237,13 @@
 				Returns this image's format.
 			</description>
 		</method>
+		<method name="get_format_name" qualifiers="static">
+			<return type="String" />
+			<param index="0" name="format" type="int" enum="Image.Format" />
+			<description>
+				Returns the name of the image format specified by [param format].
+			</description>
+		</method>
 		<method name="get_height" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
There is currently no way to get the name of an image format, which is rather important for helpful warning/error messages in non-game applications and add-ons. `<Enum>.keys()[idx]` just works for user defined enums.

Example usage:
```GDScript
#...
print("Image format ", Image.get_format_name(img.get_format()), " not supported, converting to ", Image.get_format_name(Image.FORMAT_RGB8))
# Output: Image format RGBAHalf not supported, converting to RGB8
```