### PR TITLE
Implement `get_available_rendering_drivers`

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1623,10 +1623,19 @@
 				Tries to free an object in the RenderingServer. To avoid memory leaks, this should be called after using an object as memory management does not occur automatically when using RenderingServer directly.
 			</description>
 		</method>
+		<method name="get_available_rendering_drivers" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns Dictionary of available rendering methods and its rendering drivers.
+				Rendering methods can be [code]forward_plus[/code], [code]mobile[/code], or [code]gl_compatibility[/code].
+				Rendering drivers can be [code]vulkan[/code], [code]d3d12[/code], [code]metal[/code], [code]opengl3[/code], [code]opengl3_es[/code], or [code]opengl3_angle[/code].
+				Depending on OS, returning values might be different.
+			</description>
+		</method>
 		<method name="get_current_rendering_driver_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the name of the current rendering driver. This can be [code]vulkan[/code], [code]d3d12[/code], [code]metal[/code], [code]opengl3[/code], [code]opengl3_es[/code], or [code]opengl3_angle[/code]. See also [method get_current_rendering_method].
+				Returns the name of the current rendering driver. This should be one of the values of [method get_available_rendering_drivers]. See also [method get_current_rendering_method].
 				When [member ProjectSettings.rendering/renderer/rendering_method] is [code]forward_plus[/code] or [code]mobile[/code], the rendering driver is determined by [member ProjectSettings.rendering/rendering_device/driver].
 				When [member ProjectSettings.rendering/renderer/rendering_method] is [code]gl_compatibility[/code], the rendering driver is determined by [member ProjectSettings.rendering/gl_compatibility/driver].
 				The rendering driver is also determined by the [code]--rendering-driver[/code] command line argument that overrides this project setting, or an automatic fallback that is applied depending on the hardware.
@@ -1635,7 +1644,7 @@
 		<method name="get_current_rendering_method" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the name of the current rendering method. This can be [code]forward_plus[/code], [code]mobile[/code], or [code]gl_compatibility[/code]. See also [method get_current_rendering_driver_name].
+				Returns the name of the current rendering method. This should be one of the keys of [method get_available_rendering_drivers]. See also [method get_current_rendering_driver_name].
 				The rendering method is determined by [member ProjectSettings.rendering/renderer/rendering_method], the [code]--rendering-method[/code] command line argument that overrides this project setting, or an automatic fallback that is applied depending on the hardware.
 			</description>
 		</method>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -197,6 +197,7 @@ static bool _start_success = false;
 String display_driver = "";
 String tablet_driver = "";
 String text_driver = "";
+Dictionary available_drivers = {};
 static int text_driver_idx = -1;
 static int audio_driver_idx = -1;
 
@@ -1089,6 +1090,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String default_renderer = "";
 	String default_renderer_mobile = "";
 	String renderer_hints = "";
+	Vector<String> available_methods = {};
+	Vector<String> rd_drivers = {};
+	Vector<String> gl_drivers = {};
 
 	packed_data = PackedData::get_singleton();
 	if (!packed_data) {
@@ -2411,18 +2415,44 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		GLOBAL_DEF_RST_NOVAL(PropertyInfo(Variant::ARRAY, "rendering/gl_compatibility/force_angle_on_devices", PROPERTY_HINT_ARRAY_TYPE, vformat("%s/%s:%s", Variant::DICTIONARY, PROPERTY_HINT_NONE, String())), force_angle_list);
 	}
 
-	// Start with RenderingDevice-based backends.
+	available_drivers = {};
+	// Set a default renderer if none selected. Try to choose one that matches the driver.
+	if (rendering_method.is_empty()) {
+		if (rendering_driver == "dummy") {
+			rendering_method = "dummy";
+		} else if (rendering_driver == "opengl3" || rendering_driver == "opengl3_angle" || rendering_driver == "opengl3_es") {
+			rendering_method = "gl_compatibility";
+		} else {
+			rendering_method = "forward_plus";
+		}
+	}
+
 #ifdef RD_ENABLED
-	renderer_hints = "forward_plus,mobile";
+	rd_drivers = {};
 	default_renderer_mobile = "mobile";
 #endif
-
-	// And Compatibility next, or first if Vulkan is disabled.
+#ifdef VULKAN_ENABLED
+	rd_drivers.push_back("vulkan");
+#endif
+#ifdef D3D12_ENABLED
+	rd_drivers.push_back("d3d12");
+#endif
+#ifdef METAL_ENABLED
+	rd_drivers.push_back("metal");
+#endif
+#ifdef RD_ENABLED
+	available_drivers["forward_plus"] = rd_drivers;
+	available_drivers["mobile"] = rd_drivers;
+#endif
 #ifdef GLES3_ENABLED
-	if (!renderer_hints.is_empty()) {
-		renderer_hints += ",";
-	}
-	renderer_hints += "gl_compatibility";
+	gl_drivers = { "opengl3" };
+#if defined(WINDOWS_ENABLED) || defined(MACOS_ENABLED)
+	gl_drivers.push_back("opengl3_angle");
+#endif
+#ifdef LINUXBSD_ENABLED
+	gl_drivers.push_back("opengl3_es");
+#endif
+	available_drivers["gl_compatibility"] = gl_drivers;
 	if (default_renderer_mobile.is_empty()) {
 		default_renderer_mobile = "gl_compatibility";
 	}
@@ -2433,6 +2463,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		default_renderer_mobile = "gl_compatibility";
 	}
 #endif
+	if (available_drivers.keys().is_empty()) {
+		available_drivers["dummy"] = Vector<String>{ "dummy" };
+	}
 
 	if (!rendering_method.is_empty()) {
 		if (rendering_method != "forward_plus" &&
@@ -2442,7 +2475,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			OS::get_singleton()->print("Unknown rendering method '%s', aborting.\nValid options are ",
 					rendering_method.utf8().get_data());
 
-			Vector<String> rendering_method_hints = renderer_hints.split(",");
+			Vector<String> rendering_method_hints;
+			for (int i = 0; i < available_drivers.keys().size(); i++) {
+				rendering_method_hints.push_back(available_drivers.keys()[i]);
+			}
 			rendering_method_hints.push_back("dummy");
 			for (int i = 0; i < rendering_method_hints.size(); i++) {
 				if (i == rendering_method_hints.size() - 1) {
@@ -2456,9 +2492,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			OS::get_singleton()->print(".\n");
 			goto error;
 		}
-	}
-	if (renderer_hints.is_empty()) {
-		renderer_hints = "dummy";
 	}
 
 	if (!rendering_driver.is_empty()) {
@@ -2508,48 +2541,16 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			goto error;
 		}
 
-		// Set a default renderer if none selected. Try to choose one that matches the driver.
-		if (rendering_method.is_empty()) {
-			if (rendering_driver == "dummy") {
-				rendering_method = "dummy";
-			} else if (rendering_driver == "opengl3" || rendering_driver == "opengl3_angle" || rendering_driver == "opengl3_es") {
-				rendering_method = "gl_compatibility";
-			} else {
-				rendering_method = "forward_plus";
-			}
-		}
-
 		// Now validate whether the selected driver matches with the renderer.
 		bool valid_combination = false;
-		Vector<String> available_drivers;
-		if (rendering_method == "forward_plus" || rendering_method == "mobile") {
-#ifdef VULKAN_ENABLED
-			available_drivers.push_back("vulkan");
-#endif
-#ifdef D3D12_ENABLED
-			available_drivers.push_back("d3d12");
-#endif
-#ifdef METAL_ENABLED
-			available_drivers.push_back("metal");
-#endif
-		}
-#ifdef GLES3_ENABLED
-		if (rendering_method == "gl_compatibility") {
-			available_drivers.push_back("opengl3");
-			available_drivers.push_back("opengl3_angle");
-			available_drivers.push_back("opengl3_es");
-		}
-#endif
-		if (rendering_method == "dummy") {
-			available_drivers.push_back("dummy");
-		}
 		if (available_drivers.is_empty()) {
 			OS::get_singleton()->print("Unknown renderer name '%s', aborting.\n", rendering_method.utf8().get_data());
 			goto error;
 		}
 
-		for (int i = 0; i < available_drivers.size(); i++) {
-			if (rendering_driver == available_drivers[i]) {
+		PackedStringArray current_method_drivers = available_drivers[rendering_method];
+		for (int i = 0; i < current_method_drivers.size(); i++) {
+			if (rendering_driver == current_method_drivers[i]) {
 				valid_combination = true;
 				break;
 			}
@@ -2558,8 +2559,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		if (!valid_combination) {
 			OS::get_singleton()->print("Invalid renderer/driver combination '%s' and '%s', aborting. %s only supports the following drivers ", rendering_method.utf8().get_data(), rendering_driver.utf8().get_data(), rendering_method.utf8().get_data());
 
-			for (int d = 0; d < available_drivers.size(); d++) {
-				OS::get_singleton()->print("'%s', ", available_drivers[d].utf8().get_data());
+			for (int d = 0; d < current_method_drivers.size(); d++) {
+				OS::get_singleton()->print("'%s', ", current_method_drivers[d].utf8().get_data());
 			}
 
 			OS::get_singleton()->print(".\n");
@@ -2568,7 +2569,18 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 	}
 
-	default_renderer = renderer_hints.get_slicec(',', 0);
+	available_methods = {};
+	for (int i = 0; i < available_drivers.keys().size(); i++) {
+		available_methods.push_back(available_drivers.keys()[i]);
+	}
+	default_renderer = available_methods[0];
+	renderer_hints = "";
+	for (int i = 0; i < available_methods.size(); i++) {
+		if (i > 0) {
+			renderer_hints += ",";
+		}
+		renderer_hints += available_methods[i];
+	}
 	GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "rendering/renderer/rendering_method", PROPERTY_HINT_ENUM, renderer_hints), default_renderer);
 	GLOBAL_DEF_RST_BASIC("rendering/renderer/rendering_method.mobile", default_renderer_mobile);
 	GLOBAL_DEF_RST_BASIC(PropertyInfo(Variant::STRING, "rendering/renderer/rendering_method.web", PROPERTY_HINT_ENUM, "gl_compatibility"), "gl_compatibility"); // This is a bit of a hack until we have WebGPU support.
@@ -3448,6 +3460,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 		if (profile_gpu || (!editor && bool(GLOBAL_GET("debug/settings/stdout/print_gpu_profile")))) {
 			rendering_server->set_print_gpu_profile(true);
 		}
+		RenderingServer::get_singleton()->set_available_rendering_drivers(available_drivers);
 
 		OS::get_singleton()->benchmark_end_measure("Servers", "Rendering");
 	}

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -3561,6 +3561,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_current_rendering_driver_name"), &RenderingServer::get_current_rendering_driver_name);
 	ClassDB::bind_method(D_METHOD("get_current_rendering_method"), &RenderingServer::get_current_rendering_method);
+	ClassDB::bind_method(D_METHOD("get_available_rendering_drivers"), &RenderingServer::get_available_rendering_drivers);
 
 	ClassDB::bind_method(D_METHOD("make_sphere_mesh", "latitudes", "longitudes", "radius"), &RenderingServer::make_sphere_mesh);
 	ClassDB::bind_method(D_METHOD("get_test_cube"), &RenderingServer::get_test_cube);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -82,6 +82,8 @@ protected:
 	RID white_texture;
 	RID test_material;
 
+	Dictionary _available_drivers;
+
 	Error _surface_set_data(Array p_arrays, uint64_t p_format, uint32_t *p_offsets, uint32_t p_vertex_stride, uint32_t p_normal_stride, uint32_t p_attrib_stride, uint32_t p_skin_stride, Vector<uint8_t> &r_vertex_array, Vector<uint8_t> &r_attrib_array, Vector<uint8_t> &r_skin_array, int p_vertex_array_len, Vector<uint8_t> &r_index_array, int p_index_array_len, AABB &r_aabb, Vector<AABB> &r_bone_aabb, Vector4 &r_uv_scale);
 
 	static RenderingServer *(*create_func)();
@@ -1919,6 +1921,8 @@ public:
 	virtual bool is_on_render_thread() = 0;
 	virtual void call_on_render_thread(const Callable &p_callable) = 0;
 
+	void set_available_rendering_drivers(const Dictionary &p_drivers) { _available_drivers = p_drivers; }
+	Dictionary get_available_rendering_drivers() const { return _available_drivers; }
 	String get_current_rendering_driver_name() const;
 	String get_current_rendering_method() const;
 


### PR DESCRIPTION
I am working on an application, and I want to add an option in Settings for users to change rendering driver
Which will edit `override.cfg` in the application folder for next time startup
And I found there is no way to get currently available rendering drivers/methods.

Yes, I know I can just write an array per OS ["vulkan", "d3d12", "opengl3", "opengl3_angle"]
But, [there is **ALREADY** an array in `main.cpp`](https://github.com/godotengine/godot/blob/a3e84cc2af14aa4cffbefd8e13492e59567a64e3/main/main.cpp#L2529-L2550)
Why don't we just make it useable?


Implement `get_available_rendering_drivers`, it will return a Dictionary
Its keys are rendering methods, and values are rendering drivers.
No matter if it was exposed, it's useful for other codes to access, instead of hard-coding drivers.

https://github.com/godotengine/godot/pull/85430#issuecomment-2420291888

<img width="731" height="486" alt="image" src="https://github.com/user-attachments/assets/43f28f45-693a-472a-9059-9657cddb941a" />

Project for test: [available_rendering.zip](https://github.com/user-attachments/files/25459902/available_rendering.zip)