### PR TITLE
Don't clear Array param when freeing material

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2394,15 +2394,6 @@ void MaterialStorage::material_free(RID p_rid) {
 	Material *material = material_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(material);
 
-	// Need to clear texture arrays to prevent spin locking of their RID's.
-	// This happens when the app is being closed.
-	for (KeyValue<StringName, Variant> &E : material->params) {
-		if (E.value.get_type() == Variant::ARRAY) {
-			// Clear the array for this material only (the array may be shared).
-			E.value = Variant();
-		}
-	}
-
 	material_set_shader(p_rid, RID()); //clean up shader
 	material->dependency.deleted_notify(p_rid);
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2231,15 +2231,6 @@ void MaterialStorage::material_free(RID p_rid) {
 	Material *material = material_owner.get_or_null(p_rid);
 	ERR_FAIL_NULL(material);
 
-	// Need to clear texture arrays to prevent spin locking of their RID's.
-	// This happens when the app is being closed.
-	for (KeyValue<StringName, Variant> &E : material->params) {
-		if (E.value.get_type() == Variant::ARRAY) {
-			// Clear the array for this material only (the array may be shared).
-			E.value = Variant();
-		}
-	}
-
 	material_set_shader(p_rid, RID()); //clean up shader
 	material->dependency.deleted_notify(p_rid);
 


### PR DESCRIPTION
Fixes #108815.

This reverts #71346. The code is originally introduced to fix issue #70527, but now I'm unable to reproduce it, so I think it's better to revert the change.

Another solution is duplicating Array when setting shader parameter, but it's not ideal as it changes the behavior and prevents Array from being shared across materials.