### PR TITLE
Fix releasing the old unique name when renaming a Node

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1416,20 +1416,21 @@ void Node::_set_name_nocheck(const StringName &p_name) {
 
 void Node::set_name(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Changing the name to nodes inside the SceneTree is only allowed from the main thread. Use `set_name.call_deferred(new_name)`.");
+	ERR_FAIL_COND(p_name.is_empty());
+
 	const StringName old_name = data.name;
+	if (data.unique_name_in_owner && data.owner) {
+		_release_unique_name_in_owner();
+	}
+
 	{
 		const String input_name_str = String(p_name);
-		ERR_FAIL_COND(input_name_str.is_empty());
 		const String validated_node_name_string = input_name_str.validate_node_name();
 		if (input_name_str == validated_node_name_string) {
 			data.name = p_name;
 		} else {
 			data.name = StringName(validated_node_name_string);
 		}
-	}
-
-	if (data.unique_name_in_owner && data.owner) {
-		_release_unique_name_in_owner();
 	}
 
 	if (data.parent) {


### PR DESCRIPTION
This fixes `Node::set_name()` to release the old unique name before performing the rename.  #76560 changed the code to update `data.name` before calling `_release_unique_name_in_owner()`, causing to incorrectly try releasing the new name instead of the old name.

Fixes #108683

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
