### PR TITLE
Don't use `GL_DEPTH_STENCIL_ATTACHMENT` on depth buffer from WebXR

### DIFF
--- a/drivers/gles3/storage/render_scene_buffers_gles3.h
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.h
@@ -93,7 +93,7 @@ private:
 	void _clear_back_buffers();
 	void _clear_glow_buffers();
 
-	void _rt_attach_textures(GLuint p_color, GLuint p_depth, GLsizei p_samples, uint32_t p_view_count);
+	void _rt_attach_textures(GLuint p_color, GLuint p_depth, GLsizei p_samples, uint32_t p_view_count, bool p_depth_has_stencil);
 	GLuint _rt_get_cached_fbo(GLuint p_color, GLuint p_depth, GLsizei p_samples, uint32_t p_view_count);
 
 public:

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2854,6 +2854,13 @@ GLuint TextureStorage::render_target_get_depth(RID p_render_target) const {
 	}
 }
 
+bool TextureStorage::render_target_get_depth_has_stencil(RID p_render_target) const {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL_V(rt, 0);
+
+	return rt->depth_has_stencil;
+}
+
 void TextureStorage::render_target_set_reattach_textures(RID p_render_target, bool p_reattach_textures) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -669,6 +669,7 @@ public:
 	GLuint render_target_get_fbo(RID p_render_target) const;
 	GLuint render_target_get_color(RID p_render_target) const;
 	GLuint render_target_get_depth(RID p_render_target) const;
+	bool render_target_get_depth_has_stencil(RID p_render_target) const;
 	void render_target_set_reattach_textures(RID p_render_target, bool p_reattach_textures) const;
 	bool render_target_is_reattach_textures(RID p_render_target) const;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108903

Basically, we need to propagate the `depth_has_stencil` flag from the render target into `RenderSceneBuffersGLES3` for the case where we're rendering directly to the render target (and not created our own internal intermediate buffer), so that we can choose between `GL_DEPTH_STENCIL_ATTACHMENT` and `GL_DEPTH_ATTACHMENT`

This fixes WebXR in my testing!