### PR TITLE
Ensure all MovieWriter frames have the same resolution as the first frame

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4704,7 +4704,21 @@ int Main::start() {
 	}
 
 	if (movie_writer) {
-		movie_writer->begin(DisplayServer::get_singleton()->window_get_size(), fixed_fps, Engine::get_singleton()->get_write_movie_path());
+		Size2i movie_size = Size2i(GLOBAL_GET("display/window/size/viewport_width"), GLOBAL_GET("display/window/size/viewport_height"));
+		String stretch_mode = GLOBAL_GET("display/window/stretch/mode");
+		if (stretch_mode != "viewport") {
+			// `canvas_items` and `disabled` modes use the window size override instead,
+			// which allows for higher resolution recording with 2D elements designed for a lower resolution.
+			const int window_width_override = GLOBAL_GET("display/window/size/window_width_override");
+			if (window_width_override > 0) {
+				movie_size.width = window_width_override;
+			}
+			const int window_height_override = GLOBAL_GET("display/window/size/window_height_override");
+			if (window_height_override > 0) {
+				movie_size.height = window_height_override;
+			}
+		}
+		movie_writer->begin(movie_size, fixed_fps, Engine::get_singleton()->get_write_movie_path());
 	}
 
 	GDExtensionManager::get_singleton()->startup();

--- a/servers/movie_writer/movie_writer.h
+++ b/servers/movie_writer/movie_writer.h
@@ -41,6 +41,10 @@ class MovieWriter : public Object {
 	uint64_t mix_rate = 0;
 	uint32_t audio_channels = 0;
 
+	// The output resolution, which can differ from the window size.
+	// Used as a base for resizing all subsequent frames if their resolution differs.
+	Vector2i movie_size;
+
 	float cpu_time = 0.0f;
 	float gpu_time = 0.0f;
 	uint64_t encoding_time_usec = 0;


### PR DESCRIPTION
This fixes issues with certain video formats (like OGV) and video players not supporting resolution changes during playback.

Resizing the viewport during recording is still not recommended (as cropping and resizing has a performance cost and can impact visuals), but it shouldn't cause crashes or broken files anymore. Therefore, I think https://github.com/godotengine/godot/pull/108953 is still relevant even with this PR in place.

- This closes https://github.com/godotengine/godot/issues/107316.

## Preview

*Recording a video where I resize the window in all directions, changing its aspect ratio significantly in the process.*

### Before

[out_resized.avi.zip](https://github.com/user-attachments/files/21419708/out_resized.zip)

https://github.com/user-attachments/assets/fc8c571e-da8b-4887-9320-458f1ac056e9

### After

*The blurriness near the end occurs as the window height is greatly reduced, but its width was wide enough to cover the original aspect ratio (so no cropping needs to be performed).*

[out.avi.zip](https://github.com/user-attachments/files/21419731/out.zip)

https://github.com/user-attachments/assets/e7c24836-00d9-476e-8fd3-9051779a529e