### PR TITLE
Cull descendant RPCs when any ancestor is not visible

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -299,7 +299,7 @@ void SceneReplicationInterface::_visibility_changed(int p_peer, ObjectID p_sid) 
 	_update_sync_visibility(p_peer, sync);
 }
 
-bool SceneReplicationInterface::is_rpc_visible(const ObjectID &p_oid, int p_peer) const {
+bool SceneReplicationInterface::_is_rpc_visible_on_node(const ObjectID &p_oid, int p_peer) const {
 	if (!tracked_nodes.has(p_oid)) {
 		return true; // Untracked nodes are always visible to RPCs.
 	}
@@ -336,6 +336,37 @@ bool SceneReplicationInterface::is_rpc_visible(const ObjectID &p_oid, int p_peer
 		}
 		return false; // Not visible.
 	}
+}
+
+bool SceneReplicationInterface::is_rpc_visible(const ObjectID &p_oid, int p_peer) const {
+	// Climb the hierarchy to check visibility.
+	ObjectID current = p_oid;
+	while (tracked_nodes.has(current)) {
+		if (!_is_rpc_visible_on_node(current, p_peer)) {
+			return false;
+		}
+		// find the nearest tracked parent:
+		Node *node = get_id_as<Node>(current);
+		if (!node) {
+			return true; // Not tracked, so visible.
+		}
+
+		// Find closest tracked parent.
+		ObjectID next = ObjectID();
+		Node *p = node->get_parent();
+		while (p) {
+			ObjectID pid = p->get_instance_id();
+			if (tracked_nodes.has(pid)) {
+				next = pid;
+				break;
+			}
+			p = p->get_parent();
+		}
+
+		current = next;
+	}
+
+	return true; // Not tracked, so visible.
 }
 
 Error SceneReplicationInterface::_update_sync_visibility(int p_peer, MultiplayerSynchronizer *p_sync) {

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -111,6 +111,8 @@ private:
 	Error _update_spawn_visibility(int p_peer, const ObjectID &p_oid);
 	void _free_remotes(const PeerInfo &p_info);
 
+	bool _is_rpc_visible_on_node(const ObjectID &p_oid, int p_peer) const;
+
 	template <typename T>
 	static T *get_id_as(const ObjectID &p_id) {
 		return p_id.is_valid() ? ObjectDB::get_instance<T>(p_id) : nullptr;


### PR DESCRIPTION
Previously, only the target node’s visibility was checked, so if a parent (e.g., a character) was not visible, RPCs on its descendant nodes  (e.g., a weapon) would still be sent, causing errors on the receiving peer because those nodes didn’t exist locally.

Now is_rpc_visible walks the tracked-node hierarchy and rejects the RPC if any ancestor is not visible, so RPCs on descendant nodes are properly culled.