### PR TITLE
Clear SceneTreeDock's previous node selection when removing edited scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4096,6 +4096,7 @@ bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
 void EditorNode::_remove_edited_scene(bool p_change_tab) {
 	// When scene gets closed no node is edited anymore, so make sure the editors are notified before nodes are freed.
 	hide_unused_editors(SceneTreeDock::get_singleton());
+	SceneTreeDock::get_singleton()->clear_previous_node_selection();
 
 	int new_index = editor_data.get_edited_scene();
 	int old_index = new_index;


### PR DESCRIPTION
Follow-up to PR #108883, fixes another case where the editor would crash.

I saved a `.tscn` file externally, then clicked "Reload from disk" in the popup in Godot, then Godot crashed with this:

```
================================================================
handle_crash: Program crashed with signal 11
Engine version: Godot Engine v4.5.beta.custom_build (7bd57a516477201e32e64badd04425675282b523)
Dumping the backtrace. Please include this when reporting the bug on: https://github.com/godotengine/godot/issues
[1] 1   libsystem_platform.dylib            0x00000001971bc624 _sigtramp + 56
[2] SceneTreeDock::clear_previous_node_selection() (in godot.macos.editor.arm64) + 208
[3] SceneTreeDock::_selection_changed() (in godot.macos.editor.arm64) + 164
[4] Object::emit_signalp(StringName const&, Variant const**, int) (in godot.macos.editor.arm64) + 980
[5] EditorSelection::_emit_change() (in godot.macos.editor.arm64) + 64
[6] CallQueue::_call_function(Callable const&, Variant const*, int, bool) (in godot.macos.editor.arm64) + 324
[7] CallQueue::flush() (in godot.macos.editor.arm64) + 348
```