### PR TITLE
Material Conversion Error Handling

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1900,6 +1900,7 @@ void FileSystemDock::_convert_dialog_action() {
 			for (const String &target : cached_valid_conversion_targets) {
 				if (conversion_id == selected_conversion_id && conversion->converts_to() == target) {
 					Ref<Resource> converted_res = conversion->convert(res);
+					ERR_FAIL_COND(converted_res.is_null());
 					ERR_FAIL_COND(res.is_null());
 					converted_resources.push_back(converted_res);
 					resources_to_erase_history_for.insert(res);

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -456,6 +456,7 @@ bool StandardMaterial3DConversionPlugin::handles(const Ref<Resource> &p_resource
 Ref<Resource> StandardMaterial3DConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<StandardMaterial3D> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -502,6 +503,7 @@ bool ORMMaterial3DConversionPlugin::handles(const Ref<Resource> &p_resource) con
 Ref<Resource> ORMMaterial3DConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<ORMMaterial3D> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -548,6 +550,7 @@ bool ParticleProcessMaterialConversionPlugin::handles(const Ref<Resource> &p_res
 Ref<Resource> ParticleProcessMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<ParticleProcessMaterial> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -587,6 +590,7 @@ bool CanvasItemMaterialConversionPlugin::handles(const Ref<Resource> &p_resource
 Ref<Resource> CanvasItemMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<CanvasItemMaterial> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -626,6 +630,7 @@ bool ProceduralSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resou
 Ref<Resource> ProceduralSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<ProceduralSkyMaterial> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -665,6 +670,7 @@ bool PanoramaSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resourc
 Ref<Resource> PanoramaSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<PanoramaSkyMaterial> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -704,6 +710,7 @@ bool PhysicalSkyMaterialConversionPlugin::handles(const Ref<Resource> &p_resourc
 Ref<Resource> PhysicalSkyMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<PhysicalSkyMaterial> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();
@@ -743,6 +750,7 @@ bool FogMaterialConversionPlugin::handles(const Ref<Resource> &p_resource) const
 Ref<Resource> FogMaterialConversionPlugin::convert(const Ref<Resource> &p_resource) const {
 	Ref<FogMaterial> mat = p_resource;
 	ERR_FAIL_COND_V(mat.is_null(), Ref<Resource>());
+	ERR_FAIL_COND_V(!mat->_is_initialized(), Ref<Resource>());
 
 	Ref<ShaderMaterial> smat;
 	smat.instantiate();

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -64,7 +64,6 @@ protected:
 
 	void _mark_ready();
 	void _mark_initialized(const Callable &p_add_to_dirty_list, const Callable &p_update_shader);
-	bool _is_initialized() { return init_state == INIT_STATE_READY; }
 
 	GDVIRTUAL0RC_REQUIRED(RID, _get_shader_rid)
 	GDVIRTUAL0RC_REQUIRED(Shader::Mode, _get_shader_mode)
@@ -75,6 +74,9 @@ public:
 		RENDER_PRIORITY_MAX = RS::MATERIAL_RENDER_PRIORITY_MAX,
 		RENDER_PRIORITY_MIN = RS::MATERIAL_RENDER_PRIORITY_MIN,
 	};
+
+	bool _is_initialized() { return init_state == INIT_STATE_READY; }
+
 	void set_next_pass(const Ref<Material> &p_pass);
 	Ref<Material> get_next_pass() const;
 


### PR DESCRIPTION
Bug fixes for two issues related to Material Conversions.

**Bug 1:**  Select user behaviors could call a Material Conversion Plugin on a Material that has not yet initialized, throwing errors to the console, and performing a destructive conversion, deleting the original material and producing an incorrect converted result.
<img width="719" height="263" alt="Screenshot 2025-08-06 at 10 16 41 AM" src="https://github.com/user-attachments/assets/3d986d5a-6a7e-47e1-b1ff-5fd6bb903e1a" />
**Steps to Recreate:** New Project, create a new CanvasItemMaterial resource, duplicate the CanvasItemMaterial, right click and "Convert to ShaderMaterial" on the duplicate resource.
OR
New Project, create a new CanvasItemMaterial resource, close project, reopen project, right click and "Convert to ShaderMaterial" on the CanvasItemMaterial resource.

**Fix:** Expose Material.is_initialized() as a public function instead of protected so the ConversionPlugin can check initialization state to throw the error earlier in the process. The same behaviors now produce a more clear error, and don't modify/delete any files.
<img width="765" height="127" alt="Screenshot 2025-08-06 at 10 25 16 AM" src="https://github.com/user-attachments/assets/7661f0c8-d691-47bb-86e0-480b5a06e226" />



**Bug 2:** FileSystem Dock didn't actually handle the failure of a ConversionPlugin returning a Null Ref<Resource> and would crash the editor trying to use the result.
**Steps to Recreate:** I couldn't find an in-editor way to produce this crash, because the Material Conversion plugins had only the most basic failure state (mat.is_null) which should never happen. If you edit a MaterialConversionPlugin to `ERR_FAIL_COND_V(true, Ref<Resource>());`, build Godot, and use that conversion plugin, you can see the crash occur from FileSystemDock.
**Fix:** FileSystemDock handling a convert action has a check `ERR_FAIL_COND(converted_res.is_null());`