### PR TITLE
Presort text draw calls.

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1053,7 +1053,7 @@
 			<param index="0" name="column" type="int" />
 			<param index="1" name="draw_callback" type="Callable" />
 			<description>
-				Set a custom draw callback for the gutter at the given index. [param draw_callback] must take the following arguments: A line index [int], a gutter index [int], and an area [Rect2]. This callback only works when the gutter type is [constant GUTTER_TYPE_CUSTOM] (see [method set_gutter_type]).
+				Set a custom draw callback for the gutter at the given index. [param draw_callback] must take the following arguments: A canvas item [RID], a line index [int], a gutter index [int], and an area [Rect2]. This callback only works when the gutter type is [constant GUTTER_TYPE_CUSTOM] (see [method set_gutter_type]).
 			</description>
 		</method>
 		<method name="set_gutter_draw">

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -20,6 +20,19 @@
 				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
+		<method name="add_outline_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="outline_size" type="int" default="1" />
+			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="6" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for glyph outlines to the draw list [param list].
+			</description>
+		</method>
 		<method name="add_string">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />
@@ -29,6 +42,18 @@
 			<param index="4" name="meta" type="Variant" default="null" />
 			<description>
 				Adds text span and font to draw it.
+			</description>
+		</method>
+		<method name="add_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="5" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for glyphs to the draw list [param list].
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -9,6 +9,58 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_dropcap_outline_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="outline_size" type="int" default="1" />
+			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="6" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for dropcap glyph outlines to the draw list [param list].
+			</description>
+		</method>
+		<method name="add_dropcap_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="5" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for dropcap glyphs to the draw list [param list].
+			</description>
+		</method>
+		<method name="add_line_outline_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="line" type="int" />
+			<param index="5" name="outline_size" type="int" default="1" />
+			<param index="6" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="7" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for line [param line] glyph outlines to the draw list [param list].
+			</description>
+		</method>
+		<method name="add_line_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="line" type="int" />
+			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="6" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for line [param line] glyphs to the draw list [param list].
+			</description>
+		</method>
 		<method name="add_object">
 			<return type="bool" />
 			<param index="0" name="key" type="Variant" />
@@ -20,6 +72,20 @@
 				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
+		<method name="add_outline_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="outline_size" type="int" default="1" />
+			<param index="5" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="6" name="dc_color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="7" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for paragraph glyph outlines to the draw list [param list].
+			</description>
+		</method>
 		<method name="add_string">
 			<return type="bool" />
 			<param index="0" name="text" type="String" />
@@ -29,6 +95,19 @@
 			<param index="4" name="meta" type="Variant" default="null" />
 			<description>
 				Adds text span and font to draw it.
+			</description>
+		</method>
+		<method name="add_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<param index="1" name="list" type="RID" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="5" name="dc_color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="6" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for paragraph glyphs to the draw list [param list].
 			</description>
 		</method>
 		<method name="clear">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -19,6 +19,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="create_draw_list">
+			<return type="RID" />
+			<description>
+				Creates a new, empty draw list resource.
+			</description>
+		</method>
 		<method name="create_font">
 			<return type="RID" />
 			<description>
@@ -51,6 +57,122 @@
 			<param index="4" name="color" type="Color" />
 			<description>
 				Draws box displaying character hexadecimal code. Used for replacing missing characters.
+			</description>
+		</method>
+		<method name="draw_list_add_custom" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="callback" type="Callable" />
+			<description>
+				Adds custom draw call to a draw list [param list]. [param callback] is called with one argument, [RID] of canvas item to draw it to.
+			</description>
+		</method>
+		<method name="draw_list_add_hexbox" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="index" type="int" />
+			<param index="5" name="size" type="int" />
+			<param index="6" name="modulate" type="Color" />
+			<description>
+				Adds draw call for box displaying character hexadecimal code to a draw list [param list].
+			</description>
+		</method>
+		<method name="draw_list_add_line" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="start" type="Vector2" />
+			<param index="4" name="end" type="Vector2" />
+			<param index="5" name="width" type="float" />
+			<param index="6" name="dash" type="float" />
+			<param index="7" name="modulate" type="Color" />
+			<description>
+				Adds draw call for a line to a draw list [param list].
+			</description>
+		</method>
+		<method name="draw_list_add_rect" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="rect" type="Rect2" />
+			<param index="4" name="filled" type="bool" />
+			<param index="5" name="modulate" type="Color" />
+			<description>
+				Adds draw call for a rectangle to a draw list [param list].
+			</description>
+		</method>
+		<method name="draw_list_add_texture" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="texture" type="RID" />
+			<param index="4" name="rect" type="Rect2" />
+			<param index="5" name="modulate" type="Color" />
+			<description>
+				Adds draw call for a texture to a draw list [param list].
+			</description>
+		</method>
+		<method name="draw_list_draw">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="ci" type="RID" />
+			<param index="2" name="free" type="bool" default="false" />
+			<description>
+				Processes all draw calls in the draw list [param list] to the canvas item [param ci]. If [param free] is [code]true[/code], the draw list is also deleted.
+			</description>
+		</method>
+		<method name="draw_list_reserve">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="count" type="int" />
+			<description>
+				Reserves additional space in the draw list [param list] for a [param count] draw calls.
+			</description>
+		</method>
+		<method name="draw_list_sort">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<description>
+				Sorts draw calls in the draw list using to layer index and texture id.
+			</description>
+		</method>
+		<method name="font_add_glyph_outline_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="font_rid" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="size" type="int" />
+			<param index="5" name="outline_size" type="int" />
+			<param index="6" name="pos" type="Vector2" />
+			<param index="7" name="index" type="int" />
+			<param index="8" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="9" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw call for a single glyph outline to a draw list [param list].
+			</description>
+		</method>
+		<method name="font_add_glyph_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="font_rid" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="size" type="int" />
+			<param index="5" name="pos" type="Vector2" />
+			<param index="6" name="index" type="int" />
+			<param index="7" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="8" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw call for a single glyph to a draw list [param list].
 			</description>
 		</method>
 		<method name="font_clear_glyphs">
@@ -1363,6 +1485,22 @@
 				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
+		<method name="shaped_text_add_outline_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="pos" type="Vector2" />
+			<param index="5" name="clip_l" type="float" default="-1" />
+			<param index="6" name="clip_r" type="float" default="-1" />
+			<param index="7" name="outline_size" type="int" default="1" />
+			<param index="8" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="9" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for text buffer glyph outlines to the draw list [param list].
+			</description>
+		</method>
 		<method name="shaped_text_add_string">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
@@ -1374,6 +1512,21 @@
 			<param index="6" name="meta" type="Variant" default="null" />
 			<description>
 				Adds text span and font to draw it to the text buffer.
+			</description>
+		</method>
+		<method name="shaped_text_add_to_draw_list" qualifiers="const">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="pos" type="Vector2" />
+			<param index="5" name="clip_l" type="float" default="-1" />
+			<param index="6" name="clip_r" type="float" default="-1" />
+			<param index="7" name="color" type="Color" default="Color(1, 1, 1, 1)" />
+			<param index="8" name="oversampling" type="float" default="0.0" />
+			<description>
+				Adds draw calls for text buffer glyphs to the draw list [param list].
 			</description>
 		</method>
 		<method name="shaped_text_clear">
@@ -2215,6 +2368,33 @@
 		</constant>
 		<constant name="SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE" value="16" enum="SubpixelPositioning">
 			Maximum font size which will use "one quarter of the pixel" subpixel positioning in [constant SUBPIXEL_POSITIONING_AUTO] mode.
+		</constant>
+		<constant name="DRAW_CALL_NULL" value="0" enum="DrawCallType">
+			Draw call that does nothing. This is used to initialize new [code]TextServer::DrawCallType[/code] native structures.
+		</constant>
+		<constant name="DRAW_CALL_NORMAL" value="1" enum="DrawCallType">
+			Draw call for a normal glyph or glyph outline.
+		</constant>
+		<constant name="DRAW_CALL_MSDF" value="2" enum="DrawCallType">
+			Draw call for a MSDF glyph or glyph outline.
+		</constant>
+		<constant name="DRAW_CALL_LCD" value="3" enum="DrawCallType">
+			Draw call for a LCD anti-aliased glyph or glyph outline using.
+		</constant>
+		<constant name="DRAW_CALL_HEX" value="4" enum="DrawCallType">
+			Draw call for a box displaying character hexadecimal code.
+		</constant>
+		<constant name="DRAW_CALL_LINE" value="5" enum="DrawCallType">
+			Draw call for a line.
+		</constant>
+		<constant name="DRAW_CALL_RECT" value="6" enum="DrawCallType">
+			Draw call for a rectangle.
+		</constant>
+		<constant name="DRAW_CALL_IMAGE" value="7" enum="DrawCallType">
+			Draw call for a texture.
+		</constant>
+		<constant name="DRAW_CALL_CUSTOM" value="8" enum="DrawCallType">
+			Draw call using a custom draw callback.
 		</constant>
 		<constant name="FEATURE_SIMPLE_LAYOUT" value="1" enum="Feature">
 			TextServer supports simple text layouts.

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -15,6 +15,12 @@
 				This method is called before text server is unregistered.
 			</description>
 		</method>
+		<method name="_create_draw_list" qualifiers="virtual required">
+			<return type="RID" />
+			<description>
+				Creates a new, empty draw list resource.
+			</description>
+		</method>
 		<method name="_create_font" qualifiers="virtual required">
 			<return type="RID" />
 			<description>
@@ -46,6 +52,122 @@
 			<param index="4" name="color" type="Color" />
 			<description>
 				Draws box displaying character hexadecimal code.
+			</description>
+		</method>
+		<method name="_draw_list_add_custom" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="callback" type="Callable" />
+			<description>
+				Adds custom draw call to the draw list [param list]. [param callback] is called with one argument, [RID] of canvas item to draw it to.
+			</description>
+		</method>
+		<method name="_draw_list_add_hexbox" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="pos" type="Vector2" />
+			<param index="4" name="index" type="int" />
+			<param index="5" name="size" type="int" />
+			<param index="6" name="modulate" type="Color" />
+			<description>
+				Adds draw call for box displaying character hexadecimal code to a draw list [param list].
+			</description>
+		</method>
+		<method name="_draw_list_add_line" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="start" type="Vector2" />
+			<param index="4" name="end" type="Vector2" />
+			<param index="5" name="width" type="float" />
+			<param index="6" name="dash" type="float" />
+			<param index="7" name="modulate" type="Color" />
+			<description>
+				Adds draw call for a line to a draw list [param list].
+			</description>
+		</method>
+		<method name="_draw_list_add_rect" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="rect" type="Rect2" />
+			<param index="4" name="filled" type="bool" />
+			<param index="5" name="modulate" type="Color" />
+			<description>
+				Adds draw call for a rectangle to a draw list [param list].
+			</description>
+		</method>
+		<method name="_draw_list_add_texture" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="transform" type="Transform2D" />
+			<param index="3" name="texture" type="RID" />
+			<param index="4" name="rect" type="Rect2" />
+			<param index="5" name="modulate" type="Color" />
+			<description>
+				Adds draw call for a texture to a draw list [param list].
+			</description>
+		</method>
+		<method name="_draw_list_draw" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="ci" type="RID" />
+			<param index="2" name="free" type="bool" />
+			<description>
+				Processes all draw calls in the draw list [param list] to the canvas item [param ci]. If [param free] is [code]true[/code], the draw list is also deleted.
+			</description>
+		</method>
+		<method name="_draw_list_reserve" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<param index="1" name="count" type="int" />
+			<description>
+				Reserves additional space in the draw list [param list] for a [param count] draw calls.
+			</description>
+		</method>
+		<method name="_draw_list_sort" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="list" type="RID" />
+			<description>
+				Sorts draw calls in the draw list using to layer index and texture id.
+			</description>
+		</method>
+		<method name="_font_add_glyph_outline_to_draw_list" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="font_rid" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="size" type="int" />
+			<param index="5" name="outline_size" type="int" />
+			<param index="6" name="pos" type="Vector2" />
+			<param index="7" name="index" type="int" />
+			<param index="8" name="color" type="Color" />
+			<param index="9" name="oversampling" type="float" />
+			<description>
+				Adds draw call for a single glyph outline to a draw list [param list].
+			</description>
+		</method>
+		<method name="_font_add_glyph_to_draw_list" qualifiers="virtual required const">
+			<return type="void" />
+			<param index="0" name="font_rid" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="size" type="int" />
+			<param index="5" name="pos" type="Vector2" />
+			<param index="6" name="index" type="int" />
+			<param index="7" name="color" type="Color" />
+			<param index="8" name="oversampling" type="float" />
+			<description>
+				Adds draw call for a single glyph to a draw list [param list].
 			</description>
 		</method>
 		<method name="_font_clear_glyphs" qualifiers="virtual required">
@@ -1335,6 +1457,22 @@
 				Adds inline object to the text buffer, [param key] must be unique. In the text, object is represented as [param length] object replacement characters.
 			</description>
 		</method>
+		<method name="_shaped_text_add_outline_to_draw_list" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="pos" type="Vector2" />
+			<param index="5" name="clip_l" type="float" />
+			<param index="6" name="clip_r" type="float" />
+			<param index="7" name="outline_size" type="int" />
+			<param index="8" name="color" type="Color" />
+			<param index="9" name="oversampling" type="float" />
+			<description>
+				Adds draw calls for text buffer glyph outlines to the draw list [param list].
+			</description>
+		</method>
 		<method name="_shaped_text_add_string" qualifiers="virtual required">
 			<return type="bool" />
 			<param index="0" name="shaped" type="RID" />
@@ -1346,6 +1484,21 @@
 			<param index="6" name="meta" type="Variant" />
 			<description>
 				Adds text span and font to draw it to the text buffer.
+			</description>
+		</method>
+		<method name="_shaped_text_add_to_draw_list" qualifiers="virtual const">
+			<return type="void" />
+			<param index="0" name="shaped" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="list" type="RID" />
+			<param index="3" name="transform" type="Transform2D" />
+			<param index="4" name="pos" type="Vector2" />
+			<param index="5" name="clip_l" type="float" />
+			<param index="6" name="clip_r" type="float" />
+			<param index="7" name="color" type="Color" />
+			<param index="8" name="oversampling" type="float" />
+			<description>
+				Adds draw calls for text buffer glyphs to the draw list [param list].
 			</description>
 		</method>
 		<method name="_shaped_text_clear" qualifiers="virtual required">

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -526,16 +526,15 @@ Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
 	return result;
 }
 
-void ScriptTextEditor::_inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect) {
+void ScriptTextEditor::_inline_object_draw(RID p_ci, const Dictionary &p_info, const Rect2 &p_rect) {
 	if (_is_valid_color_info(p_info)) {
 		Rect2 col_rect = p_rect.grow(-4);
 		if (color_alpha_texture.is_null()) {
 			color_alpha_texture = inline_color_picker->get_theme_icon("sample_bg", "ColorPicker");
 		}
-		RID text_ci = code_editor->get_text_editor()->get_text_canvas_item();
-		RS::get_singleton()->canvas_item_add_rect(text_ci, p_rect.grow(-3), Color(1, 1, 1));
-		color_alpha_texture->draw_rect(text_ci, col_rect);
-		RS::get_singleton()->canvas_item_add_rect(text_ci, col_rect, Color(p_info["color"]));
+		RS::get_singleton()->canvas_item_add_rect(p_ci, p_rect.grow(-3), Color(1, 1, 1));
+		color_alpha_texture->draw_rect(p_ci, col_rect);
+		RS::get_singleton()->canvas_item_add_rect(p_ci, col_rect, Color(p_info["color"]));
 	}
 }
 

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -218,7 +218,7 @@ protected:
 
 	bool _is_valid_color_info(const Dictionary &p_info);
 	Array _inline_object_parse(const String &p_text);
-	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
+	void _inline_object_draw(RID p_ci, const Dictionary &p_info, const Rect2 &p_rect);
 	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
 	String _picker_color_stringify(const Color &p_color, COLOR_MODE p_mode);
 	void _picker_color_changed(const Color &p_color);

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -99,3 +99,11 @@ Validate extension JSON: Error: Field 'builtin_classes/PackedVector3Array/method
 Validate extension JSON: Error: Field 'builtin_classes/PackedVector4Array/methods/duplicate': is_const changed value in new API, from false to true.
 
 Duplicate method made const. Compatibility methods registered.
+
+
+GH-108369
+---------
+Validate extension JSON: Error: Field 'native_structures/CaretInfo': format changed value in new API, from "Rect2 leading_caret;Rect2 trailing_caret;TextServer::Direction leading_direction;TextServer::Direction trailing_direction" to "Rect2 leading_caret;Rect2 trailing_caret;TextServer::Direction leading_direction = TextServer::DIRECTION_AUTO;TextServer::Direction trailing_direction = TextServer::DIRECTION_AUTO".
+Validate extension JSON: Error: Field 'native_structures/Glyph': format changed value in new API, from "int start = -1;int end = -1;uint8_t count = 0;uint8_t repeat = 1;uint16_t flags = 0;float x_off = 0.f;float y_off = 0.f;float advance = 0.f;RID font_rid;int font_size = 0;int32_t index = 0" to "int start = -1;int end = -1;uint8_t count = 0;uint8_t repeat = 1;uint16_t flags = 0;float x_off = 0.f;float y_off = 0.f;float advance = 0.f;RID font_rid;int font_size = 0;int32_t index = 0;int span_index = -1".
+
+Updated existing native structures to match actual definitions.

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -431,6 +431,10 @@ void TextServerAdvanced::_free_rid(const RID &p_rid) {
 			shaped_owner.free(p_rid);
 		}
 		memdelete(sd);
+	} else if (list_owner.owns(p_rid)) {
+		DrawList *dc = list_owner.get_or_null(p_rid);
+		list_owner.free(p_rid);
+		memdelete(dc);
 	}
 }
 
@@ -3928,11 +3932,18 @@ void TextServerAdvanced::_font_render_glyph(const RID &p_font_rid, const Vector2
 #endif
 }
 
-void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+void TextServerAdvanced::_font_add_glyph_to_draw_list(const RID &p_font, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+	DrawList *list = list_owner.get_or_null(p_list);
+	ERR_FAIL_NULL(list);
+
+	_imp_font_add_glyph_to_draw_list(p_font, p_layer, list, p_transform, p_size, p_pos, p_index, p_color, p_oversampling);
+}
+
+void TextServerAdvanced::_imp_font_add_glyph_to_draw_list(const RID &p_font, int64_t p_layer, TextServerAdvanced::DrawList *p_list, const Transform2D &p_transform, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
 	if (p_index == 0) {
 		return; // Non visual character, skip.
 	}
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	FontAdvanced *fd = _get_font_data(p_font);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -4031,10 +4042,19 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 					Point2 cpos = p_pos;
 					cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;
 					Size2 csize = fgl.rect.size * (double)p_size / (double)fd->msdf_source_size;
-					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, 0, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
+					GlyphDrawCall ret;
+					ret.layer = p_layer;
+					ret.texture = texture;
+					ret.dst_rect = Rect2(cpos, csize);
+					ret.src_rect = fgl.uv_rect;
+					ret.modulate = modulate;
+					ret.transform = p_transform;
+					ret.data = Vector3i(0, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
+					ret.draw_type = DRAW_CALL_MSDF;
+					p_list->calls.push_back(ret);
 				} else {
 					Point2 cpos = p_pos;
-					double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
+					double scale = _font_get_scale(p_font, p_size) / oversampling_factor;
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
 						cpos.x = cpos.x + 0.125;
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
@@ -4063,22 +4083,33 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 						csize /= oversampling_factor;
 					}
 					cpos += gpos;
-					if (lcd_aa) {
-						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate);
-					} else {
-						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, false, false);
-					}
+					GlyphDrawCall ret;
+					ret.layer = p_layer;
+					ret.texture = texture;
+					ret.dst_rect = Rect2(cpos, csize);
+					ret.src_rect = fgl.uv_rect;
+					ret.modulate = modulate;
+					ret.transform = p_transform;
+					ret.draw_type = lcd_aa ? DRAW_CALL_LCD : DRAW_CALL_NORMAL;
+					p_list->calls.push_back(ret);
 				}
 			}
 		}
 	}
 }
 
-void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+void TextServerAdvanced::_font_add_glyph_outline_to_draw_list(const RID &p_font, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+	DrawList *list = list_owner.get_or_null(p_list);
+	ERR_FAIL_NULL(list);
+
+	_imp_font_add_glyph_outline_to_draw_list(p_font, p_layer, list, p_transform, p_size, p_outline_size, p_pos, p_index, p_color, p_oversampling);
+}
+
+void TextServerAdvanced::_imp_font_add_glyph_outline_to_draw_list(const RID &p_font, int64_t p_layer, TextServerAdvanced::DrawList *p_list, const Transform2D &p_transform, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
 	if (p_index == 0) {
 		return; // Non visual character, skip.
 	}
-	FontAdvanced *fd = _get_font_data(p_font_rid);
+	FontAdvanced *fd = _get_font_data(p_font);
 	ERR_FAIL_NULL(fd);
 
 	MutexLock lock(fd->mutex);
@@ -4173,10 +4204,19 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 					Point2 cpos = p_pos;
 					cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;
 					Size2 csize = fgl.rect.size * (double)p_size / (double)fd->msdf_source_size;
-					RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, p_outline_size, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
+					GlyphDrawCall ret;
+					ret.layer = p_layer;
+					ret.texture = texture;
+					ret.dst_rect = Rect2(cpos, csize);
+					ret.src_rect = fgl.uv_rect;
+					ret.modulate = modulate;
+					ret.transform = p_transform;
+					ret.data = Vector3i(p_outline_size, fd->msdf_range, (double)p_size / (double)fd->msdf_source_size);
+					ret.draw_type = DRAW_CALL_MSDF;
+					p_list->calls.push_back(ret);
 				} else {
 					Point2 cpos = p_pos;
-					double scale = _font_get_scale(p_font_rid, p_size) / oversampling_factor;
+					double scale = _font_get_scale(p_font, p_size) / oversampling_factor;
 					if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_QUARTER) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_QUARTER_MAX_SIZE * 64)) {
 						cpos.x = cpos.x + 0.125;
 					} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_ONE_HALF) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x <= SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE * 64)) {
@@ -4205,14 +4245,34 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 						csize /= oversampling_factor;
 					}
 					cpos += gpos;
-					if (lcd_aa) {
-						RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate);
-					} else {
-						RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas, Rect2(cpos, csize), texture, fgl.uv_rect, modulate, false, false);
-					}
+					GlyphDrawCall ret;
+					ret.layer = p_layer;
+					ret.texture = texture;
+					ret.dst_rect = Rect2(cpos, csize);
+					ret.src_rect = fgl.uv_rect;
+					ret.modulate = modulate;
+					ret.transform = p_transform;
+					ret.draw_type = lcd_aa ? DRAW_CALL_LCD : DRAW_CALL_NORMAL;
+					p_list->calls.push_back(ret);
 				}
 			}
 		}
+	}
+}
+
+void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+	if (RenderingServer::get_singleton() != nullptr) {
+		DrawList dl;
+		_imp_font_add_glyph_to_draw_list(p_font_rid, 0, &dl, Transform2D(), p_size, p_pos, p_index, p_color, p_oversampling);
+		_imp_draw_list_draw(&dl, p_canvas);
+	}
+}
+
+void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const RID &p_canvas, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+	if (RenderingServer::get_singleton() != nullptr) {
+		DrawList dl;
+		_imp_font_add_glyph_outline_to_draw_list(p_font_rid, 0, &dl, Transform2D(), p_size, p_outline_size, p_pos, p_index, p_color, p_oversampling);
+		_imp_draw_list_draw(&dl, p_canvas);
 	}
 }
 
@@ -4360,6 +4420,187 @@ Dictionary TextServerAdvanced::_font_supported_variation_list(const RID &p_font_
 	FontForSizeAdvanced *ffsd = nullptr;
 	ERR_FAIL_COND_V(!_ensure_cache_for_size(fd, size, ffsd), Dictionary());
 	return fd->supported_varaitions;
+}
+
+/*************************************************************************/
+/* Draw list interface                                                   */
+/*************************************************************************/
+
+RID TextServerAdvanced::_create_draw_list() {
+	_THREAD_SAFE_METHOD_
+	DrawList *list = memnew(DrawList);
+	return list_owner.make_rid(list);
+}
+
+void TextServerAdvanced::_draw_list_sort(const RID &p_dc) {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+	list->calls.sort_custom<GlyphDrawCallCompare>();
+}
+
+void TextServerAdvanced::_draw_list_reserve(const RID &p_dc, int64_t p_new_items) {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+	list->calls.reserve(list->calls.size() + p_new_items);
+}
+
+void TextServerAdvanced::_draw_list_add_hexbox(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Vector2 &p_pos, int64_t p_index, int64_t p_size, const Color &p_modulate) const {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+
+	GlyphDrawCall dc;
+	dc.draw_type = TextServer::DRAW_CALL_HEX;
+	dc.layer = p_layer;
+	dc.transform = p_transform;
+	dc.data = Vector2i(p_index, p_size);
+	dc.modulate = p_modulate;
+	dc.dst_rect.position = p_pos;
+
+	list->calls.push_back(dc);
+}
+
+void TextServerAdvanced::_draw_list_add_rect(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Rect2 &p_rect, bool p_filled, const Color &p_modulate) const {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+
+	GlyphDrawCall dc;
+	dc.draw_type = TextServer::DRAW_CALL_RECT;
+	dc.layer = p_layer;
+	dc.transform = p_transform;
+	dc.data = p_filled;
+	dc.modulate = p_modulate;
+	dc.dst_rect = p_rect;
+
+	list->calls.push_back(dc);
+}
+
+void TextServerAdvanced::_draw_list_add_line(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Point2 &p_start, const Point2 &p_end, float p_width, float p_dash, const Color &p_modulate) const {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+
+	GlyphDrawCall dc;
+	dc.draw_type = TextServer::DRAW_CALL_LINE;
+	dc.layer = p_layer;
+	dc.transform = p_transform;
+	dc.data = Vector2(p_dash, p_width);
+	dc.modulate = p_modulate;
+	dc.dst_rect.position = p_start;
+	dc.src_rect.position = p_end;
+
+	list->calls.push_back(dc);
+}
+
+void TextServerAdvanced::_draw_list_add_texture(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, RID p_texture, const Rect2 &p_dst_rect, const Color &p_modulate) const {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+
+	GlyphDrawCall dc;
+	dc.draw_type = TextServer::DRAW_CALL_IMAGE;
+	dc.layer = p_layer;
+	dc.texture = p_texture;
+	dc.transform = p_transform;
+	dc.modulate = p_modulate;
+	dc.dst_rect = p_dst_rect;
+
+	list->calls.push_back(dc);
+}
+
+void TextServerAdvanced::_draw_list_add_custom(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Callable &p_callback) const {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+
+	GlyphDrawCall dc;
+	dc.draw_type = TextServer::DRAW_CALL_CUSTOM;
+	dc.layer = p_layer;
+	dc.data = p_callback;
+	dc.transform = p_transform;
+
+	list->calls.push_back(dc);
+}
+
+void TextServerAdvanced::_imp_draw_list_draw(TextServerAdvanced::DrawList *p_list, const RID &p_ci) const {
+	for (const GlyphDrawCall &dc : p_list->calls) {
+		RenderingServer::get_singleton()->canvas_item_add_set_transform(p_ci, dc.transform);
+		if (dc.draw_type == TextServer::DRAW_CALL_MSDF) {
+			RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(p_ci, dc.dst_rect, dc.texture, dc.src_rect, dc.modulate, dc.data.operator Vector3().x, dc.data.operator Vector3().y, dc.data.operator Vector3().z);
+		} else if (dc.draw_type == TextServer::DRAW_CALL_LCD) {
+			RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(p_ci, dc.dst_rect, dc.texture, dc.src_rect, dc.modulate);
+		} else if (dc.draw_type == TextServer::DRAW_CALL_NORMAL) {
+			RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_ci, dc.dst_rect, dc.texture, dc.src_rect, dc.modulate, false, false);
+		} else if (dc.draw_type == TextServer::DRAW_CALL_CUSTOM) {
+			const Callable &cb = dc.data.operator Callable();
+			if (cb.is_valid()) {
+				if (cb.get_argument_count() == 1) {
+					cb.call(p_ci);
+#ifndef DISABLE_DEPRECATED
+				} else if (cb.get_argument_count() == 0) {
+					cb.call();
+#endif
+				}
+			}
+		} else if (dc.draw_type == TextServer::DRAW_CALL_IMAGE) {
+			RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_ci, dc.dst_rect, dc.texture, false, dc.modulate, false);
+		} else if (dc.draw_type == TextServer::DRAW_CALL_HEX) {
+			TS->draw_hex_code_box(p_ci, dc.data.operator Vector2i().y, dc.dst_rect.position, dc.data.operator Vector2i().x, dc.modulate);
+		} else if (dc.draw_type == TextServer::DRAW_CALL_RECT) {
+			if (dc.data.operator bool()) {
+				RenderingServer::get_singleton()->canvas_item_add_rect(p_ci, dc.dst_rect, dc.modulate, false);
+			} else {
+				Vector<Vector2> points;
+				points.resize(5);
+				points.write[0] = dc.dst_rect.position;
+				points.write[1] = dc.dst_rect.position + Vector2(dc.dst_rect.size.x, 0);
+				points.write[2] = dc.dst_rect.position + dc.dst_rect.size;
+				points.write[3] = dc.dst_rect.position + Vector2(0, dc.dst_rect.size.y);
+				points.write[4] = dc.dst_rect.position;
+
+				Vector<Color> colors = { dc.modulate };
+
+				RenderingServer::get_singleton()->canvas_item_add_polyline(p_ci, points, colors, -1.0, false);
+			}
+		} else if (dc.draw_type == TextServer::DRAW_CALL_LINE) {
+			float dash = dc.data.operator Vector2().x;
+			if (dash <= 0.0) {
+				RenderingServer::get_singleton()->canvas_item_add_line(p_ci, dc.dst_rect.position, dc.src_rect.position, dc.modulate, dc.data.operator Vector2().y, false);
+			} else {
+				float length = (dc.src_rect.position - dc.dst_rect.position).length();
+				Vector2 step = dash * (dc.src_rect.position - dc.dst_rect.position).normalized();
+
+				if (length < dash || step == Vector2()) {
+					RenderingServer::get_singleton()->canvas_item_add_line(p_ci, dc.dst_rect.position, dc.src_rect.position, dc.modulate, dc.data.operator Vector2().y, false);
+					return;
+				}
+
+				int steps = Math::ceil(length / dash);
+				if (steps % 2 == 0) {
+					steps--;
+				}
+
+				Point2 off = dc.dst_rect.position + (dc.src_rect.position - dc.dst_rect.position).normalized() * (length - steps * dash) / 2.0;
+
+				Vector<Vector2> points;
+				points.resize(steps + 1);
+				for (int i = 0; i < steps; i += 2) {
+					points.write[i] = (i == 0) ? dc.dst_rect.position : off;
+					points.write[i + 1] = (i == steps - 1) ? dc.src_rect.position : (off + step);
+					off += step * 2;
+				}
+
+				Vector<Color> colors = { dc.modulate };
+
+				RenderingServer::get_singleton()->canvas_item_add_multiline(p_ci, points, colors, dc.data.operator Vector2().y, false);
+			}
+		}
+	}
+}
+
+void TextServerAdvanced::_draw_list_draw(const RID &p_dc, const RID &p_ci, bool p_free) {
+	DrawList *list = list_owner.get_or_null(p_dc);
+	ERR_FAIL_NULL(list);
+	_imp_draw_list_draw(list, p_ci);
+	if (p_free) {
+		_free_rid(p_dc);
+	}
 }
 
 /*************************************************************************/

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -584,11 +584,16 @@ class TextServerAdvanced : public TextServerExtension {
 		}
 	};
 
+	struct DrawList {
+		LocalVector<GlyphDrawCall> calls;
+	};
+
 	// Common data.
 
 	mutable RID_PtrOwner<FontAdvancedLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontAdvanced> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataAdvanced> shaped_owner;
+	mutable RID_PtrOwner<DrawList> list_owner;
 
 	_FORCE_INLINE_ FontAdvanced *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
@@ -767,6 +772,10 @@ class TextServerAdvanced : public TextServerExtension {
 	_FORCE_INLINE_ RID _find_sys_font_for_text(const RID &p_fdef, const String &p_script_code, const String &p_language, const String &p_text);
 
 	_FORCE_INLINE_ void _add_features(const Dictionary &p_source, Vector<hb_feature_t> &r_ftrs);
+
+	void _imp_font_add_glyph_to_draw_list(const RID &p_font, int64_t p_layer, TextServerAdvanced::DrawList *p_list, const Transform2D &p_transform, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const;
+	void _imp_font_add_glyph_outline_to_draw_list(const RID &p_font, int64_t p_layer, TextServerAdvanced::DrawList *p_list, const Transform2D &p_transform, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const;
+	void _imp_draw_list_draw(TextServerAdvanced::DrawList *p_list, const RID &p_ci) const;
 
 	Mutex ft_mutex;
 
@@ -997,6 +1006,9 @@ public:
 	MODBIND7C(font_draw_glyph, const RID &, const RID &, int64_t, const Vector2 &, int64_t, const Color &, float);
 	MODBIND8C(font_draw_glyph_outline, const RID &, const RID &, int64_t, int64_t, const Vector2 &, int64_t, const Color &, float);
 
+	MODBIND9C(font_add_glyph_to_draw_list, const RID &, int64_t, const RID &, const Transform2D &, int64_t, const Vector2 &, int64_t, const Color &, float);
+	MODBIND10C(font_add_glyph_outline_to_draw_list, const RID &, int64_t, const RID &, const Transform2D &, int64_t, int64_t, const Vector2 &, int64_t, const Color &, float);
+
 	MODBIND2RC(bool, font_is_language_supported, const RID &, const String &);
 	MODBIND3(font_set_language_support_override, const RID &, const String &, bool);
 	MODBIND2R(bool, font_get_language_support_override, const RID &, const String &);
@@ -1017,6 +1029,18 @@ public:
 
 	MODBIND1(reference_oversampling_level, double);
 	MODBIND1(unreference_oversampling_level, double);
+
+	/* Draw list interface */
+
+	MODBIND0R(RID, create_draw_list);
+	MODBIND1(draw_list_sort, const RID &);
+	MODBIND2(draw_list_reserve, const RID &, int64_t);
+	MODBIND7C(draw_list_add_hexbox, const RID &, int64_t, const Transform2D &, const Vector2 &, int64_t, int64_t, const Color &);
+	MODBIND6C(draw_list_add_rect, const RID &, int64_t, const Transform2D &, const Rect2 &, bool, const Color &);
+	MODBIND8C(draw_list_add_line, const RID &, int64_t, const Transform2D &, const Point2 &, const Point2 &, float, float, const Color &);
+	MODBIND6C(draw_list_add_texture, const RID &, int64_t, const Transform2D &, RID, const Rect2 &, const Color &);
+	MODBIND4C(draw_list_add_custom, const RID &, int64_t, const Transform2D &, const Callable &);
+	MODBIND3(draw_list_draw, const RID &, const RID &, bool);
 
 	/* Shaped text buffer interface */
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -488,11 +488,16 @@ class TextServerFallback : public TextServerExtension {
 		Vector<Glyph> glyphs_logical;
 	};
 
+	struct DrawList {
+		LocalVector<GlyphDrawCall> calls;
+	};
+
 	// Common data.
 
 	mutable RID_PtrOwner<FontFallbackLinkedVariation> font_var_owner;
 	mutable RID_PtrOwner<FontFallback> font_owner;
 	mutable RID_PtrOwner<ShapedTextDataFallback> shaped_owner;
+	mutable RID_PtrOwner<DrawList> list_owner;
 
 	_FORCE_INLINE_ FontFallback *_get_font_data(const RID &p_font_rid) const {
 		RID rid = p_font_rid;
@@ -594,6 +599,10 @@ class TextServerFallback : public TextServerExtension {
 	void _generate_runs(ShapedTextDataFallback *p_sd) const;
 	void _realign(ShapedTextDataFallback *p_sd) const;
 	_FORCE_INLINE_ RID _find_sys_font_for_text(const RID &p_fdef, const String &p_script_code, const String &p_language, const String &p_text);
+
+	void _imp_font_add_glyph_to_draw_list(const RID &p_font, int64_t p_layer, TextServerFallback::DrawList *p_list, const Transform2D &p_transform, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const;
+	void _imp_font_add_glyph_outline_to_draw_list(const RID &p_font, int64_t p_layer, TextServerFallback::DrawList *p_list, const Transform2D &p_transform, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const;
+	void _imp_draw_list_draw(TextServerFallback::DrawList *p_list, const RID &p_ci) const;
 
 	Mutex ft_mutex;
 
@@ -785,6 +794,9 @@ public:
 	MODBIND7C(font_draw_glyph, const RID &, const RID &, int64_t, const Vector2 &, int64_t, const Color &, float);
 	MODBIND8C(font_draw_glyph_outline, const RID &, const RID &, int64_t, int64_t, const Vector2 &, int64_t, const Color &, float);
 
+	MODBIND9C(font_add_glyph_to_draw_list, const RID &, int64_t, const RID &, const Transform2D &, int64_t, const Vector2 &, int64_t, const Color &, float);
+	MODBIND10C(font_add_glyph_outline_to_draw_list, const RID &, int64_t, const RID &, const Transform2D &, int64_t, int64_t, const Vector2 &, int64_t, const Color &, float);
+
 	MODBIND2RC(bool, font_is_language_supported, const RID &, const String &);
 	MODBIND3(font_set_language_support_override, const RID &, const String &, bool);
 	MODBIND2R(bool, font_get_language_support_override, const RID &, const String &);
@@ -805,6 +817,18 @@ public:
 
 	MODBIND1(reference_oversampling_level, double);
 	MODBIND1(unreference_oversampling_level, double);
+
+	/* Draw list interface */
+
+	MODBIND0R(RID, create_draw_list);
+	MODBIND1(draw_list_sort, const RID &);
+	MODBIND2(draw_list_reserve, const RID &, int64_t);
+	MODBIND7C(draw_list_add_hexbox, const RID &, int64_t, const Transform2D &, const Vector2 &, int64_t, int64_t, const Color &);
+	MODBIND6C(draw_list_add_rect, const RID &, int64_t, const Transform2D &, const Rect2 &, bool, const Color &);
+	MODBIND8C(draw_list_add_line, const RID &, int64_t, const Transform2D &, const Point2 &, const Point2 &, float, float, const Color &);
+	MODBIND6C(draw_list_add_texture, const RID &, int64_t, const Transform2D &, RID, const Rect2 &, const Color &);
+	MODBIND4C(draw_list_add_custom, const RID &, int64_t, const Transform2D &, const Callable &);
+	MODBIND3(draw_list_draw, const RID &, const RID &, bool);
 
 	/* Shaped text buffer interface */
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1342,9 +1342,8 @@ bool CodeEdit::is_drawing_executing_lines_gutter() const {
 	return draw_executing_lines;
 }
 
-void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 &p_region) {
+void CodeEdit::_main_gutter_draw_callback(RID p_ci, int p_line, int p_gutter, const Rect2 &p_region) {
 	bool hovering = get_hovered_gutter() == Vector2i(main_gutter, p_line);
-	RID ci = get_text_canvas_item();
 	if (draw_breakpoints && theme_cache.breakpoint_icon.is_valid()) {
 		bool breakpointed = is_line_breakpointed(p_line);
 		bool shift_pressed = Input::get_singleton()->is_key_pressed(Key::SHIFT);
@@ -1359,7 +1358,7 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 			Rect2 icon_region = p_region;
 			icon_region.position += Point2(padding, padding);
 			icon_region.size -= Point2(padding, padding) * 2;
-			theme_cache.breakpoint_icon->draw_rect(ci, icon_region, false, use_color);
+			theme_cache.breakpoint_icon->draw_rect(p_ci, icon_region, false, use_color);
 		}
 	}
 
@@ -1378,7 +1377,7 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 			Rect2 icon_region = p_region;
 			icon_region.position += Point2(horizontal_padding, 0);
 			icon_region.size -= Point2(horizontal_padding * 1.1, vertical_padding);
-			theme_cache.bookmark_icon->draw_rect(ci, icon_region, false, use_color);
+			theme_cache.bookmark_icon->draw_rect(p_ci, icon_region, false, use_color);
 		}
 	}
 
@@ -1389,7 +1388,7 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 		Rect2 icon_region = p_region;
 		icon_region.position += Point2(horizontal_padding, vertical_padding);
 		icon_region.size -= Point2(horizontal_padding, vertical_padding) * 2;
-		theme_cache.executing_line_icon->draw_rect(ci, icon_region, false, theme_cache.executing_line_color);
+		theme_cache.executing_line_icon->draw_rect(p_ci, icon_region, false, theme_cache.executing_line_color);
 	}
 }
 
@@ -1532,7 +1531,7 @@ int CodeEdit::get_line_numbers_min_digits() const {
 	return line_numbers_min_digits;
 }
 
-void CodeEdit::_line_number_draw_callback(int p_line, int p_gutter, const Rect2 &p_region) {
+void CodeEdit::_line_number_draw_callback(RID p_ci, int p_line, int p_gutter, const Rect2 &p_region) {
 	if (!Rect2(Vector2(0, 0), get_size()).intersects(p_region)) {
 		return;
 	}
@@ -1571,7 +1570,7 @@ void CodeEdit::_line_number_draw_callback(int p_line, int p_gutter, const Rect2 
 		number_color = theme_cache.line_number_color;
 	}
 
-	TS->shaped_text_draw(text_rid, get_text_canvas_item(), ofs, -1, -1, number_color);
+	TS->shaped_text_draw(text_rid, p_ci, ofs, -1, -1, number_color);
 }
 
 void CodeEdit::_clear_line_number_text_cache() {
@@ -1594,13 +1593,12 @@ bool CodeEdit::is_drawing_fold_gutter() const {
 	return is_gutter_drawn(fold_gutter);
 }
 
-void CodeEdit::_fold_gutter_draw_callback(int p_line, int p_gutter, Rect2 p_region) {
+void CodeEdit::_fold_gutter_draw_callback(RID p_ci, int p_line, int p_gutter, Rect2 p_region) {
 	if (!can_fold_line(p_line) && !is_line_folded(p_line)) {
 		set_line_gutter_clickable(p_line, fold_gutter, false);
 		return;
 	}
 	set_line_gutter_clickable(p_line, fold_gutter, true);
-	RID ci = get_text_canvas_item();
 
 	int horizontal_padding = p_region.size.x / 10;
 	int vertical_padding = p_region.size.y / 6;
@@ -1614,17 +1612,17 @@ void CodeEdit::_fold_gutter_draw_callback(int p_line, int p_gutter, Rect2 p_regi
 		Color region_icon_color = theme_cache.folded_code_region_color;
 		region_icon_color.a = MAX(region_icon_color.a, 0.4f);
 		if (can_fold) {
-			theme_cache.can_fold_code_region_icon->draw_rect(ci, p_region, false, region_icon_color);
+			theme_cache.can_fold_code_region_icon->draw_rect(p_ci, p_region, false, region_icon_color);
 		} else {
-			theme_cache.folded_code_region_icon->draw_rect(ci, p_region, false, region_icon_color);
+			theme_cache.folded_code_region_icon->draw_rect(p_ci, p_region, false, region_icon_color);
 		}
 		return;
 	}
 	if (can_fold) {
-		theme_cache.can_fold_icon->draw_rect(ci, p_region, false, theme_cache.code_folding_color);
+		theme_cache.can_fold_icon->draw_rect(p_ci, p_region, false, theme_cache.code_folding_color);
 		return;
 	}
-	theme_cache.folded_icon->draw_rect(ci, p_region, false, theme_cache.code_folding_color);
+	theme_cache.folded_icon->draw_rect(p_ci, p_region, false, theme_cache.code_folding_color);
 }
 
 /* Line Folding */

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -96,7 +96,7 @@ private:
 
 	int main_gutter = -1;
 	void _update_draw_main_gutter();
-	void _main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 &p_region);
+	void _main_gutter_draw_callback(RID p_ci, int p_line, int p_gutter, const Rect2 &p_region);
 
 	// breakpoints
 	HashMap<int, bool> breakpointed_lines;
@@ -116,12 +116,12 @@ private:
 	HashMap<int, RID> line_number_text_cache;
 	void _clear_line_number_text_cache();
 	void _update_line_number_gutter_width();
-	void _line_number_draw_callback(int p_line, int p_gutter, const Rect2 &p_region);
+	void _line_number_draw_callback(RID p_ci, int p_line, int p_gutter, const Rect2 &p_region);
 
 	/* Fold Gutter */
 	int fold_gutter = -1;
 	bool draw_fold_gutter = false;
-	void _fold_gutter_draw_callback(int p_line, int p_gutter, Rect2 p_region);
+	void _fold_gutter_draw_callback(RID p_ci, int p_line, int p_gutter, Rect2 p_region);
 
 	void _gutter_clicked(int p_line, int p_gutter);
 	void _update_gutter_indexes();

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -194,7 +194,7 @@ public:
 	~Label();
 
 	template <typename... VarArgsFunc, typename... VarArgs>
-	void draw_text(bool p_rtl, int p_ellipsis_pos, int p_ellipsis_gl_size, const Glyph *p_ellipsis_glyphs, bool p_trim_chars, int p_para_start, int p_visible_chars, bool p_trim_glyphs_ltr, int &p_processed_glyphs_step, int p_processed_glyphs, int p_visible_glyphs, bool p_trim_glyphs_rtl, int p_total_glyphs, const RID &p_ci, const Vector2 &p_ofs, int p_gl_size, int p_trim_pos, const Glyph *p_glyphs, const Color &p_color, void (*p_draw_func)(const Glyph &p_gl, const RID &p_canvas, const Color &p_font_outline_color, const Vector2 &p_ofs, VarArgsFunc... p_args), VarArgs &&...p_args) {
+	void draw_text(bool p_rtl, int p_ellipsis_pos, int p_ellipsis_gl_size, const Glyph *p_ellipsis_glyphs, bool p_trim_chars, int p_para_start, int p_visible_chars, bool p_trim_glyphs_ltr, int &p_processed_glyphs_step, int p_processed_glyphs, int p_visible_glyphs, bool p_trim_glyphs_rtl, int p_total_glyphs, int p_layer, RID p_list, const Vector2 &p_ofs, int p_gl_size, int p_trim_pos, const Glyph *p_glyphs, const Color &p_color, void (*p_draw_func)(const Glyph &p_gl, int p_layer, RID p_list, const Color &p_font_outline_color, const Vector2 &p_ofs, VarArgsFunc... p_args), VarArgs &&...p_args) {
 		p_processed_glyphs_step = p_processed_glyphs;
 		Vector2 offset_step = p_ofs; /* Draw RTL ellipsis string when necessary. */
 		if (p_rtl && p_ellipsis_pos >= 0) {
@@ -202,7 +202,7 @@ public:
 				for (int j = 0; j < p_ellipsis_glyphs[gl_idx].repeat; j++) {
 					bool skip = (p_trim_chars && p_ellipsis_glyphs[gl_idx].end + p_para_start > p_visible_chars) || (p_trim_glyphs_ltr && (p_processed_glyphs_step >= p_visible_glyphs)) || (p_trim_glyphs_rtl && (p_processed_glyphs_step < p_total_glyphs - p_visible_glyphs));
 					if (!skip) {
-						p_draw_func(p_ellipsis_glyphs[gl_idx], p_ci, p_color, offset_step, std::forward<VarArgs>(p_args)...);
+						p_draw_func(p_ellipsis_glyphs[gl_idx], p_layer, p_list, p_color, offset_step, std::forward<VarArgs>(p_args)...);
 					}
 					p_processed_glyphs_step++;
 					offset_step.x += p_ellipsis_glyphs[gl_idx].advance;
@@ -224,7 +224,7 @@ public:
 			for (int k = 0; k < p_glyphs[j].repeat; k++) {
 				bool skip = (p_trim_chars && p_glyphs[j].end + p_para_start > p_visible_chars) || (p_trim_glyphs_ltr && (p_processed_glyphs_step >= p_visible_glyphs)) || (p_trim_glyphs_rtl && (p_processed_glyphs_step < p_total_glyphs - p_visible_glyphs));
 				if (!skip) {
-					p_draw_func(p_glyphs[j], p_ci, p_color, offset_step, std::forward<VarArgs>(p_args)...);
+					p_draw_func(p_glyphs[j], p_layer, p_list, p_color, offset_step, std::forward<VarArgs>(p_args)...);
 				}
 				p_processed_glyphs_step++;
 				offset_step.x += p_glyphs[j].advance;
@@ -235,7 +235,7 @@ public:
 				for (int j = 0; j < p_ellipsis_glyphs[gl_idx].repeat; j++) {
 					bool skip = (p_trim_chars && p_ellipsis_glyphs[gl_idx].end + p_para_start > p_visible_chars) || (p_trim_glyphs_ltr && (p_processed_glyphs_step >= p_visible_glyphs)) || (p_trim_glyphs_rtl && (p_processed_glyphs_step < p_total_glyphs - p_visible_glyphs));
 					if (!skip) {
-						p_draw_func(p_ellipsis_glyphs[gl_idx], p_ci, p_color, offset_step, std::forward<VarArgs>(p_args)...);
+						p_draw_func(p_ellipsis_glyphs[gl_idx], p_layer, p_list, p_color, offset_step, std::forward<VarArgs>(p_args)...);
 					}
 					p_processed_glyphs_step++;
 					offset_step.x += p_ellipsis_glyphs[gl_idx].advance;

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -84,6 +84,11 @@ public:
 	};
 
 private:
+	enum LEDrawStep {
+		DRAW_STEP_OUTLINE,
+		DRAW_STEP_TEXT,
+	};
+
 	HorizontalAlignment alignment = HORIZONTAL_ALIGNMENT_LEFT;
 
 	bool editing = false;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -674,7 +674,7 @@ private:
 	void _set_table_size(ItemTable *p_table, int p_available_width);
 
 	void _update_line_font(ItemFrame *p_frame, int p_line, const Ref<Font> &p_base_font, int p_base_font_size);
-	int _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_shadow_color, int p_shadow_outline_size, const Point2 &p_shadow_ofs, int &r_processed_glyphs);
+	int _draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_shadow_color, int p_shadow_outline_size, const Point2 &p_shadow_ofs, int &r_processed_glyphs, RID p_list, int p_layer);
 	float _find_click_in_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep, const Point2i &p_click, ItemFrame **r_click_frame = nullptr, int *r_click_line = nullptr, Item **r_click_item = nullptr, int *r_click_char = nullptr, bool p_table = false, bool p_meta = false);
 	void _accessibility_update_line(RID p_id, ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, float p_vsep);
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -122,6 +122,15 @@ public:
 	};
 
 private:
+	enum TEDrawStep {
+		DRAW_STEP_BACKGROUND,
+		DRAW_STEP_BACKGROUND_BORDER,
+		DRAW_STEP_TEXT_OUTLINE,
+		DRAW_STEP_TEXT,
+		DRAW_STEP_FOREGROUND,
+		DRAW_STEP_MAX,
+	};
+
 	struct GutterInfo {
 		GutterType type = GutterType::GUTTER_TYPE_STRING;
 		String name = "";
@@ -657,9 +666,6 @@ private:
 	bool draw_spaces = false;
 
 	RID accessibility_text_root_element_nl;
-
-	// FIXME: Helper method to draw unfilled rects, should be moved to RenderingServer.
-	void _draw_rect_unfilled(RID p_canvas_item, const Rect2 &p_rect, const Color &p_color, real_t p_width = -1.0, bool p_antialiased = false) const;
 
 	/* Theme. */
 	Ref<StyleBox> _get_current_stylebox() const;

--- a/scene/resources/text_line.h
+++ b/scene/resources/text_line.h
@@ -119,6 +119,9 @@ public:
 	void draw(RID p_canvas, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
 	void draw_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
 
+	void add_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+	void add_outline_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+
 	int hit_test(float p_coords) const;
 
 	TextLine(const String &p_text, const Ref<Font> &p_font, int p_font_size, const String &p_language = "", TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL);

--- a/scene/resources/text_paragraph.h
+++ b/scene/resources/text_paragraph.h
@@ -169,6 +169,15 @@ public:
 	void draw_dropcap(RID p_canvas, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
 	void draw_dropcap_outline(RID p_canvas, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
 
+	void add_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1), const Color &p_dc_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+	void add_outline_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), const Color &p_dc_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+
+	void add_line_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, int p_line, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+	void add_line_outline_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, int p_line, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+
+	void add_dropcap_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+	void add_dropcap_outline_to_draw_list(int p_layer, RID p_list, const Transform2D &p_transform, const Vector2 &p_pos, int p_outline_size = 1, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const;
+
 	int hit_test(const Point2 &p_coords) const;
 
 	bool is_dirty();

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -146,8 +146,9 @@ void register_server_types() {
 	GDREGISTER_CLASS(TextServerExtension);
 	GDREGISTER_CLASS(TextServerDummy);
 
-	GDREGISTER_NATIVE_STRUCT(Glyph, "int start = -1;int end = -1;uint8_t count = 0;uint8_t repeat = 1;uint16_t flags = 0;float x_off = 0.f;float y_off = 0.f;float advance = 0.f;RID font_rid;int font_size = 0;int32_t index = 0");
-	GDREGISTER_NATIVE_STRUCT(CaretInfo, "Rect2 leading_caret;Rect2 trailing_caret;TextServer::Direction leading_direction;TextServer::Direction trailing_direction");
+	GDREGISTER_NATIVE_STRUCT(Glyph, "int start = -1;int end = -1;uint8_t count = 0;uint8_t repeat = 1;uint16_t flags = 0;float x_off = 0.f;float y_off = 0.f;float advance = 0.f;RID font_rid;int font_size = 0;int32_t index = 0;int span_index = -1");
+	GDREGISTER_NATIVE_STRUCT(CaretInfo, "Rect2 leading_caret;Rect2 trailing_caret;TextServer::Direction leading_direction = TextServer::DIRECTION_AUTO;TextServer::Direction trailing_direction = TextServer::DIRECTION_AUTO");
+	GDREGISTER_NATIVE_STRUCT(GlyphDrawCall, "TextServer::DrawCallType draw_type = TextServer::DRAW_CALL_NULL;int16_t layer = 0;Transform2D transform;RID texture;Rect2 dst_rect;Rect2 src_rect;Color modulate;Variant data;");
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TextServerManager", TextServerManager::get_singleton(), "TextServerManager"));
 

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -218,6 +218,8 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND_COMPAT(_font_draw_glyph_bind_compat_104872, "font_rid", "canvas", "size", "pos", "index", "color");
 	GDVIRTUAL_BIND_COMPAT(_font_draw_glyph_outline_bind_compat_104872, "font_rid", "canvas", "size", "outline_size", "pos", "index", "color");
 #endif
+	GDVIRTUAL_BIND(_font_add_glyph_to_draw_list, "font_rid", "layer", "list", "transform", "size", "pos", "index", "color", "oversampling");
+	GDVIRTUAL_BIND(_font_add_glyph_outline_to_draw_list, "font_rid", "layer", "list", "transform", "size", "outline_size", "pos", "index", "color", "oversampling");
 
 	GDVIRTUAL_BIND(_font_is_language_supported, "font_rid", "language");
 	GDVIRTUAL_BIND(_font_set_language_support_override, "font_rid", "language", "supported");
@@ -246,6 +248,18 @@ void TextServerExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_get_hex_code_box_size, "size", "index");
 	GDVIRTUAL_BIND(_draw_hex_code_box, "canvas", "size", "pos", "index", "color");
+
+	/* Draw list interface */
+
+	GDVIRTUAL_BIND(_create_draw_list);
+	GDVIRTUAL_BIND(_draw_list_sort, "list");
+	GDVIRTUAL_BIND(_draw_list_reserve, "list", "count");
+	GDVIRTUAL_BIND(_draw_list_add_hexbox, "list", "layer", "transform", "pos", "index", "size", "modulate");
+	GDVIRTUAL_BIND(_draw_list_add_rect, "list", "layer", "transform", "rect", "filled", "modulate");
+	GDVIRTUAL_BIND(_draw_list_add_line, "list", "layer", "transform", "start", "end", "width", "dash", "modulate");
+	GDVIRTUAL_BIND(_draw_list_add_texture, "list", "layer", "transform", "texture", "rect", "modulate");
+	GDVIRTUAL_BIND(_draw_list_add_custom, "list", "layer", "transform", "callback");
+	GDVIRTUAL_BIND(_draw_list_draw, "list", "ci", "free");
 
 	/* Shaped text buffer interface */
 
@@ -355,6 +369,8 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND_COMPAT(_shaped_text_draw_bind_compat_104872, "shaped", "canvas", "pos", "clip_l", "clip_r", "color");
 	GDVIRTUAL_BIND_COMPAT(_shaped_text_draw_outline_bind_compat_104872, "shaped", "canvas", "pos", "clip_l", "clip_r", "outline_size", "color");
 #endif
+	GDVIRTUAL_BIND(_shaped_text_add_to_draw_list, "shaped", "layer", "list", "transform", "pos", "clip_l", "clip_r", "color", "oversampling");
+	GDVIRTUAL_BIND(_shaped_text_add_outline_to_draw_list, "shaped", "layer", "list", "transform", "pos", "clip_l", "clip_r", "outline_size", "color", "oversampling");
 
 	GDVIRTUAL_BIND(_shaped_text_get_grapheme_bounds, "shaped", "pos");
 	GDVIRTUAL_BIND(_shaped_text_next_grapheme_pos, "shaped", "pos");
@@ -1032,6 +1048,14 @@ void TextServerExtension::font_draw_glyph_outline(const RID &p_font_rid, const R
 #endif
 }
 
+void TextServerExtension::font_add_glyph_to_draw_list(const RID &p_font_rid, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+	GDVIRTUAL_CALL(_font_add_glyph_to_draw_list, p_font_rid, p_layer, p_list, p_transform, p_size, p_pos, p_index, p_color, p_oversampling);
+}
+
+void TextServerExtension::font_add_glyph_outline_to_draw_list(const RID &p_font_rid, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color, float p_oversampling) const {
+	GDVIRTUAL_CALL(_font_add_glyph_outline_to_draw_list, p_font_rid, p_layer, p_list, p_transform, p_size, p_outline_size, p_pos, p_index, p_color, p_oversampling);
+}
+
 bool TextServerExtension::font_is_language_supported(const RID &p_font_rid, const String &p_language) const {
 	bool ret = false;
 	GDVIRTUAL_CALL(_font_is_language_supported, p_font_rid, p_language, ret);
@@ -1136,6 +1160,47 @@ void TextServerExtension::draw_hex_code_box(const RID &p_canvas, int64_t p_size,
 	if (!GDVIRTUAL_CALL(_draw_hex_code_box, p_canvas, p_size, p_pos, p_index, p_color)) {
 		TextServer::draw_hex_code_box(p_canvas, p_size, p_pos, p_index, p_color);
 	}
+}
+/*************************************************************************/
+/* Draw list interface                                                   */
+/*************************************************************************/
+
+RID TextServerExtension::create_draw_list() {
+	RID ret;
+	GDVIRTUAL_CALL(_create_draw_list, ret);
+	return ret;
+}
+
+void TextServerExtension::draw_list_sort(const RID &p_dc) {
+	GDVIRTUAL_CALL(_draw_list_sort, p_dc);
+}
+
+void TextServerExtension::draw_list_reserve(const RID &p_dc, int64_t p_new_items) {
+	GDVIRTUAL_CALL(_draw_list_reserve, p_dc, p_new_items);
+}
+
+void TextServerExtension::draw_list_add_hexbox(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Vector2 &p_pos, int64_t p_index, int64_t p_size, const Color &p_modulate) const {
+	GDVIRTUAL_CALL(_draw_list_add_hexbox, p_dc, p_layer, p_transform, p_pos, p_index, p_size, p_modulate);
+}
+
+void TextServerExtension::draw_list_add_rect(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Rect2 &p_rect, bool p_filled, const Color &p_modulate) const {
+	GDVIRTUAL_CALL(_draw_list_add_rect, p_dc, p_layer, p_transform, p_rect, p_filled, p_modulate);
+}
+
+void TextServerExtension::draw_list_add_line(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Point2 &p_start, const Point2 &p_end, float p_width, float p_dash, const Color &p_modulate) const {
+	GDVIRTUAL_CALL(_draw_list_add_line, p_dc, p_layer, p_transform, p_start, p_end, p_width, p_dash, p_modulate);
+}
+
+void TextServerExtension::draw_list_add_texture(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, RID p_texture, const Rect2 &p_dst_rect, const Color &p_modulate) const {
+	GDVIRTUAL_CALL(_draw_list_add_texture, p_dc, p_layer, p_transform, p_texture, p_dst_rect, p_modulate);
+}
+
+void TextServerExtension::draw_list_add_custom(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Callable &p_callback) const {
+	GDVIRTUAL_CALL(_draw_list_add_custom, p_dc, p_layer, p_transform, p_callback);
+}
+
+void TextServerExtension::draw_list_draw(const RID &p_dc, const RID &p_ci, bool p_free) {
+	GDVIRTUAL_CALL(_draw_list_draw, p_dc, p_ci, p_free);
 }
 
 /*************************************************************************/
@@ -1596,6 +1661,20 @@ void TextServerExtension::shaped_text_draw_outline(const RID &p_shaped, const RI
 	}
 #endif
 	TextServer::shaped_text_draw_outline(p_shaped, p_canvas, p_pos, p_clip_l, p_clip_r, p_outline_size, p_color, p_oversampling);
+}
+
+void TextServerExtension::shaped_text_add_to_draw_list(const RID &p_shaped, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, const Vector2 &p_pos, double p_clip_l, double p_clip_r, const Color &p_color, float p_oversampling) const {
+	if (GDVIRTUAL_CALL(_shaped_text_add_to_draw_list, p_shaped, p_layer, p_list, p_transform, p_pos, p_clip_l, p_clip_r, p_color, p_oversampling)) {
+		return;
+	}
+	TextServer::shaped_text_add_to_draw_list(p_shaped, p_layer, p_list, p_transform, p_pos, p_clip_l, p_clip_r, p_color, p_oversampling);
+}
+
+void TextServerExtension::shaped_text_add_outline_to_draw_list(const RID &p_shaped, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, const Vector2 &p_pos, double p_clip_l, double p_clip_r, int64_t p_outline_size, const Color &p_color, float p_oversampling) const {
+	if (GDVIRTUAL_CALL(_shaped_text_add_outline_to_draw_list, p_shaped, p_layer, p_list, p_transform, p_pos, p_clip_l, p_clip_r, p_outline_size, p_color, p_oversampling)) {
+		return;
+	}
+	TextServer::shaped_text_add_outline_to_draw_list(p_shaped, p_layer, p_list, p_transform, p_pos, p_clip_l, p_clip_r, p_outline_size, p_color, p_oversampling);
 }
 
 Vector2 TextServerExtension::shaped_text_get_grapheme_bounds(const RID &p_shaped, int64_t p_pos) const {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -356,6 +356,10 @@ public:
 	GDVIRTUAL6C_COMPAT(_font_draw_glyph_bind_compat_104872, _font_draw_glyph, RID, RID, int64_t, const Vector2 &, int64_t, const Color &);
 	GDVIRTUAL7C_COMPAT(_font_draw_glyph_outline_bind_compat_104872, _font_draw_glyph_outline, RID, RID, int64_t, int64_t, const Vector2 &, int64_t, const Color &);
 #endif
+	virtual void font_add_glyph_to_draw_list(const RID &p_font, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const override;
+	virtual void font_add_glyph_outline_to_draw_list(const RID &p_font, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, int64_t p_size, int64_t p_outline_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const override;
+	GDVIRTUAL9C_REQUIRED(_font_add_glyph_to_draw_list, const RID &, int64_t, const RID &, const Transform2D &, int64_t, const Vector2 &, int64_t, const Color &, float);
+	GDVIRTUAL10C_REQUIRED(_font_add_glyph_outline_to_draw_list, const RID &, int64_t, const RID &, const Transform2D &, int64_t, int64_t, const Vector2 &, int64_t, const Color &, float);
 
 	virtual bool font_is_language_supported(const RID &p_font_rid, const String &p_language) const override;
 	virtual void font_set_language_support_override(const RID &p_font_rid, const String &p_language, bool p_supported) override;
@@ -404,6 +408,27 @@ public:
 	virtual void draw_hex_code_box(const RID &p_canvas, int64_t p_size, const Vector2 &p_pos, int64_t p_index, const Color &p_color) const override;
 	GDVIRTUAL2RC(Vector2, _get_hex_code_box_size, int64_t, int64_t);
 	GDVIRTUAL5C(_draw_hex_code_box, RID, int64_t, const Vector2 &, int64_t, const Color &);
+
+	/* Draw list interface */
+
+	virtual RID create_draw_list() override;
+	virtual void draw_list_sort(const RID &p_dc) override;
+	virtual void draw_list_reserve(const RID &p_dc, int64_t p_new_items) override;
+	virtual void draw_list_add_hexbox(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Vector2 &p_pos, int64_t p_index, int64_t p_size, const Color &p_modulate) const override;
+	virtual void draw_list_add_rect(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Rect2 &p_rect, bool p_filled, const Color &p_modulate) const override;
+	virtual void draw_list_add_line(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Point2 &p_start, const Point2 &p_end, float p_width, float p_dash, const Color &p_modulate) const override;
+	virtual void draw_list_add_texture(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, RID p_texture, const Rect2 &p_dst_rect, const Color &p_modulate) const override;
+	virtual void draw_list_add_custom(const RID &p_dc, int64_t p_layer, const Transform2D &p_transform, const Callable &p_callback) const override;
+	virtual void draw_list_draw(const RID &p_dc, const RID &p_ci, bool p_free = true) override;
+	GDVIRTUAL0R_REQUIRED(RID, _create_draw_list);
+	GDVIRTUAL1_REQUIRED(_draw_list_sort, const RID &);
+	GDVIRTUAL2_REQUIRED(_draw_list_reserve, const RID &, int64_t);
+	GDVIRTUAL7C_REQUIRED(_draw_list_add_hexbox, const RID &, int64_t, const Transform2D &, const Vector2 &, int64_t, int64_t, const Color &);
+	GDVIRTUAL6C_REQUIRED(_draw_list_add_rect, const RID &, int64_t, const Transform2D &, const Rect2 &, bool, const Color &);
+	GDVIRTUAL8C_REQUIRED(_draw_list_add_line, const RID &, int64_t, const Transform2D &, const Point2 &, const Point2 &, float, float, const Color &);
+	GDVIRTUAL6C_REQUIRED(_draw_list_add_texture, const RID &, int64_t, const Transform2D &, RID, const Rect2 &, const Color &);
+	GDVIRTUAL4C_REQUIRED(_draw_list_add_custom, const RID &, int64_t, const Transform2D &, const Callable &);
+	GDVIRTUAL3_REQUIRED(_draw_list_draw, const RID &, const RID &, bool);
 
 	/* Shaped text buffer interface */
 
@@ -590,6 +615,10 @@ public:
 	GDVIRTUAL6C_COMPAT(_shaped_text_draw_bind_compat_104872, _shaped_text_draw, RID, RID, const Vector2 &, double, double, const Color &);
 	GDVIRTUAL7C_COMPAT(_shaped_text_draw_outline_bind_compat_104872, _shaped_text_draw_outline, RID, RID, const Vector2 &, double, double, int64_t, const Color &);
 #endif
+	virtual void shaped_text_add_to_draw_list(const RID &p_shaped, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, const Vector2 &p_pos, double p_clip_l = -1.0, double p_clip_r = -1.0, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const override;
+	virtual void shaped_text_add_outline_to_draw_list(const RID &p_shaped, int64_t p_layer, const RID &p_list, const Transform2D &p_transform, const Vector2 &p_pos, double p_clip_l = -1.0, double p_clip_r = -1.0, int64_t p_outline_size = 1, const Color &p_color = Color(1, 1, 1), float p_oversampling = 0.0) const override;
+	GDVIRTUAL9C(_shaped_text_add_to_draw_list, RID, int64_t, RID, const Transform2D &, const Vector2 &, double, double, const Color &, float);
+	GDVIRTUAL10C(_shaped_text_add_outline_to_draw_list, RID, int64_t, RID, const Transform2D &, const Vector2 &, double, double, int64_t, const Color &, float);
 
 	virtual Vector2 shaped_text_get_grapheme_bounds(const RID &p_shaped, int64_t p_pos) const override;
 	virtual int64_t shaped_text_next_grapheme_pos(const RID &p_shaped, int64_t p_pos) const override;


### PR DESCRIPTION
Pre-sort text draw calls to improve batching, should significantly reduce draw call number for languages with a lot of glyphs and multiline text with outlines/shadow.

## Before:

<img width="954" alt="Screenshot 2025-07-07 at 09 21 28" src="https://github.com/user-attachments/assets/f014b917-5e0b-40be-9c93-ec2f67ee83a7" />

## After:

<img width="954" alt="Screenshot 2025-07-07 at 10 43 35" src="https://github.com/user-attachments/assets/3c9615a9-875e-488c-b8df-7cb03a53033f" />

Fixes https://github.com/godotengine/godot/issues/107109
Fixes https://github.com/godotengine/godot/issues/104537