### PR TITLE
Fix root auto-translate mode ignored for child nodes when generating POT

### DIFF
--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -106,7 +106,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 		// If `auto_translate_mode` wasn't found, that means it is set to its default value (`AUTO_TRANSLATE_MODE_INHERIT`).
 		if (!auto_translate_mode_found) {
 			int idx_last = atr_owners.size() - 1;
-			if (idx_last > 0 && parent_path.begins_with(String(atr_owners[idx_last].first))) {
+			if (idx_last >= 0 && parent_path.begins_with(String(atr_owners[idx_last].first))) {
 				auto_translating = atr_owners[idx_last].second;
 			} else {
 				atr_owners.push_back(Pair(state->get_node_path(i), true));


### PR DESCRIPTION
Fixes #108744

Currently, when trying to determine whether a node using `AUTO_TRANSLATE_MODE_INHERIT` should be extracted or not, if only one of the node's ancestors has an explicit auto-translate mode, then this record is unexpectedly ignored (see the `idx_last > 0` below).

https://github.com/godotengine/godot/blob/71a9948157dc2d5cc71fcb456c9d96656678757d/editor/translations/packed_scene_translation_parser_plugin.cpp#L106-L114

I believe this is a copy-paste error. The `if` condition is copied from the block a few lines above:

https://github.com/godotengine/godot/blob/71a9948157dc2d5cc71fcb456c9d96656678757d/editor/translations/packed_scene_translation_parser_plugin.cpp#L85-L89

If I understand correctly, this code makes sure that the array acts as a stack, making the array only contain information about the current node's ancestor nodes. When switching tree branches, it removes the previous branch's data. Since the root node is always one of the ancestor nodes, skipping it makes sense here as an optimization.

CC @YeldhamDev 