### PR TITLE
Postpone adding new extension plugins to the editor

### DIFF
--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -1086,7 +1086,7 @@ PackedStringArray GDExtension::get_classes_used() const {
 
 void GDExtensionEditorPlugins::add_extension_class(const StringName &p_class_name) {
 	if (editor_node_add_plugin) {
-		editor_node_add_plugin(p_class_name);
+		callable_mp_static(editor_node_add_plugin).call_deferred(p_class_name);
 	} else {
 		extension_classes.push_back(p_class_name);
 	}


### PR DESCRIPTION
Extension EditorPlugins added during Hot Reload on Initialization level Editor were being attached to the scene tree before all the GDExtension Classes (such as already loaded resources) are re-initialized.

In general, the order of the operations looked like so:

0. Hot reload starts
1. Godot starts unloading extension. (we unregister existing EditorPlugin at this point) 
2. Godot caches all the properties on present instances & turns all the gdextension classes into native classes (GDExtension Class inheriting Resource -> Resource and so on)
3. Godot starts (re)initalizing the library – Extension registers all the classes etc
4. on the end of the initialization we run `editor_add_plugin` - which was instantly adding `EditorPlugin` to the tree, launching its lifecycle methods. 
5. `enter_tree()` – we were still in hot reload and any GDExtension class instance at this point is represented by its base class – i.e. loading any previously initialized GDExtension Resource will return "bare" resource.
6. After initialization – and launching startup callbacks – Godot finishes hot reload, changes all the aforementioned instances back to the Extension Classes and puts back all the cached properties.

----

Related godot-rust issue: https://github.com/godot-rust/gdext/issues/1132
Thread on Godot contributors chat: https://chat.godotengine.org/channel/gdextension?msg=N2sbbbuw4Z33pacWF