### PR TITLE
Fix theming for debugger button

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -344,6 +344,21 @@ void EditorDebuggerNode::_notification(int p_what) {
 			initializing = false;
 		} break;
 
+		case NOTIFICATION_THEME_CHANGED: {
+			if (last_error_count != 0 || last_warning_count != 0) {
+				if (last_error_count >= 1 && last_warning_count >= 1) {
+					debugger_button->set_button_icon(get_editor_theme_icon(SNAME("ErrorWarning")));
+					debugger_button->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+				} else if (last_error_count >= 1) {
+					debugger_button->set_button_icon(get_editor_theme_icon(SNAME("Error")));
+					debugger_button->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+				} else {
+					debugger_button->set_button_icon(get_editor_theme_icon(SNAME("Warning")));
+					debugger_button->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+				}
+			}
+		} break;
+
 		case NOTIFICATION_PROCESS: {
 			if (server.is_null()) {
 				return;


### PR DESCRIPTION
Currently, if user changes the theme from dark to light (and vice versa) - the "Debugger" button theming is not updating, and it looks terrible (on the light theme especially).

Before:

<img width="158" height="52" alt="изображение" src="https://github.com/user-attachments/assets/805dcb8e-afef-4ae5-ae7b-b006a91fe39b" />

After:

<img width="153" height="35" alt="изображение" src="https://github.com/user-attachments/assets/5e4fe5a8-0592-4c0b-8079-5ddce8382053" />

