### PR TITLE
[Accessibility] Process non-focusable windows (popups, menus) as part of the parent window tree.

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -38,7 +38,7 @@
 #include "scene/theme/theme_db.h"
 
 void Popup::_input_from_window(const Ref<InputEvent> &p_event) {
-	if ((ac_popup || get_flag(FLAG_POPUP)) && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
+	if (get_flag(FLAG_POPUP) && p_event->is_action_pressed(SNAME("ui_cancel"), false, true)) {
 		hide_reason = HIDE_REASON_CANCELED; // ESC pressed, mark as canceled unconditionally.
 		_close_pressed();
 	}
@@ -115,7 +115,7 @@ void Popup::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
-			if (!is_in_edited_scene_root() && (get_flag(FLAG_POPUP) || ac_popup)) {
+			if (!is_in_edited_scene_root() && get_flag(FLAG_POPUP)) {
 				if (hide_reason == HIDE_REASON_NONE) {
 					hide_reason = HIDE_REASON_UNFOCUSED;
 				}
@@ -126,7 +126,7 @@ void Popup::_notification(int p_what) {
 }
 
 void Popup::_parent_focused() {
-	if (popped_up && (get_flag(FLAG_POPUP) || ac_popup)) {
+	if (popped_up && get_flag(FLAG_POPUP)) {
 		if (hide_reason == HIDE_REASON_NONE) {
 			hide_reason = HIDE_REASON_UNFOCUSED;
 		}

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -40,7 +40,6 @@ class Popup : public Window {
 	GDCLASS(Popup, Window);
 
 	LocalVector<Window *> visible_parents;
-	bool ac_popup = false;
 	bool popped_up = false;
 
 public:
@@ -60,7 +59,6 @@ protected:
 	void _close_pressed();
 	virtual Rect2i _popup_adjust_rect() const override;
 	virtual void _input_from_window(const Ref<InputEvent> &p_event) override;
-	void set_ac_popup() { ac_popup = true; }
 
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3209,13 +3209,8 @@ void PopupMenu::popup(const Rect2i &p_bounds) {
 		_native_popup(p_bounds != Rect2i() ? p_bounds : Rect2i(get_position(), Size2i()));
 	} else {
 		if (is_inside_tree()) {
-			bool ac = get_tree()->is_accessibility_enabled();
-			// Note: Native popup menus need keyboard focus to work with screen reader.
-			set_flag(FLAG_POPUP, !ac);
-			set_flag(FLAG_NO_FOCUS, !is_embedded() && !ac);
-			if (ac) {
-				set_ac_popup();
-			}
+			set_flag(FLAG_POPUP, true);
+			set_flag(FLAG_NO_FOCUS, !is_embedded());
 		}
 
 		moved = Vector2();
@@ -3253,13 +3248,8 @@ void PopupMenu::set_visible(bool p_visible) {
 		}
 	} else {
 		if (is_inside_tree()) {
-			bool ac = get_tree()->is_accessibility_enabled();
-			// Note: Native popup menus need keyboard focus to work with screen reader.
-			set_flag(FLAG_POPUP, !ac);
-			set_flag(FLAG_NO_FOCUS, !is_embedded() && !ac);
-			if (ac) {
-				set_ac_popup();
-			}
+			set_flag(FLAG_POPUP, true);
+			set_flag(FLAG_NO_FOCUS, !is_embedded());
 		}
 
 		Popup::set_visible(p_visible);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -500,6 +500,7 @@ public:
 	Node *find_parent(const String &p_pattern) const;
 
 	Window *get_window() const;
+	Window *get_non_popup_window() const;
 	Window *get_last_exclusive_window() const;
 
 	_FORCE_INLINE_ SceneTree *get_tree() const {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -332,6 +332,8 @@ public:
 	void set_flag(Flags p_flag, bool p_enabled);
 	bool get_flag(Flags p_flag) const;
 
+	bool is_popup() const;
+
 	bool is_maximize_allowed() const;
 
 	void request_attention();
@@ -399,6 +401,7 @@ public:
 	Window *get_exclusive_child() const { return exclusive_child; }
 	HashSet<Window *> get_transient_children() const { return transient_children; }
 	Window *get_parent_visible_window() const;
+	Window *get_non_popup_window() const;
 	Viewport *get_parent_viewport() const;
 
 	virtual void popup(const Rect2i &p_screen_rect = Rect2i());


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/106433
Fixes https://github.com/godotengine/godot/issues/106669