### PR TITLE
Return `INVALID_ID` when `vertex_format_create` `driver_id` is invalid.

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -3914,7 +3914,7 @@ RenderingDevice::VertexFormatID RenderingDevice::vertex_format_create(const Vect
 	}
 
 	RDD::VertexFormatID driver_id = driver->vertex_format_create(vertex_descriptions, bindings);
-	ERR_FAIL_COND_V(!driver_id, 0);
+	ERR_FAIL_COND_V(!driver_id, INVALID_ID);
 
 	VertexFormatID id = (vertex_format_cache.size() | ((int64_t)ID_TYPE_VERTEX_FORMAT << ID_BASE_SHIFT));
 	vertex_format_cache[key] = id;


### PR DESCRIPTION
Fix inconsistent error return in `vertex_format_create`

When driver vertex format creation fails, `vertex_format_create()` returns `0` instead of `INVALID_ID`. This causes downstream validation failures because `0` isn't registered in the vertex format cache.

The inconsistency breaks the contract where invalid IDs should be `INVALID_ID`, not `0`. Callers expect either a valid format `ID` or `INVALID_ID` on failure.

Root cause: Driver failure returns falsy value, triggering `ERR_FAIL_COND_V(!driver_id, 0)` which returns 0 instead of the expected `INVALID_ID`.