### PR TITLE
Fix `Image` nearest and cubic resizing bias

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -801,13 +801,13 @@ static void _scale_cubic(const uint8_t *__restrict p_src, uint8_t *__restrict p_
 
 	for (uint32_t y = 0; y < p_dst_height; y++) {
 		// Y coordinates
-		oy = (double)y * yfac - 0.5f;
+		oy = (double)(y + 0.5) * yfac - 0.5;
 		oy1 = (int)oy;
 		dy = oy - (double)oy1;
 
 		for (uint32_t x = 0; x < p_dst_width; x++) {
 			// X coordinates
-			ox = (double)x * xfac - 0.5f;
+			ox = (double)(x + 0.5) * xfac - 0.5;
 			ox1 = (int)ox;
 			dx = ox - (double)ox1;
 
@@ -815,10 +815,7 @@ static void _scale_cubic(const uint8_t *__restrict p_src, uint8_t *__restrict p_
 
 			T *__restrict dst = ((T *)p_dst) + (y * p_dst_width + x) * CC;
 
-			double color[CC];
-			for (int i = 0; i < CC; i++) {
-				color[i] = 0;
-			}
+			double color[CC] = {};
 
 			for (int n = -1; n < 3; n++) {
 				// get Y coefficient
@@ -961,11 +958,11 @@ static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict
 template <int CC, typename T>
 static void _scale_nearest(const uint8_t *__restrict p_src, uint8_t *__restrict p_dst, uint32_t p_src_width, uint32_t p_src_height, uint32_t p_dst_width, uint32_t p_dst_height) {
 	for (uint32_t i = 0; i < p_dst_height; i++) {
-		uint32_t src_yofs = i * p_src_height / p_dst_height;
+		uint32_t src_yofs = (i + 0.5) * p_src_height / p_dst_height;
 		uint32_t y_ofs = src_yofs * p_src_width * CC;
 
 		for (uint32_t j = 0; j < p_dst_width; j++) {
-			uint32_t src_xofs = j * p_src_width / p_dst_width;
+			uint32_t src_xofs = (j + 0.5) * p_src_width / p_dst_width;
 			src_xofs *= CC;
 
 			for (uint32_t l = 0; l < CC; l++) {


### PR DESCRIPTION
Fixes #109092.

<details>

```gdscript
extends Node2D

func _ready() -> void:
        # Downscale: 128px -> 21px
	var tex:Texture2D = load("res://icon.svg")
	var img:=tex.get_image().duplicate()
	img.resize(21,21,Image.INTERPOLATE_BILINEAR)
	img.save_png("res://tex_bilinear.png")

	img=tex.get_image().duplicate()
	img.resize(21,21,Image.INTERPOLATE_CUBIC)
	img.save_png("res://tex_cubic.png")

	img=tex.get_image().duplicate()
	img.resize(21,21,Image.INTERPOLATE_NEAREST)
	img.save_png("res://tex_nearset.png")
	
	img=tex.get_image().duplicate()
	img.resize(21,21,Image.INTERPOLATE_TRILINEAR)
	img.save_png("res://tex_trilinear.png")

	img=tex.get_image().duplicate()
	img.resize(21,21,Image.INTERPOLATE_LANCZOS)
	img.save_png("res://tex_lanczos.png")

```

</details>

| - |Nearest | Cubic |
| - | - | - |
|This PR|<img width="64" height="64" alt="tex_nearset_d" src="https://github.com/user-attachments/assets/b965afde-80d5-45a9-a318-f2cc57be4e95" />|<img width="64" height="64" alt="tex_cubic" src="https://github.com/user-attachments/assets/b5e47447-7aef-49b8-80ee-aa25ff5b12b6" />|
| 4.4 |<img width="64" height="64" alt="tex_nearset_d" src="https://github.com/user-attachments/assets/c9688604-b0c5-45b4-9873-bfe0fab0edc2" />|<img width="64" height="64" alt="tex_cubic_d" src="https://github.com/user-attachments/assets/e72537a4-20c9-48d2-8af8-a427187bf13e" />|
|GIMP|<img width="64" height="64" alt="icon_gimp_nearest" src="https://github.com/user-attachments/assets/3dacfa43-c243-487c-8ef0-d0a65d0e5dfb" />|<img width="64" height="64" alt="icon_gimp_cubic" src="https://github.com/user-attachments/assets/93a452f9-1de1-431a-a47d-f1137caadf16" />|

Comparison with other algorithms:
| Bilinear| Trilinear| Lanczos|
| - | -| - |
|<img width="64" height="64" alt="tex_bilinear" src="https://github.com/user-attachments/assets/9ca8ac44-6586-4e0f-934a-a6e6e3efe95e" />|<img width="64" height="64" alt="tex_trilinear" src="https://github.com/user-attachments/assets/2130f80c-ee21-45e1-ad45-3935e70899c6" />|<img width="64" height="64" alt="tex_lanczos" src="https://github.com/user-attachments/assets/bff9092f-90d0-41b2-9aa7-2c50258fb07d" />|

(I don't known why the cubic scaling in GIMP is different from Godot's. I can't find any other issues with Godot's implementation)