### PR TITLE
Round gradient colors

### DIFF
--- a/scene/resources/gradient_texture.cpp
+++ b/scene/resources/gradient_texture.cpp
@@ -120,10 +120,10 @@ void GradientTexture1D::_update() const {
 				float ofs = float(i) / (width - 1);
 				Color color = g.get_color_at_offset(ofs);
 
-				wd8[i * 4 + 0] = uint8_t(CLAMP(color.r * 255.0, 0, 255));
-				wd8[i * 4 + 1] = uint8_t(CLAMP(color.g * 255.0, 0, 255));
-				wd8[i * 4 + 2] = uint8_t(CLAMP(color.b * 255.0, 0, 255));
-				wd8[i * 4 + 3] = uint8_t(CLAMP(color.a * 255.0, 0, 255));
+				wd8[i * 4 + 0] = uint8_t(color.get_r8());
+				wd8[i * 4 + 1] = uint8_t(color.get_g8());
+				wd8[i * 4 + 2] = uint8_t(color.get_b8());
+				wd8[i * 4 + 3] = uint8_t(color.get_a8());
 			}
 		}
 
@@ -259,10 +259,10 @@ void GradientTexture2D::_update() const {
 						float ofs = _get_gradient_offset_at(x, y);
 						const Color &c = g.get_color_at_offset(ofs);
 
-						wd8[(x + (y * width)) * 4 + 0] = uint8_t(CLAMP(c.r * 255.0, 0, 255));
-						wd8[(x + (y * width)) * 4 + 1] = uint8_t(CLAMP(c.g * 255.0, 0, 255));
-						wd8[(x + (y * width)) * 4 + 2] = uint8_t(CLAMP(c.b * 255.0, 0, 255));
-						wd8[(x + (y * width)) * 4 + 3] = uint8_t(CLAMP(c.a * 255.0, 0, 255));
+						wd8[(x + (y * width)) * 4 + 0] = uint8_t(c.get_r8());
+						wd8[(x + (y * width)) * 4 + 1] = uint8_t(c.get_g8());
+						wd8[(x + (y * width)) * 4 + 2] = uint8_t(c.get_b8());
+						wd8[(x + (y * width)) * 4 + 3] = uint8_t(c.get_a8());
 					}
 				}
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/100780

In majority of the cases this doesn't change anything, but if the gradient colors happen to be close you now get the full range without duplicates e.g.:
Master:
<img width="515" height="166" alt="master_color" src="https://github.com/user-attachments/assets/16442241-3a17-4497-8f3f-ff952f5642c4" />
This pr:
<img width="515" height="166" alt="pr_color" src="https://github.com/user-attachments/assets/7beb9f56-146b-4daf-9228-9e647a220b91" />
3px gradient from (11, 0, 11) to (13, 100, 13). The center pixel is now (12, 50, 12) instead of (11, 50, 11). (I know you can't see sh*t, but take a color picker and try yourself).

Rounding is necessary since color values are floats on disk and won't yield the same value when multiplied by 255.0 and floored:
E.g. 11 is represented as `0.04313725`.
```gdscript
print(String.num(0.04313725 * 255.0)) # 10.99999875
```