### PR TITLE
View resource signals in the Connections Dock

### DIFF
--- a/editor/docks/node_dock.cpp
+++ b/editor/docks/node_dock.cpp
@@ -87,15 +87,22 @@ void NodeDock::update_lists() {
 	connections->update_tree();
 }
 
-void NodeDock::set_node(Node *p_node) {
-	connections->set_node(p_node);
-	groups->set_current(p_node);
+void NodeDock::set_object(Object *p_object) {
+	connections->set_object(p_object);
+	groups->set_current(Object::cast_to<Node>(p_object));
 
-	if (p_node) {
+	if (p_object) {
 		if (connections_button->is_pressed()) {
 			connections->show();
 		} else {
 			groups->show();
+		}
+
+		if (Object::cast_to<Resource>(p_object)) {
+			show_connections();
+			groups_button->set_disabled(true);
+		} else {
+			groups_button->set_disabled(false);
 		}
 
 		mode_hb->show();
@@ -148,7 +155,7 @@ NodeDock::NodeDock() {
 
 	select_a_node = memnew(Label);
 	select_a_node->set_focus_mode(FOCUS_ACCESSIBILITY);
-	select_a_node->set_text(TTRC("Select a single node to edit its signals and groups."));
+	select_a_node->set_text(TTRC("Select a single node to edit its signals and groups, or select an independent resource to view its signals."));
 	select_a_node->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
 	select_a_node->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);

--- a/editor/docks/node_dock.h
+++ b/editor/docks/node_dock.h
@@ -62,7 +62,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_node(Node *p_node);
+	void set_object(Object *p_object);
 
 	void show_groups();
 	void show_connections();

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1359,7 +1359,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					undo_redo->add_undo_method(node, "set_scene_file_path", node->get_scene_file_path());
 					_node_replace_owner(node, node, root);
 					_node_strip_signal_inheritance(node);
-					NodeDock::get_singleton()->set_node(node); // Refresh.
+					NodeDock::get_singleton()->set_object(node); // Refresh.
 					undo_redo->add_do_method(scene_tree, "update_tree");
 					undo_redo->add_undo_method(scene_tree, "update_tree");
 					undo_redo->commit_action();
@@ -2859,7 +2859,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	editor_history->cleanup_history();
 	InspectorDock::get_singleton()->call("_prepare_history");
 	InspectorDock::get_singleton()->update(nullptr);
-	NodeDock::get_singleton()->set_node(nullptr);
+	NodeDock::get_singleton()->set_object(nullptr);
 }
 
 void SceneTreeDock::_update_script_button() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2665,7 +2665,7 @@ void EditorNode::push_node_item(Node *p_node) {
 void EditorNode::push_item(Object *p_object, const String &p_property, bool p_inspector_only) {
 	if (!p_object) {
 		InspectorDock::get_inspector_singleton()->edit(nullptr);
-		NodeDock::get_singleton()->set_node(nullptr);
+		NodeDock::get_singleton()->set_object(nullptr);
 		SceneTreeDock::get_singleton()->set_selected(nullptr);
 		InspectorDock::get_singleton()->update(nullptr);
 		hide_unused_editors();
@@ -2786,7 +2786,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 	if (!current_obj) {
 		SceneTreeDock::get_singleton()->set_selected(nullptr);
 		InspectorDock::get_inspector_singleton()->edit(nullptr);
-		NodeDock::get_singleton()->set_node(nullptr);
+		NodeDock::get_singleton()->set_object(nullptr);
 		InspectorDock::get_singleton()->update(nullptr);
 		EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		hide_unused_editors();
@@ -2820,7 +2820,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		if (!p_skip_inspector_update) {
 			InspectorDock::get_inspector_singleton()->edit(current_res);
 			SceneTreeDock::get_singleton()->set_selected(nullptr);
-			NodeDock::get_singleton()->set_node(nullptr);
+			NodeDock::get_singleton()->set_object(current_res);
 			InspectorDock::get_singleton()->update(nullptr);
 			EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 			ImportDock::get_singleton()->set_edit_path(current_res->get_path());
@@ -2850,7 +2850,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 
 		InspectorDock::get_inspector_singleton()->edit(current_node);
 		if (current_node->is_inside_tree()) {
-			NodeDock::get_singleton()->set_node(current_node);
+			NodeDock::get_singleton()->set_object(current_node);
 			SceneTreeDock::get_singleton()->set_selected(current_node);
 			SceneTreeDock::get_singleton()->set_selection({ current_node });
 			InspectorDock::get_singleton()->update(current_node);
@@ -2862,7 +2862,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 				}
 			}
 		} else {
-			NodeDock::get_singleton()->set_node(nullptr);
+			NodeDock::get_singleton()->set_object(nullptr);
 			SceneTreeDock::get_singleton()->set_selected(nullptr);
 			InspectorDock::get_singleton()->update(nullptr);
 		}
@@ -2910,7 +2910,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		}
 
 		InspectorDock::get_inspector_singleton()->edit(current_obj);
-		NodeDock::get_singleton()->set_node(nullptr);
+		NodeDock::get_singleton()->set_object(nullptr);
 		SceneTreeDock::get_singleton()->set_selected(selected_node);
 		SceneTreeDock::get_singleton()->set_selection(multi_nodes);
 		InspectorDock::get_singleton()->update(nullptr);

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -51,8 +51,8 @@ class ConnectDialog : public ConfirmationDialog {
 
 public:
 	struct ConnectionData {
-		Node *source = nullptr;
-		Node *target = nullptr;
+		Object *source = nullptr;
+		Object *target = nullptr;
 		StringName signal;
 		StringName method;
 		uint32_t flags = 0;
@@ -62,9 +62,9 @@ public:
 		ConnectionData() {}
 
 		ConnectionData(const Connection &p_connection) {
-			source = Object::cast_to<Node>(p_connection.signal.get_object());
+			source = p_connection.signal.get_object();
 			signal = p_connection.signal.get_name();
-			target = Object::cast_to<Node>(p_connection.callable.get_object());
+			target = p_connection.callable.get_object();
 			flags = p_connection.flags;
 
 			Callable base_callable;
@@ -111,7 +111,7 @@ private:
 	Label *connect_to_label = nullptr;
 	LineEdit *from_signal = nullptr;
 	LineEdit *filter_nodes = nullptr;
-	Node *source = nullptr;
+	Object *source = nullptr;
 	ConnectionData source_connection_data;
 	StringName signal;
 	PackedStringArray signal_args;
@@ -170,8 +170,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	static StringName generate_method_callback_name(Node *p_source, const String &p_signal_name, Node *p_target);
-	Node *get_source() const;
+	static StringName generate_method_callback_name(Object *p_source, const String &p_signal_name, Object *p_target);
+	Object *get_source() const;
 	ConnectionData get_source_connection_data() const;
 	StringName get_signal_name() const;
 	PackedStringArray get_signal_args() const;
@@ -230,7 +230,7 @@ class ConnectionsDock : public VBoxContainer {
 		SLOT_MENU_DISCONNECT,
 	};
 
-	Node *selected_node = nullptr;
+	Object *selected_object = nullptr;
 	ConnectionsDockTree *tree = nullptr;
 
 	ConfirmationDialog *disconnect_all_dialog = nullptr;
@@ -241,6 +241,8 @@ class ConnectionsDock : public VBoxContainer {
 	PopupMenu *signal_menu = nullptr;
 	PopupMenu *slot_menu = nullptr;
 	LineEdit *search_box = nullptr;
+
+	bool is_editing_resource = false;
 
 	void _filter_changed(const String &p_text);
 
@@ -273,7 +275,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_node(Node *p_node);
+	void set_object(Object *p_obj);
 	void update_tree();
 
 	ConnectionsDock();


### PR DESCRIPTION
This adds the ability to **view** a resource's signals in the already existing Connections Dock.

Technically, anything inheriting from Object will be viewable. There is also support for connecting and disconnecting signals from a Resource to a Node's script in the current scene, but I couldn't manage to find a way that the resource was loaded in the current scene, so I decided to disable it by disabling the buttons to bring up the connect dialog.

Closes godotengine/godot-proposals#7377

<img width="825" height="335" alt="image" src="https://github.com/user-attachments/assets/7fb0620d-407b-45de-b4cb-c90caff7b2ca" />

