### PR TITLE
Improve edited scene list

### DIFF
--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -138,7 +138,7 @@ private:
 	Vector<Callable> undo_redo_callbacks;
 	HashMap<StringName, Callable> move_element_functions;
 
-	Vector<EditedScene> edited_scene;
+	Vector<EditedScene> edited_scenes;
 	int current_edited_scene = -1;
 	int last_created_scene = 1;
 


### PR DESCRIPTION
Internal improvement to EditorData's scene list:
- Simplified `get_edited_scenes()` method
- Renamed `edited_scene` to `edited_scenes`

I also considered changing `edited_scenes` to LocalVector, but it would involve much more changes.