### PR TITLE
Fix inconsistent thumbnail width

### DIFF
--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -220,10 +220,20 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			const real_t aspect = small_image->get_size().aspect();
 			if (aspect > 1.0) {
 				new_size.y = MAX(1, new_size.y / aspect);
-			} else {
+			} else if (aspect < 1.0) {
 				new_size.x = MAX(1, new_size.x * aspect);
 			}
 			small_image->resize(new_size.x, new_size.y, Image::INTERPOLATE_CUBIC);
+
+			// Make sure the image is always square.
+			if (aspect != 1.0) {
+				Ref<Image> rect = small_image;
+				const Vector2i rect_size = rect->get_size();
+				small_image = Image::create_empty(small_thumbnail_size, small_thumbnail_size, false, rect->get_format());
+				// Blit the rectangle in the center of the square.
+				small_image->blit_rect(rect, Rect2i(Vector2i(), rect_size), (Vector2i(1, 1) * small_thumbnail_size - rect_size) / 2);
+			}
+
 			r_small_texture.instantiate();
 			r_small_texture->set_image(small_image);
 		}


### PR DESCRIPTION
Regression from #107818
<img width="123" height="89" alt="image" src="https://github.com/user-attachments/assets/7e89f1e4-76e1-42f5-838a-fa7bb479b8b8" />
Fixed:
<img width="129" height="95" alt="image" src="https://github.com/user-attachments/assets/7c661cca-b1d5-41d8-91aa-d983168b9377" />
