### PR TITLE
SCons: Ensure scanner parses external includes

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1163,6 +1163,12 @@ for key in (emitters := env.StaticObject.builder.emitter):
 for key in (emitters := env.SharedObject.builder.emitter):
     emitters[key] = ListEmitter([methods.redirect_emitter] + env.Flatten(emitters[key]))
 
+# Ensure external paths are scanned for includes.
+env["CSCANNERADVANCED"] = methods.c_scanner_advanced()
+for key in (scanner_base := env["SCANNERS"][0]).get_skeys(env):
+    if isinstance(scanner_base.function[key], type(CScan)):
+        scanner_base.function[key] = env["CSCANNERADVANCED"]
+
 # Prepend compiler launchers
 if "c_compiler_launcher" in env:
     env["CC"] = " ".join([env["c_compiler_launcher"], env["CC"]])

--- a/drivers/accesskit/SCsub
+++ b/drivers/accesskit/SCsub
@@ -13,4 +13,4 @@ if env["accesskit_sdk_path"] == "":
         env.add_source_files(env.drivers_sources, "dynwrappers/accesskit-dylib_wrap.c")
     if env["platform"] == "linuxbsd":
         env.add_source_files(env.drivers_sources, "dynwrappers/accesskit-so_wrap.c")
-    env.Prepend(CPPPATH=["#thirdparty/accesskit/include"])
+    env.Prepend(CPPEXTPATH=["#thirdparty/accesskit/include"])

--- a/drivers/apple_embedded/SCsub
+++ b/drivers/apple_embedded/SCsub
@@ -10,7 +10,7 @@ env_apple_embedded.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])
 
 # Use bundled Vulkan headers
 vulkan_dir = "#thirdparty/vulkan"
-env_apple_embedded.Prepend(CPPPATH=[vulkan_dir, vulkan_dir + "/include"])
+env_apple_embedded.Prepend(CPPEXTPATH=[vulkan_dir, vulkan_dir + "/include"])
 
 # Driver source files
 env_apple_embedded.add_source_files(env.drivers_sources, "*.mm")

--- a/drivers/sdl/SCsub
+++ b/drivers/sdl/SCsub
@@ -18,7 +18,7 @@ if env["builtin_sdl"]:
     # Common sources.
 
     env_sdl.Prepend(
-        CPPPATH=[
+        CPPEXTPATH=[
             thirdparty_dir,
             thirdparty_dir + "include",
             thirdparty_dir + "include/build_config",

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -450,7 +450,14 @@ if env["builtin_icu4c"]:
     ]
     thirdparty_sources = [thirdparty_dir + file for file in thirdparty_sources]
 
-    if not env.editor_build:
+    if env.editor_build:
+        env_icu.CommandNoCache(
+            "#thirdparty/icu4c/icudata.gen.h",
+            "#thirdparty/icu4c/icudt_godot.dat",
+            env.Run(text_server_adv_builders.make_icu_data),
+        )
+        env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/icu4c/"])
+    else:
         thirdparty_sources += ["icu_data/icudata_stub.cpp"]
 
     env_icu.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
@@ -486,15 +493,6 @@ if env["builtin_icu4c"]:
 
     lib = env_icu.add_library("icu_builtin", thirdparty_sources)
     thirdparty_obj += lib
-
-    if env.editor_build:
-        icudata = env_icu.CommandNoCache(
-            "#thirdparty/icu4c/icudata.gen.h",
-            "#thirdparty/icu4c/icudt_godot.dat",
-            env.Run(text_server_adv_builders.make_icu_data),
-        )
-        env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/icu4c/"])
-        env_icu.Depends(lib, icudata)
 
     # Needs to be appended to arrive after libscene in the linker call,
     # but we don't want it to arrive *after* system libs, so manual hack

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -84,7 +84,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     thirdparty_tvg_sources = [thirdparty_tvg_dir + file for file in thirdparty_tvg_sources]
 
     env_tvg.Append(
-        CPPPATH=[
+        CPPEXTPATH=[
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -101,7 +101,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     env_tvg.Append(CPPDEFINES=["TVG_STATIC"])
 
     env.Append(
-        CPPPATH=[
+        CPPEXTPATH=[
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -149,8 +149,8 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
     thirdparty_msdfgen_sources = [thirdparty_msdfgen_dir + file for file in thirdparty_msdfgen_sources]
 
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    env_msdfgen.Append(CPPPATH=["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
-    env.Append(CPPPATH=["../../../thirdparty/msdfgen"])
+    env_msdfgen.Append(CPPEXTPATH=["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
+    env.Append(CPPEXTPATH=["../../../thirdparty/msdfgen"])
     env.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
     env.Append(CPPDEFINES=["MODULE_MSDFGEN_ENABLED"])
 
@@ -265,11 +265,11 @@ if env["freetype_enabled"]:
         ]
         thirdparty_freetype_sources += [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
         env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-        env_freetype.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+        env_freetype.Prepend(CPPEXTPATH=[thirdparty_brotli_dir + "include"])
         env.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
 
-    env_freetype.Append(CPPPATH=[thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
-    env.Append(CPPPATH=[thirdparty_freetype_dir + "/include"])
+    env_freetype.Append(CPPEXTPATH=[thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
+    env.Append(CPPEXTPATH=[thirdparty_freetype_dir + "/include"])
 
     env_freetype.Append(
         CPPDEFINES=[
@@ -379,7 +379,7 @@ if env["freetype_enabled"]:
 thirdparty_harfbuzz_sources = [thirdparty_harfbuzz_dir + file for file in thirdparty_harfbuzz_sources]
 
 env_harfbuzz.Append(
-    CPPPATH=[
+    CPPEXTPATH=[
         "../../../thirdparty/harfbuzz/src",
         "../../../thirdparty/icu4c/common/",
         "../../../thirdparty/icu4c/i18n/",
@@ -388,7 +388,7 @@ env_harfbuzz.Append(
 
 if env["freetype_enabled"]:
     env_harfbuzz.Append(
-        CPPPATH=[
+        CPPEXTPATH=[
             "../../../thirdparty/freetype/include",
             "../../../thirdparty/graphite/include",
         ]
@@ -416,7 +416,7 @@ if env["freetype_enabled"]:
         ]
     )
 
-env.Append(CPPPATH=["../../../thirdparty/harfbuzz/src"])
+env.Append(CPPEXTPATH=["../../../thirdparty/harfbuzz/src"])
 
 lib = env_harfbuzz.Library(
     f"harfbuzz_builtin{env['suffix']}{env['LIBSUFFIX']}",
@@ -469,7 +469,7 @@ if env["graphite_enabled"] and env["freetype_enabled"]:
 
     thirdparty_graphite_sources = [thirdparty_graphite_dir + file for file in thirdparty_graphite_sources]
 
-    env_graphite.Append(CPPPATH=["../../../thirdparty/graphite/src", "../../../thirdparty/graphite/include"])
+    env_graphite.Append(CPPEXTPATH=["../../../thirdparty/graphite/src", "../../../thirdparty/graphite/include"])
     env_graphite.Append(
         CPPDEFINES=[
             "GRAPHITE2_STATIC",
@@ -704,11 +704,11 @@ if env["static_icu_data"]:
         "../../../thirdparty/icu4c/icudata.gen.h", "../../../thirdparty/icu4c/icudt_godot.dat", methods.make_icu_data
     )
     env.Append(CPPDEFINES=["ICU_STATIC_DATA"])
-    env.Append(CPPPATH=["../../../thirdparty/icu4c/"])
+    env.Append(CPPEXTPATH=["../../../thirdparty/icu4c/"])
 else:
     thirdparty_icu_sources += ["../icu_data/icudata_stub.cpp"]
 
-env_icu.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
+env_icu.Append(CPPEXTPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
 env_icu.Append(
     CPPDEFINES=[
         "U_STATIC_IMPLEMENTATION",
@@ -733,7 +733,7 @@ env.Append(
         ("U_LIB_SUFFIX_C_NAME", "_godot"),
     ]
 )
-env.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
+env.Append(CPPEXTPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
 
 if env["platform"] == "windows":
     env.Append(LIBS=["advapi32"])

--- a/modules/text_server_fb/gdextension_build/SConstruct
+++ b/modules/text_server_fb/gdextension_build/SConstruct
@@ -79,7 +79,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     thirdparty_tvg_sources = [thirdparty_tvg_dir + file for file in thirdparty_tvg_sources]
 
     env_tvg.Append(
-        CPPPATH=[
+        CPPEXTPATH=[
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -96,7 +96,7 @@ if env["thorvg_enabled"] and env["freetype_enabled"]:
     env_tvg.Append(CPPDEFINES=["TVG_STATIC"])
 
     env.Append(
-        CPPPATH=[
+        CPPEXTPATH=[
             "../../../thirdparty/thorvg/inc",
             "../../../thirdparty/thorvg/src/common",
             "../../../thirdparty/thorvg/src/renderer",
@@ -144,8 +144,8 @@ if env["msdfgen_enabled"] and env["freetype_enabled"]:
     thirdparty_msdfgen_sources = [thirdparty_msdfgen_dir + file for file in thirdparty_msdfgen_sources]
 
     env_msdfgen.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
-    env_msdfgen.Append(CPPPATH=["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
-    env.Append(CPPPATH=["../../../thirdparty/msdfgen"])
+    env_msdfgen.Append(CPPEXTPATH=["../../../thirdparty/freetype/include", "../../../thirdparty/msdfgen"])
+    env.Append(CPPEXTPATH=["../../../thirdparty/msdfgen"])
     env.Append(CPPDEFINES=[("MSDFGEN_PUBLIC", "")])
     env.Append(CPPDEFINES=["MODULE_MSDFGEN_ENABLED"])
 
@@ -260,11 +260,11 @@ if env["freetype_enabled"]:
         ]
         thirdparty_freetype_sources += [thirdparty_brotli_dir + file for file in thirdparty_brotli_sources]
         env_freetype.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
-        env_freetype.Prepend(CPPPATH=[thirdparty_brotli_dir + "include"])
+        env_freetype.Prepend(CPPEXTPATH=[thirdparty_brotli_dir + "include"])
         env.Append(CPPDEFINES=["FT_CONFIG_OPTION_USE_BROTLI"])
 
-    env_freetype.Append(CPPPATH=[thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
-    env.Append(CPPPATH=[thirdparty_freetype_dir + "/include"])
+    env_freetype.Append(CPPEXTPATH=[thirdparty_freetype_dir + "/include", thirdparty_zlib_dir, thirdparty_png_dir])
+    env.Append(CPPEXTPATH=[thirdparty_freetype_dir + "/include"])
 
     env_freetype.Append(
         CPPDEFINES=[

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -488,7 +488,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["accesskit"]:
         if env["accesskit_sdk_path"] != "":
-            env.Prepend(CPPPATH=[env["accesskit_sdk_path"] + "/include"])
+            env.Prepend(CPPEXTPATH=[env["accesskit_sdk_path"] + "/include"])
             if env["arch"] == "arm64":
                 env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/linux/arm64/static/"])
             elif env["arch"] == "arm32":

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -184,7 +184,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["accesskit"]:
         if env["accesskit_sdk_path"] != "":
-            env.Prepend(CPPPATH=[env["accesskit_sdk_path"] + "/include"])
+            env.Prepend(CPPEXTPATH=[env["accesskit_sdk_path"] + "/include"])
             if env["arch"] == "arm64" or env["arch"] == "universal":
                 env.Append(LINKFLAGS=["-L" + env["accesskit_sdk_path"] + "/lib/macos/arm64/static/"])
             if env["arch"] == "x86_64" or env["arch"] == "universal":

--- a/platform/visionos/detect.py
+++ b/platform/visionos/detect.py
@@ -153,7 +153,7 @@ def configure(env: "SConsEnvironment"):
                 "$VISIONOS_SDK_PATH/System/Library/Frameworks/QuartzCore.framework/Headers",
             ]
         )
-        env.Prepend(CPPPATH=["#thirdparty/spirv-cross"])
+        env.Prepend(CPPEXTPATH=["#thirdparty/spirv-cross"])
 
     if env["opengl3"]:
         print_warning("The visionOS platform does not support the OpenGL rendering driver")

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -414,7 +414,7 @@ def configure_msvc(env: "SConsEnvironment"):
 
     if env["accesskit"]:
         if env["accesskit_sdk_path"] != "":
-            env.Prepend(CPPPATH=[env["accesskit_sdk_path"] + "/include"])
+            env.Prepend(CPPEXTPATH=[env["accesskit_sdk_path"] + "/include"])
             if env["arch"] == "arm64":
                 env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/windows/arm64/msvc/static"])
             elif env["arch"] == "x86_64":
@@ -791,7 +791,7 @@ def configure_mingw(env: "SConsEnvironment"):
 
     if env["accesskit"]:
         if env["accesskit_sdk_path"] != "":
-            env.Prepend(CPPPATH=[env["accesskit_sdk_path"] + "/include"])
+            env.Prepend(CPPEXTPATH=[env["accesskit_sdk_path"] + "/include"])
             if env["use_llvm"]:
                 if env["arch"] == "arm64":
                     env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/windows/arm64/mingw-llvm/static/"])


### PR DESCRIPTION
In looking for solutions to enforce a specific link order for includes, I've realized that external includes are not accounted for when SCons parses dependency chains. It'll still compile just fine, but this turned out to be a big reason why several `Depends` calls were necessary. This also migrates over the remaining `#thirdparty` paths to `CPPEXTPATH`