### PR TITLE
Add "Focus Pointer" Method to the 3D Editor Plugin

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2464,6 +2464,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("spatial_editor/focus_origin", p_event)) {
 			_menu_option(VIEW_CENTER_TO_ORIGIN);
 		}
+		if (ED_IS_SHORTCUT("spatial_editor/focus_pointer", p_event)) {
+			_menu_option(VIEW_CENTER_TO_POINTER);
+		}
 		if (ED_IS_SHORTCUT("spatial_editor/focus_selection", p_event)) {
 			_menu_option(VIEW_CENTER_TO_SELECTION);
 		}
@@ -3659,6 +3662,10 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			cursor.pos = Vector3(0, 0, 0);
 
 		} break;
+		case VIEW_CENTER_TO_POINTER: {
+			focus_pointer();
+
+		} break;
 		case VIEW_CENTER_TO_SELECTION: {
 			focus_selection();
 
@@ -4486,6 +4493,19 @@ void Node3DEditorViewport::focus_selection() {
 	}
 
 	cursor.pos = center;
+}
+
+void Node3DEditorViewport::focus_pointer() {
+	Vector2 pointer = get_local_mouse_position();
+	Vector<_RayResult> results;
+
+	_find_items_at_pos(pointer, results, true);
+
+	if (!results.is_empty()) {
+		Vector3 world_ray = get_ray(pointer);
+		Vector3 world_pos = get_ray_pos(pointer);
+		cursor.pos = world_pos + world_ray * results[0].depth;
+	}
 }
 
 void Node3DEditorViewport::assign_pending_data_pointers(Node3D *p_preview_node, AABB *p_preview_bounds, AcceptDialog *p_accept) {
@@ -5778,6 +5798,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	view_display_menu->get_popup()->add_separator();
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_pointer"), VIEW_CENTER_TO_POINTER);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);
@@ -9391,6 +9412,7 @@ Node3DEditor::Node3DEditor() {
 	ED_SHORTCUT("spatial_editor/switch_perspective_orthogonal", TTRC("Switch Perspective/Orthogonal View"), Key::KP_5);
 	ED_SHORTCUT("spatial_editor/insert_anim_key", TTRC("Insert Animation Key"), Key::K);
 	ED_SHORTCUT("spatial_editor/focus_origin", TTRC("Focus Origin"), Key::O);
+	ED_SHORTCUT("spatial_editor/focus_pointer", TTRC("Focus Pointer"), KeyModifierMask::ALT | Key::F);
 	ED_SHORTCUT("spatial_editor/focus_selection", TTRC("Focus Selection"), Key::F);
 	ED_SHORTCUT_ARRAY("spatial_editor/align_transform_with_view", TTRC("Align Transform with View"),
 			{ int32_t(KeyModifierMask::ALT | KeyModifierMask::CTRL | Key::KP_0),

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -116,6 +116,7 @@ class Node3DEditorViewport : public Control {
 		VIEW_FRONT,
 		VIEW_REAR,
 		VIEW_CENTER_TO_ORIGIN,
+		VIEW_CENTER_TO_POINTER,
 		VIEW_CENTER_TO_SELECTION,
 		VIEW_ALIGN_TRANSFORM_WITH_VIEW,
 		VIEW_ALIGN_ROTATION_WITH_VIEW,
@@ -552,6 +553,7 @@ public:
 	Point2 point_to_screen(const Vector3 &p_point);
 
 	void focus_selection();
+	void focus_pointer();
 
 	void assign_pending_data_pointers(
 			Node3D *p_preview_node,


### PR DESCRIPTION
Useful to quickly navigate complex 3D scenes by focusing the viewport to the clicked position on a surface.
Can be activated by command with a keyboard shortcut, configurable in EditorSettings/Shortcuts/Focus Pointer.

Closes godotengine/godot-proposals#910

[capture.webm](https://github.com/user-attachments/assets/c7f00bc8-5757-4403-bdad-cbe1fd8b2e23)

<img width="808" height="629" alt="shortcuts" src="https://github.com/user-attachments/assets/6da224be-fbe2-44ad-9fb5-e541a6c4b8eb" />