### PR TITLE
Fix underculling of occlusion culling

### DIFF
--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -174,8 +174,7 @@ void RaycastOcclusionCull::RaycastHZBuffer::sort_rays(const Vector3 &p_camera_di
 					int k = tile_i * TILE_SIZE + tile_j;
 					int tile_index = i * tile_grid_size.x + j;
 
-					Vector3 ray_dir(camera_rays[tile_index].ray.dir_x[k], camera_rays[tile_index].ray.dir_y[k], camera_rays[tile_index].ray.dir_z[k]);
-					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k] * p_camera_dir.dot(ray_dir); // Store z-depth in view space.
+					mips[0][y * buffer_size.x + x] = camera_rays[tile_index].ray.tfar[k];
 				}
 			}
 		}

--- a/servers/rendering/renderer_scene_occlusion_cull.h
+++ b/servers/rendering/renderer_scene_occlusion_cull.h
@@ -71,7 +71,9 @@ public:
 				return false;
 			}
 
-			float min_depth = -closest_point_view.z;
+			// Force distance calculation to use double precision to avoid floating-point overflow for distant objects.
+			closest_point = closest_point - p_cam_position;
+			float min_depth = Math::sqrt((double)closest_point.x * (double)closest_point.x + (double)closest_point.y * (double)closest_point.y + (double)closest_point.z * (double)closest_point.z);
 
 			Vector2 rect_min = Vector2(FLT_MAX, FLT_MAX);
 			Vector2 rect_max = Vector2(FLT_MIN, FLT_MIN);
@@ -82,9 +84,13 @@ public:
 				Vector3 corner = Vector3(p_bounds[0] * c.x + p_bounds[3] * nc.x, p_bounds[1] * c.y + p_bounds[4] * nc.y, p_bounds[2] * c.z + p_bounds[5] * nc.z);
 				Vector3 view = p_cam_inv_transform.xform(corner);
 
+				// When using an orthogonal camera, the closest point of an AABB to the camera is guaranteed to be a corner.
+				if (p_cam_projection.is_orthogonal()) {
+					min_depth = MIN(min_depth, -view.z);
+				}
+
 				Plane vp = Plane(view, 1.0);
 				Plane projected = p_cam_projection.xform4(vp);
-				min_depth = MIN(min_depth, -view.z);
 
 				float w = projected.d;
 				if (w < 1.0) {


### PR DESCRIPTION
Fixes #106184 

This commit effectively undoes #103798, reverting to the previous behavior. To ensure that distant objects are culled correctly, I force the distance calculation to use double precision.

The video below compares this PR to v4.4.1 and v4.5.beta2 in a [test scene](https://github.com/user-attachments/files/21090324/occlusion-base.zip). In this scene, the camera is placed within a transparent occluder, so ideally, everything should be occluded at all times.

https://github.com/user-attachments/assets/eb77cb6f-4dcc-4224-8cd4-3749c1750527