### PR TITLE
D3D12: Fix shader model check, initialization error handling

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5839,7 +5839,7 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 
 #define D3D_SHADER_MODEL_TO_STRING(m_sm) vformat("%d.%d", (m_sm >> 4), (m_sm & 0xf))
 
-		ERR_FAIL_COND_V_MSG(!shader_capabilities.shader_model, ERR_UNAVAILABLE,
+		ERR_FAIL_COND_V_MSG(shader_capabilities.shader_model < SMS_TO_CHECK[ARRAY_SIZE(SMS_TO_CHECK) - 1], ERR_UNAVAILABLE,
 				vformat("No support for any of the suitable shader models (%s-%s) has been found.", D3D_SHADER_MODEL_TO_STRING(SMS_TO_CHECK[ARRAY_SIZE(SMS_TO_CHECK) - 1]), D3D_SHADER_MODEL_TO_STRING(SMS_TO_CHECK[0])));
 
 		print_verbose("- Shader:");
@@ -6058,6 +6058,8 @@ Error RenderingDeviceDriverD3D12::_initialize_command_signatures() {
 }
 
 Error RenderingDeviceDriverD3D12::initialize(uint32_t p_device_index, uint32_t p_frame_count) {
+	glsl_type_singleton_init_or_ref();
+
 	context_device = context_driver->device_get(p_device_index);
 	adapter = context_driver->create_adapter(p_device_index);
 	ERR_FAIL_NULL_V(adapter, ERR_CANT_CREATE);
@@ -6086,8 +6088,6 @@ Error RenderingDeviceDriverD3D12::initialize(uint32_t p_device_index, uint32_t p
 
 	err = _initialize_command_signatures();
 	ERR_FAIL_COND_V(err != OK, ERR_CANT_CREATE);
-
-	glsl_type_singleton_init_or_ref();
 
 	return OK;
 }

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -6688,7 +6688,6 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 	}
 
 	frame = 0;
-	frames.resize(frame_count);
 	max_timestamp_query_elements = GLOBAL_GET("debug/settings/profiler/max_timestamp_query_elements");
 
 	device = context->device_get(device_index);
@@ -6756,6 +6755,8 @@ Error RenderingDevice::initialize(RenderingContextDriver *p_context, DisplayServ
 
 	// Use the processor count as the max amount of transfer workers that can be created.
 	transfer_worker_pool_max_size = OS::get_singleton()->get_processor_count();
+
+	frames.resize(frame_count);
 
 	// Create data for all the frames.
 	for (uint32_t i = 0; i < frames.size(); i++) {

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -1575,7 +1575,9 @@ void RenderingDeviceGraph::initialize(RDD *p_driver, RenderingContextDriver::Dev
 }
 
 void RenderingDeviceGraph::finalize() {
-	_wait_for_secondary_command_buffer_tasks();
+	if (!frames.is_empty()) {
+		_wait_for_secondary_command_buffer_tasks();
+	}
 
 	for (Frame &f : frames) {
 		for (SecondaryCommandBuffer &secondary : f.secondary_command_buffers) {


### PR DESCRIPTION
Partial fix for #98207 and #98848

The D3D12 initialization code was checking whether the calls to `CheckFeatureSupport()` succeeded, but not the actual returned data, so it would continue initializing even if the Shader Model of the device was too old.

Additionally, if this code were to throw an initialization error, Godot would crash trying to uninitialize partially initialized data, due either to missing checks or bad init/deinit order.

This is only a partial fix because it doesn't automatically fallback to GL, but it at least displays a friendly error dialog (with instructions on switching renderer) instead of crashing, which is better than nothing.

In order for the automatic fallback to work, the Shader Model version check would have to be moved into the ContextDriver, but that requires the `ID3D12Device` which lives in (and is initialized by) the DeviceDriver.

~~I also bumped the minimum required Shader Model version from 6.0 to 6.1 per [this comment](https://github.com/godotengine/godot/issues/98848#issuecomment-2459449786).~~