### PR TITLE
Prevent shallow scripts from leaking into the `ResourceCache`

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -52,6 +52,7 @@ for name, path in env.module_list.items():
 
 # Generate header to be included in `tests/test_main.cpp` to run module-specific tests.
 if env["tests"]:
+    env.Append(CPPDEFINES=["TESTS_ENABLED"])
     env.CommandNoCache("modules_tests.gen.h", test_headers, env.Run(modules_builders.modules_tests_builder))
 
 # libmodules.a with only register_module_types.

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1074,6 +1074,12 @@ void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
 }
 
+void GDScript::set_path_cache(const String &p_path) {
+	if (is_root_script()) {
+		Script::set_path_cache(p_path);
+	}
+}
+
 void GDScript::set_path(const String &p_path, bool p_take_over) {
 	if (is_root_script()) {
 		Script::set_path(p_path, p_take_over);
@@ -3041,7 +3047,11 @@ Ref<GDScript> GDScriptLanguage::get_script_by_fully_qualified_name(const String 
 Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Error err;
 	bool ignoring = p_cache_mode == CACHE_MODE_IGNORE || p_cache_mode == CACHE_MODE_IGNORE_DEEP;
-	Ref<GDScript> scr = GDScriptCache::get_full_script(p_original_path, err, "", ignoring);
+	Ref<GDScript> scr = GDScriptCache::get_full_script_no_resource_cache(p_original_path, err, "", ignoring);
+	// Reset `path_cache` so that when resource loader uses `set_path()` later, the script gets added to the cache.
+	if (scr.is_valid()) {
+		scr->set_path_cache(String());
+	}
 
 	if (err && scr.is_valid()) {
 		// If !scr.is_valid(), the error was likely from scr->load_source_code(), which already generates an error.

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -310,6 +310,7 @@ public:
 
 	virtual Error reload(bool p_keep_state = false) override;
 
+	virtual void set_path_cache(const String &p_path) override;
 	virtual void set_path(const String &p_path, bool p_take_over = false) override;
 	String get_script_path() const;
 	Error load_source_code(const String &p_path);

--- a/modules/gdscript/gdscript_cache.h
+++ b/modules/gdscript/gdscript_cache.h
@@ -78,6 +78,12 @@ public:
 	~GDScriptParserRef();
 };
 
+#ifdef TESTS_ENABLED
+namespace GDScriptTests {
+class TestGDScriptCacheAccessor;
+}
+#endif // TESTS_ENABLED
+
 class GDScriptCache {
 	// String key is full path.
 	HashMap<String, GDScriptParserRef *> parser_map;
@@ -91,6 +97,9 @@ class GDScriptCache {
 	friend class GDScript;
 	friend class GDScriptParserRef;
 	friend class GDScriptInstance;
+#ifdef TESTS_ENABLED
+	friend class GDScriptTests::TestGDScriptCacheAccessor;
+#endif // TESTS_ENABLED
 
 	static GDScriptCache *singleton;
 
@@ -112,6 +121,19 @@ public:
 	static String get_source_code(const String &p_path);
 	static Vector<uint8_t> get_binary_tokens(const String &p_path);
 	static Ref<GDScript> get_shallow_script(const String &p_path, Error &r_error, const String &p_owner = String());
+	/**
+	 * Returns a fully loaded GDScript using an already cached script if one exists.
+	 *
+	 * If a new script is created, the resource will only have its patch_cache set, so it won't be present in the ResourceCache.
+	 * Mismatches between GDScriptCache and ResourceCache might trigger complex issues so when using this method ensure
+	 * that the script is added to the resource cache or removed from the GDScript cache.
+	 */
+	static Ref<GDScript> get_full_script_no_resource_cache(const String &p_path, Error &r_error, const String &p_owner = String(), bool p_update_from_disk = false);
+	/**
+	 * Returns a fully loaded GDScript using an already cached script if one exists.
+	 *
+	 * The returned instance is present in GDScriptCache and ResourceCache.
+	 */
 	static Ref<GDScript> get_full_script(const String &p_path, Error &r_error, const String &p_owner = String(), bool p_update_from_disk = false);
 	static Ref<GDScript> get_cached_script(const String &p_path);
 	static Error finish_compiling(const String &p_owner);


### PR DESCRIPTION
This is a new attempt at https://github.com/godotengine/godot/pull/96499 that also includes https://github.com/godotengine/godot/pull/102063

Fixes https://github.com/godotengine/godot/issues/95909
Fixes (maybe) https://github.com/godotengine/godot/issues/95789 (the described crash, does not occur with this PR when run from editor. I did not test exporting as mentioned in the issue though. Also the MRP trows a lot of errors when opening, nut sure if that is related).
Fixes https://github.com/godotengine/godot/issues/93433
Fixes https://github.com/godotengine/godot/issues/110332

Bugsquad edit:
Fixes [#110394](https://github.com/godotengine/godot/issues/110394)
Fixes https://github.com/godotengine/godot/issues/87397 according to @Maran23

Does not reintroduce https://github.com/godotengine/godot/issues/99006 or https://github.com/godotengine/godot/issues/101615

The main difference from https://github.com/godotengine/godot/pull/96499 is that in this PR `set_path_cache` does not interact with `GDScriptCache`. This prevents shallow loaded scripts from having any side effects on other fully loaded scripts (which would lead to https://github.com/godotengine/godot/issues/99006 and https://github.com/godotengine/godot/issues/101615). It also does not break shallow loaded script behavior since `set_path_cache` is only used when there is no shallow script for that path present.

Regardless of the specifics in here, I believe that the approach taken in this PR and #96499 is the correct one. Shallow scripts are an implementation detail of GDScript compilation. They must not end up in the `ResourceCache`. https://github.com/godotengine/godot/pull/97302 tries to fix the scripts after they leaked into the cache. Those partially loaded scripts fixing themselves when creating instances solves some issues but there is more that one could do with scripts than creating instances. Also users simply expect resource loading to do the actual loading work.
