### PR TITLE
Add Image support for partial mipmaps and implement `mipmap_limit` functionality for texture importers

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,0 +1,58 @@
+/**************************************************************************/
+/*  image.compat.inc                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "core/object/class_db.h"
+
+Error Image::_generate_mipmaps_bind_compat_108720(bool p_renormalize) {
+	return generate_mipmaps(p_renormalize, -1);
+}
+
+Ref<Image> Image::_create_empty_bind_compat_108720(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
+	return create_empty(p_width, p_height, p_use_mipmaps, p_format, -1);
+}
+
+Ref<Image> Image::_create_from_data_bind_compat_108720(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+	return create_from_data(p_width, p_height, p_use_mipmaps, p_format, p_data, -1);
+}
+
+void Image::_set_data_bind_compat_108720(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+	set_data(p_width, p_height, p_use_mipmaps, p_format, p_data, -1);
+}
+
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::_generate_mipmaps_bind_compat_108720, DEFVAL(false));
+	ClassDB::bind_compatibility_method(D_METHOD("set_data", "width", "height", "use_mipmaps", "format", "data"), &Image::_set_data_bind_compat_108720);
+	ClassDB::bind_compatibility_static_method("Image", D_METHOD("create_empty", "width", "height", "use_mipmaps", "format"), &Image::_create_empty_bind_compat_108720);
+	ClassDB::bind_compatibility_static_method("Image", D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data"), &Image::_create_from_data_bind_compat_108720);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "image.h"
+#include "image.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
@@ -481,15 +482,11 @@ Size2i Image::get_size() const {
 }
 
 bool Image::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
 }
 
 int Image::get_mipmap_count() const {
-	if (mipmaps) {
-		return get_image_required_mipmaps(width, height, format);
-	} else {
-		return 0;
-	}
+	return mipmap_count;
 }
 
 // Using template generates perfectly optimized code due to constant expression reduction and unused variable removal present in all compilers.
@@ -577,13 +574,13 @@ void Image::convert(Format p_new_format) {
 	}
 
 	// Includes the main image.
-	const int mipmap_count = get_mipmap_count() + 1;
+	const int total_mipmaps = get_mipmap_count() + 1;
 
 	if (!_are_formats_compatible(format, p_new_format)) {
 		// Use put/set pixel which is slower but works with non-byte formats.
-		Image new_img(width, height, mipmaps, p_new_format);
+		Image new_img(width, height, true, p_new_format, total_mipmaps - 1);
 
-		for (int mip = 0; mip < mipmap_count; mip++) {
+		for (int mip = 0; mip < total_mipmaps; mip++) {
 			int64_t src_mip_ofs, dst_mip_ofs;
 			int w, h;
 			_get_mipmap_offset_and_size(mip, src_mip_ofs, w, h);
@@ -605,11 +602,11 @@ void Image::convert(Format p_new_format) {
 	}
 
 	// Convert the formats in an optimized way by removing/adding color channels if necessary.
-	Image new_img(width, height, mipmaps, p_new_format);
+	Image new_img(width, height, true, p_new_format, total_mipmaps - 1);
 
 	const int conversion_type = format | p_new_format << 8;
 
-	for (int mip = 0; mip < mipmap_count; mip++) {
+	for (int mip = 0; mip < total_mipmaps; mip++) {
 		int64_t mip_offset = 0;
 		int64_t mip_size = 0;
 		int mip_width = 0;
@@ -1275,6 +1272,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 	}
 
 	Image dst(p_width, p_height, false, format);
+	float mip_ratio = has_mipmaps() ? (float)mipmap_count / Image::get_image_required_mipmaps(width, height, format) : 0.0f;
 
 	// Setup mipmap-aware scaling
 	bool mipmap_aware = p_interpolation == INTERPOLATE_TRILINEAR /* || p_interpolation == INTERPOLATE_TRICUBIC */;
@@ -1299,8 +1297,7 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 		dst2.initialize_data(p_width, p_height, false, format);
 	}
 
-	bool had_mipmaps = mipmaps;
-	if (interpolate_mipmaps && !had_mipmaps) {
+	if (interpolate_mipmaps && !has_mipmaps()) {
 		generate_mipmaps();
 	}
 	// --
@@ -1617,8 +1614,9 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 		dst._copy_internals_from(dst2);
 	}
 
-	if (had_mipmaps) {
-		dst.generate_mipmaps();
+	int new_mipmaps = Math::round(mip_ratio * Image::get_image_required_mipmaps(p_width, p_height, format));
+	if (new_mipmaps > 0) {
+		dst.generate_mipmaps(false, new_mipmaps);
 	}
 
 	_copy_internals_from(dst);
@@ -1687,8 +1685,8 @@ void Image::rotate_90(ClockDirection p_direction) {
 	ERR_FAIL_COND_MSG(width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", width));
 	ERR_FAIL_COND_MSG(height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", height));
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int old_mipmaps = get_mipmap_count();
+	if (old_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1795,8 +1793,8 @@ void Image::rotate_90(ClockDirection p_direction) {
 #undef PREV_INDEX_IN_CYCLE
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (old_mipmaps > 0) {
+		generate_mipmaps(false, old_mipmaps);
 	}
 }
 
@@ -1805,8 +1803,8 @@ void Image::rotate_180() {
 	ERR_FAIL_COND_MSG(width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", width));
 	ERR_FAIL_COND_MSG(height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", height));
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int old_mipmaps = get_mipmap_count();
+	if (old_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1829,16 +1827,16 @@ void Image::rotate_180() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (old_mipmaps > 0) {
+		generate_mipmaps(false, old_mipmaps);
 	}
 }
 
 void Image::flip_y() {
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot flip_y in compressed image formats.");
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int old_mipmaps = get_mipmap_count();
+	if (old_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1859,16 +1857,16 @@ void Image::flip_y() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (old_mipmaps > 0) {
+		generate_mipmaps(false, old_mipmaps);
 	}
 }
 
 void Image::flip_x() {
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot flip_x in compressed image formats.");
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int old_mipmaps = get_mipmap_count();
+	if (old_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1889,8 +1887,8 @@ void Image::flip_x() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (old_mipmaps > 0) {
+		generate_mipmaps(false, old_mipmaps);
 	}
 }
 
@@ -1926,16 +1924,12 @@ int64_t Image::_get_dst_image_size(int p_width, int p_height, Format p_format, i
 
 		size += s;
 
-		if (p_mipmaps >= 0) {
-			w = MAX(minw, w >> 1);
-			h = MAX(minh, h >> 1);
-		} else {
-			if (w == minw && h == minh) {
-				break;
-			}
-			w = MAX(minw, w >> 1);
-			h = MAX(minh, h >> 1);
+		if (w == minw && h == minh) {
+			break;
 		}
+
+		w = MAX(minw, w >> 1);
+		h = MAX(minh, h >> 1);
 
 		// Set mipmap size.
 		if (r_mm_width) {
@@ -2109,7 +2103,7 @@ void Image::shrink_x2() {
 	ERR_FAIL_COND(data.is_empty());
 	Vector<uint8_t> new_data;
 
-	if (mipmaps) {
+	if (has_mipmaps()) {
 		// Just use the lower mipmap as base and copy all.
 		int64_t ofs = get_mipmap_offset(1);
 		int64_t new_size = data.size() - ofs;
@@ -2134,8 +2128,8 @@ void Image::shrink_x2() {
 }
 
 void Image::normalize() {
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int old_mipmaps = get_mipmap_count();
+	if (old_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -2151,18 +2145,18 @@ void Image::normalize() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps(true);
+	if (old_mipmaps > 0) {
+		generate_mipmaps(true, old_mipmaps);
 	}
 }
 
-Error Image::generate_mipmaps(bool p_renormalize) {
+Error Image::generate_mipmaps(bool p_renormalize, int p_limit) {
 	ERR_FAIL_COND_V_MSG(is_compressed(), ERR_UNAVAILABLE, "Cannot generate mipmaps from compressed image formats.");
 	ERR_FAIL_COND_V_MSG(width == 0 || height == 0, ERR_UNCONFIGURED, "Cannot generate mipmaps with width or height equal to 0.");
 
 	int gen_mipmap_count;
 
-	int64_t size = _get_dst_image_size(width, height, format, gen_mipmap_count);
+	int64_t size = _get_dst_image_size(width, height, format, gen_mipmap_count, p_limit);
 	data.resize(size);
 	uint8_t *wp = data.ptrw();
 
@@ -2182,7 +2176,7 @@ Error Image::generate_mipmaps(bool p_renormalize) {
 		prev_h = h;
 	}
 
-	mipmaps = true;
+	mipmap_count = gen_mipmap_count;
 
 	return OK;
 }
@@ -2235,7 +2229,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 
 	int mmcount;
 
-	_get_dst_image_size(width, height, format, mmcount);
+	_get_dst_image_size(width, height, format, mmcount, get_mipmap_count());
 
 	uint8_t *base_ptr = data.ptrw();
 
@@ -2356,7 +2350,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 }
 
 void Image::clear_mipmaps() {
-	if (!mipmaps) {
+	if (!has_mipmaps()) {
 		return;
 	}
 
@@ -2369,7 +2363,7 @@ void Image::clear_mipmaps() {
 	_get_mipmap_offset_and_size(1, ofs, w, h);
 	data.resize(ofs);
 
-	mipmaps = false;
+	mipmap_count = 0;
 }
 
 bool Image::is_empty() const {
@@ -2380,25 +2374,25 @@ Vector<uint8_t> Image::get_data() const {
 	return data;
 }
 
-Ref<Image> Image::create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
+Ref<Image> Image::create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format, int p_mipmap_limit) {
 	Ref<Image> image;
 	image.instantiate();
-	image->initialize_data(p_width, p_height, p_use_mipmaps, p_format);
+	image->initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_mipmap_limit);
 	return image;
 }
 
-Ref<Image> Image::create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+Ref<Image> Image::create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit) {
 	Ref<Image> image;
 	image.instantiate();
-	image->initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_data);
+	image->initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_data, p_mipmap_limit);
 	return image;
 }
 
-void Image::set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
-	initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_data);
+void Image::set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit) {
+	initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_data, p_mipmap_limit);
 }
 
-void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
+void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, int p_mipmap_limit) {
 	ERR_FAIL_COND_MSG(p_width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", p_width));
 	ERR_FAIL_COND_MSG(p_height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", p_height));
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH,
@@ -2410,7 +2404,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm = 0;
-	int64_t size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
+	int64_t size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? p_mipmap_limit : 0);
 	data.resize(size);
 
 	{
@@ -2420,11 +2414,11 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 
 	width = p_width;
 	height = p_height;
-	mipmaps = p_use_mipmaps;
 	format = p_format;
+	mipmap_count = mm;
 }
 
-void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit) {
 	ERR_FAIL_COND_MSG(p_width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", p_width));
 	ERR_FAIL_COND_MSG(p_height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", p_height));
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH,
@@ -2435,13 +2429,12 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_WIDTH, MAX_HEIGHT, MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
-	int mm;
-	int64_t size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
+	int num_mipmaps;
+	int64_t size = _get_dst_image_size(p_width, p_height, p_format, num_mipmaps, p_use_mipmaps ? p_mipmap_limit : 0);
 
 	if (unlikely(p_data.size() != size)) {
 		String description_mipmaps = get_format_name(p_format) + " ";
-		if (p_use_mipmaps) {
-			const int num_mipmaps = get_image_required_mipmaps(p_width, p_height, p_format);
+		if (num_mipmaps > 0) {
 			if (num_mipmaps != 1) {
 				description_mipmaps += vformat("with %d mipmaps", num_mipmaps);
 			} else {
@@ -2458,15 +2451,14 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	width = p_width;
 	format = p_format;
 	data = p_data;
-
-	mipmaps = p_use_mipmaps;
+	mipmap_count = num_mipmaps;
 }
 
 void Image::initialize_data(const char **p_xpm) {
 	int size_width = 0;
 	int size_height = 0;
 	int pixelchars = 0;
-	mipmaps = false;
+	mipmap_count = 0;
 	bool has_alpha = false;
 
 	enum Status {
@@ -2868,9 +2860,9 @@ Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_qua
 	return save_webp_buffer_func(Ref<Image>((Image *)this), p_lossy, p_quality);
 }
 
-int64_t Image::get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps) {
+int64_t Image::get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps, int p_mipmap_limit) {
 	int mm;
-	return _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmaps ? -1 : 0);
+	return _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmaps ? p_mipmap_limit : 0);
 }
 
 int Image::get_image_required_mipmaps(int p_width, int p_height, Format p_format) {
@@ -3013,28 +3005,28 @@ Error Image::compress_from_channels(CompressMode p_mode, UsedChannels p_channels
 Image::Image(const char **p_xpm) {
 	width = 0;
 	height = 0;
-	mipmaps = false;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
 	initialize_data(p_xpm);
 }
 
-Image::Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
+Image::Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format, int p_mipmap_limit) {
 	width = 0;
 	height = 0;
-	mipmaps = p_use_mipmaps;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
-	initialize_data(p_width, p_height, p_use_mipmaps, p_format);
+	initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_mipmap_limit);
 }
 
-Image::Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+Image::Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit) {
 	width = 0;
 	height = 0;
-	mipmaps = p_mipmaps;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
-	initialize_data(p_width, p_height, p_mipmaps, p_format, p_data);
+	initialize_data(p_width, p_height, p_mipmaps, p_format, p_data, p_mipmap_limit);
 }
 
 Rect2i Image::get_used_rect() const {
@@ -3078,7 +3070,7 @@ Rect2i Image::get_used_rect() const {
 }
 
 Ref<Image> Image::get_region(const Rect2i &p_region) const {
-	Ref<Image> img = memnew(Image(p_region.size.x, p_region.size.y, mipmaps, format));
+	Ref<Image> img = memnew(Image(p_region.size.x, p_region.size.y, has_mipmaps(), format));
 	img->blit_rect(Ref<Image>((Image *)this), p_region, Point2i(0, 0));
 	return img;
 }
@@ -3367,7 +3359,14 @@ void Image::_set_data(const Dictionary &p_data) {
 
 	ERR_FAIL_COND(ddformat == FORMAT_MAX);
 
-	initialize_data(dwidth, dheight, dmipmaps, ddformat, ddata);
+	int mip_count = 0;
+	if (p_data.has("mipmap_count")) {
+		mip_count = int(p_data["mipmap_count"]);
+	} else {
+		mip_count = dmipmaps ? -1 : 0;
+	}
+
+	initialize_data(dwidth, dheight, true, ddformat, ddata, mip_count);
 }
 
 Dictionary Image::_get_data() const {
@@ -3375,7 +3374,8 @@ Dictionary Image::_get_data() const {
 	d["width"] = width;
 	d["height"] = height;
 	d["format"] = get_format_name(format);
-	d["mipmaps"] = mipmaps;
+	d["mipmap_count"] = mipmap_count;
+	d["mipmaps"] = has_mipmaps();
 	d["data"] = data;
 	return d;
 }
@@ -3388,7 +3388,7 @@ void Image::_copy_internals_from(const Image &p_image) {
 	format = p_image.format;
 	width = p_image.width;
 	height = p_image.height;
-	mipmaps = p_image.mipmaps;
+	mipmap_count = p_image.mipmap_count;
 	data = p_image.data;
 }
 
@@ -3861,15 +3861,15 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("crop", "width", "height"), &Image::crop);
 	ClassDB::bind_method(D_METHOD("flip_x"), &Image::flip_x);
 	ClassDB::bind_method(D_METHOD("flip_y"), &Image::flip_y);
-	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::generate_mipmaps, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize", "limit"), &Image::generate_mipmaps, DEFVAL(false), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("clear_mipmaps"), &Image::clear_mipmaps);
 
 #ifndef DISABLE_DEPRECATED
-	ClassDB::bind_static_method("Image", D_METHOD("create", "width", "height", "use_mipmaps", "format"), &Image::create_empty);
+	ClassDB::bind_static_method("Image", D_METHOD("create", "width", "height", "use_mipmaps", "format"), &Image::_create_empty_bind_compat_108720);
 #endif
-	ClassDB::bind_static_method("Image", D_METHOD("create_empty", "width", "height", "use_mipmaps", "format"), &Image::create_empty);
-	ClassDB::bind_static_method("Image", D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data"), &Image::create_from_data);
-	ClassDB::bind_method(D_METHOD("set_data", "width", "height", "use_mipmaps", "format", "data"), &Image::set_data);
+	ClassDB::bind_static_method("Image", D_METHOD("create_empty", "width", "height", "use_mipmaps", "format", "mipmap_limit"), &Image::create_empty, DEFVAL(-1));
+	ClassDB::bind_static_method("Image", D_METHOD("create_from_data", "width", "height", "use_mipmaps", "format", "data", "mipmap_limit"), &Image::create_from_data, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("set_data", "width", "height", "use_mipmaps", "format", "data", "mipmap_limit"), &Image::set_data, DEFVAL(-1));
 
 	ClassDB::bind_method(D_METHOD("is_empty"), &Image::is_empty);
 
@@ -4089,7 +4089,7 @@ Ref<Image> Image::get_image_from_mipmap(int p_mipmap) const {
 	image->format = format;
 	image->data = new_data;
 
-	image->mipmaps = false;
+	image->mipmap_count = 0;
 	return image;
 }
 
@@ -4640,7 +4640,7 @@ void Image::renormalize_uint16(uint16_t *p_rgb) {
 Image::Image(const uint8_t *p_mem_png_jpg, int p_len) {
 	width = 0;
 	height = 0;
-	mipmaps = false;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
 	if (_png_mem_loader_func) {
@@ -4672,7 +4672,7 @@ void Image::copy_internals_from(const Ref<Image> &p_image) {
 	format = p_image->format;
 	width = p_image->width;
 	height = p_image->height;
-	mipmaps = p_image->mipmaps;
+	mipmap_count = p_image->mipmap_count;
 	data = p_image->data;
 }
 

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -257,12 +257,22 @@ protected:
 
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	static Ref<Image> _create_empty_bind_compat_108720(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
+	static Ref<Image> _create_from_data_bind_compat_108720(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+
+	Error _generate_mipmaps_bind_compat_108720(bool p_renormalize = false);
+	void _set_data_bind_compat_108720(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	Format format = FORMAT_L8;
 	Vector<uint8_t> data;
 	int width = 0;
 	int height = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	void _copy_internals_from(const Image &p_image);
 
@@ -337,7 +347,7 @@ public:
 	void flip_y();
 
 	// Generate a mipmap chain of an image (creates an image 1/4 the size, with averaging of 4->1).
-	Error generate_mipmaps(bool p_renormalize = false);
+	Error generate_mipmaps(bool p_renormalize = false, int p_limit = -1);
 
 	Error generate_mipmap_roughness(RoughnessChannel p_roughness_channel, const Ref<Image> &p_normal_map);
 
@@ -345,8 +355,8 @@ public:
 	void normalize();
 
 	// Creates new internal image data of a given size and format. Current image will be lost.
-	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
-	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, int p_mipmap_limit = -1);
+	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit = -1);
 	void initialize_data(const char **p_xpm);
 
 	// Returns true when the image is empty (0,0) in size.
@@ -367,13 +377,13 @@ public:
 	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
 	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 
-	static Ref<Image> create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
-	static Ref<Image> create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
-	void set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+	static Ref<Image> create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format, int p_mipmap_limit = -1);
+	static Ref<Image> create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit = -1);
+	void set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit = -1);
 
 	Image() = default; // Create an empty image.
-	Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format); // Create an empty image of a specific size and format.
-	Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data); // Import an image of a specific size and format from a byte vector.
+	Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format, int p_mipmap_limit = -1); // Create an empty image of a specific size and format.
+	Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data, int p_mipmap_limit = -1); // Import an image of a specific size and format from a byte vector.
 	Image(const uint8_t *p_mem_png_jpg, int p_len = -1); // Import either a png or jpg from a pointer.
 	Image(const char **p_xpm); // Import an XPM image.
 
@@ -385,7 +395,7 @@ public:
 	static int get_format_block_size(Format p_format);
 	static void get_format_min_pixel_size(Format p_format, int &r_w, int &r_h);
 
-	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps = false);
+	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps = false, int p_mipmap_limit = -1);
 	static int get_image_required_mipmaps(int p_width, int p_height, Format p_format);
 	static Size2i get_image_mipmap_size(int p_width, int p_height, Format p_format, int p_mipmap);
 	static int64_t get_image_mipmap_offset(int p_width, int p_height, Format p_format, int p_mipmap);

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -138,8 +138,10 @@
 			<param index="1" name="height" type="int" />
 			<param index="2" name="use_mipmaps" type="bool" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
+			<param index="4" name="mipmap_limit" type="int" default="-1" />
 			<description>
 				Creates an empty image of the given size and format. If [param use_mipmaps] is [code]true[/code], generates mipmaps for this image (see [method generate_mipmaps]).
+				The number of generated mipmaps depends on [param mipmap_limit]: Only up to [param mipmap_limit] mipmaps are generated. If [param mipmap_limit] is [code]-1[/code], generates as many mipmaps as possible.
 			</description>
 		</method>
 		<method name="create_from_data" qualifiers="static">
@@ -149,8 +151,11 @@
 			<param index="2" name="use_mipmaps" type="bool" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<param index="4" name="data" type="PackedByteArray" />
+			<param index="5" name="mipmap_limit" type="int" default="-1" />
 			<description>
-				Creates a new image of the given size and format. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code], loads the mipmaps for this image from [param data]. See [method generate_mipmaps].
+				Creates a new image of the given size and format. Fills the image with the given raw data. If [param use_mipmaps] is [code]true[/code], loads the mipmaps for this image from [param data] (see [method generate_mipmaps]).
+				The number of loaded mipmaps depends on [param mipmap_limit]: Only up to [param mipmap_limit] mipmaps are loaded. If [param mipmap_limit] is [code]-1[/code], loads as many mipmaps as possible.
+				[b]Note:[/b] [param mipmap_limit] has to exactly represent the number of mipmaps present in [param data]. Otherwise, attempting to use the method will result in an error.
 			</description>
 		</method>
 		<method name="crop">
@@ -216,8 +221,10 @@
 		<method name="generate_mipmaps">
 			<return type="int" enum="Error" />
 			<param index="0" name="renormalize" type="bool" default="false" />
+			<param index="1" name="limit" type="int" default="-1" />
 			<description>
 				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code]. Enabling [param renormalize] when generating mipmaps for normal map textures will make sure all resulting vector values are normalized.
+				Only up to [param limit] mipmaps are generated. If [param limit] is [code]-1[/code], generates as many mipmaps as possible.
 				It is possible to check if the image has mipmaps by calling [method has_mipmaps] or [method get_mipmap_count]. Calling [method generate_mipmaps] on an image that already has mipmaps will replace existing mipmaps in the image.
 			</description>
 		</method>
@@ -562,6 +569,7 @@
 			<param index="2" name="use_mipmaps" type="bool" />
 			<param index="3" name="format" type="int" enum="Image.Format" />
 			<param index="4" name="data" type="PackedByteArray" />
+			<param index="5" name="mipmap_limit" type="int" default="-1" />
 			<description>
 				Overwrites data of an existing [Image]. Non-static equivalent of [method create_from_data].
 			</description>
@@ -636,7 +644,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{ &quot;data&quot;: PackedByteArray(), &quot;format&quot;: &quot;Lum8&quot;, &quot;height&quot;: 0, &quot;mipmaps&quot;: false, &quot;width&quot;: 0 }">
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{ &quot;data&quot;: PackedByteArray(), &quot;format&quot;: &quot;Lum8&quot;, &quot;height&quot;: 0, &quot;mipmap_count&quot;: 0, &quot;mipmaps&quot;: false, &quot;width&quot;: 0 }">
 			Holds all the image's color data in a given format. See [enum Format] constants.
 		</member>
 	</members>

--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -56,7 +56,9 @@
 			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
-			Unimplemented. This currently has no effect when changed.
+			Sets the maximum number of mipmaps for a texture. The smaller the limit, the sharper the texture will appear from a distance. This can help alleviate the overblurring of distant images, especially ones at a low resolution. Limiting the number of mipmaps may help decrease the memory usage and file size of a texture.
+			If [code]-1[/code], generates as many mipmaps as possible. If [code]0[/code], no mipmaps will be generated.
+			[b]Note:[/b] This setting has no effect if [member mipmaps/generate] is [code]false[/code].
 		</member>
 		<member name="slices/arrangement" type="int" setter="" getter="" default="1">
 			Controls how the cubemap's texture is internally laid out. When using high-resolution cubemaps, [b]2×3[/b] and [b]3×2[/b] are less prone to exceeding hardware texture size limits compared to [b]1×6[/b] and [b]6×1[/b].

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -71,7 +71,9 @@
 			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
-			Unimplemented. This currently has no effect when changed.
+			Sets the maximum number of mipmaps for a texture. The smaller the limit, the sharper the texture will appear from a distance. This can help alleviate the overblurring of distant images, especially ones at a low resolution. Limiting the number of mipmaps may help decrease the memory usage and file size of a texture.
+			If [code]-1[/code], generates as many mipmaps as possible. If [code]0[/code], no mipmaps will be generated.
+			[b]Note:[/b] This setting has no effect if [member mipmaps/generate] is [code]false[/code].
 		</member>
 		<member name="process/channel_remap/alpha" type="int" setter="" getter="" default="3">
 			Specifies the data source of the output image's alpha channel.

--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -35,6 +35,12 @@
 				Called when the [Texture3D]'s height is queried.
 			</description>
 		</method>
+		<method name="_get_mipmap_count" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+				Called when the number of mipmaps in the [Texture3D] is queried.
+			</description>
+		</method>
 		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
@@ -75,6 +81,12 @@
 			<return type="int" />
 			<description>
 				Returns the [Texture3D]'s height in pixels. Width is typically represented by the Y axis.
+			</description>
+		</method>
+		<method name="get_mipmap_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of mipmaps in the [Texture3D].
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -44,6 +44,12 @@
 				Called when the number of layers in the [TextureLayered] is queried.
 			</description>
 		</method>
+		<method name="_get_mipmap_count" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+				Called when the number of mipmaps in the [TextureLayered] is queried.
+			</description>
+		</method>
 		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
@@ -85,6 +91,12 @@
 			<return type="int" />
 			<description>
 				Returns the number of referenced [Image]s.
+			</description>
+		</method>
+		<method name="get_mipmap_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of mipmaps in the layers.
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1047,7 +1047,7 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 	texture.type = Texture::TYPE_2D;
 	texture.target = GL_TEXTURE_2D;
 	_get_gl_image_and_format(Ref<Image>(), texture.format, texture.real_format, texture.gl_format_cache, texture.gl_internal_format_cache, texture.gl_type_cache, texture.compressed, false);
-	texture.total_data_size = p_image->get_image_data_size(texture.width, texture.height, texture.format, texture.mipmaps);
+	texture.total_data_size = p_image->get_image_data_size(texture.width, texture.height, texture.format, true, texture.mipmaps);
 	texture.active = true;
 	glGenTextures(1, &texture.tex_id);
 	GLES3::Utilities::get_singleton()->texture_allocated_data(texture.tex_id, texture.total_data_size, "Texture 2D");
@@ -1139,7 +1139,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	texture.target = p_layered_type == RSE::TEXTURE_LAYERED_CUBEMAP ? GL_TEXTURE_CUBE_MAP : GL_TEXTURE_2D_ARRAY;
 	texture.layers = p_layers.size();
 	_get_gl_image_and_format(Ref<Image>(), texture.format, texture.real_format, texture.gl_format_cache, texture.gl_internal_format_cache, texture.gl_type_cache, texture.compressed, false);
-	texture.total_data_size = p_layers[0]->get_image_data_size(texture.width, texture.height, texture.format, texture.mipmaps) * texture.layers;
+	texture.total_data_size = p_layers[0]->get_image_data_size(texture.width, texture.height, texture.format, true, texture.mipmaps) * texture.layers;
 	texture.active = true;
 	glGenTextures(1, &texture.tex_id);
 	GLES3::Utilities::get_singleton()->texture_allocated_data(texture.tex_id, texture.total_data_size, "Texture Layered");
@@ -1179,7 +1179,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 	texture.type = Texture::TYPE_3D;
 	texture.target = GL_TEXTURE_3D;
 	_get_gl_image_and_format(Ref<Image>(), texture.format, texture.real_format, texture.gl_format_cache, texture.gl_internal_format_cache, texture.gl_type_cache, texture.compressed, false);
-	texture.total_data_size = p_data[0]->get_image_data_size(texture.width, texture.height, texture.format, texture.mipmaps) * texture.depth;
+	texture.total_data_size = p_data[0]->get_image_data_size(texture.width, texture.height, texture.format, true, texture.mipmaps) * texture.depth;
 	texture.active = true;
 	glGenTextures(1, &texture.tex_id);
 	GLES3::Utilities::get_singleton()->texture_allocated_data(texture.tex_id, texture.total_data_size, "Texture 3D");
@@ -1527,7 +1527,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		// It also allows for reading compressed textures, mipmaps, and more formats.
 		Vector<uint8_t> data;
 
-		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, texture->real_format, texture->mipmaps > 1);
+		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, texture->real_format, true, texture->mipmaps - 1);
 
 		data.resize(data_size * 2); // Add some memory at the end, just in case for buggy drivers.
 		uint8_t *w = data.ptrw();
@@ -1553,7 +1553,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		data.resize(data_size);
 
 		ERR_FAIL_COND_V(data.is_empty(), Ref<Image>());
-		image = Image::create_from_data(texture->alloc_width, texture->alloc_height, texture->mipmaps > 1, texture->real_format, data);
+		image = Image::create_from_data(texture->alloc_width, texture->alloc_height, true, texture->real_format, data, texture->mipmaps - 1);
 		if (image->is_empty()) {
 			const String &path_str = texture->path.is_empty() ? "with no path" : vformat("with path '%s'", texture->path);
 			ERR_FAIL_V_MSG(Ref<Image>(), vformat("Texture %s has no data.", path_str));
@@ -1699,7 +1699,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 	}
 
 	if (texture->mipmaps > 1) {
-		image->generate_mipmaps();
+		image->generate_mipmaps(false, texture->mipmaps - 1);
 	}
 
 	return image;

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -167,7 +167,7 @@ void ResourceImporterLayeredTexture::get_import_options(const String &p_path, Li
 	}
 }
 
-void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2) {
+void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2, int p_mipmap_limit) {
 	Vector<Ref<Image>> mipmap_images; //for 3D
 
 	if (mode == MODE_3D) {
@@ -259,7 +259,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 			}
 
 			if (p_mipmaps) {
-				p_images.write[i]->generate_mipmaps(p_csource == Image::COMPRESS_SOURCE_NORMAL);
+				p_images.write[i]->generate_mipmaps(p_csource == Image::COMPRESS_SOURCE_NORMAL, p_mipmap_limit);
 			} else {
 				p_images.write[i]->clear_mipmaps();
 			}
@@ -301,6 +301,7 @@ Error ResourceImporterLayeredTexture::import(ResourceUID::ID p_source_id, const 
 	bool high_quality = p_options["compress/high_quality"];
 	int hdr_compression = p_options["compress/hdr_compression"];
 	bool mipmaps = p_options["mipmaps/generate"];
+	int mipmap_limit = p_options["mipmaps/limit"];
 
 	int channel_pack = p_options["compress/channel_pack"];
 	int hslices = (p_options.has("slices/horizontal")) ? int(p_options["slices/horizontal"]) : 0;
@@ -404,6 +405,7 @@ Error ResourceImporterLayeredTexture::import(ResourceUID::ID p_source_id, const 
 	texture_import->lossy = lossy;
 	texture_import->hdr_compression = hdr_compression;
 	texture_import->mipmaps = mipmaps;
+	texture_import->mipmap_limit = mipmap_limit;
 	texture_import->used_channels = used_channels;
 	texture_import->high_quality = high_quality;
 
@@ -504,7 +506,7 @@ void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source
 	if (r_texture_import->compress_mode != COMPRESS_VRAM_COMPRESSED) {
 		// Import normally.
 		_save_tex(*r_texture_import->slices, r_texture_import->save_path + "." + extension, r_texture_import->compress_mode, r_texture_import->lossy, r_texture_import->basisu_params,
-				Image::COMPRESS_S3TC /* IGNORED */, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, false);
+				Image::COMPRESS_S3TC /* IGNORED */, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, false, r_texture_import->mipmap_limit);
 		return;
 	}
 	// Must import in all formats, in order of priority (so platform chooses the best supported one. IE, etc2 over etc).
@@ -560,7 +562,7 @@ void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source
 
 	if (use_uncompressed) {
 		_save_tex(*r_texture_import->slices, r_texture_import->save_path + "." + extension, COMPRESS_VRAM_UNCOMPRESSED, r_texture_import->lossy, r_texture_import->basisu_params,
-				Image::COMPRESS_S3TC /* IGNORED */, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, false);
+				Image::COMPRESS_S3TC /* IGNORED */, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, false, r_texture_import->mipmap_limit);
 	} else {
 		if (can_s3tc_bptc) {
 			Image::CompressMode image_compress_mode;
@@ -572,7 +574,7 @@ void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source
 				image_compress_mode = Image::COMPRESS_S3TC;
 				image_compress_format = "s3tc";
 			}
-			_save_tex(*r_texture_import->slices, r_texture_import->save_path + "." + image_compress_format + "." + extension, r_texture_import->compress_mode, r_texture_import->lossy, r_texture_import->basisu_params, image_compress_mode, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, true);
+			_save_tex(*r_texture_import->slices, r_texture_import->save_path + "." + image_compress_format + "." + extension, r_texture_import->compress_mode, r_texture_import->lossy, r_texture_import->basisu_params, image_compress_mode, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, true, r_texture_import->mipmap_limit);
 			r_texture_import->platform_variants->push_back(image_compress_format);
 		}
 
@@ -586,7 +588,7 @@ void ResourceImporterLayeredTexture::_check_compress_ctex(const String &p_source
 				image_compress_mode = Image::COMPRESS_ETC2;
 				image_compress_format = "etc2";
 			}
-			_save_tex(*r_texture_import->slices, r_texture_import->save_path + "." + image_compress_format + "." + extension, r_texture_import->compress_mode, r_texture_import->lossy, r_texture_import->basisu_params, image_compress_mode, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, true);
+			_save_tex(*r_texture_import->slices, r_texture_import->save_path + "." + image_compress_format + "." + extension, r_texture_import->compress_mode, r_texture_import->lossy, r_texture_import->basisu_params, image_compress_mode, *r_texture_import->csource, r_texture_import->used_channels, r_texture_import->mipmaps, true, r_texture_import->mipmap_limit);
 			r_texture_import->platform_variants->push_back(image_compress_format);
 		}
 	}

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -54,6 +54,7 @@ public:
 
 	int hdr_compression = 0;
 	bool mipmaps = true;
+	int mipmap_limit = -1;
 	bool high_quality = false;
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
 };
@@ -111,7 +112,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
+	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2, int p_mipmap_limit);
 
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -351,7 +351,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 	}
 }
 
-void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
+void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, int p_mipmap_limit, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 
@@ -386,7 +386,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 	}
 
 	f->store_32(flags);
-	f->store_32(p_limit_mipmap);
+	f->store_32(p_mipmap_limit);
 
 	// Reserved.
 	f->store_32(0);
@@ -405,7 +405,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 		}
 
 		if (!image->has_mipmaps() || p_force_normal) {
-			image->generate_mipmaps(p_force_normal);
+			image->generate_mipmaps(p_force_normal, p_mipmap_limit);
 		}
 
 	} else {
@@ -712,7 +712,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 
 	// Mipmaps.
 	const bool mipmaps = p_options["mipmaps/generate"];
-	const uint32_t mipmap_limit = mipmaps ? uint32_t(p_options["mipmaps/limit"]) : uint32_t(-1);
+	const int mipmap_limit = int(p_options["mipmaps/limit"]);
 
 	// Roughness.
 	const int roughness = p_options["roughness/mode"];

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -86,7 +86,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, int p_mipmap_limit, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/editor/scene/texture/texture_3d_editor_plugin.cpp
+++ b/editor/scene/texture/texture_3d_editor_plugin.cpp
@@ -164,8 +164,8 @@ void Texture3DEditor::_update_gui() {
 	const String format_name = Image::get_format_name(format);
 
 	if (texture->has_mipmaps()) {
-		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), format);
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true) * texture->get_depth();
+		const int mip_count = texture->get_mipmap_count();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true, mip_count) * texture->get_depth();
 
 		info->set_text(vformat(String::utf8("%d×%d×%d %s\n") + TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
 				texture->get_width(),

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -224,8 +224,8 @@ void TextureLayeredEditor::_update_gui() {
 	}
 
 	if (texture->has_mipmaps()) {
-		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), format);
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true) * texture->get_layers();
+		const int mip_count = texture->get_mipmap_count();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true, mip_count) * texture->get_layers();
 
 		texture_info += vformat(TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
 				mip_count,

--- a/misc/extension_api_validation/4.6-stable/GH-108720.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-108720.txt
@@ -1,0 +1,8 @@
+GH-108720
+---------
+Validate extension JSON: Error: Field 'classes/Image/methods/create_empty/arguments': size changed value in new API, from 4 to 5.
+Validate extension JSON: Error: Field 'classes/Image/methods/create_from_data/arguments': size changed value in new API, from 5 to 6.
+Validate extension JSON: Error: Field 'classes/Image/methods/set_data/arguments': size changed value in new API, from 5 to 6.
+Validate extension JSON: Error: Field 'classes/Image/methods/generate_mipmaps/arguments': size changed value in new API, from 1 to 2.
+
+Optional argument added. Compatibility methods registered.

--- a/modules/astcenc/image_compress_astcenc.cpp
+++ b/modules/astcenc/image_compress_astcenc.cpp
@@ -94,7 +94,7 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 	print_verbose(vformat("astcenc: Encoding image size %dx%d to format %s%s.", width, height, Image::get_format_name(target_format), has_mipmaps ? ", with mipmaps" : ""));
 
 	// Initialize astcenc.
-	const int64_t dest_size = Image::get_image_data_size(width, height, target_format, has_mipmaps);
+	const int64_t dest_size = Image::get_image_data_size(width, height, target_format, true, r_img->get_mipmap_count());
 	Vector<uint8_t> dest_data;
 	dest_data.resize(dest_size);
 	uint8_t *dest_write = dest_data.ptrw();
@@ -116,7 +116,7 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 	ERR_FAIL_COND_MSG(status != ASTCENC_SUCCESS,
 			vformat("astcenc: Context allocation failed: %s.", astcenc_get_error_string(status)));
 
-	const int mip_count = has_mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
+	const int mip_count = r_img->get_mipmap_count();
 	const uint8_t *src_data = r_img->ptr();
 
 	for (int i = 0; i < mip_count + 1; i++) {
@@ -168,7 +168,7 @@ void _compress_astc(Image *r_img, Image::ASTCFormat p_format) {
 	astcenc_context_free(context);
 
 	// Replace original image with compressed one.
-	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
+	r_img->set_data(width, height, true, target_format, dest_data, mip_count);
 
 	print_verbose(vformat("astcenc: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
@@ -231,17 +231,16 @@ void _decompress_astc(Image *r_img) {
 
 	const Image::Format target_format = is_hdr ? Image::FORMAT_RGBAH : Image::FORMAT_RGBA8;
 
-	const bool has_mipmaps = r_img->has_mipmaps();
 	int width = r_img->get_width();
 	int height = r_img->get_height();
 
-	const int64_t dest_size = Image::get_image_data_size(width, height, target_format, has_mipmaps);
+	const int64_t dest_size = Image::get_image_data_size(width, height, target_format, true, r_img->get_mipmap_count());
 	Vector<uint8_t> dest_data;
 	dest_data.resize(dest_size);
 	uint8_t *dest_write = dest_data.ptrw();
 
 	// Decompress image.
-	const int mip_count = has_mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
+	const int mip_count = r_img->get_mipmap_count();
 	const uint8_t *src_data = r_img->ptr();
 
 	for (int i = 0; i < mip_count + 1; i++) {
@@ -284,7 +283,7 @@ void _decompress_astc(Image *r_img) {
 	astcenc_context_free(context);
 
 	// Replace original image with compressed one.
-	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
+	r_img->set_data(width, height, true, target_format, dest_data, mip_count);
 
 	print_verbose(vformat("astcenc: Decompression took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -423,7 +423,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 
 		// Create the buffer for transcoded/decompressed data.
 		Vector<uint8_t> out_data;
-		out_data.resize(Image::get_image_data_size(transcoder.get_width(), transcoder.get_height(), image_format, transcoder.get_levels() > 1));
+		out_data.resize(Image::get_image_data_size(transcoder.get_width(), transcoder.get_height(), image_format, true, transcoder.get_levels() - 1));
 
 		uint8_t *dst = out_data.ptrw();
 		memset(dst, 0, out_data.size());
@@ -443,7 +443,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 			}
 		}
 
-		image = Image::create_from_data(transcoder.get_width(), transcoder.get_height(), transcoder.get_levels() > 1, image_format, out_data);
+		image = Image::create_from_data(transcoder.get_width(), transcoder.get_height(), true, image_format, out_data, transcoder.get_levels() - 1);
 	} else {
 		basist::basisu_transcoder transcoder;
 		ERR_FAIL_COND_V(!transcoder.validate_header(src_ptr, src_size), image);
@@ -455,7 +455,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 
 		// Create the buffer for transcoded/decompressed data.
 		Vector<uint8_t> out_data;
-		out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels > 1));
+		out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, true, basisu_info.m_total_levels - 1));
 
 		uint8_t *dst = out_data.ptrw();
 		memset(dst, 0, out_data.size());
@@ -475,7 +475,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 			}
 		}
 
-		image = Image::create_from_data(basisu_info.m_width, basisu_info.m_height, basisu_info.m_total_levels > 1, image_format, out_data);
+		image = Image::create_from_data(basisu_info.m_width, basisu_info.m_height, true, image_format, out_data, basisu_info.m_total_levels - 1);
 	}
 
 	if (needs_ra_rg_swap) {

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -273,7 +273,7 @@ void image_decompress_bcdec(Image *p_image) {
 	}
 
 	int mm_count = p_image->get_mipmap_count();
-	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(width, height, target_format, true, p_image->get_mipmap_count());
 
 	// Decompressed data.
 	Vector<uint8_t> data;
@@ -291,7 +291,7 @@ void image_decompress_bcdec(Image *p_image) {
 		decompress_image(bcdec_format, rb + src_ofs, wb + dst_ofs, mipmap_w, mipmap_h);
 	}
 
-	p_image->set_data(width, height, p_image->has_mipmaps(), target_format, data);
+	p_image->set_data(width, height, true, target_format, data, mm_count);
 
 	// Swap channels if the format is using a channel swizzle.
 	if (source_format == Image::FORMAT_DXT5_RA_AS_RG) {

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -520,11 +520,11 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		dxt1_encoding_table_buffer = compress_rd->storage_buffer_create(dxt1_encoding_table.size() * sizeof(float), Span<float>(dxt1_encoding_table).reinterpret<uint8_t>());
 	}
 
-	const int mip_count = r_img->get_mipmap_count() + 1;
+	const int mip_count = r_img->get_mipmap_count();
 
 	// Container for the compressed data.
 	Vector<uint8_t> dst_data;
-	dst_data.resize(Image::get_image_data_size(img_width, img_height, dest_format, r_img->has_mipmaps()));
+	dst_data.resize(Image::get_image_data_size(img_width, img_height, dest_format, true, r_img->get_mipmap_count()));
 	uint8_t *dst_data_ptr = dst_data.ptrw();
 
 	Vector<Vector<uint8_t>> src_images;
@@ -532,7 +532,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	Vector<uint8_t> *src_image_ptr = src_images.ptrw();
 
 	// Compress each mipmap.
-	for (int i = 0; i < mip_count; i++) {
+	for (int i = 0; i < mip_count + 1; i++) {
 		int width, height;
 		Image::get_image_mipmap_offset_and_dimensions(img_width, img_height, dest_format, i, width, height);
 
@@ -841,7 +841,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	src_images.clear();
 
 	// Set the compressed data to the image.
-	r_img->set_data(img_width, img_height, r_img->has_mipmaps(), dest_format, dst_data);
+	r_img->set_data(img_width, img_height, true, dest_format, dst_data, mip_count);
 
 	print_verbose(
 			vformat("Betsy: Encoding a %dx%d image with %d mipmaps as %s took %d ms.",

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -186,8 +186,8 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 	}
 
 	Vector<uint8_t> data;
-	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
-	int mm_count = p_image->has_mipmaps() ? Image::get_image_required_mipmaps(w, h, target_format) : 0;
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, true, p_image->get_mipmap_count());
+	int mm_count = p_image->get_mipmap_count();
 	data.resize(target_size);
 	int shift = Image::get_format_pixel_rshift(target_format);
 
@@ -282,7 +282,7 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_native_group_task(&_digest_job_queue, &job_queue, WorkerThreadPool::get_singleton()->get_thread_count(), -1, true, SNAME("CVTT Compress"));
 	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
-	p_image->set_data(w, h, p_image->has_mipmaps(), target_format, data);
+	p_image->set_data(w, h, true, target_format, data, mm_count);
 
 	print_verbose(vformat("CVTT: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
@@ -314,7 +314,7 @@ void image_decompress_cvtt(Image *p_image) {
 	const uint8_t *rb = p_image->get_data().ptr();
 
 	Vector<uint8_t> data;
-	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, true, p_image->get_mipmap_count());
 	int mm_count = p_image->get_mipmap_count();
 	data.resize(target_size);
 
@@ -393,5 +393,5 @@ void image_decompress_cvtt(Image *p_image) {
 		w >>= 1;
 		h >>= 1;
 	}
-	p_image->set_data(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
+	p_image->set_data(p_image->get_width(), p_image->get_height(), true, target_format, data, mm_count);
 }

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -404,7 +404,7 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 		}
 	}
 
-	return memnew(Image(p_width, p_height, p_mipmaps > 1, info.format, r_src_data));
+	return memnew(Image(p_width, p_height, true, info.format, r_src_data, p_mipmaps - 1));
 }
 
 static Vector<Ref<Image>> _dds_load_images(Ref<FileAccess> p_f, DDSFormat p_dds_format, uint32_t p_width, uint32_t p_height, uint32_t p_mipmaps, uint32_t p_pitch, uint32_t p_flags, uint32_t p_layer_count) {

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -162,7 +162,7 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	}
 
 	// Compress image data and (if required) mipmaps.
-	const bool has_mipmaps = r_img->has_mipmaps();
+	const int mip_count = r_img->get_mipmap_count();
 	int width = r_img->get_width();
 	int height = r_img->get_height();
 
@@ -196,12 +196,11 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 
 	// Create the buffer for compressed image data.
 	Vector<uint8_t> dest_data;
-	dest_data.resize(Image::get_image_data_size(width, height, target_format, has_mipmaps));
+	dest_data.resize(Image::get_image_data_size(width, height, target_format, true, mip_count));
 	uint8_t *dest_write = dest_data.ptrw();
 
 	const uint8_t *src_read = r_img->get_data().ptr();
 
-	const int mip_count = has_mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
 	Vector<uint32_t> padded_src;
 
 	for (int i = 0; i < mip_count + 1; i++) {
@@ -301,7 +300,7 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	}
 
 	// Replace original image with compressed one.
-	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
+	r_img->set_data(width, height, true, target_format, dest_data, mip_count);
 
 	print_verbose(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/etcpak/image_decompress_etcpak.cpp
+++ b/modules/etcpak/image_decompress_etcpak.cpp
@@ -215,7 +215,7 @@ void _decompress_etc(Image *p_image) {
 	}
 
 	int mm_count = p_image->get_mipmap_count();
-	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(width, height, target_format, true, mm_count);
 
 	// Decompressed data.
 	Vector<uint8_t> data;
@@ -233,7 +233,7 @@ void _decompress_etc(Image *p_image) {
 		decompress_image(etcpak_format, rb + src_ofs, wb + dst_ofs, mipmap_w, mipmap_h);
 	}
 
-	p_image->set_data(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
+	p_image->set_data(p_image->get_width(), p_image->get_height(), true, target_format, data, mm_count);
 
 	// Swap channels if the format is using a channel swizzle.
 	if (source_format == Image::FORMAT_ETC2_RA_AS_RG) {

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -549,7 +549,7 @@ static Ref<Image> load_from_file_access(Ref<FileAccess> f, Error *r_error) {
 		memcpy(src_data.ptrw() + prev_size, ktxTexture_GetData(ktx_texture) + offset, mip_size);
 	}
 
-	Ref<Image> img = memnew(Image(width, height, mipmaps - 1, format, src_data));
+	Ref<Image> img = memnew(Image(width, height, true, format, src_data, mipmaps - 1));
 	if (srgb) {
 		img->srgb_to_linear();
 	}

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -390,7 +390,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 				}
 			}
 
-			image->set_data(w, h, true, mipmap_images[0]->get_format(), img_data);
+			image->set_data(w, h, true, mipmap_images[0]->get_format(), img_data, mipmaps);
 			return image;
 		}
 
@@ -421,7 +421,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 		sh = MAX(sh >> 1, 1);
 		return img;
 	} else if (data_format == DATA_FORMAT_IMAGE) {
-		int size = Image::get_image_data_size(w, h, format, mipmaps ? true : false);
+		int size = Image::get_image_data_size(w, h, format, true, mipmaps);
 
 		for (uint32_t i = 0; i < mipmaps + 1; i++) {
 			int tw, th;
@@ -442,7 +442,7 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 				f->get_buffer(wr, data.size());
 			}
 
-			Ref<Image> image = Image::create_from_data(tw, th, mipmaps - i ? true : false, format, data);
+			Ref<Image> image = Image::create_from_data(tw, th, true, format, data, mipmaps - i);
 
 			return image;
 		}
@@ -526,15 +526,15 @@ Error CompressedTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &
 	f->get_32(); // ignored (data format)
 
 	f->get_32(); //ignored
-	int mipmap_count = f->get_32();
+	int mm_count = f->get_32();
 	f->get_32(); //ignored
 	f->get_32(); //ignored
 
-	r_mipmaps = mipmap_count != 0;
+	r_mipmaps = mm_count != 0;
 
 	r_data.clear();
 
-	for (int i = 0; i < (r_depth + mipmap_count); i++) {
+	for (int i = 0; i < (r_depth + mm_count); i++) {
 		Ref<Image> image = CompressedTexture2D::load_image_from_file(f, 0);
 		ERR_FAIL_COND_V(image.is_null() || image->is_empty(), ERR_CANT_OPEN);
 		if (i == 0) {
@@ -570,8 +570,8 @@ Error CompressedTexture3D::load(const String &p_path) {
 	w = tw;
 	h = th;
 	d = td;
-	mipmaps = tmm;
 	format = tfmt;
+	mipmap_count = tmm ? Image::get_image_required_mipmaps(w, h, format) : 0;
 
 	path_to_file = p_path;
 
@@ -602,7 +602,11 @@ int CompressedTexture3D::get_depth() const {
 }
 
 bool CompressedTexture3D::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
+}
+
+int CompressedTexture3D::get_mipmap_count() const {
+	return mipmap_count;
 }
 
 RID CompressedTexture3D::get_rid() const {
@@ -753,7 +757,7 @@ Error CompressedTextureLayered::load(const String &p_path) {
 
 	w = images[0]->get_width();
 	h = images[0]->get_height();
-	mipmaps = images[0]->has_mipmaps();
+	mipmap_count = images[0]->get_mipmap_count();
 	format = images[0]->get_format();
 	layers = images.size();
 
@@ -786,7 +790,11 @@ int CompressedTextureLayered::get_layers() const {
 }
 
 bool CompressedTextureLayered::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
+}
+
+int CompressedTextureLayered::get_mipmap_count() const {
+	return mipmap_count;
 }
 
 TextureLayered::LayeredType CompressedTextureLayered::get_layered_type() const {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -148,7 +148,7 @@ private:
 	int w = 0;
 	int h = 0;
 	int layers = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	LayeredType layered_type = LayeredType::LAYERED_TYPE_2D_ARRAY;
 
 	virtual void reload_from_file() override;
@@ -166,6 +166,7 @@ public:
 	int get_height() const override;
 	int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;
@@ -237,7 +238,7 @@ private:
 	int w = 0;
 	int h = 0;
 	int d = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	virtual void reload_from_file() override;
 
@@ -253,6 +254,7 @@ public:
 	int get_height() const override;
 	int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -75,7 +75,7 @@ void ImageTexture::set_image(const Ref<Image> &p_image) {
 	w = p_image->get_width();
 	h = p_image->get_height();
 	format = p_image->get_format();
-	mipmaps = p_image->has_mipmaps();
+	mipmap_count = p_image->get_mipmap_count();
 
 	if (texture.is_null()) {
 		texture = RenderingServer::get_singleton()->texture_2d_create(p_image);
@@ -100,7 +100,7 @@ void ImageTexture::update(const Ref<Image> &p_image) {
 			"The new image dimensions must match the texture size.");
 	ERR_FAIL_COND_MSG(p_image->get_format() != format,
 			"The new image format must match the texture's image format.");
-	ERR_FAIL_COND_MSG(mipmaps != p_image->has_mipmaps(),
+	ERR_FAIL_COND_MSG(mipmap_count != p_image->get_mipmap_count(),
 			"The new image mipmaps configuration must match the texture's image mipmaps configuration");
 
 	RS::get_singleton()->texture_2d_update(texture, p_image);
@@ -263,7 +263,11 @@ int ImageTextureLayered::get_layers() const {
 }
 
 bool ImageTextureLayered::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
+}
+
+int ImageTextureLayered::get_mipmap_count() const {
+	return mipmap_count;
 }
 
 ImageTextureLayered::LayeredType ImageTextureLayered::get_layered_type() const {
@@ -309,14 +313,14 @@ Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 	Image::Format new_format = p_images[0]->get_format();
 	int new_width = p_images[0]->get_width();
 	int new_height = p_images[0]->get_height();
-	bool new_mipmaps = p_images[0]->has_mipmaps();
+	int new_mipmaps = p_images[0]->get_mipmap_count();
 
 	for (int i = 1; i < p_images.size(); i++) {
 		ERR_FAIL_COND_V_MSG(p_images[i]->get_format() != new_format, ERR_INVALID_PARAMETER,
 				"All images must share the same format");
 		ERR_FAIL_COND_V_MSG(p_images[i]->get_width() != new_width || p_images[i]->get_height() != new_height, ERR_INVALID_PARAMETER,
 				"All images must share the same dimensions");
-		ERR_FAIL_COND_V_MSG(p_images[i]->has_mipmaps() != new_mipmaps, ERR_INVALID_PARAMETER,
+		ERR_FAIL_COND_V_MSG(p_images[i]->get_mipmap_count() != new_mipmaps, ERR_INVALID_PARAMETER,
 				"All images must share the usage of mipmaps");
 	}
 
@@ -333,7 +337,7 @@ Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 	width = new_width;
 	height = new_height;
 	layers = new_layers;
-	mipmaps = new_mipmaps;
+	mipmap_count = new_mipmaps;
 	return OK;
 }
 
@@ -342,7 +346,7 @@ void ImageTextureLayered::update_layer(const Ref<Image> &p_image, int p_layer) {
 	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image.");
 	ERR_FAIL_COND_MSG(p_image->get_format() != format, "Image format must match texture's image format.");
 	ERR_FAIL_COND_MSG(p_image->get_width() != width || p_image->get_height() != height, "Image size must match texture's image size.");
-	ERR_FAIL_COND_MSG(p_image->has_mipmaps() != mipmaps, "Image mipmap configuration must match texture's image mipmap configuration.");
+	ERR_FAIL_COND_MSG(p_image->get_mipmap_count() != mipmap_count, "Image mipmap configuration must match texture's image mipmap configuration.");
 	ERR_FAIL_INDEX_MSG(p_layer, layers, "Layer index is out of bounds.");
 	RS::get_singleton()->texture_2d_update(texture, p_image, p_layer);
 }
@@ -401,7 +405,11 @@ int ImageTexture3D::get_depth() const {
 	return depth;
 }
 bool ImageTexture3D::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
+}
+
+int ImageTexture3D::get_mipmap_count() const {
+	return mipmap_count;
 }
 
 Error ImageTexture3D::_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data) {
@@ -436,7 +444,7 @@ Error ImageTexture3D::create(Image::Format p_format, int p_width, int p_height, 
 	width = p_width;
 	height = p_height;
 	depth = p_depth;
-	mipmaps = p_mipmaps;
+	mipmap_count = p_mipmaps ? Image::get_image_required_mipmaps(width, height, format) : 0;
 
 	return OK;
 }

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -40,7 +40,7 @@ class ImageTexture : public Texture2D {
 
 	mutable RID texture;
 	Image::Format format = Image::FORMAT_L8;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	int w = 0;
 	int h = 0;
 	Size2 size_override;
@@ -93,7 +93,7 @@ class ImageTextureLayered : public TextureLayered {
 	int width = 0;
 	int height = 0;
 	int layers = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	Error _create_from_images(const TypedArray<Image> &p_images);
 
@@ -109,6 +109,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual LayeredType get_layered_type() const override;
 
 	Error create_from_images(Vector<Ref<Image>> p_images);
@@ -131,7 +132,7 @@ class ImageTexture3D : public Texture3D {
 	int width = 1;
 	int height = 1;
 	int depth = 1;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	bool images_stored = false;
 
 	TypedArray<Image> _get_images() const;
@@ -149,6 +150,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 
 	Error create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data);
 	void update(const Vector<Ref<Image>> &p_data);

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -64,10 +64,10 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 	compression_mode = CompressionMode(decode_uint16(data));
 	DataFormat data_format = DataFormat(decode_uint16(data + 2));
 	format = Image::Format(decode_uint32(data + 4));
-	uint32_t mipmap_count = decode_uint32(data + 8);
+	uint32_t mip_count = decode_uint32(data + 8);
 	size.width = decode_uint32(data + 12);
 	size.height = decode_uint32(data + 16);
-	mipmaps = mipmap_count > 1;
+	mipmap_count = (int)mip_count - 1;
 
 	data += 20;
 	data_size -= 20;
@@ -90,7 +90,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 			Vector<uint8_t> image_data;
 
 			ERR_FAIL_COND(data_size < 4);
-			for (uint32_t i = 0; i < mipmap_count; i++) {
+			for (uint32_t i = 0; i < mip_count; i++) {
 				uint32_t mipsize = decode_uint32(data);
 				data += 4;
 				data_size -= 4;
@@ -108,7 +108,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 				data_size -= mipsize;
 			}
 
-			image.instantiate(size.width, size.height, mipmaps, format, image_data);
+			image.instantiate(size.width, size.height, true, format, image_data, mipmap_count);
 
 		} break;
 		case COMPRESSION_MODE_BASIS_UNIVERSAL: {
@@ -120,7 +120,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 		case COMPRESSION_MODE_ETC2:
 		case COMPRESSION_MODE_BPTC:
 		case COMPRESSION_MODE_ASTC: {
-			image.instantiate(size.width, size.height, mipmaps, format, p_data.slice(20));
+			image.instantiate(size.width, size.height, true, format, p_data.slice(20), mipmap_count);
 		} break;
 	}
 	ERR_FAIL_COND(image.is_null());

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -63,7 +63,7 @@ private:
 	Vector<uint8_t> compressed_buffer;
 	Size2 size;
 	Size2 size_override;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	Image::Format format = Image::FORMAT_L8;
 
 	mutable RID texture;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -194,6 +194,12 @@ bool Texture3D::has_mipmaps() const {
 	return ret;
 }
 
+int Texture3D::get_mipmap_count() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_mipmap_count, ret);
+	return ret;
+}
+
 Vector<Ref<Image>> Texture3D::get_data() const {
 	TypedArray<Image> ret;
 	GDVIRTUAL_CALL(_get_data, ret);
@@ -211,6 +217,7 @@ void Texture3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Texture3D::get_height);
 	ClassDB::bind_method(D_METHOD("get_depth"), &Texture3D::get_depth);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Texture3D::has_mipmaps);
+	ClassDB::bind_method(D_METHOD("get_mipmap_count"), &Texture3D::get_mipmap_count);
 	ClassDB::bind_method(D_METHOD("get_data"), &Texture3D::_get_datai);
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture3D::create_placeholder);
 
@@ -219,6 +226,7 @@ void Texture3D::_bind_methods() {
 	GDVIRTUAL_BIND(_get_height);
 	GDVIRTUAL_BIND(_get_depth);
 	GDVIRTUAL_BIND(_has_mipmaps);
+	GDVIRTUAL_BIND(_get_mipmap_count);
 	GDVIRTUAL_BIND(_get_data);
 }
 
@@ -265,6 +273,12 @@ bool TextureLayered::has_mipmaps() const {
 	return ret;
 }
 
+int TextureLayered::get_mipmap_count() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_mipmap_count, ret);
+	return ret;
+}
+
 Ref<Image> TextureLayered::get_layer_data(int p_layer) const {
 	Ref<Image> ret;
 	GDVIRTUAL_CALL(_get_layer_data, p_layer, ret);
@@ -278,6 +292,7 @@ void TextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &TextureLayered::get_height);
 	ClassDB::bind_method(D_METHOD("get_layers"), &TextureLayered::get_layers);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &TextureLayered::has_mipmaps);
+	ClassDB::bind_method(D_METHOD("get_mipmap_count"), &TextureLayered::get_mipmap_count);
 	ClassDB::bind_method(D_METHOD("get_layer_data", "layer"), &TextureLayered::get_layer_data);
 
 	BIND_ENUM_CONSTANT(LAYERED_TYPE_2D_ARRAY);
@@ -290,5 +305,6 @@ void TextureLayered::_bind_methods() {
 	GDVIRTUAL_BIND(_get_height);
 	GDVIRTUAL_BIND(_get_layers);
 	GDVIRTUAL_BIND(_has_mipmaps);
+	GDVIRTUAL_BIND(_get_mipmap_count);
 	GDVIRTUAL_BIND(_get_layer_data, "layer_index");
 }

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -95,6 +95,7 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(int, _get_height)
 	GDVIRTUAL0RC_REQUIRED(int, _get_layers)
 	GDVIRTUAL0RC_REQUIRED(bool, _has_mipmaps)
+	GDVIRTUAL0RC_REQUIRED(int, _get_mipmap_count)
 	GDVIRTUAL1RC_REQUIRED(Ref<Image>, _get_layer_data, int)
 public:
 	enum LayeredType {
@@ -109,6 +110,7 @@ public:
 	virtual int get_height() const;
 	virtual int get_layers() const;
 	virtual bool has_mipmaps() const;
+	virtual int get_mipmap_count() const;
 	virtual Ref<Image> get_layer_data(int p_layer) const;
 };
 
@@ -127,6 +129,7 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(int, _get_height)
 	GDVIRTUAL0RC_REQUIRED(int, _get_depth)
 	GDVIRTUAL0RC_REQUIRED(bool, _has_mipmaps)
+	GDVIRTUAL0RC_REQUIRED(int, _get_mipmap_count)
 	GDVIRTUAL0RC_REQUIRED(TypedArray<Image>, _get_data)
 public:
 	virtual Image::Format get_format() const;
@@ -134,6 +137,7 @@ public:
 	virtual int get_height() const;
 	virtual int get_depth() const;
 	virtual bool has_mipmaps() const;
+	virtual int get_mipmap_count() const;
 	virtual Vector<Ref<Image>> get_data() const;
 	virtual Ref<Resource> create_placeholder() const;
 };

--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -163,6 +163,10 @@ bool TextureLayeredRD::has_mipmaps() const {
 	return mipmaps > 1;
 }
 
+int TextureLayeredRD::get_mipmap_count() const {
+	return mipmaps;
+}
+
 RID TextureLayeredRD::get_rid() const {
 	if (texture_rid.is_null()) {
 		// We are in trouble, create something temporary.
@@ -288,6 +292,10 @@ int Texture3DRD::get_depth() const {
 
 bool Texture3DRD::has_mipmaps() const {
 	return mipmaps > 1;
+}
+
+int Texture3DRD::get_mipmap_count() const {
+	return mipmaps;
 }
 
 RID Texture3DRD::get_rid() const {

--- a/scene/resources/texture_rd.h
+++ b/scene/resources/texture_rd.h
@@ -89,6 +89,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
@@ -146,6 +147,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	void set_texture_rd_rid(RID p_texture_rd_rid);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1012,7 +1012,7 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 	{
 		int valid_width = 0;
 		int valid_height = 0;
-		bool valid_mipmaps = false;
+		int valid_mipmaps = 0;
 		Image::Format valid_format = Image::FORMAT_MAX;
 
 		for (int i = 0; i < p_layers.size(); i++) {
@@ -1022,12 +1022,12 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 				valid_width = p_layers[i]->get_width();
 				valid_height = p_layers[i]->get_height();
 				valid_format = p_layers[i]->get_format();
-				valid_mipmaps = p_layers[i]->has_mipmaps();
+				valid_mipmaps = p_layers[i]->get_mipmap_count();
 			} else {
 				ERR_FAIL_COND(p_layers[i]->get_width() != valid_width);
 				ERR_FAIL_COND(p_layers[i]->get_height() != valid_height);
 				ERR_FAIL_COND(p_layers[i]->get_format() != valid_format);
-				ERR_FAIL_COND(p_layers[i]->has_mipmaps() != valid_mipmaps);
+				ERR_FAIL_COND(p_layers[i]->get_mipmap_count() != valid_mipmaps);
 			}
 
 			images.push_back(_validate_texture_format(p_layers[i], ret_format));
@@ -1854,10 +1854,10 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 			ndp[ofs * 4 + 2] = Math::make_half_float(float(b) / 1023.0);
 			ndp[ofs * 4 + 3] = Math::make_half_float(float(a) / 3.0);
 		}
-		image = Image::create_from_data(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, new_data);
-	} else {
-		image = Image::create_from_data(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, data);
+		data = new_data;
 	}
+
+	image = Image::create_from_data(tex->width, tex->height, true, tex->validated_format, data, tex->mipmaps - 1);
 
 	if (image->is_empty()) {
 		const String &path_str = tex->path.is_empty() ? "with no path" : vformat("with path '%s'", tex->path);
@@ -1883,7 +1883,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 
 	Vector<uint8_t> data = RD::get_singleton()->texture_get_data(tex->rd_texture, p_layer);
 	ERR_FAIL_COND_V(data.is_empty(), Ref<Image>());
-	Ref<Image> image = Image::create_from_data(tex->width, tex->height, tex->mipmaps > 1, tex->validated_format, data);
+	Ref<Image> image = Image::create_from_data(tex->width, tex->height, true, tex->validated_format, data, tex->mipmaps - 1);
 	if (image->is_empty()) {
 		const String &path_str = tex->path.is_empty() ? "with no path" : vformat("with path '%s'", tex->path);
 		ERR_FAIL_V_MSG(Ref<Image>(), vformat("Texture %s has no data.", path_str));
@@ -2070,7 +2070,7 @@ void TextureStorage::texture_debug_usage(List<RenderingServerTypes::TextureInfo>
 		tinfo.format = t->format;
 		tinfo.width = t->width;
 		tinfo.height = t->height;
-		tinfo.bytes = Image::get_image_data_size(t->width, t->height, t->format, t->mipmaps > 1);
+		tinfo.bytes = Image::get_image_data_size(t->width, t->height, t->format, true, t->mipmaps - 1);
 		tinfo.type = static_cast<RSE::TextureType>(t->type);
 
 		switch (t->type) {

--- a/tests/core/io/test_image.cpp
+++ b/tests/core/io/test_image.cpp
@@ -487,4 +487,31 @@ TEST_CASE("[Image] Convert image") {
 	CHECK_MESSAGE(image2->get_data() == image_data, "Image conversion to invalid type (Image::FORMAT_MAX + 1) should not alter image.");
 }
 
+TEST_CASE("[Image] Partial mipmaps") {
+	Ref<Image> image;
+	image.instantiate(256, 256, true, Image::FORMAT_RGBA8, 3);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+
+	image->rotate_90(CLOCKWISE);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+	image->rotate_90(COUNTERCLOCKWISE);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+	image->rotate_180();
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+
+	image->convert(Image::FORMAT_RGBAF);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+
+	image->clear_mipmaps();
+	CHECK_MESSAGE(image->get_mipmap_count() == 0, "The image's mipmap count should be equal to 0.");
+
+	image->generate_mipmaps(false, 1);
+	CHECK_MESSAGE(image->get_mipmap_count() == 1, "The image's mipmap count should be equal to 1.");
+
+	image->convert(Image::FORMAT_RGBA8);
+	image->generate_mipmaps(false, 3);
+	image->compress(Image::COMPRESS_ASTC);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+}
+
 } // namespace TestImage


### PR DESCRIPTION
Supersedes #96654
Fixes #96635
Fixes #63934

Changes the internal implementation of mipmaps in images to rely on a numeric `mipmap_count` property instead of a `mipmaps` bool.

Some methods now have an optional argument that controls the number of the mipmaps: `set_data`,  `create_empty`,  and `create_from_data`.

3D Textures have not been adjusted for this change, since the way they are constructed is slightly different from the 2D ones.

The `mipmap_limit` property in texture importers now works properly.

TODO:
- [x] Tests,
- [x] Add support for KTX files,
- [x] Add a testing project.
- [x] Fix compatibility bindings

Testing project:
[partial-mipmap-chain.zip](https://github.com/user-attachments/files/21330640/partial-mipmap-chain.zip)

