### PR TITLE
Add non-blocking `ResourceLoader::load_threaded` option without polling.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -50,6 +50,10 @@ Error ResourceLoader::load_threaded_request(const String &p_path, const String &
 	return ::ResourceLoader::load_threaded_request(p_path, p_type_hint, p_use_sub_threads, ResourceFormatLoader::CacheMode(p_cache_mode));
 }
 
+Error ResourceLoader::load_threaded(const String &p_path, const Callable &p_callback, const String &p_type_hint, bool p_use_sub_threads, CacheMode p_cache_mode) {
+	return ::ResourceLoader::load_threaded(p_path, p_callback, p_type_hint, p_use_sub_threads, ResourceFormatLoader::CacheMode(p_cache_mode));
+}
+
 ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const String &p_path, Array r_progress) {
 	float progress = 0;
 	::ResourceLoader::ThreadLoadStatus tls = ::ResourceLoader::load_threaded_get_status(p_path, &progress);
@@ -133,6 +137,7 @@ Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 }
 
 void ResourceLoader::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("load_threaded", "path", "callback", "type_hint", "use_sub_threads", "cache_mode"), &ResourceLoader::load_threaded, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE));
 	ClassDB::bind_method(D_METHOD("load_threaded_request", "path", "type_hint", "use_sub_threads", "cache_mode"), &ResourceLoader::load_threaded_request, DEFVAL(""), DEFVAL(false), DEFVAL(CACHE_MODE_REUSE));
 	ClassDB::bind_method(D_METHOD("load_threaded_get_status", "path", "progress"), &ResourceLoader::load_threaded_get_status, DEFVAL_ARRAY);
 	ClassDB::bind_method(D_METHOD("load_threaded_get", "path"), &ResourceLoader::load_threaded_get);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -37,6 +37,7 @@
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 #include "core/templates/safe_refcount.h"
+#include "core/variant/callable.h"
 #include "core/variant/typed_array.h"
 
 class MainLoop;
@@ -68,6 +69,7 @@ public:
 
 	static ResourceLoader *get_singleton() { return singleton; }
 
+	Error load_threaded(const String &p_path, const Callable &p_callback, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = ClassDB::default_array_arg);
 	Ref<Resource> load_threaded_get(const String &p_path);

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -34,6 +34,8 @@
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
+#include "core/templates/local_vector.h"
+#include "core/variant/callable.h"
 
 namespace CoreBind {
 class ResourceLoader;
@@ -130,6 +132,7 @@ public:
 		String local_path;
 		String user_path;
 		uint32_t user_rc = 0; // Having user RC implies regular RC incremented in one, until the user RC reaches zero.
+		LocalVector<Callable> user_callbacks; // Having user callbacks also in implies user_rc incremented by user_callbacks.size().
 		ThreadLoadTask *task_if_unregistered = nullptr;
 
 		void clear();
@@ -145,6 +148,7 @@ public:
 private:
 	static LoadToken *_load_threaded_request_reuse_user_token(const String &p_path);
 	static void _load_threaded_request_setup_user_token(LoadToken *p_token, const String &p_path);
+	static void _load_threaded_auto_complete_user_request(const String &p_user_path);
 
 	static Ref<Resource> _load_complete_inner(LoadToken &p_load_token, Error *r_error, MutexLock<SafeBinaryMutex<BINARY_MUTEX_TAG>> &p_thread_load_lock);
 
@@ -227,6 +231,7 @@ public:
 	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE);
 	static ThreadLoadStatus load_threaded_get_status(const String &p_path, float *r_progress = nullptr);
 	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
+	static Error load_threaded(const String &p_path, const Callable &p_callback, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE);
 
 	static bool is_within_load() { return load_nesting > 0; }
 

--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -107,6 +107,20 @@
 				[b]Note:[/b] Relative paths will be prefixed with [code]"res://"[/code] before loading, to avoid unexpected results make sure your paths are absolute.
 			</description>
 		</method>
+		<method name="load_threaded">
+			<return type="int" enum="Error" />
+			<param index="0" name="path" type="String" />
+			<param index="1" name="callback" type="Callable" />
+			<param index="2" name="type_hint" type="String" default="&quot;&quot;" />
+			<param index="3" name="use_sub_threads" type="bool" default="false" />
+			<param index="4" name="cache_mode" type="int" enum="ResourceLoader.CacheMode" default="1" />
+			<description>
+				Loads the resource using threads. All parameters are the same as in [method load_threaded_request], except for [param callback].
+				[param callback] is a callable that will automatically be invoked with the status and resource as arguments once loading finishes.
+				If loading succeeds, the arguments will be [constant THREAD_LOAD_LOADED] and the loaded resource (as returned by [method load_threaded_get]); otherwise, they will be [constant THREAD_LOAD_FAILED] and [code]null[/code].
+				[b]Note:[/b] This method automatically decrements the request count (as [method load_threaded_get] would) before calling the [param callback].
+			</description>
+		</method>
 		<method name="load_threaded_get">
 			<return type="Resource" />
 			<param index="0" name="path" type="String" />
@@ -120,7 +134,7 @@
 			<param index="0" name="path" type="String" />
 			<param index="1" name="progress" type="Array" default="[]" />
 			<description>
-				Returns the status of a threaded loading operation started with [method load_threaded_request] for the resource at [param path].
+				Returns the status of a threaded loading operation started with [method load_threaded_request] or [method load_threaded] for the resource at [param path].
 				An array variable can optionally be passed via [param progress], and will return a one-element array containing the ratio of completion of the threaded loading (between [code]0.0[/code] and [code]1.0[/code]).
 				[b]Note:[/b] The recommended way of using this method is to call it during different frames (e.g., in [method Node._process], instead of a loop).
 			</description>


### PR DESCRIPTION
Possible implementation for https://github.com/godotengine/godot-proposals/issues/10386 using completion callbacks.

Adds a `ResourceLoader.load_threaded` method that takes a callback to be called when loading finishes.
The idea for it is to simplify background resource loading API in cases where no blocking is expected.
Loading progress can still be captured with `ResourceLoader.load_threaded_get_status` (as for `ResourceLoader.load_threaded_request`).

Simple case, before:
```gdscript
extends Node2D

const RESOURCE: String = "res://res/image.png"
var loading_active: bool = false

func _ready() -> void:
    ResourceLoader.load_threaded_request(RESOURCE)
    loading_active = true

func _process(_delta: float) -> void:
    if loading_active:
        var status = ResourceLoader.load_threaded_get_status(RESOURCE)
        if status != ResourceLoader.THREAD_LOAD_IN_PROGRESS:
            loading_active = false
            var resource = null
            if status == ResourceLoader.THREAD_LOAD_LOADED:
                resource = ResourceLoader.load_threaded_get(RESOURCE)
            _on_loaded(status, resource)
            

func _on_loaded(status, resource) -> void:
    print(status, ' ', resource.get_size())
    $TextureRect.texture = resource
    $TextureRect.size = resource.get_size()
```
Same case, after:
```gdscript
extends Node2D

const RESOURCE: String = "res://res/image.png"

func _ready() -> void:
    ResourceLoader.load_threaded(RESOURCE, _on_loaded)

func _on_loaded(status, resource) -> void:
    print(status, ' ', resource.get_size())
    $TextureRect.texture = resource
    $TextureRect.size = resource.get_size()
```
