### PR TITLE
Add a debug version for Godot's maven central artifact

### DIFF
--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -4,6 +4,7 @@ plugins {
 }
 
 ext {
+    DEBUG_PUBLISH_ARTIFACT_ID = 'godot-debug'
     PUBLISH_ARTIFACT_ID = 'godot'
     TOOLS_PUBLISH_ARTIFACT_ID = 'godot-tools'
 }
@@ -184,6 +185,10 @@ android {
     }
 
     publishing {
+        singleVariant("templateDebug") {
+            withSourcesJar()
+            withJavadocJar()
+        }
         singleVariant("templateRelease") {
             withSourcesJar()
             withJavadocJar()

--- a/platform/android/java/scripts/publish-module.gradle
+++ b/platform/android/java/scripts/publish-module.gradle
@@ -7,6 +7,58 @@ version = PUBLISH_VERSION
 afterEvaluate {
     publishing {
         publications {
+            templateDebug(MavenPublication) {
+                from components.templateDebug
+
+                // The coordinates of the library, being set from variables that
+                // we'll set up later
+                groupId ossrhGroupId
+                artifactId DEBUG_PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
+
+                // Mostly self-explanatory metadata
+                pom {
+                    name = DEBUG_PUBLISH_ARTIFACT_ID
+                    description = 'Godot Engine Android Library - (Debug) Template Build'
+                    url = 'https://godotengine.org/'
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://github.com/godotengine/godot/blob/master/LICENSE.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'm4gr3d'
+                            name = 'Fredia Huya-Kouadio'
+                            email = 'fhuyakou@gmail.com'
+                        }
+                        developer {
+                            id = 'reduz'
+                            name = 'Juan Linietsky'
+                            email = 'reduzio@gmail.com'
+                        }
+                        developer {
+                            id = 'akien-mga'
+                            name = 'Rémi Verschelde'
+                            email = 'rverschelde@gmail.com'
+                        }
+                        developer {
+                            id = 'godotengine'
+                            name = 'Godot Engine contributors'
+                            email = 'contact@godotengine.org'
+                        }
+                    }
+
+                    // Version control info - if you're using GitHub, follow the
+                    // format as seen here
+                    scm {
+                        connection = 'scm:git:github.com/godotengine/godot.git'
+                        developerConnection = 'scm:git:ssh://github.com/godotengine/godot.git'
+                        url = 'https://github.com/godotengine/godot/tree/master'
+                    }
+                }
+            }
             templateRelease(MavenPublication) {
                 from components.templateRelease
 


### PR DESCRIPTION
This is a workaround to the issue described in https://github.com/godotengine/godot-cpp/issues/1820 and provide users of the Godot Android library with an alternate artifact that they can use in their development process.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
