### PR TITLE
Remove an unnecessary include of main/ code from core/

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -36,10 +36,6 @@
 #include "core/os/os.h"
 #include "core/string/locales.h"
 
-#ifdef TOOLS_ENABLED
-#include "main/main.h"
-#endif
-
 Vector<TranslationServer::LocaleScriptInfo> TranslationServer::locale_script_info;
 
 HashMap<String, String> TranslationServer::language_map;


### PR DESCRIPTION
Code in core/ generally should not depend on code from main/

This include was added in #41100 in order to call `Main::is_project_manager()`.
The `is_project_manager()` check was later removed in #52742 but this include was never cleaned up.

This clean-up is related to #108429.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
