### PR TITLE
Fix issue with array comparison reference

### DIFF
--- a/core/templates/sort_array.h
+++ b/core/templates/sort_array.h
@@ -168,17 +168,17 @@ public:
 	inline int64_t partitioner(int64_t p_first, int64_t p_last, int64_t p_pivot, T *p_array) const {
 		const int64_t unmodified_first = p_first;
 		const int64_t unmodified_last = p_last;
-		const T &pivot_element = p_array[p_pivot];
+		const T *pivot_element_location = &p_array[p_pivot];
 
 		while (true) {
-			while (p_first != p_pivot && compare(p_array[p_first], pivot_element)) {
+			while (p_first != p_pivot && compare(p_array[p_first], *pivot_element_location)) {
 				if constexpr (Validate) {
 					ERR_BAD_COMPARE(p_first == unmodified_last - 1);
 				}
 				p_first++;
 			}
 			p_last--;
-			while (p_last != p_pivot && compare(pivot_element, p_array[p_last])) {
+			while (p_last != p_pivot && compare(*pivot_element_location, p_array[p_last])) {
 				if constexpr (Validate) {
 					ERR_BAD_COMPARE(p_last == unmodified_first);
 				}
@@ -189,6 +189,11 @@ public:
 				return p_first;
 			}
 
+			if (pivot_element_location == &p_array[p_first]) {
+				pivot_element_location = &p_array[p_last];
+			} else if (pivot_element_location == &p_array[p_last]) {
+				pivot_element_location = &p_array[p_first];
+			}
 			SWAP(p_array[p_first], p_array[p_last]);
 			p_first++;
 		}


### PR DESCRIPTION
Fixes #108435.

Using a const reference here seems reasonable at a glance, but there's actually a swap operation that can happen in the loop body that causes the partitioning to be incorrect. This doesn't seem to actually cause incorrectness in practice, because there's a final insertion sort pass, but it does degrade the sort's performance as a result.

This was originally not a const reference before #106661, so this isn't introducing anything new, just fixing it to match the old behavior.

As a bit more proof, here's a HotSpot flamegraph for 108435:
![image](https://github.com/user-attachments/assets/7519b60f-5648-4ad3-88ae-ed1f813e9381)
The large SortArray blocks are all in the `final_insertion_sort`, which ends up needing to sort the array itself.