### PR TITLE
Never duplicate Scripts when duplicating resources recursively

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -298,6 +298,12 @@ Variant Resource::_duplicate_recursive(const Variant &p_variant, const Duplicate
 							DEV_ASSERT(false);
 						}
 					}
+					if (should_duplicate) {
+						Ref<Script> scr = sr;
+						if (scr.is_valid()) {
+							should_duplicate = false;
+						}
+					}
 				}
 			}
 			if (should_duplicate) {


### PR DESCRIPTION
This allows to duplicate PackedScenes safely
Fixes #108220

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
