### PR TITLE
Compatibility: Set `GL_TEXTURE_MAX_LEVEL` to the number of mipmaps

### DIFF
--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -280,10 +280,10 @@ struct Texture {
 					max_lod = 0;
 				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_NEAREST_MIPMAP_NEAREST;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				} else {
 					pmin = GL_NEAREST_MIPMAP_LINEAR;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				}
 			} break;
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
@@ -297,10 +297,10 @@ struct Texture {
 					max_lod = 0;
 				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_LINEAR_MIPMAP_NEAREST;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				} else {
 					pmin = GL_LINEAR_MIPMAP_LINEAR;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				}
 			} break;
 			default: {


### PR DESCRIPTION
Required for implementing partial mipmap chains in images.

Sets the maximal LOD level in the Compatibility renderer to the actual number of mipmaps in an image. Setting it to 1000 functions correctly for now, but makes the texture not render when it has an incomplete mipmap chain.