### PR TITLE
Handle NaN and Infinity in JSON stringify function (reverted)

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -75,6 +75,17 @@ void JSON::_stringify(String &r_result, const Variant &p_var, const String &p_in
 		case Variant::FLOAT: {
 			const double num = p_var;
 
+			// JSON does not support NaN or Infinity, so use extremely large numbers for infinity.
+			if (!Math::is_finite(num)) {
+				if (num == Math::INF) {
+					r_result += "1e99999";
+				} else if (num == -Math::INF) {
+					r_result += "-1e99999";
+				} else {
+					r_result += "\"NaN\"";
+				}
+				return;
+			}
 			// Only for exactly 0. If we have approximately 0 let the user decide how much
 			// precision they want.
 			if (num == double(0.0)) {

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -75,7 +75,18 @@ TEST_CASE("[JSON] Stringify arrays") {
 	full_precision_array.push_back(0.123456789012345677);
 	CHECK(JSON::stringify(full_precision_array, "", true, true) == "[0.123456789012345677]");
 
+	Array non_finite_array;
+	non_finite_array.push_back(Math::INF);
+	non_finite_array.push_back(-Math::INF);
+	non_finite_array.push_back(Math::NaN);
+	CHECK(JSON::stringify(non_finite_array) == "[1e99999,-1e99999,\"NaN\"]");
+
 	ERR_PRINT_OFF
+	Array non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_array));
+	CHECK(non_finite_round_trip[0] == Variant(Math::INF));
+	CHECK(non_finite_round_trip[1] == Variant(-Math::INF));
+	CHECK(non_finite_round_trip[2].get_type() == Variant::STRING);
+
 	Array self_array;
 	self_array.push_back(self_array);
 	CHECK(JSON::stringify(self_array) == "[\"[...]\"]");
@@ -113,7 +124,18 @@ TEST_CASE("[JSON] Stringify dictionaries") {
 	full_precision_dictionary["key"] = 0.123456789012345677;
 	CHECK(JSON::stringify(full_precision_dictionary, "", true, true) == "{\"key\":0.123456789012345677}");
 
+	Dictionary non_finite_dictionary;
+	non_finite_dictionary["-inf"] = -Math::INF;
+	non_finite_dictionary["inf"] = Math::INF;
+	non_finite_dictionary["nan"] = Math::NaN;
+	CHECK(JSON::stringify(non_finite_dictionary) == "{\"-inf\":-1e99999,\"inf\":1e99999,\"nan\":\"NaN\"}");
+
 	ERR_PRINT_OFF
+	Dictionary non_finite_round_trip = JSON::parse_string(JSON::stringify(non_finite_dictionary));
+	CHECK(non_finite_round_trip["-inf"] == Variant(-Math::INF));
+	CHECK(non_finite_round_trip["inf"] == Variant(Math::INF));
+	CHECK(non_finite_round_trip["nan"].get_type() == Variant::STRING);
+
 	Dictionary self_dictionary;
 	self_dictionary["key"] = self_dictionary;
 	CHECK(JSON::stringify(self_dictionary) == "{\"key\":\"{...}\"}");


### PR DESCRIPTION
Fixes #89777

The JSON specification does not support NaN or Infinity values. However, it does support scientific notation. https://www.json.org/json-en.html

Without this PR, trying to export JSON containing NaN or Infinity will result in invalid JSON, which cannot be parsed back by Godot, nor can it be parsed by web browsers.

With this PR, trying to export JSON containing NaN and Infinity will result in valid JSON, with Infinity being replaced with extremely large numbers, and NaN being replaced with null. These large values are read in as Infinity both by Godot and by web browsers, and this seems to be a common trick in the JSON ecosystem. See https://github.com/graphite-project/graphite-web/issues/813

The unit tests added in this PR include examples of round-trip parsing, and the same tests fail without the other changes.

Why `1e99999`: This is greater than the maximum value of an IEEE-standard 256-bit octuple-precision float, which is a bit over `1e78913`, pretty much guaranteeing an overflow to infinity since it will happen for all IEEE-standard floating point sizes. Also, just as a general note, this number is big enough that human readers should be able to tell that this is not intended to be a finite float value.