### PR TITLE
Make editor property clipboard static

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1337,10 +1337,10 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 void EditorProperty::menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_COPY_VALUE: {
-			InspectorDock::get_inspector_singleton()->set_property_clipboard(object->get(property));
+			EditorInspector::set_property_clipboard(object->get(property));
 		} break;
 		case MENU_PASTE_VALUE: {
-			emit_changed(property, InspectorDock::get_inspector_singleton()->get_property_clipboard());
+			emit_changed(property, EditorInspector::get_property_clipboard());
 		} break;
 		case MENU_COPY_PROPERTY_PATH: {
 			DisplayServer::get_singleton()->clipboard_set(property_path);
@@ -5614,7 +5614,7 @@ void EditorInspector::set_property_clipboard(const Variant &p_value) {
 	property_clipboard = p_value;
 }
 
-Variant EditorInspector::get_property_clipboard() const {
+Variant EditorInspector::get_property_clipboard() {
 	return property_clipboard;
 }
 
@@ -5726,7 +5726,6 @@ EditorInspector::EditorInspector() {
 	set_process(false);
 	set_focus_mode(FocusMode::FOCUS_ALL);
 	property_focusable = -1;
-	property_clipboard = Variant();
 
 	get_v_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &EditorInspector::_vscroll_changed));
 	update_scroll_request = -1;

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -38,14 +38,12 @@
 
 class AddMetadataDialog;
 class AcceptDialog;
-class ConfirmationDialog;
 class EditorInspector;
 class EditorValidationPanel;
 class HSeparator;
 class LineEdit;
 class MarginContainer;
 class OptionButton;
-class PanelContainer;
 class PopupMenu;
 class SpinBox;
 class StyleBoxFlat;
@@ -715,7 +713,8 @@ class EditorInspector : public ScrollContainer {
 
 	String property_prefix; // Used for sectioned inspector.
 	String object_class;
-	Variant property_clipboard;
+
+	static inline Variant property_clipboard;
 
 	bool restrict_to_basic = false;
 
@@ -783,6 +782,9 @@ public:
 	static void initialize_section_theme(EditorInspectorSection::ThemeCache &p_cache, Control *p_control);
 	static void initialize_category_theme(EditorInspectorCategory::ThemeCache &p_cache, Control *p_control);
 
+	static void set_property_clipboard(const Variant &p_value);
+	static Variant get_property_clipboard();
+
 	bool is_main_editor_inspector() const;
 	String get_selected_path() const;
 
@@ -839,8 +841,6 @@ public:
 	void set_use_deletable_properties(bool p_enabled);
 
 	void set_restrict_to_basic_settings(bool p_restrict);
-	void set_property_clipboard(const Variant &p_value);
-	Variant get_property_clipboard() const;
 
 	EditorInspector();
 };

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -34,6 +34,7 @@
 
 class CheckBox;
 class ColorPickerButton;
+class ConfirmationDialog;
 class CreateDialog;
 class EditorFileDialog;
 class EditorLocaleDialog;
@@ -41,7 +42,6 @@ class EditorResourcePicker;
 class EditorSpinSlider;
 class EditorVariantTypePopupMenu;
 class MenuButton;
-class PropertySelector;
 class SceneTreeDialog;
 class TextEdit;
 class TextureButton;


### PR DESCRIPTION
In the inspector, the Copy/Paste Value feature in a property's context menu is implemented via an internal property clipboard. This is because the value copied is a Variant instead of a simple string.

Currently each `EditorInspector` instance has a property clipboard. However, it is always the property clipboard of the Inspector dock's instance that is used by the copy/paste feature for all properties. This usage is necessary because we need to support pasting across different `EditorInspector` instances.

This PR makes the property clipboard a static member of `EditorInspector`.