### PR TITLE
Add confirmation dialog to filesystem dock when moving or copying files

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1878,6 +1878,10 @@ void FileSystemDock::_duplicate_operation_confirm(const String &p_path) {
 	_try_duplicate_item(to_duplicate, p_path);
 }
 
+void FileSystemDock::_move_confirm() {
+	_move_operation_confirm(confirm_move_to_dir, confirm_to_copy);
+}
+
 void FileSystemDock::_overwrite_dialog_action(bool p_overwrite) {
 	overwrite_dialog->hide();
 	_move_operation_confirm(to_move_path, to_move_or_copy, p_overwrite ? OVERWRITE_REPLACE : OVERWRITE_RENAME);
@@ -3116,11 +3120,19 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 				}
 			}
 			if (!to_move.is_empty()) {
+				String move_confirm_text;
+				confirm_move_to_dir = to_dir;
+
 				if (Input::get_singleton()->is_key_pressed(Key::CMD_OR_CTRL)) {
-					_move_operation_confirm(to_dir, true);
+					move_confirm_text = vformat(TTR("Copy %d selected item(s) to \"%s\"?"), to_move.size(), target_dir);
+					confirm_to_copy = true;
 				} else {
-					_move_operation_confirm(to_dir);
+					move_confirm_text = vformat(TTR("Move %d selected item(s) to \"%s\"?"), to_move.size(), target_dir);
+					confirm_to_copy = false;
 				}
+
+				move_confirm_dialog->set_text(move_confirm_text);
+				move_confirm_dialog->popup_centered();
 			}
 		} else if (favorite) {
 			// Add the files from favorites.
@@ -4392,6 +4404,10 @@ FileSystemDock::FileSystemDock() {
 	add_child(conversion_dialog);
 	conversion_dialog->set_ok_button_text(TTRC("Convert"));
 	conversion_dialog->connect(SceneStringName(confirmed), callable_mp(this, &FileSystemDock::_convert_dialog_action));
+
+	move_confirm_dialog = memnew(ConfirmationDialog);
+	add_child(move_confirm_dialog);
+	move_confirm_dialog->connect(SceneStringName(confirmed), callable_mp(this, &FileSystemDock::_move_confirm));
 
 	uncollapsed_paths_before_search = Vector<String>();
 

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -196,11 +196,15 @@ private:
 	Label *overwrite_dialog_file_list = nullptr;
 
 	ConfirmationDialog *conversion_dialog = nullptr;
+	ConfirmationDialog *move_confirm_dialog = nullptr;
 
 	SceneCreateDialog *make_scene_dialog = nullptr;
 	ScriptCreateDialog *make_script_dialog = nullptr;
 	ShaderCreateDialog *make_shader_dialog = nullptr;
 	CreateDialog *new_resource_dialog = nullptr;
+
+	String confirm_move_to_dir;
+	bool confirm_to_copy = false;
 
 	bool always_show_folders = false;
 	int thumbnail_size_setting = 0;
@@ -299,6 +303,7 @@ private:
 	void _make_scene_confirm();
 	void _rename_operation_confirm();
 	void _duplicate_operation_confirm(const String &p_path);
+	void _move_confirm();
 	void _overwrite_dialog_action(bool p_overwrite);
 	void _convert_dialog_action();
 	Vector<String> _check_existing();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7862.

This adds a confirmation dialog to the file system when the user moves or copies one or more files.
As discussed in the PR, the option to disable the confirmation was not added, and the dialog shows where the files will be moved or copied to.

![CleanShot 2025-07-27 at 10 37 29](https://github.com/user-attachments/assets/b446c534-e919-4785-9df2-39341c2bd7d3)
