### PR TITLE
Fix `TabBar` minimum size with `clip_tabs` enabled

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -44,6 +44,7 @@ Size2 TabBar::get_minimum_size() const {
 	}
 
 	int y_margin = MAX(MAX(MAX(theme_cache.tab_unselected_style->get_minimum_size().height, theme_cache.tab_hovered_style->get_minimum_size().height), theme_cache.tab_selected_style->get_minimum_size().height), theme_cache.tab_disabled_style->get_minimum_size().height);
+	int max_tab_width = 0;
 
 	for (int i = 0; i < tabs.size(); i++) {
 		if (tabs[i].hidden) {
@@ -102,10 +103,14 @@ Size2 TabBar::get_minimum_size() const {
 		if (i < tabs.size() - 1) {
 			ms.width += theme_cache.tab_separation;
 		}
+
+		if (ms.width - ofs > max_tab_width) {
+			max_tab_width = ms.width - ofs;
+		}
 	}
 
 	if (clip_tabs) {
-		ms.width = 0;
+		ms.width = max_tab_width + (get_tab_count() > 1 ? theme_cache.decrement_icon->get_width() + theme_cache.increment_icon->get_width() : 0);
 	}
 
 	return ms;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -948,17 +948,17 @@ Size2 TabContainer::get_minimum_size() const {
 
 	if (tabs_visible) {
 		ms = tab_bar->get_minimum_size();
-		ms.x += theme_cache.tabbar_style->get_margin(SIDE_LEFT) + theme_cache.tabbar_style->get_margin(SIDE_RIGHT);
-		ms.y += theme_cache.tabbar_style->get_margin(SIDE_TOP) + theme_cache.tabbar_style->get_margin(SIDE_BOTTOM);
+		ms.width += theme_cache.tabbar_style->get_margin(SIDE_LEFT) + theme_cache.tabbar_style->get_margin(SIDE_RIGHT);
+		ms.height += theme_cache.tabbar_style->get_margin(SIDE_TOP) + theme_cache.tabbar_style->get_margin(SIDE_BOTTOM);
 
 		if (!get_clip_tabs()) {
 			if (get_popup()) {
-				ms.x += theme_cache.menu_icon->get_width();
+				ms.width += theme_cache.menu_icon->get_width();
 			}
 
 			if (theme_cache.side_margin > 0 && get_tab_alignment() != TabBar::ALIGNMENT_CENTER &&
 					(get_tab_alignment() != TabBar::ALIGNMENT_RIGHT || !get_popup())) {
-				ms.x += theme_cache.side_margin;
+				ms.width += theme_cache.side_margin;
 			}
 		}
 	}
@@ -975,12 +975,12 @@ Size2 TabContainer::get_minimum_size() const {
 		Size2 cms = c->get_combined_minimum_size();
 		largest_child_min_size = largest_child_min_size.max(cms);
 	}
-	ms.y += largest_child_min_size.y;
+	ms.height += largest_child_min_size.height;
 
 	Size2 panel_ms = theme_cache.panel_style->get_minimum_size();
 
-	ms.x = MAX(ms.x, largest_child_min_size.x + panel_ms.x);
-	ms.y += panel_ms.y;
+	ms.width = MAX(ms.width, largest_child_min_size.width + panel_ms.width);
+	ms.height += panel_ms.height;
 
 	return ms;
 }

--- a/tests/scene/test_tab_bar.h
+++ b/tests/scene/test_tab_bar.h
@@ -820,10 +820,11 @@ TEST_CASE("[SceneTree][TabBar] layout and offset") {
 		MessageQueue::get_singleton()->flush();
 		CHECK(tab_bar->get_tab_offset() == 0);
 
-		// Horizontal size and minimum size get set to 0.
-		CHECK(tab_bar->get_minimum_size().x == 0);
+		// Horizontal size and minimum size get set to the widest tab plus arrow icons.
+		const float offset_button_size = tab_bar->get_theme_icon("decrement_icon")->get_width() + tab_bar->get_theme_icon("increment_icon")->get_width();
+		CHECK(tab_bar->get_minimum_size().x == offset_button_size + MAX(tab_rects[0].size.x, MAX(tab_rects[1].size.x, tab_rects[2].size.x)));
 		CHECK(tab_bar->get_minimum_size().y == all_tabs_size.y);
-		CHECK(tab_bar->get_size().x == 0);
+		CHECK(tab_bar->get_size().x == offset_button_size + MAX(tab_rects[0].size.x, MAX(tab_rects[1].size.x, tab_rects[2].size.x)));
 		CHECK(tab_bar->get_size().y == all_tabs_size.y);
 	}
 


### PR DESCRIPTION
Currently, when `clip_tabs` is enabled, `TabContainer` and `TabBar`'s minimum sizes are set to 0, resulting in incorrect drawing:

<img width="204" height="104" alt="Incorrect Minimum Size" src="https://github.com/user-attachments/assets/318d6bda-09f7-4ba5-93ca-1fc3292e918a" />

This PR fixes this by including the proper calculation for the width of the `TabBar` when `clip_tabs` is enabled, which means that the minimum width is the width of the current tab plus the arrow icons. It also includes a style change to clarify in `TabContainer::get_minimum_size()` that it is working with widths and heights, to bring it more in line with `TabBar::get_minimum_size()`