### PR TITLE
Fix wrong "location" substring matching when HTTP status is 301 or 302

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -240,7 +240,7 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 		String new_request;
 
 		for (const String &E : rheaders) {
-			if (E.containsn("Location: ")) {
+			if (E.to_lower().begins_with("location: ")) {
 				new_request = E.substr(9).strip_edges();
 			}
 		}


### PR DESCRIPTION
## Description:

This PR addresses an issue with the parsing of the Location header when handling HTTP status codes 301 or 302.

### Problem:
Previously, headers with a name matching the pattern *-location (e.g., X-location, My-location) were incorrectly interpreted as redirect targets. This caused unintended behavior when following redirects.

### Fix:
Updated the logic to only recognize the standard Location header (case-insensitive) for determining redirect URLs in 301/302 responses.

Reference:
https://http.dev/redirects

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/102960*