### PR TITLE
Fix overflowing render priority for stencil mode outline and xray

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -64,6 +64,7 @@ Ref<Material> Material::get_next_pass() const {
 void Material::set_render_priority(int p_priority) {
 	ERR_FAIL_COND(p_priority < RENDER_PRIORITY_MIN);
 	ERR_FAIL_COND(p_priority > RENDER_PRIORITY_MAX);
+
 	render_priority = p_priority;
 
 	if (material.is_valid()) {
@@ -3215,6 +3216,11 @@ Ref<BaseMaterial3D> BaseMaterial3D::_get_stencil_next_pass() const {
 void BaseMaterial3D::set_stencil_mode(StencilMode p_stencil_mode) {
 	if (stencil_mode == p_stencil_mode) {
 		return;
+	}
+
+	if (p_stencil_mode == StencilMode::STENCIL_MODE_OUTLINE || p_stencil_mode == StencilMode::STENCIL_MODE_XRAY) {
+		ERR_FAIL_COND_EDMSG(get_render_priority() >= RENDER_PRIORITY_MAX,
+				vformat("Cannot use stencil mode Outline or Xray, when render priority is RENDER_PRIORITY_MAX(%d).", RENDER_PRIORITY_MAX));
 	}
 
 	stencil_mode = p_stencil_mode;


### PR DESCRIPTION
Fixes #108905 

Stencil modes outline and xray set the render priority to 1 + previous priority, which can make it bigger than the MAX.
I clamped the priority to RENDER_PRIORITY_MAX.

This works, but I am not sure, if the rendering will still be correct in that case.
If it is not, I am not sure, how a _proper_ fix would look like.