### PR TITLE
Fix LineEdit right alignment when using right icon

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1252,7 +1252,7 @@ void LineEdit::_notification(int p_what) {
 						x_ofs = MAX(style->get_margin(SIDE_LEFT), int(size.width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 					}
 				} else {
-					x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
+					x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width());
 				}
 			}
 
@@ -1406,7 +1406,7 @@ void LineEdit::_notification(int p_what) {
 						x_ofs = MAX(style->get_margin(SIDE_LEFT), int(size.width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 					}
 				} else {
-					x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
+					x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width());
 				}
 
 				ofs_max -= r_icon->get_width();
@@ -1801,7 +1801,7 @@ void LineEdit::set_caret_at_pixel_pos(int p_x) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
-			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
+			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width());
 		}
 	}
 
@@ -1852,7 +1852,7 @@ Vector2 LineEdit::get_caret_pixel_pos() {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
-			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
+			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width());
 		}
 	}
 
@@ -2204,7 +2204,7 @@ void LineEdit::set_caret_column(int p_column) {
 				x_ofs = MAX(style->get_margin(SIDE_LEFT), int(get_size().width - text_width - r_icon->get_width() - style->get_margin(SIDE_RIGHT) * 2) / 2);
 			}
 		} else {
-			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width() - style->get_margin(SIDE_RIGHT));
+			x_ofs = MAX(style->get_margin(SIDE_LEFT), x_ofs - r_icon->get_width());
 		}
 		ofs_max -= r_icon->get_width();
 	}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109326

Before:
<img width="310" height="367" alt="Screenshot_20250805_122723" src="https://github.com/user-attachments/assets/a2627f2d-d394-4f24-8e10-314e0fdf3cb4" />


After:
<img width="310" height="367" alt="Screenshot_20250805_122745" src="https://github.com/user-attachments/assets/152b7c8b-25d4-4c35-84d5-7ba226d2bb5e" />


