### PR TITLE
Fix: Infinite Loop in SpriteFrames Editor when auto slicing compressed png sprite sheet

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -507,7 +507,7 @@ void SpriteFramesEditor::_update_show_settings() {
 }
 
 void SpriteFramesEditor::_auto_slice_sprite_sheet() {
-	if (updating_split_settings) {
+	if (updating_split_settings || split_sheet_preview->get_texture()->get_image()->is_compressed()) {
 		return;
 	}
 	updating_split_settings = true;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
fix: #108635 - small issue easy fix
Can be reverted if ever `get_pixel()`(core/io/image.cpp:3260) supports compressed formats.