### PR TITLE
Document ThorVG import limitations in SVG classes/methods

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -392,6 +392,7 @@
 				Loads an image from the UTF-8 binary contents of an [b]uncompressed[/b] SVG file ([b].svg[/b]).
 				[b]Note:[/b] Beware when using compressed SVG files (like [b].svgz[/b]), they need to be [code]decompressed[/code] before loading.
 				[b]Note:[/b] This method is only available in engine builds with the SVG module enabled. By default, the SVG module is enabled, but it can be disabled at build-time using the [code]module_svg_enabled=no[/code] SCons option.
+				[b]Note:[/b] SVGs are rasterized using [url=https://www.thorvg.org/]ThorVG[/url] when importing them. [url=https://www.thorvg.org/about#:~:text=certain%20features%20remain%20unsupported%20within%20the%20current%20framework]Support is limited[/url]; complex vectors may not render correctly. [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#doc-importing-images-svg-text]Text must be converted to paths[/url]; otherwise, it won't appear in the rasterized image. You can check whether ThorVG can render a certain vector correctly using its [url=https://www.thorvg.org/viewer]web-based viewer[/url]. For complex vectors, rendering them to PNGs using [url=https://inkscape.org/]Inkscape[/url] is often a better solution. This can be automated thanks to its [url=https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Export_files]command-line interface[/url].
 			</description>
 		</method>
 		<method name="load_svg_from_string">
@@ -401,6 +402,7 @@
 			<description>
 				Loads an image from the string contents of an SVG file ([b].svg[/b]).
 				[b]Note:[/b] This method is only available in engine builds with the SVG module enabled. By default, the SVG module is enabled, but it can be disabled at build-time using the [code]module_svg_enabled=no[/code] SCons option.
+				[b]Note:[/b] SVGs are rasterized using [url=https://www.thorvg.org/]ThorVG[/url] when importing them. [url=https://www.thorvg.org/about#:~:text=certain%20features%20remain%20unsupported%20within%20the%20current%20framework]Support is limited[/url]; complex vectors may not render correctly. [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#doc-importing-images-svg-text]Text must be converted to paths[/url]; otherwise, it won't appear in the rasterized image. You can check whether ThorVG can render a certain vector correctly using its [url=https://www.thorvg.org/viewer]web-based viewer[/url]. For complex vectors, rendering them to PNGs using [url=https://inkscape.org/]Inkscape[/url] is often a better solution. This can be automated thanks to its [url=https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Export_files]command-line interface[/url].
 			</description>
 		</method>
 		<method name="load_tga_from_buffer">

--- a/doc/classes/ResourceImporterSVG.xml
+++ b/doc/classes/ResourceImporterSVG.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This importer imports [SVGTexture] resources. See also [ResourceImporterTexture] and [ResourceImporterImage].
+		[b]Note:[/b] SVGs are rasterized using [url=https://www.thorvg.org/]ThorVG[/url] when importing them. [url=https://www.thorvg.org/about#:~:text=certain%20features%20remain%20unsupported%20within%20the%20current%20framework]Support is limited[/url]; complex vectors may not render correctly. [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#doc-importing-images-svg-text]Text must be converted to paths[/url]; otherwise, it won't appear in the rasterized image. You can check whether ThorVG can render a certain vector correctly using its [url=https://www.thorvg.org/viewer]web-based viewer[/url]. For complex vectors, rendering them to PNGs using [url=https://inkscape.org/]Inkscape[/url] is often a better solution. This can be automated thanks to its [url=https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Export_files]command-line interface[/url].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/SVGTexture.xml
+++ b/doc/classes/SVGTexture.xml
@@ -5,6 +5,8 @@
 	</brief_description>
 	<description>
 		A scalable [Texture2D] based on an SVG image. [SVGTexture]s are automatically re-rasterized to match font oversampling.
+		[b]Note:[/b] This class is only available in engine builds with the SVG module enabled. By default, the SVG module is enabled, but it can be disabled at build-time using the [code]module_svg_enabled=no[/code] SCons option.
+		[b]Note:[/b] SVGs are rasterized using [url=https://www.thorvg.org/]ThorVG[/url] when importing them. [url=https://www.thorvg.org/about#:~:text=certain%20features%20remain%20unsupported%20within%20the%20current%20framework]Support is limited[/url]; complex vectors may not render correctly. [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#doc-importing-images-svg-text]Text must be converted to paths[/url]; otherwise, it won't appear in the rasterized image. You can check whether ThorVG can render a certain vector correctly using its [url=https://www.thorvg.org/viewer]web-based viewer[/url]. For complex vectors, rendering them to PNGs using [url=https://inkscape.org/]Inkscape[/url] is often a better solution. This can be automated thanks to its [url=https://wiki.inkscape.org/wiki/index.php/Using_the_Command_Line#Export_files]command-line interface[/url].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
- See also https://github.com/godotengine/godot-docs/pull/11117.

The notice on converting text to paths might be outdated now (ThorVG says it's supported), but I don't know if it can "see" the fonts the Godot project is currently using, or system fonts for that matter. It's likely better to err on the side of safety for now.

- This closes https://github.com/godotengine/godot/issues/108348.
