### PR TITLE
Fix crash when GDScript scripts are reloaded during initial import

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -187,9 +187,9 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 		return instance;
 	}
 
-	initializer = _super_constructor(this);
-	if (initializer != nullptr) {
-		initializer->call(instance, p_args, p_argcount, r_error);
+	GDScriptFunction *applicable_initializer = _super_constructor(this);
+	if (applicable_initializer != nullptr) {
+		applicable_initializer->call(instance, p_args, p_argcount, r_error);
 		if (r_error.error != Callable::CallError::CALL_OK) {
 			String error_text = Variant::get_call_error_text(instance->owner, "_init", p_args, p_argcount, r_error);
 			instance->script = Ref<GDScript>();


### PR DESCRIPTION
Fixes #108946.

As [talked about](https://chat.godotengine.org/channel/gdscript?msg=vqn4o7aH6PK6FS96T) on the contributor's chat, this seems to fix a GDScript crash we've been seeing, where when a certain class is instantiated during `GDScriptLanguage::reload_scripts` its `initializer` is found to be pointing to stale memory of some sort, leading to a crash when called.

Note that this will mean that `initializer` will no longer cache the first valid initializer, meaning `_super_constructor` will traverse the class hierarchy every time, so this comes with a slight performance hit, but I doubt it'll make much of a difference.