### PR TITLE
Fix `StringName` errors causing infinite recursion

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -107,7 +107,10 @@ void StringName::cleanup() {
 }
 
 void StringName::unref() {
-	ERR_FAIL_COND(!configured);
+	if (unlikely(!configured)) {
+		fprintf(stderr, "Failed to unreference StringName. Its global state has either not been set up or has already been cleaned up.\n");
+		return;
+	}
 
 	if (_data && _data->refcount.unref()) {
 		MutexLock lock(Table::mutex);
@@ -194,7 +197,10 @@ StringName &StringName::operator=(const StringName &p_name) {
 StringName::StringName(const StringName &p_name) {
 	_data = nullptr;
 
-	ERR_FAIL_COND(!configured);
+	if (unlikely(!configured)) {
+		fprintf(stderr, "Failed to create StringName. Its global state has either not been set up or has already been cleaned up.\n");
+		return;
+	}
 
 	if (p_name._data && p_name._data->refcount.ref()) {
 		_data = p_name._data;
@@ -204,7 +210,10 @@ StringName::StringName(const StringName &p_name) {
 StringName::StringName(const char *p_name, bool p_static) {
 	_data = nullptr;
 
-	ERR_FAIL_COND(!configured);
+	if (unlikely(!configured)) {
+		fprintf(stderr, "Failed to create StringName. Its global state has either not been set up or has already been cleaned up.\n");
+		return;
+	}
 
 	if (!p_name || p_name[0] == 0) {
 		return; //empty, ignore


### PR DESCRIPTION
Fixes #108838.

This fixes the infinite recursion that can happen when the `!configured` errors in `StringName` are emitted, after having called `OS.add_logger` at any point during the program.

This is achieved using a similar approach to what #85397 did for `CallQueue`, by replacing the `ERR_*` macros with `fprintf(stderr, ...)`.