### PR TITLE
Use different blend func on Mobile for Multiply

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -295,7 +295,20 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 			"WIREFRAME:", p_pipeline_key.wireframe);
 #endif
 
-	RD::PipelineColorBlendState::Attachment blend_attachment = blend_mode_to_blend_attachment(BlendMode(blend_mode));
+	RD::PipelineColorBlendState::Attachment blend_attachment;
+	// On mobile, 0.5 is pure white. Compensate when multiplying by doubling the result.
+	if (BlendMode(blend_mode) == BLEND_MODE_MUL) {
+		blend_attachment.enable_blend = true;
+		blend_attachment.alpha_blend_op = RD::BLEND_OP_ADD;
+		blend_attachment.color_blend_op = RD::BLEND_OP_ADD;
+		blend_attachment.src_color_blend_factor = RD::BLEND_FACTOR_DST_COLOR;
+		blend_attachment.dst_color_blend_factor = RD::BLEND_FACTOR_SRC_COLOR;
+		blend_attachment.src_alpha_blend_factor = RD::BLEND_FACTOR_DST_ALPHA;
+		blend_attachment.dst_alpha_blend_factor = RD::BLEND_FACTOR_ZERO;
+	} else {
+		blend_attachment = blend_mode_to_blend_attachment(BlendMode(blend_mode));
+	}
+
 	RD::PipelineColorBlendState blend_state_blend;
 	blend_state_blend.attachments.push_back(blend_attachment);
 	RD::PipelineColorBlendState blend_state_opaque = RD::PipelineColorBlendState::create_disabled(1);


### PR DESCRIPTION
Closes: https://github.com/godotengine/godot/issues/96961
(Issue marked for documentation but since a fix is possible I consider this to be a bugfix.)

Title. On forward mobile color values are effectively halved during the blending stage (pure white is 0.5).  Due to this, attachments with blend factors involving colors won't look correct. Luckily, in the case of the basic Multiply blend mode, the output can be doubled by multiplying on both sides of the function.

0.5 grey on top of icon (Remember to set tonemap to linear when testing):
| Master Mobile | Master Forward | PR Mobile
| ------------- | ------------- |------------- |
|<img width="708" height="686" alt="Screenshot 2025-07-21 225233" src="https://github.com/user-attachments/assets/40edfb0f-9dff-4cd3-80a0-64ec657ce30b" />| <img width="695" height="686" alt="Screenshot 2025-07-21 225151" src="https://github.com/user-attachments/assets/d99dd69c-3afa-491a-a89e-5531d9c4a808" />|<img width="677" height="657" alt="Screenshot 2025-07-21 225121" src="https://github.com/user-attachments/assets/474a5512-688c-41ba-aa41-7fe9b3164964" />|

Added comment for future so this patchwork can be removed if the behavior changes. (Which would be necessary for implementing any new blend modes, other than min, max or inverse subtract.)


