### PR TITLE
[Windows] Add Intel Gen9.5 (Kaby Lake) GPUs to Angle blocklist.

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2369,6 +2369,34 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		FORCE_ANGLE("0x8086", "0x193B"); // Intel(R) Iris Pro Graphics 580, Gen9, Skylake
 		FORCE_ANGLE("Intel", "Intel(R) Iris Pro Graphics P580");
 		FORCE_ANGLE("0x8086", "0x193D"); // Intel(R) Iris Pro Graphics P580, Gen9, Skylake
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 610");
+		FORCE_ANGLE("0x8086", "0x5902"); // Intel(R) HD Graphics 610, Gen9.5, Kaby Lake
+		FORCE_ANGLE("0x8086", "0x5906");
+		FORCE_ANGLE("0x8086", "0x5908");
+		FORCE_ANGLE("0x8086", "0x590A");
+		FORCE_ANGLE("0x8086", "0x590B");
+		FORCE_ANGLE("0x8086", "0x590E");
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 615");
+		FORCE_ANGLE("0x8086", "0x5913"); // Intel(R) HD Graphics 615, Gen9.5, Kaby Lake
+		FORCE_ANGLE("0x8086", "0x5915");
+		FORCE_ANGLE("0x8086", "0x591E");
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 620");
+		FORCE_ANGLE("0x8086", "0x5916"); // Intel(R) HD Graphics 620, Gen9.5, Kaby Lake
+		FORCE_ANGLE("0x8086", "0x5917");
+		FORCE_ANGLE("0x8086", "0x5921");
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 630");
+		FORCE_ANGLE("0x8086", "0x5912"); // Intel(R) HD Graphics 630, Gen9.5, Kaby Lake
+		FORCE_ANGLE("0x8086", "0x591B");
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics 635");
+		FORCE_ANGLE("0x8086", "0x5923"); // Intel(R) HD Graphics 635, Gen9.5, Kaby Lake
+		FORCE_ANGLE("Intel", "Intel(R) Iris Plus Graphics 640");
+		FORCE_ANGLE("0x8086", "0x5926"); // Intel(R) Iris Plus Graphics 640, Gen9.5, Kaby Lake
+		FORCE_ANGLE("Intel", "Intel(R) Iris Plus Graphics 650");
+		FORCE_ANGLE("0x8086", "0x5927"); // Iris Plus Graphics 650, Gen9.5, Kaby Lake
+		FORCE_ANGLE("0x8086", "0x593B");
+		FORCE_ANGLE("Intel", "Intel(R) HD Graphics P630");
+		FORCE_ANGLE("0x8086", "0x591A"); // Intel(R) HD Graphics P630, Gen9.5, Kaby Lake
+		FORCE_ANGLE("0x8086", "0x591D");
 
 #undef FORCE_ANGLE
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/79955#issuecomment-2435795356
