### PR TITLE
Fix MissingNode `{get,set}_original_scene` bindings

### DIFF
--- a/scene/main/missing_node.cpp
+++ b/scene/main/missing_node.cpp
@@ -101,8 +101,8 @@ void MissingNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_original_class", "name"), &MissingNode::set_original_class);
 	ClassDB::bind_method(D_METHOD("get_original_class"), &MissingNode::get_original_class);
 
-	ClassDB::bind_method(D_METHOD("set_original_scene", "name"), &MissingNode::set_original_class);
-	ClassDB::bind_method(D_METHOD("get_original_scene"), &MissingNode::get_original_class);
+	ClassDB::bind_method(D_METHOD("set_original_scene", "name"), &MissingNode::set_original_scene);
+	ClassDB::bind_method(D_METHOD("get_original_scene"), &MissingNode::get_original_scene);
 
 	ClassDB::bind_method(D_METHOD("set_recording_properties", "enable"), &MissingNode::set_recording_properties);
 	ClassDB::bind_method(D_METHOD("is_recording_properties"), &MissingNode::is_recording_properties);


### PR DESCRIPTION
Looks like these were bound to the wrong methods since they were exposed in https://github.com/godotengine/godot/pull/86781.