### PR TITLE
linux/bsd/mac: Use pkill to stop remote instance over SSH

### DIFF
--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -192,7 +192,7 @@ void EditorExportPlatformLinuxBSD::get_export_options(List<ExportOption> *r_opti
 						"\"{temp_dir}/{exe_name}\" {cmd_args}";
 
 	String cleanup_script = "#!/usr/bin/env bash\n"
-							"kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")\n"
+							"pkill -x -f \"{temp_dir}/{exe_name} {cmd_args}\"\n"
 							"rm -rf \"{temp_dir}\"";
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ssh_remote_deploy/enabled"), false, true));

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -595,7 +595,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 						"open \"{temp_dir}/{exe_name}.app\" --args {cmd_args}";
 
 	String cleanup_script = "#!/usr/bin/env bash\n"
-							"kill $(pgrep -x -f \"{temp_dir}/{exe_name}.app/Contents/MacOS/{exe_name} {cmd_args}\")\n"
+							"pkill -x -f \"{temp_dir}/{exe_name}.app/Contents/MacOS/{exe_name} {cmd_args}\"\n"
 							"rm -rf \"{temp_dir}\"";
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "ssh_remote_deploy/enabled"), false, true));


### PR DESCRIPTION
Previously, the PIDs of any running instances of the game on the remote device were found with `pgrep`, whose output was passed as parameters to `kill`. The problem with doing this is that passing zero arguments to `kill` (which happens when no instances of the game are running remotely) is an error: it shows the command usage, and exits with status 2 indicating a command-line syntax error:

    $ kill
    kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
    $ echo $?
    2

As far as I can tell, all systems that have a `pgrep` command also have a `pkill` command which accepts (a superset of) the same parameters as `pgrep` and kills the matched processes instead of listing them on STDOUT.

In the case where no processes match, `pkill` exits with status 1; but does so silently.

Invoke `pkill` rather than `pgrep` + `kill`.
