### PR TITLE
Make TextureRD use correct srgb format in 3D

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1725,12 +1725,20 @@ void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_textur
 	texture.rd_type = tf.texture_type;
 	texture.rd_view = rd_view;
 	texture.rd_format = imfmt.rd_format;
+
+	if (imfmt.rd_format_srgb != RD::DATA_FORMAT_MAX) {
+		// Allow creating shared srgb texture even users didn't explicitly add them.
+		RD::get_singleton()->_texture_ensure_shareable_format(p_rd_texture, imfmt.rd_format);
+		RD::get_singleton()->_texture_ensure_shareable_format(p_rd_texture, imfmt.rd_format_srgb);
+	}
+
 	// We create a shared texture here even if our view matches, so we don't obtain ownership.
 	texture.rd_texture = RD::get_singleton()->texture_create_shared(rd_view, p_rd_texture);
-	if (imfmt.rd_format_srgb != RD::DATA_FORMAT_MAX) {
-		rd_view.format_override = imfmt.rd_format_srgb == tf.format ? RD::DATA_FORMAT_MAX : imfmt.rd_format;
+
+	if (imfmt.rd_format_srgb != RD::DATA_FORMAT_MAX && RD::get_singleton()->texture_is_format_supported_for_usage(imfmt.rd_format_srgb, RD::TEXTURE_USAGE_SAMPLING_BIT)) {
+		// The texture support srgb override, create it for 3D usage.
+		rd_view.format_override = imfmt.rd_format_srgb == tf.format ? RD::DATA_FORMAT_MAX : imfmt.rd_format_srgb;
 		texture.rd_format_srgb = imfmt.rd_format_srgb;
-		// We create a shared texture here even if our view matches, so we don't obtain ownership.
 		texture.rd_texture_srgb = RD::get_singleton()->texture_create_shared(rd_view, p_rd_texture);
 	}
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1901,6 +1901,14 @@ uint32_t RenderingDevice::_texture_vrs_method_to_usage_bits() const {
 	}
 }
 
+void RenderingDevice::_texture_ensure_shareable_format(RID p_texture, const DataFormat &p_shareable_format) {
+	Texture *texture = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_NULL(texture);
+	if (!texture->allowed_shared_formats.has(p_shareable_format)) {
+		texture->allowed_shared_formats.push_back(p_shareable_format);
+	}
+}
+
 Vector<uint8_t> RenderingDevice::_texture_get_data(Texture *tex, uint32_t p_layer, bool p_2d) {
 	uint32_t width, height, depth;
 	uint32_t tight_mip_size = get_image_format_required_size(tex->format, tex->width, tex->height, p_2d ? 1 : tex->depth, tex->mipmaps, &width, &height, &depth);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -356,6 +356,7 @@ public:
 	void _texture_copy_shared(RID p_src_texture_rid, Texture *p_src_texture, RID p_dst_texture_rid, Texture *p_dst_texture);
 	void _texture_create_reinterpret_buffer(Texture *p_texture);
 	uint32_t _texture_vrs_method_to_usage_bits() const;
+	void _texture_ensure_shareable_format(RID p_texture, const DataFormat &p_shareable_format);
 
 	struct TextureGetDataRequest {
 		uint32_t frame_local_index = 0;


### PR DESCRIPTION
Fixes #103836. Fixes #106515.

Before, the `rd_texture_srgb.format_override` of non-srgb is incorrectly set to `rd_format`, which causes TextureRD not to use srgb format in 3D and display wrong color.
This PR fixes the issue, and allows `RenderingServer.texture_rd_create` to work with `*_SRGB` format even users don't explicitly add the shareable formats.

Test project:
R8G8B8A8_SRGB: https://github.com/beicause/godot-demo-projects/tree/rasterize-mesh-texture/rendering/mesh_texture_rd
R8G8B8A8_UNORM: https://github.com/beicause/godot-demo-projects/tree/mesh-tex-rd-unorm/rendering/mesh_texture_rd