### PR TITLE
Remove outdated note from EditorScript description

### DIFF
--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -29,7 +29,6 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] The script is run in the Editor context, which means the output is visible in the console window started with the Editor (stdout) instead of the usual Godot [b]Output[/b] dock.
 		[b]Note:[/b] EditorScript is [RefCounted], meaning it is destroyed when nothing references it. This can cause errors during asynchronous operations if there are no references to the script.
 	</description>
 	<tutorials>


### PR DESCRIPTION
I think it's outdated since Godot 3.0.