### PR TITLE
Add OpenXR 1.1 support

### DIFF
--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -128,3 +128,11 @@ Validate extension JSON: Error: Field 'builtin_classes/PackedVector3Array/method
 Validate extension JSON: Error: Field 'builtin_classes/PackedVector4Array/methods/bsearch': is_const changed value in new API, from false to true.
 
 bsearch method made const. Compatibility methods registered.
+
+
+GH-109302
+---------
+
+Validate extension JSON: Error: Field 'classes/OpenXRExtensionWrapper/methods/_set_instance_create_info_and_get_next_pointer/arguments': size changed value in new API, from 1 to 2.
+Validate extension JSON: Error: Field 'classes/OpenXRExtensionWrapper/methods/_set_instance_create_info_and_get_next_pointer/arguments/0': type changed value in new API, from "void*" to "int".
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OpenXRExtensionWrapper/methods/_get_requested_extensions': arguments

--- a/modules/openxr/action_map/openxr_action_map.cpp
+++ b/modules/openxr/action_map/openxr_action_map.cpp
@@ -261,7 +261,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click,/user/hand/right/input/menu/click");
 	profile->add_new_binding(select_button, "/user/hand/left/input/select/click,/user/hand/right/input/select/click");
 	// generic has no support for triggers, grip, A/B buttons, nor joystick/trackpad inputs.
@@ -273,7 +273,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click,/user/hand/right/input/menu/click");
 	profile->add_new_binding(select_button, "/user/hand/left/input/system/click,/user/hand/right/input/system/click");
 	// wmr controller has no a/b/x/y buttons.
@@ -294,7 +294,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	// wmr controllers have no select button we can use.
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click,/user/hand/right/input/menu/click");
 	// wmr controller has no a/b/x/y buttons.
@@ -317,7 +317,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	// touch controllers have no select button we can use.
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click,/user/hand/right/input/system/click"); // right hand system click may not be available.
 	profile->add_new_binding(ax_button, "/user/hand/left/input/x/click,/user/hand/right/input/a/click"); // x on left hand, a on right hand.
@@ -342,7 +342,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	profile->add_new_binding(select_button, "/user/hand/left/input/system/click,/user/hand/right/input/system/click"); // system click may not be available.
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click");
 	profile->add_new_binding(ax_button, "/user/hand/left/input/x/click,/user/hand/right/input/a/click"); // x on left hand, a on right hand.
@@ -367,7 +367,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	// index controllers have no select button we can use.
 	profile->add_new_binding(menu_button, "/user/hand/left/input/system/click,/user/hand/right/input/system/click");
 	profile->add_new_binding(ax_button, "/user/hand/left/input/a/click,/user/hand/right/input/a/click"); // a on both controllers.
@@ -396,7 +396,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	// hpmr controllers have no select button we can use.
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click,/user/hand/right/input/menu/click");
 	// hpmr controllers only register click, not touch, on our a/b/x/y buttons.
@@ -419,7 +419,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	// Odyssey controllers have no select button we can use.
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click,/user/hand/right/input/menu/click");
 	// Odyssey controller has no a/b/x/y buttons.
@@ -442,7 +442,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click");
 	profile->add_new_binding(select_button, "/user/hand/right/input/system/click"); // we'll map system to select.
 	profile->add_new_binding(ax_button, "/user/hand/left/input/x/click,/user/hand/right/input/a/click"); // x on left hand, a on right hand.
@@ -466,7 +466,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	profile->add_new_binding(menu_button, "/user/hand/left/input/menu/click");
 	profile->add_new_binding(select_button, "/user/hand/right/input/system/click"); // we'll map system to select.
 	profile->add_new_binding(ax_button, "/user/hand/left/input/x/click,/user/hand/right/input/a/click"); // x on left hand, a on right hand.
@@ -490,7 +490,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 	profile->add_new_binding(menu_button, "/user/hand/left/input/home/click,/user/hand/right/input/home/click");
 	profile->add_new_binding(trigger, "/user/hand/left/input/trigger/value,/user/hand/right/input/trigger/value");
 	profile->add_new_binding(trigger_click, "/user/hand/left/input/trigger/click,/user/hand/right/input/trigger/click");
@@ -551,7 +551,7 @@ void OpenXRActionMap::create_default_action_sets() {
 	profile->add_new_binding(default_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(aim_pose, "/user/hand/left/input/aim/pose,/user/hand/right/input/aim/pose");
 	profile->add_new_binding(grip_pose, "/user/hand/left/input/grip/pose,/user/hand/right/input/grip/pose");
-	profile->add_new_binding(palm_pose, "/user/hand/left/input/palm_ext/pose,/user/hand/right/input/palm_ext/pose");
+	profile->add_new_binding(palm_pose, "/user/hand/left/input/grip_surface/pose,/user/hand/right/input/grip_surface/pose");
 
 	// Use pinch as primary.
 	profile->add_new_binding(primary, "/user/hand/left/input/pinch_ext/value,/user/hand/right/input/pinch_ext/value");

--- a/modules/openxr/action_map/openxr_interaction_profile.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile.cpp
@@ -79,7 +79,14 @@ Ref<OpenXRAction> OpenXRIPBinding::get_action() const {
 }
 
 void OpenXRIPBinding::set_binding_path(const String &p_path) {
-	binding_path = p_path;
+	OpenXRInteractionProfileMetadata *pmd = OpenXRInteractionProfileMetadata::get_singleton();
+	if (pmd) {
+		binding_path = pmd->check_path_name(p_path);
+	} else {
+		// OpenXR not enabled, ignore checks.
+		binding_path = p_path;
+	}
+
 	emit_changed();
 }
 
@@ -244,7 +251,7 @@ void OpenXRInteractionProfile::set_interaction_profile_path(const String &p_inpu
 	if (pmd) {
 		interaction_profile_path = pmd->check_profile_name(p_input_profile_path);
 	} else {
-		// OpenXR module not enabled, ignore checks.
+		// OpenXR not enabled, ignore checks.
 		interaction_profile_path = p_input_profile_path;
 	}
 	emit_changed();

--- a/modules/openxr/action_map/openxr_interaction_profile_metadata.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile_metadata.cpp
@@ -47,9 +47,10 @@ OpenXRInteractionProfileMetadata::~OpenXRInteractionProfileMetadata() {
 
 void OpenXRInteractionProfileMetadata::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("register_profile_rename", "old_name", "new_name"), &OpenXRInteractionProfileMetadata::register_profile_rename);
-	ClassDB::bind_method(D_METHOD("register_top_level_path", "display_name", "openxr_path", "openxr_extension_name"), &OpenXRInteractionProfileMetadata::register_top_level_path);
-	ClassDB::bind_method(D_METHOD("register_interaction_profile", "display_name", "openxr_path", "openxr_extension_name"), &OpenXRInteractionProfileMetadata::register_interaction_profile);
-	ClassDB::bind_method(D_METHOD("register_io_path", "interaction_profile", "display_name", "toplevel_path", "openxr_path", "openxr_extension_name", "action_type"), &OpenXRInteractionProfileMetadata::register_io_path);
+	ClassDB::bind_method(D_METHOD("register_path_rename", "old_name", "new_name"), &OpenXRInteractionProfileMetadata::register_path_rename);
+	ClassDB::bind_method(D_METHOD("register_top_level_path", "display_name", "openxr_path", "openxr_extension_names"), &OpenXRInteractionProfileMetadata::register_top_level_path);
+	ClassDB::bind_method(D_METHOD("register_interaction_profile", "display_name", "openxr_path", "openxr_extension_names"), &OpenXRInteractionProfileMetadata::register_interaction_profile);
+	ClassDB::bind_method(D_METHOD("register_io_path", "interaction_profile", "display_name", "toplevel_path", "openxr_path", "openxr_extension_names", "action_type"), &OpenXRInteractionProfileMetadata::register_io_path);
 }
 
 void OpenXRInteractionProfileMetadata::register_profile_rename(const String &p_old_name, const String &p_new_name) {
@@ -66,30 +67,44 @@ String OpenXRInteractionProfileMetadata::check_profile_name(const String &p_name
 	return p_name;
 }
 
-void OpenXRInteractionProfileMetadata::register_top_level_path(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_name) {
+void OpenXRInteractionProfileMetadata::register_path_rename(const String &p_old_name, const String &p_new_name) {
+	ERR_FAIL_COND(path_renames.has(p_old_name));
+
+	path_renames[p_old_name] = p_new_name;
+}
+
+String OpenXRInteractionProfileMetadata::check_path_name(const String &p_name) const {
+	if (path_renames.has(p_name)) {
+		return path_renames[p_name];
+	}
+
+	return p_name;
+}
+
+void OpenXRInteractionProfileMetadata::register_top_level_path(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_names) {
 	ERR_FAIL_COND_MSG(has_top_level_path(p_openxr_path), p_openxr_path + " had already been registered");
 
 	TopLevelPath new_toplevel_path = {
 		p_display_name,
 		p_openxr_path,
-		p_openxr_extension_name
+		p_openxr_extension_names
 	};
 
 	top_level_paths.push_back(new_toplevel_path);
 }
 
-void OpenXRInteractionProfileMetadata::register_interaction_profile(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_name) {
+void OpenXRInteractionProfileMetadata::register_interaction_profile(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_names) {
 	ERR_FAIL_COND_MSG(has_interaction_profile(p_openxr_path), p_openxr_path + " has already been registered");
 
 	InteractionProfile new_profile;
 	new_profile.display_name = p_display_name;
 	new_profile.openxr_path = p_openxr_path;
-	new_profile.openxr_extension_name = p_openxr_extension_name;
+	new_profile.openxr_extension_names = p_openxr_extension_names;
 
 	interaction_profiles.push_back(new_profile);
 }
 
-void OpenXRInteractionProfileMetadata::register_io_path(const String &p_interaction_profile, const String &p_display_name, const String &p_toplevel_path, const String &p_openxr_path, const String &p_openxr_extension_name, OpenXRAction::ActionType p_action_type) {
+void OpenXRInteractionProfileMetadata::register_io_path(const String &p_interaction_profile, const String &p_display_name, const String &p_toplevel_path, const String &p_openxr_path, const String &p_openxr_extension_names, OpenXRAction::ActionType p_action_type) {
 	ERR_FAIL_COND_MSG(!has_interaction_profile(p_interaction_profile), "Unknown interaction profile " + p_interaction_profile);
 	ERR_FAIL_COND_MSG(!has_top_level_path(p_toplevel_path), "Unknown top level path " + p_toplevel_path);
 
@@ -101,7 +116,7 @@ void OpenXRInteractionProfileMetadata::register_io_path(const String &p_interact
 				p_display_name,
 				p_toplevel_path,
 				p_openxr_path,
-				p_openxr_extension_name,
+				p_openxr_extension_names,
 				p_action_type
 			};
 
@@ -130,10 +145,10 @@ String OpenXRInteractionProfileMetadata::get_top_level_name(const String &p_open
 	return String();
 }
 
-String OpenXRInteractionProfileMetadata::get_top_level_extension(const String &p_openxr_path) const {
+String OpenXRInteractionProfileMetadata::get_top_level_extensions(const String &p_openxr_path) const {
 	for (int i = 0; i < top_level_paths.size(); i++) {
 		if (top_level_paths[i].openxr_path == p_openxr_path) {
-			return top_level_paths[i].openxr_extension_name;
+			return top_level_paths[i].openxr_extension_names;
 		}
 	}
 
@@ -150,10 +165,10 @@ bool OpenXRInteractionProfileMetadata::has_interaction_profile(const String &p_o
 	return false;
 }
 
-String OpenXRInteractionProfileMetadata::get_interaction_profile_extension(const String &p_openxr_path) const {
+String OpenXRInteractionProfileMetadata::get_interaction_profile_extensions(const String &p_openxr_path) const {
 	for (const InteractionProfile &interaction_profile : interaction_profiles) {
 		if (interaction_profile.openxr_path == p_openxr_path) {
-			return interaction_profile.openxr_extension_name;
+			return interaction_profile.openxr_extension_names;
 		}
 	}
 
@@ -218,6 +233,11 @@ void OpenXRInteractionProfileMetadata::_register_core_metadata() {
 
 	// Note that we'll make an exception for XR_EXT_palm_pose, which is used everywhere
 
+	// OpenXR 1.1 uses various new names.
+	// We use the new names in our action map and translate back IF OpenXR 1.1 is not supported.
+	register_path_rename("/user/hand/left/input/palm_ext/pose", "/user/hand/left/input/grip_surface/pose");
+	register_path_rename("/user/hand/right/input/palm_ext/pose", "/user/hand/right/input/grip_surface/pose");
+
 	// Our core toplevel paths
 	register_top_level_path("Left hand controller", "/user/hand/left", "");
 	register_top_level_path("Right hand controller", "/user/hand/right", "");
@@ -231,7 +251,7 @@ void OpenXRInteractionProfileMetadata::_register_core_metadata() {
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			register_io_path(profile_path, "Menu click", user_path, user_path + "/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 			register_io_path(profile_path, "Select click", user_path, user_path + "/input/select/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
@@ -246,7 +266,7 @@ void OpenXRInteractionProfileMetadata::_register_core_metadata() {
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			register_io_path(profile_path, "Menu click", user_path, user_path + "/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 			register_io_path(profile_path, "System click", user_path, user_path + "/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
@@ -275,7 +295,7 @@ void OpenXRInteractionProfileMetadata::_register_core_metadata() {
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			register_io_path(profile_path, "Menu click", user_path, user_path + "/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
@@ -310,7 +330,7 @@ void OpenXRInteractionProfileMetadata::_register_core_metadata() {
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			register_io_path(profile_path, "Trigger", user_path, user_path + "/input/trigger/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 			register_io_path(profile_path, "Trigger touch", user_path, user_path + "/input/trigger/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
@@ -349,7 +369,7 @@ void OpenXRInteractionProfileMetadata::_register_core_metadata() {
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			register_io_path(profile_path, "System click", user_path, user_path + "/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 

--- a/modules/openxr/action_map/openxr_interaction_profile_metadata.h
+++ b/modules/openxr/action_map/openxr_interaction_profile_metadata.h
@@ -64,21 +64,21 @@ public:
 	struct TopLevelPath {
 		String display_name; // User friendly display name (i.e. Left controller)
 		String openxr_path; // Path in OpenXR (i.e. /user/hand/left)
-		String openxr_extension_name; // If set, only available if extension is enabled (i.e. XR_HTCX_vive_tracker_interaction)
+		String openxr_extension_names; // If set, only available if extension is enabled (i.e. XR_HTCX_vive_tracker_interaction)
 	};
 
 	struct IOPath {
 		String display_name; // User friendly display name (i.e. Grip pose (left controller))
 		String top_level_path; // Top level path identifying the usage of the device in relation to this input/output
 		String openxr_path; // Path in OpenXR (i.e. /user/hand/left/input/grip/pose)
-		String openxr_extension_name; // If set, only available if extension is enabled (i.e. XR_EXT_palm_pose)
+		String openxr_extension_names; // If set, only available if extension is enabled (i.e. XR_EXT_palm_pose)
 		OpenXRAction::ActionType action_type; // Type of input/output
 	};
 
 	struct InteractionProfile {
 		String display_name; // User friendly display name (i.e. Simple controller)
 		String openxr_path; // Path in OpenXR (i.e. /interaction_profiles/khr/simple_controller)
-		String openxr_extension_name; // If set, only available if extension is enabled (i.e. XR_HTCX_vive_tracker_interaction)
+		String openxr_extension_names; // If set, only available if extension is enabled (i.e. XR_HTCX_vive_tracker_interaction)
 		Vector<IOPath> io_paths; // Inputs and outputs for this device
 
 		bool has_io_path(const String &p_io_path) const;
@@ -89,6 +89,8 @@ private:
 	static OpenXRInteractionProfileMetadata *singleton;
 
 	HashMap<String, String> profile_renames;
+	HashMap<String, String> path_renames;
+
 	Vector<TopLevelPath> top_level_paths;
 	Vector<InteractionProfile> interaction_profiles;
 
@@ -106,17 +108,20 @@ public:
 	void register_profile_rename(const String &p_old_name, const String &p_new_name);
 	String check_profile_name(const String &p_name) const;
 
-	void register_top_level_path(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_name);
+	void register_path_rename(const String &p_old_name, const String &p_new_name);
+	String check_path_name(const String &p_name) const;
+
+	void register_top_level_path(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_names);
 	bool has_top_level_path(const String &p_openxr_path) const;
 	String get_top_level_name(const String &p_openxr_path) const;
-	String get_top_level_extension(const String &p_openxr_path) const;
+	String get_top_level_extensions(const String &p_openxr_path) const;
 
-	void register_interaction_profile(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_name);
+	void register_interaction_profile(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_names);
 	bool has_interaction_profile(const String &p_openxr_path) const;
-	String get_interaction_profile_extension(const String &p_openxr_path) const;
+	String get_interaction_profile_extensions(const String &p_openxr_path) const;
 	const InteractionProfile *get_profile(const String &p_openxr_path) const;
 	PackedStringArray get_interaction_profile_paths() const;
 
-	void register_io_path(const String &p_interaction_profile, const String &p_display_name, const String &p_toplevel_path, const String &p_openxr_path, const String &p_openxr_extension_name, OpenXRAction::ActionType p_action_type);
+	void register_io_path(const String &p_interaction_profile, const String &p_display_name, const String &p_toplevel_path, const String &p_openxr_path, const String &p_openxr_extension_names, OpenXRAction::ActionType p_action_type);
 	const IOPath *get_io_path(const String &p_interaction_profile, const String &p_io_path) const;
 };

--- a/modules/openxr/doc_classes/OpenXRAPIExtension.xml
+++ b/modules/openxr/doc_classes/OpenXRAPIExtension.xml
@@ -85,6 +85,12 @@
 				Returns the predicted display timing for the next frame.
 			</description>
 		</method>
+		<method name="get_openxr_version">
+			<return type="int" />
+			<description>
+				Returns the version of OpenXR that was initialized. Only valid after the OpenXR instance has been created. See [url=https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_MAKE_VERSION]XR_MAKE_VERSION[/url] for how the version is calculated.
+			</description>
+		</method>
 		<method name="get_play_space">
 			<return type="int" />
 			<description>

--- a/modules/openxr/doc_classes/OpenXRExtensionWrapper.xml
+++ b/modules/openxr/doc_classes/OpenXRExtensionWrapper.xml
@@ -42,8 +42,9 @@
 		</method>
 		<method name="_get_requested_extensions" qualifiers="virtual">
 			<return type="Dictionary" />
+			<param index="0" name="xr_version" type="int" />
 			<description>
-				Returns a [Dictionary] of OpenXR extensions related to this extension. The [Dictionary] should contain the name of the extension, mapped to a [code]bool *[/code] cast to an integer:
+				Returns a [Dictionary] of OpenXR extensions related to this extension. [param xr_version] specifies the OpenXR version we're instantiating. This will be zero if the editor requests this list to flag supported features. The [Dictionary] should contain the name of the extension, mapped to a [code]bool *[/code] cast to an integer:
 				- If the [code]bool *[/code] is a [code]nullptr[/code] this extension is mandatory.
 				- If the [code]bool *[/code] points to a boolean, the boolean will be updated to [code]true[/code] if the extension is enabled.
 			</description>
@@ -269,9 +270,10 @@
 		</method>
 		<method name="_set_instance_create_info_and_get_next_pointer" qualifiers="virtual">
 			<return type="int" />
-			<param index="0" name="next_pointer" type="void*" />
+			<param index="0" name="xr_version" type="int" />
+			<param index="1" name="next_pointer" type="void*" />
 			<description>
-				Add additional data structures when the OpenXR instance is created.
+				Add additional data structures when the OpenXR instance is created. [param xr_version] specifies the OpenXR version we're instantiating.
 			</description>
 		</method>
 		<method name="_set_projection_views_and_get_next_pointer" qualifiers="virtual">

--- a/modules/openxr/doc_classes/OpenXRInteractionProfileMetadata.xml
+++ b/modules/openxr/doc_classes/OpenXRInteractionProfileMetadata.xml
@@ -13,10 +13,10 @@
 			<return type="void" />
 			<param index="0" name="display_name" type="String" />
 			<param index="1" name="openxr_path" type="String" />
-			<param index="2" name="openxr_extension_name" type="String" />
+			<param index="2" name="openxr_extension_names" type="String" />
 			<description>
 				Registers an interaction profile using its OpenXR designation (e.g. [code]/interaction_profiles/khr/simple_controller[/code] is the profile for OpenXR's simple controller profile).
-				[param display_name] is the description shown to the user. [param openxr_path] is the interaction profile path being registered. [param openxr_extension_name] optionally restricts this profile to the given extension being enabled/available. If the extension is not available, the profile and all related entries used in an action map are filtered out.
+				[param display_name] is the description shown to the user. [param openxr_path] is the interaction profile path being registered. [param openxr_extension_names] optionally restricts this profile to the given extension being enabled/available. If the extension is not available, the profile and all related entries used in an action map are filtered out.
 			</description>
 		</method>
 		<method name="register_io_path">
@@ -25,10 +25,18 @@
 			<param index="1" name="display_name" type="String" />
 			<param index="2" name="toplevel_path" type="String" />
 			<param index="3" name="openxr_path" type="String" />
-			<param index="4" name="openxr_extension_name" type="String" />
+			<param index="4" name="openxr_extension_names" type="String" />
 			<param index="5" name="action_type" type="int" enum="OpenXRAction.ActionType" />
 			<description>
-				Registers an input/output path for the given [param interaction_profile]. The profile should previously have been registered using [method register_interaction_profile]. [param display_name] is the description shown to the user. [param toplevel_path] specifies the bind path this input/output can be bound to (e.g. [code]/user/hand/left[/code] or [code]/user/hand/right[/code]). [param openxr_path] is the action input/output being registered (e.g. [code]/user/hand/left/input/aim/pose[/code]). [param openxr_extension_name] restricts this input/output to an enabled/available extension, this doesn't need to repeat the extension on the profile but relates to overlapping extension (e.g. [code]XR_EXT_palm_pose[/code] that introduces [code]…/input/palm_ext/pose[/code] input paths). [param action_type] defines the type of input or output provided by OpenXR.
+				Registers an input/output path for the given [param interaction_profile]. The profile should previously have been registered using [method register_interaction_profile]. [param display_name] is the description shown to the user. [param toplevel_path] specifies the bind path this input/output can be bound to (e.g. [code]/user/hand/left[/code] or [code]/user/hand/right[/code]). [param openxr_path] is the action input/output being registered (e.g. [code]/user/hand/left/input/aim/pose[/code]). [param openxr_extension_names] restricts this input/output to an enabled/available extension, this doesn't need to repeat the extension on the profile but relates to overlapping extension (e.g. [code]XR_EXT_palm_pose[/code] that introduces [code]…/input/palm_ext/pose[/code] input paths). [param action_type] defines the type of input or output provided by OpenXR.
+			</description>
+		</method>
+		<method name="register_path_rename">
+			<return type="void" />
+			<param index="0" name="old_name" type="String" />
+			<param index="1" name="new_name" type="String" />
+			<description>
+				Allows for renaming old input/output paths to new paths in order to load and process older action maps.
 			</description>
 		</method>
 		<method name="register_profile_rename">
@@ -36,17 +44,17 @@
 			<param index="0" name="old_name" type="String" />
 			<param index="1" name="new_name" type="String" />
 			<description>
-				Allows for renaming old interaction profile paths to new paths to maintain backwards compatibility with older action maps.
+				Allows for renaming old interaction profile paths to new paths in order to load and process older action maps.
 			</description>
 		</method>
 		<method name="register_top_level_path">
 			<return type="void" />
 			<param index="0" name="display_name" type="String" />
 			<param index="1" name="openxr_path" type="String" />
-			<param index="2" name="openxr_extension_name" type="String" />
+			<param index="2" name="openxr_extension_names" type="String" />
 			<description>
 				Registers a top level path to which profiles can be bound. For instance [code]/user/hand/left[/code] refers to the bind point for the player's left hand. Extensions can register additional top level paths, for instance a haptic vest extension might register [code]/user/body/vest[/code].
-				[param display_name] is the name shown to the user. [param openxr_path] is the top level path being registered. [param openxr_extension_name] is optional and ensures the top level path is only used if the specified extension is available/enabled.
+				[param display_name] is the name shown to the user. [param openxr_path] is the top level path being registered. [param openxr_extension_names] is optional and ensures the top level path is only used if the specified extension is available/enabled.
 				When a top level path ends up being bound by OpenXR, an [XRPositionalTracker] is instantiated to manage the state of the device.
 			</description>
 		</method>

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -78,7 +78,7 @@ void OpenXRSelectInteractionProfileDialog::open(const PackedStringArray &p_do_no
 		memdelete(main_vb->get_child(1));
 	}
 
-	PackedStringArray requested_extensions = OpenXRAPI::get_all_requested_extensions();
+	PackedStringArray requested_extensions = OpenXRAPI::get_all_requested_extensions(0);
 
 	selected_interaction_profile = "";
 	ip_buttons.clear();
@@ -86,8 +86,12 @@ void OpenXRSelectInteractionProfileDialog::open(const PackedStringArray &p_do_no
 	// In with the new.
 	PackedStringArray interaction_profiles = meta_data->get_interaction_profile_paths();
 	for (const String &path : interaction_profiles) {
-		const String extension = meta_data->get_interaction_profile_extension(path);
-		if (!p_do_not_include.has(path) && (extension.is_empty() || requested_extensions.has(extension))) {
+		const Vector<String> extensions = meta_data->get_interaction_profile_extensions(path).split(",", false);
+		bool extension_is_requested = extensions.is_empty(); // If none, then yes we can use this.
+		for (const String &extension : extensions) {
+			extension_is_requested |= requested_extensions.has(extension);
+		}
+		if (!p_do_not_include.has(path) && extension_is_requested) {
 			Button *ip_button = memnew(Button);
 			ip_button->set_flat(true);
 			ip_button->set_text(meta_data->get_profile(path)->display_name);

--- a/modules/openxr/extensions/openxr_android_thread_settings_extension.cpp
+++ b/modules/openxr/extensions/openxr_android_thread_settings_extension.cpp
@@ -62,7 +62,7 @@ void OpenXRAndroidThreadSettingsExtension::_bind_methods() {
 	BIND_ENUM_CONSTANT(THREAD_TYPE_RENDERER_WORKER);
 }
 
-HashMap<String, bool *> OpenXRAndroidThreadSettingsExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRAndroidThreadSettingsExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 #ifdef XR_USE_PLATFORM_ANDROID

--- a/modules/openxr/extensions/openxr_android_thread_settings_extension.h
+++ b/modules/openxr/extensions/openxr_android_thread_settings_extension.h
@@ -50,7 +50,7 @@ public:
 	OpenXRAndroidThreadSettingsExtension();
 	virtual ~OpenXRAndroidThreadSettingsExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 	virtual void on_instance_created(XrInstance p_instance) override;
 	virtual void on_session_created(XrSession p_session) override;
 

--- a/modules/openxr/extensions/openxr_composition_layer_depth_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_depth_extension.cpp
@@ -44,7 +44,7 @@ OpenXRCompositionLayerDepthExtension::~OpenXRCompositionLayerDepthExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRCompositionLayerDepthExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRCompositionLayerDepthExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_KHR_COMPOSITION_LAYER_DEPTH_EXTENSION_NAME] = &available;

--- a/modules/openxr/extensions/openxr_composition_layer_depth_extension.h
+++ b/modules/openxr/extensions/openxr_composition_layer_depth_extension.h
@@ -44,7 +44,7 @@ public:
 	OpenXRCompositionLayerDepthExtension();
 	virtual ~OpenXRCompositionLayerDepthExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 	bool is_available();
 	virtual int get_composition_layer_count() override;
 	virtual XrCompositionLayerBaseHeader *get_composition_layer(int p_index) override;

--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -56,7 +56,7 @@ OpenXRCompositionLayerExtension::~OpenXRCompositionLayerExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRCompositionLayerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRCompositionLayerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_KHR_COMPOSITION_LAYER_CYLINDER_EXTENSION_NAME] = &cylinder_ext_available;

--- a/modules/openxr/extensions/openxr_composition_layer_extension.h
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.h
@@ -126,7 +126,7 @@ public:
 	OpenXRCompositionLayerExtension();
 	virtual ~OpenXRCompositionLayerExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_session_created(const XrSession p_session) override;
 	virtual void on_session_destroyed() override;

--- a/modules/openxr/extensions/openxr_debug_utils_extension.cpp
+++ b/modules/openxr/extensions/openxr_debug_utils_extension.cpp
@@ -50,7 +50,7 @@ OpenXRDebugUtilsExtension::~OpenXRDebugUtilsExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRDebugUtilsExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRDebugUtilsExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_EXT_DEBUG_UTILS_EXTENSION_NAME] = &debug_utils_ext;

--- a/modules/openxr/extensions/openxr_debug_utils_extension.h
+++ b/modules/openxr/extensions/openxr_debug_utils_extension.h
@@ -45,7 +45,7 @@ public:
 	OpenXRDebugUtilsExtension();
 	virtual ~OpenXRDebugUtilsExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;
 

--- a/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
+++ b/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
@@ -52,7 +52,7 @@ OpenXRDPadBindingExtension::~OpenXRDPadBindingExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRDPadBindingExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRDPadBindingExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// Note, we're dependent on the binding modifier extension, this may be requested by multiple extension wrappers.

--- a/modules/openxr/extensions/openxr_dpad_binding_extension.h
+++ b/modules/openxr/extensions/openxr_dpad_binding_extension.h
@@ -48,7 +48,7 @@ public:
 	OpenXRDPadBindingExtension();
 	virtual ~OpenXRDPadBindingExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -34,9 +34,9 @@
 #include "../openxr_api_extension.h"
 
 void OpenXRExtensionWrapper::_bind_methods() {
-	GDVIRTUAL_BIND(_get_requested_extensions);
+	GDVIRTUAL_BIND(_get_requested_extensions, "xr_version");
 	GDVIRTUAL_BIND(_set_system_properties_and_get_next_pointer, "next_pointer");
-	GDVIRTUAL_BIND(_set_instance_create_info_and_get_next_pointer, "next_pointer");
+	GDVIRTUAL_BIND(_set_instance_create_info_and_get_next_pointer, "xr_version", "next_pointer");
 	GDVIRTUAL_BIND(_set_session_create_and_get_next_pointer, "next_pointer");
 	GDVIRTUAL_BIND(_set_swapchain_create_info_and_get_next_pointer, "next_pointer");
 	GDVIRTUAL_BIND(_set_hand_joint_locations_and_get_next_pointer, "hand_index", "next_pointer");
@@ -79,14 +79,19 @@ void OpenXRExtensionWrapper::_bind_methods() {
 	GDVIRTUAL_BIND(_on_viewport_composition_layer_destroyed, "layer");
 	GDVIRTUAL_BIND(_set_android_surface_swapchain_create_info_and_get_next_pointer, "property_values", "next_pointer");
 
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_get_requested_extensions_bind_compat_109302);
+	GDVIRTUAL_BIND_COMPAT(_set_instance_create_info_and_get_next_pointer_bind_compat_109302, "next_pointer");
+#endif
+
 	ClassDB::bind_method(D_METHOD("get_openxr_api"), &OpenXRExtensionWrapper::_gdextension_get_openxr_api);
 	ClassDB::bind_method(D_METHOD("register_extension_wrapper"), &OpenXRExtensionWrapper::_gdextension_register_extension_wrapper);
 }
 
-HashMap<String, bool *> OpenXRExtensionWrapper::get_requested_extensions() {
+HashMap<String, bool *> OpenXRExtensionWrapper::get_requested_extensions(XrVersion p_xr_version) {
 	Dictionary request_extension;
 
-	if (GDVIRTUAL_CALL(_get_requested_extensions, request_extension)) {
+	if (GDVIRTUAL_CALL(_get_requested_extensions, (uint64_t)p_xr_version, request_extension)) {
 		HashMap<String, bool *> result;
 		for (const KeyValue<Variant, Variant> &kv : request_extension) {
 			GDExtensionPtr<bool> value = VariantCaster<GDExtensionPtr<bool>>::cast(kv.value);
@@ -94,6 +99,17 @@ HashMap<String, bool *> OpenXRExtensionWrapper::get_requested_extensions() {
 		}
 		return result;
 	}
+
+#ifndef DISABLE_DEPRECATED
+	if (GDVIRTUAL_CALL(_get_requested_extensions_bind_compat_109302, request_extension)) {
+		HashMap<String, bool *> result;
+		for (const KeyValue<Variant, Variant> &kv : request_extension) {
+			GDExtensionPtr<bool> value = VariantCaster<GDExtensionPtr<bool>>::cast(kv.value);
+			result.insert(kv.key, value);
+		}
+		return result;
+	}
+#endif
 
 	return HashMap<String, bool *>();
 }
@@ -108,12 +124,18 @@ void *OpenXRExtensionWrapper::set_system_properties_and_get_next_pointer(void *p
 	return nullptr;
 }
 
-void *OpenXRExtensionWrapper::set_instance_create_info_and_get_next_pointer(void *p_next_pointer) {
+void *OpenXRExtensionWrapper::set_instance_create_info_and_get_next_pointer(XrVersion p_xr_version, void *p_next_pointer) {
 	uint64_t pointer;
 
-	if (GDVIRTUAL_CALL(_set_instance_create_info_and_get_next_pointer, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+	if (GDVIRTUAL_CALL(_set_instance_create_info_and_get_next_pointer, (uint64_t)p_xr_version, GDExtensionPtr<void>(p_next_pointer), pointer)) {
 		return reinterpret_cast<void *>(pointer);
 	}
+
+#ifndef DISABLE_DEPRECATED
+	if (GDVIRTUAL_CALL(_set_instance_create_info_and_get_next_pointer_bind_compat_109302, GDExtensionPtr<void>(p_next_pointer), pointer)) {
+		return reinterpret_cast<void *>(pointer);
+	}
+#endif
 
 	return nullptr;
 }

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -60,12 +60,15 @@ protected:
 
 public:
 	// `get_requested_extensions` should return a list of OpenXR extensions related to this extension.
+	// This function can be called multiple times.
+	// p_xr_version is the OpenXR version which we're attempting to initialize.
+	// Note: when called from the editor, p_xr_version will be 0 and we should return any extension we may initialize.
 	// If the bool * is a nullptr this extension is mandatory
 	// If the bool * points to a boolean, the boolean will be updated
 	// to true if the extension is enabled.
-	virtual HashMap<String, bool *> get_requested_extensions();
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_xr_version);
 
-	GDVIRTUAL0R(Dictionary, _get_requested_extensions);
+	GDVIRTUAL1R(Dictionary, _get_requested_extensions, uint64_t);
 
 	// These functions allow an extension to add entries to a struct chain.
 	// `p_next_pointer` points to the last struct that was created for this chain
@@ -74,7 +77,7 @@ public:
 	// If you are not adding any structs, just return `p_next_pointer`.
 	// See existing extensions for examples of this implementation.
 	virtual void *set_system_properties_and_get_next_pointer(void *p_next_pointer); // Add additional data structures when we interrogate OpenXR's system abilities.
-	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer); // Add additional data structures when we create our OpenXR instance.
+	virtual void *set_instance_create_info_and_get_next_pointer(XrVersion p_xr_version, void *p_next_pointer); // Add additional data structures when we create our OpenXR instance.
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer); // Add additional data structures when we create our OpenXR session.
 	virtual void *set_swapchain_create_info_and_get_next_pointer(void *p_next_pointer); // Add additional data structures when creating OpenXR swap chains.
 	virtual void *set_hand_joint_locations_and_get_next_pointer(int p_hand_index, void *p_next_pointer);
@@ -91,7 +94,7 @@ public:
 
 	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
 	GDVIRTUAL1R(uint64_t, _set_system_properties_and_get_next_pointer, GDExtensionPtr<void>);
-	GDVIRTUAL1R(uint64_t, _set_instance_create_info_and_get_next_pointer, GDExtensionPtr<void>);
+	GDVIRTUAL2R(uint64_t, _set_instance_create_info_and_get_next_pointer, uint64_t, GDExtensionPtr<void>);
 	GDVIRTUAL1R(uint64_t, _set_session_create_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL1R(uint64_t, _set_swapchain_create_info_and_get_next_pointer, GDExtensionPtr<void>);
 	GDVIRTUAL2R(uint64_t, _set_hand_joint_locations_and_get_next_pointer, int, GDExtensionPtr<void>);
@@ -106,6 +109,11 @@ public:
 	GDVIRTUAL1(_prepare_view_configuration, int);
 	GDVIRTUAL2R(uint64_t, _set_view_configuration_and_get_next_pointer, uint32_t, GDExtensionPtr<void>);
 	GDVIRTUAL1C(_print_view_configuration_info, int);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0R_COMPAT(_get_requested_extensions_bind_compat_109302, Dictionary, _get_requested_extensions);
+	GDVIRTUAL1R_COMPAT(_set_instance_create_info_and_get_next_pointer_bind_compat_109302, uint64_t, _set_instance_create_info_and_get_next_pointer, GDExtensionPtr<void>);
+#endif
 
 	virtual PackedStringArray get_suggested_tracker_names();
 

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.cpp
@@ -51,7 +51,7 @@ OpenXREyeGazeInteractionExtension::~OpenXREyeGazeInteractionExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXREyeGazeInteractionExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXREyeGazeInteractionExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// Only enable this extension when requested.

--- a/modules/openxr/extensions/openxr_eye_gaze_interaction.h
+++ b/modules/openxr/extensions/openxr_eye_gaze_interaction.h
@@ -44,7 +44,7 @@ public:
 	OpenXREyeGazeInteractionExtension();
 	~OpenXREyeGazeInteractionExtension();
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 	virtual void *set_system_properties_and_get_next_pointer(void *p_next_pointer) override;
 
 	PackedStringArray get_suggested_tracker_names() override;

--- a/modules/openxr/extensions/openxr_fb_display_refresh_rate_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_display_refresh_rate_extension.cpp
@@ -45,7 +45,7 @@ OpenXRDisplayRefreshRateExtension::~OpenXRDisplayRefreshRateExtension() {
 	display_refresh_rate_ext = false;
 }
 
-HashMap<String, bool *> OpenXRDisplayRefreshRateExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRDisplayRefreshRateExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_FB_DISPLAY_REFRESH_RATE_EXTENSION_NAME] = &display_refresh_rate_ext;

--- a/modules/openxr/extensions/openxr_fb_display_refresh_rate_extension.h
+++ b/modules/openxr/extensions/openxr_fb_display_refresh_rate_extension.h
@@ -51,7 +51,7 @@ public:
 	OpenXRDisplayRefreshRateExtension();
 	virtual ~OpenXRDisplayRefreshRateExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_foveation_extension.cpp
@@ -75,7 +75,7 @@ OpenXRFBFoveationExtension::~OpenXRFBFoveationExtension() {
 	swapchain_update_state_ext = nullptr;
 }
 
-HashMap<String, bool *> OpenXRFBFoveationExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRFBFoveationExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_FB_FOVEATION_EXTENSION_NAME] = &fb_foveation_ext;

--- a/modules/openxr/extensions/openxr_fb_foveation_extension.h
+++ b/modules/openxr/extensions/openxr_fb_foveation_extension.h
@@ -52,7 +52,7 @@ public:
 	OpenXRFBFoveationExtension(const String &p_rendering_driver);
 	virtual ~OpenXRFBFoveationExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
@@ -61,7 +61,7 @@ OpenXRFBUpdateSwapchainExtension::~OpenXRFBUpdateSwapchainExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRFBUpdateSwapchainExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRFBUpdateSwapchainExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_FB_SWAPCHAIN_UPDATE_STATE_EXTENSION_NAME] = &fb_swapchain_update_state_ext;

--- a/modules/openxr/extensions/openxr_fb_update_swapchain_extension.h
+++ b/modules/openxr/extensions/openxr_fb_update_swapchain_extension.h
@@ -54,7 +54,7 @@ public:
 	OpenXRFBUpdateSwapchainExtension(const String &p_rendering_driver);
 	virtual ~OpenXRFBUpdateSwapchainExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
+++ b/modules/openxr/extensions/openxr_frame_synthesis_extension.cpp
@@ -68,7 +68,7 @@ OpenXRFrameSynthesisExtension::~OpenXRFrameSynthesisExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRFrameSynthesisExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRFrameSynthesisExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	if (GLOBAL_GET("xr/openxr/extensions/frame_synthesis")) {

--- a/modules/openxr/extensions/openxr_frame_synthesis_extension.h
+++ b/modules/openxr/extensions/openxr_frame_synthesis_extension.h
@@ -44,7 +44,7 @@ public:
 	OpenXRFrameSynthesisExtension();
 	virtual ~OpenXRFrameSynthesisExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/openxr_future_extension.cpp
+++ b/modules/openxr/extensions/openxr_future_extension.cpp
@@ -129,7 +129,7 @@ void OpenXRFutureExtension::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cancel_future", "future"), &OpenXRFutureExtension::_cancel_future);
 }
 
-HashMap<String, bool *> OpenXRFutureExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRFutureExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_EXT_FUTURE_EXTENSION_NAME] = &future_ext;

--- a/modules/openxr/extensions/openxr_future_extension.h
+++ b/modules/openxr/extensions/openxr_future_extension.h
@@ -104,7 +104,7 @@ public:
 	OpenXRFutureExtension();
 	virtual ~OpenXRFutureExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
@@ -31,6 +31,7 @@
 #include "openxr_hand_interaction_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 #include "core/config/project_settings.h"
 
 #include <openxr/openxr.h>
@@ -49,7 +50,7 @@ OpenXRHandInteractionExtension::~OpenXRHandInteractionExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRHandInteractionExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRHandInteractionExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// Only enable this extension when requested.
@@ -78,7 +79,7 @@ void OpenXRHandInteractionExtension::on_register_metadata() {
 		openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 		openxr_metadata->register_io_path(profile_path, "Pinch pose", user_path, user_path + "/input/pinch_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 		openxr_metadata->register_io_path(profile_path, "Poke pose", user_path, user_path + "/input/poke_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-		openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+		openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 		openxr_metadata->register_io_path(profile_path, "Pinch", user_path, user_path + "/input/pinch_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 		openxr_metadata->register_io_path(profile_path, "Pinch ready", user_path, user_path + "/input/pinch_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);

--- a/modules/openxr/extensions/openxr_hand_interaction_extension.h
+++ b/modules/openxr/extensions/openxr_hand_interaction_extension.h
@@ -61,7 +61,7 @@ public:
 	OpenXRHandInteractionExtension();
 	virtual ~OpenXRHandInteractionExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -55,7 +55,7 @@ OpenXRHandTrackingExtension::~OpenXRHandTrackingExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRHandTrackingExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRHandTrackingExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	unobstructed_data_source = GLOBAL_GET("xr/openxr/extensions/hand_tracking_unobstructed_data_source");

--- a/modules/openxr/extensions/openxr_hand_tracking_extension.h
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.h
@@ -76,7 +76,7 @@ public:
 	OpenXRHandTrackingExtension();
 	virtual ~OpenXRHandTrackingExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/openxr_htc_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_controller_extension.cpp
@@ -31,12 +31,17 @@
 #include "openxr_htc_controller_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 
-HashMap<String, bool *> OpenXRHTCControllerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRHTCControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-	request_extensions[XR_HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available[HTC_VIVE_COSMOS];
-	request_extensions[XR_HTC_VIVE_FOCUS3_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available[HTC_VIVE_FOCUS3];
+	if (p_version < XR_API_VERSION_1_1_0) {
+		// Extensions where promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		request_extensions[XR_HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available[HTC_VIVE_COSMOS];
+		request_extensions[XR_HTC_VIVE_FOCUS3_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available[HTC_VIVE_FOCUS3];
+	}
+
 	request_extensions[XR_HTC_HAND_INTERACTION_EXTENSION_NAME] = &available[HTC_HAND_INTERACTION];
 
 	return request_extensions;
@@ -63,11 +68,11 @@ void OpenXRHTCControllerExtension::on_register_metadata() {
 
 	{ // HTC Vive Cosmos controller
 		const String profile_path = "/interaction_profiles/htc/vive_cosmos_controller";
-		openxr_metadata->register_interaction_profile("Vive Cosmos controller", profile_path, XR_HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME);
+		openxr_metadata->register_interaction_profile("Vive Cosmos controller", profile_path, XR_HTC_VIVE_COSMOS_CONTROLLER_INTERACTION_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Shoulder click", user_path, user_path + "/input/shoulder/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
@@ -98,11 +103,11 @@ void OpenXRHTCControllerExtension::on_register_metadata() {
 
 	{ // HTC Vive Focus 3 controller
 		const String profile_path = "/interaction_profiles/htc/vive_focus3_controller";
-		openxr_metadata->register_interaction_profile("Vive Focus 3 controller", profile_path, XR_HTC_VIVE_FOCUS3_CONTROLLER_INTERACTION_EXTENSION_NAME);
+		openxr_metadata->register_interaction_profile("Vive Focus 3 controller", profile_path, XR_HTC_VIVE_FOCUS3_CONTROLLER_INTERACTION_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Trigger", user_path, user_path + "/input/trigger/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 			openxr_metadata->register_io_path(profile_path, "Trigger click", user_path, user_path + "/input/trigger/click", "", OpenXRAction::OPENXR_ACTION_BOOL);

--- a/modules/openxr/extensions/openxr_htc_controller_extension.h
+++ b/modules/openxr/extensions/openxr_htc_controller_extension.h
@@ -47,7 +47,7 @@ public:
 		HTC_MAX_CONTROLLERS
 	};
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	PackedStringArray get_suggested_tracker_names() override;
 

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.cpp
@@ -34,7 +34,7 @@
 
 #include "core/string/print_string.h"
 
-HashMap<String, bool *> OpenXRHTCViveTrackerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRHTCViveTrackerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_HTCX_VIVE_TRACKER_INTERACTION_EXTENSION_NAME] = &available;

--- a/modules/openxr/extensions/openxr_htc_vive_tracker_extension.h
+++ b/modules/openxr/extensions/openxr_htc_vive_tracker_extension.h
@@ -39,7 +39,7 @@ protected:
 	static void _bind_methods() {}
 
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	PackedStringArray get_suggested_tracker_names() override;
 

--- a/modules/openxr/extensions/openxr_huawei_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_huawei_controller_extension.cpp
@@ -31,8 +31,9 @@
 #include "openxr_huawei_controller_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 
-HashMap<String, bool *> OpenXRHuaweiControllerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRHuaweiControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_HUAWEI_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
@@ -55,6 +56,7 @@ void OpenXRHuaweiControllerExtension::on_register_metadata() {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Home click", user_path, user_path + "/input/home/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 			openxr_metadata->register_io_path(profile_path, "Back click", user_path, user_path + "/input/back/click", "", OpenXRAction::OPENXR_ACTION_BOOL);

--- a/modules/openxr/extensions/openxr_huawei_controller_extension.h
+++ b/modules/openxr/extensions/openxr_huawei_controller_extension.h
@@ -39,7 +39,7 @@ protected:
 	static void _bind_methods() {}
 
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_local_floor_extension.cpp
+++ b/modules/openxr/extensions/openxr_local_floor_extension.cpp
@@ -30,6 +30,8 @@
 
 #include "openxr_local_floor_extension.h"
 
+#include "../openxr_api.h"
+
 OpenXRLocalFloorExtension *OpenXRLocalFloorExtension::singleton = nullptr;
 
 OpenXRLocalFloorExtension *OpenXRLocalFloorExtension::get_singleton() {
@@ -44,10 +46,13 @@ OpenXRLocalFloorExtension::~OpenXRLocalFloorExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRLocalFloorExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRLocalFloorExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-	request_extensions[XR_EXT_LOCAL_FLOOR_EXTENSION_NAME] = &available;
+	if (p_version < XR_API_VERSION_1_1_0) {
+		// Extension was promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		request_extensions[XR_EXT_LOCAL_FLOOR_EXTENSION_NAME] = &available;
+	}
 
 	return request_extensions;
 }

--- a/modules/openxr/extensions/openxr_local_floor_extension.h
+++ b/modules/openxr/extensions/openxr_local_floor_extension.h
@@ -44,7 +44,7 @@ public:
 	OpenXRLocalFloorExtension();
 	virtual ~OpenXRLocalFloorExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_meta_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_meta_controller_extension.cpp
@@ -31,13 +31,30 @@
 #include "openxr_meta_controller_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 
-HashMap<String, bool *> OpenXRMetaControllerExtension::get_requested_extensions() {
+const char *touch_controller = "/interaction_profiles/oculus/touch_controller";
+const char *touch_pro_controller = "/interaction_profiles/meta/touch_pro_controller";
+const char *touch_plus_controller = "/interaction_profiles/meta/touch_plus_controller";
+const char *rift_cv1_controller = "/interaction_profiles/meta/touch_controller_rift_cv1";
+const char *quest1_rift_s_controller = "/interaction_profiles/meta/touch_controller_quest_1_rift_s";
+const char *quest2_controller = "/interaction_profiles/meta/touch_controller_quest_2";
+
+// Vendor extension paths (promoted)
+const char *touch_controller_pro_fb = "/interaction_profiles/facebook/touch_controller_pro";
+const char *touch_controller_plus_fb = "/interaction_profiles/facebook/touch_controller_plus";
+const char *touch_controller_plus_meta = "/interaction_profiles/meta/touch_controller_plus";
+
+HashMap<String, bool *> OpenXRMetaControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
+	if (p_version < XR_API_VERSION_1_1_0) {
+		// Extensions where promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		request_extensions[XR_FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME] = &available[META_TOUCH_PRO];
+		request_extensions[XR_META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME] = &available[META_TOUCH_PLUS];
+	}
+
 	request_extensions[XR_FB_TOUCH_CONTROLLER_PROXIMITY_EXTENSION_NAME] = &available[META_TOUCH_PROXIMITY];
-	request_extensions[XR_FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME] = &available[META_TOUCH_PRO];
-	request_extensions[XR_META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME] = &available[META_TOUCH_PLUS];
 
 	return request_extensions;
 }
@@ -50,34 +67,69 @@ void OpenXRMetaControllerExtension::on_register_metadata() {
 	OpenXRInteractionProfileMetadata *openxr_metadata = OpenXRInteractionProfileMetadata::get_singleton();
 	ERR_FAIL_NULL(openxr_metadata);
 
-	// Note, we register controllers regardless if they are supported on the current hardware.
+	// Note, we register controllers regardless if they are supported on the current hardware,
+	// this allows the editor to configure controllers for other platforms.
+	// Unsupported entries will be filtered out of the action map if applicable.
 
-	{ // Normal touch controller is part of the core spec, but we do have some extensions.
-		const String profile_path = "/interaction_profiles/oculus/touch_controller";
+	// OpenXR 1.1 uses various new names for profile and input/output paths.
+	// We use these new names in our action map and translate back IF OpenXR 1.1 is not supported.
+	openxr_metadata->register_profile_rename(touch_controller_pro_fb, touch_pro_controller);
+	openxr_metadata->register_profile_rename(touch_controller_plus_fb, touch_controller_plus_meta); // This was an incorrect profile path that we need to correct.
+	openxr_metadata->register_profile_rename(touch_controller_plus_meta, touch_plus_controller);
+
+	openxr_metadata->register_path_rename("/user/hand/left/input/stylus_fb/force", "/user/hand/left/input/stylus/force");
+	openxr_metadata->register_path_rename("/user/hand/right/input/stylus_fb/force", "/user/hand/right/input/stylus/force");
+	openxr_metadata->register_path_rename("/user/hand/left/input/trigger/proximity_fb", "/user/hand/left/input/trigger/proximity");
+	openxr_metadata->register_path_rename("/user/hand/right/input/trigger/proximity_fb", "/user/hand/right/input/trigger/proximity");
+	openxr_metadata->register_path_rename("/user/hand/left/output/haptic_trigger_fb", "/user/hand/left/output/haptic_trigger");
+	openxr_metadata->register_path_rename("/user/hand/right/output/haptic_trigger_fb", "/user/hand/right/output/haptic_trigger");
+	openxr_metadata->register_path_rename("/user/hand/left/output/haptic_thumb_fb", "/user/hand/left/output/haptic_thumb");
+	openxr_metadata->register_path_rename("/user/hand/right/output/haptic_thumb_fb", "/user/hand/right/output/haptic_thumb");
+	openxr_metadata->register_path_rename("/user/hand/left/input/thumb_fb/proximity_fb", "/user/hand/left/input/thumb_resting_surfaces/proximity");
+	openxr_metadata->register_path_rename("/user/hand/right/input/thumb_fb/proximity_fb", "/user/hand/right/input/thumb_resting_surfaces/proximity");
+	openxr_metadata->register_path_rename("/user/hand/left/input/trigger/curl_fb", "/user/hand/left/input/trigger_curl/value");
+	openxr_metadata->register_path_rename("/user/hand/right/input/trigger/curl_fb", "/user/hand/right/input/trigger_curl/value");
+	openxr_metadata->register_path_rename("/user/hand/left/input/trigger/slide_fb", "/user/hand/left/input/trigger_slide/value");
+	openxr_metadata->register_path_rename("/user/hand/right/input/trigger/slide_fb", "/user/hand/right/input/trigger_slide/value");
+
+	openxr_metadata->register_path_rename("/user/hand/left/input/trigger/proximity_meta", "/user/hand/left/input/trigger/proximity");
+	openxr_metadata->register_path_rename("/user/hand/right/input/trigger/proximity_meta", "/user/hand/right/input/trigger/proximity");
+	openxr_metadata->register_path_rename("/user/hand/left/input/thumb_meta/proximity_meta", "/user/hand/left/input/thumb_resting_surfaces/proximity");
+	openxr_metadata->register_path_rename("/user/hand/right/input/thumb_meta/proximity_meta", "/user/hand/right/input/thumb_resting_surfaces/proximity");
+	openxr_metadata->register_path_rename("/user/hand/left/input/trigger/curl_meta", "/user/hand/left/input/trigger_curl/value");
+	openxr_metadata->register_path_rename("/user/hand/right/input/trigger/curl_meta", "/user/hand/right/input/trigger_curl/value");
+	openxr_metadata->register_path_rename("/user/hand/left/input/trigger/slide_meta", "/user/hand/left/input/trigger_slide/value");
+	openxr_metadata->register_path_rename("/user/hand/right/input/trigger/slide_meta", "/user/hand/right/input/trigger_slide/value");
+
+	{ // Normal touch controller is part of the core spec and still relies on the XR_FB_touch_controller_proximity extension for these two new paths.
+		const String profile_path = touch_controller;
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
-			openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity_fb ", "XR_FB_touch_controller_proximity", OpenXRAction::OPENXR_ACTION_BOOL);
-			openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_fb/proximity_fb ", "XR_FB_touch_controller_proximity", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity", XR_FB_TOUCH_CONTROLLER_PROXIMITY_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_resting_surfaces/proximity", XR_FB_TOUCH_CONTROLLER_PROXIMITY_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_BOOL);
 		}
 	}
 
 	{ // Touch controller pro (Quest Pro)
-		const String profile_path = "/interaction_profiles/facebook/touch_controller_pro";
-		openxr_metadata->register_interaction_profile("Touch controller pro", profile_path, "XR_FB_touch_controller_pro");
+		const String profile_path = touch_pro_controller;
+		openxr_metadata->register_interaction_profile("Touch controller pro", profile_path, XR_FB_TOUCH_CONTROLLER_PRO_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+
+			openxr_metadata->register_io_path(profile_path, "Pinch pose", user_path, user_path + "/input/pinch_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Poke pose", user_path, user_path + "/input/poke_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Trigger", user_path, user_path + "/input/trigger/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 			openxr_metadata->register_io_path(profile_path, "Trigger touch", user_path, user_path + "/input/trigger/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
-			openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity_fb", "", OpenXRAction::OPENXR_ACTION_BOOL);
-			openxr_metadata->register_io_path(profile_path, "Trigger curl", user_path, user_path + "/input/trigger/curl_fb", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-			openxr_metadata->register_io_path(profile_path, "Trigger slide", user_path, user_path + "/input/trigger/slide_fb", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Trigger curl", user_path, user_path + "/input/trigger_curl/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Trigger slide", user_path, user_path + "/input/trigger_slide/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 			openxr_metadata->register_io_path(profile_path, "Trigger force", user_path, user_path + "/input/trigger/force", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 
 			openxr_metadata->register_io_path(profile_path, "Squeeze", user_path, user_path + "/input/squeeze/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 
-			openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_fb/proximity_fb", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_resting_surfaces/proximity", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
 			openxr_metadata->register_io_path(profile_path, "Thumbstick", user_path, user_path + "/input/thumbstick", "", OpenXRAction::OPENXR_ACTION_VECTOR2);
 			openxr_metadata->register_io_path(profile_path, "Thumbstick X", user_path, user_path + "/input/thumbstick/x", "", OpenXRAction::OPENXR_ACTION_FLOAT);
@@ -92,11 +144,11 @@ void OpenXRMetaControllerExtension::on_register_metadata() {
 			openxr_metadata->register_io_path(profile_path, "Thumbrest touch", user_path, user_path + "/input/thumbrest/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
 			openxr_metadata->register_io_path(profile_path, "Thumbrest force", user_path, user_path + "/input/thumbrest/force", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 
-			openxr_metadata->register_io_path(profile_path, "Stylus force", user_path, user_path + "/input/stylus_fb/force", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Stylus force", user_path, user_path + "/input/stylus/force", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 
 			openxr_metadata->register_io_path(profile_path, "Haptic output", user_path, user_path + "/output/haptic", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
-			openxr_metadata->register_io_path(profile_path, "Haptic trigger output", user_path, user_path + "/output/haptic_trigger_fb", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
-			openxr_metadata->register_io_path(profile_path, "Haptic thumb output", user_path, user_path + "/output/haptic_thumb_fb", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
+			openxr_metadata->register_io_path(profile_path, "Haptic trigger output", user_path, user_path + "/output/haptic_trigger", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
+			openxr_metadata->register_io_path(profile_path, "Haptic thumb output", user_path, user_path + "/output/haptic_thumb", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
 		}
 
 		openxr_metadata->register_io_path(profile_path, "Menu click", "/user/hand/left", "/user/hand/left/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
@@ -112,24 +164,27 @@ void OpenXRMetaControllerExtension::on_register_metadata() {
 		openxr_metadata->register_io_path(profile_path, "B touch", "/user/hand/right", "/user/hand/right/input/b/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
 	}
 
-	{ // Touch controller plus (Quest 3)
-		const String profile_path = "/interaction_profiles/meta/touch_controller_plus";
-		openxr_metadata->register_interaction_profile("Touch controller plus", profile_path, "XR_META_touch_controller_plus");
+	{ // Touch controller plus (Quest 3 + 3S)
+		const String profile_path = touch_plus_controller;
+		openxr_metadata->register_interaction_profile("Touch controller plus", profile_path, XR_META_TOUCH_CONTROLLER_PLUS_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+
+			openxr_metadata->register_io_path(profile_path, "Pinch pose", user_path, user_path + "/input/pinch_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Poke pose", user_path, user_path + "/input/poke_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Trigger", user_path, user_path + "/input/trigger/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 			openxr_metadata->register_io_path(profile_path, "Trigger touch", user_path, user_path + "/input/trigger/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
-			openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity_meta", "", OpenXRAction::OPENXR_ACTION_BOOL);
-			openxr_metadata->register_io_path(profile_path, "Trigger curl", user_path, user_path + "/input/trigger/curl_meta", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-			openxr_metadata->register_io_path(profile_path, "Trigger slide", user_path, user_path + "/input/trigger/slide_meta", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Trigger curl", user_path, user_path + "/input/trigger_curl/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+			openxr_metadata->register_io_path(profile_path, "Trigger slide", user_path, user_path + "/input/trigger_slide/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 			openxr_metadata->register_io_path(profile_path, "Trigger force", user_path, user_path + "/input/trigger/force", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 
 			openxr_metadata->register_io_path(profile_path, "Squeeze", user_path, user_path + "/input/squeeze/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 
-			openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_meta/proximity_meta", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_resting_surfaces/proximity", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
 			openxr_metadata->register_io_path(profile_path, "Thumbstick", user_path, user_path + "/input/thumbstick", "", OpenXRAction::OPENXR_ACTION_VECTOR2);
 			openxr_metadata->register_io_path(profile_path, "Thumbstick X", user_path, user_path + "/input/thumbstick/x", "", OpenXRAction::OPENXR_ACTION_FLOAT);
@@ -157,5 +212,58 @@ void OpenXRMetaControllerExtension::on_register_metadata() {
 		openxr_metadata->register_io_path(profile_path, "A touch", "/user/hand/right", "/user/hand/right/input/a/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
 		openxr_metadata->register_io_path(profile_path, "B click", "/user/hand/right", "/user/hand/right/input/b/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 		openxr_metadata->register_io_path(profile_path, "B touch", "/user/hand/right", "/user/hand/right/input/b/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+	}
+
+	{
+		// In OpenXR 1.1 we have controller profiles for Meta legacy controllers. They are all the same as the normal touch controller profile.
+		openxr_metadata->register_interaction_profile("Touch controller Rift CV1", rift_cv1_controller, XR_OPENXR_1_1_NAME);
+		openxr_metadata->register_interaction_profile("Touch controller Quest 1 or Rift S", quest1_rift_s_controller, XR_OPENXR_1_1_NAME);
+		openxr_metadata->register_interaction_profile("Touch controller Quest 2", quest2_controller, XR_OPENXR_1_1_NAME);
+
+		for (const String profile_path : { rift_cv1_controller, quest1_rift_s_controller, quest2_controller }) {
+			for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
+				openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+				openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+				openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+
+				openxr_metadata->register_io_path(profile_path, "Pinch pose", user_path, user_path + "/input/pinch_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+				openxr_metadata->register_io_path(profile_path, "Poke pose", user_path, user_path + "/input/poke_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+
+				openxr_metadata->register_io_path(profile_path, "Trigger", user_path, user_path + "/input/trigger/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+				openxr_metadata->register_io_path(profile_path, "Trigger touch", user_path, user_path + "/input/trigger/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+				openxr_metadata->register_io_path(profile_path, "Squeeze", user_path, user_path + "/input/squeeze/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+
+				// Note, unlike the default touch controller interaction profile, these are not dependent on the XR_FB_touch_controller_proximity extension!
+				openxr_metadata->register_io_path(profile_path, "Trigger proximity", user_path, user_path + "/input/trigger/proximity", "", OpenXRAction::OPENXR_ACTION_BOOL);
+				openxr_metadata->register_io_path(profile_path, "Thumb proximity", user_path, user_path + "/input/thumb_resting_surfaces/proximity", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+				openxr_metadata->register_io_path(profile_path, "Thumbstick", user_path, user_path + "/input/thumbstick", "", OpenXRAction::OPENXR_ACTION_VECTOR2);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick X", user_path, user_path + "/input/thumbstick/x", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick Y", user_path, user_path + "/input/thumbstick/y", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick click", user_path, user_path + "/input/thumbstick/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick touch", user_path, user_path + "/input/thumbstick/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Up", user_path, user_path + "/input/thumbstick/dpad_up", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Down", user_path, user_path + "/input/thumbstick/dpad_down", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Left", user_path, user_path + "/input/thumbstick/dpad_left", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+				openxr_metadata->register_io_path(profile_path, "Thumbstick Dpad Right", user_path, user_path + "/input/thumbstick/dpad_right", "XR_EXT_dpad_binding", OpenXRAction::OPENXR_ACTION_BOOL);
+
+				openxr_metadata->register_io_path(profile_path, "Thumbrest touch", user_path, user_path + "/input/thumbrest/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+				openxr_metadata->register_io_path(profile_path, "Haptic output", user_path, user_path + "/output/haptic", "", OpenXRAction::OPENXR_ACTION_HAPTIC);
+			}
+
+			openxr_metadata->register_io_path(profile_path, "Menu click", "/user/hand/left", "/user/hand/left/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "System click", "/user/hand/right", "/user/hand/right/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+			openxr_metadata->register_io_path(profile_path, "X click", "/user/hand/left", "/user/hand/left/input/x/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "X touch", "/user/hand/left", "/user/hand/left/input/x/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Y click", "/user/hand/left", "/user/hand/left/input/y/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "Y touch", "/user/hand/left", "/user/hand/left/input/y/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "A click", "/user/hand/right", "/user/hand/right/input/a/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "A touch", "/user/hand/right", "/user/hand/right/input/a/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "B click", "/user/hand/right", "/user/hand/right/input/b/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
+			openxr_metadata->register_io_path(profile_path, "B touch", "/user/hand/right", "/user/hand/right/input/b/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		}
 	}
 }

--- a/modules/openxr/extensions/openxr_meta_controller_extension.h
+++ b/modules/openxr/extensions/openxr_meta_controller_extension.h
@@ -46,7 +46,7 @@ public:
 		META_MAX_CONTROLLERS
 	};
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available(MetaControllers p_type);
 

--- a/modules/openxr/extensions/openxr_ml2_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_ml2_controller_extension.cpp
@@ -31,11 +31,15 @@
 #include "openxr_ml2_controller_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 
-HashMap<String, bool *> OpenXRML2ControllerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRML2ControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-	request_extensions[XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
+	if (p_version < XR_API_VERSION_1_1_0) {
+		// Extension was promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		request_extensions[XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
+	}
 
 	return request_extensions;
 }
@@ -50,7 +54,7 @@ void OpenXRML2ControllerExtension::on_register_metadata() {
 
 	// Magic Leap 2 Controller
 	const String profile_path = "/interaction_profiles/ml/ml2_controller";
-	openxr_metadata->register_interaction_profile("Magic Leap 2 controller", profile_path, XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME);
+	openxr_metadata->register_interaction_profile("Magic Leap 2 controller", profile_path, XR_ML_ML2_CONTROLLER_INTERACTION_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 	for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 		openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 		openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);

--- a/modules/openxr/extensions/openxr_ml2_controller_extension.h
+++ b/modules/openxr/extensions/openxr_ml2_controller_extension.h
@@ -39,7 +39,7 @@ protected:
 	static void _bind_methods() {}
 
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_mxink_extension.cpp
+++ b/modules/openxr/extensions/openxr_mxink_extension.cpp
@@ -35,7 +35,7 @@
 // Not in base XR libs needs def
 #define XR_LOGITECH_MX_INK_STYLUS_INTERACTION_EXTENSION_NAME "XR_LOGITECH_mx_ink_stylus_interaction"
 
-HashMap<String, bool *> OpenXRMxInkExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRMxInkExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_LOGITECH_MX_INK_STYLUS_INTERACTION_EXTENSION_NAME] = &available;

--- a/modules/openxr/extensions/openxr_mxink_extension.h
+++ b/modules/openxr/extensions/openxr_mxink_extension.h
@@ -39,7 +39,7 @@ protected:
 	static void _bind_methods() {}
 
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_palm_pose_extension.cpp
+++ b/modules/openxr/extensions/openxr_palm_pose_extension.cpp
@@ -30,6 +30,8 @@
 
 #include "openxr_palm_pose_extension.h"
 
+#include "../openxr_api.h"
+
 OpenXRPalmPoseExtension *OpenXRPalmPoseExtension::singleton = nullptr;
 
 OpenXRPalmPoseExtension *OpenXRPalmPoseExtension::get_singleton() {
@@ -44,10 +46,13 @@ OpenXRPalmPoseExtension::~OpenXRPalmPoseExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRPalmPoseExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRPalmPoseExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
-	request_extensions[XR_EXT_PALM_POSE_EXTENSION_NAME] = &available;
+	if (p_version < XR_API_VERSION_1_1_0) {
+		// Extension was promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		request_extensions[XR_EXT_PALM_POSE_EXTENSION_NAME] = &available;
+	}
 
 	return request_extensions;
 }

--- a/modules/openxr/extensions/openxr_palm_pose_extension.h
+++ b/modules/openxr/extensions/openxr_palm_pose_extension.h
@@ -44,7 +44,7 @@ public:
 	OpenXRPalmPoseExtension();
 	virtual ~OpenXRPalmPoseExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_performance_settings_extension.cpp
+++ b/modules/openxr/extensions/openxr_performance_settings_extension.cpp
@@ -46,7 +46,7 @@ OpenXRPerformanceSettingsExtension::~OpenXRPerformanceSettingsExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRPerformanceSettingsExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRPerformanceSettingsExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_EXT_PERFORMANCE_SETTINGS_EXTENSION_NAME] = &available;

--- a/modules/openxr/extensions/openxr_performance_settings_extension.h
+++ b/modules/openxr/extensions/openxr_performance_settings_extension.h
@@ -41,7 +41,7 @@ public:
 	OpenXRPerformanceSettingsExtension();
 	virtual ~OpenXRPerformanceSettingsExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual bool on_event_polled(const XrEventDataBuffer &event) override;

--- a/modules/openxr/extensions/openxr_pico_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_pico_controller_extension.cpp
@@ -31,15 +31,20 @@
 #include "openxr_pico_controller_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 
-HashMap<String, bool *> OpenXRPicoControllerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRPicoControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// Note, this used to be XR_PICO_controller_interaction but that has since been retired
 	// and was never part of the OpenXX specification.
 	// All PICO devices should be updated to an OS supporting the official extension.
 
-	request_extensions[XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
+	if (true || p_version < XR_API_VERSION_1_1_0) {
+		// Extension was promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		// Note, we still need it for pico4_interaction, hence the temporary `if (true || ...`
+		request_extensions[XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME] = &available;
+	}
 
 	return request_extensions;
 }
@@ -57,11 +62,11 @@ void OpenXRPicoControllerExtension::on_register_metadata() {
 
 	{ // Pico neo 3 controller.
 		const String profile_path = "/interaction_profiles/bytedance/pico_neo3_controller";
-		openxr_metadata->register_interaction_profile("Pico Neo3 controller", profile_path, XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME);
+		openxr_metadata->register_interaction_profile("Pico Neo3 controller", profile_path, XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Menu click", user_path, user_path + "/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 			openxr_metadata->register_io_path(profile_path, "System click", user_path, user_path + "/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
@@ -94,11 +99,11 @@ void OpenXRPicoControllerExtension::on_register_metadata() {
 
 	{ // Pico 4 controller.
 		const String profile_path = "/interaction_profiles/bytedance/pico4_controller";
-		openxr_metadata->register_interaction_profile("Pico 4 controller", profile_path, XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME);
+		openxr_metadata->register_interaction_profile("Pico 4 controller", profile_path, XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "System click", user_path, user_path + "/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
@@ -131,13 +136,13 @@ void OpenXRPicoControllerExtension::on_register_metadata() {
 		openxr_metadata->register_io_path(profile_path, "B touch", "/user/hand/right", "/user/hand/right/input/b/touch", "", OpenXRAction::OPENXR_ACTION_BOOL);
 	}
 
-	{ // Pico 4 Ultra controller.
+	{ // Pico 4 Ultra controller, note: not provided by OpenXR 1.1
 		const String profile_path = "/interaction_profiles/bytedance/pico4s_controller";
 		openxr_metadata->register_interaction_profile("Pico 4 Ultra controller", profile_path, XR_BD_CONTROLLER_INTERACTION_EXTENSION_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "System click", user_path, user_path + "/input/system/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 

--- a/modules/openxr/extensions/openxr_pico_controller_extension.h
+++ b/modules/openxr/extensions/openxr_pico_controller_extension.h
@@ -39,7 +39,7 @@ protected:
 	static void _bind_methods() {}
 
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_render_model_extension.cpp
+++ b/modules/openxr/extensions/openxr_render_model_extension.cpp
@@ -71,11 +71,14 @@ OpenXRRenderModelExtension::~OpenXRRenderModelExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRRenderModelExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRRenderModelExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	if (GLOBAL_GET("xr/openxr/extensions/render_model")) {
-		request_extensions[XR_EXT_UUID_EXTENSION_NAME] = &uuid_ext;
+		if (p_version < XR_API_VERSION_1_1_0) {
+			// Extension was promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+			request_extensions[XR_EXT_UUID_EXTENSION_NAME] = &uuid_ext;
+		}
 		request_extensions[XR_EXT_RENDER_MODEL_EXTENSION_NAME] = &render_model_ext;
 		request_extensions[XR_EXT_INTERACTION_RENDER_MODEL_EXTENSION_NAME] = &interaction_render_model_ext;
 	}

--- a/modules/openxr/extensions/openxr_render_model_extension.h
+++ b/modules/openxr/extensions/openxr_render_model_extension.h
@@ -74,7 +74,7 @@ public:
 	OpenXRRenderModelExtension();
 	virtual ~OpenXRRenderModelExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_session_created(const XrSession p_session) override;

--- a/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
+++ b/modules/openxr/extensions/openxr_valve_analog_threshold_extension.cpp
@@ -53,7 +53,7 @@ OpenXRValveAnalogThresholdExtension::~OpenXRValveAnalogThresholdExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRValveAnalogThresholdExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRValveAnalogThresholdExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// Note, we're dependent on the binding modifier extension, this may be requested by multiple extension wrappers.

--- a/modules/openxr/extensions/openxr_valve_analog_threshold_extension.h
+++ b/modules/openxr/extensions/openxr_valve_analog_threshold_extension.h
@@ -48,7 +48,7 @@ public:
 	OpenXRValveAnalogThresholdExtension();
 	virtual ~OpenXRValveAnalogThresholdExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available();
 

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.cpp
@@ -69,7 +69,7 @@ OpenXRVisibilityMaskExtension::~OpenXRVisibilityMaskExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRVisibilityMaskExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRVisibilityMaskExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_KHR_VISIBILITY_MASK_EXTENSION_NAME] = &available;

--- a/modules/openxr/extensions/openxr_visibility_mask_extension.h
+++ b/modules/openxr/extensions/openxr_visibility_mask_extension.h
@@ -58,7 +58,7 @@ public:
 	OpenXRVisibilityMaskExtension();
 	virtual ~OpenXRVisibilityMaskExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 

--- a/modules/openxr/extensions/openxr_wmr_controller_extension.cpp
+++ b/modules/openxr/extensions/openxr_wmr_controller_extension.cpp
@@ -31,13 +31,17 @@
 #include "openxr_wmr_controller_extension.h"
 
 #include "../action_map/openxr_interaction_profile_metadata.h"
+#include "../openxr_api.h"
 
-HashMap<String, bool *> OpenXRWMRControllerExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRWMRControllerExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// Note HP G2 is available on WMR and SteamVR, but Odessey is only available on WMR
-	request_extensions[XR_EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME] = &available[WMR_HPMR];
-	request_extensions[XR_EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME] = &available[WMR_SAMSUNG_ODESSY];
+	if (p_version < XR_API_VERSION_1_1_0) {
+		// Extensions where promoted in OpenXR 1.1, only include it in OpenXR 1.0.
+		request_extensions[XR_EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME] = &available[WMR_HPMR];
+		request_extensions[XR_EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME] = &available[WMR_SAMSUNG_ODESSY];
+	}
 	request_extensions[XR_MSFT_HAND_INTERACTION_EXTENSION_NAME] = &available[WMR_HAND_INTERACTION];
 
 	return request_extensions;
@@ -53,11 +57,11 @@ void OpenXRWMRControllerExtension::on_register_metadata() {
 
 	{ // HP MR controller (newer G2 controllers)
 		const String profile_path = "/interaction_profiles/hp/mixed_reality_controller";
-		openxr_metadata->register_interaction_profile("HPMR controller", profile_path, XR_EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME);
+		openxr_metadata->register_interaction_profile("HPMR controller", profile_path, XR_EXT_HP_MIXED_REALITY_CONTROLLER_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Menu click", user_path, user_path + "/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
@@ -84,11 +88,11 @@ void OpenXRWMRControllerExtension::on_register_metadata() {
 
 	{ // Samsung Odyssey controller
 		const String profile_path = "/interaction_profiles/samsung/odyssey_controller";
-		openxr_metadata->register_interaction_profile("Samsung Odyssey controller", profile_path, XR_EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME);
+		openxr_metadata->register_interaction_profile("Samsung Odyssey controller", profile_path, XR_EXT_SAMSUNG_ODYSSEY_CONTROLLER_EXTENSION_NAME "," XR_OPENXR_1_1_NAME);
 		for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
 			openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Menu click", user_path, user_path + "/input/menu/click", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
@@ -125,7 +129,7 @@ void OpenXRWMRControllerExtension::on_register_metadata() {
 			openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Pinch pose", user_path, user_path + "/input/pinch_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 			openxr_metadata->register_io_path(profile_path, "Poke pose", user_path, user_path + "/input/poke_ext/pose", XR_EXT_HAND_INTERACTION_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
-			openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+			openxr_metadata->register_io_path(profile_path, "Grip surface pose", user_path, user_path + "/input/grip_surface/pose", XR_EXT_PALM_POSE_EXTENSION_NAME "," XR_KHR_MAINTENANCE1_EXTENSION_NAME "," XR_OPENXR_1_1_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
 			openxr_metadata->register_io_path(profile_path, "Select (pinch)", user_path, user_path + "/input/select/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
 

--- a/modules/openxr/extensions/openxr_wmr_controller_extension.h
+++ b/modules/openxr/extensions/openxr_wmr_controller_extension.h
@@ -46,7 +46,7 @@ public:
 		WMR_MAX_CONTROLLERS
 	};
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	bool is_available(WMRControllers p_type);
 

--- a/modules/openxr/extensions/platform/openxr_android_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_android_extension.cpp
@@ -55,7 +55,7 @@ OpenXRAndroidExtension::OpenXRAndroidExtension() {
 	activity_object = env->NewGlobalRef(static_cast<OS_Android *>(OS::get_singleton())->get_godot_java()->get_activity());
 }
 
-HashMap<String, bool *> OpenXRAndroidExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRAndroidExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	// XR_KHR_LOADER_INIT_EXTENSION_NAME is a dependency of XR_KHR_LOADER_INIT_ANDROID_EXTENSION_NAME
@@ -87,7 +87,7 @@ void OpenXRAndroidExtension::on_before_instance_created() {
 // This is reasonably safe as the struct is only used during initialization and the extension is a singleton.
 static XrInstanceCreateInfoAndroidKHR instance_create_info;
 
-void *OpenXRAndroidExtension::set_instance_create_info_and_get_next_pointer(void *p_next_pointer) {
+void *OpenXRAndroidExtension::set_instance_create_info_and_get_next_pointer(XrVersion p_xr_version, void *p_next_pointer) {
 	if (!create_instance_extension_available) {
 		if (!loader_init_android_extension_available) {
 			WARN_PRINT("No Android extensions available, couldn't pass JVM and Activity to OpenXR");

--- a/modules/openxr/extensions/platform/openxr_android_extension.h
+++ b/modules/openxr/extensions/platform/openxr_android_extension.h
@@ -41,9 +41,9 @@ public:
 
 	OpenXRAndroidExtension();
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 	virtual void on_before_instance_created() override;
-	virtual void *set_instance_create_info_and_get_next_pointer(void *p_next_pointer) override;
+	virtual void *set_instance_create_info_and_get_next_pointer(XrVersion p_xr_version, void *p_next_pointer) override;
 
 	virtual ~OpenXRAndroidExtension() override;
 

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
@@ -37,7 +37,7 @@
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-HashMap<String, bool *> OpenXRD3D12Extension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRD3D12Extension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_KHR_D3D12_ENABLE_EXTENSION_NAME] = nullptr;

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.h
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.h
@@ -44,7 +44,7 @@
 
 class OpenXRD3D12Extension : public OpenXRGraphicsExtensionWrapper, D3D12Hooks {
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;

--- a/modules/openxr/extensions/platform/openxr_metal_extension.h
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.h
@@ -41,7 +41,7 @@
 
 class OpenXRMetalExtension : public OpenXRGraphicsExtensionWrapper {
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -35,7 +35,7 @@
 #import "drivers/metal/rendering_device_driver_metal.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-HashMap<String, bool *> OpenXRMetalExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRMetalExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_KHR_METAL_ENABLE_EXTENSION_NAME] = nullptr;

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.cpp
@@ -56,7 +56,7 @@
 // feature off.
 // See: https://registry.khronos.org/OpenGL/extensions/EXT/EXT_sRGB_write_control.txt
 
-HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXROpenGLExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 #ifdef ANDROID_ENABLED

--- a/modules/openxr/extensions/platform/openxr_opengl_extension.h
+++ b/modules/openxr/extensions/platform/openxr_opengl_extension.h
@@ -43,7 +43,7 @@
 
 class OpenXROpenGLExtension : public OpenXRGraphicsExtensionWrapper {
 public:
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.cpp
@@ -39,7 +39,7 @@
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_globals.h"
 
-HashMap<String, bool *> OpenXRVulkanExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRVulkanExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	request_extensions[XR_KHR_VULKAN_ENABLE2_EXTENSION_NAME] = nullptr; // must be available

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.h
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.h
@@ -45,7 +45,7 @@ public:
 	OpenXRVulkanExtension() = default;
 	virtual ~OpenXRVulkanExtension() override = default;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.cpp
@@ -332,7 +332,7 @@ void OpenXRSpatialAnchorCapability::_bind_methods() {
 	BIND_ENUM_CONSTANT(PERSISTENCE_SCOPE_LOCAL_ANCHORS);
 }
 
-HashMap<String, bool *> OpenXRSpatialAnchorCapability::get_requested_extensions() {
+HashMap<String, bool *> OpenXRSpatialAnchorCapability::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enabled") && GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enable_spatial_anchors")) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_anchor.h
@@ -158,7 +158,7 @@ public:
 	OpenXRSpatialAnchorCapability();
 	virtual ~OpenXRSpatialAnchorCapability() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.cpp
@@ -106,7 +106,7 @@ OpenXRSpatialEntityExtension::~OpenXRSpatialEntityExtension() {
 	singleton = nullptr;
 }
 
-HashMap<String, bool *> OpenXRSpatialEntityExtension::get_requested_extensions() {
+HashMap<String, bool *> OpenXRSpatialEntityExtension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enabled")) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_entity_extension.h
@@ -69,7 +69,7 @@ public:
 	OpenXRSpatialEntityExtension();
 	virtual ~OpenXRSpatialEntityExtension() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void on_instance_destroyed() override;

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.cpp
@@ -444,7 +444,7 @@ void OpenXRSpatialMarkerTrackingCapability::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_april_tag_supported"), &OpenXRSpatialMarkerTrackingCapability::is_april_tag_supported);
 }
 
-HashMap<String, bool *> OpenXRSpatialMarkerTrackingCapability::get_requested_extensions() {
+HashMap<String, bool *> OpenXRSpatialMarkerTrackingCapability::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enabled") && GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enable_marker_tracking")) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_marker_tracking.h
@@ -228,7 +228,7 @@ public:
 	OpenXRSpatialMarkerTrackingCapability();
 	virtual ~OpenXRSpatialMarkerTrackingCapability() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_session_created(const XrSession p_session) override;
 	virtual void on_session_destroyed() override;

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -583,7 +583,7 @@ void OpenXRSpatialPlaneTrackingCapability::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_supported"), &OpenXRSpatialPlaneTrackingCapability::is_supported);
 }
 
-HashMap<String, bool *> OpenXRSpatialPlaneTrackingCapability::get_requested_extensions() {
+HashMap<String, bool *> OpenXRSpatialPlaneTrackingCapability::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;
 
 	if (GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enabled") && GLOBAL_GET_CACHED(bool, "xr/openxr/extensions/spatial_entity/enable_plane_tracking")) {

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
@@ -219,7 +219,7 @@ public:
 	OpenXRSpatialPlaneTrackingCapability();
 	virtual ~OpenXRSpatialPlaneTrackingCapability() override;
 
-	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual HashMap<String, bool *> get_requested_extensions(XrVersion p_version) override;
 
 	virtual void on_session_created(const XrSession p_session) override;
 	virtual void on_session_destroyed() override;

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -46,6 +46,11 @@
 
 #include <openxr/openxr.h>
 
+// Name we add to our extensions if OpenXR 1.1 context is available.
+#define XR_OPENXR_1_1_NAME "OPENXR_1_1"
+
+#define XR_API_VERSION_1_1_0 XR_MAKE_VERSION(1, 1, 0)
+
 // forward declarations, we don't want to include these fully
 class OpenXRInterface;
 
@@ -91,7 +96,7 @@ private:
 
 	// extensions
 	LocalVector<XrExtensionProperties> supported_extensions;
-	Vector<CharString> enabled_extensions;
+	LocalVector<CharString> enabled_extensions;
 
 	// composition layer providers
 	Vector<OpenXRExtensionWrapper *> composition_layer_providers;
@@ -112,6 +117,7 @@ private:
 	PackedInt64Array supported_swapchain_formats;
 
 	// system info
+	XrVersion openxr_version;
 	String runtime_name;
 	String runtime_version;
 
@@ -180,7 +186,13 @@ private:
 	bool load_layer_properties();
 	bool load_supported_extensions();
 	bool is_extension_supported(const String &p_extension) const;
-	bool is_extension_enabled(const String &p_extension) const;
+	bool is_any_extension_enabled(const String &p_extensions) const;
+
+	struct RequestExtension {
+		String name;
+		bool *enabled;
+	};
+	XrResult attempt_create_instance(XrVersion p_version);
 
 	bool openxr_loader_init();
 	bool resolve_instance_openxr_symbols();
@@ -299,6 +311,7 @@ private:
 
 	struct InteractionProfile { // Interaction profiles define suggested bindings between the physical inputs on controller types and our actions
 		String name; // Name of the interaction profile (i.e. "/interaction_profiles/valve/index_controller")
+		CharString internal_name; // Internal name of the interaction profile (translated if required)
 		XrPath path; // OpenXR path for this profile
 		Vector<XrActionSuggestedBinding> bindings; // OpenXR action bindings
 		Vector<PackedByteArray> modifiers; // Array of modifiers we'll add into XrBindingModificationsKHR
@@ -306,6 +319,9 @@ private:
 	RID_Owner<InteractionProfile, true> interaction_profile_owner;
 	RID get_interaction_profile_rid(XrPath p_path);
 	XrPath get_interaction_profile_path(RID p_interaction_profile);
+
+	CharString get_interaction_profile_internal_name(const String &p_interaction_profile_name) const;
+	const char *check_profile_path(const CharString &p_interaction_profile_name, const char *p_path) const;
 
 	struct OrderedCompositionLayer {
 		const XrCompositionLayerBaseHeader *composition_layer;
@@ -436,6 +452,7 @@ public:
 		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_update_main_swapchain_size_rt));
 	}
 
+	XrVersion get_openxr_version() const { return openxr_version; }
 	XrInstance get_instance() const { return instance; }
 	XrSystemId get_system_id() const { return system_id; }
 	XrSession get_session() const { return session; }
@@ -480,7 +497,7 @@ public:
 	static const Vector<OpenXRExtensionWrapper *> &get_registered_extension_wrappers();
 	static void register_extension_metadata();
 	static void cleanup_extension_wrappers();
-	static PackedStringArray get_all_requested_extensions();
+	static PackedStringArray get_all_requested_extensions(XrVersion p_xr_version);
 
 	void set_form_factor(XrFormFactor p_form_factor);
 	XrFormFactor get_form_factor() const { return form_factor; }

--- a/modules/openxr/openxr_api_extension.cpp
+++ b/modules/openxr/openxr_api_extension.cpp
@@ -34,6 +34,7 @@
 #include "openxr_api_extension.compat.inc"
 
 void OpenXRAPIExtension::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_openxr_version"), &OpenXRAPIExtension::get_openxr_version);
 	ClassDB::bind_method(D_METHOD("get_instance"), &OpenXRAPIExtension::get_instance);
 	ClassDB::bind_method(D_METHOD("get_system_id"), &OpenXRAPIExtension::get_system_id);
 	ClassDB::bind_method(D_METHOD("get_session"), &OpenXRAPIExtension::get_session);
@@ -100,6 +101,11 @@ void OpenXRAPIExtension::_bind_methods() {
 	BIND_ENUM_CONSTANT(OPENXR_ALPHA_BLEND_MODE_SUPPORT_NONE);
 	BIND_ENUM_CONSTANT(OPENXR_ALPHA_BLEND_MODE_SUPPORT_REAL);
 	BIND_ENUM_CONSTANT(OPENXR_ALPHA_BLEND_MODE_SUPPORT_EMULATING);
+}
+
+uint64_t OpenXRAPIExtension::get_openxr_version() {
+	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
+	return (uint64_t)OpenXRAPI::get_singleton()->get_openxr_version();
 }
 
 uint64_t OpenXRAPIExtension::get_instance() {

--- a/modules/openxr/openxr_api_extension.h
+++ b/modules/openxr/openxr_api_extension.h
@@ -56,6 +56,7 @@ protected:
 #endif
 
 public:
+	uint64_t get_openxr_version();
 	uint64_t get_instance();
 	uint64_t get_system_id();
 	uint64_t get_session();


### PR DESCRIPTION
This PR adds in support for OpenXR 1.1.

> [!WARNING]
> This PR will change the action map in your project to conform to the new naming applied in OpenXR 1.1.
> While fallback for OpenXR 1.0 runtimes is implemented, you can't downgrade your project to earlier versions of Godot.
> If you are testing, make sure to backup your `openxr_action_map.tres` file (or better yet, the whole project).

More and more XR runtimes support OpenXR 1.1 and there are a few advantages to using it as it guarantees the existence of a number of features. 

There are however a number of difficulties with this which I had to go through a few tries before settling on the current approach.

1. You can't check which version is supported. You have to attempt to initialise OpenXR 1.1, and if it fails, attempt to initialise OpenXR 1.0. While in itself not difficult, we want to configure 1.1 differently than 1.0, so we're now duplicating some of the initialisation
2. Various extensions have now been promoted in OpenXR 1.1, however enabling these extensions leads to doubling up on logic as certain items in the action map have been renamed. As such we are filtering out these extensions. We are also taking the new names as leading and renaming items in the action map on load to the new names.
3. To ensure backwards compatibility with OpenXR 1.0, we are reversing the renaming if applicable.
4. We can now filter the action map on multiple extensions to remove entries that are not supported by the runtime.

There are a few todos/considerations left:
- [ ] This needs thorough testing as submitting unsupported paths in action maps to runtimes leads to the entire action map being discarded (this will need to be part of the review process).
- [x] There are additional touch profiles for older touch controllers, though there is an argument for not supporting this.

> [!IMPORTANT]
> Until recently our vendors plugin contained the OpenXR loader v1.0.34 which does **not** support OpenXR 1.1.
> You must install the vendor plugin 4.x or later.

> [!NOTE]
> For those who wish to review this PR:
> - SteamVR only supports OpenXR 1.0 and is a good test bed for the fallback logic
> - PICO 4 ultra and Quest 3/3s both support OpenXR 1.1
> - https://github.com/godotengine/godot-demo-projects/tree/master/xr/openxr_hand_tracking_demo, now that it has controller fallback, is a good test project, though admittedly we really should make a controller centric test project.
>
> Finally this PR reverts the temporary fix that prevents the buggy aim pose on Meta. The assumption is that we'll merge this long after Meta pushes out their runtime fix for this. But while testing you will run into this.

> [!IMPORTANT]
> This should not be merged until the following is solved:
> *We explicitly set the version to 1.0.48 in order to workaround a bug (see #108850) in Meta's runtime.*

*Contributed by Khronos Group through the Godot Integration Project*