### PR TITLE
Fix the absolute `NodePath` was calculated incorrectly when "Reparent to New Node"

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1966,7 +1966,6 @@ void SceneTreeDock::fill_path_renames(Node *p_node, Node *p_new_parent, HashMap<
 		base_path.push_back(n->get_name());
 		n = n->get_parent();
 	}
-	base_path.reverse();
 
 	Vector<StringName> new_base_path;
 	if (p_new_parent) {
@@ -1976,8 +1975,14 @@ void SceneTreeDock::fill_path_renames(Node *p_node, Node *p_new_parent, HashMap<
 			n = n->get_parent();
 		}
 
+		// For the case Reparent to New Node, the new parent has not yet been added to the tree.
+		if (!p_new_parent->is_inside_tree()) {
+			new_base_path.append_array(base_path);
+		}
+
 		new_base_path.reverse();
 	}
+	base_path.reverse();
 
 	_fill_path_renames(base_path, new_base_path, p_node, p_renames);
 }

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -176,7 +176,7 @@ void MeshInstance3D::_resolve_skeleton_path() {
 	Ref<SkinReference> new_skin_reference;
 
 	if (!skeleton_path.is_empty()) {
-		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(get_node(skeleton_path));
+		Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(get_node_or_null(skeleton_path)); // skeleton_path may be outdated when reparenting.
 		if (skeleton) {
 			if (skin_internal.is_null()) {
 				new_skin_reference = skeleton->register_skin(skeleton->create_skin_from_rest_transforms());


### PR DESCRIPTION
Since the new parent node has not yet been added to the tree, the `new_base_path` needs to be calculated using the `base_path`.

Fix #108700, fix #102804, fix #80589.

_________________

~~Since `MeshInstance3D` enters the tree first and then changes the `NodePath` value in properties.
So when entering the tree, it will use the outdated `skeleton_path`.~~

https://github.com/godotengine/godot/blob/f92f1ce9c07d35b0e3843415bf99a509d3a51add/scene/3d/mesh_instance_3d.cpp#L344-L346

https://github.com/godotengine/godot/blob/f92f1ce9c07d35b0e3843415bf99a509d3a51add/scene/3d/mesh_instance_3d.cpp#L179

~~You may still receive a similar error message.~~ Fixed.





<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
