### PR TITLE
Fix spinbox formatting to fix linking

### DIFF
--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -51,7 +51,7 @@
 		</member>
 		<member name="custom_arrow_step" type="float" setter="set_custom_arrow_step" getter="get_custom_arrow_step" default="0.0">
 			If not [code]0[/code], sets the step when interacting with the arrow buttons of the [SpinBox].
-			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member step].
+			[b]Note:[/b] [member Range.value] will still be rounded to a multiple of [member Range.step].
 		</member>
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2151,6 +2151,12 @@ def format_text_block(
                                         state,
                                     )
 
+                                elif class_def.properties[target_name].overrides is not None:
+                                    print_error(
+                                        f'{state.current_class}.xml: Invalid member reference "{link_target}" in {context_name}. The reference must point to the original definition, not to the override.',
+                                        state,
+                                    )
+
                             elif tag_state.name == "signal" and target_name not in class_def.signals:
                                 print_error(
                                     f'{state.current_class}.xml: Unresolved signal reference "{link_target}" in {context_name}.',


### PR DESCRIPTION
Right now the CI is failing for godot-docs (See the failing job [here](https://github.com/godotengine/godot-docs/actions/runs/16388498102/job/46311331676)). A line in the spinbox class is referencing a property, and doing so correctly. But the property isn't generating the proper `:ref:` it needs to be a link. See below

<img width="1195" height="476" alt="Properties" src="https://github.com/user-attachments/assets/91ec3965-74d0-4bf9-bb44-e80ef24f7c09" />

The only thing that's different about those two properties is the lack of `</member>` so I'm guessing that's the problem. Once merged we need to manually trigger a doc PR to sync the class reference and that should fix the CI, assuming this is the correct fix.