### PR TITLE
Fix circular dependencies between libraries

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1172,18 +1172,39 @@ if "cpp_compiler_launcher" in env:
 # Build subdirs, the build order is dependent on link order.
 Export("env")
 
+# Build subdirectories.
+# There is currently no dependency hierarchy between the following subdirectories:
+# each one uses files from the other subdirectories.  This means that we have to
+# link them all into one library.
 SConscript("core/SCsub")
 SConscript("servers/SCsub")
 SConscript("scene/SCsub")
 if env.editor_build:
     SConscript("editor/SCsub")
+else:
+    env.editor_sources = []
 SConscript("drivers/SCsub")
-
 SConscript("platform/SCsub")
 SConscript("modules/SCsub")
 if env["tests"]:
     SConscript("tests/SCsub")
+else:
+    env.tests_sources = []
 SConscript("main/SCsub")
+
+godot_sources = (
+    env.core_sources
+    + env.scene_sources
+    + env.drivers_sources
+    + env.servers_sources
+    + env.editor_sources
+    + env.main_sources
+    + env.modules_sources
+    + env.platform_sources
+    + env.tests_sources
+)
+lib = env.add_library("godot_core", godot_sources)
+env.Prepend(LIBS=[lib])
 
 SConscript("platform/" + env["platform"] + "/SCsub")  # Build selected platform.
 

--- a/core/SCsub
+++ b/core/SCsub
@@ -230,11 +230,3 @@ SConscript("templates/SCsub")
 SConscript("string/SCsub")
 SConscript("config/SCsub")
 SConscript("error/SCsub")
-
-
-# Build it all as a library
-lib = env.add_library("core", env.core_sources)
-env.Prepend(LIBS=[lib])
-
-# Needed to force rebuilding the core files when the thirdparty code is updated.
-env.Depends(lib, thirdparty_obj)

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -69,6 +69,3 @@ if env["sdl"] and env["platform"] in ["linuxbsd", "macos", "windows"]:
 SConscript("png/SCsub")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
-
-lib = env.add_library("drivers", env.drivers_sources)
-env.Prepend(LIBS=[lib])

--- a/editor/SCsub
+++ b/editor/SCsub
@@ -110,6 +110,3 @@ if env.editor_build:
     SConscript("themes/SCsub")
     SConscript("translations/SCsub")
     SConscript("version_control/SCsub")
-
-    lib = env.add_library("editor", env.editor_sources)
-    env.Prepend(LIBS=[lib])

--- a/main/SCsub
+++ b/main/SCsub
@@ -35,6 +35,3 @@ env_main.CommandNoCache(
     "#main/app_icon.png",
     env.Run(main_builders.make_app_icon),
 )
-
-lib = env_main.add_library("main", env.main_sources)
-env.Prepend(LIBS=[lib])

--- a/modules/SCsub
+++ b/modules/SCsub
@@ -27,6 +27,8 @@ register_module_types = env.CommandNoCache(
     env.Run(modules_builders.register_module_types_builder),
 )
 
+all_module_sources = []
+env_modules.add_source_files(all_module_sources, register_module_types)
 
 test_headers = []
 # libmodule_<name>.a for each active module.
@@ -37,9 +39,7 @@ for name, path in env.module_list.items():
     base_path = path if os.path.isabs(path) else name
     SConscript(base_path + "/SCsub")
 
-    if env.modules_sources:
-        lib = env_modules.add_library("module_%s" % name, env.modules_sources)
-        env.Prepend(LIBS=[lib])
+    all_module_sources.extend(env.modules_sources)
 
     if env["tests"]:
         # Lookup potential headers in `tests` subfolder.
@@ -54,10 +54,4 @@ for name, path in env.module_list.items():
 if env["tests"]:
     env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_builders.modules_tests_builder))
 
-# libmodules.a with only register_module_types.
-# Must be last so that all libmodule_<name>.a libraries are on the right side
-# in the linker command.
-env.modules_sources = []
-env_modules.add_source_files(env.modules_sources, register_module_types)
-lib = env_modules.add_library("modules", env.modules_sources)
-env.Prepend(LIBS=[lib])
+env.modules_sources = all_module_sources

--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -87,19 +87,7 @@ if env["builtin_freetype"]:
     env_thirdparty.disable_warnings()
     lib = env_thirdparty.add_library("freetype_builtin", thirdparty_sources)
     thirdparty_obj += lib
-
-    # Needs to be appended to arrive after libscene in the linker call,
-    # but we don't want it to arrive *after* system libs, so manual hack
-    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-    # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
+    env.Prepend(LIBS=[lib])
 
 
 # Godot source files

--- a/modules/msdfgen/SCsub
+++ b/modules/msdfgen/SCsub
@@ -46,19 +46,7 @@ if env["builtin_msdfgen"]:
 
     lib = env_msdfgen.add_library("msdfgen_builtin", thirdparty_sources)
     thirdparty_obj += lib
-
-    # Needs to be appended to arrive after libscene in the linker call,
-    # but we don't want it to arrive *after* system libs, so manual hack
-    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-    # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
+    env.Prepend(LIBS=[lib])
 
 
 # Godot source files

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -13,6 +13,7 @@ env_text_server_adv = env_modules.Clone()
 thirdparty_obj = []
 freetype_enabled = "freetype" in env.module_list
 msdfgen_enabled = "msdfgen" in env.module_list
+builtin_libs = []
 
 if "svg" in env.module_list:
     env_text_server_adv.Prepend(
@@ -156,19 +157,7 @@ if env["builtin_harfbuzz"]:
 
     lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)
     thirdparty_obj += lib
-
-    # Needs to be appended to arrive after libscene in the linker call,
-    # but we don't want it to arrive *after* system libs, so manual hack
-    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-    # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
+    builtin_libs.append(lib)
 
 
 if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
@@ -226,19 +215,7 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
 
     lib = env_graphite.add_library("graphite_builtin", thirdparty_sources)
     thirdparty_obj += lib
-
-    # Needs to be appended to arrive after libscene in the linker call,
-    # but we don't want it to arrive *after* system libs, so manual hack
-    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-    # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
+    builtin_libs.append(lib)
 
 
 if env["builtin_icu4c"]:
@@ -501,18 +478,9 @@ if env["builtin_icu4c"]:
         env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/icu4c/"])
         env_icu.Depends(lib, icudata)
 
-    # Needs to be appended to arrive after libscene in the linker call,
-    # but we don't want it to arrive *after* system libs, so manual hack
-    # LIBS contains first SCons Library objects ("SCons.Node.FS.File object")
-    # and then plain strings for system library. We insert between the two.
-    inserted = False
-    for idx, linklib in enumerate(env["LIBS"]):
-        if isinstance(linklib, (str, bytes)):  # first system lib such as "X11", otherwise SCons lib object
-            env["LIBS"].insert(idx, lib)
-            inserted = True
-            break
-    if not inserted:
-        env.Append(LIBS=[lib])
+    builtin_libs.append(lib)
+
+env.Prepend(LIBS=builtin_libs)
 
 
 # Godot source files

--- a/platform/SCsub
+++ b/platform/SCsub
@@ -25,6 +25,3 @@ register_platform_apis = env.CommandNoCache(
 env.add_source_files(env.platform_sources, register_platform_apis)
 for platform in env.platform_apis:
     env.add_source_files(env.platform_sources, f"{platform}/api/*.cpp")
-
-lib = env.add_library("platform", env.platform_sources)
-env.Prepend(LIBS=[lib])

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -184,6 +184,10 @@ def configure(env: "SConsEnvironment"):
     env["RANLIB"] = os.path.join(compiler_path, "llvm-ranlib")
     env["AS"] = os.path.join(compiler_path, "clang")
 
+    # Use TempFileMunge since some AR invocations are too long otherwise
+    env["ARCOM_ORIG"] = env["ARCOM"]
+    env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
+
     env.Append(
         CCFLAGS=(["-fpic", "-ffunction-sections", "-funwind-tables", "-fstack-protector-strong", "-fvisibility=hidden"])
     )

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -207,6 +207,10 @@ def configure(env: "SConsEnvironment"):
 
     env.Append(CCFLAGS=["-pipe"])
 
+    # Use TempFileMunge since some AR invocations are too long otherwise
+    env["ARCOM_ORIG"] = env["ARCOM"]
+    env["ARCOM"] = "${TEMPFILE('$ARCOM_ORIG', '$ARCOMSTR')}"
+
     ## Dependencies
 
     if env["use_sowrap"]:

--- a/scene/SCsub
+++ b/scene/SCsub
@@ -19,7 +19,3 @@ SConscript("audio/SCsub")
 SConscript("resources/SCsub")
 SConscript("debugger/SCsub")
 SConscript("theme/SCsub")
-
-# Build it all as a library
-lib = env.add_library("scene", env.scene_sources)
-env.Prepend(LIBS=[lib])

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -35,7 +35,3 @@ if not env["disable_physics_3d"]:
 if not env["disable_xr"]:
     env.add_source_files(env.servers_sources, "xr_server.cpp")
     SConscript("xr/SCsub")
-
-lib = env.add_library("servers", env.servers_sources)
-
-env.Prepend(LIBS=[lib])

--- a/tests/SCsub
+++ b/tests/SCsub
@@ -18,6 +18,3 @@ if env["disable_exceptions"]:
     env_tests.Append(CPPDEFINES=["DOCTEST_CONFIG_NO_EXCEPTIONS_BUT_WITH_ALL_ASSERTS"])
 
 env_tests.add_source_files(env.tests_sources, "*.cpp")
-
-lib = env_tests.add_library("tests", env.tests_sources)
-env.Prepend(LIBS=[lib])


### PR DESCRIPTION
Fix circular dependencies between libraries

This merges the libraries from scene/, core/ drivers/, servers/, main/,
editor/, platform/, modules/, and tests/ into a single library.

Each of these directories includes code from the others, so trying to
build them as separate libraries causes problems, because they all
circularly depend on each other.  I'm sort of surprised that the build
has worked up until now, given that code in core/ depends on symbols
from modules/, scene/ and servers/.

This fixes #108429, and is needed to help unblock #108415.