### PR TITLE
Docs: Fix typo in `Object.get_signal_list`

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -698,7 +698,7 @@
 			<return type="Dictionary[]" />
 			<description>
 				Returns the list of existing signals as an [Array] of dictionaries.
-				[b]Note:[/b] Due of the implementation, each [Dictionary] is formatted very similarly to the returned values of [method get_method_list].
+				[b]Note:[/b] Due to the implementation, each [Dictionary] is formatted very similarly to the returned values of [method get_method_list].
 			</description>
 		</method>
 		<method name="get_translation_domain" qualifiers="const">


### PR DESCRIPTION
Fixed typo in the docs for `Object#get_signal_list`.