### PR TITLE
Stop clearing editor_plugin_screen on script edit

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2926,6 +2926,9 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 				if (!changing_scene) {
 					main_plugin->edit(current_obj);
 				}
+			} else if (Object::cast_to<Script>(current_obj)) {
+				editor_main_screen->select(plugin_index);
+				main_plugin->edit(current_obj);
 			} else if (main_plugin != editor_plugin_screen) {
 				// Unedit previous plugin.
 				editor_plugin_screen->edit(nullptr);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109114

I found the issue was `editor_main_screen` calling `edit()`, as that would clear the gizmos.

This is my first time contributing code to an open source project, and my C++ is rusty, so if I'm a bit off, then hopefully this will be a stepping stone for a better fix