### PR TITLE
Fix `ProgressDialog` errors during first scan.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -851,7 +851,7 @@ void EditorNode::_notification(int p_what) {
 
 			command_palette->register_shortcuts_as_command();
 
-			callable_mp(this, &EditorNode::_begin_first_scan).call_deferred();
+			_begin_first_scan();
 
 			last_dark_mode_state = DisplayServer::get_singleton()->is_dark_mode();
 			last_system_accent_color = DisplayServer::get_singleton()->get_accent_color();

--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -166,6 +166,14 @@ void ProgressDialog::_popup() {
 
 	center_panel->set_custom_minimum_size(ms);
 
+	if (is_ready()) {
+		_reparent_and_show();
+	} else {
+		callable_mp(this, &ProgressDialog::_reparent_and_show).call_deferred();
+	}
+}
+
+void ProgressDialog::_reparent_and_show() {
 	Window *current_window = SceneTree::get_singleton()->get_root()->get_last_exclusive_window();
 	ERR_FAIL_NULL(current_window);
 	reparent(current_window);

--- a/editor/gui/progress_dialog.h
+++ b/editor/gui/progress_dialog.h
@@ -89,6 +89,7 @@ class ProgressDialog : public CenterContainer {
 	void _cancel_pressed();
 
 	void _update_ui();
+	void _reparent_and_show();
 	bool canceled = false;
 
 protected:


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/108446
* Fixes: https://github.com/godotengine/godot/issues/100900


Note: On Windows, minimizing the window while loading the project no longer throw errors, other issues can't be reproduced since users have reported that it happens randomly and I think they have minimized the window during loading without noticing it was the main reason.