### PR TITLE
Fix folding node in scene tree dock

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -399,9 +399,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 
 	if (can_rename) {
 		bool collapsed = p_node->is_displayed_folded();
-		if (collapsed) {
-			p_item->set_collapsed(true);
-		}
+		p_item->set_collapsed(collapsed);
 	}
 
 	Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(p_node, "Node");


### PR DESCRIPTION
A small edit that fixes expanding a node folding in scene tree editor.
The problem was calling `set_display_folded` and emitting `editor_state_changed` was collapsing the node but not expanding it.  
  
With this fix, this editor script below works:  
```gdscript
var root : Node = EditorInterface.get_edited_scene_root()
var nodes : Array = get_all_visible_nodes(root)
for node : Node in nodes:
	node.set_display_folded(!node.visible)
	node.editor_state_changed.emit()
```
Here's an animation of the custom tool using `set_display_folded` (folding from node visibility):  
  
![godot_folding_node](https://github.com/user-attachments/assets/c44125ef-1864-432d-b400-7a4329766759)
