### PR TITLE
Fix `force_update_transform` not working on kinematic bodies

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -305,9 +305,10 @@ void GodotBody2D::set_state(PhysicsServer2D::BodyState p_state, const Variant &p
 				new_transform = p_variant;
 				//wakeup_neighbours();
 				set_active(true);
+				_set_transform(p_variant);
+				_set_inv_transform(get_transform().affine_inverse());
+
 				if (first_time_kinematic) {
-					_set_transform(p_variant);
-					_set_inv_transform(get_transform().affine_inverse());
 					first_time_kinematic = false;
 				}
 			} else if (mode == PhysicsServer2D::BODY_MODE_STATIC) {

--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -356,12 +356,12 @@ void GodotBody3D::set_state(PhysicsServer3D::BodyState p_state, const Variant &p
 				new_transform = p_variant;
 				//wakeup_neighbours();
 				set_active(true);
+				_set_transform(p_variant);
+				_set_inv_transform(get_transform().affine_inverse());
+
 				if (first_time_kinematic) {
-					_set_transform(p_variant);
-					_set_inv_transform(get_transform().affine_inverse());
 					first_time_kinematic = false;
 				}
-
 			} else if (mode == PhysicsServer3D::BODY_MODE_STATIC) {
 				_set_transform(p_variant);
 				_set_inv_transform(get_transform().affine_inverse());


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes #76256 

Test project: 
[force_update_transform_bug_2025-07-29.zip](https://github.com/user-attachments/files/21492725/force_update_transform_bug_2025-07-29.zip)

This was introduced way back in a change for this issue #776 (in 1.0 stable), had to do with _set_transform only being applied if the body was a first time kinematic.