### PR TITLE
Improve GDScript error messages when using top-level or reserved keywords

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1110,6 +1110,13 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 					push_error(R"(The "master" keyword was removed in Godot 4. Use the "@rpc" annotation with "any_peer" and perform a check inside the function instead.)");
 				} else if (previous.get_identifier() == "mastersync") {
 					push_error(R"(The "mastersync" keyword was removed in Godot 4. Use the "@rpc" annotation with "any_peer" and "call_local", and perform a check inside the function instead.)");
+				} else if (previous.get_identifier() == "namespace" || previous.get_identifier() == "trait" || previous.get_identifier() == "yield") {
+					// `yield` has a dedicated warning for projects being converted from Godot 3, but top-level usage of `yield` wasn't valid in Godot 3 anyway.
+					push_error(vformat(R"(The "%s" keyword is reserved for future use, but is currently unimplemented in GDScript.)", previous.get_name()));
+				} else if (GDScriptLanguage::get_singleton()->get_reserved_words().has(previous.get_identifier())) {
+					push_error(vformat(R"(Top-level %s is not allowed in GDScript. Place it within a function instead.)", previous.get_debug_name()));
+				} else if (String(previous.get_name()) == "Indent") {
+					push_error(R"(Unexpected indentation in class body.)");
 				} else {
 					push_error(vformat(R"(Unexpected %s in class body.)", previous.get_debug_name()));
 				}
@@ -2041,7 +2048,12 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 					has_ended_lambda = true;
 				} else {
 					advance();
-					push_error(vformat(R"(Expected statement, found "%s" instead.)", previous.get_name()));
+					if (previous.get_identifier() == "namespace" || previous.get_identifier() == "trait") {
+						// `yield` is also reserved for future use, but has a dedicated warning for projects being converted from Godot 3.
+						push_error(vformat(R"(The "%s" keyword is reserved for future use, but is currently unimplemented in GDScript.)", previous.get_name()));
+					} else {
+						push_error(vformat(R"(Expected statement, found "%s" instead.)", previous.get_name()));
+					}
 				}
 			} else {
 				end_statement("expression");

--- a/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_namespace.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_namespace.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func ready():
+    namespace example

--- a/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_namespace.out
+++ b/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_namespace.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The "namespace" keyword is reserved for future use, but is currently unimplemented in GDScript.

--- a/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_trait.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_trait.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func ready():
+    trait example

--- a/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_trait.out
+++ b/modules/gdscript/tests/scripts/parser/errors/reserved_keyword_trait.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The "trait" keyword is reserved for future use, but is currently unimplemented in GDScript.

--- a/modules/gdscript/tests/scripts/parser/errors/top_level_if.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/top_level_if.gd
@@ -1,0 +1,8 @@
+extends Node
+
+if true:
+	pass
+
+func test():
+	if true:
+		pass

--- a/modules/gdscript/tests/scripts/parser/errors/top_level_if.out
+++ b/modules/gdscript/tests/scripts/parser/errors/top_level_if.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Top-level "if" is not allowed in GDScript. Place it within a function instead.

--- a/modules/gdscript/tests/scripts/parser/errors/top_level_namespace.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/top_level_namespace.gd
@@ -1,0 +1,3 @@
+extends Node
+
+namespace example

--- a/modules/gdscript/tests/scripts/parser/errors/top_level_namespace.out
+++ b/modules/gdscript/tests/scripts/parser/errors/top_level_namespace.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The "namespace" keyword is reserved for future use, but is currently unimplemented in GDScript.

--- a/modules/gdscript/tests/scripts/parser/errors/top_level_trait.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/top_level_trait.gd
@@ -1,0 +1,3 @@
+extends Node
+
+trait example

--- a/modules/gdscript/tests/scripts/parser/errors/top_level_trait.out
+++ b/modules/gdscript/tests/scripts/parser/errors/top_level_trait.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+The "trait" keyword is reserved for future use, but is currently unimplemented in GDScript.

--- a/modules/gdscript/tests/scripts/parser/errors/unexpected_indent_in_class_body.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/unexpected_indent_in_class_body.gd
@@ -1,0 +1,4 @@
+extends Node
+
+    func _ready():
+        pass

--- a/modules/gdscript/tests/scripts/parser/errors/unexpected_indent_in_class_body.out
+++ b/modules/gdscript/tests/scripts/parser/errors/unexpected_indent_in_class_body.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Unexpected indentation in class body.


### PR DESCRIPTION
- Improve error message when there is unexpected indentation in the class body.

See https://forum.godotengine.org/t/if-statements-not-working/117929 (and numerous other similar posts I've seen over the last few months).

## Preview

<img width="843" height="230" alt="Screenshot_20250731_235443" src="https://github.com/user-attachments/assets/247a78fe-58fe-443d-b797-8f0054088214" />

<img width="503" height="235" alt="Screenshot_20250801_000057" src="https://github.com/user-attachments/assets/dc4311af-b573-43e0-b864-c7fe4f2cbcba" />
