### PR TITLE
Remove selective shader baking.

### DIFF
--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -397,14 +397,8 @@ void ShaderBakerExportPlugin::_customize_shader_version(ShaderRD *p_shader, RID 
 
 	for (int64_t i = 0; i < variant_count; i++) {
 		int group = p_shader->get_variant_to_group(i);
-		if (p_shader->has_variant_bake_for(i)) {
-			if (!p_shader->get_variant_bake_for(i, shader_cache_platform_name + "_" + shader_cache_renderer_name + "_" + shader_container_driver) || !groups_to_compile.has(group)) {
-				continue;
-			}
-		} else {
-			if (!p_shader->is_variant_enabled(i) || !groups_to_compile.has(group)) {
-				continue;
-			}
+		if (!p_shader->is_variant_enabled(i) || !groups_to_compile.has(group)) {
+			continue;
 		}
 
 		WorkItem work_item;

--- a/servers/rendering/renderer_rd/cluster_builder_rd.cpp
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.cpp
@@ -136,26 +136,6 @@ ClusterBuilderSharedDataRD::ClusterBuilderSharedDataRD() {
 			cluster_render.cluster_render_shader.set_variant_enabled(ClusterRender::SHADER_USE_ATTACHMENT_MOLTENVK, false);
 		}
 #endif
-		// Do not bake default (with "gl_HelperInvocation" and image atomics) variants for macOS/iOS Vulkan, but bake it for the rest of configs (including Metal).
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL, "macos_forward_clustered_vulkan", false, true);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL, "ios_forward_clustered_vulkan", false, true);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT, "macos_forward_clustered_vulkan", false, true);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT, "ios_forward_clustered_vulkan", false, true);
-
-		// Bake no "gl_HelperInvocation" and no "image atomics" variants for macOS/iOS Vulkan only.
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL_MOLTENVK, "macos_forward_clustered_vulkan", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL_MOLTENVK, "ios_forward_clustered_vulkan", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT_MOLTENVK, "macos_forward_clustered_vulkan", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT_MOLTENVK, "ios_forward_clustered_vulkan", true, false);
-
-		// Bake no "image atomics" variants for macOS/iOS/visionOS Metal only.
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL_NO_ATOMICS, "macos_forward_clustered_metal", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL_NO_ATOMICS, "ios_forward_clustered_metal", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_NORMAL_NO_ATOMICS, "visionos_forward_clustered_metal", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT_NO_ATOMICS, "macos_forward_clustered_metal", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT_NO_ATOMICS, "ios_forward_clustered_metal", true, false);
-		cluster_render.cluster_render_shader.set_variants_bake_for(ClusterRender::SHADER_USE_ATTACHMENT_NO_ATOMICS, "visionos_forward_clustered_metal", true, false);
-
 		cluster_render.shader_version = cluster_render.cluster_render_shader.version_create();
 		cluster_render.shader = cluster_render.cluster_render_shader.version_get_shader(cluster_render.shader_version, shader_variant);
 		cluster_render.shader_pipelines[ClusterRender::PIPELINE_NORMAL] = RD::get_singleton()->render_pipeline_create(cluster_render.shader, fb_format, vertex_format, RD::RENDER_PRIMITIVE_TRIANGLES, rasterization_state, RD::PipelineMultisampleState(), RD::PipelineDepthStencilState(), blend_state, 0);

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -222,15 +222,6 @@ void Fog::init_fog_shader(uint32_t p_max_directional_lights, int p_roughness_lay
 		} else {
 			volumetric_fog.shader.set_variant_enabled(0, false);
 		}
-		// Always bake default (with image atomics) variant.
-		volumetric_fog.shader.set_variants_bake_for(0, "*", true, true);
-
-		// Bake no "image atomics" variant for macOS/iOS (Vulkan and Metal) and visionOS (Metal).
-		volumetric_fog.shader.set_variants_bake_for(1, "macos_forward_clustered_vulkan", true, false);
-		volumetric_fog.shader.set_variants_bake_for(1, "macos_forward_clustered_metal", true, false);
-		volumetric_fog.shader.set_variants_bake_for(1, "ios_forward_clustered_vulkan", true, false);
-		volumetric_fog.shader.set_variants_bake_for(1, "ios_forward_clustered_metal", true, false);
-		volumetric_fog.shader.set_variants_bake_for(1, "visionos_forward_clustered_metal", true, false);
 
 		material_storage->shader_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_FOG, _create_fog_shader_funcs);
 		material_storage->material_set_data_request_function(RendererRD::MaterialStorage::SHADER_TYPE_FOG, _create_fog_material_funcs);
@@ -333,15 +324,6 @@ ALBEDO = vec3(1.0);
 			} else {
 				volumetric_fog.process_shader.set_variant_enabled(i, false);
 			}
-			// Always bake default (with image atomics) variant.
-			volumetric_fog.process_shader.set_variants_bake_for(i, "*", true, true);
-
-			// Bake no "image atomics" variant for macOS/iOS (Vulkan and Metal) and visionOS (Metal) only.
-			volumetric_fog.process_shader.set_variants_bake_for(i + VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_MAX, "macos_forward_clustered_vulkan", true, false);
-			volumetric_fog.process_shader.set_variants_bake_for(i + VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_MAX, "macos_forward_clustered_metal", true, false);
-			volumetric_fog.process_shader.set_variants_bake_for(i + VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_MAX, "ios_forward_clustered_vulkan", true, false);
-			volumetric_fog.process_shader.set_variants_bake_for(i + VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_MAX, "ios_forward_clustered_metal", true, false);
-			volumetric_fog.process_shader.set_variants_bake_for(i + VolumetricFogShader::VOLUMETRIC_FOG_PROCESS_SHADER_MAX, "visionos_forward_clustered_metal", true, false);
 		}
 
 		volumetric_fog.process_shader_version = volumetric_fog.process_shader.version_create();

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -262,7 +262,7 @@ void ShaderRD::_build_variant_code(StringBuilder &builder, uint32_t p_variant, c
 }
 
 Vector<String> ShaderRD::_build_variant_stage_sources(uint32_t p_variant, CompileData p_data) {
-	if (!variants_enabled[p_variant] && !variants_bake_for.has(p_variant)) {
+	if (!variants_enabled[p_variant]) {
 		return Vector<String>(); // Variant is disabled, return.
 	}
 
@@ -463,11 +463,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 	for (uint32_t i = 0; i < variant_count; i++) {
 		int variant_id = group_to_variant_map[p_group][i];
 		uint32_t variant_size = f->get_32();
-		ERR_FAIL_COND_V(variant_size == 0 && variants_enabled[variant_id], false);
-		if (!variants_enabled[variant_id] && !variants_bake_for.has(variant_id)) {
-			continue;
-		}
-		if (variant_size == 0) {
+		if (!variants_enabled[variant_id] || variant_size == 0) {
 			continue;
 		}
 		Vector<uint8_t> variant_bytes;
@@ -482,7 +478,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 
 	for (uint32_t i = 0; i < variant_count; i++) {
 		int variant_id = group_to_variant_map[p_group][i];
-		if ((!variants_enabled[variant_id] && !variants_bake_for.has(variant_id)) || p_version->variant_data[variant_id].is_empty()) {
+		if (!variants_enabled[variant_id]) {
 			p_version->variants.write[variant_id] = RID();
 			continue;
 		}
@@ -575,7 +571,7 @@ void ShaderRD::_compile_version_end(Version *p_version, int p_group) {
 	if (!all_valid) {
 		// Clear versions if they exist.
 		for (int i = 0; i < variant_defines.size(); i++) {
-			if ((!variants_enabled[i] && !variants_bake_for.has(i)) || !group_enabled[variant_defines[i].group]) {
+			if (!variants_enabled[i] || !group_enabled[variant_defines[i].group]) {
 				continue; // Disabled.
 			}
 			if (!p_version->variants[i].is_null()) {

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -60,8 +60,6 @@ private:
 	CharString general_defines;
 	Vector<VariantDefine> variant_defines;
 	Vector<bool> variants_enabled;
-	HashMap<int, HashMap<String, bool>> variants_bake_for;
-	HashMap<int, bool> variants_bake_for_def;
 	Vector<uint32_t> variant_to_group;
 	HashMap<int, LocalVector<int>> group_to_variant_map;
 	Vector<bool> group_enabled;
@@ -217,25 +215,6 @@ public:
 	bool is_variant_enabled(int p_variant) const;
 	int64_t get_variant_count() const;
 	int get_variant_to_group(int p_variant) const;
-
-	bool has_variant_bake_for(int p_variant) const {
-		return variants_bake_for.has(p_variant);
-	}
-
-	bool get_variant_bake_for(int p_variant, const String &p_name) const {
-		if (!variants_bake_for.has(p_variant)) {
-			return is_variant_enabled(p_variant);
-		}
-		if (!variants_bake_for[p_variant].has(p_name.to_lower())) {
-			return variants_bake_for_def[p_variant];
-		}
-		return variants_bake_for[p_variant][p_name.to_lower()];
-	}
-
-	void set_variants_bake_for(int p_variant, const String &p_name, bool p_enable, bool p_default) {
-		variants_bake_for[p_variant][p_name.to_lower()] = p_enable;
-		variants_bake_for_def[p_variant] = p_default;
-	}
 
 	// Enable/disable groups for things that might be enabled at run time.
 	void enable_group(int p_group);


### PR DESCRIPTION
Partially reverts #107794 and #108510. Runtimes checks are still present, so it should not reintroduce https://github.com/godotengine/godot/issues/107753. But won't bake all shaders variants, missing shaders will be compiled on first start.