### PR TITLE
[.NET] Remove EFS update on reloading assemblies

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ScriptManagerBridge.cs
@@ -355,17 +355,6 @@ namespace Godot.Bridge
                     }
                 }
             }
-
-            // This method may be called before initialization.
-            if (NativeFuncs.godotsharp_dotnet_module_is_initialized().ToBool() && Engine.IsEditorHint())
-            {
-                if (_pathTypeBiMap.Paths.Count > 0)
-                {
-                    string[] scriptPaths = _pathTypeBiMap.Paths.ToArray();
-                    using godot_packed_string_array scriptPathsNative = Marshaling.ConvertSystemArrayToNativePackedStringArray(scriptPaths);
-                    NativeFuncs.godotsharp_internal_editor_file_system_update_files(scriptPathsNative);
-                }
-            }
         }
 
         [UnmanagedCallersOnly]


### PR DESCRIPTION
Updating the files at this point is too early, the scripts haven't been updated yet so their type info is empty.

It looks like EFS is updated anyway without doing it explicitly in `LookupScriptsInAssembly`, and it happens after the scripts have updated their info. So this code seems unnecessary.

However, we may want to test thoroughly that it doesn't break C# global classes when reloading assemblies.

- Fixes https://github.com/godotengine/godot/issues/104052