### PR TITLE
Reduce icon size in editor inspector NodePath properties to match design size

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3260,6 +3260,8 @@ EditorPropertyNodePath::EditorPropertyNodePath() {
 	assign->set_h_size_flags(SIZE_EXPAND_FILL);
 	assign->set_clip_text(true);
 	assign->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	// Use a constant width for the icon to avoid sizing issues or blurry icons.
+	assign->add_theme_constant_override("icon_max_width", get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 	assign->set_expand_icon(true);
 	assign->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyNodePath::_node_assign));
 	assign->connect(SceneStringName(draw), callable_mp(this, &EditorPropertyNodePath::_assign_draw));


### PR DESCRIPTION
Previously, icons were displayed at a slightly higher size than they were designed for, which made them look blurry.

## Preview

Before | After
-|-
<img width="250" height="57" alt="Screenshot_20250722_225014" src="https://github.com/user-attachments/assets/37445e5b-f359-4b7f-8be5-d7be9adfab37" /> | <img width="266" height="56" alt="Screenshot_20250722_230047" src="https://github.com/user-attachments/assets/58dea1c7-1feb-417d-aa35-cb3c8d1f7d1b" />
