### PR TITLE
Fix camera removal detection after toggling monitoring on Linux

### DIFF
--- a/modules/camera/camera_linux.cpp
+++ b/modules/camera/camera_linux.cpp
@@ -169,6 +169,7 @@ inline void CameraLinux::set_monitoring_feeds(bool p_monitoring_feeds) {
 
 	CameraServer::set_monitoring_feeds(p_monitoring_feeds);
 	if (p_monitoring_feeds) {
+		exit_flag.clear();
 		camera_thread.start(CameraLinux::camera_thread_func, this);
 	} else {
 		exit_flag.set();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

fixed: #108582

Clear `exit_flag` when re-enabling camera monitoring to ensure the monitoring thread can properly detect device removal. 
Previously, the thread would not run after being restarted because `exit_flag` remained set from the previous disable operation.

This fixes an issue where USB cameras disconnected after toggling monitoring_feeds would continue to appear in the feeds list.
