### PR TITLE
Add documentation about logging from `Logger` not being supported

### DIFF
--- a/doc/classes/Logger.xml
+++ b/doc/classes/Logger.xml
@@ -25,6 +25,7 @@
 				Additionally, [param script_backtraces] provides backtraces for each of the script languages. These will only contain stack frames in editor builds and debug builds by default. To enable them for release builds as well, you need to enable [member ProjectSettings.debug/settings/gdscript/always_track_call_stacks].
 				[b]Warning:[/b] This method will be called from threads other than the main thread, possibly at the same time, so you will need to have some kind of thread-safety in your implementation of it, like a [Mutex].
 				[b]Note:[/b] [param script_backtraces] will not contain any captured variables, due to its prohibitively high cost. To get those you will need to capture the backtraces yourself, from within the [Logger] virtual methods, using [method Engine.capture_script_backtraces].
+				[b]Note:[/b] Logging errors from this method using functions like [method @GlobalScope.push_error] or [method @GlobalScope.push_warning] is not supported, as it could cause infinite recursion. These errors will only show up in the console output.
 			</description>
 		</method>
 		<method name="_log_message" qualifiers="virtual">
@@ -34,6 +35,7 @@
 			<description>
 				Called when a message is logged. If [param error] is [code]true[/code], then this message was meant to be sent to [code]stderr[/code].
 				[b]Warning:[/b] This method will be called from threads other than the main thread, possibly at the same time, so you will need to have some kind of thread-safety in your implementation of it, like a [Mutex].
+				[b]Note:[/b] Logging another message from this method using functions like [method @GlobalScope.print] is not supported, as it could cause infinite recursion. These messages will only show up in the console output.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Fixes #109129.

This makes explicit that we don't support logging from the `Logger` virtual methods, which happened to be possible prior #108860 (mostly as a "happy accident") but which no longer is.