### PR TITLE
[macOS] Add input action (CMD + W) to close dialogs.

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -410,6 +410,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
 	{ "ui_unicode_start",                              TTRC("Start Unicode Character Input") },
 	{ "ui_colorpicker_delete_preset",                  TTRC("ColorPicker: Delete Preset") },
 	{ "ui_accessibility_drag_and_drop",                TTRC("Accessibility: Keyboard Drag and Drop") },
+	{ "ui_close_window",                               TTRC("Close Window") },
 	{ "",                                              ""}
 	/* clang-format on */
 };
@@ -497,6 +498,12 @@ const HashMap<String, List<Ref<InputEvent>>> &InputMap::get_builtins() {
 
 	inputs = List<Ref<InputEvent>>();
 	default_builtin_cache.insert("ui_accessibility_drag_and_drop", inputs);
+
+	inputs = List<Ref<InputEvent>>();
+#ifdef MACOS_ENABLED
+	inputs.push_back(InputEventKey::create_reference(Key::W | KeyModifierMask::META));
+#endif
+	default_builtin_cache.insert("ui_close_window", inputs);
 
 	// ///// UI basic Shortcuts /////
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1258,6 +1258,10 @@
 			Default [InputEventAction] to discard a modal or pending input.
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
 		</member>
+		<member name="input/ui_close_window" type="Dictionary" setter="" getter="">
+			Default [InputEventAction] to close currently focused [AcceptDialog].
+			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.
+		</member>
 		<member name="input/ui_colorpicker_delete_preset" type="Dictionary" setter="" getter="">
 			Default [InputEventAction] to delete a color preset in a [ColorPicker].
 			[b]Note:[/b] Default [code]ui_*[/code] actions cannot be removed as they are necessary for the internal logic of several [Control]s. The events assigned to the action can however be modified.

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -37,7 +37,7 @@
 // AcceptDialog
 
 void AcceptDialog::_input_from_window(const Ref<InputEvent> &p_event) {
-	if (close_on_escape && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+	if ((close_on_escape && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) || p_event->is_action_pressed(SNAME("ui_close_window"), false, true)) {
 		_cancel_pressed();
 	}
 	Window::_input_from_window(p_event);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/86200 and partially https://github.com/godotengine/godot/issues/109007.