### PR TITLE
Document usage of correct return types for connect and emit in Signal

### DIFF
--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -176,7 +176,7 @@
 	</constructors>
 	<methods>
 		<method name="connect">
-			<return type="int" />
+			<return type="int" enum="Error" />
 			<param index="0" name="callable" type="Callable" />
 			<param index="1" name="flags" type="int" default="0" />
 			<description>
@@ -200,7 +200,7 @@
 			</description>
 		</method>
 		<method name="emit" qualifiers="vararg const">
-			<return type="void" />
+			<return type="int" enum="Error" />
 			<description>
 				Emits this signal. All [Callable]s connected to this signal will be triggered. This method supports a variable number of arguments, so parameters can be passed as a comma separated list.
 			</description>


### PR DESCRIPTION
Update documentation of Signal to correctly denote that `connect` and `emit` function returns an Error
https://github.com/godotengine/godot/blob/master/core/variant/callable.h#L195