### PR TITLE
Fix debanding not being used in the 2D editor when enabled in Project Settings

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -510,6 +510,11 @@ void EditorNode::_update_from_settings() {
 	Viewport::MSAA msaa = Viewport::MSAA(int(GLOBAL_GET("rendering/anti_aliasing/quality/msaa_2d")));
 	scene_root->set_msaa_2d(msaa);
 
+	// 2D doesn't use a dedicated SubViewport like 3D does, so we apply it on the root viewport instead.
+	bool use_debanding = GLOBAL_GET("rendering/anti_aliasing/quality/use_debanding");
+	scene_root->set_use_debanding(use_debanding);
+	get_viewport()->set_use_debanding(use_debanding);
+
 	bool use_hdr_2d = GLOBAL_GET("rendering/viewport/hdr_2d");
 	scene_root->set_use_hdr_2d(use_hdr_2d);
 	get_viewport()->set_use_hdr_2d(use_hdr_2d);


### PR DESCRIPTION
Note that the debanding Viewport property still needs to be set on the 3D viewport to ensure it still works there.

- This closes https://github.com/godotengine/godot/issues/108948.

## Preview

<img width="782" height="815" alt="image" src="https://github.com/user-attachments/assets/3070d8a2-eed6-4aed-b790-a368a79d83da" />
