### PR TITLE
Fix SceneTreeDock crash when upgrading project files

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2925,8 +2925,11 @@ void SceneTreeDock::_selection_changed() {
 	}
 
 	// Untrack script changes in previously selected nodes.
-	for (Node *node : node_previous_selection) {
-		node->disconnect(CoreStringName(script_changed), callable_mp(this, &SceneTreeDock::_queue_update_script_button));
+	for (ObjectID instance_id : node_previous_selection) {
+		Node *node = ObjectDB::get_instance<Node>(instance_id);
+		if (node) {
+			node->disconnect(CoreStringName(script_changed), callable_mp(this, &SceneTreeDock::_queue_update_script_button));
+		}
 	}
 
 	// Track script changes in newly selected nodes.
@@ -2934,7 +2937,7 @@ void SceneTreeDock::_selection_changed() {
 	node_previous_selection.reserve(editor_selection->get_selection().size());
 	for (const KeyValue<Node *, Object *> &E : editor_selection->get_selection()) {
 		Node *node = E.key;
-		node_previous_selection.push_back(node);
+		node_previous_selection.push_back(node->get_instance_id());
 		node->connect(CoreStringName(script_changed), callable_mp(this, &SceneTreeDock::_queue_update_script_button));
 	}
 	_queue_update_script_button();

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -135,7 +135,7 @@ class SceneTreeDock : public VBoxContainer {
 
 	EditorData *editor_data = nullptr;
 	EditorSelection *editor_selection = nullptr;
-	LocalVector<Node *> node_previous_selection;
+	LocalVector<ObjectID> node_previous_selection;
 	bool update_script_button_queued = false;
 
 	List<Node *> node_clipboard;


### PR DESCRIPTION
This is a crash I noticed when upgrading project files on my small 4.5.beta project.

The `node_previous_selection` array may reference deleted objects. Selected objects stored in the `editor_selection` are not ref counted, and may be deleted at any moment.

Not sure if this is the appropriate fix, but it looks like the most robust solution to me.
I also considered adding a signal to SceneTreeDock when a selected object gets removed from the tree, but I felt this was sub-optimal and prone to errors anyways.