### PR TITLE
[Linux] Fix narrowing conversion error in 32-bit builds.

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -524,7 +524,7 @@ String DirAccessUnix::get_filesystem_type() const {
 	if (statfs(current_dir.utf8().get_data(), &fs) != 0) {
 		return "";
 	}
-	switch (fs.f_type) {
+	switch (static_cast<unsigned int>(fs.f_type)) {
 		case 0x0000adf5:
 			return "ADFS";
 		case 0x0000adff:


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108074

> The __fsword_t type used for various fields in the statfs structure definition is a glibc internal type, not intended for public use. This leaves the programmer in a bit of a conundrum when trying to copy or compare these fields to local variables in a program.  Using unsigned int for such variables suffices on most systems.