### PR TITLE
Write directories to export preset's export_files when entire folder is selected

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -295,7 +295,13 @@ void EditorExport::load_config() {
 			Vector<String> files = config->get_value(section, "export_files");
 
 			for (int i = 0; i < files.size(); i++) {
-				if (!FileAccess::exists(files[i])) {
+				if (files[i].ends_with("/")) {
+					if (!DirAccess::exists(files[i])) {
+						preset->remove_export_file(files[i]);
+					} else {
+						preset->add_export_file(files[i]);
+					}
+				} else if (!FileAccess::exists(files[i])) {
 					preset->remove_export_file(files[i]);
 				} else {
 					preset->add_export_file(files[i]);

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1108,8 +1108,16 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 	} else if (p_preset->get_export_filter() == EditorExportPreset::EXCLUDE_SELECTED_RESOURCES) {
 		_export_find_resources(EditorFileSystem::get_singleton()->get_filesystem(), paths);
 		Vector<String> files = p_preset->get_files_to_export();
-		for (int i = 0; i < files.size(); i++) {
-			paths.erase(files[i]);
+		for (const String &file : files) {
+			if (file.ends_with("/")) {
+				HashSet<String> subdir_paths;
+				_export_find_resources(EditorFileSystem::get_singleton()->get_filesystem_path(file), subdir_paths);
+				for (const String &subdir_path : subdir_paths) {
+					paths.erase(subdir_path);
+				}
+			} else {
+				paths.erase(file);
+			}
 		}
 	} else if (p_preset->get_export_filter() == EditorExportPreset::EXPORT_CUSTOMIZED) {
 		_export_find_customized_resources(p_preset, EditorFileSystem::get_singleton()->get_filesystem(), p_preset->get_file_export_mode("res://"), paths);
@@ -1117,6 +1125,20 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 		bool scenes_only = p_preset->get_export_filter() == EditorExportPreset::EXPORT_SELECTED_SCENES;
 
 		Vector<String> files = p_preset->get_files_to_export();
+		int f = 0;
+		while (f < files.size()) {
+			const String &file = files[f];
+			if (file.ends_with("/")) {
+				HashSet<String> subdir_paths;
+				_export_find_resources(EditorFileSystem::get_singleton()->get_filesystem_path(file), subdir_paths);
+				for (const String &subdir_path : subdir_paths) {
+					files.push_back(subdir_path);
+				}
+				files.erase(file);
+				f--;
+			}
+			f++;
+		}
 		for (int i = 0; i < files.size(); i++) {
 			if (scenes_only && ResourceLoader::get_resource_type(files[i]) != "PackedScene") {
 				continue;

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -195,7 +195,7 @@ void EditorExportPreset::update_files() {
 	{
 		Vector<String> to_remove;
 		for (const String &E : selected_files) {
-			if (!FileAccess::exists(E)) {
+			if ((E.ends_with("/") && !DirAccess::exists(E)) || (!E.ends_with("/") && !FileAccess::exists(E))) {
 				to_remove.push_back(E);
 			}
 		}

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -993,6 +993,7 @@ void ProjectExportDialog::_fill_resource_tree() {
 	include_margin->show();
 
 	_fill_tree(EditorFileSystem::get_singleton()->get_filesystem(), root, current, f);
+	_update_tree(root, current, f);
 
 	if (f == EditorExportPreset::EXPORT_CUSTOMIZED) {
 		_propagate_file_export_mode(include_files->get_root(), EditorExportPreset::MODE_FILE_NOT_CUSTOMIZED);
@@ -1056,16 +1057,37 @@ bool ProjectExportDialog::_fill_tree(EditorFileSystemDirectory *p_dir, TreeItem 
 		file->set_editable(0, true);
 		file->set_metadata(0, path);
 
-		if (p_export_filter == EditorExportPreset::EXPORT_CUSTOMIZED) {
-			_setup_item_for_file_mode(file, current->get_file_export_mode(path));
-		} else {
-			file->set_checked(0, current->has_export_file(path));
-			file->propagate_check(0);
-		}
-
 		used = true;
 	}
 	return used;
+}
+
+void ProjectExportDialog::_update_tree(TreeItem *p_item, Ref<EditorExportPreset> &p_current, EditorExportPreset::ExportFilter p_export_filter) {
+	bool has_export_dir = false;
+	TreeItem *p_parent_item = p_item->get_parent();
+	while (p_parent_item) {
+		if (p_current->has_export_file(p_parent_item->get_metadata(0))) {
+			has_export_dir = true;
+			break;
+		}
+		p_parent_item = p_parent_item->get_parent();
+	}
+
+	TreeItem *p_file = p_item;
+	while (p_file) {
+		String path = p_file->get_metadata(0);
+		if (p_export_filter == EditorExportPreset::EXPORT_CUSTOMIZED) {
+			_setup_item_for_file_mode(p_file, p_current->get_file_export_mode(path));
+		} else if (has_export_dir || p_current->has_export_file(path)) {
+			p_file->set_checked(0, true);
+			p_file->propagate_check(0);
+		}
+		p_file = p_file->get_next();
+	}
+
+	for (int i = 0; i < p_item->get_child_count(); i++) {
+		_update_tree(p_item->get_child(i), p_current, p_export_filter);
+	}
 }
 
 void ProjectExportDialog::_propagate_file_export_mode(TreeItem *p_item, EditorExportPreset::FileExportMode p_inherited_export_mode) {
@@ -1128,13 +1150,50 @@ void ProjectExportDialog::_check_propagated_to_item(Object *p_obj, int column) {
 		return;
 	}
 	TreeItem *item = Object::cast_to<TreeItem>(p_obj);
+	if (!item) {
+		return;
+	}
+	TreeItem *parent_item = item->get_parent();
 	String path = item->get_metadata(0);
-	if (item && !path.ends_with("/")) {
-		bool added = item->is_checked(0);
-		if (added) {
+	if (item->is_checked(0)) {
+		if (path.ends_with("/")) {
+			for (int i = 0; i < item->get_child_count(); i++) {
+				current->remove_export_file(item->get_child(i)->get_metadata(0));
+			}
+		}
+		if (!parent_item || (parent_item && !parent_item->is_checked(0))) {
 			current->add_export_file(path);
-		} else {
-			current->remove_export_file(path);
+			if (parent_item) {
+				Vector<String> checked_items;
+				bool entire_folder_checked = true;
+				for (int i = 0; i < parent_item->get_child_count(); i++) {
+					TreeItem *sibling = parent_item->get_child(i);
+					if (sibling->is_checked(0)) {
+						checked_items.push_back(sibling->get_metadata(0));
+					} else {
+						entire_folder_checked = false;
+						break;
+					}
+				}
+				if (entire_folder_checked) {
+					current->add_export_file(parent_item->get_metadata(0));
+					for (const String &checked_item : checked_items) {
+						current->remove_export_file(checked_item);
+					}
+				}
+			}
+		}
+	} else {
+		current->remove_export_file(path);
+		if (parent_item && parent_item->is_checked(0)) {
+			current->remove_export_file(parent_item->get_metadata(0));
+			for (int i = 0; i < parent_item->get_child_count(); i++) {
+				TreeItem *sibling = parent_item->get_child(i);
+				if (sibling == item) {
+					continue;
+				}
+				current->add_export_file(sibling->get_metadata(0));
+			}
 		}
 	}
 }

--- a/editor/export/project_export.h
+++ b/editor/export/project_export.h
@@ -150,6 +150,7 @@ class ProjectExportDialog : public ConfirmationDialog {
 	void _fill_resource_tree();
 	void _setup_item_for_file_mode(TreeItem *p_item, EditorExportPreset::FileExportMode p_mode);
 	bool _fill_tree(EditorFileSystemDirectory *p_dir, TreeItem *p_item, Ref<EditorExportPreset> &current, EditorExportPreset::ExportFilter p_export_filter);
+	void _update_tree(TreeItem *p_item, Ref<EditorExportPreset> &p_current, EditorExportPreset::ExportFilter p_export_filter);
 	void _propagate_file_export_mode(TreeItem *p_item, EditorExportPreset::FileExportMode p_inherited_export_mode);
 	void _tree_changed();
 	void _check_propagated_to_item(Object *p_obj, int column);


### PR DESCRIPTION
This PR helps declutter `export_presets.cfg` by replacing individual files with directories in `export_files` entries where relevant (when all files in a directory are selected). Updating the selection in the editor's export dialog automatically switches from files to directories or from directories to files as needed.

As a nice side-effect, this also means that when a folder is added to `export_files`, creating new files (or subfolders) in that folder will automatically include them, instead of having to manually update affected presets.

> [!important]
> This changes the current behavior of the export logic, with regards to later additions to the filesystem.
> 
> The current master branch explicitly lists every file that is selected in the tree, which has the following implications:
> - The `export_files` lists is exhaustive, what is found in the list is what will be included/excluded during export.
> - Any addition to the filesystem (new files, with or without subfolders) is ignored, and export templates must be updated accordingly.
>
> On the other hand, this PR behaves as follows:
> - The `export_files` list is not exhaustive from a file point of view, but listed directories include all subdirectories and files within.
> - When files are added to the filesystem (with or without subfolders), in a directory that is listed in `export_files` (or subdirectory thereof), those files are implicitly selected as well, so templates that include/exclude folders will automatically add the new subfolders/files in those folders.
> - Of course, if you deselect a file inside a previously selected folder, `export_files` is updated to reflect the changes.
> 
> The main implication is that the behavior switches from "never update the list that was explicitly defined at one point in time" to "select anything that is inside an already selected directory". Here, "selected directory" means that everything in the directory is selected, and any later addition to that directory is assumed to be included as well.
>
> I can acknowledge that this change may confuse some users, but I also believe that the current behavior is a bigger issue, as every single time you create a new file inside a directory that you previously selected, you *have to* add that file to the template, and you can see the previously selected folder is now in a partially-selected state instead (my use case being an entire folder containing files to be excluded from export (as those will be exported as separate PCK files), but new files keep creeping in if I forget to update the template).

Closes godotengine/godot-proposals#12760.

For illustration purposes, an export preset in one of my projects looks like the following:
<img width="265" height="453" alt="export_preset" src="https://github.com/user-attachments/assets/7119bf0f-6fc1-433d-8a2f-edd25556963c" />
In the current master branch, this results in 696 entries in `export_files`, which results in a 45,499-character line; with this PR, we only have 8 entries, and a 262-character line.
```
master:
export_files=PackedStringArray("res://addons/gdscript_xml_converter/bin/convert_xml.gd", "res://addons/gdscript_xml_converter/src/class_definition/annotation_def.gd", [...693 other files...], "res://modules/module_tab.tscn")

This PR:
export_files=PackedStringArray("res://addons/gdscript_xml_converter/", "res://addons/gdUnit4/", "res://addons/godot_color_maps/", "res://addons/godot_insim/demo/", "res://addons/godot_insim/test/", "res://docs_generator/", "res://experiments/", "res://modules/")
```

For both "export selected resources" and "export all resources in the project except resources checked below", exported PCK files are identical to current master (if there are unit tests for exporting, let me know).

> [!note]
> Opening the export dialog with this PR will automatically update the `export_presets.cfg` file to use the new format; going back to master will remove all folders from `export_files` entries, which will likely result in missing files in the affected export templates.