### PR TITLE
Improve connection bind deletion

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -245,12 +245,8 @@ void ConnectDialog::_add_bind() {
 /*
  * Remove parameter bind from connection.
  */
-void ConnectDialog::_remove_bind() {
-	String st = bind_editor->get_selected_path();
-	if (st.is_empty()) {
-		return;
-	}
-	int idx = st.get_slicec('/', 1).to_int() - 1;
+void ConnectDialog::_remove_bind(const String &p_bind) {
+	int idx = p_bind.get_slicec('/', 1).to_int() - 1;
 
 	ERR_FAIL_INDEX(idx, cdbinds->params.size());
 	cdbinds->params.remove_at(idx);
@@ -895,18 +891,14 @@ ConnectDialog::ConnectDialog() {
 	add_bind->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_add_bind));
 	bind_controls.push_back(add_bind);
 
-	Button *del_bind = memnew(Button);
-	del_bind->set_text(TTR("Remove"));
-	add_bind_hb->add_child(del_bind);
-	del_bind->connect(SceneStringName(pressed), callable_mp(this, &ConnectDialog::_remove_bind));
-	bind_controls.push_back(del_bind);
-
 	vbc_right->add_margin_child(TTR("Add Extra Call Argument:"), add_bind_hb);
 
 	bind_editor = memnew(EditorInspector);
 	bind_editor->set_accessibility_name(TTRC("Extra Call Arguments:"));
 	bind_editor->set_theme_type_variation("ScrollContainerSecondary");
+	bind_editor->set_use_deletable_properties(true);
 	bind_controls.push_back(bind_editor);
+	bind_editor->connect("property_deleted", callable_mp(this, &ConnectDialog::_remove_bind));
 
 	vbc_right->add_margin_child(TTR("Extra Call Arguments:"), bind_editor, true);
 

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -161,7 +161,7 @@ private:
 
 	void _unbind_count_changed(double p_count);
 	void _add_bind();
-	void _remove_bind();
+	void _remove_bind(const String &p_bind);
 	void _advanced_pressed();
 	void _update_ok_enabled();
 	void _update_warning_label();


### PR DESCRIPTION
Makes connection binds deletable directly, instead of via an awkward Remove button.

https://github.com/user-attachments/assets/efbec379-2e61-4709-819a-801bdb13ea74

Closes #60477
