### PR TITLE
[Web] Make `emscriptenThreadPool` and `godotThreadPool` values automatic

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -425,7 +425,7 @@ let setStatusMode;
 let setStatusNotice;
 let video_driver = '';
 
-function clearPersistence() { // eslint-disable-line no-unused-vars
+async function clearPersistence() { // eslint-disable-line no-unused-vars
 	function deleteDB(path) {
 		return new Promise(function (resolve, reject) {
 			const req = indexedDB.deleteDatabase(path);
@@ -440,16 +440,30 @@ function clearPersistence() { // eslint-disable-line no-unused-vars
 			};
 		});
 	}
+	async function removeServiceWorkerAndCache() {
+		const registrations = await navigator.serviceWorker.getRegistrations();
+		for (const registration of registrations) {
+			// eslint-disable-next-line no-await-in-loop
+			for (const key of await (caches?.keys() ?? [])) {
+				await caches.delete(key); // eslint-disable-line no-await-in-loop
+			}
+			await registration.unregister(); // eslint-disable-line no-await-in-loop
+		}
+	}
 	if (!window.confirm('Are you sure you want to delete all the locally stored files?\nClicking "OK" will permanently remove your projects and editor settings!')) {
 		return;
 	}
-	Promise.all([
-		deleteDB('/home/web_user'),
-	]).then(function (results) {
+	try {
+		await Promise.all([
+			deleteDB('/home/web_user'),
+			removeServiceWorkerAndCache(),
+		]);
 		alert('Done.');
-	}).catch(function (err) {
+		window.location.reload();
+	} catch (error) {
+		console.error('Error deleting local files:', error);
 		alert('Error deleting local files. Please retry after reloading the page.');
-	});
+	}
 }
 
 function selectVideoMode() {

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -256,7 +256,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(CCFLAGS=["-sUSE_PTHREADS=1"])
         env.Append(LINKFLAGS=["-sUSE_PTHREADS=1"])
         env.Append(LINKFLAGS=["-sDEFAULT_PTHREAD_STACK_SIZE=%sKB" % env["default_pthread_stack_size"]])
-        env.Append(LINKFLAGS=["-sPTHREAD_POOL_SIZE=\"Module['emscriptenPoolSize']||8\""])
+        env.Append(LINKFLAGS=["-sPTHREAD_POOL_SIZE='Module['emscriptenPoolSize'] ?? navigator.hardwareConcurrency'"])
         env.Append(LINKFLAGS=["-sWASM_MEM_MAX=2048MB"])
         if not env["dlink_enabled"]:
             # Workaround https://github.com/emscripten-core/emscripten/issues/21844#issuecomment-2116936414.

--- a/platform/web/doc_classes/EditorExportPlatformWeb.xml
+++ b/platform/web/doc_classes/EditorExportPlatformWeb.xml
@@ -79,14 +79,6 @@
 			- [b]Landscape:[/b] Forces a horizontal layout (wider than it is taller).
 			- [b]Portrait:[/b] Forces a vertical layout (taller than it is wider).
 		</member>
-		<member name="threads/emscripten_pool_size" type="int" setter="" getter="">
-			The number of threads that emscripten will allocate at startup. A smaller value will allocate fewer threads and consume fewer system resources, but you may run the risk of running out of threads in the pool and needing to allocate more threads at run time which may cause a deadlock.
-			[b]Note:[/b] Some browsers have a hard cap on the number of threads that can be allocated, so it is best to be cautious and keep this number low.
-		</member>
-		<member name="threads/godot_pool_size" type="int" setter="" getter="">
-			Override for the default size of the [WorkerThreadPool]. This setting is used when [member ProjectSettings.threading/worker_pool/max_threads] size is set to -1 (which it is by default). This size must be smaller than [member threads/emscripten_pool_size] otherwise deadlocks may occur.
-			When using threads this size needs to be large enough to accommodate features that rely on having a dedicated thread like [member ProjectSettings.physics/2d/run_on_separate_thread] or [member ProjectSettings.rendering/driver/threads/thread_model]. In general, it is best to ensure that this is at least 4 and is at least 2 or 3 less than [member threads/emscripten_pool_size].
-		</member>
 		<member name="variant/extensions_support" type="bool" setter="" getter="">
 			If [code]true[/code] enables [GDExtension] support for this web build.
 		</member>

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -149,9 +149,6 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 	config["fileSizes"] = p_file_sizes;
 	config["ensureCrossOriginIsolationHeaders"] = (bool)p_preset->get("progressive_web_app/ensure_cross_origin_isolation_headers");
 
-	config["godotPoolSize"] = p_preset->get("threads/godot_pool_size");
-	config["emscriptenPoolSize"] = p_preset->get("threads/emscripten_pool_size");
-
 	String head_include;
 	if (p_preset->get("html/export_icon")) {
 		head_include += "<link id=\"-gd-engine-icon\" rel=\"icon\" type=\"image/png\" href=\"" + p_name + ".icon.png\" />\n";
@@ -386,19 +383,12 @@ void EditorExportPlatformWeb::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_180x180", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_512x512", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::COLOR, "progressive_web_app/background_color", PROPERTY_HINT_COLOR_NO_ALPHA), Color()));
-
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "threads/emscripten_pool_size"), 8));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "threads/godot_pool_size"), 4));
 }
 
 bool EditorExportPlatformWeb::get_export_option_visibility(const EditorExportPreset *p_preset, const String &p_option) const {
 	bool advanced_options_enabled = p_preset->are_advanced_options_enabled();
 	if (p_option == "custom_template/debug" || p_option == "custom_template/release") {
 		return advanced_options_enabled;
-	}
-
-	if (p_option == "threads/godot_pool_size" || p_option == "threads/emscripten_pool_size") {
-		return p_preset->get("variant/thread_support").operator bool();
 	}
 
 	return true;

--- a/platform/web/js/engine/config.js
+++ b/platform/web/js/engine/config.js
@@ -17,6 +17,9 @@ const EngineConfig = {}; // eslint-disable-line no-unused-vars
  * @ignore
  */
 const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-vars
+	const emscriptenPoolSize = Math.max(navigator.hardwareConcurrency, 6);
+	const godotPoolSize = Math.max(3, Math.floor(emscriptenPoolSize / 4));
+
 	const cfg = /** @lends {InternalConfig.prototype} */ {
 		/**
 		 * Whether to unload the engine automatically after the instance is initialized.
@@ -137,12 +140,12 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 * @ignore
 		 * @type {number}
 		 */
-		emscriptenPoolSize: 8,
+		emscriptenPoolSize,
 		/**
 		 * @ignore
 		 * @type {number}
 		 */
-		godotPoolSize: 4,
+		godotPoolSize,
 		/**
 		 * A callback function for handling Godot's ``OS.execute`` calls.
 		 *

--- a/platform/web/js/libs/library_godot_os.js
+++ b/platform/web/js/libs/library_godot_os.js
@@ -71,6 +71,7 @@ const GodotConfig = {
 			GodotConfig.locale = p_opts['locale'] || GodotConfig.locale;
 			GodotConfig.virtual_keyboard = p_opts['virtualKeyboard'];
 			GodotConfig.persistent_drops = !!p_opts['persistentDrops'];
+			GodotConfig.emscripten_pool_size = p_opts['emscriptenPoolSize'];
 			GodotConfig.godot_pool_size = p_opts['godotPoolSize'];
 			GodotConfig.on_execute = p_opts['onExecute'];
 			GodotConfig.on_exit = p_opts['onExit'];
@@ -343,9 +344,13 @@ const GodotOS = {
 	godot_js_os_hw_concurrency_get__proxy: 'sync',
 	godot_js_os_hw_concurrency_get__sig: 'i',
 	godot_js_os_hw_concurrency_get: function () {
+		if (typeof PThread === 'undefined') {
+			// Threads aren't supported, so default to `1`.
+			return 1;
+		}
+
 		// TODO Godot core needs fixing to avoid spawning too many threads (> 24).
-		const concurrency = navigator.hardwareConcurrency || 1;
-		return concurrency < 2 ? concurrency : 2;
+		return Math.max(GodotConfig.emscripten_pool_size, 2);
 	},
 
 	godot_js_os_thread_pool_size_get__proxy: 'sync',


### PR DESCRIPTION
> [!WARNING]
>Needs testing. I had issues testing the fix on iOS and iPadOS, but I don't think it's related.

Instead of exposing `emscriptenThreadPool` and `godotThreadPool` in export settings, this PR makes it so that it uses `navigator.hardwareConcurrency` as a base, with minimum values.

Fixes #108484.

> [!NOTE]
> The PR also makes the `Clear persistent data` button actually clear the service worker. Needed to test the fix on mobile platforms.