### PR TITLE
Area2D/3D: Check if reference exists before emitting entered/exited signals

### DIFF
--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -141,9 +141,13 @@ void Area2D::_body_enter_tree(ObjectID p_id) {
 	ERR_FAIL_COND(E->value.in_tree);
 
 	E->value.in_tree = true;
-	emit_signal(SceneStringName(body_entered), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(body_shape_entered), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+
+	// Only emit if the body is actually overlapping
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(body_entered), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(body_shape_entered), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		}
 	}
 }
 
@@ -155,9 +159,12 @@ void Area2D::_body_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
-	emit_signal(SceneStringName(body_exited), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(body_shape_exited), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(body_exited), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(body_shape_exited), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		}
 	}
 }
 
@@ -252,9 +259,12 @@ void Area2D::_area_enter_tree(ObjectID p_id) {
 	ERR_FAIL_COND(E->value.in_tree);
 
 	E->value.in_tree = true;
-	emit_signal(SceneStringName(area_entered), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(area_shape_entered), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(area_entered), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(area_shape_entered), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+		}
 	}
 }
 
@@ -266,9 +276,12 @@ void Area2D::_area_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
-	emit_signal(SceneStringName(area_exited), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(area_shape_exited), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(area_exited), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(area_shape_exited), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+		}
 	}
 }
 

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -198,9 +198,11 @@ void Area3D::_body_enter_tree(ObjectID p_id) {
 	ERR_FAIL_COND(E->value.in_tree);
 
 	E->value.in_tree = true;
-	emit_signal(SceneStringName(body_entered), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(body_shape_entered), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(body_entered), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(body_shape_entered), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		}
 	}
 }
 
@@ -212,9 +214,11 @@ void Area3D::_body_exit_tree(ObjectID p_id) {
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
-	emit_signal(SceneStringName(body_exited), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(body_shape_exited), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(body_exited), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(body_shape_exited), E->value.rid, node, E->value.shapes[i].body_shape, E->value.shapes[i].area_shape);
+		}
 	}
 }
 
@@ -404,9 +408,11 @@ void Area3D::_area_enter_tree(ObjectID p_id) {
 	ERR_FAIL_COND(E->value.in_tree);
 
 	E->value.in_tree = true;
-	emit_signal(SceneStringName(area_entered), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(area_shape_entered), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(area_entered), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(area_shape_entered), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+		}
 	}
 }
 
@@ -417,10 +423,13 @@ void Area3D::_area_exit_tree(ObjectID p_id) {
 	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
+
 	E->value.in_tree = false;
-	emit_signal(SceneStringName(area_exited), node);
-	for (int i = 0; i < E->value.shapes.size(); i++) {
-		emit_signal(SceneStringName(area_shape_exited), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+	if (E->value.rc > 0) {
+		emit_signal(SceneStringName(area_exited), node);
+		for (int i = 0; i < E->value.shapes.size(); i++) {
+			emit_signal(SceneStringName(area_shape_exited), E->value.rid, node, E->value.shapes[i].area_shape, E->value.shapes[i].self_shape);
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->


Solves half of #14578 (fixes the infinite recursion problem)

Both the bugs mentioned in this [comment](https://github.com/godotengine/godot/issues/14578#issuecomment-1881650217) were replicable in 4.5-beta3 

A simple fix where it checks for a reference to the collided object and then emits the signal (it might need some testing, my impostor syndrome says it can't be that simple when it's been present for so long)

As for the dual signal emission, it might require the signal emission to be moved to _body_inout function and might cause some regressions so haven't touched it here (potentially fixable via adding an is_reparenting check there but haven't tested, maybe for another pr...)