### PR TITLE
Document `AnimationMixer.animation_started` not being emitted for looping animations

### DIFF
--- a/doc/classes/AnimationMixer.xml
+++ b/doc/classes/AnimationMixer.xml
@@ -350,6 +350,7 @@
 			<param index="0" name="anim_name" type="StringName" />
 			<description>
 				Notifies when an animation starts playing.
+				[b]Note:[/b] This signal is not emitted if an animation is looping.
 			</description>
 		</signal>
 		<signal name="caches_cleared">


### PR DESCRIPTION
* See https://github.com/godotengine/godot-docs-user-notes/discussions/280#discussioncomment-11550801.
