### PR TITLE
Reference `--display-driver` and `--rendering-driver` in each other's command line details

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -576,7 +576,7 @@ void Main::print_help(const char *p_binary) {
 	}
 	OS::get_singleton()->print("].\n");
 
-	print_help_option("--display-driver <driver>", "Display driver (and rendering driver) [");
+	print_help_option("--display-driver <driver>", "Display driver (and matching --rendering-driver) [");
 	for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
 		if (i > 0) {
 			OS::get_singleton()->print(", ");
@@ -596,7 +596,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("", "Lower values make sound playback more reactive but increase CPU usage, and may result in audio cracking if the CPU can't keep up.\n");
 
 	print_help_option("--rendering-method <renderer>", "Renderer name. Requires driver support.\n");
-	print_help_option("--rendering-driver <driver>", "Rendering driver (depends on display driver).\n");
+	print_help_option("--rendering-driver <driver>", "Rendering driver (options depend on --display-driver).\n");
 	print_help_option("--gpu-index <device_index>", "Use a specific GPU (run with --verbose to get a list of available devices).\n");
 	print_help_option("--text-driver <driver>", "Text driver (used for font rendering, bidirectional support and shaping).\n");
 	print_help_option("--tablet-driver <driver>", "Pen tablet input driver.\n");


### PR DESCRIPTION
This links together the rendering and display driver documentation.

## Rationale

When going through the help docs to try and debug an issue with a different configuration, at first I only found the display driver argument, and I assumed it would need to be passed in like `--rendering-driver "x11 vulkan"` rather than requiring a separate argument.