### PR TITLE
Deprecate updown icon

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -133,8 +133,8 @@
 		<theme_item name="up_pressed" data_type="icon" type="Texture2D">
 			Up button icon when the button is being pressed.
 		</theme_item>
-		<theme_item name="updown" data_type="icon" type="Texture2D">
-			Single texture representing both the up and down buttons icons. It is displayed in the middle of the buttons and does not change upon interaction. It is recommended to use individual [theme_item up] and [theme_item down] graphics for better usability. This can also be used as additional decoration between the two buttons.
+		<theme_item name="updown" data_type="icon" type="Texture2D" deprecated="Use [theme_item up] and [theme_item down] instead.">
+			Single texture representing both the up and down buttons icons. It is displayed in the middle of the buttons and does not change upon interaction. If a valid icon is assigned, it will replace [theme_item up] and [theme_item down].
 		</theme_item>
 		<theme_item name="down_background" data_type="style" type="StyleBox">
 			Background style of the down button.

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -399,7 +399,9 @@ inline void SpinBox::_compute_sizes() {
 
 inline int SpinBox::_get_widest_button_icon_width() {
 	int max = 0;
+#ifndef DISABLE_DEPRECATED
 	max = MAX(max, theme_cache.updown_icon->get_width());
+#endif
 	max = MAX(max, theme_cache.up_icon->get_width());
 	max = MAX(max, theme_cache.up_hover_icon->get_width());
 	max = MAX(max, theme_cache.up_pressed_icon->get_width());
@@ -417,7 +419,6 @@ void SpinBox::_notification(int p_what) {
 			_update_text(true);
 			_compute_sizes();
 
-			RID ci = get_canvas_item();
 			Size2i size = get_size();
 
 			Ref<StyleBox> up_stylebox = theme_cache.up_base_stylebox;
@@ -457,9 +458,6 @@ void SpinBox::_notification(int p_what) {
 				down_icon_modulate = theme_cache.down_hover_icon_modulate;
 			}
 
-			int updown_icon_left = sizing_cache.buttons_left + (sizing_cache.buttons_width - theme_cache.updown_icon->get_width()) / 2;
-			int updown_icon_top = (size.height - theme_cache.updown_icon->get_height()) / 2;
-
 			// Compute center icon positions once we know which one is used.
 			int up_icon_left = sizing_cache.buttons_left + (sizing_cache.buttons_width - up_icon->get_width()) / 2;
 			int up_icon_top = (sizing_cache.button_up_height - up_icon->get_height()) / 2;
@@ -474,8 +472,16 @@ void SpinBox::_notification(int p_what) {
 			draw_style_box(up_stylebox, Rect2(sizing_cache.buttons_left, 0, sizing_cache.buttons_width, sizing_cache.button_up_height));
 			draw_style_box(down_stylebox, Rect2(sizing_cache.buttons_left, sizing_cache.second_button_top, sizing_cache.buttons_width, sizing_cache.button_down_height));
 
+#ifndef DISABLE_DEPRECATED
+			if (theme_cache.is_updown_assigned) {
+				int updown_icon_left = sizing_cache.buttons_left + (sizing_cache.buttons_width - theme_cache.updown_icon->get_width()) / 2;
+				int updown_icon_top = (size.height - theme_cache.updown_icon->get_height()) / 2;
+
+				theme_cache.updown_icon->draw(get_canvas_item(), Point2i(updown_icon_left, updown_icon_top));
+				break; // If updown is a valid texture, skip other arrows (for compatibility).
+			}
+#endif
 			// Draw arrows.
-			theme_cache.updown_icon->draw(ci, Point2i(updown_icon_left, updown_icon_top));
 			draw_texture(up_icon, Point2i(up_icon_left, up_icon_top), up_icon_modulate);
 			draw_texture(down_icon, Point2i(down_icon_left, down_icon_top), down_icon_modulate);
 
@@ -503,6 +509,9 @@ void SpinBox::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {
+#ifndef DISABLE_DEPRECATED
+			theme_cache.is_updown_assigned = !theme_cache.updown_icon->get_size().is_zero_approx();
+#endif
 			callable_mp((Control *)this, &Control::update_minimum_size).call_deferred();
 			callable_mp((Control *)get_line_edit(), &Control::update_minimum_size).call_deferred();
 		} break;
@@ -647,9 +656,9 @@ void SpinBox::_bind_methods() {
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, buttons_width);
 #ifndef DISABLE_DEPRECATED
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, SpinBox, set_min_buttons_width_from_icons);
-#endif
 
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, SpinBox, updown_icon, "updown");
+#endif
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, SpinBox, up_icon, "up");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, SpinBox, up_hover_icon, "up_hover");
 	BIND_THEME_ITEM_CUSTOM(Theme::DATA_TYPE_ICON, SpinBox, up_pressed_icon, "up_pressed");

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -102,7 +102,6 @@ class SpinBox : public Range {
 	inline int _get_widest_button_icon_width();
 
 	struct ThemeCache {
-		Ref<Texture2D> updown_icon;
 		Ref<Texture2D> up_icon;
 		Ref<Texture2D> up_hover_icon;
 		Ref<Texture2D> up_pressed_icon;
@@ -137,6 +136,8 @@ class SpinBox : public Range {
 		int field_and_buttons_separation = 0;
 		int buttons_width = 0;
 #ifndef DISABLE_DEPRECATED
+		Ref<Texture2D> updown_icon;
+		bool is_updown_assigned = false;
 		bool set_min_buttons_width_from_icons = false;
 #endif
 	} theme_cache;


### PR DESCRIPTION
Fixes #104033

When `updown` is assigned, `up` and `down` will not display, preserving compatibility when someone has a custom icon assigned.