### PR TITLE
Revert "Fix incorrect anchor preset when custom offset is set"

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1043,10 +1043,6 @@ int Control::_get_anchors_layout_preset() const {
 	float top = get_anchor(SIDE_TOP);
 	float bottom = get_anchor(SIDE_BOTTOM);
 
-	if (get_offset(SIDE_LEFT) != 0.0 || get_offset(SIDE_RIGHT) != 0.0 || get_offset(SIDE_TOP) != 0.0 || get_offset(SIDE_BOTTOM) != 0.0) {
-		return -1;
-	}
-
 	if (left == (float)ANCHOR_BEGIN && right == (float)ANCHOR_BEGIN && top == (float)ANCHOR_BEGIN && bottom == (float)ANCHOR_BEGIN) {
 		return (int)LayoutPreset::PRESET_TOP_LEFT;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This reverts commit 21b1530cd4172d09653ff72b74f3152afc4024f2
As suggested in https://github.com/godotengine/godot/pull/108442#issuecomment-3148671133
Reopens https://github.com/godotengine/godot/issues/105854

- *Bugsquad edit: This closes https://github.com/godotengine/godot/issues/109761*