### PR TITLE
Do not require editor restart when changing `Path3D` Tilt Disk Size setting

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.h
+++ b/editor/scene/3d/path_3d_editor_plugin.h
@@ -59,7 +59,6 @@ class Path3DGizmo : public EditorNode3DGizmo {
 	mutable Vector3 original;
 	mutable float orig_in_length;
 	mutable float orig_out_length;
-	mutable float disk_size = 0.8;
 
 	// Index that should have swapped control points for achieving an outwards curve.
 	int swapped_control_points_idx = -1;
@@ -77,13 +76,11 @@ public:
 	virtual void commit_handle(int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel = false) override;
 
 	virtual void redraw() override;
-	Path3DGizmo(Path3D *p_path = nullptr, float p_disk_size = 0.8);
+	Path3DGizmo(Path3D *p_path = nullptr);
 };
 
 class Path3DGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(Path3DGizmoPlugin, EditorNode3DGizmoPlugin);
-
-	float disk_size = 0.8;
 
 	// Locking basis is meant to ensure a predictable behavior during translation of the curve points in "local space transform mode".
 	// Without the locking, the gizmo/point, in "local space transform mode", wouldn't follow a straight path and would curve and twitch in an unpredictable way.
@@ -105,7 +102,7 @@ public:
 	virtual void commit_subgizmos(const EditorNode3DGizmo *p_gizmo, const Vector<int> &p_ids, const Vector<Transform3D> &p_restore, bool p_cancel = false) override;
 
 	int get_priority() const override;
-	Path3DGizmoPlugin(float p_disk_size);
+	Path3DGizmoPlugin();
 };
 
 class Path3DEditorPlugin : public EditorPlugin {
@@ -130,8 +127,6 @@ class Path3DEditorPlugin : public EditorPlugin {
 
 	Button *create_curve_button = nullptr;
 	ConfirmationDialog *clear_points_dialog = nullptr;
-
-	float disk_size = 0.8;
 
 	enum Mode {
 		MODE_CREATE,
@@ -166,6 +161,7 @@ class Path3DEditorPlugin : public EditorPlugin {
 	};
 
 protected:
+	virtual void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -902,7 +902,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/ik_chain", Color(0.6, 0.9, 0.8), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	_initial_set("editors/3d_gizmos/gizmo_settings/bone_axis_length", (float)0.1);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d_gizmos/gizmo_settings/bone_shape", 1, "Wire,Octahedron");
-	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size", 0.8, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size", 0.8, "", PROPERTY_USAGE_DEFAULT)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size", 0.4, "0.0,1.0,0.001,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 
 	// If a line is a multiple of this, it uses the primary grid color.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Previously you had this prompt:

<img width="1325" height="60" alt="image" src="https://github.com/user-attachments/assets/84864b45-1e6b-4f1f-855f-b55ae1b0531a" />

Now:

https://github.com/user-attachments/assets/a6d0fea7-d538-4765-8b96-082082aa81f1


<i>Bugsquad edit:</i>
- Fixes https://github.com/godotengine/godot/issues/84908