### PR TITLE
[3.x] `Batching` - Fix `MultiRect` casting to wrong type

### DIFF
--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -3209,59 +3209,35 @@ PREAMBLE(bool)::_sort_items_match(const BSortItem &p_a, const BSortItem &p_b) co
 		return false;
 	}
 
-	// tested outside function
-	//	if (a->commands.size() != 1)
-	//		return false;
-
-	const RasterizerCanvas::Item::Command &cb = *b->commands[0];
-	if ((cb.type != RasterizerCanvas::Item::Command::TYPE_RECT) && (cb.type != RasterizerCanvas::Item::Command::TYPE_MULTIRECT)) {
-		return false;
-	}
+	// Tested outside function.
+	// DEV_ASSERT(a->commands.size() == 1);
 
 	const RasterizerCanvas::Item::Command &ca = *a->commands[0];
-	// tested outside function
-	//	if (ca.type != Item::Command::TYPE_RECT)
-	//		return false;
+	const RasterizerCanvas::Item::Command &cb = *b->commands[0];
 
-	const RasterizerCanvas::Item::CommandRect *rect_a = static_cast<const RasterizerCanvas::Item::CommandRect *>(&ca);
-	const RasterizerCanvas::Item::CommandRect *rect_b = static_cast<const RasterizerCanvas::Item::CommandRect *>(&cb);
+	if ((ca.type == RasterizerCanvas::Item::Command::TYPE_RECT) && (cb.type == RasterizerCanvas::Item::Command::TYPE_RECT)) {
+		const RasterizerCanvas::Item::CommandRect *rect_a = static_cast<const RasterizerCanvas::Item::CommandRect *>(&ca);
+		const RasterizerCanvas::Item::CommandRect *rect_b = static_cast<const RasterizerCanvas::Item::CommandRect *>(&cb);
 
-	if (rect_a->texture != rect_b->texture) {
-		return false;
+		if (rect_a->texture != rect_b->texture) {
+			return false;
+		}
+
+		return true;
 	}
 
-	/* ALTERNATIVE APPROACH NOT LIMITED TO RECTS
-const RasterizerCanvas::Item::Command &ca = *a->commands[0];
-const RasterizerCanvas::Item::Command &cb = *b->commands[0];
+	if ((ca.type == RasterizerCanvas::Item::Command::TYPE_MULTIRECT) && (cb.type == RasterizerCanvas::Item::Command::TYPE_MULTIRECT)) {
+		const RasterizerCanvas::Item::CommandMultiRect *rect_a = static_cast<const RasterizerCanvas::Item::CommandMultiRect *>(&ca);
+		const RasterizerCanvas::Item::CommandMultiRect *rect_b = static_cast<const RasterizerCanvas::Item::CommandMultiRect *>(&cb);
 
-if (ca.type != cb.type)
+		if (rect_a->texture != rect_b->texture) {
+			return false;
+		}
+
+		return true;
+	}
+
 	return false;
-
-// do textures match?
-switch (ca.type)
-{
-default:
-	break;
-case RasterizerCanvas::Item::Command::TYPE_RECT:
-	{
-		const RasterizerCanvas::Item::CommandRect *comm_a = static_cast<const RasterizerCanvas::Item::CommandRect *>(&ca);
-		const RasterizerCanvas::Item::CommandRect *comm_b = static_cast<const RasterizerCanvas::Item::CommandRect *>(&cb);
-		if (comm_a->texture != comm_b->texture)
-			return false;
-	}
-	break;
-case RasterizerCanvas::Item::Command::TYPE_POLYGON:
-	{
-		const RasterizerCanvas::Item::CommandPolygon *comm_a = static_cast<const RasterizerCanvas::Item::CommandPolygon *>(&ca);
-		const RasterizerCanvas::Item::CommandPolygon *comm_b = static_cast<const RasterizerCanvas::Item::CommandPolygon *>(&cb);
-		if (comm_a->texture != comm_b->texture)
-			return false;
-	}
-	break;
-}
-*/
-
-	return true;
 }
 
 PREAMBLE(bool)::sort_items_from(int p_start) {


### PR DESCRIPTION
When investigating another UBSan bug I noticed an error report in the batching, sure enough I was not doing a proper check and casting to the wrong type with confusion between `Rect` and `MultiRect`.

Here we add proper check either for pair of `Rects` or pair of `MultiRects`, all other cases return false as before.

This fix prevents UB and possibly a memory leak(!).

The error log:
```
drivers/gles_common/rasterizer_canvas_batcher.h:3226:54: runtime error: downcast of address 0x60b0002d98b0 which does not point to an object of type 'CommandRect'
0x60b0002d98b0: note: object is of type 'RasterizerCanvas::Item::CommandMultiRect'
 be be be be  80 a6 da 1c 00 00 00 00  0c 00 00 00 be be be be  d0 2f 3c 00 10 61 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'RasterizerCanvas::Item::CommandMultiRect'
drivers/gles_common/rasterizer_canvas_batcher.h:32[27](https://github.com/lawnjelly/godot/actions/runs/16604074774/job/46971451983#step:13:28):54: runtime error: downcast of address 0x60b0002d9800 which does not point to an object of type 'CommandRect'
0x60b0002d9800: note: object is of type 'RasterizerCanvas::Item::CommandMultiRect'
 be be be be  80 a6 da 1c 00 00 00 00  0c 00 00 00 be be be be  d0 2f 3c 00 10 61 00 00  00 00 00 00
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'RasterizerCanvas::Item::CommandMultiRect'
drivers/gles3/rasterizer_canvas_gles3.cpp:1881:12: runtime error: load of value 190, which is not a valid value for type 'bool'
```

## Notes
* Must run this sanitizer build more often, there are a few more bugs here I can fix. 
* I probably introduced this bug in #68960

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
