### PR TITLE
Add MicrophoneFeed with direct access to the microphone input buffer

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1598,6 +1598,8 @@
 		<member name="Marshalls" type="Marshalls" setter="" getter="">
 			The [Marshalls] singleton.
 		</member>
+		<member name="MicrophoneServer" type="MicrophoneServer" setter="" getter="">
+		</member>
 		<member name="NativeMenu" type="NativeMenu" setter="" getter="">
 			The [NativeMenu] singleton.
 			[b]Note:[/b] Only implemented on macOS.

--- a/doc/classes/MicrophoneFeed.xml
+++ b/doc/classes/MicrophoneFeed.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MicrophoneFeed" inherits="RefCounted" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A microphone feed gives you access to a single physical microphone attached to your device.
+	</brief_description>
+	<description>
+		A microphone feed gives you access to a single physical microphone attached to your device.
+		When enabled, Godot will start acquiring stereo sample frames at the [method AudioServer.get_input_mix_rate]
+		and writing them into an internal buffer of size [method get_buffer_length_frames].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_buffer_length_frames">
+			<return type="int" />
+			<description>
+				Returns the absolute size of the microphone input buffer.
+				This is set as some multiple of the audio latency and can be used to
+				estimate the minimum rate at which the frames are fetched.
+			</description>
+		</method>
+		<method name="get_frames">
+			<return type="PackedVector2Array" />
+			<param index="0" name="frames" type="int" />
+			<description>
+				Gets the next [param frames] audio samples from the internal microphone buffer.
+				The buffer is filled at the rate of [method AudioServer.get_input_mix_rate] frames per second when [member feed_is_active] is true.
+				Returns a [PackedVector2Array] containing exactly [param frames] audio samples if available, or an empty [PackedVector2Array].
+				The samples are signed floating-point PCM between [code]-1[/code] and [code]1[/code]. You will have to scale them if you want to use them as 8 or 16-bit integer samples. ([code]v = 0x7fff * samples[0].x[/code])
+			</description>
+		</method>
+		<method name="get_frames_available">
+			<return type="int" />
+			<description>
+				Returns the number of frames available to read using [method get_frames].
+			</description>
+		</method>
+		<method name="get_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the microphone's name.
+			</description>
+		</method>
+		<method name="set_name">
+			<return type="void" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Sets the microphone's name.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="feed_is_active" type="bool" setter="set_active" getter="is_active" default="false">
+			If [code]true[/code], the microphone feed is active.
+		</member>
+	</members>
+</class>

--- a/doc/classes/MicrophoneServer.xml
+++ b/doc/classes/MicrophoneServer.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="MicrophoneServer" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Server keeping track of different microphones accessible in Godot.
+	</brief_description>
+	<description>
+		The [MicrophoneServer] keeps track of different microphones accessible in Godot.
+		[b]Note:[/b] There is currently only one default microphone implemented across all the platforms.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="get_feed">
+			<return type="MicrophoneFeed" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the [MicrophoneFeed] corresponding to the microphone with the given [param index].
+			</description>
+		</method>
+		<method name="get_feed_count">
+			<return type="int" />
+			<description>
+				Returns the number of [MicrophoneFeed]s registered.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/drivers/pulseaudio/audio_driver_pulseaudio.cpp
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.cpp
@@ -762,6 +762,9 @@ void AudioDriverPulseAudio::finish_input_device() {
 }
 
 Error AudioDriverPulseAudio::input_start() {
+	if (pa_rec_str) {
+		return ERR_ALREADY_IN_USE;
+	}
 	lock();
 	Error err = init_input_device();
 	unlock();

--- a/drivers/wasapi/audio_driver_wasapi.cpp
+++ b/drivers/wasapi/audio_driver_wasapi.cpp
@@ -1004,6 +1004,10 @@ void AudioDriverWASAPI::finish() {
 }
 
 Error AudioDriverWASAPI::input_start() {
+	if (audio_input.active.is_set()) {
+		return ERR_ALREADY_IN_USE;
+	}
+
 	Error err = init_input_device();
 	if (err != OK) {
 		ERR_PRINT("WASAPI: init_input_device error");
@@ -1023,11 +1027,9 @@ Error AudioDriverWASAPI::input_stop() {
 	if (audio_input.active.is_set()) {
 		audio_input.audio_client->Stop();
 		audio_input.active.clear();
-
-		return OK;
 	}
 
-	return FAILED;
+	return OK;
 }
 
 PackedStringArray AudioDriverWASAPI::get_input_device_list() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -70,6 +70,7 @@
 #include "servers/audio_server.h"
 #include "servers/camera_server.h"
 #include "servers/display_server.h"
+#include "servers/microphone_server.h"
 #include "servers/movie_writer/movie_writer.h"
 #include "servers/register_server_types.h"
 #include "servers/rendering/rendering_server_default.h"
@@ -171,6 +172,7 @@ static SteamTracker *steam_tracker = nullptr;
 // Initialized in setup2()
 static AudioServer *audio_server = nullptr;
 static CameraServer *camera_server = nullptr;
+static MicrophoneServer *microphone_server = nullptr;
 static DisplayServer *display_server = nullptr;
 static RenderingServer *rendering_server = nullptr;
 static TextServerManager *tsman = nullptr;
@@ -3709,6 +3711,8 @@ Error Main::setup2(bool p_show_boot_logo) {
 
 	camera_server = CameraServer::create();
 
+	microphone_server = MicrophoneServer::create();
+
 	MAIN_PRINT("Main: Load Physics");
 
 	initialize_physics();
@@ -5085,6 +5089,10 @@ void Main::cleanup(bool p_force) {
 
 	if (camera_server) {
 		memdelete(camera_server);
+	}
+
+	if (microphone_server) {
+		memdelete(microphone_server);
 	}
 
 	OS::get_singleton()->finalize();

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -195,7 +195,9 @@ void AudioDriverOpenSL::_record_buffer_callback(SLAndroidSimpleBufferQueueItf qu
 void AudioDriverOpenSL::_record_buffer_callbacks(SLAndroidSimpleBufferQueueItf queueItf, void *pContext) {
 	AudioDriverOpenSL *ad = static_cast<AudioDriverOpenSL *>(pContext);
 
+	ad->lock();
 	ad->_record_buffer_callback(queueItf);
+	ad->unlock();
 }
 
 Error AudioDriverOpenSL::init_input_device() {
@@ -271,7 +273,11 @@ Error AudioDriverOpenSL::input_start() {
 	}
 
 	if (OS::get_singleton()->request_permission("RECORD_AUDIO")) {
-		return init_input_device();
+		Error err = init_input_device();
+		if (err != OK) {
+			input_stop();
+		}
+		return err;
 	}
 
 	WARN_PRINT("Unable to start audio capture - No RECORD_AUDIO permission");
@@ -279,20 +285,18 @@ Error AudioDriverOpenSL::input_start() {
 }
 
 Error AudioDriverOpenSL::input_stop() {
-	if (!recordItf || !recordBufferQueueItf) {
-		return ERR_CANT_OPEN;
+	if (recordItf) {
+		(*recordItf)->SetRecordState(recordItf, SL_RECORDSTATE_STOPPED);
+		recordItf = nullptr;
 	}
 
-	SLuint32 state;
-	SLresult res = (*recordItf)->GetRecordState(recordItf, &state);
-	ERR_FAIL_COND_V(res != SL_RESULT_SUCCESS, ERR_CANT_OPEN);
-
-	if (state != SL_RECORDSTATE_STOPPED) {
-		res = (*recordItf)->SetRecordState(recordItf, SL_RECORDSTATE_STOPPED);
-		ERR_FAIL_COND_V(res != SL_RESULT_SUCCESS, ERR_CANT_OPEN);
-
-		res = (*recordBufferQueueItf)->Clear(recordBufferQueueItf);
-		ERR_FAIL_COND_V(res != SL_RESULT_SUCCESS, ERR_CANT_OPEN);
+	if (recordBufferQueueItf) {
+		(*recordBufferQueueItf)->Clear(recordBufferQueueItf);
+		recordBufferQueueItf = nullptr;
+	}
+	if (recorder) {
+		(*recorder)->Destroy(recorder);
+		recorder = nullptr;
 	}
 
 	return OK;

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -7,6 +7,7 @@ env.servers_sources = []
 
 env.add_source_files(env.servers_sources, "audio_server.cpp")
 env.add_source_files(env.servers_sources, "camera_server.cpp")
+env.add_source_files(env.servers_sources, "microphone_server.cpp")
 env.add_source_files(env.servers_sources, "display_server.cpp")
 env.add_source_files(env.servers_sources, "navigation_server_2d.cpp")
 env.add_source_files(env.servers_sources, "navigation_server_3d.cpp")
@@ -16,6 +17,7 @@ env.add_source_files(env.servers_sources, "text_server.cpp")
 
 SConscript("audio/SCsub")
 SConscript("camera/SCsub")
+SConscript("microphone/SCsub")
 SConscript("debugger/SCsub")
 SConscript("display/SCsub")
 SConscript("extensions/SCsub")

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -109,6 +109,9 @@ void AudioDriver::input_buffer_write(int32_t sample) {
 			input_size++;
 		}
 	} else {
+		// This protection was added at https://github.com/godotengine/godot/commit/f529649cece9f08002c527fca25c45a5e66d2a4b due to a "possible crash".
+		// This cannot have happened unless two non-locked threads entered function simultaneously, which was possible when multiple calls to
+		// AudioDriver::input_start() did not raise an error condition.
 		WARN_PRINT("input_buffer_write: Invalid input_position=" + itos(input_position) + " input_buffer.size()=" + itos(input_buffer.size()));
 	}
 }

--- a/servers/microphone/SCsub
+++ b/servers/microphone/SCsub
@@ -1,0 +1,6 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+
+env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/microphone/microphone_feed.cpp
+++ b/servers/microphone/microphone_feed.cpp
@@ -1,0 +1,154 @@
+/**************************************************************************/
+/*  microphone_feed.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "microphone_feed.h"
+#include "core/config/project_settings.h"
+#include "servers/audio_server.h"
+
+void MicrophoneFeed::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_name"), &MicrophoneFeed::get_name);
+	ClassDB::bind_method(D_METHOD("set_name", "name"), &MicrophoneFeed::set_name);
+
+	ClassDB::bind_method(D_METHOD("is_active"), &MicrophoneFeed::is_active);
+	ClassDB::bind_method(D_METHOD("set_active", "active"), &MicrophoneFeed::set_active);
+
+	ClassDB::bind_method(D_METHOD("get_frames_available"), &MicrophoneFeed::get_frames_available);
+	ClassDB::bind_method(D_METHOD("get_frames", "frames"), &MicrophoneFeed::get_frames);
+	ClassDB::bind_method(D_METHOD("get_buffer_length_frames"), &MicrophoneFeed::get_buffer_length_frames);
+
+	ADD_GROUP("Feed", "feed_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "feed_is_active"), "set_active", "is_active");
+}
+
+String MicrophoneFeed::get_name() const {
+	return name;
+}
+
+void MicrophoneFeed::set_name(String p_name) {
+	name = p_name;
+}
+
+MicrophoneFeed::MicrophoneFeed() {
+	// initialize our feed
+	name = "???";
+}
+
+MicrophoneFeed::MicrophoneFeed(String p_name) {
+	// initialize our feed
+	name = p_name;
+}
+
+MicrophoneFeed::~MicrophoneFeed() {
+}
+
+bool MicrophoneFeed::is_active() const {
+	return active;
+}
+
+Error MicrophoneFeed::start_microphone() {
+	if (!GLOBAL_GET("audio/driver/enable_input")) {
+		WARN_PRINT("You must enable the project setting \"audio/driver/enable_input\" to use audio capture.");
+		return FAILED;
+	}
+
+	microphone_buffer_ofs = 0;
+	return AudioDriver::get_singleton()->input_start();
+}
+
+Error MicrophoneFeed::stop_microphone() {
+	return AudioDriver::get_singleton()->input_stop();
+}
+
+void MicrophoneFeed::set_active(bool p_is_active) {
+	Error e = OK;
+	if (p_is_active == active) {
+		// all good
+	} else if (p_is_active) {
+		// attempt to activate this feed
+		e = start_microphone();
+		if (e == OK) {
+			active = true;
+		}
+	} else {
+		// just deactivate it
+		e = stop_microphone();
+		active = false;
+	}
+	if (e != OK) {
+		WARN_PRINT("MicrophoneFeed.set_active(" + itos(p_is_active) + ") encountered error " + itos(e) + ".");
+	}
+}
+
+int MicrophoneFeed::get_frames_available() {
+	AudioDriver *ad = AudioDriver::get_singleton();
+	ad->lock();
+	int input_position = ad->get_input_position();
+	if (input_position < microphone_buffer_ofs) {
+		int buffsize = ad->get_input_buffer().size();
+		input_position += buffsize;
+	}
+	ad->unlock();
+	return (input_position - microphone_buffer_ofs) / 2;
+}
+
+int MicrophoneFeed::get_buffer_length_frames() {
+	AudioDriver *ad = AudioDriver::get_singleton();
+	ad->lock();
+	int buffsize = ad->get_input_buffer().size();
+	ad->unlock();
+	return buffsize / 2;
+}
+
+PackedVector2Array MicrophoneFeed::get_frames(int p_frames) {
+	PackedVector2Array ret;
+	AudioDriver *ad = AudioDriver::get_singleton();
+	ad->lock();
+	int input_position = ad->get_input_position();
+	Vector<int32_t> buf = ad->get_input_buffer();
+	if (input_position < microphone_buffer_ofs) {
+		input_position += buf.size();
+	}
+	if ((microphone_buffer_ofs + p_frames * 2 <= input_position) && (p_frames >= 0)) {
+		ret.resize(p_frames);
+		for (int i = 0; i < p_frames; i++) {
+			float l = (buf[microphone_buffer_ofs++] >> 16) / 32768.f;
+			if (microphone_buffer_ofs >= buf.size()) {
+				microphone_buffer_ofs = 0;
+			}
+			float r = (buf[microphone_buffer_ofs++] >> 16) / 32768.f;
+			if (microphone_buffer_ofs >= buf.size()) {
+				microphone_buffer_ofs = 0;
+			}
+			ret.write[i] = Vector2(l, r);
+		}
+	}
+	ad->unlock();
+	return ret;
+}

--- a/servers/microphone/microphone_feed.h
+++ b/servers/microphone/microphone_feed.h
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  microphone_feed.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/variant/typed_array.h"
+
+class MicrophoneFeed : public RefCounted {
+	GDCLASS(MicrophoneFeed, RefCounted);
+
+	String name; // name of our microphone feed
+
+	static void _bind_methods();
+
+protected:
+	int microphone_buffer_ofs = 0;
+	bool active;
+	Error start_microphone();
+	Error stop_microphone();
+
+public:
+	bool is_active() const;
+	void set_active(bool p_is_active);
+
+	int get_frames_available();
+	PackedVector2Array get_frames(int p_frames);
+	int get_buffer_length_frames();
+
+	String get_name() const;
+	void set_name(String p_name);
+
+	MicrophoneFeed();
+	MicrophoneFeed(String p_name);
+	virtual ~MicrophoneFeed();
+};

--- a/servers/microphone_server.cpp
+++ b/servers/microphone_server.cpp
@@ -1,0 +1,69 @@
+/**************************************************************************/
+/*  microphone_server.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "microphone_server.h"
+#include "core/variant/typed_array.h"
+#include "rendering_server.h"
+#include "servers/microphone/microphone_feed.h"
+
+////////////////////////////////////////////////////////
+// MicrophoneServer
+
+MicrophoneServer::CreateFunc MicrophoneServer::create_func = nullptr;
+
+void MicrophoneServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_feed", "index"), &MicrophoneServer::get_feed);
+	ClassDB::bind_method(D_METHOD("get_feed_count"), &MicrophoneServer::get_feed_count);
+}
+
+MicrophoneServer *MicrophoneServer::singleton = nullptr;
+
+MicrophoneServer *MicrophoneServer::get_singleton() {
+	return singleton;
+}
+
+Ref<MicrophoneFeed> MicrophoneServer::get_feed(int p_index) {
+	ERR_FAIL_INDEX_V(p_index, 1, nullptr);
+
+	return default_feed;
+}
+
+int MicrophoneServer::get_feed_count() {
+	return 1;
+}
+
+MicrophoneServer::MicrophoneServer() {
+	default_feed = memnew(MicrophoneFeed("Default"));
+	singleton = this;
+}
+
+MicrophoneServer::~MicrophoneServer() {
+	singleton = nullptr;
+}

--- a/servers/microphone_server.h
+++ b/servers/microphone_server.h
@@ -1,0 +1,79 @@
+/**************************************************************************/
+/*  microphone_server.h                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/class_db.h"
+#include "core/object/ref_counted.h"
+#include "core/os/thread_safe.h"
+#include "core/templates/rid.h"
+#include "core/variant/variant.h"
+
+/**
+	The microphone server is a singleton object that gives access to th
+	audio input buffer.
+**/
+
+class MicrophoneFeed;
+template <typename T>
+class TypedArray;
+
+class MicrophoneServer : public Object {
+	GDCLASS(MicrophoneServer, Object);
+	_THREAD_SAFE_CLASS_
+
+public:
+	typedef MicrophoneServer *(*CreateFunc)();
+
+private:
+protected:
+	static CreateFunc create_func;
+
+	Ref<MicrophoneFeed> default_feed;
+
+	static MicrophoneServer *singleton;
+
+	static void _bind_methods();
+
+public:
+	static MicrophoneServer *get_singleton();
+
+	static MicrophoneServer *create() {
+		MicrophoneServer *server = memnew(MicrophoneServer);
+		return server;
+	}
+
+	// Get our feeds.
+	Ref<MicrophoneFeed> get_feed(int p_index);
+	int get_feed_count();
+
+	MicrophoneServer();
+	~MicrophoneServer();
+};

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -58,6 +58,8 @@
 #include "debugger/servers_debugger.h"
 #include "display/native_menu.h"
 #include "display_server.h"
+#include "microphone/microphone_feed.h"
+#include "microphone_server.h"
 #include "movie_writer/movie_writer.h"
 #include "movie_writer/movie_writer_pngwav.h"
 #include "rendering/renderer_rd/framebuffer_cache_rd.h"
@@ -161,6 +163,8 @@ void register_server_types() {
 
 	GDREGISTER_CLASS(CameraServer);
 
+	GDREGISTER_CLASS(MicrophoneServer);
+
 	GDREGISTER_ABSTRACT_CLASS(RenderingDevice);
 
 	GDREGISTER_CLASS(AudioStream);
@@ -255,6 +259,8 @@ void register_server_types() {
 	GDREGISTER_CLASS(UniformSetCacheRD);
 
 	GDREGISTER_CLASS(CameraFeed);
+
+	GDREGISTER_CLASS(MicrophoneFeed);
 
 	GDREGISTER_VIRTUAL_CLASS(MovieWriter);
 
@@ -369,6 +375,7 @@ void register_server_singletons() {
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("AudioServer", AudioServer::get_singleton(), "AudioServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("CameraServer", CameraServer::get_singleton(), "CameraServer"));
+	Engine::get_singleton()->add_singleton(Engine::Singleton("MicrophoneServer", MicrophoneServer::get_singleton(), "MicrophoneServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("DisplayServer", DisplayServer::get_singleton(), "DisplayServer"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("NativeMenu", NativeMenu::get_singleton(), "NativeMenu"));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("RenderingServer", RenderingServer::get_singleton(), "RenderingServer"));


### PR DESCRIPTION
Direct access to the microphone buffer is required to reduce audio latency for the use-case of VoIP, and to repair the fundamental design flaw of connecting the audio input stream to the audio output stream under the mistaken assumption that they will always proceed at exactly the same rate for all time on every platform.  A diagram of the current design and the improved situation [can be seen here]( https://github.com/godotengine/godot/pull/105244#issuecomment-2830480213).

The following issues are illustrative of the flaw in the current design.
* Issue #80173
* Issue #95120
* Issue #86428 -- which works by packing zero values into the audio stream when the buffer under-runs, causing a degradation of the sound quality
* Issue #112836 (possibly due to the above)
* (Observed Godot3) Issue #54544 

This PR is a re-implementation of two previous attempts to find an appropriate place for the `get_microphone_frames()` function:
 * PR #100508 
 * PR #105244 

This also resolves godotengine/godot-proposals#11347 (proposal).

A comprehensive demo is at:
https://github.com/goatchurchprime/godot-demo-projects/tree/gtch/micplotfeed/audio/mic_feed

As discussed at length in the Audio Group meetings, this API is designed to future-proof for the case when there might be more than one microphone data stream, even though only a single microphone input has been hard-coded throughout the AudioDriver code on all platforms.

Accordingly, I have modeled a framework based on the `CameraServer` and `CameraFeed` objects and created the new object `MicrophoneServer` that has a single `MicrophoneFeed`. 

This `MicrophoneFeed` contains the following functions: 

```GDScript
is_active() -> bool
set_active(p_is_active : bool) -> void

get_frames_available() -> int
get_frames(p_frames ->) -> PackedVector2Array
get_buffer_length_frames() -> int
```

In the class [AudioEffectCapture](https://docs.godotengine.org/en/stable/classes/class_audioeffectcapture.html#methods), the function that is equivalent to `get_frames()` is known as `get_buffer()`.

The function `get_buffer_length_frames()` is needed to predict when the overflow condition is likely. 