### PR TITLE
MacOS: Fix embedded screen_get_scale API

### DIFF
--- a/platform/macos/display_server_embedded.h
+++ b/platform/macos/display_server_embedded.h
@@ -39,10 +39,12 @@ class RenderingContextDriver;
 class RenderingDevice;
 
 struct DisplayServerEmbeddedState {
-	/// Default to a scale of 2.0, which is the most common.
+	/*! Default to a scale of 2.0, which is the most common. */
 	float screen_max_scale = 2.0f;
 	float screen_dpi = 96.0f;
-	/// The display ID of the window which is displaying the embedded process content.
+	/*! Scale for window displaying embedded content */
+	float screen_window_scale = 2.0f;
+	/*! The display ID of the window which is displaying the embedded process content. */
 	uint32_t display_id = -1;
 
 	void serialize(PackedByteArray &r_data);
@@ -157,6 +159,7 @@ public:
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_scale(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 
 	virtual Vector<DisplayServer::WindowID> get_window_list() const override;

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -542,6 +542,21 @@ int DisplayServerEmbedded::screen_get_dpi(int p_screen) const {
 	return 96;
 }
 
+float DisplayServerEmbedded::screen_get_scale(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	switch (p_screen) {
+		case SCREEN_WITH_MOUSE_FOCUS:
+		case SCREEN_WITH_KEYBOARD_FOCUS:
+		case SCREEN_PRIMARY:
+		case SCREEN_OF_MAIN_WINDOW:
+		case 0:
+			return state.screen_window_scale;
+		default:
+			return 1.0;
+	}
+}
+
 float DisplayServerEmbedded::screen_get_refresh_rate(int p_screen) const {
 	_THREAD_SAFE_METHOD_
 
@@ -830,15 +845,16 @@ void DisplayServerEmbedded::swap_buffers() {
 }
 
 void DisplayServerEmbeddedState::serialize(PackedByteArray &r_data) {
-	r_data.resize(12);
+	r_data.resize(16);
 
 	uint8_t *data = r_data.ptrw();
 	data += encode_float(screen_max_scale, data);
 	data += encode_float(screen_dpi, data);
+	data += encode_float(screen_window_scale, data);
 	data += encode_uint32(display_id, data);
 
 	// Assert we had enough space.
-	DEV_ASSERT((data - r_data.ptrw()) >= r_data.size());
+	DEV_ASSERT(r_data.size() >= (data - r_data.ptrw()));
 }
 
 Error DisplayServerEmbeddedState::deserialize(const PackedByteArray &p_data) {
@@ -847,6 +863,8 @@ Error DisplayServerEmbeddedState::deserialize(const PackedByteArray &p_data) {
 	screen_max_scale = decode_float(data);
 	data += sizeof(float);
 	screen_dpi = decode_float(data);
+	data += sizeof(float);
+	screen_window_scale = decode_float(data);
 	data += sizeof(float);
 	display_id = decode_uint32(data);
 

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -135,7 +135,10 @@ void EmbeddedProcessMacOS::display_state_changed() {
 	DisplayServerEmbeddedState state;
 	state.screen_max_scale = ds->screen_get_max_scale();
 	state.screen_dpi = ds->screen_get_dpi();
-	state.display_id = ds->window_get_display_id(window->get_window_id());
+	DisplayServer::WindowID wid = window->get_window_id();
+	state.screen_window_scale = ds->screen_get_scale(ds->window_get_current_screen(wid));
+	state.display_id = ds->window_get_display_id(wid);
+
 	PackedByteArray data;
 	state.serialize(data);
 	script_debugger->send_message("embed:ds_state", { data });


### PR DESCRIPTION
Closes #108949

This ensures that `screen_get_scale` returns the correct value for the window displaying the embedded content. If the window is moved, `screen_get_scale` will reflected the current screen.