### PR TITLE
SceneTree List cleanup

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1586,13 +1586,14 @@ void SceneTree::get_nodes_in_group(const StringName &p_group, List<Node *> *p_li
 void SceneTree::_flush_delete_queue() {
 	_THREAD_SAFE_METHOD_
 
-	while (delete_queue.size()) {
-		Object *obj = ObjectDB::get_instance(delete_queue.front()->get());
+	for (const ObjectID &id : delete_queue) {
+		Object *obj = ObjectDB::get_instance(id);
 		if (obj) {
 			memdelete(obj);
 		}
-		delete_queue.pop_front();
 	}
+
+	delete_queue.clear();
 }
 
 void SceneTree::queue_delete(Object *p_object) {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -183,7 +183,7 @@ private:
 	int nodes_removed_on_group_call_lock = 0;
 	HashSet<Node *> nodes_removed_on_group_call; // Skip erased nodes.
 
-	List<ObjectID> delete_queue;
+	LocalVector<ObjectID> delete_queue;
 
 	uint64_t accessibility_upd_per_sec = 0;
 	bool accessibility_force_update = true;


### PR DESCRIPTION
Changes ~~tweens, timers, and~~ `delete_queue` in the SceneTree class to use a LocalVector instead of a List.

~~For `tweens` and `timers` there might have been some reasoning in using a List because the erase operation would be faster than a Vector. However, since the order of the List doesn't actually matter with how these are used I figured that iterating the Vector in reverse and using remove_at_unordered would make the removal just as fast as the List since it doesn't have to shift around all the element on every deletion.~~ Edit: Tweens and timers ended up needing to be a List.

`delete_queue` was more straightforward I didn't have to change much there to make it work other than clearing the queue after freeing all the memory instead of removing at each element in the loop.

Im not sure how to do an accurate performance benchmark for this, but it's the same idea that worked well in a previous PR I made: https://github.com/godotengine/godot/pull/105700 so it should have similar benefits since the only usage of these is iterating over them, which should be faster for a Vector than a List.

I tested on 5 different demo projects and everything seems to be working the same still with no issues. I also tried to make some tweens and timers and everything is still working there too.

If this looks good I saw some more List usage in the SceneTree I want to cleanup but want to do in a separate PRs since it will have to touch a lot more files.
I want to make SceneTree::get_nodes_in_group return a Vector instead of having to pass in a List, this will make it faster and simplify the bindings.
I also think the xform_change_list can do the same things it does now as a Vector, but it would require a slightly different interface that works just like the delete_queue interface but it seems doable.