### PR TITLE
Fix `FindInFilesPanel` sizing issues

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -706,15 +706,19 @@ FindInFilesPanel::FindInFilesPanel() {
 		hbc->add_child(find_label);
 
 		_search_text_label = memnew(Label);
+		_search_text_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
+		_search_text_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		_search_text_label->set_focus_mode(FOCUS_ACCESSIBILITY);
+		_search_text_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 		_search_text_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 		hbc->add_child(_search_text_label);
 
 		_progress_bar = memnew(ProgressBar);
 		_progress_bar->set_h_size_flags(SIZE_EXPAND_FILL);
 		_progress_bar->set_v_size_flags(SIZE_SHRINK_CENTER);
+		_progress_bar->set_stretch_ratio(2.0);
+		_progress_bar->set_visible(false);
 		hbc->add_child(_progress_bar);
-		set_progress_visible(false);
 
 		_status_label = memnew(Label);
 		_status_label->set_focus_mode(FOCUS_ACCESSIBILITY);
@@ -812,9 +816,13 @@ void FindInFilesPanel::start_search() {
 
 	_status_label->set_text(TTRC("Searching..."));
 	_search_text_label->set_text(_finder->get_search_text());
+	_search_text_label->set_tooltip_text(_finder->get_search_text());
+
+	int label_min_width = _search_text_label->get_minimum_size().x + _search_text_label->get_character_bounds(0).size.x;
+	_search_text_label->set_custom_minimum_size(Size2(label_min_width, 0));
 
 	set_process(true);
-	set_progress_visible(true);
+	_progress_bar->set_visible(true);
 
 	_finder->start();
 
@@ -828,7 +836,7 @@ void FindInFilesPanel::stop_search() {
 
 	_status_label->set_text("");
 	update_replace_buttons();
-	set_progress_visible(false);
+	_progress_bar->set_visible(false);
 	_refresh_button->show();
 	_cancel_button->hide();
 }
@@ -967,7 +975,7 @@ void FindInFilesPanel::_on_item_edited() {
 void FindInFilesPanel::_on_finished() {
 	update_matches_text();
 	update_replace_buttons();
-	set_progress_visible(false);
+	_progress_bar->set_visible(false);
 	_refresh_button->show();
 	_cancel_button->hide();
 }
@@ -1176,10 +1184,6 @@ void FindInFilesPanel::update_matches_text() {
 	}
 
 	_status_label->set_text(results_text);
-}
-
-void FindInFilesPanel::set_progress_visible(bool p_visible) {
-	_progress_bar->set_self_modulate(Color(1, 1, 1, p_visible ? 1 : 0));
 }
 
 void FindInFilesPanel::_bind_methods() {

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -32,6 +32,7 @@
 
 #include "core/templates/hash_map.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/margin_container.h"
 
 // Performs the actual search
 class FindInFiles : public Node {
@@ -165,8 +166,8 @@ class TreeItem;
 class ProgressBar;
 
 // Display search results
-class FindInFilesPanel : public Control {
-	GDCLASS(FindInFilesPanel, Control);
+class FindInFilesPanel : public MarginContainer {
+	GDCLASS(FindInFilesPanel, MarginContainer);
 
 public:
 	static const char *SIGNAL_RESULT_SELECTED;
@@ -214,7 +215,6 @@ private:
 
 	void draw_result_text(Object *item_obj, Rect2 rect);
 
-	void set_progress_visible(bool p_visible);
 	void clear();
 
 	FindInFiles *_finder = nullptr;


### PR DESCRIPTION
Current `master`:


https://github.com/user-attachments/assets/c48248ae-d15e-432f-9d55-0c5048eb5019

This PR:


https://github.com/user-attachments/assets/dca005f2-803a-4be1-9a01-1996bc94dc94

- Text trimming with ellipses is enabled for `_search_text_label`. Unfortunately this leads to hiding all searched text when width is minimum - feel free to suggest how it could be improved.
- Now `_search_text_label` has a tooltip (to see the entire searched text if it's partially trimmed).
- `FindInFilesPanel` inherits from `MarginContainer`.

Part of long-term task started in https://github.com/godotengine/godot/pull/102301.