### PR TITLE
Use `LocalVector` for scene tree `xform_change_list`

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -74,12 +74,13 @@ Node3DGizmo::Node3DGizmo() {
 
 void Node3D::_notify_dirty() {
 #ifdef TOOLS_ENABLED
-	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !xform_change.in_list()) {
+	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !data.xform_change_queued) {
 #else
-	if (data.notify_transform && !data.ignore_notification && !xform_change.in_list()) {
+	if (data.notify_transform && !data.ignore_notification && !data.xform_change_queued) {
 
 #endif
-		get_tree()->xform_change_list.add(&xform_change);
+		set_xform_change_queued(true);
+		get_tree()->xform_3d_change_list.push_back(this);
 	}
 }
 
@@ -98,8 +99,9 @@ void Node3D::_update_rotation_and_scale() const {
 }
 
 void Node3D::_propagate_transform_changed_deferred() {
-	if (is_inside_tree() && !xform_change.in_list()) {
-		get_tree()->xform_change_list.add(&xform_change);
+	if (is_inside_tree() && !data.xform_change_queued) {
+		set_xform_change_queued(true);
+		get_tree()->xform_3d_change_list.push_back(this);
 	}
 }
 
@@ -115,12 +117,13 @@ void Node3D::_propagate_transform_changed(Node3D *p_origin) {
 		E->_propagate_transform_changed(p_origin);
 	}
 #ifdef TOOLS_ENABLED
-	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !xform_change.in_list()) {
+	if ((!data.gizmos.is_empty() || data.notify_transform) && !data.ignore_notification && !data.xform_change_queued) {
 #else
-	if (data.notify_transform && !data.ignore_notification && !xform_change.in_list()) {
+	if (data.notify_transform && !data.ignore_notification && !data.xform_change_queued) {
 #endif
 		if (likely(is_accessible_from_caller_thread())) {
-			get_tree()->xform_change_list.add(&xform_change);
+			set_xform_change_queued(true);
+			get_tree()->xform_3d_change_list.push_back(this);
 		} else {
 			// This should very rarely happen, but if it does at least make sure the notification is received eventually.
 			callable_mp(this, &Node3D::_propagate_transform_changed_deferred).call_deferred();
@@ -199,8 +202,9 @@ void Node3D::_notification(int p_what) {
 			}
 
 			notification(NOTIFICATION_EXIT_WORLD, true);
-			if (xform_change.in_list()) {
-				get_tree()->xform_change_list.remove(&xform_change);
+			if (data.xform_change_queued) {
+				set_xform_change_queued(false);
+				get_tree()->xform_3d_change_list.erase(this);
 			}
 			if (data.C) {
 				data.parent->data.children.erase(data.C);
@@ -365,6 +369,10 @@ void Node3D::fti_notify_node_changed(bool p_transform_changed) {
 	if (is_inside_tree()) {
 		get_tree()->get_scene_tree_fti().node_3d_notify_changed(*this, p_transform_changed);
 	}
+}
+
+void Node3D::set_xform_change_queued(bool p_queued) {
+	data.xform_change_queued = p_queued;
 }
 
 void Node3D::set_transform(const Transform3D &p_transform) {
@@ -1266,10 +1274,11 @@ bool Node3D::is_local_transform_notification_enabled() const {
 void Node3D::force_update_transform() {
 	ERR_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
-	if (!xform_change.in_list()) {
+	if (!data.xform_change_queued) {
 		return; //nothing to update
 	}
-	get_tree()->xform_change_list.remove(&xform_change);
+	set_xform_change_queued(false);
+	get_tree()->xform_3d_change_list.erase(this);
 
 	notification(NOTIFICATION_TRANSFORM_CHANGED);
 }
@@ -1518,7 +1527,7 @@ void Node3D::_bind_methods() {
 }
 
 Node3D::Node3D() :
-		xform_change(this), _client_physics_interpolation_node_3d_list(this) {
+		_client_physics_interpolation_node_3d_list(this) {
 	// Default member initializer for bitfield is a C++20 extension, so:
 
 	data.top_level = false;
@@ -1527,6 +1536,7 @@ Node3D::Node3D() :
 	data.ignore_notification = false;
 	data.notify_local_transform = false;
 	data.notify_transform = false;
+	data.xform_change_queued = false;
 
 	data.visible = true;
 	data.disable_scale = false;

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -95,7 +95,6 @@ private:
 		uint64_t timeout_physics_tick = 0;
 	};
 
-	mutable SelfList<Node> xform_change;
 	SelfList<Node3D> _client_physics_interpolation_node_3d_list;
 
 	// This Data struct is to avoid namespace pollution in derived classes.
@@ -133,6 +132,7 @@ private:
 		bool ignore_notification : 1;
 		bool notify_local_transform : 1;
 		bool notify_transform : 1;
+		bool xform_change_queued : 1;
 
 		bool visible : 1;
 		bool disable_scale : 1;
@@ -263,6 +263,7 @@ public:
 	Vector3 get_global_rotation() const;
 	Vector3 get_global_rotation_degrees() const;
 
+	void set_xform_change_queued(bool p_queued);
 	void set_transform(const Transform3D &p_transform);
 	void set_basis(const Basis &p_basis);
 	void set_quaternion(const Quaternion &p_quaternion);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -359,8 +359,9 @@ void CanvasItem::_notification(int p_what) {
 			_update_texture_filter_changed(false);
 			_update_texture_repeat_changed(false);
 
-			if (!block_transform_notify && !xform_change.in_list()) {
-				get_tree()->xform_change_list.add(&xform_change);
+			if (!block_transform_notify && !xform_change_queued) {
+				set_xform_change_queued(true);
+				get_tree()->xform_canvas_item_change_list.push_back(this);
 			}
 
 			if (get_viewport()) {
@@ -384,8 +385,9 @@ void CanvasItem::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			ERR_MAIN_THREAD_GUARD;
 
-			if (xform_change.in_list()) {
-				get_tree()->xform_change_list.remove(&xform_change);
+			if (xform_change_queued) {
+				set_xform_change_queued(false);
+				get_tree()->xform_canvas_item_change_list.erase(this);
 			}
 			_exit_canvas();
 			if (C) {
@@ -1026,8 +1028,9 @@ void CanvasItem::draw_char_outline(const Ref<Font> &p_font, const Point2 &p_pos,
 }
 
 void CanvasItem::_notify_transform_deferred() {
-	if (is_inside_tree() && notify_transform && !xform_change.in_list()) {
-		get_tree()->xform_change_list.add(&xform_change);
+	if (is_inside_tree() && notify_transform && !xform_change_queued) {
+		set_xform_change_queued(true);
+		get_tree()->xform_canvas_item_change_list.push_back(this);
 	}
 }
 
@@ -1038,17 +1041,18 @@ void CanvasItem::_notify_transform(CanvasItem *p_node) {
 	 * notification anyway).
 	 */
 
-	if (/*p_node->xform_change.in_list() &&*/ p_node->_is_global_invalid()) {
+	if (p_node->_is_global_invalid()) {
 		return; //nothing to do
 	}
 
 	p_node->_set_global_invalid(true);
 
-	if (p_node->notify_transform && !p_node->xform_change.in_list()) {
+	if (p_node->notify_transform && !p_node->xform_change_queued) {
 		if (!p_node->block_transform_notify) {
 			if (p_node->is_inside_tree()) {
 				if (is_accessible_from_caller_thread()) {
-					get_tree()->xform_change_list.add(&p_node->xform_change);
+					p_node->set_xform_change_queued(true);
+					get_tree()->xform_canvas_item_change_list.push_back(p_node);
 				} else {
 					// Should be rare, but still needs to be handled.
 					callable_mp(p_node, &CanvasItem::_notify_transform_deferred).call_deferred();
@@ -1140,6 +1144,10 @@ RID CanvasItem::get_viewport_rid() const {
 	ERR_READ_THREAD_GUARD_V(RID());
 	ERR_FAIL_COND_V(!is_inside_tree(), RID());
 	return get_viewport()->get_viewport_rid();
+}
+
+void CanvasItem::set_xform_change_queued(bool p_queued) {
+	xform_change_queued = p_queued;
 }
 
 void CanvasItem::set_block_transform_notify(bool p_enable) {
@@ -1246,11 +1254,12 @@ Vector2 CanvasItem::get_local_mouse_position() const {
 void CanvasItem::force_update_transform() {
 	ERR_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
-	if (!xform_change.in_list()) {
+	if (!xform_change_queued) {
 		return;
 	}
 
-	get_tree()->xform_change_list.remove(&xform_change);
+	set_xform_change_queued(false);
+	get_tree()->xform_canvas_item_change_list.erase(this);
 
 	notification(NOTIFICATION_TRANSFORM_CHANGED);
 }
@@ -1726,8 +1735,7 @@ CanvasItem::TextureRepeat CanvasItem::get_texture_repeat_in_tree() const {
 	return (TextureRepeat)texture_repeat_cache;
 }
 
-CanvasItem::CanvasItem() :
-		xform_change(this) {
+CanvasItem::CanvasItem() {
 	canvas_item = RenderingServer::get_singleton()->canvas_item_create();
 }
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -72,9 +72,6 @@ public:
 	};
 
 private:
-	mutable SelfList<Node>
-			xform_change;
-
 	RID canvas_item;
 	StringName canvas_group;
 
@@ -104,6 +101,7 @@ private:
 	bool use_parent_material = false;
 	bool notify_local_transform = false;
 	bool notify_transform = false;
+	bool xform_change_queued = false;
 	bool hide_clip_children = false;
 
 	ClipChildrenMode clip_children_mode = CLIP_CHILDREN_DISABLED;
@@ -355,6 +353,7 @@ public:
 		return canvas_item;
 	}
 
+	void set_xform_change_queued(bool p_queued);
 	void set_block_transform_notify(bool p_enable);
 	bool is_block_transform_notify_enabled() const;
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -192,13 +192,24 @@ void SceneTree::remove_from_group(const StringName &p_group, Node *p_node) {
 void SceneTree::flush_transform_notifications() {
 	_THREAD_SAFE_METHOD_
 
-	SelfList<Node> *n = xform_change_list.first();
-	while (n) {
-		Node *node = n->self();
-		SelfList<Node> *nx = n->next();
-		xform_change_list.remove(n);
-		n = nx;
-		node->notification(NOTIFICATION_TRANSFORM_CHANGED);
+#ifndef _3D_DISABLED
+	if (xform_3d_change_list.size() > 0) {
+		for (Node3D *node : xform_3d_change_list) {
+			node->notification(NOTIFICATION_TRANSFORM_CHANGED);
+			node->set_xform_change_queued(false);
+		}
+
+		xform_3d_change_list.clear();
+	}
+#endif
+
+	if (xform_canvas_item_change_list.size() > 0) {
+		for (CanvasItem *node : xform_canvas_item_change_list) {
+			node->notification(NOTIFICATION_TRANSFORM_CHANGED);
+			node->set_xform_change_queued(false);
+		}
+
+		xform_canvas_item_change_list.clear();
 	}
 }
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -44,6 +44,7 @@ class Node;
 #ifndef _3D_DISABLED
 class Node3D;
 #endif
+class CanvasItem;
 class Window;
 class Material;
 class Mesh;
@@ -253,7 +254,10 @@ private:
 	friend class Node3D;
 	friend class Viewport;
 
-	SelfList<Node>::List xform_change_list;
+#ifndef _3D_DISABLED
+	LocalVector<Node3D *> xform_3d_change_list;
+#endif
+	LocalVector<CanvasItem *> xform_canvas_item_change_list;
 
 #ifdef DEBUG_ENABLED // No live editor in release build.
 	friend class LiveEditor;


### PR DESCRIPTION
Final follow up to https://github.com/godotengine/godot/pull/108491 that does a similar optimization replacing SceneTree::xform_change_list with a Vector.

## How it worked before (I think)
From what I can gather from reading the code the way the xform_change_list worked was:

The xform_change_list was a SelfList::List stored in the scene tree and every CanvasItem and Node3D node also had a SelfList stored.

The xform_change_list is used to queue up node transformation notifications, every frame the `flush_transform_notifications` function gets called 8 different times in various parts of the iteration loop. All this does is send the `NOTIFICATION_TRANSFORM_CHANGED` to every node in the change list and then after the notification is send the node gets removed from the xform change list.

There are also 2 other ways the nodes can get removed from the xform change list. Node3D and CanvasItem can also erase themselves from the change list when they exit the tree but In my testing with a few of the demo projects this seems to pretty much never happen. Node3D and CanvasItem also have a `force_update_transform` function that can erase from the list but this is only used 1 time in the engine in joint_2d.

So 99% of the time the xform_change_list gets used all it does it iterate over the whole list and then clear it. So it seems like a Vector should be much better here, there are ordered erases that could potentially be slower with the Vector but since the list gets flushed 8 times every frame these almost never happen.

## How it works after my changes

The scene tree no longer stores a SelfList::List, this has been changed to 2 Vectors: a Vector<Node3D*> and a Vector<CanvasItem*>.

Individual nodes no longer store a SelfList either, this has been replace with a bool member variable. Before the only thing the SelfList really did in the individual nodes was checking if it was in the xform change list. So this could be replaced with a bool variable but this also means the scene tree has to let the nodes know when they get removed from the xform change list, before this information was propagated via the SelfList's _root but now the flush_transform_notifications explicitly tells the node it is no longer in the list.

This is the reason I used 2 Vectors with each node type instead of just 1 with a Node*, the Node class doesn't have anything to do with transforms so it seemed to me the ideal way to notify the nodes they have been removed from the list without having to do a ton of casting was to just store them separately.

Other than those changes everything else still works the same, the Vectors still get flushed in the same way the SelfList was originally and all the operations in the nodes are also the same.