### PR TITLE
Optimize retrieval-by-index methods in Dictionary

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -67,28 +67,45 @@ LocalVector<Variant> Dictionary::get_key_list() const {
 	return keys;
 }
 
-Variant Dictionary::get_key_at_index(int p_index) const {
-	int index = 0;
-	for (const KeyValue<Variant, Variant> &E : _p->variant_map) {
-		if (index == p_index) {
-			return E.key;
-		}
-		index++;
+const KeyValue<Variant, Variant> *Dictionary::get_key_value_at_index(int p_index) const {
+	const int n = size();
+	if (p_index < -n || p_index >= n) {
+		return nullptr; // Check out of bounds
 	}
 
-	return Variant();
+	if (p_index < 0) {
+		p_index += n; // Convert negative index to positive.
+	}
+
+	HashMap<Variant, Variant, VariantHasher, StringLikeVariantComparator>::ConstIterator E;
+	if (p_index < n / 2) {
+		E = _p->variant_map.begin();
+		for (int i = 0; i < p_index; ++i) {
+			++E;
+		}
+	} else {
+		E = _p->variant_map.last();
+		for (int i = n - 1; i > p_index; --i) {
+			--E;
+		}
+	}
+	return &(*E);
+}
+
+Variant Dictionary::get_key_at_index(int p_index) const {
+	const KeyValue<Variant, Variant> *E = get_key_value_at_index(p_index);
+	if (E == nullptr) {
+		return Variant();
+	}
+	return E->key;
 }
 
 Variant Dictionary::get_value_at_index(int p_index) const {
-	int index = 0;
-	for (const KeyValue<Variant, Variant> &E : _p->variant_map) {
-		if (index == p_index) {
-			return E.value;
-		}
-		index++;
+	const KeyValue<Variant, Variant> *E = get_key_value_at_index(p_index);
+	if (E == nullptr) {
+		return Variant();
 	}
-
-	return Variant();
+	return E->value;
 }
 
 // WARNING: This operator does not validate the value type. For scripting/extensions this is

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -57,6 +57,7 @@ public:
 	ConstIterator end() const;
 
 	LocalVector<Variant> get_key_list() const;
+	const KeyValue<Variant, Variant> *get_key_value_at_index(int p_index) const;
 	Variant get_key_at_index(int p_index) const;
 	Variant get_value_at_index(int p_index) const;
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -1243,8 +1243,14 @@ int32_t godotsharp_dictionary_count(const Dictionary *p_self) {
 }
 
 void godotsharp_dictionary_key_value_pair_at(const Dictionary *p_self, int32_t p_index, Variant *r_key, Variant *r_value) {
-	memnew_placement(r_key, Variant(p_self->get_key_at_index(p_index)));
-	memnew_placement(r_value, Variant(p_self->get_value_at_index(p_index)));
+	const KeyValue<Variant, Variant> *E = p_self->get_key_value_at_index(p_index);
+	if (E == nullptr) {
+		memnew_placement(r_key, Variant());
+		memnew_placement(r_value, Variant());
+	} else {
+		memnew_placement(r_key, Variant(E->key));
+		memnew_placement(r_value, Variant(E->value));
+	}
 }
 
 void godotsharp_dictionary_add(Dictionary *p_self, const Variant *p_key, const Variant *p_value) {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -115,10 +115,56 @@ TEST_CASE("[Dictionary] get_key_at_index()") {
 	Variant val = map.get_key_at_index(0);
 	CHECK(int(val) == 4);
 	map[3] = 1;
+	map[2] = 0;
 	val = map.get_key_at_index(0);
 	CHECK(int(val) == 4);
 	val = map.get_key_at_index(1);
 	CHECK(int(val) == 3);
+	val = map.get_key_at_index(2);
+	CHECK(int(val) == 2);
+
+	// Test negative indices
+	val = map.get_key_at_index(-3);
+	CHECK(int(val) == 4);
+	val = map.get_key_at_index(-2);
+	CHECK(int(val) == 3);
+	val = map.get_key_at_index(-1);
+	CHECK(int(val) == 2);
+
+	// Test out of bounds
+	val = map.get_key_at_index(3);
+	CHECK_EQ(val, Variant());
+	val = map.get_key_at_index(-4);
+	CHECK_EQ(val, Variant());
+}
+
+TEST_CASE("[Dictionary] get_value_at_index()") {
+	Dictionary map;
+	map[4] = 3;
+	Variant val = map.get_value_at_index(0);
+	CHECK(int(val) == 3);
+	map[3] = 1;
+	map[2] = 0;
+	val = map.get_value_at_index(0);
+	CHECK(int(val) == 3);
+	val = map.get_value_at_index(1);
+	CHECK(int(val) == 1);
+	val = map.get_value_at_index(2);
+	CHECK(int(val) == 0);
+
+	// Test negative indices
+	val = map.get_value_at_index(-3);
+	CHECK(int(val) == 3);
+	val = map.get_value_at_index(-2);
+	CHECK(int(val) == 1);
+	val = map.get_value_at_index(-1);
+	CHECK(int(val) == 0);
+
+	// Test out of bounds
+	val = map.get_value_at_index(3);
+	CHECK_EQ(val, Variant());
+	val = map.get_value_at_index(-4);
+	CHECK_EQ(val, Variant());
 }
 
 TEST_CASE("[Dictionary] getptr()") {


### PR DESCRIPTION
This PR optimizes the internal retrieval-by-index methods in `Dictionary`. The changes in this PR were previously part of #104473 which tried to change too much in one PR and ended up in a deadlock.

The changes here are:

1. Optimized `Dictionary.get_key_at_index` and `Dictionary.get_value_at_index` by adding backwards traversal when requested index is in the latter half of `Dictionary`.

2. Support for negative indices (useful if using -1 to retrieve most recently added key).

3. Optimizes C# usage of these function which were previously traversing dictionaries twice.

Also, I've add more comprehensive unit tests for these functions.