### PR TITLE
[Unix] Replace symlink target, not the link itself when using backup save mode.

### DIFF
--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -437,7 +437,7 @@ Error DirAccessUnix::remove(String p_path) {
 	}
 
 	struct stat flags = {};
-	if ((lstat(p_path.utf8().get_data(), &flags) != 0)) {
+	if (lstat(p_path.utf8().get_data(), &flags) != 0) {
 		return FAILED;
 	}
 
@@ -467,7 +467,7 @@ bool DirAccessUnix::is_link(String p_file) {
 	}
 
 	struct stat flags = {};
-	if ((lstat(p_file.utf8().get_data(), &flags) != 0)) {
+	if (lstat(p_file.utf8().get_data(), &flags) != 0) {
 		return false;
 	}
 
@@ -484,8 +484,8 @@ String DirAccessUnix::read_link(String p_file) {
 		p_file = p_file.left(-1);
 	}
 
-	char buf[256];
-	memset(buf, 0, 256);
+	char buf[PATH_MAX];
+	memset(buf, 0, PATH_MAX);
 	ssize_t len = readlink(p_file.utf8().get_data(), buf, sizeof(buf));
 	String link;
 	if (len > 0) {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1130,8 +1130,8 @@ String OS_Unix::get_user_data_dir(const String &p_user_dir) const {
 String OS_Unix::get_executable_path() const {
 #ifdef __linux__
 	//fix for running from a symlink
-	char buf[256];
-	memset(buf, 0, 256);
+	char buf[PATH_MAX];
+	memset(buf, 0, PATH_MAX);
 	ssize_t len = readlink("/proc/self/exe", buf, sizeof(buf));
 	String b;
 	if (len > 0) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109364
