### PR TITLE
Fix NavigationAgent never reaching target

### DIFF
--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -683,7 +683,7 @@ bool NavigationAgent2D::is_target_reachable() {
 }
 
 bool NavigationAgent2D::_is_target_reachable() const {
-	return target_desired_distance >= _get_final_position().distance_to(target_position);
+	return _is_within_target_distance(_get_final_position());
 }
 
 bool NavigationAgent2D::is_navigation_finished() {
@@ -853,7 +853,7 @@ bool NavigationAgent2D::_is_within_waypoint_distance(const Vector2 &p_origin) co
 }
 
 bool NavigationAgent2D::_is_within_target_distance(const Vector2 &p_origin) const {
-	return p_origin.distance_to(target_position) < target_desired_distance;
+	return p_origin.distance_to(target_position) <= target_desired_distance;
 }
 
 void NavigationAgent2D::_trigger_waypoint_reached() {

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -747,7 +747,7 @@ bool NavigationAgent3D::is_target_reachable() {
 }
 
 bool NavigationAgent3D::_is_target_reachable() const {
-	return target_desired_distance >= _get_final_position().distance_to(target_position);
+	return _is_within_target_distance(_get_final_position());
 }
 
 bool NavigationAgent3D::is_navigation_finished() {
@@ -923,7 +923,7 @@ bool NavigationAgent3D::_is_within_waypoint_distance(const Vector3 &p_origin) co
 }
 
 bool NavigationAgent3D::_is_within_target_distance(const Vector3 &p_origin) const {
-	return p_origin.distance_to(target_position) < target_desired_distance;
+	return p_origin.distance_to(target_position) <= target_desired_distance;
 }
 
 void NavigationAgent3D::_trigger_waypoint_reached() {


### PR DESCRIPTION
In the case where the distance between the last waypoint and the target position was exactly equal to `target_desired_distance`, the NavigationAgent would never reach its destination.

_is_within_target_distance would return false, but _is_target_reachable would return true. Causing navigation to never finish.

This is quite tricky to test rigorously, so I made sure it fixed the issue I was encountering with a NavigationAgent2D, while also not breaking regular navigation path.