### PR TITLE
Add environment variable access defines to SDL linux build config

### DIFF
--- a/drivers/sdl/SDL_build_config_private.h
+++ b/drivers/sdl/SDL_build_config_private.h
@@ -87,6 +87,9 @@
 #ifdef __linux__
 #define HAVE_INOTIFY 1
 #define HAVE_INOTIFY_INIT1 1
+#define HAVE_GETENV 1
+#define HAVE_SETENV 1
+#define HAVE_UNSETENV 1
 #endif
 
 // TODO: handle dynamic loading with SOWRAP_ENABLED


### PR DESCRIPTION
Enables SDL's access to environment variables on Linux by adding necessary build configuration defines.

This fixes an issue where SDL couldn't read environment variables on Linux systems, particularly affecting SteamDeck users where environment variables allow for the steamdeck's own controller to work.

Closes https://github.com/godotengine/godot/issues/108311 as well as enabling end-user configuration of SDL via environment variables on linux.