### PR TITLE
Add a way to check if the game was started with the main scene

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -606,6 +606,10 @@ bool OS::has_feature(const String &p_feature) {
 #endif
 	}
 
+	if (p_feature == "custom_scene") {
+		return _custom_scene;
+	}
+
 	if (_check_internal_feature_support(p_feature)) {
 		return true;
 	}

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -62,6 +62,7 @@ class OS {
 	bool _writing_movie = false;
 	bool _in_editor = false;
 	bool _embedded_in_editor = false;
+	bool _custom_scene = false;
 
 	CompositeLogger *_logger = nullptr;
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4532,6 +4532,12 @@ int Main::start() {
 				ERR_FAIL_NULL_V_MSG(scene, EXIT_FAILURE, "Failed loading scene: " + local_game_path + ".");
 				sml->add_current_scene(scene);
 
+				if (game_path == ResourceUID::ensure_path(String(GLOBAL_GET("application/run/main_scene")))) {
+					OS::get_singleton()->_custom_scene = false;
+				} else {
+					OS::get_singleton()->_custom_scene = true;
+				}
+
 #ifdef MACOS_ENABLED
 				String mac_icon_path = GLOBAL_GET("application/config/macos_native_icon");
 				if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_NATIVE_ICON) && !mac_icon_path.is_empty()) {


### PR DESCRIPTION
This PR adds the ability to check if the project was started with the main scene with an already existing method `OS.has_feature("custom_scene")`. This check is set once when the game starts and will not change afterwards, even after changing scenes. This check will always return false in the editor.

This is useful if a scene that needs testing has nodes that are dependent on other parent or sibling nodes that may not be available if ran independently.
Example:
```gdscript
func _ready() -> void:
	if OS.has_feature("custom_scene"):
		camera = Camera3D.new()
		add_child(camera)
	else:
		camera = get_parent().get_child("Camera3D")
````

Closes godotengine/godot-proposals#11835
