### PR TITLE
Make bottom panel into available dock slot

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -61,11 +61,22 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="close">
+			<return type="void" />
+			<description>
+				Closes the dock, making its tab hidden.
+			</description>
+		</method>
+		<method name="open">
+			<return type="void" />
+			<description>
+				Opens the dock. It will appear in the last used dock slot. If the dock has no default slot, it will be opened floating.
+			</description>
+		</method>
 	</methods>
 	<members>
-		<member name="available_layouts" type="int" setter="set_available_layouts" getter="get_available_layouts" enum="EditorDock.DockLayout" is_bitfield="true" default="1">
-			The available layouts for this dock, as a bitmask.
-			If you want to make all layouts available, use [code]available_layouts = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_HORIZONTAL[/code].
+		<member name="available_layouts" type="int" setter="set_available_layouts" getter="get_available_layouts" enum="EditorDock.DockLayout" is_bitfield="true" default="5">
+			The available layouts for this dock, as a bitmask. By default, the dock allows vertical and floating layouts.
 		</member>
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="default_slot" type="int" setter="set_default_slot" getter="get_default_slot" enum="EditorPlugin.DockSlot" default="-1">
@@ -78,6 +89,9 @@
 		<member name="dock_shortcut" type="Shortcut" setter="set_dock_shortcut" getter="get_dock_shortcut">
 			The shortcut used to open the dock. This property can only be set before this dock is added via [method EditorPlugin.add_dock].
 		</member>
+		<member name="global" type="bool" setter="set_global" getter="is_global" default="true">
+			If [code]true[/code], the dock appears in the [b]Editor &gt; Editor Docks[/b] menu and can be closed. Non-global docks can still be closed using [method close].
+		</member>
 		<member name="icon_name" type="StringName" setter="set_icon_name" getter="get_icon_name" default="&amp;&quot;&quot;">
 			The icon for the dock, as a name from the [code]EditorIcons[/code] theme type in the editor theme. You can find the list of available icons [url=https://godot-editor-icons.github.io/]here[/url].
 		</member>
@@ -87,14 +101,25 @@
 		<member name="title" type="String" setter="set_title" getter="get_title" default="&quot;&quot;">
 			The title of the dock's tab. If empty, the dock's [member Node.name] will be used. If the name is auto-generated (contains [code]@[/code]), the first child's name will be used instead.
 		</member>
+		<member name="title_color" type="Color" setter="set_title_color" getter="get_title_color" default="Color(0, 0, 0, 0)">
+			The color of the dock tab's title. If its alpha is [code]0.0[/code], the default font color will be used.
+		</member>
+		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
+			If [code]true[/code], the dock is not automatically opened or closed when loading an editor layout, only moved. It also can't be opened using a shortcut. This is meant for docks that are opened and closed in specific cases, such as when selecting a [TileMap] or [AnimationTree] node.
+		</member>
 	</members>
 	<constants>
 		<constant name="DOCK_LAYOUT_VERTICAL" value="1" enum="DockLayout" is_bitfield="true">
 			Allows placing the dock in the vertical dock slots on either side of the editor.
-			[b]Note:[/b] Currently this flag has no effect because the bottom panel is not a proper dock slot. This means that the dock can always be vertical.
 		</constant>
 		<constant name="DOCK_LAYOUT_HORIZONTAL" value="2" enum="DockLayout" is_bitfield="true">
-			Allows placing the dock in the editor's bottom panel. Implement [method _update_layout] to handle changing layouts.
+			Allows placing the dock in the editor's bottom panel.
+		</constant>
+		<constant name="DOCK_LAYOUT_FLOATING" value="4" enum="DockLayout" is_bitfield="true">
+			Allows making the dock floating (opened as a separate window).
+		</constant>
+		<constant name="DOCK_LAYOUT_ALL" value="7" enum="DockLayout" is_bitfield="true">
+			Allows placing the dock in all available slots.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -424,7 +424,7 @@
 				[b]Note:[/b] A plugin instance can belong only to a single context menu slot.
 			</description>
 		</method>
-		<method name="add_control_to_bottom_panel">
+		<method name="add_control_to_bottom_panel" deprecated="Use [method add_dock] instead, with [member EditorDock.default_slot] set to [constant DOCK_SLOT_BOTTOM].">
 			<return type="Button" />
 			<param index="0" name="control" type="Control" />
 			<param index="1" name="title" type="String" />
@@ -662,7 +662,7 @@
 				Removes the specified context menu plugin.
 			</description>
 		</method>
-		<method name="remove_control_from_bottom_panel">
+		<method name="remove_control_from_bottom_panel" deprecated="Use [method remove_dock] instead.">
 			<return type="void" />
 			<param index="0" name="control" type="Control" />
 			<description>
@@ -910,7 +910,10 @@
 		<constant name="DOCK_SLOT_RIGHT_BR" value="7" enum="DockSlot">
 			Dock slot, right side, bottom-right (empty in default layout).
 		</constant>
-		<constant name="DOCK_SLOT_MAX" value="8" enum="DockSlot">
+		<constant name="DOCK_SLOT_BOTTOM" value="8" enum="DockSlot">
+			Bottom panel.
+		</constant>
+		<constant name="DOCK_SLOT_MAX" value="9" enum="DockSlot">
 			Represents the size of the [enum DockSlot] enum.
 		</constant>
 		<constant name="AFTER_GUI_INPUT_PASS" value="0" enum="AfterGUIInput">

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -121,6 +121,7 @@ private:
 
 	ScriptEditorDebugger *_add_debugger();
 	void _update_errors();
+	void _update_margins();
 
 	friend class DebuggerEditorPlugin;
 	friend class DebugAdapterParser;

--- a/editor/docks/dock_constants.h
+++ b/editor/docks/dock_constants.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_bottom_panel.h                                                 */
+/*  dock_constants.h                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,59 +30,26 @@
 
 #pragma once
 
-#include "scene/gui/tab_container.h"
+namespace DockConstants {
 
-class Button;
-class ConfigFile;
-class EditorDock;
-class EditorToaster;
-class HBoxContainer;
-
-class EditorBottomPanel : public TabContainer {
-	GDCLASS(EditorBottomPanel, TabContainer);
-
-	HBoxContainer *bottom_hbox = nullptr;
-	Control *icon_spacer = nullptr;
-	EditorToaster *editor_toaster = nullptr;
-	Button *pin_button = nullptr;
-	Button *expand_button = nullptr;
-	Popup *layout_popup = nullptr;
-
-	int previous_tab = -1;
-	bool lock_panel_switching = false;
-	LocalVector<Control *> bottom_docks;
-	LocalVector<Ref<Shortcut>> dock_shortcuts;
-	HashMap<String, int> dock_offsets;
-
-	LocalVector<Button *> legacy_buttons;
-	void _on_button_visibility_changed(Button *p_button, EditorDock *p_dock);
-
-	void _repaint();
-	void _on_tab_changed(int p_idx);
-	void _pin_button_toggled(bool p_pressed);
-	void _expand_button_toggled(bool p_pressed);
-	void _update_center_split_offset();
-	EditorDock *_get_dock_from_control(Control *p_control) const;
-
-protected:
-	void _notification(int p_what);
-
-public:
-	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
-	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
-
-	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
-	void remove_item(Control *p_item);
-	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
-	void move_item_to_end(Control *p_item);
-	void hide_bottom_panel();
-	void toggle_last_opened_bottom_panel();
-	void set_expanded(bool p_expanded);
-	void _theme_changed();
-
-	void set_bottom_panel_offset(int p_offset);
-	int get_bottom_panel_offset();
-
-	EditorBottomPanel();
-	~EditorBottomPanel();
+enum DockSlot {
+	DOCK_SLOT_NONE = -1,
+	DOCK_SLOT_LEFT_UL,
+	DOCK_SLOT_LEFT_BL,
+	DOCK_SLOT_LEFT_UR,
+	DOCK_SLOT_LEFT_BR,
+	DOCK_SLOT_RIGHT_UL,
+	DOCK_SLOT_RIGHT_BL,
+	DOCK_SLOT_RIGHT_UR,
+	DOCK_SLOT_RIGHT_BR,
+	DOCK_SLOT_BOTTOM,
+	DOCK_SLOT_MAX
 };
+
+enum DockLayout {
+	DOCK_LAYOUT_VERTICAL = 1,
+	DOCK_LAYOUT_HORIZONTAL = 2,
+	DOCK_LAYOUT_FLOATING = 4,
+};
+
+}; //namespace DockConstants

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -43,30 +43,34 @@ class EditorDock : public MarginContainer {
 
 public:
 	enum DockLayout {
-		DOCK_LAYOUT_VERTICAL = 1,
-		DOCK_LAYOUT_HORIZONTAL = 2,
+		DOCK_LAYOUT_VERTICAL = DockConstants::DOCK_LAYOUT_VERTICAL,
+		DOCK_LAYOUT_HORIZONTAL = DockConstants::DOCK_LAYOUT_HORIZONTAL,
+		DOCK_LAYOUT_FLOATING = DockConstants::DOCK_LAYOUT_FLOATING,
+		DOCK_LAYOUT_ALL = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_HORIZONTAL | DOCK_LAYOUT_FLOATING,
 	};
 
 private:
 	friend class EditorDockManager;
 	friend class DockContextPopup;
+	friend class DockShortcutHandler;
 
 	String title;
 	String layout_key;
 	StringName icon_name;
 	Ref<Texture2D> dock_icon;
+	Color title_color = Color(0, 0, 0, 0);
 	Ref<Shortcut> shortcut;
-	EditorDockManager::DockSlot default_slot = EditorDockManager::DOCK_SLOT_NONE;
+	DockConstants::DockSlot default_slot = DockConstants::DOCK_SLOT_NONE;
+	bool global = true;
+	bool transient = false;
 
-	BitField<DockLayout> available_layouts = DOCK_LAYOUT_VERTICAL;
+	BitField<DockLayout> available_layouts = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_FLOATING;
 
-	bool open = false;
+	bool is_open = false;
 	bool enabled = true;
-	bool at_bottom = false;
 	int previous_tab_index = -1;
-	bool previous_at_bottom = false;
 	WindowWrapper *dock_window = nullptr;
-	int dock_slot_index = EditorDockManager::DOCK_SLOT_NONE;
+	int dock_slot_index = DockConstants::DOCK_SLOT_NONE;
 
 	void _set_default_slot_bind(EditorPlugin::DockSlot p_slot);
 	EditorPlugin::DockSlot _get_default_slot_bind() const { return (EditorPlugin::DockSlot)default_slot; }
@@ -81,11 +85,20 @@ protected:
 public:
 	EditorDock();
 
+	void open();
+	void close();
+
 	void set_title(const String &p_title);
 	String get_title() const { return title; }
 
 	void set_layout_key(const String &p_key) { layout_key = p_key; }
 	String get_layout_key() const { return layout_key; }
+
+	void set_global(bool p_global);
+	bool is_global() const { return global; }
+
+	void set_transient(bool p_transient) { transient = p_transient; }
+	bool is_transient() const { return transient; }
 
 	void set_icon_name(const StringName &p_name);
 	StringName get_icon_name() const { return icon_name; }
@@ -93,11 +106,14 @@ public:
 	void set_dock_icon(const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_dock_icon() const { return dock_icon; }
 
-	void set_dock_shortcut(const Ref<Shortcut> &p_shortcut) { shortcut = p_shortcut; }
+	void set_title_color(const Color &p_color);
+	Color get_title_color() const { return title_color; }
+
+	void set_dock_shortcut(const Ref<Shortcut> &p_shortcut);
 	Ref<Shortcut> get_dock_shortcut() const { return shortcut; }
 
-	void set_default_slot(EditorDockManager::DockSlot p_slot);
-	EditorDockManager::DockSlot get_default_slot() const { return default_slot; }
+	void set_default_slot(DockConstants::DockSlot p_slot);
+	DockConstants::DockSlot get_default_slot() const { return default_slot; }
 
 	void set_available_layouts(BitField<DockLayout> p_layouts) { available_layouts = p_layouts; }
 	BitField<DockLayout> get_available_layouts() const { return available_layouts; }

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -614,8 +614,6 @@ void FileSystemDock::_notification(int p_what) {
 			file_list_search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 			file_list_button_sort->set_button_icon(get_editor_theme_icon(SNAME("Sort")));
 
-			button_dock_placement->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
-
 			if (is_layout_rtl()) {
 				button_hist_next->set_button_icon(get_editor_theme_icon(SNAME("Back")));
 				button_hist_prev->set_button_icon(get_editor_theme_icon(SNAME("Forward")));
@@ -2796,10 +2794,6 @@ void FileSystemDock::_rescan() {
 	EditorFileSystem::get_singleton()->scan();
 }
 
-void FileSystemDock::_change_bottom_dock_placement() {
-	EditorDockManager::get_singleton()->bottom_dock_show_placement_popup(button_dock_placement->get_screen_rect(), this);
-}
-
 void FileSystemDock::_change_split_mode() {
 	DisplayMode next_mode = DISPLAY_MODE_TREE_ONLY;
 	if (display_mode == DISPLAY_MODE_VSPLIT) {
@@ -4086,10 +4080,11 @@ MenuButton *FileSystemDock::_create_file_menu_button() {
 }
 
 void FileSystemDock::update_layout(EditorDock::DockLayout p_layout) {
-	horizontal = p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL;
-	if (button_dock_placement->is_visible() == horizontal) {
+	bool new_horizontal = (p_layout == EditorDock::DOCK_LAYOUT_HORIZONTAL);
+	if (horizontal == new_horizontal) {
 		return;
 	}
+	horizontal = new_horizontal;
 
 	if (horizontal) {
 		path_hb->reparent(toolbar_hbc, false);
@@ -4119,7 +4114,6 @@ void FileSystemDock::update_layout(EditorDock::DockLayout p_layout) {
 		set_file_list_display_mode(new_file_display_mode);
 		set_custom_minimum_size(Size2(0, 0));
 	}
-	button_dock_placement->set_visible(horizontal);
 }
 
 void FileSystemDock::save_layout_to_config(Ref<ConfigFile> &p_layout, const String &p_section) const {
@@ -4211,8 +4205,8 @@ FileSystemDock::FileSystemDock() {
 	set_name(TTRC("FileSystem"));
 	set_icon_name("Folder");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_filesystem", TTRC("Open FileSystem Dock"), KeyModifierMask::ALT | Key::F));
-	set_default_slot(EditorDockManager::DOCK_SLOT_LEFT_BR);
-	set_available_layouts(DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_HORIZONTAL);
+	set_default_slot(DockConstants::DOCK_SLOT_LEFT_BR);
+	set_available_layouts(DOCK_LAYOUT_ALL);
 
 	ProjectSettings::get_singleton()->add_hidden_prefix("file_customization/");
 
@@ -4291,13 +4285,6 @@ FileSystemDock::FileSystemDock() {
 	button_toggle_display_mode->set_tooltip_text(TTRC("Change Split Mode"));
 	button_toggle_display_mode->set_theme_type_variation("FlatMenuButton");
 	toolbar_hbc->add_child(button_toggle_display_mode);
-
-	button_dock_placement = memnew(Button);
-	button_dock_placement->set_theme_type_variation("FlatMenuButton");
-	button_dock_placement->set_accessibility_name(TTRC("Dock Placement"));
-	button_dock_placement->connect(SceneStringName(pressed), callable_mp(this, &FileSystemDock::_change_bottom_dock_placement));
-	button_dock_placement->hide();
-	toolbar_hbc->add_child(button_dock_placement);
 
 	toolbar2_hbc = memnew(HBoxContainer);
 	top_vbc->add_child(toolbar2_hbc);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -160,8 +160,6 @@ private:
 
 	HashSet<String> favorites;
 
-	Button *button_dock_placement = nullptr;
-
 	Button *button_toggle_display_mode = nullptr;
 	Button *button_file_list_display_mode = nullptr;
 	Button *button_hist_next = nullptr;
@@ -378,8 +376,6 @@ private:
 	void _feature_profile_changed();
 	void _project_settings_changed();
 	static Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
-
-	void _change_bottom_dock_placement();
 
 private:
 	inline static FileSystemDock *singleton = nullptr;

--- a/editor/docks/history_dock.cpp
+++ b/editor/docks/history_dock.cpp
@@ -239,7 +239,7 @@ HistoryDock::HistoryDock() {
 	set_name(TTRC("History"));
 	set_icon_name("History");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_history", TTRC("Open History Dock")));
-	set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
 
 	ur_manager = EditorUndoRedoManager::get_singleton();
 	ur_manager->connect("history_changed", callable_mp(this, &HistoryDock::on_history_changed));

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -747,7 +747,7 @@ ImportDock::ImportDock() {
 	set_name(TTRC("Import"));
 	set_icon_name("FileAccess");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_import", TTRC("Open Import Dock")));
-	set_default_slot(EditorDockManager::DOCK_SLOT_LEFT_UR);
+	set_default_slot(DockConstants::DOCK_SLOT_LEFT_UR);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -719,7 +719,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	set_name(TTRC("Inspector"));
 	set_icon_name("AnimationTrackList");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_inspector", TTRC("Open Inspector Dock")));
-	set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/docks/node_dock.cpp
+++ b/editor/docks/node_dock.cpp
@@ -93,7 +93,7 @@ NodeDock::NodeDock() {
 	set_name(TTRC("Node"));
 	set_icon_name("Object");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_node", TTRC("Open Node Dock")));
-	set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
+	set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
 
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4716,7 +4716,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 	set_name(TTRC("Scene"));
 	set_icon_name("PackedScene");
 	set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_scene", TTRC("Open Scene Dock")));
-	set_default_slot(EditorDockManager::DOCK_SLOT_LEFT_UR);
+	set_default_slot(DockConstants::DOCK_SLOT_LEFT_UR);
 
 	singleton = this;
 	editor_data = &p_editor_data;

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -33,6 +33,7 @@
 #include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
 #include "core/version.h"
+#include "editor/docks/editor_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -42,7 +43,6 @@
 #include "editor/themes/editor_scale.h"
 #include "modules/regex/regex.h"
 #include "scene/gui/separator.h"
-#include "scene/gui/tab_container.h"
 #include "scene/main/timer.h"
 #include "scene/resources/font.h"
 
@@ -286,11 +286,10 @@ void EditorLog::add_message(const String &p_msg, MessageType p_type) {
 }
 
 void EditorLog::_set_dock_tab_icon(Ref<Texture2D> p_icon) {
-	// This is the sole reason to include "tab_container.h" here.
-	TabContainer *parent = Object::cast_to<TabContainer>(get_parent());
+	// TODO: Remove this hack once EditorLog is converted to a dock.
+	EditorDock *parent = Object::cast_to<EditorDock>(get_parent());
 	if (parent) {
-		int idx = parent->get_tab_idx_from_control(this);
-		parent->set_tab_icon(idx, p_icon);
+		parent->set_dock_icon(p_icon);
 	}
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -928,6 +928,15 @@ void EditorNode::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			started_timestamp = Time::get_singleton()->get_unix_time_from_system();
 
+			// Store the default order of bottom docks. It can only be determined dynamically.
+			PackedStringArray bottom_docks;
+			bottom_docks.reserve_exact(bottom_panel->get_tab_count());
+			for (int i = 0; i < bottom_panel->get_tab_count(); i++) {
+				EditorDock *dock = Object::cast_to<EditorDock>(bottom_panel->get_tab_control(i));
+				bottom_docks.append(dock->get_effective_layout_key());
+			}
+			default_layout->set_value("docks", "dock_9", String(",").join(bottom_docks));
+
 			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
 			RenderingServer::get_singleton()->viewport_set_environment_mode(get_viewport()->get_viewport_rid(), RenderingServer::VIEWPORT_ENVIRONMENT_DISABLED);
 			DisplayServer::get_singleton()->screen_set_keep_on(EDITOR_GET("interface/editor/keep_screen_on"));
@@ -8231,13 +8240,13 @@ EditorNode::EditorNode() {
 	left_l_vsplit->set_vertical(true);
 	left_l_hsplit->add_child(left_l_vsplit);
 
-	TabContainer *dock_slot[EditorDockManager::DOCK_SLOT_MAX];
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UL]->set_name("DockSlotLeftUL");
-	left_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UL]);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BL]->set_name("DockSlotLeftBL");
-	left_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BL]);
+	TabContainer *dock_slot[DockConstants::DOCK_SLOT_MAX];
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_UL] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_UL]->set_name("DockSlotLeftUL");
+	left_l_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_LEFT_UL]);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_BL] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_BL]->set_name("DockSlotLeftBL");
+	left_l_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_LEFT_BL]);
 
 	left_r_hsplit = memnew(DockSplitContainer);
 	left_r_hsplit->set_name("DockHSplitLeftR");
@@ -8246,12 +8255,12 @@ EditorNode::EditorNode() {
 	left_r_vsplit->set_name("DockVSplitLeftR");
 	left_r_vsplit->set_vertical(true);
 	left_r_hsplit->add_child(left_r_vsplit);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UR]->set_name("DockSlotLeftUR");
-	left_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_UR]);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BR]->set_name("DockSlotLeftBR");
-	left_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_LEFT_BR]);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_UR] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_UR]->set_name("DockSlotLeftUR");
+	left_r_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_LEFT_UR]);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_BR] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_LEFT_BR]->set_name("DockSlotLeftBR");
+	left_r_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_LEFT_BR]);
 
 	main_hsplit = memnew(DockSplitContainer);
 	main_hsplit->set_name("DockHSplitMain");
@@ -8277,23 +8286,23 @@ EditorNode::EditorNode() {
 	right_l_vsplit->set_name("DockVSplitRightL");
 	right_l_vsplit->set_vertical(true);
 	right_hsplit->add_child(right_l_vsplit);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UL]->set_name("DockSlotRightUL");
-	right_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UL]);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BL] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BL]->set_name("DockSlotRightBL");
-	right_l_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BL]);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_UL] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_UL]->set_name("DockSlotRightUL");
+	right_l_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_RIGHT_UL]);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_BL] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_BL]->set_name("DockSlotRightBL");
+	right_l_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_RIGHT_BL]);
 
 	right_r_vsplit = memnew(DockSplitContainer);
 	right_r_vsplit->set_name("DockVSplitRightR");
 	right_r_vsplit->set_vertical(true);
 	right_hsplit->add_child(right_r_vsplit);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UR]->set_name("DockSlotRightUR");
-	right_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_UR]);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR] = memnew(TabContainer);
-	dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR]->set_name("DockSlotRightBR");
-	right_r_vsplit->add_child(dock_slot[EditorDockManager::DOCK_SLOT_RIGHT_BR]);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_UR] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_UR]->set_name("DockSlotRightUR");
+	right_r_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_RIGHT_UR]);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_BR] = memnew(TabContainer);
+	dock_slot[DockConstants::DOCK_SLOT_RIGHT_BR]->set_name("DockSlotRightBR");
+	right_r_vsplit->add_child(dock_slot[DockConstants::DOCK_SLOT_RIGHT_BR]);
 
 	editor_dock_manager = memnew(EditorDockManager);
 
@@ -8308,8 +8317,8 @@ EditorNode::EditorNode() {
 	editor_dock_manager->add_hsplit(main_hsplit);
 	editor_dock_manager->add_hsplit(right_hsplit);
 
-	for (int i = 0; i < EditorDockManager::DOCK_SLOT_MAX; i++) {
-		editor_dock_manager->register_dock_slot((EditorDockManager::DockSlot)i, dock_slot[i]);
+	for (int i = 0; i < DockConstants::DOCK_SLOT_BOTTOM; i++) {
+		editor_dock_manager->register_dock_slot((DockConstants::DockSlot)i, dock_slot[i], DockConstants::DOCK_LAYOUT_VERTICAL);
 	}
 
 	editor_layout_save_delay_timer = memnew(Timer);
@@ -8774,6 +8783,7 @@ EditorNode::EditorNode() {
 	// Bottom panels.
 
 	bottom_panel = memnew(EditorBottomPanel);
+	editor_dock_manager->register_dock_slot(DockConstants::DOCK_SLOT_BOTTOM, bottom_panel, DockConstants::DOCK_LAYOUT_HORIZONTAL);
 	bottom_panel->set_theme_type_variation("BottomPanel");
 	center_split->add_child(bottom_panel);
 	center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -81,12 +81,12 @@ void EditorPlugin::remove_autoload_singleton(const String &p_name) {
 	EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_remove(p_name);
 }
 
+#ifndef DISABLE_DEPRECATED
 Button *EditorPlugin::add_control_to_bottom_panel(Control *p_control, const String &p_title, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_NULL_V(p_control, nullptr);
 	return EditorNode::get_bottom_panel()->add_item(p_title, p_control, p_shortcut);
 }
 
-#ifndef DISABLE_DEPRECATED
 void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut) {
 	ERR_FAIL_NULL(p_control);
 	ERR_FAIL_COND(legacy_docks.has(p_control));
@@ -94,7 +94,7 @@ void EditorPlugin::add_control_to_dock(DockSlot p_slot, Control *p_control, cons
 	EditorDock *dock = memnew(EditorDock);
 	dock->set_title(p_control->get_name());
 	dock->set_dock_shortcut(p_shortcut);
-	dock->set_default_slot((EditorDockManager::DockSlot)p_slot);
+	dock->set_default_slot((DockConstants::DockSlot)p_slot);
 	dock->add_child(p_control);
 	legacy_docks[p_control] = dock;
 
@@ -115,12 +115,12 @@ void EditorPlugin::set_dock_tab_icon(Control *p_control, const Ref<Texture2D> &p
 	ERR_FAIL_COND(!legacy_docks.has(p_control));
 	legacy_docks[p_control]->set_dock_icon(p_icon);
 }
-#endif
 
 void EditorPlugin::remove_control_from_bottom_panel(Control *p_control) {
 	ERR_FAIL_NULL(p_control);
 	EditorNode::get_bottom_panel()->remove_item(p_control);
 }
+#endif
 
 void EditorPlugin::add_dock(EditorDock *p_dock) {
 	EditorDockManager::get_singleton()->add_dock(p_dock);
@@ -622,8 +622,6 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_dock", "dock"), &EditorPlugin::add_dock);
 	ClassDB::bind_method(D_METHOD("remove_dock", "dock"), &EditorPlugin::remove_dock);
 	ClassDB::bind_method(D_METHOD("add_control_to_container", "container", "control"), &EditorPlugin::add_control_to_container);
-	ClassDB::bind_method(D_METHOD("add_control_to_bottom_panel", "control", "title", "shortcut"), &EditorPlugin::add_control_to_bottom_panel, DEFVAL(Ref<Shortcut>()));
-	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
 	ClassDB::bind_method(D_METHOD("remove_control_from_container", "container", "control"), &EditorPlugin::remove_control_from_container);
 	ClassDB::bind_method(D_METHOD("add_tool_menu_item", "name", "callable"), &EditorPlugin::add_tool_menu_item);
 	ClassDB::bind_method(D_METHOD("add_tool_submenu_item", "name", "submenu"), &EditorPlugin::add_tool_submenu_item);
@@ -636,6 +634,8 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_control_to_dock", "slot", "control", "shortcut"), &EditorPlugin::add_control_to_dock, DEFVAL(Ref<Shortcut>()));
 	ClassDB::bind_method(D_METHOD("remove_control_from_docks", "control"), &EditorPlugin::remove_control_from_docks);
 	ClassDB::bind_method(D_METHOD("set_dock_tab_icon", "control", "icon"), &EditorPlugin::set_dock_tab_icon);
+	ClassDB::bind_method(D_METHOD("add_control_to_bottom_panel", "control", "title", "shortcut"), &EditorPlugin::add_control_to_bottom_panel, DEFVAL(Ref<Shortcut>()));
+	ClassDB::bind_method(D_METHOD("remove_control_from_bottom_panel", "control"), &EditorPlugin::remove_control_from_bottom_panel);
 #endif
 
 	ClassDB::bind_method(D_METHOD("add_autoload_singleton", "name", "path"), &EditorPlugin::add_autoload_singleton);
@@ -734,6 +734,7 @@ void EditorPlugin::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BL);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_UR);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_RIGHT_BR);
+	BIND_ENUM_CONSTANT(DOCK_SLOT_BOTTOM);
 	BIND_ENUM_CONSTANT(DOCK_SLOT_MAX);
 
 	BIND_ENUM_CONSTANT(AFTER_GUI_INPUT_PASS);

--- a/editor/plugins/editor_plugin.h
+++ b/editor/plugins/editor_plugin.h
@@ -89,16 +89,17 @@ public:
 	};
 
 	enum DockSlot {
-		DOCK_SLOT_NONE = EditorDockManager::DOCK_SLOT_NONE,
-		DOCK_SLOT_LEFT_UL = EditorDockManager::DOCK_SLOT_LEFT_UL,
-		DOCK_SLOT_LEFT_BL = EditorDockManager::DOCK_SLOT_LEFT_BL,
-		DOCK_SLOT_LEFT_UR = EditorDockManager::DOCK_SLOT_LEFT_UR,
-		DOCK_SLOT_LEFT_BR = EditorDockManager::DOCK_SLOT_LEFT_BR,
-		DOCK_SLOT_RIGHT_UL = EditorDockManager::DOCK_SLOT_RIGHT_UL,
-		DOCK_SLOT_RIGHT_BL = EditorDockManager::DOCK_SLOT_RIGHT_BL,
-		DOCK_SLOT_RIGHT_UR = EditorDockManager::DOCK_SLOT_RIGHT_UR,
-		DOCK_SLOT_RIGHT_BR = EditorDockManager::DOCK_SLOT_RIGHT_BR,
-		DOCK_SLOT_MAX = EditorDockManager::DOCK_SLOT_MAX
+		DOCK_SLOT_NONE = DockConstants::DOCK_SLOT_NONE,
+		DOCK_SLOT_LEFT_UL = DockConstants::DOCK_SLOT_LEFT_UL,
+		DOCK_SLOT_LEFT_BL = DockConstants::DOCK_SLOT_LEFT_BL,
+		DOCK_SLOT_LEFT_UR = DockConstants::DOCK_SLOT_LEFT_UR,
+		DOCK_SLOT_LEFT_BR = DockConstants::DOCK_SLOT_LEFT_BR,
+		DOCK_SLOT_RIGHT_UL = DockConstants::DOCK_SLOT_RIGHT_UL,
+		DOCK_SLOT_RIGHT_BL = DockConstants::DOCK_SLOT_RIGHT_BL,
+		DOCK_SLOT_RIGHT_UR = DockConstants::DOCK_SLOT_RIGHT_UR,
+		DOCK_SLOT_RIGHT_BR = DockConstants::DOCK_SLOT_RIGHT_BR,
+		DOCK_SLOT_BOTTOM = DockConstants::DOCK_SLOT_BOTTOM,
+		DOCK_SLOT_MAX = DockConstants::DOCK_SLOT_MAX
 	};
 
 	enum AfterGUIInput {
@@ -150,6 +151,9 @@ protected:
 	void add_control_to_dock(DockSlot p_slot, Control *p_control, const Ref<Shortcut> &p_shortcut = nullptr);
 	void remove_control_from_docks(Control *p_control);
 	void set_dock_tab_icon(Control *p_control, const Ref<Texture2D> &p_icon);
+
+	Button *add_control_to_bottom_panel(Control *p_control, const String &p_title, const Ref<Shortcut> &p_shortcut = nullptr);
+	void remove_control_from_bottom_panel(Control *p_control);
 #endif
 
 public:
@@ -157,8 +161,6 @@ public:
 
 	void add_control_to_container(CustomControlContainer p_location, Control *p_control);
 	void remove_control_from_container(CustomControlContainer p_location, Control *p_control);
-	Button *add_control_to_bottom_panel(Control *p_control, const String &p_title, const Ref<Shortcut> &p_shortcut = nullptr);
-	void remove_control_from_bottom_panel(Control *p_control);
 
 	void add_dock(EditorDock *p_dock);
 	void remove_dock(EditorDock *p_dock);

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -1926,10 +1926,10 @@ void ThemeItemEditorDialog::_select_another_theme_cbk(const String &p_path) {
 
 void ThemeItemEditorDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_POSTINITIALIZE: {
 			connect("about_to_popup", callable_mp(this, &ThemeItemEditorDialog::_dialog_about_to_show));
-			[[fallthrough]];
-		}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			edit_items_add_color->set_button_icon(get_editor_theme_icon(SNAME("Color")));
 			edit_items_add_constant->set_button_icon(get_editor_theme_icon(SNAME("MemberConstant")));
@@ -2271,10 +2271,10 @@ void ThemeTypeDialog::_add_type_confirmed() {
 
 void ThemeTypeDialog::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_POSTINITIALIZE: {
 			connect("about_to_popup", callable_mp(this, &ThemeTypeDialog::_dialog_about_to_show));
-			[[fallthrough]];
-		}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_add_type_options();
 		} break;

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -201,12 +201,14 @@ void ThemeEditorPreview::_reset_picker_overlay() {
 
 void ThemeEditorPreview::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			connect(SceneStringName(visibility_changed), callable_mp(this, &ThemeEditorPreview::_preview_visibility_changed));
+		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (is_visible_in_tree()) {
 				set_process(true);
 			}
-
-			connect(SceneStringName(visibility_changed), callable_mp(this, &ThemeEditorPreview::_preview_visibility_changed));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/os/os.h"
+#include "editor/docks/editor_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_bottom_panel.h"
@@ -1365,6 +1366,18 @@ void FindInFilesContainer::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("files_modified", PropertyInfo(Variant::STRING, "paths")));
 
 	ADD_SIGNAL(MethodInfo("close_button_clicked"));
+}
+
+void FindInFilesContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			// TODO: Replace this hack once FindInFilesContainer is converted to a dock. It should be in the constructor.
+			EditorDock *parent = Object::cast_to<EditorDock>(get_parent());
+			if (parent) {
+				parent->set_clip_contents(false);
+			}
+		} break;
+	}
 }
 
 void FindInFilesContainer::_on_theme_changed() {

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -278,6 +278,7 @@ class FindInFilesContainer : public MarginContainer {
 
 protected:
 	static void _bind_methods();
+	void _notification(int p_what);
 
 	void _on_find_in_files_result_selected(const String &p_fpath, int p_line_number, int p_begin, int p_end);
 	void _on_find_in_files_modified_files(const PackedStringArray &p_paths);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4555,7 +4555,6 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 	find_in_files->connect("result_selected", callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect("files_modified", callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
 	find_in_files->connect("close_button_clicked", callable_mp(this, &ScriptEditor::_on_find_in_files_close_button_clicked));
-	find_in_files->hide();
 	find_in_files_button->hide();
 
 	history_pos = -1;

--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -1151,7 +1151,7 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	version_commit_dock->set_layout_key("VersionCommit");
 	version_commit_dock->set_icon_name("VcsBranches");
 	version_commit_dock->set_dock_shortcut(ED_SHORTCUT_AND_COMMAND("docks/open_version_control", TTRC("Open Version Control Dock")));
-	version_commit_dock->set_default_slot(EditorDockManager::DOCK_SLOT_RIGHT_UL);
+	version_commit_dock->set_default_slot(DockConstants::DOCK_SLOT_RIGHT_UL);
 
 	VBoxContainer *dock_vb = memnew(VBoxContainer);
 	version_commit_dock->add_child(dock_vb);

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1184,8 +1184,6 @@ void GridMapEditor::_update_theme() {
 void GridMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			mesh_library_palette->connect(SceneStringName(item_selected), callable_mp(this, &GridMapEditor::_item_selected_cbk));
-
 			const RID scenario = get_tree()->get_root()->get_world_3d()->get_scenario();
 
 			for (int i = 0; i < 3; i++) {
@@ -1585,6 +1583,7 @@ GridMapEditor::GridMapEditor() {
 	add_child(mesh_library_palette);
 	mesh_library_palette->set_v_size_flags(SIZE_EXPAND_FILL);
 	mesh_library_palette->connect(SceneStringName(gui_input), callable_mp(this, &GridMapEditor::_mesh_library_palette_input));
+	mesh_library_palette->connect(SceneStringName(item_selected), callable_mp(this, &GridMapEditor::_item_selected_cbk));
 
 	info_message = memnew(Label);
 	info_message->set_focus_mode(FOCUS_ACCESSIBILITY);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -284,7 +284,6 @@ void CanvasItem::_enter_canvas() {
 		}
 	}
 
-	pending_update = false;
 	queue_redraw();
 
 	notification(NOTIFICATION_ENTER_CANVAS);


### PR DESCRIPTION
Supersedes #106426

Adds a `DOCK_SLOT_BOTTOM`, which corresponds to bottom panel. All bottom panel controls are now docks. For compatibility, the old bottom editors are just wrapped in EditorDock.

This mostly brings changes to the dock popup, but also allows dragging docks between sides and bottom (currently only FileSystem):

https://github.com/user-attachments/assets/7edcc165-777b-45c0-a003-64faecb63961

Other than that, the current dock slot is now properly highlighted, slots unavailable for the current dock are darkened. The "Move to Bottom" button is replaced with a bottom dock slot.

I also added 3 new EditorDock properties: `global` (whether it appears in dock menu and can be closed), `hidden` (whether its tab is hidden) and `title_color`. All old bottom docks are non-global.

Dock's layout is now properly respected, i.e. you can make a dock that is horizontal only (in #106503 the `LAYOUT_VERTICAL` flag was effectively unused). I also added a `LAYOUT_FLOATING` flag, which determines whether the dock can float (all legacy bottom docks can't float).

In follow-ups I plan to update legacy docks to the new system, which would allow stuff like vertical ShaderEditor (it's already possible, but the editor is not adjusted for that, so the option is blocked). I will probably open a tracker for that.

A side-effect of these changes is that bottom docks can be rearranged, but I think it's not really a problem 🤔

Also for the future, I think EditorDockManager can be refactored, as it does too much. Some of its code can be moved to EditorDock and some of its code can be delegated to a new EditorDockContainer class extending TabContainer (the bottom panel would inherit it too). Also the main screen could potentially become a dock slot.