### PR TITLE
Metal: Remove invalid assumption for image atomic operations

### DIFF
--- a/drivers/metal/metal_device_properties.h
+++ b/drivers/metal/metal_device_properties.h
@@ -94,8 +94,9 @@ struct API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0)) MetalFeatures {
 	bool metal_fx_spatial = false; /**< If true, Metal FX spatial functions are supported. */
 	bool metal_fx_temporal = false; /**< If true, Metal FX temporal functions are supported. */
 	bool supports_gpu_address = false; /**< If true, referencing a GPU address in a shader is supported. */
-	bool supports_image_atomic_32_bit = false; /**< If true, 32-bit atomic operations on images are supported. */
-	bool supports_image_atomic_64_bit = false; /**< If true, 64-bit atomic operations on images are supported. */
+	bool supports_image_atomic_32_bit = false; /**< If true, 32-bit atomic operations on images are supported by the GPU. */
+	bool supports_image_atomic_64_bit = false; /**< If true, 64-bit atomic operations on images are supported by the GPU. */
+	bool supports_native_image_atomics = false; /**< If true, native image atomic operations are supported by the OS. */
 };
 
 struct MetalLimits {

--- a/drivers/metal/metal_device_properties.mm
+++ b/drivers/metal/metal_device_properties.mm
@@ -122,10 +122,12 @@ void MetalDeviceProperties::init_features(id<MTLDevice> p_device) {
 	features.simdReduction = [p_device supportsFamily:MTLGPUFamilyApple7];
 	features.argument_buffers_tier = p_device.argumentBuffersSupport;
 	features.supports_image_atomic_32_bit = [p_device supportsFamily:MTLGPUFamilyApple6];
-	features.supports_image_atomic_64_bit = [p_device supportsFamily:MTLGPUFamilyApple8];
+	features.supports_image_atomic_64_bit = [p_device supportsFamily:MTLGPUFamilyApple9] || ([p_device supportsFamily:MTLGPUFamilyApple8] && [p_device supportsFamily:MTLGPUFamilyMac2]);
+	if (@available(macOS 14.0, iOS 17.0, tvOS 17.0, visionOS 1.0, *)) {
+		features.supports_native_image_atomics = true;
+	}
 	if (OS::get_singleton()->get_environment("GODOT_MTL_DISABLE_IMAGE_ATOMICS") == "1") {
-		features.supports_image_atomic_32_bit = false;
-		features.supports_image_atomic_64_bit = false;
+		features.supports_native_image_atomics = false;
 	}
 
 	if (@available(macOS 13.0, iOS 16.0, tvOS 16.0, *)) {


### PR DESCRIPTION
Fix image atomic checks, which require minimum OS version too.

Closes #108445