### PR TITLE
Allow processing low priority threads on calling thread in the WTP.

### DIFF
--- a/core/object/worker_thread_pool.cpp
+++ b/core/object/worker_thread_pool.cpp
@@ -225,7 +225,7 @@ void WorkerThreadPool::_post_tasks(Task **p_tasks, uint32_t p_count, bool p_high
 	// in custom builds.
 
 	// Avoid calling pump tasks or low priority tasks from the calling thread.
-	bool process_on_calling_thread = threads.is_empty() && p_high_priority && !p_pump_task;
+	bool process_on_calling_thread = threads.is_empty() && !p_pump_task;
 	if (process_on_calling_thread) {
 		p_lock.temp_unlock();
 		for (uint32_t i = 0; i < p_count; i++) {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109148

In theory, low priority tasks should always go to the queue and never be executed on the calling thread. However, when using NO_THREADS build, all tasks need to execute on the calling thread. Because the low priority queue will never get processed (since there are no threads in the thread pool). 

Ideally for 4.6 or later we would re-evaluate this code and have a separate path for NO_THREADS builds. But for now, its best just to remove the addition of this check since it isn't necessary to fix the problem that https://github.com/godotengine/godot/pull/108697 was created to solve. 
