### PR TITLE
Autocompletion: Remove duplicate code

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1791,18 +1791,6 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 		found = true;
 	} else {
 		switch (p_expression->type) {
-			case GDScriptParser::Node::LITERAL: {
-				const GDScriptParser::LiteralNode *literal = static_cast<const GDScriptParser::LiteralNode *>(p_expression);
-				r_type = _type_from_variant(literal->value, p_context);
-				found = true;
-			} break;
-			case GDScriptParser::Node::SELF: {
-				if (p_context.current_class) {
-					r_type.type = p_context.current_class->get_datatype();
-					r_type.type.is_meta_type = false;
-					found = true;
-				}
-			} break;
 			case GDScriptParser::Node::IDENTIFIER: {
 				const GDScriptParser::IdentifierNode *id = static_cast<const GDScriptParser::IdentifierNode *>(p_expression);
 				found = _guess_identifier_type(p_context, id, r_type);


### PR DESCRIPTION
Removes two cases from `_guess_expression_type` that are not needed:

- `GDScriptParser::Node::LITERAL` is always marked as constant by the analyzer. This case was dead code since constant nodes are handled earlier in the function.
- `GDScriptParser::Node::SELF` yielded the exactly same result as the analyzer in `reduce_self`. We don't need this duplicated code, since the function falls back to the analyzer result later.