### PR TITLE
Avoid unnecessary copy in `ClassDB::get_property_list`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1542,13 +1542,9 @@ void ClassDB::get_property_list(const StringName &p_class, List<PropertyInfo> *p
 	ClassInfo *check = type;
 	while (check) {
 		for (const PropertyInfo &pi : check->property_list) {
+			p_list->push_back(pi);
 			if (p_validator) {
-				// Making a copy as we may modify it.
-				PropertyInfo pi_mut = pi;
-				p_validator->validate_property(pi_mut);
-				p_list->push_back(pi_mut);
-			} else {
-				p_list->push_back(pi);
+				p_validator->validate_property(p_list->back()->get());
 			}
 		}
 


### PR DESCRIPTION
I was poking around the Alloc > Duplicate benchmark and noticed that there's an unnecessary copy happening in `ClassDB::get_property_list`. `validate_property` must be run on a copy of the `PropertyInfo`, but a copy has to be made during `push_back` anyways, so we can rearrange things a bit and only perform one copy instead of two.

I ran the Alloc > Duplicate benchmark nine times for each and dropped the top two and bottom two of each:
```
optimize-duplicate
------------------------------
Running benchmark: C++/Alloc/duplicate
Result: {"time":4387.0}
Result: {"time":4422.0}
Result: {"time":4426.0}
Result: {"time":4432.0}
Result: {"time":4443.0}

master
------------------------------
Running benchmark: C++/Alloc/duplicate
Result: {"time":4704.0}
Result: {"time":4710.0}
Result: {"time":4730.0}
Result: {"time":4736.0}
Result: {"time":4764.0}
```

It's only a ~6.5% speedup, but it's a pretty core function so it seemed worth a PR.