### PR TITLE
Fix `free()` can't be used in release exports

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1027,6 +1027,13 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			}
 			return true;
 		}
+
+		// "free()" is registered as a special method in virtual_methods_map, which is not available
+		// in release export, so we handle it here as a special case.
+		if (p_method == CoreStringName(free_)) {
+			*r_info = MethodInfo("free");
+			return true;
+		}
 #endif // DEBUG_ENABLED
 
 		if (p_no_inheritance) {


### PR DESCRIPTION
- Fix https://github.com/godotengine/godot/issues/73036

`free()` is registered as a special method with `ClassDB::add_virtual_method()`, but the virtual method map is excluded from non-DEBUG_ENABLED builds, meaning `free()` doesn't exist for the parser in release export and any project calling it directly will break with a parser error.