### PR TITLE
Fix bad text contrast on readonly EditorPropertyArray/Dict/Res

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -759,6 +759,7 @@ void EditorProperty::_update_property_bg() {
 			add_theme_style_override("bg_selected", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), EditorStringName(EditorStyles)));
 			add_theme_style_override("bg", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), EditorStringName(EditorStyles)));
 			add_theme_color_override("property_color", get_theme_color(SNAME("sub_inspector_property_color"), EditorStringName(EditorStyles)));
+			add_theme_color_override("readonly_color", get_theme_color(SNAME("sub_inspector_property_color"), EditorStringName(EditorStyles)));
 			bottom_editor->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), EditorStringName(EditorStyles)));
 		} else {
 			bottom_editor->add_theme_style_override(SceneStringName(panel), get_theme_stylebox("sub_inspector_bg_no_border", EditorStringName(EditorStyles)));
@@ -767,6 +768,7 @@ void EditorProperty::_update_property_bg() {
 		remove_theme_style_override("bg_selected");
 		remove_theme_style_override("bg");
 		remove_theme_color_override("property_color");
+		remove_theme_color_override("readonly_color");
 	}
 	end_bulk_theme_override();
 	queue_redraw();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/108244

Not sure this is the best approach, but you can at least read the text now.


[Screencast_20250722_170322.webm](https://github.com/user-attachments/assets/c7ad2352-936b-4b17-a732-dc4871ad79ff)

