### PR TITLE
Add item ID to GridMap palette

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -953,12 +953,8 @@ void GridMapEditor::update_palette() {
 
 	for (_CGMEItemSort &E : il) {
 		int id = E.id;
-		String name = mesh_library->get_item_name(id);
+		String name = mesh_library->get_item_name(id) + " # " + itos(id);
 		Ref<Texture2D> preview = mesh_library->get_item_preview(id);
-
-		if (name.is_empty()) {
-			name = "#" + itos(id);
-		}
 
 		if (!filter.is_empty() && !filter.is_subsequence_ofn(name)) {
 			continue;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Closes https://github.com/godotengine/godot-proposals/issues/5866

Changes the display name of the items in the following way:
- If there is a custom name: "name # id"
- If there isn't a custom name: " # id"

Note that now there is a space before the #, which makes nameless items longer. I think that's fine?

Also, I don't know what I'm doing. I think I followed the step by step correctly though.