### PR TITLE
VideoStreamPlayer: Fix calling seek(0) from stop()

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -624,7 +624,6 @@ void VideoStreamPlaybackTheora::play() {
 
 void VideoStreamPlaybackTheora::stop() {
 	playing = false;
-	seek(0);
 }
 
 bool VideoStreamPlaybackTheora::is_playing() const {

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -163,6 +163,7 @@ void VideoStreamPlayer::_notification(int p_notification) {
 
 			if (!playback->is_playing()) {
 				resampler.flush();
+				playback->seek(0);
 				if (loop) {
 					play();
 					return;
@@ -260,7 +261,7 @@ bool VideoStreamPlayer::has_loop() const {
 }
 
 void VideoStreamPlayer::set_stream(const Ref<VideoStream> &p_stream) {
-	stop();
+	_stop();
 
 	// Make sure to handle stream changes seamlessly, e.g. when done via
 	// translation remapping.
@@ -342,17 +343,25 @@ void VideoStreamPlayer::play() {
 	}
 }
 
-void VideoStreamPlayer::stop() {
+bool VideoStreamPlayer::_stop() {
 	if (!is_inside_tree()) {
-		return;
+		return false;
 	}
 	if (playback.is_null()) {
-		return;
+		return false;
 	}
 
 	playback->stop();
 	resampler.flush();
 	set_process_internal(false);
+
+	return true;
+}
+
+void VideoStreamPlayer::stop() {
+	if (_stop()) {
+		playback->seek(0);
+	}
 }
 
 bool VideoStreamPlayer::is_playing() const {

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -81,6 +81,7 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_notification);
 	void _validate_property(PropertyInfo &p_property) const;
+	bool _stop();
 
 public:
 	Size2 get_minimum_size() const override;


### PR DESCRIPTION
The docs say that `VideoStreamPlayer::stop` should set the stream position to 0, while `VideoStreamPlayback::_stop`  shouldn't. Now it's actually being done in VideoStreamPlayback.

I've changed it in accordance with the docs. It makes more sense, and it allows more control to VideoStreamPlayer, avoiding some unnecessary seeks. Calling `set_stream` would seek to 0 in the current video stream before loading the new one.

It also fixes an issue raised by #108600 when re-importing a video that would result in an unnecessary seek on a video file that was being replaced by the import and caused the editor to freeze.