### PR TITLE
[3.x] Fix texture3d save

### DIFF
--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -113,7 +113,11 @@ Error ResourceSaver::save(const String &p_path, const RES &p_resource, uint32_t 
 			rwcopy->set_path(local_path);
 		}
 
+		p_resource->before_save();
+
 		err = saver[i]->save(p_path, p_resource, p_flags);
+
+		p_resource->after_save();
 
 		if (err == OK) {
 #ifdef TOOLS_ENABLED

--- a/core/resource.h
+++ b/core/resource.h
@@ -87,6 +87,9 @@ public:
 
 	static Node *(*_get_local_scene_func)(); //used by editor
 
+	virtual void before_save() const {};
+	virtual void after_save() const {};
+
 	virtual bool editor_can_reload_from_file();
 	virtual void reload_from_file();
 

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -486,6 +486,8 @@ public:
 	};
 
 private:
+	mutable Vector<Ref<Image>> *layer_images;
+
 	String path_to_file;
 	bool is_3d;
 	RID texture;
@@ -505,6 +507,10 @@ protected:
 	static void _bind_methods();
 
 public:
+
+	virtual void before_save() const override;
+	virtual void after_save() const override;
+
 	void set_flags(uint32_t p_flags);
 	uint32_t get_flags() const;
 


### PR DESCRIPTION
This bug applies to Godot 3.x. I haven't tried it in 4.x, but I the source code in question changed a lot in 4.x, so I have no reason to believe this is still a bug in 4.x.

In 3.x, there's a bug when using ResourceSaver to save a Texture3D. If you try to save a Texture3D as a tres, you will notice that all the layers will have null assigned to them.

When Godot accesses the layer images of a Texture3D, it creates a new Image every time. This causes a problem in the resource saver because it accesses the images twice. The first time it creates a new Image to write that image as a SubResource in the tres file. Later on, when Godot tries to write the layers used by the Texture3D, it creates another Image for each layer and uses that Image to try to find the Image's resource id in internal_resources. But it doesn't work because it's not the same Image. The pixel values might be the same. But the pointer to the Image doesn't match the pointer stored in internal_resources.

To fix the bug, whenever a Texture3D is saved using the ResourceSaver, I temporarily cache the Image resources inside the Texture3D resource. The first time a layer image is accessed, the code works as it did previously except at the end of the function, a reference is saved to that image inside the Texture3D object. So when the Image is accessed the second time, instead of using OpenGL to make a new image, the cached image is returned which is the exact same Image as was created during the first access. After ResourceSaver has finished saving the Texture3D, the cached resources are deleted.

Here's some gdscript which you can use to reproduce the problem (and verify that my changes fix the problem). Just put it in a _ready function.

	var texture = Texture3D.new()

	var voxelCount = 8

	texture.create(voxelCount, voxelCount, voxelCount, Image.FORMAT_RGBA8)

	var images = []

	for i in range(voxelCount):
		var image = Image.new()

		image.create(voxelCount, voxelCount, false, Image.FORMAT_RGBA8)

		image.fill(Color(1.0, 1.0, 1.0, 1.0))

		texture.set_layer_data(image, i)

		images.push_back(image)

	ResourceSaver.save("res://testTexture3D.tres", texture);

	# Verify that my changes didn't break the saving of other resources
	ResourceSaver.save("res://testImage.tres", images[0])
