### PR TITLE
Relocate `add_root_node` method to `EditorInterface` from `EditorScript` and deprecate old method

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -19,6 +19,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="add_root_node">
+			<return type="void" />
+			<param index="0" name="node" type="Node" />
+			<description>
+				Makes [param node] root of the currently opened scene. Only works if the scene is empty. If the [param node] is a scene instance, an inheriting scene will be created.
+			</description>
+		</method>
 		<method name="close_scene">
 			<return type="int" enum="Error" />
 			<description>

--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -41,7 +41,7 @@
 				This method is executed by the Editor when [b]File &gt; Run[/b] is used.
 			</description>
 		</method>
-		<method name="add_root_node">
+		<method name="add_root_node" deprecated="Use [method EditorInterface.add_root_node] instead.">
 			<return type="void" />
 			<param index="0" name="node" type="Node" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -32,6 +32,7 @@
 #include "editor_interface.compat.inc"
 
 #include "core/config/project_settings.h"
+#include "core/io/resource_loader.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_main_screen.h"
@@ -58,6 +59,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/main/window.h"
+#include "scene/resources/packed_scene.h"
 #include "scene/resources/theme.h"
 
 EditorInterface *EditorInterface::singleton = nullptr;
@@ -358,6 +360,28 @@ void EditorInterface::make_scene_preview(const String &p_path, Node *p_scene, in
 
 	EditorResourcePreview::get_singleton()->check_for_invalidation(p_path);
 	EditorFileSystem::get_singleton()->emit_signal(SNAME("filesystem_changed"));
+}
+
+void EditorInterface::add_root_node(Node *p_node) {
+	if (EditorNode::get_singleton()->get_edited_scene()) {
+		ERR_PRINT("EditorInterface::add_root_node: The current scene already has a root node.");
+		return;
+	}
+
+	const String &scene_path = p_node->get_scene_file_path();
+	if (!scene_path.is_empty()) {
+		Ref<PackedScene> scene = ResourceLoader::load(scene_path);
+		if (scene.is_valid()) {
+			memfree(scene->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE)); // Ensure node cache.
+
+			p_node->set_scene_inherited_state(scene->get_state());
+			p_node->set_scene_file_path(String());
+		}
+	}
+
+	EditorNode::get_singleton()->set_edited_scene(p_node);
+	EditorUndoRedoManager::get_singleton()->set_history_as_unsaved(EditorNode::get_editor_data().get_current_edited_scene_history_id());
+	EditorSceneTabs::get_singleton()->update_scene_tabs();
 }
 
 void EditorInterface::set_plugin_enabled(const String &p_plugin, bool p_enabled) {
@@ -845,6 +869,8 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_open_scenes"), &EditorInterface::get_open_scenes);
 	ClassDB::bind_method(D_METHOD("get_open_scene_roots"), &EditorInterface::get_open_scene_roots);
 	ClassDB::bind_method(D_METHOD("get_edited_scene_root"), &EditorInterface::get_edited_scene_root);
+
+	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorInterface::add_root_node);
 
 	ClassDB::bind_method(D_METHOD("save_scene"), &EditorInterface::save_scene);
 	ClassDB::bind_method(D_METHOD("save_scene_as", "path", "with_preview"), &EditorInterface::save_scene_as, DEFVAL(true));

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -173,6 +173,8 @@ public:
 	TypedArray<Node> get_open_scene_roots() const;
 	Node *get_edited_scene_root() const;
 
+	void add_root_node(Node *p_node);
+
 	Error save_scene();
 	void save_scene_as(const String &p_scene, bool p_with_preview = true);
 	void mark_scene_as_unsaved();

--- a/editor/script/editor_script.cpp
+++ b/editor/script/editor_script.cpp
@@ -38,30 +38,8 @@
 #include "scene/resources/packed_scene.h"
 
 void EditorScript::add_root_node(Node *p_node) {
-	if (!EditorNode::get_singleton()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("Write your logic in the _run() method."));
-		return;
-	}
-
-	if (EditorNode::get_singleton()->get_edited_scene()) {
-		EditorNode::add_io_error("EditorScript::add_root_node: " + TTR("The current scene already has a root node."));
-		return;
-	}
-
-	const String &scene_path = p_node->get_scene_file_path();
-	if (!scene_path.is_empty()) {
-		Ref<PackedScene> scene = ResourceLoader::load(scene_path);
-		if (scene.is_valid()) {
-			memfree(scene->instantiate(PackedScene::GEN_EDIT_STATE_INSTANCE)); // Ensure node cache.
-
-			p_node->set_scene_inherited_state(scene->get_state());
-			p_node->set_scene_file_path(String());
-		}
-	}
-
-	EditorNode::get_singleton()->set_edited_scene(p_node);
-	EditorUndoRedoManager::get_singleton()->set_history_as_unsaved(EditorNode::get_editor_data().get_current_edited_scene_history_id());
-	EditorSceneTabs::get_singleton()->update_scene_tabs();
+	WARN_DEPRECATED_MSG("EditorScript::add_root_node is deprecated. Use EditorInterface::add_root_node instead.");
+	EditorInterface::get_singleton()->add_root_node(p_node);
 }
 
 Node *EditorScript::get_scene() const {


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot/pull/93726 (in that I think this method should be added to `EditorInterface` too).

This method was not functional at all until 4.3 thanks to this PR: https://github.com/godotengine/godot/pull/90136, but I don't believe it should belong in `EditorScript` because it worsens API discoverability and violates SRP since `EditorInterface` is meant to be the class that manipulates editor related data. It also leads to weird code where I have to create an instance of an `EditorScript` just to call this method in a script that doesn't inherit it. 