### PR TITLE
Update timeline when calling AnimationPlayer::seek() from an editor tool

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -337,6 +337,12 @@
 				Emitted when [member current_animation] changes.
 			</description>
 		</signal>
+		<signal name="seeked">
+			<param index="0" name="time" type="float" />
+			<description>
+				Emitted when [method seek] is called.
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="ANIMATION_PROCESS_PHYSICS" value="0" enum="AnimationProcessCallback" deprecated="See [constant AnimationMixer.ANIMATION_CALLBACK_MODE_PROCESS_PHYSICS].">

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1410,6 +1410,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_timeline_o
 		player->seek_internal(pos, true, true, false);
 	}
 
+	frame->set_value(pos);
 	track_editor->set_anim_pos(pos);
 }
 

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1217,6 +1217,9 @@ void AnimationPlayerEditor::edit(AnimationMixer *p_node, AnimationPlayer *p_play
 		if (player->is_connected(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed))) {
 			player->disconnect(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed));
 		}
+		if (player->is_connected(SNAME("seeked"), callable_mp(this, &AnimationPlayerEditor::_animation_player_seeked))) {
+			player->disconnect(SNAME("seeked"), callable_mp(this, &AnimationPlayerEditor::_animation_player_seeked));
+		}
 	}
 
 	AnimationTree *tree = Object::cast_to<AnimationTree>(p_node);
@@ -1246,6 +1249,9 @@ void AnimationPlayerEditor::edit(AnimationMixer *p_node, AnimationPlayer *p_play
 		}
 		if (!player->is_connected(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed))) {
 			player->connect(SNAME("current_animation_changed"), callable_mp(this, &AnimationPlayerEditor::_current_animation_changed));
+		}
+		if (!player->is_connected(SNAME("seeked"), callable_mp(this, &AnimationPlayerEditor::_animation_player_seeked))) {
+			player->connect(SNAME("seeked"), callable_mp(this, &AnimationPlayerEditor::_animation_player_seeked));
 		}
 		_update_player();
 
@@ -1412,6 +1418,10 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_timeline_o
 
 	frame->set_value(pos);
 	track_editor->set_anim_pos(pos);
+}
+
+void AnimationPlayerEditor::_animation_player_seeked(float p_value) {
+	_seek_value_changed(p_value, false);
 }
 
 void AnimationPlayerEditor::_animation_player_changed(Object *p_pl) {

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -199,6 +199,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _animation_resource_edit();
 	void _scale_changed(const String &p_scale);
 	void _seek_value_changed(float p_value, bool p_timeline_only = false);
+	void _animation_player_seeked(float p_value);
 	void _blend_editor_next_changed(const int p_idx);
 
 	void _edit_animation_blend();

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -675,6 +675,8 @@ void AnimationPlayer::seek_internal(double p_time, bool p_update, bool p_update_
 
 void AnimationPlayer::seek(double p_time, bool p_update, bool p_update_only) {
 	seek_internal(p_time, p_update, p_update_only);
+	// Notify the AnimationPlayerEditor that the time changed.
+	emit_signal(SNAME("seeked"), p_time);
 }
 
 void AnimationPlayer::advance(double p_time) {
@@ -1030,6 +1032,7 @@ void AnimationPlayer::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo(SNAME("current_animation_changed"), PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo(SNAME("animation_changed"), PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
+	ADD_SIGNAL(MethodInfo(SNAME("seeked"), PropertyInfo(Variant::FLOAT, "time")));
 }
 
 AnimationPlayer::AnimationPlayer() {


### PR DESCRIPTION
When calling `seek()` from an editor tool while the AnimationPlayer is paused, the timeline wouldn't update visually because the AnimationPlayerEditor was never notified about it.

This PR fixes this by emitting the new signal `seeked` whenever `seek()` is called, which AnimationPlayerEditor subscribes to.

https://github.com/user-attachments/assets/347779a8-b1ff-40c7-ad78-571047d499a0

This PR also fixes the frame SpinBox not being updated in `AnimationPlayerEditor::_seek_value_changed`:

https://github.com/user-attachments/assets/1d3eeaa4-6596-4d21-80fa-a0c35dd8c040

https://github.com/user-attachments/assets/e9400edb-378d-4180-9f44-f37809301ed2