### PR TITLE
Revert "SoftBody3D: Support physics Interpolation"

### DIFF
--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -40,19 +40,11 @@ class SoftBodyRenderingServerHandler : public PhysicsServer3DRenderingServerHand
 
 	RID mesh;
 	int surface = 0;
-	AABB aabb_prev;
-	AABB aabb_curr;
-	Vector<uint8_t> buffer[2];
-	Vector<uint8_t> *buffer_prev = nullptr;
-	Vector<uint8_t> *buffer_curr = nullptr;
-	Vector<uint8_t> buffer_interp;
-	uint32_t vertex_count = 0;
+	Vector<uint8_t> buffer;
 	uint32_t stride = 0;
 	uint32_t normal_stride = 0;
 	uint32_t offset_vertices = 0;
 	uint32_t offset_normal = 0;
-
-	AABB aabb_last;
 
 	uint8_t *write_buffer = nullptr;
 
@@ -63,8 +55,7 @@ private:
 	void clear();
 	void open();
 	void close();
-	void fti_pump();
-	void commit_changes(real_t p_interpolation_fraction);
+	void commit_changes();
 
 public:
 	void set_vertex(int p_vertex_id, const Vector3 &p_vertex) override;
@@ -116,8 +107,7 @@ private:
 	void _update_pickable();
 
 	void _update_physics_server();
-	void _update_soft_mesh();
-	void _commit_soft_mesh(real_t p_interpolation_fraction);
+	void _draw_soft_mesh();
 
 	void _prepare_physics_server();
 	void _become_mesh_owner();
@@ -133,8 +123,6 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
-
-	void _physics_interpolated_changed() override;
 
 #ifndef DISABLE_DEPRECATED
 	void _pin_point_bind_compat_94684(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath());


### PR DESCRIPTION
This reverts commit cc52fd777ea9fcbb6e121154860b4ee14af3724f.

Fixes: https://github.com/godotengine/godot/issues/108209

Unfortunately it seems we aren't going to be able to fix the regressions caused by https://github.com/godotengine/godot/pull/106863 in time for 4.5, so we need to revert it and try again for a later release. 

There have been two partial attempts to fix the issue:
1. https://github.com/godotengine/godot/pull/108229 (from @lawnjelly)
2. https://github.com/godotengine/godot/issues/108209#issuecomment-3030574089 (from @simpkins)

But neither are targeting 4.5 for a proper fix so we need to revert. 
