### PR TITLE
Add `null` and range checks to `DisplayServerMacOSBase::clipboard_get()`.

### DIFF
--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -62,6 +62,9 @@ String DisplayServerMacOSBase::clipboard_get() const {
 	}
 
 	NSArray *objectsToPaste = [pasteboard readObjectsForClasses:classArray options:options];
+	if (!objectsToPaste || [objectsToPaste count] < 1) {
+		return "";
+	}
 	NSString *string = [objectsToPaste objectAtIndex:0];
 
 	String ret;


### PR DESCRIPTION
Should fix https://github.com/godotengine/godot/issues/108370