### PR TITLE
Automatically open newly created script

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2746,6 +2746,10 @@ void FileSystemDock::_resource_created() {
 	EditorNode::get_singleton()->save_resource_as(Ref<Resource>(r), fpath);
 }
 
+void FileSystemDock::_script_or_shader_created(const Ref<Resource> &p_resource) {
+	EditorNode::get_singleton()->push_item(p_resource.ptr());
+}
+
 void FileSystemDock::_search_changed(const String &p_text, const Control *p_from) {
 	if (searched_tokens.is_empty()) {
 		// Register the uncollapsed paths before they change.
@@ -4441,9 +4445,12 @@ FileSystemDock::FileSystemDock() {
 	make_script_dialog = memnew(ScriptCreateDialog);
 	make_script_dialog->set_title(TTRC("Create Script"));
 	add_child(make_script_dialog);
+	make_script_dialog->connect("script_created", callable_mp(this, &FileSystemDock::_script_or_shader_created));
 
 	make_shader_dialog = memnew(ShaderCreateDialog);
 	add_child(make_shader_dialog);
+	make_shader_dialog->connect("shader_created", callable_mp(this, &FileSystemDock::_script_or_shader_created));
+	make_shader_dialog->connect("shader_include_created", callable_mp(this, &FileSystemDock::_script_or_shader_created));
 
 	new_resource_dialog = memnew(CreateDialog);
 	add_child(new_resource_dialog);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -313,6 +313,7 @@ private:
 	void _folder_removed(const String &p_folder);
 
 	void _resource_created();
+	void _script_or_shader_created(const Ref<Resource> &p_resource);
 	void _make_scene_confirm();
 	void _rename_operation_confirm();
 	void _duplicate_operation_confirm(const String &p_path);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1318,13 +1318,13 @@ void ScriptEditor::_file_dialog_action(const String &p_file) {
 					EditorFileSystem::get_singleton()->update_file(p_file);
 				}
 			}
-
-			if (!open_textfile_after_create) {
-				return;
-			}
 			[[fallthrough]];
 		}
 		case FILE_MENU_OPEN: {
+			if (!is_visible_in_tree()) {
+				// When created from outside the editor.
+				EditorNode::get_singleton()->get_editor_main_screen()->select(EditorMainScreen::EDITOR_SCRIPT);
+			}
 			open_file(p_file);
 			file_dialog_option = -1;
 		} break;
@@ -1403,7 +1403,6 @@ void ScriptEditor::_menu_option(int p_option) {
 			}
 			file_dialog->set_title(TTRC("New Text File..."));
 			file_dialog->popup_file_dialog();
-			open_textfile_after_create = true;
 		} break;
 		case FILE_MENU_OPEN: {
 			file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
@@ -2908,7 +2907,6 @@ void ScriptEditor::open_text_file_create_dialog(const String &p_base_path, const
 	_menu_option(FILE_MENU_NEW_TEXTFILE);
 	file_dialog->set_current_dir(p_base_path);
 	file_dialog->set_current_file(p_base_name);
-	open_textfile_after_create = false;
 }
 
 Ref<Resource> ScriptEditor::open_file(const String &p_file) {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -452,7 +452,6 @@ class ScriptEditor : public PanelContainer {
 	void _scene_saved_callback(const String &p_path);
 	void _mark_built_in_scripts_as_saved(const String &p_parent_path);
 
-	bool open_textfile_after_create = true;
 	bool trim_trailing_whitespace_on_save;
 	bool trim_final_newlines_on_save;
 	bool convert_indent_on_save;


### PR DESCRIPTION

https://github.com/user-attachments/assets/ccffaf81-ef31-4da7-bfd6-71b7f2fd176f

It's especially useful when you create a script inside a folded directory; you no longer need to search for it to open.

We do it already with other resources.