### PR TITLE
Fix main editor title after changing language

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -764,6 +764,7 @@ bool EditorNode::_is_project_data_missing() {
 void EditorNode::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
+			_update_title();
 			callable_mp(this, &EditorNode::_titlebar_resized).call_deferred();
 		} break;
 


### PR DESCRIPTION
Currently, after changing editor's language, title of the main editor window becomes

> Project Name (Debug)