### PR TITLE
Move Material3D conversion editor plugins to their own folder

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -143,6 +143,7 @@
 #include "editor/run/editor_run.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/run/game_view_plugin.h"
+#include "editor/scene/3d/material_3d_conversion_plugins.h"
 #include "editor/scene/3d/mesh_library_editor_plugin.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/scene/3d/root_motion_editor_plugin.h"

--- a/editor/scene/3d/material_3d_conversion_plugins.cpp
+++ b/editor/scene/3d/material_3d_conversion_plugins.cpp
@@ -1,0 +1,153 @@
+/**************************************************************************/
+/*  material_3d_conversion_plugins.cpp                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "material_3d_conversion_plugins.h"
+
+#include "editor/scene/material_editor_plugin.h"
+#include "scene/resources/3d/fog_material.h"
+#include "scene/resources/3d/sky_material.h"
+
+String StandardMaterial3DConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool StandardMaterial3DConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<StandardMaterial3D> mat = p_resource;
+	return mat.is_valid();
+}
+
+Ref<Resource> StandardMaterial3DConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	Ref<StandardMaterial3D> mat = p_resource;
+	Ref<ShaderMaterial> smat = MaterialEditor::make_shader_material(mat, false);
+	if (smat.is_null()) {
+		return smat;
+	}
+
+	List<PropertyInfo> params;
+	RS::get_singleton()->get_shader_parameter_list(mat->get_shader_rid(), &params);
+
+	for (const PropertyInfo &E : params) {
+		// Texture parameter has to be treated specially since StandardMaterial3D saved it
+		// as RID but ShaderMaterial needs Texture itself
+		Ref<Texture2D> texture = mat->get_texture_by_name(E.name);
+		if (texture.is_valid()) {
+			smat->set_shader_parameter(E.name, texture);
+		} else {
+			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+			smat->set_shader_parameter(E.name, value);
+		}
+	}
+	return smat;
+}
+
+String ORMMaterial3DConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool ORMMaterial3DConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<ORMMaterial3D> mat = p_resource;
+	return mat.is_valid();
+}
+
+Ref<Resource> ORMMaterial3DConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	Ref<ORMMaterial3D> mat = p_resource;
+	Ref<ShaderMaterial> smat = MaterialEditor::make_shader_material(mat, false);
+	if (smat.is_null()) {
+		return smat;
+	}
+
+	List<PropertyInfo> params;
+	RS::get_singleton()->get_shader_parameter_list(mat->get_shader_rid(), &params);
+
+	for (const PropertyInfo &E : params) {
+		// Texture parameter has to be treated specially since ORMMaterial3D saved it
+		// as RID but ShaderMaterial needs Texture itself
+		Ref<Texture2D> texture = mat->get_texture_by_name(E.name);
+		if (texture.is_valid()) {
+			smat->set_shader_parameter(E.name, texture);
+		} else {
+			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
+			smat->set_shader_parameter(E.name, value);
+		}
+	}
+	return smat;
+}
+
+String ProceduralSkyMaterialConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool ProceduralSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<ProceduralSkyMaterial> mat = p_resource;
+	return mat.is_valid();
+}
+
+Ref<Resource> ProceduralSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	return MaterialEditor::make_shader_material(p_resource);
+}
+
+String PanoramaSkyMaterialConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool PanoramaSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<PanoramaSkyMaterial> mat = p_resource;
+	return mat.is_valid();
+}
+
+Ref<Resource> PanoramaSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	return MaterialEditor::make_shader_material(p_resource);
+}
+
+String PhysicalSkyMaterialConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool PhysicalSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<PhysicalSkyMaterial> mat = p_resource;
+	return mat.is_valid();
+}
+
+Ref<Resource> PhysicalSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	return MaterialEditor::make_shader_material(p_resource);
+}
+
+String FogMaterialConversionPlugin::converts_to() const {
+	return "ShaderMaterial";
+}
+
+bool FogMaterialConversionPlugin::handles(const Ref<Resource> &p_resource) const {
+	Ref<FogMaterial> mat = p_resource;
+	return mat.is_valid();
+}
+
+Ref<Resource> FogMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
+	return MaterialEditor::make_shader_material(p_resource);
+}

--- a/editor/scene/3d/material_3d_conversion_plugins.h
+++ b/editor/scene/3d/material_3d_conversion_plugins.h
@@ -1,0 +1,87 @@
+/**************************************************************************/
+/*  material_3d_conversion_plugins.h                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_resource_conversion_plugin.h"
+
+class StandardMaterial3DConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(StandardMaterial3DConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+};
+
+class ORMMaterial3DConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(ORMMaterial3DConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+};
+
+class ProceduralSkyMaterialConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(ProceduralSkyMaterialConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+};
+
+class PanoramaSkyMaterialConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(PanoramaSkyMaterialConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+};
+
+class PhysicalSkyMaterialConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(PhysicalSkyMaterialConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+};
+
+class FogMaterialConversionPlugin : public EditorResourceConversionPlugin {
+	GDCLASS(FogMaterialConversionPlugin, EditorResourceConversionPlugin);
+
+public:
+	virtual String converts_to() const override;
+	virtual bool handles(const Ref<Resource> &p_resource) const override;
+	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
+};

--- a/editor/scene/material_editor_plugin.h
+++ b/editor/scene/material_editor_plugin.h
@@ -49,41 +49,13 @@ class Label;
 class MaterialEditor : public Control {
 	GDCLASS(MaterialEditor, Control);
 
-	Vector2 rot;
-
-	SubViewportContainer *vc_2d = nullptr;
-	SubViewport *viewport_2d = nullptr;
-	HBoxContainer *layout_2d = nullptr;
-	ColorRect *rect_instance = nullptr;
-
+	// Both 2D and 3D materials.
+	Ref<Material> material;
 	SubViewportContainer *vc = nullptr;
 	SubViewport *viewport = nullptr;
-	Node3D *rotation = nullptr;
-	MeshInstance3D *sphere_instance = nullptr;
-	MeshInstance3D *box_instance = nullptr;
-	MeshInstance3D *quad_instance = nullptr;
-	DirectionalLight3D *light1 = nullptr;
-	DirectionalLight3D *light2 = nullptr;
-	Camera3D *camera = nullptr;
-	Ref<CameraAttributesPractical> camera_attributes;
-
-	Ref<SphereMesh> sphere_mesh;
-	Ref<BoxMesh> box_mesh;
-	Ref<QuadMesh> quad_mesh;
-
 	VBoxContainer *layout_error = nullptr;
 	Label *error_label = nullptr;
 	bool is_unsupported_shader_mode = false;
-
-	HBoxContainer *layout_3d = nullptr;
-
-	Ref<Material> material;
-
-	Button *sphere_switch = nullptr;
-	Button *box_switch = nullptr;
-	Button *quad_switch = nullptr;
-	Button *light_1_switch = nullptr;
-	Button *light_2_switch = nullptr;
 
 	struct ThemeCache {
 		Ref<Texture2D> light_1_icon;
@@ -94,21 +66,50 @@ class MaterialEditor : public Control {
 		Ref<Texture2D> checkerboard;
 	} theme_cache;
 
+	// 2D canvas materials.
+	SubViewportContainer *vc_2d = nullptr;
+	SubViewport *viewport_2d = nullptr;
+	HBoxContainer *layout_2d = nullptr;
+	ColorRect *rect_instance = nullptr;
+
+	// 3D spatial materials.
+	Vector2 rot;
+	Node3D *rotation = nullptr;
+	MeshInstance3D *sphere_instance = nullptr;
+	MeshInstance3D *box_instance = nullptr;
+	MeshInstance3D *quad_instance = nullptr;
+	DirectionalLight3D *light1 = nullptr;
+	DirectionalLight3D *light2 = nullptr;
+	Camera3D *camera = nullptr;
+	Ref<CameraAttributesPractical> camera_attributes;
+	Ref<SphereMesh> sphere_mesh;
+	Ref<BoxMesh> box_mesh;
+	Ref<QuadMesh> quad_mesh;
+	HBoxContainer *layout_3d = nullptr;
+
+	Button *sphere_switch = nullptr;
+	Button *box_switch = nullptr;
+	Button *quad_switch = nullptr;
+	Button *light_1_switch = nullptr;
+	Button *light_2_switch = nullptr;
+
 	void _on_light_1_switch_pressed();
 	void _on_light_2_switch_pressed();
 	void _on_sphere_switch_pressed();
 	void _on_box_switch_pressed();
 	void _on_quad_switch_pressed();
 
-protected:
-	virtual void _update_theme_item_cache() override;
-	void _notification(int p_what);
-	void gui_input(const Ref<InputEvent> &p_event) override;
 	void _set_rotation(real_t p_x_degrees, real_t p_y_degrees);
 	void _store_rotation_metadata();
 	void _update_rotation();
 
+protected:
+	virtual void _update_theme_item_cache() override;
+	void _notification(int p_what);
+	void gui_input(const Ref<InputEvent> &p_event) override;
+
 public:
+	static Ref<ShaderMaterial> make_shader_material(const Ref<Material> &p_from, bool p_copy_params = true);
 	void edit(Ref<Material> p_material, const Ref<Environment> &p_env);
 	MaterialEditor();
 };
@@ -135,24 +136,6 @@ public:
 	MaterialEditorPlugin();
 };
 
-class StandardMaterial3DConversionPlugin : public EditorResourceConversionPlugin {
-	GDCLASS(StandardMaterial3DConversionPlugin, EditorResourceConversionPlugin);
-
-public:
-	virtual String converts_to() const override;
-	virtual bool handles(const Ref<Resource> &p_resource) const override;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
-};
-
-class ORMMaterial3DConversionPlugin : public EditorResourceConversionPlugin {
-	GDCLASS(ORMMaterial3DConversionPlugin, EditorResourceConversionPlugin);
-
-public:
-	virtual String converts_to() const override;
-	virtual bool handles(const Ref<Resource> &p_resource) const override;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
-};
-
 class ParticleProcessMaterialConversionPlugin : public EditorResourceConversionPlugin {
 	GDCLASS(ParticleProcessMaterialConversionPlugin, EditorResourceConversionPlugin);
 
@@ -164,42 +147,6 @@ public:
 
 class CanvasItemMaterialConversionPlugin : public EditorResourceConversionPlugin {
 	GDCLASS(CanvasItemMaterialConversionPlugin, EditorResourceConversionPlugin);
-
-public:
-	virtual String converts_to() const override;
-	virtual bool handles(const Ref<Resource> &p_resource) const override;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
-};
-
-class ProceduralSkyMaterialConversionPlugin : public EditorResourceConversionPlugin {
-	GDCLASS(ProceduralSkyMaterialConversionPlugin, EditorResourceConversionPlugin);
-
-public:
-	virtual String converts_to() const override;
-	virtual bool handles(const Ref<Resource> &p_resource) const override;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
-};
-
-class PanoramaSkyMaterialConversionPlugin : public EditorResourceConversionPlugin {
-	GDCLASS(PanoramaSkyMaterialConversionPlugin, EditorResourceConversionPlugin);
-
-public:
-	virtual String converts_to() const override;
-	virtual bool handles(const Ref<Resource> &p_resource) const override;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
-};
-
-class PhysicalSkyMaterialConversionPlugin : public EditorResourceConversionPlugin {
-	GDCLASS(PhysicalSkyMaterialConversionPlugin, EditorResourceConversionPlugin);
-
-public:
-	virtual String converts_to() const override;
-	virtual bool handles(const Ref<Resource> &p_resource) const override;
-	virtual Ref<Resource> convert(const Ref<Resource> &p_resource) const override;
-};
-
-class FogMaterialConversionPlugin : public EditorResourceConversionPlugin {
-	GDCLASS(FogMaterialConversionPlugin, EditorResourceConversionPlugin);
 
 public:
 	virtual String converts_to() const override;


### PR DESCRIPTION
As a follow-up to some recent editor organization efforts such as PR #104696, this PR does 2 things:

* Move 3D material conversion plugins to the `editor/scene/3d/` folder.
* Organize 2D and 3D specific parts inside of `MaterialEditor`.
  * Most of the moves are in the header, but I also moved the `vc->` lines to the end of those switch case blocks, and moved `set_custom_minimum_size` to the start of the constructor so it's no longer in the middle of the 3D code.

A future PR could possibly break up `MaterialEditor` into 2 editor plugins, but that would be a significant change, and I don't have a strong justification for that, the only thing I could think of is the ability to compile with 3D disabled. So, for this PR, `MaterialEditor` is still kept intact and functionally the same (briefly tested), just organized a little bit.

Since the goal stated by @AThousandShips is to do all the editor file organization at once, I've given this the 4.5 milestone, but it's also not critical for 4.5, so it could be delayed if needed.