### PR TITLE
Add project settings for default importers

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -508,6 +508,13 @@ void ResourceFormatImporter::get_importers(List<Ref<ResourceImporter>> *r_import
 }
 
 Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_file(const String &p_file) const {
+	const String extension = p_file.get_extension().to_lower();
+
+	Ref<ResourceImporter> default_importer = get_default_importer_by_extension(extension);
+	if (default_importer.is_valid()) {
+		return default_importer;
+	}
+
 	Ref<ResourceImporter> importer;
 	float priority = 0;
 
@@ -524,6 +531,25 @@ Ref<ResourceImporter> ResourceFormatImporter::get_importer_by_file(const String 
 	}
 
 	return importer;
+}
+
+Ref<ResourceImporter> ResourceFormatImporter::get_default_importer_by_extension(const String &p_extension) const {
+	// Early return if the setting doesn't exist.
+	if (!ProjectSettings::get_singleton()->has_setting("default_resource_importers/" + p_extension)) {
+		return Ref<ResourceImporter>();
+	}
+	const String importer_name = GLOBAL_GET("default_resource_importers/" + p_extension);
+
+	Ref<ResourceImporter> importer = get_importer_by_name(importer_name);
+	if (importer.is_valid()) {
+		List<String> extensions;
+		importer->get_recognized_extensions(&extensions);
+		if (extensions.find(p_extension)) {
+			return importer;
+		}
+	}
+
+	return Ref<ResourceImporter>();
 }
 
 String ResourceFormatImporter::get_import_base_path(const String &p_for_file) const {

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -92,6 +92,7 @@ public:
 	void remove_importer(const Ref<ResourceImporter> &p_importer) { importers.erase(p_importer); }
 	Ref<ResourceImporter> get_importer_by_name(const String &p_name) const;
 	Ref<ResourceImporter> get_importer_by_file(const String &p_file) const;
+	Ref<ResourceImporter> get_default_importer_by_extension(const String &p_extension) const;
 	void get_importers_for_file(const String &p_file, List<Ref<ResourceImporter>> *r_importers);
 	void get_importers(List<Ref<ResourceImporter>> *r_importers);
 

--- a/editor/import/import_defaults_editor.cpp
+++ b/editor/import/import_defaults_editor.cpp
@@ -38,8 +38,9 @@
 #include "scene/gui/center_container.h"
 #include "scene/gui/label.h"
 
-class ImportDefaultsEditorSettings : public Object {
-	GDCLASS(ImportDefaultsEditorSettings, Object)
+// Importer-specific default options (e.g., texture import settings).
+class ImporterDefaultSettings : public Object {
+	GDCLASS(ImporterDefaultSettings, Object)
 	friend class ImportDefaultsEditor;
 	List<PropertyInfo> properties;
 	HashMap<StringName, Variant> values;
@@ -77,37 +78,160 @@ protected:
 	}
 };
 
+// File extension default importers.
+class ExtensionImporterSettings : public Object {
+	GDCLASS(ExtensionImporterSettings, Object)
+
+	friend class ImportDefaultsEditor;
+
+	List<PropertyInfo> properties;
+	HashMap<StringName, Variant> values;
+
+public:
+	ExtensionImporterSettings() {
+		// Add hidden prefix for default resource importers.
+		ProjectSettings::get_singleton()->add_hidden_prefix("default_resource_importers/");
+	}
+
+private:
+	void _refresh_extensions() {
+		properties.clear();
+		values.clear();
+
+		List<String> all_extensions;
+		ResourceFormatImporter::get_singleton()->get_recognized_extensions(&all_extensions);
+		all_extensions.sort();
+
+		for (const String &extension : all_extensions) {
+			// Retrieve the current default importer (if any).
+			Ref<ResourceImporter> default_importer = ResourceFormatImporter::get_singleton()->get_default_importer_by_extension(extension);
+			values[extension] = 0; // Initialize a default fallback value.
+
+			// Create a property for this extension.
+			PropertyInfo pinfo;
+			pinfo.name = extension;
+			pinfo.type = Variant::INT;
+			pinfo.hint = PropertyHint::PROPERTY_HINT_ENUM;
+
+			// Construct the hint string.
+			List<Ref<ResourceImporter>> importers;
+			ResourceFormatImporter::get_singleton()->get_importers_for_file("dummy." + extension, &importers);
+
+			// Build the default option text with default importer name.
+			String default_text = "Default Importer";
+			if (!importers.is_empty()) {
+				String auto_default = importers.front()->get()->get_visible_name();
+				default_text = vformat(TTR("Default (%s)"), auto_default);
+			}
+			pinfo.hint_string = default_text;
+
+			int i = 1; // We start at 1 to allow for the empty "Default" choice.
+			for (const Ref<ResourceImporter> &importer : importers) {
+				// Add the importer to the selectbox.
+				pinfo.hint_string += "," + importer->get_visible_name();
+				// If that's our valid default importer, set the default value.
+				if (default_importer.is_valid() && default_importer->get_importer_name() == importer->get_importer_name()) {
+					values[extension] = i;
+				}
+				++i;
+			}
+
+			properties.push_back(pinfo); // Finally add the property to the object.
+		}
+	}
+
+	bool save_extension_importer(const String &p_extension) const {
+		Variant index;
+		if (_get(p_extension, index)) {
+			Variant value; // Fall back to default (unset the setting).
+			if ((int)index > 0) {
+				int real_index = (int)index - 1; // Account for the default empty value.
+				List<Ref<ResourceImporter>> importers;
+				ResourceFormatImporter::get_singleton()->get_importers_for_file("dummy." + p_extension, &importers);
+				if (importers.size() > real_index) {
+					// If we have a valid importer at this index, that's the one.
+					int current = 0;
+					for (const Ref<ResourceImporter> &importer : importers) {
+						if (current == real_index) {
+							value = importer->get_importer_name();
+							break;
+						}
+						current++;
+					}
+				}
+			}
+
+			const String setting_name = "default_resource_importers/" + p_extension;
+			ProjectSettings::get_singleton()->set(setting_name, value);
+			ProjectSettings::get_singleton()->save();
+
+			return true;
+		}
+
+		return false;
+	}
+
+protected:
+	bool _set(const StringName &p_name, const Variant &p_value) {
+		if (values.has(p_name)) {
+			values[p_name] = p_value;
+			return true;
+		}
+		return false;
+	}
+
+	bool _get(const StringName &p_name, Variant &r_ret) const {
+		if (values.has(p_name)) {
+			r_ret = values[p_name];
+			return true;
+		}
+		r_ret = Variant();
+		return false;
+	}
+
+	void _get_property_list(List<PropertyInfo> *p_list) const {
+		*p_list = properties;
+	}
+};
+
 void ImportDefaultsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_PREDELETE: {
-			inspector->edit(nullptr);
+			importer_defaults_inspector->edit(nullptr);
+			extension_importer_inspector->edit(nullptr);
 		} break;
 	}
 }
 
 void ImportDefaultsEditor::_reset() {
-	if (settings->importer.is_valid()) {
-		settings->values = settings->default_values;
-		settings->notify_property_list_changed();
+	if (importer_settings->importer.is_valid()) {
+		importer_settings->values = importer_settings->default_values;
+		importer_settings->notify_property_list_changed();
 	}
 }
 
 void ImportDefaultsEditor::_save() {
-	if (settings->importer.is_valid()) {
+	if (importer_settings->importer.is_valid()) {
 		Dictionary modified;
 
-		for (const KeyValue<StringName, Variant> &E : settings->values) {
-			if (E.value != settings->default_values[E.key]) {
+		for (const KeyValue<StringName, Variant> &E : importer_settings->values) {
+			if (E.value != importer_settings->default_values[E.key]) {
 				modified[E.key] = E.value;
 			}
 		}
 
 		if (modified.size()) {
-			ProjectSettings::get_singleton()->set("importer_defaults/" + settings->importer->get_importer_name(), modified);
+			ProjectSettings::get_singleton()->set("importer_defaults/" + importer_settings->importer->get_importer_name(), modified);
 		} else {
-			ProjectSettings::get_singleton()->set("importer_defaults/" + settings->importer->get_importer_name(), Variant());
+			ProjectSettings::get_singleton()->set("importer_defaults/" + importer_settings->importer->get_importer_name(), Variant());
 		}
 		ProjectSettings::get_singleton()->save();
+	}
+}
+
+void ImportDefaultsEditor::_save_extension_importer(const String &p_property_name) {
+	if (extension_settings->save_extension_importer(p_property_name)) {
+		emit_signal(SNAME("project_settings_changed"));
 	}
 }
 
@@ -122,9 +246,9 @@ void ImportDefaultsEditor::_update_importer() {
 		}
 	}
 
-	settings->properties.clear();
-	settings->values.clear();
-	settings->importer = importer;
+	importer_settings->properties.clear();
+	importer_settings->values.clear();
+	importer_settings->importer = importer;
 
 	if (importer.is_valid()) {
 		List<ResourceImporter::ImportOption> options;
@@ -135,13 +259,13 @@ void ImportDefaultsEditor::_update_importer() {
 		}
 
 		for (const ResourceImporter::ImportOption &E : options) {
-			settings->properties.push_back(E.option);
+			importer_settings->properties.push_back(E.option);
 			if (d.has(E.option.name)) {
-				settings->values[E.option.name] = d[E.option.name];
+				importer_settings->values[E.option.name] = d[E.option.name];
 			} else {
-				settings->values[E.option.name] = E.default_value;
+				importer_settings->values[E.option.name] = E.default_value;
 			}
-			settings->default_values[E.option.name] = E.default_value;
+			importer_settings->default_values[E.option.name] = E.default_value;
 		}
 
 		save_defaults->set_disabled(false);
@@ -152,19 +276,22 @@ void ImportDefaultsEditor::_update_importer() {
 		reset_defaults->set_disabled(true);
 	}
 
-	settings->notify_property_list_changed();
+	importer_settings->notify_property_list_changed();
 
 	// Set the importer class to fetch the correct class in the XML class reference.
 	// This allows tooltips to display when hovering properties.
-	inspector->set_object_class(importer->get_class_name());
-	inspector->edit(settings);
+	importer_defaults_inspector->set_object_class(importer->get_class_name());
+	importer_defaults_inspector->edit(importer_settings);
 }
 
 void ImportDefaultsEditor::_importer_selected(int p_index) {
 	_update_importer();
 }
 
-void ImportDefaultsEditor::clear() {
+void ImportDefaultsEditor::update_editors() {
+	extension_settings->_refresh_extensions();
+	extension_importer_inspector->edit(extension_settings);
+
 	String last_selected;
 
 	if (importers->get_selected() >= 0) {
@@ -195,10 +322,27 @@ void ImportDefaultsEditor::clear() {
 			_update_importer();
 		}
 	}
+	// Only triggers if anything is selected.
+	if (importers->get_selected() == -1) {
+		_update_importer();
+	}
 }
 
 ImportDefaultsEditor::ImportDefaultsEditor() {
 	ProjectSettings::get_singleton()->add_hidden_prefix("importer_defaults/");
+
+	// Initialize settings objects.
+	extension_settings = memnew(ExtensionImporterSettings);
+	importer_settings = memnew(ImporterDefaultSettings);
+
+	tabs = memnew(TabContainer);
+	tabs->set_v_size_flags(SIZE_EXPAND_FILL);
+	add_child(tabs);
+
+	// Importer defaults.
+	VBoxContainer *importer_defaults_tab = memnew(VBoxContainer);
+	importer_defaults_tab->set_name(TTRC("Importer Defaults"));
+	tabs->add_child(importer_defaults_tab);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_child(memnew(Label(TTRC("Importer:"))));
@@ -211,25 +355,40 @@ ImportDefaultsEditor::ImportDefaultsEditor() {
 	reset_defaults->set_disabled(true);
 	reset_defaults->connect(SceneStringName(pressed), callable_mp(this, &ImportDefaultsEditor::_reset));
 	hb->add_child(reset_defaults);
-	add_child(hb);
+	importer_defaults_tab->add_child(hb);
 
-	inspector = memnew(EditorInspector);
-	add_child(inspector);
-	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	importer_defaults_inspector = memnew(EditorInspector);
+	importer_defaults_tab->add_child(importer_defaults_inspector);
+	importer_defaults_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	// Make it possible to display tooltips stored in the XML class reference.
 	// The object name is set when the importer changes in `_update_importer()`.
-	inspector->set_use_doc_hints(true);
+	importer_defaults_inspector->set_use_doc_hints(true);
+
+	// Default Importers by extension (second tab).
+	VBoxContainer *default_importers_tab = memnew(VBoxContainer);
+	default_importers_tab->set_name(TTRC("Extension Defaults"));
+	tabs->add_child(default_importers_tab);
+
+	Label *extension_importers_label = memnew(Label);
+	extension_importers_label->set_text(TTRC("Select default importer for each file extension:"));
+	default_importers_tab->add_child(extension_importers_label);
+
+	extension_importer_inspector = memnew(EditorInspector);
+	extension_importer_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
+	extension_importer_inspector->set_property_name_style(EditorPropertyNameProcessor::STYLE_RAW);
+	extension_importer_inspector->set_use_settings_name_style(false);
+	default_importers_tab->add_child(extension_importer_inspector);
+	extension_importer_inspector->connect("property_edited", callable_mp(this, &ImportDefaultsEditor::_save_extension_importer));
 
 	CenterContainer *cc = memnew(CenterContainer);
 	save_defaults = memnew(Button);
 	save_defaults->set_text(TTRC("Save"));
 	save_defaults->connect(SceneStringName(pressed), callable_mp(this, &ImportDefaultsEditor::_save));
 	cc->add_child(save_defaults);
-	add_child(cc);
-
-	settings = memnew(ImportDefaultsEditorSettings);
+	importer_defaults_tab->add_child(cc);
 }
 
 ImportDefaultsEditor::~ImportDefaultsEditor() {
-	memdelete(settings);
+	memdelete(importer_settings);
+	memdelete(extension_settings);
 }

--- a/editor/import/import_defaults_editor.h
+++ b/editor/import/import_defaults_editor.h
@@ -33,32 +33,38 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/option_button.h"
+#include "scene/gui/tab_container.h"
 
-class ImportDefaultsEditorSettings;
+class ImporterDefaultSettings;
+class ExtensionImporterSettings;
 class EditorInspector;
 
 class ImportDefaultsEditor : public VBoxContainer {
 	GDCLASS(ImportDefaultsEditor, VBoxContainer)
 
+	TabContainer *tabs = nullptr;
+
 	OptionButton *importers = nullptr;
 	Button *save_defaults = nullptr;
 	Button *reset_defaults = nullptr;
 
-	EditorInspector *inspector = nullptr;
-
-	ImportDefaultsEditorSettings *settings = nullptr;
+	EditorInspector *importer_defaults_inspector = nullptr;
+	EditorInspector *extension_importer_inspector = nullptr;
+	ImporterDefaultSettings *importer_settings = nullptr;
+	ExtensionImporterSettings *extension_settings = nullptr;
 
 	void _update_importer();
 	void _importer_selected(int p_index);
 
 	void _reset();
 	void _save();
+	void _save_extension_importer(const String &p_property_name);
 
 protected:
 	void _notification(int p_what);
 
 public:
-	void clear();
+	void update_editors();
 
 	ImportDefaultsEditor();
 	~ImportDefaultsEditor();

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -65,7 +65,7 @@ void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	autoload_settings->update_autoload();
 	group_settings->update_groups();
 	plugin_settings->update_plugins();
-	import_defaults_editor->clear();
+	import_defaults_editor->update_editors();
 
 	if (p_clear_filter) {
 		search_box->clear();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes https://github.com/godotengine/godot-proposals/issues/12770.
Closes #108512 

Doesn't import older files by default to maintain .import settings, could use the tools -> upgrade project files for that

<img width="1174" height="527" alt="image" src="https://github.com/user-attachments/assets/10695790-32c9-4b05-8929-2145cb27c38c" />

Toggling it on and adding a svg file would import it as a SVGTexture else as a CompressedTexture2D

**Production edit:** Closes https://github.com/godotengine/godot-proposals/issues/2500