### PR TITLE
Avoid possible divide by zero in scene.

### DIFF
--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -510,7 +510,11 @@ void GPUParticles3D::_notification(int p_what) {
 		// Use internal process when emitting and one_shot is on so that when
 		// the shot ends the editor can properly update.
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			const Vector3 velocity = (get_global_position() - previous_position) / get_process_delta_time();
+			double delta = get_process_delta_time();
+			if (delta == 0) {
+				delta = CMP_EPSILON;
+			}
+			const Vector3 velocity = (get_global_position() - previous_position) / delta;
 
 			if (velocity != previous_velocity) {
 				RS::get_singleton()->particles_set_emitter_velocity(particles, velocity);
@@ -539,9 +543,13 @@ void GPUParticles3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			double delta = get_physics_process_delta_time();
+			if (delta == 0) {
+				delta = CMP_EPSILON;
+			}
 			// Update velocity in physics process, so that velocity calculations remain correct
 			// if the physics tick rate is lower than the rendered framerate (especially without physics interpolation).
-			const Vector3 velocity = (get_global_position() - previous_position) / get_physics_process_delta_time();
+			const Vector3 velocity = (get_global_position() - previous_position) / delta;
 
 			if (velocity != previous_velocity) {
 				RS::get_singleton()->particles_set_emitter_velocity(particles, velocity);

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -410,9 +410,13 @@ void ScrollBar::_notification(int p_what) {
 
 				} else {
 					if (time_since_motion == 0 || time_since_motion > 0.1) {
+						double delta = get_process_delta_time();
+						if (delta == 0) {
+							delta = CMP_EPSILON;
+						}
 						Vector2 diff = drag_node_accum - last_drag_node_accum;
 						last_drag_node_accum = drag_node_accum;
-						drag_node_speed = diff / get_process_delta_time();
+						drag_node_speed = diff / delta;
 					}
 
 					time_since_motion += get_process_delta_time();

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -581,9 +581,13 @@ void ScrollContainer::_notification(int p_what) {
 
 				} else {
 					if (time_since_motion == 0 || time_since_motion > 0.1) {
+						double delta = get_process_delta_time();
+						if (delta == 0) {
+							delta = CMP_EPSILON;
+						}
 						Vector2 diff = drag_accum - last_drag_accum;
 						last_drag_accum = drag_accum;
-						drag_speed = diff / get_process_delta_time();
+						drag_speed = diff / delta;
 					}
 
 					time_since_motion += get_process_delta_time();


### PR DESCRIPTION
Both of these functions are used in a divide, so returning 0 will just cause a crash.
