### PR TITLE
Fix stuck actions after calling InputMap::action_erase_events

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -228,6 +228,10 @@ void InputMap::action_erase_events(const StringName &p_action) {
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), suggest_actions(p_action));
 
 	input_map[p_action].inputs.clear();
+
+	if (Input::get_singleton()->is_action_pressed(p_action)) {
+		Input::get_singleton()->action_release(p_action);
+	}
 }
 
 TypedArray<InputEvent> InputMap::_action_get_events(const StringName &p_action) {


### PR DESCRIPTION
Fixes #108710 .

Input actions were getting released on `InputMap::action_erase_event()` but not `InputMap::action_erase_events()`, so if a key was being pressed during the call to `action_erase_events()`, it would get stuck as pressed until reassigning the event and pressing the key again.

See the MRP for details.