### PR TITLE
Fix: Prevents crash when thread counts is set to zero.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -345,6 +345,10 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 		}
 	}
 
+	if (p_name == StringName("threading/worker_pool/max_threads") && int(p_value) == 0) {
+		props[p_name].variant = -1;
+	}
+
 	_queue_changed();
 	return true;
 }

--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -762,7 +762,7 @@ void WorkerThreadPool::init(int p_thread_count, float p_low_priority_task_ratio)
 
 	runlevel = RUNLEVEL_NORMAL;
 
-	if (p_thread_count < 0) {
+	if (p_thread_count <= 0) {
 		p_thread_count = OS::get_singleton()->get_default_thread_pool_size();
 	}
 


### PR DESCRIPTION
Prevents user from setting zero thread counts via GUI, and the worker thread pool will auto detect thread count if it is set to zero.

Fixes #107733 
