### PR TITLE
[macOS] Fix `warp_mouse` in game mode.

### DIFF
--- a/platform/macos/display_server_embedded.h
+++ b/platform/macos/display_server_embedded.h
@@ -140,6 +140,7 @@ public:
 	virtual void mouse_set_mode_override_enabled(bool p_override_enabled) override;
 	virtual bool mouse_is_mode_override_enabled() const override;
 
+	virtual void warp_mouse(const Point2i &p_position) override;
 	virtual Point2i mouse_get_position() const override;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
 

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -320,6 +320,11 @@ bool DisplayServerEmbedded::mouse_is_mode_override_enabled() const {
 	return mouse_mode_override_enabled;
 }
 
+void DisplayServerEmbedded::warp_mouse(const Point2i &p_position) {
+	_THREAD_SAFE_METHOD_
+	EngineDebugger::get_singleton()->send_message("game_view:warp_mouse", { p_position });
+}
+
 Point2i DisplayServerEmbedded::mouse_get_position() const {
 	_THREAD_SAFE_METHOD_
 
@@ -470,19 +475,19 @@ bool DisplayServerEmbedded::has_feature(Feature p_feature) const {
 #endif
 		case FEATURE_CURSOR_SHAPE:
 		case FEATURE_IME:
-			// case FEATURE_CUSTOM_CURSOR_SHAPE:
+		case FEATURE_CUSTOM_CURSOR_SHAPE:
 			// case FEATURE_HIDPI:
 			// case FEATURE_ICON:
-			// case FEATURE_MOUSE:
-			// case FEATURE_MOUSE_WARP:
+		case FEATURE_MOUSE:
+		case FEATURE_MOUSE_WARP:
 			// case FEATURE_NATIVE_DIALOG:
 			// case FEATURE_NATIVE_ICON:
 			// case FEATURE_WINDOW_TRANSPARENCY:
-			// case FEATURE_CLIPBOARD:
+		case FEATURE_CLIPBOARD:
 			// case FEATURE_KEEP_SCREEN_ON:
 			// case FEATURE_ORIENTATION:
 			// case FEATURE_VIRTUAL_KEYBOARD:
-			// case FEATURE_TEXT_TO_SPEECH:
+		case FEATURE_TEXT_TO_SPEECH:
 			// case FEATURE_TOUCHSCREEN:
 			return true;
 		default:

--- a/platform/macos/editor/embedded_game_view_plugin.h
+++ b/platform/macos/editor/embedded_game_view_plugin.h
@@ -58,6 +58,7 @@ class GameViewDebuggerMacOS : public GameViewDebugger {
 	bool _msg_window_set_ime_position(const Array &p_args);
 	bool _msg_joy_start(const Array &p_args);
 	bool _msg_joy_stop(const Array &p_args);
+	bool _msg_warp_mouse(const Array &p_args);
 
 public:
 	virtual bool capture(const String &p_message, const Array &p_data, int p_session) override;

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -38,14 +38,14 @@
 HashMap<String, GameViewDebuggerMacOS::ParseMessageFunc> GameViewDebuggerMacOS::parse_message_handlers;
 
 bool GameViewDebuggerMacOS::_msg_set_context_id(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "set_context_id: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "set_context_id: invalid number of arguments.");
 
 	embedded_process->set_context_id(p_args[0]);
 	return true;
 }
 
 bool GameViewDebuggerMacOS::_msg_cursor_set_shape(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "cursor_set_shape: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "cursor_set_shape: invalid number of arguments.");
 
 	Control::CursorShape shape = Control::CursorShape(p_args[0]);
 	embedded_process->get_layer_host()->set_default_cursor_shape(static_cast<Control::CursorShape>(shape));
@@ -54,7 +54,7 @@ bool GameViewDebuggerMacOS::_msg_cursor_set_shape(const Array &p_args) {
 }
 
 bool GameViewDebuggerMacOS::_msg_cursor_set_custom_image(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 3, false, "cursor_set_custom_image: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 3, false, "cursor_set_custom_image: invalid number of arguments.");
 
 	Ref<Image> image;
 	image.instantiate();
@@ -71,7 +71,7 @@ bool GameViewDebuggerMacOS::_msg_cursor_set_custom_image(const Array &p_args) {
 }
 
 bool GameViewDebuggerMacOS::_msg_mouse_set_mode(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "mouse_set_mode: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "mouse_set_mode: invalid number of arguments.");
 
 	DisplayServer::MouseMode mode = DisplayServer::MouseMode(p_args[0]);
 	embedded_process->mouse_set_mode(mode);
@@ -80,7 +80,7 @@ bool GameViewDebuggerMacOS::_msg_mouse_set_mode(const Array &p_args) {
 }
 
 bool GameViewDebuggerMacOS::_msg_window_set_ime_active(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "window_set_ime_active: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "window_set_ime_active: invalid number of arguments.");
 
 	bool active = p_args[0];
 	DisplayServer::WindowID wid = embedded_process->get_window()->get_window_id();
@@ -89,7 +89,7 @@ bool GameViewDebuggerMacOS::_msg_window_set_ime_active(const Array &p_args) {
 }
 
 bool GameViewDebuggerMacOS::_msg_window_set_ime_position(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "window_set_ime_position: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "window_set_ime_position: invalid number of arguments.");
 
 	Point2i pos = p_args[0];
 	Point2i xpos = embedded_process->get_layer_host()->get_global_transform_with_canvas().xform(pos);
@@ -99,7 +99,7 @@ bool GameViewDebuggerMacOS::_msg_window_set_ime_position(const Array &p_args) {
 }
 
 bool GameViewDebuggerMacOS::_msg_joy_start(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 3, false, "joy_start: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 3, false, "joy_start: invalid number of arguments.");
 
 	int joy_id = p_args[0];
 	float duration = p_args[1];
@@ -109,10 +109,18 @@ bool GameViewDebuggerMacOS::_msg_joy_start(const Array &p_args) {
 }
 
 bool GameViewDebuggerMacOS::_msg_joy_stop(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "joy_stop: invalid number of arguments");
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "joy_stop: invalid number of arguments.");
 
 	int joy_id = p_args[0];
 	Input::get_singleton()->stop_joy_vibration(joy_id);
+	return true;
+}
+
+bool GameViewDebuggerMacOS::_msg_warp_mouse(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, false, "warp_mouse: invalid number of arguments.");
+
+	Vector2i pos = p_args[0];
+	embedded_process->get_layer_host()->warp_mouse(pos);
 	return true;
 }
 
@@ -125,6 +133,7 @@ void GameViewDebuggerMacOS::_init_capture_message_handlers() {
 	parse_message_handlers["game_view:window_set_ime_position"] = &GameViewDebuggerMacOS::_msg_window_set_ime_position;
 	parse_message_handlers["game_view:joy_start"] = &GameViewDebuggerMacOS::_msg_joy_start;
 	parse_message_handlers["game_view:joy_stop"] = &GameViewDebuggerMacOS::_msg_joy_stop;
+	parse_message_handlers["game_view:warp_mouse"] = &GameViewDebuggerMacOS::_msg_warp_mouse;
 }
 
 bool GameViewDebuggerMacOS::capture(const String &p_message, const Array &p_data, int p_session) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108746

Also fixes missing DS feature flags.