### PR TITLE
Correct ShapeCast collision_result doc

### DIFF
--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -140,7 +140,7 @@
 			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="collision_result" type="Array" setter="" getter="get_collision_result" default="[]">
-			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method PhysicsDirectSpaceState2D.get_rest_info] method.
+			Returns the complete collision information from the collision sweep. The resulting array contains a list of dictionaries, one for each collision. Each element includes all fields from the [method PhysicsDirectSpaceState2D.get_rest_info] method with a [code]collider[/code] field for the object associated with the [code]collider_id[/code], using [method @GlobalScope.instance_from_id].
 		</member>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			If [code]true[/code], collisions will be reported.

--- a/doc/classes/ShapeCast3D.xml
+++ b/doc/classes/ShapeCast3D.xml
@@ -147,7 +147,7 @@
 			The shape's collision mask. Only objects in at least one collision layer enabled in the mask will be detected. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
 		</member>
 		<member name="collision_result" type="Array" setter="" getter="get_collision_result" default="[]">
-			Returns the complete collision information from the collision sweep. The data returned is the same as in the [method PhysicsDirectSpaceState3D.get_rest_info] method.
+			Returns the complete collision information from the collision sweep. The resulting array contains a list of dictionaries, one for each collision. Each element includes all fields from the [method PhysicsDirectSpaceState3D.get_rest_info] method with a [code]collider[/code] field for the object associated with the [code]collider_id[/code], using [method @GlobalScope.instance_from_id].
 		</member>
 		<member name="debug_shape_custom_color" type="Color" setter="set_debug_shape_custom_color" getter="get_debug_shape_custom_color" default="Color(0, 0, 0, 1)">
 			The custom color to use to draw the shape in the editor and at run-time if [b]Visible Collision Shapes[/b] is enabled in the [b]Debug[/b] menu. This color will be highlighted at run-time if the [ShapeCast3D] is colliding with something.


### PR DESCRIPTION
This would close the following godot-docs issue: https://github.com/godotengine/godot-docs/issues/9737

## Current Documentation

[Shapecast3D.collision_result](https://docs.godotengine.org/en/3.6/classes/class_shapecast.html#class-shapecast-property-collision-result) claims it returns data the same as `PhysicsDirectSpaceState3D.get_rest_info()`

## Problem

Checking Godot's Core I can see it returns an **additional** collider field: 
https://github.com/godotengine/godot/blob/d7cc121e6469d0d998bf214e3a87e37961e6f1bb/scene/3d/physics/shape_cast_3d.cpp#L477-L495

This is the same for Shapecast2d: 
https://github.com/godotengine/godot/blob/d7cc121e6469d0d998bf214e3a87e37961e6f1bb/scene/2d/physics/shape_cast_2d.cpp#L384-L402

## What This PR Adds

This PR appends to the documentation string to mention this additional field for both ShapeCast2D and ShapeCast3D.

