### PR TITLE
Fix unwanted resource duplication in the theme editor

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -441,23 +441,32 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 			EditorSettings::get_singleton()->set_resource_clipboard(edited_resource);
 		} break;
 
-		case OBJ_MENU_PASTE:
+		case OBJ_MENU_PASTE: {
+			edited_resource = EditorSettings::get_singleton()->get_resource_clipboard();
+			bool make_unique = true;
+
+			// Automatically make resource unique if it belongs to another scene or resource.
+			if (!EditorNode::get_singleton()->get_edited_scene() || !edited_resource->is_built_in() || edited_resource->get_path().get_slice("::", 0) == EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path()) {
+				make_unique = false;
+			} else if (resource_owner) {
+				Resource *res = Object::cast_to<Resource>(resource_owner);
+				if (res && edited_resource->get_path().get_slice("::", 0) == res->get_path().get_slice("::", 0)) {
+					make_unique = false;
+				}
+			}
+
+			if (make_unique) {
+				_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE);
+			} else {
+				_resource_changed();
+			}
+		} break;
+
 		case OBJ_MENU_PASTE_AS_UNIQUE: {
 			edited_resource = EditorSettings::get_singleton()->get_resource_clipboard();
-			if (p_which == OBJ_MENU_PASTE_AS_UNIQUE ||
-					(EditorNode::get_singleton()->get_edited_scene() && edited_resource->is_built_in() && edited_resource->get_path().get_slice("::", 0) != EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path())) {
-				// Automatically make resource unique if it belongs to another scene,
-				// or if requested by the user with the Paste as Unique option.
-				if (p_which == OBJ_MENU_PASTE_AS_UNIQUE) {
-					// Use the recursive version when using Paste as Unique.
-					// This will show up a dialog to select which resources to make unique.
-					_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
-				} else {
-					_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE);
-				}
-				return;
-			}
-			_resource_changed();
+			// Use the recursive version when using Paste as Unique.
+			// This will show up a dialog to select which resources to make unique.
+			_edit_menu_cbk(OBJ_MENU_MAKE_UNIQUE_RECURSIVE);
 		} break;
 
 		case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2672,6 +2672,7 @@ void ThemeTypeEditor::_update_type_items() {
 			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_base_type("Font");
+			item_editor->set_resource_owner(*edited_theme);
 			item_control->add_child(item_editor);
 
 			if (E.value) {
@@ -2743,6 +2744,7 @@ void ThemeTypeEditor::_update_type_items() {
 			EditorResourcePicker *item_editor = memnew(EditorResourcePicker);
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_base_type("Texture2D");
+			item_editor->set_resource_owner(*edited_theme);
 			item_control->add_child(item_editor);
 
 			if (E.value) {
@@ -2781,6 +2783,7 @@ void ThemeTypeEditor::_update_type_items() {
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_stretch_ratio(1.5);
 			item_editor->set_base_type("StyleBox");
+			item_editor->set_resource_owner(*edited_theme);
 
 			Button *pin_leader_button = memnew(Button);
 			pin_leader_button->set_flat(true);
@@ -2816,6 +2819,7 @@ void ThemeTypeEditor::_update_type_items() {
 			item_editor->set_h_size_flags(SIZE_EXPAND_FILL);
 			item_editor->set_stretch_ratio(1.5);
 			item_editor->set_base_type("StyleBox");
+			item_editor->set_resource_owner(*edited_theme);
 
 			if (E.value) {
 				if (edited_theme->has_stylebox(E.key, edited_type)) {


### PR DESCRIPTION
This PR makes use of the `resource_owner` functionality in the `EditorResourcePicker` to check not only if the copied resource is from another scene, but also from another parent resource before automatically making it unique.

Fixes #80797.