### PR TITLE
Add CameraFeed support for Windows

### DIFF
--- a/doc/classes/CameraFeed.xml
+++ b/doc/classes/CameraFeed.xml
@@ -6,7 +6,7 @@
 	<description>
 		A camera feed gives you access to a single physical camera attached to your device. When enabled, Godot will start capturing frames from the camera which can then be used. See also [CameraServer].
 		[b]Note:[/b] Many cameras will return YCbCr images which are split into two textures and need to be combined in a shader. Godot does this automatically for you if you set the environment to show the camera image in the background.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, and iOS. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS, and Windows. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CameraServer.xml
+++ b/doc/classes/CameraServer.xml
@@ -6,7 +6,7 @@
 	<description>
 		The [CameraServer] keeps track of different cameras accessible in Godot. These are external cameras such as webcams or the cameras on your phone.
 		It is notably used to provide AR modules with a video feed from the camera.
-		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, and iOS. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
+		[b]Note:[/b] This class is currently only implemented on Linux, Android, macOS, iOS, and Windows. On other platforms no [CameraFeed]s will be available. To get a [CameraFeed] on iOS, enable [member EditorExportPlatformIOS.modules/camera].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/modules/camera/SCsub
+++ b/modules/camera/SCsub
@@ -10,7 +10,12 @@ if env["platform"] in ["windows", "macos", "linuxbsd", "android", "ios", "vision
     env_camera.add_source_files(env.modules_sources, "register_types.cpp")
 
 if env["platform"] == "windows":
+    env_camera.add_source_files(env.modules_sources, "buffer_decoder.cpp")
     env_camera.add_source_files(env.modules_sources, "camera_win.cpp")
+    if env.msvc:
+        env.Append(LINKFLAGS=["mf.lib", "mfplat.lib", "mfreadwrite.lib", "mfuuid.lib"])
+    else:
+        env.Append(LIBS=["mf", "mfplat", "mfreadwrite", "mfuuid"])
 
 elif env["platform"] == "macos":
     env_camera.add_source_files(env.modules_sources, "camera_apple.mm")

--- a/modules/camera/buffer_decoder.cpp
+++ b/modules/camera/buffer_decoder.cpp
@@ -32,17 +32,19 @@
 
 #include "servers/camera/camera_feed.h"
 
+#ifdef LINUXBSD_ENABLED
 #include <linux/videodev2.h>
+#endif
 
 BufferDecoder::BufferDecoder(CameraFeed *p_camera_feed) {
 	camera_feed = p_camera_feed;
 	width = camera_feed->get_format().width;
 	height = camera_feed->get_format().height;
-	image.instantiate();
 }
 
 AbstractYuyvBufferDecoder::AbstractYuyvBufferDecoder(CameraFeed *p_camera_feed) :
 		BufferDecoder(p_camera_feed) {
+#ifdef LINUXBSD_ENABLED
 	switch (camera_feed->get_format().pixel_format) {
 		case V4L2_PIX_FMT_YYUV:
 			component_indexes = new int[4]{ 0, 1, 2, 3 };
@@ -59,6 +61,9 @@ AbstractYuyvBufferDecoder::AbstractYuyvBufferDecoder(CameraFeed *p_camera_feed) 
 		default:
 			component_indexes = new int[4]{ 0, 2, 1, 3 };
 	}
+#else
+	component_indexes = new int[4]{ 0, 2, 1, 3 };
+#endif
 }
 
 AbstractYuyvBufferDecoder::~AbstractYuyvBufferDecoder() {
@@ -69,43 +74,40 @@ SeparateYuyvBufferDecoder::SeparateYuyvBufferDecoder(CameraFeed *p_camera_feed) 
 		AbstractYuyvBufferDecoder(p_camera_feed) {
 	y_image_data.resize(width * height);
 	cbcr_image_data.resize(width * height);
-	y_image.instantiate();
-	cbcr_image.instantiate();
 }
 
-void SeparateYuyvBufferDecoder::decode(StreamingBuffer p_buffer) {
+void SeparateYuyvBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	uint8_t *y_dst = (uint8_t *)y_image_data.ptrw();
 	uint8_t *uv_dst = (uint8_t *)cbcr_image_data.ptrw();
 	uint8_t *src = (uint8_t *)p_buffer.start;
-	uint8_t *y0_src = src + component_indexes[0];
-	uint8_t *y1_src = src + component_indexes[1];
-	uint8_t *u_src = src + component_indexes[2];
-	uint8_t *v_src = src + component_indexes[3];
+	int32_t pitch = p_buffer.pitch != 0 ? abs(p_buffer.pitch) : width * 2;
 
-	for (int i = 0; i < width * height; i += 2) {
-		*y_dst++ = *y0_src;
-		*y_dst++ = *y1_src;
-		*uv_dst++ = *u_src;
-		*uv_dst++ = *v_src;
+	for (int y = 0; y < height; y++) {
+		uint8_t *row_src = src + y * pitch;
+		uint8_t *y0_src = row_src + component_indexes[0];
+		uint8_t *y1_src = row_src + component_indexes[1];
+		uint8_t *u_src = row_src + component_indexes[2];
+		uint8_t *v_src = row_src + component_indexes[3];
 
-		y0_src += 4;
-		y1_src += 4;
-		u_src += 4;
-		v_src += 4;
+		for (int x = 0; x < width; x += 2) {
+			*y_dst++ = *y0_src;
+			*y_dst++ = *y1_src;
+			*uv_dst++ = *u_src;
+			*uv_dst++ = *v_src;
+
+			y0_src += 4;
+			y1_src += 4;
+			u_src += 4;
+			v_src += 4;
+		}
 	}
 
-	if (y_image.is_valid()) {
-		y_image->set_data(width, height, false, Image::FORMAT_L8, y_image_data);
-	} else {
-		y_image.instantiate(width, height, false, Image::FORMAT_RGB8, y_image_data);
-	}
-	if (cbcr_image.is_valid()) {
-		cbcr_image->set_data(width, height, false, Image::FORMAT_L8, cbcr_image_data);
-	} else {
-		cbcr_image.instantiate(width, height, false, Image::FORMAT_RGB8, cbcr_image_data);
-	}
+	// Deferred: the feed setters touch the RenderingServer, which must not be
+	// called from this capture thread.
+	Ref<Image> y_image = Image::create_from_data(width, height, false, Image::FORMAT_L8, y_image_data);
+	Ref<Image> cbcr_image = Image::create_from_data(width / 2, height, false, Image::FORMAT_RG8, cbcr_image_data);
 
-	camera_feed->set_ycbcr_images(y_image, cbcr_image);
+	camera_feed->call_deferred("set_ycbcr_images", y_image, cbcr_image);
 }
 
 YuyvToGrayscaleBufferDecoder::YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_feed) :
@@ -113,27 +115,28 @@ YuyvToGrayscaleBufferDecoder::YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_
 	image_data.resize(width * height);
 }
 
-void YuyvToGrayscaleBufferDecoder::decode(StreamingBuffer p_buffer) {
+void YuyvToGrayscaleBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
 	uint8_t *src = (uint8_t *)p_buffer.start;
-	uint8_t *y0_src = src + component_indexes[0];
-	uint8_t *y1_src = src + component_indexes[1];
+	int32_t pitch = p_buffer.pitch != 0 ? abs(p_buffer.pitch) : width * 2;
 
-	for (int i = 0; i < width * height; i += 2) {
-		*dst++ = *y0_src;
-		*dst++ = *y1_src;
+	for (int y = 0; y < height; y++) {
+		uint8_t *row_src = src + y * pitch;
+		uint8_t *y0_src = row_src + component_indexes[0];
+		uint8_t *y1_src = row_src + component_indexes[1];
 
-		y0_src += 4;
-		y1_src += 4;
+		for (int x = 0; x < width; x += 2) {
+			*dst++ = *y0_src;
+			*dst++ = *y1_src;
+
+			y0_src += 4;
+			y1_src += 4;
+		}
 	}
 
-	if (image.is_valid()) {
-		image->set_data(width, height, false, Image::FORMAT_L8, image_data);
-	} else {
-		image.instantiate(width, height, false, Image::FORMAT_RGB8, image_data);
-	}
+	Ref<Image> image = Image::create_from_data(width, height, false, Image::FORMAT_L8, image_data);
 
-	camera_feed->set_rgb_image(image);
+	camera_feed->call_deferred("set_rgb_image", image);
 }
 
 YuyvToRgbBufferDecoder::YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed) :
@@ -141,72 +144,144 @@ YuyvToRgbBufferDecoder::YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed) :
 	image_data.resize(width * height * 3);
 }
 
-void YuyvToRgbBufferDecoder::decode(StreamingBuffer p_buffer) {
+void YuyvToRgbBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	uint8_t *src = (uint8_t *)p_buffer.start;
-	uint8_t *y0_src = src + component_indexes[0];
-	uint8_t *y1_src = src + component_indexes[1];
-	uint8_t *u_src = src + component_indexes[2];
-	uint8_t *v_src = src + component_indexes[3];
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
+	int32_t pitch = p_buffer.pitch != 0 ? abs(p_buffer.pitch) : width * 2;
 
-	for (int i = 0; i < width * height; i += 2) {
-		int u = *u_src;
-		int v = *v_src;
-		int u1 = (((u - 128) << 7) + (u - 128)) >> 6;
-		int rg = (((u - 128) << 1) + (u - 128) + ((v - 128) << 2) + ((v - 128) << 1)) >> 3;
-		int v1 = (((v - 128) << 1) + (v - 128)) >> 1;
+	for (int y = 0; y < height; y++) {
+		uint8_t *row_src = src + y * pitch;
+		uint8_t *y0_src = row_src + component_indexes[0];
+		uint8_t *y1_src = row_src + component_indexes[1];
+		uint8_t *u_src = row_src + component_indexes[2];
+		uint8_t *v_src = row_src + component_indexes[3];
 
-		*dst++ = CLAMP(*y0_src + v1, 0, 255);
-		*dst++ = CLAMP(*y0_src - rg, 0, 255);
-		*dst++ = CLAMP(*y0_src + u1, 0, 255);
+		for (int x = 0; x < width; x += 2) {
+			int u = *u_src;
+			int v = *v_src;
+			int u1 = (((u - 128) << 7) + (u - 128)) >> 6;
+			int rg = (((u - 128) << 1) + (u - 128) + ((v - 128) << 2) + ((v - 128) << 1)) >> 3;
+			int v1 = (((v - 128) << 1) + (v - 128)) >> 1;
 
-		*dst++ = CLAMP(*y1_src + v1, 0, 255);
-		*dst++ = CLAMP(*y1_src - rg, 0, 255);
-		*dst++ = CLAMP(*y1_src + u1, 0, 255);
+			*dst++ = CLAMP(*y0_src + v1, 0, 255);
+			*dst++ = CLAMP(*y0_src - rg, 0, 255);
+			*dst++ = CLAMP(*y0_src + u1, 0, 255);
 
-		y0_src += 4;
-		y1_src += 4;
-		u_src += 4;
-		v_src += 4;
+			*dst++ = CLAMP(*y1_src + v1, 0, 255);
+			*dst++ = CLAMP(*y1_src - rg, 0, 255);
+			*dst++ = CLAMP(*y1_src + u1, 0, 255);
+
+			y0_src += 4;
+			y1_src += 4;
+			u_src += 4;
+			v_src += 4;
+		}
 	}
 
-	if (image.is_valid()) {
-		image->set_data(width, height, false, Image::FORMAT_RGB8, image_data);
-	} else {
-		image.instantiate(width, height, false, Image::FORMAT_RGB8, image_data);
-	}
+	Ref<Image> image = Image::create_from_data(width, height, false, Image::FORMAT_RGB8, image_data);
 
-	camera_feed->set_rgb_image(image);
+	camera_feed->call_deferred("set_rgb_image", image);
 }
 
-CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba) :
+CopyBufferDecoder::CopyBufferDecoder(CameraFeed *p_camera_feed, CopyFormat p_format) :
 		BufferDecoder(p_camera_feed) {
-	rgba = p_rgba;
-	image_data.resize(width * height * (rgba ? 4 : 2));
+	format = p_format.format;
+	convert_bgr = p_format.convert_bgr;
+	src_stride = p_format.src_stride;
+	image_data.resize(width * height * p_format.dst_stride);
 }
 
-void CopyBufferDecoder::decode(StreamingBuffer p_buffer) {
+void CopyBufferDecoder::decode(const StreamingBuffer &p_buffer) {
+	uint8_t *scan_line0 = (uint8_t *)p_buffer.start;
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
-	memcpy(dst, p_buffer.start, p_buffer.length);
+	int32_t pitch = p_buffer.pitch;
 
-	if (image.is_valid()) {
-		image->set_data(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);
-	} else {
-		image.instantiate(width, height, false, rgba ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8, image_data);
+	// If pitch is not set, calculate from buffer length (assumes top-down, contiguous).
+	if (pitch == 0) {
+		pitch = p_buffer.length / height;
 	}
 
-	camera_feed->set_rgb_image(image);
+	if (convert_bgr) {
+		// Windows RGB24 uses BGR byte order.
+		// See: https://learn.microsoft.com/en-us/windows/win32/directshow/uncompressed-rgb-video-subtypes
+		for (int y = 0; y < height; y++) {
+			uint8_t *row_src = scan_line0 + y * pitch;
+			for (int x = 0; x < width; x++) {
+				dst[0] = row_src[2];
+				dst[1] = row_src[1];
+				dst[2] = row_src[0];
+				dst += 3;
+				// src_stride is 3 for RGB24 (BGR) and 4 for RGB32/ARGB32 (BGRX/BGRA).
+				row_src += src_stride;
+			}
+		}
+	} else {
+		// Copy only the pixel data (width * bytes_per_pixel), not the full
+		// pitch which may include padding from stride alignment.
+		int row_bytes = image_data.size() / height;
+		for (int y = 0; y < height; y++) {
+			uint8_t *row_src = scan_line0 + y * pitch;
+			memcpy(dst, row_src, row_bytes);
+			dst += row_bytes;
+		}
+	}
+
+	Ref<Image> image = Image::create_from_data(width, height, false, format, image_data);
+
+	camera_feed->call_deferred("set_rgb_image", image);
 }
 
 JpegBufferDecoder::JpegBufferDecoder(CameraFeed *p_camera_feed) :
 		BufferDecoder(p_camera_feed) {
 }
 
-void JpegBufferDecoder::decode(StreamingBuffer p_buffer) {
+void JpegBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 	image_data.resize(p_buffer.length);
 	uint8_t *dst = (uint8_t *)image_data.ptrw();
 	memcpy(dst, p_buffer.start, p_buffer.length);
+
+	Ref<Image> image;
+	image.instantiate();
 	if (image->load_jpg_from_buffer(image_data) == OK) {
-		camera_feed->set_rgb_image(image);
+		camera_feed->call_deferred("set_rgb_image", image);
 	}
+}
+
+Nv12BufferDecoder::Nv12BufferDecoder(CameraFeed *p_camera_feed) :
+		BufferDecoder(p_camera_feed) {
+	data_y.resize(width * height);
+	data_uv.resize(width * (height / 2));
+}
+
+void Nv12BufferDecoder::decode(const StreamingBuffer &p_buffer) {
+	// NV12 format: Y plane followed by interleaved UV plane.
+	// Create separate Y and UV images for YCbCr format.
+	uint8_t *y_dst = (uint8_t *)data_y.ptrw();
+	uint8_t *uv_dst = (uint8_t *)data_uv.ptrw();
+
+	uint8_t *src = (uint8_t *)p_buffer.start;
+	int stride = p_buffer.pitch != 0 ? abs(p_buffer.pitch) : width;
+
+	// Copy Y plane row by row (stride may differ from width due to alignment).
+	for (int y = 0; y < height; y++) {
+		memcpy(y_dst + y * width, src + y * stride, width);
+	}
+
+	// Copy UV plane row by row (half height, same stride).
+	uint8_t *uv_src = src + stride * height;
+	for (int y = 0; y < height / 2; y++) {
+		memcpy(uv_dst + y * width, uv_src + y * stride, width);
+	}
+
+	Ref<Image> image_y = Image::create_from_data(width, height, false, Image::FORMAT_L8, data_y);
+	Ref<Image> image_uv = Image::create_from_data(width / 2, height / 2, false, Image::FORMAT_RG8, data_uv);
+
+	camera_feed->call_deferred("set_ycbcr_images", image_y, image_uv);
+}
+
+NullBufferDecoder::NullBufferDecoder(CameraFeed *p_camera_feed) :
+		BufferDecoder(p_camera_feed) {
+}
+
+void NullBufferDecoder::decode(const StreamingBuffer &p_buffer) {
 }

--- a/modules/camera/buffer_decoder.h
+++ b/modules/camera/buffer_decoder.h
@@ -38,17 +38,17 @@ class CameraFeed;
 struct StreamingBuffer {
 	void *start = nullptr;
 	size_t length = 0;
+	int32_t pitch = 0; // Row stride in bytes (negative for bottom-up images).
 };
 
 class BufferDecoder {
 protected:
 	CameraFeed *camera_feed = nullptr;
-	Ref<Image> image;
 	int width = 0;
 	int height = 0;
 
 public:
-	virtual void decode(StreamingBuffer p_buffer) = 0;
+	virtual void decode(const StreamingBuffer &p_buffer) = 0;
 
 	BufferDecoder(CameraFeed *p_camera_feed);
 	virtual ~BufferDecoder() {}
@@ -67,12 +67,10 @@ class SeparateYuyvBufferDecoder : public AbstractYuyvBufferDecoder {
 private:
 	Vector<uint8_t> y_image_data;
 	Vector<uint8_t> cbcr_image_data;
-	Ref<Image> y_image;
-	Ref<Image> cbcr_image;
 
 public:
 	SeparateYuyvBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class YuyvToGrayscaleBufferDecoder : public AbstractYuyvBufferDecoder {
@@ -81,7 +79,7 @@ private:
 
 public:
 	YuyvToGrayscaleBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class YuyvToRgbBufferDecoder : public AbstractYuyvBufferDecoder {
@@ -90,17 +88,34 @@ private:
 
 public:
 	YuyvToRgbBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class CopyBufferDecoder : public BufferDecoder {
 private:
 	Vector<uint8_t> image_data;
-	bool rgba = false;
+	Image::Format format;
+	bool convert_bgr;
+	int src_stride;
 
 public:
-	CopyBufferDecoder(CameraFeed *p_camera_feed, bool p_rgba);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	struct CopyFormat {
+		int src_stride; // Input bytes per pixel (>= dst_stride; extra bytes are dropped).
+		int dst_stride; // Output bytes per pixel.
+		Image::Format format;
+		bool convert_bgr;
+	};
+	static inline constexpr const CopyFormat la = { 2, 2, Image::FORMAT_LA8, false };
+	static inline constexpr const CopyFormat rgb = { 3, 3, Image::FORMAT_RGB8, false };
+	static inline constexpr const CopyFormat rgba = { 4, 4, Image::FORMAT_RGBA8, false };
+	// Windows RGB24 uses BGR byte order. See:
+	// https://learn.microsoft.com/en-us/windows/win32/directshow/uncompressed-rgb-video-subtypes
+	static inline constexpr const CopyFormat bgr = { 3, 3, Image::FORMAT_RGB8, true };
+	// Windows RGB32/ARGB32 are stored as BGRX/BGRA; drop the 4th byte and swap to RGB24.
+	static inline constexpr const CopyFormat bgrx = { 4, 3, Image::FORMAT_RGB8, true };
+
+	CopyBufferDecoder(CameraFeed *p_camera_feed, CopyFormat p_format);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };
 
 class JpegBufferDecoder : public BufferDecoder {
@@ -109,5 +124,21 @@ private:
 
 public:
 	JpegBufferDecoder(CameraFeed *p_camera_feed);
-	virtual void decode(StreamingBuffer p_buffer) override;
+	virtual void decode(const StreamingBuffer &p_buffer) override;
+};
+
+class Nv12BufferDecoder : public BufferDecoder {
+private:
+	Vector<uint8_t> data_y;
+	Vector<uint8_t> data_uv;
+
+public:
+	Nv12BufferDecoder(CameraFeed *p_camera_feed);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
+};
+
+class NullBufferDecoder : public BufferDecoder {
+public:
+	NullBufferDecoder(CameraFeed *p_camera_feed);
+	virtual void decode(const StreamingBuffer &p_buffer) override;
 };

--- a/modules/camera/camera_feed_linux.cpp
+++ b/modules/camera/camera_feed_linux.cpp
@@ -258,12 +258,12 @@ BufferDecoder *CameraFeedLinux::_create_buffer_decoder() {
 				return memnew(YuyvToGrayscaleBufferDecoder(this));
 			}
 			if (output == "copy") {
-				return memnew(CopyBufferDecoder(this, false));
+				return memnew(CopyBufferDecoder(this, CopyBufferDecoder::la));
 			}
 			return memnew(YuyvToRgbBufferDecoder(this));
 		}
 		default:
-			return memnew(CopyBufferDecoder(this, true));
+			return memnew(CopyBufferDecoder(this, CopyBufferDecoder::rgba));
 	}
 }
 

--- a/modules/camera/camera_win.cpp
+++ b/modules/camera/camera_win.cpp
@@ -32,65 +32,721 @@
 
 #include "servers/camera/camera_feed.h"
 
-///@TODO sorry guys, I got about 80% through implementing this using DirectShow only
-// to find out Microsoft deprecated half the API and its replacement is as confusing
-// as they could make it. Joey suggested looking into libuvc which offers a more direct
-// route to webcams over USB and this is very promising but it wouldn't compile on
-// windows for me...I've gutted the classes I implemented DirectShow in just to have
-// a skeleton for someone to work on, mail me for more details or if you want a copy....
-
 //////////////////////////////////////////////////////////////////////////
 // CameraFeedWindows - Subclass for our camera feed on windows
 
-/// @TODO need to implement this
+Ref<CameraFeedWindows> CameraFeedWindows::create(IMFActivate *imf_camera_device) {
+	Ref<CameraFeedWindows> feed = memnew(CameraFeedWindows);
 
-class CameraFeedWindows : public CameraFeed {
-private:
-protected:
-public:
-	CameraFeedWindows();
-	virtual ~CameraFeedWindows();
+	UINT32 len;
+	HRESULT hr;
 
-	bool activate_feed();
-	void deactivate_feed();
-};
+	// Store IMFActivate for reactivation.
+	feed->imf_activate = imf_camera_device;
+	feed->imf_activate->AddRef();
 
-CameraFeedWindows::CameraFeedWindows() {
-	///@TODO implement this, should store information about our available camera
+	// Get camera ID.
+	wchar_t *camera_id = nullptr;
+	hr = imf_camera_device->GetAllocatedString(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_SYMBOLIC_LINK, &camera_id, &len);
+	ERR_FAIL_COND_V_MSG(FAILED(hr), {}, "Unable to get camera ID.");
+	feed->device_id = camera_id;
+	CoTaskMemFree(camera_id);
+
+	// Get name.
+	wchar_t *camera_name = nullptr;
+	hr = imf_camera_device->GetAllocatedString(MF_DEVSOURCE_ATTRIBUTE_FRIENDLY_NAME, &camera_name, &len);
+	ERR_FAIL_COND_V_MSG(FAILED(hr), {}, "Unable to get camera name.");
+	feed->name = camera_name;
+	CoTaskMemFree(camera_name);
+
+	// Get media imf_media_source.
+	IMFMediaSource *imf_media_source = nullptr;
+	hr = imf_camera_device->ActivateObject(IID_PPV_ARGS(&imf_media_source));
+	ERR_FAIL_COND_V_MSG(FAILED(hr), {}, "Unable to activate device.");
+
+	// Get information about device.
+	IMFPresentationDescriptor *imf_presentation_descriptor = nullptr;
+	hr = imf_media_source->CreatePresentationDescriptor(&imf_presentation_descriptor);
+	if (FAILED(hr)) {
+		ERR_PRINT("Unable to create presentation descriptor.");
+		imf_media_source->Release();
+		imf_camera_device->ShutdownObject();
+		return {};
+	}
+
+	// Get information about video stream.
+	BOOL selected;
+	IMFStreamDescriptor *imf_stream_descriptor = nullptr;
+	hr = imf_presentation_descriptor->GetStreamDescriptorByIndex(0, &selected, &imf_stream_descriptor);
+	if (FAILED(hr)) {
+		ERR_PRINT("Unable to get stream descriptor.");
+		imf_presentation_descriptor->Release();
+		imf_media_source->Release();
+		imf_camera_device->ShutdownObject();
+		return {};
+	}
+
+	// Get information about supported media types.
+	IMFMediaTypeHandler *imf_media_type_handler = nullptr;
+	hr = imf_stream_descriptor->GetMediaTypeHandler(&imf_media_type_handler);
+	if (FAILED(hr)) {
+		ERR_PRINT("Unable to get media type handler.");
+		imf_stream_descriptor->Release();
+		imf_presentation_descriptor->Release();
+		imf_media_source->Release();
+		imf_camera_device->ShutdownObject();
+		return {};
+	}
+
+	// Actually fill the feed formats.
+	feed->fill_formats(imf_media_type_handler);
+
+	// Release all COM objects.
+	imf_media_type_handler->Release();
+	imf_stream_descriptor->Release();
+	imf_presentation_descriptor->Release();
+	imf_media_source->Release();
+
+	// Shut down the temporary media source so the device is not held open
+	// between format enumeration and the eventual activate_feed() call.
+	imf_camera_device->ShutdownObject();
+
+	return feed;
+}
+
+void CameraFeedWindows::fill_formats(IMFMediaTypeHandler *imf_media_type_handler) {
+	HRESULT hr;
+	// Get supported media types.
+	DWORD media_type_count = 0;
+	hr = imf_media_type_handler->GetMediaTypeCount(&media_type_count);
+	ERR_FAIL_COND_MSG(FAILED(hr), "Unable to get media type count.");
+
+	// Track unique format combinations after RGB24 conversion.
+	Vector<FormatKey> seen_formats;
+
+	// First pass: collect all formats and check for RGB24.
+	Vector<TempFormat> temp_formats;
+
+	for (DWORD i = 0; i < media_type_count; i++) {
+		// Get media type.
+		IMFMediaType *imf_media_type;
+		hr = imf_media_type_handler->GetMediaTypeByIndex(i, &imf_media_type);
+		ERR_CONTINUE_MSG(FAILED(hr), "Unable to get media type at index.");
+
+		// Get video_format.
+		GUID video_format;
+		hr = imf_media_type->GetGUID(MF_MT_SUBTYPE, &video_format);
+		if (FAILED(hr)) {
+			ERR_PRINT("Unable to get video format for media type.");
+			imf_media_type->Release();
+			continue;
+		}
+
+		// Check if this format can be converted to RGB24.
+		bool supported_fmt = false;
+
+		// Formats directly supported by BufferDecoder.
+		if (video_format == MFVideoFormat_RGB24 ||
+				video_format == MFVideoFormat_NV12 ||
+				video_format == MFVideoFormat_YUY2 ||
+				video_format == MFVideoFormat_MJPG) {
+			supported_fmt = true;
+		}
+		// Additional formats commonly supported by Media Foundation conversion.
+		else if (video_format == MFVideoFormat_RGB32 ||
+				video_format == MFVideoFormat_ARGB32 ||
+				video_format == MFVideoFormat_UYVY ||
+				video_format == MFVideoFormat_YVYU ||
+				video_format == MFVideoFormat_I420 ||
+				video_format == MFVideoFormat_IYUV ||
+				video_format == MFVideoFormat_YV12) {
+			supported_fmt = true;
+		}
+		// H264 requires codec availability - exclude by default.
+		// Users can install Media Feature Pack if needed.
+
+		if (!supported_fmt) {
+			uint32_t format = video_format.Data1;
+			if (!warned_formats.has(format)) {
+				if (format <= 255) {
+					print_verbose(vformat("Skipping unsupported video format %d.", format));
+				} else {
+					uint8_t *chars = (uint8_t *)&format;
+					print_verbose(vformat("Skipping unsupported video format %c%c%c%c.", chars[0], chars[1], chars[2], chars[3]));
+				}
+				warned_formats.append(format);
+			}
+
+			imf_media_type->Release();
+			continue;
+		}
+
+		// Get image size.
+		UINT32 width = 0, height = 0;
+		hr = MFGetAttributeSize(imf_media_type, MF_MT_FRAME_SIZE, &width, &height);
+		if (FAILED(hr)) {
+			ERR_PRINT("Unable to get frame size for media type.");
+			imf_media_type->Release();
+			continue;
+		}
+
+		UINT32 numerator = 0, denominator = 0;
+		hr = MFGetAttributeRatio(imf_media_type, MF_MT_FRAME_RATE, &numerator, &denominator);
+		if (FAILED(hr)) {
+			ERR_PRINT("Unable to get frame rate for media type.");
+			imf_media_type->Release();
+			continue;
+		}
+
+		// Store format information temporarily.
+		TempFormat temp;
+		temp.video_format = video_format;
+		temp.media_type_index = i;
+		temp.is_rgb24 = (video_format == MFVideoFormat_RGB24);
+
+		// Set format string.
+		FeedFormat format;
+		if (video_format == MFVideoFormat_RGB24) {
+			format.format = "RGB24";
+		} else if (video_format == MFVideoFormat_RGB32) {
+			format.format = "RGB32";
+		} else if (video_format == MFVideoFormat_ARGB32) {
+			format.format = "ARGB32";
+		} else if (video_format == MFVideoFormat_NV12) {
+			format.format = "NV12";
+		} else if (video_format == MFVideoFormat_YUY2) {
+			format.format = "YUY2";
+		} else if (video_format == MFVideoFormat_UYVY) {
+			format.format = "UYVY";
+		} else if (video_format == MFVideoFormat_YVYU) {
+			format.format = "YVYU";
+		} else if (video_format == MFVideoFormat_I420) {
+			format.format = "I420";
+		} else if (video_format == MFVideoFormat_IYUV) {
+			format.format = "IYUV";
+		} else if (video_format == MFVideoFormat_YV12) {
+			format.format = "YV12";
+		} else if (video_format == MFVideoFormat_MJPG) {
+			format.format = "MJPG";
+		}
+		format.width = width;
+		format.height = height;
+		format.frame_numerator = numerator;
+		format.frame_denominator = denominator;
+
+		temp.format = format;
+		temp_formats.append(temp);
+
+		imf_media_type->Release();
+	}
+
+	// Second pass: add formats, prioritizing RGB24.
+	for (const TempFormat &temp : temp_formats) {
+		FormatKey key;
+		key.width = temp.format.width;
+		key.height = temp.format.height;
+		key.frame_numerator = temp.format.frame_numerator;
+		key.frame_denominator = temp.format.frame_denominator;
+		key.video_format = temp.video_format;
+		key.is_rgb24 = temp.is_rgb24;
+
+		// Check if this combination already exists.
+		bool should_add = true;
+		bool replaced_existing = false;
+		for (const FormatKey &seen : seen_formats) {
+			if (seen == key) {
+				// If we already have this combination and it was RGB24, skip non-RGB24.
+				if (seen.is_rgb24 && !temp.is_rgb24) {
+					should_add = false;
+					break;
+				} else if (!seen.is_rgb24 && temp.is_rgb24) {
+					// If we have non-RGB24 and this is RGB24, replace it.
+					// Remove the existing non-RGB24 format.
+					for (int j = formats.size() - 1; j >= 0; j--) {
+						if (formats[j].width == key.width &&
+								formats[j].height == key.height &&
+								formats[j].frame_numerator == key.frame_numerator &&
+								formats[j].frame_denominator == key.frame_denominator) {
+							formats.remove_at(j);
+							format_guids.remove_at(j);
+							format_mediatypes.remove_at(j);
+							break;
+						}
+					}
+					// Update seen_formats in-place; do not append a new entry.
+					for (int j = 0; j < seen_formats.size(); j++) {
+						if (seen_formats[j] == key) {
+							seen_formats.write[j].is_rgb24 = true;
+							break;
+						}
+					}
+					replaced_existing = true;
+					break;
+				}
+				// Both are the same type, skip.
+				else {
+					should_add = false;
+					break;
+				}
+			}
+		}
+
+		if (should_add) {
+			// Only append a new seen_formats entry if we did not update one in-place.
+			if (!replaced_existing) {
+				seen_formats.append(key);
+			}
+
+			// Add format.
+			formats.append(temp.format);
+			format_guids.append(temp.video_format);
+			format_mediatypes.append(temp.media_type_index);
+		}
+	}
 }
 
 CameraFeedWindows::~CameraFeedWindows() {
-	// make sure we stop recording if we are!
 	if (is_active()) {
 		deactivate_feed();
-	};
+	}
 
-	///@TODO free up anything used by this
+	// Release IMFActivate.
+	if (imf_activate != nullptr) {
+		imf_activate->Release();
+		imf_activate = nullptr;
+	}
+}
+
+bool IMFMediaSource_set_media_type(IMFMediaSource *imf_media_source, uint32_t media_type_index) {
+	bool result = false;
+	HRESULT hr;
+
+	IMFPresentationDescriptor *imf_presentation_descriptor;
+	hr = imf_media_source->CreatePresentationDescriptor(&imf_presentation_descriptor);
+	if (SUCCEEDED(hr)) {
+		BOOL selected;
+		IMFStreamDescriptor *imf_stream_descriptor;
+		hr = imf_presentation_descriptor->GetStreamDescriptorByIndex(0, &selected, &imf_stream_descriptor);
+		if (SUCCEEDED(hr)) {
+			// Get information about supported media types.
+			IMFMediaTypeHandler *imf_media_type_handler;
+			hr = imf_stream_descriptor->GetMediaTypeHandler(&imf_media_type_handler);
+			if (SUCCEEDED(hr)) {
+				IMFMediaType *imf_media_type;
+				hr = imf_media_type_handler->GetMediaTypeByIndex(media_type_index, &imf_media_type);
+				if (SUCCEEDED(hr)) {
+					// Set media type.
+					hr = imf_media_type_handler->SetCurrentMediaType(imf_media_type);
+					if (SUCCEEDED(hr)) {
+						result = true;
+					}
+					imf_media_type->Release();
+				}
+
+				imf_media_type_handler->Release();
+			}
+
+			imf_stream_descriptor->Release();
+		}
+
+		imf_presentation_descriptor->Release();
+	}
+
+	return result;
 }
 
 bool CameraFeedWindows::activate_feed() {
-	///@TODO this should activate our camera and start the process of capturing frames
+	ERR_FAIL_COND_V_MSG(selected_format == -1, false, "CameraFeed format needs to be set before activating.");
+	ERR_FAIL_INDEX_V_MSG(selected_format, formats.size(), false, "Invalid format index for CameraFeed.");
+	ERR_FAIL_COND_V_MSG(imf_activate == nullptr, false, "IMFActivate is null, cannot activate camera feed.");
+
+	bool result = false;
+	HRESULT hr;
+
+	// Create media source.
+	hr = imf_activate->ActivateObject(IID_PPV_ARGS(&imf_media_source));
+	if (SUCCEEDED(hr)) {
+		bool media_type_set = IMFMediaSource_set_media_type(imf_media_source, format_mediatypes[selected_format]);
+
+		if (media_type_set) {
+			// Create media imf_source_reader.
+			IMFAttributes *reader_attributes = nullptr;
+			hr = MFCreateAttributes(&reader_attributes, 2);
+			if (SUCCEEDED(hr)) {
+				// Enable hardware acceleration if available.
+				hr = reader_attributes->SetUINT32(MF_SOURCE_READER_ENABLE_VIDEO_PROCESSING, TRUE);
+				// Hint to disconnect media source on shutdown to help unblock.
+				reader_attributes->SetUINT32(MF_SOURCE_READER_DISCONNECT_MEDIASOURCE_ON_SHUTDOWN, TRUE);
+
+				hr = MFCreateSourceReaderFromMediaSource(imf_media_source, reader_attributes, &imf_source_reader);
+				reader_attributes->Release();
+
+				if (SUCCEEDED(hr)) {
+					// Ensure we are reading the first video stream.
+					imf_source_reader->SetStreamSelection(MF_SOURCE_READER_FIRST_VIDEO_STREAM, TRUE);
+
+					// Configure source reader to convert to RGB24.
+					IMFMediaType *output_type = nullptr;
+					hr = MFCreateMediaType(&output_type);
+					if (SUCCEEDED(hr)) {
+						hr = output_type->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video);
+						hr = output_type->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_RGB24);
+
+						// Try to set RGB24 as output format.
+						hr = imf_source_reader->SetCurrentMediaType(
+								MF_SOURCE_READER_FIRST_VIDEO_STREAM,
+								nullptr,
+								output_type);
+
+						if (SUCCEEDED(hr)) {
+							result = true;
+							use_mf_conversion = true;
+							// Windows RGB24 uses BGR byte order. See:
+							// https://learn.microsoft.com/en-us/windows/win32/directshow/uncompressed-rgb-video-subtypes
+							buffer_decoder = memnew(CopyBufferDecoder(this, CopyBufferDecoder::bgr));
+						} else {
+							print_verbose(vformat("Media Foundation RGB24 conversion unavailable (0x%08x); trying manual decoder.", (uint32_t)hr));
+							// Fallback to manual conversion for formats that support it.
+							const GUID &video_format = format_guids[selected_format];
+							if (video_format == MFVideoFormat_MJPG ||
+									video_format == MFVideoFormat_NV12 ||
+									video_format == MFVideoFormat_YUY2 ||
+									video_format == MFVideoFormat_RGB24 ||
+									video_format == MFVideoFormat_RGB32 ||
+									video_format == MFVideoFormat_ARGB32) {
+								result = true;
+								use_mf_conversion = false;
+								// Create buffer decoder.
+								buffer_decoder = _create_buffer_decoder();
+							} else {
+								// Format not supported by either method.
+								ERR_PRINT("Format not supported by Media Foundation conversion or manual decoder.");
+								result = false;
+							}
+						}
+
+						output_type->Release();
+					}
+
+					if (result) {
+						// Start reading.
+						exit_flag.clear();
+						worker = memnew(std::thread(capture, this));
+					}
+				}
+			}
+		}
+	} else {
+		ERR_PRINT(vformat("IMFActivate::ActivateObject failed: 0x%08x.", (uint32_t)hr));
+		// If another application is using the device, provide a human-readable hint.
+		if (hr == HRESULT_FROM_WIN32(ERROR_SHARING_VIOLATION)) {
+			ERR_PRINT("Check that no other applications are currently using the camera.");
+		}
+	}
+
+	if (!result) {
+		// Clean up COM resources on failure to prevent leaks.
+		if (imf_source_reader != nullptr) {
+			imf_source_reader->Release();
+			imf_source_reader = nullptr;
+		}
+		if (imf_media_source != nullptr) {
+			imf_media_source->Release();
+			imf_media_source = nullptr;
+		}
+	}
+
+	return result;
+}
+
+void CameraFeedWindows::deactivate_feed() {
+	if (worker != nullptr) {
+		exit_flag.set();
+		// Attempt to unblock ReadSample by deselecting and flushing the stream.
+		if (imf_source_reader) {
+			imf_source_reader->SetStreamSelection(MF_SOURCE_READER_FIRST_VIDEO_STREAM, FALSE);
+			imf_source_reader->Flush(MF_SOURCE_READER_FIRST_VIDEO_STREAM);
+		}
+		worker->join();
+		memdelete(worker);
+		worker = nullptr;
+	}
+
+	if (buffer_decoder != nullptr) {
+		memdelete(buffer_decoder);
+		buffer_decoder = nullptr;
+	}
+
+	// Release in safe order: reader first, then media source.
+	if (imf_source_reader != nullptr) {
+		imf_source_reader->Release();
+		imf_source_reader = nullptr;
+	}
+
+	if (imf_media_source != nullptr) {
+		imf_media_source->Release();
+		imf_media_source = nullptr;
+	}
+
+	// Shutdown the device.
+	if (imf_activate != nullptr) {
+		imf_activate->ShutdownObject();
+	}
+}
+
+void CameraFeedWindows::capture(CameraFeedWindows *feed) {
+	print_verbose("Camera feed is now streaming.");
+	// Initialize COM on this worker thread to safely use MF objects here.
+	HRESULT hr = CoInitializeEx(nullptr, COINIT_MULTITHREADED);
+	if (FAILED(hr)) {
+		ERR_PRINT(vformat("CoInitializeEx failed on capture thread: 0x%08x.", (uint32_t)hr));
+		return;
+	}
+	while (!feed->exit_flag.is_set()) {
+		feed->read();
+	}
+	CoUninitialize();
+}
+
+void CameraFeedWindows::read() {
+	HRESULT hr = S_OK;
+	DWORD flags;
+	IMFSample *pSample = nullptr;
+
+	hr = imf_source_reader->ReadSample(
+			MF_SOURCE_READER_FIRST_VIDEO_STREAM, // Stream index.
+			0, // Flags.
+			nullptr, // Actual stream index (not needed).
+			&flags, // Receives status flags.
+			nullptr, // Timestamp (not needed).
+			&pSample // Receives the sample or nullptr.
+	);
+
+	if (FAILED(hr)) {
+		ERR_PRINT(vformat("ReadSample failed: 0x%08x.", (uint32_t)hr));
+		exit_flag.set();
+		return;
+	}
+
+	// End of stream.
+	if (flags & MF_SOURCE_READERF_ENDOFSTREAM) {
+		print_verbose("\tEnd of stream.");
+		exit_flag.set();
+	}
+	if (flags & MF_SOURCE_READERF_NEWSTREAM) {
+		print_verbose("\tNew stream.");
+	}
+	if (flags & MF_SOURCE_READERF_NATIVEMEDIATYPECHANGED) {
+		print_verbose("\tNative type changed.");
+	}
+	if (flags & MF_SOURCE_READERF_CURRENTMEDIATYPECHANGED) {
+		print_verbose("\tCurrent type changed.");
+	}
+	if (flags & MF_SOURCE_READERF_STREAMTICK) {
+		print_verbose("\tStream tick.");
+	}
+
+	// Process sample.
+	if (pSample) {
+		IMFMediaBuffer *buffer = nullptr;
+		hr = pSample->ConvertToContiguousBuffer(&buffer);
+		if (SUCCEEDED(hr) && buffer) {
+			BYTE *data = nullptr;
+			DWORD buffer_length = 0;
+			bool used_2d_buffer = false;
+
+			// Try IMF2DBuffer for stride information (faster).
+			IMF2DBuffer *buffer2d = nullptr;
+			if (SUCCEEDED(buffer->QueryInterface(IID_PPV_ARGS(&buffer2d)))) {
+				LONG pitch = 0;
+				BYTE *scan_line = nullptr;
+				hr = buffer2d->Lock2D(&scan_line, &pitch);
+				if (SUCCEEDED(hr)) {
+					data = scan_line;
+					buffer_length = abs(pitch) * get_format().height;
+					used_2d_buffer = true;
+
+					StreamingBuffer streaming_buffer;
+					streaming_buffer.start = data;
+					streaming_buffer.length = buffer_length;
+					streaming_buffer.pitch = pitch;
+
+					if (buffer_decoder) {
+						buffer_decoder->decode(streaming_buffer);
+					}
+
+					buffer2d->Unlock2D();
+				}
+				buffer2d->Release();
+			}
+
+			// Fallback: Use standard buffer lock.
+			if (!used_2d_buffer) {
+				hr = buffer->Lock(&data, nullptr, &buffer_length);
+				if (SUCCEEDED(hr)) {
+					StreamingBuffer streaming_buffer;
+					streaming_buffer.length = buffer_length;
+
+					if (use_mf_conversion) {
+						// CopyBufferDecoder expects bottom-up image layout.
+						// Lock() returns pointer to buffer start, but we need pointer to
+						// last row to match Lock2D layout for negative pitch iteration.
+						int row_stride = buffer_length / get_format().height;
+						streaming_buffer.start = data + buffer_length - row_stride;
+						streaming_buffer.pitch = -row_stride;
+					} else {
+						// Other decoders (YUY2, NV12, etc.) expect contiguous memory.
+						streaming_buffer.start = data;
+						streaming_buffer.pitch = 0;
+					}
+
+					if (buffer_decoder) {
+						buffer_decoder->decode(streaming_buffer);
+					}
+
+					buffer->Unlock();
+				} else {
+					ERR_PRINT(vformat("IMFMediaBuffer::Lock failed: 0x%08x.", (uint32_t)hr));
+				}
+			}
+
+			buffer->Release();
+		} else {
+			ERR_PRINT(vformat("ConvertToContiguousBuffer failed: 0x%08x.", (uint32_t)hr));
+		}
+		pSample->Release();
+	}
+}
+
+Array CameraFeedWindows::get_formats() const {
+	Array result;
+	for (const FeedFormat &format : formats) {
+		Dictionary dictionary;
+		dictionary["width"] = format.width;
+		dictionary["height"] = format.height;
+		dictionary["format"] = format.format;
+		dictionary["frame_numerator"] = format.frame_numerator;
+		dictionary["frame_denominator"] = format.frame_denominator;
+		result.push_back(dictionary);
+	}
+	return result;
+}
+
+CameraFeed::FeedFormat CameraFeedWindows::get_format() const {
+	FeedFormat feed_format = {};
+	return selected_format == -1 ? feed_format : formats[selected_format];
+}
+
+bool CameraFeedWindows::set_format(int p_index, const Dictionary &p_parameters) {
+	ERR_FAIL_COND_V_MSG(active, false, "Feed is active.");
+	ERR_FAIL_INDEX_V_MSG(p_index, formats.size(), false, "Invalid format index for CameraFeed.");
+	selected_format = p_index;
+	parameters = p_parameters.duplicate();
 
 	return true;
 }
 
-///@TODO we should probably have a callback method here that is being called by the
-// camera API which provides frames and call back into the CameraServer to update our texture
+BufferDecoder *CameraFeedWindows::_create_buffer_decoder() {
+	const GUID &video_format = format_guids[selected_format];
 
-void CameraFeedWindows::deactivate_feed() {
-	///@TODO this should deactivate our camera and stop the process of capturing frames
+	// Only create decoder for formats that Media Foundation can't convert.
+	if (video_format == MFVideoFormat_MJPG) {
+		return memnew(JpegBufferDecoder(this));
+	} else if (video_format == MFVideoFormat_NV12) {
+		return memnew(Nv12BufferDecoder(this));
+	} else if (video_format == MFVideoFormat_YUY2) {
+		return memnew(SeparateYuyvBufferDecoder(this));
+	} else if (video_format == MFVideoFormat_RGB24) {
+		// Windows RGB24 uses BGR byte order. See:
+		// https://learn.microsoft.com/en-us/windows/win32/directshow/uncompressed-rgb-video-subtypes
+		return memnew(CopyBufferDecoder(this, CopyBufferDecoder::bgr));
+	} else if (video_format == MFVideoFormat_RGB32 || video_format == MFVideoFormat_ARGB32) {
+		// Windows RGB32/ARGB32 are stored as BGRX/BGRA; drop the 4th byte and swap to RGB24.
+		return memnew(CopyBufferDecoder(this, CopyBufferDecoder::bgrx));
+	}
+
+	// Default to null decoder for unsupported formats.
+	// These formats will rely on Media Foundation conversion.
+	return memnew(NullBufferDecoder(this));
 }
 
 //////////////////////////////////////////////////////////////////////////
 // CameraWindows - Subclass for our camera server on windows
 
-void CameraWindows::add_active_cameras() {
-	///@TODO scan through any active cameras and create CameraFeedWindows objects for them
+void CameraWindows::update_feeds() {
+	remove_all_feeds();
+
+	// Create an attribute store to hold the search criteria.
+	IMFAttributes *source_attributes;
+	HRESULT hr = MFCreateAttributes(&source_attributes, 1);
+
+	if (SUCCEEDED(hr)) {
+		// Request video capture devices.
+		hr = source_attributes->SetGUID(MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE, MF_DEVSOURCE_ATTRIBUTE_SOURCE_TYPE_VIDCAP_GUID);
+
+		if (SUCCEEDED(hr)) {
+			// Process devices.
+			UINT32 count = 0;
+			IMFActivate **devices;
+			hr = MFEnumDeviceSources(source_attributes, &devices, &count);
+			if (FAILED(hr)) {
+				ERR_PRINT("Error enumerating devices.");
+			} else {
+				// Create feeds for all supported media sources.
+				for (DWORD i = 0; i < count; i++) {
+					IMFActivate *device = devices[i];
+					Ref<CameraFeedWindows> feed = CameraFeedWindows::create(device);
+					if (feed.is_valid()) {
+						add_feed(feed);
+					}
+					device->Release();
+				}
+
+				CoTaskMemFree(devices);
+			}
+		}
+
+		source_attributes->Release();
+	}
+
+	emit_signal(SNAME(CameraServer::feeds_updated_signal_name));
+}
+
+void CameraWindows::remove_all_feeds() {
+	for (int i = feeds.size() - 1; i >= 0; i--) {
+		remove_feed(feeds[i]);
+	}
 }
 
 CameraWindows::CameraWindows() {
-	// Find cameras active right now
-	add_active_cameras();
+	// The Media Foundation platform is initialized lazily on first use
+	// (see set_monitoring_feeds()), so projects that don't use the camera
+	// never load or initialize it.
+}
 
-	// need to add something that will react to devices being connected/removed...
+CameraWindows::~CameraWindows() {
+	remove_all_feeds();
+	if (mf_initialized) {
+		MFShutdown();
+	}
+}
+
+void CameraWindows::set_monitoring_feeds(bool p_monitoring_feeds) {
+	if (p_monitoring_feeds == monitoring_feeds) {
+		return;
+	}
+
+	if (p_monitoring_feeds && !mf_initialized) {
+		// Initialize the Media Foundation platform on first use.
+		HRESULT hr = MFStartup(MF_VERSION);
+		ERR_FAIL_COND_MSG(FAILED(hr), "Unable to initialize Media Foundation platform.");
+		mf_initialized = true;
+	}
+
+	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
+	if (monitoring_feeds) {
+		update_feeds();
+	} else {
+		remove_all_feeds();
+	}
 }

--- a/modules/camera/camera_win.h
+++ b/modules/camera/camera_win.h
@@ -30,13 +30,90 @@
 
 #pragma once
 
+#include "buffer_decoder.h"
+
+#include "servers/camera/camera_feed.h"
 #include "servers/camera/camera_server.h"
+
+#include <windows.h>
+
+#include <mfapi.h>
+#include <mferror.h>
+#include <mfidl.h>
+#include <mfreadwrite.h>
+
+#include <thread>
+
+class CameraFeedWindows : public CameraFeed {
+private:
+	// Format tracking structures.
+	struct FormatKey {
+		int width;
+		int height;
+		int frame_numerator;
+		int frame_denominator;
+		GUID video_format;
+		bool is_rgb24; // Track if this was originally RGB24.
+
+		bool operator==(const FormatKey &other) const {
+			return width == other.width &&
+					height == other.height &&
+					frame_numerator == other.frame_numerator &&
+					frame_denominator == other.frame_denominator &&
+					video_format == other.video_format;
+		}
+	};
+
+	struct TempFormat {
+		FeedFormat format;
+		GUID video_format;
+		DWORD media_type_index;
+		bool is_rgb24;
+	};
+
+	String device_id;
+	IMFActivate *imf_activate = nullptr;
+	IMFMediaSource *imf_media_source = nullptr;
+
+	IMFSourceReader *imf_source_reader = nullptr;
+	std::thread *worker = nullptr;
+	Vector<GUID> format_guids;
+	Vector<uint32_t> format_mediatypes;
+
+	Vector<uint32_t> warned_formats;
+
+	BufferDecoder *buffer_decoder = nullptr;
+	bool use_mf_conversion = false;
+	SafeFlag exit_flag;
+
+	static void capture(CameraFeedWindows *feed);
+
+	void read();
+	void fill_formats(IMFMediaTypeHandler *imf_media_type_handler);
+	BufferDecoder *_create_buffer_decoder();
+
+public:
+	static Ref<CameraFeedWindows> create(IMFActivate *pDevice);
+	virtual ~CameraFeedWindows();
+
+	virtual Array get_formats() const override;
+	virtual FeedFormat get_format() const override;
+	virtual bool set_format(int p_index, const Dictionary &p_parameters) override;
+
+	virtual bool activate_feed() override;
+	virtual void deactivate_feed() override;
+};
 
 class CameraWindows : public CameraServer {
 private:
-	void add_active_cameras();
+	bool mf_initialized = false;
+
+	void update_feeds();
+	void remove_all_feeds();
 
 public:
 	CameraWindows();
-	~CameraWindows() {}
+	~CameraWindows();
+
+	virtual void set_monitoring_feeds(bool p_monitoring_feeds) override;
 };


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Following https://github.com/godotengine/godot/pull/105476

This adds CameraFeed support for Windows.
The added implementation includes:

- Documentation updates
- Pixel format conversion with BufferDecoder class
- Added signal comments assuming
  - #104809 
  - #108165

___

- *Production edit: This closes https://github.com/godotengine/godot/pull/105476 by superseding it.*