### PR TITLE
GDExtension: Call startup callback only after reload is fully finished

### DIFF
--- a/core/extension/gdextension_manager.h
+++ b/core/extension/gdextension_manager.h
@@ -57,6 +57,7 @@ public:
 
 private:
 	LoadStatus _load_extension_internal(const Ref<GDExtension> &p_extension, bool p_first_load);
+	void _finish_load_extension(const Ref<GDExtension> &p_extension);
 	LoadStatus _unload_extension_internal(const Ref<GDExtension> &p_extension);
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
It was brought up on chat.godotengine.org by @Yarwin that we're currently calling a GDExtension's startup callback _before_ the extension has been fully reloaded, when any objects that use its classes are in an inconsistent state.

Instead, we'd want the startup callback to be called after reload is fully finished, so that the state is roughly the same as if the extension was being loaded for the first time.

This PR attempts to do that, by moving the "after load" stuff into a `_finish_load_extension()` method, which won't be called automatically on reload, so that the reload process can call it at the end

This startup callback was functionality added for Godot 4.5, it'd be good to get the order correct before release