### PR TITLE
Improve scene tree root options

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -984,9 +984,6 @@
 		<member name="interface/editors/derive_script_globals_by_name" type="bool" setter="" getter="">
 			If [code]true[/code], when extending a script, the global class name of the script is inserted in the script creation dialog, if it exists. If [code]false[/code], the script's file path is always inserted.
 		</member>
-		<member name="interface/editors/show_scene_tree_root_selection" type="bool" setter="" getter="">
-			If [code]true[/code], the Scene dock will display buttons to quickly add a root node to a newly created scene.
-		</member>
 		<member name="interface/inspector/auto_unfold_foreign_scenes" type="bool" setter="" getter="">
 			If [code]true[/code], automatically unfolds Inspector property groups containing modified values when opening a scene for the first time. Only affects scenes without saved folding preferences and only unfolds groups with properties that have been changed from their default values.
 			[b]Note:[/b] This setting only works in specific scenarios: when opening a scene brought in from another project, or when opening a new scene that already has modified properties (e.g., from version control). Duplicated scenes are not considered foreign, so this setting will not affect them.

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -169,8 +169,6 @@ class SceneTreeDock : public VBoxContainer {
 	PopupMenu *menu_properties = nullptr;
 	ConfirmationDialog *clear_inherit_confirm = nullptr;
 
-	bool first_enter = true;
-
 	void _create();
 	Node *_do_create(Node *p_parent);
 	void _post_do_create(Node *p_child);
@@ -179,7 +177,7 @@ class SceneTreeDock : public VBoxContainer {
 	Node *pending_click_select = nullptr;
 	bool tree_clicked = false;
 
-	VBoxContainer *create_root_dialog = nullptr;
+	VBoxContainer *create_root_options = nullptr;
 	String selected_favorite_root;
 
 	Ref<ShaderMaterial> selected_shader_material;
@@ -278,7 +276,9 @@ class SceneTreeDock : public VBoxContainer {
 	void _remote_tree_selected();
 	void _local_tree_selected();
 
-	void _update_create_root_dialog(bool p_initializing = false);
+	void _update_create_root_options();
+	void _update_create_root_options_visibility();
+	void _toggle_favorite_nodes(bool p_enabled);
 	void _favorite_root_selected(const String &p_class);
 
 	void _feature_profile_changed();

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -964,6 +964,7 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 	if (!filter.strip_edges().is_empty() || !show_all_nodes) {
 		_update_filter(nullptr, p_scroll_to_selected);
 	}
+	emit_signal(SNAME("tree_updated"));
 }
 
 bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_selected) {
@@ -2101,6 +2102,7 @@ void SceneTreeEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("files_dropped", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files"), PropertyInfo(Variant::NODE_PATH, "to_path"), PropertyInfo(Variant::INT, "type")));
 	ADD_SIGNAL(MethodInfo("script_dropped", PropertyInfo(Variant::STRING, "file"), PropertyInfo(Variant::NODE_PATH, "to_path")));
 	ADD_SIGNAL(MethodInfo("rmb_pressed", PropertyInfo(Variant::VECTOR2, "position")));
+	ADD_SIGNAL(MethodInfo("tree_updated"));
 
 	ADD_SIGNAL(MethodInfo("open"));
 	ADD_SIGNAL(MethodInfo("open_script"));

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -541,7 +541,6 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 #endif
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/collapse_main_menu", is_android_editor, "")
 
-	_initial_set("interface/editors/show_scene_tree_root_selection", true);
 	_initial_set("interface/editors/derive_script_globals_by_name", true);
 	_initial_set("docks/scene_tree/ask_before_revoking_unique_name", true);
 


### PR DESCRIPTION
Numerous internal improvements to the root node options that show when scene is empty. No functionality change.
- Renamed `create_root_dialog` (and related methods) to `create_root_options`
- Moved root options initialization to the constructor instead of READY
- Changed the options visibility to update on scene tree change instead of _every frame_
- Removed `show_scene_tree_root_selection` editor setting (it was useless IMO)
- Removed redundant `first_enter` flag
- Removed `remote_tree` null checks (they were done inconsistently anyway, and remote tree pretty much always exists)

The third point may have positive impact on editor's CPU usage. It was checking an editor setting every frame...
It may also bring regressions ;)