### PR TITLE
Fix lingering grid from TileMapLayer editor

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3667,6 +3667,12 @@ void TileMapLayerEditor::_notification(int p_what) {
 			get_tree()->disconnect("node_removed", callable_mp(this, &TileMapLayerEditor::_node_change));
 		} break;
 
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (custom_overlay) {
+				custom_overlay->set_visible(is_visible_in_tree());
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			missing_tile_texture = get_editor_theme_icon(SNAME("StatusWarning"));
 			warning_pattern_texture = get_editor_theme_icon(SNAME("WarningPattern"));


### PR DESCRIPTION
Fixes regression from #107001

The grid would sometimes stay permanently after TileMapLayer is deselected. The easiest way to reproduce is selecting TileMapLayer and pressing Ctrl+J. The editor closes, but the grid stays.