### PR TITLE
Prompt to save modified scene missing when quitting editor with running project.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3312,8 +3312,14 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 				p_confirmed = false;
 			}
 
+			if (p_confirmed && stop_project_confirmation && project_run_bar->is_playing()) {
+				project_run_bar->stop_playing();
+				stop_project_confirmation = false;
+				p_confirmed = false;
+			}
+
 			if (!p_confirmed) {
-				if (project_run_bar->is_playing()) {
+				if (!stop_project_confirmation && project_run_bar->is_playing()) {
 					if (p_option == PROJECT_RELOAD_CURRENT_PROJECT) {
 						confirmation->set_text(TTR("Stop running project before reloading the current project?"));
 						confirmation->set_ok_button_text(TTR("Stop & Reload"));
@@ -3324,6 +3330,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					confirmation->reset_size();
 					confirmation->popup_centered();
 					confirmation_button->hide();
+					stop_project_confirmation = true;
 					break;
 				}
 
@@ -6209,6 +6216,10 @@ void EditorNode::_cancel_close_scene_tab() {
 	}
 }
 
+void EditorNode::_cancel_confirmation() {
+	stop_project_confirmation = false;
+}
+
 void EditorNode::_prepare_save_confirmation_popup() {
 	if (save_confirmation->get_window() != get_last_exclusive_window()) {
 		save_confirmation->reparent(get_last_exclusive_window());
@@ -8410,6 +8421,7 @@ EditorNode::EditorNode() {
 	confirmation->set_min_size(Vector2(450.0 * EDSCALE, 0));
 	confirmation->connect(SceneStringName(confirmed), callable_mp(this, &EditorNode::_menu_confirm_current));
 	confirmation->connect("custom_action", callable_mp(this, &EditorNode::_discard_changes));
+	confirmation->connect("canceled", callable_mp(this, &EditorNode::_cancel_confirmation));
 
 	save_confirmation = memnew(ConfirmationDialog);
 	save_confirmation->add_button(TTRC("Don't Save"), DisplayServer::get_singleton()->get_swap_cancel_ok(), "discard");

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -376,6 +376,7 @@ private:
 	Node *_last_instantiated_scene = nullptr;
 
 	ConfirmationDialog *confirmation = nullptr;
+	bool stop_project_confirmation = false;
 	Button *confirmation_button = nullptr;
 	ConfirmationDialog *save_confirmation = nullptr;
 	ConfirmationDialog *import_confirmation = nullptr;
@@ -598,6 +599,7 @@ private:
 	void _discard_changes(const String &p_str = String());
 	void _scene_tab_closed(int p_tab);
 	void _cancel_close_scene_tab();
+	void _cancel_confirmation();
 
 	void _prepare_save_confirmation_popup();
 


### PR DESCRIPTION
Fixes #108448


tested on MacOs:

<details><summary>Video: Stop & Quit -> Save & Close</summary>

https://github.com/user-attachments/assets/a5764204-7c62-4c07-86da-1a1940888821

</details>


Do we really want to always display `Stop & Quit` first?
Maybe we should first check if there are any unsaved scenes (etc.). If there are, we could skip showing `Stop & Quit`. 


