### PR TITLE
Document AudioStreamInteractive only supporting Ogg Vorbis and MP3 formats

### DIFF
--- a/doc/classes/AudioStreamWAV.xml
+++ b/doc/classes/AudioStreamWAV.xml
@@ -6,6 +6,7 @@
 	<description>
 		AudioStreamWAV stores sound samples loaded from WAV files. To play the stored sound, use an [AudioStreamPlayer] (for non-positional audio) or [AudioStreamPlayer2D]/[AudioStreamPlayer3D] (for positional audio). The sound can be looped.
 		This class can also be used to store dynamically-generated PCM audio data. See also [AudioStreamGenerator] for procedural audio generation.
+		[b]Note:[/b] Since the WAV format is best used for sound effects rather than music, it does not support [AudioStreamInteractive] functionality such as BPM-based fading. To use [AudioStreamInteractive], convert the WAV audio to Ogg Vorbis or MP3 using an external tool, then use the resulting file as an audio clip.
 	</description>
 	<tutorials>
 		<link title="Runtime file loading and saving">$DOCS_URL/tutorials/io/runtime_file_loading_and_saving.html</link>

--- a/modules/interactive_music/doc_classes/AudioStreamInteractive.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamInteractive.xml
@@ -6,6 +6,7 @@
 	<description>
 		This is an audio stream that can playback music interactively, combining clips and a transition table. Clips must be added first, and then the transition rules via the [method add_transition]. Additionally, this stream exports a property parameter to control the playback via [AudioStreamPlayer], [AudioStreamPlayer2D], or [AudioStreamPlayer3D].
 		The way this is used is by filling a number of clips, then configuring the transition table. From there, clips are selected for playback and the music will smoothly go from the current to the new one while using the corresponding transition rule defined in the transition table.
+		[b]Note:[/b] Only the Ogg Vorbis and MP3 audio formats are supported for clips. If you have music in the WAV format, you will need to convert it to Ogg Vorbis or MP3 format using an external tool before using it with [AudioStreamInteractive].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot/issues/108184.
