### PR TITLE
[macOS] Add method to get liquid glass icon theme and set icon variants.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -895,6 +895,15 @@
 				[b]Note:[/b] This doesn't affect native dialogs such as the ones spawned by [method DisplayServer.dialog_show].
 			</description>
 		</method>
+		<method name="get_system_icon_theme" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns system application icon theme information. Returned [Dictionary] contains the floating entries:
+				- [code]theme : String[/code] icon theme name, one of the following values: "RegularLight", "RegularDark", "ClearLight", "ClearDark", "ClearAutomatic", "TintedLight", "TintedDark", "TintedAutomatic".
+				- [code]tint : Color[/code] icon tint color.
+				[b]Note:[/b] This method is implemented on macOS.
+			</description>
+		</method>
 		<method name="get_window_at_screen_position" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="position" type="Vector2i" />
@@ -1871,6 +1880,14 @@
 			<description>
 				Sets the [param callable] that should be called when system theme settings are changed. Callback method should have zero arguments.
 				[b]Note:[/b] This method is implemented on Android, iOS, macOS, Windows, and Linux (X11/Wayland).
+			</description>
+		</method>
+		<method name="set_themed_icons">
+			<return type="void" />
+			<param index="0" name="images" type="Dictionary" />
+			<description>
+				Sets themed variants of the application icon, [param images] should contain images with the following keys: "RegularLight", "RegularDark", "ClearLight", "ClearDark", "TintedLight", "TintedDark".
+				[b]Note:[/b] This method is implemented on macOS.
 			</description>
 		</method>
 		<method name="show_emoji_and_symbol_picker" qualifiers="const">

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -210,6 +210,17 @@ private:
 	IndicatorID indicator_id_counter = 0;
 	HashMap<IndicatorID, IndicatorData> indicators;
 
+	struct SysIconTheme {
+		String theme;
+		Color tint;
+	};
+	SysIconTheme cur_theme;
+	Thread check_for_changes_thread;
+	SafeFlag quit_request;
+
+	static void _check_for_changes_poll_thread(void *ud);
+	SysIconTheme _get_sys_theme() const;
+
 	IOPMAssertionID screen_keep_on_assertion = kIOPMNullAssertionID;
 
 	Callable help_search_callback;
@@ -222,6 +233,10 @@ private:
 	List<MenuCall> deferred_menu_calls;
 
 	Callable system_theme_changed;
+
+	Dictionary themed_icons;
+
+	void _update_themed_icon();
 
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, const Rect2i &p_rect);
 	void _update_window_style(WindowData p_wd, WindowID p_window);
@@ -301,6 +316,7 @@ public:
 
 	virtual bool is_dark_mode_supported() const override;
 	virtual bool is_dark_mode() const override;
+	virtual Dictionary get_system_icon_theme() const override;
 	virtual Color get_accent_color() const override;
 	virtual Color get_base_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
@@ -453,6 +469,7 @@ public:
 
 	virtual void set_native_icon(const String &p_filename) override;
 	virtual void set_icon(const Ref<Image> &p_icon) override;
+	virtual void set_themed_icons(const Dictionary &p_icons) override;
 
 	virtual IndicatorID create_status_indicator(const Ref<Texture2D> &p_icon, const String &p_tooltip, const Callable &p_callback) override;
 	virtual void status_indicator_set_icon(IndicatorID p_id, const Ref<Texture2D> &p_icon) override;

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1364,6 +1364,7 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_dark_mode_supported"), &DisplayServer::is_dark_mode_supported);
 	ClassDB::bind_method(D_METHOD("is_dark_mode"), &DisplayServer::is_dark_mode);
+	ClassDB::bind_method(D_METHOD("get_system_icon_theme"), &DisplayServer::get_system_icon_theme);
 	ClassDB::bind_method(D_METHOD("get_accent_color"), &DisplayServer::get_accent_color);
 	ClassDB::bind_method(D_METHOD("get_base_color"), &DisplayServer::get_base_color);
 	ClassDB::bind_method(D_METHOD("set_system_theme_change_callback", "callable"), &DisplayServer::set_system_theme_change_callback);
@@ -1603,6 +1604,7 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_native_icon", "filename"), &DisplayServer::set_native_icon);
 	ClassDB::bind_method(D_METHOD("set_icon", "image"), &DisplayServer::set_icon);
+	ClassDB::bind_method(D_METHOD("set_themed_icons", "images"), &DisplayServer::set_themed_icons);
 
 	ClassDB::bind_method(D_METHOD("create_status_indicator", "icon", "tooltip", "callback"), &DisplayServer::create_status_indicator);
 	ClassDB::bind_method(D_METHOD("status_indicator_set_icon", "id", "icon"), &DisplayServer::status_indicator_set_icon);

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -270,6 +270,7 @@ public:
 
 	virtual bool is_dark_mode_supported() const { return false; }
 	virtual bool is_dark_mode() const { return false; }
+	virtual Dictionary get_system_icon_theme() const { return Dictionary(); }
 	virtual Color get_accent_color() const { return Color(0, 0, 0, 0); }
 	virtual Color get_base_color() const { return Color(0, 0, 0, 0); }
 	virtual void set_system_theme_change_callback(const Callable &p_callable) {}
@@ -858,6 +859,7 @@ public:
 
 	virtual void set_native_icon(const String &p_filename);
 	virtual void set_icon(const Ref<Image> &p_icon);
+	virtual void set_themed_icons(const Dictionary &p_icons) {}
 
 	virtual IndicatorID create_status_indicator(const Ref<Texture2D> &p_icon, const String &p_tooltip, const Callable &p_callback);
 	virtual void status_indicator_set_icon(IndicatorID p_id, const Ref<Texture2D> &p_icon);


### PR DESCRIPTION
Adds methods to get icon theme and set multiple icon variants (correct one is automatically selected and tinted).

### TODO
- [x] Automatically update icon when system settings are changed (probably there is a notification, but it is not documented).
- [x] Add project settings for themed icons (can be reused for Android and iOS exports as well) - https://github.com/godotengine/godot/pull/108794.

https://github.com/user-attachments/assets/4d16fb57-798d-4675-b0c7-6238740b0b4a