### PR TITLE
Update the OpenXR Vendors plugin for the XR editor to the latest stable version

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -15,7 +15,7 @@ ext.versions = [
     // Also update 'platform/android/detect.py#get_ndk_version()' when this is updated.
     ndkVersion         : '28.1.13356709',
     splashscreenVersion: '1.0.1',
-    openxrVendorsVersion: '4.1.0-stable'
+    openxrVendorsVersion: '4.1.1-stable'
 
 ]
 

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -108,7 +108,7 @@ android {
         }
 
         boolean devBuild = buildType == "dev"
-        boolean debugSymbols = devBuild || (buildType == "debug" && isAndroidStudio())
+        boolean debugSymbols = devBuild
         boolean runTests = devBuild
         boolean storeRelease = buildType == "release"
         boolean productionBuild = storeRelease


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/108841 due to a patch release (v4.1.1) of the OpenXR Vendors plugin.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
