### PR TITLE
Improve ViewportTexture errors when invalid node paths are used

### DIFF
--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -11,7 +11,7 @@
 		[b]Note:[/b] When using a [Viewport] with [member Viewport.use_hdr_2d] set to [code]true[/code], the returned texture will be an HDR image encoded in linear space. This may look darker than normal when displayed directly on screen. To convert to gamma space, you can do the following:
 		[codeblock]
 		img.convert(Image.FORMAT_RGBA8)
-		imb.linear_to_srgb()
+		img.linear_to_srgb()
 		[/codeblock]
 		[b]Note:[/b] Some nodes such as [Decal], [Light3D], and [PointLight2D] do not support using [ViewportTexture] directly. To use texture data from a [ViewportTexture] in these nodes, you need to create an [ImageTexture] by calling [method Texture2D.get_image] on the [ViewportTexture] and passing the result to [method ImageTexture.create_from_image]. This conversion is a slow operation, so it should not be performed every frame.
 	</description>

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -185,7 +185,7 @@ Ref<Image> ViewportTexture::get_image() const {
 
 void ViewportTexture::_err_print_viewport_not_set() const {
 	if (!vp_pending && !vp_changed) {
-		ERR_PRINT("Viewport Texture must be set to use it.");
+		ERR_PRINT("ViewportTexture must have its Viewport Path property set to a valid SubViewport node to use it.");
 	}
 }
 
@@ -194,9 +194,15 @@ void ViewportTexture::_setup_local_to_scene(const Node *p_loc_scene) {
 	vp_pending = false;
 
 	Node *vpn = p_loc_scene->get_node_or_null(path);
-	ERR_FAIL_NULL_MSG(vpn, "Path to node is invalid: '" + String(path) + "'.");
+	String local_path;
+	if (get_local_scene()) {
+		local_path = String(get_local_scene()->get_path());
+	} else {
+		local_path = "(no local scene)";
+	}
+	ERR_FAIL_NULL_MSG(vpn, vformat("%s: Path to node is invalid: %s.", local_path, path));
 	vp = Object::cast_to<Viewport>(vpn);
-	ERR_FAIL_NULL_MSG(vp, "Path to node does not point to a viewport: '" + String(path) + "'.");
+	ERR_FAIL_NULL_MSG(vp, vformat("%s: Path to node does not point to a viewport: %s.", local_path, path));
 
 	vp->viewport_textures.insert(this);
 


### PR DESCRIPTION
This also mentions what exactly needs to be done to have a functional ViewportTexture.

Note that the node path printed is not guaranteed to be the immediate owner of the resource, but it should always be a parent node of the resource somehow. This is due to how Resource's "Local to Scene" works. This is something we need to improve the communication upon, as it's not obvious.

Also, this will currently print very long node paths when in the editor:

```
ERROR: /root/@EditorNode@20442/@Panel@14/@VBoxContainer@15/DockHSplitLeftL/DockHSplitLeftR/DockHSplitMain/@VBoxContainer@26/DockVSplitCenter/@VSplitContainer@62/@VBoxContainer@63/@EditorMainScreen@103/MainScreen/@CanvasItemEditor@10871/@VSplitContainer@10516/@HSplitContainer@10518/@HSplitContainer@10520/@Control@10521/@SubViewportContainer@10522/@SubViewport@10523/Node3D: Path to node is invalid: .
```

We should find a way to fix this somehow, preferably in a way that doesn't change behavior in the editor only (as it could be confusing).

- This closes https://github.com/godotengine/godot-proposals/issues/12879.

**Testing project:** [test_viewporttexture.zip](https://github.com/user-attachments/files/21474689/test_viewporttexture.zip)

## Preview

### Before

<img width="788" height="185" alt="Before" src="https://github.com/user-attachments/assets/ce000e6f-5742-416e-8c54-0dc31f23794f" />

### After

<img width="995" height="186" alt="After" src="https://github.com/user-attachments/assets/d20c3aa0-c62c-4d9e-90bf-e08c91a1d4ee" />

