### PR TITLE
[Windows export] Move debug symbol sections on export.

### DIFF
--- a/platform/windows/export/template_modifier.cpp
+++ b/platform/windows/export/template_modifier.cpp
@@ -574,9 +574,20 @@ Error TemplateModifier::_modify_template(const Ref<EditorExportPreset> &p_preset
 
 	Vector<SectionEntry> section_entries = _get_section_entries(template_file);
 	ERR_FAIL_COND_V(section_entries.size() < 2, ERR_CANT_OPEN);
-	ERR_FAIL_COND_V(section_entries[section_entries.size() - 2].name != String(".rsrc"), ERR_CANT_OPEN);
-	ERR_FAIL_COND_V(section_entries[section_entries.size() - 1].name != String(".reloc"), ERR_CANT_OPEN);
-	// TODO fail on not sorted by physical address?
+
+	// Find resource (".rsrc") and relocation (".reloc") sections, usually last two, but ".debug_*" sections (referenced as "/[n]"), symbol table, and string table can follow.
+	int resource_index = section_entries.size() - 2;
+	int relocations_index = section_entries.size() - 1;
+	for (int i = 0; i < section_entries.size(); i++) {
+		if (section_entries[i].name == ".rsrc") {
+			resource_index = i;
+		} else if (section_entries[i].name == ".reloc") {
+			relocations_index = i;
+		}
+	}
+
+	ERR_FAIL_COND_V(section_entries[resource_index].name != ".rsrc", ERR_CANT_OPEN);
+	ERR_FAIL_COND_V(section_entries[relocations_index].name != ".reloc", ERR_CANT_OPEN);
 
 	uint64_t original_template_size = template_file->get_length();
 
@@ -584,27 +595,58 @@ Error TemplateModifier::_modify_template(const Ref<EditorExportPreset> &p_preset
 
 	VersionInfo version_info = _create_version_info(_get_strings(p_preset));
 
-	SectionEntry resources_section_entry = section_entries.get(section_entries.size() - 2);
+	SectionEntry &resources_section_entry = section_entries.write[resource_index];
 	uint32_t old_resources_size_of_raw_data = resources_section_entry.size_of_raw_data;
 	Vector<uint8_t> resources = _create_resources(resources_section_entry.virtual_address, group_icon, version_info);
 	resources_section_entry.virtual_size = resources.size();
 	resources.resize_initialized(_snap(resources.size(), BLOCK_SIZE));
 	resources_section_entry.size_of_raw_data = resources.size();
 
-	SectionEntry relocations_section_entry = section_entries.get(section_entries.size() - 1);
-	uint32_t old_relocations_virtual_address = relocations_section_entry.virtual_address;
-	template_file->seek(relocations_section_entry.pointer_to_raw_data);
-	Vector<uint8_t> relocations = template_file->get_buffer(relocations_section_entry.size_of_raw_data);
-	relocations_section_entry.pointer_to_raw_data = resources_section_entry.pointer_to_raw_data + resources_section_entry.size_of_raw_data;
-	relocations_section_entry.virtual_address = resources_section_entry.virtual_address + _snap(resources_section_entry.virtual_size, PE_PAGE_SIZE);
+	int32_t raw_size_delta = resources_section_entry.size_of_raw_data - old_resources_size_of_raw_data;
+	uint32_t old_last_section_virtual_address = section_entries.get(section_entries.size() - 1).virtual_address;
+
+	// Some data (e.g. DWARF debug symbols) can be placed after the last section.
+	uint32_t old_footer_offset = section_entries.get(section_entries.size() - 1).pointer_to_raw_data + section_entries.get(section_entries.size() - 1).size_of_raw_data;
+
+	// Copy and update sections after ".rsrc".
+	Vector<Vector<uint8_t>> moved_section_data;
+	uint32_t prev_virtual_address = resources_section_entry.virtual_address;
+	uint32_t prev_virtual_size = resources_section_entry.virtual_size;
+	for (int i = resource_index + 1; i < section_entries.size(); i++) {
+		SectionEntry &section_entry = section_entries.write[i];
+		template_file->seek(section_entry.pointer_to_raw_data);
+		Vector<uint8_t> data = template_file->get_buffer(section_entry.size_of_raw_data);
+		moved_section_data.push_back(data);
+		section_entry.pointer_to_raw_data += raw_size_delta;
+		section_entry.virtual_address = prev_virtual_address + _snap(prev_virtual_size, PE_PAGE_SIZE);
+		prev_virtual_address = section_entry.virtual_address;
+		prev_virtual_size = section_entry.virtual_size;
+	}
+
+	// Copy COFF symbol table and string table after the last section.
+	uint32_t footer_size = template_file->get_length() - old_footer_offset;
+	template_file->seek(old_footer_offset);
+	Vector<uint8_t> footer;
+	if (footer_size > 0) {
+		footer = template_file->get_buffer(footer_size);
+	}
 
 	uint32_t pe_header_offset = _get_pe_header_offset(template_file);
+
+	// Update symbol table pointer.
+	template_file->seek(pe_header_offset + 12);
+	uint32_t symbols_offset = template_file->get_32();
+	if (symbols_offset > resources_section_entry.pointer_to_raw_data) {
+		template_file->seek(pe_header_offset + 12);
+		template_file->store_32(symbols_offset + raw_size_delta);
+	}
 
 	template_file->seek(pe_header_offset + MAGIC_NUMBER_OFFSET);
 	uint16_t magic_number = template_file->get_16();
 	ERR_FAIL_COND_V_MSG(magic_number != 0x10b && magic_number != 0x20b, ERR_CANT_OPEN, vformat("Magic number has wrong value: %04x", magic_number));
 	bool pe32plus = magic_number == 0x20b;
 
+	// Update image size.
 	template_file->seek(pe_header_offset + SIZE_OF_INITIALIZED_DATA_OFFSET);
 	uint32_t size_of_initialized_data = template_file->get_32();
 	size_of_initialized_data += resources_section_entry.size_of_raw_data - old_resources_size_of_raw_data;
@@ -613,30 +655,43 @@ Error TemplateModifier::_modify_template(const Ref<EditorExportPreset> &p_preset
 
 	template_file->seek(pe_header_offset + SIZE_OF_IMAGE_OFFSET);
 	uint32_t size_of_image = template_file->get_32();
-	size_of_image += relocations_section_entry.virtual_address - old_relocations_virtual_address;
+	size_of_image += section_entries.get(section_entries.size() - 1).virtual_address - old_last_section_virtual_address;
 	template_file->seek(pe_header_offset + SIZE_OF_IMAGE_OFFSET);
 	template_file->store_32(size_of_image);
 
 	uint32_t optional_header_offset = pe_header_offset + COFF_HEADER_SIZE;
 
+	// Update resource section size.
 	template_file->seek(optional_header_offset + (pe32plus ? 132 : 116));
 	template_file->store_32(resources_section_entry.virtual_size);
 
+	// Update relocation section size and pointer.
 	template_file->seek(optional_header_offset + (pe32plus ? 152 : 136));
-	template_file->store_32(relocations_section_entry.virtual_address);
-	template_file->store_32(relocations_section_entry.virtual_size);
+	template_file->store_32(section_entries[relocations_index].virtual_address);
+	template_file->store_32(section_entries[relocations_index].virtual_size);
 
-	template_file->seek(optional_header_offset + (pe32plus ? 240 : 224) + SectionEntry::SIZE * (section_entries.size() - 2));
+	template_file->seek(optional_header_offset + (pe32plus ? 240 : 224) + SectionEntry::SIZE * resource_index);
 	template_file->store_buffer(resources_section_entry.save());
-	template_file->store_buffer(relocations_section_entry.save());
+	for (int i = resource_index + 1; i < section_entries.size(); i++) {
+		template_file->seek(optional_header_offset + (pe32plus ? 240 : 224) + SectionEntry::SIZE * i);
+		template_file->store_buffer(section_entries[i].save());
+	}
 
+	// Write new resource section.
 	template_file->seek(resources_section_entry.pointer_to_raw_data);
 	template_file->store_buffer(resources);
-	template_file->store_buffer(relocations);
+	// Write the rest of sections.
+	for (const Vector<uint8_t> &data : moved_section_data) {
+		template_file->store_buffer(data);
+	}
+	// Write footer data.
+	if (footer_size > 0) {
+		template_file->store_buffer(footer);
+	}
 
 	if (template_file->get_position() < original_template_size) {
 		template_file->close();
-		_truncate(p_template_path, relocations_section_entry.pointer_to_raw_data + relocations_section_entry.size_of_raw_data);
+		_truncate(p_template_path, section_entries.get(section_entries.size() - 1).pointer_to_raw_data + section_entries.get(section_entries.size() - 1).size_of_raw_data + footer_size);
 	}
 
 	return OK;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108145

Moves all `.debug_*` section, COFF symbol table and COFF string table to the new locations after adding resources.