### PR TITLE
[GDScript] Strip comments from abstract function signatures, fix crash on multi-line autocompletion string insert.

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1653,7 +1653,7 @@ bool GDScriptParser::parse_function_signature(FunctionNode *p_function, SuiteNod
 	if (p_type == "function" && p_signature_start != -1) {
 		const int signature_end_pos = tokenizer->get_current_position() - 1;
 		const String source_code = tokenizer->get_source_code();
-		p_function->signature = source_code.substr(p_signature_start, signature_end_pos - p_signature_start).strip_edges(false, true);
+		p_function->signature = source_code.substr(p_signature_start, signature_end_pos - p_signature_start).get_slice("#", 0).strip_edges(false, true);
 	}
 #endif // TOOLS_ENABLED
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2378,6 +2378,7 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 		}
 
 		// Handle merging of symbols eg strings, brackets.
+		caret_line = get_caret_line(i);
 		const String line = get_line(caret_line);
 		char32_t next_char = line[get_caret_column(i)];
 		char32_t last_completion_char = insert_text[insert_text.length() - 1];


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108639

- Fixes crash on multi-line autocompletion string insert (`caret_line` update after insertion).
- Strips comments from abstract function signatures (abstract functions have no `:` at the end, and a comment that is placed after it was added to the signature).