### PR TITLE
[Web] Disable GDScript LSP

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -330,3 +330,6 @@ def configure(env: "SConsEnvironment"):
     # This workaround creates a closure that prevents the garbage collector from freeing the WebGL context.
     # We also only use WebGL2, and changing context version is not widely supported anyway.
     env.Append(LINKFLAGS=["-sGL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0"])
+
+    # Disable GDScript LSP (as the Web platform is not compatible with TCP).
+    env.Append(CPPDEFINES=["GDSCRIPT_NO_LSP"])


### PR DESCRIPTION
Currently fixing the 4.5 Web editor build.

Stumbled upon this issue, it seems that GDScriptLanguageServer is starting every frame the server if it didn't start.

https://github.com/user-attachments/assets/21b53afa-d89d-433b-8a81-e8ae6217e3c0

~~The fix could be also to detect multiple failures and stop, but I just added a temporary fix (disabling `start()` for Web).~~

Disabled instead the GDScript LSP directly (`GDSCRIPT_NO_LSP`) as @HolonProduction [suggested](https://github.com/godotengine/godot/pull/108714#discussion_r2213896450).