### PR TITLE
Improve render sorting for alpha pass

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -43,6 +43,7 @@ static_assert(std::is_trivially_destructible_v<std::atomic<uint64_t>>);
 GODOT_GCC_WARNING_PUSH
 GODOT_GCC_WARNING_IGNORE("-Wplacement-new") // Silence a false positive warning (see GH-52119).
 GODOT_GCC_WARNING_IGNORE("-Wmaybe-uninitialized") // False positive raised when using constexpr.
+GODOT_MSVC_WARNING_PUSH_AND_IGNORE(4724) // False positive potential mod by 0 (added in GH-106593)
 
 template <typename T>
 class CowData {
@@ -440,6 +441,7 @@ CowData<T>::CowData(std::initializer_list<T> p_init) {
 	}
 }
 
+GODOT_MSVC_WARNING_POP
 GODOT_GCC_WARNING_POP
 
 // Zero-constructing CowData initializes _ptr to nullptr (and thus empty).

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -65,6 +65,7 @@
 		</member>
 		<member name="sorting_offset" type="float" setter="set_sorting_offset" getter="get_sorting_offset" default="0.0">
 			The amount by which the depth of this [VisualInstance3D] will be adjusted when sorting by depth. Uses the same units as the engine (which are typically meters). Adjusting it to a higher value will make the [VisualInstance3D] reliably draw on top of other [VisualInstance3D]s that are otherwise positioned at the same spot. To ensure it always draws on top of other objects around it (not positioned at the same spot), set the value to be greater than the distance between this [VisualInstance3D] and the other nearby [VisualInstance3D]s.
+			[b]Note:[/b] This is only effective on instances with transparent (alpha-blended) materials. Opaque or alpha scissor/hash sorting is not affected by [member sorting_offset], so it cannot resolve Z-fighting issues.
 		</member>
 		<member name="sorting_use_aabb_center" type="bool" setter="set_sorting_use_aabb_center" getter="is_sorting_use_aabb_center">
 			If [code]true[/code], the object is sorted based on the [AABB] center. The object will be sorted based on the global position otherwise.

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -272,6 +272,22 @@ private:
 			};
 		} sort;
 
+		union {
+			struct {
+				uint64_t sort_key;
+			};
+			struct {
+				//Ids dont need to be accurate just used to prevent inconsistency between frames
+				uint64_t shader_id : 10;
+				uint64_t material_id : 11;
+				uint64_t geometry_id : 11;
+
+				uint64_t material_depth : 8;
+				uint64_t surface_index : 8;
+				uint64_t EXTRA_SPACE : 16;
+			};
+		} transparent_sort;
+
 		RS::PrimitiveType primitive = RS::PRIMITIVE_MAX;
 		uint32_t flags = 0;
 		uint32_t surface_index = 0;
@@ -375,7 +391,7 @@ private:
 	PagedAllocator<GeometryInstanceGLES3> geometry_instance_alloc;
 	PagedAllocator<GeometryInstanceSurface> geometry_instance_surface_alloc;
 
-	void _geometry_instance_add_surface_with_material(GeometryInstanceGLES3 *ginstance, uint32_t p_surface, GLES3::SceneMaterialData *p_material, uint32_t p_material_id, uint32_t p_shader_id, RID p_mesh);
+	void _geometry_instance_add_surface_with_material(GeometryInstanceGLES3 *ginstance, uint32_t p_surface, GLES3::SceneMaterialData *p_material, uint32_t p_material_id, uint8_t p_material_depth, uint32_t p_shader_id, RID p_mesh);
 	void _geometry_instance_add_surface_with_material_chain(GeometryInstanceGLES3 *ginstance, uint32_t p_surface, GLES3::SceneMaterialData *p_material, RID p_mat_src, RID p_mesh);
 	void _geometry_instance_add_surface(GeometryInstanceGLES3 *ginstance, uint32_t p_surface, RID p_material, RID p_mesh);
 	void _geometry_instance_update(RenderGeometryInstance *p_geometry_instance);
@@ -688,15 +704,29 @@ private:
 			sorter.sort(elements.ptr(), elements.size());
 		}
 
-		struct SortByReverseDepthAndPriority {
+		struct StandardSceneSort {
 			_FORCE_INLINE_ bool operator()(const GeometryInstanceSurface *A, const GeometryInstanceSurface *B) const {
-				return (A->sort.priority == B->sort.priority) ? (A->owner->depth > B->owner->depth) : (A->sort.priority < B->sort.priority);
+				if (A->sort.priority == B->sort.priority) {
+					if (Math::is_equal_approx(A->owner->depth, B->owner->depth)) { //could maybe just be strict equality
+						return A->transparent_sort.sort_key < B->transparent_sort.sort_key;
+					}
+					return (A->owner->depth > B->owner->depth);
+				}
+				return A->sort.priority < B->sort.priority;
 			}
 		};
 
-		void sort_by_reverse_depth_and_priority() { //used for alpha
-
-			SortArray<GeometryInstanceSurface *, SortByReverseDepthAndPriority> sorter;
+		void sort_by_standard_scene_sort() {
+			// used for standard scene sorting also known as the alpha sort
+			// this is used for sorting transparent objects
+			//
+			// sorts in the order of:
+			// 1. material priority
+			// 2. object depth
+			// 3. surface index
+			// 4. material depth used for next-pass sorting
+			// 5. object ids used for constant buffer sorting
+			SortArray<GeometryInstanceSurface *, StandardSceneSort> sorter;
 			sorter.sort(elements.ptr(), elements.size());
 		}
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1854,7 +1854,14 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	_fill_render_list(RENDER_LIST_OPAQUE, p_render_data, PASS_MODE_COLOR, using_sdfgi, using_sdfgi || using_voxelgi, using_motion_pass);
 	render_list[RENDER_LIST_OPAQUE].sort_by_key();
 	render_list[RENDER_LIST_MOTION].sort_by_key();
-	render_list[RENDER_LIST_ALPHA].sort_by_reverse_depth_and_priority();
+
+	// sorts in the order of:
+	// 1. material priority
+	// 2. object depth
+	// 3. surface index
+	// 4. material depth used for next-pass sorting
+	// 5. object ids used for constant buffer sorting
+	render_list[RENDER_LIST_ALPHA].sort_by_standard_scene_sort();
 
 	int *render_info = p_render_data->render_info ? p_render_data->render_info->info[RS::VIEWPORT_RENDER_INFO_TYPE_VISIBLE] : (int *)nullptr;
 	_fill_instance_data(RENDER_LIST_OPAQUE, render_info);
@@ -3959,7 +3966,7 @@ void RenderForwardClustered::_update_global_pipeline_data_requirements_from_ligh
 	global_pipeline_data_required.use_shadow_dual_paraboloid = light_storage->get_shadow_dual_paraboloid_used();
 }
 
-void RenderForwardClustered::_geometry_instance_add_surface_with_material(GeometryInstanceForwardClustered *ginstance, uint32_t p_surface, SceneShaderForwardClustered::MaterialData *p_material, uint32_t p_material_id, uint32_t p_shader_id, RID p_mesh) {
+void RenderForwardClustered::_geometry_instance_add_surface_with_material(GeometryInstanceForwardClustered *ginstance, uint32_t p_surface, SceneShaderForwardClustered::MaterialData *p_material, uint32_t p_material_id, uint8_t p_material_depth, uint32_t p_shader_id, RID p_mesh) {
 	RendererRD::MeshStorage *mesh_storage = RendererRD::MeshStorage::get_singleton();
 	uint32_t flags = 0;
 
@@ -4066,15 +4073,18 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material(Geomet
 
 	sdcache->sort.sort_key1 = 0;
 	sdcache->sort.sort_key2 = 0;
+	sdcache->transparent_sort.sort_key = 0;
 
-	sdcache->sort.surface_index = p_surface;
-	sdcache->sort.material_id = p_material_id;
-	sdcache->sort.shader_id = p_shader_id;
-	sdcache->sort.geometry_id = p_mesh.get_local_index(); //only meshes can repeat anyway
+	sdcache->transparent_sort.surface_index = sdcache->sort.surface_index = p_surface;
+	sdcache->transparent_sort.material_id = sdcache->sort.material_id = p_material_id;
+	sdcache->transparent_sort.shader_id = sdcache->sort.shader_id = p_shader_id;
+	sdcache->transparent_sort.geometry_id = sdcache->sort.geometry_id = p_mesh.get_local_index(); //only meshes can repeat anyway
 	sdcache->sort.uses_forward_gi = ginstance->can_sdfgi;
 	sdcache->sort.priority = p_material->priority;
 	sdcache->sort.uses_projector = ginstance->using_projectors;
 	sdcache->sort.uses_softshadow = ginstance->using_softshadows;
+
+	sdcache->transparent_sort.material_depth = p_material_depth;
 
 	uint64_t format = RendererRD::MeshStorage::get_singleton()->mesh_surface_get_format(sdcache->surface);
 	if (p_material->shader_data->uses_tangent && !(format & RS::ARRAY_FORMAT_TANGENT)) {
@@ -4098,9 +4108,11 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material_chain(
 	SceneShaderForwardClustered::MaterialData *material = p_material;
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
-	_geometry_instance_add_surface_with_material(ginstance, p_surface, material, p_mat_src.get_local_index(), material_storage->material_get_shader_id(p_mat_src), p_mesh);
+	uint8_t material_depth = 0;
+	_geometry_instance_add_surface_with_material(ginstance, p_surface, material, p_mat_src.get_local_index(), material_depth, material_storage->material_get_shader_id(p_mat_src), p_mesh);
 
 	while (material->next_pass.is_valid()) {
+		material_depth++;
 		RID next_pass = material->next_pass;
 		material = static_cast<SceneShaderForwardClustered::MaterialData *>(material_storage->material_get_data(next_pass, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (!material || !material->shader_data->is_valid()) {
@@ -4109,7 +4121,7 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material_chain(
 		if (ginstance->data->dirty_dependencies) {
 			material_storage->material_update_dependency(next_pass, &ginstance->data->dependency_tracker);
 		}
-		_geometry_instance_add_surface_with_material(ginstance, p_surface, material, next_pass.get_local_index(), material_storage->material_get_shader_id(next_pass), p_mesh);
+		_geometry_instance_add_surface_with_material(ginstance, p_surface, material, next_pass.get_local_index(), material_depth, material_storage->material_get_shader_id(next_pass), p_mesh);
 	}
 }
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -510,6 +510,22 @@ private:
 			};
 		} sort;
 
+		union {
+			struct {
+				uint64_t sort_key;
+			};
+			struct {
+				//Ids dont need to be accurate just used to prevent inconsistency between frames
+				uint64_t shader_id : 10;
+				uint64_t material_id : 11;
+				uint64_t geometry_id : 11;
+
+				uint64_t material_depth : 8;
+				uint64_t surface_index : 8;
+				uint64_t EXTRA_SPACE : 16;
+			};
+		} transparent_sort;
+
 		RS::PrimitiveType primitive = RS::PRIMITIVE_MAX;
 		uint32_t flags = 0;
 		uint32_t surface_index = 0;
@@ -634,7 +650,7 @@ private:
 
 	void _update_global_pipeline_data_requirements_from_project();
 	void _update_global_pipeline_data_requirements_from_light_storage();
-	void _geometry_instance_add_surface_with_material(GeometryInstanceForwardClustered *ginstance, uint32_t p_surface, SceneShaderForwardClustered::MaterialData *p_material, uint32_t p_material_id, uint32_t p_shader_id, RID p_mesh);
+	void _geometry_instance_add_surface_with_material(GeometryInstanceForwardClustered *ginstance, uint32_t p_surface, SceneShaderForwardClustered::MaterialData *p_material, uint32_t p_material_id, uint8_t p_material_depth, uint32_t p_shader_id, RID p_mesh);
 	void _geometry_instance_add_surface_with_material_chain(GeometryInstanceForwardClustered *ginstance, uint32_t p_surface, SceneShaderForwardClustered::MaterialData *p_material, RID p_mat_src, RID p_mesh);
 	void _geometry_instance_add_surface(GeometryInstanceForwardClustered *ginstance, uint32_t p_surface, RID p_material, RID p_mesh);
 	void _geometry_instance_update(RenderGeometryInstance *p_geometry_instance);
@@ -693,15 +709,29 @@ private:
 			sorter.sort(elements.ptr(), elements.size());
 		}
 
-		struct SortByReverseDepthAndPriority {
+		struct StandardSceneSort {
 			_FORCE_INLINE_ bool operator()(const GeometryInstanceSurfaceDataCache *A, const GeometryInstanceSurfaceDataCache *B) const {
-				return (A->sort.priority == B->sort.priority) ? (A->owner->depth > B->owner->depth) : (A->sort.priority < B->sort.priority);
+				if (A->sort.priority == B->sort.priority) {
+					if (Math::is_equal_approx(A->owner->depth, B->owner->depth)) { //could maybe just be strict equality
+						return A->transparent_sort.sort_key < B->transparent_sort.sort_key;
+					}
+					return (A->owner->depth > B->owner->depth);
+				}
+				return A->sort.priority < B->sort.priority;
 			}
 		};
 
-		void sort_by_reverse_depth_and_priority() { //used for alpha
-
-			SortArray<GeometryInstanceSurfaceDataCache *, SortByReverseDepthAndPriority> sorter;
+		void sort_by_standard_scene_sort() {
+			// used for standard scene sorting also known as the alpha sort
+			// this is used for sorting transparent objects
+			//
+			// sorts in the order of:
+			// 1. material priority
+			// 2. object depth
+			// 3. surface index
+			// 4. material depth used for next-pass sorting
+			// 5. object ids used for constant buffer sorting
+			SortArray<GeometryInstanceSurfaceDataCache *, StandardSceneSort> sorter;
 			sorter.sort(elements.ptr(), elements.size());
 		}
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -894,7 +894,15 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	} else {
 		render_list[RENDER_LIST_OPAQUE].sort_by_key();
 	}
-	render_list[RENDER_LIST_ALPHA].sort_by_reverse_depth_and_priority();
+
+	// sorts in the order of:
+	// 1. material priority
+	// 2. object depth
+	// 3. surface index
+	// 4. material depth used for next-pass sorting
+	// 5. object ids used for constant buffer sorting
+	render_list[RENDER_LIST_ALPHA].sort_by_standard_scene_sort();
+
 	_fill_instance_data(RENDER_LIST_OPAQUE);
 	_fill_instance_data(RENDER_LIST_ALPHA);
 
@@ -2653,7 +2661,7 @@ void RenderForwardMobile::_update_global_pipeline_data_requirements_from_light_s
 	global_pipeline_data_required.use_shadow_dual_paraboloid = light_storage->get_shadow_dual_paraboloid_used();
 }
 
-void RenderForwardMobile::_geometry_instance_add_surface_with_material(GeometryInstanceForwardMobile *ginstance, uint32_t p_surface, SceneShaderForwardMobile::MaterialData *p_material, uint32_t p_material_id, uint32_t p_shader_id, RID p_mesh) {
+void RenderForwardMobile::_geometry_instance_add_surface_with_material(GeometryInstanceForwardMobile *ginstance, uint32_t p_surface, SceneShaderForwardMobile::MaterialData *p_material, uint32_t p_material_id, uint8_t p_material_depth, uint32_t p_shader_id, RID p_mesh) {
 	RendererRD::MeshStorage *mesh_storage = RendererRD::MeshStorage::get_singleton();
 	uint32_t flags = 0;
 
@@ -2756,12 +2764,14 @@ void RenderForwardMobile::_geometry_instance_add_surface_with_material(GeometryI
 
 	sdcache->sort.sort_key1 = 0;
 	sdcache->sort.sort_key2 = 0;
+	sdcache->transparent_sort.sort_key = 0;
 
-	sdcache->sort.surface_index = p_surface;
-	sdcache->sort.material_id = p_material_id;
-	sdcache->sort.shader_id = p_shader_id;
-	sdcache->sort.geometry_id = p_mesh.get_local_index();
+	sdcache->transparent_sort.surface_index = sdcache->sort.surface_index = p_surface;
+	sdcache->transparent_sort.material_id = sdcache->sort.material_id = p_material_id;
+	sdcache->transparent_sort.shader_id = sdcache->sort.shader_id = p_shader_id;
+	sdcache->transparent_sort.geometry_id = sdcache->sort.geometry_id = p_mesh.get_local_index();
 	sdcache->sort.priority = p_material->priority;
+	sdcache->transparent_sort.material_depth = p_material_depth;
 
 	uint64_t format = RendererRD::MeshStorage::get_singleton()->mesh_surface_get_format(sdcache->surface);
 	if (p_material->shader_data->uses_tangent && !(format & RS::ARRAY_FORMAT_TANGENT)) {
@@ -2785,9 +2795,11 @@ void RenderForwardMobile::_geometry_instance_add_surface_with_material_chain(Geo
 	SceneShaderForwardMobile::MaterialData *material = p_material;
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
-	_geometry_instance_add_surface_with_material(ginstance, p_surface, material, p_mat_src.get_local_index(), material_storage->material_get_shader_id(p_mat_src), p_mesh);
+	uint8_t material_depth = 0;
+	_geometry_instance_add_surface_with_material(ginstance, p_surface, material, p_mat_src.get_local_index(), material_depth, material_storage->material_get_shader_id(p_mat_src), p_mesh);
 
 	while (material->next_pass.is_valid()) {
+		material_depth++;
 		RID next_pass = material->next_pass;
 		material = static_cast<SceneShaderForwardMobile::MaterialData *>(material_storage->material_get_data(next_pass, RendererRD::MaterialStorage::SHADER_TYPE_3D));
 		if (!material || !material->shader_data->is_valid()) {
@@ -2796,7 +2808,7 @@ void RenderForwardMobile::_geometry_instance_add_surface_with_material_chain(Geo
 		if (ginstance->data->dirty_dependencies) {
 			material_storage->material_update_dependency(next_pass, &ginstance->data->dependency_tracker);
 		}
-		_geometry_instance_add_surface_with_material(ginstance, p_surface, material, next_pass.get_local_index(), material_storage->material_get_shader_id(next_pass), p_mesh);
+		_geometry_instance_add_surface_with_material(ginstance, p_surface, material, next_pass.get_local_index(), material_depth, material_storage->material_get_shader_id(next_pass), p_mesh);
 	}
 }
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -367,15 +367,29 @@ private:
 			sorter.sort(elements.ptr(), elements.size());
 		}
 
-		struct SortByReverseDepthAndPriority {
+		struct StandardSceneSort {
 			_FORCE_INLINE_ bool operator()(const GeometryInstanceSurfaceDataCache *A, const GeometryInstanceSurfaceDataCache *B) const {
-				return (A->sort.priority == B->sort.priority) ? (A->owner->depth > B->owner->depth) : (A->sort.priority < B->sort.priority);
+				if (A->sort.priority == B->sort.priority) {
+					if (Math::is_equal_approx(A->owner->depth, B->owner->depth)) { //could maybe just be strict equality
+						return A->transparent_sort.sort_key < B->transparent_sort.sort_key;
+					}
+					return (A->owner->depth > B->owner->depth);
+				}
+				return A->sort.priority < B->sort.priority;
 			}
 		};
 
-		void sort_by_reverse_depth_and_priority() { //used for alpha
-
-			SortArray<GeometryInstanceSurfaceDataCache *, SortByReverseDepthAndPriority> sorter;
+		void sort_by_standard_scene_sort() {
+			// used for standard scene sorting also known as the alpha sort
+			// this is used for sorting transparent objects
+			//
+			// sorts in the order of:
+			// 1. material priority
+			// 2. object depth
+			// 3. surface index
+			// 4. material depth used for next-pass sorting
+			// 5. object ids used for constant buffer sorting
+			SortArray<GeometryInstanceSurfaceDataCache *, StandardSceneSort> sorter;
 			sorter.sort(elements.ptr(), elements.size());
 		}
 
@@ -486,6 +500,22 @@ protected:
 				uint64_t shader_id : 32;
 			};
 		} sort;
+
+		union {
+			struct {
+				uint64_t sort_key;
+			};
+			struct {
+				//Ids dont need to be accurate just used to prevent inconsistency between frames
+				uint64_t shader_id : 10;
+				uint64_t material_id : 11;
+				uint64_t geometry_id : 11;
+
+				uint64_t material_depth : 8;
+				uint64_t surface_index : 8;
+				uint64_t EXTRA_SPACE : 16;
+			};
+		} transparent_sort;
 
 		RS::PrimitiveType primitive = RS::PRIMITIVE_MAX;
 		uint32_t flags = 0;
@@ -675,7 +705,7 @@ public:
 
 	void _update_global_pipeline_data_requirements_from_project();
 	void _update_global_pipeline_data_requirements_from_light_storage();
-	void _geometry_instance_add_surface_with_material(GeometryInstanceForwardMobile *ginstance, uint32_t p_surface, SceneShaderForwardMobile::MaterialData *p_material, uint32_t p_material_id, uint32_t p_shader_id, RID p_mesh);
+	void _geometry_instance_add_surface_with_material(GeometryInstanceForwardMobile *ginstance, uint32_t p_surface, SceneShaderForwardMobile::MaterialData *p_material, uint32_t p_material_id, uint8_t p_material_depth, uint32_t p_shader_id, RID p_mesh);
 	void _geometry_instance_add_surface_with_material_chain(GeometryInstanceForwardMobile *ginstance, uint32_t p_surface, SceneShaderForwardMobile::MaterialData *p_material, RID p_mat_src, RID p_mesh);
 	void _geometry_instance_add_surface(GeometryInstanceForwardMobile *ginstance, uint32_t p_surface, RID p_material, RID p_mesh);
 	void _geometry_instance_update(RenderGeometryInstance *p_geometry_instance);


### PR DESCRIPTION
Made sorting more deterministic for transparent objects by making it fallow

Sorting Order

    material priority
    object depth
    surface index used because most other engines work in this way
    material depth used for next-pass sorting
    geometry id used for constant render sorting to make more predictable

Continuation on [PR](https://github.com/godotengine/godot/pull/106593) without stacked sorting order with just the raw render order fixes