### PR TITLE
[SplitContainer] Fix inability to override touch dragger icon and add theme colors to touch dragger 

### DIFF
--- a/doc/classes/SplitContainer.xml
+++ b/doc/classes/SplitContainer.xml
@@ -94,6 +94,15 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="touch_dragger_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.3)">
+			The color of the touch dragger.
+		</theme_item>
+		<theme_item name="touch_dragger_hover_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.6)">
+			The color of the touch dragger when hovered.
+		</theme_item>
+		<theme_item name="touch_dragger_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the touch dragger when pressed.
+		</theme_item>
 		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If [code]1[/code] ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If [code]0[/code] ([code]false[/code]), it's always visible. The [member dragger_visibility] must be [constant DRAGGER_VISIBLE].
 		</theme_item>

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -376,6 +376,10 @@ void SplitContainer::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
+			if (touch_dragger) {
+				touch_dragger->set_modulate(theme_cache.touch_dragger_color);
+				touch_dragger->set_texture(_get_touch_dragger_icon());
+			}
 		} break;
 	}
 }
@@ -542,7 +546,7 @@ void SplitContainer::set_touch_dragger_enabled(bool p_enabled) {
 		touch_dragger->set_texture(_get_touch_dragger_icon());
 		touch_dragger->set_anchors_and_offsets_preset(Control::PRESET_CENTER);
 		touch_dragger->set_default_cursor_shape(vertical ? CURSOR_VSPLIT : CURSOR_HSPLIT);
-		touch_dragger->set_modulate(Color(1, 1, 1, 0.3));
+		touch_dragger->set_modulate(theme_cache.touch_dragger_color);
 		touch_dragger->connect(SceneStringName(gui_input), callable_mp(this, &SplitContainer::_touch_dragger_gui_input));
 		touch_dragger->connect(SceneStringName(mouse_exited), callable_mp(this, &SplitContainer::_touch_dragger_mouse_exited));
 		dragging_area_control->add_child(touch_dragger, false, Node::INTERNAL_MODE_FRONT);
@@ -561,7 +565,7 @@ bool SplitContainer::is_touch_dragger_enabled() const {
 
 void SplitContainer::_touch_dragger_mouse_exited() {
 	if (!dragging_area_control->dragging) {
-		touch_dragger->set_modulate(Color(1, 1, 1, 0.3));
+		touch_dragger->set_modulate(theme_cache.touch_dragger_color);
 	}
 }
 
@@ -571,17 +575,16 @@ void SplitContainer::_touch_dragger_gui_input(const Ref<InputEvent> &p_event) {
 	}
 	Ref<InputEventMouseMotion> mm = p_event;
 	Ref<InputEventMouseButton> mb = p_event;
-
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (mb->is_pressed()) {
-			touch_dragger->set_modulate(Color(1, 1, 1, 1));
+			touch_dragger->set_modulate(theme_cache.touch_dragger_pressed_color);
 		} else {
-			touch_dragger->set_modulate(Color(1, 1, 1, 0.3));
+			touch_dragger->set_modulate(theme_cache.touch_dragger_color);
 		}
 	}
 
 	if (mm.is_valid() && !dragging_area_control->dragging) {
-		touch_dragger->set_modulate(Color(1, 1, 1, 0.6));
+		touch_dragger->set_modulate(theme_cache.touch_dragger_hover_color);
 	}
 }
 
@@ -640,6 +643,9 @@ void SplitContainer::_bind_methods() {
 	BIND_ENUM_CONSTANT(DRAGGER_HIDDEN);
 	BIND_ENUM_CONSTANT(DRAGGER_HIDDEN_COLLAPSED);
 
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, SplitContainer, touch_dragger_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, SplitContainer, touch_dragger_pressed_color);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_COLOR, SplitContainer, touch_dragger_hover_color);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SplitContainer, separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SplitContainer, minimum_grab_thickness);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SplitContainer, autohide);

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -88,6 +88,9 @@ private:
 	TextureRect *touch_dragger = nullptr;
 
 	struct ThemeCache {
+		Color touch_dragger_color;
+		Color touch_dragger_pressed_color;
+		Color touch_dragger_hover_color;
 		int separation = 0;
 		int minimum_grab_thickness = 0;
 		bool autohide = false;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1204,6 +1204,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	// Containers
 
+	theme->set_color("touch_dragger_color", "SplitContainer", Color(1, 1, 1, 0.3));
+	theme->set_color("touch_dragger_pressed_color", "SplitContainer", Color(1, 1, 1, 1));
+	theme->set_color("touch_dragger_hover_color", "SplitContainer", Color(1, 1, 1, 0.6));
+
 	theme->set_icon("h_touch_dragger", "SplitContainer", icons["h_dragger"]);
 	theme->set_icon("v_touch_dragger", "SplitContainer", icons["v_dragger"]);
 	theme->set_icon("touch_dragger", "VSplitContainer", icons["v_dragger"]);


### PR DESCRIPTION
- *Production edit: Follow-up to https://github.com/godotengine/godot/pull/105994.*

Fixes issue where the new (and great!) touch dragger icon would not update when the default theme touch dragger icon was overridden.

Also adds three new theme colors for the touch dragger normal, hovered and pressed states, which were previously hard-coded colors.

Fixes #108719
