### PR TITLE
Update documentation for `DriverResource` enum .

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1146,24 +1146,28 @@
 			Represents the size of the [enum DeviceType] enum.
 		</constant>
 		<constant name="DRIVER_RESOURCE_LOGICAL_DEVICE" value="0" enum="DriverResource">
-			Specific device object based on a physical device.
-			- Vulkan: Vulkan device driver resource ([code]VkDevice[/code]) ([code]rid[/code] parameter is ignored).
+			Specific device object based on a physical device ([code]rid[/code] parameter is ignored).
+			- Vulkan: Vulkan device driver resource ([code]VkDevice[/code]).
+			- D3D12: D3D12 device driver resource ([code]ID3D12Device[/code]).
+			- Metal: Metal device driver resource ([code]MTLDevice[/code]).
 		</constant>
 		<constant name="DRIVER_RESOURCE_PHYSICAL_DEVICE" value="1" enum="DriverResource">
-			Physical device the specific logical device is based on.
-			- Vulkan: [code]VkDevice[/code] ([code]rid[/code] parameter is ignored).
+			Physical device the specific logical device is based on ([code]rid[/code] parameter is ignored).
+			- Vulkan: [code]VkPhysicalDevice[/code].
+			- D3D12: [code]IDXGIAdapter[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_TOPMOST_OBJECT" value="2" enum="DriverResource">
-			Top-most graphics API entry object.
-			- Vulkan: [code]VkInstance[/code] ([code]rid[/code] parameter is ignored).
+			Top-most graphics API entry object ([code]rid[/code] parameter is ignored).
+			- Vulkan: [code]VkInstance[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_COMMAND_QUEUE" value="3" enum="DriverResource">
-			The main graphics-compute command queue.
-			- Vulkan: [code]VkQueue[/code] ([code]rid[/code] parameter is ignored).
+			The main graphics-compute command queue ([code]rid[/code] parameter is ignored).
+			- Vulkan: [code]VkQueue[/code].
+			- Metal: [code]MTLCommandQueue[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_QUEUE_FAMILY" value="4" enum="DriverResource">
-			The specific family the main queue belongs to.
-			- Vulkan: The queue family index, a [code]uint32_t[/code] ([code]rid[/code] parameter is ignored).
+			The specific family the main queue belongs to ([code]rid[/code] parameter is ignored).
+			- Vulkan: The queue family index, a [code]uint32_t[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_TEXTURE" value="5" enum="DriverResource">
 			- Vulkan: [code]VkImage[/code].
@@ -1171,10 +1175,12 @@
 		<constant name="DRIVER_RESOURCE_TEXTURE_VIEW" value="6" enum="DriverResource">
 			The view of an owned or shared texture.
 			- Vulkan: [code]VkImageView[/code].
+			- D3D12: [code]ID3D12Resource[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_TEXTURE_DATA_FORMAT" value="7" enum="DriverResource">
 			The native id of the data format of the texture.
 			- Vulkan: [code]VkFormat[/code].
+			- D3D12: [code]DXGI_FORMAT[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_SAMPLER" value="8" enum="DriverResource">
 			- Vulkan: [code]VkSampler[/code].
@@ -1185,12 +1191,15 @@
 		<constant name="DRIVER_RESOURCE_BUFFER" value="10" enum="DriverResource">
 			Buffer of any kind of (storage, vertex, etc.).
 			- Vulkan: [code]VkBuffer[/code].
+			- D3D12: [code]ID3D12Resource[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_COMPUTE_PIPELINE" value="11" enum="DriverResource">
 			- Vulkan: [code]VkPipeline[/code].
+			- Metal: [code]MTLComputePipelineState[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_RENDER_PIPELINE" value="12" enum="DriverResource">
 			- Vulkan: [code]VkPipeline[/code].
+			- Metal: [code]MTLRenderPipelineState[/code].
 		</constant>
 		<constant name="DRIVER_RESOURCE_VULKAN_DEVICE" value="0" enum="DriverResource" deprecated="Use [constant DRIVER_RESOURCE_LOGICAL_DEVICE] instead.">
 		</constant>


### PR DESCRIPTION
Updated and expanded the documentation for the DriverResource enum, to more accurately reflect the actual object types returned by `RenderingDevice::get_driver_resource` in different backends.