### PR TITLE
Fix ICU support data loading

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -25,6 +25,9 @@ if "svg" in env.module_list:
     # Enable ThorVG static object linking.
     env_text_server_adv.Append(CPPDEFINES=["TVG_STATIC"])
 
+if env["builtin_icu4c"]:
+    env_text_server_adv.Append(CPPDEFINES=["HAVE_ICU_BUILTIN"])
+
 if env["builtin_harfbuzz"]:
     env_harfbuzz = env_modules.Clone()
     env_harfbuzz.disable_warnings()

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -434,7 +434,7 @@ bool TextServerAdvanced::_has(const RID &p_rid) {
 bool TextServerAdvanced::_load_support_data(const String &p_filename) {
 	_THREAD_SAFE_METHOD_
 
-#ifdef ICU_STATIC_DATA
+#if defined(ICU_STATIC_DATA) || !defined(HAVE_ICU_BUILTIN)
 	if (!icu_data_loaded) {
 		UErrorCode err = U_ZERO_ERROR;
 		u_init(&err); // Do not check for errors, since we only load part of the data.


### PR DESCRIPTION
Tried to build 4.4.1 for Debian without the static ICU data nor built-in ICU library and noticed an editor unit test failing:

```
===============================================================================
./tests/servers/test_text_server.h:43:
TEST SUITE: [TextServer]
TEST CASE:  [TextServer] Init, font loading and shaping
  [TextServer] Strip Diacritics

./tests/servers/test_text_server.h:811: ERROR: CHECK( ts->strip_diacritics(U"ٱلسَّلَامُ عَلَيْكُمْ") == U"ٱلسلام عليكم" ) is NOT correct!
  values: CHECK( ٱلسَّلَامُ عَلَيْكُمْ == [{?}, {?}, {?}, {?}, {?}, {?}, {?}, {?}, {?}, {?}, {?}, {?}, {?}] )

===============================================================================
[doctest] test cases:    1166 |    1164 passed | 2 failed | 1 skipped
[doctest] assertions: 2422710 | 2422705 passed | 5 failed |
[doctest] Status: FAILURE!
```

The `WARNING: ICU data is not loaded, Unicode security and spoofing detection disabled.` was a hint that my earlier fix (https://github.com/godotengine/godot/pull/97648) was no longer working.

I made a change to the preprocessor logic that makes sense to me, because without the static data then just `u_init` is needed because that will find the correct data at runtime. This fixes the 4.4.1 editor tests for Debian.

But the question is, why did this logic work for https://github.com/godotengine/godot/commit/3d60ce9389bab3bbb0af325a00e6773c0860f225? I inverted the logic here to fix Debian, but everything else seems to continue to pass unit tests?