### PR TITLE
Update toolbar on curve change in Path3D editor

### DIFF
--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -548,6 +548,7 @@ Path3DGizmo::Path3DGizmo(Path3D *p_path, float p_disk_size) {
 
 	// Connecting to a signal once, rather than plaguing the implementation with calls to `Node3DEditor::update_transform_gizmo`.
 	path->connect("curve_changed", callable_mp(this, &Path3DGizmo::_update_transform_gizmo));
+	path->connect("curve_changed", callable_mp(Path3DEditorPlugin::singleton, &Path3DEditorPlugin::_update_toolbar));
 	path->connect("debug_color_changed", callable_mp(this, &Path3DGizmo::redraw));
 
 	Path3DEditorPlugin::singleton->curve_edit->connect(SceneStringName(pressed), callable_mp(this, &Path3DGizmo::redraw));


### PR DESCRIPTION
Resolves #109150 

This pull request introduces a small bugfix to the `Path3DGizmo` constructor in the `path_3d_editor_plugin.cpp` file. The change ensures that the toolbar is updated whenever the `curve_changed` signal is emitted.

**Testing project:** [curve-and-toolbar-sync.zip](https://github.com/user-attachments/files/21542432/curve-and-toolbar-sync.zip)

## Preview
![test_scene tscn - Curve and Toolbar sync - Godot Engine 2025-08-01 11-24-06](https://github.com/user-attachments/assets/d032bd89-ba89-4a70-b31c-3a0fae3de7db)
