### PR TITLE
Remove unused member variables in `EditorInspector`

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -40,7 +40,6 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_toaster.h"
-#include "editor/gui/editor_validation_panel.h"
 #include "editor/inspector/add_metadata_dialog.h"
 #include "editor/inspector/editor_properties.h"
 #include "editor/inspector/editor_property_name_processor.h"

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -40,7 +40,6 @@ class AddMetadataDialog;
 class AcceptDialog;
 class ConfirmationDialog;
 class EditorInspector;
-class EditorValidationPanel;
 class HSeparator;
 class LineEdit;
 class MarginContainer;
@@ -760,9 +759,6 @@ class EditorInspector : public ScrollContainer {
 	void _section_toggled_by_user(const String &p_path, bool p_value);
 
 	AddMetadataDialog *add_meta_dialog = nullptr;
-	LineEdit *add_meta_name = nullptr;
-	OptionButton *add_meta_type = nullptr;
-	EditorValidationPanel *validation_panel = nullptr;
 
 	void _add_meta_confirm();
 	void _show_add_meta_dialog();


### PR DESCRIPTION
These member variables are left overs of the old add metadata dialog (now `AddMetadataDialog`).