### PR TITLE
VRAM Uncompressed: Optimize channels when possible

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3491,27 +3491,67 @@ Image::UsedChannels Image::detect_used_channels(CompressSource p_source) const {
 	return used_channels;
 }
 
-void Image::optimize_channels() {
-	switch (detect_used_channels()) {
+void Image::optimize_from_channels(UsedChannels p_channels) {
+	switch (p_channels) {
 		case USED_CHANNELS_L:
-			convert(FORMAT_L8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_L8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBH);
+			}
 			break;
 		case USED_CHANNELS_LA:
-			convert(FORMAT_LA8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_LA8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBAF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBAH);
+			}
 			break;
 		case USED_CHANNELS_R:
-			convert(FORMAT_R8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_R8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBE9995) {
+				convert(FORMAT_RH);
+			}
 			break;
 		case USED_CHANNELS_RG:
-			convert(FORMAT_RG8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_RG8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBE9995) {
+				convert(FORMAT_RGH);
+			}
 			break;
 		case USED_CHANNELS_RGB:
-			convert(FORMAT_RGB8);
+			if ((format >= FORMAT_L8 && format <= FORMAT_RGBA8) || format == FORMAT_RGB565) {
+				convert(FORMAT_RGB8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBH);
+			}
 			break;
 		case USED_CHANNELS_RGBA:
-			convert(FORMAT_RGBA8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
+				convert(FORMAT_RGBA8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBAF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBAH);
+			}
 			break;
 	}
+}
+
+void Image::optimize_channels() {
+	optimize_from_channels(detect_used_channels());
 }
 
 void Image::_bind_methods() {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -428,6 +428,7 @@ public:
 	void convert_rgba8_to_bgra8();
 
 	UsedChannels detect_used_channels(CompressSource p_source = COMPRESS_SOURCE_GENERIC) const;
+	void optimize_from_channels(UsedChannels p_channels);
 	void optimize_channels();
 
 	Color get_pixelv(const Point2i &p_point) const;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -327,13 +327,15 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 
 		} break;
 		case COMPRESS_VRAM_UNCOMPRESSED: {
-			f->store_32(CompressedTexture2D::DATA_FORMAT_IMAGE);
-			f->store_16(p_image->get_width());
-			f->store_16(p_image->get_height());
-			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
-			f->store_buffer(p_image->get_data());
+			Ref<Image> image = p_image->duplicate();
+			image->optimize_from_channels(p_channels);
 
+			f->store_32(CompressedTexture2D::DATA_FORMAT_IMAGE);
+			f->store_16(image->get_width());
+			f->store_16(image->get_height());
+			f->store_32(image->get_mipmap_count());
+			f->store_32(image->get_format());
+			f->store_buffer(image->get_data());
 		} break;
 		case COMPRESS_BASIS_UNIVERSAL: {
 			f->store_32(CompressedTexture2D::DATA_FORMAT_BASIS_UNIVERSAL);
@@ -420,7 +422,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 	// Optimization: Only check for color channels when compressing as BasisU or VRAM.
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
 
-	if (p_compress_mode == COMPRESS_BASIS_UNIVERSAL || p_compress_mode == COMPRESS_VRAM_COMPRESSED) {
+	if (p_compress_mode == COMPRESS_BASIS_UNIVERSAL || p_compress_mode == COMPRESS_VRAM_COMPRESSED || p_compress_mode == COMPRESS_VRAM_UNCOMPRESSED) {
 		Image::CompressSource comp_source = Image::COMPRESS_SOURCE_GENERIC;
 		if (p_force_normal) {
 			comp_source = Image::COMPRESS_SOURCE_NORMAL;


### PR DESCRIPTION
Makes the VRAM Uncompressed import mode properly detect/optimize color channels present in an image based on the import settings.

This required modifying the `optimize_channels` method to account for non-8-bit formats.