### PR TITLE
Fix missing `AnimationNode::property_cache` invalidation

### DIFF
--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -124,6 +124,7 @@ public:
 
 private:
 	mutable AHashMap<StringName, int> property_cache;
+	mutable void *guard_source_tree = nullptr;
 
 public:
 	void set_node_state_base_path(const StringName p_base_path) {
@@ -146,6 +147,7 @@ public:
 
 	void make_cache_dirty() {
 		property_cache.clear();
+		guard_source_tree = nullptr;
 	}
 	Array _get_filters() const;
 	void _set_filters(const Array &p_filters);


### PR DESCRIPTION
This is temporary solution for #109257 I'm not able to figure out real problem with cache and not completely sure is property_cache variable is guilty at all. But this PR solves problem with error spamming ( Animation::validate_type_match: Type mismatch between initial and final value: float and bool ) for me.