### PR TITLE
Fix internal JSON stringify not preserving p_full_precision

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -73,18 +73,18 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 			r_result += itos(p_var);
 			return;
 		case Variant::FLOAT: {
-			double num = p_var;
+			const double num = p_var;
 
 			// Only for exactly 0. If we have approximately 0 let the user decide how much
 			// precision they want.
-			if (num == double(0)) {
+			if (num == double(0.0)) {
 				r_result += "0.0";
 				return;
 			}
 
-			double magnitude = std::log10(Math::abs(num));
-			int total_digits = p_full_precision ? 17 : 14;
-			int precision = MAX(1, total_digits - (int)Math::floor(magnitude));
+			const double magnitude = std::log10(Math::abs(num));
+			const int total_digits = p_full_precision ? 17 : 14;
+			const int precision = MAX(1, total_digits - (int)Math::floor(magnitude));
 
 			r_result += String::num(num, precision);
 			return;
@@ -120,7 +120,7 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 					r_result += end_statement;
 				}
 				_add_indent(r_result, p_indent, p_cur_indent + 1);
-				_stringify(r_result, var, p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				_stringify(r_result, var, p_indent, p_cur_indent + 1, p_sort_keys, p_markers, p_full_precision);
 			}
 			r_result += end_statement;
 			_add_indent(r_result, p_indent, p_cur_indent);
@@ -154,9 +154,9 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 					r_result += end_statement;
 				}
 				_add_indent(r_result, p_indent, p_cur_indent + 1);
-				_stringify(r_result, String(key), p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				_stringify(r_result, String(key), p_indent, p_cur_indent + 1, p_sort_keys, p_markers, p_full_precision);
 				r_result += colon;
-				_stringify(r_result, d[key], p_indent, p_cur_indent + 1, p_sort_keys, p_markers);
+				_stringify(r_result, d[key], p_indent, p_cur_indent + 1, p_sort_keys, p_markers, p_full_precision);
 			}
 
 			r_result += end_statement;

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -72,7 +72,7 @@ class JSON : public Resource {
 	static const char *tk_name[];
 
 	static void _add_indent(String &r_result, const String &p_indent, int p_size);
-	static void _stringify(String &r_result, const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision = false);
+	static void _stringify(String &r_result, const Variant &p_var, const String &p_indent, int p_cur_indent, bool p_sort_keys, HashSet<const void *> &p_markers, bool p_full_precision);
 	static Error _get_token(const char32_t *p_str, int &index, int p_len, Token &r_token, int &line, String &r_err_str);
 	static Error _parse_value(Variant &value, Token &token, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);
 	static Error _parse_array(Array &array, const char32_t *p_str, int &index, int p_len, int &line, int p_depth, String &r_err_str);

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -71,6 +71,10 @@ TEST_CASE("[JSON] Stringify arrays") {
 	indented_array.push_back(nested_array);
 	CHECK(JSON::stringify(indented_array, "\t") == "[\n\t0,\n\t1,\n\t2,\n\t3,\n\t4,\n\t[\n\t\t0,\n\t\t1,\n\t\t2,\n\t\t3,\n\t\t4\n\t]\n]");
 
+	Array full_precision_array;
+	full_precision_array.push_back(0.123456789012345677);
+	CHECK(JSON::stringify(full_precision_array, "", true, true) == "[0.123456789012345677]");
+
 	ERR_PRINT_OFF
 	Array self_array;
 	self_array.push_back(self_array);
@@ -104,6 +108,10 @@ TEST_CASE("[JSON] Stringify dictionaries") {
 	inner["key"] = "value";
 	outer["inner"] = inner;
 	CHECK(JSON::stringify(outer) == "{\"inner\":{\"key\":\"value\"}}");
+
+	Dictionary full_precision_dictionary;
+	full_precision_dictionary["key"] = 0.123456789012345677;
+	CHECK(JSON::stringify(full_precision_dictionary, "", true, true) == "{\"key\":0.123456789012345677}");
 
 	ERR_PRINT_OFF
 	Dictionary self_dictionary;


### PR DESCRIPTION
If you ran `JSON.stringify` on a single float, the `p_full_precision` option worked. However, this argument was not passed into the recursive calls, so if you tried to stringify an Array or Dictionary with floats in it, this option was broken.

This PR fixes that problem, and removes the default argument from the internal function to prevent this problem happening in the future. The public version of the function still has a default argument for `p_full_precision`. I also threw in making a few variables `const` while I was at it.