### PR TITLE
AnimationNodeStateMachine: fix clicking on a node with the create tool

### DIFF
--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -154,6 +154,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		if (mb.is_valid() && mb->is_pressed() && !box_selecting && !connecting && ((tool_select->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) || (tool_create->is_pressed() && mb->get_button_index() == MouseButton::LEFT))) {
 			connecting_from = StringName();
 			_open_menu(mb->get_position());
+			return;
 		}
 	}
 


### PR DESCRIPTION
This fixes the AnimationNodeStateMachine editor to avoid both creating a new node and selecting the existing node when clicking on an existing node with the create tool.  Previously the code fell through after opening the pop-up menu, and also ran the code to select the existing node under the cursor.  This resulted in the editor getting into a confused state after creating the new node, thinking it is dragging a node but not having any node selected.

This is just a minimal fix for now.  In the long run it seems like this function could probably use some refactoring.  The current mechanism of using many separate booleans (box_selecting, connecting, dragging_selected, etc) to track the state seems a bit fragile.  There are still other ways to get into a somewhat confused state, such as right clicking while in the middle of dragging a node.

Fixes #108691

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
