### PR TITLE
Use inotify to detect devices for better reliability on Linux

### DIFF
--- a/drivers/sdl/SDL_build_config_private.h
+++ b/drivers/sdl/SDL_build_config_private.h
@@ -84,6 +84,11 @@
 #define HAVE_LINUX_INPUT_H 1
 #define HAVE_POLL 1
 
+#ifdef __linux__
+#define HAVE_INOTIFY 1
+#define HAVE_INOTIFY_INIT1 1
+#endif
+
 // TODO: handle dynamic loading with SOWRAP_ENABLED
 
 // (even though DBus can also be loaded with SOWRAP_ENABLED, we load it


### PR DESCRIPTION
Fix the issue that some devices were not detected when hot plugged.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fix #108362.