### PR TITLE
[3.x] Fix some `UBSan` warnings

### DIFF
--- a/core/class_db.cpp
+++ b/core/class_db.cpp
@@ -425,6 +425,9 @@ uint64_t ClassDB::get_api_hash(APIType p_api) {
 
 			for (List<StringName>::Element *F = snames.front(); F; F = F->next()) {
 				hash = hash_djb2_one_64(F->get().hash(), hash);
+
+				// Note: Casting an int to uint64_t is picked up by UBSan,
+				// this could cause dodgy hashes.
 				hash = hash_djb2_one_64(t->constant_map[F->get()], hash);
 			}
 		}

--- a/core/command_queue_mt.h
+++ b/core/command_queue_mt.h
@@ -326,7 +326,7 @@ class CommandQueueMT {
 	template <class T>
 	T *allocate() {
 		// alloc size is size+T+safeguard
-		uint32_t alloc_size = ((sizeof(T) + 8 - 1) & ~(8 - 1)) + 8;
+		uint32_t alloc_size = (((sizeof(T) + 8) - 1) & (~(uint32_t)(8 - 1))) + 8;
 
 		// Assert that the buffer is big enough to hold at least two messages.
 		ERR_FAIL_COND_V(alloc_size * 2 + sizeof(uint32_t) > command_mem_size, nullptr);
@@ -376,7 +376,8 @@ class CommandQueueMT {
 		// Allocate the size and the 'in use' bit.
 		// First bit used to mark if command is still in use (1)
 		// or if it has been destroyed and can be deallocated (0).
-		uint32_t size = (sizeof(T) + 8 - 1) & ~(8 - 1);
+		uint32_t size = ((sizeof(T) + 8) - 1) & (~(uint32_t)(8 - 1));
+
 		uint32_t *p = (uint32_t *)&command_mem[write_ptr];
 		*p = (size << 1) | 1;
 		write_ptr += 8;
@@ -445,7 +446,7 @@ class CommandQueueMT {
 
 		cmd->post();
 		cmd->~CommandBase();
-		*(uint32_t *)&command_mem[size_ptr] &= ~1;
+		*(uint32_t *)&command_mem[size_ptr] &= ~(uint32_t)1;
 
 		if (p_lock) {
 			unlock();

--- a/core/hashfuncs.h
+++ b/core/hashfuncs.h
@@ -81,7 +81,7 @@ static inline uint32_t hash_one_uint64(uint64_t p_int) {
 	v = v ^ (v >> 11);
 	v = v + (v << 6);
 	v = v ^ (v >> 22);
-	return (int)v;
+	return (uint32_t)v;
 }
 
 static inline uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev = 5381) {

--- a/core/image.cpp
+++ b/core/image.cpp
@@ -709,7 +709,7 @@ static void _scale_bilinear(const uint8_t *__restrict p_src, uint8_t *__restrict
 					uint32_t interp_down = p01 + (((p11 - p01) * src_xofs_frac) >> FRAC_BITS);
 					uint32_t interp = interp_up + (((interp_down - interp_up) * src_yofs_frac) >> FRAC_BITS);
 					interp >>= FRAC_BITS;
-					p_dst[i * p_dst_width * CC + j * CC + l] = interp;
+					p_dst[i * p_dst_width * CC + j * CC + l] = (uint8_t)interp;
 				} else if (sizeof(T) == 2) { //half float
 
 					float xofs_frac = float(src_xofs_frac) / (1 << FRAC_BITS);

--- a/core/pooled_list.h
+++ b/core/pooled_list.h
@@ -185,7 +185,7 @@ public:
 		U list_id = _active_map[p_id];
 
 		// zero the _active map to detect bugs (only in debug?)
-		_active_map[p_id] = -1;
+		_active_map[p_id] = std::numeric_limits<U>::max();
 
 		_active_list.remove_unordered(list_id);
 

--- a/core/rid_handle.h
+++ b/core/rid_handle.h
@@ -108,7 +108,7 @@ public:
 	}
 	bool is_valid() const { return _id != 0; }
 
-	uint32_t get_id() const { return _id ? _handle_data : 0; }
+	uint32_t get_id() const { return _id ? _id : 0; }
 };
 
 class RID : public RID_Handle {

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2520,6 +2520,9 @@ uint32_t Variant::recursive_hash(int p_recursion_count) const {
 			return _data._bool ? 1 : 0;
 		} break;
 		case INT: {
+			// Note: This is flagged by UBSan.
+			// Casting from int64_t to uint32_t is *implementation defined* behaviour
+			// rather than UB, but is still suspect.
 			return _data._int;
 		} break;
 		case REAL: {

--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -137,7 +137,7 @@ void RasterizerCanvasBaseGLES2::canvas_begin() {
 void RasterizerCanvasBaseGLES2::canvas_end() {
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (uint32_t i = 0; i < VS::ARRAY_MAX; i++) {
 		glDisableVertexAttribArray(i);
 	}
 
@@ -910,7 +910,7 @@ void RasterizerCanvasBaseGLES2::draw_lens_distortion_rect(const Rect2 &p_rect, f
 	// and cleanup
 	glBindBuffer(GL_ARRAY_BUFFER, 0);
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (uint32_t i = 0; i < VS::ARRAY_MAX; i++) {
 		glDisableVertexAttribArray(i);
 	}
 }

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -886,7 +886,7 @@ void RasterizerCanvasGLES2::render_batches(Item *p_current_clip, bool &r_reclip,
 										glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_id);
 									}
 
-									for (int k = 0; k < VS::ARRAY_MAX - 1; k++) {
+									for (int k = 0; k < (int)VS::ARRAY_MAX - 1; k++) {
 										if (s->attribs[k].enabled) {
 											glEnableVertexAttribArray(k);
 											glVertexAttribPointer(s->attribs[k].index, s->attribs[k].size, s->attribs[k].type, s->attribs[k].normalized, s->attribs[k].stride, CAST_INT_TO_UCHAR_PTR(s->attribs[k].offset));
@@ -913,7 +913,7 @@ void RasterizerCanvasGLES2::render_batches(Item *p_current_clip, bool &r_reclip,
 									}
 								}
 
-								for (int j = 1; j < VS::ARRAY_MAX - 1; j++) {
+								for (uint32_t j = 1; j < VS::ARRAY_MAX - 1; j++) {
 									glDisableVertexAttribArray(j);
 								}
 							}
@@ -983,7 +983,7 @@ void RasterizerCanvasGLES2::render_batches(Item *p_current_clip, bool &r_reclip,
 									glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_id);
 								}
 
-								for (int k = 0; k < VS::ARRAY_MAX - 1; k++) {
+								for (int k = 0; k < (int)VS::ARRAY_MAX - 1; k++) {
 									if (s->attribs[k].enabled) {
 										glEnableVertexAttribArray(k);
 										glVertexAttribPointer(s->attribs[k].index, s->attribs[k].size, s->attribs[k].type, s->attribs[k].normalized, s->attribs[k].stride, CAST_INT_TO_UCHAR_PTR(s->attribs[k].offset));

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -668,7 +668,7 @@ bool RasterizerSceneGLES2::reflection_probe_instance_postprocess_step(RID p_inst
 		glDisable(GL_BLEND);
 		glDepthMask(GL_FALSE);
 
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			glDisableVertexAttribArray(i);
 		}
 	}
@@ -1483,7 +1483,7 @@ void RasterizerSceneGLES2::_setup_geometry(RenderList::Element *p_element, Raste
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_id);
 			}
 
-			for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+			for (int i = 0; i < (int)VS::ARRAY_MAX - 1; i++) {
 				if (s->attribs[i].enabled) {
 					glEnableVertexAttribArray(i);
 
@@ -1664,7 +1664,7 @@ void RasterizerSceneGLES2::_setup_geometry(RenderList::Element *p_element, Raste
 				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_id);
 			}
 
-			for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+			for (int i = 0; i < (int)VS::ARRAY_MAX - 1; i++) {
 				if (s->attribs[i].enabled) {
 					glEnableVertexAttribArray(i);
 					glVertexAttribPointer(s->attribs[i].index, s->attribs[i].size, s->attribs[i].type, s->attribs[i].normalized, s->attribs[i].stride, CAST_INT_TO_UCHAR_PTR(s->attribs[i].offset));

--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -1198,7 +1198,7 @@ void RasterizerStorageGLES2::sky_set_texture(RID p_sky, RID p_panorama, int p_ra
 		glDisable(GL_SCISSOR_TEST);
 		glDisable(GL_BLEND);
 
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			glDisableVertexAttribArray(i);
 		}
 	}
@@ -2092,7 +2092,7 @@ static PoolVector<uint8_t> _unpack_half_floats(const PoolVector<uint8_t> &array,
 	int src_stride = 0;
 	int dst_stride = 0;
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		to_convert[i] = 0;
 		if (!(p_format & (1 << i))) {
 			src_size[i] = 0;
@@ -2238,7 +2238,7 @@ static PoolVector<uint8_t> _unpack_half_floats(const PoolVector<uint8_t> &array,
 	int src_offset = 0;
 	int dst_offset = 0;
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		if (src_size[i] == 0) {
 			continue; //no go
 		}
@@ -2296,7 +2296,7 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	int positions_stride = 0;
 	bool uses_half_float = false;
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		attribs[i].index = i;
 
 		if (!(p_format & (1 << i))) {
@@ -2480,11 +2480,11 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 
 	if (use_split_stream) {
 		attribs[VS::ARRAY_VERTEX].stride = positions_stride;
-		for (int i = 1; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 1; i < VS::ARRAY_MAX - 1; i++) {
 			attribs[i].stride = attributes_stride;
 		}
 	} else {
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			attribs[i].stride = positions_stride + attributes_stride;
 		}
 	}
@@ -2575,7 +2575,7 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 		surface->skeleton_bone_used.write[i] = !(surface->skeleton_bone_aabb[i].size.x < 0 || surface->skeleton_bone_aabb[i].size.y < 0 || surface->skeleton_bone_aabb[i].size.z < 0);
 	}
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (uint32_t i = 0; i < VS::ARRAY_MAX; i++) {
 		surface->attribs[i] = attribs[i];
 	}
 
@@ -3873,7 +3873,7 @@ void RasterizerStorageGLES2::update_dirty_blend_shapes() {
 					}
 				}
 
-				for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+				for (int i = 0; i < (int)VS::ARRAY_MAX - 1; i++) {
 					if (s->attribs[i].enabled) {
 						// Read all attributes
 						for (int j = 0; j < s->array_len; j++) {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -3397,7 +3397,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 	int attributes_stride = 0;
 	int positions_stride = 0;
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		attribs[i].index = i;
 
 		if (!(p_format & (1 << i))) {
@@ -3580,11 +3580,11 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 
 	if (use_split_stream) {
 		attribs[VS::ARRAY_VERTEX].stride = positions_stride;
-		for (int i = 1; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 1; i < VS::ARRAY_MAX - 1; i++) {
 			attribs[i].stride = attributes_stride;
 		}
 	} else {
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			attribs[i].stride = positions_stride + attributes_stride;
 		}
 	}
@@ -3659,7 +3659,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 		}
 	}
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (uint32_t i = 0; i < VS::ARRAY_MAX; i++) {
 		surface->attribs[i] = attribs[i];
 	}
 
@@ -3695,7 +3695,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 				glBindBuffer(GL_ARRAY_BUFFER, surface->vertex_id);
 			}
 
-			for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+			for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 				if (!attribs[i].enabled) {
 					continue;
 				}
@@ -3793,7 +3793,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 					glBindBuffer(GL_ARRAY_BUFFER, surface->vertex_id);
 				}
 
-				for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+				for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 					if (!attribs[i].enabled) {
 						continue;
 					}
@@ -3836,7 +3836,7 @@ void RasterizerStorageGLES3::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 			glBindVertexArray(mt.array_id);
 			glBindBuffer(GL_ARRAY_BUFFER, mt.vertex_id);
 
-			for (int j = 0; j < VS::ARRAY_MAX - 1; j++) {
+			for (uint32_t j = 0; j < VS::ARRAY_MAX - 1; j++) {
 				if (!attribs[j].enabled) {
 					continue;
 				}
@@ -4306,7 +4306,7 @@ void RasterizerStorageGLES3::mesh_render_blend_shapes(Surface *s, const float *p
 		4 * 4
 	};
 
-	for (int i = 1; i < VS::ARRAY_MAX - 1; i++) {
+	for (int i = 1; i < (int)VS::ARRAY_MAX - 1; i++) {
 		shaders.blend_shapes.set_conditional(cond[i], s->format & (1 << i)); //enable conditional for format
 		if (s->format & (1 << i)) {
 			stride += sizes[i];
@@ -4356,7 +4356,7 @@ void RasterizerStorageGLES3::mesh_render_blend_shapes(Surface *s, const float *p
 		shaders.blend_shapes.set_uniform(BlendShapeShaderGLES3::BLEND_AMOUNT, weight);
 
 		int ofs = 0;
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (int i = 0; i < (int)VS::ARRAY_MAX - 1; i++) {
 			if (s->format & (1 << i)) {
 				glEnableVertexAttribArray(i + 8);
 				switch (i) {
@@ -4424,7 +4424,7 @@ void RasterizerStorageGLES3::mesh_render_blend_shapes(Surface *s, const float *p
 	glBindBuffer(GL_ARRAY_BUFFER, resources.transform_feedback_buffers[0]);
 
 	int ofs = 0;
-	for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX - 1; i++) {
 		if (s->format & (1 << i)) {
 			glEnableVertexAttribArray(i);
 			switch (i) {

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -1072,9 +1072,10 @@ void ShaderGLES3::_setup_uniforms(CustomCode *p_cc) const {
 
 	// assign uniform block bind points
 	for (int i = 0; i < ubo_count; i++) {
-		GLint loc = glGetUniformBlockIndex(version->ids.main, ubo_pairs[i].name);
-		if (loc >= 0)
+		GLuint loc = glGetUniformBlockIndex(version->ids.main, ubo_pairs[i].name);
+		if (loc != GL_INVALID_INDEX) {
 			glUniformBlockBinding(version->ids.main, loc, ubo_pairs[i].index);
+		}
 	}
 
 	if (p_cc) {

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -437,9 +437,9 @@ int ShaderGLES3::_get_uniform(int p_which) const {
 void ShaderGLES3::_set_conditional(int p_which, bool p_value) {
 	ERR_FAIL_INDEX(p_which, conditional_count);
 	if (p_value) {
-		new_conditional_version.version |= (1 << p_which);
+		new_conditional_version.version |= (1 << (uint32_t)p_which);
 	} else {
-		new_conditional_version.version &= ~(1 << p_which);
+		new_conditional_version.version &= ~(uint32_t)(1 << (uint32_t)p_which);
 	}
 }
 

--- a/drivers/png/image_loader_png.cpp
+++ b/drivers/png/image_loader_png.cpp
@@ -61,6 +61,12 @@ Ref<Image> ImageLoaderPNG::load_mem_png(const uint8_t *p_png, int p_size) {
 	Ref<Image> img;
 	img.instance();
 
+	// Note:
+	// For some png loading, p_size is set to -1 on entry, even though p_png is valid.
+	// p_size casts to a very large value when calling png_to_image.
+	// It seems to work okay, but flags with UBSan.
+	// Could do with investigation.
+
 	// the value of p_force_linear does not matter since it only applies to 16 bit
 	Error err = PNGDriverCommon::png_to_image(p_png, p_size, false, img);
 	ERR_FAIL_COND_V(err, Ref<Image>());

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -508,8 +508,15 @@ void SpatialEditorViewport::_update_camera(float p_interp_delta) {
 			const float translation_inertia = EDITOR_GET_CACHED(float, "editors/3d/navigation_feel/translation_inertia");
 			const float zoom_inertia = EDITOR_GET_CACHED(float, "editors/3d/navigation_feel/zoom_inertia");
 
-			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
-			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, MIN(1.f, p_interp_delta * (1 / orbit_inertia)));
+			float lerp_fraction = 1;
+
+			// Prevent divide by zero.
+			if (orbit_inertia > CMP_EPSILON) {
+				lerp_fraction = MIN(1.f, p_interp_delta * (1 / orbit_inertia));
+			}
+
+			camera_cursor.x_rot = Math::lerp(old_camera_cursor.x_rot, cursor.x_rot, lerp_fraction);
+			camera_cursor.y_rot = Math::lerp(old_camera_cursor.y_rot, cursor.y_rot, lerp_fraction);
 
 			if (Math::abs(camera_cursor.x_rot - cursor.x_rot) < 0.1) {
 				camera_cursor.x_rot = cursor.x_rot;

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -51,7 +51,7 @@ protected:
 	NodePath skeleton_path;
 
 	struct SoftwareSkinning {
-		enum Flags {
+		enum Flags : uint32_t {
 			// Data flags.
 			FLAG_TRANSFORM_NORMALS = 1 << 0,
 

--- a/scene/3d/room_manager.h
+++ b/scene/3d/room_manager.h
@@ -262,7 +262,7 @@ private:
 	real_t _settings_roaming_expansion_margin = 1.0;
 
 	// debug override camera
-	ObjectID _godot_preview_camera_ID = -1;
+	ObjectID _godot_preview_camera_ID = std::numeric_limits<ObjectID>::max();
 	// local version of the godot camera frustum,
 	// to prevent updating the visual server (and causing
 	// a screen refresh) where not necessary.

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -990,12 +990,12 @@ void ArrayMesh::add_surface_from_arrays_cpu(PrimitiveType p_primitive, const Arr
 	s->arrays = p_arrays;
 	s->blend_shapes = p_blend_shapes;
 
-	if (p_arrays.size() > VS::ARRAY_VERTEX) {
+	if (p_arrays.size() > (int)VS::ARRAY_VERTEX) {
 		// This is horrible but VisualServer uses this .. it may do a conversion to PoolVector3Array?
 		// Maybe this rarely happens.
 		s->num_verts = PoolVector3Array(p_arrays[VS::ARRAY_VERTEX]).size();
 	}
-	if (p_arrays.size() > VS::ARRAY_INDEX) {
+	if (p_arrays.size() > (int)VS::ARRAY_INDEX) {
 		s->num_inds = PoolIntArray(p_arrays[VS::ARRAY_INDEX]).size();
 	}
 }

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -121,13 +121,14 @@ public:
 };
 
 class AudioDriverManager {
-	enum {
+	enum : int32_t {
 
 		MAX_DRIVERS = 10
 	};
 
 public:
-	enum MuteFlags {
+	// Specify uint32_t to prevent UBSan errors on bitwise operations.
+	enum MuteFlags : uint32_t {
 		// User enables or disables audio, e.g. via button in editor.
 		MUTE_FLAG_DISABLED = 1 << 0,
 		// Whether app is in focus.

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -118,7 +118,7 @@ public:
 			disable_3d_by_usage = false;
 			keep_3d_linear = false;
 			debug_draw = VS::VIEWPORT_DEBUG_DRAW_DISABLED;
-			for (int i = 0; i < VS::VIEWPORT_RENDER_INFO_MAX; i++) {
+			for (uint32_t i = 0; i < VS::VIEWPORT_RENDER_INFO_MAX; i++) {
 				render_info[i] = 0;
 			}
 			use_arvr = false;

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -406,7 +406,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 
 	int max_bone = 0;
 
-	for (int ai = 0; ai < VS::ARRAY_MAX; ai++) {
+	for (int ai = 0; ai < (int)VS::ARRAY_MAX; ai++) {
 		if (!(p_format & (1 << ai))) { // no array
 			continue;
 		}
@@ -857,7 +857,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 }
 
 uint32_t VisualServer::mesh_surface_get_format_offset(uint32_t p_format, int p_vertex_len, int p_index_len, int p_array_index) const {
-	ERR_FAIL_INDEX_V(p_array_index, ARRAY_MAX, 0);
+	ERR_FAIL_INDEX_V(p_array_index, (int)ARRAY_MAX, 0);
 	uint32_t offsets[ARRAY_MAX];
 	uint32_t strides[ARRAY_MAX];
 	mesh_surface_make_offsets_from_format(p_format, p_vertex_len, p_index_len, offsets, strides);
@@ -865,7 +865,7 @@ uint32_t VisualServer::mesh_surface_get_format_offset(uint32_t p_format, int p_v
 }
 
 uint32_t VisualServer::mesh_surface_get_format_stride(uint32_t p_format, int p_vertex_len, int p_index_len, int p_array_index) const {
-	ERR_FAIL_INDEX_V(p_array_index, ARRAY_MAX, 0);
+	ERR_FAIL_INDEX_V(p_array_index, (int)ARRAY_MAX, 0);
 	uint32_t offsets[ARRAY_MAX];
 	uint32_t strides[ARRAY_MAX];
 	mesh_surface_make_offsets_from_format(p_format, p_vertex_len, p_index_len, offsets, strides);
@@ -879,7 +879,7 @@ void VisualServer::mesh_surface_make_offsets_from_format(uint32_t p_format, int 
 	int attributes_stride = 0;
 	int positions_stride = 0;
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		r_offsets[i] = 0; //reset
 
 		if (!(p_format & (1 << i))) { // no array
@@ -1029,11 +1029,11 @@ void VisualServer::mesh_surface_make_offsets_from_format(uint32_t p_format, int 
 
 	if (use_split_stream) {
 		r_strides[VS::ARRAY_VERTEX] = positions_stride;
-		for (int i = 1; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 1; i < VS::ARRAY_MAX - 1; i++) {
 			r_strides[i] = attributes_stride;
 		}
 	} else {
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			r_strides[i] = positions_stride + attributes_stride;
 		}
 	}
@@ -1077,7 +1077,7 @@ bool VisualServer::_mesh_find_format(VS::PrimitiveType p_primitive, const Array 
 		}
 	}
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		r_offsets[i] = 0; //reset
 
 		if (!(r_format & (1 << i))) { // no array
@@ -1297,11 +1297,11 @@ void VisualServer::mesh_add_surface_from_arrays(RID p_mesh, PrimitiveType p_prim
 
 	if (use_split_stream) {
 		strides[VS::ARRAY_VERTEX] = positions_stride;
-		for (int i = 1; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 1; i < VS::ARRAY_MAX - 1; i++) {
 			strides[i] = attributes_stride;
 		}
 	} else {
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			strides[i] = positions_stride + attributes_stride;
 		}
 	}
@@ -1350,7 +1350,7 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 	int attributes_stride = 0;
 	int positions_stride = 0;
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		offsets[i] = 0; //reset
 
 		if (!(p_format & (1 << i))) { // no array
@@ -1499,11 +1499,11 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 
 	if (use_split_stream) {
 		strides[VS::ARRAY_VERTEX] = positions_stride;
-		for (int i = 1; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 1; i < VS::ARRAY_MAX - 1; i++) {
 			strides[i] = attributes_stride;
 		}
 	} else {
-		for (int i = 0; i < VS::ARRAY_MAX - 1; i++) {
+		for (uint32_t i = 0; i < VS::ARRAY_MAX - 1; i++) {
 			strides[i] = positions_stride + attributes_stride;
 		}
 	}
@@ -1513,7 +1513,7 @@ Array VisualServer::_get_array_from_surface(uint32_t p_format, PoolVector<uint8_
 
 	PoolVector<uint8_t>::Read r = p_vertex_data.read();
 
-	for (int i = 0; i < VS::ARRAY_MAX; i++) {
+	for (int i = 0; i < (int)VS::ARRAY_MAX; i++) {
 		if (!(p_format & (1 << i))) {
 			continue;
 		}

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -89,7 +89,7 @@ public:
 
 	/* TEXTURE API */
 
-	enum TextureFlags : unsigned int { // unsigned to stop sanitizer complaining about bit operations on ints
+	enum TextureFlags : uint32_t { // unsigned to stop sanitizer complaining about bit operations on ints
 		TEXTURE_FLAG_MIPMAPS = 1, /// Enable automatic mipmap generation - when available
 		TEXTURE_FLAG_REPEAT = 2, /// Repeat texture (Tiling), otherwise Clamping
 		TEXTURE_FLAG_FILTER = 4, /// Create texture with linear (or available) filter
@@ -100,7 +100,7 @@ public:
 		TEXTURE_FLAGS_DEFAULT = TEXTURE_FLAG_REPEAT | TEXTURE_FLAG_MIPMAPS | TEXTURE_FLAG_FILTER
 	};
 
-	enum TextureType {
+	enum TextureType : uint32_t {
 		TEXTURE_TYPE_2D,
 		TEXTURE_TYPE_EXTERNAL,
 		TEXTURE_TYPE_CUBEMAP,
@@ -108,7 +108,7 @@ public:
 		TEXTURE_TYPE_3D,
 	};
 
-	enum CubeMapSide {
+	enum CubeMapSide : uint32_t {
 
 		CUBEMAP_LEFT,
 		CUBEMAP_RIGHT,
@@ -232,7 +232,7 @@ public:
 
 	/* MESH API */
 
-	enum ArrayType {
+	enum ArrayType : uint32_t {
 
 		ARRAY_VERTEX = 0,
 		ARRAY_NORMAL = 1,
@@ -246,7 +246,7 @@ public:
 		ARRAY_MAX = 9
 	};
 
-	enum ArrayFormat {
+	enum ArrayFormat : uint32_t {
 		/* ARRAY FORMAT FLAGS */
 		ARRAY_FORMAT_VERTEX = 1 << ARRAY_VERTEX, // mandatory
 		ARRAY_FORMAT_NORMAL = 1 << ARRAY_NORMAL,
@@ -279,7 +279,7 @@ public:
 
 	};
 
-	enum PrimitiveType {
+	enum PrimitiveType : uint32_t {
 		PRIMITIVE_POINTS = 0,
 		PRIMITIVE_LINES = 1,
 		PRIMITIVE_LINE_STRIP = 2,
@@ -305,7 +305,7 @@ public:
 	virtual void mesh_set_blend_shape_count(RID p_mesh, int p_amount) = 0;
 	virtual int mesh_get_blend_shape_count(RID p_mesh) const = 0;
 
-	enum BlendShapeMode {
+	enum BlendShapeMode : uint32_t {
 		BLEND_SHAPE_MODE_NORMALIZED,
 		BLEND_SHAPE_MODE_RELATIVE,
 	};
@@ -347,26 +347,26 @@ public:
 
 	virtual RID multimesh_create() = 0;
 
-	enum MultimeshTransformFormat {
+	enum MultimeshTransformFormat : uint32_t {
 		MULTIMESH_TRANSFORM_2D,
 		MULTIMESH_TRANSFORM_3D,
 	};
 
-	enum MultimeshColorFormat {
+	enum MultimeshColorFormat : uint32_t {
 		MULTIMESH_COLOR_NONE,
 		MULTIMESH_COLOR_8BIT,
 		MULTIMESH_COLOR_FLOAT,
 		MULTIMESH_COLOR_MAX,
 	};
 
-	enum MultimeshCustomDataFormat {
+	enum MultimeshCustomDataFormat : uint32_t {
 		MULTIMESH_CUSTOM_DATA_NONE,
 		MULTIMESH_CUSTOM_DATA_8BIT,
 		MULTIMESH_CUSTOM_DATA_FLOAT,
 		MULTIMESH_CUSTOM_DATA_MAX,
 	};
 
-	enum MultimeshPhysicsInterpolationQuality {
+	enum MultimeshPhysicsInterpolationQuality : uint32_t {
 		MULTIMESH_INTERP_QUALITY_FAST,
 		MULTIMESH_INTERP_QUALITY_HIGH,
 	};
@@ -429,13 +429,13 @@ public:
 
 	/* Light API */
 
-	enum LightType {
+	enum LightType : uint32_t {
 		LIGHT_DIRECTIONAL,
 		LIGHT_OMNI,
 		LIGHT_SPOT
 	};
 
-	enum LightParam {
+	enum LightParam : uint32_t {
 
 		LIGHT_PARAM_ENERGY,
 		LIGHT_PARAM_INDIRECT_ENERGY,
@@ -472,7 +472,7 @@ public:
 	virtual void light_set_use_gi(RID p_light, bool p_enable) = 0;
 
 	// bake mode
-	enum LightBakeMode {
+	enum LightBakeMode : uint32_t {
 		LIGHT_BAKE_DISABLED,
 		LIGHT_BAKE_INDIRECT,
 		LIGHT_BAKE_ALL
@@ -481,7 +481,7 @@ public:
 	virtual void light_set_bake_mode(RID p_light, LightBakeMode p_bake_mode) = 0;
 
 	// omni light
-	enum LightOmniShadowMode {
+	enum LightOmniShadowMode : uint32_t {
 		LIGHT_OMNI_SHADOW_DUAL_PARABOLOID,
 		LIGHT_OMNI_SHADOW_CUBE,
 	};
@@ -489,7 +489,7 @@ public:
 	virtual void light_omni_set_shadow_mode(RID p_light, LightOmniShadowMode p_mode) = 0;
 
 	// omni light
-	enum LightOmniShadowDetail {
+	enum LightOmniShadowDetail : uint32_t {
 		LIGHT_OMNI_SHADOW_DETAIL_VERTICAL,
 		LIGHT_OMNI_SHADOW_DETAIL_HORIZONTAL
 	};
@@ -497,7 +497,7 @@ public:
 	virtual void light_omni_set_shadow_detail(RID p_light, LightOmniShadowDetail p_detail) = 0;
 
 	// directional light
-	enum LightDirectionalShadowMode {
+	enum LightDirectionalShadowMode : uint32_t {
 		LIGHT_DIRECTIONAL_SHADOW_ORTHOGONAL,
 		LIGHT_DIRECTIONAL_SHADOW_PARALLEL_2_SPLITS,
 		LIGHT_DIRECTIONAL_SHADOW_PARALLEL_3_SPLITS,
@@ -507,7 +507,7 @@ public:
 	virtual void light_directional_set_shadow_mode(RID p_light, LightDirectionalShadowMode p_mode) = 0;
 	virtual void light_directional_set_blend_splits(RID p_light, bool p_enable) = 0;
 
-	enum LightDirectionalShadowDepthRangeMode {
+	enum LightDirectionalShadowDepthRangeMode : uint32_t {
 		LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_STABLE,
 		LIGHT_DIRECTIONAL_SHADOW_DEPTH_RANGE_OPTIMIZED,
 
@@ -519,7 +519,7 @@ public:
 
 	virtual RID reflection_probe_create() = 0;
 
-	enum ReflectionProbeUpdateMode {
+	enum ReflectionProbeUpdateMode : uint32_t {
 		REFLECTION_PROBE_UPDATE_ONCE,
 		REFLECTION_PROBE_UPDATE_ALWAYS,
 	};
@@ -613,7 +613,7 @@ public:
 	virtual void particles_request_process(RID p_particles) = 0;
 	virtual void particles_restart(RID p_particles) = 0;
 
-	enum ParticlesDrawOrder {
+	enum ParticlesDrawOrder : uint32_t {
 		PARTICLES_DRAW_ORDER_INDEX,
 		PARTICLES_DRAW_ORDER_LIFETIME,
 		PARTICLES_DRAW_ORDER_VIEW_DEPTH,
@@ -661,7 +661,7 @@ public:
 	virtual void viewport_set_render_direct_to_screen(RID p_viewport, bool p_enable) = 0;
 	virtual void viewport_detach(RID p_viewport) = 0;
 
-	enum ViewportUpdateMode {
+	enum ViewportUpdateMode : uint32_t {
 		VIEWPORT_UPDATE_DISABLED,
 		VIEWPORT_UPDATE_ONCE, //then goes to disabled, must be manually updated
 		VIEWPORT_UPDATE_WHEN_VISIBLE, // default
@@ -671,7 +671,7 @@ public:
 	virtual void viewport_set_update_mode(RID p_viewport, ViewportUpdateMode p_mode) = 0;
 	virtual void viewport_set_vflip(RID p_viewport, bool p_enable) = 0;
 
-	enum ViewportClearMode {
+	enum ViewportClearMode : uint32_t {
 
 		VIEWPORT_CLEAR_ALWAYS,
 		VIEWPORT_CLEAR_NEVER,
@@ -701,7 +701,7 @@ public:
 	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;
 
-	enum ViewportMSAA {
+	enum ViewportMSAA : uint32_t {
 		VIEWPORT_MSAA_DISABLED,
 		VIEWPORT_MSAA_2X,
 		VIEWPORT_MSAA_4X,
@@ -716,7 +716,7 @@ public:
 	virtual void viewport_set_use_debanding(RID p_viewport, bool p_debanding) = 0;
 	virtual void viewport_set_sharpen_intensity(RID p_viewport, float p_intensity) = 0;
 
-	enum ViewportUsage {
+	enum ViewportUsage : uint32_t {
 		VIEWPORT_USAGE_2D,
 		VIEWPORT_USAGE_2D_NO_SAMPLING,
 		VIEWPORT_USAGE_3D,
@@ -727,7 +727,7 @@ public:
 	virtual void viewport_set_use_32_bpc_depth(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_usage(RID p_viewport, ViewportUsage p_usage) = 0;
 
-	enum ViewportRenderInfo {
+	enum ViewportRenderInfo : uint32_t {
 
 		VIEWPORT_RENDER_INFO_OBJECTS_IN_FRAME,
 		VIEWPORT_RENDER_INFO_VERTICES_IN_FRAME,
@@ -742,7 +742,7 @@ public:
 
 	virtual int viewport_get_render_info(RID p_viewport, ViewportRenderInfo p_info) = 0;
 
-	enum ViewportDebugDraw {
+	enum ViewportDebugDraw : uint32_t {
 		VIEWPORT_DEBUG_DRAW_DISABLED,
 		VIEWPORT_DEBUG_DRAW_UNSHADED,
 		VIEWPORT_DEBUG_DRAW_OVERDRAW,
@@ -755,7 +755,7 @@ public:
 
 	virtual RID environment_create() = 0;
 
-	enum EnvironmentBG {
+	enum EnvironmentBG : uint32_t {
 
 		ENV_BG_CLEAR_COLOR,
 		ENV_BG_COLOR,
@@ -781,7 +781,7 @@ public:
 	//set default SSR options
 	//set default SSSSS options
 
-	enum EnvironmentDOFBlurQuality {
+	enum EnvironmentDOFBlurQuality : uint32_t {
 		ENV_DOF_BLUR_QUALITY_LOW,
 		ENV_DOF_BLUR_QUALITY_MEDIUM,
 		ENV_DOF_BLUR_QUALITY_HIGH,
@@ -790,7 +790,7 @@ public:
 	virtual void environment_set_dof_blur_near(RID p_env, bool p_enable, float p_distance, float p_transition, float p_far_amount, EnvironmentDOFBlurQuality p_quality) = 0;
 	virtual void environment_set_dof_blur_far(RID p_env, bool p_enable, float p_distance, float p_transition, float p_far_amount, EnvironmentDOFBlurQuality p_quality) = 0;
 
-	enum EnvironmentGlowBlendMode {
+	enum EnvironmentGlowBlendMode : uint32_t {
 		GLOW_BLEND_MODE_ADDITIVE,
 		GLOW_BLEND_MODE_SCREEN,
 		GLOW_BLEND_MODE_SOFTLIGHT,
@@ -799,7 +799,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality) = 0;
 	virtual void environment_set_glow_map(RID p_env, float p_glow_map_strength, RID p_glow_map) = 0;
 
-	enum EnvironmentToneMapper {
+	enum EnvironmentToneMapper : uint32_t {
 		ENV_TONE_MAPPER_LINEAR,
 		ENV_TONE_MAPPER_REINHARD,
 		ENV_TONE_MAPPER_FILMIC,
@@ -812,13 +812,13 @@ public:
 
 	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
 
-	enum EnvironmentSSAOQuality {
+	enum EnvironmentSSAOQuality : uint32_t {
 		ENV_SSAO_QUALITY_LOW,
 		ENV_SSAO_QUALITY_MEDIUM,
 		ENV_SSAO_QUALITY_HIGH,
 	};
 
-	enum EnvironmentSSAOBlur {
+	enum EnvironmentSSAOBlur : uint32_t {
 		ENV_SSAO_BLUR_DISABLED,
 		ENV_SSAO_BLUR_1x1,
 		ENV_SSAO_BLUR_2x2,
@@ -839,7 +839,7 @@ public:
 
 	virtual RID scenario_create() = 0;
 
-	enum ScenarioDebugMode {
+	enum ScenarioDebugMode : uint32_t {
 		SCENARIO_DEBUG_DISABLED,
 		SCENARIO_DEBUG_WIREFRAME,
 		SCENARIO_DEBUG_OVERDRAW,
@@ -854,7 +854,7 @@ public:
 
 	/* INSTANCING API */
 
-	enum InstanceType {
+	enum InstanceType : uint32_t {
 
 		INSTANCE_NONE,
 		INSTANCE_MESH,
@@ -895,7 +895,7 @@ public:
 
 	/* PORTALS API */
 
-	enum InstancePortalMode {
+	enum InstancePortalMode : uint32_t {
 		INSTANCE_PORTAL_MODE_STATIC, // not moving within a room
 		INSTANCE_PORTAL_MODE_DYNAMIC, //  moving within room
 		INSTANCE_PORTAL_MODE_ROAMING, // moving between rooms
@@ -924,7 +924,7 @@ public:
 
 	/* OCCLUDERS API */
 
-	enum OccluderType {
+	enum OccluderType : uint32_t {
 		OCCLUDER_TYPE_UNDEFINED,
 		OCCLUDER_TYPE_SPHERE,
 		OCCLUDER_TYPE_MESH,
@@ -947,7 +947,7 @@ public:
 
 	/* ROOMS API */
 
-	enum RoomsDebugFeature {
+	enum RoomsDebugFeature : uint32_t {
 		ROOMS_DEBUG_SPRAWL,
 	};
 
@@ -981,13 +981,13 @@ public:
 	Array _instances_cull_ray_bind(const Vector3 &p_from, const Vector3 &p_to, RID p_scenario = RID()) const;
 	Array _instances_cull_convex_bind(const Array &p_convex, RID p_scenario = RID()) const;
 
-	enum InstanceFlags {
+	enum InstanceFlags : uint32_t {
 		INSTANCE_FLAG_USE_BAKED_LIGHT,
 		INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE,
 		INSTANCE_FLAG_MAX
 	};
 
-	enum ShadowCastingSetting {
+	enum ShadowCastingSetting : uint32_t {
 		SHADOW_CASTING_SETTING_OFF,
 		SHADOW_CASTING_SETTING_ON,
 		SHADOW_CASTING_SETTING_DOUBLE_SIDED,
@@ -1027,7 +1027,7 @@ public:
 	virtual void canvas_item_set_draw_behind_parent(RID p_item, bool p_enable) = 0;
 	virtual void canvas_item_set_use_identity_transform(RID p_item, bool p_enable) = 0;
 
-	enum NinePatchAxisMode {
+	enum NinePatchAxisMode : uint32_t {
 		NINE_PATCH_STRETCH,
 		NINE_PATCH_TILE,
 		NINE_PATCH_TILE_FIT,
@@ -1095,7 +1095,7 @@ public:
 	virtual void canvas_light_reset_physics_interpolation(RID p_light) = 0;
 	virtual void canvas_light_transform_physics_interpolation(RID p_light, const Transform2D &p_transform) = 0;
 
-	enum CanvasLightMode {
+	enum CanvasLightMode : uint32_t {
 		CANVAS_LIGHT_MODE_ADD,
 		CANVAS_LIGHT_MODE_SUB,
 		CANVAS_LIGHT_MODE_MIX,
@@ -1104,7 +1104,7 @@ public:
 
 	virtual void canvas_light_set_mode(RID p_light, CanvasLightMode p_mode) = 0;
 
-	enum CanvasLightShadowFilter {
+	enum CanvasLightShadowFilter : uint32_t {
 		CANVAS_LIGHT_FILTER_NONE,
 		CANVAS_LIGHT_FILTER_PCF3,
 		CANVAS_LIGHT_FILTER_PCF5,
@@ -1135,7 +1135,7 @@ public:
 	virtual void canvas_occluder_polygon_set_shape(RID p_occluder_polygon, const PoolVector<Vector2> &p_shape, bool p_closed) = 0;
 	virtual void canvas_occluder_polygon_set_shape_as_lines(RID p_occluder_polygon, const PoolVector<Vector2> &p_shape) = 0;
 
-	enum CanvasOccluderPolygonCullMode {
+	enum CanvasOccluderPolygonCullMode : uint32_t {
 		CANVAS_OCCLUDER_POLYGON_CULL_DISABLED,
 		CANVAS_OCCLUDER_POLYGON_CULL_CLOCKWISE,
 		CANVAS_OCCLUDER_POLYGON_CULL_COUNTER_CLOCKWISE,
@@ -1155,7 +1155,7 @@ public:
 
 	/* EVENT QUEUING */
 
-	enum ChangedPriority {
+	enum ChangedPriority : uint32_t {
 		CHANGED_PRIORITY_ANY = 0,
 		CHANGED_PRIORITY_LOW,
 		CHANGED_PRIORITY_HIGH,
@@ -1171,7 +1171,7 @@ public:
 
 	/* STATUS INFORMATION */
 
-	enum RenderInfo {
+	enum RenderInfo : uint32_t {
 
 		INFO_OBJECTS_IN_FRAME,
 		INFO_VERTICES_IN_FRAME,
@@ -1210,7 +1210,7 @@ public:
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 	virtual void set_shader_time_scale(float p_scale) = 0;
 
-	enum Features {
+	enum Features : uint32_t {
 		FEATURE_SHADERS,
 		FEATURE_MULTITHREADED,
 	};


### PR DESCRIPTION
Covers some low hanging fruit:

* Fix use of integers in bitwise expressions
* Fix flagged casting in hashes
* Use `std::numeric_limits<U>::max()` instead of -1
* Use `uint32_t` explicit type for enums used in bitwise operations
* Mark a few UBsan flagged areas with comments

## Notes
* Most of these were flagged by the CI UBSan test project.
* There are still numerous UBSan bugs remaining even after this PR, in particular, jetpaca crashes on running, due to writing over previously freed memory, due to some thread await bug.
* These may not have caused problems in the wild, but are worth closing.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
