### PR TITLE
SCons: Enable `werror` for non-MSVC linkers

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1030,6 +1030,7 @@ else:  # GCC, Clang
 
     if env["werror"]:
         env.AppendUnique(CCFLAGS=["-Werror"])
+        env.AppendUnique(LINKFLAGS=["-Wl,--fatal-warnings" if env["platform"] != "macos" else "-Wl,-fatal_warnings"])
 
 if hasattr(detect, "get_program_suffix"):
     suffix = "." + detect.get_program_suffix()

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -164,10 +164,6 @@ def configure(env: "SConsEnvironment"):
     ## Copy env variables.
     env["ENV"] = os.environ
 
-    # This makes `wasm-ld` treat all warnings as errors.
-    if env["werror"]:
-        env.Append(LINKFLAGS=["-Wl,--fatal-warnings"])
-
     # LTO
     if env["lto"] == "auto":  # Enable LTO for production.
         env["lto"] = "thin"


### PR DESCRIPTION
The `werror` setting has always enabled warnings-as-errors for the compiler, but the linker has been applied inconsistently. Currently, only MSVC has linker warnings as errors in a universal manner; clang/gcc only enables them for web builds. This PR removes the web-specific implementation, instead applying it at a global level