### PR TITLE
GDScript: Don't stop annotation argument parsing at file end

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1785,7 +1785,7 @@ GDScriptParser::AnnotationNode *GDScriptParser::parse_annotation(uint32_t p_vali
 			}
 
 			argument_index++;
-		} while (match(GDScriptTokenizer::Token::COMMA) && !is_at_end());
+		} while (match(GDScriptTokenizer::Token::COMMA));
 
 		pop_multiline();
 		consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected ")" after annotation arguments.)*");


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109301

Aligns `parse_annoation` with `parse_call` which will also not stop argument parsing when at the end of the file. Thus allowing us to push a new completion context, before parsing finally fails in `parse_expression`.
