### PR TITLE
Document `OS.get_video_adapter_driver_info()` being slow to call the first time

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -611,6 +611,25 @@
 				The first element holds the driver name, such as [code]nvidia[/code], [code]amdgpu[/code], etc.
 				The second element holds the driver version. For example, on the [code]nvidia[/code] driver on a Linux/BSD platform, the version is in the format [code]510.85.02[/code]. For Windows, the driver's format is [code]31.0.15.1659[/code].
 				[b]Note:[/b] This method is only supported on Linux/BSD and Windows when not running in headless mode. On other platforms, it returns an empty array.
+				[b]Note:[/b] This method will run slowly the first time it is called in a session; it can take several seconds depending on the operating system and hardware. It is blocking if called on the main thread, so it's recommended to call it on a separate thread using [Thread]. This allows the engine to keep running while the information is being retrieved. However, [method get_video_adapter_driver_info] is [i]not[/i] thread-safe, so it should not be called from multiple threads at the same time.
+				[codeblocks]
+				[gdscript]
+				var thread = Thread.new()
+
+				func _ready():
+					thread.start(
+						func():
+							var driver_info = OS.get_video_adapter_driver_info()
+							if not driver_info.is_empty():
+								print("Driver: %s %s" % [driver_info[0], driver_info[1]])
+							else:
+								print("Driver: (unknown)")
+					)
+
+				func _exit_tree():
+					thread.wait_to_finish()
+				[/gdscript]
+				[/codeblocks]
 			</description>
 		</method>
 		<method name="has_environment" qualifiers="const">


### PR DESCRIPTION
- Add a code sample that shows how to call it from a thread to avoid blocking the engine.

Note that even with https://github.com/godotengine/godot/issues/109317#issuecomment-3156543057 in place, querying the driver on Linux + NVIDIA still takes 0.5 seconds here, so the thread workaround is recommended regardless. Maybe there is a way to speed up the query on Linux too, but looking at the [implementation](https://github.com/godotengine/godot/blob/c81fd6c51233a727da528cf7f74137d56b5d6efe/platform/linuxbsd/os_linuxbsd.cpp#L329-L450), I didn't see any way to do that.

___

- This closes https://github.com/godotengine/godot/issues/109317.

**Testing project:** [test_driver_info.zip](https://github.com/user-attachments/files/21607454/test_driver_info.zip)