### PR TITLE
[macOS] Fix disabling native menu items in system menus.

### DIFF
--- a/platform/macos/godot_application_delegate.h
+++ b/platform/macos/godot_application_delegate.h
@@ -37,7 +37,7 @@
 
 class OS_MacOS_NSApp;
 
-@interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate>
+@interface GodotApplicationDelegate : NSObject <NSUserInterfaceItemSearching, NSApplicationDelegate, NSMenuItemValidation>
 
 - (GodotApplicationDelegate *)initWithOS:(OS_MacOS_NSApp *)os;
 

--- a/platform/macos/godot_application_delegate.mm
+++ b/platform/macos/godot_application_delegate.mm
@@ -31,6 +31,7 @@
 #import "godot_application_delegate.h"
 
 #import "display_server_macos.h"
+#import "godot_menu_item.h"
 #import "key_mapping_macos.h"
 #import "native_menu_macos.h"
 #import "os_macos.h"
@@ -280,6 +281,16 @@ constexpr static NSEventModifierFlags FLAGS = NSEventModifierFlagCommand | NSEve
 		ke->set_location(KeyMappingMacOS::translate_location(key));
 		input->parse_input_event(ke);
 	}
+}
+
+- (BOOL)validateMenuItem:(NSMenuItem *)item {
+	if (item) {
+		GodotMenuItem *value = [item representedObject];
+		if (value) {
+			return value->enabled;
+		}
+	}
+	return YES;
 }
 
 - (void)globalMenuCallback:(id)sender {

--- a/platform/macos/godot_menu_item.h
+++ b/platform/macos/godot_menu_item.h
@@ -53,6 +53,7 @@ enum GlobalMenuCheckType {
 	Key accel;
 	GlobalMenuCheckType checkable_type;
 	bool checked;
+	bool enabled;
 	int max_states;
 	int state;
 	Ref<Image> img;

--- a/platform/macos/godot_menu_item.mm
+++ b/platform/macos/godot_menu_item.mm
@@ -38,6 +38,7 @@
 	self->callback = Callable();
 	self->key_callback = Callable();
 	self->checkable_type = GlobalMenuCheckType::CHECKABLE_TYPE_NONE;
+	self->enabled = true;
 	self->checked = false;
 	self->max_states = 0;
 	self->state = 0;

--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -1204,6 +1204,8 @@ void NativeMenuMacOS::set_item_disabled(const RID &p_rid, int p_idx, bool p_disa
 	ERR_FAIL_COND(p_idx >= item_start + item_count);
 	NSMenuItem *menu_item = [md->menu itemAtIndex:p_idx];
 	if (menu_item) {
+		GodotMenuItem *obj = [menu_item representedObject];
+		obj->enabled = !p_disabled;
 		[menu_item setEnabled:(!p_disabled)];
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108580

Some system menus have `AutoenablesItems` enabled to handle default system items and therefore require `NSMenuItemValidation` protocol to disable custom items.