### PR TITLE
Fix sphere gizmo handle position

### DIFF
--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -396,7 +396,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(points, material, false, collision_color);
 		p_gizmo->add_collision_segments(points);
 		Vector<Vector3> handles;
-		handles.push_back(Vector3(r, 0, 0));
+		handles.push_back(Vector3(radius, 0, 0));
 		p_gizmo->add_handles(handles, handles_material);
 	}
 


### PR DESCRIPTION
Fixes #108490.

The use of `r` was changed in #103910, so this use to calculate the handles needs to be updated to use `radius`, instead.