### PR TITLE
Deactivate orientation gizmo on window exit

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -317,6 +317,10 @@ void ViewportRotationControl::_notification(int p_what) {
 			focused_axis = -2;
 			queue_redraw();
 		} break;
+
+		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			gizmo_activated = false;
+		} break;
 	}
 }
 


### PR DESCRIPTION
Fix #106932 
