### PR TITLE
Fix metadata formatting in inspector

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -3983,6 +3983,10 @@ void EditorInspector::update_tree() {
 		if ((p.usage & PROPERTY_USAGE_SCRIPT_VARIABLE) && name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED) {
 			name_style = EditorPropertyNameProcessor::STYLE_CAPITALIZED;
 		}
+		// Metadata entries are accessed by String, so we should show the actual key name directly.
+		if (path.begins_with("metadata/")) {
+			name_style = EditorPropertyNameProcessor::STYLE_RAW;
+		}
 		const String property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(name_override, name_style, p.name, doc_name) + feature_tag;
 
 		// Remove the property from the path.


### PR DESCRIPTION
Fixes #82938

Metadata now ignores inspector property styling to avoid unnecessary confusion.

Before:
<img width="353" height="134" alt="image" src="https://github.com/user-attachments/assets/9c487597-a49a-4e9a-9d87-8d5d558afc5f" />

After:
<img width="352" height="135" alt="image" src="https://github.com/user-attachments/assets/2cf47bae-40c8-4ab8-a42e-b622a48e9292" />
