### PR TITLE
Theora: Fix get_playback_position when using video delay

### DIFF
--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -644,10 +644,12 @@ double VideoStreamPlaybackTheora::get_length() const {
 }
 
 double VideoStreamPlaybackTheora::get_playback_position() const {
-	return get_time();
+	return time;
 }
 
 void VideoStreamPlaybackTheora::seek(double p_time) {
+	ERR_FAIL_COND(p_time < 0.0);
+
 	if (file.is_null()) {
 		return;
 	}


### PR DESCRIPTION
When video delay compensation was set to something other than zero, the `get_playback_position` would return the compensated position.

Example: For video delay compensation set to 500ms, setting `stream_position` to zero and immediately reading it would return -0.5.

This is changed to return the real stream position, and I've also added a check to ensure that `stream_position` isn't set to a negative value.