### PR TITLE
Fix scene tree node folding

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -399,9 +399,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 
 	if (can_rename) {
 		bool collapsed = p_node->is_displayed_folded();
-		if (collapsed) {
-			p_item->set_collapsed(true);
-		}
+		p_item->set_collapsed(collapsed);
 	}
 
 	Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(p_node, "Node");


### PR DESCRIPTION
A small edit that fixes expanding a node folding in scene tree editor.
The problem was calling `set_display_folded` and emitting `editor_state_changed` was collapsing the node but not expanding it.