### PR TITLE
Add a Swappy installation script for easier Android builds

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -58,16 +58,8 @@ jobs:
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
-      - name: Download pre-built Android Swappy Frame Pacing Library
-        uses: dsaltares/fetch-gh-release-asset@1.1.2
-        with:
-          repo: godotengine/godot-swappy
-          version: tags/from-source-2025-01-31
-          file: godot-swappy.7z
-          target: swappy/godot-swappy.7z
-
-      - name: Extract pre-built Android Swappy Frame Pacing Library
-        run: 7za x -y swappy/godot-swappy.7z -o${{github.workspace}}/thirdparty/swappy-frame-pacing
+      - name: Download Swappy
+        run: python ./misc/scripts/install_swappy_android.py
 
       - name: Compilation
         uses: ./.github/actions/godot-build

--- a/misc/scripts/install_swappy_android.py
+++ b/misc/scripts/install_swappy_android.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import sys
+import tempfile
+import urllib.request
+from zipfile import ZipFile
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
+
+from misc.utility.color import Ansi, color_print
+
+# Swappy
+# Check for latest version: https://github.com/godotengine/godot-swappy/releases/latest
+swappy_tag = "from-source-2025-01-31"
+swappy_filename = "godot-swappy.zip"
+swappy_folder = "thirdparty/swappy-frame-pacing"
+swappy_archs = [
+    "arm64-v8a",
+    "armeabi-v7a",
+    "x86",
+    "x86_64",
+]
+
+swappy_archive_destination = os.path.join(tempfile.gettempdir(), swappy_filename)
+
+if os.path.isfile(swappy_archive_destination):
+    os.remove(swappy_archive_destination)
+
+print(f"Downloading Swappy {swappy_tag} ...")
+urllib.request.urlretrieve(
+    f"https://github.com/godotengine/godot-swappy/releases/download/{swappy_tag}/{swappy_filename}",
+    swappy_archive_destination,
+)
+
+for arch in swappy_archs:
+    folder = os.path.join(swappy_folder, arch)
+    if os.path.exists(folder):
+        print(f"Removing existing local Swappy installation in {folder} ...")
+        shutil.rmtree(folder)
+
+print(f"Extracting Swappy {swappy_tag} to {swappy_folder} ...")
+with ZipFile(swappy_archive_destination, "r") as zip_file:
+    for arch in swappy_archs:
+        zip_file.getinfo(f"{arch}/libswappy_static.a").filename = os.path.join(
+            swappy_folder, f"{arch}/libswappy_static.a"
+        )
+        zip_file.extract(f"{arch}/libswappy_static.a")
+os.remove(swappy_archive_destination)
+print("Swappy installed successfully.\n")
+
+# Complete message
+color_print(f'{Ansi.GREEN}Swappy was installed to "{swappy_folder}" successfully!')
+color_print(
+    f'{Ansi.GREEN}You can now build Godot with Swappy support enabled by running "scons platform=android swappy=yes".'
+)

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -191,12 +191,8 @@ def configure(env: "SConsEnvironment"):
     has_swappy = detect_swappy()
     if not has_swappy:
         print_warning(
-            "Swappy Frame Pacing not detected! It is strongly recommended you download it from https://github.com/godotengine/godot-swappy/releases and extract it so that the following files can be found:\n"
-            + " thirdparty/swappy-frame-pacing/arm64-v8a/libswappy_static.a\n"
-            + " thirdparty/swappy-frame-pacing/armeabi-v7a/libswappy_static.a\n"
-            + " thirdparty/swappy-frame-pacing/x86/libswappy_static.a\n"
-            + " thirdparty/swappy-frame-pacing/x86_64/libswappy_static.a\n"
-            + "Without Swappy, Godot apps on Android will inevitable suffer stutter and struggle to keep consistent 30/60/90/120 fps. Though Swappy cannot guarantee your app will be stutter-free, not having Swappy will guarantee there will be stutter even on the best phones and the most simple of scenes."
+            "Swappy Frame Pacing not detected! It is strongly recommended you run `python misc/scripts/install_swappy_android.py` to download and install Swappy before compiling.\n"
+            + "Without Swappy, Godot apps on Android will inevitably suffer stutter and struggle to keep a consistent framerate. Although Swappy cannot guarantee your app will be stutter-free, not having Swappy will guarantee there will be stutter even on the best phones and the most simple of scenes."
         )
         if env["swappy"]:
             print_error("Use build option `swappy=no` to ignore missing Swappy dependency and build without it.")


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/96439
and https://github.com/godotengine/godot/pull/109889 (can be merged independently).

Run `python misc/scripts/install_swappy_android.py` and Swappy libraries will automatically be installed to the correct location.

Run the script again when needed to update to the latest version.

This could likely be cherry-picked to 4.5.
