### PR TITLE
Do not poll for system theme changes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8861,12 +8861,6 @@ EditorNode::EditorNode() {
 
 	follow_system_theme = EDITOR_GET("interface/theme/follow_system_theme");
 	use_system_accent_color = EDITOR_GET("interface/theme/use_system_accent_color");
-	system_theme_timer = memnew(Timer);
-	system_theme_timer->set_wait_time(1.0);
-	system_theme_timer->connect("timeout", callable_mp(this, &EditorNode::_check_system_theme_changed));
-	add_child(system_theme_timer);
-	system_theme_timer->set_owner(get_owner());
-	system_theme_timer->set_autostart(true);
 }
 
 EditorNode::~EditorNode() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -362,7 +362,6 @@ private:
 
 	Ref<Theme> theme;
 
-	Timer *system_theme_timer = nullptr;
 	bool follow_system_theme = false;
 	bool use_system_accent_color = false;
 	bool last_dark_mode_state = false;


### PR DESCRIPTION
The DisplayServer interface has change notification for theme changes. As far as I can tell, all display servers with a concept of system theme also implement the DisplayServer::set_system_theme_change_callback(const Callable &p_callable) method. So there should be no need to poll every second for the system theme.

---

This change is only lightly tested on a single platform (GNOME 43). I spotted the polling while working on #108704. The cost of polling is not huge, but in the XDG implementation (and possibly others) it's a blocking IPC call – probably better avoided.