### PR TITLE
Use of `XrSwapchainCreateFlags` for `OpenXRCompositionLayer`

### DIFF
--- a/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
+++ b/modules/openxr/doc_classes/OpenXRCompositionLayer.xml
@@ -49,6 +49,10 @@
 		<member name="layer_viewport" type="SubViewport" setter="set_layer_viewport" getter="get_layer_viewport">
 			The [SubViewport] to render on the composition layer.
 		</member>
+		<member name="protected_content" type="bool" setter="set_protected_content" getter="is_protected_content" default="false">
+			If enabled, the OpenXR swapchain will be created with the [code]XR_SWAPCHAIN_CREATE_PROTECTED_CONTENT_BIT[/code] flag, which will protect its contents from CPU access.
+			When used with an Android Surface, this may allow DRM content to be presented, and will only take effect when the Surface is first created; later changes to this property will have no effect.
+		</member>
 		<member name="sort_order" type="int" setter="set_sort_order" getter="get_sort_order" default="1">
 			The sort order for this composition layer. Higher numbers will be shown in front of lower numbers.
 			[b]Note:[/b] This will have no effect if a fallback mesh is being used.

--- a/modules/openxr/extensions/openxr_composition_layer_extension.h
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.h
@@ -161,6 +161,7 @@ private:
 		Size2i viewport_size;
 		OpenXRAPI::OpenXRSwapChainInfo swapchain_info;
 		bool static_image = false;
+		bool swapchain_protected_content = false;
 	} subviewport;
 
 #ifdef ANDROID_ENABLED
@@ -171,6 +172,7 @@ private:
 #endif
 
 	bool use_android_surface = false;
+	bool protected_content = false;
 	Size2i swapchain_size;
 
 	OpenXRAPI *openxr_api = nullptr;
@@ -203,6 +205,9 @@ public:
 
 	void set_use_android_surface(bool p_enable, Size2i p_size);
 	bool get_use_android_surface() const { return use_android_surface; }
+
+	void set_protected_content(bool p_protected_content) { protected_content = p_protected_content; }
+	bool is_protected_content() const { return protected_content; }
 
 	Ref<JavaObject> get_android_surface();
 

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -113,6 +113,9 @@ void OpenXRCompositionLayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_android_surface"), &OpenXRCompositionLayer::get_android_surface);
 	ClassDB::bind_method(D_METHOD("is_natively_supported"), &OpenXRCompositionLayer::is_natively_supported);
 
+	ClassDB::bind_method(D_METHOD("is_protected_content"), &OpenXRCompositionLayer::is_protected_content);
+	ClassDB::bind_method(D_METHOD("set_protected_content", "protected_content"), &OpenXRCompositionLayer::set_protected_content);
+
 	ClassDB::bind_method(D_METHOD("set_min_filter", "mode"), &OpenXRCompositionLayer::set_min_filter);
 	ClassDB::bind_method(D_METHOD("get_min_filter"), &OpenXRCompositionLayer::get_min_filter);
 
@@ -150,6 +153,7 @@ void OpenXRCompositionLayer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "layer_viewport", PROPERTY_HINT_NODE_TYPE, "SubViewport"), "set_layer_viewport", "get_layer_viewport");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_android_surface", PROPERTY_HINT_NONE, ""), "set_use_android_surface", "get_use_android_surface");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "protected_content", PROPERTY_HINT_NONE, ""), "set_protected_content", "is_protected_content");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "android_surface_size", PROPERTY_HINT_NONE, ""), "set_android_surface_size", "get_android_surface_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sort_order", PROPERTY_HINT_NONE, ""), "set_sort_order", "get_sort_order");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "alpha_blend", PROPERTY_HINT_NONE, ""), "set_alpha_blend", "get_alpha_blend");
@@ -408,6 +412,14 @@ bool OpenXRCompositionLayer::is_natively_supported() const {
 		return composition_layer_extension->is_available(openxr_layer_provider->get_openxr_type());
 	}
 	return false;
+}
+
+void OpenXRCompositionLayer::set_protected_content(bool p_protected_content) {
+	openxr_layer_provider->set_protected_content(p_protected_content);
+}
+
+bool OpenXRCompositionLayer::is_protected_content() const {
+	return openxr_layer_provider->is_protected_content();
 }
 
 void OpenXRCompositionLayer::set_min_filter(Filter p_mode) {

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -153,6 +153,9 @@ public:
 	Ref<JavaObject> get_android_surface();
 	bool is_natively_supported() const;
 
+	void set_protected_content(bool p_protected_content);
+	bool is_protected_content() const;
+
 	void set_min_filter(Filter p_mode);
 	Filter get_min_filter() const;
 


### PR DESCRIPTION
Introduces SwapchainCreateFlags enum to control swapchain creation (NORMAL, STATIC, PROTECTED) in OpenXR composition layers.
This allows the user to set  SwapChainCreate Flags to either have one static image on the composition layer or set the protected content flag which allows stuff like Widevine DRM protected videos to be displayed on the composition layer


As this is the first time **ever** creating something with c++, i am open for feedback, will try my best to answer to your guys' feedback and improve the code. 

A question I have already: Should I rename the values in the enum, as "normal", "static" and "protected" are not that informative and "normal" is just not normal. it just sets a 0 as bit

Thanks ^^