### PR TITLE
Fix error when dragging non-resource file

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -737,9 +737,11 @@ bool EditorResourcePicker::_is_drop_valid(const Dictionary &p_drag_data) const {
 	} else if (drag_data.has("type") && String(drag_data["type"]) == "files") {
 		Vector<String> files = drag_data["files"];
 
-		// TODO: Extract the typename of the dropped filepath's resource in a more performant way, without fully loading it.
 		if (files.size() == 1) {
-			res = ResourceLoader::load(files[0]);
+			if (ResourceLoader::exists(files[0])) {
+				// TODO: Extract the typename of the dropped filepath's resource in a more performant way, without fully loading it.
+				res = ResourceLoader::load(files[0]);
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixes #89996
Fixes #101461

When dragging a file the editor now checks if the file can be loaded as a resource before trying to load it.