### PR TITLE
GDScript: Fix `and`, `or`, and `not` failing to infer with Variant argument

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3142,6 +3142,11 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 		result.type_source = left_type.type_source;
 		result.kind = GDScriptParser::DataType::BUILTIN;
 		result.builtin_type = Variant::STRING;
+	} else if (p_binary_op->variant_op == Variant::OP_AND || p_binary_op->variant_op == Variant::OP_OR) {
+		// The operators "and" and "or" operate on all types and always return a boolean.
+		result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
+		result.kind = GDScriptParser::DataType::BUILTIN;
+		result.builtin_type = Variant::BOOL;
 	} else if (left_type.is_variant() || right_type.is_variant()) {
 		// Cannot infer type because one operand can be anything.
 		result.kind = GDScriptParser::DataType::VARIANT;
@@ -5233,8 +5238,20 @@ void GDScriptAnalyzer::reduce_unary_op(GDScriptParser::UnaryOpNode *p_unary_op) 
 	}
 
 	if (operand_type.is_variant()) {
-		result.kind = GDScriptParser::DataType::VARIANT;
-		mark_node_unsafe(p_unary_op);
+		switch (p_unary_op->operation) {
+			case GDScriptParser::UnaryOpNode::OP_LOGIC_NOT:
+				// Logical NOT accepts values of any type and always returns a boolean.
+				result.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
+				result.kind = GDScriptParser::DataType::BUILTIN;
+				result.builtin_type = Variant::BOOL;
+				break;
+			case GDScriptParser::UnaryOpNode::OP_POSITIVE:
+			case GDScriptParser::UnaryOpNode::OP_NEGATIVE:
+			case GDScriptParser::UnaryOpNode::OP_COMPLEMENT:
+				result.kind = GDScriptParser::DataType::VARIANT;
+				mark_node_unsafe(p_unary_op);
+				break;
+		}
 	} else {
 		bool valid = false;
 		result = get_operation_type(p_unary_op->variant_op, operand_type, valid, p_unary_op);

--- a/modules/gdscript/tests/scripts/analyzer/features/logical_ops_infer.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/logical_ops_infer.gd
@@ -1,0 +1,10 @@
+func test():
+	var x: Variant = 42
+
+	var a := not x
+	var b := x and x
+	var c := x or x
+
+	var _a_is_bool: bool = a
+	var _b_is_bool: bool = b
+	var _c_is_bool: bool = c

--- a/modules/gdscript/tests/scripts/analyzer/features/logical_ops_infer.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/logical_ops_infer.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
Type analysis would fail to infer the result of these operators as boolean if the argument did not have a static non-Variant type. This is inconsistent with the observed evaluation of these operators which returns a boolean for all possible types.

Fixes #108808.

Someone should probably check my work here. I'm not certain on coding style things like using `if` vs. `switch`. I can't help but feel like unnecessary work is being done before these new code paths. Also, it may be wrong! I have checked that the bitwise `&` and `|` have not been erroneously affected at least.

Oh, and I haven't written tests yet! I will do that.