### PR TITLE
Add instance uniforms to particles process shaders

### DIFF
--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -164,6 +164,8 @@ uniform bool clear;
 uniform uint total_particles;
 uniform bool use_fractional_delta;
 
+uniform uint instance_offset;
+
 uint hash(uint x) {
 	x = ((x >> uint(16)) ^ x) * uint(0x45d9f3b);
 	x = ((x >> uint(16)) ^ x) * uint(0x45d9f3b);

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1473,6 +1473,7 @@ MaterialStorage::MaterialStorage() {
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
 
 		actions.global_buffer_array_variable = "global_shader_uniforms";
+		actions.instance_uniform_index_variable = "instance_offset";
 
 		shaders.compiler_particles.initialize(actions);
 	}

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -769,6 +769,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::CLEAR, p_particles->clear, version, variant, specialization);
 	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::TOTAL_PARTICLES, uint32_t(p_particles->amount), version, variant, specialization);
 	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::USE_FRACTIONAL_DELTA, p_particles->fractional_delta, version, variant, specialization);
+	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::INSTANCE_OFFSET, p_particles->instance_uniforms_ofs, version, variant, specialization);
 
 	p_particles->clear = false;
 
@@ -1223,6 +1224,12 @@ bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, false);
 	return !particles->emitting && particles->inactive;
+}
+
+void GLES3::ParticlesStorage::particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+	particles->instance_uniforms_ofs = (uint32_t)p_offset;
 }
 
 /* PARTICLES COLLISION API */

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -244,6 +244,8 @@ private:
 		double trail_length = 1.0;
 		bool trails_enabled = false;
 
+		uint32_t instance_uniforms_ofs = 0;
+
 		Particles() :
 				update_list(this) {
 			random_seed = Math::rand();
@@ -374,6 +376,8 @@ public:
 
 	virtual void update_particles() override;
 	virtual bool particles_is_inactive(RID p_particles) const override;
+
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) override;
 
 	_FORCE_INLINE_ RS::ParticlesMode particles_get_mode(RID p_particles) {
 		Particles *particles = particles_owner.get_or_null(p_particles);

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -148,14 +148,16 @@ void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 		return;
 	}
 
-	if (process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
+	if (Engine::get_singleton()->is_editor_hint() && process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
 		process_material->disconnect("emission_shape_changed", callable_mp((CanvasItem *)this, &GPUParticles2D::queue_redraw));
+		process_material->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 	}
 
 	process_material = p_material;
 
-	if (process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
+	if (Engine::get_singleton()->is_editor_hint() && process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
 		process_material->connect("emission_shape_changed", callable_mp((CanvasItem *)this, &GPUParticles2D::queue_redraw));
+		process_material->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 	}
 
 	queue_redraw();
@@ -173,6 +175,10 @@ void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 	RS::get_singleton()->particles_set_process_material(particles, material_rid);
 
 	update_configuration_warnings();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		notify_property_list_changed();
+	}
 }
 
 void GPUParticles2D::set_trail_enabled(bool p_enabled) {

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -147,27 +147,29 @@ void GPUParticles3D::set_use_local_coordinates(bool p_enable) {
 }
 
 void GPUParticles3D::set_process_material(const Ref<Material> &p_material) {
-#ifdef TOOLS_ENABLED
-	if (process_material.is_valid()) {
+	if (Engine::get_singleton()->is_editor_hint() && process_material.is_valid()) {
 		if (Ref<ParticleProcessMaterial>(process_material).is_valid()) {
 			process_material->disconnect("emission_shape_changed", callable_mp((Node3D *)this, &GPUParticles3D::update_gizmos));
+			process_material->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 		}
 	}
-#endif
 
 	process_material = p_material;
 	RID material_rid;
 	if (process_material.is_valid()) {
 		material_rid = process_material->get_rid();
-#ifdef TOOLS_ENABLED
-		if (Ref<ParticleProcessMaterial>(process_material).is_valid()) {
+		if (Engine::get_singleton()->is_editor_hint() && Ref<ParticleProcessMaterial>(process_material).is_valid()) {
 			process_material->connect("emission_shape_changed", callable_mp((Node3D *)this, &GPUParticles3D::update_gizmos));
+			process_material->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 		}
-#endif
 	}
 	RS::get_singleton()->particles_set_process_material(particles, material_rid);
 
 	update_configuration_warnings();
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		notify_property_list_changed();
+	}
 }
 
 void GPUParticles3D::set_speed_scale(double p_scale) {

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -123,6 +123,7 @@ public:
 	virtual void particles_collision_instance_set_active(RID p_collision_instance, bool p_active) override {}
 
 	virtual bool particles_is_inactive(RID p_particles) const override { return false; }
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) override {}
 };
 
 } // namespace RendererDummy

--- a/servers/rendering/instance_uniforms.cpp
+++ b/servers/rendering/instance_uniforms.cpp
@@ -131,7 +131,7 @@ Variant InstanceUniforms::get_default(const StringName &p_name) const {
 }
 
 void InstanceUniforms::get_property_list(List<PropertyInfo> &r_parameters) const {
-	Vector<StringName> names;
+	LocalVector<StringName> names;
 
 	// Invalid items won't be saved, but will remain in memory in case of shader compilation failure.
 	for (const KeyValue<StringName, Item> &kv : _parameters) {

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -63,6 +63,11 @@ void RendererCanvasCull::_dependency_deleted(const RID &p_dependency, Dependency
 
 	if (p_dependency == item->material) {
 		_canvas_cull_singleton->canvas_item_set_material(item->self, RID());
+	} else if (item->commands && item->commands->type == Item::Command::TYPE_PARTICLES) {
+		Item::CommandParticles *particle_cmd = static_cast<Item::CommandParticles *>(item->commands);
+		if (p_dependency == particle_cmd->particles) {
+			particle_cmd->particles = RID();
+		}
 	}
 	_canvas_cull_singleton->_item_queue_update(item, true);
 }
@@ -1775,11 +1780,13 @@ void RendererCanvasCull::canvas_item_add_particles(RID p_item, RID p_particles, 
 	Item::CommandParticles *part = canvas_item->alloc_command<Item::CommandParticles>();
 	ERR_FAIL_NULL(part);
 	part->particles = p_particles;
-
 	part->texture = p_texture;
 
 	//take the chance and request processing for them, at least once until they become visible again
 	RSG::particles_storage->particles_request_process(p_particles);
+
+	// Need to update instance uniforms.
+	_item_queue_update(canvas_item, true);
 }
 
 void RendererCanvasCull::canvas_item_add_multimesh(RID p_item, RID p_mesh, RID p_texture) {
@@ -2533,8 +2540,24 @@ void RendererCanvasCull::_update_dirty_item(Item *p_item) {
 			RSG::material_storage->material_update_dependency(material, &p_item->dependency_tracker);
 		}
 
+		bool is_particles = p_item->commands && p_item->commands->type == Item::Command::TYPE_PARTICLES;
+		const Item::CommandParticles *particles_cmd = is_particles ? static_cast<const Item::CommandParticles *>(p_item->commands) : nullptr;
+
+		if (is_particles && particles_cmd->particles.is_valid()) {
+			RSG::utilities->base_update_dependency(particles_cmd->particles, &p_item->dependency_tracker);
+			RID process_material = RSG::particles_storage->particles_get_process_material(particles_cmd->particles);
+			if (process_material.is_valid()) {
+				p_item->instance_uniforms.materials_append(process_material);
+				RSG::material_storage->material_update_dependency(process_material, &p_item->dependency_tracker);
+			}
+		}
+
 		if (p_item->instance_uniforms.materials_finish(p_item->self)) {
 			p_item->instance_allocated_shader_uniforms_offset = p_item->instance_uniforms.location();
+		}
+
+		if (is_particles && particles_cmd->particles.is_valid()) {
+			RSG::particles_storage->particles_set_instance_uniform_offset(particles_cmd->particles, p_item->instance_uniforms.location());
 		}
 
 		p_item->dependency_tracker.update_end();

--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "servers/rendering/renderer_geometry_instance.h"
+#include "servers/rendering/rendering_server_globals.h"
 
 void RenderGeometryInstanceBase::set_skeleton(RID p_skeleton) {
 	data->skeleton = p_skeleton;
@@ -124,7 +125,9 @@ void RenderGeometryInstanceBase::set_use_dynamic_gi(bool p_enable) {
 
 void RenderGeometryInstanceBase::set_instance_shader_uniforms_offset(int32_t p_offset) {
 	shader_uniforms_offset = p_offset;
-
+	if (data->base_type == RS::INSTANCE_PARTICLES) {
+		RSG::particles_storage->particles_set_instance_uniform_offset(data->base, p_offset);
+	}
 	_mark_dirty();
 }
 

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -184,6 +184,8 @@ layout(push_constant, std430) uniform Params {
 	bool sub_emitter_mode;
 	bool can_emit;
 	bool trail_pass;
+	uvec3 pad;
+	uint instance_uniforms_ofs;
 }
 params;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -121,6 +121,7 @@ ParticlesStorage::ParticlesStorage() {
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
 		actions.global_buffer_array_variable = "global_shader_uniforms.data";
+		actions.instance_uniform_index_variable = "params.instance_uniforms_ofs";
 
 		particles_shader.compiler.initialize(actions);
 	}
@@ -1124,6 +1125,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	push_constant.use_fractional_delta = p_particles->fractional_delta;
 	push_constant.sub_emitter_mode = !p_particles->emitting && p_particles->emission_buffer && (p_particles->emission_buffer->particle_count > 0 || p_particles->force_sub_emit);
 	push_constant.trail_pass = false;
+	push_constant.instance_uniforms_ofs = p_particles->shader_uniforms_offset;
 
 	p_particles->force_sub_emit = false; //reset
 
@@ -1667,6 +1669,13 @@ bool ParticlesStorage::particles_is_inactive(RID p_particles) const {
 	const Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL_V(particles, false);
 	return !particles->emitting && particles->inactive;
+}
+
+void ParticlesStorage::particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->shader_uniforms_offset = (uint32_t)p_offset;
 }
 
 /* Particles SHADER */

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -233,6 +233,8 @@ private:
 		uint64_t instance_motion_vectors_last_change = -1;
 		bool instance_motion_vectors_enabled = false;
 
+		uint32_t shader_uniforms_offset = 0;
+
 		bool clear = true;
 
 		bool force_sub_emit = false;
@@ -283,6 +285,9 @@ private:
 			uint32_t sub_emitter_mode;
 			uint32_t can_emit;
 			uint32_t trail_pass;
+
+			uint32_t pad[3];
+			uint32_t instance_uniforms_ofs = 0;
 		};
 
 		ParticlesShaderRD shader;
@@ -488,6 +493,8 @@ public:
 	virtual void particles_set_view_axis(RID p_particles, const Vector3 &p_axis, const Vector3 &p_up_axis) override;
 
 	virtual bool particles_is_inactive(RID p_particles) const override;
+
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) override;
 
 	_FORCE_INLINE_ RS::ParticlesMode particles_get_mode(RID p_particles) {
 		Particles *particles = particles_owner.get_or_null(p_particles);

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -4100,6 +4100,13 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) const {
 				p_instance->instance_uniforms.materials_append(p_instance->material_overlay);
 			}
 
+			if (p_instance->base_type == RS::INSTANCE_PARTICLES) {
+				RID process_material = RSG::particles_storage->particles_get_process_material(p_instance->base);
+				if (process_material.is_valid()) {
+					p_instance->instance_uniforms.materials_append(process_material);
+				}
+			}
+
 			if (can_cast_shadows != geom->can_cast_shadows) {
 				//ability to cast shadows change, let lights now
 				for (const Instance *E : geom->lights) {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9454,7 +9454,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 						}
 					}
 #endif // DEBUG_ENABLED
-					if (shader_type_identifier != StringName() && String(shader_type_identifier) != "spatial" && String(shader_type_identifier) != "canvas_item") {
+					if (shader_type_identifier != StringName() && String(shader_type_identifier) != "spatial" && String(shader_type_identifier) != "canvas_item" && String(shader_type_identifier) != "particles") {
 						_set_error(vformat(RTR("Uniform instances are not yet implemented for '%s' shaders."), shader_type_identifier));
 						return ERR_PARSE_ERROR;
 					}

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -78,6 +78,8 @@ public:
 
 	virtual bool particles_is_inactive(RID p_particles) const = 0;
 
+	virtual void particles_set_instance_uniform_offset(RID p_particles, int32_t p_offset) = 0;
+
 	virtual void particles_set_draw_order(RID p_particles, RS::ParticlesDrawOrder p_order) = 0;
 
 	virtual void particles_set_draw_passes(RID p_particles, int p_count) = 0;


### PR DESCRIPTION
Salvages #81459.

Supports:
- [x] 3D gpu particles
- [x] RD renderer
- [x] Compatibility renderer

TODO:
- [x] 2D gpu particles
- [x] Update property list when particles process shader changed

The same particles process material can be used for 2D and 3D simultaneously with different instance uniforms.
<img width="512" alt="屏幕截图_20250802_235311" src="https://github.com/user-attachments/assets/f3466eed-7354-452e-9b7e-db89ff44be28" />

Test project: https://github.com/beicause/particles-instance-uniforms-test.