### PR TITLE
Fix editor segfault when using a `Path3D` without a `Curve3D`

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -741,7 +741,7 @@ void Path3DEditorPlugin::edit(Object *p_object) {
 	} else {
 		Path3D *pre = path;
 		path = nullptr;
-		if (pre) {
+		if (pre && pre->get_curve().is_valid()) {
 			pre->get_curve()->emit_signal(CoreStringName(changed));
 		}
 	}


### PR DESCRIPTION
Fixes #109033.

That issue bisects to #104318. Previously, `make_visible(false)` was called first, which resulted in `path` getting set to `nullptr`. This meant that the `if (pre)` check wouldn't pass, and no crash would occur. 

The actual issue seems to be the lack of null guard, so I added one.