### PR TITLE
Fix ColorPresetButton pressed color

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -2625,7 +2625,12 @@ void ColorPresetButton::_notification(int p_what) {
 
 			if (sb_flat.is_valid()) {
 				sb_flat->set_border_width(SIDE_BOTTOM, 2);
-				if (get_draw_mode() == DRAW_PRESSED || get_draw_mode() == DRAW_HOVER_PRESSED) {
+
+				DrawMode draw_mode = get_draw_mode();
+				// Draw the white "shadow" only when actually pressed. The complex logic is caused by the enabled toggle_mode.
+				bool draw_white = !has_focus() && (draw_mode == DRAW_PRESSED || draw_mode == DRAW_HOVER_PRESSED);
+				draw_white = draw_white || (draw_mode == DRAW_NORMAL && is_pressed());
+				if (draw_white) {
 					sb_flat->set_border_color(Color(1, 1, 1, 1));
 				} else {
 					sb_flat->set_border_color(Color(0, 0, 0, 1));


### PR DESCRIPTION
Related to #108814
ColorPresetButton draws either black or white shadow depending on whether it's pressed. However the button has `toggle_mode` enabled, so determining the proper state is more tricky. I made it show as white when pressed not focused or when clicked, and black in other cases.

https://github.com/user-attachments/assets/0ca873e7-30d8-46e8-8b8a-98325ffc67ee

Note that this is only visible with the aforementioned PR included.