### PR TITLE
Disable auto translation of flag names in the inspector

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -931,6 +931,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 
 EditorPropertyFlags::EditorPropertyFlags() {
 	vbox = memnew(VBoxContainer);
+	vbox->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	add_child(vbox);
 }
 


### PR DESCRIPTION
Fixes #108514

This is the same as enum names. Custom flag names should not be translated and we currently don't extract flags names for translation in the editor. So the translation should be disabled.