### PR TITLE
Fix ScriptEditor inline color wrong line number

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -404,7 +404,7 @@ bool ScriptTextEditor::_is_valid_color_info(const Dictionary &p_info) {
 	return true;
 }
 
-Array ScriptTextEditor::_inline_object_parse(const String &p_text, int p_line) {
+Array ScriptTextEditor::_inline_object_parse(const String &p_text) {
 	Array result;
 	int i_end_previous = 0;
 	int i_start = p_text.find("Color");
@@ -426,7 +426,6 @@ Array ScriptTextEditor::_inline_object_parse(const String &p_text, int p_line) {
 		}
 
 		Dictionary color_info;
-		color_info["line"] = p_line;
 		color_info["column"] = i_start;
 		color_info["width_ratio"] = 1.0;
 		color_info["color_end"] = i_par_end;

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -205,7 +205,7 @@ protected:
 	void _warning_clicked(const Variant &p_line);
 
 	bool _is_valid_color_info(const Dictionary &p_info);
-	Array _inline_object_parse(const String &p_text, int p_line);
+	Array _inline_object_parse(const String &p_text);
 	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
 	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
 	String _picker_color_stringify(const Color &p_color, COLOR_MODE p_mode);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -255,7 +255,7 @@ inline bool is_inline_info_valid(const Variant &p_info) {
 		return false;
 	}
 	Dictionary info = p_info;
-	if (!info.get_valid("column").is_num() || !info.get_valid("line").is_num() || !info.get_valid("width_ratio").is_num()) {
+	if (!info.get_valid("column").is_num() || !info.get_valid("width_ratio").is_num()) {
 		return false;
 	}
 	return true;
@@ -300,7 +300,7 @@ void TextEdit::Text::invalidate_cache(int p_line, bool p_text_changed) {
 		int from = 0;
 		if (inline_object_parser.is_valid()) {
 			// Insert inline object.
-			Variant parsed_result = inline_object_parser.call(text_with_ime, p_line);
+			Variant parsed_result = inline_object_parser.call(text_with_ime);
 			if (parsed_result.is_array()) {
 				Array object_infos = parsed_result;
 				for (Variant val : object_infos) {
@@ -2386,12 +2386,13 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					float wrap_indent = wrap_i > first_indent_line ? MIN(text.get_indent_offset(pos.y, is_layout_rtl()), wrap_at_column * 0.6) : 0.0;
 
 					Ref<TextParagraph> ldata = text.get_line_data(line);
-					for (Variant k : ldata->get_line_objects(wrap_i)) {
-						if (!is_inline_info_valid(k)) {
+					for (const Variant &inline_key : ldata->get_line_objects(wrap_i)) {
+						if (!is_inline_info_valid(inline_key)) {
 							continue;
 						}
-						Dictionary info = k;
-						Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, k);
+						Dictionary info = inline_key.duplicate();
+						info["line"] = line;
+						Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, inline_key);
 						obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
 
 						if (mpos.x > obj_rect.position.x && mpos.x < obj_rect.get_end().x) {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/108331

Removes the line from the inline object, it doesn't need to be stored there and it didn't get updated.

To test: add or remove a line somewhere above an inline color object and try to use it.