### PR TITLE
Fix collision solver to use correct motion parameters in static world boundary checks

### DIFF
--- a/modules/godot_physics_2d/godot_collision_solver_2d.cpp
+++ b/modules/godot_physics_2d/godot_collision_solver_2d.cpp
@@ -239,7 +239,7 @@ bool GodotCollisionSolver2D::solve(const GodotShape2D *p_shape_A, const Transfor
 		}
 
 		if (swap) {
-			return solve_static_world_boundary(p_shape_B, p_transform_B, p_shape_A, p_transform_A, p_motion_A, p_result_callback, p_userdata, true, p_margin_A);
+			return solve_static_world_boundary(p_shape_B, p_transform_B, p_shape_A, p_transform_A, p_motion_B, p_result_callback, p_userdata, true, p_margin_B);
 		} else {
 			return solve_static_world_boundary(p_shape_A, p_transform_A, p_shape_B, p_transform_B, p_motion_B, p_result_callback, p_userdata, false, p_margin_B);
 		}


### PR DESCRIPTION
This pull request fixes an issue in the 2D collision solver where the incorrect motion parameters were being used during static world boundary checks. Previously, when the `swap` flag was set, the solver would pass `p_motion_A` and `p_margin_A` to `solve_static_world_boundary`, even though the correct parameters should have been `p_motion_B` and `p_margin_B` to match the swapped shapes and transforms.

With this change, the collision solver now consistently uses the correct motion and margin parameters for each shape, ensuring accurate collision detection and resolution when interacting with static world boundaries.