### PR TITLE
Fix: Make `get_space_left` on Windows use `current_dir` instead of process CWD

### DIFF
--- a/drivers/windows/dir_access_windows.cpp
+++ b/drivers/windows/dir_access_windows.cpp
@@ -329,7 +329,14 @@ Error DirAccessWindows::remove(String p_path) {
 
 uint64_t DirAccessWindows::get_space_left() {
 	uint64_t bytes = 0;
-	if (!GetDiskFreeSpaceEx(nullptr, (PULARGE_INTEGER)&bytes, nullptr, nullptr)) {
+
+	String path = fix_path(current_dir);
+
+	if (!path.ends_with("\\")) {
+		path += "\\";
+	}
+
+	if (!GetDiskFreeSpaceExW((LPCWSTR)(path.utf16().get_data()), (PULARGE_INTEGER)&bytes, nullptr, nullptr)) {
 		return 0;
 	}
 


### PR DESCRIPTION
This PR fixes a behavioral inconsistency in `DirAccessWindows::get_space_left()`, where the method incorrectly queries the available disk space of the process's current working directory (CWD) instead of the directory tracked by the DirAccess instance via current_dir, as is correctly done on Unix platforms.

## Problem

The original Windows implementation uses:

```cpp
GetDiskFreeSpaceEx(nullptr, ...)
```

Passing `nullptr` causes the API to use the **current process directory**, not the directory path that the `DirAccess` object is logically operating on.

This leads to incorrect results in the following cases:

- When the process is running on drive `D:` but the `DirAccess` object has opened a path on drive `C:`.
- When calling `change_dir()` on a `DirAccess` object, which updates `current_dir`, but `get_space_left()` continues to use the wrong drive.

This results in behavioral inconsistency between platforms.

Fixes https://github.com/godotengine/godot/issues/108966