### PR TITLE
SCons: Strip warnings if disabled

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -875,37 +875,34 @@ elif env.msvc:
 
 # Configure compiler warnings
 env.AppendUnique(CCFLAGS=["$WARNLEVEL"])
-if env.msvc and not methods.using_clang(env):  # MSVC
-    # Disable warnings which we don't plan to fix.
-    disabled_warnings = [
-        "/wd4100",  # C4100 (unreferenced formal parameter): Doesn't play nice with polymorphism.
-        "/wd4127",  # C4127 (conditional expression is constant)
-        "/wd4201",  # C4201 (non-standard nameless struct/union): Only relevant for C89.
-        "/wd4244",  # C4244 C4245 C4267 (narrowing conversions): Unavoidable at this scale.
-        "/wd4245",
-        "/wd4267",
-        "/wd4305",  # C4305 (truncation): double to float or real_t, too hard to avoid.
-        "/wd4324",  # C4820 (structure was padded due to alignment specifier)
-        "/wd4514",  # C4514 (unreferenced inline function has been removed)
-        "/wd4714",  # C4714 (function marked as __forceinline not inlined)
-        "/wd4820",  # C4820 (padding added after construct)
-    ]
+if env["warnings"] == "no":
+    env.disable_warnings()
 
+elif env.msvc and not methods.using_clang(env):  # MSVC
+    # Disable warnings which we don't plan to fix.
+    env.AppendUnique(
+        CCFLAGS=[
+            "/wd4100",  # C4100 (unreferenced formal parameter): Doesn't play nice with polymorphism.
+            "/wd4127",  # C4127 (conditional expression is constant)
+            "/wd4201",  # C4201 (non-standard nameless struct/union): Only relevant for C89.
+            "/wd4244",  # C4244 C4245 C4267 (narrowing conversions): Unavoidable at this scale.
+            "/wd4245",
+            "/wd4267",
+            "/wd4305",  # C4305 (truncation): double to float or real_t, too hard to avoid.
+            "/wd4324",  # C4820 (structure was padded due to alignment specifier)
+            "/wd4514",  # C4514 (unreferenced inline function has been removed)
+            "/wd4714",  # C4714 (function marked as __forceinline not inlined)
+            "/wd4820",  # C4820 (padding added after construct)
+        ]
+    )
     if env["warnings"] == "extra":
         env["WARNLEVEL"] = "/W4"
-        env.AppendUnique(CCFLAGS=disabled_warnings)
     elif env["warnings"] == "all":
         env["WARNLEVEL"] = "/W3"
         # C4458 is like -Wshadow. Part of /W4 but let's apply it for the default /W3 too.
-        env.AppendUnique(CCFLAGS=["/w34458"] + disabled_warnings)
+        env.AppendUnique(CCFLAGS=["/w34458"])
     elif env["warnings"] == "moderate":
         env["WARNLEVEL"] = "/W2"
-        env.AppendUnique(CCFLAGS=disabled_warnings)
-    else:  # 'no'
-        env["WARNLEVEL"] = "/w"
-        # C4267 is particularly finicky & needs to be explicitly disabled.
-        env.AppendUnique(CCFLAGS=["/wd4267"])
-
     if env["werror"]:
         env.AppendUnique(CCFLAGS=["/WX"])
         env.AppendUnique(LINKFLAGS=["/WX"])
@@ -959,8 +956,6 @@ else:  # GCC, Clang
         env.AppendUnique(CCFLAGS=common_warnings)
     elif env["warnings"] == "moderate":
         env.AppendUnique(CCFLAGS=["-Wno-unused"] + common_warnings)
-    else:  # 'no'
-        env["WARNLEVEL"] = "-w"
 
     if env["werror"]:
         env.AppendUnique(CCFLAGS=["-Werror"])

--- a/methods.py
+++ b/methods.py
@@ -106,12 +106,25 @@ def redirect_emitter(target, source, env):
     return redirected_targets, source
 
 
-def disable_warnings(self):
-    # 'self' is the environment
-    if self.msvc and not using_clang(self):
-        self["WARNLEVEL"] = "/w"
+def disable_warnings(env):
+    """
+    Disables warnings for a given environment. Explicitly removes warnings made up to
+    that point in order to reduce recompilation times. Will unilaterally enable warning errors
+    in order to catch any warnings which erroneously slip through the cracks & need to be
+    explicitly excluded in `WARNLEVEL`.
+
+    This is a one-way process. Should only be used for third-party environments, or
+    an environment where warnings are entirely disabled from the start.
+    """
+    if env.msvc and not using_clang(env):
+        WARN_CHECK = ("/w", "/W")
+        env["WARNLEVEL"] = ["/w", "/WX", "/wd4244", "/wd4267"]
     else:
-        self["WARNLEVEL"] = "-w"
+        WARN_CHECK = ("-w", "-W")
+        env["WARNLEVEL"] = ["-w", "-Werror"]
+    env["CCFLAGS"] = [x for x in env["CCFLAGS"] if not x.startswith(WARN_CHECK)]
+    env["CFLAGS"] = [x for x in env["CFLAGS"] if not x.startswith(WARN_CHECK)]
+    env["CXXFLAGS"] = [x for x in env["CXXFLAGS"] if not x.startswith(WARN_CHECK)]
 
 
 def force_optimization_on_debug(self):


### PR DESCRIPTION
This integrates a means of reducing recompilation times when changing warning levels and/or warnings-as-errors. Godot-specific files will inevitably have to recompile, so this explicitly targets the thirdparty folders which are already disabling warnings outright. By removing their warnings completely, they will disregard all warning/werror specifications; hardcoded substitutions will be used instead