### PR TITLE
Fix allow any descendant to be used as a Root Type in Scene Import

### DIFF
--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -1386,6 +1386,13 @@ Node *ResourceImporterScene::_replace_node_with_type_and_script(Node *p_node, St
 			p_script = ResourceLoader::load(ScriptServer::get_global_class_path(p_node_type));
 		}
 		p_node_type = ScriptServer::get_global_class_base(p_node_type);
+		while (!p_node_type.is_empty()) {
+			if (ScriptServer::is_global_class(p_node_type)) {
+				p_node_type = ScriptServer::get_global_class_base(p_node_type);
+			} else {
+				break;
+			}
+		}
 	}
 	if (!p_node_type.is_empty() && p_node->get_class_name() != p_node_type) {
 		// If the user specified a Godot node type that does not match


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #108809

* Bubble up the Node Type til it finds the base Godot Type, if not fails same as before.
