### PR TITLE
`ThemeEditor`: Reorganize/fix UI to make it fit in editor (at its minimum size in single-window mode) better

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -440,8 +440,12 @@ class ThemeEditor : public VBoxContainer {
 
 	Ref<Theme> theme;
 
+	Button *theme_edit_button = nullptr;
+	Button *theme_close_button = nullptr;
+
 	TabBar *preview_tabs = nullptr;
 	PanelContainer *preview_tabs_content = nullptr;
+	Control *add_preview_button_ph = nullptr;
 	Button *add_preview_button = nullptr;
 	EditorFileDialog *preview_scene_dialog = nullptr;
 
@@ -466,6 +470,7 @@ class ThemeEditor : public VBoxContainer {
 	void _remove_preview_tab_invalid(Node *p_tab_control);
 	void _update_preview_tab(Node *p_tab_control);
 	void _preview_control_picked(String p_class_name);
+	void _preview_tabs_resized();
 
 protected:
 	void _notification(int p_what);

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -251,7 +251,6 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	picker_button->connect(SceneStringName(pressed), callable_mp(this, &ThemeEditorPreview::_picker_button_cbk));
 
 	MarginContainer *preview_body = memnew(MarginContainer);
-	preview_body->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	preview_body->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(preview_body);
 


### PR DESCRIPTION
Replace text for add preview / close buttons with icons, remove theme preview custom minimum width, fix "Manage Items" window size in single-window mode and editor window at minimum size. 
This allows to reduce minimum size of `ThemeEditor`, improving (partially fixing) the use of non-standard editor layouts (for example, 2 columns for left dock and 1 column for right dock) without panels pushed out of screen.

| 4.5 beta 3 | PR |
| --- | --- |
| <img width="1024" height="600" alt="Godot_v4 5-beta3_win64_KyEbXAurPz" src="https://github.com/user-attachments/assets/b9c7402b-a3f4-4af6-a066-65f65e2a052c" /> | <img width="1024" height="600" alt="godot windows editor dev x86_64_8hsh5LIC4U" src="https://github.com/user-attachments/assets/0096435b-93af-48c0-a097-cf48f07f831c" /> |

https://github.com/user-attachments/assets/6345fc48-af08-4caf-ac03-fb1b3b610f02

Related to https://github.com/godotengine/godot/pull/102301

---

UPD: Now it looks a bit different (after addressing @KoBeWi feedback) and also closes https://github.com/godotengine/godot-proposals/issues/9372:


https://github.com/user-attachments/assets/badd3221-f8df-4ad4-a418-4e440d27641e


