### PR TITLE
Fix VisualShader conversion failing with subresources

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1925,6 +1925,8 @@ void FileSystemDock::_convert_dialog_action() {
 		Ref<Resource> original_resource = selected_resources.get(i);
 		Ref<Resource> new_resource = converted_resources.get(i);
 
+		// Notify plugins that the original resource is removed.
+		emit_signal(SNAME("file_removed"), original_resource->get_path());
 		// Overwrite the path.
 		new_resource->set_path(original_resource->get_path(), true);
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -484,8 +484,11 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin_for_resource(edited_resource);
 				ERR_FAIL_INDEX(to_type, conversions.size());
 
-				edited_resource = conversions[to_type]->convert(edited_resource);
-				_resource_changed();
+				Ref<Resource> converted_resource = conversions[to_type]->convert(edited_resource);
+				if (converted_resource.is_valid()) {
+					edited_resource = converted_resource;
+					_resource_changed();
+				}
 				break;
 			}
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -183,6 +183,7 @@ public: // internal methods
 
 	void add_node(Type p_type, const Ref<VisualShaderNode> &p_node, const Vector2 &p_position, int p_id);
 	void set_node_position(Type p_type, int p_id, const Vector2 &p_position);
+	int has_node_embeds() const;
 
 	void add_varying(const String &p_name, VaryingMode p_mode, VaryingType p_type);
 	void remove_varying(const String &p_name);


### PR DESCRIPTION
(Attempts to) Resolve: https://github.com/godotengine/godot/issues/101375

Visual Shaders can have Subresources such as Textures embedded directly in the Visual Shader, and some users find this desirable to better preview the Visual Shader's behavior. However, this breaks the conversion from Visual Shader to Text GDShader because a Text GDshader cannot have SubResources (the appropriate place for these resources would be as a Shader Parameter on a ShaderMaterial).

This PR aligns with @QbieShay's suggestion that 
> I think that converting to shader a visual shader with embedded textures should just fail and print a warning/error.

And resolves the issue by adding a has_node_embeds function to the VisualShader class. Has_node_embeds iterates over the child nodes, and searches through the object properties for embedded resources. The conversion plugin calls this function to catch and throw appropriate errors/warnings.

Note: ConversionPlugin fail states can cause a crash in FileSystem_Dock.cpp - I've mirrored a catch for that from https://github.com/godotengine/godot/pull/109369 to here.

<img width="868" height="118" alt="Screenshot 2025-08-06 at 1 57 49 PM" src="https://github.com/user-attachments/assets/d8a94720-5a02-4609-abc1-e1d5a210c2f0" />

This PR could unblock https://github.com/godotengine/godot/pull/102918, which could decrease file sizes and improve load times. Would require a little more work to have that PRs code handle a failed conversion.

More ideal solutions could be developed in the future such as:
* Disallowing subresource embeds in VisualShaders, and forcing resource references to go through the appropriate ShaderParameters on a Material Resource
* Automatically making embeds 'unique' or creating a Material with the appropriate parameters upon conversion

But I believe this code is still a necessary step to resolve the core error (Conversion deleting subresources) and to track VisualShader subresources for compatibility with future changes.