### PR TITLE
Make nested playbacks accessible for synced audio

### DIFF
--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -263,6 +263,12 @@ int AudioStreamPlaybackSynchronized::mix(AudioFrame *p_buffer, float p_rate_scal
 	return p_frames;
 }
 
+Ref<AudioStreamPlayback> AudioStreamPlaybackSynchronized::get_playback(int p_index) {
+	ERR_FAIL_INDEX_V_MSG(p_index, stream->stream_count, Ref<AudioStreamPlayback>(), "Stream index out of bounds.");
+
+	return playback[p_index];
+}
+
 void AudioStreamPlaybackSynchronized::tag_used_streams() {
 	if (active) {
 		for (int i = 0; i < stream->stream_count; i++) {
@@ -318,4 +324,8 @@ void AudioStreamPlaybackSynchronized::_update_playback_instances() {
 			playback[i].unref();
 		}
 	}
+}
+
+void AudioStreamPlaybackSynchronized::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_playback", "stream_index"), &AudioStreamPlaybackSynchronized::get_playback);
 }

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -103,6 +103,9 @@ private:
 
 	void _update_playback_instances();
 
+protected:
+	static void _bind_methods();
+
 public:
 	virtual void start(double p_from_pos = 0.0) override;
 	virtual void stop() override;
@@ -111,6 +114,7 @@ public:
 	virtual double get_playback_position() const override;
 	virtual void seek(double p_time) override;
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
+	Ref<AudioStreamPlayback> get_playback(int p_index);
 
 	virtual void tag_used_streams() override;
 

--- a/modules/interactive_music/doc_classes/AudioStreamPlaybackSynchronized.xml
+++ b/modules/interactive_music/doc_classes/AudioStreamPlaybackSynchronized.xml
@@ -8,4 +8,13 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_playback">
+			<return type="AudioStreamPlayback" />
+			<param index="0" name="stream_index" type="int" />
+			<description>
+				Return playback of sub-stream, by index.
+			</description>
+		</method>
+	</methods>
 </class>


### PR DESCRIPTION
Add AudioStreamPlayback.get_playback() to make the internal playbacks of AudioStreamPlaybackSynchronized accessible. This allows us for example to get the playback of a AudioStreamPlaybackInteractive nested inside an AudioStreamPlaybackSynchronized for switching the current clip its playing.

This implements option 1 of godotengine/godot-proposals#12957

---
Draft of what I was trying out to solve my problem. See godotengine/godot-proposals#12957 for details. I'm not sure if this is the better option of the two.