### PR TITLE
Add `Engine.get_copyright_text()` to conveniently comply with open source licenses + open source copyright warning

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -221,6 +221,10 @@ String Engine::get_license_text() const {
 	return String(GODOT_LICENSE_TEXT);
 }
 
+String Engine::get_copyright_text() const {
+	return String::utf8(GODOT_COPYRIGHT_TEXT);
+}
+
 String Engine::get_architecture_name() const {
 #if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	return "x86_64";

--- a/core/config/engine.h
+++ b/core/config/engine.h
@@ -185,6 +185,7 @@ public:
 	Dictionary get_donor_info() const;
 	Dictionary get_license_info() const;
 	String get_license_text() const;
+	String get_copyright_text() const;
 
 	void set_write_movie_path(const String &p_path);
 	String get_write_movie_path() const;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1939,6 +1939,10 @@ String Engine::get_license_text() const {
 	return ::Engine::get_singleton()->get_license_text();
 }
 
+String Engine::get_copyright_text() const {
+	return ::Engine::get_singleton()->get_copyright_text();
+}
+
 String Engine::get_architecture_name() const {
 	return ::Engine::get_singleton()->get_architecture_name();
 }
@@ -2079,6 +2083,7 @@ void Engine::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_donor_info"), &Engine::get_donor_info);
 	ClassDB::bind_method(D_METHOD("get_license_info"), &Engine::get_license_info);
 	ClassDB::bind_method(D_METHOD("get_license_text"), &Engine::get_license_text);
+	ClassDB::bind_method(D_METHOD("get_copyright_text"), &Engine::get_copyright_text);
 
 	ClassDB::bind_method(D_METHOD("get_architecture_name"), &Engine::get_architecture_name);
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -603,6 +603,7 @@ public:
 	Dictionary get_donor_info() const;
 	Dictionary get_license_info() const;
 	String get_license_text() const;
+	String get_copyright_text() const;
 
 	String get_architecture_name() const;
 

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -289,3 +289,8 @@ struct ComponentCopyright {{
                     to_raw += [line]
             file.write(f"{methods.to_raw_cstring(to_raw)},\n\n")
         file.write("};\n\n")
+
+        file.write("inline const char *GODOT_COPYRIGHT_TEXT = {\n")
+        with open(src_copyright, "r", encoding="utf-8") as copyright_file:
+            file.write(methods.to_raw_cstring(copyright_file.read()))
+        file.write("};\n\n")

--- a/doc/classes/Engine.xml
+++ b/doc/classes/Engine.xml
@@ -75,6 +75,40 @@
 				Returns the full Godot license text.
 			</description>
 		</method>
+		<method name="get_copyright_text" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the full Godot Engine copyright text that includes the copyright information about Godot Engine itself and every thirdparty component that Godot Engine includes.
+				Displaying the contents of the string this method returns is enough to comply with Godot Engine's open source license and every thirdparty component's open source license.
+				[b]Note:[/b] Every project that uses open source libraries (such as Godot Engine games) has to comply with the licenses of the libraries, otherwise the game developer would be breaching the copyright.
+				[b]Note:[/b] Fortunately, this method makes it easy to comply with the licenses, the only thing you have to do is create a scene with a [Label] node, set the label's [code]text[/code] property at runtime and make the label scroll. Here's an example code to make this work, assuming you already have a scene with a [Label] node called "Text" and the scene is accessible from the game:
+				[codeblocks]
+				[gdscript]
+				@onready var text_label := $Text
+				func _ready() -> void:
+					text_label.text = Engine.get_copyright_text()
+
+				func _process(delta: float) -> void:
+					text_label.position.y -= 60 * delta # Move 60 pixels higher every second
+				[/gdscript]
+				[csharp]
+				Label text_label;
+				public override void _Ready()
+				{
+					text_label = GetNode&lt;Label&gt;("Text");
+					text_label.Text = Engine.GetCopyrightText();
+				}
+
+				public override void _Process(float delta)
+				{
+					var position = text_label.Position;
+					position.Y -= 60 * delta // Move 60 pixels higher every second
+					text_label.Position = position;
+				}
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="get_main_loop" qualifiers="const">
 			<return type="MainLoop" />
 			<description>

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -124,6 +124,9 @@ class ProjectExportDialog : public ConfirmationDialog {
 	Label *export_warning = nullptr;
 	HBoxContainer *export_templates_error = nullptr;
 
+	ConfirmationDialog *open_source_warning = nullptr;
+	RichTextLabel *open_source_warning_text = nullptr;
+
 	String default_filename;
 
 	bool exporting = false;
@@ -161,6 +164,8 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _patch_file_selected(const String &p_path);
 	void _patch_delete_confirmed();
 	void _patch_add_pack_pressed();
+
+	void _open_source_ok_pressed();
 
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12850

This method allows the game developers to easily and conveniently comply with open source licenses of Godot Engine and the thirdparty libraries Godot uses. Also added a warning message that every Godot game has to comply with the open source licenses, it can be opened by opening the Export dialog, and after opening once it won't open again, here's what the warning looks like:
<img width="812" height="249" alt="image" src="https://github.com/user-attachments/assets/4953d9ee-3513-4941-9d9f-ffeff50f7b14" />
After pressing OK it takes the user to the `Engine.get_copyright_text()` documentation.

I'm not sure this is the right way to add new popup windows, but it does its job :D

~~But there's a known bug that I'm not sure how to fix: this method doesn't work well with unicode characters:
<img width="530" height="90" alt="image" src="https://github.com/user-attachments/assets/0c2fa36d-d17d-4e9b-93e9-fa1d12a6d2cb" />
Even though the text looks correct in Visual Studio and VS Code:
<img width="649" height="175" alt="image" src="https://github.com/user-attachments/assets/409ef603-3805-484e-b017-0667c67edd70" />~~
EDIT: the bug was fixed!