### PR TITLE
Fix ColorPresetButton `preset_focus` is set to wrong type in default theme

### DIFF
--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -1129,7 +1129,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	preset_sb->set_anti_aliased(false);
 
 	theme->set_stylebox("preset_fg", "ColorPresetButton", preset_sb);
-	theme->set_stylebox("preset_focus", "ColorPicker", focus);
+	theme->set_stylebox("preset_focus", "ColorPresetButton", focus);
 	theme->set_icon("preset_bg", "ColorPresetButton", icons["mini_checkerboard"]);
 	theme->set_icon("overbright_indicator", "ColorPresetButton", icons["color_picker_overbright"]);
 


### PR DESCRIPTION
Fix #105356.

Before 
![Screenshot_20250721_113403_edit_476100069460164](https://github.com/user-attachments/assets/3ba5b442-f9fe-406e-b476-8fc79ab3c2f5)


After
![Screenshot_20250721_113352](https://github.com/user-attachments/assets/ca666a11-28e2-4b2f-8fa5-41927da99811)

