### PR TITLE
Keep collapsed state for actions when modifying Input Map

### DIFF
--- a/editor/settings/action_map_editor.cpp
+++ b/editor/settings/action_map_editor.cpp
@@ -423,8 +423,18 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		actions_cache = p_action_infos;
 	}
 
+	HashSet<String> collapsed_actions;
+	TreeItem *root = action_tree->get_root();
+	if (root) {
+		for (TreeItem *child = root->get_first_child(); child; child = child->get_next()) {
+			if (child->is_collapsed()) {
+				collapsed_actions.insert(child->get_meta("__name"));
+			}
+		}
+	}
+
 	action_tree->clear();
-	TreeItem *root = action_tree->create_item();
+	root = action_tree->create_item();
 
 	for (const ActionInfo &action_info : actions_cache) {
 		const Array events = action_info.action["events"];
@@ -444,6 +454,7 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 		ERR_FAIL_NULL(action_item);
 		action_item->set_meta("__action", action_info.action);
 		action_item->set_meta("__name", action_info.name);
+		action_item->set_collapsed(collapsed_actions.has(action_info.name));
 
 		// First Column - Action Name
 		action_item->set_auto_translate_mode(0, AUTO_TRANSLATE_MODE_DISABLED);


### PR DESCRIPTION
Changing the Input Map in Project Settings (adding/removing/renaming actions, reordering, or changing action events) causes the action list `Tree` to be cleared/repopulated.  Updated `ActionMapEditor::update_action_list` to store which actions were collapsed before clearing, so they can remain collapsed after modifications.

Fixes #109212

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
