### PR TITLE
Add keypad codes to the keysym unicode map.

### DIFF
--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -1114,6 +1114,28 @@ void KeyMappingX11::initialize() {
 	xkeysym_unicode_map[0x13BE] = 0x0178;
 	xkeysym_unicode_map[0x20AC] = 0x20AC;
 
+	// Support keypad keycodes such as `XK_KP_Equal`.
+	// Values can be found in `X11/keysymdef.h` on line 278.
+	xkeysym_unicode_map[0xFF80] = 0x0020;
+	xkeysym_unicode_map[0xFF89] = 0x0009;
+	xkeysym_unicode_map[0xFFBD] = 0x003D;
+	xkeysym_unicode_map[0xFFAA] = 0x002A;
+	xkeysym_unicode_map[0xFFAB] = 0x002B;
+	xkeysym_unicode_map[0xFFAC] = 0x002C;
+	xkeysym_unicode_map[0xFFAD] = 0x002D;
+	xkeysym_unicode_map[0xFFAE] = 0x002E;
+	xkeysym_unicode_map[0xFFAF] = 0x002F;
+	xkeysym_unicode_map[0xFFB0] = 0x0030;
+	xkeysym_unicode_map[0xFFB1] = 0x0031;
+	xkeysym_unicode_map[0xFFB2] = 0x0032;
+	xkeysym_unicode_map[0xFFB3] = 0x0033;
+	xkeysym_unicode_map[0xFFB4] = 0x0034;
+	xkeysym_unicode_map[0xFFB5] = 0x0035;
+	xkeysym_unicode_map[0xFFB6] = 0x0036;
+	xkeysym_unicode_map[0xFFB7] = 0x0037;
+	xkeysym_unicode_map[0xFFB8] = 0x0038;
+	xkeysym_unicode_map[0xFFB9] = 0x0039;
+
 	// Scancode to physical location map.
 	// Ctrl.
 	location_map[0x25] = KeyLocation::LEFT;


### PR DESCRIPTION
## Issue
Linux X11 users are unable to type '=' using a keypad. The key is registered but the unicode character does not show up in text input anywhere in the application. Fixes issue #74578.

## Cause
The function `KeyMappingX11::get_unicode_from_keysym` relies on a HashMap, `xkeysym_unicode_map`, to get unicode code points from the keysym code. However, this map does not include mappings from keypad keysyms.

## Solution
Add the missing keypad keysym mappings (found in `X11/keysymdef.h` on lines 280-316)  to `xkeysym_unicode_map`.

### Testing
This solution was tested successfully on the 4.4.1-stable release build.