### PR TITLE
Fix incorrect projection matrix for GI

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -3881,8 +3881,8 @@ void GI::process_gi(Ref<RenderSceneBuffersRD> p_render_buffers, const RID *p_nor
 	// these are only used if we have 1 view, else we use the projections in our scene data
 	push_constant.proj_info[0] = -2.0f / (internal_size.x * p_projections[0].columns[0][0]);
 	push_constant.proj_info[1] = -2.0f / (internal_size.y * p_projections[0].columns[1][1]);
-	push_constant.proj_info[2] = (1.0f - p_projections[0].columns[0][2]) / p_projections[0].columns[0][0];
-	push_constant.proj_info[3] = (1.0f + p_projections[0].columns[1][2]) / p_projections[0].columns[1][1];
+	push_constant.proj_info[2] = (1.0f - p_projections[0].columns[2][0]) / p_projections[0].columns[0][0];
+	push_constant.proj_info[3] = (1.0f + p_projections[0].columns[2][1]) / p_projections[0].columns[1][1];
 
 	bool use_sdfgi = p_render_buffers->has_custom_data(RB_SCOPE_SDFGI);
 	bool use_voxel_gi_instances = push_constant.max_voxel_gi_instances > 0;


### PR DESCRIPTION
so I think this problem was a *lot* simpler than I thought. it looks like when these lines were written originally, the column order was backwards. `[0][2]` and `[1][2]` are both always 0.0 in my testing, unused elements of the matrix as far as I can tell, while `[2][0]` and `[2][1]` appear to be the intended ones.

note that this fixes voxel GI and SDFGI, but *not* screen space effects. thus, this is only a partial fix for https://github.com/godotengine/godot/issues/108508. these exact same lines also exist in `ss_effects.cpp`, and applying the same fix here *does* fix the X axis, but it does not fix the Y axis, so I'm leaving it as-is for someone else to tackle, because I think at least SSR might need more work than just this projection fixed in order to support an offset frustum.