### PR TITLE
Forward mouse events to embedded no-focus windows.

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4686,7 +4686,7 @@ void EditorHelpBitTooltip::popup_under_cursor() {
 	// When `FLAG_POPUP` is false, it prevents the editor from losing focus when displaying the tooltip.
 	// This way, clicks and double-clicks are still available outside the tooltip.
 	set_flag(Window::FLAG_POPUP, false);
-	set_flag(Window::FLAG_NO_FOCUS, !is_embedded());
+	set_flag(Window::FLAG_NO_FOCUS, true);
 	popup(r);
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108409

Remove hacks previously used for embedded tooltips, and make embedded window mouse event handling more similar to native windows.