### PR TITLE
Fix translation files removed by `--convert-3to4`

### DIFF
--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -458,6 +458,7 @@ bool ProjectConverter3To4::convert() {
 				rename_joypad_buttons_and_axes(source_lines, reg_container);
 				rename_common(RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, source_lines);
 				custom_rename(source_lines, "config_version=4", "config_version=5");
+				custom_rename(source_lines, "^\\[locale\\]$", "[internationalization]", false);
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else if (file_name.ends_with(".import")) {
@@ -642,6 +643,7 @@ bool ProjectConverter3To4::validate_conversion() {
 				changed_elements.append_array(check_for_rename_input_map_scancode(lines, reg_container));
 				changed_elements.append_array(check_for_rename_joypad_buttons_and_axes(lines, reg_container));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::input_map_renames, reg_container.input_map_regexes, lines));
+				changed_elements.append_array(check_for_custom_rename(lines, "^\\[locale\\]$", "[internationalization]", false));
 			} else if (file_name.ends_with(".csproj")) {
 				// TODO
 			} else {
@@ -2832,8 +2834,8 @@ Vector<String> ProjectConverter3To4::check_for_rename_input_map_scancode(Vector<
 	return found_renames;
 }
 
-void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to) {
-	RegEx reg = RegEx(String("\\b") + from + "\\b");
+void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to, bool p_add_boundary_check) {
+	RegEx reg = RegEx(p_add_boundary_check ? "\\b" + from + "\\b" : from);
 	CRASH_COND(!reg.is_valid());
 	for (SourceLine &source_line : source_lines) {
 		if (source_line.is_comment) {
@@ -2847,10 +2849,10 @@ void ProjectConverter3To4::custom_rename(Vector<SourceLine> &source_lines, const
 	}
 }
 
-Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lines, const String &from, const String &to) {
+Vector<String> ProjectConverter3To4::check_for_custom_rename(Vector<String> &lines, const String &from, const String &to, bool p_add_boundary_check) {
 	Vector<String> found_renames;
 
-	RegEx reg = RegEx(String("\\b") + from + "\\b");
+	RegEx reg = RegEx(p_add_boundary_check ? "\\b" + from + "\\b" : from);
 	CRASH_COND(!reg.is_valid());
 
 	int current_line = 1;

--- a/editor/project_upgrade/project_converter_3_to_4.h
+++ b/editor/project_upgrade/project_converter_3_to_4.h
@@ -79,8 +79,8 @@ class ProjectConverter3To4 {
 	void rename_joypad_buttons_and_axes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_joypad_buttons_and_axes(Vector<String> &lines, const RegExContainer &reg_container);
 
-	void custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to);
-	Vector<String> check_for_custom_rename(Vector<String> &lines, const String &from, const String &to);
+	void custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to, bool p_add_boundary_check = true);
+	Vector<String> check_for_custom_rename(Vector<String> &lines, const String &from, const String &to, bool p_add_boundary_check = true);
 
 	void rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<SourceLine> &source_lines);
 	Vector<String> check_for_rename_common(const char *array[][2], LocalVector<RegEx *> &cached_regexes, Vector<String> &lines);

--- a/editor/project_upgrade/renames_map_3_to_4.cpp
+++ b/editor/project_upgrade/renames_map_3_to_4.cpp
@@ -1362,6 +1362,10 @@ const char *RenamesMap3To4::project_settings_renames[][2] = {
 	{ "rendering/quality/shadow_atlas/size.mobile", "rendering/lights_and_shadows/shadow_atlas/size.mobile" },
 	{ "rendering/vram_compression/import_etc2", "rendering/textures/vram_compression/import_etc2_astc" },
 	{ "rendering/vram_compression/import_s3tc", "rendering/textures/vram_compression/import_s3tc_bptc" },
+	{ "locale/fallback", "internationalization/locale/fallback" },
+	{ "locale/test", "internationalization/locale/test" },
+	{ "locale/translation_remaps", "internationalization/locale/translation_remaps" },
+	{ "locale/translations", "internationalization/locale/translations" },
 
 	{ nullptr, nullptr },
 };
@@ -1407,6 +1411,10 @@ const char *RenamesMap3To4::project_godot_renames[][2] = {
 	{ "quality/shadow_atlas/size.mobile", "lights_and_shadows/shadow_atlas/size.mobile" },
 	{ "vram_compression/import_etc2", "textures/vram_compression/import_etc2_astc" },
 	{ "vram_compression/import_s3tc", "textures/vram_compression/import_s3tc_bptc" },
+	{ "fallback", "locale/fallback" },
+	{ "test", "locale/test" },
+	{ "translation_remaps", "locale/translation_remaps" },
+	{ "translations", "locale/translations" },
 
 	{ nullptr, nullptr },
 };


### PR DESCRIPTION
Fixes #78595
Supersedes #82826

The project settings `locale/test`, `locale/fallback`, `locale/translations`, `locale/translation_remaps` are prefixed with `internationalization/` in 4.x.

The tricky part is in `project.godot` where the first segment of the name is saved as the section name in INI format. That is, we need to rename `[locale]` into `[internationalization]` (the brackets are included to avoid false positives). However, section names occupies a whole line, it does not match `\b\[locale\]\b` because the beginning or end of a line is not considered a word boundary. So this PR adds an extra parameter to `custom_rename()` to skip adding `\b`s automatically.