### PR TITLE
[PCKPacker] Add method to add files from buffer.

### DIFF
--- a/core/io/pck_packer.h
+++ b/core/io/pck_packer.h
@@ -60,9 +60,12 @@ class PCKPacker : public RefCounted {
 	};
 	Vector<File> files;
 
+	Error _add_file(const String &p_target_path, const String &p_source_path, const Vector<uint8_t> &p_data, bool p_encrypt = false);
+
 public:
 	Error pck_start(const String &p_pck_path, int p_alignment = 32, const String &p_key = "0000000000000000000000000000000000000000000000000000000000000000", bool p_encrypt_directory = false);
 	Error add_file(const String &p_target_path, const String &p_source_path, bool p_encrypt = false);
+	Error add_file_from_buffer(const String &p_target_path, const Vector<uint8_t> &p_data, bool p_encrypt = false);
 	Error add_file_removal(const String &p_target_path);
 	Error flush(bool p_verbose = false);
 

--- a/doc/classes/PCKPacker.xml
+++ b/doc/classes/PCKPacker.xml
@@ -34,6 +34,15 @@
 				Adds the [param source_path] file to the current PCK package at the [param target_path] internal path. The [code]res://[/code] prefix for [param target_path] is optional and stripped internally. File content is immediately written to the PCK.
 			</description>
 		</method>
+		<method name="add_file_from_buffer">
+			<return type="int" enum="Error" />
+			<param index="0" name="target_path" type="String" />
+			<param index="1" name="data" type="PackedByteArray" />
+			<param index="2" name="encrypt" type="bool" default="false" />
+			<description>
+				Adds the [param data] to the current PCK package at the [param target_path] internal path. The [code]res://[/code] prefix for [param target_path] is optional and stripped internally. File content is immediately written to the PCK.
+			</description>
+		</method>
 		<method name="add_file_removal">
 			<return type="int" enum="Error" />
 			<param index="0" name="target_path" type="String" />

--- a/tests/core/io/test_pck_packer.h
+++ b/tests/core/io/test_pck_packer.h
@@ -101,6 +101,9 @@ TEST_CASE("[PCKPacker] Pack a PCK file with some files and directories") {
 			pck_packer.add_file("some/directories with spaces/to/create/icon.png", base_dir.path_join("../logo.png")) == OK,
 			"Overriding a non-flushed file to an existing subdirectory in the PCK should return an OK error code.");
 	CHECK_MESSAGE(
+			pck_packer.add_file_from_buffer("buffer/new.txt", String("Hello world!").to_utf8_buffer()) == OK,
+			"Adding a file from a buffer to the PCK in a new subdirectory should return an OK error code.");
+	CHECK_MESSAGE(
 			pck_packer.flush() == OK,
 			"Flushing the PCK should return an OK error code.");
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/12806
Also fixes off by one file index in the verbose `flush` print.

It was problematic before 4.4, since it was storing all files at once at `flush`, but in 4.5 files are saved immediately, so it makes sense to allow writing from buffer.