### PR TITLE
[macOS] Move more methods to base DisplayServer.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -37,8 +37,6 @@
 #include "gl_manager_macos_legacy.h"
 #endif // GLES3_ENABLED
 
-#import "native_menu_macos.h"
-
 #if defined(RD_ENABLED)
 #include "servers/rendering/rendering_device.h"
 
@@ -172,9 +170,6 @@ private:
 	Vector<KeyEvent> key_event_buffer;
 	int key_event_pos = 0;
 
-	id menu_delegate = nullptr;
-	NativeMenuMacOS *native_menu = nullptr;
-
 	Point2i im_selection;
 	String im_text;
 
@@ -192,8 +187,6 @@ private:
 	WindowID last_focused_window = INVALID_WINDOW_ID;
 	WindowID window_id_counter = MAIN_WINDOW_ID;
 	float display_max_scale = 1.f;
-	mutable Point2i origin;
-	mutable bool displays_arrangement_dirty = true;
 	bool is_resizing = false;
 
 	CursorShape cursor_shape = CURSOR_ARROW;
@@ -201,14 +194,6 @@ private:
 	HashMap<CursorShape, Vector<Variant>> cursors_cache;
 
 	HashMap<WindowID, WindowData> windows;
-
-	struct IndicatorData {
-		id delegate;
-		id item;
-	};
-
-	IndicatorID indicator_id_counter = 0;
-	HashMap<IndicatorID, IndicatorData> indicators;
 
 	IOPMAssertionID screen_keep_on_assertion = kIOPMNullAssertionID;
 
@@ -221,14 +206,8 @@ private:
 	};
 	List<MenuCall> deferred_menu_calls;
 
-	Callable system_theme_changed;
-
 	WindowID _create_window(WindowMode p_mode, VSyncMode p_vsync_mode, const Rect2i &p_rect);
 	void _update_window_style(WindowData p_wd, WindowID p_window);
-
-	void _update_displays_arrangement() const;
-	Point2i _get_native_screen_position(int p_screen) const;
-	static void _displays_arrangement_changed(CGDirectDisplayID display_id, CGDisplayChangeSummaryFlags flags, void *user_info);
 
 	static void _dispatch_input_events(const Ref<InputEvent> &p_event);
 	void _dispatch_input_event(const Ref<InputEvent> &p_event);
@@ -250,13 +229,8 @@ private:
 public:
 	void menu_callback(id p_sender);
 
-	void emit_system_theme_changed();
-
 	bool has_window(WindowID p_window) const;
 	WindowData &get_window(WindowID p_window);
-
-	NSImage *_convert_to_nsimg(Ref<Image> &p_image) const;
-	Point2i _get_screens_origin() const;
 
 	void set_menu_delegate(NSMenu *p_menu);
 
@@ -299,19 +273,11 @@ public:
 	Callable _help_get_search_callback() const;
 	Callable _help_get_action_callback() const;
 
-	virtual bool is_dark_mode_supported() const override;
-	virtual bool is_dark_mode() const override;
-	virtual Color get_accent_color() const override;
-	virtual Color get_base_color() const override;
-	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
-
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;
 
 	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, WindowID p_window_id) override;
 	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, WindowID p_window_id) override;
-
-	virtual void beep() const override;
 
 	virtual void mouse_set_mode(MouseMode p_mode) override;
 	virtual MouseMode mouse_get_mode() const override;
@@ -422,11 +388,6 @@ public:
 	virtual void window_set_window_buttons_offset(const Vector2i &p_offset, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Vector3i window_get_safe_title_margins(WindowID p_window = MAIN_WINDOW_ID) const override;
 
-	virtual int accessibility_should_increase_contrast() const override;
-	virtual int accessibility_should_reduce_animation() const override;
-	virtual int accessibility_should_reduce_transparency() const override;
-	virtual int accessibility_screen_reader_active() const override;
-
 	virtual Point2i ime_get_selection() const override;
 	virtual String ime_get_text() const override;
 
@@ -434,8 +395,6 @@ public:
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;
 	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
-
-	virtual bool get_swap_cancel_ok() override;
 
 	virtual void enable_for_stealing_focus(OS::ProcessID pid) override;
 #ifdef TOOLS_ENABLED
@@ -453,14 +412,6 @@ public:
 
 	virtual void set_native_icon(const String &p_filename) override;
 	virtual void set_icon(const Ref<Image> &p_icon) override;
-
-	virtual IndicatorID create_status_indicator(const Ref<Texture2D> &p_icon, const String &p_tooltip, const Callable &p_callback) override;
-	virtual void status_indicator_set_icon(IndicatorID p_id, const Ref<Texture2D> &p_icon) override;
-	virtual void status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) override;
-	virtual void status_indicator_set_menu(IndicatorID p_id, const RID &p_menu_rid) override;
-	virtual void status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) override;
-	virtual Rect2 status_indicator_get_rect(IndicatorID p_id) const override;
-	virtual void delete_status_indicator(IndicatorID p_id) override;
 
 	virtual bool is_window_transparency_available() const override;
 

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -29,13 +29,209 @@
 /**************************************************************************/
 
 #import "display_server_macos_base.h"
+
+#import "godot_application_delegate.h"
+#import "godot_menu_delegate.h"
+#import "godot_menu_item.h"
+#import "godot_status_item.h"
 #import "key_mapping_macos.h"
+#import "native_menu_macos.h"
 #import "tts_macos.h"
 
 #include "core/config/project_settings.h"
 #include "drivers/png/png_driver_common.h"
+#include "scene/resources/image_texture.h"
 
 #import <Carbon/Carbon.h>
+
+NSImage *DisplayServerMacOSBase::_convert_to_nsimg(Ref<Image> &p_image) const {
+	p_image->convert(Image::FORMAT_RGBA8);
+	NSBitmapImageRep *imgrep = [[NSBitmapImageRep alloc]
+			initWithBitmapDataPlanes:nullptr
+						  pixelsWide:p_image->get_width()
+						  pixelsHigh:p_image->get_height()
+					   bitsPerSample:8
+					 samplesPerPixel:4
+							hasAlpha:YES
+							isPlanar:NO
+					  colorSpaceName:NSDeviceRGBColorSpace
+						 bytesPerRow:int(p_image->get_width()) * 4
+						bitsPerPixel:32];
+	ERR_FAIL_NULL_V(imgrep, nil);
+	uint8_t *pixels = [imgrep bitmapData];
+
+	int len = p_image->get_width() * p_image->get_height();
+	const uint8_t *r = p_image->get_data().ptr();
+
+	/* Premultiply the alpha channel */
+	for (int i = 0; i < len; i++) {
+		uint8_t alpha = r[i * 4 + 3];
+		pixels[i * 4 + 0] = (uint8_t)(((uint16_t)r[i * 4 + 0] * alpha) / 255);
+		pixels[i * 4 + 1] = (uint8_t)(((uint16_t)r[i * 4 + 1] * alpha) / 255);
+		pixels[i * 4 + 2] = (uint8_t)(((uint16_t)r[i * 4 + 2] * alpha) / 255);
+		pixels[i * 4 + 3] = alpha;
+	}
+
+	NSImage *nsimg = [[NSImage alloc] initWithSize:NSMakeSize(p_image->get_width(), p_image->get_height())];
+	ERR_FAIL_NULL_V(nsimg, nil);
+	[nsimg addRepresentation:imgrep];
+	return nsimg;
+}
+
+void DisplayServerMacOSBase::_update_displays_arrangement() const {
+	origin = Point2i();
+
+	for (int i = 0; i < get_screen_count(); i++) {
+		Point2i position = _get_native_screen_position(i);
+		if (position.x < origin.x) {
+			origin.x = position.x;
+		}
+		if (position.y > origin.y) {
+			origin.y = position.y;
+		}
+	}
+	displays_arrangement_dirty = false;
+}
+
+Point2i DisplayServerMacOSBase::_get_native_screen_position(int p_screen) const {
+	NSArray *screenArray = [NSScreen screens];
+	if ((NSUInteger)p_screen < [screenArray count]) {
+		NSRect nsrect = [[screenArray objectAtIndex:p_screen] frame];
+		// Return the top-left corner of the screen, for macOS the y starts at the bottom.
+		return Point2i(nsrect.origin.x, nsrect.origin.y + nsrect.size.height) * screen_get_max_scale();
+	}
+
+	return Point2i();
+}
+
+void DisplayServerMacOSBase::_displays_arrangement_changed(CGDirectDisplayID display_id, CGDisplayChangeSummaryFlags flags, void *user_info) {
+	DisplayServerMacOSBase *ds = (DisplayServerMacOSBase *)DisplayServer::get_singleton();
+	if (ds) {
+		ds->displays_arrangement_dirty = true;
+	}
+}
+
+Point2i DisplayServerMacOSBase::_get_screens_origin() const {
+	// Returns the native top-left screen coordinate of the smallest rectangle
+	// that encompasses all screens. Needed in get_screen_position(),
+	// window_get_position, and window_set_position()
+	// to convert between macOS native screen coordinates and the ones expected by Godot.
+
+	if (displays_arrangement_dirty) {
+		_update_displays_arrangement();
+	}
+
+	return origin;
+}
+
+bool DisplayServerMacOSBase::is_dark_mode_supported() const {
+	if (@available(macOS 10.14, *)) {
+		return true;
+	} else {
+		return false;
+	}
+}
+
+bool DisplayServerMacOSBase::is_dark_mode() const {
+	if (@available(macOS 10.14, *)) {
+		if (![[NSUserDefaults standardUserDefaults] objectForKey:@"AppleInterfaceStyle"]) {
+			return false;
+		} else {
+			return ([[[NSUserDefaults standardUserDefaults] stringForKey:@"AppleInterfaceStyle"] isEqual:@"Dark"]);
+		}
+	} else {
+		return false;
+	}
+}
+
+Color DisplayServerMacOSBase::get_accent_color() const {
+	if (@available(macOS 10.14, *)) {
+		__block NSColor *color = nullptr;
+		if (@available(macOS 11.0, *)) {
+			[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
+				color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+			}];
+		} else {
+			NSAppearance *saved_appearance = [NSAppearance currentAppearance];
+			[NSAppearance setCurrentAppearance:[NSApp effectiveAppearance]];
+			color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+			[NSAppearance setCurrentAppearance:saved_appearance];
+		}
+		if (color) {
+			CGFloat components[4];
+			[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
+			return Color(components[0], components[1], components[2], components[3]);
+		} else {
+			return Color(0, 0, 0, 0);
+		}
+	} else {
+		return Color(0, 0, 0, 0);
+	}
+}
+
+Color DisplayServerMacOSBase::get_base_color() const {
+	if (@available(macOS 10.14, *)) {
+		__block NSColor *color = nullptr;
+		if (@available(macOS 11.0, *)) {
+			[NSApp.effectiveAppearance performAsCurrentDrawingAppearance:^{
+				color = [[NSColor windowBackgroundColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+			}];
+		} else {
+			NSAppearance *saved_appearance = [NSAppearance currentAppearance];
+			[NSAppearance setCurrentAppearance:[NSApp effectiveAppearance]];
+			color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
+			[NSAppearance setCurrentAppearance:saved_appearance];
+		}
+		if (color) {
+			CGFloat components[4];
+			[color getRed:&components[0] green:&components[1] blue:&components[2] alpha:&components[3]];
+			return Color(components[0], components[1], components[2], components[3]);
+		} else {
+			return Color(0, 0, 0, 0);
+		}
+	} else {
+		return Color(0, 0, 0, 0);
+	}
+}
+
+void DisplayServerMacOSBase::set_system_theme_change_callback(const Callable &p_callable) {
+	system_theme_changed = p_callable;
+}
+
+void DisplayServerMacOSBase::emit_system_theme_changed() {
+	if (system_theme_changed.is_valid()) {
+		Variant ret;
+		Callable::CallError ce;
+		system_theme_changed.callp(nullptr, 0, ret, ce);
+		if (ce.error != Callable::CallError::CALL_OK) {
+			ERR_PRINT(vformat("Failed to execute system theme changed callback: %s.", Variant::get_callable_error_text(system_theme_changed, nullptr, 0, ce)));
+		}
+	}
+}
+
+void DisplayServerMacOSBase::beep() const {
+	NSBeep();
+}
+
+int DisplayServerMacOSBase::accessibility_should_increase_contrast() const {
+	return [(GodotApplicationDelegate *)[[NSApplication sharedApplication] delegate] getHighContrast];
+}
+
+int DisplayServerMacOSBase::accessibility_should_reduce_animation() const {
+	return [(GodotApplicationDelegate *)[[NSApplication sharedApplication] delegate] getReduceMotion];
+}
+
+int DisplayServerMacOSBase::accessibility_should_reduce_transparency() const {
+	return [(GodotApplicationDelegate *)[[NSApplication sharedApplication] delegate] getReduceTransparency];
+}
+
+int DisplayServerMacOSBase::accessibility_screen_reader_active() const {
+	return [(GodotApplicationDelegate *)[[NSApplication sharedApplication] delegate] getVoiceOver];
+}
+
+bool DisplayServerMacOSBase::get_swap_cancel_ok() {
+	return false;
+}
 
 void DisplayServerMacOSBase::clipboard_set(const String &p_text) {
 	_THREAD_SAFE_METHOD_
@@ -301,7 +497,117 @@ void DisplayServerMacOSBase::show_emoji_and_symbol_picker() const {
 	[[NSApplication sharedApplication] orderFrontCharacterPalette:nil];
 }
 
+DisplayServer::IndicatorID DisplayServerMacOSBase::create_status_indicator(const Ref<Texture2D> &p_icon, const String &p_tooltip, const Callable &p_callback) {
+	NSImage *nsimg = nullptr;
+	if (p_icon.is_valid() && p_icon->get_width() > 0 && p_icon->get_height() > 0 && p_icon->get_image().is_valid()) {
+		Ref<Image> img = p_icon->get_image();
+		img = img->duplicate();
+		if (img->is_compressed()) {
+			img->decompress();
+		}
+		nsimg = _convert_to_nsimg(img);
+	}
+
+	IndicatorData idat;
+
+	NSStatusItem *item = [[NSStatusBar systemStatusBar] statusItemWithLength:NSSquareStatusItemLength];
+	idat.item = item;
+	idat.delegate = [[GodotStatusItemDelegate alloc] init];
+	[idat.delegate setCallback:p_callback];
+
+	item.button.image = nsimg;
+	item.button.imagePosition = NSImageOnly;
+	item.button.imageScaling = NSImageScaleProportionallyUpOrDown;
+	item.button.target = idat.delegate;
+	item.button.action = @selector(click:);
+	[item.button sendActionOn:(NSEventMaskLeftMouseDown | NSEventMaskRightMouseDown | NSEventMaskOtherMouseDown)];
+	item.button.toolTip = [NSString stringWithUTF8String:p_tooltip.utf8().get_data()];
+
+	IndicatorID iid = indicator_id_counter++;
+	indicators[iid] = idat;
+
+	return iid;
+}
+
+void DisplayServerMacOSBase::status_indicator_set_icon(IndicatorID p_id, const Ref<Texture2D> &p_icon) {
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	NSImage *nsimg = nullptr;
+	if (p_icon.is_valid() && p_icon->get_width() > 0 && p_icon->get_height() > 0 && p_icon->get_image().is_valid()) {
+		Ref<Image> img = p_icon->get_image();
+		img = img->duplicate();
+		if (img->is_compressed()) {
+			img->decompress();
+		}
+		nsimg = _convert_to_nsimg(img);
+	}
+
+	NSStatusItem *item = indicators[p_id].item;
+	item.button.image = nsimg;
+}
+
+void DisplayServerMacOSBase::status_indicator_set_tooltip(IndicatorID p_id, const String &p_tooltip) {
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	NSStatusItem *item = indicators[p_id].item;
+	item.button.toolTip = [NSString stringWithUTF8String:p_tooltip.utf8().get_data()];
+}
+
+void DisplayServerMacOSBase::status_indicator_set_menu(IndicatorID p_id, const RID &p_menu_rid) {
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	NSStatusItem *item = indicators[p_id].item;
+	if (p_menu_rid.is_valid() && native_menu->has_menu(p_menu_rid)) {
+		NSMenu *menu = native_menu->get_native_menu_handle(p_menu_rid);
+		item.menu = menu;
+	} else {
+		item.menu = nullptr;
+	}
+}
+
+void DisplayServerMacOSBase::status_indicator_set_callback(IndicatorID p_id, const Callable &p_callback) {
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	[indicators[p_id].delegate setCallback:p_callback];
+}
+
+Rect2 DisplayServerMacOSBase::status_indicator_get_rect(IndicatorID p_id) const {
+	ERR_FAIL_COND_V(!indicators.has(p_id), Rect2());
+
+	NSStatusItem *item = indicators[p_id].item;
+	NSView *v = item.button;
+	const NSRect contentRect = [v frame];
+	const NSRect nsrect = [v.window convertRectToScreen:contentRect];
+	Rect2 rect;
+
+	// Return the position of the top-left corner, for macOS the y starts at the bottom.
+	const float scale = screen_get_max_scale();
+	rect.size.x = nsrect.size.width;
+	rect.size.y = nsrect.size.height;
+	rect.size *= scale;
+	rect.position.x = nsrect.origin.x;
+	rect.position.y = (nsrect.origin.y + nsrect.size.height);
+	rect.position *= scale;
+	rect.position -= _get_screens_origin();
+	// macOS native y-coordinate relative to _get_screens_origin() is negative,
+	// Godot expects a positive value.
+	rect.position.y *= -1;
+	return rect;
+}
+
+void DisplayServerMacOSBase::delete_status_indicator(IndicatorID p_id) {
+	ERR_FAIL_COND(!indicators.has(p_id));
+
+	[[NSStatusBar systemStatusBar] removeStatusItem:indicators[p_id].item];
+	indicators.erase(p_id);
+}
+
 DisplayServerMacOSBase::DisplayServerMacOSBase() {
+	native_menu = memnew(NativeMenuMacOS);
+
+	// Register to be notified on displays arrangement changes.
+	CGDisplayRegisterReconfigurationCallback(_displays_arrangement_changed, nullptr);
+
 	// Init TTS
 	bool tts_enabled = GLOBAL_GET("audio/general/text_to_speech");
 	if (tts_enabled) {
@@ -317,4 +623,17 @@ DisplayServerMacOSBase::DisplayServerMacOSBase() {
 
 DisplayServerMacOSBase::~DisplayServerMacOSBase() {
 	CFNotificationCenterRemoveObserver(CFNotificationCenterGetDistributedCenter(), nullptr, kTISNotifySelectedKeyboardInputSourceChanged, nullptr);
+
+	// Destroy all status indicators.
+	for (HashMap<IndicatorID, IndicatorData>::Iterator E = indicators.begin(); E; ++E) {
+		[[NSStatusBar systemStatusBar] removeStatusItem:E->value.item];
+	}
+
+	// Destroy native menu.
+	if (native_menu) {
+		memdelete(native_menu);
+		native_menu = nullptr;
+	}
+
+	CGDisplayRemoveReconfigurationCallback(_displays_arrangement_changed, nullptr);
 }


### PR DESCRIPTION
Follow up to https://github.com/godotengine/godot/pull/107926, move `StatusIndicator` and system theme and accessibility methods to `DisplayServerMacOSBase`.