### PR TITLE
Add suffix to EditorSpinSlider tooltips

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -40,9 +40,9 @@
 String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
 	if (!read_only && grabber->is_visible()) {
 		Key key = (OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos") || OS::get_singleton()->has_feature("web_ios")) ? Key::META : Key::CTRL;
-		return TS->format_number(rtos(get_value())) + "\n\n" + vformat(TTR("Hold %s to round to integers.\nHold Shift for more precise changes."), find_keycode_name(key));
+		return TS->format_number(rtos(get_value())) + suffix + "\n\n" + vformat(TTR("Hold %s to round to integers.\nHold Shift for more precise changes."), find_keycode_name(key));
 	}
-	return TS->format_number(rtos(get_value()));
+	return TS->format_number(rtos(get_value())) + suffix;
 }
 
 String EditorSpinSlider::get_text_value() const {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/108898

After:


<img width="346" height="860" alt="Screenshot_20250724_133515" src="https://github.com/user-attachments/assets/47ed3186-5962-49ba-a48f-6bc890ebec8e" />
