### PR TITLE
CI: Generate debug build for Android

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -26,14 +26,14 @@ jobs:
               arch=arm64
               production=yes
 
-          - name: Template arm32 (target=template_release, arch=arm32)
+          - name: Template arm32 (target=template_debug, arch=arm32)
             cache-name: android-template-arm32
-            target: template_release
+            target: template_debug
             scons-flags: arch=arm32
 
-          - name: Template arm64 (target=template_release, arch=arm64)
+          - name: Template arm64 (target=template_debug, arch=arm64)
             cache-name: android-template-arm64
-            target: template_release
+            target: template_debug
             scons-flags: arch=arm64
 
     steps:
@@ -82,7 +82,7 @@ jobs:
         continue-on-error: true
 
       - name: Generate Godot templates
-        if: matrix.target == 'template_release'
+        if: matrix.target == 'template_debug'
         run: |
           cd platform/android/java
           ./gradlew generateGodotTemplates


### PR DESCRIPTION
Currently, the CI generates release builds that include only the release version of the godot-lib aar file. This causes Gradle errors when a user tries to export a debug build, as the required debug AAR is missing. See https://github.com/godotengine/godot/issues/108438#issuecomment-3053751953

These CI artifacts are primarily used for testing and debugging, so this PR updates the workflow file to generate debug builds instead.