### PR TITLE
Add camera gizmos size in settings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -363,8 +363,8 @@
 		<member name="editors/3d/manipulator_gizmo_size" type="int" setter="" getter="">
 			Size of the default gizmo for moving, rotating, and scaling 3D nodes.
 		</member>
-		<member name="editors/3d/camera_gizmo_icon_size" type="int" setter="" getter="">
-			Size of the camera gizmo icon.
+		<member name="editors/3d_gizmos/gizmo_settings/icon_size" type="float" setter="" getter="">
+			Size of the 3D gizmo icons.
 		</member>
 		<member name="editors/3d/navigation/emulate_3_button_mouse" type="bool" setter="" getter="">
 			If [code]true[/code], enables 3-button mouse emulation mode. This is useful on laptops when using a trackpad.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -363,9 +363,6 @@
 		<member name="editors/3d/manipulator_gizmo_size" type="int" setter="" getter="">
 			Size of the default gizmo for moving, rotating, and scaling 3D nodes.
 		</member>
-		<member name="editors/3d_gizmos/gizmo_settings/icon_size" type="float" setter="" getter="">
-			Size of the 3D gizmo icons.
-		</member>
 		<member name="editors/3d/navigation/emulate_3_button_mouse" type="bool" setter="" getter="">
 			If [code]true[/code], enables 3-button mouse emulation mode. This is useful on laptops when using a trackpad.
 			When 3-button mouse emulation mode is enabled, the pan, zoom and orbit modifiers can always be used in the 3D editor viewport, even when not holding down any mouse button.
@@ -526,6 +523,12 @@
 		</member>
 		<member name="editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size" type="float" setter="" getter="">
 			Size of the disk gizmo displayed when editing [Path3D]'s tilt handles.
+		</member>
+		<member name="editors/3d_gizmos/gizmo_settings/icon_size" type="float" setter="" getter="">
+			Size of the 3D gizmo icons.
+		</member>
+		<member name="editors/3d_gizmos/gizmo_settings/camera_frustum_scale" type="float" setter="" getter="">
+			Scale of the camera frustum gizmo shape.
 		</member>
 		<member name="editors/animation/autorename_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], automatically updates animation tracks' target paths when renaming or reparenting nodes in the Scene tree dock.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -518,17 +518,17 @@
 		<member name="editors/3d_gizmos/gizmo_settings/bone_shape" type="int" setter="" getter="">
 			The shape of [Skeleton3D] bone gizmos in the 3D editor. [b]Wire[/b] is a thin line, while [b]Octahedron[/b] is a set of lines that represent a thicker hollow line pointing in a specific direction (similar to most 3D animation software).
 		</member>
+		<member name="editors/3d_gizmos/gizmo_settings/camera_frustum_scale" type="float" setter="" getter="">
+			Scale of the camera frustum gizmo shape.
+		</member>
+		<member name="editors/3d_gizmos/gizmo_settings/icon_size" type="float" setter="" getter="">
+			Size of the 3D gizmo icons.
+		</member>
 		<member name="editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size" type="float" setter="" getter="">
 			Size of probe gizmos displayed when editing [LightmapGI] and [LightmapProbe] nodes. Setting this to [code]0.0[/code] will hide the probe spheres of [LightmapGI] and wireframes of [LightmapProbe] nodes, but will keep the wireframes linking probes from [LightmapGI] and billboard icons from [LightmapProbe] intact.
 		</member>
 		<member name="editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size" type="float" setter="" getter="">
 			Size of the disk gizmo displayed when editing [Path3D]'s tilt handles.
-		</member>
-		<member name="editors/3d_gizmos/gizmo_settings/icon_size" type="float" setter="" getter="">
-			Size of the 3D gizmo icons.
-		</member>
-		<member name="editors/3d_gizmos/gizmo_settings/camera_frustum_scale" type="float" setter="" getter="">
-			Scale of the camera frustum gizmo shape.
 		</member>
 		<member name="editors/animation/autorename_animation_tracks" type="bool" setter="" getter="">
 			If [code]true[/code], automatically updates animation tracks' target paths when renaming or reparenting nodes in the Scene tree dock.

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -363,6 +363,9 @@
 		<member name="editors/3d/manipulator_gizmo_size" type="int" setter="" getter="">
 			Size of the default gizmo for moving, rotating, and scaling 3D nodes.
 		</member>
+		<member name="editors/3d/camera_gizmo_icon_size" type="int" setter="" getter="">
+			Size of the camera gizmo icon.
+		</member>
 		<member name="editors/3d/navigation/emulate_3_button_mouse" type="bool" setter="" getter="">
 			If [code]true[/code], enables 3-button mouse emulation mode. This is useful on laptops when using a trackpad.
 			When 3-button mouse emulation mode is enabled, the pan, zoom and orbit modifiers can always be used in the 3D editor viewport, even when not holding down any mouse button.

--- a/editor/scene/3d/gizmos/audio_listener_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_listener_3d_gizmo_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/settings/editor_settings.h"
 #include "scene/3d/audio_listener_3d.h"
 
 AudioListener3DGizmoPlugin::AudioListener3DGizmoPlugin() {
@@ -52,5 +53,8 @@ int AudioListener3DGizmoPlugin::get_priority() const {
 
 void AudioListener3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Ref<Material> icon = get_material("audio_listener_3d_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+
+	p_gizmo->clear();
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/audio_stream_player_3d_gizmo_plugin.cpp
@@ -310,5 +310,6 @@ void AudioStreamPlayer3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	const Ref<Material> icon = get_material("stream_player_3d_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
@@ -255,8 +255,8 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 #undef ADD_TRIANGLE
 #undef ADD_QUAD
 
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
 	p_gizmo->add_lines(lines, material);
-	const real_t icon_size = EDITOR_GET("editors/3d/camera_gizmo_icon_size");
 	p_gizmo->add_unscaled_billboard(icon, icon_size);
 	p_gizmo->add_collision_segments(lines);
 

--- a/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
@@ -191,7 +191,7 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			}
 			Vector3 nside = Vector3(-side.x, side.y, side.z);
 			Vector3 up = Vector3(0, hsize * size_factor.y, 0);
-			
+
 			side *= frustum_scale;
 			nside *= frustum_scale;
 			up *= frustum_scale;

--- a/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
@@ -150,6 +150,8 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Size2i viewport_size = Node3DEditor::get_camera_viewport_size(camera);
 	const real_t viewport_aspect = viewport_size.x > 0 && viewport_size.y > 0 ? viewport_size.aspect() : 1.0;
 	const Size2 size_factor = viewport_aspect > 1.0 ? Size2(1.0, 1.0 / viewport_aspect) : Size2(viewport_aspect, 1.0);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	const real_t frustum_scale = EDITOR_GET("editors/3d_gizmos/gizmo_settings/camera_frustum_scale");
 
 #define ADD_TRIANGLE(m_a, m_b, m_c) \
 	{                               \
@@ -189,6 +191,10 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			}
 			Vector3 nside = Vector3(-side.x, side.y, side.z);
 			Vector3 up = Vector3(0, hsize * size_factor.y, 0);
+			
+			side *= frustum_scale;
+			nside *= frustum_scale;
+			up *= frustum_scale;
 
 			ADD_TRIANGLE(Vector3(), side + up, side - up);
 			ADD_TRIANGLE(Vector3(), nside + up, nside - up);
@@ -196,9 +202,9 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			ADD_TRIANGLE(Vector3(), side - up, nside - up);
 
 			handles.push_back(side);
-			side.x = MIN(side.x, hsize * 0.25);
+			side.x /= 4.0;
 			nside.x = -side.x;
-			Vector3 tup(0, up.y + hsize / 2, side.z);
+			Vector3 tup(0, up.y + side.x, side.z);
 			ADD_TRIANGLE(tup, side + up, nside + up);
 		} break;
 
@@ -255,7 +261,6 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 #undef ADD_TRIANGLE
 #undef ADD_QUAD
 
-	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
 	p_gizmo->add_lines(lines, material);
 	p_gizmo->add_unscaled_billboard(icon, icon_size);
 	p_gizmo->add_collision_segments(lines);

--- a/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/camera_3d_gizmo_plugin.cpp
@@ -256,7 +256,8 @@ void Camera3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 #undef ADD_QUAD
 
 	p_gizmo->add_lines(lines, material);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d/camera_gizmo_icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 	p_gizmo->add_collision_segments(lines);
 
 	if (!handles.is_empty()) {

--- a/editor/scene/3d/gizmos/cpu_particles_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/cpu_particles_3d_gizmo_plugin.cpp
@@ -103,5 +103,6 @@ void CPUParticles3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	Ref<Material> icon = get_material("particles_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/gizmos/decal_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/decal_gizmo_plugin.cpp
@@ -124,8 +124,9 @@ void DecalGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Vector<Vector3> handles = helper->box_get_handles(decal->get_size());
 	Ref<Material> material = get_material("decal_material", p_gizmo);
 	const Ref<Material> icon = get_material("decal_icon", p_gizmo);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
 
 	p_gizmo->add_lines(lines, material);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 	p_gizmo->add_handles(handles, get_material("handles"));
 }

--- a/editor/scene/3d/gizmos/fog_volume_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/fog_volume_gizmo_plugin.cpp
@@ -119,7 +119,8 @@ void FogVolumeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(lines, material);
 		p_gizmo->add_collision_segments(lines);
 		const Ref<Material> icon = get_material("fog_volume_icon", p_gizmo);
-		p_gizmo->add_unscaled_billboard(icon, 0.05);
+		const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+		p_gizmo->add_unscaled_billboard(icon, icon_size);
 		p_gizmo->add_handles(handles, handles_material);
 	}
 }

--- a/editor/scene/3d/gizmos/gpu_particles_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/gpu_particles_3d_gizmo_plugin.cpp
@@ -80,5 +80,6 @@ void GPUParticles3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	Ref<Material> icon = get_material("particles_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/gizmos/light_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/light_3d_gizmo_plugin.cpp
@@ -33,6 +33,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "scene/3d/light_3d.h"
 
@@ -193,7 +194,8 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		}
 
 		Ref<Material> icon = get_material("light_directional_icon", p_gizmo);
-		p_gizmo->add_unscaled_billboard(icon, 0.05, color);
+		const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+		p_gizmo->add_unscaled_billboard(icon, icon_size, color);
 	}
 
 	if (Object::cast_to<OmniLight3D>(light)) {
@@ -236,7 +238,8 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		}
 
 		const Ref<Material> icon = get_material("light_omni_icon", p_gizmo);
-		p_gizmo->add_unscaled_billboard(icon, 0.05, color);
+		const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+		p_gizmo->add_unscaled_billboard(icon, icon_size, color);
 	}
 
 	if (Object::cast_to<SpotLight3D>(light)) {
@@ -284,7 +287,8 @@ void Light3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		}
 
 		const Ref<Material> icon = get_material("light_spot_icon", p_gizmo);
-		p_gizmo->add_unscaled_billboard(icon, 0.05, color);
+		const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+		p_gizmo->add_unscaled_billboard(icon, icon_size, color);
 	}
 }
 

--- a/editor/scene/3d/gizmos/light_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/light_3d_gizmo_plugin.cpp
@@ -33,8 +33,8 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
-#include "editor/settings/editor_settings.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "editor/settings/editor_settings.h"
 #include "scene/3d/light_3d.h"
 
 Light3DGizmoPlugin::Light3DGizmoPlugin() {

--- a/editor/scene/3d/gizmos/lightmap_gi_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/lightmap_gi_gizmo_plugin.cpp
@@ -75,10 +75,11 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Ref<Material> icon = get_material("baked_indirect_light_icon", p_gizmo);
 	LightmapGI *baker = Object::cast_to<LightmapGI>(p_gizmo->get_node_3d());
 	Ref<LightmapGIData> data = baker->get_light_data();
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
 
 	p_gizmo->clear();
 
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 
 	if (data.is_null() || !p_gizmo->is_selected()) {
 		return;

--- a/editor/scene/3d/gizmos/lightmap_probe_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/lightmap_probe_gizmo_plugin.cpp
@@ -122,5 +122,6 @@ void LightmapProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		p_gizmo->add_lines(lines, material_lines);
 	}
 	const Ref<Material> icon = get_material("lightmap_probe_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/reflection_probe_gizmo_plugin.cpp
@@ -208,5 +208,6 @@ void ReflectionProbeGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	Ref<Material> icon = get_material("reflection_probe_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/gizmos/voxel_gi_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/voxel_gi_gizmo_plugin.cpp
@@ -160,5 +160,6 @@ void VoxelGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	Ref<Material> icon = get_material("voxel_gi_icon", p_gizmo);
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
+	const real_t icon_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/icon_size");
+	p_gizmo->add_unscaled_billboard(icon, icon_size);
 }

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -8402,6 +8402,7 @@ void Node3DEditor::_notification(int p_what) {
 			environ_state->set_custom_minimum_size(environ_vb->get_combined_minimum_size());
 
 			ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditor::update_all_gizmos).bind(Variant()));
+			EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditor::update_all_gizmos).bind(Variant()));
 		} break;
 
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -891,6 +891,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/3d_gizmos/gizmo_settings/bone_shape", 1, "Wire,Octahedron");
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size", 0.8, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size", 0.4, "0.0,1.0,0.001,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/icon_size", 0.05, "0.01,0.1,0.01", PROPERTY_USAGE_DEFAULT);
 
 	// If a line is a multiple of this, it uses the primary grid color.
 	// Use a power of 2 value by default as it's more common to use powers of 2 in level design.
@@ -948,7 +949,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// 3D: Manipulator
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_size", 80, "16,160,1");
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/camera_gizmo_icon_size", 0.05, "0.01,0.1,0.01", PROPERTY_USAGE_DEFAULT);
 
 	// 2D
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07), true);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -892,6 +892,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size", 0.8, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/lightmap_gi_probe_size", 0.4, "0.0,1.0,0.001,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/icon_size", 0.05, "0.01,0.1,0.01", PROPERTY_USAGE_DEFAULT);
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d_gizmos/gizmo_settings/camera_frustum_scale", 1.0, "0.1,10.0,0.1", PROPERTY_USAGE_DEFAULT);
 
 	// If a line is a multiple of this, it uses the primary grid color.
 	// Use a power of 2 value by default as it's more common to use powers of 2 in level design.

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -948,6 +948,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// 3D: Manipulator
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_size", 80, "16,160,1");
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/camera_gizmo_icon_size", 0.05, "0.01,0.1,0.001", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_BASIC_SETTING);
 
 	// 2D
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07), true);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -948,7 +948,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// 3D: Manipulator
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_size", 80, "16,160,1");
 	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/manipulator_gizmo_opacity", 0.9, "0,1,0.01", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
-	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/camera_gizmo_icon_size", 0.05, "0.01,0.1,0.001", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_EDITOR_BASIC_SETTING);
+	EDITOR_SETTING_USAGE(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/camera_gizmo_icon_size", 0.05, "0.01,0.1,0.01", PROPERTY_USAGE_DEFAULT);
 
 	// 2D
 	_initial_set("editors/2d/grid_color", Color(1.0, 1.0, 1.0, 0.07), true);


### PR DESCRIPTION
Adding a parameter in editor settings to change camera gizmo size in 3D view.  
  
<img width="672" height="449" alt="Screenshot from 2025-07-22 16-10-06" src="https://github.com/user-attachments/assets/94d57df9-075e-4415-8ac1-dca304d5c560" />  
  
I did not find how to send a notification to update the gizmo while changing the value. If anyone knows where to it would be useful to see the modification happening live.  
  
![godot_camera_gizmo_size](https://github.com/user-attachments/assets/8b646fb0-5177-4be1-9a9d-42a9f7fea318)
