### PR TITLE
Add missing OpenXR paths to /user/vive_tracker_htcx

### DIFF
--- a/modules/openxr/action_map/openxr_action_map.cpp
+++ b/modules/openxr/action_map/openxr_action_map.cpp
@@ -227,6 +227,10 @@ void OpenXRActionMap::create_default_action_sets() {
 			"/user/vive_tracker_htcx/role/chest,"
 			"/user/vive_tracker_htcx/role/camera,"
 			"/user/vive_tracker_htcx/role/keyboard,"
+			"/user/vive_tracker_htcx/role/left_wrist,"
+			"/user/vive_tracker_htcx/role/right_wrist,"
+			"/user/vive_tracker_htcx/role/left_ankle,"
+			"/user/vive_tracker_htcx/role/right_ankle,"
 			"/user/eyes_ext");
 	Ref<OpenXRAction> aim_pose = action_set->add_new_action("aim_pose", "Aim pose", OpenXRAction::OPENXR_ACTION_POSE, "/user/hand/left,/user/hand/right");
 	Ref<OpenXRAction> grip_pose = action_set->add_new_action("grip_pose", "Grip pose", OpenXRAction::OPENXR_ACTION_POSE, "/user/hand/left,/user/hand/right");
@@ -246,7 +250,11 @@ void OpenXRActionMap::create_default_action_sets() {
 			"/user/vive_tracker_htcx/role/waist,"
 			"/user/vive_tracker_htcx/role/chest,"
 			"/user/vive_tracker_htcx/role/camera,"
-			"/user/vive_tracker_htcx/role/keyboard");
+			"/user/vive_tracker_htcx/role/keyboard,"
+			"/user/vive_tracker_htcx/role/left_wrist,"
+			"/user/vive_tracker_htcx/role/right_wrist,"
+			"/user/vive_tracker_htcx/role/left_ankle,"
+			"/user/vive_tracker_htcx/role/right_ankle");
 
 	// Create our interaction profiles.
 	Ref<OpenXRInteractionProfile> profile = OpenXRInteractionProfile::new_profile("/interaction_profiles/khr/simple_controller");
@@ -508,7 +516,11 @@ void OpenXRActionMap::create_default_action_sets() {
 			"/user/vive_tracker_htcx/role/waist/input/grip/pose,"
 			"/user/vive_tracker_htcx/role/chest/input/grip/pose,"
 			"/user/vive_tracker_htcx/role/camera/input/grip/pose,"
-			"/user/vive_tracker_htcx/role/keyboard/input/grip/pose");
+			"/user/vive_tracker_htcx/role/keyboard/input/grip/pose,"
+			"/user/vive_tracker_htcx/role/left_wrist/input/grip/pose,"
+			"/user/vive_tracker_htcx/role/right_wrist/input/grip/pose,"
+			"/user/vive_tracker_htcx/role/left_ankle/input/grip/pose,"
+			"/user/vive_tracker_htcx/role/right_ankle/input/grip/pose");
 	profile->add_new_binding(haptic,
 			// "/user/vive_tracker_htcx/role/handheld_object/output/haptic," <-- getting errors on this one.
 			"/user/vive_tracker_htcx/role/left_foot/output/haptic,"
@@ -522,7 +534,11 @@ void OpenXRActionMap::create_default_action_sets() {
 			"/user/vive_tracker_htcx/role/waist/output/haptic,"
 			"/user/vive_tracker_htcx/role/chest/output/haptic,"
 			"/user/vive_tracker_htcx/role/camera/output/haptic,"
-			"/user/vive_tracker_htcx/role/keyboard/output/haptic");
+			"/user/vive_tracker_htcx/role/keyboard/output/haptic,"
+			"/user/vive_tracker_htcx/role/left_wrist/output/haptic,"
+			"/user/vive_tracker_htcx/role/right_wrist/output/haptic,"
+			"/user/vive_tracker_htcx/role/left_ankle/output/haptic,"
+			"/user/vive_tracker_htcx/role/right_ankle/output/haptic");
 	add_interaction_profile(profile);
 
 	// Create our eye gaze interaction profile.

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
@@ -57,6 +57,10 @@ PackedStringArray OpenXRHTCViveTrackerExtension::get_suggested_tracker_names() {
 		"/user/vive_tracker_htcx/role/chest",
 		"/user/vive_tracker_htcx/role/camera",
 		"/user/vive_tracker_htcx/role/keyboard",
+		"/user/vive_tracker_htcx/role/left_wrist",
+		"/user/vive_tracker_htcx/role/right_wrist",
+		"/user/vive_tracker_htcx/role/left_ankle",
+		"/user/vive_tracker_htcx/role/right_ankle",
 	};
 	return arr;
 }
@@ -82,6 +86,10 @@ void OpenXRHTCViveTrackerExtension::on_register_metadata() {
 	openxr_metadata->register_top_level_path("Chest tracker", "/user/vive_tracker_htcx/role/chest", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
 	openxr_metadata->register_top_level_path("Camera tracker", "/user/vive_tracker_htcx/role/camera", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
 	openxr_metadata->register_top_level_path("Keyboard tracker", "/user/vive_tracker_htcx/role/keyboard", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
+	openxr_metadata->register_top_level_path("Left wrist tracker", "/user/vive_tracker_htcx/role/left_wrist", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
+	openxr_metadata->register_top_level_path("Right wrist tracker", "/user/vive_tracker_htcx/role/right_wrist", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
+	openxr_metadata->register_top_level_path("Left ankle tracker", "/user/vive_tracker_htcx/role/left_ankle", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
+	openxr_metadata->register_top_level_path("Right ankle tracker", "/user/vive_tracker_htcx/role/right_ankle", XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME);
 
 	{ // HTC Vive tracker
 		// Interestingly enough trackers don't have buttons or inputs, yet these are defined in the spec.
@@ -102,6 +110,10 @@ void OpenXRHTCViveTrackerExtension::on_register_metadata() {
 					 "/user/vive_tracker_htcx/role/chest",
 					 "/user/vive_tracker_htcx/role/camera",
 					 "/user/vive_tracker_htcx/role/keyboard",
+					 "/user/vive_tracker_htcx/role/left_wrist",
+					 "/user/vive_tracker_htcx/role/right_wrist",
+					 "/user/vive_tracker_htcx/role/left_ankle",
+					 "/user/vive_tracker_htcx/role/right_ankle",
 			 }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 


### PR DESCRIPTION
Add 4 missing paths for wrist and ankle to XR_HTCX_vive_tracker_interaction.

I noticed that some vive trackers were randomly not registering with Godot. After fiddling for a long time, I realized that the trackers which weren't working were using the wrist and ankle roles. This should fix this inconsistency and make Godot detect trackers more reliably.

These are already available in OpenXR 1.0, but with a note that they were added in rev. 3 of the extension back in 2023, so probably they were overlooked:
https://registry.khronos.org/OpenXR/specs/1.0/html/xrspec.html#XR_HTCX_vive_tracker_interaction

I don't think this is adding a new feature, just updating Godot to full compliance with a spec it already supports. I think this is a low risk change, and I would like this to get in for Godot 4.5 so I can give people a full body tracking addon I'm working on without having to explain that some roles are missing from Godot.