### PR TITLE
Disable window resizing by default in Movie Maker mode

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1593,6 +1593,9 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "display/window/size/initial_screen", PROPERTY_HINT_RANGE, "0,64,1,or_greater"), 0);
 
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
+	// Prevent window resizing by default when recording a movie, as it can cause unexpected resolution changes
+	// during recording (which are not supported by all formats).
+	GLOBAL_DEF_BASIC("display/window/size/resizable.movie", false);
 	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
 	GLOBAL_DEF("display/window/size/always_on_top", false);
 	GLOBAL_DEF("display/window/size/transparent", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1008,6 +1008,9 @@
 			[b]Note:[/b] Certain window managers can be configured to ignore the non-resizable status of a window. Do not rely on this setting as a guarantee that the window will [i]never[/i] be resizable.
 			[b]Note:[/b] This setting is ignored on iOS.
 		</member>
+		<member name="display/window/size/resizable.movie" type="bool" setter="" getter="" default="false">
+			Movie Maker override for [member display/window/size/resizable] to prevent accidental resolution changes while recording a video.
+		</member>
 		<member name="display/window/size/sharp_corners" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], the main window uses sharp corners by default.
 			[b]Note:[/b] This property is implemented only on Windows (11).


### PR DESCRIPTION
This overrides the `display/window/size/resizable` project setting for the `movie` feature tag. Set it to `true` to allow resizing again, but keep in mind not all video formats support resolution changes while recording (and not all video players will be able to handle it either).

While this is a safeguard for some situations, it won't cover all use cases:

- Game window embedding always allows the window to be resizable, regardless of the project setting's value.
- The window can be resized by a script or external tools.

A better long-term solution is to [resize all video frames to match the viewport base resolution displayed in the project settings](https://github.com/godotengine/godot/pull/108954). This will have a performance cost if the viewport resolution doesn't match the video resolution, but it will work for all formats and will handle all kinds of runtime situations.

- This partially addresses https://github.com/godotengine/godot/issues/107316.
