### PR TITLE
[.NET] Fix `Quaternion(Vector3, Vector3)` constructor when vectors are the same

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -576,6 +576,10 @@ namespace Godot
             {
                 if (d >= 0.0f)
                 {
+                    X = 0.0f;
+                    Y = 0.0f;
+                    Z = 0.0f;
+                    W = 1.0f;
                     return; // Vectors are same.
                 }
                 Vector3 axis = n0.GetAnyPerpendicular();


### PR DESCRIPTION
- As @aaronfranke rightly pointed out, in C++ Quaternions are default initialized to the identity, so we have to set the X, Y, Z, and W values before returning.
- Fixes https://github.com/godotengine/godot/issues/109261