### PR TITLE
Fix `Basis` scale drift in `PathFollow3D`

### DIFF
--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -301,6 +301,7 @@ void PathFollow3D::update_transform() {
 			const Basis twist(tangent, tilt);
 			t.basis = twist * t.basis;
 		}
+		t.basis.orthonormalize();
 	}
 
 	// Apply offset and scale.


### PR DESCRIPTION
Fixes #92329.

There's floating point error that accumulates over time in the scale of the `Basis` that `PathFollow3D` produces. I narrowed it down to this `else` block, and tried putting the orthonormalization on a few different lines. From my tests, all three of `sample_baked_with_rotation`, `correct_posture`, and the `tilt_enabled` block produce a meaningful amount of error. A single call to `orthonormalize` after all of them is enough to stop the error from carrying into the next iteration. 