### PR TITLE
Make getting a path from UID cache slightly faster

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -328,19 +328,22 @@ Error ResourceUID::update_cache() {
 }
 
 String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const String &p_uid_string) {
-	const uint32_t entry_count = p_cache_file->get_32();
-	CharString cs;
-	for (uint32_t i = 0; i < entry_count; i++) {
-		int64_t id = p_cache_file->get_64();
-		int32_t len = p_cache_file->get_32();
-		cs.resize_uninitialized(len + 1);
-		ERR_FAIL_COND_V(cs.size() != len + 1, String());
-		cs[len] = 0;
-		int32_t rl = p_cache_file->get_buffer((uint8_t *)cs.ptrw(), len);
-		ERR_FAIL_COND_V(rl != len, String());
+	const int64_t uid_from_string = singleton->text_to_id(p_uid_string);
+	if (uid_from_string != INVALID_ID) {
+		const uint32_t entry_count = p_cache_file->get_32();
+		CharString cs;
+		for (uint32_t i = 0; i < entry_count; i++) {
+			int64_t id = p_cache_file->get_64();
+			int32_t len = p_cache_file->get_32();
+			cs.resize_uninitialized(len + 1);
+			ERR_FAIL_COND_V(cs.size() != len + 1, String());
+			cs[len] = 0;
+			int32_t rl = p_cache_file->get_buffer((uint8_t *)cs.ptrw(), len);
+			ERR_FAIL_COND_V(rl != len, String());
 
-		if (singleton->id_to_text(id) == p_uid_string) {
-			return String::utf8(cs.get_data());
+			if (id == uid_from_string) {
+				return String::utf8(cs.get_data());
+			}
 		}
 	}
 	return String();


### PR DESCRIPTION
Instead of converting each entry's integer UID to text and do a slow String-to-String comparison with the provided string UID every iteration, we may convert the string UID into an integer just once and compare directly.

This isn't a performance-demanding function (it's only used by the project manager *once* to get icon paths from UID), but I thought it wouldn't hurt anyway. Maybe it should do a ***tiny*** speed-up if there are too much projects using an UID icon to read.

**Update**: If the converted UID happens to be invalid, the entire read is now skipped.
