### PR TITLE
Adjust StyleBoxFlat antialiasing to account for Viewport oversampling

### DIFF
--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -30,8 +30,8 @@
 
 #include "style_box_flat.h"
 
-#include "scene/main/scene_tree.h"
-#include "scene/main/window.h"
+#include "scene/main/canvas_item.h"
+#include "scene/main/viewport.h"
 #include "servers/rendering/rendering_server.h"
 
 float StyleBoxFlat::get_style_margin(Side p_side) const {
@@ -497,17 +497,18 @@ void StyleBoxFlat::draw(RID p_canvas_item, const Rect2 &p_rect) const {
 	real_t aa_size_scaled = 1.0f;
 	if (aa_on) {
 		real_t scale_factor = 1.0f;
-		const SceneTree *tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
-		if (tree) {
-			const Window *window = tree->get_root();
-			const Vector2 stretch_scale = window->get_stretch_transform().get_scale();
-			scale_factor = MIN(stretch_scale.x, stretch_scale.y);
+		CanvasItem *ci = CanvasItem::get_current_item_drawn();
+		if (ci) {
+			Viewport *vp = ci->get_viewport();
+			if (vp) {
+				scale_factor = vp->get_oversampling();
+			}
 		}
 
 		// Adjust AA feather size to account for the 2D scale factor, so that
 		// antialiasing doesn't become blurry at viewport resolutions higher
 		// than the default when using the `canvas_items` stretch mode
-		// (or when using `content_scale_factor` values different than `1.0`).
+		// (or when using `oversampling` values different than `1.0`).
 		aa_size_scaled = aa_size / scale_factor;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Original proposal: https://github.com/godotengine/godot-proposals/issues/12949

This adjusts the original antialiasing of `StyleBoxFlat` introduced in https://github.com/godotengine/godot/pull/92997 to account for the new per-viewport oversampling introduced later in https://github.com/godotengine/godot/pull/104872

Previously the `StyleBoxFlat` took the root window's stretch transform into account, independent of what the current render target was. Once per-viewport oversampling got introduced, text rendering scaled properly, but rounded corners did not, resulting in blurry edges.

In the original proposal I suggested to move the `TextServer::set_current_drawn_item_oversampling` to the `RenderingServer` instead, but looking into the implemention of the `RenderingServer` I am afraid that the new `get_current_drawn_item_oversampling` would introduce unnecessary synchronization, even though the `RenderingServer` would only be used to temporarily hold a `double`.

**Testing project:**

[test_styleboxflat_antialiasing_stretch.zip](https://github.com/user-attachments/files/21621164/test_styleboxflat_antialiasing_stretch.zip)

**Preview:**

Before this PR:

<img width="1778" height="1169" alt="before" src="https://github.com/user-attachments/assets/30e74887-bc44-4b3a-b0bf-e45460af3d87" />

After this PR:

<img width="1778" height="1169" alt="after" src="https://github.com/user-attachments/assets/80b59cf7-0bfc-4f00-8deb-e59e36d37500" />