### PR TITLE
Improve Multiplayer performance

### DIFF
--- a/modules/multiplayer/multiplayer_synchronizer.cpp
+++ b/modules/multiplayer/multiplayer_synchronizer.cpp
@@ -34,13 +34,13 @@
 #include "core/object/class_db.h"
 #include "scene/main/multiplayer_api.h"
 
-Object *MultiplayerSynchronizer::_get_prop_target(Object *p_obj, const NodePath &p_path) {
+Node *MultiplayerSynchronizer::_get_prop_target(Node *p_node, const NodePath &p_path) {
 	if (p_path.get_name_count() == 0) {
-		return p_obj;
+		return p_node;
 	}
-	Node *node = Object::cast_to<Node>(p_obj);
-	ERR_FAIL_COND_V_MSG(!node || !node->has_node(p_path), nullptr, vformat("Node '%s' not found.", p_path));
-	return node->get_node(p_path);
+	Node *target = p_node ? p_node->get_node_or_null(p_path) : nullptr;
+	ERR_FAIL_COND_V_MSG(!p_node || !target, nullptr, vformat("Node '%s' not found.", p_path));
+	return target;
 }
 
 void MultiplayerSynchronizer::_stop() {
@@ -154,14 +154,14 @@ PackedStringArray MultiplayerSynchronizer::get_configuration_warnings() const {
 	return warnings;
 }
 
-Error MultiplayerSynchronizer::get_state(const List<NodePath> &p_properties, Object *p_obj, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs) {
-	ERR_FAIL_NULL_V(p_obj, ERR_INVALID_PARAMETER);
+Error MultiplayerSynchronizer::get_state(const LocalVector<NodePath> &p_properties, Node *p_node, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs) {
+	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 	r_variant.resize(p_properties.size());
 	r_variant_ptrs.resize(r_variant.size());
 	int i = 0;
 	for (const NodePath &prop : p_properties) {
 		bool valid = false;
-		const Object *obj = _get_prop_target(p_obj, prop);
+		const Node *obj = _get_prop_target(p_node, prop);
 		ERR_FAIL_NULL_V(obj, FAILED);
 		r_variant.write[i] = obj->get_indexed(prop.get_subnames(), &valid);
 		r_variant_ptrs.write[i] = &r_variant[i];
@@ -171,11 +171,11 @@ Error MultiplayerSynchronizer::get_state(const List<NodePath> &p_properties, Obj
 	return OK;
 }
 
-Error MultiplayerSynchronizer::set_state(const List<NodePath> &p_properties, Object *p_obj, const Vector<Variant> &p_state) {
-	ERR_FAIL_NULL_V(p_obj, ERR_INVALID_PARAMETER);
+Error MultiplayerSynchronizer::set_state(const LocalVector<NodePath> &p_properties, Node *p_node, const Vector<Variant> &p_state) {
+	ERR_FAIL_NULL_V(p_node, ERR_INVALID_PARAMETER);
 	int i = 0;
 	for (const NodePath &prop : p_properties) {
-		Object *obj = _get_prop_target(p_obj, prop);
+		Node *obj = _get_prop_target(p_node, prop);
 		ERR_FAIL_NULL_V(obj, FAILED);
 		obj->set_indexed(prop.get_subnames(), p_state[i]);
 		i += 1;
@@ -373,7 +373,7 @@ void MultiplayerSynchronizer::set_multiplayer_authority(int p_peer_id, bool p_re
 
 Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 	ERR_FAIL_COND_V(replication_config.is_null(), FAILED);
-	const List<NodePath> props(replication_config->get_watch_properties());
+	const LocalVector<NodePath> &props = replication_config->get_watch_properties();
 	if (props.size() != watchers.size()) {
 		watchers.resize(props.size());
 	}
@@ -387,7 +387,7 @@ Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 	for (const NodePath &prop : props) {
 		idx++;
 		bool valid = false;
-		const Object *obj = _get_prop_target(node, prop);
+		const Node *obj = _get_prop_target(node, prop);
 		ERR_CONTINUE_MSG(!obj, vformat("Node not found for property '%s'.", prop));
 		Variant v = obj->get_indexed(prop.get_subnames(), &valid);
 		ERR_CONTINUE_MSG(!valid, vformat("Property '%s' not found.", prop));
@@ -404,9 +404,9 @@ Error MultiplayerSynchronizer::_watch_changes(uint64_t p_usec) {
 	return OK;
 }
 
-List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint64_t p_last_usec, uint64_t &r_indexes) {
+LocalVector<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint64_t p_last_usec, uint64_t &r_indexes) {
 	r_indexes = 0;
-	List<Variant> out;
+	LocalVector<Variant> out;
 
 	if (last_watch_usec == p_cur_usec) {
 		// We already watched for changes in this frame.
@@ -434,10 +434,10 @@ List<Variant> MultiplayerSynchronizer::get_delta_state(uint64_t p_cur_usec, uint
 	return out;
 }
 
-List<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes) {
-	List<NodePath> out;
+LocalVector<NodePath> MultiplayerSynchronizer::get_delta_properties(uint64_t p_indexes) {
+	LocalVector<NodePath> out;
 	ERR_FAIL_COND_V(replication_config.is_null(), out);
-	const List<NodePath> watch_props(replication_config->get_watch_properties());
+	const LocalVector<NodePath> &watch_props = replication_config->get_watch_properties();
 	int idx = 0;
 	for (const NodePath &prop : watch_props) {
 		if ((p_indexes & (1ULL << idx++)) == 0) {

--- a/modules/multiplayer/multiplayer_synchronizer.h
+++ b/modules/multiplayer/multiplayer_synchronizer.h
@@ -67,7 +67,7 @@ private:
 	uint32_t net_id = 0;
 	bool sync_started = false;
 
-	static Object *_get_prop_target(Object *p_obj, const NodePath &p_prop);
+	static Node *_get_prop_target(Node *p_node, const NodePath &p_prop);
 	void _start();
 	void _stop();
 	void _update_process();
@@ -78,8 +78,8 @@ protected:
 	void _notification(int p_what);
 
 public:
-	static Error get_state(const List<NodePath> &p_properties, Object *p_obj, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs);
-	static Error set_state(const List<NodePath> &p_properties, Object *p_obj, const Vector<Variant> &p_state);
+	static Error get_state(const LocalVector<NodePath> &p_properties, Node *p_node, Vector<Variant> &r_variant, Vector<const Variant *> &r_variant_ptrs);
+	static Error set_state(const LocalVector<NodePath> &p_properties, Node *p_node, const Vector<Variant> &p_state);
 
 	void reset();
 	Node *get_root_node();
@@ -116,8 +116,8 @@ public:
 	void remove_visibility_filter(Callable p_callback);
 	VisibilityUpdateMode get_visibility_update_mode() const;
 
-	List<Variant> get_delta_state(uint64_t p_cur_usec, uint64_t p_last_usec, uint64_t &r_indexes);
-	List<NodePath> get_delta_properties(uint64_t p_indexes);
+	LocalVector<Variant> get_delta_state(uint64_t p_cur_usec, uint64_t p_last_usec, uint64_t &r_indexes);
+	LocalVector<NodePath> get_delta_properties(uint64_t p_indexes);
 	SceneReplicationConfig *get_replication_config_ptr() const;
 
 	MultiplayerSynchronizer();

--- a/modules/multiplayer/scene_cache_interface.cpp
+++ b/modules/multiplayer/scene_cache_interface.cpp
@@ -167,7 +167,7 @@ void SceneCacheInterface::process_confirm_path(int p_from, const uint8_t *p_pack
 	*confirmed = true;
 }
 
-Error SceneCacheInterface::_send_confirm_path(Node *p_node, NodeCache &p_cache, const List<int> &p_peers) {
+Error SceneCacheInterface::_send_confirm_path(Node *p_node, NodeCache &p_cache, const LocalVector<int> &p_peers) {
 	// Encode function name.
 	const CharString path = String(multiplayer->get_root_path().rel_path_to(p_node->get_path())).utf8();
 	const int path_len = encode_cstring(path.get_data(), nullptr);
@@ -214,30 +214,28 @@ bool SceneCacheInterface::is_cache_confirmed(Node *p_node, int p_peer) {
 	return confirmed && *confirmed;
 }
 
-int SceneCacheInterface::make_object_cache(Object *p_obj) {
-	Node *node = Object::cast_to<Node>(p_obj);
-	ERR_FAIL_NULL_V(node, -1);
-	NodeCache &cache = _track(node);
+int SceneCacheInterface::make_object_cache(Node *p_node) {
+	ERR_FAIL_NULL_V(p_node, -1);
+	NodeCache &cache = _track(p_node);
 	if (cache.cache_id == 0) {
 		cache.cache_id = last_send_cache_id++;
-		assigned_ids[cache.cache_id] = p_obj->get_instance_id();
+		assigned_ids[cache.cache_id] = p_node->get_instance_id();
 	}
 	return cache.cache_id;
 }
 
-bool SceneCacheInterface::send_object_cache(Object *p_obj, int p_peer_id, int &r_id) {
-	Node *node = Object::cast_to<Node>(p_obj);
-	ERR_FAIL_NULL_V(node, false);
+bool SceneCacheInterface::send_object_cache(Node *p_node, int p_peer_id, int &r_id) {
+	ERR_FAIL_NULL_V(p_node, false);
 	// See if the path is cached.
-	NodeCache &cache = _track(node);
+	NodeCache &cache = _track(p_node);
 	if (cache.cache_id == 0) {
 		cache.cache_id = last_send_cache_id++;
-		assigned_ids[cache.cache_id] = p_obj->get_instance_id();
+		assigned_ids[cache.cache_id] = p_node->get_instance_id();
 	}
 	r_id = cache.cache_id;
 
 	bool has_all_peers = true;
-	List<int> peers_to_add; // If one is missing, take note to add it.
+	LocalVector<int> peers_to_add; // If one is missing, take note to add it.
 
 	if (p_peer_id > 0) {
 		// Fast single peer check.
@@ -268,13 +266,13 @@ bool SceneCacheInterface::send_object_cache(Object *p_obj, int p_peer_id, int &r
 	}
 
 	if (peers_to_add.size()) {
-		_send_confirm_path(node, cache, peers_to_add);
+		_send_confirm_path(p_node, cache, peers_to_add);
 	}
 
 	return has_all_peers;
 }
 
-Object *SceneCacheInterface::get_cached_object(int p_from, uint32_t p_cache_id) {
+Node *SceneCacheInterface::get_cached_object(int p_from, uint32_t p_cache_id) {
 	PeerInfo *pinfo = peers_info.getptr(p_from);
 	ERR_FAIL_NULL_V(pinfo, nullptr);
 

--- a/modules/multiplayer/scene_cache_interface.h
+++ b/modules/multiplayer/scene_cache_interface.h
@@ -72,7 +72,7 @@ private:
 	NodeCache &_track(Node *p_node);
 
 protected:
-	Error _send_confirm_path(Node *p_node, NodeCache &p_cache, const List<int> &p_peers);
+	Error _send_confirm_path(Node *p_node, NodeCache &p_cache, const LocalVector<int> &p_peers);
 
 public:
 	void clear();
@@ -81,9 +81,9 @@ public:
 	void process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len);
 
 	// Returns true if all peers have cached path.
-	bool send_object_cache(Object *p_obj, int p_target, int &p_id);
-	int make_object_cache(Object *p_obj);
-	Object *get_cached_object(int p_from, uint32_t p_cache_id);
+	bool send_object_cache(Node *p_node, int p_target, int &p_id);
+	int make_object_cache(Node *p_node);
+	Node *get_cached_object(int p_from, uint32_t p_cache_id);
 	bool is_cache_confirmed(Node *p_path, int p_peer);
 
 	SceneCacheInterface(SceneMultiplayer *p_multiplayer) { multiplayer = p_multiplayer; }

--- a/modules/multiplayer/scene_multiplayer.cpp
+++ b/modules/multiplayer/scene_multiplayer.cpp
@@ -38,13 +38,13 @@
 
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneMultiplayer::_profile_bandwidth(const String &p_what, int p_value) {
-	if (EngineDebugger::is_profiling("multiplayer:bandwidth")) {
+	if (EngineDebugger::is_profiling(SNAME("multiplayer:bandwidth"))) {
 		Array values = {
 			p_what,
 			OS::get_singleton()->get_ticks_msec(),
 			p_value
 		};
-		EngineDebugger::profiler_add_frame_data("multiplayer:bandwidth", values);
+		EngineDebugger::profiler_add_frame_data(SNAME("multiplayer:bandwidth"), values);
 	}
 }
 #endif
@@ -571,8 +571,8 @@ bool SceneMultiplayer::is_object_decoding_allowed() const {
 	return allow_object_decoding;
 }
 
-String SceneMultiplayer::get_rpc_md5(const Object *p_obj) {
-	return rpc->get_rpc_md5(p_obj);
+String SceneMultiplayer::get_rpc_md5(const Node *p_node) {
+	return rpc->get_rpc_md5(p_node);
 }
 
 Error SceneMultiplayer::rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {

--- a/modules/multiplayer/scene_multiplayer.h
+++ b/modules/multiplayer/scene_multiplayer.h
@@ -180,7 +180,7 @@ public:
 
 	Error send_command(int p_to, const uint8_t *p_packet, int p_packet_len); // Used internally to relay packets when needed.
 	Error send_bytes(Vector<uint8_t> p_data, int p_to = MultiplayerPeer::TARGET_PEER_BROADCAST, MultiplayerPeer::TransferMode p_mode = MultiplayerPeer::TRANSFER_MODE_RELIABLE, int p_channel = 0);
-	String get_rpc_md5(const Object *p_obj);
+	String get_rpc_md5(const Node *p_node);
 
 	const HashSet<int> get_connected_peers() const { return HashSet<int>(connected_peers); }
 

--- a/modules/multiplayer/scene_replication_config.cpp
+++ b/modules/multiplayer/scene_replication_config.cpp
@@ -249,21 +249,21 @@ void SceneReplicationConfig::_update() {
 	}
 }
 
-const List<NodePath> &SceneReplicationConfig::get_spawn_properties() {
+const LocalVector<NodePath> &SceneReplicationConfig::get_spawn_properties() {
 	if (dirty) {
 		_update();
 	}
 	return spawn_props;
 }
 
-const List<NodePath> &SceneReplicationConfig::get_sync_properties() {
+const LocalVector<NodePath> &SceneReplicationConfig::get_sync_properties() {
 	if (dirty) {
 		_update();
 	}
 	return sync_props;
 }
 
-const List<NodePath> &SceneReplicationConfig::get_watch_properties() {
+const LocalVector<NodePath> &SceneReplicationConfig::get_watch_properties() {
 	if (dirty) {
 		_update();
 	}

--- a/modules/multiplayer/scene_replication_config.h
+++ b/modules/multiplayer/scene_replication_config.h
@@ -63,9 +63,9 @@ private:
 	};
 
 	List<ReplicationProperty> properties;
-	List<NodePath> spawn_props;
-	List<NodePath> sync_props;
-	List<NodePath> watch_props;
+	LocalVector<NodePath> spawn_props;
+	LocalVector<NodePath> sync_props;
+	LocalVector<NodePath> watch_props;
 	bool dirty = false;
 
 	void _update();
@@ -99,9 +99,9 @@ public:
 	ReplicationMode property_get_replication_mode(const NodePath &p_path);
 	void property_set_replication_mode(const NodePath &p_path, ReplicationMode p_mode);
 
-	const List<NodePath> &get_spawn_properties();
-	const List<NodePath> &get_sync_properties();
-	const List<NodePath> &get_watch_properties();
+	const LocalVector<NodePath> &get_spawn_properties();
+	const LocalVector<NodePath> &get_sync_properties();
+	const LocalVector<NodePath> &get_watch_properties();
 
 	SceneReplicationConfig() {}
 };

--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -44,9 +44,9 @@
 
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneReplicationInterface::_profile_node_data(const String &p_what, ObjectID p_id, int p_size) {
-	if (EngineDebugger::is_profiling("multiplayer:replication")) {
+	if (EngineDebugger::is_profiling(SNAME("multiplayer:replication"))) {
 		Array values = { p_what, p_id, p_size };
-		EngineDebugger::profiler_add_frame_data("multiplayer:replication", values);
+		EngineDebugger::profiler_add_frame_data(SNAME("multiplayer:replication"), values);
 	}
 }
 #endif
@@ -143,7 +143,7 @@ void SceneReplicationInterface::on_network_process() {
 	// Process syncs.
 	uint64_t usec = OS::get_singleton()->get_ticks_usec();
 	for (KeyValue<int, PeerInfo> &E : peers_info) {
-		const HashSet<ObjectID> to_sync(E.value.sync_nodes);
+		const HashSet<ObjectID> &to_sync = E.value.sync_nodes;
 		if (to_sync.is_empty()) {
 			continue; // Nothing to sync
 		}
@@ -241,8 +241,13 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		// Try to apply synchronizer Net ID
 		ERR_FAIL_COND_V_MSG(pending_sync_net_ids.is_empty(), ERR_INVALID_DATA, vformat("The MultiplayerSynchronizer at path \"%s\" is unable to process the pending spawn since it has no network ID. This might happen when changing the multiplayer authority during the \"_ready\" callback. Make sure to only change the authority of multiplayer synchronizers during the \"_enter_tree\" callback of their multiplayer spawner.", sync->get_path()));
 		ERR_FAIL_COND_V(!peers_info.has(pending_spawn_remote), ERR_INVALID_DATA);
-		uint32_t net_id = pending_sync_net_ids.front()->get();
-		pending_sync_net_ids.pop_front();
+		uint32_t net_id = pending_sync_net_ids[pending_sync_head++];
+		// when we’ve consumed them all, clear and reset
+		if (pending_sync_head == pending_sync_net_ids.size()) {
+			pending_sync_net_ids.clear();
+			pending_sync_head = 0;
+		}
+
 		peers_info[pending_spawn_remote].recv_sync_ids[net_id] = sync->get_instance_id();
 		sync->set_net_id(net_id);
 
@@ -250,7 +255,7 @@ Error SceneReplicationInterface::on_replication_start(Object *p_obj, Variant p_c
 		if (pending_buffer_size > 0) {
 			ERR_FAIL_COND_V(!node || !sync->get_replication_config_ptr(), ERR_UNCONFIGURED);
 			int consumed = 0;
-			const List<NodePath> props(sync->get_replication_config_ptr()->get_spawn_properties());
+			const LocalVector<NodePath> &props = sync->get_replication_config_ptr()->get_spawn_properties();
 			Vector<Variant> vars;
 			vars.resize(props.size());
 			Error err = MultiplayerAPI::decode_and_decompress_variants(vars, pending_buffer, pending_buffer_size, consumed);
@@ -387,7 +392,7 @@ Error SceneReplicationInterface::_update_spawn_visibility(int p_peer, const Obje
 	ERR_FAIL_NULL_V(spawner, ERR_BUG);
 	ERR_FAIL_COND_V(!_has_authority(spawner), ERR_BUG);
 	ERR_FAIL_COND_V(!tracked_nodes.has(p_oid), ERR_BUG);
-	const HashSet<ObjectID> synchronizers(tracked_nodes[p_oid].synchronizers);
+	const HashSet<ObjectID> &synchronizers = tracked_nodes[p_oid].synchronizers;
 	bool is_visible = true;
 	for (const ObjectID &sid : synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(sid);
@@ -489,9 +494,9 @@ Error SceneReplicationInterface::_make_spawn_packet(Node *p_node, MultiplayerSpa
 	}
 
 	// Prepare spawn state.
-	List<NodePath> state_props;
-	List<uint32_t> sync_ids;
-	const HashSet<ObjectID> synchronizers(tnode->synchronizers);
+	LocalVector<NodePath> state_props;
+	LocalVector<uint32_t> sync_ids;
+	const HashSet<ObjectID> &synchronizers = tnode->synchronizers;
 	for (const ObjectID &sid : synchronizers) {
 		MultiplayerSynchronizer *sync = get_id_as<MultiplayerSynchronizer>(sid);
 		if (!_has_authority(sync)) {
@@ -584,7 +589,7 @@ Error SceneReplicationInterface::on_spawn_receive(int p_from, const uint8_t *p_b
 	uint32_t name_len = decode_uint32(&p_buffer[ofs]);
 	ofs += 4;
 	ERR_FAIL_COND_V_MSG(name_len + (sync_len * 4) > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA, vformat("Invalid spawn packet size: %d, wants: %d", p_buffer_len, ofs + name_len + (sync_len * 4)));
-	List<uint32_t> sync_ids;
+	LocalVector<uint32_t> sync_ids;
 	for (uint32_t i = 0; i < sync_len; i++) {
 		sync_ids.push_back(decode_uint32(&p_buffer[ofs]));
 		ofs += 4;
@@ -721,7 +726,7 @@ void SceneReplicationInterface::_send_delta(int p_peer, const HashSet<ObjectID> 
 		}
 		uint64_t last_usec = p_last_watch_usecs.has(oid) ? p_last_watch_usecs[oid] : 0;
 		uint64_t indexes;
-		List<Variant> delta = sync->get_delta_state(p_usec, last_usec, indexes);
+		LocalVector<Variant> delta = sync->get_delta_state(p_usec, last_usec, indexes);
 
 		if (!delta.size()) {
 			continue; // Nothing to update.
@@ -780,7 +785,7 @@ Error SceneReplicationInterface::on_delta_receive(int p_from, const uint8_t *p_b
 			ofs += size;
 			ERR_CONTINUE_MSG(true, "Ignoring delta for non-authority or invalid synchronizer.");
 		}
-		List<NodePath> props = sync->get_delta_properties(indexes);
+		LocalVector<NodePath> props = sync->get_delta_properties(indexes);
 		ERR_FAIL_COND_V(props.is_empty(), ERR_INVALID_DATA);
 		Vector<Variant> vars;
 		vars.resize(props.size());
@@ -824,7 +829,7 @@ void SceneReplicationInterface::_send_sync(int p_peer, const HashSet<ObjectID> &
 		int size;
 		Vector<Variant> vars;
 		Vector<const Variant *> varp;
-		const List<NodePath> props(sync->get_replication_config_ptr()->get_sync_properties());
+		const LocalVector<NodePath> &props = sync->get_replication_config_ptr()->get_sync_properties();
 		Error err = MultiplayerSynchronizer::get_state(props, node, vars, varp);
 		ERR_CONTINUE_MSG(err != OK, "Unable to retrieve sync state.");
 		err = MultiplayerAPI::encode_and_compress_variants(varp.ptrw(), varp.size(), nullptr, size);
@@ -883,7 +888,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 			ofs += size;
 			continue;
 		}
-		const List<NodePath> props(sync->get_replication_config_ptr()->get_sync_properties());
+		const LocalVector<NodePath> &props = sync->get_replication_config_ptr()->get_sync_properties();
 		Vector<Variant> vars;
 		vars.resize(props.size());
 		int consumed;

--- a/modules/multiplayer/scene_replication_interface.h
+++ b/modules/multiplayer/scene_replication_interface.h
@@ -84,7 +84,8 @@ private:
 	int pending_spawn_remote = 0;
 	const uint8_t *pending_buffer = nullptr;
 	int pending_buffer_size = 0;
-	List<uint32_t> pending_sync_net_ids;
+	LocalVector<uint32_t> pending_sync_net_ids;
+	uint32_t pending_sync_head = 0;
 
 	// Replicator config.
 	SceneMultiplayer *multiplayer = nullptr;

--- a/modules/multiplayer/scene_rpc_interface.cpp
+++ b/modules/multiplayer/scene_rpc_interface.cpp
@@ -55,9 +55,9 @@
 
 #ifdef DEBUG_ENABLED
 _FORCE_INLINE_ void SceneRPCInterface::_profile_node_data(const String &p_what, ObjectID p_id, int p_size) {
-	if (EngineDebugger::is_profiling("multiplayer:rpc")) {
+	if (EngineDebugger::is_profiling(SNAME("multiplayer:rpc"))) {
 		Array values = { p_what, p_id, p_size };
-		EngineDebugger::profiler_add_frame_data("multiplayer:rpc", values);
+		EngineDebugger::profiler_add_frame_data(SNAME("multiplayer:rpc"), values);
 	}
 }
 #endif
@@ -116,10 +116,9 @@ const SceneRPCInterface::RPCConfigCache &SceneRPCInterface::_get_node_config(con
 	return rpc_cache[oid];
 }
 
-String SceneRPCInterface::get_rpc_md5(const Object *p_obj) {
-	const Node *node = Object::cast_to<Node>(p_obj);
-	ERR_FAIL_NULL_V(node, "");
-	const RPCConfigCache cache = _get_node_config(node);
+String SceneRPCInterface::get_rpc_md5(const Node *p_node) {
+	ERR_FAIL_NULL_V(p_node, "");
+	const RPCConfigCache cache = _get_node_config(p_node);
 	String rpc_list;
 	for (const KeyValue<uint16_t, RPCConfig> &config : cache.configs) {
 		rpc_list += String(config.value.name);

--- a/modules/multiplayer/scene_rpc_interface.h
+++ b/modules/multiplayer/scene_rpc_interface.h
@@ -101,7 +101,7 @@ protected:
 public:
 	Error rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
 	void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len);
-	String get_rpc_md5(const Object *p_obj);
+	String get_rpc_md5(const Node *p_node);
 
 	SceneRPCInterface(SceneMultiplayer *p_multiplayer, SceneCacheInterface *p_cache, SceneReplicationInterface *p_replicator) {
 		multiplayer = p_multiplayer;


### PR DESCRIPTION
- Replaced `List` with `LocalVector`.
- Switched to `const` references to avoid unnecessary copies.
- Removed unneeded dynamic casts (`Object::cast_to` is quite expensive in hot paths!).
- Fixed profiler tags to use `SNAME`.