### PR TITLE
[3.x] Android: Update to target API 35, NDK r28, 16kb page size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,6 +79,7 @@ local.properties
 *.iml
 .gradletasknamecache
 project.properties
+platform/android/java/build/
 platform/android/java/*/.cxx/
 platform/android/java/*/build/
 platform/android/java/*/libs/

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
 
+import platform
+import sys
+
 Import("env")
 
 android_files = [
@@ -39,18 +42,34 @@ lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSU
 env.Depends(lib, thirdparty_obj)
 
 lib_arch_dir = ""
+triple_target_dir = ""
 if env["android_arch"] == "armv7":
     lib_arch_dir = "armeabi-v7a"
+    triple_target_dir = "arm-linux-androideabi"
 elif env["android_arch"] == "arm64v8":
     lib_arch_dir = "arm64-v8a"
+    triple_target_dir = "aarch64-linux-android"
 elif env["android_arch"] == "x86":
     lib_arch_dir = "x86"
+    triple_target_dir = "i686-linux-android"
 elif env["android_arch"] == "x86_64":
     lib_arch_dir = "x86_64"
+    triple_target_dir = "x86_64-linux-android"
 else:
     print("WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin")
 
-if lib_arch_dir != "":
+host_subpath = ""
+if sys.platform.startswith("linux"):
+    host_subpath = "linux-x86_64"
+elif sys.platform.startswith("darwin"):
+    host_subpath = "darwin-x86_64"
+elif sys.platform.startswith("win"):
+    if platform.machine().endswith("64"):
+        host_subpath = "windows-x86_64"
+    else:
+        host_subpath = "windows"
+
+if lib_arch_dir != "" and host_subpath != "":
     if env["target"] == "release":
         lib_type_dir = "release"
     elif env["target"] == "release_debug":
@@ -71,7 +90,5 @@ if lib_arch_dir != "":
         out_dir + "/libgodot_android.so", "#bin/libgodot" + env["SHLIBSUFFIX"], Move("$TARGET", "$SOURCE")
     )
 
-    stl_lib_path = (
-        str(env["ANDROID_NDK_ROOT"]) + "/sources/cxx-stl/llvm-libc++/libs/" + lib_arch_dir + "/libc++_shared.so"
-    )
+    stl_lib_path = f"{env['ANDROID_NDK_ROOT']}/toolchains/llvm/prebuilt/{host_subpath}/sysroot/usr/lib/{triple_target_dir}/libc++_shared.so"
     env_android.Command(out_dir + "/libc++_shared.so", stl_lib_path, Copy("$TARGET", "$SOURCE"))

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -21,7 +21,7 @@ def get_opts():
 
     return [
         ("ANDROID_SDK_ROOT", "Path to the Android SDK", get_env_android_sdk_root()),
-        ("ndk_platform", 'Target platform (android-<api>, e.g. "android-19")', "android-19"),
+        ("ndk_platform", 'Target platform (android-<api>, e.g. "android-24")', "android-24"),
         EnumVariable("android_arch", "Target architecture", "armv7", ("armv7", "arm64v8", "x86", "x86_64")),
         BoolVariable("android_neon", "Enable NEON support (armv7 only)", True),
         BoolVariable("store_release", "Editor build for Google Play Store (for official builds only)", False),
@@ -43,7 +43,7 @@ def get_android_ndk_root(env):
 
 # This is kept in sync with the value in 'platform/android/java/app/config.gradle'.
 def get_ndk_version():
-    return "23.2.8568313"
+    return "28.1.13356709"
 
 
 def get_flags():
@@ -89,15 +89,6 @@ def configure(env):
     if env["android_arch"] == "armv7" and env["android_neon"]:
         neon_text = " (with NEON)"
     print("Building for Android (" + env["android_arch"] + ")" + neon_text)
-
-    if get_min_sdk_version(env["ndk_platform"]) < 21:
-        if env["android_arch"] == "x86_64" or env["android_arch"] == "arm64v8":
-            print(
-                "WARNING: android_arch="
-                + env["android_arch"]
-                + " is not supported by ndk_platform lower than android-21; setting ndk_platform=android-21"
-            )
-            env["ndk_platform"] = "android-21"
 
     if env["android_arch"] == "armv7":
         target_triple = "armv7a-linux-androideabi"
@@ -185,9 +176,7 @@ def configure(env):
         CCFLAGS="-fpic -ffunction-sections -funwind-tables -fstack-protector-strong -fvisibility=hidden -fno-strict-aliasing".split()
     )
     env.Append(CPPDEFINES=["NO_STATVFS", "GLES_ENABLED"])
-
-    if get_min_sdk_version(env["ndk_platform"]) >= 24:
-        env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
+    env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
 
     env["neon_enabled"] = False
     if env["android_arch"] == "x86":

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -224,10 +224,10 @@ static const int EXPORT_FORMAT_APK = 0;
 static const int EXPORT_FORMAT_AAB = 1;
 
 static const char *APK_ASSETS_DIRECTORY = "res://android/build/assets";
-static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPacks/installTime/src/main/assets";
+static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPackInstallTime/src/main/assets";
 
-static const int DEFAULT_MIN_SDK_VERSION = 19; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
-static const int DEFAULT_TARGET_SDK_VERSION = 34; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
+static const int DEFAULT_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
+static const int DEFAULT_TARGET_SDK_VERSION = 35; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED
 void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -226,7 +226,7 @@ static const int EXPORT_FORMAT_AAB = 1;
 static const char *APK_ASSETS_DIRECTORY = "res://android/build/assets";
 static const char *AAB_ASSETS_DIRECTORY = "res://android/build/assetPackInstallTime/src/main/assets";
 
-static const int DEFAULT_MIN_SDK_VERSION = 21; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
+static const int DEFAULT_MIN_SDK_VERSION = 24; // Should match the value in 'platform/android/java/app/config.gradle#minSdk'
 static const int DEFAULT_TARGET_SDK_VERSION = 35; // Should match the value in 'platform/android/java/app/config.gradle#targetSdk'
 
 #ifndef ANDROID_ENABLED
@@ -3388,7 +3388,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	}
 
 	// Let's zip-align (must be done before signing)
-
+	static const int PAGE_SIZE_KB = 16 * 1024;
 	static const int ZIP_ALIGNMENT = 4;
 
 	// If we're not signing the apk, then the next step should be the last.
@@ -3440,6 +3440,12 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 			// Uncompressed file => Align
 			long new_offset = file_offset + bias;
 			padding = (ZIP_ALIGNMENT - (new_offset % ZIP_ALIGNMENT)) % ZIP_ALIGNMENT;
+			const char *ext = strrchr(fname, '.');
+			if (ext && strcmp(ext, ".so") == 0) {
+				padding = (PAGE_SIZE_KB - (new_offset % PAGE_SIZE_KB)) % PAGE_SIZE_KB;
+			} else {
+				padding = (ZIP_ALIGNMENT - (new_offset % ZIP_ALIGNMENT)) % ZIP_ALIGNMENT;
+			}
 		}
 
 		memset(extra + info.size_file_extra, 0, padding);

--- a/platform/android/java/app/assetPackInstallTime/build.gradle
+++ b/platform/android/java/app/assetPackInstallTime/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 assetPack {
-    packName = "installTime" // Directory name for the asset pack
+    packName = "assetPackInstallTime" // Directory name for the asset pack
     dynamicDelivery {
         deliveryType = "install-time" // Delivery mode
     }

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         mavenCentral()
         gradlePluginPortal()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/"}
 //CHUNK_BUILDSCRIPT_REPOSITORIES_BEGIN
 //CHUNK_BUILDSCRIPT_REPOSITORIES_END
     }
@@ -34,6 +35,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/"}
 //CHUNK_ALLPROJECTS_REPOSITORIES_BEGIN
 //CHUNK_ALLPROJECTS_REPOSITORIES_END
 

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -101,7 +101,7 @@ android {
         jvmTarget = versions.javaVersion
     }
 
-    assetPacks = [":assetPacks:installTime"]
+    assetPacks = [":assetPackInstallTime"]
 
     namespace = 'com.godot.game'
 

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,14 +1,14 @@
 ext.versions = [
     androidGradlePlugin: '8.6.1',
     compileSdk         : 35,
-    minSdk             : 21, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    minSdk             : 24, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 35, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '35.0.0',
     kotlinVersion      : '2.1.20',
     fragmentVersion    : '1.8.6',
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
-    ndkVersion         : '23.2.8568313' // Also update 'platform/android/detect.py#get_ndk_version' when this is updated.
+    ndkVersion         : '28.1.13356709' // Also update 'platform/android/detect.py#get_ndk_version' when this is updated.
 
 ]
 

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,11 +1,11 @@
 ext.versions = [
-    androidGradlePlugin: '8.2.0',
-    compileSdk         : 34,
-    minSdk             : 19, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
-    targetSdk          : 34, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
-    buildTools         : '34.0.0',
-    kotlinVersion      : '1.9.20',
-    fragmentVersion    : '1.6.2',
+    androidGradlePlugin: '8.6.1',
+    compileSdk         : 35,
+    minSdk             : 21, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
+    targetSdk          : 35, // Also update 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
+    buildTools         : '35.0.0',
+    kotlinVersion      : '2.1.20',
+    fragmentVersion    : '1.8.6',
     nexusPublishVersion: '1.3.0',
     javaVersion        : JavaVersion.VERSION_17,
     ndkVersion         : '23.2.8568313' // Also update 'platform/android/detect.py#get_ndk_version' when this is updated.

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -11,6 +11,7 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/"}
     }
 }
 

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -14,4 +14,4 @@ pluginManagement {
     }
 }
 
-include ':assetPacks:installTime'
+include ':assetPackInstallTime'

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -18,6 +18,7 @@ allprojects {
         mavenCentral()
         gradlePluginPortal()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/"}
     }
 }
 

--- a/platform/android/java/gradle/wrapper/gradle-wrapper.properties
+++ b/platform/android/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
+++ b/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Non functional cmake build file used to provide Android Studio editor support to the project.
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.10)
 project(godot)
 
 set(CMAKE_CXX_STANDARD 14)

--- a/platform/android/java/scripts/publish-module.gradle
+++ b/platform/android/java/scripts/publish-module.gradle
@@ -43,6 +43,11 @@ afterEvaluate {
                             name = 'Rémi Verschelde'
                             email = 'rverschelde@gmail.com'
                         }
+                        developer {
+                            id = 'godotengine'
+                            name = 'Godot Engine contributors'
+                            email = 'contact@godotengine.org'
+                        }
                         // Add all other devs here...
                     }
 

--- a/platform/android/java/scripts/publish-root.gradle
+++ b/platform/android/java/scripts/publish-root.gradle
@@ -31,8 +31,8 @@ nexusPublishing {
             stagingProfileId = sonatypeStagingProfileId
             username = ossrhUsername
             password = ossrhPassword
-            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
-            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -24,5 +24,5 @@ include ':lib'
 include ':nativeSrcsConfigs'
 include ':editor'
 
-include ':assetPacks:installTime'
-project(':assetPacks:installTime').projectDir = file("app/assetPacks/installTime")
+include ':assetPackInstallTime'
+project(':assetPackInstallTime').projectDir = file("app/assetPackInstallTime")

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -14,6 +14,7 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
         maven { url "https://plugins.gradle.org/m2/" }
+        maven { url "https://central.sonatype.com/repository/maven-snapshots/"}
     }
 }
 


### PR DESCRIPTION
This simply bumps the required version numbers for the Android codebase for 3.x, so that users can avoid the policy change removals from the Play store slated for August 31.

Tested on only a Pixel 9 XL Pro (don't have any other devices). Should fix https://github.com/godotengine/godot/issues/108161.