### PR TITLE
Correct raycast closest hit calculation by subtracting ray origin

### DIFF
--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -175,7 +175,7 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 			Transform2D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 			shape_point = xform.xform(shape_point);
 
-			real_t ld = normal.dot(shape_point);
+			real_t ld = normal.dot(shape_point - begin);
 
 			if (ld < min_d) {
 				min_d = ld;


### PR DESCRIPTION
This PR corrects the calculation of the closest hit point in the 2D raycast implementation of Godot Physics. Previously, the distance was computed using the dot product of the normal and the transformed shape point, which did not account for the ray's origin. This could result in incorrect hit distances, especially when the ray did not start at the origin.