### PR TITLE
Document some deadlocks in the physics server code

### DIFF
--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -136,6 +136,10 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 		return;
 	}
 
+	// TODO: calling RenderingServer::mesh_surface_get_arrays() from the physics thread
+	// is not safe and can deadlock when physics/3d/run_on_separate_thread is enabled.
+	// This method blocks on the main thread to return data, but the main thread may be
+	// blocked waiting on us in PhysicsServer3D::sync().
 	Array arrays = RenderingServer::get_singleton()->mesh_surface_get_arrays(soft_mesh, 0);
 	ERR_FAIL_COND(arrays.is_empty());
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -128,6 +128,10 @@ bool JoltSoftBody3D::_ref_shared_data() {
 	if (iter_shared_data == mesh_to_shared.end()) {
 		RenderingServer *rendering = RenderingServer::get_singleton();
 
+		// TODO: calling RenderingServer::mesh_surface_get_arrays() from the physics thread
+		// is not safe and can deadlock when physics/3d/run_on_separate_thread is enabled.
+		// This method blocks on the main thread to return data, but the main thread may be
+		// blocked waiting on us in PhysicsServer3D::sync().
 		const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
 		ERR_FAIL_COND_V(mesh_data.is_empty(), false);
 


### PR DESCRIPTION
Add some comments documenting locations where `PhysicsServer3D::soft_body_set_mesh()` can deadlock.

godotengine/godot-proposals#12670 has a proposal for some alternate thread-safe soft body APIs.  In the meantime it seems worth at least documenting some of the current pitfalls in the code.

Note that most people typically won't run into this deadlock today because they will crash in `PhysicsServer3D::soft_body_update_rendering_server()` first if trying to use SoftBody3D with a separate physics thread.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
