### PR TITLE
Fix incorrect light values on blend import

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -146,6 +146,7 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	parameters_map["export_keep_originals"] = unpack_original_images;
 	parameters_map["export_format"] = "GLTF_SEPARATE";
 	parameters_map["export_yup"] = true;
+	parameters_map["export_import_convert_lighting_mode"] = "COMPAT";
 
 	if (p_options.has(SNAME("blender/nodes/custom_properties")) && p_options[SNAME("blender/nodes/custom_properties")]) {
 		parameters_map["export_extras"] = true;

--- a/modules/gltf/extensions/gltf_light.cpp
+++ b/modules/gltf/extensions/gltf_light.cpp
@@ -182,6 +182,7 @@ Light3D *GLTFLight::to_node() const {
 		return nullptr;
 	}
 	light->set_color(color.linear_to_srgb());
+	light->set_param(Light3D::PARAM_ATTENUATION, 2.0);
 	return light;
 }
 


### PR DESCRIPTION
This commit changes the Blender glTF export process to output light intensities in "unitless" lighting mode, which brings the brightness levels down to usable ranges when not using physical lighting units.

Physical lighting units could be fixed by e.g. using the default lighting mode, and passing the exported lumens into Godot's own light intensity parameter (which is also in lumens). That's not included in this PR due to it being a less clear fix, and Blender possibly changing their watt-to-lumen conversion in the near future.

Additionally, this sets the light attenuation for glTF (and thus Blender) imports to 2.0 by default, to match the attenuation seen in Cycles and EEVEE.

Fixes #92168.

### Screenshots

The screenshots using physical light units use camera attributes tuned so that the default Blender cube looks right (3 f-stop, 100 Hz shutter speed, 1200 ISO sensitivity). Alas, the results are still somewhat inconsistent between light types when using physical light units, leading to especially wrong results for directional lights.

The non-physical light units screenshots are using the default camera attributes' exposure, which seems to lead to a lightly brighter look than Blender by default, but it's not too far off, and the light intensities between light types are consistent.

| Blender Cycles | Blender EEVEE | Godot (physical light units) | Godot (non-physical light units) |
|---|---|---|---|
| ![render-blender-4 4 3-cycles](https://github.com/user-attachments/assets/6c789178-a331-427f-b298-ba1d1574b965) | ![render-blender-4 4 3-eevee](https://github.com/user-attachments/assets/02fc9e63-317d-49bf-bace-877eb7abcf1e) | ![render-godot-PR-forward+](https://github.com/user-attachments/assets/221f0236-ac0b-4991-aea6-70c58379bef5) | ![render-godot-PR-forward+-non-physical](https://github.com/user-attachments/assets/b37e90e4-3566-4259-be30-873989d2efd2) |
| ![render-blender-4 4 3-cycles](https://github.com/user-attachments/assets/cff5022c-74eb-430d-8728-22446da76169) | ![render-blender-4 4 3-eevee](https://github.com/user-attachments/assets/4e53abaf-cb08-4637-903c-0d564333109f) | ![render-godot-PR-forward+](https://github.com/user-attachments/assets/7e2414c9-330a-4440-af4f-13e37e493f1b) | ![render-godot-PR-forward+-non-physical](https://github.com/user-attachments/assets/708faafb-751c-44d3-a570-6f0f25280233) |
| ![render-blender-4 4 3-cycles](https://github.com/user-attachments/assets/ec3bcd32-9bc4-48d0-bd18-dce77ccbbd63) | ![render-blender-4 4 3-eevee](https://github.com/user-attachments/assets/a3408ac8-3c2f-4272-8d9d-5caf68dada25) | ![render-godot-PR-forward+](https://github.com/user-attachments/assets/d13dc790-4f59-4080-8d78-b4f9e4bb588b) | ![render-godot-PR-forward+-non-physical](https://github.com/user-attachments/assets/6a488a51-4999-4a27-b54b-b31d44307348) |
| ![render-blender-4 4 3-cycles](https://github.com/user-attachments/assets/cde14727-4ecd-4316-9d5b-33c1de83e428) | ![render-blender-4 4 3-eevee](https://github.com/user-attachments/assets/aac30a2d-91e1-43f7-99e3-dd6e89445922) | ![render-godot-PR-forward+](https://github.com/user-attachments/assets/04fea6ba-99d6-40ad-adde-8d5ef2982b38) | ![render-godot-PR-forward+-non-physical](https://github.com/user-attachments/assets/b43687fe-b898-47af-b6e0-bf24085ecbd0) |

(The Godot screenshots reflect commit 54fd2853b17c5633b1553389d9aeac37f72845da.)

The first scene is just the default Blender cube with the background taken out to ease calibration. The second one has all the three light types, to validate that they look appropriate relative to each other. The third one has a single directional light, which is The Sun levels of bright, except it has an almost black color to avoid overexposing the default ("indoors") exposure. The fourth one is the Blender scene included in the issue's MRP, with the background set to black (since that can't be accounted for by this import process, and the default Godot background is too bright for this exposure with physical light units).

The point of the three scenes is to move around the lights, use different intensities, and then see if the same exposure settings lead to matching results with Blender. Evidently the physical lighting path ends up having problematic directional lights, but everything else certainly looks better than without this PR (where all these are just pure white when facing towards a light).

Here's the project including all the scenes that those screenshots are from: 
[light-tests.zip](https://github.com/user-attachments/files/21800538/light-tests.zip)

