### PR TITLE
Add Tapered Capsule 3D Shape and Mesh Classes

### DIFF
--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1326,6 +1326,11 @@
 			<description>
 			</description>
 		</method>
+		<method name="_tapered_capsule_shape_create" qualifiers="virtual required">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_world_boundary_shape_create" qualifiers="virtual required">
 			<return type="RID" />
 			<description>

--- a/doc/classes/TaperedCapsuleMesh.xml
+++ b/doc/classes/TaperedCapsuleMesh.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TaperedCapsuleMesh" inherits="PrimitiveMesh" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A mesh that is tapered capsule-shaped [PrimitiveMesh].
+	</brief_description>
+	<description>
+		A mesh that is a tapered capsule-shaped [PrimitiveMesh]. A tapered capsule is a cylinder with hemispherical ends where the hemispheres can have different radii, creating a tapered or cone-like appearance. The shape is defined by two radii ([member radius_top] for the top hemisphere and [member radius_bottom] for the bottom hemisphere) and a [member mid_height] for the cylindrical section between them.
+		This shape is useful for creating various organic forms, projectiles, or tapered objects where smooth transitions between different radii are needed.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
+			Total height of the tapered capsule, calculated as [member mid_height] + [member radius_top] + [member radius_bottom]. This is the full extent from the bottom of the lower hemisphere to the top of the upper hemisphere. Setting this property adjusts [member mid_height] while keeping the radii unchanged.
+		</member>
+		<member name="mid_height" type="float" setter="set_mid_height" getter="get_mid_height" default="1.0">
+			Height of the cylindrical section of the tapered capsule (excluding the hemispherical ends). This is the distance between the centers of the two hemispheres.
+			[b]Note:[/b] The [member mid_height] must be greater than [code]0.0[/code]. Unlike regular capsules, tapered capsules can have any positive height regardless of the radius values, allowing for creative shapes where hemispheres can conceptually overlap.
+		</member>
+		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">
+			Number of radial segments around the tapered capsule. Higher values result in a smoother, more detailed shape at the cost of performance.
+		</member>
+		<member name="radius_bottom" type="float" setter="set_radius_bottom" getter="get_radius_bottom" default="0.5">
+			Radius of the bottom hemisphere of the tapered capsule. This determines the size of the lower hemispherical end. When [member radius_bottom] differs from [member radius_top], the cylindrical section becomes tapered, creating a cone-like transition between the hemispheres.
+		</member>
+		<member name="radius_top" type="float" setter="set_radius_top" getter="get_radius_top" default="0.5">
+			Radius of the top hemisphere of the tapered capsule. This determines the size of the upper hemispherical end.
+		</member>
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="8">
+			Number of edge rings along the height of the tapered capsule. Changing [member rings] does not have any visual impact unless a shader or procedural mesh tool is used to alter the vertex data. Higher values result in more subdivisions, which can be used to create smoother-looking effects with shaders or procedural mesh tools (at the cost of performance).
+		</member>
+	</members>
+</class>

--- a/doc/classes/TaperedCapsuleShape3D.xml
+++ b/doc/classes/TaperedCapsuleShape3D.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TaperedCapsuleShape3D" inherits="Shape3D" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		A 3D tapered capsule shape used for physics collision.
+	</brief_description>
+	<description>
+		A 3D tapered capsule shape, intended for use in physics. Usually used to provide a shape for a [CollisionShape3D]. A tapered capsule consists of a cylinder with hemispherical ends where the hemispheres can have different radii, creating a tapered or cone-like collision shape.
+		This shape is particularly useful for projectiles, organic forms, or any collision object that needs smooth transitions between different sizes. The tapered design allows for more realistic physics interactions compared to basic geometric shapes.
+		[b]Performance:[/b] [TaperedCapsuleShape3D] provides good collision detection performance, similar to [CapsuleShape3D]. It is more complex than basic shapes like [SphereShape3D] and [BoxShape3D], but offers more flexibility for specific use cases.
+	</description>
+	<tutorials>
+		<link title="3D Physics Tests Demo">https://godotengine.org/asset-library/asset/2747</link>
+	</tutorials>
+	<members>
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
+			The total height of the tapered capsule, calculated as [member mid_height] + [member radius_top] + [member radius_bottom]. This is the full extent from the bottom of the lower hemisphere to the top of the upper hemisphere. Setting this property adjusts [member mid_height] while keeping the radii unchanged.
+		</member>
+		<member name="mid_height" type="float" setter="set_mid_height" getter="get_mid_height" default="1.0">
+			The height of the cylindrical section of the tapered capsule (excluding the hemispherical ends). This is the distance between the centers of the two hemispheres.
+			[b]Note:[/b] The [member mid_height] must be greater than [code]0.0[/code]. Unlike regular capsules, tapered capsules can have any positive height regardless of the radius values, providing more flexibility in collision shape design.
+		</member>
+		<member name="radius_bottom" type="float" setter="set_radius_bottom" getter="get_radius_bottom" default="0.5">
+			The radius of the bottom hemisphere of the tapered capsule. This determines the size of the lower hemispherical end of the collision shape. When [member radius_bottom] differs from [member radius_top], the cylindrical section becomes tapered, creating a cone-like transition between the hemispheres for more complex collision detection.
+		</member>
+		<member name="radius_top" type="float" setter="set_radius_top" getter="get_radius_top" default="0.5">
+			The radius of the top hemisphere of the tapered capsule. This determines the size of the upper hemispherical end of the collision shape.
+		</member>
+	</members>
+</class>

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -74,6 +74,15 @@ RID GodotPhysicsServer3D::capsule_shape_create() {
 	shape->set_self(rid);
 	return rid;
 }
+
+RID GodotPhysicsServer3D::tapered_capsule_shape_create() {
+	// For now, fallback to regular capsule since Godot physics doesn't have tapered capsules
+	GodotShape3D *shape = memnew(GodotCapsuleShape3D);
+	RID rid = shape_owner.make_rid(shape);
+	shape->set_self(rid);
+	return rid;
+}
+
 RID GodotPhysicsServer3D::cylinder_shape_create() {
 	GodotShape3D *shape = memnew(GodotCylinderShape3D);
 	RID rid = shape_owner.make_rid(shape);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -84,6 +84,7 @@ public:
 	virtual RID box_shape_create() override;
 	virtual RID capsule_shape_create() override;
 	virtual RID cylinder_shape_create() override;
+	virtual RID tapered_capsule_shape_create() override;
 	virtual RID convex_polygon_shape_create() override;
 	virtual RID concave_polygon_shape_create() override;
 	virtual RID heightmap_shape_create() override;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -48,6 +48,7 @@
 #include "shapes/jolt_height_map_shape_3d.h"
 #include "shapes/jolt_separation_ray_shape_3d.h"
 #include "shapes/jolt_sphere_shape_3d.h"
+#include "shapes/jolt_tapered_capsule_shape_3d.h"
 #include "shapes/jolt_world_boundary_shape_3d.h"
 #include "spaces/jolt_job_system.h"
 #include "spaces/jolt_physics_direct_space_state_3d.h"
@@ -93,7 +94,14 @@ RID JoltPhysicsServer3D::box_shape_create() {
 }
 
 RID JoltPhysicsServer3D::capsule_shape_create() {
-	JoltShape3D *shape = memnew(JoltCapsuleShape3D);
+	JoltShape3D *shape = memnew(JoltTaperedCapsuleShape3D);
+	RID rid = shape_owner.make_rid(shape);
+	shape->set_rid(rid);
+	return rid;
+}
+
+RID JoltPhysicsServer3D::tapered_capsule_shape_create() {
+	JoltShape3D *shape = memnew(JoltTaperedCapsuleShape3D);
 	RID rid = shape_owner.make_rid(shape);
 	shape->set_rid(rid);
 	return rid;

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -130,6 +130,7 @@ public:
 	virtual RID sphere_shape_create() override;
 	virtual RID box_shape_create() override;
 	virtual RID capsule_shape_create() override;
+	virtual RID tapered_capsule_shape_create() override;
 	virtual RID cylinder_shape_create() override;
 	virtual RID convex_polygon_shape_create() override;
 	virtual RID concave_polygon_shape_create() override;

--- a/modules/jolt_physics/shapes/jolt_tapered_capsule_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_tapered_capsule_shape_3d.cpp
@@ -1,0 +1,109 @@
+/**************************************************************************/
+/*  jolt_tapered_capsule_shape_3d.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "jolt_tapered_capsule_shape_3d.h"
+
+#include "../misc/jolt_type_conversions.h"
+
+#include "Jolt/Physics/Collision/Shape/TaperedCapsuleShape.h"
+
+JPH::ShapeRefC JoltTaperedCapsuleShape3D::_build() const {
+	ERR_FAIL_COND_V_MSG(radius_top <= 0.0f, nullptr, vformat("Failed to build Jolt Physics tapered capsule shape with %s. Its radius_top must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(radius_bottom <= 0.0f, nullptr, vformat("Failed to build Jolt Physics tapered capsule shape with %s. Its radius_bottom must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(mid_height <= 0.0f, nullptr, vformat("Failed to build Jolt Physics tapered capsule shape with %s. Its mid_height must be greater than 0. This shape belongs to %s.", to_string(), _owners_to_string()));
+	ERR_FAIL_COND_V_MSG(mid_height < radius_top + radius_bottom, nullptr, vformat("Failed to build Jolt Physics tapered capsule shape with %s. Its mid_height must be at least the sum of its radii. This shape belongs to %s.", to_string(), _owners_to_string()));
+
+	const float half_height = mid_height / 2.0f;
+
+	const JPH::TaperedCapsuleShapeSettings shape_settings(half_height, radius_top, radius_bottom);
+	const JPH::ShapeSettings::ShapeResult shape_result = shape_settings.Create();
+	ERR_FAIL_COND_V_MSG(shape_result.HasError(), nullptr, vformat("Failed to build Jolt Physics tapered capsule shape with %s. It returned the following error: '%s'. This shape belongs to %s.", to_string(), to_godot(shape_result.GetError()), _owners_to_string()));
+
+	return shape_result.Get();
+}
+
+Variant JoltTaperedCapsuleShape3D::get_data() const {
+	Vector<double> data;
+	data.resize(3);
+	data.write[0] = radius_top;
+	data.write[1] = radius_bottom;
+	data.write[2] = mid_height;
+	return data;
+}
+
+void JoltTaperedCapsuleShape3D::set_data(const Variant &p_data) {
+	if (p_data.get_type() == Variant::DICTIONARY) {
+		// Handle SHAPE_CAPSULE data
+		const Dictionary data = p_data;
+		const Variant maybe_radius = data.get("radius", Variant());
+		const Variant maybe_height = data.get("height", Variant());
+		if (maybe_radius.get_type() == Variant::FLOAT && maybe_height.get_type() == Variant::FLOAT) {
+			real_t radius = maybe_radius;
+			real_t height = maybe_height;
+			if (radius == radius_top && radius == radius_bottom && height == mid_height) {
+				return;
+			}
+			radius_top = radius;
+			radius_bottom = radius;
+			mid_height = height;
+			destroy();
+			return;
+		}
+	}
+
+	if (p_data.get_type() == Variant::PACKED_FLOAT32_ARRAY || p_data.get_type() == Variant::PACKED_FLOAT64_ARRAY) {
+		const Vector<real_t> data = p_data;
+		if (data.size() == 3) {
+			real_t new_radius_top = data[0];
+			real_t new_radius_bottom = data[1];
+			real_t new_mid_height = data[2];
+			if (new_radius_top == radius_top && new_radius_bottom == radius_bottom && new_mid_height == mid_height) {
+				return;
+			}
+			radius_top = new_radius_top;
+			radius_bottom = new_radius_bottom;
+			mid_height = new_mid_height;
+			destroy();
+			return;
+		}
+	}
+
+	ERR_FAIL_MSG("Invalid data for JoltTaperedCapsuleShape3D");
+}
+
+AABB JoltTaperedCapsuleShape3D::get_aabb() const {
+	const float max_radius = MAX(radius_top, radius_bottom);
+	const Vector3 half_extents(max_radius, mid_height / 2.0f + max_radius, max_radius);
+	return AABB(-half_extents, half_extents * 2.0f);
+}
+
+String JoltTaperedCapsuleShape3D::to_string() const {
+	return vformat("{radius_top=%f radius_bottom=%f mid_height=%f}", radius_top, radius_bottom, mid_height);
+}

--- a/modules/jolt_physics/shapes/jolt_tapered_capsule_shape_3d.h
+++ b/modules/jolt_physics/shapes/jolt_tapered_capsule_shape_3d.h
@@ -1,0 +1,55 @@
+/**************************************************************************/
+/*  jolt_tapered_capsule_shape_3d.h                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "jolt_shape_3d.h"
+
+class JoltTaperedCapsuleShape3D final : public JoltShape3D {
+	float radius_top = 0.0f;
+	float radius_bottom = 0.0f;
+	float mid_height = 0.0f;
+
+	virtual JPH::ShapeRefC _build() const override;
+
+public:
+	virtual ShapeType get_type() const override { return ShapeType::SHAPE_CAPSULE; } // Still SHAPE_CAPSULE for physics server
+	virtual bool is_convex() const override { return true; }
+
+	virtual Variant get_data() const override;
+	virtual void set_data(const Variant &p_data) override;
+
+	virtual float get_margin() const override { return 0.0f; }
+	virtual void set_margin(float p_margin) override {}
+
+	virtual AABB get_aabb() const override;
+
+	String to_string() const;
+};

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -274,6 +274,8 @@
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "scene/resources/3d/sky_material.h"
+#include "scene/resources/3d/tapered_capsule_mesh.h"
+#include "scene/resources/3d/tapered_capsule_shape_3d.h"
 #include "scene/resources/3d/world_3d.h"
 #ifndef NAVIGATION_3D_DISABLED
 #include "scene/3d/navigation/navigation_agent_3d.h"
@@ -993,6 +995,7 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(PrimitiveMesh);
 	GDREGISTER_CLASS(BoxMesh);
 	GDREGISTER_CLASS(CapsuleMesh);
+	GDREGISTER_CLASS(TaperedCapsuleMesh);
 	GDREGISTER_CLASS(CylinderMesh);
 	GDREGISTER_CLASS(PlaneMesh);
 	GDREGISTER_CLASS(PrismMesh);
@@ -1003,6 +1006,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(TubeTrailMesh);
 	GDREGISTER_CLASS(RibbonTrailMesh);
 	GDREGISTER_CLASS(PointMesh);
+	GDREGISTER_CLASS(TaperedCapsuleMesh);
 	GDREGISTER_ABSTRACT_CLASS(BaseMaterial3D);
 	GDREGISTER_CLASS(StandardMaterial3D);
 	GDREGISTER_CLASS(ORMMaterial3D);
@@ -1027,6 +1031,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(WorldBoundaryShape3D);
 	GDREGISTER_CLASS(ConvexPolygonShape3D);
 	GDREGISTER_CLASS(ConcavePolygonShape3D);
+	GDREGISTER_CLASS(TaperedCapsuleShape3D);
 #endif // PHYSICS_3D_DISABLED
 	GDREGISTER_CLASS(World3D);
 

--- a/scene/resources/3d/SCsub
+++ b/scene/resources/3d/SCsub
@@ -11,6 +11,7 @@ env.add_source_files(env.scene_sources, "mesh_library.cpp")
 env.add_source_files(env.scene_sources, "primitive_meshes.cpp")
 env.add_source_files(env.scene_sources, "skin.cpp")
 env.add_source_files(env.scene_sources, "sky_material.cpp")
+env.add_source_files(env.scene_sources, "tapered_capsule_mesh.cpp")
 env.add_source_files(env.scene_sources, "world_3d.cpp")
 env.add_source_files(env.scene_sources, "skeleton/*.cpp")
 
@@ -25,6 +26,7 @@ if not env["disable_physics_3d"]:
     env.add_source_files(env.scene_sources, "separation_ray_shape_3d.cpp")
     env.add_source_files(env.scene_sources, "shape_3d.cpp")
     env.add_source_files(env.scene_sources, "sphere_shape_3d.cpp")
+    env.add_source_files(env.scene_sources, "tapered_capsule_shape_3d.cpp")
     env.add_source_files(env.scene_sources, "world_boundary_shape_3d.cpp")
 if not env["disable_navigation_3d"]:
     env.add_source_files(env.scene_sources, "navigation_mesh_source_geometry_data_3d.cpp")

--- a/scene/resources/3d/tapered_capsule_mesh.cpp
+++ b/scene/resources/3d/tapered_capsule_mesh.cpp
@@ -1,0 +1,374 @@
+/**************************************************************************/
+/*  tapered_capsule_mesh.cpp                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tapered_capsule_mesh.h"
+
+#include "core/config/project_settings.h"
+#include "core/math/math_funcs.h"
+#include "scene/resources/theme.h"
+#include "scene/theme/theme_db.h"
+#include "servers/rendering/rendering_server.h"
+#include "thirdparty/misc/polypartition.h"
+
+void TaperedCapsuleMesh::_update_lightmap_size() {
+	if (get_add_uv2()) {
+		// size must have changed, update lightmap size hint
+		Size2i _lightmap_size_hint;
+		real_t padding = get_uv2_padding();
+
+		real_t max_radius = MAX(radius_top, radius_bottom);
+
+		real_t radial_length = max_radius * Math::PI * 0.5; // circumference of 90 degree bend
+		real_t vertical_length = radial_length * 2 + mid_height + padding; // total vertical length
+
+		_lightmap_size_hint.x = MAX(1.0, 4.0 * radial_length / texel_size) + padding;
+		_lightmap_size_hint.y = MAX(1.0, vertical_length / texel_size) + padding;
+
+		set_lightmap_size_hint(_lightmap_size_hint);
+	}
+}
+
+void TaperedCapsuleMesh::_create_mesh_array(Array &p_arr) const {
+	bool _add_uv2 = get_add_uv2();
+	real_t _uv2_padding = get_uv2_padding() * texel_size;
+
+	create_mesh_array(p_arr, radius_top, radius_bottom, mid_height, radial_segments, rings, _add_uv2, _uv2_padding);
+}
+
+void TaperedCapsuleMesh::create_mesh_array(Array &p_arr, real_t p_radius_top, real_t p_radius_bottom, real_t p_mid_height, int p_radial_segments, int p_rings, bool p_add_uv2, const real_t p_uv2_padding) {
+	int i, j, prevrow, thisrow, point;
+	real_t x, y, z, u, v, w;
+
+	// Use LocalVector for operations and copy to Vector at the end to save the cost of CoW semantics which aren't
+	// needed here and are very expensive in such a hot loop. Use reserve to avoid repeated memory allocations.
+	int num_points = (p_rings + 2) * (p_radial_segments + 1) * 2 + (p_rings + 2) * (p_radial_segments + 1);
+	LocalVector<Vector3> points;
+	points.reserve(num_points);
+	LocalVector<Vector3> normals;
+	normals.reserve(num_points);
+	LocalVector<float> tangents;
+	tangents.reserve(num_points * 4);
+	LocalVector<Vector2> uvs;
+	uvs.reserve(num_points);
+	LocalVector<Vector2> uv2s;
+	if (p_add_uv2) {
+		uv2s.reserve(num_points);
+	}
+	LocalVector<int> indices;
+	indices.reserve((p_rings + 1) * (p_radial_segments) * 6 * 2 + (p_rings + 1) * (p_radial_segments) * 6);
+	point = 0;
+
+#define ADD_TANGENT(m_x, m_y, m_z, m_d) \
+	tangents.push_back(m_x);            \
+	tangents.push_back(m_y);            \
+	tangents.push_back(m_z);            \
+	tangents.push_back(m_d);
+
+	// Calculate UV2 parameters
+	real_t total_height = p_mid_height + p_radius_top + p_radius_bottom;
+	real_t total_vertical_length = total_height + p_uv2_padding;
+
+	real_t uv2_v_top = p_radius_top / total_vertical_length;
+	real_t uv2_v_cylinder = p_mid_height / total_vertical_length;
+	real_t uv2_v_bottom = p_radius_bottom / total_vertical_length;
+
+	real_t max_circumference = MAX(p_radius_top, p_radius_bottom) * Math::TAU;
+	real_t uv2_h_scale = max_circumference / (max_circumference + p_uv2_padding);
+
+	/* top hemisphere */
+	thisrow = 0;
+	prevrow = 0;
+	for (j = 0; j <= (p_rings + 1); j++) {
+		v = j;
+		v /= (p_rings + 1);
+		if (j == (p_rings + 1)) {
+			w = 1.0;
+			y = 0.0;
+		} else {
+			w = Math::sin(0.5 * Math::PI * v);
+			y = Math::cos(0.5 * Math::PI * v);
+		}
+
+		for (i = 0; i <= p_radial_segments; i++) {
+			u = i;
+			u /= p_radial_segments;
+
+			if (i == p_radial_segments) {
+				x = 0.0;
+				z = 1.0;
+			} else {
+				x = -Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
+			}
+
+			Vector3 p = Vector3(x * w, y, -z * w);
+			points.push_back(p * p_radius_top + Vector3(0.0, total_height * 0.5 - p_radius_top, 0.0));
+			normals.push_back(p);
+			ADD_TANGENT(-z, 0.0, -x, 1.0)
+			uvs.push_back(Vector2(u, v * 0.5)); // UV for top hemisphere
+			if (p_add_uv2) {
+				uv2s.push_back(Vector2(u * uv2_h_scale, v * uv2_v_top));
+			}
+			point++;
+
+			if (i > 0 && j > 0) {
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i - 1);
+
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i - 1);
+			}
+		}
+
+		prevrow = thisrow;
+		thisrow = point;
+	}
+
+	/* cylinder */
+	thisrow = point;
+	prevrow = point - (p_radial_segments + 1); // Start from the last row of the top hemisphere
+	for (j = 0; j <= (p_rings + 1); j++) { // Use rings for cylinder segments too for consistency
+		v = j;
+		v /= (p_rings + 1);
+
+		real_t current_radius = p_radius_top + (p_radius_bottom - p_radius_top) * v;
+		y = (total_height * 0.5 - p_radius_top) - (p_mid_height * v);
+
+		for (i = 0; i <= p_radial_segments; i++) {
+			u = i;
+			u /= p_radial_segments;
+
+			if (i == p_radial_segments) {
+				x = 0.0;
+				z = 1.0;
+			} else {
+				x = -Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
+			}
+
+			Vector3 p = Vector3(x * current_radius, y, -z * current_radius);
+			points.push_back(p);
+			normals.push_back(Vector3(x, 0.0, -z).normalized()); // Normal points outwards
+			ADD_TANGENT(-z, 0.0, -x, 1.0)
+			uvs.push_back(Vector2(u, 0.5 + v * 0.5)); // UV for cylinder
+			if (p_add_uv2) {
+				uv2s.push_back(Vector2(u * uv2_h_scale, uv2_v_top + v * uv2_v_cylinder));
+			}
+			point++;
+
+			if (i > 0 && j > 0) {
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i - 1);
+
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i - 1);
+			}
+		}
+
+		prevrow = thisrow;
+		thisrow = point;
+	}
+
+	/* bottom hemisphere */
+	thisrow = point;
+	prevrow = point - (p_radial_segments + 1); // Start from the last row of the cylinder
+	for (j = 0; j <= (p_rings + 1); j++) {
+		v = j;
+		v /= (p_rings + 1);
+		if (j == (p_rings + 1)) {
+			w = 0.0;
+			y = -1.0;
+		} else {
+			w = Math::cos(0.5 * Math::PI * v);
+			y = -Math::sin(0.5 * Math::PI * v);
+		}
+
+		for (i = 0; i <= p_radial_segments; i++) {
+			u = i;
+			u /= p_radial_segments;
+
+			if (i == p_radial_segments) {
+				x = 0.0;
+				z = 1.0;
+			} else {
+				x = -Math::sin(u * Math::TAU);
+				z = Math::cos(u * Math::TAU);
+			}
+
+			Vector3 p = Vector3(x * w, y, -z * w);
+			points.push_back(p * p_radius_bottom + Vector3(0.0, -total_height * 0.5 + p_radius_bottom, 0.0));
+			normals.push_back(p);
+			ADD_TANGENT(-z, 0.0, -x, 1.0)
+			uvs.push_back(Vector2(u, 0.5 + v * 0.5)); // UV for bottom hemisphere (can reuse cylinder UV space)
+			if (p_add_uv2) {
+				uv2s.push_back(Vector2(u * uv2_h_scale, uv2_v_top + uv2_v_cylinder + v * uv2_v_bottom));
+			}
+			point++;
+
+			if (i > 0 && j > 0) {
+				indices.push_back(prevrow + i - 1);
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i - 1);
+
+				indices.push_back(prevrow + i);
+				indices.push_back(thisrow + i);
+				indices.push_back(thisrow + i - 1);
+			}
+		}
+
+		prevrow = thisrow;
+		thisrow = point;
+	}
+
+	p_arr[RS::ARRAY_VERTEX] = Vector<Vector3>(points);
+	p_arr[RS::ARRAY_NORMAL] = Vector<Vector3>(normals);
+	p_arr[RS::ARRAY_TANGENT] = Vector<float>(tangents);
+	p_arr[RS::ARRAY_TEX_UV] = Vector<Vector2>(uvs);
+	if (p_add_uv2) {
+		p_arr[RS::ARRAY_TEX_UV2] = Vector<Vector2>(uv2s);
+	}
+	p_arr[RS::ARRAY_INDEX] = Vector<int>(indices);
+}
+
+void TaperedCapsuleMesh::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius_top", "radius_top"), &TaperedCapsuleMesh::set_radius_top);
+	ClassDB::bind_method(D_METHOD("get_radius_top"), &TaperedCapsuleMesh::get_radius_top);
+	ClassDB::bind_method(D_METHOD("set_radius_bottom", "radius_bottom"), &TaperedCapsuleMesh::set_radius_bottom);
+	ClassDB::bind_method(D_METHOD("get_radius_bottom"), &TaperedCapsuleMesh::get_radius_bottom);
+	ClassDB::bind_method(D_METHOD("set_mid_height", "mid_height"), &TaperedCapsuleMesh::set_mid_height);
+	ClassDB::bind_method(D_METHOD("get_mid_height"), &TaperedCapsuleMesh::get_mid_height);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &TaperedCapsuleMesh::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &TaperedCapsuleMesh::get_height);
+
+	ClassDB::bind_method(D_METHOD("set_radial_segments", "segments"), &TaperedCapsuleMesh::set_radial_segments);
+	ClassDB::bind_method(D_METHOD("get_radial_segments"), &TaperedCapsuleMesh::get_radial_segments);
+	ClassDB::bind_method(D_METHOD("set_rings", "rings"), &TaperedCapsuleMesh::set_rings);
+	ClassDB::bind_method(D_METHOD("get_rings"), &TaperedCapsuleMesh::get_rings);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius_top", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_radius_top", "get_radius_top");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius_bottom", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_radius_bottom", "get_radius_bottom");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mid_height", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_mid_height", "get_mid_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater,suffix:m"), "set_height", "get_height");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "0,100,1,or_greater"), "set_rings", "get_rings");
+
+	ADD_LINKED_PROPERTY("radius_top", "height");
+	ADD_LINKED_PROPERTY("radius_bottom", "height");
+	ADD_LINKED_PROPERTY("mid_height", "height");
+	ADD_LINKED_PROPERTY("height", "radius_top");
+	ADD_LINKED_PROPERTY("height", "radius_bottom");
+	ADD_LINKED_PROPERTY("height", "mid_height");
+}
+
+void TaperedCapsuleMesh::set_radius_top(const real_t p_radius_top) {
+	if (Math::is_equal_approx(radius_top, p_radius_top)) {
+		return;
+	}
+
+	radius_top = p_radius_top;
+	_update_lightmap_size();
+	request_update();
+}
+
+real_t TaperedCapsuleMesh::get_radius_top() const {
+	return radius_top;
+}
+
+void TaperedCapsuleMesh::set_radius_bottom(const real_t p_radius_bottom) {
+	if (Math::is_equal_approx(radius_bottom, p_radius_bottom)) {
+		return;
+	}
+
+	radius_bottom = p_radius_bottom;
+	_update_lightmap_size();
+	request_update();
+}
+
+real_t TaperedCapsuleMesh::get_radius_bottom() const {
+	return radius_bottom;
+}
+
+void TaperedCapsuleMesh::set_mid_height(const real_t p_mid_height) {
+	ERR_FAIL_COND(p_mid_height <= 0);
+	if (Math::is_equal_approx(mid_height, p_mid_height)) {
+		return;
+	}
+
+	mid_height = p_mid_height;
+	_update_lightmap_size();
+	request_update();
+}
+
+real_t TaperedCapsuleMesh::get_mid_height() const {
+	return mid_height;
+}
+
+void TaperedCapsuleMesh::set_height(const real_t p_height) {
+	real_t new_mid_height = p_height - radius_top - radius_bottom;
+	if (new_mid_height <= 0) {
+		new_mid_height = 0.001f; // Minimum to avoid invalid mesh
+	}
+	set_mid_height(new_mid_height);
+}
+
+real_t TaperedCapsuleMesh::get_height() const {
+	return mid_height + radius_top + radius_bottom;
+}
+
+void TaperedCapsuleMesh::set_radial_segments(const int p_segments) {
+	if (radial_segments == p_segments) {
+		return;
+	}
+
+	radial_segments = p_segments > 4 ? p_segments : 4;
+	request_update();
+}
+
+int TaperedCapsuleMesh::get_radial_segments() const {
+	return radial_segments;
+}
+
+void TaperedCapsuleMesh::set_rings(const int p_rings) {
+	if (rings == p_rings) {
+		return;
+	}
+
+	ERR_FAIL_COND(p_rings < 0);
+	rings = p_rings;
+	request_update();
+}
+
+int TaperedCapsuleMesh::get_rings() const {
+	return rings;
+}

--- a/scene/resources/3d/tapered_capsule_mesh.h
+++ b/scene/resources/3d/tapered_capsule_mesh.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  tapered_capsule_mesh.h                                                */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/mesh.h"
+
+class TaperedCapsuleMesh : public PrimitiveMesh {
+	GDCLASS(TaperedCapsuleMesh, PrimitiveMesh);
+
+private:
+	real_t radius_top = 0.5;
+	real_t radius_bottom = 0.5;
+	real_t mid_height = 1.0;
+	int radial_segments = 64;
+	int rings = 8;
+
+protected:
+	static void _bind_methods();
+	virtual void _create_mesh_array(Array &p_arr) const override;
+
+	virtual void _update_lightmap_size() override;
+
+public:
+	static void create_mesh_array(Array &p_arr, real_t p_radius_top, real_t p_radius_bottom, real_t p_mid_height, int p_radial_segments = 64, int p_rings = 8, bool p_add_uv2 = false, const real_t p_uv2_padding = 1.0);
+
+	void set_radius_top(const real_t p_radius_top);
+	real_t get_radius_top() const;
+
+	void set_radius_bottom(const real_t p_radius_bottom);
+	real_t get_radius_bottom() const;
+
+	void set_mid_height(const real_t p_mid_height);
+	real_t get_mid_height() const;
+
+	void set_height(const real_t p_height);
+	real_t get_height() const;
+
+	void set_radial_segments(const int p_segments);
+	int get_radial_segments() const;
+
+	void set_rings(const int p_rings);
+	int get_rings() const;
+};

--- a/scene/resources/3d/tapered_capsule_shape_3d.cpp
+++ b/scene/resources/3d/tapered_capsule_shape_3d.cpp
@@ -1,0 +1,229 @@
+/**************************************************************************/
+/*  tapered_capsule_shape_3d.cpp                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tapered_capsule_shape_3d.h"
+
+#include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/3d/tapered_capsule_mesh.h" // Include the header for TaperedCapsuleMesh
+#include "servers/physics_3d/physics_server_3d.h"
+
+Vector<Vector3> TaperedCapsuleShape3D::get_debug_mesh_lines() const {
+	Vector<Vector3> points;
+
+	// Top hemisphere
+	real_t r1 = get_radius_top();
+	real_t h = get_mid_height();
+	Vector3 top_center = Vector3(0, h * 0.5f, 0);
+	for (int i = 0; i < 360; i++) {
+		real_t ra = Math::deg_to_rad((real_t)i);
+		real_t rb = Math::deg_to_rad((real_t)i + 1);
+		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r1;
+		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r1;
+
+		points.push_back(Vector3(a.x, 0, a.y) + top_center);
+		points.push_back(Vector3(b.x, 0, b.y) + top_center);
+
+		if (i % 90 == 0) {
+			points.push_back(Vector3(0, a.x, a.y) + top_center);
+			points.push_back(Vector3(0, b.x, b.y) + top_center);
+			points.push_back(Vector3(a.y, a.x, 0) + top_center);
+			points.push_back(Vector3(b.y, b.x, 0) + top_center);
+		}
+	}
+
+	// Bottom hemisphere
+	real_t r2 = get_radius_bottom();
+	Vector3 bottom_center = Vector3(0, -h * 0.5f, 0);
+	for (int i = 0; i < 360; i++) {
+		real_t ra = Math::deg_to_rad((real_t)i);
+		real_t rb = Math::deg_to_rad((real_t)i + 1);
+		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * r2;
+		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * r2;
+
+		points.push_back(Vector3(a.x, 0, a.y) + bottom_center);
+		points.push_back(Vector3(b.x, 0, b.y) + bottom_center);
+
+		if (i % 90 == 0) {
+			points.push_back(Vector3(0, a.x, a.y) + bottom_center);
+			points.push_back(Vector3(0, b.x, b.y) + bottom_center);
+			points.push_back(Vector3(a.y, a.x, 0) + bottom_center);
+			points.push_back(Vector3(b.y, b.x, 0) + bottom_center);
+		}
+	}
+
+	// Connecting lines (cylinder part)
+	points.push_back(Vector3(r1, h * 0.5f, 0));
+	points.push_back(Vector3(r2, -h * 0.5f, 0));
+	points.push_back(Vector3(-r1, h * 0.5f, 0));
+	points.push_back(Vector3(-r2, -h * 0.5f, 0));
+	points.push_back(Vector3(0, h * 0.5f, r1));
+	points.push_back(Vector3(0, -h * 0.5f, r2));
+	points.push_back(Vector3(0, h * 0.5f, -r1));
+	points.push_back(Vector3(0, -h * 0.5f, -r2));
+
+	return points;
+}
+
+Ref<ArrayMesh> TaperedCapsuleShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+	Array capsule_array;
+	capsule_array.resize(RS::ARRAY_MAX);
+	TaperedCapsuleMesh::create_mesh_array(capsule_array, radius_top, radius_bottom, mid_height, 32, 8);
+
+	Vector<Color> colors;
+	const PackedVector3Array &verts = capsule_array[RS::ARRAY_VERTEX];
+	const int32_t verts_size = verts.size();
+	for (int i = 0; i < verts_size; i++) {
+		colors.append(p_modulate);
+	}
+
+	Ref<ArrayMesh> capsule_mesh = memnew(ArrayMesh);
+	capsule_array[RS::ARRAY_COLOR] = colors;
+	capsule_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, capsule_array);
+	return capsule_mesh;
+}
+
+real_t TaperedCapsuleShape3D::get_enclosing_radius() const {
+	return MAX(radius_top, radius_bottom) + mid_height * 0.5f;
+}
+
+void TaperedCapsuleShape3D::_update_shape() {
+	Dictionary d;
+	d["radius"] = (radius_top + radius_bottom) / 2.0;
+	d["height"] = mid_height;
+	PhysicsServer3D::get_singleton()->shape_set_data(get_shape(), d);
+	Shape3D::_update_shape();
+}
+
+void TaperedCapsuleShape3D::set_radius_top(real_t p_radius_top) {
+	ERR_FAIL_COND_MSG(p_radius_top < 0.0f, "TaperedCapsuleShape3D radius_top cannot be negative.");
+	radius_top = p_radius_top;
+	_update_shape();
+	emit_changed();
+}
+
+real_t TaperedCapsuleShape3D::get_radius_top() const {
+	return radius_top;
+}
+
+void TaperedCapsuleShape3D::set_radius_bottom(real_t p_radius_bottom) {
+	ERR_FAIL_COND_MSG(p_radius_bottom < 0.0f, "TaperedCapsuleShape3D radius_bottom cannot be negative.");
+	radius_bottom = p_radius_bottom;
+	_update_shape();
+	emit_changed();
+}
+
+real_t TaperedCapsuleShape3D::get_radius_bottom() const {
+	return radius_bottom;
+}
+
+void TaperedCapsuleShape3D::set_mid_height(real_t p_mid_height) {
+	ERR_FAIL_COND_MSG(p_mid_height <= 0.0f, "TaperedCapsuleShape3D mid_height must be positive.");
+	mid_height = p_mid_height;
+	_update_shape();
+	emit_changed();
+}
+
+real_t TaperedCapsuleShape3D::get_mid_height() const {
+	return mid_height;
+}
+
+void TaperedCapsuleShape3D::set_height(real_t p_height) {
+	real_t new_mid_height = p_height - radius_top - radius_bottom;
+	if (new_mid_height <= 0) {
+		new_mid_height = 0.001f; // Minimum
+	}
+	set_mid_height(new_mid_height);
+}
+
+real_t TaperedCapsuleShape3D::get_height() const {
+	return mid_height + radius_top + radius_bottom;
+}
+
+Variant TaperedCapsuleShape3D::get_data() const {
+	Vector<real_t> data;
+	data.resize(3);
+	data.write[0] = radius_top;
+	data.write[1] = radius_bottom;
+	data.write[2] = mid_height;
+	return data;
+}
+
+void TaperedCapsuleShape3D::set_data(const Variant &p_data) {
+	if (p_data.get_type() == Variant::ARRAY) {
+		// Backward compatibility with dictionary
+		const Dictionary data = p_data;
+		const Variant maybe_radius_top = data.get("radius_top", Variant());
+		const Variant maybe_radius_bottom = data.get("radius_bottom", Variant());
+		const Variant maybe_height = data.get("height", Variant());
+		if (maybe_radius_top.get_type() == Variant::FLOAT && maybe_radius_bottom.get_type() == Variant::FLOAT && maybe_height.get_type() == Variant::FLOAT) {
+			set_radius_top(maybe_radius_top);
+			set_radius_bottom(maybe_radius_bottom);
+			set_height(maybe_height);
+			return;
+		}
+	}
+
+	ERR_FAIL_COND(p_data.get_type() != Variant::PACKED_FLOAT64_ARRAY);
+
+	const Vector<real_t> data = p_data;
+	ERR_FAIL_COND(data.size() != 3);
+
+	set_radius_top(data[0]);
+	set_radius_bottom(data[1]);
+	set_mid_height(data[2]);
+}
+
+void TaperedCapsuleShape3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_radius_top", "radius_top"), &TaperedCapsuleShape3D::set_radius_top);
+	ClassDB::bind_method(D_METHOD("get_radius_top"), &TaperedCapsuleShape3D::get_radius_top);
+	ClassDB::bind_method(D_METHOD("set_radius_bottom", "radius_bottom"), &TaperedCapsuleShape3D::set_radius_bottom);
+	ClassDB::bind_method(D_METHOD("get_radius_bottom"), &TaperedCapsuleShape3D::get_radius_bottom);
+	ClassDB::bind_method(D_METHOD("set_mid_height", "mid_height"), &TaperedCapsuleShape3D::set_mid_height);
+	ClassDB::bind_method(D_METHOD("get_mid_height"), &TaperedCapsuleShape3D::get_mid_height);
+	ClassDB::bind_method(D_METHOD("set_height", "height"), &TaperedCapsuleShape3D::set_height);
+	ClassDB::bind_method(D_METHOD("get_height"), &TaperedCapsuleShape3D::get_height);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius_top", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_radius_top", "get_radius_top");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius_bottom", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_radius_bottom", "get_radius_bottom");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mid_height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_mid_height", "get_mid_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_height", "get_height");
+
+	ADD_LINKED_PROPERTY("radius_top", "height");
+	ADD_LINKED_PROPERTY("radius_bottom", "height");
+	ADD_LINKED_PROPERTY("mid_height", "height");
+	ADD_LINKED_PROPERTY("height", "radius_top");
+	ADD_LINKED_PROPERTY("height", "radius_bottom");
+	ADD_LINKED_PROPERTY("height", "mid_height");
+}
+
+TaperedCapsuleShape3D::TaperedCapsuleShape3D() :
+		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_CAPSULE)) {
+	_update_shape();
+}

--- a/scene/resources/3d/tapered_capsule_shape_3d.h
+++ b/scene/resources/3d/tapered_capsule_shape_3d.h
@@ -1,0 +1,72 @@
+/**************************************************************************/
+/*  tapered_capsule_shape_3d.h                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/resources/3d/shape_3d.h"
+#include "servers/physics_3d/physics_server_3d.h"
+
+class ArrayMesh;
+
+class TaperedCapsuleShape3D : public Shape3D {
+	GDCLASS(TaperedCapsuleShape3D, Shape3D);
+	real_t radius_top = 0.5;
+	real_t radius_bottom = 0.5;
+	real_t mid_height = 1.0; // Height of the cylindrical part
+
+protected:
+	static void _bind_methods();
+
+	virtual void _update_shape() override;
+
+public:
+	void set_radius_top(real_t p_radius_top);
+	real_t get_radius_top() const;
+
+	void set_radius_bottom(real_t p_radius_bottom);
+	real_t get_radius_bottom() const;
+
+	void set_mid_height(real_t p_mid_height);
+	real_t get_mid_height() const;
+
+	void set_height(real_t p_height);
+	real_t get_height() const;
+
+	virtual Vector<Vector3> get_debug_mesh_lines() const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual real_t get_enclosing_radius() const override;
+
+	virtual Variant get_data() const;
+	virtual void set_data(const Variant &p_data);
+
+	virtual PhysicsServer3D::ShapeType get_type() const { return PhysicsServer3D::SHAPE_CAPSULE; } // Use capsule type for physics server compatibility
+
+	TaperedCapsuleShape3D();
+};

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -258,6 +258,7 @@ public:
 		SHAPE_HEIGHTMAP, ///< dict( int:"width", int:"depth",float:"cell_size", float_array:"heights"
 		SHAPE_SOFT_BODY, ///< Used internally, can't be created from the physics server.
 		SHAPE_CUSTOM, ///< Server-Implementation based custom shape, calling shape_create() with this value will result in an error
+		SHAPE_TAPERED_CAPSULE, ///< dict( float:"radius_top", float:"radius_bottom", float:"height"):tapered capsule
 	};
 
 	RID shape_create(ShapeType p_shape);
@@ -268,6 +269,7 @@ public:
 	virtual RID box_shape_create() = 0;
 	virtual RID capsule_shape_create() = 0;
 	virtual RID cylinder_shape_create() = 0;
+	virtual RID tapered_capsule_shape_create() = 0;
 	virtual RID convex_polygon_shape_create() = 0;
 	virtual RID concave_polygon_shape_create() = 0;
 	virtual RID heightmap_shape_create() = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -140,6 +140,7 @@ public:
 	virtual RID sphere_shape_create() override { return RID(); }
 	virtual RID box_shape_create() override { return RID(); }
 	virtual RID capsule_shape_create() override { return RID(); }
+	virtual RID tapered_capsule_shape_create() override { return RID(); }
 	virtual RID cylinder_shape_create() override { return RID(); }
 	virtual RID convex_polygon_shape_create() override { return RID(); }
 	virtual RID concave_polygon_shape_create() override { return RID(); }

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -142,6 +142,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_sphere_shape_create);
 	GDVIRTUAL_BIND(_box_shape_create);
 	GDVIRTUAL_BIND(_capsule_shape_create);
+	GDVIRTUAL_BIND(_tapered_capsule_shape_create);
 	GDVIRTUAL_BIND(_cylinder_shape_create);
 	GDVIRTUAL_BIND(_convex_polygon_shape_create);
 	GDVIRTUAL_BIND(_concave_polygon_shape_create);

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -216,6 +216,7 @@ public:
 	EXBIND0R(RID, sphere_shape_create)
 	EXBIND0R(RID, box_shape_create)
 	EXBIND0R(RID, capsule_shape_create)
+	EXBIND0R(RID, tapered_capsule_shape_create)
 	EXBIND0R(RID, cylinder_shape_create)
 	EXBIND0R(RID, convex_polygon_shape_create)
 	EXBIND0R(RID, concave_polygon_shape_create)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -88,6 +88,7 @@ public:
 	FUNCRID(box_shape)
 	FUNCRID(capsule_shape)
 	FUNCRID(cylinder_shape)
+	FUNCRID(tapered_capsule_shape)
 	FUNCRID(convex_polygon_shape)
 	FUNCRID(concave_polygon_shape)
 	FUNCRID(heightmap_shape)


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot-proposals/issues/12875


https://github.com/user-attachments/assets/f07ab383-4e0b-4412-a166-3ea7a3bc9bad

[world-prototype-game-project.zip](https://github.com/user-attachments/files/21450421/world-prototype-game-project.zip)
