### PR TITLE
Thirdparty: Fix SDL arm64 compilation on Windows

### DIFF
--- a/thirdparty/sdl/patches/0004-errno-include.patch
+++ b/thirdparty/sdl/patches/0004-errno-include.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/sdl/stdlib/SDL_malloc.c b/thirdparty/sdl/stdlib/SDL_malloc.c
+index 008675f312..00118b8ae6 100644
+--- a/thirdparty/sdl/stdlib/SDL_malloc.c
++++ b/thirdparty/sdl/stdlib/SDL_malloc.c
+@@ -586,7 +586,7 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
+ #define LACKS_STRING_H
+ #define LACKS_STRINGS_H
+ #define LACKS_SYS_TYPES_H
+-#define LACKS_ERRNO_H
++// #define LACKS_ERRNO_H // File uses `EINVAL` and `ENOMEM` defines, so include is required. Legacy exclusion?
+ #define LACKS_SCHED_H
+ #ifndef MALLOC_FAILURE_ACTION
+ #define MALLOC_FAILURE_ACTION

--- a/thirdparty/sdl/stdlib/SDL_malloc.c
+++ b/thirdparty/sdl/stdlib/SDL_malloc.c
@@ -586,7 +586,7 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #define LACKS_STRING_H
 #define LACKS_STRINGS_H
 #define LACKS_SYS_TYPES_H
-#define LACKS_ERRNO_H
+// #define LACKS_ERRNO_H // File uses `EINVAL` and `ENOMEM` defines, so include is required. Legacy exclusion?
 #define LACKS_SCHED_H
 #ifndef MALLOC_FAILURE_ACTION
 #define MALLOC_FAILURE_ACTION


### PR DESCRIPTION
Arm64 builds failed for Windows for beta 2, and that was ultiamtely down to `errno.h` being excluded. This was caused by a define which explicitly removes the include, but didn't affect x86 compilation because some other header just so happened to include it anyway. This removes the exlusion define entirely.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/108345*