### PR TITLE
Fix button down signal not emitting on first press after being disabled

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -61,6 +61,7 @@
 		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false" keywords="enabled">
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
+			[b]Note:[/b] If the button is disabled while held down, [signal button_up] will be emitted.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside" default="false">

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -266,6 +266,10 @@ void BaseButton::set_disabled(bool p_disabled) {
 		}
 		status.press_attempt = false;
 		status.pressing_inside = false;
+		if (status.pressed_down_with_focus) {
+			status.pressed_down_with_focus = false;
+			emit_signal(SNAME("button_up"));
+		}
 	}
 	queue_accessibility_update();
 	queue_redraw();


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/108908

The button_up signal behavior changes in some cases after disabling the button, like in NOTIFICATION_FOCUS_EXIT it is no longer emitted when disabled in this case. Not sure if this is okay or not?
If not we could set status.pressed_down_with_focus = false in set_disabled when it's set to false instead of true like the pr is currently?

*Bugsquad edit:* Supersedes #103901
