### PR TITLE
Improve auto-translation of the replication editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8370,7 +8370,7 @@ EditorNode::EditorNode() {
 
 	warning = memnew(AcceptDialog);
 	warning->set_unparent_when_invisible(true);
-	warning->add_button(TTR("Copy Text"), true, "copy");
+	warning->add_button(TTRC("Copy Text"), true, "copy");
 	warning->connect("custom_action", callable_mp(this, &EditorNode::_copy_warning));
 
 	ED_SHORTCUT("editor/next_tab", TTRC("Next Scene Tab"), KeyModifierMask::CTRL + Key::TAB);

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -68,11 +68,11 @@ void PropertySelector::_sbox_input(const Ref<InputEvent> &p_event) {
 
 void PropertySelector::_update_search() {
 	if (properties) {
-		set_title(TTR("Select Property"));
+		set_title(TTRC("Select Property"));
 	} else if (virtuals_only) {
-		set_title(TTR("Select Virtual Method"));
+		set_title(TTRC("Select Virtual Method"));
 	} else {
-		set_title(TTR("Select Method"));
+		set_title(TTRC("Select Method"));
 	}
 
 	search_options->clear();
@@ -668,7 +668,6 @@ void PropertySelector::_bind_methods() {
 PropertySelector::PropertySelector() {
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
-	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
 	search_box->set_accessibility_name(TTRC("Search:"));
 	search_box->set_clear_button_enabled(true);
@@ -677,8 +676,8 @@ PropertySelector::PropertySelector() {
 	vbc->add_margin_child(TTRC("Search:"), search_box);
 	search_options = memnew(Tree);
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	vbc->add_margin_child(TTR("Matches:"), search_options, true);
-	set_ok_button_text(TTR("Open"));
+	vbc->add_margin_child(TTRC("Matches:"), search_options, true);
+	set_ok_button_text(TTRC("Open"));
 	get_ok_button()->set_disabled(true);
 	register_text_enter(search_box);
 	set_hide_on_ok(false);
@@ -689,5 +688,5 @@ PropertySelector::PropertySelector() {
 	help_bit = memnew(EditorHelpBit);
 	help_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);
 	help_bit->connect("request_hide", callable_mp(this, &PropertySelector::_hide_requested));
-	vbc->add_margin_child(TTR("Description:"), help_bit);
+	vbc->add_margin_child(TTRC("Description:"), help_bit);
 }

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -2256,9 +2256,8 @@ void SceneTreeDialog::set_valid_types(const Vector<StringName> &p_valid) {
 	content->move_child(allowed_types_hbox, 0);
 
 	{
-		Label *label = memnew(Label);
+		Label *label = memnew(Label(TTRC("Allowed:")));
 		allowed_types_hbox->add_child(label);
-		label->set_text(TTR("Allowed:"));
 	}
 
 	HFlowContainer *hflow = memnew(HFlowContainer);
@@ -2373,7 +2372,7 @@ void SceneTreeDialog::_bind_methods() {
 }
 
 SceneTreeDialog::SceneTreeDialog() {
-	set_title(TTR("Select a Node"));
+	set_title(TTRC("Select a Node"));
 	content = memnew(VBoxContainer);
 	add_child(content);
 
@@ -2382,7 +2381,7 @@ SceneTreeDialog::SceneTreeDialog() {
 
 	filter = memnew(LineEdit);
 	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	filter->set_placeholder(TTR("Filter Nodes"));
+	filter->set_placeholder(TTRC("Filter Nodes"));
 	filter->set_clear_button_enabled(true);
 	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect(SceneStringName(text_changed), callable_mp(this, &SceneTreeDialog::_filter_changed));
@@ -2394,7 +2393,7 @@ SceneTreeDialog::SceneTreeDialog() {
 
 	// Add 'Show All' button to HBoxContainer next to the filter, visible only when valid_types is defined.
 	show_all_nodes = memnew(CheckButton);
-	show_all_nodes->set_text(TTR("Show All"));
+	show_all_nodes->set_text(TTRC("Show All"));
 	show_all_nodes->connect(SceneStringName(toggled), callable_mp(this, &SceneTreeDialog::_show_all_nodes_changed));
 	show_all_nodes->set_h_size_flags(Control::SIZE_SHRINK_BEGIN);
 	show_all_nodes->hide();

--- a/modules/multiplayer/editor/replication_editor.cpp
+++ b/modules/multiplayer/editor/replication_editor.cpp
@@ -105,12 +105,12 @@ void ReplicationEditor::_pick_node_selected(NodePath p_path) {
 
 void ReplicationEditor::_pick_new_property() {
 	if (current == nullptr) {
-		EditorNode::get_singleton()->show_warning(TTR("Select a replicator node in order to pick a property to add to it."));
+		EditorNode::get_singleton()->show_warning(TTRC("Select a replicator node in order to pick a property to add to it."));
 		return;
 	}
 	Node *root = current->get_node(current->get_root_path());
 	if (!root) {
-		EditorNode::get_singleton()->show_warning(TTR("Not possible to add a new property to synchronize without a root."));
+		EditorNode::get_singleton()->show_warning(TTRC("Not possible to add a new property to synchronize without a root."));
 		return;
 	}
 	pick_node->popup_scenetree_dialog(nullptr, current);
@@ -122,7 +122,7 @@ void ReplicationEditor::_add_sync_property(String p_path) {
 	config = current->get_replication_config();
 
 	if (config.is_valid() && config->has_property(p_path)) {
-		EditorNode::get_singleton()->show_warning(TTR("Property is already being synchronized."));
+		EditorNode::get_singleton()->show_warning(TTRC("Property is already being synchronized."));
 		return;
 	}
 
@@ -166,7 +166,7 @@ ReplicationEditor::ReplicationEditor() {
 
 	pick_node = memnew(SceneTreeDialog);
 	add_child(pick_node);
-	pick_node->set_title(TTR("Pick a node to synchronize:"));
+	pick_node->set_title(TTRC("Pick a node to synchronize:"));
 	pick_node->connect("selected", callable_mp(this, &ReplicationEditor::_pick_node_selected));
 	pick_node->get_filter_line_edit()->connect(SceneStringName(text_changed), callable_mp(this, &ReplicationEditor::_pick_node_filter_text_changed));
 
@@ -223,15 +223,14 @@ ReplicationEditor::ReplicationEditor() {
 	HBoxContainer *hb = memnew(HBoxContainer);
 	vb->add_child(hb);
 
-	add_pick_button = memnew(Button);
+	add_pick_button = memnew(Button(TTRC("Add property to sync...")));
 	add_pick_button->connect(SceneStringName(pressed), callable_mp(this, &ReplicationEditor::_pick_new_property));
-	add_pick_button->set_text(TTR("Add property to sync..."));
 	hb->add_child(add_pick_button);
 
 	VSeparator *vs = memnew(VSeparator);
 	vs->set_custom_minimum_size(Size2(30 * EDSCALE, 0));
 	hb->add_child(vs);
-	hb->add_child(memnew(Label(TTR("Path:"))));
+	hb->add_child(memnew(Label(TTRC("Path:"))));
 
 	np_line_edit = memnew(LineEdit);
 	np_line_edit->set_placeholder(":property");
@@ -240,9 +239,8 @@ ReplicationEditor::ReplicationEditor() {
 	np_line_edit->connect(SceneStringName(text_submitted), callable_mp(this, &ReplicationEditor::_np_text_submitted));
 	hb->add_child(np_line_edit);
 
-	add_from_path_button = memnew(Button);
+	add_from_path_button = memnew(Button(TTRC("Add from path")));
 	add_from_path_button->connect(SceneStringName(pressed), callable_mp(this, &ReplicationEditor::_add_pressed));
-	add_from_path_button->set_text(TTR("Add from path"));
 	hb->add_child(add_from_path_button);
 
 	vs = memnew(VSeparator);
@@ -252,19 +250,19 @@ ReplicationEditor::ReplicationEditor() {
 	pin = memnew(Button);
 	pin->set_theme_type_variation(SceneStringName(FlatButton));
 	pin->set_toggle_mode(true);
-	pin->set_tooltip_text(TTR("Pin replication editor"));
+	pin->set_tooltip_text(TTRC("Pin replication editor"));
 	hb->add_child(pin);
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
 	tree->set_columns(4);
 	tree->set_column_titles_visible(true);
-	tree->set_column_title(0, TTR("Properties"));
+	tree->set_column_title(0, TTRC("Properties"));
 	tree->set_column_expand(0, true);
-	tree->set_column_title(1, TTR("Spawn"));
+	tree->set_column_title(1, TTRC("Spawn"));
 	tree->set_column_expand(1, false);
 	tree->set_column_custom_minimum_width(1, 100);
-	tree->set_column_title(2, TTR("Replicate"));
+	tree->set_column_title(2, TTRC("Replicate"));
 	tree->set_column_custom_minimum_width(2, 100);
 	tree->set_column_expand(2, false);
 	tree->set_column_expand(3, false);
@@ -274,9 +272,8 @@ ReplicationEditor::ReplicationEditor() {
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_child(tree);
 
-	drop_label = memnew(Label);
+	drop_label = memnew(Label(TTRC("Add properties using the options above, or\ndrag them from the inspector and drop them here.")));
 	drop_label->set_focus_mode(FOCUS_ACCESSIBILITY);
-	drop_label->set_text(TTR("Add properties using the options above, or\ndrag them from the inspector and drop them here."));
 	drop_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	drop_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	tree->add_child(drop_label);
@@ -313,12 +310,12 @@ bool ReplicationEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &
 
 void ReplicationEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	if (current == nullptr) {
-		EditorNode::get_singleton()->show_warning(TTR("Select a replicator node in order to pick a property to add to it."));
+		EditorNode::get_singleton()->show_warning(TTRC("Select a replicator node in order to pick a property to add to it."));
 		return;
 	}
 	Node *root = current->get_node(current->get_root_path());
 	if (!root) {
-		EditorNode::get_singleton()->show_warning(TTR("Not possible to add a new property to synchronize without a root."));
+		EditorNode::get_singleton()->show_warning(TTRC("Not possible to add a new property to synchronize without a root."));
 		return;
 	}
 
@@ -345,8 +342,21 @@ void ReplicationEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_da
 	_add_sync_property(path);
 }
 
+void _set_replication_mode_options(TreeItem *p_item) {
+	p_item->set_text(2, TTR("Never", "Replication Mode") + "," + TTR("Always", "Replication Mode") + "," + TTR("On Change", "Replication Mode"));
+}
+
 void ReplicationEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			TreeItem *root = tree->get_root();
+			if (root) {
+				for (TreeItem *ti = root->get_first_child(); ti; ti = ti->get_next()) {
+					_set_replication_mode_options(ti);
+				}
+			}
+		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (!EditorThemeManager::is_generated_theme_outdated()) {
 				break;
@@ -363,17 +373,17 @@ void ReplicationEditor::_notification(int p_what) {
 
 void ReplicationEditor::_add_pressed() {
 	if (!current) {
-		EditorNode::get_singleton()->show_warning(TTR("Please select a MultiplayerSynchronizer first."));
+		EditorNode::get_singleton()->show_warning(TTRC("Please select a MultiplayerSynchronizer first."));
 		return;
 	}
 	if (current->get_root_path().is_empty()) {
-		EditorNode::get_singleton()->show_warning(TTR("The MultiplayerSynchronizer needs a root path."));
+		EditorNode::get_singleton()->show_warning(TTRC("The MultiplayerSynchronizer needs a root path."));
 		return;
 	}
 	String np_text = np_line_edit->get_text();
 
 	if (np_text.is_empty()) {
-		EditorNode::get_singleton()->show_warning(TTR("Property/path must not be empty."));
+		EditorNode::get_singleton()->show_warning(TTRC("Property/path must not be empty."));
 		return;
 	}
 
@@ -420,7 +430,7 @@ void ReplicationEditor::_tree_item_edited() {
 		int old_value = config->property_get_replication_mode(prop);
 		// We have a hard limit of 64 watchable properties per synchronizer.
 		if (value == SceneReplicationConfig::REPLICATION_MODE_ON_CHANGE && config->get_watch_properties().size() >= 64) {
-			EditorNode::get_singleton()->show_warning(TTR("Each MultiplayerSynchronizer can have no more than 64 watched properties."));
+			EditorNode::get_singleton()->show_warning(TTRC("Each MultiplayerSynchronizer can have no more than 64 watched properties."));
 			ti->set_range(column, old_value);
 			return;
 		}
@@ -552,6 +562,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 	item->set_selectable(2, false);
 	item->set_selectable(3, false);
 	item->set_text(0, prop);
+	item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);
 	item->set_metadata(0, prop);
 	Node *root_node = current && !current->get_root_path().is_empty() ? current->get_node(current->get_root_path()) : nullptr;
 	Ref<Texture2D> icon = _get_class_icon(root_node);
@@ -568,7 +579,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 		Variant value = node->get(subpath, &valid);
 		if (valid && !can_sync(value)) {
 			item->set_icon(0, get_theme_icon(SNAME("StatusWarning"), EditorStringName(EditorIcons)));
-			item->set_tooltip_text(0, TTR("Property of this type not supported."));
+			item->set_tooltip_text(0, TTRC("Property of this type not supported."));
 		} else {
 			item->set_icon(0, icon);
 		}
@@ -583,7 +594,8 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 	item->set_text_alignment(2, HORIZONTAL_ALIGNMENT_CENTER);
 	item->set_cell_mode(2, TreeItem::CELL_MODE_RANGE);
 	item->set_range_config(2, 0, 2, 1);
-	item->set_text(2, TTR("Never", "Replication Mode") + "," + TTR("Always", "Replication Mode") + "," + TTR("On Change", "Replication Mode"));
+	item->set_auto_translate_mode(2, AUTO_TRANSLATE_MODE_DISABLED);
+	_set_replication_mode_options(item);
 	item->set_range(2, (int)p_mode);
 	item->set_editable(2, true);
 }


### PR DESCRIPTION
Part of https://github.com/godotengine/godot/issues/104574

Cleans up `TTR()` usages in `ReplicationEditor`, `SceneTreeDialog`, and `PropertySelector`.

Also makes the "Copy Text" button in the general warning dialog use `TTRC()`.