### PR TITLE
[Codeowners] Minor improvements after restructure

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,8 +44,9 @@
 
 # Editor
 
+/editor/                                      @godotengine/docks
 /editor/script/                               @godotengine/script-editor
-/editor/shader/                               @godotengine/shaders
+/editor/shader/                               @godotengine/script-editor @godotengine/shaders
 /editor/animation/                            @godotengine/animation
 /editor/audio/                                @godotengine/audio
 /editor/debugger/                             @godotengine/debugger
@@ -57,9 +58,12 @@
 /editor/inspector/                            @godotengine/docks
 /editor/scene/                                @godotengine/core
 /editor/scene/2d/                             @godotengine/2d-editor
+/editor/scene/2d/physics                      @godotengine/2d-editor @godotengine/physics
 /editor/scene/3d/                             @godotengine/3d-editor
+/editor/scene/3d/physics                      @godotengine/3d-editor @godotengine/physics
 /editor/scene/gui/                            @godotengine/usability @godotengine/gui-nodes
 /editor/themes/                               @godotengine/usability @godotengine/gui-nodes
+/editor/translations/                         @godotengine/usability
 
 # Main
 


### PR DESCRIPTION
Follow-up to the recent restructure, some low hanging fruit cases, will do a larger sweep when I'm back but thought I'd get these to improve the coverage

Also making the `docks` team the default for all editor component, at least until we restructure the specific responsibilities, as that's how (at least I) review requests are manually added to the editor code when no one else fits better (still keeping the explicit areas like `/editor/docs/` and `/editor/inspector` to ensure they are separate if we change what `/editor/` gets

Without this the following areas are not directly owned, and aren't clear-cut as "docks":
* `editor/file_system`
* `editor/project_upgrade`
* `editor/export`
* `editor/asset_library`

Which would be good to discuss when I'm back

Will also do a sweep of other parts of the engine for owners when I'm back, as there are some areas that are lacking in owners

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
