### PR TITLE
Prevent invalid and ambiguous tag names

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1014,6 +1014,24 @@ void ProjectManager::_set_new_tag_name(const String p_name) {
 		return;
 	}
 
+	if (p_name[0] == '_' || p_name[p_name.length() - 1] == '_') {
+		tag_error->set_text(TTRC("Tag name can't begin or end with underscore."));
+		return;
+	}
+
+	bool was_underscore = false;
+	for (const char32_t &c : p_name.span()) {
+		if (c == '_') {
+			if (was_underscore) {
+				tag_error->set_text(TTRC("Tag name can't contain consecutive underscores."));
+				return;
+			}
+			was_underscore = true;
+		} else {
+			was_underscore = false;
+		}
+	}
+
 	for (const String &c : forbidden_tag_characters) {
 		if (p_name.contains(c)) {
 			tag_error->set_text(vformat(TTRC("These characters are not allowed in tags: %s."), String(" ").join(forbidden_tag_characters)));
@@ -1830,6 +1848,8 @@ ProjectManager::ProjectManager() {
 		create_tag_btn->set_accessibility_name(TTRC("Create Tag"));
 		all_tags->add_child(create_tag_btn);
 		create_tag_btn->connect(SceneStringName(pressed), callable_mp((Window *)create_tag_dialog, &Window::popup_centered).bind(Vector2i(500, 0) * EDSCALE));
+
+		_set_new_tag_name("");
 	}
 
 	// Initialize project list.


### PR DESCRIPTION
When creating new tag, it was possible to accept the name immediately if you didn't make any changes, allowing for empty tag name.
<img width="198" height="88" alt="image" src="https://github.com/user-attachments/assets/dd94727f-78e1-4534-b58f-351499e3350d" />
This PR prevents that and also fixes #109050 along with a few similar cases.