### PR TITLE
Fix `printraw` causing infinite recursion in `Logger._log_message`

### DIFF
--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -298,6 +298,19 @@ void __print_line_rich(const String &p_string) {
 	is_printing = false;
 }
 
+void print_raw(const String &p_string) {
+	if (is_printing) {
+		__print_fallback(p_string, true);
+		return;
+	}
+
+	is_printing = true;
+
+	OS::get_singleton()->print("%s", p_string.utf8().get_data());
+
+	is_printing = false;
+}
+
 void print_error(const String &p_string) {
 	if (!CoreGlobals::print_error_enabled) {
 		return;

--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -57,6 +57,7 @@ void remove_print_handler(const PrintHandlerList *p_handler);
 
 extern void __print_line(const String &p_string);
 extern void __print_line_rich(const String &p_string);
+extern void print_raw(const String &p_string);
 extern void print_error(const String &p_string);
 extern bool is_print_verbose_enabled();
 

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1011,7 +1011,7 @@ void VariantUtilityFunctions::prints(const Variant **p_args, int p_arg_count, Ca
 }
 
 void VariantUtilityFunctions::printraw(const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-	OS::get_singleton()->print("%s", join_string(p_args, p_arg_count).utf8().get_data());
+	print_raw(join_string(p_args, p_arg_count));
 	r_error.error = Callable::CallError::CALL_OK;
 }
 


### PR DESCRIPTION
Fixes #109134.

This effectively just moves the implementation of `VariantUtilityFunctions::printraw` to a new `print_raw` function in `print_string.{h,cpp}` so that it can be covered by the same reentrance guard that `print`, `printerr`, `print_rich` and all the rest of them are covered by, thus preventing the infinite recursion in the exact same way.