### PR TITLE
Add default texture filtering option for materials

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4226,6 +4226,14 @@ void RasterizerSceneGLES3::decals_set_filter(RS::DecalFilter p_filter) {
 void RasterizerSceneGLES3::light_projectors_set_filter(RS::LightProjectorFilter p_filter) {
 }
 
+void RasterizerSceneGLES3::base_material_3d_set_default_filter(RS::MaterialFilter p_filter) {
+	if (RS::get_singleton()->base_material_3d_default_filter == p_filter) {
+		return;
+	}
+
+	RS::get_singleton()->base_material_3d_default_filter = p_filter;
+}
+
 void RasterizerSceneGLES3::lightmaps_set_bicubic_filter(bool p_enable) {
 	lightmap_bicubic_upscale = p_enable;
 }
@@ -4243,6 +4251,7 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 
 	positional_soft_shadow_filter_set_quality((RS::ShadowQuality)(int)GLOBAL_GET("rendering/lights_and_shadows/positional_shadow/soft_shadow_filter_quality"));
 	directional_soft_shadow_filter_set_quality((RS::ShadowQuality)(int)GLOBAL_GET("rendering/lights_and_shadows/directional_shadow/soft_shadow_filter_quality"));
+	base_material_3d_set_default_filter(RS::MaterialFilter(int(GLOBAL_GET("rendering/textures/default_filters/base_material_3d_filter"))));
 	lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));
 
 	{

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -939,6 +939,7 @@ public:
 
 	void decals_set_filter(RS::DecalFilter p_filter) override;
 	void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override;
+	void base_material_3d_set_default_filter(RS::MaterialFilter p_filter) override;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) override;
 
 	RasterizerSceneGLES3();

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -141,7 +141,7 @@ void Label3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_hash_scale", PROPERTY_HINT_RANGE, "0,2,0.01"), "set_alpha_hash_scale", "get_alpha_hash_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alpha_antialiasing_mode", PROPERTY_HINT_ENUM, "Disabled,Alpha Edge Blend,Alpha Edge Clip"), "set_alpha_antialiasing", "get_alpha_antialiasing");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_antialiasing_edge", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_antialiasing_edge", "get_alpha_antialiasing_edge");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Default:-1,Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "outline_render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_outline_render_priority", "get_outline_render_priority");
 

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -138,7 +138,7 @@ private:
 
 	RID base_material;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
-	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_DEFAULT;
 
 	bool pending_update = false;
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -680,7 +680,7 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_hash_scale", PROPERTY_HINT_RANGE, "0,2,0.01"), "set_alpha_hash_scale", "get_alpha_hash_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alpha_antialiasing_mode", PROPERTY_HINT_ENUM, "Disabled,Alpha Edge Blend,Alpha Edge Clip"), "set_alpha_antialiasing", "get_alpha_antialiasing");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_antialiasing_edge", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_antialiasing_edge", "get_alpha_antialiasing_edge");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Default:-1,Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 
 	BIND_ENUM_CONSTANT(FLAG_TRANSPARENT);

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -91,7 +91,7 @@ private:
 	StandardMaterial3D::AlphaAntiAliasing alpha_antialiasing_mode = StandardMaterial3D::ALPHA_ANTIALIASING_OFF;
 	float alpha_antialiasing_edge = 0.0f;
 	StandardMaterial3D::BillboardMode billboard_mode = StandardMaterial3D::BILLBOARD_DISABLED;
-	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	StandardMaterial3D::TextureFilter texture_filter = StandardMaterial3D::TEXTURE_FILTER_DEFAULT;
 	bool pending_update = false;
 	void _im_update();
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -728,6 +728,34 @@ void BaseMaterial3D::_update_shader() {
 	// looks broken with nearest-neighbor filtering (with and without Deep Parallax).
 	String texfilter_height_str;
 	switch (texture_filter) {
+		case TEXTURE_FILTER_DEFAULT:
+			switch (RS::get_singleton()->base_material_3d_get_default_filter()) {
+				case RS::MATERIAL_FILTER_NEAREST:
+					texfilter_str = "filter_nearest";
+					texfilter_height_str = "filter_linear";
+					break;
+				case RS::MATERIAL_FILTER_LINEAR:
+					texfilter_str = "filter_linear";
+					texfilter_height_str = "filter_linear";
+					break;
+				case RS::MATERIAL_FILTER_NEAREST_MIPMAPS:
+					texfilter_str = "filter_nearest_mipmap";
+					texfilter_height_str = "filter_linear_mipmap";
+					break;
+				case RS::MATERIAL_FILTER_LINEAR_MIPMAPS:
+					texfilter_str = "filter_linear_mipmap";
+					texfilter_height_str = "filter_linear_mipmap";
+					break;
+				case RS::MATERIAL_FILTER_NEAREST_MIPMAPS_ANISOTROPIC:
+					texfilter_str = "filter_nearest_mipmap_anisotropic";
+					texfilter_height_str = "filter_linear_mipmap_anisotropic";
+					break;
+				case RS::MATERIAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC:
+					texfilter_str = "filter_linear_mipmap_anisotropic";
+					texfilter_height_str = "filter_linear_mipmap_anisotropic";
+					break;
+			}
+			break;
 		case TEXTURE_FILTER_NEAREST:
 			texfilter_str = "filter_nearest";
 			texfilter_height_str = "filter_linear";
@@ -3708,7 +3736,7 @@ void BaseMaterial3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "uv2_world_triplanar"), "set_flag", "get_flag", FLAG_UV2_USE_WORLD_TRIPLANAR);
 
 	ADD_GROUP("Sampling", "texture_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Default:-1,Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "texture_repeat"), "set_flag", "get_flag", FLAG_USE_TEXTURE_REPEAT);
 
 	ADD_GROUP("Shadows", "");
@@ -3780,6 +3808,7 @@ void BaseMaterial3D::_bind_methods() {
 	BIND_ENUM_CONSTANT(TEXTURE_ORM);
 	BIND_ENUM_CONSTANT(TEXTURE_MAX);
 
+	BIND_ENUM_CONSTANT(TEXTURE_FILTER_DEFAULT);
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_NEAREST);
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_LINEAR);
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -167,6 +167,7 @@ public:
 	};
 
 	enum TextureFilter {
+		TEXTURE_FILTER_DEFAULT = -1,
 		TEXTURE_FILTER_NEAREST,
 		TEXTURE_FILTER_LINEAR,
 		TEXTURE_FILTER_NEAREST_WITH_MIPMAPS,
@@ -569,7 +570,7 @@ private:
 	Transparency transparency = TRANSPARENCY_DISABLED;
 	ShadingMode shading_mode = SHADING_MODE_PER_PIXEL;
 
-	TextureFilter texture_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS;
+	TextureFilter texture_filter = TEXTURE_FILTER_DEFAULT;
 
 	Vector3 uv1_scale;
 	Vector3 uv1_offset;
@@ -876,7 +877,7 @@ public:
 	static void finish_shaders();
 	static void flush_changes();
 
-	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_LINEAR_WITH_MIPMAPS, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, RID *r_shader_rid = nullptr);
+	static Ref<Material> get_material_for_2d(bool p_shaded, Transparency p_transparency, bool p_double_sided, bool p_billboard = false, bool p_billboard_y = false, bool p_msdf = false, bool p_no_depth = false, bool p_fixed_size = false, TextureFilter p_filter = TEXTURE_FILTER_DEFAULT, AlphaAntiAliasing p_alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF, RID *r_shader_rid = nullptr);
 
 	virtual RID get_rid() const override;
 	virtual RID get_shader_rid() const override;

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -192,6 +192,7 @@ public:
 
 	virtual void decals_set_filter(RS::DecalFilter p_filter) override {}
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override {}
+	virtual void base_material_3d_set_default_filter(RS::MaterialFilter p_filter) override {}
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) override {}
 
 	RasterizerSceneDummy() {}

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1132,6 +1132,14 @@ void RendererSceneRenderRD::light_projectors_set_filter(RenderingServer::LightPr
 	_update_shader_quality_settings();
 }
 
+void RendererSceneRenderRD::base_material_3d_set_default_filter(RenderingServer::MaterialFilter p_filter) {
+	if (RS::get_singleton()->base_material_3d_default_filter == p_filter) {
+		return;
+	}
+
+	RS::get_singleton()->base_material_3d_default_filter = p_filter;
+}
+
 void RendererSceneRenderRD::lightmaps_set_bicubic_filter(bool p_enable) {
 	if (lightmap_filter_bicubic == p_enable) {
 		return;
@@ -1593,6 +1601,7 @@ void RendererSceneRenderRD::init() {
 
 	decals_set_filter(RS::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
 	light_projectors_set_filter(RS::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
+	base_material_3d_set_default_filter(RS::MaterialFilter(int(GLOBAL_GET("rendering/textures/default_filters/base_material_3d_filter"))));
 	lightmaps_set_bicubic_filter(GLOBAL_GET("rendering/lightmapping/lightmap_gi/use_bicubic_filter"));
 
 	cull_argument.set_page_pool(&cull_argument_pool);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -267,6 +267,7 @@ public:
 
 	virtual void decals_set_filter(RS::DecalFilter p_filter) override;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override;
+	virtual void base_material_3d_set_default_filter(RS::MaterialFilter p_filter) override;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) override;
 
 	_FORCE_INLINE_ RS::ShadowQuality shadows_quality_get() const {

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1389,6 +1389,7 @@ public:
 
 	PASS1(decals_set_filter, RS::DecalFilter)
 	PASS1(light_projectors_set_filter, RS::LightProjectorFilter)
+	PASS1(base_material_3d_set_default_filter, RS::MaterialFilter)
 	PASS1(lightmaps_set_bicubic_filter, bool)
 
 	virtual void update();

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -341,6 +341,7 @@ public:
 
 	virtual void decals_set_filter(RS::DecalFilter p_filter) = 0;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) = 0;
+	virtual void base_material_3d_set_default_filter(RS::MaterialFilter p_filter) = 0;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) = 0;
 
 	virtual void update() = 0;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -354,6 +354,7 @@ public:
 
 	virtual void decals_set_filter(RS::DecalFilter p_filter) = 0;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) = 0;
+	virtual void base_material_3d_set_default_filter(RS::MaterialFilter p_filter) = 0;
 	virtual void lightmaps_set_bicubic_filter(bool p_enable) = 0;
 
 	virtual bool free(RID p_rid) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -849,6 +849,7 @@ public:
 	FUNC1(directional_soft_shadow_filter_set_quality, ShadowQuality);
 	FUNC1(decals_set_filter, RS::DecalFilter);
 	FUNC1(light_projectors_set_filter, RS::LightProjectorFilter);
+	FUNC1(base_material_3d_set_default_filter, RS::MaterialFilter);
 	FUNC1(lightmaps_set_bicubic_filter, bool);
 
 	/* CAMERA ATTRIBUTES */

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2077,6 +2077,14 @@ TypedArray<Image> RenderingServer::_bake_render_uv2(RID p_base, const TypedArray
 	return bake_render_uv2(p_base, mat_overrides, p_image_size);
 }
 
+void RenderingServer::base_material_3d_set_default_filter(RenderingServer::MaterialFilter p_filter) {
+	if (base_material_3d_default_filter == p_filter) {
+		return;
+	}
+
+	base_material_3d_default_filter = p_filter;
+}
+
 void RenderingServer::_particles_set_trail_bind_poses(RID p_particles, const TypedArray<Transform3D> &p_bind_poses) {
 	Vector<Transform3D> tbposes;
 	tbposes.resize(p_bind_poses.size());
@@ -2341,8 +2349,17 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("material_set_next_pass", "material", "next_material"), &RenderingServer::material_set_next_pass);
 
+	ClassDB::bind_method(D_METHOD("base_material_3d_set_default_filter", "filter"), &RenderingServer::base_material_3d_set_default_filter);
+
 	BIND_CONSTANT(MATERIAL_RENDER_PRIORITY_MIN);
 	BIND_CONSTANT(MATERIAL_RENDER_PRIORITY_MAX);
+
+	BIND_ENUM_CONSTANT(MATERIAL_FILTER_NEAREST);
+	BIND_ENUM_CONSTANT(MATERIAL_FILTER_LINEAR);
+	BIND_ENUM_CONSTANT(MATERIAL_FILTER_NEAREST_MIPMAPS);
+	BIND_ENUM_CONSTANT(MATERIAL_FILTER_LINEAR_MIPMAPS);
+	BIND_ENUM_CONSTANT(MATERIAL_FILTER_NEAREST_MIPMAPS_ANISOTROPIC);
+	BIND_ENUM_CONSTANT(MATERIAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC);
 
 	/* MESH API */
 
@@ -3663,6 +3680,8 @@ void RenderingServer::init() {
 
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/enable", true);
 	GLOBAL_DEF_RST("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
+
+	GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::INT, "rendering/textures/default_filters/base_material_3d_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), 3);
 
 	GLOBAL_DEF_RST("rendering/textures/default_filters/use_nearest_mipmap_filter", false);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/default_filters/anisotropic_filtering_level", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),2× (Faster),4× (Fast),8× (Average),16× (Slow)")), 2);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -259,6 +259,17 @@ public:
 		MATERIAL_RENDER_PRIORITY_MAX = 127,
 	};
 
+	enum MaterialFilter {
+		MATERIAL_FILTER_NEAREST,
+		MATERIAL_FILTER_LINEAR,
+		MATERIAL_FILTER_NEAREST_MIPMAPS,
+		MATERIAL_FILTER_LINEAR_MIPMAPS,
+		MATERIAL_FILTER_NEAREST_MIPMAPS_ANISOTROPIC,
+		MATERIAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC,
+	};
+
+	MaterialFilter base_material_3d_default_filter = MATERIAL_FILTER_LINEAR_MIPMAPS;
+
 	virtual RID material_create() = 0;
 	virtual RID material_create_from_shader(RID p_next_pass, int p_render_priority, RID p_shader) = 0;
 
@@ -270,6 +281,10 @@ public:
 	virtual void material_set_render_priority(RID p_material, int priority) = 0;
 
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) = 0;
+
+	virtual void base_material_3d_set_default_filter(MaterialFilter p_filter) = 0;
+
+	_FORCE_INLINE_ MaterialFilter base_material_3d_get_default_filter() const { return base_material_3d_default_filter; }
 
 	/* MESH API */
 
@@ -1934,6 +1949,7 @@ VARIANT_ENUM_CAST(RenderingServer::ReflectionProbeAmbientMode);
 VARIANT_ENUM_CAST(RenderingServer::VoxelGIQuality);
 VARIANT_ENUM_CAST(RenderingServer::DecalTexture);
 VARIANT_ENUM_CAST(RenderingServer::DecalFilter);
+VARIANT_ENUM_CAST(RenderingServer::MaterialFilter);
 VARIANT_ENUM_CAST(RenderingServer::ParticlesMode);
 VARIANT_ENUM_CAST(RenderingServer::ParticlesTransformAlign);
 VARIANT_ENUM_CAST(RenderingServer::ParticlesDrawOrder);


### PR DESCRIPTION
Resolves godotengine/godot-proposals#5228, based off the work of @Calinou 

While it does require an editor restart it's still an improvement over manually changing all materials.