### PR TITLE
[TextEdit] Draw guidelines under the text and caret.

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -70,28 +70,9 @@ void CodeEdit::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
-			const Size2 size = get_size();
 			const bool caret_visible = is_caret_visible();
 			const bool rtl = is_layout_rtl();
 			const int row_height = get_line_height();
-
-			if (line_length_guideline_columns.size() > 0) {
-				const int xmargin_beg = theme_cache.style_normal->get_margin(SIDE_LEFT) + get_total_gutter_width();
-				const int xmargin_end = size.width - theme_cache.style_normal->get_margin(SIDE_RIGHT) - (is_drawing_minimap() ? get_minimap_width() : 0);
-
-				for (int i = 0; i < line_length_guideline_columns.size(); i++) {
-					const int column_pos = theme_cache.font->get_string_size(String("0").repeat((int)line_length_guideline_columns[i]), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
-					const int xoffset = xmargin_beg + column_pos - get_h_scroll();
-					if (xoffset > xmargin_beg && xoffset < xmargin_end) {
-						Color guideline_color = (i == 0) ? theme_cache.line_length_guideline_color : theme_cache.line_length_guideline_color * Color(1, 1, 1, 0.5);
-						if (rtl) {
-							RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(size.width - xoffset, 0), Point2(size.width - xoffset, size.height), guideline_color);
-							continue;
-						}
-						RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(xoffset, 0), Point2(xoffset, size.height), guideline_color);
-					}
-				}
-			}
 
 			if (caret_visible) {
 				const bool draw_code_completion = code_completion_active && !code_completion_options.is_empty();
@@ -277,6 +258,32 @@ void CodeEdit::_notification(int p_what) {
 		case NOTIFICATION_MOUSE_EXIT: {
 			symbol_tooltip_timer->stop();
 		} break;
+	}
+}
+
+void CodeEdit::_draw_guidelines() {
+	if (line_length_guideline_columns.is_empty()) {
+		return;
+	}
+
+	RID ci = get_canvas_item();
+	const Size2 size = get_size();
+	const bool rtl = is_layout_rtl();
+
+	const int xmargin_beg = theme_cache.style_normal->get_margin(SIDE_LEFT) + get_total_gutter_width();
+	const int xmargin_end = size.width - theme_cache.style_normal->get_margin(SIDE_RIGHT) - (is_drawing_minimap() ? get_minimap_width() : 0);
+
+	for (int i = 0; i < line_length_guideline_columns.size(); i++) {
+		const int column_pos = theme_cache.font->get_string_size(String("0").repeat((int)line_length_guideline_columns[i]), HORIZONTAL_ALIGNMENT_LEFT, -1, theme_cache.font_size).x;
+		const int xoffset = xmargin_beg + column_pos - get_h_scroll();
+		if (xoffset > xmargin_beg && xoffset < xmargin_end) {
+			Color guideline_color = (i == 0) ? theme_cache.line_length_guideline_color : theme_cache.line_length_guideline_color * Color(1, 1, 1, 0.5);
+			if (rtl) {
+				RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(size.width - xoffset, 0), Point2(size.width - xoffset, size.height), guideline_color);
+				continue;
+			}
+			RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2(xoffset, 0), Point2(xoffset, size.height), guideline_color);
+		}
 	}
 }
 

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -325,6 +325,8 @@ protected:
 
 	virtual void _unhide_carets() override;
 
+	virtual void _draw_guidelines() override;
+
 	/* Text manipulation */
 
 	// Overridable actions

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1304,6 +1304,9 @@ void TextEdit::_notification(int p_what) {
 				bottom_limit_y -= theme_cache.style_normal->get_margin(SIDE_BOTTOM);
 			}
 
+			// Draw guidelines.
+			_draw_guidelines();
+
 			// Draw main text.
 			line_drawing_cache.clear();
 			int row_height = draw_placeholder ? placeholder_line_height + theme_cache.line_spacing : get_line_height();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -696,6 +696,7 @@ protected:
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
+	virtual void _draw_guidelines() {}
 	virtual void _update_theme_item_cache() override;
 
 	/* Internal API for CodeEdit, pending public API. */


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/92238
Fixes https://github.com/godotengine/godot/issues/108481

Adds an internal virtual method to draw guidelines in the middle of `TextEdit` draw instead of using own `DRAW`.

Before:
<img width="1083" height="250" alt="Screenshot 2025-07-14 at 10 49 29" src="https://github.com/user-attachments/assets/2bae8e77-c900-4d80-a79f-c53702c99360" />

After:
<img width="1083" height="250" alt="Screenshot 2025-07-14 at 10 51 09" src="https://github.com/user-attachments/assets/4db7a6e4-ad13-4dde-92a2-32def6e949b4" />
