### PR TITLE
[Physics] Add early return if step is `0`

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -112,6 +112,9 @@ uint32_t Engine::get_frame_delay() const {
 }
 
 void Engine::set_time_scale(double p_scale) {
+	if (p_scale < 0) {
+		return;
+	}
 	_time_scale = p_scale;
 }
 

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -346,7 +346,7 @@
 		<member name="time_scale" type="float" setter="set_time_scale" getter="get_time_scale" default="1.0">
 			The speed multiplier at which the in-game clock updates, compared to real time. For example, if set to [code]2.0[/code] the game runs twice as fast, and if set to [code]0.5[/code] the game runs half as fast.
 			This value affects [Timer], [SceneTreeTimer], and all other simulations that make use of [code]delta[/code] time (such as [method Node._process] and [method Node._physics_process]).
-			[b]Note:[/b] It's recommended to keep this property above [code]0.0[/code], as the game may behave unexpectedly otherwise.
+			[b]Note:[/b] Any negative value will be ignored.
 			[b]Note:[/b] This does not affect audio playback speed. Use [member AudioServer.playback_speed_scale] to adjust audio playback speed independently of [member Engine.time_scale].
 			[b]Note:[/b] This does not automatically adjust [member physics_ticks_per_second]. With values above [code]1.0[/code] physics simulation may become less precise, as each physics tick will stretch over a larger period of engine time. If you're modifying [member Engine.time_scale] to speed up simulation by a large factor, consider also increasing [member physics_ticks_per_second] to make the simulation more reliable.
 		</member>

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1288,7 +1288,7 @@ void GodotPhysicsServer2D::init() {
 }
 
 void GodotPhysicsServer2D::step(real_t p_step) {
-	if (!active) {
+	if (!active || Math::is_zero_approx(p_step)) {
 		return;
 	}
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1671,7 +1671,7 @@ void GodotPhysicsServer3D::init() {
 }
 
 void GodotPhysicsServer3D::step(real_t p_step) {
-	if (!active) {
+	if (!active || Math::is_zero_approx(p_step)) {
 		return;
 	}
 

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1614,7 +1614,7 @@ void JoltPhysicsServer3D::finish() {
 }
 
 void JoltPhysicsServer3D::step(real_t p_step) {
-	if (!active) {
+	if (!active || Math::is_zero_approx(p_step)) {
 		return;
 	}
 


### PR DESCRIPTION
Early return physics servers step if step is equal to zero. The bodies shouldn't move if the time_scale is equal to zero, so why should the engine step through the bodies?

Edit: Added a check that removes the ability to set negative values to `Engine.time_scale`.

Fixes #108879.

MRP (using @passivestar physics demo): [godot-physics-demo-time-scale-zero.zip](https://github.com/user-attachments/files/21395614/godot-physics-demo-time-scale-zero.zip)

https://github.com/user-attachments/assets/e30201b6-b7fb-485e-850c-2bc0213df1d2