### PR TITLE
Improve auto-translation of Debugger

### DIFF
--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -165,19 +165,19 @@ EditorExpressionEvaluator::EditorExpressionEvaluator() {
 
 	clear_on_run_checkbox = memnew(CheckBox);
 	clear_on_run_checkbox->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	clear_on_run_checkbox->set_text(TTR("Clear on Run"));
+	clear_on_run_checkbox->set_text(TTRC("Clear on Run"));
 	clear_on_run_checkbox->set_pressed(true);
 	hb->add_child(clear_on_run_checkbox);
 
 	evaluate_btn = memnew(Button);
 	evaluate_btn->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	evaluate_btn->set_text(TTR("Evaluate"));
+	evaluate_btn->set_text(TTRC("Evaluate"));
 	evaluate_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorExpressionEvaluator::_evaluate));
 	hb->add_child(evaluate_btn);
 
 	clear_btn = memnew(Button);
 	clear_btn->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
-	clear_btn->set_text(TTR("Clear"));
+	clear_btn->set_text(TTRC("Clear"));
 	clear_btn->connect(SceneStringName(pressed), callable_mp(this, &EditorExpressionEvaluator::_clear));
 	hb->add_child(clear_btn);
 

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -242,6 +242,7 @@ TreeItem *EditorPerformanceProfiler::_get_monitor_base(const StringName &p_base_
 
 	TreeItem *base = monitor_tree->create_item(monitor_tree->get_root());
 	base->set_text(0, EditorPropertyNameProcessor::get_singleton()->process_name(p_base_name, EditorPropertyNameProcessor::get_settings_style()));
+	base->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 	base->set_editable(0, false);
 	base->set_selectable(0, false);
 	base->set_expand_right(0, true);
@@ -386,6 +387,15 @@ List<float> *EditorPerformanceProfiler::get_monitor_data(const StringName &p_nam
 
 void EditorPerformanceProfiler::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (is_ready()) {
+				_build_monitor_tree();
+				if (monitor_draw->is_visible_in_tree()) {
+					monitor_draw->queue_redraw();
+				}
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			for (KeyValue<StringName, TreeItem *> &E : base_map) {
 				E.value->set_custom_font(0, get_theme_font(SNAME("bold"), EditorStringName(EditorFonts)));
@@ -401,16 +411,15 @@ void EditorPerformanceProfiler::_notification(int p_what) {
 }
 
 EditorPerformanceProfiler::EditorPerformanceProfiler() {
-	set_name(TTR("Monitors"));
+	set_name(TTRC("Monitors"));
 	set_split_offset(340 * EDSCALE);
 
 	monitor_tree = memnew(Tree);
 	monitor_tree->set_custom_minimum_size(Size2(300, 0) * EDSCALE);
-	monitor_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	monitor_tree->set_columns(2);
-	monitor_tree->set_column_title(0, TTR("Monitor"));
+	monitor_tree->set_column_title(0, TTRC("Monitor"));
 	monitor_tree->set_column_expand(0, true);
-	monitor_tree->set_column_title(1, TTR("Value"));
+	monitor_tree->set_column_title(1, TTRC("Value"));
 	monitor_tree->set_column_custom_minimum_width(1, 100 * EDSCALE);
 	monitor_tree->set_column_expand(1, false);
 	monitor_tree->set_column_titles_visible(true);
@@ -429,7 +438,7 @@ EditorPerformanceProfiler::EditorPerformanceProfiler() {
 
 	info_message = memnew(Label);
 	info_message->set_focus_mode(FOCUS_ACCESSIBILITY);
-	info_message->set_text(TTR("Pick one or more items from the list to display the graph."));
+	info_message->set_text(TTRC("Pick one or more items from the list to display the graph."));
 	info_message->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	info_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	info_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -359,6 +359,7 @@ void EditorProfiler::_update_frame() {
 		category->set_editable(0, true);
 		category->set_metadata(0, m.categories[i].signature);
 		category->set_text(0, String(m.categories[i].name));
+		category->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 		category->set_text(1, _get_time_as_text(m, m.categories[i].total_time, 1));
 
 		if (plot_sigs.has(m.categories[i].signature)) {
@@ -376,6 +377,7 @@ void EditorProfiler::_update_frame() {
 			item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 			item->set_editable(0, true);
 			item->set_text(0, it.name);
+			item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 			item->set_metadata(0, it.signature);
 			item->set_metadata(1, it.script);
 			item->set_metadata(2, it.line);
@@ -404,10 +406,10 @@ void EditorProfiler::_update_frame() {
 void EditorProfiler::_update_button_text() {
 	if (activate->is_pressed()) {
 		activate->set_button_icon(get_editor_theme_icon(SNAME("Stop")));
-		activate->set_text(TTR("Stop"));
+		activate->set_text(TTRC("Stop"));
 	} else {
 		activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
-		activate->set_text(TTR("Start"));
+		activate->set_text(TTRC("Start"));
 	}
 }
 
@@ -438,9 +440,14 @@ void EditorProfiler::_autostart_toggled(bool p_toggled_on) {
 
 void EditorProfiler::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
-		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (is_ready()) {
+				_update_frame();
+			}
+			[[fallthrough]];
+		}
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
 			clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 
@@ -673,18 +680,18 @@ EditorProfiler::EditorProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_disabled(true);
-	activate->set_text(TTR("Start"));
+	activate->set_text(TTRC("Start"));
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_activate_pressed));
 	container->add_child(activate);
 
 	clear_button = memnew(Button);
-	clear_button->set_text(TTR("Clear"));
+	clear_button->set_text(TTRC("Clear"));
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_clear_pressed));
 	clear_button->set_disabled(true);
 	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
-	autostart_checkbox->set_text(TTR("Autostart"));
+	autostart_checkbox->set_text(TTRC("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorProfiler::_autostart_toggled));
 	container->add_child(autostart_checkbox);
@@ -693,14 +700,14 @@ EditorProfiler::EditorProfiler() {
 	hb_measure->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
 	container->add_child(hb_measure);
 
-	hb_measure->add_child(memnew(Label(TTR("Measure:"))));
+	hb_measure->add_child(memnew(Label(TTRC("Measure:"))));
 
 	display_mode = memnew(OptionButton);
 	display_mode->set_accessibility_name(TTRC("Measure:"));
-	display_mode->add_item(TTR("Frame Time (ms)"));
-	display_mode->add_item(TTR("Average Time (ms)"));
-	display_mode->add_item(TTR("Frame %"));
-	display_mode->add_item(TTR("Physics Frame %"));
+	display_mode->add_item(TTRC("Frame Time (ms)"));
+	display_mode->add_item(TTRC("Average Time (ms)"));
+	display_mode->add_item(TTRC("Frame %"));
+	display_mode->add_item(TTRC("Physics Frame %"));
 	display_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorProfiler::_combo_changed));
 
 	hb_measure->add_child(display_mode);
@@ -709,19 +716,19 @@ EditorProfiler::EditorProfiler() {
 	hb_time->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
 	container->add_child(hb_time);
 
-	hb_time->add_child(memnew(Label(TTR("Time:"))));
+	hb_time->add_child(memnew(Label(TTRC("Time:"))));
 
 	display_time = memnew(OptionButton);
 	display_time->set_accessibility_name(TTRC("Time:"));
 	// TRANSLATORS: This is an option in the profiler to display the time spent in a function, including the time spent in other functions called by that function.
-	display_time->add_item(TTR("Inclusive"));
+	display_time->add_item(TTRC("Inclusive"));
 	// TRANSLATORS: This is an option in the profiler to display the time spent in a function, exincluding the time spent in other functions called by that function.
-	display_time->add_item(TTR("Self"));
-	display_time->set_tooltip_text(TTR("Inclusive: Includes time from other functions called by this function.\nUse this to spot bottlenecks.\n\nSelf: Only count the time spent in the function itself, not in other functions called by that function.\nUse this to find individual functions to optimize."));
+	display_time->add_item(TTRC("Self"));
+	display_time->set_tooltip_text(TTRC("Inclusive: Includes time from other functions called by this function.\nUse this to spot bottlenecks.\n\nSelf: Only count the time spent in the function itself, not in other functions called by that function.\nUse this to find individual functions to optimize."));
 	display_time->connect(SceneStringName(item_selected), callable_mp(this, &EditorProfiler::_combo_changed));
 	hb_time->add_child(display_time);
 
-	display_internal_profiles = memnew(CheckButton(TTR("Display internal functions")));
+	display_internal_profiles = memnew(CheckButton(TTRC("Display internal functions")));
 	display_internal_profiles->set_visible(EDITOR_GET("debugger/profile_native_calls"));
 	display_internal_profiles->set_pressed(false);
 	display_internal_profiles->connect(SceneStringName(pressed), callable_mp(this, &EditorProfiler::_internal_profiles_pressed));
@@ -732,7 +739,7 @@ EditorProfiler::EditorProfiler() {
 	hb_frame->set_v_size_flags(SIZE_SHRINK_BEGIN);
 	hb->add_child(hb_frame);
 
-	hb_frame->add_child(memnew(Label(TTR("Frame #:"))));
+	hb_frame->add_child(memnew(Label(TTRC("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_accessibility_name(TTRC("Frame #:"));
@@ -747,22 +754,21 @@ EditorProfiler::EditorProfiler() {
 	h_split->set_v_size_flags(SIZE_EXPAND_FILL);
 
 	variables = memnew(Tree);
-	variables->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	variables->set_custom_minimum_size(Size2(320, 0) * EDSCALE);
 	variables->set_hide_folding(true);
 	h_split->add_child(variables);
 	variables->set_hide_root(true);
 	variables->set_columns(3);
 	variables->set_column_titles_visible(true);
-	variables->set_column_title(0, TTR("Name"));
+	variables->set_column_title(0, TTRC("Name"));
 	variables->set_column_expand(0, true);
 	variables->set_column_clip_content(0, true);
 	variables->set_column_custom_minimum_width(0, 60);
-	variables->set_column_title(1, TTR("Time"));
+	variables->set_column_title(1, TTRC("Time"));
 	variables->set_column_expand(1, false);
 	variables->set_column_clip_content(1, true);
 	variables->set_column_custom_minimum_width(1, 75 * EDSCALE);
-	variables->set_column_title(2, TTR("Calls"));
+	variables->set_column_title(2, TTRC("Calls"));
 	variables->set_column_expand(2, false);
 	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 50 * EDSCALE);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -422,12 +422,12 @@ void EditorVisualProfiler::_update_frame(bool p_focus_selected) {
 void EditorVisualProfiler::_activate_pressed() {
 	if (activate->is_pressed()) {
 		activate->set_button_icon(get_editor_theme_icon(SNAME("Stop")));
-		activate->set_text(TTR("Stop"));
+		activate->set_text(TTRC("Stop"));
 		_clear_pressed(); //always clear on start
 		clear_button->set_disabled(false);
 	} else {
 		activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
-		activate->set_text(TTR("Start"));
+		activate->set_text(TTRC("Start"));
 	}
 	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
@@ -445,9 +445,14 @@ void EditorVisualProfiler::_autostart_toggled(bool p_toggled_on) {
 
 void EditorVisualProfiler::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
-		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (is_ready()) {
+				_update_frame();
+			}
+			[[fallthrough]];
+		}
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
 			clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 		} break;
@@ -668,10 +673,10 @@ void EditorVisualProfiler::_bind_methods() {
 void EditorVisualProfiler::_update_button_text() {
 	if (activate->is_pressed()) {
 		activate->set_button_icon(get_editor_theme_icon(SNAME("Stop")));
-		activate->set_text(TTR("Stop"));
+		activate->set_text(TTRC("Stop"));
 	} else {
 		activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
-		activate->set_text(TTR("Start"));
+		activate->set_text(TTRC("Start"));
 	}
 }
 
@@ -757,18 +762,18 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
 	activate->set_disabled(true);
-	activate->set_text(TTR("Start"));
+	activate->set_text(TTRC("Start"));
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_activate_pressed));
 	container->add_child(activate);
 
 	clear_button = memnew(Button);
-	clear_button->set_text(TTR("Clear"));
+	clear_button->set_text(TTRC("Clear"));
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_clear_pressed));
 	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
-	autostart_checkbox->set_text(TTR("Autostart"));
+	autostart_checkbox->set_text(TTRC("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_visual_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorVisualProfiler::_autostart_toggled));
 	container->add_child(autostart_checkbox);
@@ -777,21 +782,21 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	hb_measure->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
 	container->add_child(hb_measure);
 
-	hb_measure->add_child(memnew(Label(TTR("Measure:"))));
+	hb_measure->add_child(memnew(Label(TTRC("Measure:"))));
 
 	display_mode = memnew(OptionButton);
 	display_mode->set_accessibility_name(TTRC("Measure:"));
-	display_mode->add_item(TTR("Frame Time (ms)"));
-	display_mode->add_item(TTR("Frame %"));
+	display_mode->add_item(TTRC("Frame Time (ms)"));
+	display_mode->add_item(TTRC("Frame %"));
 	display_mode->connect(SceneStringName(item_selected), callable_mp(this, &EditorVisualProfiler::_combo_changed));
 
 	hb_measure->add_child(display_mode);
 
-	frame_relative = memnew(CheckBox(TTR("Fit to Frame")));
+	frame_relative = memnew(CheckBox(TTRC("Fit to Frame")));
 	frame_relative->set_pressed(true);
 	container->add_child(frame_relative);
 	frame_relative->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_update_plot));
-	linked = memnew(CheckBox(TTR("Linked")));
+	linked = memnew(CheckBox(TTRC("Linked")));
 	linked->set_pressed(true);
 	container->add_child(linked);
 	linked->connect(SceneStringName(pressed), callable_mp(this, &EditorVisualProfiler::_update_plot));
@@ -801,7 +806,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	hb_frame->set_v_size_flags(SIZE_SHRINK_BEGIN);
 	hb->add_child(hb_frame);
 
-	hb_frame->add_child(memnew(Label(TTR("Frame #:"))));
+	hb_frame->add_child(memnew(Label(TTRC("Frame #:"))));
 
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_accessibility_name(TTRC("Frame #:"));
@@ -820,15 +825,15 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->set_hide_root(true);
 	variables->set_columns(3);
 	variables->set_column_titles_visible(true);
-	variables->set_column_title(0, TTR("Name"));
+	variables->set_column_title(0, TTRC("Name"));
 	variables->set_column_expand(0, true);
 	variables->set_column_clip_content(0, true);
 	variables->set_column_custom_minimum_width(0, 60);
-	variables->set_column_title(1, TTR("CPU"));
+	variables->set_column_title(1, TTRC("CPU"));
 	variables->set_column_expand(1, false);
 	variables->set_column_clip_content(1, true);
 	variables->set_column_custom_minimum_width(1, 75 * EDSCALE);
-	variables->set_column_title(2, TTR("GPU"));
+	variables->set_column_title(2, TTRC("GPU"));
 	variables->set_column_expand(2, false);
 	variables->set_column_clip_content(2, true);
 	variables->set_column_custom_minimum_width(2, 75 * EDSCALE);

--- a/modules/multiplayer/editor/editor_network_profiler.cpp
+++ b/modules/multiplayer/editor/editor_network_profiler.cpp
@@ -46,6 +46,19 @@ void EditorNetworkProfiler::_bind_methods() {
 
 void EditorNetworkProfiler::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			// TRANSLATORS: This is the label for the network profiler's incoming bandwidth.
+			down_label->set_text(TTR("Down", "Network"));
+			// TRANSLATORS: This is the label for the network profiler's outgoing bandwidth.
+			up_label->set_text(TTR("Up", "Network"));
+
+			set_bandwidth(incoming_bandwidth, outgoing_bandwidth);
+
+			if (is_ready()) {
+				refresh_rpc_data();
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			if (activate->is_pressed()) {
 				activate->set_button_icon(theme_cache.stop_icon);
@@ -188,10 +201,10 @@ void EditorNetworkProfiler::_activate_pressed() {
 void EditorNetworkProfiler::_update_button_text() {
 	if (activate->is_pressed()) {
 		activate->set_button_icon(theme_cache.stop_icon);
-		activate->set_text(TTR("Stop"));
+		activate->set_text(TTRC("Stop"));
 	} else {
 		activate->set_button_icon(theme_cache.play_icon);
-		activate->set_text(TTR("Start"));
+		activate->set_text(TTRC("Start"));
 	}
 }
 
@@ -283,6 +296,9 @@ void EditorNetworkProfiler::add_sync_frame_data(const SyncInfo &p_frame) {
 }
 
 void EditorNetworkProfiler::set_bandwidth(int p_incoming, int p_outgoing) {
+	incoming_bandwidth = p_incoming;
+	outgoing_bandwidth = p_outgoing;
+
 	incoming_bandwidth_text->set_text(vformat(TTR("%s/s"), String::humanize_size(p_incoming)));
 	outgoing_bandwidth_text->set_text(vformat(TTR("%s/s"), String::humanize_size(p_outgoing)));
 
@@ -307,19 +323,19 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 
 	activate = memnew(Button);
 	activate->set_toggle_mode(true);
-	activate->set_text(TTR("Start"));
+	activate->set_text(TTRC("Start"));
 	activate->set_disabled(true);
 	activate->connect(SceneStringName(pressed), callable_mp(this, &EditorNetworkProfiler::_activate_pressed));
 	container->add_child(activate);
 
 	clear_button = memnew(Button);
-	clear_button->set_text(TTR("Clear"));
+	clear_button->set_text(TTRC("Clear"));
 	clear_button->set_disabled(true);
 	clear_button->connect(SceneStringName(pressed), callable_mp(this, &EditorNetworkProfiler::_clear_pressed));
 	container->add_child(clear_button);
 
 	CheckBox *autostart_checkbox = memnew(CheckBox);
-	autostart_checkbox->set_text(TTR("Autostart"));
+	autostart_checkbox->set_text(TTRC("Autostart"));
 	autostart_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "autostart_network_profiler", false));
 	autostart_checkbox->connect(SceneStringName(toggled), callable_mp(this, &EditorNetworkProfiler::_autostart_toggled));
 	container->add_child(autostart_checkbox);
@@ -332,11 +348,10 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
 	container->add_child(hb);
 
-	Label *lb = memnew(Label);
-	// TRANSLATORS: This is the label for the network profiler's incoming bandwidth.
-	lb->set_focus_mode(FOCUS_ACCESSIBILITY);
-	lb->set_text(TTR("Down", "Network"));
-	hb->add_child(lb);
+	down_label = memnew(Label);
+	down_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	down_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	hb->add_child(down_label);
 
 	incoming_bandwidth_text = memnew(LineEdit);
 	incoming_bandwidth_text->set_editable(false);
@@ -349,11 +364,10 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	down_up_spacer->set_custom_minimum_size(Size2(30, 0) * EDSCALE);
 	hb->add_child(down_up_spacer);
 
-	lb = memnew(Label);
-	// TRANSLATORS: This is the label for the network profiler's outgoing bandwidth.
-	lb->set_focus_mode(FOCUS_ACCESSIBILITY);
-	lb->set_text(TTR("Up", "Network"));
-	hb->add_child(lb);
+	up_label = memnew(Label);
+	up_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+	up_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	hb->add_child(up_label);
 
 	outgoing_bandwidth_text = memnew(LineEdit);
 	outgoing_bandwidth_text->set_editable(false);
@@ -361,9 +375,6 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	outgoing_bandwidth_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	outgoing_bandwidth_text->set_accessibility_name(TTRC("Outgoing Bandwidth"));
 	hb->add_child(outgoing_bandwidth_text);
-
-	// Set initial texts in the incoming/outgoing bandwidth labels
-	set_bandwidth(0, 0);
 
 	HSplitContainer *sc = memnew(HSplitContainer);
 	add_child(sc);
@@ -380,15 +391,15 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	counters_display->set_hide_root(true);
 	counters_display->set_columns(3);
 	counters_display->set_column_titles_visible(true);
-	counters_display->set_column_title(0, TTR("Node"));
+	counters_display->set_column_title(0, TTRC("Node"));
 	counters_display->set_column_expand(0, true);
 	counters_display->set_column_clip_content(0, true);
 	counters_display->set_column_custom_minimum_width(0, 60 * EDSCALE);
-	counters_display->set_column_title(1, TTR("Incoming RPC"));
+	counters_display->set_column_title(1, TTRC("Incoming RPC"));
 	counters_display->set_column_expand(1, false);
 	counters_display->set_column_clip_content(1, true);
 	counters_display->set_column_custom_minimum_width(1, 120 * EDSCALE);
-	counters_display->set_column_title(2, TTR("Outgoing RPC"));
+	counters_display->set_column_title(2, TTRC("Outgoing RPC"));
 	counters_display->set_column_expand(2, false);
 	counters_display->set_column_clip_content(2, true);
 	counters_display->set_column_custom_minimum_width(2, 120 * EDSCALE);
@@ -403,23 +414,23 @@ EditorNetworkProfiler::EditorNetworkProfiler() {
 	replication_display->set_hide_root(true);
 	replication_display->set_columns(5);
 	replication_display->set_column_titles_visible(true);
-	replication_display->set_column_title(0, TTR("Root"));
+	replication_display->set_column_title(0, TTRC("Root"));
 	replication_display->set_column_expand(0, true);
 	replication_display->set_column_clip_content(0, true);
 	replication_display->set_column_custom_minimum_width(0, 80 * EDSCALE);
-	replication_display->set_column_title(1, TTR("Synchronizer"));
+	replication_display->set_column_title(1, TTRC("Synchronizer"));
 	replication_display->set_column_expand(1, true);
 	replication_display->set_column_clip_content(1, true);
 	replication_display->set_column_custom_minimum_width(1, 80 * EDSCALE);
-	replication_display->set_column_title(2, TTR("Config"));
+	replication_display->set_column_title(2, TTRC("Config"));
 	replication_display->set_column_expand(2, true);
 	replication_display->set_column_clip_content(2, true);
 	replication_display->set_column_custom_minimum_width(2, 80 * EDSCALE);
-	replication_display->set_column_title(3, TTR("Count"));
+	replication_display->set_column_title(3, TTRC("Count"));
 	replication_display->set_column_expand(3, false);
 	replication_display->set_column_clip_content(3, true);
 	replication_display->set_column_custom_minimum_width(3, 80 * EDSCALE);
-	replication_display->set_column_title(4, TTR("Size"));
+	replication_display->set_column_title(4, TTRC("Size"));
 	replication_display->set_column_expand(4, false);
 	replication_display->set_column_clip_content(4, true);
 	replication_display->set_column_custom_minimum_width(4, 80 * EDSCALE);

--- a/modules/multiplayer/editor/editor_network_profiler.h
+++ b/modules/multiplayer/editor/editor_network_profiler.h
@@ -70,6 +70,12 @@ private:
 	LineEdit *outgoing_bandwidth_text = nullptr;
 	Tree *replication_display = nullptr;
 
+	Label *up_label = nullptr;
+	Label *down_label = nullptr;
+
+	int incoming_bandwidth = 0;
+	int outgoing_bandwidth = 0;
+
 	HashMap<ObjectID, RPCNodeInfo> rpc_data;
 	HashMap<ObjectID, SyncInfo> sync_data;
 	HashMap<ObjectID, NodeInfo> node_data;

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -105,7 +105,7 @@ void MultiplayerEditorDebugger::setup_session(int p_session_id) {
 	EditorNetworkProfiler *profiler = memnew(EditorNetworkProfiler);
 	profiler->connect("enable_profiling", callable_mp(this, &MultiplayerEditorDebugger::_profiler_activate).bind(p_session_id));
 	profiler->connect("open_request", callable_mp(this, &MultiplayerEditorDebugger::_open_request));
-	profiler->set_name(TTR("Network Profiler"));
+	profiler->set_name(TTRC("Network Profiler"));
 	session->connect("started", callable_mp(profiler, &EditorNetworkProfiler::started));
 	session->connect("stopped", callable_mp(profiler, &EditorNetworkProfiler::stopped));
 	session->add_session_tab(profiler);


### PR DESCRIPTION
Part of #104574

Handles everything in Debugger bottom panel, except some stuff coming from message callbacks (not worth the effort, and I think these strings are temporary anyway).