### PR TITLE
Make file part of errors/warnings clickable in Output panel

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -33,11 +33,14 @@
 #include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
 #include "core/version.h"
+#include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/file_system/editor_paths.h"
+#include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "modules/regex/regex.h"
 #include "scene/gui/separator.h"
 #include "scene/resources/font.h"
 
@@ -46,9 +49,9 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 
 	String err_str;
 	if (p_errorexp && p_errorexp[0]) {
-		err_str = String::utf8(p_errorexp);
+		err_str = String::utf8(p_errorexp).replace("[", "[lb]");
 	} else {
-		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error);
+		err_str = vformat("[url]%s:%d[/url] - %s", String::utf8(p_file).replace("[", "[lb]"), p_line, String::utf8(p_error).replace("[", "[lb]"));
 	}
 
 	MessageType message_type = p_type == ERR_HANDLER_WARNING ? MSG_TYPE_WARNING : MSG_TYPE_ERROR;
@@ -196,7 +199,23 @@ void EditorLog::_load_state() {
 }
 
 void EditorLog::_meta_clicked(const String &p_meta) {
-	OS::get_singleton()->shell_open(p_meta);
+	Ref<RegExMatch> uri_match = RegEx(R"(^([a-zA-Z][a-zA-Z0-9+.-]*):(?://)?(.+?)(?::([0-9]+))?$)").search(p_meta);
+	if (uri_match.is_null()) {
+		return;
+	}
+
+	String scheme = uri_match->get_string(1);
+	if (scheme == "res") {
+		String file = uri_match->get_string(2);
+		int line = (int)uri_match->get_string(3).to_int();
+		if (ResourceLoader::exists(file)) {
+			Ref<Resource> res = ResourceLoader::load(file);
+			ScriptEditor::get_singleton()->edit(res, line - 1, 0);
+			InspectorDock::get_singleton()->edit_resource(res);
+		}
+	} else {
+		OS::get_singleton()->shell_open(p_meta);
+	}
 }
 
 void EditorLog::_clear_request() {
@@ -384,7 +403,8 @@ void EditorLog::_add_log_line(LogMessage &p_message, bool p_replace_previous) {
 		log->pop();
 	}
 
-	if (p_message.type == MSG_TYPE_STD_RICH) {
+	// Note that errors and warnings only support BBCode in the file part of the message.
+	if (p_message.type == MSG_TYPE_STD_RICH || p_message.type == MSG_TYPE_ERROR || p_message.type == MSG_TYPE_WARNING) {
 		log->append_text(p_message.text);
 	} else {
 		log->add_text(p_message.text);


### PR DESCRIPTION
Fixes godotengine/godot-proposals#1628.
Fixes godotengine/godot-proposals#10000.
Relates to #57896.
Relates to #87216.

This makes the file and line part of error messages in the Output panel clickable, by simply wrapping both in a `[url]` BBCode tag, parsing those URIs in `EditorLog::_meta_clicked` and then opening the file in much the same way as the editor normally would, either in the built-in script editor or external editor, depending on the user's editor settings.

This PR takes a more conservative approach compared to #57896, by not trying to find every possible URL in the log and instead only concerning itself with the thing we already know is a file path, which saves us from any costly/error-prone parsing of the log itself.

One potentially controversial change here is that `EditorLog::_meta_clicked` will now early-out if it gets passed an invalid URI, meaning anything that doesn't start with something like `res:`, `file:`, `mailto:` or whatever else. The reason for this being that errors/warnings emitted from C++ will include relative file paths (e.g. `editor/editor_log.cpp:201`) which I couldn't see an easy way to deal with, and forwarding those to `OS::shell_open` will typically open the user's browser at that (bogus) path, so I opted to have it do nothing instead.

We could of course just not wrap the relative C++ paths in `[url]` to begin with, but again, I wanted to avoid any type of costly/error-prone parsing during logging if possible.

I'm happy to change it back to default to `OS::shell_open` for all non-URIs, but I figure since the express intent of #87216 was to allow for things like `file:` and `mailto:` then this behavior might be desirable anyway.

---

**Contributed by [W4 Games](https://w4games.com)** 🍀