### PR TITLE
OpenGL: Fix crash at startup with "Thread Model" set to "Separate"

### DIFF
--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -376,8 +376,12 @@ Size2i RenderingServerDefault::get_maximum_viewport_size() const {
 void RenderingServerDefault::_assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id) {
 	server_thread = Thread::get_caller_id();
 	server_task_id = p_pump_task_id;
-	// This is needed because the main RD is created on the main thread.
-	RenderingDevice::get_singleton()->make_current();
+
+	RenderingDevice *rd = RenderingDevice::get_singleton();
+	if (rd) {
+		// This is needed because the main RD is created on the main thread.
+		rd->make_current();
+	}
 }
 
 void RenderingServerDefault::_thread_exit() {


### PR DESCRIPTION
Presently, when running a project with the OpenGL renderer and "Thread Model" set to "Separate", it'll crash with a segfault at startup.

Here's the backtrace:

<details>

```
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.5.beta.custom_build (2d113cc224cb9be07866d003819fcef2226a52ea)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] /lib/x86_64-linux-gnu/libc.so.6(+0x42520) [0x7256f2a42520] (??:0)
[2] RenderingDevice::make_current() (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/rendering_device.cpp:8096)
[3] RenderingServerDefault::_assign_mt_ids(long) (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/rendering_server_default.cpp:381)
[4] void CommandQueueMT::Command<RenderingServerDefault, void (RenderingServerDefault::*)(long), false, long&>::call_impl<0ul>(IndexSequence<0ul>) (/home/dsnopek/Sync/Projects/default/godot-4/core/templates/command_queue_mt.h:70 (discriminator 4))
[5] CommandQueueMT::Command<RenderingServerDefault, void (RenderingServerDefault::*)(long), false, long&>::call() (/home/dsnopek/Sync/Projects/default/godot-4/core/templates/command_queue_mt.h:63)
[6] CommandQueueMT::_flush() (/home/dsnopek/Sync/Projects/default/godot-4/core/templates/command_queue_mt.h:170)
[7] CommandQueueMT::flush_all() (/home/dsnopek/Sync/Projects/default/godot-4/core/templates/command_queue_mt.h:238)
[8] RenderingServerDefault::_thread_loop() (/home/dsnopek/Sync/Projects/default/godot-4/servers/rendering/rendering_server_default.cpp:390)
[9] void call_with_variant_args_helper<RenderingServerDefault>(RenderingServerDefault*, void (RenderingServerDefault::*)(), Variant const**, Callable::CallError&, IndexSequence<>) (/home/dsnopek/Sync/Projects/default/godot-4/core/variant/binder_common.h:228 (discriminator 4))
[10] void call_with_variant_args<RenderingServerDefault>(RenderingServerDefault*, void (RenderingServerDefault::*)(), Variant const**, int, Callable::CallError&) (/home/dsnopek/Sync/Projects/default/godot-4/core/variant/binder_common.h:338)
[11] CallableCustomMethodPointer<RenderingServerDefault, void>::call(Variant const**, int, Variant&, Callable::CallError&) const (/home/dsnopek/Sync/Projects/default/godot-4/core/object/callable_method_pointer.h:107)
[12] Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const (/home/dsnopek/Sync/Projects/default/godot-4/core/variant/callable.cpp:57)
[13] Variant Callable::call<>() const (/home/dsnopek/Sync/Projects/default/godot-4/core/variant/variant.h:953)
[14] WorkerThreadPool::_process_task(WorkerThreadPool::Task*) (/home/dsnopek/Sync/Projects/default/godot-4/core/object/worker_thread_pool.cpp:144)
[15] WorkerThreadPool::_thread_function(void*) (/home/dsnopek/Sync/Projects/default/godot-4/core/object/worker_thread_pool.cpp:218)
[16] Thread::callback(unsigned long, Thread::Settings const&, void (*)(void*), void*) (/home/dsnopek/Sync/Projects/default/godot-4/core/os/thread.cpp:66)
[17] void std::__invoke_impl<void, void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(std::__invoke_other, void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:61)
[18] std::__invoke_result<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>::type std::__invoke<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*>(void (*&&)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long&&, Thread::Settings&&, void (*&&)(void*), void*&&) (/usr/include/c++/11/bits/invoke.h:97)
[19] void std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*> >::_M_invoke<0ul, 1ul, 2ul, 3ul, 4ul>(std::_Index_tuple<0ul, 1ul, 2ul, 3ul, 4ul>) (/usr/include/c++/11/bits/std_thread.h:259)
[20] std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*> >::operator()() (/usr/include/c++/11/bits/std_thread.h:266)
[21] std::thread::_State_impl<std::thread::_Invoker<std::tuple<void (*)(unsigned long, Thread::Settings const&, void (*)(void*), void*), unsigned long, Thread::Settings, void (*)(void*), void*> > >::_M_run() (/usr/include/c++/11/bits/std_thread.h:211)
[22] /home/dsnopek/Sync/Projects/default/godot-4/bin/godot.linuxbsd.editor.dev.x86_64(+0x99830e4) [0x5b723c7160e4] (thread.o:?)
[23] /lib/x86_64-linux-gnu/libc.so.6(+0x94ac3) [0x7256f2a94ac3] (??:0)
[24] /lib/x86_64-linux-gnu/libc.so.6(+0x126850) [0x7256f2b26850] (??:0)
-- END OF C++ BACKTRACE --
```
</details>

It appears that it's calling into `RenderingDevice::get_singleton()->make_current()`, but when running the project with OpenGL, it appears the `RenderingDevice` singleton is never created.