### PR TITLE
Remove const label from create_local_rendering_device

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1104,7 +1104,7 @@
 				Sets the compositor effects for the specified compositor RID. [param effects] should be an array containing RIDs created with [method compositor_effect_create].
 			</description>
 		</method>
-		<method name="create_local_rendering_device" qualifiers="const">
+		<method name="create_local_rendering_device">
 			<return type="RenderingDevice" />
 			<description>
 				Creates a RenderingDevice that can be used to do draw and compute operations on a separate thread. Cannot draw to the screen nor share data with the global RenderingDevice.

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1891,7 +1891,7 @@ RenderingDevice *RenderingServer::get_rendering_device() const {
 	return RenderingDevice::get_singleton();
 }
 
-RenderingDevice *RenderingServer::create_local_rendering_device() const {
+RenderingDevice *RenderingServer::create_local_rendering_device() {
 	RenderingDevice *device = RenderingDevice::get_singleton();
 	if (!device) {
 		return nullptr;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1861,7 +1861,7 @@ public:
 	virtual Size2i get_maximum_viewport_size() const = 0;
 
 	RenderingDevice *get_rendering_device() const;
-	RenderingDevice *create_local_rendering_device() const;
+	RenderingDevice *create_local_rendering_device();
 
 	bool is_render_loop_enabled() const;
 	void set_render_loop_enabled(bool p_enabled);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109193

This is one option for fixing https://github.com/godotengine/godot/issues/109193. 

The core of the issue is twofold:
1. When doing code completion for an object that is the return value of a function, GDScript will actually call the function if it is `const` so it can do code completion on for that object
2. `RenderingServer.create_local_rendering_device()` is marked as const. And is technically const, but it does allocate a bunch of CPU and GPU resources and is not ref counted so it never gets freed

I opted to solve the issue by removing `const` from `create_local_rendering_device()` since it doesn't really need it.

I am worried that this will break compatibility for GDExtensions. If it does, and we can't accept the breakage, then perhaps there is a way for us to modify code complete to cache the return values of functions that it calls so we don't endlessly leak memory.

CC @HolonProduction 