### PR TITLE
Update `ClassDB::class_call_static` doc

### DIFF
--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -21,7 +21,7 @@
 			<param index="0" name="class" type="StringName" />
 			<param index="1" name="method" type="StringName" />
 			<description>
-				Calls a static method on a class.
+				Calls a static method on a built-in or GDExtension class. For custom script classes you should reference the [code]class_name[/code] and the static method.
 			</description>
 		</method>
 		<method name="class_exists" qualifiers="const">


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Makes it clear that `ClassDB::class_call_static` only works on engine and GDExtension classes