### PR TITLE
Fix crash in SceneTreeDock when closing a scene with a selected node

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2925,12 +2925,9 @@ void SceneTreeDock::_selection_changed() {
 	}
 
 	// Untrack script changes in previously selected nodes.
-	for (Node *node : node_previous_selection) {
-		node->disconnect(CoreStringName(script_changed), callable_mp(this, &SceneTreeDock::_queue_update_script_button));
-	}
+	clear_previous_node_selection();
 
 	// Track script changes in newly selected nodes.
-	node_previous_selection.clear();
 	node_previous_selection.reserve(editor_selection->get_selection().size());
 	for (const KeyValue<Node *, Object *> &E : editor_selection->get_selection()) {
 		Node *node = E.key;
@@ -3371,6 +3368,13 @@ static bool _is_same_selection(const Vector<Node *> &p_first, const List<Node *>
 		}
 	}
 	return true;
+}
+
+void SceneTreeDock::clear_previous_node_selection() {
+	for (Node *node : node_previous_selection) {
+		node->disconnect(CoreStringName(script_changed), callable_mp(this, &SceneTreeDock::_queue_update_script_button));
+	}
+	node_previous_selection.clear();
 }
 
 void SceneTreeDock::set_selection(const Vector<Node *> &p_nodes) {

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -324,6 +324,7 @@ public:
 	void set_edited_scene(Node *p_scene);
 	void instantiate(const String &p_file);
 	void instantiate_scenes(const Vector<String> &p_files, Node *p_parent = nullptr);
+	void clear_previous_node_selection();
 	void set_selection(const Vector<Node *> &p_nodes);
 	void set_selected(Node *p_node, bool p_emit_selected = false);
 	void fill_path_renames(Node *p_node, Node *p_new_parent, HashMap<Node *, NodePath> *p_renames);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4248,6 +4248,7 @@ void EditorNode::_set_current_scene_nocheck(int p_idx) {
 	Node *old_scene = get_editor_data().get_edited_scene_root();
 
 	editor_selection->clear();
+	SceneTreeDock::get_singleton()->clear_previous_node_selection();
 	editor_data.set_edited_scene(p_idx);
 
 	Node *new_scene = editor_data.get_edited_scene_root();


### PR DESCRIPTION
This PR fixes a crash when closing a scene when a node is selected. This code:

```cpp
for (Node *node : node_previous_selection) {
	node->disconnect(CoreStringName(script_changed), callable_mp(this, &SceneTreeDock::_queue_update_script_button));
}
```

crashed on `node->disconnect` because `node` is a previously freed object by the time this runs.

I considered validating the objects like in PR #108791, but we should really properly clear out the selection instead. I also saw PR #108785 after writing this, and both accomplish the same thing, except that this PR clears out SceneTreeDock's previously selected nodes at the same time as EditorSelection itself is cleared of those nodes.

*Bugsquad edit:* Fixes #108783 Supersedes #108791 Supersedes #108785