### PR TITLE
Do not require editor restart when changing manipulator gizmo opacity setting

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -7977,6 +7977,38 @@ void Node3DEditor::_finish_grid() {
 	}
 }
 
+void Node3DEditor::update_gizmo_opacity() {
+	if (!origin_instance.is_valid()) {
+		return;
+	}
+
+	const float opacity = EDITOR_GET("editors/3d/manipulator_gizmo_opacity");
+
+	for (int i = 0; i < 3; i++) {
+		Color col = gizmo_color[i]->get_albedo();
+		col.a = opacity;
+		gizmo_color[i]->set_albedo(col);
+
+		col = gizmo_color_hl[i]->get_albedo();
+		col.a = 1.0;
+		gizmo_color_hl[i]->set_albedo(col);
+
+		col = plane_gizmo_color[i]->get_albedo();
+		col.a = opacity;
+		plane_gizmo_color[i]->set_albedo(col);
+
+		col = plane_gizmo_color_hl[i]->get_albedo();
+		col.a = 1.0;
+		plane_gizmo_color_hl[i]->set_albedo(col);
+	}
+}
+
+void Node3DEditor::_on_editor_settings_changed() {
+	if (EditorSettings::get_singleton()->get_changed_settings().has("editors/3d/manipulator_gizmo_opacity")) {
+		update_gizmo_opacity();
+	}
+}
+
 void Node3DEditor::update_grid() {
 	const Camera3D::ProjectionType current_projection = viewports[0]->camera->get_projection();
 
@@ -8402,6 +8434,7 @@ void Node3DEditor::_notification(int p_what) {
 			environ_state->set_custom_minimum_size(environ_vb->get_combined_minimum_size());
 
 			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditor::update_all_gizmos).bind(Variant()));
+			EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditor::_on_editor_settings_changed));
 		} break;
 
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
@@ -8422,6 +8455,7 @@ void Node3DEditor::_notification(int p_what) {
 
 		case NOTIFICATION_EXIT_TREE: {
 			_finish_indicators();
+			EditorSettings::get_singleton()->disconnect("settings_changed", callable_mp(this, &Node3DEditor::_on_editor_settings_changed));
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -805,6 +805,7 @@ private:
 	HashMap<Control *, VSeparator *> context_toolbar_separators;
 
 	void _update_context_toolbar();
+	void _on_editor_settings_changed();
 
 	void _generate_selection_boxes();
 
@@ -969,6 +970,7 @@ public:
 	void update_grid();
 	void update_transform_gizmo();
 	void update_all_gizmos(Node *p_node = nullptr);
+	void update_gizmo_opacity();
 	void snap_selected_nodes_to_floor();
 	void select_gizmo_highlight_axis(int p_axis);
 	void set_custom_camera(Node *p_camera) { custom_camera = p_camera; }

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -945,7 +945,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// 3D: Manipulator
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_size", 80, "16,160,1");
-	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01")
 
 	// 2D
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07), true);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot/pull/108546

Previously you had this prompt:

<img width="1325" height="60" alt="image" src="https://github.com/user-attachments/assets/49d5b976-c9ae-4aa1-a114-2c8773c6f5b5" />

Now:

https://github.com/user-attachments/assets/509129c0-6c84-427b-804a-c0fbc075e985

