### PR TITLE
[Windows] Add SSE4.2 support runtime check.

### DIFF
--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -37,6 +37,20 @@ common_win_wrap = [
     "console_wrapper_windows.cpp",
 ]
 
+env_wrap = env.Clone()
+
+if env["arch"] == "x86_64":
+    env_cpp_check = env.Clone()
+    env_cpp_check.add_source_files(sources, ["cpu_feature_validation.c"])
+    if env.msvc:
+        if "/d2archSSE42" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("/d2archSSE42")
+        env.Append(LINKFLAGS=["/ENTRY:ShimMainCRTStartup"])
+    else:
+        if "-msse4.2" in env_cpp_check["CCFLAGS"]:
+            env_cpp_check["CCFLAGS"].remove("-msse4.2")
+        env.Append(LINKFLAGS=["-Wl,--entry=ShimMainCRTStartup"])
+
 
 def arrange_program_clean(prog):
     """
@@ -74,7 +88,6 @@ if env.msvc:
 
 # Build console wrapper app.
 if env["windows_subsystem"] == "gui":
-    env_wrap = env.Clone()
     res_wrap_file = "godot_res_wrap.rc"
     res_wrap_target = "godot_res_wrap" + env["OBJSUFFIX"]
     res_wrap_obj = env_wrap.RES(res_wrap_target, res_wrap_file)

--- a/platform/windows/cpu_feature_validation.c
+++ b/platform/windows/cpu_feature_validation.c
@@ -1,0 +1,50 @@
+/**************************************************************************/
+/*  cpu_feature_validation.c                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include <windows.h>
+
+#ifdef WINDOWS_SUBSYSTEM_CONSOLE
+extern int WINAPI mainCRTStartup();
+#else
+extern int WINAPI WinMainCRTStartup();
+#endif
+
+extern int WINAPI ShimMainCRTStartup() {
+	if (IsProcessorFeaturePresent(PF_SSE4_2_INSTRUCTIONS_AVAILABLE)) {
+#ifdef WINDOWS_SUBSYSTEM_CONSOLE
+		return mainCRTStartup();
+#else
+		return WinMainCRTStartup();
+#endif
+	} else {
+		MessageBoxW(NULL, L"A CPU with SSE4.2 instruction set support is required.", L"Godot Engine", MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
+		return -1;
+	}
+}


### PR DESCRIPTION
Adds entry point override to check for SSE4.2 support and show readable error message instead of silently crashing.

TODO:

- [x] Test with GCC
- [x] Test with clang
- [x] Test with MSVC

Test function is used as entry point, so it is executed before CRT init and is too primitive to contain any SSE instructions:

<details>
  <summary>clang disassembly </summary>

```
                             ShimMainCRTStartup
       140116e20 48 83 ec 28     SUB        RSP,0x28
       140116e24 b9 26 00        MOV        ECX,0x26
                 00 00
       140116e29 e8 72 5f        CALL       KERNEL32.DLL::IsProcessorFeaturePresent
                 77 04
       140116e2e 85 c0           TEST       EAX,EAX
       140116e30 74 09           JZ         LAB_140116e3b
       140116e32 48 83 c4 28     ADD        RSP,0x28
       140116e36 e9 05 a3        JMP        WinMainCRTStartup
                 ee ff
                             LAB_140116e3b                                   XREF[1]:     140116e30(j)  
       140116e3b 48 8d 15        LEA        RDX,[0x1448bc56a]
                 28 57 7a 04
       140116e42 4c 8d 05        LEA        R8,[0x1448bc5d8]
                 8f 57 7a 04
       140116e49 31 c9           XOR        ECX,ECX
       140116e4b 41 b9 30        MOV        R9D,0x2030
                 20 00 00
       140116e51 ff 15 89        CALL       USER32.DLL::MessageBoxW
                 b0 1a 05
       140116e57 b8 ff ff        MOV        EAX,0xffffffff
                 ff ff
       140116e5c 48 83 c4 28     ADD        RSP,0x28
       140116e60 c3              RET
```

</details>


<details>
  <summary>GCC disassembly </summary>

```
                             ShimMainCRTStartup
       1400462e0 55              PUSH       RBP
       1400462e1 48 89 e5        MOV        RBP,RSP
       1400462e4 48 83 ec 20     SUB        RSP,0x20
       1400462e8 b9 26 00        MOV        ECX,0x26
                 00 00
       1400462ed e8 46 20        CALL       KERNEL32.DLL::IsProcessorFeaturePresent
                 88 03
       1400462f2 85 c0           TEST       EAX,EAX
       1400462f4 0f 95 c0        SETNZ      AL
       1400462f7 84 c0           TEST       AL,AL
       1400462f9 74 07           JZ         LAB_140046302
       1400462fb e8 00 b1        CALL       WinMainCRTStartup
                 fb ff
       140046300 eb 2d           JMP        LAB_14004632f
                             LAB_140046302                                   XREF[1]:     1400462f9(j)  
       140046302 48 8d 15        LEA        RDX,[0x1468657f0]
                 e7 f4 81 06
       140046309 48 8d 05        LEA        RAX,[0x146865810]
                 00 f5 81 06
       140046310 41 b9 30        MOV        R9D,0x2030
                 20 00 00
       140046316 49 89 d0        MOV        R8,RDX
       140046319 48 89 c2        MOV        RDX,RAX
       14004631c b9 00 00        MOV        ECX,0x0
                 00 00
       140046321 48 8b 05        MOV        RAX,qword ptr [->USER32.DLL::MessageBoxW]
                 90 5b 02 0a
       140046328 ff d0           CALL       RAX=>USER32.DLL::MessageBoxW
       14004632a b8 ff ff        MOV        EAX,0xffffffff
                 ff ff
                             LAB_14004632f                                   XREF[1]:     140046300(j)  
       14004632f 48 83 c4 20     ADD        RSP,0x20
       140046333 5d              POP        RBP
       140046334 c3              RET
```

</details>

<details>
  <summary>MSVC disassembly </summary>

```
                             ShimMainCRTStartup
       1400aa0d0 48  83  ec       SUB        RSP,0x28
                 28
       1400aa0d4 b9  26  00       MOV        ECX,0x26
                 00  00
       1400aa0d9 ff  15  19       CALL       qword ptr [->KERNEL32.DLL::IsProcessorFeaturePresent]
                 62  8d  05
       1400aa0df 85  c0           TEST       EAX,EAX
       1400aa0e1 74  09           JZ         LAB_1400aa0ec
       1400aa0e3 48  83  c4       ADD        RSP,0x28
                 28
       1400aa0e7 e9  3c  83       JMP        WinMainCRTStartup
                 83  05
                             LAB_1400aa0ec                                   XREF[1]:     1400aa0e1 (j)   
       1400aa0ec 41  b9  30       MOV        R9D,0x2030
                 20  00  00
       1400aa0f2 4c  8d  05       LEA        R8,[0x145991eb8]
                 bf  7d  8e 
                 05
       1400aa0f9 48  8d  15       LEA        RDX,[0x145991ee0]
                 e0  7d  8e 
                 05
       1400aa100 33  c9           XOR        ECX,ECX
       1400aa102 ff  15  20       CALL       qword ptr [->USER32.DLL::MessageBoxW]
                 6d  8d  05
       1400aa108 b8  ff  ff       MOV        EAX,0xffffffff
                 ff  ff
       1400aa10d 48  83  c4       ADD        RSP,0x28
                 28
       1400aa111 c3               RET

```

</details>

Fixes https://github.com/godotengine/godot/issues/108178