### PR TITLE
Cancel save dialog on editor exit

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6207,6 +6207,8 @@ void EditorNode::_cancel_close_scene_tab() {
 	if (_is_closing_editor()) {
 		tab_closing_menu_option = -1;
 	}
+	changing_scene = false;
+	tabs_to_close.clear();
 }
 
 void EditorNode::_prepare_save_confirmation_popup() {


### PR DESCRIPTION
Fixes: #102271
Fixes: #108675


The solution seems very simple. 
 - Clear the `tabs_to_close` list so the user isn't spammed with confirmation dialogs: [comment](https://github.com/godotengine/godot/issues/108675#issuecomment-3079724758)
- `changing_scene = false;` so that `Top Panel` with `2D / 3D / Script` etc. remains functional.

```cpp
void EditorNode::_cancel_close_scene_tab() {
	if (_is_closing_editor()) {
		tab_closing_menu_option = -1;
	}
	changing_scene = false;
	tabs_to_close.clear();
}

```

-----------

### Test on MacOS

https://github.com/user-attachments/assets/4c0cd19f-c497-410a-9fb3-8bd9bcf23cf5

