### PR TITLE
Fix inheriting from abstract classes dialog

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -76,6 +76,10 @@ void CreateDialog::popup_create(bool p_dont_clear, bool p_replace_mode, const St
 	}
 }
 
+void CreateDialog::for_inherit() {
+	allow_abstract_scripts = true;
+}
+
 void CreateDialog::_fill_type_list() {
 	List<StringName> complete_type_list;
 	ClassDB::get_class_list(&complete_type_list);
@@ -222,7 +226,7 @@ bool CreateDialog::_should_hide_type(const StringName &p_type) const {
 		// Abstract scripts cannot be instantiated.
 		String path = ScriptServer::get_global_class_path(p_type);
 		Ref<Script> scr = ResourceLoader::load(path, "Script");
-		return scr.is_null() || scr->is_abstract();
+		return scr.is_null() || (!allow_abstract_scripts && scr->is_abstract());
 	}
 
 	return false;
@@ -363,7 +367,9 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 		type_name = p_type;
 		text = p_type;
 
-		is_abstract = ScriptServer::is_global_class_abstract(p_type);
+		if (!allow_abstract_scripts) {
+			is_abstract = ScriptServer::is_global_class_abstract(p_type);
+		}
 
 		String tooltip = TTR("Script path: %s");
 		bool is_tool = ScriptServer::is_global_class_tool(p_type);
@@ -392,7 +398,7 @@ void CreateDialog::_configure_search_option_item(TreeItem *r_item, const StringN
 	r_item->set_metadata(0, meta);
 
 	bool can_instantiate = (p_type_category == TypeCategory::CPP_TYPE && ClassDB::can_instantiate(p_type)) ||
-			(p_type_category == TypeCategory::OTHER_TYPE && !is_abstract);
+			(p_type_category == TypeCategory::OTHER_TYPE && !(!allow_abstract_scripts && is_abstract));
 	bool instantiable = can_instantiate && !(ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type));
 
 	r_item->set_meta(SNAME("__instantiable"), instantiable);

--- a/editor/gui/create_dialog.h
+++ b/editor/gui/create_dialog.h
@@ -56,6 +56,7 @@ class CreateDialog : public ConfirmationDialog {
 
 	String base_type;
 	bool is_base_type_node = false;
+	bool allow_abstract_scripts = false;
 	String icon_fallback;
 	String preferred_search_result_type;
 
@@ -125,6 +126,7 @@ public:
 	void set_preferred_search_result_type(const String &p_preferred_type) { preferred_search_result_type = p_preferred_type; }
 
 	void popup_create(bool p_dont_clear, bool p_replace_mode = false, const String &p_current_type = "", const String &p_current_name = "");
+	void for_inherit();
 
 	CreateDialog();
 };

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -994,6 +994,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	select_class = memnew(CreateDialog);
 	select_class->connect("create", callable_mp(this, &ScriptCreateDialog::_create));
+	select_class->for_inherit();
 	add_child(select_class);
 
 	file_browse = memnew(EditorFileDialog);


### PR DESCRIPTION
Fixes #108242

Script classes marked as abstract could not be selected when defining inheritence for newly created scripts.

Does not change behaviour for in-built abstract classes (which cannot be extended by scripts).

Unsure if this is the best implementation, but it fixes the problem.