### PR TITLE
Add CharacterBody2D side detection methods against walls

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -135,6 +135,18 @@
 				Returns [code]true[/code] if the body collided only with a wall on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code]. The [member up_direction] and [member floor_max_angle] are used to determine whether a surface is "wall" or not.
 			</description>
 		</method>
+		<method name="is_on_wall_from_left" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body's left side collided with a wall on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code]. The [member up_direction] and [member floor_max_angle] are used to determine whether a surface is "wall" or not.
+			</description>
+		</method>
+		<method name="is_on_wall_from_right" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the body's right side collided with a wall on the last call of [method move_and_slide]. Otherwise, returns [code]false[/code]. The [member up_direction] and [member floor_max_angle] are used to determine whether a surface is "wall" or not.
+			</description>
+		</method>
 		<method name="move_and_slide">
 			<return type="bool" />
 			<description>

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -446,6 +446,14 @@ bool CharacterBody2D::is_on_wall_only() const {
 	return on_wall && !on_floor && !on_ceiling;
 }
 
+bool CharacterBody2D::is_on_wall_from_left() const {
+	return on_wall && wall_normal.cross(up_direction) < 0;
+}
+
+bool CharacterBody2D::is_on_wall_from_right() const {
+	return on_wall && wall_normal.cross(up_direction) > 0;
+}
+
 bool CharacterBody2D::is_on_ceiling() const {
 	return on_ceiling;
 }
@@ -704,6 +712,8 @@ void CharacterBody2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_on_ceiling_only"), &CharacterBody2D::is_on_ceiling_only);
 	ClassDB::bind_method(D_METHOD("is_on_wall"), &CharacterBody2D::is_on_wall);
 	ClassDB::bind_method(D_METHOD("is_on_wall_only"), &CharacterBody2D::is_on_wall_only);
+	ClassDB::bind_method(D_METHOD("is_on_wall_from_left"), &CharacterBody2D::is_on_wall_from_left);
+	ClassDB::bind_method(D_METHOD("is_on_wall_from_right"), &CharacterBody2D::is_on_wall_from_right);
 	ClassDB::bind_method(D_METHOD("get_floor_normal"), &CharacterBody2D::get_floor_normal);
 	ClassDB::bind_method(D_METHOD("get_wall_normal"), &CharacterBody2D::get_wall_normal);
 	ClassDB::bind_method(D_METHOD("get_last_motion"), &CharacterBody2D::get_last_motion);

--- a/scene/2d/physics/character_body_2d.h
+++ b/scene/2d/physics/character_body_2d.h
@@ -56,6 +56,8 @@ public:
 	bool is_on_floor_only() const;
 	bool is_on_wall() const;
 	bool is_on_wall_only() const;
+	bool is_on_wall_from_left() const;
+	bool is_on_wall_from_right() const;
 	bool is_on_ceiling() const;
 	bool is_on_ceiling_only() const;
 	const Vector2 &get_last_motion() const;


### PR DESCRIPTION
## Summary
- Add `is_on_wall_from_left()` method to detect left-side body collisions against walls
- Add `is_on_wall_from_right()` method to detect right-side body collisions against walls
- Include complete XML documentation for both methods

## Implementation Details
- Uses cross product of `wall_normal` and `up_direction` for directional detection
- Integrates with existing `on_wall`, `up_direction`, and `floor_max_angle` system
- Methods return `false` when not touching any wall

## Files Modified
- `scene/2d/physics/character_body_2d.h` - Method declarations
- `scene/2d/physics/character_body_2d.cpp` - Implementation and GDScript bindings
- `doc/classes/CharacterBody2D.xml` - Complete documentation

## Use Cases
- Side-specific collision responses
- Enhanced platformer & top view controls

## Testing
- Cross product logic verified for proper left/right detection
- Builds successfully with `scons platform=linuxbsd target=editor`
- Documentation follows existing CharacterBody2D patterns