### PR TITLE
[macOS] Add Tahoe 26.0 to version alias

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -315,7 +315,9 @@ String OS_MacOS::get_version() const {
 String OS_MacOS::get_version_alias() const {
 	NSOperatingSystemVersion ver = [NSProcessInfo processInfo].operatingSystemVersion;
 	String macos_string;
-	if (ver.majorVersion == 15) {
+	if (ver.majorVersion == 26) {
+		macos_string += "Tahoe";
+	} else if (ver.majorVersion == 15) {
 		macos_string += "Sequoia";
 	} else if (ver.majorVersion == 14) {
 		macos_string += "Sonoma";


### PR DESCRIPTION
Add missing macOS Tahoe 26.0 version alias.

```
Godot v4.5.beta (0dd917826) - macOS Unknown (26.0.0) - Multi-window, 1 monitor - OpenGL 3 (Compatibility) - Apple M3 Max - Apple M3 Max (16 threads) - 48.00 GiB memory
```

becomes 

```
Godot v4.5.beta (0dd917826) - macOS Tahoe (26.0.0) - Multi-window, 1 monitor - OpenGL 3 (Compatibility) - Apple M3 Max - Apple M3 Max (16 threads) - 48.00 GiB memory
```

Tahoe is predicted to come out in September/October.