### PR TITLE
Specify Apache license version for Grisu2

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -309,7 +309,7 @@ Files: thirdparty/grisu2/*
 Comment: Grisu2 float serialization algorithm
 Copyright: 2009, Florian Loitsch
  2018-2023, The simdjson authors
-License: Expat and Apache
+License: Expat and Apache-2.0
 
 Files: thirdparty/harfbuzz/*
 Comment: HarfBuzz text shaping library


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
The grisu2 algorithm implementation used was originally released under the MIT license, then the simdjson authors slightly modified it and their changes are released under [Apache 2.0 license](https://github.com/simdjson/simdjson/blob/master/LICENSE).