### PR TITLE
Fix can't remove inspector plugins after reaching max count

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3475,8 +3475,6 @@ void EditorInspector::add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 }
 
 void EditorInspector::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin) {
-	ERR_FAIL_COND(inspector_plugin_count == MAX_PLUGINS);
-
 	int idx = -1;
 	for (int i = 0; i < inspector_plugin_count; i++) {
 		if (inspector_plugins[i] == p_plugin) {


### PR DESCRIPTION
The condition only makes sense for `add_inspector_plugin()`. Probably a copy-paste error.