### PR TITLE
Document `Tree.item_collapsed` also being emitted when the item is expanded

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -431,7 +431,8 @@
 		<signal name="item_collapsed">
 			<param index="0" name="item" type="TreeItem" />
 			<description>
-				Emitted when an item is collapsed by a click on the folding arrow.
+				Emitted when an item is expanded or collapsed by clicking on the folding arrow or through code.
+				[b]Note:[/b] Despite its name, this signal is also emitted when an item is expanded.
 			</description>
 		</signal>
 		<signal name="item_edited">


### PR DESCRIPTION
This also mentions that the signal is emitted [even when the item is expanded/collapsed through code](https://github.com/godotengine/godot/issues/60206).

* See https://github.com/godotengine/godot-proposals/discussions/12810.
