### PR TITLE
Properly update region editor window when undoing changes to `region_rect`

### DIFF
--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -881,18 +881,23 @@ void TextureRegionEditor::_node_removed(Node *p_node) {
 void TextureRegionEditor::_clear_edited_object() {
 	if (node_sprite_2d) {
 		node_sprite_2d->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
+		node_sprite_2d->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
 	if (node_sprite_3d) {
 		node_sprite_3d->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
+		node_sprite_3d->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
 	if (node_ninepatch) {
 		node_ninepatch->disconnect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
+		node_ninepatch->disconnect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
 	if (res_stylebox.is_valid()) {
 		res_stylebox->disconnect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
+		res_stylebox->disconnect_changed(callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
 	if (res_atlas_texture.is_valid()) {
 		res_atlas_texture->disconnect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
+		res_atlas_texture->disconnect_changed(callable_mp(this, &TextureRegionEditor::_edit_region));
 	}
 
 	node_sprite_2d = nullptr;
@@ -922,8 +927,10 @@ void TextureRegionEditor::edit(Object *p_obj) {
 
 		if (is_resource) {
 			Object::cast_to<Resource>(p_obj)->connect_changed(callable_mp(this, &TextureRegionEditor::_texture_changed));
+			Object::cast_to<Resource>(p_obj)->connect_changed(callable_mp(this, &TextureRegionEditor::_edit_region));
 		} else {
 			p_obj->connect(SceneStringName(texture_changed), callable_mp(this, &TextureRegionEditor::_texture_changed));
+			p_obj->connect(SceneStringName(item_rect_changed), callable_mp(this, &TextureRegionEditor::_edit_region));
 		}
 		_edit_region();
 	}


### PR DESCRIPTION
Fixes #108519

Fixes the Region Editor dialog window not updating when the associated Rect2 `region_rect` is modified in the inspector.