### PR TITLE
Move advanced toggle state out of export presets

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -48,7 +48,6 @@ void EditorExport::_save() {
 		config->set_value(section, "name", preset->get_name());
 		config->set_value(section, "platform", preset->get_platform()->get_name());
 		config->set_value(section, "runnable", preset->is_runnable());
-		config->set_value(section, "advanced_options", preset->are_advanced_options_enabled());
 		config->set_value(section, "dedicated_server", preset->is_dedicated_server());
 		config->set_value(section, "custom_features", preset->get_custom_features());
 
@@ -262,7 +261,6 @@ void EditorExport::load_config() {
 		}
 
 		preset->set_name(config->get_value(section, "name"));
-		preset->set_advanced_options_enabled(config->get_value(section, "advanced_options", false));
 		preset->set_runnable(config->get_value(section, "runnable"));
 		preset->set_dedicated_server(config->get_value(section, "dedicated_server", false));
 

--- a/editor/export/editor_export_preset.cpp
+++ b/editor/export/editor_export_preset.cpp
@@ -31,6 +31,7 @@
 #include "editor_export.h"
 
 #include "core/config/project_settings.h"
+#include "editor/settings/editor_settings.h"
 
 bool EditorExportPreset::_set(const StringName &p_name, const Variant &p_value) {
 	values[p_name] = p_value;
@@ -316,17 +317,8 @@ bool EditorExportPreset::is_runnable() const {
 	return runnable;
 }
 
-void EditorExportPreset::set_advanced_options_enabled(bool p_enabled) {
-	if (advanced_options_enabled == p_enabled) {
-		return;
-	}
-	advanced_options_enabled = p_enabled;
-	EditorExport::singleton->save_presets();
-	notify_property_list_changed();
-}
-
 bool EditorExportPreset::are_advanced_options_enabled() const {
-	return advanced_options_enabled;
+	return EDITOR_GET("_export_preset_advanced_mode");
 }
 
 void EditorExportPreset::set_dedicated_server(bool p_enable) {

--- a/editor/export/editor_export_preset.h
+++ b/editor/export/editor_export_preset.h
@@ -70,7 +70,6 @@ private:
 	HashSet<String> selected_files;
 	HashMap<String, FileExportMode> customized_files;
 	bool runnable = false;
-	bool advanced_options_enabled = false;
 	bool dedicated_server = false;
 
 	Vector<String> patches;
@@ -133,7 +132,6 @@ public:
 	void set_runnable(bool p_enable);
 	bool is_runnable() const;
 
-	void set_advanced_options_enabled(bool p_enabled);
 	bool are_advanced_options_enabled() const;
 
 	void set_dedicated_server(bool p_enable);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -284,7 +284,6 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 	export_path->setup(extension_vector, false, true, false);
 	export_path->update_property();
 	advanced_options->set_disabled(false);
-	advanced_options->set_pressed(current->are_advanced_options_enabled());
 	runnable->set_disabled(false);
 	runnable->set_pressed(current->is_runnable());
 	if (parameters->get_edited_object() != current.ptr()) {
@@ -491,11 +490,13 @@ void ProjectExportDialog::_advanced_options_pressed() {
 	if (updating) {
 		return;
 	}
+	EditorSettings::get_singleton()->set_setting("_export_preset_advanced_mode", advanced_options->is_pressed());
+	EditorSettings::get_singleton()->save();
 
 	Ref<EditorExportPreset> current = get_current_preset();
-	ERR_FAIL_COND(current.is_null());
-
-	current->set_advanced_options_enabled(advanced_options->is_pressed());
+	if (current.is_valid()) {
+		current->notify_property_list_changed();
+	}
 	_update_presets();
 }
 
@@ -702,7 +703,6 @@ void ProjectExportDialog::_duplicate_preset() {
 	if (make_runnable) {
 		preset->set_runnable(make_runnable);
 	}
-	preset->set_advanced_options_enabled(current->are_advanced_options_enabled());
 	preset->set_dedicated_server(current->is_dedicated_server());
 	preset->set_export_filter(current->get_export_filter());
 	preset->set_include_filter(current->get_include_filter());
@@ -1500,6 +1500,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	advanced_options = memnew(CheckButton);
 	advanced_options->set_text(TTR("Advanced Options"));
 	advanced_options->set_tooltip_text(TTR("If checked, the advanced options will be shown."));
+	advanced_options->set_pressed(EDITOR_GET("_export_preset_advanced_mode"));
 	advanced_options->connect(SceneStringName(pressed), callable_mp(this, &ProjectExportDialog::_advanced_options_pressed));
 
 	HBoxContainer *preset_configs_container = memnew(HBoxContainer);


### PR DESCRIPTION
Editor export dialog got an advanced toggle some time ago, but for whatever reason the state of this button is stored inside the preset itself.

This PR moves it to a hidden editor setting, so the state is stored globally for all presets and projects. The method `are_advanced_options_enabled()` is still there, now it just returns the value of the setting. Though #108169 would be nice to have here .-.