### PR TITLE
Gridmap Editor - Reset clipboard when the editor is unselected

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1030,6 +1030,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 
 	if (!node) {
 		set_process(false);
+		_clear_clipboard_data();
 		for (int i = 0; i < 3; i++) {
 			RenderingServer::get_singleton()->instance_set_visible(grid_instance[i], false);
 		}


### PR DESCRIPTION
fix: https://github.com/godotengine/godot/issues/70890
and probably fix: https://github.com/godotengine/godot/issues/50323 
if code hasnt changed much from 3.x

This resets the clipboard data when the gridmap editor is unselected, this avoids leaving behind the paste selection meshes,
User experience should not be affected since the selection data is currently marked as inactive when the editor regains focus,
thus making it impossible to copy and paste between editor "visits"

Making it possible would probably be nice but at least this prevents the editor from leaving a mess when unselected
