### PR TITLE
Fix division by zero in clearcoat specular BRDF

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1448,7 +1448,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 		float cLdotH5 = SchlickFresnel(cLdotH);
 #endif
 		float Dr = D_GGX(ccNdotH, mix(0.001, 0.1, clearcoat_roughness));
-		float Gr = 0.25 / (cLdotH * cLdotH);
+		float Gr = 0.25 / (cLdotH * cLdotH + 1e-4);
 		float Fr = mix(.04, 1.0, cLdotH5);
 		float clearcoat_specular_brdf_NL = clearcoat * Gr * Fr * Dr * cNdotL;
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -167,7 +167,7 @@ void light_compute(hvec3 N, hvec3 L, hvec3 V, half A, hvec3 light_color, bool is
 		half cLdotH5 = SchlickFresnel(cLdotH);
 
 		half Dr = D_GGX(ccNdotH, half(mix(half(0.001), half(0.1), clearcoat_roughness)), vertex_normal, H);
-		half Gr = half(0.25) / (cLdotH * cLdotH);
+		half Gr = half(0.25) / (cLdotH * cLdotH + half(1e-4));
 		half Fr = mix(half(0.04), half(1.0), cLdotH5);
 		half clearcoat_specular_brdf_NL = clearcoat * Gr * Fr * Dr * cNdotL;
 


### PR DESCRIPTION
This PR fixes a bug where the clearcoat implementation could generate NaN values at grazing angles, causing visual artifacts such as flickering.

The issue is resolved by adding a small epsilon value to the denominator of the Gr term in the clearcoat specular BRDF calculation, preventing division by zero. 

Fixes #86530
