### PR TITLE
Fix Android TTS on-demand init.

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/tts/GodotTTS.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/tts/GodotTTS.java
@@ -56,15 +56,21 @@ import java.util.Set;
  * </ul>
  */
 @Keep
-public class GodotTTS extends UtteranceProgressListener {
+public class GodotTTS extends UtteranceProgressListener implements TextToSpeech.OnInitListener {
 	// Note: These constants must be in sync with DisplayServer::TTSUtteranceEvent enum from "servers/display_server.h".
 	final private static int EVENT_START = 0;
 	final private static int EVENT_END = 1;
 	final private static int EVENT_CANCEL = 2;
 	final private static int EVENT_BOUNDARY = 3;
 
+	// Note: These constants must be in sync with TTS_Android constants from "platform/android/tts_android.h".
+	final private static int INIT_STATE_UNKNOWN = 0;
+	final private static int INIT_STATE_SUCCESS = 1;
+	final private static int INIT_STATE_FAIL = -1;
+
 	private final Context context;
 	private TextToSpeech synth;
+	private int state;
 	private LinkedList<GodotUtterance> queue;
 	final private Object lock = new Object();
 	private GodotUtterance lastUtterance;
@@ -82,6 +88,9 @@ public class GodotTTS extends UtteranceProgressListener {
 			GodotUtterance message = queue.pollFirst();
 
 			Set<Voice> voices = synth.getVoices();
+			if (voices == null) {
+				return;
+			}
 			for (Voice v : voices) {
 				if (v.getName().equals(message.voice)) {
 					synth.setVoice(v);
@@ -189,10 +198,25 @@ public class GodotTTS extends UtteranceProgressListener {
 	 * Initialize synth and query.
 	 */
 	public void init() {
-		synth = new TextToSpeech(context, null);
+		state = INIT_STATE_UNKNOWN;
+		synth = new TextToSpeech(context, this);
 		queue = new LinkedList<GodotUtterance>();
 
 		synth.setOnUtteranceProgressListener(this);
+	}
+
+	/**
+	 * Called by TTS engine when initialization is finished.
+	 */
+	@Override
+	public void onInit(int status) {
+		synchronized (lock) {
+			if (status == TextToSpeech.SUCCESS) {
+				state = INIT_STATE_SUCCESS;
+			} else {
+				state = INIT_STATE_FAIL;
+			}
+		}
 	}
 
 	/**
@@ -200,6 +224,9 @@ public class GodotTTS extends UtteranceProgressListener {
 	 */
 	public void speak(String text, String voice, int volume, float pitch, float rate, int utterance_id, boolean interrupt) {
 		synchronized (lock) {
+			if (state != INIT_STATE_SUCCESS) {
+				return;
+			}
 			GodotUtterance message = new GodotUtterance(text, voice, volume, pitch, rate, utterance_id);
 			queue.addLast(message);
 
@@ -216,6 +243,9 @@ public class GodotTTS extends UtteranceProgressListener {
 	 */
 	public void pauseSpeaking() {
 		synchronized (lock) {
+			if (state != INIT_STATE_SUCCESS) {
+				return;
+			}
 			if (!paused) {
 				paused = true;
 				synth.stop();
@@ -228,10 +258,16 @@ public class GodotTTS extends UtteranceProgressListener {
 	 */
 	public void resumeSpeaking() {
 		synchronized (lock) {
+			if (state != INIT_STATE_SUCCESS) {
+				return;
+			}
 			if (lastUtterance != null && paused) {
 				int mode = TextToSpeech.QUEUE_FLUSH;
 
 				Set<Voice> voices = synth.getVoices();
+				if (voices == null) {
+					return;
+				}
 				for (Voice v : voices) {
 					if (v.getName().equals(lastUtterance.voice)) {
 						synth.setVoice(v);
@@ -261,6 +297,9 @@ public class GodotTTS extends UtteranceProgressListener {
 	 */
 	public void stopSpeaking() {
 		synchronized (lock) {
+			if (state != INIT_STATE_SUCCESS) {
+				return;
+			}
 			for (GodotUtterance u : queue) {
 				GodotLib.ttsCallback(EVENT_CANCEL, u.id, 0);
 			}
@@ -282,13 +321,21 @@ public class GodotTTS extends UtteranceProgressListener {
 	 * Returns voice information.
 	 */
 	public String[] getVoices() {
-		Set<Voice> voices = synth.getVoices();
-		String[] list = new String[voices.size()];
-		int i = 0;
-		for (Voice v : voices) {
-			list[i++] = v.getLocale().toString() + ";" + v.getName();
+		synchronized (lock) {
+			if (state != INIT_STATE_SUCCESS) {
+				return new String[0];
+			}
+			Set<Voice> voices = synth.getVoices();
+			if (voices == null) {
+				return new String[0];
+			}
+			String[] list = new String[voices.size()];
+			int i = 0;
+			for (Voice v : voices) {
+				list[i++] = v.getLocale().toString() + ";" + v.getName();
+			}
+			return list;
 		}
-		return list;
 	}
 
 	/**
@@ -303,5 +350,14 @@ public class GodotTTS extends UtteranceProgressListener {
 	 */
 	public boolean isPaused() {
 		return paused;
+	}
+
+	/**
+	 * Returns INIT_STATE_SUCCESS if the synthesizer initialization finished successfully, INIT_STATE_FAIL if initialization failed, and INIT_STATE_UNKNOWN otherwise.
+	 */
+	public int getState() {
+		synchronized (lock) {
+			return state;
+		}
 	}
 }

--- a/platform/android/tts_android.h
+++ b/platform/android/tts_android.h
@@ -39,6 +39,10 @@
 #include <jni.h>
 
 class TTS_Android {
+	static inline int INIT_STATE_UNKNOWN = 0;
+	static inline int INIT_STATE_SUCCESS = 1;
+	static inline int INIT_STATE_FAIL = -1;
+
 	static bool initialized;
 	static jobject tts;
 	static jclass cls;
@@ -46,15 +50,22 @@ class TTS_Android {
 	static jmethodID _init;
 	static jmethodID _is_speaking;
 	static jmethodID _is_paused;
+	static jmethodID _get_state;
 	static jmethodID _get_voices;
 	static jmethodID _speak;
 	static jmethodID _pause_speaking;
 	static jmethodID _resume_speaking;
 	static jmethodID _stop_speaking;
 
+	static Thread init_thread;
+	static SafeFlag quit_request;
+	static SafeFlag init_done;
+
+	static void _thread_function(void *self);
+
 	static HashMap<int, Char16String> ids;
 
-	static void initialize_tts();
+	static void initialize_tts(bool p_wait = true);
 
 public:
 	static void setup(jobject p_tts);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109156

- Adds `onInit` listener and a bunch of null checks for `voices`.
- Runs TTS init in a thread (and wait for state change if it is initialized on demand).