### PR TITLE
Add WMF video playing only audio.

### DIFF
--- a/modules/wmf/SCsub
+++ b/modules/wmf/SCsub
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+from misc.utility.scons_hints import *
+
+Import("env")
+
+if env.msvc:
+    env.Append(
+        LINKFLAGS=["mfplat.lib", "mf.lib", "wmcodecdspuuid.lib", "mfuuid.lib", "mfreadwrite.lib", "strmiids.lib"]
+    )
+else:
+    env.Append(LIBS=["mfplat", "mf", "wmcodecdspuuid", "mfuuid", "mfreadwrite", "strmiids"])
+
+Import("env_modules")
+
+env_wmf = env_modules.Clone()
+
+env_wmf.add_source_files(env.modules_sources, "*.cpp")
+Export("env")

--- a/modules/wmf/audio_sample_grabber_callback.cpp
+++ b/modules/wmf/audio_sample_grabber_callback.cpp
@@ -1,0 +1,225 @@
+/**************************************************************************/
+/*  audio_sample_grabber_callback.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "audio_sample_grabber_callback.h"
+#include "core/string/print_string.h"
+#include "video_stream_wmf.h"
+#include <mfapi.h>
+#include <minwindef.h>
+#include <shlwapi.h>
+#include <cassert>
+#include <cstdio>
+#include <new>
+
+AudioSampleGrabberCallback::AudioSampleGrabberCallback(VideoStreamPlaybackWMF *p_playback, Mutex &p_mtx) :
+		m_cRef(1), playback(p_playback) {
+	AudioServer *audio_server = AudioServer::get_singleton();
+	if (audio_server) {
+		output_sample_rate = audio_server->get_mix_rate();
+		print_line("AudioSampleGrabberCallback: Using Godot mix rate: " + itos(output_sample_rate));
+	} else {
+		output_sample_rate = 44100; // Fallback
+		print_line("AudioSampleGrabberCallback: AudioServer not available, using fallback: " + itos(output_sample_rate));
+	}
+}
+
+HRESULT AudioSampleGrabberCallback::CreateInstance(AudioSampleGrabberCallback **ppCB, VideoStreamPlaybackWMF *playback, Mutex &mtx) {
+	*ppCB = new (std::nothrow) AudioSampleGrabberCallback(playback, mtx);
+	if (ppCB == nullptr) {
+		return E_OUTOFMEMORY;
+	}
+	return S_OK;
+}
+
+AudioSampleGrabberCallback::~AudioSampleGrabberCallback() {
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::QueryInterface(REFIID riid, void **ppv) {
+	static const QITAB qit[] = {
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable : 4838)
+#endif
+		QITABENT(AudioSampleGrabberCallback, IMFSampleGrabberSinkCallback),
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+		{ 0, 0 }
+	};
+	return QISearch(this, qit, riid, ppv);
+}
+
+STDMETHODIMP_(ULONG)
+AudioSampleGrabberCallback::AddRef() {
+	return InterlockedIncrement(&m_cRef);
+}
+
+STDMETHODIMP_(ULONG)
+AudioSampleGrabberCallback::Release() {
+	ULONG cRef = InterlockedDecrement(&m_cRef);
+	if (cRef == 0) {
+		delete this;
+	}
+	return cRef;
+}
+
+// IMFClockStateSink methods
+STDMETHODIMP AudioSampleGrabberCallback::OnClockStart(MFTIME hnsSystemTime, LONGLONG llClockStartOffset) {
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnClockStop(MFTIME hnsSystemTime) {
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnClockPause(MFTIME hnsSystemTime) {
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnClockRestart(MFTIME hnsSystemTime) {
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnClockSetRate(MFTIME hnsSystemTime, float flRate) {
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnSetPresentationClock(IMFPresentationClock *pClock) {
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnProcessSample(REFGUID guidMajorMediaType,
+		DWORD dwSampleFlags,
+		LONGLONG llSampleTime,
+		LONGLONG llSampleDuration,
+		const BYTE *pSampleBuffer,
+		DWORD dwSampleSize) {
+	if (input_sample_rate == 0 || input_channels == 0) {
+		return S_OK;
+	}
+
+	Vector<float> input_float;
+	convert_to_float(pSampleBuffer, dwSampleSize, input_float);
+
+	Vector<float> output_float;
+	if (input_sample_rate != output_sample_rate) {
+		resample_audio(input_float.ptr(), input_float.size() / input_channels, output_float);
+	} else {
+		output_float = input_float;
+	}
+
+	if (playback) {
+		playback->add_audio_data(llSampleTime, output_float);
+	}
+
+	return S_OK;
+}
+
+STDMETHODIMP AudioSampleGrabberCallback::OnShutdown() {
+	print_line("AudioSampleGrabberCallback::OnShutdown");
+	return S_OK;
+}
+
+void AudioSampleGrabberCallback::set_audio_format(int sample_rate, int channels) {
+	input_sample_rate = sample_rate;
+	input_channels = channels;
+
+	if (output_sample_rate > 0) {
+		resample_ratio = (double)output_sample_rate / (double)input_sample_rate;
+	}
+
+	print_line("Audio format set: " + itos(input_sample_rate) + "Hz, " + itos(input_channels) + " channels");
+	print_line("Resample ratio: " + rtos(resample_ratio));
+}
+
+void AudioSampleGrabberCallback::set_output_format(int sample_rate, int channels) {
+	output_sample_rate = sample_rate;
+	output_channels = channels;
+
+	if (input_sample_rate > 0) {
+		resample_ratio = (double)output_sample_rate / (double)input_sample_rate;
+	}
+}
+
+void AudioSampleGrabberCallback::convert_to_float(const BYTE *input, DWORD input_size, Vector<float> &output) {
+	// Assume 16-bit PCM input (most common)
+	int sample_count = input_size / 2; // 2 bytes per 16-bit sample
+	output.resize(sample_count);
+
+	const int16_t *input_samples = reinterpret_cast<const int16_t *>(input);
+	float *output_samples = output.ptrw();
+
+	for (int i = 0; i < sample_count; i++) {
+		// Convert 16-bit PCM to float (-1.0 to 1.0)
+		output_samples[i] = (float)input_samples[i] / 32768.0f;
+	}
+}
+
+void AudioSampleGrabberCallback::resample_audio(const float *input, int input_samples, Vector<float> &output) {
+	if (resample_ratio == 1.0) {
+		int total_samples = input_samples * input_channels;
+		output.resize(total_samples);
+		memcpy(output.ptrw(), input, total_samples * sizeof(float));
+		return;
+	}
+
+	// Simple linear interpolation resampling
+	int output_samples = (int)(input_samples * resample_ratio);
+	output.resize(output_samples * output_channels);
+
+	float *output_ptr = output.ptrw();
+
+	for (int i = 0; i < output_samples; i++) {
+		double src_index = (double)i / resample_ratio;
+		int src_index_int = (int)src_index;
+		double frac = src_index - src_index_int;
+
+		for (int ch = 0; ch < input_channels && ch < output_channels; ch++) {
+			float sample1 = 0.0f;
+			float sample2 = 0.0f;
+
+			if (src_index_int < input_samples) {
+				sample1 = input[src_index_int * input_channels + ch];
+			}
+			if (src_index_int + 1 < input_samples) {
+				sample2 = input[(src_index_int + 1) * input_channels + ch];
+			}
+
+			// Linear interpolation
+			float interpolated = sample1 + (sample2 - sample1) * frac;
+			output_ptr[i * output_channels + ch] = interpolated;
+		}
+
+		// Fill remaining output channels with zeros if input has fewer channels
+		for (int ch = input_channels; ch < output_channels; ch++) {
+			output_ptr[i * output_channels + ch] = 0.0f;
+		}
+	}
+}

--- a/modules/wmf/audio_sample_grabber_callback.h
+++ b/modules/wmf/audio_sample_grabber_callback.h
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*  audio_sample_grabber_callback.h                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/os/mutex.h"
+#include "core/templates/vector.h"
+#include "servers/audio_server.h"
+#include <mfapi.h>
+#include <mfidl.h>
+
+class VideoStreamPlaybackWMF;
+
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnon-virtual-dtor"
+#endif
+
+class AudioSampleGrabberCallback : public IMFSampleGrabberSinkCallback {
+private:
+	long m_cRef;
+	VideoStreamPlaybackWMF *playback;
+
+	int input_sample_rate = 0;
+	int input_channels = 0;
+	int output_sample_rate = 0; // Will be set from AudioServer
+	int output_channels = 2; // Stereo
+
+	Vector<float> resample_buffer;
+	double resample_ratio = 1.0;
+
+public:
+	AudioSampleGrabberCallback(VideoStreamPlaybackWMF *playback, Mutex &mtx);
+	virtual ~AudioSampleGrabberCallback();
+
+	static HRESULT CreateInstance(AudioSampleGrabberCallback **ppCB, VideoStreamPlaybackWMF *playback, Mutex &mtx);
+
+	// IUnknown methods
+	STDMETHODIMP QueryInterface(REFIID riid, void **ppv) override;
+	STDMETHODIMP_(ULONG)
+	AddRef() override;
+	STDMETHODIMP_(ULONG)
+	Release() override;
+
+	// IMFClockStateSink methods
+	STDMETHODIMP OnClockStart(MFTIME hnsSystemTime, LONGLONG llClockStartOffset) override;
+	STDMETHODIMP OnClockStop(MFTIME hnsSystemTime) override;
+	STDMETHODIMP OnClockPause(MFTIME hnsSystemTime) override;
+	STDMETHODIMP OnClockRestart(MFTIME hnsSystemTime) override;
+	STDMETHODIMP OnClockSetRate(MFTIME hnsSystemTime, float flRate) override;
+
+	// IMFSampleGrabberSinkCallback methods
+	STDMETHODIMP OnSetPresentationClock(IMFPresentationClock *pClock) override;
+	STDMETHODIMP OnProcessSample(REFGUID guidMajorMediaType, DWORD dwSampleFlags,
+			LONGLONG llSampleTime, LONGLONG llSampleDuration, const BYTE *pSampleBuffer,
+			DWORD dwSampleSize) override;
+	STDMETHODIMP OnShutdown() override;
+
+	void set_audio_format(int sample_rate, int channels);
+	void set_output_format(int sample_rate, int channels);
+
+private:
+	void resample_audio(const float *input, int input_samples, Vector<float> &output);
+	void convert_to_float(const BYTE *input, DWORD input_size, Vector<float> &output);
+};
+
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif

--- a/modules/wmf/config.py
+++ b/modules/wmf/config.py
@@ -1,0 +1,16 @@
+def can_build(env, platform):
+    return platform == "windows"
+
+
+def configure(env):
+    pass
+
+
+def get_doc_classes():
+    return [
+        "WindowsMediaFoundation",
+    ]
+
+
+def get_doc_path():
+    return "doc_classes"

--- a/modules/wmf/register_types.cpp
+++ b/modules/wmf/register_types.cpp
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  register_types.cpp                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "register_types.h"
+#include "resource_importer_wmf_video.h"
+#include "video_stream_wmf.h"
+
+#include "mfapi.h"
+#include <stdio.h>
+
+static Ref<ResourceFormatLoaderWMF> resource_loader_wmf;
+
+void initialize_wmf_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+	MFStartup(MF_VERSION, MFSTARTUP_FULL);
+
+	resource_loader_wmf.instantiate();
+	ResourceLoader::add_resource_format_loader(resource_loader_wmf, true);
+
+#ifdef TOOLS_ENABLED
+	Ref<ResourceImporterWMFVideo> wmfv_import;
+	wmfv_import.instantiate();
+	ResourceFormatImporter::get_singleton()->add_importer(wmfv_import);
+#endif
+	GDREGISTER_CLASS(VideoStreamWMF);
+}
+
+void uninitialize_wmf_module(ModuleInitializationLevel p_level) {
+	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
+		return;
+	}
+	ResourceLoader::remove_resource_format_loader(resource_loader_wmf);
+	resource_loader_wmf.unref();
+	MFShutdown();
+}

--- a/modules/wmf/register_types.h
+++ b/modules/wmf/register_types.h
@@ -1,0 +1,36 @@
+/**************************************************************************/
+/*  register_types.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "modules/register_module_types.h"
+
+void initialize_wmf_module(ModuleInitializationLevel p_level);
+void uninitialize_wmf_module(ModuleInitializationLevel p_level);

--- a/modules/wmf/resource_importer_wmf_video.cpp
+++ b/modules/wmf/resource_importer_wmf_video.cpp
@@ -1,0 +1,101 @@
+/**************************************************************************/
+/*  resource_importer_wmf_video.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "resource_importer_wmf_video.h"
+
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
+#include "core/io/file_access.h"
+#include "core/io/resource_saver.h"
+#include "video_stream_wmf.h"
+
+String ResourceImporterWMFVideo::get_importer_name() const {
+	return "WindowsMediaFoundation";
+}
+
+String ResourceImporterWMFVideo::get_visible_name() const {
+	return "WindowsMediaFoundation";
+}
+
+void ResourceImporterWMFVideo::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("mp4");
+	p_extensions->push_back("avi");
+	p_extensions->push_back("mkv");
+	p_extensions->push_back("webm");
+}
+
+String ResourceImporterWMFVideo::get_save_extension() const {
+	return "wmfvstr";
+}
+
+String ResourceImporterWMFVideo::get_resource_type() const {
+	return "VideoStreamWMF";
+}
+
+bool ResourceImporterWMFVideo::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+	return true;
+}
+
+int ResourceImporterWMFVideo::get_preset_count() const {
+	return 0;
+}
+
+String ResourceImporterWMFVideo::get_preset_name(int p_idx) const {
+	return String();
+}
+
+void ResourceImporterWMFVideo::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "loop"), false));
+}
+
+Error ResourceImporterWMFVideo::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
+	ERR_FAIL_COND_V(p_source_file.is_empty(), ERR_INVALID_PARAMETER);
+
+	// Load the video file data into memory
+	Error err;
+	Ref<FileAccess> file = FileAccess::open(p_source_file, FileAccess::READ, &err);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot open file '" + p_source_file + "'.");
+
+	Vector<uint8_t> data;
+	uint64_t len = file->get_length();
+	data.resize(len);
+	uint64_t bytes_read = file->get_buffer(data.ptrw(), len);
+	ERR_FAIL_COND_V(bytes_read == 0, ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V_MSG(bytes_read != len, ERR_FILE_CORRUPT, "Cannot read file '" + p_source_file + "'.");
+	file.unref();
+
+	Ref<VideoStreamWMF> wmfv_stream;
+	wmfv_stream.instantiate();
+	wmfv_stream->set_file(p_source_file); // Keep file path for fallback
+	return ResourceSaver::save(wmfv_stream, p_save_path + ".wmfvstr");
+}
+
+ResourceImporterWMFVideo::ResourceImporterWMFVideo() {
+}

--- a/modules/wmf/resource_importer_wmf_video.h
+++ b/modules/wmf/resource_importer_wmf_video.h
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  resource_importer_wmf_video.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource_importer.h"
+
+class ResourceImporterWMFVideo : public ResourceImporter {
+	GDCLASS(ResourceImporterWMFVideo, ResourceImporter)
+
+public:
+	virtual String get_importer_name() const override;
+	virtual String get_visible_name() const override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual String get_save_extension() const override;
+	virtual String get_resource_type() const override;
+
+	virtual int get_preset_count() const override;
+	virtual String get_preset_name(int p_idx) const override;
+	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
+	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
+
+	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
+
+	ResourceImporterWMFVideo();
+};

--- a/modules/wmf/video_stream_wmf.cpp
+++ b/modules/wmf/video_stream_wmf.cpp
@@ -1,0 +1,787 @@
+/**************************************************************************/
+/*  video_stream_wmf.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "video_stream_wmf.h"
+
+#include "audio_sample_grabber_callback.h"
+#include "core/config/project_settings.h"
+#include "core/error/error_list.h"
+#include "core/error/error_macros.h"
+#include "core/io/file_access.h"
+#include "core/object/object.h"
+#include "scene/resources/image_texture.h"
+#include "servers/audio_server.h"
+#include <mfapi.h>
+#include <mferror.h>
+#include <mftransform.h>
+#include <shlwapi.h>
+#include <wmcodecdsp.h>
+
+#ifdef __MINGW32__
+#include <initguid.h>
+
+#if defined(__GNUC__) && __GNUC__ < 13
+DEFINE_GUID(CLSID_VideoProcessorMFT, 0x88753808, 0x311a, 0x4a01, 0x83, 0xd0, 0x4, 0x58, 0xb2, 0xc4, 0x25, 0xf);
+#endif // __GNUC__ < 12
+
+#ifndef IID_IMFVideoProcessorControl
+DEFINE_GUID(IID_IMFVideoProcessorControl, 0xA3F675D7, 0x2744, 0x46dd, 0x95, 0x67, 0x94, 0xBB, 0x04, 0x20, 0x6F, 0x4C);
+#endif
+#endif // __MINGW32__
+
+#define CHECK_HR(func)                                                           \
+	if (SUCCEEDED(hr)) {                                                         \
+		hr = (func);                                                             \
+		if (FAILED(hr)) {                                                        \
+			print_line(vformat("%s failed, return:%s", __FUNCTION__, itos(hr))); \
+		}                                                                        \
+	}
+#define SafeRelease(p)      \
+	{                       \
+		if (p) {            \
+			(p)->Release(); \
+			(p) = nullptr;  \
+		}                   \
+	}
+
+HRESULT AddSourceNode(IMFTopology *pTopology, IMFMediaSource *pSource,
+		IMFPresentationDescriptor *pPD, IMFStreamDescriptor *pSD,
+		IMFTopologyNode **ppNode) {
+	IMFTopologyNode *pNode = NULL;
+
+	HRESULT hr = S_OK;
+	CHECK_HR(MFCreateTopologyNode(MF_TOPOLOGY_SOURCESTREAM_NODE, &pNode));
+	CHECK_HR(pNode->SetUnknown(MF_TOPONODE_SOURCE, pSource));
+	CHECK_HR(pNode->SetUnknown(MF_TOPONODE_PRESENTATION_DESCRIPTOR, pPD));
+	CHECK_HR(pNode->SetUnknown(MF_TOPONODE_STREAM_DESCRIPTOR, pSD));
+	CHECK_HR(pTopology->AddNode(pNode));
+
+	if (SUCCEEDED(hr)) {
+		*ppNode = pNode;
+		(*ppNode)->AddRef();
+	}
+	SafeRelease(pNode);
+	return hr;
+}
+
+// Add an output node to a topology.
+HRESULT AddOutputNode(IMFTopology *pTopology, // Topology.
+		IMFActivate *pActivate, // Media sink activation object.
+		DWORD dwId, // Identifier of the stream sink.
+		IMFTopologyNode **ppNode) // Receives the node pointer.
+{
+	IMFTopologyNode *pNode = NULL;
+
+	HRESULT hr = S_OK;
+	CHECK_HR(MFCreateTopologyNode(MF_TOPOLOGY_OUTPUT_NODE, &pNode));
+	CHECK_HR(pNode->SetObject(pActivate));
+	CHECK_HR(pNode->SetUINT32(MF_TOPONODE_STREAMID, dwId));
+	CHECK_HR(pNode->SetUINT32(MF_TOPONODE_NOSHUTDOWN_ON_REMOVE, FALSE));
+	CHECK_HR(pTopology->AddNode(pNode));
+
+	// Return the pointer to the caller.
+	if (SUCCEEDED(hr)) {
+		*ppNode = pNode;
+		(*ppNode)->AddRef();
+	}
+
+	SafeRelease(pNode);
+	return hr;
+}
+
+HRESULT AddColourConversionNode(IMFTopology *pTopology,
+		IMFMediaType *inputType,
+		IMFTransform **ppColorTransform) {
+	HRESULT hr = S_OK;
+
+	IMFTransform *colorTransform = nullptr;
+	// Use Video Processor MFT instead of Color Convert DMO for better video conversion
+	CHECK_HR(CoCreateInstance(CLSID_VideoProcessorMFT, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&colorTransform)));
+
+	UINT32 uWidth = 0, uHeight = 0;
+	MFGetAttributeSize(inputType, MF_MT_FRAME_SIZE, &uWidth, &uHeight);
+	print_line("Video Processor MFT setup for: " + itos(uWidth) + "x" + itos(uHeight));
+
+	IMFMediaType *pInType = nullptr;
+	CHECK_HR(MFCreateMediaType(&pInType));
+	CHECK_HR(pInType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
+	CHECK_HR(pInType->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_NV12));
+	CHECK_HR(MFSetAttributeSize(pInType, MF_MT_FRAME_SIZE, uWidth, uHeight));
+	CHECK_HR(pInType->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
+
+	hr = colorTransform->SetInputType(0, pInType, 0);
+	if (FAILED(hr)) {
+		print_line("Failed to set input type: " + itos(hr));
+		SafeRelease(pInType);
+		SafeRelease(colorTransform);
+		return hr;
+	}
+
+	// Try ARGB32 first (better RGB ordering), fallback to RGB32
+	IMFMediaType *pOutType = nullptr;
+	CHECK_HR(MFCreateMediaType(&pOutType));
+	CHECK_HR(pOutType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Video));
+
+	hr = pOutType->SetGUID(MF_MT_SUBTYPE, MFVideoFormat_ARGB32);
+
+	CHECK_HR(MFSetAttributeSize(pOutType, MF_MT_FRAME_SIZE, uWidth, uHeight));
+	CHECK_HR(pOutType->SetUINT32(MF_MT_INTERLACE_MODE, MFVideoInterlace_Progressive));
+
+	// Set positive stride for top-down output (standard for RGB formats)
+	LONG outStride = (LONG)(uWidth * 4); // 4 bytes per pixel for ARGB32/RGB32
+	CHECK_HR(pOutType->SetUINT32(MF_MT_DEFAULT_STRIDE, (UINT32)outStride));
+
+	hr = colorTransform->SetOutputType(0, pOutType, 0);
+	if (FAILED(hr)) {
+		print_line("Failed to set output type: " + itos(hr));
+		SafeRelease(pInType);
+		SafeRelease(pOutType);
+		SafeRelease(colorTransform);
+		return hr;
+	}
+
+	print_line("Video Processor MFT setup successful");
+	*ppColorTransform = colorTransform;
+
+	SafeRelease(pInType);
+	SafeRelease(pOutType);
+	return S_OK;
+}
+
+HRESULT CreateAudioSampleGrabber(UINT32 sample_rate, UINT32 channels, AudioSampleGrabberCallback *pAudioSampleGrabber, IMFActivate **pSinkActivate) {
+	HRESULT hr = S_OK;
+	IMFMediaType *pType = NULL;
+
+	CHECK_HR(MFCreateMediaType(&pType));
+	CHECK_HR(pType->SetGUID(MF_MT_MAJOR_TYPE, MFMediaType_Audio));
+	CHECK_HR(pType->SetGUID(MF_MT_SUBTYPE, MFAudioFormat_PCM));
+	CHECK_HR(pType->SetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, sample_rate));
+	CHECK_HR(pType->SetUINT32(MF_MT_AUDIO_NUM_CHANNELS, channels));
+	CHECK_HR(pType->SetUINT32(MF_MT_AUDIO_BITS_PER_SAMPLE, 16));
+	CHECK_HR(pType->SetUINT32(MF_MT_AUDIO_BLOCK_ALIGNMENT, channels * 2)); // 2 bytes per sample for 16-bit
+	CHECK_HR(pType->SetUINT32(MF_MT_AUDIO_AVG_BYTES_PER_SECOND, sample_rate * channels * 2));
+	CHECK_HR(MFCreateSampleGrabberSinkActivate(pType, pAudioSampleGrabber, pSinkActivate));
+
+	SafeRelease(pType);
+	return hr;
+}
+
+// Create the topology.
+HRESULT CreateTopology(IMFMediaSource *pSource, AudioSampleGrabberCallback *pAudioSampleGrabber, IMFTopology **ppTopo, VideoStreamPlaybackWMF::StreamInfo *info, VideoStreamPlaybackWMF *playback) {
+	IMFTopology *pTopology = NULL;
+	IMFPresentationDescriptor *pPD = NULL;
+	IMFStreamDescriptor *pSD = NULL;
+	IMFMediaTypeHandler *pHandler = NULL;
+	IMFTopologyNode *inputNode = NULL;
+	IMFTopologyNode *outputNode = NULL;
+	IMFTopologyNode *inputNodeAudio = NULL;
+	IMFTopologyNode *outputNodeAudio = NULL;
+	IMFActivate *audioActivate = NULL;
+
+	HRESULT hr = S_OK;
+
+	CHECK_HR(MFCreateTopology(&pTopology));
+	CHECK_HR(pSource->CreatePresentationDescriptor(&pPD));
+
+	DWORD cStreams = 0;
+	CHECK_HR(pPD->GetStreamDescriptorCount(&cStreams));
+
+	print_line(itos(cStreams) + " streams");
+
+	// First pass: Select all streams we want to use
+	for (DWORD i = 0; i < cStreams; i++) {
+		BOOL bSelected = FALSE;
+		GUID majorType;
+		IMFStreamDescriptor *pTempSD = NULL;
+		IMFMediaTypeHandler *pTempHandler = NULL;
+
+		CHECK_HR(pPD->GetStreamDescriptorByIndex(i, &bSelected, &pTempSD));
+		CHECK_HR(pTempSD->GetMediaTypeHandler(&pTempHandler));
+		CHECK_HR(pTempHandler->GetMajorType(&majorType));
+
+		String type_name = "Unknown";
+		if (majorType == MFMediaType_Video) {
+			type_name = "Video";
+		} else if (majorType == MFMediaType_Audio) {
+			type_name = "Audio";
+		}
+
+		print_line("Stream " + itos(i) + " initial check: Selected=" + itos(bSelected) + ", Type=" + type_name);
+
+		if (majorType == MFMediaType_Video || majorType == MFMediaType_Audio) {
+			if (!bSelected) {
+				print_line("Selecting stream " + itos(i) + " (" + type_name + ")");
+				CHECK_HR(pPD->SelectStream(i));
+			} else {
+				print_line("Stream " + itos(i) + " (" + type_name + ") already selected");
+			}
+		}
+
+		SafeRelease(pTempSD);
+		SafeRelease(pTempHandler);
+	}
+
+	for (DWORD i = 0; i < cStreams; i++) {
+		BOOL bSelected = FALSE;
+		GUID majorType;
+
+		CHECK_HR(pPD->GetStreamDescriptorByIndex(i, &bSelected, &pSD));
+		CHECK_HR(pSD->GetMediaTypeHandler(&pHandler));
+		CHECK_HR(pHandler->GetMajorType(&majorType));
+
+		print_line("Stream " + itos(i) + ": Selected=" + itos(bSelected) + ", Type=" + (majorType == MFMediaType_Video ? "Video" : majorType == MFMediaType_Audio ? "Audio"
+																																								  : "Other"));
+
+		if (majorType == MFMediaType_Audio && bSelected) {
+			print_line("Audio Stream");
+
+			// Get audio format information
+			IMFMediaType *pAudioType = NULL;
+			CHECK_HR(pHandler->GetMediaTypeByIndex(0, &pAudioType));
+
+			UINT32 sample_rate = 0, channels = 0;
+			pAudioType->GetUINT32(MF_MT_AUDIO_SAMPLES_PER_SECOND, &sample_rate);
+			pAudioType->GetUINT32(MF_MT_AUDIO_NUM_CHANNELS, &channels);
+
+			print_line("Audio format: " + itos(sample_rate) + "Hz, " + itos(channels) + " channels");
+
+			// Set audio format in the callback
+			if (pAudioSampleGrabber) {
+				pAudioSampleGrabber->set_audio_format(sample_rate, channels);
+			}
+
+			// Set audio format in the playback instance
+			if (playback) {
+				playback->set_audio_format(sample_rate, channels);
+			}
+
+			// Create audio sample grabber instead of audio renderer
+			IMFActivate *pAudioSinkActivate = NULL;
+			CHECK_HR(CreateAudioSampleGrabber(sample_rate, channels, pAudioSampleGrabber, &pAudioSinkActivate));
+
+			CHECK_HR(AddSourceNode(pTopology, pSource, pPD, pSD, &inputNodeAudio));
+			CHECK_HR(AddOutputNode(pTopology, pAudioSinkActivate, 0, &outputNodeAudio));
+			CHECK_HR(inputNodeAudio->ConnectOutput(0, outputNodeAudio, 0));
+
+			SafeRelease(pAudioType);
+			SafeRelease(pAudioSinkActivate);
+		} else {
+			print_line("Stream deselected");
+			CHECK_HR(pPD->DeselectStream(i));
+		}
+		SafeRelease(pSD);
+		SafeRelease(pHandler);
+	}
+
+	if (SUCCEEDED(hr)) {
+		*ppTopo = pTopology;
+		(*ppTopo)->AddRef();
+	}
+	SafeRelease(pTopology);
+	SafeRelease(inputNode);
+	SafeRelease(outputNode);
+	SafeRelease(pPD);
+	SafeRelease(pHandler);
+	SafeRelease(audioActivate);
+	return hr;
+}
+
+HRESULT CreateMediaSource(const String &p_file, IMFMediaSource **pMediaSource) {
+	ERR_FAIL_COND_V(p_file.is_empty(), E_FAIL);
+
+	IMFSourceResolver *pSourceResolver = nullptr;
+	IUnknown *pSource = nullptr;
+
+	// Create the source resolver.
+	HRESULT hr = S_OK;
+	CHECK_HR(MFCreateSourceResolver(&pSourceResolver));
+
+	print_line("Original File:" + p_file);
+
+	String file_path = p_file;
+
+	// Handle Godot resource paths
+	if (p_file.begins_with("res://")) {
+		// Convert resource path to global path
+		file_path = ProjectSettings::get_singleton()->globalize_path(p_file);
+		print_line("Globalized Path: " + file_path);
+	}
+
+	// Verify the file exists
+	Error e;
+	Ref<FileAccess> fa = FileAccess::open(file_path, FileAccess::READ, &e);
+	if (e != OK) {
+		print_line("Failed to open file: " + file_path + " Error: " + itos(e));
+		SafeRelease(pSourceResolver);
+		return E_FAIL;
+	}
+	fa.unref();
+
+	// Convert to Windows path format if needed
+	file_path = file_path.replace("/", "\\");
+	print_line("Final Path: " + file_path);
+
+	MF_OBJECT_TYPE ObjectType;
+	CHECK_HR(pSourceResolver->CreateObjectFromURL((LPCWSTR)file_path.utf16().ptrw(),
+			MF_RESOLUTION_MEDIASOURCE, nullptr, &ObjectType, &pSource));
+	CHECK_HR(pSource->QueryInterface(IID_PPV_ARGS(pMediaSource)));
+
+	SafeRelease(pSourceResolver);
+	SafeRelease(pSource);
+
+	return hr;
+}
+
+void VideoStreamPlaybackWMF::shutdown_stream() {
+	if (media_source) {
+		media_source->Stop();
+		media_source->Shutdown();
+	}
+	if (media_session) {
+		media_session->Stop();
+		media_session->Shutdown();
+	}
+
+	SafeRelease(topology);
+	SafeRelease(media_source);
+	SafeRelease(media_session);
+	SafeRelease(presentation_clock);
+	//SafeRelease(sample_grabber_callback);
+
+	is_video_playing = false;
+	is_video_paused = false;
+	is_video_seekable = false;
+
+	stream_info.size = Point2i(0, 0);
+	stream_info.fps = 0;
+	stream_info.duration = 0;
+}
+
+void VideoStreamPlaybackWMF::play() {
+	if (is_video_playing) {
+		return;
+	}
+
+	if (media_session) {
+		HRESULT hr = S_OK;
+
+		PROPVARIANT var;
+		PropVariantInit(&var);
+		CHECK_HR(media_session->Start(&GUID_NULL, &var));
+
+		if (SUCCEEDED(hr)) {
+			is_video_playing = true;
+		}
+	}
+}
+
+void VideoStreamPlaybackWMF::stop() {
+	if (media_session) {
+		HRESULT hr = S_OK;
+		CHECK_HR(media_session->Stop());
+
+		if (SUCCEEDED(hr)) {
+			is_video_playing = false;
+		}
+	}
+}
+
+bool VideoStreamPlaybackWMF::is_playing() const {
+	return is_video_playing;
+}
+
+void VideoStreamPlaybackWMF::set_paused(bool p_paused) {
+	print_line(String(__FUNCTION__) + ": " + itos(p_paused));
+	is_video_paused = p_paused;
+
+	if (media_session) {
+		HRESULT hr = S_OK;
+		if (p_paused) {
+			CHECK_HR(media_session->Pause());
+		} else {
+			PROPVARIANT var;
+			PropVariantInit(&var);
+			CHECK_HR(media_session->Start(&GUID_NULL, &var));
+		}
+	}
+}
+
+bool VideoStreamPlaybackWMF::is_paused() const {
+	return is_video_paused;
+}
+
+double VideoStreamPlaybackWMF::get_length() const {
+	return stream_info.duration;
+}
+
+String VideoStreamPlaybackWMF::get_stream_name() const {
+	return String("A video file");
+}
+
+int VideoStreamPlaybackWMF::get_loop_count() const {
+	return 0;
+}
+
+double VideoStreamPlaybackWMF::get_playback_position() const {
+	return time;
+}
+
+void VideoStreamPlaybackWMF::seek(double p_time) {
+	print_line(String(__FUNCTION__) + ": " + rtos(p_time));
+
+	time = p_time;
+
+	if (media_session) {
+		double wmf_time = p_time * 10000000.0;
+
+		HRESULT hr = S_OK;
+		PROPVARIANT varStart;
+		varStart.vt = VT_I8;
+		varStart.hVal.QuadPart = (MFTIME)wmf_time;
+		CHECK_HR(media_session->Start(NULL, &varStart));
+
+		if (is_video_paused) {
+			media_session->Pause();
+		}
+	}
+}
+
+void VideoStreamPlaybackWMF::set_file(const String &p_file) {
+	ERR_FAIL_COND(p_file.is_empty());
+
+	shutdown_stream();
+
+	HRESULT hr = S_OK;
+
+	CHECK_HR(CreateMediaSource(p_file, &media_source));
+	CHECK_HR(MFCreateMediaSession(nullptr, &media_session));
+
+	CHECK_HR(AudioSampleGrabberCallback::CreateInstance(&audio_sample_grabber_callback, this, audio_mtx));
+	CHECK_HR(CreateTopology(media_source, audio_sample_grabber_callback, &topology, &stream_info, this));
+
+	CHECK_HR(media_session->SetTopology(0, topology));
+
+	if (SUCCEEDED(hr)) {
+		IMFRateControl *m_pRate;
+		HRESULT hrRate = MFGetService(media_session, MF_RATE_CONTROL_SERVICE, IID_PPV_ARGS(&m_pRate));
+
+		if (SUCCEEDED(hrRate)) {
+			BOOL bThin = false;
+			float fRate = 0.f;
+			CHECK_HR(m_pRate->GetRate(&bThin, &fRate));
+			//print_line("Thin = " + itos(bThin) + ", Playback Rate:" + rtos(fRate));
+		}
+
+		DWORD caps = 0;
+		CHECK_HR(media_session->GetSessionCapabilities(&caps));
+		if ((caps & MFSESSIONCAP_SEEK) != 0) {
+			is_video_seekable = true;
+		}
+
+		IMFClock *clock;
+		if (SUCCEEDED(media_session->GetClock(&clock))) {
+			CHECK_HR(clock->QueryInterface(IID_PPV_ARGS(&presentation_clock)));
+		}
+	} else {
+		SafeRelease(media_session);
+	}
+}
+
+Ref<Texture2D> VideoStreamPlaybackWMF::get_texture() const {
+	return texture;
+}
+
+void VideoStreamPlaybackWMF::update(double p_delta) {
+	if (!is_video_playing || is_video_paused) {
+		return;
+	}
+
+	time += p_delta;
+	double current_time = time;
+
+	if (media_session) {
+		HRESULT hr = S_OK;
+		HRESULT hrStatus = S_OK;
+		MediaEventType met = 0;
+		IMFMediaEvent *event = nullptr;
+
+		hr = media_session->GetEvent(MF_EVENT_FLAG_NO_WAIT, &event);
+		if (SUCCEEDED(hr)) {
+			hr = event->GetStatus(&hrStatus);
+			if (SUCCEEDED(hr)) {
+				hr = event->GetType(&met);
+				if (SUCCEEDED(hr)) {
+					if (met == MESessionEnded) {
+						// We're done playing
+						media_session->Stop();
+						is_video_playing = false;
+						SafeRelease(event);
+						return;
+					}
+				}
+			}
+		}
+		SafeRelease(event);
+
+		// Process audio frames
+		bool audio_ready = false;
+		while (!audio_ready) {
+			if (!send_audio()) {
+				audio_ready = true;
+				break;
+			}
+			// If we successfully sent audio, check if there's more
+			if (audio_read_frame_idx == audio_write_frame_idx) {
+				audio_ready = true; // No more audio data
+			}
+		}
+
+		// Check if we have frames available and if it's time to display the next frame
+		if (read_frame_idx != write_frame_idx) {
+			mtx.lock();
+			FrameData &the_frame = cache_frames.write[read_frame_idx];
+			double frame_time = the_frame.sample_time / 10000000.0; // Convert from 100ns units to seconds
+			mtx.unlock();
+
+			// If it's time to display this frame
+			if (current_time >= frame_time) {
+				present();
+			}
+		}
+	}
+}
+
+void VideoStreamPlaybackWMF::set_mix_callback(AudioMixCallback p_callback, void *p_userdata) {
+	mix_callback = p_callback;
+	mix_udata = p_userdata;
+}
+
+int VideoStreamPlaybackWMF::get_channels() const {
+	return audio_channels;
+}
+
+int VideoStreamPlaybackWMF::get_mix_rate() const {
+	return audio_sample_rate;
+}
+
+void VideoStreamPlaybackWMF::set_audio_track(int p_idx) {
+	//print_line(__FUNCTION__ ": " + itos(p_idx));
+}
+
+FrameData *VideoStreamPlaybackWMF::get_next_writable_frame() {
+	return &cache_frames.write[write_frame_idx];
+}
+
+void VideoStreamPlaybackWMF::write_frame_done() {
+	MutexLock lock(mtx);
+	int next_write_frame_idx = (write_frame_idx + 1) % cache_frames.size();
+
+	// TODO: just ignore the buffer full case for now because sometimes one Player may hit this if forever
+	// claiming all memory eventually...
+	if (read_frame_idx == next_write_frame_idx) {
+		//print_line(itos(id) + " Chase up! W:" + itos(write_frame_idx) + " R:" + itos(read_frame_idx) + " Size:" + itos(cache_frames.size()));
+		// the time gap between videos is larger than the buffer size
+		// need to extend the buffer size
+
+		/*
+		int current_size = cache_frames.size();
+		cache_frames.resize(current_size + 10);
+
+		const int rgb24_frame_size = stream_info.size.x * stream_info.size.y * 3;
+		for (int i = 0; i < cache_frames.size(); ++i) {
+			cache_frames.write[i].data.resize(rgb24_frame_size);
+		}
+		next_write_frame_idx = write_frame_idx + 1;
+		*/
+	}
+
+	write_frame_idx = next_write_frame_idx;
+}
+
+void VideoStreamPlaybackWMF::present() {
+	if (read_frame_idx == write_frame_idx) {
+		return;
+	}
+	mtx.lock();
+	FrameData &the_frame = cache_frames.write[read_frame_idx];
+	read_frame_idx = (read_frame_idx + 1) % cache_frames.size();
+	mtx.unlock();
+
+	// Check if frame data is valid for RGBA format
+	if (the_frame.data.size() != stream_info.size.x * stream_info.size.y * 4) {
+		return;
+	}
+
+	Ref<Image> img = memnew(Image(stream_info.size.x, stream_info.size.y, 0, Image::FORMAT_RGBA8, the_frame.data));
+	texture->update(img);
+}
+
+int64_t VideoStreamPlaybackWMF::next_sample_time() {
+	MutexLock lock(mtx);
+	int64_t sample_time = INT64_MAX;
+	if (!cache_frames.is_empty()) {
+		sample_time = cache_frames[read_frame_idx].sample_time;
+	}
+	return sample_time;
+}
+
+bool VideoStreamPlaybackWMF::send_audio() {
+	if (audio_read_frame_idx == audio_write_frame_idx) {
+		return true; // No audio data available
+	}
+
+	audio_mtx.lock();
+	AudioData &audio_frame = audio_cache_frames.write[audio_read_frame_idx];
+	audio_mtx.unlock();
+
+	if (mix_callback && !audio_frame.data.is_empty()) {
+		int frames = audio_frame.data.size() / audio_channels;
+		if (frames > 0) {
+			int mixed = mix_callback(mix_udata, audio_frame.data.ptr(), frames);
+			if (mixed == frames) {
+				// All audio was consumed, advance to next frame
+				audio_mtx.lock();
+				audio_read_frame_idx = (audio_read_frame_idx + 1) % audio_cache_frames.size();
+				audio_mtx.unlock();
+				return true;
+			} else {
+				// Not all audio was consumed, keep this frame for next time
+				return false;
+			}
+		}
+	}
+
+	// No mix callback or empty data, just advance
+	audio_mtx.lock();
+	audio_read_frame_idx = (audio_read_frame_idx + 1) % audio_cache_frames.size();
+	audio_mtx.unlock();
+	return true;
+}
+
+void VideoStreamPlaybackWMF::add_audio_data(int64_t sample_time, const Vector<float> &audio_data) {
+	MutexLock lock(audio_mtx);
+
+	AudioData *audio_frame = get_next_writable_audio_frame();
+	audio_frame->sample_time = sample_time;
+	audio_frame->data = audio_data;
+
+	write_audio_frame_done();
+}
+
+AudioData *VideoStreamPlaybackWMF::get_next_writable_audio_frame() {
+	return &audio_cache_frames.write[audio_write_frame_idx];
+}
+
+void VideoStreamPlaybackWMF::write_audio_frame_done() {
+	int next_write_frame_idx = (audio_write_frame_idx + 1) % audio_cache_frames.size();
+
+	// Handle buffer overflow
+	if (audio_read_frame_idx == next_write_frame_idx) {
+		// Buffer full, advance read index to make room
+		audio_read_frame_idx = (audio_read_frame_idx + 1) % audio_cache_frames.size();
+	}
+
+	audio_write_frame_idx = next_write_frame_idx;
+}
+
+void VideoStreamPlaybackWMF::set_audio_format(int sample_rate, int channels) {
+	audio_sample_rate = sample_rate;
+	audio_channels = channels;
+	print_line("Audio format set: " + itos(sample_rate) + "Hz, " + itos(channels) + " channels");
+}
+
+static int counter = 0;
+
+VideoStreamPlaybackWMF::VideoStreamPlaybackWMF() :
+		media_session(NULL), media_source(NULL), topology(NULL), presentation_clock(NULL), audio_sample_grabber_callback(nullptr), read_frame_idx(0), write_frame_idx(0), audio_read_frame_idx(0), audio_write_frame_idx(0), is_video_playing(false), is_video_paused(false), is_video_seekable(false), time(0.0), next_frame_time(0.0), current_frame_time(-1.0), frame_ready(false), audio_channels(0), audio_sample_rate(0), audio_buffer_pos(0) {
+	id = counter;
+	counter++;
+
+	texture = Ref<ImageTexture>(memnew(ImageTexture));
+	// make sure cache_frames.size() is something more than 0
+	cache_frames.resize(24);
+	audio_cache_frames.resize(24);
+
+	// Get Godot's audio settings
+	AudioServer *audio_server = AudioServer::get_singleton();
+	if (audio_server) {
+		audio_sample_rate = audio_server->get_mix_rate();
+		audio_channels = 2; // Default to stereo
+	}
+}
+
+VideoStreamPlaybackWMF::~VideoStreamPlaybackWMF() {
+	shutdown_stream();
+}
+
+void VideoStreamWMF::_bind_methods() {}
+
+Ref<Resource> ResourceFormatLoaderWMF::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		if (r_error) {
+			*r_error = ERR_CANT_OPEN;
+		}
+		return Ref<Resource>();
+	}
+
+	VideoStreamWMF *stream = memnew(VideoStreamWMF);
+	stream->set_file(p_path);
+
+	Ref<VideoStreamWMF> wmf_stream = Ref<VideoStreamWMF>(stream);
+
+	if (r_error) {
+		*r_error = OK;
+	}
+
+	return wmf_stream;
+}
+
+void ResourceFormatLoaderWMF::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("mp4");
+	p_extensions->push_back("avi");
+	p_extensions->push_back("wmv");
+	p_extensions->push_back("mov");
+	p_extensions->push_back("mkv");
+	p_extensions->push_back("webm");
+	p_extensions->push_back("flv");
+}
+
+bool ResourceFormatLoaderWMF::handles_type(const String &p_type) const {
+	return ClassDB::is_parent_class(p_type, "VideoStream");
+}
+
+String ResourceFormatLoaderWMF::get_resource_type(const String &p_path) const {
+	String el = p_path.get_extension().to_lower();
+	if (el == "mp4" || el == "avi" || el == "wmv" || el == "mov" || el == "mkv" || el == "webm" || el == "flv") {
+		return "VideoStreamWMF";
+	}
+	return "";
+}

--- a/modules/wmf/video_stream_wmf.h
+++ b/modules/wmf/video_stream_wmf.h
@@ -1,0 +1,183 @@
+/**************************************************************************/
+/*  video_stream_wmf.h                                                    */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/io/resource_loader.h"
+#include "core/os/mutex.h"
+#include "scene/resources/image_texture.h"
+#include "scene/resources/video_stream.h"
+
+#include <deque>
+
+class SampleGrabberCallback;
+class AudioSampleGrabberCallback;
+struct IMFMediaSession;
+struct IMFMediaSource;
+struct IMFTopology;
+struct IMFPresentationClock;
+
+struct FrameData {
+	int64_t sample_time = 0;
+	Vector<uint8_t> data;
+};
+
+struct AudioData {
+	int64_t sample_time = 0;
+	Vector<float> data;
+};
+
+class VideoStreamPlaybackWMF : public VideoStreamPlayback {
+	GDCLASS(VideoStreamPlaybackWMF, VideoStreamPlayback);
+
+	IMFMediaSession *media_session;
+	IMFMediaSource *media_source;
+	IMFTopology *topology;
+	IMFPresentationClock *presentation_clock;
+	AudioSampleGrabberCallback *audio_sample_grabber_callback;
+
+	Vector<FrameData> cache_frames;
+	int read_frame_idx = 0;
+	int write_frame_idx = 0;
+
+	Vector<AudioData> audio_cache_frames;
+	int audio_read_frame_idx = 0;
+	int audio_write_frame_idx = 0;
+
+	Vector<uint8_t> frame_data;
+	Ref<ImageTexture> texture;
+	Mutex mtx;
+	Mutex audio_mtx;
+
+	bool is_video_playing = false;
+	bool is_video_paused = false;
+	bool is_video_seekable = false;
+
+	double time = 0.0;
+	double next_frame_time = 0.0;
+	double current_frame_time = -1.0;
+	bool frame_ready = false;
+
+	int id = 0;
+
+	AudioMixCallback mix_callback = nullptr;
+	void *mix_udata = nullptr;
+
+	// Audio properties
+	int audio_channels = 0;
+	int audio_sample_rate = 0;
+	Vector<float> audio_buffer;
+	int audio_buffer_pos = 0;
+
+	void shutdown_stream();
+
+public:
+	struct StreamInfo {
+		Point2i size;
+		float fps = 0.0f;
+		float duration = 0.0f;
+	};
+	StreamInfo stream_info;
+
+	virtual void play() override;
+	virtual void stop() override;
+	virtual bool is_playing() const override;
+
+	virtual void set_paused(bool p_paused) override;
+	virtual bool is_paused() const override;
+
+	virtual double get_length() const override;
+	virtual String get_stream_name() const;
+
+	virtual int get_loop_count() const;
+
+	virtual double get_playback_position() const override;
+	virtual void seek(double p_time) override;
+
+	void set_file(const String &p_file);
+
+	virtual Ref<Texture2D> get_texture() const override;
+	virtual void update(double p_delta) override;
+
+	virtual void set_mix_callback(AudioMixCallback p_callback, void *p_userdata) override;
+	virtual int get_channels() const override;
+	virtual int get_mix_rate() const override;
+
+	virtual void set_audio_track(int p_idx) override;
+
+	FrameData *get_next_writable_frame();
+	void write_frame_done();
+	void present();
+
+	int64_t next_sample_time();
+
+	// Audio methods
+	bool send_audio();
+	void add_audio_data(int64_t sample_time, const Vector<float> &audio_data);
+	AudioData *get_next_writable_audio_frame();
+	void write_audio_frame_done();
+	void set_audio_format(int sample_rate, int channels);
+
+	VideoStreamPlaybackWMF();
+	~VideoStreamPlaybackWMF();
+};
+
+class VideoStreamWMF : public VideoStream {
+	GDCLASS(VideoStreamWMF, VideoStream);
+
+	String file;
+	int audio_track = 0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Ref<VideoStreamPlayback> instantiate_playback() override {
+		Ref<VideoStreamPlaybackWMF> pb = memnew(VideoStreamPlaybackWMF);
+		pb->set_audio_track(audio_track);
+		pb->set_file(file);
+		return pb;
+	}
+
+	void set_file(const String &p_file) { file = p_file; }
+	String get_file() const { return file; }
+
+	void set_audio_track(int p_track) override { audio_track = p_track; }
+
+	VideoStreamWMF() { audio_track = 0; }
+};
+
+class ResourceFormatLoaderWMF : public ResourceFormatLoader {
+public:
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual bool handles_type(const String &p_type) const override;
+	virtual String get_resource_type(const String &p_path) const override;
+};

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,4 +90,5 @@ ignore-words-list = [
 	"textin",
 	"thirdparty",
 	"vai",
+	"pEvents",
 ]


### PR DESCRIPTION
Work in progress for https://github.com/godotengine/godot-proposals/issues/12864 and https://github.com/godotengine/godot/pull/108976

The idea is divide and conquer the problem of playing video into only playing video and only playing audio. Then extracting into a container demuxed into video and audio which is then synced.

V-Sekai development community focuses on providing social VR functionality for the open source Godot Engine.