### PR TITLE
Add debugger message to allow re-running a project and reconnecting to debugger

### DIFF
--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -39,6 +39,7 @@ class DebugAdapterParser;
 class EditorDebuggerPlugin;
 class EditorDebuggerTree;
 class EditorDebuggerRemoteObjects;
+class EditorRunBar;
 class MenuButton;
 class ScriptEditorDebugger;
 class TabContainer;
@@ -142,6 +143,9 @@ protected:
 	void _remote_objects_requested(const TypedArray<uint64_t> &p_ids, int p_debugger);
 	void _remote_selection_cleared(int p_debugger);
 	void _save_node_requested(ObjectID p_id, const String &p_file, int p_debugger);
+
+	void _run_scene_requested(const String &p_scene, const Vector<String> &p_args, int p_debugger);
+	void _run_scene_internal(EditorRunBar *p_editor_run_bar, const String &p_scene, const Vector<String> &p_args);
 
 	void _breakpoint_set_in_tree(Ref<RefCounted> p_script, int p_line, bool p_enabled, int p_debugger);
 	void _breakpoints_cleared_in_tree(int p_debugger);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -926,6 +926,11 @@ void ScriptEditorDebugger::_msg_embed_next_frame(uint64_t p_thread_id, const Arr
 	emit_signal(SNAME("embed_shortcut_requested"), EMBED_NEXT_FRAME);
 }
 
+void ScriptEditorDebugger::_msg_run_scene(uint64_t p_thread_id, const Array &p_data) {
+	ERR_FAIL_COND(p_data.size() < 2);
+	emit_signal(SNAME("run_scene_requested"), p_data[0], p_data[1]);
+}
+
 void ScriptEditorDebugger::_parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data) {
 	emit_signal(SNAME("debug_data"), p_msg, p_data);
 
@@ -976,6 +981,7 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["window:title"] = &ScriptEditorDebugger::_msg_window_title;
 	parse_message_handlers["request_embed_suspend_toggle"] = &ScriptEditorDebugger::_msg_embed_suspend_toggle;
 	parse_message_handlers["request_embed_next_frame"] = &ScriptEditorDebugger::_msg_embed_next_frame;
+	parse_message_handlers["request_run_scene"] = &ScriptEditorDebugger::_msg_run_scene;
 }
 
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {
@@ -1944,6 +1950,7 @@ void ScriptEditorDebugger::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("clear_breakpoints"));
 	ADD_SIGNAL(MethodInfo("errors_cleared"));
 	ADD_SIGNAL(MethodInfo("embed_shortcut_requested", PropertyInfo(Variant::INT, "embed_shortcut_action")));
+	ADD_SIGNAL(MethodInfo("run_scene_requested", PropertyInfo(Variant::STRING, "scene"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));
 }
 
 void ScriptEditorDebugger::add_debugger_tab(Control *p_control) {

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -228,6 +228,7 @@ private:
 	void _msg_window_title(uint64_t p_thread_id, const Array &p_data);
 	void _msg_embed_suspend_toggle(uint64_t p_thread_id, const Array &p_data);
 	void _msg_embed_next_frame(uint64_t p_thread_id, const Array &p_data);
+	void _msg_run_scene(uint64_t p_thread_id, const Array &p_data);
 
 	void _parse_message(const String &p_msg, uint64_t p_thread_id, const Array &p_data);
 	void _set_reason_text(const String &p_reason, MessageType p_type);


### PR DESCRIPTION
This contains just the debugger part that was originally in https://github.com/godotengine/godot/pull/107671

This aims to allow a project launched from the editor, to re-launch itself with different arguments, while reconnecting to the debugger and ensuring that the embedded game view still works after being re-launched

The ultimate goal is to allow the [godot_openxr_vendor](https://github.com/GodotVR/godot_openxr_vendors) extension to simulate running a hybrid immersive/flat VR app on desktop, so you don't need to deploy to the headset for testing.

See https://github.com/GodotVR/godot_openxr_vendors/pull/312 for the rest of the implementation of that (also depends on https://github.com/godotengine/godot/pull/107671)