### PR TITLE
Never overwrite motion vectors in the transparent pass

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2359,10 +2359,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	{
 		uint32_t transparent_color_pass_flags = (color_pass_flags | uint32_t(COLOR_PASS_FLAG_TRANSPARENT)) & ~uint32_t(COLOR_PASS_FLAG_SEPARATE_SPECULAR);
-		if (using_motion_pass) {
-			// Motion vectors on transparent draw calls are not required when using the reactive mask.
-			transparent_color_pass_flags &= ~uint32_t(COLOR_PASS_FLAG_MOTION_VECTORS);
-		}
+		// Motion vectors should not be overwritten by transparent objects.
+		transparent_color_pass_flags &= ~uint32_t(COLOR_PASS_FLAG_MOTION_VECTORS);
 
 		RID alpha_framebuffer = rb_data.is_valid() ? rb_data->get_color_pass_fb(transparent_color_pass_flags) : color_only_framebuffer;
 		RenderListParameters render_list_params(render_list[RENDER_LIST_ALPHA].elements.ptr(), render_list[RENDER_LIST_ALPHA].element_info.ptr(), render_list[RENDER_LIST_ALPHA].elements.size(), reverse_cull, PASS_MODE_COLOR, transparent_color_pass_flags, rb_data.is_null(), p_render_data->directional_light_soft_shadows, rp_uniform_set, get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_WIREFRAME, Vector2(), p_render_data->scene_data->lod_distance_multiplier, p_render_data->scene_data->screen_mesh_lod_threshold, p_render_data->scene_data->view_count, 0, base_specialization);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/103629

The problem here is that when using TAA we allow transparent objects to write into the motion vector buffer. Since you can't blend MVs, it just overwrites the value that is currently there. When using the full screen quad trick this makes it so you lose all of your MVs and cannot effectively reproject the previous frame's samples. 

In 4.3 this wasn't a big deal since we rejected the contribution from previous frames entirely. That's why 4.3 was so sharp, but the jitter from TAA was noticeable when the camera was not moving. Now that we actually reproject the previous frames, we need to have good MVs. 

A final complicating factor, for FSR2, this wasn't a big deal for 2 reasons:
1. MV writes in transparent passes were already disabled (i.e. `using_motion_pass` is true only when using FSR2)
2. Most of the MVs are derived from depth, so the issue only affected dynamic objects anyway

This PR makes it so we always disable MV writes for transparent objects. Its almost always not desirable to have transparent objects overwrite MVs. The only cases you would want to do so are when:
1. The transparent object is not actually transparent (its just in the transparent queue because it reads from the screen texture or depth texture)
2. You have a particular effect that would benefit from MVs. 

To address those cases, we should add a way for users to manually write to the MV buffer in a follow up PR. 