### PR TITLE
[macOS] Use "file" icon for bundles in the file dialogs.

### DIFF
--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -229,6 +229,7 @@ void EditorFileDialog::_update_theme_item_cache() {
 	theme_cache.filter_box = get_editor_theme_icon(SNAME("Search"));
 	theme_cache.file_sort_button = get_editor_theme_icon(SNAME("Sort"));
 
+	theme_cache.file = get_editor_theme_icon(SNAME("File"));
 	theme_cache.folder = get_editor_theme_icon(SNAME("Folder"));
 	theme_cache.folder_icon_color = get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog"));
 
@@ -1114,9 +1115,9 @@ void EditorFileDialog::update_file_list() {
 			item_list->add_item(dir_name);
 
 			if (display_mode == DISPLAY_THUMBNAILS) {
-				item_list->set_item_icon(-1, folder_thumbnail);
+				item_list->set_item_icon(-1, bundle ? file_thumbnail : folder_thumbnail);
 			} else {
-				item_list->set_item_icon(-1, theme_cache.folder);
+				item_list->set_item_icon(-1, bundle ? theme_cache.file : theme_cache.folder);
 			}
 
 			Dictionary d;

--- a/editor/gui/editor_file_dialog.h
+++ b/editor/gui/editor_file_dialog.h
@@ -185,6 +185,7 @@ private:
 		Ref<Texture2D> filter_box;
 		Ref<Texture2D> file_sort_button;
 
+		Ref<Texture2D> file;
 		Ref<Texture2D> folder;
 		Color folder_icon_color;
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -882,9 +882,9 @@ void FileDialog::update_file_list() {
 
 	for (const DirInfo &info : filtered_dirs) {
 		if (display_mode == DISPLAY_THUMBNAILS) {
-			file_list->add_item(info.name, theme_cache.folder_thumbnail);
+			file_list->add_item(info.name, info.bundle ? theme_cache.file_thumbnail : theme_cache.folder_thumbnail);
 		} else {
-			file_list->add_item(info.name, theme_cache.folder);
+			file_list->add_item(info.name, info.bundle ? theme_cache.file : theme_cache.folder);
 		}
 		file_list->set_item_icon_modulate(-1, theme_cache.folder_icon_color);
 


### PR DESCRIPTION
Built-in file dialogs can detect [bundles](https://en.wikipedia.org/wiki/Bundle_(macOS)) and allow selecting them as files, but were using folder icon for them, which might be confusing.

This PR changes it to use generic file icon (but with folder color) instead.

`AppIcon.icon` is bundle this screenshot:
<img width="684" height="285" alt="Screenshot 2025-07-20 at 16 43 21" src="https://github.com/user-attachments/assets/ca6223db-f762-46a1-9dce-2dbe56843efd" />
