### PR TITLE
Fix external resource IDs being lost for default properties

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -672,25 +672,25 @@ void Resource::set_as_translation_remapped(bool p_remapped) {
 }
 
 // Helps keep IDs the same when loading/saving scenes. An empty ID clears the entry, and an empty ID is returned when not found.
-void Resource::set_id_for_path(const String &p_path, const String &p_id) {
+void Resource::set_resource_id_for_path(const String &p_referrer_path, const String &p_resource_path, const String &p_id) {
 #ifdef TOOLS_ENABLED
 	if (p_id.is_empty()) {
 		ResourceCache::path_cache_lock.write_lock();
-		ResourceCache::resource_path_cache[p_path].erase(get_path());
+		ResourceCache::resource_path_cache[p_referrer_path].erase(p_resource_path);
 		ResourceCache::path_cache_lock.write_unlock();
 	} else {
 		ResourceCache::path_cache_lock.write_lock();
-		ResourceCache::resource_path_cache[p_path][get_path()] = p_id;
+		ResourceCache::resource_path_cache[p_referrer_path][p_resource_path] = p_id;
 		ResourceCache::path_cache_lock.write_unlock();
 	}
 #endif
 }
 
-String Resource::get_id_for_path(const String &p_path) const {
+String Resource::get_id_for_path(const String &p_referrer_path) const {
 #ifdef TOOLS_ENABLED
 	ResourceCache::path_cache_lock.read_lock();
-	if (ResourceCache::resource_path_cache[p_path].has(get_path())) {
-		String result = ResourceCache::resource_path_cache[p_path][get_path()];
+	if (ResourceCache::resource_path_cache[p_referrer_path].has(get_path())) {
+		String result = ResourceCache::resource_path_cache[p_referrer_path][get_path()];
 		ResourceCache::path_cache_lock.read_unlock();
 		return result;
 	} else {

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -181,8 +181,9 @@ public:
 	virtual RID get_rid() const; // Some resources may offer conversion to RID.
 
 	// Helps keep IDs the same when loading/saving scenes. An empty ID clears the entry, and an empty ID is returned when not found.
-	void set_id_for_path(const String &p_path, const String &p_id);
-	String get_id_for_path(const String &p_path) const;
+	static void set_resource_id_for_path(const String &p_referrer_path, const String &p_resource_path, const String &p_id);
+	void set_id_for_path(const String &p_referrer_path, const String &p_id) { set_resource_id_for_path(p_referrer_path, get_path(), p_id); }
+	String get_id_for_path(const String &p_referrer_path) const;
 
 	Resource();
 	~Resource();

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -157,10 +157,6 @@ Error ResourceLoaderText::_parse_ext_resource(VariantParser::Stream *p_stream, R
 					}
 				}
 			} else {
-#ifdef TOOLS_ENABLED
-				//remember ID for saving
-				res->set_id_for_path(local_path, id);
-#endif
 				r_res = res;
 			}
 		} else {
@@ -485,6 +481,13 @@ Error ResourceLoaderText::load() {
 
 		resource_current++;
 	}
+
+#ifdef TOOLS_ENABLED
+	for (const KeyValue<String, ExtResource> &E : ext_resources) {
+		// Remember ID for saving.
+		Resource::set_resource_id_for_path(local_path, E.value.path, E.key);
+	}
+#endif
 
 	//these are the ones that count
 	resources_total -= resource_current;


### PR DESCRIPTION
Fixes #108973.

This fixes the issue where certain `[ext_resource ...]` entries in `*.tres` files would end up with new IDs after upgrading from 4.4 to 4.5, due to there no longer being an `ExtResource` reference in the resource file if the property referencing it was left at its default value (and thus omitted entirely).

This is achieved by simply moving where we cache these `ext_resource` IDs, so that it's now done for every `ext_resource` entry as opposed to for every `ExtResource` reference.