### PR TITLE
GitHub Actions: Test project exporting on CI

### DIFF
--- a/.github/actions/godot-project-export/action.yml
+++ b/.github/actions/godot-project-export/action.yml
@@ -1,0 +1,55 @@
+name: Export Godot project
+description: Export a test Godot project.
+
+inputs:
+  bin:
+    description: The path to the Godot executable
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Import resources and export project
+      shell: sh
+      run: |
+        git clone --depth=1 https://github.com/godotengine/godot-tests.git /tmp/godot-tests
+
+        echo "Exporting project for Linux (PCK)"
+        ${{ inputs.bin }} --headless --path /tmp/godot-tests/tests/test_project/ --export-pack "Linux" /tmp/test_project.pck 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+        echo "Exporting project for Linux (ZIP)"
+        ${{ inputs.bin }} --headless --path /tmp/godot-tests/tests/test_project/ --export-pack "Linux" /tmp/test_project.zip 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+        echo "Exporting project for Linux as dedicated server (PCK)"
+        ${{ inputs.bin }} --headless --path /tmp/godot-tests/tests/test_project/ --export-pack "Linux Server" /tmp/test_project_server.pck 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+    - name: Run project files from folder
+      shell: sh
+      run: |
+        xvfb-run ${{ inputs.bin }} --path /tmp/godot-tests/tests/test_project/ --language fr --resolution 64x64 --write-movie /tmp/test_project_folder.png --quit 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+        ${{ inputs.bin }} --headless --path /tmp/godot-tests/tests/test_project/ --quit 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+    - name: Run exported project PCK/ZIP
+      shell: sh
+      run: |
+        xvfb-run ${{ inputs.bin }} --main-pack /tmp/test_project.pck --language fr --resolution 64x64 --write-movie /tmp/test_project_pck.png --quit 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+        xvfb-run ${{ inputs.bin }} --main-pack /tmp/test_project.zip --language fr --resolution 64x64 --write-movie /tmp/test_project_zip.png --quit 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+        # Headless mode is implied for dedicated server PCKs.
+        ${{ inputs.bin }} --main-pack /tmp/test_project_server.pck --quit 2>&1 | tee log.txt || true
+        GODOT_CHECK_CI_LOG_ALL_ERRORS=1 misc/scripts/check_ci_log.py log.txt
+
+        echo "Checking whether video output from project folder and exported project match..."
+        md5sum /tmp/test_project*.png | md5sum --check
+
+        echo "Checking whether audio output from project folder and exported project match..."
+        md5sum /tmp/test_project*.wav | md5sum --check

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -35,6 +35,7 @@ jobs:
             build-mono: true
             doc-test: true
             proj-conv: true
+            proj-export: true
             api-compat: true
             artifact: true
             # Validate godot-cpp compatibility on one arbitrary editor build.
@@ -118,7 +119,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install libwayland-bin  # TODO: Figure out somehow how to embed this one.
-          if [ "${{ matrix.proj-test }}" == "true" ]; then
+          if [ "${{ matrix.proj-test }}" == "true" -o "${{ matrix.proj-export }}" == "true" ]; then
             sudo apt-get install mesa-vulkan-drivers
           fi
 
@@ -254,6 +255,13 @@ jobs:
       - name: Test Godot project
         uses: ./.github/actions/godot-project-test
         if: matrix.proj-test
+        with:
+          bin: ${{ matrix.bin }}
+
+      # Test project export
+      - name: Test project export
+        uses: ./.github/actions/godot-project-export
+        if: matrix.proj-export
         with:
           bin: ${{ matrix.bin }}
 

--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import sys
 
 if len(sys.argv) < 2:
@@ -56,6 +57,12 @@ if file_contents.find("ObjectDB instances leaked at exit") != -1:
 if file_contents.find("Assertion failed") != -1:
     print("ERROR: Assertion failed in project, check execution log for more info")
     sys.exit(55)
+
+if os.environ.get("GODOT_CHECK_CI_LOG_ALL_ERRORS"):
+    # If any occurrence of "ERROR:" is found in the log, we consider it a failure.
+    if file_contents.find("ERROR:") != -1:
+        print("ERROR: 'ERROR:' found in log and GODOT_CHECK_CI_LOG_ALL_ERRORS is set.")
+        sys.exit(56)
 
 # For now Godot leaks a lot of rendering stuff so for now we just show info
 # about it and this needs to be re-enabled after fixing this memory leaks.


### PR DESCRIPTION
This allows finding issues in headless project export early on, including when exporting for a dedicated server.

We also use this opportunity to check whether the audiovisual output between the project being run from its files and the exported PCK matches (it should always be a perfect match, assuming the same GPU is used for both runs). This can be used to catch audiovisual discrepancies, which could indicate a bug in the export process. This also tests Movie Maker mode functionality while we're at it.

The test project is currently part of the main repository, so I've attempted to minimize the file size while making use of as many Godot features as possible. We could move this test project to a separate repository, but this would increase the complexity of the setup and make it harder for contributors to test this project locally (as well as further improve it).

This export test is performed on the **Linux Editor w/ Mono** job, which will allow for testing C# (not implemented in this PR yet).

The development of this PR has already uncovered several bugs so far:

- https://github.com/godotengine/godot/issues/109097
- https://github.com/godotengine/godot/issues/109098
- https://github.com/godotengine/godot/issues/109099
- https://github.com/godotengine/godot/issues/109141
- https://github.com/godotengine/godot/issues/109145
- https://github.com/godotengine/godot/issues/109177
- CSV translation causes errors to be printed on export, even though it's functional (no issue open yet?)
  - I can't reproduce this in a new project, such as [test_csv_export_error.zip](https://github.com/user-attachments/files/23510854/test_csv_export_error.zip).

## Preview

The project features:

- LightmapGI setup, as well as most 3D rendering features enabled.
- Custom text and visual shaders (the black and white spheres), with parameters set to non-default values. Global and per-instance uniforms are also used in the text shader. The default parameters are red, while the overrides are green. If the project is run/exported correctly, you should only see green spheres, not red ones.
- All texture compression types (with and without mipmaps) as shown in the top-left corners. **Size Limit** is also used here, with a size of 29×29 to ensure we have valid behavior for texture sizes that aren't a multiple of 4.
- 3D scene import in all supported formats (the apples).
- Translation and font imports (standard, LCD subpixel, MSDF, bitmap).
- GDScript, ~~C#~~ and ~~GDExtension C++ using godot-cpp~~.
  - C# work moved to this branch: https://github.com/Calinou/godot/tree/ci-test-project-export-csharp
  - GDExtension work moved to this ZIP: [addons.zip](https://github.com/user-attachments/files/23680381/addons.zip)
  - Actions code to build the extension:

<details>

```yaml
    - name: Build test GDExtension
      shell: sh
      run: |
        cd misc/test_project/addons/test_extension/
        git clone --depth=1 https://github.com/godotengine/godot-cpp.git src/godot-cpp/
        scons target=template_debug
        scons target=template_release
        cd ../../../../
```
</details>

- ~~OBJ scene/mesh import~~
  - Moved to this branch due to errors being printed on export on CI (not on my machine): https://github.com/Calinou/godot/tree/ci-test-project-export-obj-voxelgi
- ~~VoxelGI export~~
  - Moved to this branch due to errors being printed on export on CI (not on my machine): https://github.com/Calinou/godot/tree/ci-test-project-export-obj-voxelgi
  - https://github.com/godotengine/godot/pull/112744 fixes the issue, so we can readd VoxelGI to the test project once that PR is merged.
- ~~Audio playback~~
  - Removed due to [leaked instances on exit](https://github.com/godotengine/godot/issues/76745), causing CI to fail.
  - Sound files to be readded when the issue is fixed: [sounds.zip](https://github.com/user-attachments/files/23630380/sounds.zip)

<img width="1152" height="648" alt="image" src="https://github.com/user-attachments/assets/f4778015-ec4a-45c2-b2c5-3569aade11e8" />

## TODO

- [ ] Add DDS and KTX texture loading.
- [ ] Add more resource types. Perhaps use an EditorScript to generate all of them, which might uncover some more bugs in the process.

For a future PR (due to the complexity):

- [ ] Test exporting to Android with both Gradle and APK workflows. This will require waiting on the Android build to finish, then making this CI job download the artifacts and use them for export. It would also require setting up the Android SDK before exporting.
- [ ] Test exporting to Windows and web platforms. Not as involved as Android, but it'll still require changing the CI setup to add dependencies to other platforms' workflows.
- [ ] Test exporting to macOS and iOS. This requires using a macOS host, which may not be technically feasible due to https://github.com/godotengine/godot/issues/101773.