### PR TITLE
Add fast `Array` <-> `Vector<Variant>` conversions.

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -122,6 +122,10 @@ void Array::clear() {
 	_p->array.clear();
 }
 
+const Vector<Variant> &Array::as_vector() const {
+	return _p->array;
+}
+
 bool Array::operator==(const Array &p_array) const {
 	return recursive_equal(p_array, 0);
 }
@@ -938,6 +942,12 @@ bool Array::is_read_only() const {
 Array::Array(const Array &p_from) {
 	_p = nullptr;
 	_ref(p_from);
+}
+
+Array::Array(Vector<Variant> &&p_from) {
+	_p = memnew(ArrayPrivate);
+	_p->refcount.init();
+	_p->array = std::move(p_from);
 }
 
 Array::Array(std::initializer_list<Variant> p_init) {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -39,6 +39,8 @@
 class Callable;
 class StringName;
 class Variant;
+template <typename>
+class Vector;
 
 struct ArrayPrivate;
 struct ContainerType;
@@ -120,6 +122,8 @@ public:
 	int size() const;
 	bool is_empty() const;
 	void clear();
+
+	const Vector<Variant> &as_vector() const;
 
 	bool operator==(const Array &p_array) const;
 	bool operator!=(const Array &p_array) const;
@@ -203,6 +207,7 @@ public:
 
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
+	explicit Array(Vector<Variant> &&p_from);
 	Array(std::initializer_list<Variant> p_init);
 	Array();
 	~Array();

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -136,12 +136,7 @@ Callable Callable::bindv(const Array &p_arguments) {
 		return *this; // No point in creating a new callable if nothing is bound.
 	}
 
-	Vector<Variant> args;
-	args.resize(p_arguments.size());
-	for (int i = 0; i < p_arguments.size(); i++) {
-		args.write[i] = p_arguments[i];
-	}
-	return Callable(memnew(CallableCustomBind(*this, args)));
+	return Callable(memnew(CallableCustomBind(*this, Vector(p_arguments.as_vector()))));
 }
 
 Callable Callable::unbind(int p_argcount) const {
@@ -217,12 +212,7 @@ void Callable::get_bound_arguments_ref(Vector<Variant> &r_arguments) const {
 Array Callable::get_bound_arguments() const {
 	Vector<Variant> arr;
 	get_bound_arguments_ref(arr);
-	Array ret;
-	ret.resize(arr.size());
-	for (int i = 0; i < arr.size(); i++) {
-		ret[i] = arr[i];
-	}
-	return ret;
+	return Array(std::move(arr));
 }
 
 int Callable::get_unbound_arguments_count() const {

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2267,20 +2267,7 @@ Variant::operator Vector<Face3>() const {
 }
 
 Variant::operator Vector<Variant>() const {
-	Array va = operator Array();
-	Vector<Variant> variants;
-	int va_size = va.size();
-	if (va_size == 0) {
-		return variants;
-	}
-
-	variants.resize(va_size);
-	Variant *w = variants.ptrw();
-	for (int i = 0; i < va_size; i++) {
-		w[i] = va[i];
-	}
-
-	return variants;
+	return Vector(operator Array().as_vector());
 }
 
 Variant::operator Vector<StringName>() const {


### PR DESCRIPTION
`Array` uses `Vector<Variant>` as backing. We can expose this fact for performance boost in some situations. Especially:

- Convert `Array` to `Vector<Variant>` with a CoW copy instead of a full copy
    - This conversion is called a bunch of times throughout the codebase. One caller is `bindv`, which this should noticeably accelerate.
- Convert `Vector<Variant>` to `Array` with a CoW copy instead of a full copy

Both of these use-cases should go from `O(N)` to `O(1)`.
There might be more use-cases through the code base, but these are the only ones I found.

It could be argued that `Array` should not expose the fact that it is using `Vector` as backing, but I think it won't change anytime soon:
- It has been so for a long time.
- We cannot use any other type because it needs to be CoW based.
- Contiguous `Variant` storage is required because even though it can be typed, access can still be untyped.
