### PR TITLE
ShaderEditor Bug Fixes

### DIFF
--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -71,6 +71,7 @@ void ShaderEditorPlugin::_update_shader_list() {
 			text = TTR("[unsaved]");
 		} else if (shader->is_built_in()) {
 			const String &shader_name = shader->get_name();
+			path = text.get_slice("::", 0);
 			if (!shader_name.is_empty()) {
 				text = vformat("%s (%s)", shader_name, text.get_slice("::", 0));
 			}
@@ -246,12 +247,25 @@ void ShaderEditorPlugin::set_window_layout(Ref<ConfigFile> p_layout) {
 	String selected_shader = p_layout->get_value("ShaderEditor", "selected_shader");
 	for (int i = 0; i < shaders.size(); i++) {
 		String path = shaders[i];
-		Ref<Resource> res = ResourceLoader::load(path);
-		if (res.is_valid()) {
-			edit(res.ptr());
-		}
-		if (selected_shader == path) {
-			selected_shader_idx = i;
+		if (!path.contains("::")) {
+			Ref<Resource> res = ResourceLoader::load(path);
+			if (res.is_valid()) {
+				edit(res.ptr());
+			}
+			if (selected_shader == path) {
+				selected_shader_idx = i;
+			}
+		} else {
+			Ref<Resource> res = ResourceLoader::load(path.get_slice("::", 0));
+			if (res.is_valid()) {
+				Ref<Resource> sub_res = ResourceLoader::load(path);
+				if (sub_res.is_valid()) {
+					edit(sub_res.ptr());
+				}
+				if (selected_shader == path) {
+					selected_shader_idx = i;
+				}
+			}
 		}
 	}
 
@@ -610,6 +624,9 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 		case FILE_MENU_SHOW_IN_FILE_SYSTEM: {
 			Ref<Resource> shader = _get_current_shader();
 			String path = shader->get_path();
+			if (shader->is_built_in()) {
+				path = path.get_slice("::", 0);
+			}
 			if (!path.is_empty()) {
 				FileSystemDock::get_singleton()->navigate_to_path(path);
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/102642

The ShaderEditor had a few cases where it would not handle BuiltIn / Subresource Shaders correctly.

1. Upon re-launching, the ShaderEditor would not re-open BuiltIn Shaders, and throw an error (`ERROR: Resource file not found: res://new_canvas_item_material.tres::Shader_okjdl`)
2. Deleting the Parent Resource of a BuiltIn Shader would not remove it from the ShaderEditor
3. Selecting "Show in FileSystem" from the ShaderEditor would not show the Parent Resource of a BuiltIn Shader

To test these issues, the easiest way is to create a CanvasItemMaterial, and from the inspector Convert To Shader Material. This creates a ShaderMaterial with the CanvasItem Shader as a BuiltIn/SubResource, and from there you should be able to observe the incorrect behaviors.

This PR adds some extra case handling to address these issues. A few of the cases could behave incorrectly if legitimate files have File Names including "::", but I believe this is the case for most Godot SubResource handling?
