### PR TITLE
Fix `local_to_scene` duplication of typed dictionary 

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -330,7 +330,7 @@ Variant Resource::_duplicate_recursive(const Variant &p_variant, const Duplicate
 			const Dictionary &src = p_variant;
 			Dictionary dst;
 			if (src.is_typed()) {
-				dst.set_typed(src.get_key_type(), src.get_value_type());
+				dst.set_typed(src.get_typed_key_builtin(), src.get_typed_key_class_name(), src.get_typed_key_script(), src.get_typed_value_builtin(), src.get_typed_value_class_name(), src.get_typed_value_script());
 			}
 			for (const Variant &k : src.get_key_list()) {
 				const Variant &v = src[k];


### PR DESCRIPTION
Typed Dictionary properties in local_to_scene resources are reset during instantiation due to incomplete duplication of type info.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/109316*