### PR TITLE
Make the behavior of `rendering/rendering_device/driver` consistent with `--rendering-driver`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2576,6 +2576,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			rendering_driver = GLOBAL_GET("rendering/gl_compatibility/driver");
 		} else {
 			rendering_driver = GLOBAL_GET("rendering/rendering_device/driver");
+			if (rendering_driver == "opengl3" || rendering_driver == "opengl3_angle" || rendering_driver == "opengl3_es") {
+				rendering_method = "gl_compatibility";
+			}
 		}
 	}
 


### PR DESCRIPTION
Currently, the `--rendering-device` command supports direct switching between `d3d12`, `vulkan`, and `opengl3`, among others. Although the `rendering/rendering_device/driver` setting in the configuration file can also be set to `opengl3`, doing so may cause rendering bugs in child windows:
<img width="1920" height="1080" alt="图片" src="https://github.com/user-attachments/assets/88955824-0aea-4f0e-b8fd-da0f2b4566d6" />
Through examining the source code, I discovered that this occurs because when reading `--rendering-device`, if `rendering_driver` is set to `opengl3`, it automatically sets `rendering_method` to `gl_compatibility`. However, reading from the configuration file does not trigger this behavior, so I added it manually.
This is not the conventional usage of `rendering/rendering_device/driver`, but I'd like to allow users to switch rendering APIs via `override.cfg` in my project. Whether it's `d3d12`, `vulkan`, or `opengl3`, different users have reported rendering issues with each. Previously, users could only switch APIs using `--rendering-device`, which wasn't very convenient. Enabling `rendering/rendering_device/driver` to be properly set to `opengl3` would be much more user-friendly (sparing users the need to simultaneously change both `rendering/renderer/rendering_method` and `rendering/rendering_device/driver`).