### PR TITLE
OpenXR: Work around bug with Meta runtime on 1.0.49

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -598,13 +598,18 @@ bool OpenXRAPI::create_instance() {
 		extension_ptrs.push_back(enabled_extensions[i].get_data());
 	}
 
+	// We explicitly set the version to 1.0.48 in order to workaround a bug (see #108850) in Meta's runtime.
+	// Once that is fixed, restore this to using XR_API_VERSION_1_0, which is the version associated with the
+	// OpenXR headers that we're using.
+	XrVersion openxr_version = XR_MAKE_VERSION(1, 0, 48);
+
 	// Create our OpenXR instance
 	XrApplicationInfo application_info{
 		"Godot Engine", // applicationName, if we're running a game we'll update this down below.
 		1, // applicationVersion, we don't currently have this
 		"Godot Engine", // engineName
 		GODOT_VERSION_MAJOR * 10000 + GODOT_VERSION_MINOR * 100 + GODOT_VERSION_PATCH, // engineVersion 4.0 -> 40000, 4.0.1 -> 40001, 4.1 -> 40100, etc.
-		XR_API_VERSION_1_0 // apiVersion
+		openxr_version, // apiVersion
 	};
 
 	void *next_pointer = nullptr;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108850

This works around a bug in Meta's OpenXR runtime, which gives incorrect aim pose transforms if the OpenXR version used by the application is 1.0.49 or later. We can remove the workaround once Meta fixes this in their runtime.

This does fix the issue on the Meta Quest 3 in my testing, however, the more important question is if this will cause problems on other runtimes, in particular those that support OpenXR render models (support added in https://github.com/godotengine/godot/pull/107388) which is part of OpenXR 1.x.49. Hopefully, they aren't checking the version and features from 1.x.49 will work anyway :crossed_fingers: 

Will need some testing on a variety of OpenXR runtimes