### PR TITLE
Use a fixed-width font for the expression evaluator

### DIFF
--- a/editor/debugger/editor_expression_evaluator.cpp
+++ b/editor/debugger/editor_expression_evaluator.cpp
@@ -32,6 +32,7 @@
 
 #include "editor/debugger/editor_debugger_inspector.h"
 #include "editor/debugger/script_editor_debugger.h"
+#include "editor/editor_string_names.h"
 #include "scene/gui/button.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/line_edit.h"
@@ -98,6 +99,10 @@ void EditorExpressionEvaluator::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			EditorDebuggerNode::get_singleton()->connect("breaked", callable_mp(this, &EditorExpressionEvaluator::_on_debugger_breaked));
 			EditorDebuggerNode::get_singleton()->connect("clear_execution", callable_mp(this, &EditorExpressionEvaluator::_on_debugger_clear_execution));
+		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+			expression_input->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("expression"), EditorStringName(EditorFonts)));
+			expression_input->add_theme_font_size_override(SceneStringName(font_size), get_theme_font_size(SNAME("expression_size"), EditorStringName(EditorFonts)));
 		} break;
 	}
 }


### PR DESCRIPTION
- This closes https://github.com/godotengine/godot-proposals/issues/12904.

We could perhaps do this for the Output panel's filter LineEdit too, but it would make more sense with something like https://github.com/godotengine/godot-proposals/issues/7091 in place.

## Preview

*Ignore the section being created here, which is an [unrelated bug](https://github.com/godotengine/godot/issues/98714) in this case.*

<img width="294" height="156" alt="image" src="https://github.com/user-attachments/assets/fb4de4f5-9d18-44ae-a957-398063c5223f" />
