### PR TITLE
Fix shader editor menu switch on hover for file button

### DIFF
--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -796,6 +796,7 @@ void ShaderEditorPlugin::_switch_to_editor(ShaderEditor *p_editor) {
 	VisualShaderEditor *vs_editor = Object::cast_to<VisualShaderEditor>(p_editor);
 	if (vs_editor) {
 		file_menu->get_parent()->remove_child(file_menu);
+		file_menu->set_switch_on_hover(false);
 		bar->add_child(file_menu);
 		bar->move_child(file_menu, 2); // Toggle Files Panel button + separator.
 
@@ -809,6 +810,7 @@ void ShaderEditorPlugin::_switch_to_editor(ShaderEditor *p_editor) {
 		// Just swapped from a visual shader editor.
 		if (file_menu->get_parent() != menu_hb) {
 			file_menu->get_parent()->remove_child(file_menu);
+			file_menu->set_switch_on_hover(true);
 			menu_hb->add_child(file_menu);
 			menu_hb->move_child(file_menu, 0);
 
@@ -900,6 +902,7 @@ ShaderEditorPlugin::ShaderEditorPlugin() {
 	main_container->add_child(menu_hb);
 	file_menu = memnew(MenuButton);
 	file_menu->set_text(TTR("File"));
+	file_menu->set_switch_on_hover(true);
 	file_menu->set_shortcut_context(files_split);
 	_setup_popup_menu(FILE, file_menu->get_popup());
 	file_menu->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &ShaderEditorPlugin::_menu_item_pressed));


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/108876

[Screencast_20250722_223753.webm](https://github.com/user-attachments/assets/5d50985d-7348-4666-8cd3-b0f7e3358eba)

Switch on hover is turned off for File button in the visual shader editor. It felt a bit strange to have file and mange varyings switch on hover when they are so far away from each other.

<img width="885" height="335" alt="Screenshot_20250722_223841" src="https://github.com/user-attachments/assets/7a7dbb87-979a-445c-9674-5ac17aaf371c" />
