### PR TITLE
SCons: Ensure `CPPDEFINES` is properly utilized

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -34,7 +34,7 @@ env_thirdparty_vma.disable_warnings()
 thirdparty_sources_vma = [thirdparty_dir + "/vk_mem_alloc.cpp"]
 
 if env["use_volk"]:
-    env_thirdparty_vma.AppendUnique(CPPDEFINES=["VMA_STATIC_VULKAN_FUNCTIONS=1"])
+    env_thirdparty_vma.AppendUnique(CPPDEFINES=[("VMA_STATIC_VULKAN_FUNCTIONS", 1)])
     env_thirdparty_volk = env.Clone()
     env_thirdparty_volk.disable_warnings()
 
@@ -43,10 +43,10 @@ if env["use_volk"]:
 elif env["platform"] == "android":
     # Our current NDK version only provides old Vulkan headers,
     # so we have to limit VMA.
-    env_thirdparty_vma.AppendUnique(CPPDEFINES=["VMA_VULKAN_VERSION=1000000"])
+    env_thirdparty_vma.AppendUnique(CPPDEFINES=[("VMA_VULKAN_VERSION", 1000000)])
 elif env["platform"] == "macos" or env["platform"] == "ios":
     # MoltenVK supports only Vulkan 1.1 API, limit VMA to the same version.
-    env_thirdparty_vma.AppendUnique(CPPDEFINES=["VMA_VULKAN_VERSION=1001000"])
+    env_thirdparty_vma.AppendUnique(CPPDEFINES=[("VMA_VULKAN_VERSION", 1001000)])
 
 env_thirdparty_vma.add_source_files(thirdparty_obj, thirdparty_sources_vma)
 

--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -6,7 +6,7 @@ Import("env_modules")
 
 env_csg = env_modules.Clone()
 
-env_csg.Append(CPPDEFINES=("MANIFOLD_PAR", "-1"))
+env_csg.Append(CPPDEFINES=[("MANIFOLD_PAR", -1)])
 
 # Thirdparty source files
 

--- a/modules/glslang/SCsub
+++ b/modules/glslang/SCsub
@@ -66,7 +66,7 @@ if env["builtin_glslang"]:
     # and in installed public headers.
     env_glslang.Prepend(CPPEXTPATH=[thirdparty_dir, "#thirdparty"])
 
-    env_glslang.Append(CPPDEFINES=["ENABLE_OPT=0"])
+    env_glslang.Append(CPPDEFINES=[("ENABLE_OPT", 0)])
 
     env_thirdparty = env_glslang.Clone()
     env_thirdparty.disable_warnings()

--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -18,7 +18,7 @@ thirdparty_obj = []
 if env["platform"] == "android":
     # may need to set OPENXR_ANDROID_VERSION_SUFFIX
     env_openxr.AppendUnique(CPPDEFINES=["XR_OS_ANDROID", "XR_USE_PLATFORM_ANDROID"])
-    env_openxr.AppendUnique(CPPDEFINES=["JSON_USE_EXCEPTION=0"])
+    env_openxr.AppendUnique(CPPDEFINES=[("JSON_USE_EXCEPTION", 0)])
 
     # may need to include java parts of the openxr loader
 elif env["platform"] == "linuxbsd":

--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -119,38 +119,30 @@ if env["builtin_harfbuzz"]:
 
     env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/harfbuzz/src"])
 
-    env_harfbuzz.Append(CCFLAGS=["-DHAVE_ICU"])
+    env_harfbuzz.Append(CPPDEFINES=["HAVE_ICU"])
     if env["builtin_icu4c"]:
         env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
         env_harfbuzz.Append(
-            CCFLAGS=[
-                "-DU_STATIC_IMPLEMENTATION",
-                "-DU_HAVE_LIB_SUFFIX=1",
-                "-DU_LIB_SUFFIX_C_NAME=_godot",
-                "-DHAVE_ICU_BUILTIN",
+            CPPDEFINES=[
+                "U_STATIC_IMPLEMENTATION",
+                ("U_HAVE_LIB_SUFFIX", 1),
+                ("U_LIB_SUFFIX_C_NAME", "_godot"),
+                "HAVE_ICU_BUILTIN",
             ]
         )
 
     if freetype_enabled:
-        env_harfbuzz.Append(
-            CCFLAGS=[
-                "-DHAVE_FREETYPE",
-            ]
-        )
+        env_harfbuzz.Append(CPPDEFINES=["HAVE_FREETYPE"])
         if env["graphite"]:
-            env_harfbuzz.Append(
-                CCFLAGS=[
-                    "-DHAVE_GRAPHITE2",
-                ]
-            )
+            env_harfbuzz.Append(CPPDEFINES=["HAVE_GRAPHITE2"])
         if env["builtin_freetype"]:
             env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/freetype/include"])
         if env["builtin_graphite"] and env["graphite"]:
             env_harfbuzz.Prepend(CPPEXTPATH=["#thirdparty/graphite/include"])
-            env_harfbuzz.Append(CCFLAGS=["-DGRAPHITE2_STATIC"])
+            env_harfbuzz.Append(CPPDEFINES=["GRAPHITE2_STATIC"])
 
     if env["platform"] in ["android", "linuxbsd", "web"]:
-        env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
+        env_harfbuzz.Append(CPPDEFINES=["HAVE_PTHREAD"])
 
     env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/harfbuzz/src"])
 
@@ -217,10 +209,10 @@ if env["builtin_graphite"] and freetype_enabled and env["graphite"]:
 
     env_graphite.Prepend(CPPEXTPATH=["#thirdparty/graphite/src", "#thirdparty/graphite/include"])
     env_graphite.Append(
-        CCFLAGS=[
-            "-DGRAPHITE2_STATIC",
-            "-DGRAPHITE2_NTRACING",
-            "-DGRAPHITE2_NFILEFACE",
+        CPPDEFINES=[
+            "GRAPHITE2_STATIC",
+            "GRAPHITE2_NTRACING",
+            "GRAPHITE2_NFILEFACE",
         ]
     )
 
@@ -460,32 +452,32 @@ if env["builtin_icu4c"]:
 
     env_icu.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
     env_icu.Append(
-        CXXFLAGS=[
-            "-DU_STATIC_IMPLEMENTATION",
-            "-DU_COMMON_IMPLEMENTATION",
-            "-DUCONFIG_NO_COLLATION",
-            "-DUCONFIG_NO_CONVERSION",
-            "-DUCONFIG_NO_FORMATTING",
-            "-DUCONFIG_NO_SERVICE",
-            "-DUCONFIG_NO_IDNA",
-            "-DUCONFIG_NO_FILE_IO",
-            "-DUCONFIG_NO_TRANSLITERATION",
-            "-DUCONFIG_NO_REGULAR_EXPRESSIONS",
-            "-DPKGDATA_MODE=static",
-            "-DU_ENABLE_DYLOAD=0",
-            "-DU_HAVE_LIB_SUFFIX=1",
-            "-DU_LIB_SUFFIX_C_NAME=_godot",
+        CPPDEFINES=[
+            "U_STATIC_IMPLEMENTATION",
+            "U_COMMON_IMPLEMENTATION",
+            "UCONFIG_NO_COLLATION",
+            "UCONFIG_NO_CONVERSION",
+            "UCONFIG_NO_FORMATTING",
+            "UCONFIG_NO_SERVICE",
+            "UCONFIG_NO_IDNA",
+            "UCONFIG_NO_FILE_IO",
+            "UCONFIG_NO_TRANSLITERATION",
+            "UCONFIG_NO_REGULAR_EXPRESSIONS",
+            ("PKGDATA_MODE", "static"),
+            ("U_ENABLE_DYLOAD", 0),
+            ("U_HAVE_LIB_SUFFIX", 1),
+            ("U_LIB_SUFFIX_C_NAME", "_godot"),
         ]
     )
     env_text_server_adv.Append(
-        CXXFLAGS=[
-            "-DU_STATIC_IMPLEMENTATION",
-            "-DU_HAVE_LIB_SUFFIX=1",
-            "-DU_LIB_SUFFIX_C_NAME=_godot",
+        CPPDEFINES=[
+            "U_STATIC_IMPLEMENTATION",
+            ("U_HAVE_LIB_SUFFIX", 1),
+            ("U_LIB_SUFFIX_C_NAME", "_godot"),
         ]
     )
     if env.editor_build:
-        env_text_server_adv.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
+        env_text_server_adv.Append(CPPDEFINES=["ICU_STATIC_DATA"])
 
     env_text_server_adv.Prepend(CPPEXTPATH=["#thirdparty/icu4c/common/", "#thirdparty/icu4c/i18n/"])
 

--- a/modules/text_server_adv/gdextension_build/SConstruct
+++ b/modules/text_server_adv/gdextension_build/SConstruct
@@ -395,24 +395,24 @@ if env["freetype_enabled"]:
     )
 
 if env["platform"] == "android" or env["platform"] == "linuxbsd":
-    env_harfbuzz.Append(CCFLAGS=["-DHAVE_PTHREAD"])
+    env_harfbuzz.Append(CPPDEFINES=["HAVE_PTHREAD"])
 
 env_harfbuzz.Append(
-    CCFLAGS=[
-        "-DU_STATIC_IMPLEMENTATION",
-        "-DU_HAVE_LIB_SUFFIX=1",
-        "-DU_LIB_SUFFIX_C_NAME=_godot",
-        "-DHAVE_ICU_BUILTIN",
-        "-DHAVE_ICU",
+    CPPDEFINES=[
+        "U_STATIC_IMPLEMENTATION",
+        ("U_HAVE_LIB_SUFFIX", 1),
+        ("U_LIB_SUFFIX_C_NAME", "_godot"),
+        "HAVE_ICU_BUILTIN",
+        "HAVE_ICU",
     ]
 )
 
 if env["freetype_enabled"]:
     env_harfbuzz.Append(
-        CCFLAGS=[
-            "-DHAVE_FREETYPE",
-            "-DHAVE_GRAPHITE2",
-            "-DGRAPHITE2_STATIC",
+        CPPDEFINES=[
+            "HAVE_FREETYPE",
+            "HAVE_GRAPHITE2",
+            "GRAPHITE2_STATIC",
         ]
     )
 
@@ -471,10 +471,10 @@ if env["graphite_enabled"] and env["freetype_enabled"]:
 
     env_graphite.Append(CPPPATH=["../../../thirdparty/graphite/src", "../../../thirdparty/graphite/include"])
     env_graphite.Append(
-        CCFLAGS=[
-            "-DGRAPHITE2_STATIC",
-            "-DGRAPHITE2_NTRACING",
-            "-DGRAPHITE2_NFILEFACE",
+        CPPDEFINES=[
+            "GRAPHITE2_STATIC",
+            "GRAPHITE2_NTRACING",
+            "GRAPHITE2_NFILEFACE",
         ]
     )
 
@@ -703,34 +703,34 @@ if env["static_icu_data"]:
     env_icu.Command(
         "../../../thirdparty/icu4c/icudata.gen.h", "../../../thirdparty/icu4c/icudt_godot.dat", methods.make_icu_data
     )
-    env.Append(CXXFLAGS=["-DICU_STATIC_DATA"])
+    env.Append(CPPDEFINES=["ICU_STATIC_DATA"])
     env.Append(CPPPATH=["../../../thirdparty/icu4c/"])
 else:
     thirdparty_icu_sources += ["../icu_data/icudata_stub.cpp"]
 
 env_icu.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])
 env_icu.Append(
-    CXXFLAGS=[
-        "-DU_STATIC_IMPLEMENTATION",
-        "-DU_COMMON_IMPLEMENTATION",
-        "-DUCONFIG_NO_COLLATION",
-        "-DUCONFIG_NO_CONVERSION",
-        "-DUCONFIG_NO_FORMATTING",
-        "-DUCONFIG_NO_SERVICE",
-        "-DUCONFIG_NO_IDNA",
-        "-DUCONFIG_NO_FILE_IO",
-        "-DUCONFIG_NO_TRANSLITERATION",
-        "-DPKGDATA_MODE=static",
-        "-DU_ENABLE_DYLOAD=0",
-        "-DU_HAVE_LIB_SUFFIX=1",
-        "-DU_LIB_SUFFIX_C_NAME=_godot",
+    CPPDEFINES=[
+        "U_STATIC_IMPLEMENTATION",
+        "U_COMMON_IMPLEMENTATION",
+        "UCONFIG_NO_COLLATION",
+        "UCONFIG_NO_CONVERSION",
+        "UCONFIG_NO_FORMATTING",
+        "UCONFIG_NO_SERVICE",
+        "UCONFIG_NO_IDNA",
+        "UCONFIG_NO_FILE_IO",
+        "UCONFIG_NO_TRANSLITERATION",
+        ("PKGDATA_MODE", "static"),
+        ("U_ENABLE_DYLOAD", 0),
+        ("U_HAVE_LIB_SUFFIX", 1),
+        ("U_LIB_SUFFIX_C_NAME", "_godot"),
     ]
 )
 env.Append(
-    CXXFLAGS=[
-        "-DU_STATIC_IMPLEMENTATION",
-        "-DU_HAVE_LIB_SUFFIX=1",
-        "-DU_LIB_SUFFIX_C_NAME=_godot",
+    CPPDEFINES=[
+        "U_STATIC_IMPLEMENTATION",
+        ("U_HAVE_LIB_SUFFIX", 1),
+        ("U_LIB_SUFFIX_C_NAME", "_godot"),
     ]
 )
 env.Append(CPPPATH=["../../../thirdparty/icu4c/common/", "../../../thirdparty/icu4c/i18n/"])

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -144,7 +144,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"
-        env.Append(CCFLAGS=["-DSANITIZERS_ENABLED"])
+        env.Append(CPPDEFINES=["SANITIZERS_ENABLED"])
 
         if env["use_ubsan"]:
             env.Append(

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -153,7 +153,7 @@ def configure(env: "SConsEnvironment"):
 
     if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
         env.extra_suffix += ".san"
-        env.Append(CCFLAGS=["-DSANITIZERS_ENABLED"])
+        env.Append(CPPDEFINES=["SANITIZERS_ENABLED"])
 
         if env["use_ubsan"]:
             env.Append(

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -402,8 +402,8 @@ def configure_msvc(env: "SConsEnvironment"):
             "WINMIDI_ENABLED",
             "TYPED_METHOD_BIND",
             "WIN32",
-            "WINVER=0x0A00",
-            "_WIN32_WINNT=0x0A00",
+            ("WINVER", "0x0A00"),
+            ("_WIN32_WINNT", "0x0A00"),
         ]
     )
     env.AppendUnique(CPPDEFINES=["NOMINMAX"])  # disable bogus min/max WinDef.h macros
@@ -793,8 +793,8 @@ def configure_mingw(env: "SConsEnvironment"):
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(
         CPPDEFINES=[
-            "WINVER=0x0A00",
-            "_WIN32_WINNT=0x0A00",
+            ("WINVER", "0x0A00"),
+            ("_WIN32_WINNT", "0x0A00"),
         ]
     )
     env.Append(


### PR DESCRIPTION
A handful of defines in SCons are declared in non-portable manner. This addresses that issue by guaranteeing `CPPDEFINES` is used instead of `CCFLAGS` with compiler-specific prefixes/suffixes.