### PR TITLE
Allow setting `SVGTexture` oversampling factor for `Sprite3D`.

### DIFF
--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -18,6 +18,9 @@
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
 			The number of columns in the sprite sheet. When this property is changed, [member frame] is adjusted so that the same visual frame is maintained (same row and column). If that's impossible, [member frame] is reset to [code]0[/code].
 		</member>
+		<member name="oversampling" type="float" setter="set_oversampling" getter="get_oversampling" default="1.0">
+			Oversampling factor used to render [DPITexture].
+		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 			If [code]true[/code], the sprite will use [member region_rect] and display only the specified part of its texture.
 		</member>

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -116,6 +116,7 @@ protected:
 	uint32_t attrib_stride = 0;
 	uint32_t skin_stride = 0;
 	uint32_t mesh_surface_format = 0;
+	double oversampling = 1.0;
 
 	void _queue_redraw();
 
@@ -200,6 +201,9 @@ public:
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
 
+	void set_oversampling(float p_oversampling);
+	float get_oversampling() const;
+
 	void set_region_enabled(bool p_region);
 	bool is_region_enabled() const;
 
@@ -221,7 +225,7 @@ public:
 	virtual Rect2 get_item_rect() const override;
 
 	Sprite3D();
-	//~Sprite3D();
+	~Sprite3D();
 };
 
 class AnimatedSprite3D : public SpriteBase3D {

--- a/scene/resources/dpi_texture.cpp
+++ b/scene/resources/dpi_texture.cpp
@@ -269,6 +269,10 @@ RID DPITexture::get_rid() const {
 	return _ensure_scale(1.0);
 }
 
+RID DPITexture::get_rid_for_scale(double p_scale) const {
+	return _ensure_scale(p_scale);
+}
+
 bool DPITexture::has_alpha() const {
 	return true;
 }

--- a/scene/resources/dpi_texture.h
+++ b/scene/resources/dpi_texture.h
@@ -89,6 +89,7 @@ public:
 	int get_height() const override;
 
 	virtual RID get_rid() const override;
+	virtual RID get_rid_for_scale(double p_scale) const;
 
 	bool has_alpha() const override;
 	virtual RID get_scaled_rid() const override;


### PR DESCRIPTION
Partially implements https://github.com/godotengine/godot-proposals/issues/12842


https://github.com/user-attachments/assets/ddf790a7-787b-4efe-932d-74382168f2e9

