### PR TITLE
Workaround: use set(0, -2) to disable angular limit (halfRange < 0)

### DIFF
--- a/modules/bullet/hinge_joint_bullet.cpp
+++ b/modules/bullet/hinge_joint_bullet.cpp
@@ -146,7 +146,7 @@ void HingeJointBullet::set_flag(PhysicsServer::HingeJointFlag p_flag, bool p_val
 	switch (p_flag) {
 		case PhysicsServer::HINGE_JOINT_FLAG_USE_LIMIT:
 			if (!p_value) {
-				hingeConstraint->setLimit(-Math_PI, Math_PI);
+				hingeConstraint->setLimit(0, -2);
 			}
 			break;
 		case PhysicsServer::HINGE_JOINT_FLAG_ENABLE_MOTOR:


### PR DESCRIPTION
Avoids using set(-PI, PI), which incorrectly results in halfRange = PI and hasLimit() returning true.

Using set(0, -2) causes halfRange = -1, which disables the limit as intended (halfRange < 0 → no limit).

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
