### PR TITLE
Implement `Edit in Compatibility` in project manager

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -667,27 +667,6 @@ void ProjectManager::_open_selected_projects_check_recovery_mode() {
 		return;
 	}
 
-	_open_selected_projects_check_compatibility();
-}
-
-void ProjectManager::_open_selected_projects_check_compatibility() {
-	Vector<ProjectList::Item> selected_projects = project_list->get_selected_projects();
-
-	if (selected_projects.is_empty()) {
-		return;
-	}
-
-	const ProjectList::Item &project = selected_projects[0];
-	if (project.missing) {
-		return;
-	}
-
-	open_in_compatibility = false;
-	if (project.unsupported_features.has("Forward Plus") || project.unsupported_features.has("Mobile")) {
-		_open_compatibility_ask(false);
-		return;
-	}
-
 	_open_selected_projects_check_warnings();
 }
 

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -188,7 +188,6 @@ class ProjectManager : public Control {
 	void _open_selected_projects_with_migration();
 	void _open_selected_projects_check_warnings();
 	void _open_selected_projects_check_recovery_mode();
-	void _open_selected_projects_check_compatibility();
 
 	void _install_project(const String &p_zip_path, const String &p_title);
 	void _import_project();

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -177,6 +177,7 @@ class ProjectManager : public Control {
 	ConfirmationDialog *multi_open_ask = nullptr;
 	ConfirmationDialog *multi_run_ask = nullptr;
 	ConfirmationDialog *open_recovery_mode_ask = nullptr;
+	ConfirmationDialog *open_compatibility_ask = nullptr;
 
 	ProjectDialog *project_dialog = nullptr;
 
@@ -187,6 +188,7 @@ class ProjectManager : public Control {
 	void _open_selected_projects_with_migration();
 	void _open_selected_projects_check_warnings();
 	void _open_selected_projects_check_recovery_mode();
+	void _open_selected_projects_check_compatibility();
 
 	void _install_project(const String &p_zip_path, const String &p_title);
 	void _import_project();
@@ -201,6 +203,7 @@ class ProjectManager : public Control {
 	void _update_project_buttons();
 	void _open_options_popup();
 	void _open_recovery_mode_ask(bool manual = false);
+	void _open_compatibility_ask(bool manual = false);
 
 	void _on_project_created(const String &dir, bool edit);
 	void _on_project_duplicated(const String &p_original_path, const String &p_duplicate_path, bool p_edit);
@@ -208,6 +211,8 @@ class ProjectManager : public Control {
 	void _on_open_options_selected(int p_option);
 	void _on_recovery_mode_popup_open_normal();
 	void _on_recovery_mode_popup_open_recovery();
+	void _on_compatibility_popup_open_normal();
+	void _on_compatibility_popup_open_compatibility();
 
 	void _on_order_option_changed(int p_idx);
 	void _on_search_term_changed(const String &p_term);
@@ -248,6 +253,7 @@ class ProjectManager : public Control {
 
 	String version_convert_feature;
 	bool open_in_recovery_mode = false;
+	bool open_in_compatibility = false;
 	bool open_in_verbose_mode = false;
 
 #ifndef DISABLE_DEPRECATED

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1944,6 +1944,10 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Win
 									"If possible, consider updating your video card drivers or using the OpenGL 3 driver.\n\n"
 									"You can enable the OpenGL 3 driver by starting the engine from the\n"
 									"command line with the command:\n\n    \"%s\" --rendering-driver opengl3\n\n"
+#ifdef TOOLS_ENABLED
+									"Or you can also click the \"Edit in Compatibility\" sub-option\n"
+									"under the \"Edit\" button in the Project Manager.\n\n"
+#endif
 									"If you recently updated your video card drivers, try rebooting.",
 									executable_name),
 							"Unable to initialize Vulkan video driver");

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -7050,6 +7050,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 									"If possible, consider updating your video card drivers or using the OpenGL 3 driver.\n\n"
 									"You can enable the OpenGL 3 driver by starting the engine from the\n"
 									"command line with the command:\n\n    \"%s\" --rendering-driver opengl3\n\n"
+#ifdef TOOLS_ENABLED
+									"Or you can also click the \"Edit in Compatibility\" sub-option\n"
+									"under the \"Edit\" button in the Project Manager.\n\n"
+#endif
 									"If you recently updated your video card drivers, try rebooting.",
 									executable_name),
 							"Unable to initialize Vulkan video driver");

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3538,7 +3538,12 @@ DisplayServer *DisplayServerMacOS::create_func(const String &p_rendering_driver,
 					vformat("Your video card drivers seem not to support the required Vulkan version.\n\n"
 							"If possible, consider updating your macOS version or using the OpenGL 3 driver.\n\n"
 							"You can enable the OpenGL 3 driver by starting the engine from the\n"
-							"command line with the command:\n\n    %s",
+							"command line with the command:\n\n    %s\n\n"
+#ifdef TOOLS_ENABLED
+							"Or you can also click the \"Edit in Compatibility\" sub-option\n"
+							"under the \"Edit\" button in the Project Manager.\n\n"
+#endif
+							,
 							executable_command),
 					"Unable to initialize Vulkan video driver");
 		} else {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7280,6 +7280,10 @@ DisplayServer *DisplayServerWindows::create_func(const String &p_rendering_drive
 							"If possible, consider updating your video card drivers or using the OpenGL 3 driver.\n\n"
 							"You can enable the OpenGL 3 driver by starting the engine from the\n"
 							"command line with the command:\n\n    \"%s\" --rendering-driver opengl3\n\n"
+#ifdef TOOLS_ENABLED
+							"Or you can also click the \"Edit in Compatibility\" sub-option\n"
+							"under the \"Edit\" button in the Project Manager.\n\n"
+#endif
 							"If you have recently updated your video card drivers, try rebooting.",
 							String(" or ").join(drivers),
 							executable_name),


### PR DESCRIPTION
Fixes godotengine/godot-proposals#12314

Add an sub-option `Edit in Compatibility` under the Edit button in Project Manager
<img width="229" height="160" alt="d919da46e815fcbdea85df9f28daf1be" src="https://github.com/user-attachments/assets/9ace92ac-1e2f-4006-969e-8901ec8e6c3a" />

After #97142 was merged, this is not that much necessary ik
But u know, sometimes downloaded a project with `Fallback to OpenGL 3` disabled
Then you have to edit `project.godot` manually or use a cmdline argument
Just add a button, not that hard