### PR TITLE
Deprecate `get_scene()` in `EditorScript` class

### DIFF
--- a/doc/classes/EditorScript.xml
+++ b/doc/classes/EditorScript.xml
@@ -53,7 +53,7 @@
 				Returns the [EditorInterface] singleton instance.
 			</description>
 		</method>
-		<method name="get_scene" qualifiers="const">
+		<method name="get_scene" qualifiers="const" deprecated="Use [method EditorInterface.get_edited_scene_root] instead.">
 			<return type="Node" />
 			<description>
 				Returns the edited (current) scene's root [Node]. Equivalent of [method EditorInterface.get_edited_scene_root].

--- a/editor/script/editor_script.cpp
+++ b/editor/script/editor_script.cpp
@@ -37,12 +37,14 @@
 #include "scene/main/node.h"
 #include "scene/resources/packed_scene.h"
 
+#ifndef DISABLE_DEPRECATED
 void EditorScript::add_root_node(Node *p_node) {
 	WARN_DEPRECATED_MSG("EditorScript::add_root_node is deprecated. Use EditorInterface::add_root_node instead.");
 	EditorInterface::get_singleton()->add_root_node(p_node);
 }
 
 Node *EditorScript::get_scene() const {
+	WARN_DEPRECATED_MSG("EditorScript::get_scene is deprecated. Use EditorInterface::get_edited_scene_root instead.");
 	if (!EditorNode::get_singleton()) {
 		EditorNode::add_io_error("EditorScript::get_scene: " + TTR("Write your logic in the _run() method."));
 		return nullptr;
@@ -52,17 +54,23 @@ Node *EditorScript::get_scene() const {
 }
 
 EditorInterface *EditorScript::get_editor_interface() const {
+	WARN_DEPRECATED_MSG("EditorInterface is a global singleton and can be accessed directly by its name.");
 	return EditorInterface::get_singleton();
 }
+#endif // DISABLE_DEPRECATED
 
 void EditorScript::run() {
 	GDVIRTUAL_CALL(_run);
 }
 
 void EditorScript::_bind_methods() {
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("add_root_node", "node"), &EditorScript::add_root_node);
+
 	ClassDB::bind_method(D_METHOD("get_scene"), &EditorScript::get_scene);
+
 	ClassDB::bind_method(D_METHOD("get_editor_interface"), &EditorScript::get_editor_interface);
+#endif // DISABLE_DEPRECATED
 
 	GDVIRTUAL_BIND(_run);
 }

--- a/editor/script/editor_script.h
+++ b/editor/script/editor_script.h
@@ -47,7 +47,9 @@ protected:
 
 public:
 	void add_root_node(Node *p_node);
+#ifndef DISABLE_DEPRECATED
 	Node *get_scene() const;
+#endif // DISABLE_DEPRECATED
 	EditorInterface *get_editor_interface() const;
 
 	virtual void run();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Related: https://github.com/godotengine/godot/pull/109049

This method should be marked as deprecated with the editor warning to properly guide users to use the correct method in the `EditorInterface` class. This PR finalizes the deprecations of all methods in the `EditorScript` class that already have equivalent outside functionality. 

This will help track methods that should be removed during the next major update. 