### PR TITLE
[EditorExportPlatform] Move initialization to a dedicated method.

### DIFF
--- a/doc/classes/EditorExportPlatformExtension.xml
+++ b/doc/classes/EditorExportPlatformExtension.xml
@@ -221,6 +221,12 @@
 				Returns [code]true[/code] if project configuration is valid.
 			</description>
 		</method>
+		<method name="_initialize" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Initializes the plugin. Called by the editor when platform is registered.
+			</description>
+		</method>
 		<method name="_is_executable" qualifiers="virtual const">
 			<return type="bool" />
 			<param index="0" name="path" type="String" />

--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -127,6 +127,7 @@ void EditorExport::_bind_methods() {
 }
 
 void EditorExport::add_export_platform(const Ref<EditorExportPlatform> &p_platform) {
+	p_platform->initialize();
 	export_platforms.push_back(p_platform);
 
 	should_update_presets = true;

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -349,6 +349,8 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {}
 	virtual String get_debug_protocol() const { return "tcp://"; }
 	virtual HashMap<String, Variant> get_custom_project_settings(const Ref<EditorExportPreset> &p_preset) const { return HashMap<String, Variant>(); }
+
+	virtual void initialize() {}
 };
 
 VARIANT_ENUM_CAST(EditorExportPlatform::ExportMessageType)

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2873,23 +2873,21 @@ Error EditorExportPlatformAppleEmbedded::run(const Ref<EditorExportPreset> &p_pr
 #endif
 }
 
-EditorExportPlatformAppleEmbedded::EditorExportPlatformAppleEmbedded(const char *p_platform_logo_svg, const char *p_run_icon_svg) {
-	if (EditorNode::get_singleton()) {
-		Ref<Image> img = memnew(Image);
-		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
+void EditorExportPlatformAppleEmbedded::_initialize(const char *p_platform_logo_svg, const char *p_run_icon_svg) {
+	Ref<Image> img = memnew(Image);
+	const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);
 
-		ImageLoaderSVG::create_image_from_string(img, p_platform_logo_svg, EDSCALE, upsample, false);
-		logo = ImageTexture::create_from_image(img);
+	ImageLoaderSVG::create_image_from_string(img, p_platform_logo_svg, EDSCALE, upsample, false);
+	logo = ImageTexture::create_from_image(img);
 
-		ImageLoaderSVG::create_image_from_string(img, p_run_icon_svg, EDSCALE, upsample, false);
-		run_icon = ImageTexture::create_from_image(img);
+	ImageLoaderSVG::create_image_from_string(img, p_run_icon_svg, EDSCALE, upsample, false);
+	run_icon = ImageTexture::create_from_image(img);
 
-		plugins_changed.set();
-		devices_changed.set();
+	plugins_changed.set();
+	devices_changed.set();
 #ifdef MACOS_ENABLED
-		_update_preset_status();
+	_update_preset_status();
 #endif
-	}
 }
 
 EditorExportPlatformAppleEmbedded::~EditorExportPlatformAppleEmbedded() {

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -196,6 +196,8 @@ protected:
 		r_features->push_back("apple_embedded");
 	}
 
+	void _initialize(const char *p_platform_logo_svg, const char *p_run_icon_svg);
+
 public:
 	virtual Ref<Texture2D> get_logo() const override { return logo; }
 	virtual Ref<Texture2D> get_run_icon() const override { return run_icon; }
@@ -246,7 +248,6 @@ public:
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override {
 	}
 
-	EditorExportPlatformAppleEmbedded(const char *p_platform_logo_svg, const char *p_run_icon_svg);
 	~EditorExportPlatformAppleEmbedded();
 
 	/// List the gdip files in the directory specified by the p_path parameter.

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -77,6 +77,8 @@ void EditorExportPlatformExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_platform_features);
 
 	GDVIRTUAL_BIND(_get_debug_protocol);
+
+	GDVIRTUAL_BIND(_initialize);
 }
 
 void EditorExportPlatformExtension::get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const {
@@ -346,6 +348,10 @@ String EditorExportPlatformExtension::get_debug_protocol() const {
 		return ret;
 	}
 	return EditorExportPlatform::get_debug_protocol();
+}
+
+void EditorExportPlatformExtension::initialize() {
+	GDVIRTUAL_CALL(_initialize);
 }
 
 EditorExportPlatformExtension::EditorExportPlatformExtension() {

--- a/editor/export/editor_export_platform_extension.h
+++ b/editor/export/editor_export_platform_extension.h
@@ -147,6 +147,9 @@ public:
 	virtual String get_debug_protocol() const override;
 	GDVIRTUAL0RC(String, _get_debug_protocol);
 
+	virtual void initialize() override;
+	GDVIRTUAL0(_initialize);
+
 	EditorExportPlatformExtension();
 	~EditorExportPlatformExtension();
 };

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -4226,7 +4226,7 @@ void EditorExportPlatformAndroid::get_platform_features(List<String> *r_features
 void EditorExportPlatformAndroid::resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) {
 }
 
-EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
+void EditorExportPlatformAndroid::initialize() {
 	if (EditorNode::get_singleton()) {
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -279,7 +279,7 @@ public:
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, HashSet<String> &p_features) override;
 
-	EditorExportPlatformAndroid();
+	virtual void initialize() override;
 
 	~EditorExportPlatformAndroid();
 };

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -33,13 +33,17 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
+#include "editor/editor_node.h"
+
 Vector<String> EditorExportPlatformIOS::device_types({ "iPhone", "iPad" });
 
-EditorExportPlatformIOS::EditorExportPlatformIOS() :
-		EditorExportPlatformAppleEmbedded(_ios_logo_svg, _ios_run_icon_svg) {
+void EditorExportPlatformIOS::initialize() {
+	if (EditorNode::get_singleton()) {
+		EditorExportPlatformAppleEmbedded::_initialize(_ios_logo_svg, _ios_run_icon_svg);
 #ifdef MACOS_ENABLED
-	_start_remote_device_poller_thread();
+		_start_remote_device_poller_thread();
 #endif
+	}
 }
 
 EditorExportPlatformIOS::~EditorExportPlatformIOS() {

--- a/platform/ios/export/export_plugin.h
+++ b/platform/ios/export/export_plugin.h
@@ -61,6 +61,6 @@ public:
 		r_features->push_back("ios");
 	}
 
-	EditorExportPlatformIOS();
+	virtual void initialize() override;
 	~EditorExportPlatformIOS();
 };

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -608,7 +608,7 @@ Error EditorExportPlatformLinuxBSD::run(const Ref<EditorExportPreset> &p_preset,
 #undef CLEANUP_AND_RETURN
 }
 
-EditorExportPlatformLinuxBSD::EditorExportPlatformLinuxBSD() {
+void EditorExportPlatformLinuxBSD::initialize() {
 	if (EditorNode::get_singleton()) {
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -89,5 +89,5 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual void cleanup() override;
 
-	EditorExportPlatformLinuxBSD();
+	virtual void initialize() override;
 };

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2718,7 +2718,7 @@ Error EditorExportPlatformMacOS::run(const Ref<EditorExportPreset> &p_preset, in
 #undef CLEANUP_AND_RETURN
 }
 
-EditorExportPlatformMacOS::EditorExportPlatformMacOS() {
+void EditorExportPlatformMacOS::initialize() {
 	if (EditorNode::get_singleton()) {
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -169,5 +169,5 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual void cleanup() override;
 
-	EditorExportPlatformMacOS();
+	virtual void initialize() override;
 };

--- a/platform/visionos/export/export_plugin.cpp
+++ b/platform/visionos/export/export_plugin.cpp
@@ -33,13 +33,17 @@
 #include "logo_svg.gen.h"
 #include "run_icon_svg.gen.h"
 
+#include "editor/editor_node.h"
+
 Vector<String> EditorExportPlatformVisionOS::device_types({ "realityDevice" });
 
-EditorExportPlatformVisionOS::EditorExportPlatformVisionOS() :
-		EditorExportPlatformAppleEmbedded(_visionos_logo_svg, _visionos_run_icon_svg) {
+void EditorExportPlatformVisionOS::initialize() {
+	if (EditorNode::get_singleton()) {
+		EditorExportPlatformAppleEmbedded::_initialize(_visionos_logo_svg, _visionos_run_icon_svg);
 #ifdef MACOS_ENABLED
-	_start_remote_device_poller_thread();
+		_start_remote_device_poller_thread();
 #endif
+	}
 }
 
 EditorExportPlatformVisionOS::~EditorExportPlatformVisionOS() {

--- a/platform/visionos/export/export_plugin.h
+++ b/platform/visionos/export/export_plugin.h
@@ -56,6 +56,6 @@ public:
 		r_features->push_back("visionos");
 	}
 
-	EditorExportPlatformVisionOS();
+	virtual void initialize() override;
 	~EditorExportPlatformVisionOS();
 };

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -916,7 +916,7 @@ Ref<Texture2D> EditorExportPlatformWeb::get_run_icon() const {
 	return run_icon;
 }
 
-EditorExportPlatformWeb::EditorExportPlatformWeb() {
+void EditorExportPlatformWeb::initialize() {
 	if (EditorNode::get_singleton()) {
 		server.instantiate();
 

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -148,6 +148,6 @@ public:
 
 	String get_debug_protocol() const override { return "ws://"; }
 
-	EditorExportPlatformWeb();
+	virtual void initialize() override;
 	~EditorExportPlatformWeb();
 };

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -1090,7 +1090,7 @@ Error EditorExportPlatformWindows::run(const Ref<EditorExportPreset> &p_preset, 
 #undef CLEANUP_AND_RETURN
 }
 
-EditorExportPlatformWindows::EditorExportPlatformWindows() {
+void EditorExportPlatformWindows::initialize() {
 	if (EditorNode::get_singleton()) {
 		Ref<Image> img = memnew(Image);
 		const bool upsample = !Math::is_equal_approx(Math::round(EDSCALE), EDSCALE);

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -97,5 +97,5 @@ public:
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual void cleanup() override;
 
-	EditorExportPlatformWindows();
+	virtual void initialize() override;
 };


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/108484#issuecomment-3067098749, previously `EditorNode::get_singleton()` was sufficient to prevent unnecessary init and thread creation when CLI `doctool` was used, but seems like editor is instantiating plugins to update docs in the runtime as well.

Note: will NOT fix. https://github.com/godotengine/godot/issues/108484
