### PR TITLE
Prefer atomically updating code coverage counters

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -139,8 +139,8 @@ def configure(env: "SConsEnvironment"):
             env.Append(LINKFLAGS=["-fuse-ld=%s" % env["linker"]])
 
     if env["use_coverage"]:
-        env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])
-        env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])
+        env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs", "-fprofile-update=prefer-atomic"])
+        env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs", "-fprofile-update=prefer-atomic"])
 
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -177,8 +177,8 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-Wl,-stack_size," + hex(STACK_SIZE)])
 
     if env["use_coverage"]:
-        env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs"])
-        env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])
+        env.Append(CCFLAGS=["-ftest-coverage", "-fprofile-arcs", "-fprofile-update=prefer-atomic"])
+        env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs", "-fprofile-update=prefer-atomic"])
 
     ## Dependencies
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

While trying to generate a code coverage report with `gcovr`/`grcov`, the tools were detecting data corruption issues such as negative value counters and nonexistent data offsets in the code coverage data generated at runtime (i.e. the `*.gcda` files).

These values were being updated by multiple threads corrupting these.

This PR adds the `-fprofile-update=prefer-atomic` flag when `use_coverage` is enabled in order to update the code coverage data atomically in platforms where this is supported by the compiler.