### PR TITLE
Optimize lossless/lossy texture channels during loading

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3409,6 +3409,67 @@ void Image::adjust_bcs(float p_brightness, float p_contrast, float p_saturation)
 	}
 }
 
+Image::Format Image::find_optimized_format(Format p_format, UsedChannels p_channels) {
+	switch (p_channels) {
+		case USED_CHANNELS_L:
+			if (p_format >= FORMAT_L8 && p_format <= FORMAT_RGB565) {
+				return FORMAT_L8;
+			} else if (p_format >= FORMAT_RF && p_format <= FORMAT_RGBAF) {
+				return FORMAT_RGBF;
+			} else if (p_format >= FORMAT_RH && p_format <= FORMAT_RGBAH) {
+				return FORMAT_RGBH;
+			}
+			break;
+		case USED_CHANNELS_LA:
+			if (p_format >= FORMAT_L8 && p_format <= FORMAT_RGB565) {
+				return FORMAT_LA8;
+			} else if (p_format >= FORMAT_RF && p_format <= FORMAT_RGBAF) {
+				return FORMAT_RGBAF;
+			} else if (p_format >= FORMAT_RH && p_format <= FORMAT_RGBAH) {
+				return FORMAT_RGBAH;
+			}
+			break;
+		case USED_CHANNELS_R:
+			if (p_format >= FORMAT_L8 && p_format <= FORMAT_RGB565) {
+				return FORMAT_R8;
+			} else if (p_format >= FORMAT_RF && p_format <= FORMAT_RGBAF) {
+				return FORMAT_RF;
+			} else if (p_format >= FORMAT_RH && p_format <= FORMAT_RGBE9995) {
+				return FORMAT_RH;
+			}
+			break;
+		case USED_CHANNELS_RG:
+			if (p_format >= FORMAT_L8 && p_format <= FORMAT_RGB565) {
+				return FORMAT_RG8;
+			} else if (p_format >= FORMAT_RF && p_format <= FORMAT_RGBAF) {
+				return FORMAT_RGF;
+			} else if (p_format >= FORMAT_RH && p_format <= FORMAT_RGBE9995) {
+				return FORMAT_RGH;
+			}
+			break;
+		case USED_CHANNELS_RGB:
+			if ((p_format >= FORMAT_L8 && p_format <= FORMAT_RGBA8) || p_format == FORMAT_RGB565) {
+				return FORMAT_RGB8;
+			} else if (p_format >= FORMAT_RF && p_format <= FORMAT_RGBAF) {
+				return FORMAT_RGBF;
+			} else if (p_format >= FORMAT_RH && p_format <= FORMAT_RGBAH) {
+				return FORMAT_RGBH;
+			}
+			break;
+		case USED_CHANNELS_RGBA:
+			if (p_format >= FORMAT_L8 && p_format <= FORMAT_RGBA8) {
+				return FORMAT_RGBA8;
+			} else if (p_format >= FORMAT_RF && p_format <= FORMAT_RGBAF) {
+				return FORMAT_RGBAF;
+			} else if (p_format >= FORMAT_RH && p_format <= FORMAT_RGBAH) {
+				return FORMAT_RGBAH;
+			}
+			break;
+	}
+
+	return p_format;
+}
+
 Image::UsedChannels Image::detect_used_channels(CompressSource p_source) const {
 	ERR_FAIL_COND_V(data.is_empty(), USED_CHANNELS_RGBA);
 	ERR_FAIL_COND_V(is_compressed(), USED_CHANNELS_RGBA);
@@ -3489,62 +3550,7 @@ Image::UsedChannels Image::detect_used_channels(CompressSource p_source) const {
 }
 
 void Image::optimize_from_channels(UsedChannels p_channels) {
-	switch (p_channels) {
-		case USED_CHANNELS_L:
-			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
-				convert(FORMAT_L8);
-			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
-				convert(FORMAT_RGBF);
-			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
-				convert(FORMAT_RGBH);
-			}
-			break;
-		case USED_CHANNELS_LA:
-			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
-				convert(FORMAT_LA8);
-			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
-				convert(FORMAT_RGBAF);
-			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
-				convert(FORMAT_RGBAH);
-			}
-			break;
-		case USED_CHANNELS_R:
-			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
-				convert(FORMAT_R8);
-			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
-				convert(FORMAT_RF);
-			} else if (format >= FORMAT_RH && format <= FORMAT_RGBE9995) {
-				convert(FORMAT_RH);
-			}
-			break;
-		case USED_CHANNELS_RG:
-			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
-				convert(FORMAT_RG8);
-			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
-				convert(FORMAT_RGF);
-			} else if (format >= FORMAT_RH && format <= FORMAT_RGBE9995) {
-				convert(FORMAT_RGH);
-			}
-			break;
-		case USED_CHANNELS_RGB:
-			if ((format >= FORMAT_L8 && format <= FORMAT_RGBA8) || format == FORMAT_RGB565) {
-				convert(FORMAT_RGB8);
-			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
-				convert(FORMAT_RGBF);
-			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
-				convert(FORMAT_RGBH);
-			}
-			break;
-		case USED_CHANNELS_RGBA:
-			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
-				convert(FORMAT_RGBA8);
-			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
-				convert(FORMAT_RGBAF);
-			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
-				convert(FORMAT_RGBAH);
-			}
-			break;
-	}
+	convert(find_optimized_format(format, p_channels));
 }
 
 void Image::optimize_channels() {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3488,27 +3488,67 @@ Image::UsedChannels Image::detect_used_channels(CompressSource p_source) const {
 	return used_channels;
 }
 
-void Image::optimize_channels() {
-	switch (detect_used_channels()) {
+void Image::optimize_from_channels(UsedChannels p_channels) {
+	switch (p_channels) {
 		case USED_CHANNELS_L:
-			convert(FORMAT_L8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_L8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBH);
+			}
 			break;
 		case USED_CHANNELS_LA:
-			convert(FORMAT_LA8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_LA8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBAF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBAH);
+			}
 			break;
 		case USED_CHANNELS_R:
-			convert(FORMAT_R8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_R8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBE9995) {
+				convert(FORMAT_RH);
+			}
 			break;
 		case USED_CHANNELS_RG:
-			convert(FORMAT_RG8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGB565) {
+				convert(FORMAT_RG8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBE9995) {
+				convert(FORMAT_RGH);
+			}
 			break;
 		case USED_CHANNELS_RGB:
-			convert(FORMAT_RGB8);
+			if ((format >= FORMAT_L8 && format <= FORMAT_RGBA8) || format == FORMAT_RGB565) {
+				convert(FORMAT_RGB8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBH);
+			}
 			break;
 		case USED_CHANNELS_RGBA:
-			convert(FORMAT_RGBA8);
+			if (format >= FORMAT_L8 && format <= FORMAT_RGBA8) {
+				convert(FORMAT_RGBA8);
+			} else if (format >= FORMAT_RF && format <= FORMAT_RGBAF) {
+				convert(FORMAT_RGBAF);
+			} else if (format >= FORMAT_RH && format <= FORMAT_RGBAH) {
+				convert(FORMAT_RGBAH);
+			}
 			break;
 	}
+}
+
+void Image::optimize_channels() {
+	optimize_from_channels(detect_used_channels());
 }
 
 void Image::_bind_methods() {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -428,6 +428,7 @@ public:
 	void convert_rgba8_to_bgra8();
 
 	UsedChannels detect_used_channels(CompressSource p_source = COMPRESS_SOURCE_GENERIC) const;
+	void optimize_from_channels(UsedChannels p_channels);
 	void optimize_channels();
 
 	Color get_pixelv(const Point2i &p_point) const;

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -427,6 +427,7 @@ public:
 	void convert_ra_rgba8_to_rg();
 	void convert_rgba8_to_bgra8();
 
+	static Format find_optimized_format(Format p_format, UsedChannels p_channels);
 	UsedChannels detect_used_channels(CompressSource p_source = COMPRESS_SOURCE_GENERIC) const;
 	void optimize_from_channels(UsedChannels p_channels);
 	void optimize_channels();

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -327,13 +327,15 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 
 		} break;
 		case COMPRESS_VRAM_UNCOMPRESSED: {
-			f->store_32(CompressedTexture2D::DATA_FORMAT_IMAGE);
-			f->store_16(p_image->get_width());
-			f->store_16(p_image->get_height());
-			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
-			f->store_buffer(p_image->get_data());
+			Ref<Image> image = p_image->duplicate();
+			image->optimize_from_channels(p_channels);
 
+			f->store_32(CompressedTexture2D::DATA_FORMAT_IMAGE);
+			f->store_16(image->get_width());
+			f->store_16(image->get_height());
+			f->store_32(image->get_mipmap_count());
+			f->store_32(image->get_format());
+			f->store_buffer(image->get_data());
 		} break;
 		case COMPRESS_BASIS_UNIVERSAL: {
 			f->store_32(CompressedTexture2D::DATA_FORMAT_BASIS_UNIVERSAL);
@@ -420,7 +422,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 	// Optimization: Only check for color channels when compressing as BasisU or VRAM.
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
 
-	if (p_compress_mode == COMPRESS_BASIS_UNIVERSAL || p_compress_mode == COMPRESS_VRAM_COMPRESSED) {
+	if (p_compress_mode == COMPRESS_BASIS_UNIVERSAL || p_compress_mode == COMPRESS_VRAM_COMPRESSED || p_compress_mode == COMPRESS_VRAM_UNCOMPRESSED) {
 		Image::CompressSource comp_source = Image::COMPRESS_SOURCE_GENERIC;
 		if (p_force_normal) {
 			comp_source = Image::COMPRESS_SOURCE_NORMAL;

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -281,7 +281,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			f->store_16(p_image->get_width());
 			f->store_16(p_image->get_height());
 			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
+			f->store_32(Image::find_optimized_format(p_image->get_format(), p_channels));
 
 			for (int i = 0; i < p_image->get_mipmap_count() + 1; i++) {
 				Vector<uint8_t> data;
@@ -303,7 +303,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 			f->store_16(p_image->get_width());
 			f->store_16(p_image->get_height());
 			f->store_32(p_image->get_mipmap_count());
-			f->store_32(p_image->get_format());
+			f->store_32(Image::find_optimized_format(p_image->get_format(), p_channels));
 
 			for (int i = 0; i < p_image->get_mipmap_count() + 1; i++) {
 				Vector<uint8_t> data = Image::webp_lossy_packer(i ? p_image->get_image_from_mipmap(i) : p_image, p_lossy_quality);
@@ -419,21 +419,14 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 		image->generate_mipmap_roughness(p_roughness_channel, p_normal);
 	}
 
-	// Optimization: Only check for color channels when compressing as BasisU or VRAM.
-	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
-
-	if (p_compress_mode == COMPRESS_BASIS_UNIVERSAL || p_compress_mode == COMPRESS_VRAM_COMPRESSED || p_compress_mode == COMPRESS_VRAM_UNCOMPRESSED) {
-		Image::CompressSource comp_source = Image::COMPRESS_SOURCE_GENERIC;
-		if (p_force_normal) {
-			comp_source = Image::COMPRESS_SOURCE_NORMAL;
-		} else if (p_srgb_friendly) {
-			comp_source = Image::COMPRESS_SOURCE_SRGB;
-		}
-
-		used_channels = image->detect_used_channels(comp_source);
+	Image::CompressSource comp_source = Image::COMPRESS_SOURCE_GENERIC;
+	if (p_force_normal) {
+		comp_source = Image::COMPRESS_SOURCE_NORMAL;
+	} else if (p_srgb_friendly) {
+		comp_source = Image::COMPRESS_SOURCE_SRGB;
 	}
 
-	save_to_ctex_format(f, image, p_compress_mode, used_channels, p_vram_compression, p_lossy_quality, p_basisu_params);
+	save_to_ctex_format(f, image, p_compress_mode, image->detect_used_channels(comp_source), p_vram_compression, p_lossy_quality, p_basisu_params);
 }
 
 void ResourceImporterTexture::_save_editor_meta(const Dictionary &p_metadata, const String &p_to_path) {

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -359,8 +359,6 @@ Ref<Image> CompressedTexture2D::load_image_from_file(Ref<FileAccess> f, int p_si
 			sh = MAX(sh >> 1, 1);
 		}
 
-		//print_line("mipmap read total: " + itos(mipmap_images.size()));
-
 		Ref<Image> image;
 		image.instantiate();
 


### PR DESCRIPTION
Depends on #108375

Fixes [#12811](https://github.com/godotengine/godot-proposals/issues/12811)
Fixes #56523

Optimizes the texture color channels when importing them as lossless/lossy, then using the stored `format` property reconverts it during loading. This has a small load-time cost that needs to be measured.

TODO:
- [ ] Measure the performance impact,
- [x] Don't convert the image during import. Ideally, the importer should only store the most fitting format calculated based on the present channels.