### PR TITLE
Fix editor one-click icons not showing.

### DIFF
--- a/doc/classes/EditorExportPlatformExtension.xml
+++ b/doc/classes/EditorExportPlatformExtension.xml
@@ -149,7 +149,7 @@
 			</description>
 		</method>
 		<method name="_get_option_icon" qualifiers="virtual const">
-			<return type="ImageTexture" />
+			<return type="Texture2D" />
 			<param index="0" name="device" type="int" />
 			<description>
 				Returns the item icon for the specified [param device] in the one-click deploy menu. The icon should be 16×16 pixels, adjusted for the current editor scale (see [method EditorInterface.get_editor_scale]).

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -417,9 +417,9 @@ Error EditorExportPlatform::_save_zip_patch_file(void *p_userdata, const String 
 	return _save_zip_file(p_userdata, p_path, p_data, p_file, p_total, p_enc_in_filters, p_enc_ex_filters, p_key, p_seed);
 }
 
-Ref<ImageTexture> EditorExportPlatform::get_option_icon(int p_index) const {
+Ref<Texture2D> EditorExportPlatform::get_option_icon(int p_index) const {
 	Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
-	ERR_FAIL_COND_V(theme.is_null(), Ref<ImageTexture>());
+	ERR_FAIL_COND_V(theme.is_null(), Ref<Texture2D>());
 	return theme->get_icon(SNAME("Play"), EditorStringName(EditorIcons));
 }
 

--- a/editor/export/editor_export_platform.h
+++ b/editor/export/editor_export_platform.h
@@ -326,7 +326,7 @@ public:
 	virtual bool poll_export() { return false; }
 	virtual int get_options_count() const { return 0; }
 	virtual String get_options_tooltip() const { return ""; }
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const;
+	virtual Ref<Texture2D> get_option_icon(int p_index) const;
 	virtual String get_option_label(int p_device) const { return ""; }
 	virtual String get_option_tooltip(int p_device) const { return ""; }
 	virtual String get_device_architecture(int p_device) const { return ""; }

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2325,10 +2325,10 @@ String EditorExportPlatformAppleEmbedded::get_options_tooltip() const {
 	return TTR("Select device from the list");
 }
 
-Ref<ImageTexture> EditorExportPlatformAppleEmbedded::get_option_icon(int p_index) const {
+Ref<Texture2D> EditorExportPlatformAppleEmbedded::get_option_icon(int p_index) const {
 	MutexLock lock(device_lock);
 
-	Ref<ImageTexture> icon;
+	Ref<Texture2D> icon;
 	if (p_index >= 0 || p_index < devices.size()) {
 		Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 		if (theme.is_valid()) {

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -202,7 +202,7 @@ public:
 
 	virtual int get_options_count() const override;
 	virtual String get_options_tooltip() const override;
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
+	virtual Ref<Texture2D> get_option_icon(int p_index) const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_device, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;

--- a/editor/export/editor_export_platform_extension.cpp
+++ b/editor/export/editor_export_platform_extension.cpp
@@ -53,6 +53,10 @@ void EditorExportPlatformExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_get_options_tooltip);
 
 	GDVIRTUAL_BIND(_get_option_icon, "device");
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_option_icon_bind_compat_108825, "device");
+#endif
+
 	GDVIRTUAL_BIND(_get_option_label, "device");
 	GDVIRTUAL_BIND(_get_option_tooltip, "device");
 	GDVIRTUAL_BIND(_get_device_architecture, "device");
@@ -178,11 +182,17 @@ String EditorExportPlatformExtension::get_options_tooltip() const {
 	return ret;
 }
 
-Ref<ImageTexture> EditorExportPlatformExtension::get_option_icon(int p_index) const {
-	Ref<ImageTexture> ret;
+Ref<Texture2D> EditorExportPlatformExtension::get_option_icon(int p_index) const {
+	Ref<Texture2D> ret;
 	if (GDVIRTUAL_CALL(_get_option_icon, p_index, ret)) {
 		return ret;
 	}
+#ifndef DISABLE_DEPRECATED
+	Ref<ImageTexture> comp_ret;
+	if (GDVIRTUAL_CALL(_get_option_icon_bind_compat_108825, p_index, comp_ret)) {
+		return comp_ret;
+	}
+#endif
 	return EditorExportPlatform::get_option_icon(p_index);
 }
 

--- a/editor/export/editor_export_platform_extension.h
+++ b/editor/export/editor_export_platform_extension.h
@@ -79,8 +79,12 @@ public:
 	virtual String get_options_tooltip() const override;
 	GDVIRTUAL0RC(String, _get_options_tooltip);
 
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
-	GDVIRTUAL1RC(Ref<ImageTexture>, _get_option_icon, int);
+	virtual Ref<Texture2D> get_option_icon(int p_index) const override;
+	GDVIRTUAL1RC(Ref<Texture2D>, _get_option_icon, int);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL1RC_COMPAT(_get_option_icon_bind_compat_108825, Ref<ImageTexture>, _get_option_icon, int)
+#endif
 
 	virtual String get_option_label(int p_device) const override;
 	GDVIRTUAL1RC(String, _get_option_label, int);

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -321,3 +321,10 @@ Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/a
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments': size changed value in new API, from 11 to 12.
 
 Optional argument added. Compatibility methods registered.
+
+
+GH-108825
+---------
+Validate extension JSON: Error: Field 'classes/EditorExportPlatformExtension/methods/_get_option_icon/return_value': type changed value in new API, from "ImageTexture" to "Texture2D".
+
+Return type changed to allow returning both ImageTexture and SVGTexture. Compatibility method registered.

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -425,8 +425,12 @@ bool EditorExportPlatformLinuxBSD::poll_export() {
 	return menu_options != prev;
 }
 
-Ref<ImageTexture> EditorExportPlatformLinuxBSD::get_option_icon(int p_index) const {
-	return p_index == 1 ? stop_icon : EditorExportPlatform::get_option_icon(p_index);
+Ref<Texture2D> EditorExportPlatformLinuxBSD::get_option_icon(int p_index) const {
+	if (p_index == 1) {
+		return stop_icon;
+	} else {
+		return EditorExportPlatform::get_option_icon(p_index);
+	}
 }
 
 int EditorExportPlatformLinuxBSD::get_options_count() const {

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -82,7 +82,7 @@ public:
 
 	virtual Ref<Texture2D> get_run_icon() const override;
 	virtual bool poll_export() override;
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
+	virtual Ref<Texture2D> get_option_icon(int p_index) const override;
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -2527,8 +2527,12 @@ bool EditorExportPlatformMacOS::poll_export() {
 	return menu_options != prev;
 }
 
-Ref<ImageTexture> EditorExportPlatformMacOS::get_option_icon(int p_index) const {
-	return p_index == 1 ? stop_icon : EditorExportPlatform::get_option_icon(p_index);
+Ref<Texture2D> EditorExportPlatformMacOS::get_option_icon(int p_index) const {
+	if (p_index == 1) {
+		return stop_icon;
+	} else {
+		return EditorExportPlatform::get_option_icon(p_index);
+	}
 }
 
 int EditorExportPlatformMacOS::get_options_count() const {

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -162,7 +162,7 @@ public:
 
 	virtual Ref<Texture2D> get_run_icon() const override;
 	virtual bool poll_export() override;
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
+	virtual Ref<Texture2D> get_option_icon(int p_index) const override;
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -647,8 +647,8 @@ bool EditorExportPlatformWeb::poll_export() {
 	return remote_debug_state != prev_remote_debug_state;
 }
 
-Ref<ImageTexture> EditorExportPlatformWeb::get_option_icon(int p_index) const {
-	Ref<ImageTexture> play_icon = EditorExportPlatform::get_option_icon(p_index);
+Ref<Texture2D> EditorExportPlatformWeb::get_option_icon(int p_index) const {
+	Ref<Texture2D> play_icon = EditorExportPlatform::get_option_icon(p_index);
 
 	switch (remote_debug_state) {
 		case REMOTE_DEBUG_STATE_UNAVAILABLE: {

--- a/platform/web/export/export_plugin.h
+++ b/platform/web/export/export_plugin.h
@@ -134,7 +134,7 @@ public:
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
+	virtual Ref<Texture2D> get_option_icon(int p_index) const override;
 	virtual Error run(const Ref<EditorExportPreset> &p_preset, int p_option, BitField<EditorExportPlatform::DebugFlags> p_debug_flags) override;
 	virtual Ref<Texture2D> get_run_icon() const override;
 

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -907,8 +907,12 @@ bool EditorExportPlatformWindows::poll_export() {
 	return menu_options != prev;
 }
 
-Ref<ImageTexture> EditorExportPlatformWindows::get_option_icon(int p_index) const {
-	return p_index == 1 ? stop_icon : EditorExportPlatform::get_option_icon(p_index);
+Ref<Texture2D> EditorExportPlatformWindows::get_option_icon(int p_index) const {
+	if (p_index == 1) {
+		return stop_icon;
+	} else {
+		return EditorExportPlatform::get_option_icon(p_index);
+	}
 }
 
 int EditorExportPlatformWindows::get_options_count() const {

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -90,7 +90,7 @@ public:
 
 	virtual Ref<Texture2D> get_run_icon() const override;
 	virtual bool poll_export() override;
-	virtual Ref<ImageTexture> get_option_icon(int p_index) const override;
+	virtual Ref<Texture2D> get_option_icon(int p_index) const override;
 	virtual int get_options_count() const override;
 	virtual String get_option_label(int p_index) const override;
 	virtual String get_option_tooltip(int p_index) const override;


### PR DESCRIPTION
Default editor icons were changed to `SVGTexture`, therefore this method should return generic `Texture2D` to work with both custom image textures and editor textures.

Before:
<img width="408" height="254" alt="Screenshot 2025-07-21 at 12 18 30" src="https://github.com/user-attachments/assets/89be51e9-a30c-4b3d-ba19-5438a05d4cbb" />

After:
<img width="408" height="254" alt="Screenshot 2025-07-21 at 12 17 59" src="https://github.com/user-attachments/assets/fc942843-d906-4a58-b7fb-9939fa3f2bac" />
