### PR TITLE
Add missing copyright for pitch shift

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -145,6 +145,12 @@ Copyright: 2001, Robert Penner
  2007-2014, Juan Linietsky, Ariel Manzur
 License: Expat
 
+Files: servers/audio/effects/audio_effect_pitch_shift.cpp
+Copyright: 2014-present Godot Engine contributors
+ 2007-2014 Juan Linietsky, Ariel Manzur
+ 1999-2015 Stephan M. Bernsee <s.bernsee [AT] zynaptiq [DOT] com>
+License: Expat and WOL
+
 Files: ./servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
 Comment: NVidia's FXAA 3.11, simplified by Simon Rodriguez
 Copyright: 2014-2015, NVIDIA CORPORATION
@@ -2272,6 +2278,15 @@ License: Unlicense
  OTHER DEALINGS IN THE SOFTWARE.
  .
  For more information, please refer to <https://unlicense.org/>
+
+License: WOL
+                          The Wide Open License (WOL)
+ .
+ Permission to use, copy, modify, distribute and sell this software and its
+ documentation for any purpose is hereby granted without fee, provided that
+ the above copyright notice and this license appear in all source copies.
+ THIS SOFTWARE IS PROVIDED "AS IS" WITHOUT EXPRESS OR IMPLIED WARRANTY OF
+ ANY KIND. See https://dspguru.com/wide-open-license/ for more information.
 
 License: Zlib
  This software is provided 'as-is', without any express or implied


### PR DESCRIPTION
I attempted to package Godot 4.3 into Debian but the packaging was [rejected](https://alioth-lists.debian.net/pipermail/pkg-games-devel/2025-April/069027.html) by our copyright review team with the following note:

> please also mention at least Stephan M. Bernsee and the Wide Open License in your debian/copyright.

This should fix that missing copyright.