### PR TITLE
Fix editor CanvasItem 2D artifacts with rendering/2d/snap/snap_2d_transforms_to_pixel

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -347,7 +347,7 @@ void RendererCanvasCull::_cull_canvas_item(Item *p_canvas_item, const Transform2
 
 		Transform2D parent_xform = p_parent_xform;
 
-		if (snapping_2d_transforms_to_pixel) {
+		if (snapping_2d_transforms_to_pixel && !Engine::get_singleton()->is_editor_hint()) {
 			self_xform.columns[2] = (self_xform.columns[2] + Point2(0.5, 0.5)).floor();
 			parent_xform.columns[2] = (parent_xform.columns[2] + Point2(0.5, 0.5)).floor();
 		}


### PR DESCRIPTION
Fixes #96966 

The "Snap 2D Transforms to Pixel" option is useful for low-res pixel-perfect games, but it causes rendering issues when moving and resizing very small 2D CanvasItems inside the editor.
It makes sense to only enable this in-game, because the editor camera doesn't snap to pixels when working at high zoom levels.

Before:

https://github.com/user-attachments/assets/bfe92e8a-b4d1-4304-85bc-c1ad9d828a69

After:

https://github.com/user-attachments/assets/dd4f4baa-9fa3-4fb5-8c45-5dae249e61eb

