### PR TITLE
Fix export path "leaking" between presets

### DIFF
--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -280,6 +280,7 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 		extension_vector.push_back("*." + extension);
 	}
 
+	export_path->get_path_edit()->clear();
 	export_path->setup(extension_vector, false, true, false);
 	export_path->update_property();
 	advanced_options->set_disabled(false);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -184,6 +184,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	LineEdit *get_path_edit() const { return path; }
+
 	void setup(const Vector<String> &p_extensions, bool p_folder, bool p_global, bool p_enable_uid);
 	void set_save_mode();
 	virtual void update_property() override;


### PR DESCRIPTION
When you undo export path field, it may restore path from another preset.

https://github.com/user-attachments/assets/044a8d8d-3b49-4741-92d1-9d2e6f7c0e76

