### PR TITLE
Fix new autoload scripts using file name instead of user defined name

### DIFF
--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -603,7 +603,6 @@ void EditorAutoloadSettings::_script_created(Ref<Script> p_script) {
 	FileSystemDock::get_singleton()->get_script_create_dialog()->hide();
 	path = p_script->get_path().get_base_dir();
 	autoload_add_path->set_text(p_script->get_path());
-	autoload_add_name->set_text(p_script->get_path().get_file().get_basename().to_pascal_case());
 	_autoload_add();
 }
 


### PR DESCRIPTION
Fixes #108575

When creating a new script through the autoload window the newly created autoload will have the name you defined before creating the script. Previously it would use a PascalCase version of the file name instead.

https://github.com/user-attachments/assets/6e7ee52b-9d48-45ab-babf-a83170cc5566

