### PR TITLE
Shaders: Fix crash by returning the actual type rather than TYPE_BOOL

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -1570,7 +1570,7 @@ bool ShaderLanguage::_validate_operator(const BlockNode *p_block, const Function
 			DataType na = p_op->arguments[0]->get_datatype();
 			DataType nb = p_op->arguments[1]->get_datatype();
 			valid = na == nb;
-			ret_type = TYPE_BOOL;
+			ret_type = na;
 		} break;
 		case OP_LESS:
 		case OP_LESS_EQUAL:


### PR DESCRIPTION
Added the fix https://github.com/godotengine/godot/issues/109011
