### PR TITLE
Change Input Map filter to not disable and setting show_builtin_action button to pressed

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -235,15 +235,6 @@ void ActionMapEditor::_set_show_builtin_actions(bool p_show) {
 }
 
 void ActionMapEditor::_on_search_bar_value_changed() {
-	if (action_list_search_bar->is_searching()) {
-		show_builtin_actions_checkbutton->set_pressed_no_signal(true);
-		show_builtin_actions_checkbutton->set_disabled(true);
-		show_builtin_actions_checkbutton->set_tooltip_text(TTRC("Built-in actions are always shown when searching."));
-	} else {
-		show_builtin_actions_checkbutton->set_pressed_no_signal(show_builtin_actions);
-		show_builtin_actions_checkbutton->set_disabled(false);
-		show_builtin_actions_checkbutton->set_tooltip_text(String());
-	}
 	update_action_list();
 }
 
@@ -432,7 +423,7 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 			continue;
 		}
 
-		if (!action_info.editable && !action_list_search_bar->is_searching() && !show_builtin_actions) {
+		if (!action_info.editable && !show_builtin_actions) {
 			continue;
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/108938

Before:

[Screencast_20250724_184017.webm](https://github.com/user-attachments/assets/b7bebe9d-a7f7-4070-84a5-f34ade616327)

After:

[Screencast_20250724_183909.webm](https://github.com/user-attachments/assets/116462f3-7488-4086-bbb3-6838e14aff19)

