### PR TITLE
GDExtension: Add `mem_alloc2` (and friends) so padding can be requested

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -261,6 +261,7 @@ static void gdextension_get_godot_version2(GDExtensionGodotVersion2 *r_godot_ver
 }
 
 // Memory Functions
+#ifndef DISABLE_DEPRECATED
 static void *gdextension_mem_alloc(size_t p_size) {
 	return memalloc(p_size);
 }
@@ -271,6 +272,19 @@ static void *gdextension_mem_realloc(void *p_mem, size_t p_size) {
 
 static void gdextension_mem_free(void *p_mem) {
 	memfree(p_mem);
+}
+#endif
+
+static void *gdextension_mem_alloc2(size_t p_size, GDExtensionBool p_prepad_align) {
+	return Memory::alloc_static(p_size, p_prepad_align);
+}
+
+static void *gdextension_mem_realloc2(void *p_mem, size_t p_size, GDExtensionBool p_prepad_align) {
+	return Memory::realloc_static(p_mem, p_size, p_prepad_align);
+}
+
+static void gdextension_mem_free2(void *p_mem, GDExtensionBool p_prepad_align) {
+	Memory::free_static(p_mem, p_prepad_align);
 }
 
 // Helper print functions.
@@ -1687,9 +1701,14 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(get_godot_version);
 #endif // DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(get_godot_version2);
+#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(mem_alloc);
 	REGISTER_INTERFACE_FUNC(mem_realloc);
 	REGISTER_INTERFACE_FUNC(mem_free);
+#endif // DISABLE_DEPRECATED
+	REGISTER_INTERFACE_FUNC(mem_alloc2);
+	REGISTER_INTERFACE_FUNC(mem_realloc2);
+	REGISTER_INTERFACE_FUNC(mem_free2);
 	REGISTER_INTERFACE_FUNC(print_error);
 	REGISTER_INTERFACE_FUNC(print_error_with_message);
 	REGISTER_INTERFACE_FUNC(print_warning);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -856,6 +856,7 @@ typedef void (*GDExtensionInterfaceGetGodotVersion2)(GDExtensionGodotVersion2 *r
 /**
  * @name mem_alloc
  * @since 4.1
+ * @deprecated in Godot 4.6. Use `mem_alloc2` instead.
  *
  * Allocates memory.
  *
@@ -868,6 +869,7 @@ typedef void *(*GDExtensionInterfaceMemAlloc)(size_t p_bytes);
 /**
  * @name mem_realloc
  * @since 4.1
+ * @deprecated in Godot 4.6. Use `mem_realloc2` instead.
  *
  * Reallocates memory.
  *
@@ -881,6 +883,7 @@ typedef void *(*GDExtensionInterfaceMemRealloc)(void *p_ptr, size_t p_bytes);
 /**
  * @name mem_free
  * @since 4.1
+ * @deprecated in Godot 4.6. Use `mem_free2` instead.
  *
  * Frees memory.
  *
@@ -888,7 +891,45 @@ typedef void *(*GDExtensionInterfaceMemRealloc)(void *p_ptr, size_t p_bytes);
  */
 typedef void (*GDExtensionInterfaceMemFree)(void *p_ptr);
 
-/* INTERFACE: Godot Core */
+/**
+ * @name mem_alloc2
+ * @since 4.6
+ *
+ * Allocates memory.
+ *
+ * @param p_bytes The amount of memory to allocate in bytes.
+ * @param p_pad_align If true, the returned memory will have prepadding of at least 8 bytes.
+ *
+ * @return A pointer to the allocated memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemAlloc2)(size_t p_bytes, GDExtensionBool p_pad_align);
+
+/**
+ * @name mem_realloc2
+ * @since 4.6
+ *
+ * Reallocates memory.
+ *
+ * @param p_ptr A pointer to the previously allocated memory.
+ * @param p_bytes The number of bytes to resize the memory block to.
+ * @param p_pad_align If true, the returned memory will have prepadding of at least 8 bytes.
+ *
+ * @return A pointer to the allocated memory, or NULL if unsuccessful.
+ */
+typedef void *(*GDExtensionInterfaceMemRealloc2)(void *p_ptr, size_t p_bytes, GDExtensionBool p_pad_align);
+
+/**
+ * @name mem_free2
+ * @since 4.6
+ *
+ * Frees memory.
+ *
+ * @param p_ptr A pointer to the previously allocated memory.
+ * @param p_pad_align If true, the given memory was allocated with prepadding.
+ */
+typedef void (*GDExtensionInterfaceMemFree2)(void *p_ptr, GDExtensionBool p_pad_align);
+
+//* INTERFACE: Godot Core */
 
 /**
  * @name print_error


### PR DESCRIPTION
This is part of my plan to address https://github.com/godotengine/godot-cpp/issues/1820 in godot-cpp

If we are able to request padding, then we should be able to make debug builds of GDExtensions (specifically ones using godot-cpp) not cause heap corruption when used with release builds of Godot

Given that we're towards the end of the development cycle for Godot 4.5, I'm targeting this for Godot 4.6