### PR TITLE
Refactor duplicated XDG portal code, and remove a buggy fallback path

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -141,7 +141,7 @@ bool FreeDesktopPortalDesktop::read_setting(const char *p_namespace, const char 
 	dbus_message_unref(message);
 	if (dbus_error_is_set(&error)) {
 		if (OS::get_singleton()->is_stdout_verbose()) {
-			ERR_PRINT(vformat("Error on D-Bus communication: %s", error.message));
+			ERR_PRINT(vformat("Failed to read setting %s %s: %s", p_namespace, p_key, error.message));
 		}
 		dbus_error_free(&error);
 		dbus_connection_unref(bus);

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -543,7 +543,7 @@ bool FreeDesktopPortalDesktop::color_picker(const String &p_xid, const Callable 
 	return true;
 }
 
-bool FreeDesktopPortalDesktop::_is_interface_supported(const char *p_iface) {
+bool FreeDesktopPortalDesktop::_is_interface_supported(const char *p_iface, const uint32_t minimum_version) {
 	bool supported = false;
 	DBusError err;
 	dbus_error_init(&err);
@@ -570,8 +570,8 @@ bool FreeDesktopPortalDesktop::_is_interface_supported(const char *p_iface) {
 					dbus_message_iter_recurse(&iter, &iter_ver);
 					dbus_uint32_t ver_code;
 					dbus_message_iter_get_basic(&iter_ver, &ver_code);
-					print_verbose(vformat("PortalDesktop: %s version %d detected.", p_iface, ver_code));
-					supported = true;
+					print_verbose(vformat("PortalDesktop: %s version %d detected, version %d required.", p_iface, ver_code, minimum_version));
+					supported = ver_code >= minimum_version;
 				}
 				dbus_message_unref(reply);
 			}
@@ -585,7 +585,7 @@ bool FreeDesktopPortalDesktop::_is_interface_supported(const char *p_iface) {
 bool FreeDesktopPortalDesktop::is_file_chooser_supported() {
 	static int supported = -1;
 	if (supported == -1) {
-		supported = _is_interface_supported(BUS_INTERFACE_FILE_CHOOSER);
+		supported = _is_interface_supported(BUS_INTERFACE_FILE_CHOOSER, 3);
 	}
 	return supported;
 }
@@ -593,7 +593,7 @@ bool FreeDesktopPortalDesktop::is_file_chooser_supported() {
 bool FreeDesktopPortalDesktop::is_settings_supported() {
 	static int supported = -1;
 	if (supported == -1) {
-		supported = _is_interface_supported(BUS_INTERFACE_SETTINGS);
+		supported = _is_interface_supported(BUS_INTERFACE_SETTINGS, 1);
 	}
 	return supported;
 }
@@ -601,7 +601,7 @@ bool FreeDesktopPortalDesktop::is_settings_supported() {
 bool FreeDesktopPortalDesktop::is_screenshot_supported() {
 	static int supported = -1;
 	if (supported == -1) {
-		supported = _is_interface_supported(BUS_INTERFACE_SCREENSHOT);
+		supported = _is_interface_supported(BUS_INTERFACE_SCREENSHOT, 1);
 	}
 	return supported;
 }

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -111,7 +111,7 @@ private:
 	String theme_path;
 	Callable system_theme_changed;
 	void _system_theme_changed_callback();
-	bool _is_interface_supported(const char *p_iface);
+	bool _is_interface_supported(const char *p_iface, uint32_t minimum_version);
 
 	static void _thread_monitor(void *p_ud);
 

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -59,8 +59,12 @@ private:
 	static void append_dbus_dict_filters(DBusMessageIter *p_iter, const Vector<String> &p_filter_names, const Vector<String> &p_filter_exts, const Vector<String> &p_filter_mimes);
 	static void append_dbus_dict_string(DBusMessageIter *p_iter, const String &p_key, const String &p_value, bool p_as_byte_array = false);
 	static void append_dbus_dict_bool(DBusMessageIter *p_iter, const String &p_key, bool p_value);
+
 	static bool file_chooser_parse_response(DBusMessageIter *p_iter, const Vector<String> &p_names, const HashMap<String, String> &p_ids, bool &r_cancel, Vector<String> &r_urls, int &r_index, Dictionary &r_options);
 	static bool color_picker_parse_response(DBusMessageIter *p_iter, bool &r_cancel, Color &r_color);
+
+	static Error make_request_token(String &token);
+	bool send_request(DBusMessage *message, const String &token, String &response_path, String &response_filter);
 
 	struct ColorPickerData {
 		Callable callback;


### PR DESCRIPTION
While looking at what changes would be necessary to support the XDG Inhibit portal (#108634) I found that there was a fair amount of duplicated code to use the FileChooser and Screenshot (i.e. color-picker) portals that would need to be duplicated again.

This PR refactors that code, fixing a latent bug in a fallback path in the process. It then adds portal version checking so that the fallback path in question can be removed entirely.