### PR TITLE
[Web] Fix inappropriate `memfree()` use

### DIFF
--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -108,7 +108,8 @@ void print_web_header() {
 	// Emscripten.
 	char *emscripten_version_char = godot_js_emscripten_get_version();
 	String emscripten_version = vformat("Emscripten %s", emscripten_version_char);
-	memfree(emscripten_version_char);
+	// `free()` is used here because it's not memory that was allocated by Godot.
+	free(emscripten_version_char);
 
 	// Build features.
 	String thread_support = OS::get_singleton()->has_feature("threads")


### PR DESCRIPTION
- ~~Adds `godot_js_runtime_free()`, a way to call `GodotRuntime.free()` from C++~~
- ~~Fixes an issue where `memfree()` would throw, but `GodotRuntime.free()` wouldn't.~~

- Uses `free()` instead of `memfree()` as that memory was not allocated by Godot

Fixes #108873