### PR TITLE
Add expression history to evaluator

### DIFF
--- a/editor/debugger/editor_expression_evaluator.h
+++ b/editor/debugger/editor_expression_evaluator.h
@@ -52,6 +52,10 @@ private:
 
 	EditorDebuggerInspector *inspector = nullptr;
 
+	LocalVector<String> expression_history;
+	int expression_index = -1;
+
+	void _line_edit_gui_input(const Ref<InputEvent> &p_event);
 	void _evaluate();
 	void _clear();
 


### PR DESCRIPTION
Allows going back to previous expressions with Up/Down.

https://github.com/user-attachments/assets/61aad5df-c774-4e78-9f26-7623a0ac6354

The history is kept for the editor session.