### PR TITLE
[macOS] Add support for exporting macOS 26 Liquid Glass icons.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -309,8 +309,13 @@ String OS::get_bundle_resource_dir() const {
 	return ".";
 }
 
-// Path to macOS .app bundle embedded icon
+// Path to macOS .app bundle embedded icon (.icns file).
 String OS::get_bundle_icon_path() const {
+	return String();
+}
+
+// Name of macOS .app bundle embedded icon (Liquid Glass asset name).
+String OS::get_bundle_icon_name() const {
 	return String();
 }
 

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -294,6 +294,7 @@ public:
 	virtual String get_temp_path() const;
 	virtual String get_bundle_resource_dir() const;
 	virtual String get_bundle_icon_path() const;
+	virtual String get_bundle_icon_name() const;
 
 	virtual String get_user_data_dir(const String &p_user_dir) const;
 	virtual String get_user_data_dir() const;

--- a/editor/inspector/editor_property_name_processor.cpp
+++ b/editor/inspector/editor_property_name_processor.cpp
@@ -148,6 +148,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["aa"] = "AA";
 	capitalize_string_remaps["aabb"] = "AABB";
 	capitalize_string_remaps["adb"] = "ADB";
+	capitalize_string_remaps["actool"] = "actool";
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["api"] = "API";
 	capitalize_string_remaps["apk"] = "APK";

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4533,8 +4533,13 @@ int Main::start() {
 				sml->add_current_scene(scene);
 
 #ifdef MACOS_ENABLED
+#ifndef TOOLS_ENABLED
+				if ((FileAccess::exists(OS::get_singleton()->get_bundle_resource_dir().path_join("Assets.car")) && !OS::get_singleton()->get_bundle_icon_name().is_empty()) || (!OS::get_singleton()->get_bundle_icon_path().is_empty())) {
+					has_icon = true; // Bundle has embedded icon, do not override with project icon.
+				}
+#endif
 				String mac_icon_path = GLOBAL_GET("application/config/macos_native_icon");
-				if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_ICON) && !mac_icon_path.is_empty()) {
+				if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_ICON) && !mac_icon_path.is_empty() && !has_icon) {
 					DisplayServer::get_singleton()->set_native_icon(mac_icon_path);
 					has_icon = true;
 				}

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -12,6 +12,7 @@
 	<string>$name</string>
 	<key>CFBundleIconFile</key>
 	<string>icon.icns</string>
+$liquid_glass_icon
 	<key>CFBundleIdentifier</key>
 	<string>$bundle_identifier</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -38,6 +38,11 @@
 		<member name="application/icon_interpolation" type="int" setter="" getter="">
 			Interpolation method used to resize application icon.
 		</member>
+		<member name="application/liquid_glass_icon" type="String" setter="" getter="">
+			macOS 26 Liquid Glass icon source file. Use [url=https://developer.apple.com/icon-composer/]Icon Composer[/url] to create Liquid Glass icons.
+			[b]Note:[/b] Supported when exporting from macOS only, Xcode 26+ required.
+			[b]Note:[/b] Liquid Glass icons are supported on macOS 26 only, use [member application/icon] to set the icon for older macOS versions.
+		</member>
 		<member name="application/min_macos_version_arm64" type="String" setter="" getter="">
 			Minimum version of macOS required for this application to run on Apple Silicon Macs, in the [code]major.minor.patch[/code] or [code]major.minor[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]).
 		</member>

--- a/platform/macos/export/export.cpp
+++ b/platform/macos/export/export.cpp
@@ -45,6 +45,8 @@ void register_macos_exporter() {
 #else
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/macos/rcodesign", PROPERTY_HINT_GLOBAL_FILE));
 #endif
+	EDITOR_DEF_BASIC("export/macos/actool", "");
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/macos/actool", PROPERTY_HINT_GLOBAL_FILE));
 #endif
 
 	Ref<EditorExportPlatformMacOS> platform;

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -85,9 +85,10 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	int menu_options = 0;
 
 	void _fix_privacy_manifest(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist);
-	void _fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary);
+	void _fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary, bool p_lg_icon_exported, const String &p_lg_icon);
 	void _make_icon(const Ref<EditorExportPreset> &p_preset, const Ref<Image> &p_icon, Vector<uint8_t> &p_data);
 
+	Error _export_liquid_glass_icon(const Ref<EditorExportPreset> &p_preset, const String &p_app_path, const String &p_icon_path);
 	Error _notarize(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	void _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, bool p_warn = true, bool p_set_id = false);
 	void _code_sign_directory(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, const String &p_helper_ent_path, bool p_should_error_on_non_code = true);

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -103,6 +103,7 @@ public:
 	virtual String get_temp_path() const override;
 	virtual String get_bundle_resource_dir() const override;
 	virtual String get_bundle_icon_path() const override;
+	virtual String get_bundle_icon_name() const override;
 	virtual String get_godot_dir_name() const override;
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -469,6 +469,19 @@ String OS_MacOS::get_bundle_icon_path() const {
 	return ret;
 }
 
+String OS_MacOS::get_bundle_icon_name() const {
+	String ret;
+
+	NSBundle *main = [NSBundle mainBundle];
+	if (main) {
+		NSString *icon_name = [[main infoDictionary] objectForKey:@"CFBundleIconName"];
+		if (icon_name) {
+			ret.append_utf8([icon_name UTF8String]);
+		}
+	}
+	return ret;
+}
+
 // Get properly capitalized engine name for system paths
 String OS_MacOS::get_godot_dir_name() const {
 	return String(GODOT_VERSION_SHORT_NAME).capitalize();


### PR DESCRIPTION
Adds option to specify new [Icon Composer](https://developer.apple.com/icon-composer/) `.icon` file on export to set liquid glass style icon for macOS 26.

Require Xcode 26 to compile icon asset catalog, if it's not an active Xcode version path to the `actool` can be set using `export/macos/actool` editor setting (e.g, to `/Applications/Xcode-beta.app/Contents/Developer/usr/bin/actool`). And only works when exporting from the macOS for the same reason.