### PR TITLE
OpenXR: Fix required extension tooltip

### DIFF
--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -246,7 +246,7 @@ void OpenXRInteractionProfileEditor::_add_io_path(VBoxContainer *p_container, co
 		path_label->set_text(p_io_path->display_name);
 	} else {
 		path_label->set_text(p_io_path->display_name + "*");
-		p_container->set_tooltip_text(vformat(TTR("Note: This binding path requires extension %s support."), p_io_path->openxr_extension_name));
+		path_hb->set_tooltip_text(vformat(TTR("Note: This binding path requires extension %s support."), p_io_path->openxr_extension_name));
 	}
 	path_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	path_hb->add_child(path_label);


### PR DESCRIPTION
Small fix that I ran into by accident, this tooltip:

<img width="821" height="350" alt="image" src="https://github.com/user-attachments/assets/007c3577-e9eb-4929-a0a8-d9a6b91d2d1e" />

Was not being shown correctly as it was being added on the main container, causing the last tooltip encountered to show up on all bindings.