### PR TITLE
Fix random pitch upward bias in `AudioStreamRandomizer`

### DIFF
--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -799,10 +799,13 @@ AudioStreamRandomizer::AudioStreamRandomizer() {
 void AudioStreamPlaybackRandomizer::start(double p_from_pos) {
 	playing = playback;
 	{
-		float range_from = 1.0 / randomizer->random_pitch_scale;
-		float range_to = randomizer->random_pitch_scale;
+		// GH-10238 : Pitch_scale is multiplicative, so picking a random number for it without log
+		// conversion will bias it towards higher pitches (0.5 is down one octave, 2.0 is up one octave).
+		// See: https://pressbooks.pub/sound/chapter/pitch-and-frequency-in-music/
+		float range_from = Math::log(1.0f / randomizer->random_pitch_scale);
+		float range_to = Math::log(randomizer->random_pitch_scale);
 
-		pitch_scale = range_from + Math::randf() * (range_to - range_from);
+		pitch_scale = Math::exp(range_from + Math::randf() * (range_to - range_from));
 	}
 	{
 		float range_from = -randomizer->random_volume_offset_db;


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/103742 was requested to be split into two PRs, so here is one of them -

This fixes the random pitch upward bias as pointed out in https://github.com/godotengine/godot-proposals/discussions/10238

Essentially, random_pitch is multiplicative. A pitch scale of 0.5 is down one octave, and a pitch scale of 2.0 is up one octave. 1.0 is perceptually no shift. Because 1.0 is not in the middle of 0.5 and 2.0, picking randomly between 0.5 and 2.0 will bias towards higher pitches. This PR fixes that by picking randomly between the _logs_ of the low and high values, then converting the chosen value back to a usable pitch multiplier.