### PR TITLE
Save the changes before duplicating resource files

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3105,8 +3105,31 @@ Error EditorFileSystem::_copy_file(const String &p_from, const String &p_to) {
 		}
 	} else {
 		// Load the resource and save it again in the new location (this generates a new UID).
-		Error err;
-		Ref<Resource> res = ResourceLoader::load(p_from, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+		Error err = OK;
+		Ref<Resource> res = ResourceCache::get_ref(p_from);
+		if (res.is_null()) {
+			res = ResourceLoader::load(p_from, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+		} else {
+			bool edited = false;
+			List<Ref<Resource>> cached;
+			ResourceCache::get_cached_resources(&cached);
+			for (Ref<Resource> &resource : cached) {
+				if (!resource->is_edited()) {
+					continue;
+				}
+				if (!resource->get_path().begins_with(p_from)) {
+					continue;
+				}
+				// The resource or one of its built-in resources is edited.
+				edited = true;
+				resource->set_edited(false);
+			}
+
+			if (edited) {
+				// Save cached resources to prevent changes from being lost and to prevent discrepancies.
+				EditorNode::get_singleton()->save_resource(res);
+			}
+		}
 		if (err == OK && res.is_valid()) {
 			err = ResourceSaver::save(res, p_to, ResourceSaver::FLAG_COMPRESS);
 			if (err != OK) {


### PR DESCRIPTION
First synchronize the in-memory data to the file, and then copy the file. This can avoid differences between the copied file and the source file.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fix part of #101738, see https://github.com/godotengine/godot/issues/101738#issuecomment-3094512007, reason 3.

Since switching edited resources does not automatically synchronize changes to disk. And there is no function or prompt to save all changed resources. Therefore, when closing a project, some modifications to resources (especially independently saved resources rather than resources in the scene) may be lost. This should be fixed in the future.


