### PR TITLE
pcre2: Backport a fix causing duplicate symbol definitions

### DIFF
--- a/thirdparty/pcre2/src/pcre2_internal.h
+++ b/thirdparty/pcre2/src/pcre2_internal.h
@@ -2165,6 +2165,7 @@ is available. */
 
 #define _pcre2_auto_possessify       PCRE2_SUFFIX(_pcre2_auto_possessify_)
 #define _pcre2_check_escape          PCRE2_SUFFIX(_pcre2_check_escape_)
+#define _pcre2_ckd_smul              PCRE2_SUFFIX(_pcre2_ckd_smul_)
 #define _pcre2_extuni                PCRE2_SUFFIX(_pcre2_extuni_)
 #define _pcre2_find_bracket          PCRE2_SUFFIX(_pcre2_find_bracket_)
 #define _pcre2_is_newline            PCRE2_SUFFIX(_pcre2_is_newline_)


### PR DESCRIPTION
modules/regex/SCsub compiles the pcre2 sources twice: once for 16-bit and once for 32-bit code unit width.  Most of the pcre2 code uses a `PCRE2_SUFFIX()` macro to append the code unit width suffix to the function name to avoid conflicting function names when compiling this way.  However, this was missed for the internal `chd_smul` function, resulting in both the 16-bit and 32-bit versions defining a function with the same name. The duplicate symbol definition was only triggering a warning at link time and was not causing the build to fail, but this means that either the 16-bit or 32-bit code will end up calling a function that operates on the incorrect data type.

This backports the fix already applied upstream.  (Buried in one line of https://github.com/PCRE2Project/pcre2/commit/9a868b060) pcre2 does not yet have any new releases that include this fix.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
