### PR TITLE
Add `visible_characters` and `visible_ratio` to `Label3D`

### DIFF
--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -23,6 +23,12 @@
 				Returns the value of the specified flag.
 			</description>
 		</method>
+		<method name="get_total_character_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total number of printable characters in the text (excluding spaces and newlines).
+			</description>
+		</method>
 		<method name="set_draw_flag">
 			<return type="void" />
 			<param index="0" name="flag" type="int" enum="Label3D.DrawFlags" />
@@ -135,6 +141,16 @@
 		</member>
 		<member name="vertical_alignment" type="int" setter="set_vertical_alignment" getter="get_vertical_alignment" enum="VerticalAlignment" default="1">
 			Controls the text's vertical alignment. Supports top, center, and bottom.
+		</member>
+		<member name="visible_characters" type="int" setter="set_visible_characters" getter="get_visible_characters" default="-1">
+			The number of characters to display. If set to [code]-1[/code], all characters are displayed. This can be useful when animating the text appearing in a dialog box.
+			[b]Note:[/b] Setting this property updates [member visible_ratio] accordingly.
+		</member>
+		<member name="visible_characters_behavior" type="int" setter="set_visible_characters_behavior" getter="get_visible_characters_behavior" enum="TextServer.VisibleCharactersBehavior" default="0">
+		</member>
+		<member name="visible_ratio" type="float" setter="set_visible_ratio" getter="get_visible_ratio" default="1.0">
+			The fraction of characters to display, relative to the total number of characters (see [method get_total_character_count]). If set to [code]1.0[/code], all characters are displayed. If set to [code]0.5[/code], only half of the characters will be displayed. This can be useful when animating the text appearing in a dialog box.
+			[b]Note:[/b] Setting this property updates [member visible_characters] accordingly.
 		</member>
 		<member name="width" type="float" setter="set_width" getter="get_width" default="500.0">
 			Text width (in pixels), used for autowrap and fill alignment.

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -128,6 +128,10 @@ private:
 
 	float line_spacing = 0.f;
 
+	TextServer::VisibleCharactersBehavior visible_chars_behavior = TextServer::VC_CHARS_BEFORE_SHAPING;
+	int visible_characters = -1;
+	float visible_ratio = 1.0;
+
 	String language;
 	TextServer::Direction text_direction = TextServer::DIRECTION_AUTO;
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
@@ -146,7 +150,9 @@ private:
 	bool dirty_font = true;
 	bool dirty_text = true;
 
-	void _generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, const Color &p_modulate, int p_priority = 0, int p_outline_size = 0);
+	bool _is_glyph_visible(const Glyph &p_glyph, int p_index, int p_total_glyphs);
+
+	void _generate_glyph_surfaces(int p_index, int p_total_glyphs, const Glyph &p_glyph, Vector2 &r_offset, const Color &p_modulate, int p_priority = 0, int p_outline_size = 0);
 
 protected:
 	GDVIRTUAL2RC(TypedArray<Vector3i>, _structured_text_parser, Array, String)
@@ -200,6 +206,17 @@ public:
 
 	void set_font_size(int p_size);
 	int get_font_size() const;
+
+	void set_visible_characters_behavior(TextServer::VisibleCharactersBehavior p_behavior);
+	TextServer::VisibleCharactersBehavior get_visible_characters_behavior() const;
+
+	void set_visible_characters(int p_amount);
+	int get_visible_characters() const;
+
+	void set_visible_ratio(float p_ratio);
+	float get_visible_ratio() const;
+
+	int get_total_character_count() const;
 
 	void set_outline_size(int p_size);
 	int get_outline_size() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12891

This pull request adds `visible_characters ` and `visible_ratio` to Label3D, these are meant to behave the same as they do in the 2d Label node. It can be useful for dialogue and any other cases where you have to gradually display text. 


https://github.com/user-attachments/assets/493cd02b-b9b1-4dfe-9790-0df725064dd2

<img width="482" height="112" alt="screenshot" src="https://github.com/user-attachments/assets/a338e8fd-e88e-4e93-8a2e-e995036a8386" />
