### PR TITLE
Fix snapping logic in Range

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -64,7 +64,7 @@
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="0" />
 		<member name="step" type="float" setter="set_step" getter="get_step" default="0.01">
-			If greater than 0, [member value] will always be rounded to a multiple of this property's value. If [member rounded] is also [code]true[/code], [member value] will first be rounded to a multiple of this property's value, then rounded to the nearest integer.
+			If greater than 0, [member value] will always be rounded to a multiple of this property's value above [member min_value]. For example, if [member min_value] is [code]0.1[/code] and step is 0.2, then [member value] is limited to [code]0.1[/code], [code]0.3[/code], [code]0.5[/code], and so on. If [member rounded] is also [code]true[/code], [member value] will first be rounded to a multiple of this property's value, then rounded to the nearest integer.
 		</member>
 		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">
 			Range's current value. Changing this property (even via code) will trigger [signal value_changed] signal. Use [method set_value_no_signal] if you want to avoid it.

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -140,7 +140,9 @@ void Range::_set_value_no_signal(double p_val) {
 
 double Range::_calc_value(double p_val, double p_step) const {
 	if (p_step > 0) {
-		p_val = Math::round((p_val - shared->min) / p_step) * p_step + shared->min;
+		// TODO: In the future, change `step` to a more suitable type for more robust precise calculations.
+		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
+		p_val = Math::snapped(p_val - shared->min, p_step) + shared->min;
 	}
 
 	if (_rounded_values) {

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -30,6 +30,28 @@
 
 #include "range.h"
 
+#include "thirdparty/misc/r128.h"
+
+double Range::_snapped_r128(double p_value, double p_step) {
+	if (p_step != 0) {
+		// All these lines are the equivalent of: p_value = Math::floor(p_value / p_step + 0.5) * p_step;
+		// Convert to String to force rounding to a decimal value (not a binary one).
+		String step_str = String::num(p_step);
+		String value_str = String::num(p_value);
+		R128 step_r128;
+		R128 value_r128;
+		const R128 half_r128 = R128(0.5);
+		r128FromString(&step_r128, step_str.ascii().get_data(), nullptr);
+		r128FromString(&value_r128, value_str.ascii().get_data(), nullptr);
+		r128Div(&value_r128, &value_r128, &step_r128);
+		r128Add(&value_r128, &value_r128, &half_r128);
+		r128Floor(&value_r128, &value_r128);
+		r128Mul(&value_r128, &value_r128, &step_r128);
+		p_value = value_r128;
+	}
+	return p_value;
+}
+
 PackedStringArray Range::get_configuration_warnings() const {
 	PackedStringArray warnings = Control::get_configuration_warnings();
 
@@ -140,9 +162,8 @@ void Range::_set_value_no_signal(double p_val) {
 
 double Range::_calc_value(double p_val, double p_step) const {
 	if (p_step > 0) {
-		// TODO: In the future, change `step` to a more suitable type for more robust precise calculations.
 		// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
-		p_val = Math::snapped(p_val - shared->min, p_step) + shared->min;
+		p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;
 	}
 
 	if (_rounded_values) {

--- a/scene/gui/range.h
+++ b/scene/gui/range.h
@@ -62,6 +62,7 @@ class Range : public Control {
 	void _set_value_no_signal(double p_val);
 
 protected:
+	static double _snapped_r128(double p_value, double p_step);
 	double _calc_value(double p_val, double p_step) const;
 	virtual void _value_changed(double p_value);
 	void _notify_shared_value_changed() { shared->emit_value_changed(); }


### PR DESCRIPTION
This PR is a fix for issue https://github.com/godotengine/godot/issues/107095. Fixes https://github.com/godotengine/godot/issues/107095.

This PR changes Range's step feature to use `r128.h` instead of the existing algorithm.

In master:

```
0.1 -> 0.09999999999126885
0.2 -> 0.19999999999708962
0.3 -> 0.29999999998835847
0.4 -> 0.39999999999417923
0.5 -> 0.5
0.6 -> 0.5999999999912689
0.7 -> 0.6999999999970896
0.8 -> 0.7999999999883585
0.9 -> 0.8999999999941792
1.0 -> 1.0
1.1 -> 1.0999999999912689
1.2 -> 1.1999999999970896
1.3 -> 1.2999999999883585
```

With this PR: everything works as expected.

Old PR description:

<details>

This PR is a partial fix for issue https://github.com/godotengine/godot/issues/107095, but not a full fix.

This PR changes Range's step feature to use `Math::snapped` instead of this custom algorithm.

With this PR:

```
0.1 -> 0.09999999999999999
0.2 -> 0.19999999999999998
0.3 -> 0.3
0.4 -> 0.39999999999999997
0.5 -> 0.5
0.6 -> 0.6
0.7 -> 0.7
0.8 -> 0.7999999999999999
0.9 -> 0.8999999999999999
1.0 -> 1.0
1.1 -> 1.0999999999999999
1.2 -> 1.2
```

The new results with this PR are approximately 99.9995% closer to the desired value, and in some cases, match exactly.

Ok... but what about fixing this further? Unfortunately, it's not really possible to do that. The `step` value we're plugging into `Math::snapped` simply doesn't have enough precision for this. When a property hint has a step size of `0.001`, that gets converted into the nearest possible float, which is technically `0.00100000000000000002081668171172`. And, the number `0.1` is technically not a multiple of that value, even though it is a multiple of the decimal `0.001`.

The only solution I can think of to fix this further would be to use 128-bit floats instead of 64-bit floats, store the step size in 128-bit, do the math in 128-bit, and then store the computed value as 64-bit. If we were using C++23 or later, we could switch to [`std::float128_t`](https://en.cppreference.com/w/cpp/types/floating-point.html). Without C++23, the best we could do is platform-specific compiler extensions or a library. My recommendation is, for now, merge the 99.9995% fix in this PR while Godot uses C++17, and then we can switch the step size to 128-bit in the future when Godot requires C++23.