### PR TITLE
Add syncing of changes in editor's audio bus to the running game

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -65,6 +65,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/tree.h"
+#include "servers/audio_server.h"
 #include "servers/debugger/servers_debugger.h"
 #include "servers/display_server.h"
 
@@ -1418,6 +1419,18 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 			msg.push_back(*p_args[i]);
 		}
 		_put_msg("scene:live_res_call", msg);
+
+		return;
+	}
+
+	AudioServer *audio_server = Object::cast_to<AudioServer>(p_base);
+
+	if (audio_server) {
+		Array msg = { p_name };
+		for (int i = 0; i < p_argcount; i++) {
+			msg.push_back(*p_args[i]);
+		}
+		_put_msg("scene:live_audio_server_call", msg);
 
 		return;
 	}

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -32,6 +32,8 @@
 
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
 #include "core/io/dir_access.h"
 #include "core/io/marshalls.h"
 #include "core/math/math_fieldwise.h"
@@ -337,6 +339,28 @@ Error SceneDebugger::_msg_live_res_call(const Array &p_args) {
 	return OK;
 }
 
+Error SceneDebugger::_msg_live_audio_server_call(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.size() < 2, ERR_INVALID_DATA);
+
+	AudioServer *audio_server = AudioServer::get_singleton();
+	ERR_FAIL_COND_V(!audio_server, ERR_UNAVAILABLE);
+
+	LocalVector<Variant> args;
+	LocalVector<Variant *> argptrs;
+	args.resize(p_args.size() - 1);
+	argptrs.resize(args.size());
+	for (uint32_t i = 0; i < args.size(); i++) {
+		args[i] = p_args[i + 1];
+		argptrs[i] = &args[i];
+	}
+
+	Callable::CallError ce;
+	audio_server->callp(p_args[0], argptrs.size() ? (const Variant **)argptrs.ptr() : nullptr, argptrs.size(), ce);
+	ERR_FAIL_COND_V(ce.error != Callable::CallError::CALL_OK, FAILED);
+
+	return OK;
+}
+
 Error SceneDebugger::_msg_live_create_node(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 	LiveEditor::get_singleton()->_create_node_func(p_args[0], p_args[1], p_args[2]);
@@ -517,6 +541,7 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["live_res_prop"] = _msg_live_res_prop;
 	message_handlers["live_node_call"] = _msg_live_node_call;
 	message_handlers["live_res_call"] = _msg_live_res_call;
+	message_handlers["live_audio_server_call"] = _msg_live_audio_server_call;
 	message_handlers["live_create_node"] = _msg_live_create_node;
 	message_handlers["live_instantiate_node"] = _msg_live_instantiate_node;
 	message_handlers["live_remove_node"] = _msg_live_remove_node;

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -104,6 +104,7 @@ private:
 	static Error _msg_live_res_prop(const Array &p_args);
 	static Error _msg_live_node_call(const Array &p_args);
 	static Error _msg_live_res_call(const Array &p_args);
+	static Error _msg_live_audio_server_call(const Array &p_args);
 	static Error _msg_live_create_node(const Array &p_args);
 	static Error _msg_live_instantiate_node(const Array &p_args);
 	static Error _msg_live_remove_node(const Array &p_args);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Partially solves https://github.com/godotengine/godot-proposals/issues/1186

Implemented:
- Syncing Audio pane's bus gain, mute, solo, bypass and toggling existing effects

NOT implemented:
- Adding/removing effects. Well, adding new effects doesn't work. Removing existing effects does.
- Syncing VU meters from the game to the editor
- Toggle button for the syncing functionality. Akin to Unity's "Edit in play mode"
- Syncing bus state from the running game to the editor. Aka. scripts can change gains/mutes/effects/etc.