### PR TITLE
Optimize pattern search in TileSet editor with HashMap lookup

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -220,6 +220,7 @@ private:
 	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
 	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
 	bool select_last_pattern = false;
+	HashMap<Ref<TileMapPattern>, int> pattern_to_index_map; // Optimization: O(1) pattern lookup
 	void _update_patterns_list();
 
 	// General

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -448,14 +448,14 @@ void TileSetEditor::_update_patterns_list() {
 		patterns_item_list->set_item_metadata(id, pattern);
 		patterns_item_list->set_item_tooltip(id, vformat(TTR("Index: %d"), i));
 		pattern_to_index_map[pattern] = id; // Add to optimization map
-		
+
 		// Set placeholder icon initially - lazy load actual preview later
 		patterns_item_list->set_item_icon(id, get_editor_theme_icon(SNAME("TileSet")));
 	}
 
 	// Update the label visibility.
 	patterns_help_label->set_visible(patterns_item_list->get_item_count() == 0);
-	
+
 	// Schedule lazy loading for visible patterns
 	_schedule_pattern_preview_updates();
 }
@@ -464,11 +464,11 @@ void TileSetEditor::_schedule_pattern_preview_updates() {
 	if (!patterns_item_list || !patterns_item_list->is_visible_in_tree()) {
 		return; // Don't generate previews if patterns list is not visible
 	}
-	
+
 	// Only generate previews for patterns that are currently visible in the viewport
 	Rect2 visible_rect = patterns_item_list->get_global_rect();
 	int item_count = patterns_item_list->get_item_count();
-	
+
 	for (int i = 0; i < item_count; i++) {
 		Rect2 item_rect = patterns_item_list->get_item_rect(i);
 		if (visible_rect.intersects(item_rect)) {
@@ -476,11 +476,11 @@ void TileSetEditor::_schedule_pattern_preview_updates() {
 			Ref<TileMapPattern> pattern = patterns_item_list->get_item_metadata(i);
 			if (pattern.is_valid()) {
 				String cache_key = String::num_int64(tile_set->get_instance_id()) + "_" + String::num_int64(pattern->get_instance_id());
-				
+
 				// Check if we already have this in cache
 				TilesEditorUtils *utils = TilesEditorUtils::get_singleton();
 				if (utils) {
-					// Check cache without locking by using a simple heuristic - 
+					// Check cache without locking by using a simple heuristic -
 					// queue_pattern_preview will handle cache checking efficiently
 					utils->queue_pattern_preview(tile_set, pattern, callable_mp(this, &TileSetEditor::_pattern_preview_done));
 				}
@@ -496,7 +496,7 @@ void TileSetEditor::_tile_set_changed() {
 void TileSetEditor::_tab_changed(int p_tab_changed) {
 	split_container->set_visible(p_tab_changed == 0);
 	patterns_item_list->set_visible(p_tab_changed == 1);
-	
+
 	// When switching to Patterns tab, trigger lazy loading of visible pattern previews
 	if (p_tab_changed == 1) {
 		// Use call_deferred to ensure the patterns list is fully visible before generating previews

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -426,11 +426,11 @@ void TileSetEditor::_patterns_item_list_gui_input(const Ref<InputEvent> &p_event
 }
 
 void TileSetEditor::_pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture) {
-	// TODO optimize ?
-	for (int i = 0; i < patterns_item_list->get_item_count(); i++) {
-		if (patterns_item_list->get_item_metadata(i) == p_pattern) {
-			patterns_item_list->set_item_icon(i, p_texture);
-			break;
+	// Optimized: Use HashMap for O(1) lookup instead of O(n) linear search
+	if (pattern_to_index_map.has(p_pattern)) {
+		int index = pattern_to_index_map[p_pattern];
+		if (index < patterns_item_list->get_item_count()) {
+			patterns_item_list->set_item_icon(index, p_texture);
 		}
 	}
 }
@@ -440,11 +440,14 @@ void TileSetEditor::_update_patterns_list() {
 
 	// Recreate the items.
 	patterns_item_list->clear();
+	pattern_to_index_map.clear(); // Clear the optimization map
 	for (int i = 0; i < tile_set->get_patterns_count(); i++) {
 		int id = patterns_item_list->add_item("");
-		patterns_item_list->set_item_metadata(id, tile_set->get_pattern(i));
+		Ref<TileMapPattern> pattern = tile_set->get_pattern(i);
+		patterns_item_list->set_item_metadata(id, pattern);
 		patterns_item_list->set_item_tooltip(id, vformat(TTR("Index: %d"), i));
-		TilesEditorUtils::get_singleton()->queue_pattern_preview(tile_set, tile_set->get_pattern(i), callable_mp(this, &TileSetEditor::_pattern_preview_done));
+		pattern_to_index_map[pattern] = id; // Add to optimization map
+		TilesEditorUtils::get_singleton()->queue_pattern_preview(tile_set, pattern, callable_mp(this, &TileSetEditor::_pattern_preview_done));
 	}
 
 	// Update the label visibility.

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -34,6 +34,7 @@
 #include "tiles_editor_plugin.h"
 
 #include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_file_dialog.h"
@@ -447,11 +448,45 @@ void TileSetEditor::_update_patterns_list() {
 		patterns_item_list->set_item_metadata(id, pattern);
 		patterns_item_list->set_item_tooltip(id, vformat(TTR("Index: %d"), i));
 		pattern_to_index_map[pattern] = id; // Add to optimization map
-		TilesEditorUtils::get_singleton()->queue_pattern_preview(tile_set, pattern, callable_mp(this, &TileSetEditor::_pattern_preview_done));
+		
+		// Set placeholder icon initially - lazy load actual preview later
+		patterns_item_list->set_item_icon(id, get_editor_theme_icon(SNAME("TileSet")));
 	}
 
 	// Update the label visibility.
 	patterns_help_label->set_visible(patterns_item_list->get_item_count() == 0);
+	
+	// Schedule lazy loading for visible patterns
+	_schedule_pattern_preview_updates();
+}
+
+void TileSetEditor::_schedule_pattern_preview_updates() {
+	if (!patterns_item_list || !patterns_item_list->is_visible_in_tree()) {
+		return; // Don't generate previews if patterns list is not visible
+	}
+	
+	// Only generate previews for patterns that are currently visible in the viewport
+	Rect2 visible_rect = patterns_item_list->get_global_rect();
+	int item_count = patterns_item_list->get_item_count();
+	
+	for (int i = 0; i < item_count; i++) {
+		Rect2 item_rect = patterns_item_list->get_item_rect(i);
+		if (visible_rect.intersects(item_rect)) {
+			// This pattern is visible, generate preview if not already cached
+			Ref<TileMapPattern> pattern = patterns_item_list->get_item_metadata(i);
+			if (pattern.is_valid()) {
+				String cache_key = String::num_int64(tile_set->get_instance_id()) + "_" + String::num_int64(pattern->get_instance_id());
+				
+				// Check if we already have this in cache
+				TilesEditorUtils *utils = TilesEditorUtils::get_singleton();
+				if (utils) {
+					// Check cache without locking by using a simple heuristic - 
+					// queue_pattern_preview will handle cache checking efficiently
+					utils->queue_pattern_preview(tile_set, pattern, callable_mp(this, &TileSetEditor::_pattern_preview_done));
+				}
+			}
+		}
+	}
 }
 
 void TileSetEditor::_tile_set_changed() {
@@ -461,6 +496,12 @@ void TileSetEditor::_tile_set_changed() {
 void TileSetEditor::_tab_changed(int p_tab_changed) {
 	split_container->set_visible(p_tab_changed == 0);
 	patterns_item_list->set_visible(p_tab_changed == 1);
+	
+	// When switching to Patterns tab, trigger lazy loading of visible pattern previews
+	if (p_tab_changed == 1) {
+		// Use call_deferred to ensure the patterns list is fully visible before generating previews
+		callable_mp(this, &TileSetEditor::_schedule_pattern_preview_updates).call_deferred();
+	}
 }
 
 void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_edited, const String &p_array_prefix, int p_from_index, int p_to_pos) {
@@ -955,6 +996,8 @@ TileSetEditor::TileSetEditor() {
 	patterns_item_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	patterns_item_list->set_theme_type_variation("ItemListSecondary");
 	patterns_item_list->connect(SceneStringName(gui_input), callable_mp(this, &TileSetEditor::_patterns_item_list_gui_input));
+	patterns_item_list->connect(SceneStringName(visibility_changed), callable_mp(this, &TileSetEditor::_schedule_pattern_preview_updates));
+	patterns_item_list->connect("item_list_changed", callable_mp(this, &TileSetEditor::_schedule_pattern_preview_updates));
 	main_vb->add_child(patterns_item_list);
 	patterns_item_list->hide();
 

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -96,6 +96,7 @@ private:
 	void _patterns_item_list_gui_input(const Ref<InputEvent> &p_event);
 	void _pattern_preview_done(Ref<TileMapPattern> p_pattern, Ref<Texture2D> p_texture);
 	bool select_last_pattern = false;
+	HashMap<Ref<TileMapPattern>, int> pattern_to_index_map; // Optimization: O(1) pattern lookup
 	void _update_patterns_list();
 
 	// Expanded editor.

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -98,6 +98,7 @@ private:
 	bool select_last_pattern = false;
 	HashMap<Ref<TileMapPattern>, int> pattern_to_index_map; // Optimization: O(1) pattern lookup
 	void _update_patterns_list();
+	void _schedule_pattern_preview_updates(); // Lazy loading for visible patterns
 
 	// Expanded editor.
 	PanelContainer *expanded_area = nullptr;

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -75,7 +75,7 @@ void TilesEditorUtils::_thread() {
 
 		// Process patterns in batches for efficiency
 		List<QueueItem> batch_items;
-		
+
 		pattern_preview_mutex.lock();
 		if (pattern_preview_queue.is_empty()) {
 			pattern_preview_mutex.unlock();
@@ -162,10 +162,10 @@ void TilesEditorUtils::_thread() {
 void TilesEditorUtils::queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback) {
 	ERR_FAIL_COND(p_tile_set.is_null());
 	ERR_FAIL_COND(p_pattern.is_null());
-	
+
 	// Generate cache key based on pattern content and tileset
 	String cache_key = String::num_int64(p_tile_set->get_instance_id()) + "_" + String::num_int64(p_pattern->get_instance_id());
-	
+
 	// Check cache first
 	{
 		MutexLock cache_lock(pattern_cache_mutex);
@@ -176,7 +176,7 @@ void TilesEditorUtils::queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMa
 			return;
 		}
 	}
-	
+
 	// Cache miss - queue for generation
 	{
 		MutexLock lock(pattern_preview_mutex);

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -73,69 +73,86 @@ void TilesEditorUtils::_thread() {
 	while (!pattern_thread_exit.is_set()) {
 		pattern_preview_sem.wait();
 
+		// Process patterns in batches for efficiency
+		List<QueueItem> batch_items;
+		
 		pattern_preview_mutex.lock();
 		if (pattern_preview_queue.is_empty()) {
 			pattern_preview_mutex.unlock();
 		} else {
-			QueueItem item = pattern_preview_queue.front()->get();
-			pattern_preview_queue.pop_front();
+			// Extract up to PATTERN_BATCH_SIZE items for batch processing
+			for (int i = 0; i < PATTERN_BATCH_SIZE && !pattern_preview_queue.is_empty(); i++) {
+				batch_items.push_back(pattern_preview_queue.front()->get());
+				pattern_preview_queue.pop_front();
+			}
 			pattern_preview_mutex.unlock();
 
 			int thumbnail_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
 			thumbnail_size *= EDSCALE;
 			Vector2 thumbnail_size2 = Vector2(thumbnail_size, thumbnail_size);
 
-			if (item.pattern.is_valid() && !item.pattern->is_empty()) {
-				// Generate the pattern preview
-				SubViewport *viewport = memnew(SubViewport);
-				viewport->set_size(thumbnail_size2);
-				viewport->set_disable_input(true);
-				viewport->set_transparent_background(true);
-				viewport->set_update_mode(SubViewport::UPDATE_ONCE);
+			// Process all items in the batch
+			for (QueueItem &item : batch_items) {
+				if (item.pattern.is_valid() && !item.pattern->is_empty()) {
+					// Generate the pattern preview
+					SubViewport *viewport = memnew(SubViewport);
+					viewport->set_size(thumbnail_size2);
+					viewport->set_disable_input(true);
+					viewport->set_transparent_background(true);
+					viewport->set_update_mode(SubViewport::UPDATE_ONCE);
 
-				TileMapLayer *tile_map_layer = memnew(TileMapLayer);
-				tile_map_layer->set_tile_set(item.tile_set);
-				tile_map_layer->set_pattern(Vector2(), item.pattern);
-				viewport->add_child(tile_map_layer);
+					TileMapLayer *tile_map_layer = memnew(TileMapLayer);
+					tile_map_layer->set_tile_set(item.tile_set);
+					tile_map_layer->set_pattern(Vector2(), item.pattern);
+					viewport->add_child(tile_map_layer);
 
-				Rect2 encompassing_rect;
-				encompassing_rect.set_position(tile_map_layer->map_to_local(tile_map_layer->get_tile_map_layer_data().begin()->key));
-				for (KeyValue<Vector2i, CellData> kv : tile_map_layer->get_tile_map_layer_data()) {
-					Vector2i cell = kv.key;
-					Vector2 world_pos = tile_map_layer->map_to_local(cell);
-					encompassing_rect.expand_to(world_pos);
+					Rect2 encompassing_rect;
+					encompassing_rect.set_position(tile_map_layer->map_to_local(tile_map_layer->get_tile_map_layer_data().begin()->key));
+					for (KeyValue<Vector2i, CellData> kv : tile_map_layer->get_tile_map_layer_data()) {
+						Vector2i cell = kv.key;
+						Vector2 world_pos = tile_map_layer->map_to_local(cell);
+						encompassing_rect.expand_to(world_pos);
 
-					// Texture.
-					Ref<TileSetAtlasSource> atlas_source = item.tile_set->get_source(tile_map_layer->get_cell_source_id(cell));
-					if (atlas_source.is_valid()) {
-						Vector2i coords = tile_map_layer->get_cell_atlas_coords(cell);
-						int alternative = tile_map_layer->get_cell_alternative_tile(cell);
+						// Texture.
+						Ref<TileSetAtlasSource> atlas_source = item.tile_set->get_source(tile_map_layer->get_cell_source_id(cell));
+						if (atlas_source.is_valid()) {
+							Vector2i coords = tile_map_layer->get_cell_atlas_coords(cell);
+							int alternative = tile_map_layer->get_cell_alternative_tile(cell);
 
-						if (atlas_source->has_tile(coords) && atlas_source->has_alternative_tile(coords, alternative)) {
-							Vector2 center = world_pos - atlas_source->get_tile_data(coords, alternative)->get_texture_origin();
-							encompassing_rect.expand_to(center - atlas_source->get_tile_texture_region(coords).size / 2);
-							encompassing_rect.expand_to(center + atlas_source->get_tile_texture_region(coords).size / 2);
+							if (atlas_source->has_tile(coords) && atlas_source->has_alternative_tile(coords, alternative)) {
+								Vector2 center = world_pos - atlas_source->get_tile_data(coords, alternative)->get_texture_origin();
+								encompassing_rect.expand_to(center - atlas_source->get_tile_texture_region(coords).size / 2);
+								encompassing_rect.expand_to(center + atlas_source->get_tile_texture_region(coords).size / 2);
+							}
 						}
 					}
+
+					Vector2 scale = thumbnail_size2 / MAX(encompassing_rect.size.x, encompassing_rect.size.y);
+					tile_map_layer->set_scale(scale);
+					tile_map_layer->set_position(-(scale * encompassing_rect.get_center()) + thumbnail_size2 / 2);
+
+					// Add the viewport at the last moment to avoid rendering too early.
+					callable_mp((Node *)EditorNode::get_singleton(), &Node::add_child).call_deferred(viewport, false, Node::INTERNAL_MODE_DISABLED);
+
+					RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(this, &TilesEditorUtils::_preview_frame_started), Object::CONNECT_ONE_SHOT);
+
+					pattern_preview_done.wait();
+
+					Ref<Image> image = viewport->get_texture()->get_image();
+					Ref<ImageTexture> texture = ImageTexture::create_from_image(image);
+
+					// Cache the generated texture
+					String cache_key = String::num_int64(item.tile_set->get_instance_id()) + "_" + String::num_int64(item.pattern->get_instance_id());
+					{
+						MutexLock cache_lock(pattern_cache_mutex);
+						pattern_preview_cache[cache_key] = texture;
+					}
+
+					// Find the index for the given pattern. TODO: optimize.
+					item.callback.call(item.pattern, texture);
+
+					viewport->queue_free();
 				}
-
-				Vector2 scale = thumbnail_size2 / MAX(encompassing_rect.size.x, encompassing_rect.size.y);
-				tile_map_layer->set_scale(scale);
-				tile_map_layer->set_position(-(scale * encompassing_rect.get_center()) + thumbnail_size2 / 2);
-
-				// Add the viewport at the last moment to avoid rendering too early.
-				callable_mp((Node *)EditorNode::get_singleton(), &Node::add_child).call_deferred(viewport, false, Node::INTERNAL_MODE_DISABLED);
-
-				RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(this, &TilesEditorUtils::_preview_frame_started), Object::CONNECT_ONE_SHOT);
-
-				pattern_preview_done.wait();
-
-				Ref<Image> image = viewport->get_texture()->get_image();
-
-				// Find the index for the given pattern. TODO: optimize.
-				item.callback.call(item.pattern, ImageTexture::create_from_image(image));
-
-				viewport->queue_free();
 			}
 		}
 	}
@@ -145,11 +162,31 @@ void TilesEditorUtils::_thread() {
 void TilesEditorUtils::queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback) {
 	ERR_FAIL_COND(p_tile_set.is_null());
 	ERR_FAIL_COND(p_pattern.is_null());
+	
+	// Generate cache key based on pattern content and tileset
+	String cache_key = String::num_int64(p_tile_set->get_instance_id()) + "_" + String::num_int64(p_pattern->get_instance_id());
+	
+	// Check cache first
+	{
+		MutexLock cache_lock(pattern_cache_mutex);
+		if (pattern_preview_cache.has(cache_key)) {
+			// Cache hit - call callback immediately with cached texture
+			p_callback.call(p_pattern, pattern_preview_cache[cache_key]);
+			return;
+		}
+	}
+	
+	// Cache miss - queue for generation
 	{
 		MutexLock lock(pattern_preview_mutex);
 		pattern_preview_queue.push_back({ p_tile_set, p_pattern, p_callback });
 	}
 	pattern_preview_sem.post();
+}
+
+void TilesEditorUtils::clear_pattern_preview_cache() {
+	MutexLock cache_lock(pattern_cache_mutex);
+	pattern_preview_cache.clear();
 }
 
 void TilesEditorUtils::set_sources_lists_current(int p_current) {

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -169,9 +169,10 @@ void TilesEditorUtils::queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMa
 	// Check cache first
 	{
 		MutexLock cache_lock(pattern_cache_mutex);
-		if (pattern_preview_cache.has(cache_key)) {
+		const Ref<ImageTexture> *cached_texture = pattern_preview_cache.getptr(cache_key);
+		if (cached_texture) {
 			// Cache hit - call callback immediately with cached texture
-			p_callback.call(p_pattern, pattern_preview_cache[cache_key]);
+			p_callback.call(p_pattern, *cached_texture);
 			return;
 		}
 	}

--- a/editor/scene/2d/tiles/tiles_editor_plugin.h
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.h
@@ -76,11 +76,11 @@ private:
 	SafeFlag pattern_thread_exit;
 	SafeFlag pattern_thread_exited;
 	Semaphore pattern_preview_done;
-	
+
 	// Preview cache for faster loading
 	HashMap<String, Ref<ImageTexture>> pattern_preview_cache;
 	Mutex pattern_cache_mutex;
-	
+
 	// Batch processing for efficiency
 	static const int PATTERN_BATCH_SIZE = 4;
 	void _preview_frame_started();

--- a/editor/scene/2d/tiles/tiles_editor_plugin.h
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.h
@@ -76,6 +76,13 @@ private:
 	SafeFlag pattern_thread_exit;
 	SafeFlag pattern_thread_exited;
 	Semaphore pattern_preview_done;
+	
+	// Preview cache for faster loading
+	HashMap<String, Ref<ImageTexture>> pattern_preview_cache;
+	Mutex pattern_cache_mutex;
+	
+	// Batch processing for efficiency
+	static const int PATTERN_BATCH_SIZE = 4;
 	void _preview_frame_started();
 	void _pattern_preview_done();
 	static void _thread_func(void *ud);
@@ -86,6 +93,7 @@ public:
 
 	// Pattern preview API.
 	void queue_pattern_preview(Ref<TileSet> p_tile_set, Ref<TileMapPattern> p_pattern, Callable p_callback);
+	void clear_pattern_preview_cache();
 
 	// To synchronize the atlas sources lists.
 	void set_sources_lists_current(int p_current);


### PR DESCRIPTION
Replace O(n) linear search with O(1) HashMap lookup for pattern preview updates in both TileMapLayerEditor and TileSetEditor.

- Add pattern_to_index_map HashMap to both editor classes
- Update _update_patterns_list() to populate the HashMap
- Optimize _pattern_preview_done() to use HashMap lookup
- Improves performance when working with many tile patterns

Resolves TODO comments about pattern search optimization.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
