### PR TITLE
Fix Tree cell text vertical alignment

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2466,7 +2466,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			Point2i text_pos = item_rect.position;
-			text_pos.y += Math::floor(p_draw_ofs.y) - _get_title_button_height();
+			text_pos.y += Math::floor((item_rect.size.y - p_item->cells[i].text_buf->get_size().y) * 0.5);
 
 			switch (p_item->cells[i].mode) {
 				case TreeItem::CELL_MODE_STRING: {


### PR DESCRIPTION
Fixes text alignment in range cells by using the same [code](https://github.com/godotengine/godot/blob/0dd9178269e447aca805bc4b4a9a840119c10275/scene/gui/tree.cpp#L2088) that cells of other types are using via `draw_item_rect()`.

This issue is more noticeable with custom cell height, i.e when using a custom theme as reported [here](https://github.com/passivestar/godot-minimal-theme/issues/35).

| Before | After |
|--------|--------|
| ![b1](https://github.com/user-attachments/assets/cf222e1f-3fa3-4655-98ef-9f12fea06387) | ![a1](https://github.com/user-attachments/assets/322dd1dd-598d-4e42-a966-ce27e84be76d) |
| ![b2](https://github.com/user-attachments/assets/c4bc9264-2719-4acf-bdb0-a3bc20653b17) | ![a2](https://github.com/user-attachments/assets/4c1b4e5a-4781-4587-8f2a-212448f234df) |
| ![b3](https://github.com/user-attachments/assets/c66de71f-7e21-4d05-8cec-f9b8697f0b44) | ![a3](https://github.com/user-attachments/assets/dcd6e66b-fd23-4e5f-b969-09039583c08b) |
