### PR TITLE
Use explicit public access modifier in C# code

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IHandshake.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IHandshake.cs
@@ -4,7 +4,7 @@ namespace GodotTools.IdeMessaging
 {
     public interface IHandshake
     {
-        string GetHandshakeLine(string identity);
-        bool IsValidPeerHandshake(string handshake, [NotNullWhen(true)] out string? identity, ILogger logger);
+        public string GetHandshakeLine(string identity);
+        public bool IsValidPeerHandshake(string handshake, [NotNullWhen(true)] out string? identity, ILogger logger);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/ILogger.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/ILogger.cs
@@ -4,10 +4,10 @@ namespace GodotTools.IdeMessaging
 {
     public interface ILogger
     {
-        void LogDebug(string message);
-        void LogInfo(string message);
-        void LogWarning(string message);
-        void LogError(string message);
-        void LogError(string message, Exception e);
+        public void LogDebug(string message);
+        public void LogInfo(string message);
+        public void LogWarning(string message);
+        public void LogError(string message);
+        public void LogError(string message, Exception e);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IMessageHandler.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IMessageHandler.cs
@@ -4,6 +4,6 @@ namespace GodotTools.IdeMessaging
 {
     public interface IMessageHandler
     {
-        Task<MessageContent> HandleRequest(Peer peer, string id, MessageContent content, ILogger logger);
+        public Task<MessageContent> HandleRequest(Peer peer, string id, MessageContent content, ILogger logger);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
@@ -281,13 +281,13 @@ namespace GodotTools.OpenVisualStudio
         private interface IOleMessageFilter
         {
             [PreserveSig]
-            int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
+            public int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
 
             [PreserveSig]
-            int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
+            public int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
 
             [PreserveSig]
-            int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
+            public int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
         }
 
         #endregion

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
@@ -9,7 +9,7 @@ namespace Godot
         /// Gets an Awaiter for this <see cref="IAwaitable"/>.
         /// </summary>
         /// <returns>An Awaiter.</returns>
-        IAwaiter GetAwaiter();
+        public IAwaiter GetAwaiter();
     }
 
     /// <summary>
@@ -22,6 +22,6 @@ namespace Godot
         /// Gets an Awaiter for this <see cref="IAwaitable{TResult}"/>.
         /// </summary>
         /// <returns>An Awaiter.</returns>
-        IAwaiter<TResult> GetAwaiter();
+        public IAwaiter<TResult> GetAwaiter();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -10,12 +10,12 @@ namespace Godot
         /// <summary>
         /// The completion status of this <see cref="IAwaiter"/>.
         /// </summary>
-        bool IsCompleted { get; }
+        public bool IsCompleted { get; }
 
         /// <summary>
         /// Gets the result of completion for this <see cref="IAwaiter"/>.
         /// </summary>
-        void GetResult();
+        public void GetResult();
     }
 
     /// <summary>
@@ -27,11 +27,11 @@ namespace Godot
         /// <summary>
         /// The completion status of this <see cref="IAwaiter{TResult}"/>.
         /// </summary>
-        bool IsCompleted { get; }
+        public bool IsCompleted { get; }
 
         /// <summary>
         /// Gets the result of completion for this <see cref="IAwaiter{TResult}"/>.
         /// </summary>
-        TResult GetResult();
+        public TResult GetResult();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
@@ -10,12 +10,12 @@ namespace Godot
         /// Executed before serializing this instance's state when reloading assemblies.
         /// Clear any data that should not be serialized.
         /// </summary>
-        void OnBeforeSerialize();
+        public void OnBeforeSerialize();
 
         /// <summary>
         /// Executed after deserializing this instance's state after reloading assemblies.
         /// Restore any state that has been lost.
         /// </summary>
-        void OnAfterDeserialize();
+        public void OnAfterDeserialize();
     }
 }


### PR DESCRIPTION
Why? One reason only: These are automatically added by `dotnet-format` when running `pre-commit run --all-files` in the Godot repository. With these changes committed, running the formatter won't produce any diffs.

Arguably, the code not complying with the formatter is a bug, but I'll label this as an enhancement.