### PR TITLE
Improve error when `update_doc()` fails

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3733,7 +3733,7 @@ bool ScriptEditor::_help_tab_goto(const String &p_name, const String &p_desc) {
 }
 
 void ScriptEditor::update_doc(const String &p_name) {
-	ERR_FAIL_COND(!EditorHelp::has_doc(p_name));
+	ERR_FAIL_COND_MSG(!EditorHelp::has_doc(p_name), vformat("Can't update documentation for \"%s\".", p_name));
 
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));


### PR DESCRIPTION
I'm sometimes getting annoying `!EditorHelp::has_doc(p_name)` error printed in the output. It's random, and when I restart to debug, it's no longer happening. The error prints when you save a script, but what exactly triggers it is a mystery.

This PR improves the message by printing the `p_name`, which might make it easier to pinpoint should the error happen again.