### PR TITLE
Add `Callable.prebind()`

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -131,6 +131,15 @@ Callable Callable::bindp(const Variant **p_arguments, int p_argcount) const {
 	return Callable(memnew(CallableCustomBind(*this, args)));
 }
 
+Callable Callable::prebindp(const Variant **p_arguments, int p_argcount) const {
+	Vector<Variant> args;
+	args.resize(p_argcount);
+	for (int i = 0; i < p_argcount; i++) {
+		args.write[i] = *p_arguments[i];
+	}
+	return Callable(memnew(CallableCustomPrebind(*this, args)));
+}
+
 Callable Callable::bindv(const Array &p_arguments) {
 	if (p_arguments.is_empty()) {
 		return *this; // No point in creating a new callable if nothing is bound.

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -101,6 +101,7 @@ public:
 	Callable bindv(const Array &p_arguments);
 
 	Callable bindp(const Variant **p_arguments, int p_argcount) const;
+	Callable prebindp(const Variant **p_arguments, int p_argcount) const;
 	Callable unbind(int p_argcount) const;
 
 	Object *get_object() const;

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -170,6 +170,19 @@ CallableCustomBind::CallableCustomBind(const Callable &p_callable, const Vector<
 CallableCustomBind::~CallableCustomBind() {
 }
 
+void CallableCustomPrebind::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
+	const Variant **args = (const Variant **)alloca(sizeof(Variant *) * (binds.size() + p_argcount));
+	for (int i = 0; i < binds.size(); i++) {
+		args[i] = (const Variant *)&binds[i];
+	}
+	int bind_count = binds.size();
+	for (int i = 0; i < p_argcount; i++) {
+		args[i + bind_count] = (const Variant *)p_arguments[i];
+	}
+
+	callable.callp(args, p_argcount + binds.size(), r_return_value, r_call_error);
+}
+
 //////////////////////////////////
 
 uint32_t CallableCustomUnbind::hash() const {

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -34,11 +34,12 @@
 #include "core/variant/variant.h"
 
 class CallableCustomBind : public CallableCustom {
-	Callable callable;
-	Vector<Variant> binds;
-
 	static bool _equal_func(const CallableCustom *p_a, const CallableCustom *p_b);
 	static bool _less_func(const CallableCustom *p_a, const CallableCustom *p_b);
+
+protected:
+	Callable callable;
+	Vector<Variant> binds;
 
 public:
 	//for every type that inherits, these must always be the same for this type
@@ -61,6 +62,14 @@ public:
 
 	CallableCustomBind(const Callable &p_callable, const Vector<Variant> &p_binds);
 	virtual ~CallableCustomBind();
+};
+
+class CallableCustomPrebind : public CallableCustomBind {
+public:
+	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
+
+	CallableCustomPrebind(const Callable &p_callable, const Vector<Variant> &p_binds) :
+			CallableCustomBind(p_callable, p_binds) {}
 };
 
 class CallableCustomUnbind : public CallableCustom {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1201,6 +1201,11 @@ struct _VariantCall {
 		r_ret = callable->bindp(p_args, p_argcount);
 	}
 
+	static void func_Callable_prebind(Variant *v, const Variant **p_args, int p_argcount, Variant &r_ret, Callable::CallError &r_error) {
+		Callable *callable = VariantGetInternalPtr<Callable>::get_ptr(v);
+		r_ret = callable->prebindp(p_args, p_argcount);
+	}
+
 	static int func_Callable_get_argument_count(Callable *p_callable) {
 		return p_callable->get_argument_count();
 	}
@@ -2308,6 +2313,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_custom(Callable, rpc, _VariantCall::func_Callable_rpc, false, Variant);
 	bind_custom1(Callable, rpc_id, _VariantCall::func_Callable_rpc_id, Variant::INT, "peer_id");
 	bind_custom(Callable, bind, _VariantCall::func_Callable_bind, true, Callable);
+	bind_custom(Callable, prebind, _VariantCall::func_Callable_prebind, true, Callable);
 
 	/* Signal */
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/4920
Closes https://github.com/godotengine/godot-proposals/issues/10533

This is a minimal implementation for now, it's missing documentation and editor changes. I just wonder if I didn't miss anything 🤔

It does work. This prints `[1, 2, 3, 4, 5, 6]`:
```GDScript
@tool
extends EditorScript

func test(...args):
	print(args)

func _run() -> void:
	var c = test.prebind(1, 2).bind(5, 6) # Order of calls does not matter.
	c.call(3, 4)
```