### PR TITLE
Add a conic fill mode to GradientTexture2D

### DIFF
--- a/doc/classes/GradientTexture2D.xml
+++ b/doc/classes/GradientTexture2D.xml
@@ -46,6 +46,9 @@
 		<constant name="FILL_SQUARE" value="2" enum="Fill">
 			The colors are linearly interpolated in a square pattern.
 		</constant>
+		<constant name="FILL_CONIC" value="3" enum="Fill">
+			The colors are linearly interpolated in a conic pattern.
+		</constant>
 		<constant name="REPEAT_NONE" value="0" enum="Repeat">
 			The gradient fill is restricted to the range defined by [member fill_from] to [member fill_to] offsets.
 		</constant>

--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -301,6 +301,8 @@ float GradientTexture2D::_get_gradient_offset_at(int x, int y) const {
 		ofs = (pos - fill_from).length() / (fill_to - fill_from).length();
 	} else if (fill == Fill::FILL_SQUARE) {
 		ofs = MAX(Math::abs(pos.x - fill_from.x), Math::abs(pos.y - fill_from.y)) / MAX(Math::abs(fill_to.x - fill_from.x), Math::abs(fill_to.y - fill_from.y));
+	} else if (fill == Fill::FILL_CONIC) {
+		ofs = Math::fposmod((pos - fill_from).angle() - (fill_to - fill_from).angle(), (float)Math::TAU) / Math::TAU;
 	}
 	if (repeat == Repeat::REPEAT_NONE) {
 		ofs = CLAMP(ofs, 0.0, 1.0);
@@ -441,7 +443,7 @@ void GradientTexture2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hdr"), "set_use_hdr", "is_using_hdr");
 
 	ADD_GROUP("Fill", "fill_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill", PROPERTY_HINT_ENUM, "Linear,Radial,Square"), "set_fill", "get_fill");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fill", PROPERTY_HINT_ENUM, "Linear,Radial,Square,Conic"), "set_fill", "get_fill");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "fill_from"), "set_fill_from", "get_fill_from");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "fill_to"), "set_fill_to", "get_fill_to");
 
@@ -451,6 +453,7 @@ void GradientTexture2D::_bind_methods() {
 	BIND_ENUM_CONSTANT(FILL_LINEAR);
 	BIND_ENUM_CONSTANT(FILL_RADIAL);
 	BIND_ENUM_CONSTANT(FILL_SQUARE);
+	BIND_ENUM_CONSTANT(FILL_CONIC);
 
 	BIND_ENUM_CONSTANT(REPEAT_NONE);
 	BIND_ENUM_CONSTANT(REPEAT);

--- a/scene/resources/gradient_texture.h
+++ b/scene/resources/gradient_texture.h
@@ -77,6 +77,7 @@ public:
 		FILL_LINEAR,
 		FILL_RADIAL,
 		FILL_SQUARE,
+		FILL_CONIC,
 	};
 	enum Repeat {
 		REPEAT_NONE,


### PR DESCRIPTION
A conic gradient fill mode equivalent to [CSS conic-gradient](https://developer.mozilla.org/en-US/docs/Web/CSS/gradient/conic-gradient)

<img width="1619" height="944" alt="image" src="https://github.com/user-attachments/assets/1558e236-283a-4e3c-9ccf-c20a390ec246" />