### PR TITLE
Use `EditorUndoRedoManager` to track the property changes of the configured `InputEvent` in the plugin

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -153,6 +153,9 @@ int64_t InputEventFromWindow::get_window_id() const {
 ///////////////////////////////////
 
 void InputEventWithModifiers::set_command_or_control_autoremap(bool p_enabled) {
+	if (command_or_control_autoremap == p_enabled) {
+		return;
+	}
 	command_or_control_autoremap = p_enabled;
 	if (command_or_control_autoremap) {
 		if (OS::get_singleton()->has_feature("macos") || OS::get_singleton()->has_feature("web_macos") || OS::get_singleton()->has_feature("web_ios")) {
@@ -166,6 +169,7 @@ void InputEventWithModifiers::set_command_or_control_autoremap(bool p_enabled) {
 		ctrl_pressed = false;
 		meta_pressed = false;
 	}
+	notify_property_list_changed();
 	emit_changed();
 }
 
@@ -309,9 +313,11 @@ void InputEventWithModifiers::_validate_property(PropertyInfo &p_property) const
 		// Cannot be used with Meta/Command or Control!
 		if (p_property.name == "meta_pressed") {
 			p_property.usage ^= PROPERTY_USAGE_STORAGE;
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 		}
 		if (p_property.name == "ctrl_pressed") {
 			p_property.usage ^= PROPERTY_USAGE_STORAGE;
+			p_property.usage ^= PROPERTY_USAGE_EDITOR;
 		}
 	} else {
 		if (p_property.name == "command_or_control_autoremap") {


### PR DESCRIPTION
This allows undo and redo, and can mark in time whether the handled `InputEvent` resource is edited.

`command_or_control_autoremap` needs to be handled separately, as its value will change the usage of other properties.

Avoid the following error message:
```
ERROR: Command or Control autoremapping is enabled, cannot set Control directly! 
at: set_ctrl_pressed (core/input/input_event.cpp:203)
ERROR: Command or Control autoremapping is enabled, cannot set Meta directly! 
at: set_meta_pressed (core/input/input_event.cpp:213)
```

Fix part of #101738, see https://github.com/godotengine/godot/issues/101738#issuecomment-3117862620.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Supersedes #108986.