### PR TITLE
Restore Anchors Only preset mode

### DIFF
--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -810,13 +810,21 @@ void ControlEditorToolbar::_anchors_preset_selected(int p_preset) {
 	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Change Anchors, Offsets, Grow Direction"));
+	if (!reposition_button->is_pressed()) {
+		undo_redo->create_action(TTR("Change Anchors, Grow Direction"));
+	} else {
+		undo_redo->create_action(TTR("Change Anchors, Offsets, Grow Direction"));
+	}
 
 	for (Node *E : selection) {
 		Control *control = Object::cast_to<Control>(E);
 		if (control) {
 			undo_redo->add_do_property(control, "layout_mode", LayoutMode::LAYOUT_MODE_ANCHORS);
 			undo_redo->add_do_property(control, "anchors_preset", preset);
+			if (!reposition_button->is_pressed()) {
+				undo_redo->add_do_property(control, "position", control->get_position());
+				undo_redo->add_do_property(control, "size", control->get_size());
+			}
 			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
 		}
 	}
@@ -1206,6 +1214,13 @@ ControlEditorToolbar::ControlEditorToolbar() {
 	anchors_picker->set_h_size_flags(SIZE_SHRINK_CENTER);
 	anchors_button->get_popup_hbox()->add_child(anchors_picker);
 	anchors_picker->connect("anchors_preset_selected", callable_mp(this, &ControlEditorToolbar::_anchors_preset_selected));
+
+	reposition_button = memnew(CheckBox);
+	reposition_button->set_text(TTRC("Reposition"));
+	reposition_button->set_tooltip_text(TTRC("If disabled, picking a preset will only adjust the anchors, without moving the Control."));
+	reposition_button->set_h_size_flags(SIZE_SHRINK_CENTER);
+	reposition_button->set_pressed(true);
+	anchors_button->get_popup_hbox()->add_child(reposition_button);
 
 	anchors_button->get_popup_hbox()->add_child(memnew(HSeparator));
 

--- a/editor/scene/gui/control_editor_plugin.h
+++ b/editor/scene/gui/control_editor_plugin.h
@@ -218,6 +218,7 @@ class ControlEditorToolbar : public HBoxContainer {
 	ControlEditorPopupButton *anchors_button = nullptr;
 	ControlEditorPopupButton *containers_button = nullptr;
 	Button *anchor_mode_button = nullptr;
+	CheckBox *reposition_button = nullptr;
 
 	AnchorPresetPicker *anchors_picker = nullptr;
 


### PR DESCRIPTION
Restores the anchors-only option when picking Control anchor presets. It existed in Godot 3, but got lost at some point. See https://github.com/godotengine/godot/pull/63358#issuecomment-1215907453 for some discussion.

https://github.com/user-attachments/assets/ddf54767-3bb2-4322-9893-b35ae1afb3d4

