### PR TITLE
[Copyright] Fix spelling of license

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -555,7 +555,7 @@ License: Zlib
 Files: thirdparty/sdl/hidapi/*
 Comment: hidapi
 Copyright: 2010, Alan Ott, Signal 11 Software
-License: BSD-3-Clause
+License: BSD-3-clause
 
 Files: thirdparty/spirv-cross/*
 Comment: SPIRV-Cross


### PR DESCRIPTION
When using automated checks for listing licenses this fails to look up without fixing the spelling as only `BSD-3-clause` is stored in the `Engine` entries.

Discovered while working on an automated listing of licenses for a game project

This was the only entry I could find, but there might be other ones

* Fixes: https://github.com/godotengine/godot/issues/110695

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
