### PR TITLE
Fix SVGTexture oversampling in the tile map.

### DIFF
--- a/doc/classes/TileSetAtlasSource.xml
+++ b/doc/classes/TileSetAtlasSource.xml
@@ -275,6 +275,7 @@
 		<member name="use_texture_padding" type="bool" setter="set_use_texture_padding" getter="get_use_texture_padding" default="true">
 			If [code]true[/code], generates an internal texture with an additional one pixel padding around each tile. Texture padding avoids a common artifact where lines appear between tiles.
 			Disabling this setting might lead a small performance improvement, as generating the internal texture requires both memory and processing time when the TileSetAtlasSource resource is modified.
+			[b]Note:[/b] If [code]true[/code], and [member texture] is set to [SVGTexture], [SVGTexture] will be converted to [ImageTexture] and automatically oversampling will not work.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -36,7 +36,9 @@
 #include "core/templates/a_hash_map.h"
 #include "scene/2d/tile_map.h"
 #include "scene/gui/control.h"
+#include "scene/main/viewport.h"
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
+#include "scene/resources/svg_texture.h"
 #include "scene/resources/world_2d.h"
 
 #ifndef PHYSICS_2D_DISABLED
@@ -197,6 +199,25 @@ void TileMapLayer::_debug_update(bool p_force_cleanup) {
 
 #endif // DEBUG_ENABLED
 
+PackedStringArray TileMapLayer::get_configuration_warnings() const {
+	PackedStringArray warnings = Node2D::get_configuration_warnings();
+	if (tile_set.is_valid()) {
+		for (int i = 0; i < tile_set->get_source_count(); i++) {
+			int sid = tile_set->get_source_id(i);
+			TileSetSource *source = *tile_set->get_source(sid);
+			TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
+			if (atlas_source && atlas_source->get_use_texture_padding()) {
+				Ref<SVGTexture> texture = atlas_source->get_texture();
+				if (texture.is_valid()) {
+					warnings.push_back(RTR("The TileSet includes at least one source with an SVGTexture and texture padding enabled. Automatic oversampling will not work for this source."));
+					break;
+				}
+			}
+		}
+	}
+	return warnings;
+}
+
 /////////////////////////////// Rendering //////////////////////////////////////
 void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 	RenderingServer *rs = RenderingServer::get_singleton();
@@ -219,6 +240,32 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 		rs->canvas_item_set_modulate(get_canvas_item(), layer_modulate);
 	}
 
+	// ----------- Look for SVG textures -----------
+	bool force_redraw = false;
+	if (!forced_cleanup) {
+		if (tile_set.is_null()) {
+			has_scalable_textures = false;
+		} else if (dirty.flags[TileMapLayer::DIRTY_FLAGS_TILE_SET]) {
+			has_scalable_textures = false;
+			for (int i = 0; i < tile_set->get_source_count(); i++) {
+				int sid = tile_set->get_source_id(i);
+				TileSetSource *source = *tile_set->get_source(sid);
+				TileSetAtlasSource *atlas_source = Object::cast_to<TileSetAtlasSource>(source);
+				if (atlas_source) {
+					Texture2D *texture = *atlas_source->get_texture();
+					if (Object::cast_to<SVGTexture>(texture) && !atlas_source->get_use_texture_padding()) {
+						has_scalable_textures = true;
+						break;
+					}
+				}
+			}
+		}
+		if (has_scalable_textures && get_viewport() && dirty.flags[DIRTY_FLAGS_OVERSAMPLING]) {
+			force_redraw = true;
+			oversampling = get_viewport()->get_oversampling();
+		}
+	}
+
 	// ----------- Quadrants processing -----------
 
 	// List all rendering quadrants to update, creating new ones if needed.
@@ -228,7 +275,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 	// If so, recreate everything.
 	bool quadrant_shape_changed = dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ENABLED] || dirty.flags[DIRTY_FLAGS_TILE_SET] ||
 			(is_y_sort_enabled() && (dirty.flags[DIRTY_FLAGS_LAYER_Y_SORT_ORIGIN] || dirty.flags[DIRTY_FLAGS_LAYER_X_DRAW_ORDER_REVERSED] || dirty.flags[DIRTY_FLAGS_LAYER_LOCAL_TRANSFORM])) ||
-			(!is_y_sort_enabled() && dirty.flags[DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE]);
+			(!is_y_sort_enabled() && dirty.flags[DIRTY_FLAGS_LAYER_RENDERING_QUADRANT_SIZE]) || force_redraw;
 
 	// Free all quadrants.
 	if (forced_cleanup || quadrant_shape_changed) {
@@ -246,7 +293,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 
 	if (!forced_cleanup) {
 		// List all quadrants to update, recreating them if needed.
-		if (dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || _rendering_was_cleaned_up) {
+		if (dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || _rendering_was_cleaned_up || force_redraw) {
 			// Update all cells.
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
 				CellData &cell_data = kv.value;
@@ -258,6 +305,10 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 				CellData &cell_data = *cell_data_list_element->self();
 				_rendering_quadrants_update_cell(cell_data, dirty_rendering_quadrant_list);
 			}
+		}
+
+		if (has_scalable_textures && !is_drawing()) {
+			CanvasItem::set_current_item_drawn(this);
 		}
 
 		// Update all dirty quadrants.
@@ -386,6 +437,10 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 			}
 
 			quadrant_list_element = next_quadrant_list_element;
+		}
+
+		if (has_scalable_textures && !is_drawing()) {
+			CanvasItem::set_current_item_drawn(nullptr);
 		}
 
 		dirty_rendering_quadrant_list.clear();
@@ -1944,6 +1999,7 @@ RBSet<TerrainConstraint> TileMapLayer::_get_terrain_constraints_from_painted_cel
 void TileMapLayer::_tile_set_changed() {
 	dirty.flags[DIRTY_FLAGS_TILE_SET] = true;
 	_queue_internal_update();
+	update_configuration_warnings();
 	emit_signal(CoreStringName(changed));
 }
 
@@ -2095,6 +2151,13 @@ void TileMapLayer::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			dirty.flags[DIRTY_FLAGS_LAYER_VISIBILITY] = true;
 			_queue_internal_update();
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			if (has_scalable_textures && get_viewport() && (get_viewport()->get_oversampling() != oversampling)) {
+				dirty.flags[DIRTY_FLAGS_OVERSAMPLING] = true;
+				_queue_internal_update();
+			}
 		} break;
 	}
 

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -367,6 +367,8 @@ public:
 
 		DIRTY_FLAGS_TILE_SET,
 
+		DIRTY_FLAGS_OVERSAMPLING,
+
 		DIRTY_FLAGS_MAX,
 	};
 
@@ -378,6 +380,9 @@ private:
 
 	bool enabled = true;
 	Ref<TileSet> tile_set;
+
+	bool has_scalable_textures = false;
+	double oversampling = 0.0;
 
 	HighlightMode highlight_mode = HIGHLIGHT_MODE_DEFAULT;
 
@@ -505,6 +510,8 @@ protected:
 
 	virtual void _update_self_texture_filter(RS::CanvasItemTextureFilter p_texture_filter) override;
 	virtual void _update_self_texture_repeat(RS::CanvasItemTextureRepeat p_texture_repeat) override;
+
+	virtual PackedStringArray get_configuration_warnings() const override;
 
 public:
 #ifdef TOOLS_ENABLED

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -126,8 +126,13 @@ bool CanvasItem::is_visible() const {
 }
 
 CanvasItem *CanvasItem::current_item_drawn = nullptr;
+
 CanvasItem *CanvasItem::get_current_item_drawn() {
 	return current_item_drawn;
+}
+
+void CanvasItem::set_current_item_drawn(CanvasItem *p_ci) {
+	current_item_drawn = p_ci;
 }
 
 void CanvasItem::_redraw_callback() {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -332,6 +332,9 @@ public:
 	void draw_end_animation();
 
 	static CanvasItem *get_current_item_drawn();
+	static void set_current_item_drawn(CanvasItem *p_ci);
+
+	bool is_drawing() const { return drawing; }
 
 	/* RECT / TRANSFORM */
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109000

- Adds oversampling support for `TileMapLayer`
- Adds configuration warning if `SVGTexture` is used and `use_texture_padding` is set (since it converts texture to an `ImageTexture` and can't work with oversampling).

### Before:
https://github.com/user-attachments/assets/9bf77864-d007-41ed-9a5a-4ca324751617

### After:
https://github.com/user-attachments/assets/f8a17bfa-e5f7-4a96-ae89-ce1368355509

