### PR TITLE
Add icon & clear button to Select Method dialog search bar

### DIFF
--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -519,6 +519,10 @@ void PropertySelector::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect(SceneStringName(confirmed), callable_mp(this, &PropertySelector::_confirmed));
 		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
+		} break;
 	}
 }
 
@@ -666,9 +670,11 @@ PropertySelector::PropertySelector() {
 	add_child(vbc);
 	//set_child_rect(vbc);
 	search_box = memnew(LineEdit);
-	vbc->add_margin_child(TTR("Search:"), search_box);
+	search_box->set_accessibility_name(TTRC("Search:"));
+	search_box->set_clear_button_enabled(true);
 	search_box->connect(SceneStringName(text_changed), callable_mp(this, &PropertySelector::_text_changed));
 	search_box->connect(SceneStringName(gui_input), callable_mp(this, &PropertySelector::_sbox_input));
+	vbc->add_margin_child(TTRC("Search:"), search_box);
 	search_options = memnew(Tree);
 	search_options->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);


### PR DESCRIPTION
Search bar in the Select Method dialog was missing clear button and icon like other search/filter boxes have in the editor.

Before:
<img width="1554" height="201" alt="Screenshot_20250806_221055" src="https://github.com/user-attachments/assets/06892347-8f39-41b0-b287-0d97662e3925" />


After:
<img width="1554" height="201" alt="Screenshot_20250806_220722" src="https://github.com/user-attachments/assets/d82f821e-bbaa-412d-8370-234a61019e4e" />

Saw that other search boxes had set_accessibility_name set. So added this here as well, is this correct?