### PR TITLE
Fix error after renaming animation in Animation Library Editor

### DIFF
--- a/editor/animation/animation_library_editor.h
+++ b/editor/animation/animation_library_editor.h
@@ -104,8 +104,7 @@ class AnimationLibraryEditor : public AcceptDialog {
 	void _load_files(const PackedStringArray &p_paths);
 
 	void _save_mixer_lib_folding(TreeItem *p_item);
-	Vector<uint64_t> _load_mixer_libs_folding();
-	void _load_config_libs_folding(Vector<uint64_t> &p_lib_ids, ConfigFile *p_config, String p_section);
+	Vector<String> _load_mixer_libs_folding();
 	String _get_mixer_signature() const;
 
 	void _item_renamed();

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -259,16 +259,6 @@ bool AnimationMixer::has_animation_library(const StringName &p_name) const {
 	return false;
 }
 
-StringName AnimationMixer::get_animation_library_name(const Ref<AnimationLibrary> &p_animation_library) const {
-	ERR_FAIL_COND_V(p_animation_library.is_null(), StringName());
-	for (const AnimationLibraryData &lib : animation_libraries) {
-		if (lib.library == p_animation_library) {
-			return lib.name;
-		}
-	}
-	return StringName();
-}
-
 StringName AnimationMixer::find_animation_library(const Ref<Animation> &p_animation) const {
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		if (E.value.animation == p_animation) {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -403,7 +403,6 @@ public:
 	void get_animation_library_list(List<StringName> *p_animations) const;
 	Ref<AnimationLibrary> get_animation_library(const StringName &p_name) const;
 	bool has_animation_library(const StringName &p_name) const;
-	StringName get_animation_library_name(const Ref<AnimationLibrary> &p_animation_library) const;
 	StringName find_animation_library(const Ref<Animation> &p_animation) const;
 	Error add_animation_library(const StringName &p_name, const Ref<AnimationLibrary> &p_animation_library);
 	void remove_animation_library(const StringName &p_name);


### PR DESCRIPTION
Fixes #109088
Bugsquad edit: Fixes #115185

When nothing is collapsed, the stored `id` is empty. Spliting an empty string results in an array containing one empty string, thus creating a non-existing ID. According to #86481, when an ID does not exist, it should fall back to searching by name. But there is no fall back logic in `update_tree()`.

The spliting problem could have been avoided, as `ConfigFile` supports `Variant` values. It's unnecessary to manually serialize the array and the numbers inside.

But in the end, there is no point storing _both_ the instance ID and the corresponding name. This PR removes the dependency on instance IDs.