### PR TITLE
Add `SVGTexture`support to `NinePatchRect`, `TextureProgressBar` and `StyleBoxTexture`.

### DIFF
--- a/doc/classes/SVGTexture.xml
+++ b/doc/classes/SVGTexture.xml
@@ -19,6 +19,12 @@
 				Creates a new [SVGTexture] and initializes it by allocating and setting the SVG data from string.
 			</description>
 		</method>
+		<method name="get_scaled_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of the texture rasterized to match the oversampling of the currently drawn canvas item.
+			</description>
+		</method>
 		<method name="get_source" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -45,7 +45,7 @@ void NinePatchRect::_notification(int p_what) {
 			texture->get_rect_region(rect, src_rect, rect, src_rect);
 
 			RID ci = get_canvas_item();
-			RS::get_singleton()->canvas_item_add_nine_patch(ci, rect, src_rect, texture->get_rid(), Vector2(margin[SIDE_LEFT], margin[SIDE_TOP]), Vector2(margin[SIDE_RIGHT], margin[SIDE_BOTTOM]), RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center);
+			RS::get_singleton()->canvas_item_add_nine_patch(ci, rect, src_rect, texture->get_scaled_rid(), Vector2(margin[SIDE_LEFT], margin[SIDE_TOP]), Vector2(margin[SIDE_RIGHT], margin[SIDE_BOTTOM]), RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center);
 		} break;
 	}
 }

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -424,7 +424,7 @@ void TextureProgressBar::draw_nine_patch_stretched(const Ref<Texture2D> &p_textu
 	p_texture->get_rect_region(dst_rect, src_rect, dst_rect, src_rect);
 
 	RID ci = get_canvas_item();
-	RS::get_singleton()->canvas_item_add_nine_patch(ci, dst_rect, src_rect, p_texture->get_rid(), topleft, bottomright, RS::NINE_PATCH_STRETCH, RS::NINE_PATCH_STRETCH, true, p_modulate);
+	RS::get_singleton()->canvas_item_add_nine_patch(ci, dst_rect, src_rect, p_texture->get_scaled_rid(), topleft, bottomright, RS::NINE_PATCH_STRETCH, RS::NINE_PATCH_STRETCH, true, p_modulate);
 }
 
 void TextureProgressBar::_notification(int p_what) {

--- a/scene/resources/style_box_texture.cpp
+++ b/scene/resources/style_box_texture.cpp
@@ -178,7 +178,7 @@ void StyleBoxTexture::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	Vector2 start_offset = Vector2(texture_margin[SIDE_LEFT], texture_margin[SIDE_TOP]);
 	Vector2 end_offset = Vector2(texture_margin[SIDE_RIGHT], texture_margin[SIDE_BOTTOM]);
 
-	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_rid(), start_offset, end_offset, RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center, modulate);
+	RenderingServer::get_singleton()->canvas_item_add_nine_patch(p_canvas_item, rect, src_rect, texture->get_scaled_rid(), start_offset, end_offset, RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center, modulate);
 }
 
 void StyleBoxTexture::_bind_methods() {

--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -273,7 +273,7 @@ bool SVGTexture::has_alpha() const {
 	return true;
 }
 
-void SVGTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
+RID SVGTexture::get_scaled_rid() const {
 	double scale = 1.0;
 	CanvasItem *ci = CanvasItem::get_current_item_drawn();
 	if (ci) {
@@ -282,37 +282,19 @@ void SVGTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_mod
 			scale = vp->get_oversampling();
 		}
 	}
-	RID rid = _ensure_scale(scale);
+	return _ensure_scale(scale);
+}
 
-	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, size), rid, false, p_modulate, p_transpose);
+void SVGTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, size), get_scaled_rid(), false, p_modulate, p_transpose);
 }
 
 void SVGTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {
-	double scale = 1.0;
-	CanvasItem *ci = CanvasItem::get_current_item_drawn();
-	if (ci) {
-		Viewport *vp = ci->get_viewport();
-		if (vp) {
-			scale = vp->get_oversampling();
-		}
-	}
-	RID rid = _ensure_scale(scale);
-
-	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, p_rect, rid, p_tile, p_modulate, p_transpose);
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, p_rect, get_scaled_rid(), p_tile, p_modulate, p_transpose);
 }
 
 void SVGTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) const {
-	double scale = 1.0;
-	CanvasItem *ci = CanvasItem::get_current_item_drawn();
-	if (ci) {
-		Viewport *vp = ci->get_viewport();
-		if (vp) {
-			scale = vp->get_oversampling();
-		}
-	}
-	RID rid = _ensure_scale(scale);
-
-	RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, rid, p_src_rect, p_modulate, p_transpose, p_clip_uv);
+	RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, get_scaled_rid(), p_src_rect, p_modulate, p_transpose, p_clip_uv);
 }
 
 bool SVGTexture::is_pixel_opaque(int p_x, int p_y) const {
@@ -382,6 +364,7 @@ void SVGTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_color_map", "color_map"), &SVGTexture::set_color_map);
 	ClassDB::bind_method(D_METHOD("get_color_map"), &SVGTexture::get_color_map);
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &SVGTexture::set_size_override);
+	ClassDB::bind_method(D_METHOD("get_scaled_rid"), &SVGTexture::get_scaled_rid);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "_source", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_STORAGE), "set_source", "get_source");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "base_scale", PROPERTY_HINT_RANGE, "0.01,10.0,0.01"), "set_base_scale", "get_base_scale");

--- a/scene/resources/svg_texture.h
+++ b/scene/resources/svg_texture.h
@@ -91,6 +91,7 @@ public:
 	virtual RID get_rid() const override;
 
 	bool has_alpha() const override;
+	virtual RID get_scaled_rid() const override;
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -66,6 +66,7 @@ public:
 
 	virtual bool has_alpha() const;
 
+	virtual RID get_scaled_rid() const { return get_rid(); }
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109106