### PR TITLE
Update property list when instance uniforms changed for `CanvasItem` and `GeometryInstance3D`

### DIFF
--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -359,13 +359,17 @@ int MeshInstance3D::get_surface_override_material_count() const {
 void MeshInstance3D::set_surface_override_material(int p_surface, const Ref<Material> &p_material) {
 	ERR_FAIL_INDEX(p_surface, surface_override_materials.size());
 
-	surface_override_materials.write[p_surface] = p_material;
-
 	if (surface_override_materials[p_surface].is_valid()) {
+		surface_override_materials[p_surface]->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
+	}
+	surface_override_materials.write[p_surface] = p_material;
+	if (surface_override_materials[p_surface].is_valid()) {
+		surface_override_materials[p_surface]->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 		RS::get_singleton()->instance_set_surface_override_material(get_instance(), p_surface, surface_override_materials[p_surface]->get_rid());
 	} else {
 		RS::get_singleton()->instance_set_surface_override_material(get_instance(), p_surface, RID());
 	}
+	notify_property_list_changed(); // Instance uniforms may be changed.
 }
 
 Ref<Material> MeshInstance3D::get_surface_override_material(int p_surface) const {

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -221,6 +221,7 @@ void GeometryInstance3D::set_material_override(const Ref<Material> &p_material) 
 		material_override->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
 	}
 	RS::get_singleton()->instance_geometry_set_material_override(get_instance(), p_material.is_valid() ? p_material->get_rid() : RID());
+	notify_property_list_changed(); // Instance uniforms may be changed.
 }
 
 Ref<Material> GeometryInstance3D::get_material_override() const {
@@ -228,8 +229,15 @@ Ref<Material> GeometryInstance3D::get_material_override() const {
 }
 
 void GeometryInstance3D::set_material_overlay(const Ref<Material> &p_material) {
+	if (material_overlay.is_valid()) {
+		material_overlay->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
+	}
 	material_overlay = p_material;
+	if (material_overlay.is_valid()) {
+		material_overlay->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
+	}
 	RS::get_singleton()->instance_geometry_set_material_overlay(get_instance(), p_material.is_valid() ? p_material->get_rid() : RID());
+	notify_property_list_changed(); // Instance uniforms may be changed.
 }
 
 Ref<Material> GeometryInstance3D::get_material_overlay() const {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1168,13 +1168,19 @@ bool CanvasItem::is_draw_behind_parent_enabled() const {
 
 void CanvasItem::set_material(const Ref<Material> &p_material) {
 	ERR_THREAD_GUARD;
+	if (material.is_valid()) {
+		material->disconnect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
+	}
 	material = p_material;
+	if (material.is_valid()) {
+		material->connect(CoreStringName(property_list_changed), callable_mp((Object *)this, &Object::notify_property_list_changed));
+	}
 	RID rid;
 	if (material.is_valid()) {
 		rid = material->get_rid();
 	}
 	RS::get_singleton()->canvas_item_set_material(canvas_item, rid);
-	notify_property_list_changed(); //properties for material exposed
+	notify_property_list_changed(); // Instance uniforms may be changed.
 }
 
 void CanvasItem::set_use_parent_material(bool p_use_parent_material) {


### PR DESCRIPTION
Fixes:
- `CanvasItem` doesn't update instance uniform properties when material shader changed
- `GeometryInstance3D` doesn't update instance uniform properties when `material_override` set or `material_overlay` shader changed
- `MeshInstance3D` doesn't update instance uniform properties when surface material overrides changed

Remaining issue: `MeshInstance3D` doesn't update instance uniform properties when the materials of its surfaces changed. Fixing this would need to track every surface's material and greatly increase the complexity, may not be worth it.