### PR TITLE
Fix C# environment variables access on Linux (SDL-related bug)

### DIFF
--- a/drivers/sdl/SDL_build_config_private.h
+++ b/drivers/sdl/SDL_build_config_private.h
@@ -87,9 +87,11 @@
 #ifdef __linux__
 #define HAVE_INOTIFY 1
 #define HAVE_INOTIFY_INIT1 1
-#define HAVE_GETENV 1
-#define HAVE_SETENV 1
-#define HAVE_UNSETENV 1
+// Don't add these defines, for some reason they mess with C#'s ability
+// to use environment variables (see GH-109024)
+//#define HAVE_GETENV 1
+//#define HAVE_SETENV 1
+//#define HAVE_UNSETENV 1
 #endif
 
 #ifdef DBUS_ENABLED

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -972,6 +972,7 @@ Patches:
 - `0003-std-include.patch` (GH-108144)
 - `0004-errno-include.patch` (GH-108354)
 - `0005-fix-libudev-dbus.patch` (GH-108373)
+- `0006-fix-cs-environ.patch` (GH-109283)
 
 The SDL source code folder includes `hidapi` library inside of folder `thirdparty/sdl/hidapi/`.
 Its version and license is described in this file under `hidapi`.

--- a/thirdparty/sdl/patches/0006-fix-cs-environ.patch
+++ b/thirdparty/sdl/patches/0006-fix-cs-environ.patch
@@ -1,0 +1,65 @@
+diff --git a/thirdparty/sdl/stdlib/SDL_getenv.c b/thirdparty/sdl/stdlib/SDL_getenv.c
+index b4a19224655..e23f8a0ea0d 100644
+--- a/thirdparty/sdl/stdlib/SDL_getenv.c
++++ b/thirdparty/sdl/stdlib/SDL_getenv.c
+@@ -50,6 +50,9 @@ extern char **environ;
+ static char **environ;
+ #endif
+ 
++#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
++#include <stdlib.h>
++#endif
+ 
+ struct SDL_Environment
+ {
+@@ -149,6 +152,9 @@ SDL_Environment *SDL_CreateEnvironment(bool populated)
+ 
+ const char *SDL_GetEnvironmentVariable(SDL_Environment *env, const char *name)
+ {
++#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
++    return getenv(name);
++#else
+     const char *result = NULL;
+ 
+     if (!env) {
+@@ -168,6 +174,7 @@ const char *SDL_GetEnvironmentVariable(SDL_Environment *env, const char *name)
+     SDL_UnlockMutex(env->lock);
+ 
+     return result;
++#endif
+ }
+ 
+ typedef struct CountEnvStringsData
+@@ -246,6 +253,9 @@ char **SDL_GetEnvironmentVariables(SDL_Environment *env)
+ 
+ bool SDL_SetEnvironmentVariable(SDL_Environment *env, const char *name, const char *value, bool overwrite)
+ {
++#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
++    return setenv(name, value, overwrite);
++#else
+     bool result = false;
+ 
+     if (!env) {
+@@ -281,10 +291,14 @@ bool SDL_SetEnvironmentVariable(SDL_Environment *env, const char *name, const ch
+     SDL_UnlockMutex(env->lock);
+ 
+     return result;
++#endif
+ }
+ 
+ bool SDL_UnsetEnvironmentVariable(SDL_Environment *env, const char *name)
+ {
++#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
++    return unsetenv(name);
++#else
+     bool result = false;
+ 
+     if (!env) {
+@@ -305,6 +319,7 @@ bool SDL_UnsetEnvironmentVariable(SDL_Environment *env, const char *name)
+     SDL_UnlockMutex(env->lock);
+ 
+     return result;
++#endif
+ }
+ 
+ void SDL_DestroyEnvironment(SDL_Environment *env)

--- a/thirdparty/sdl/stdlib/SDL_getenv.c
+++ b/thirdparty/sdl/stdlib/SDL_getenv.c
@@ -50,6 +50,9 @@ extern char **environ;
 static char **environ;
 #endif
 
+#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
+#include <stdlib.h>
+#endif
 
 struct SDL_Environment
 {
@@ -149,6 +152,9 @@ SDL_Environment *SDL_CreateEnvironment(bool populated)
 
 const char *SDL_GetEnvironmentVariable(SDL_Environment *env, const char *name)
 {
+#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
+    return getenv(name);
+#else
     const char *result = NULL;
 
     if (!env) {
@@ -168,6 +174,7 @@ const char *SDL_GetEnvironmentVariable(SDL_Environment *env, const char *name)
     SDL_UnlockMutex(env->lock);
 
     return result;
+#endif
 }
 
 typedef struct CountEnvStringsData
@@ -246,6 +253,9 @@ char **SDL_GetEnvironmentVariables(SDL_Environment *env)
 
 bool SDL_SetEnvironmentVariable(SDL_Environment *env, const char *name, const char *value, bool overwrite)
 {
+#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
+    return setenv(name, value, overwrite);
+#else
     bool result = false;
 
     if (!env) {
@@ -281,10 +291,14 @@ bool SDL_SetEnvironmentVariable(SDL_Environment *env, const char *name, const ch
     SDL_UnlockMutex(env->lock);
 
     return result;
+#endif
 }
 
 bool SDL_UnsetEnvironmentVariable(SDL_Environment *env, const char *name)
 {
+#if defined(SDL_PLATFORM_LINUX) || defined(SDL_PLATFORM_MACOS) || defined(SDL_PLATFORM_FREEBSD)
+    return unsetenv(name);
+#else
     bool result = false;
 
     if (!env) {
@@ -305,6 +319,7 @@ bool SDL_UnsetEnvironmentVariable(SDL_Environment *env, const char *name)
     SDL_UnlockMutex(env->lock);
 
     return result;
+#endif
 }
 
 void SDL_DestroyEnvironment(SDL_Environment *env)


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109024

For some reason, these SDL defines mess with C#'s ability to use environment variables on Linux, I'm not sure why that is happening, but this fix was tested and it should resolve the issue (see https://github.com/godotengine/godot/issues/109024#issuecomment-3137304522 ).

This fix must also be tested on a Steam Deck in case it messes with Steam Deck's built in controls or Steam Input, because otherwise it would be a regression from https://github.com/godotengine/godot/pull/108350 (I don't have a Steam Deck, so I can't test it myself :( )

And also, the bug is only reproducible with HAVE_GETENV, HAVE_SETENV and HAVE_UNSETENV defined, and if they're all defined, SDL defines HAVE_LIBC_ENVIRONMENT here:
https://github.com/godotengine/godot/blob/45509c284cc8779f7e791b0d7dc3d639b3cc2fcc/thirdparty/sdl/stdlib/SDL_getenv.c#L35-L47
I'm not an expert in C# integration in C++ or environment variables, but if someone has an idea on why this piece of code messes with C#, we would like to know!

TODO:
- [x] Fix Steam Deck controls