### PR TITLE
GDScript: Add a `@final` annotation for methods and classes

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -175,6 +175,8 @@ static void _add_qualifiers_to_rt(const String &p_qualifiers, RichTextLabel *p_r
 			hint = TTR("This method does not need an instance to be called.\nIt can be called directly using the class name.");
 		} else if (qualifier == "abstract") {
 			hint = TTR("This method must be implemented to complete the abstract class.");
+		} else if (qualifier == "final") {
+			hint = TTR("This method must not be overridden by a subclass.");
 		}
 
 		p_rt->add_text(" ");

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -762,6 +762,45 @@
 				[b]Note:[/b] Avoid storing lambda callables in member variables of [RefCounted]-based classes (e.g. resources), as this can lead to memory leaks. Use only method callables and optionally [method Callable.bind] or [method Callable.unbind].
 			</description>
 		</annotation>
+		<annotation name="@final">
+			<return type="void" />
+			<description>
+				Modifies the following class or method as final. A final class may not be extended, and a final method may not be overridden.
+				You can annotate a class (including anonymous scripts) as final:
+				[codeblock]
+				# A.gd
+				@final class_name A
+
+				# B.gd
+				class_name B extends A # Error: The base class "A" is marked as final and cannot be extended.
+
+				# C.gd
+				@final extends RefCounted
+				[/codeblock]
+				You can also annotate a method as final:
+				[codeblock]
+				# E.gd
+				class_name E extends Node
+
+				@final func my_final_method():
+				    pass
+
+				# F.gd
+				class_name F extends E
+
+				func my_final_method(): # Error: The method "my_final_method" is marked as final and cannot be overridden.
+				    pass
+				[/codeblock]
+				Final scripts cannot be attached to nodes whose types do not match the script base type exactly. For example, given the following script:
+				[codeblock]
+				# MyNode.gd
+				@final extends Node
+				[/codeblock]
+				This script can only be attached to a node whose direct type is [code skip-lint]Node[/code], but not a descendent of Node (e.g., [code skip-lint]Node2D[/code]).
+				[b]Note:[/b] The annotation [code skip-lint]@final[/code] is a modifier, meaning that it is syntax-related instead of engine-specific.
+				[b]Note:[/b] Abstract classes and methods cannot be marked as final, and vice versa.
+			</description>
+		</annotation>
 		<annotation name="@icon">
 			<return type="void" />
 			<param index="0" name="icon_path" type="String" />

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -441,6 +441,12 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					}
 					method_doc.qualifiers += "static";
 				}
+				if (m_func->is_final) {
+					if (!method_doc.qualifiers.is_empty()) {
+						method_doc.qualifiers += " ";
+					}
+					method_doc.qualifiers += "final";
+				}
 
 				if (func_name == "_init" || func_name == "_static_init") {
 					method_doc.return_type = "void";

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -425,10 +425,21 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 
 	if (top->native.is_valid()) {
 		if (!p_this->is_class(top->native->get_name())) {
+			String errMsg = vformat("Script inherits from native type '%s', so it can't be assigned to an object of type: '%s'", top->native->get_name(), p_this->get_class());
 			if (EngineDebugger::is_active()) {
-				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
+				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, errMsg);
 			}
-			ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type '" + p_this->get_class() + "'" + ".");
+			ERR_FAIL_V_MSG(nullptr, errMsg);
+		}
+
+		// To allow for future serialization optimizations (i.e. not saving the script path), final scripts may not be attached to objects with different base types.
+		// See discussion on https://github.com/godotengine/godot/pull/109263
+		if (this->_is_final && this->get_instance_base_type() != p_this->get_class_name()) {
+			String errMsg = vformat("Cannot set object script. Script '%s' is final, and the base type '%s' does not match the object's base type '%s'.", this->get_path(), this->get_instance_base_type(), p_this->get_class_name());
+			if (EngineDebugger::is_active()) {
+				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, errMsg);
+			}
+			ERR_FAIL_V_MSG(nullptr, errMsg);
 		}
 	}
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -60,6 +60,7 @@ class GDScript : public Script {
 	bool valid = false;
 	bool reloading = false;
 	bool _is_abstract = false;
+	bool _is_final = false;
 
 	struct MemberInfo {
 		int index = 0;

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -626,8 +626,14 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 		return ERR_PARSE_ERROR;
 	}
 
-	// Check for cyclic inheritance.
+	// Ensure we aren't extending a final class.
 	const GDScriptParser::ClassNode *base_class = result.class_type;
+	if (base_class != nullptr && base_class->is_final) {
+		push_error(vformat(R"(The base class "%s" is marked as final and cannot be extended.)", base_class->fqcn.get_file()), p_class);
+		return ERR_PARSE_ERROR;
+	}
+
+	// Check for cyclic inheritance.
 	while (base_class) {
 		if (base_class->fqcn == p_class->fqcn) {
 			push_error("Cyclic inheritance.", p_class);
@@ -1937,6 +1943,19 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 					} else {
 						valid = valid && is_type_compatible(current_par_type, parent_par_type);
 					}
+				}
+
+				// Validate that the method is not overriding a `final` method.
+				const GDScriptParser::ClassNode *base_class = base_type.class_type;
+				while (base_class) {
+					if (base_class->has_function(p_function->identifier->name)) {
+						GDScriptParser::FunctionNode *base_function = base_class->get_member(p_function->identifier->name).function;
+						if (base_function != nullptr && base_function->is_final) {
+							push_error(vformat(R"(Function "%s" is marked as final and cannot be overridden.)", p_function->identifier->name), p_function);
+							break;
+						}
+					}
+					base_class = base_class->base_type.class_type;
 				}
 			}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2745,6 +2745,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 
 	p_script->tool = parser->is_tool();
 	p_script->_is_abstract = p_class->is_abstract;
+	p_script->_is_final = p_class->is_final;
 
 	if (p_script->local_name != StringName()) {
 		if (GDScriptAnalyzer::class_exists(p_script->local_name)) {

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -147,6 +147,7 @@ GDScriptParser::GDScriptParser() {
 		register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 		register_annotation(MethodInfo("@static_unload"), AnnotationInfo::SCRIPT, &GDScriptParser::static_unload_annotation);
 		register_annotation(MethodInfo("@abstract"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::abstract_annotation);
+		register_annotation(MethodInfo("@final"), AnnotationInfo::SCRIPT | AnnotationInfo::CLASS | AnnotationInfo::FUNCTION, &GDScriptParser::final_annotation);
 		// Onready annotation.
 		register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 		// Export annotations.
@@ -4508,6 +4509,10 @@ bool GDScriptParser::abstract_annotation(AnnotationNode *p_annotation, Node *p_t
 			push_error(R"("@abstract" annotation can only be used once per class.)", p_annotation);
 			return false;
 		}
+		if (class_node->is_final) {
+			push_error(R"("@abstract" annotation cannot be applied to a final class.)", p_annotation);
+			return false;
+		}
 		class_node->is_abstract = true;
 		return true;
 	}
@@ -4521,10 +4526,49 @@ bool GDScriptParser::abstract_annotation(AnnotationNode *p_annotation, Node *p_t
 			push_error(R"("@abstract" annotation can only be used once per function.)", p_annotation);
 			return false;
 		}
+		if (function_node->is_final) {
+			push_error(R"("@abstract" annotation cannot be applied to a final function.)", p_annotation);
+			return false;
+		}
 		function_node->is_abstract = true;
 		return true;
 	}
 	ERR_FAIL_V_MSG(false, R"("@abstract" annotation can only be applied to classes and functions.)");
+}
+
+bool GDScriptParser::final_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	// NOTE: Use `p_target`, **not** `p_class`, because when `p_target` is a class then `p_class` refers to the outer class.
+	if (p_target->type == Node::CLASS) {
+		ClassNode *class_node = static_cast<ClassNode *>(p_target);
+		if (class_node->is_final) {
+			push_error(R"("@final" annotation can only be used once per class.)", p_annotation);
+			return false;
+		}
+		if (class_node->is_abstract) {
+			push_error(R"("@final" annotation cannot be applied to an abstract class.)", p_annotation);
+			return false;
+		}
+		class_node->is_final = true;
+		return true;
+	}
+	if (p_target->type == Node::FUNCTION) {
+		FunctionNode *function_node = static_cast<FunctionNode *>(p_target);
+		if (function_node->is_static) {
+			push_error(R"("@final" annotation cannot be applied to static functions.)", p_annotation);
+			return false;
+		}
+		if (function_node->is_final) {
+			push_error(R"("@final" annotation can only be used once per function.)", p_annotation);
+			return false;
+		}
+		if (function_node->is_abstract) {
+			push_error(R"("@final" annotation cannot be applied to an abstract function.)", p_annotation);
+			return false;
+		}
+		function_node->is_final = true;
+		return true;
+	}
+	ERR_FAIL_V_MSG(false, R"("@final" annotation can only be applied to classes and functions.)");
 }
 
 bool GDScriptParser::onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -757,6 +757,8 @@ public:
 		bool extends_used = false;
 		bool onready_used = false;
 		bool is_abstract = false;
+		// If the class is final or not. Final classes must not be extended by another class.
+		bool is_final = false;
 		bool has_static_data = false;
 		bool annotated_static_unload = false;
 		String extends_path;
@@ -876,6 +878,8 @@ public:
 
 		SuiteNode *body = nullptr;
 		bool is_abstract = false;
+		// If the function is final or not. Final functions must not be overridden by a child class.
+		bool is_final = false;
 		bool is_static = false; // For lambdas it's determined in the analyzer.
 		bool is_coroutine = false;
 		Variant rpc_config;
@@ -1597,6 +1601,7 @@ private:
 	bool icon_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool final_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_classes.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_classes.gd
@@ -1,0 +1,11 @@
+@final @abstract class AbstractFinalClass:
+    pass
+
+@final class A:
+    pass
+
+class B extends A:
+    pass
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_classes.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_classes.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 1: "@abstract" annotation cannot be applied to a final class.
+>> ERROR at line 7: The base class "final_classes.gd::A" is marked as final and cannot be extended.

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_methods.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_methods.gd
@@ -1,0 +1,17 @@
+class A:
+    @final func foo():
+        pass
+
+    @final func bar():
+        pass
+
+class B extends A:
+    func foo():
+        pass
+
+class C extends B:
+    func bar():
+        pass
+
+func test():
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/final_methods.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/final_methods.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 9: Function "foo" is marked as final and cannot be overridden.
+>> ERROR at line 13: Function "bar" is marked as final and cannot be overridden.


### PR DESCRIPTION
This PR adds the `@final` annotation, which can be used on Methods and Classes to mark them as non-extensible. For classes, that means no class may `extend` that class. For methods, it means that no subclass may override that method.

This is a continuation of https://github.com/godotengine/godot/pull/107722

The differences from the former PR are as follows:
1. `is_final()` is not exposed to GDScript. This matches with the fact that we did not expose `is_abstract()` to GDS.
2. `@final` is only usable on _named_ classes (and not script files).

Closes https://github.com/godotengine/godot-proposals/issues/10500
Closes https://github.com/godotengine/godot-proposals/issues/1311

___
To address some broader discussion around the usage of `@final` in GDS:

Per @dalexeev:
> Personally, I would prefer virtual/override over final.

Virtual, Override, and Final have different behaviors and all work concurrently. Introduction of `@final` does not preclude introduction of either of the other two. On a virtual method, final means no further methods may override it. You would still want a `@final` annotation even in a non-virtual-by-default model. Hence this opinion has no impact on this change.

Further on that note, GDS already has virtual-by-default semantics **as a core language feature**. Changing that, at this point in the language, is a non-starter.

Per @HolonProduction:
> So a final class that extends from Node should not be attachable to Node2D IMO

I don't know enough about GD's serialization to comment on this effectively. I'm not sure I follow how this would improve the security of serialization.