### PR TITLE
Fix EditorTitleBar excessive width

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -86,6 +86,7 @@ class EditorResourcePreview;
 class EditorResourceConversionPlugin;
 class EditorRunBar;
 class EditorSceneTabs;
+class EditorScrollBox;
 class EditorSelectionHistory;
 class EditorSettingsDialog;
 class EditorTitleBar;
@@ -327,12 +328,11 @@ private:
 	Control *left_menu_spacer = nullptr;
 	Control *right_menu_spacer = nullptr;
 	EditorTitleBar *title_bar = nullptr;
+	HBoxContainer *title_left_hbox = nullptr;
+	HBoxContainer *title_right_hbox = nullptr;
+	EditorScrollBox *menu_scroll_box = nullptr;
+	EditorScrollBox *main_scroll_box = nullptr;
 	EditorRunBar *project_run_bar = nullptr;
-	HBoxContainer *right_menu_hb = nullptr;
-
-	// Spacers to center 2D / 3D / Script buttons.
-	HBoxContainer *left_spacer = nullptr;
-	Control *right_spacer = nullptr;
 
 	Control *menu_btn_spacer = nullptr;
 	MenuButton *main_menu_button = nullptr;
@@ -575,9 +575,9 @@ private:
 	void _version_control_menu_option(int p_idx);
 	void _close_messages();
 	void _show_messages();
-	void _vp_resized();
 	void _titlebar_resized();
 	void _viewport_resized();
+	void _adjust_project_title();
 
 	void _update_undo_redo_allowed();
 
@@ -735,6 +735,7 @@ public:
 	static EditorFolding &get_editor_folding() { return singleton->editor_folding; }
 
 	static EditorTitleBar *get_title_bar() { return singleton->title_bar; }
+	static HBoxContainer *get_title_bar_right_hbox() { return singleton->title_right_hbox; }
 	static VSplitContainer *get_top_split() { return singleton->top_split; }
 	static EditorBottomPanel *get_bottom_panel() { return singleton->bottom_panel; }
 	static EditorMainScreen *get_editor_main_screen() { return singleton->editor_main_screen; }

--- a/editor/gui/editor_bottom_panel.cpp
+++ b/editor/gui/editor_bottom_panel.cpp
@@ -33,13 +33,13 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/gui/editor_scroll_box.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/gui/editor_version_button.h"
 #include "editor/settings/editor_command_palette.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
-#include "scene/gui/scroll_container.h"
 #include "scene/gui/split_container.h"
 
 void EditorBottomPanel::_notification(int p_what) {
@@ -47,19 +47,6 @@ void EditorBottomPanel::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			pin_button->set_button_icon(get_editor_theme_icon(SNAME("Pin")));
 			expand_button->set_button_icon(get_editor_theme_icon(SNAME("ExpandBottomDock")));
-			left_button->set_button_icon(get_editor_theme_icon(SNAME("Back")));
-			right_button->set_button_icon(get_editor_theme_icon(SNAME("Forward")));
-		} break;
-
-		case NOTIFICATION_TRANSLATION_CHANGED:
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			if (is_layout_rtl()) {
-				bottom_hbox->move_child(left_button, button_scroll->get_index() + 1);
-				bottom_hbox->move_child(right_button, 0);
-			} else {
-				bottom_hbox->move_child(right_button, button_scroll->get_index() + 1);
-				bottom_hbox->move_child(left_button, 0);
-			}
 		} break;
 	}
 }
@@ -71,42 +58,6 @@ void EditorBottomPanel::_switch_by_control(bool p_visible, Control *p_control, b
 			return;
 		}
 	}
-}
-
-void EditorBottomPanel::_scroll(bool p_right) {
-	HScrollBar *h_scroll = button_scroll->get_h_scroll_bar();
-	if (Input::get_singleton()->is_key_pressed(Key::CTRL)) {
-		h_scroll->set_value(p_right ? h_scroll->get_max() : 0);
-	} else if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
-		h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * (p_right ? 1 : -1));
-	} else {
-		h_scroll->set_value(h_scroll->get_value() + (h_scroll->get_page() * 0.5) * (p_right ? 1 : -1));
-	}
-}
-
-void EditorBottomPanel::_update_scroll_buttons() {
-	bool show_arrows = button_hbox->get_size().width > button_scroll->get_size().width;
-	left_button->set_visible(show_arrows);
-	right_button->set_visible(show_arrows);
-
-	if (show_arrows) {
-		_update_disabled_buttons();
-	}
-}
-
-void EditorBottomPanel::_update_disabled_buttons() {
-	HScrollBar *h_scroll = button_scroll->get_h_scroll_bar();
-	left_button->set_disabled(h_scroll->get_value() == 0);
-	right_button->set_disabled(h_scroll->get_value() + h_scroll->get_page() == h_scroll->get_max());
-}
-
-void EditorBottomPanel::_ensure_control_visible(ObjectID p_id) {
-	Control *c = ObjectDB::get_instance<Control>(p_id);
-	if (!c) {
-		return;
-	}
-
-	button_scroll->ensure_control_visible(c);
 }
 
 void EditorBottomPanel::_switch_to_item(bool p_visible, int p_idx, bool p_ignore_lock) {
@@ -143,7 +94,8 @@ void EditorBottomPanel::_switch_to_item(bool p_visible, int p_idx, bool p_ignore
 		if (expand_button->is_pressed()) {
 			EditorNode::get_top_split()->hide();
 		}
-		callable_mp(this, &EditorBottomPanel::_ensure_control_visible).call_deferred(items[p_idx].button->get_instance_id());
+		callable_mp((EditorScrollBox *)scroll_box, &EditorScrollBox::ensure_control_visible).call_deferred(items[p_idx].button->get_instance_id());
+
 	} else {
 		add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("BottomPanel"), EditorStringName(EditorStyles)));
 		items[p_idx].button->set_pressed_no_signal(false);
@@ -314,37 +266,13 @@ EditorBottomPanel::EditorBottomPanel() {
 	bottom_hbox->set_custom_minimum_size(Size2(0, 24 * EDSCALE)); // Adjust for the height of the "Expand Bottom Dock" icon.
 	item_vbox->add_child(bottom_hbox);
 
-	left_button = memnew(Button);
-	left_button->set_tooltip_text(TTRC("Scroll Left\nHold Ctrl to scroll to the begin.\nHold Shift to scroll one page."));
-	left_button->set_accessibility_name(TTRC("Scroll Left"));
-	left_button->set_theme_type_variation("BottomPanelButton");
-	left_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	left_button->connect(SceneStringName(pressed), callable_mp(this, &EditorBottomPanel::_scroll).bind(false));
-	bottom_hbox->add_child(left_button);
-	left_button->hide();
-
-	button_scroll = memnew(ScrollContainer);
-	button_scroll->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	button_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_SHOW_NEVER);
-	button_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-	button_scroll->get_h_scroll_bar()->connect(CoreStringName(changed), callable_mp(this, &EditorBottomPanel::_update_scroll_buttons), CONNECT_DEFERRED);
-	button_scroll->get_h_scroll_bar()->connect(SceneStringName(value_changed), callable_mp(this, &EditorBottomPanel::_update_disabled_buttons).unbind(1), CONNECT_DEFERRED);
-	bottom_hbox->add_child(button_scroll);
-
-	right_button = memnew(Button);
-	right_button->set_tooltip_text(TTRC("Scroll Right\nHold Ctrl to scroll to the end.\nHold Shift to scroll one page."));
-	right_button->set_accessibility_name(TTRC("Scroll Right"));
-	right_button->set_theme_type_variation("BottomPanelButton");
-	right_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	right_button->connect(SceneStringName(pressed), callable_mp(this, &EditorBottomPanel::_scroll).bind(true));
-	bottom_hbox->add_child(right_button);
-	right_button->hide();
-
-	callable_mp(this, &EditorBottomPanel::_update_scroll_buttons).call_deferred();
+	scroll_box = memnew(EditorScrollBox);
+	scroll_box->set_custom_minimum_size(Size2(128 * EDSCALE, 0));
+	bottom_hbox->add_child(scroll_box);
 
 	button_hbox = memnew(HBoxContainer);
 	button_hbox->set_h_size_flags(Control::SIZE_EXPAND | Control::SIZE_SHRINK_BEGIN);
-	button_scroll->add_child(button_hbox);
+	scroll_box->set_control(button_hbox);
 
 	editor_toaster = memnew(EditorToaster);
 	bottom_hbox->add_child(editor_toaster);

--- a/editor/gui/editor_scroll_box.cpp
+++ b/editor/gui/editor_scroll_box.cpp
@@ -1,0 +1,198 @@
+/**************************************************************************/
+/*  editor_scroll_box.cpp                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "editor_scroll_box.h"
+
+#include "scene/gui/button.h"
+#include "scene/gui/scroll_bar.h"
+#include "scene/gui/scroll_container.h"
+#include "scene/theme/theme_db.h"
+
+void EditorScrollBox::ensure_control_visible(ObjectID p_id) {
+	Control *c = ObjectDB::get_instance<Control>(p_id);
+	if (!c) {
+		return;
+	}
+
+	scroll_container->ensure_control_visible(c);
+}
+
+// Use set_control(nullptr) to remove the control used by the ScrollContainer.
+void EditorScrollBox::set_control(Control *p_control) {
+	if (p_control) {
+		ERR_FAIL_COND_MSG(has_control(), "Container already has a control, use set_control(nullptr) to remove it.");
+	}
+	if (control) {
+		control->disconnect(SceneStringName(resized), callable_mp(this, &EditorScrollBox::_update_buttons));
+		scroll_container->remove_child(p_control);
+		control = nullptr;
+	}
+
+	if (!p_control) {
+		_update_buttons();
+		return;
+	}
+
+	if (p_control->get_parent()) {
+		p_control->get_parent()->remove_child(p_control);
+	}
+
+	control = p_control;
+	control->connect(SceneStringName(resized), callable_mp(this, &EditorScrollBox::_update_buttons));
+	scroll_container->add_child(p_control);
+
+	_update_buttons();
+}
+
+bool EditorScrollBox::has_control() const {
+	return control != nullptr;
+}
+
+Button *EditorScrollBox::get_right_button() const {
+	return is_layout_rtl() ? left_button : right_button;
+}
+
+Button *EditorScrollBox::get_left_button() const {
+	return is_layout_rtl() ? right_button : left_button;
+}
+
+void EditorScrollBox::_scroll(bool p_right) {
+	if (is_layout_rtl()) {
+		p_right = !p_right;
+	}
+
+	HScrollBar *hscroll_bar = scroll_container->get_h_scroll_bar();
+	if (Input::get_singleton()->is_key_pressed(Key::CTRL)) {
+		hscroll_bar->set_value(p_right ? hscroll_bar->get_max() : 0);
+	} else if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
+		hscroll_bar->set_value(hscroll_bar->get_value() + hscroll_bar->get_page() * (p_right ? 1 : -1));
+	} else {
+		hscroll_bar->set_value(hscroll_bar->get_value() + (hscroll_bar->get_page() * 0.5) * (p_right ? 1 : -1));
+	}
+}
+
+// Update the buttons visibility and disabled state.
+void EditorScrollBox::_update_buttons() {
+	bool show_arrows = control && control->get_size().width > scroll_container->get_size().width;
+	left_button->set_visible(show_arrows);
+	right_button->set_visible(show_arrows);
+
+	if (show_arrows) {
+		_update_disabled_buttons();
+	}
+}
+
+void EditorScrollBox::_update_buttons_icon_and_tooltip() {
+	Button *button = get_left_button();
+	button->set_button_icon(theme_cache.arrow_left);
+	button->set_accessibility_name(TTRC("Scroll Left"));
+	button->set_tooltip_text(TTRC("Scroll Left\nHold Ctrl to scroll to the begin.\nHold Shift to scroll one page."));
+
+	button = get_right_button();
+	button->set_button_icon(theme_cache.arrow_right);
+	button->set_accessibility_name(TTRC("Scroll Right"));
+	button->set_tooltip_text(TTRC("Scroll Right\nHold Ctrl to scroll to the end.\nHold Shift to scroll one page."));
+}
+
+void EditorScrollBox::_update_disabled_buttons() {
+	HScrollBar *scroll_bar = scroll_container->get_h_scroll_bar();
+
+	get_left_button()->set_disabled(scroll_bar->get_value() == 0);
+	get_right_button()->set_disabled(scroll_bar->get_value() + scroll_bar->get_page() == scroll_bar->get_max());
+}
+
+void EditorScrollBox::_accessibility_action_scroll_left(const Variant &p_data) {
+	_scroll(false);
+}
+
+void EditorScrollBox::_accessibility_action_scroll_right(const Variant &p_data) {
+	_scroll(true);
+}
+
+void EditorScrollBox::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
+			RID ae = get_accessibility_element();
+			ERR_FAIL_COND(ae.is_null());
+			DisplayServer::get_singleton()->accessibility_update_set_role(ae, DisplayServer::AccessibilityRole::ROLE_SCROLL_VIEW);
+
+			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_SCROLL_LEFT, callable_mp(this, &EditorScrollBox::_accessibility_action_scroll_left));
+			DisplayServer::get_singleton()->accessibility_update_add_action(ae, DisplayServer::AccessibilityAction::ACTION_SCROLL_RIGHT, callable_mp(this, &EditorScrollBox::_accessibility_action_scroll_right));
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			_update_buttons_icon_and_tooltip();
+			_update_buttons();
+		} break;
+
+		case NOTIFICATION_RESIZED: {
+			_update_buttons();
+		} break;
+	}
+}
+
+void EditorScrollBox::_bind_methods() {
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, EditorScrollBox, arrow_left);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_ICON, EditorScrollBox, arrow_right);
+}
+
+EditorScrollBox::EditorScrollBox() {
+	set_h_size_flags(SIZE_EXPAND_FILL);
+
+	left_button = memnew(Button);
+	left_button->set_theme_type_variation("BottomPanelButton");
+	left_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	left_button->connect(SceneStringName(pressed), callable_mp(this, &EditorScrollBox::_scroll).bind(false));
+	add_child(left_button);
+	left_button->hide();
+
+	scroll_container = memnew(ScrollContainer);
+	scroll_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_SHOW_NEVER);
+	scroll_container->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	scroll_container->set_force_pass_scroll_events(false);
+	scroll_container->set_follow_focus(true);
+	add_child(scroll_container);
+
+	HScrollBar *hscroll = scroll_container->get_h_scroll_bar();
+	hscroll->connect(CoreStringName(changed), callable_mp(this, &EditorScrollBox::_update_buttons), CONNECT_DEFERRED);
+	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &EditorScrollBox::_update_disabled_buttons).unbind(1), CONNECT_DEFERRED);
+
+	right_button = memnew(Button);
+	right_button->set_theme_type_variation("BottomPanelButton");
+	right_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	right_button->connect(SceneStringName(pressed), callable_mp(this, &EditorScrollBox::_scroll).bind(true));
+	add_child(right_button);
+	right_button->hide();
+
+	_update_buttons_icon_and_tooltip();
+}

--- a/editor/gui/editor_scroll_box.h
+++ b/editor/gui/editor_scroll_box.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_bottom_panel.h                                                 */
+/*  editor_scroll_box.h                                                   */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,58 +30,47 @@
 
 #pragma once
 
-#include "scene/gui/panel_container.h"
+#include "scene/gui/box_container.h"
 
 class Button;
-class ConfigFile;
-class EditorToaster;
-class HBoxContainer;
-class VBoxContainer;
 class ScrollContainer;
-class EditorScrollBox;
 
-class EditorBottomPanel : public PanelContainer {
-	GDCLASS(EditorBottomPanel, PanelContainer);
+class EditorScrollBox : public HBoxContainer {
+	GDCLASS(EditorScrollBox, HBoxContainer)
 
-	struct BottomPanelItem {
-		String name;
-		Control *control = nullptr;
-		Button *button = nullptr;
-	};
+	struct ThemeCache {
+		Ref<Texture2D> arrow_left;
+		Ref<Texture2D> arrow_right;
+	} theme_cache;
 
-	Vector<BottomPanelItem> items;
-	bool lock_panel_switching = false;
+	Button *left_button = nullptr;
+	Button *right_button = nullptr;
+	ScrollContainer *scroll_container = nullptr;
+	Control *control = nullptr;
 
-	VBoxContainer *item_vbox = nullptr;
-	HBoxContainer *bottom_hbox = nullptr;
-	EditorScrollBox *scroll_box = nullptr;
-	HBoxContainer *button_hbox = nullptr;
-	EditorToaster *editor_toaster = nullptr;
-	Button *pin_button = nullptr;
-	Button *expand_button = nullptr;
-	Control *last_opened_control = nullptr;
-
-	void _switch_by_control(bool p_visible, Control *p_control, bool p_ignore_lock = false);
-	void _switch_to_item(bool p_visible, int p_idx, bool p_ignore_lock = false);
-	void _pin_button_toggled(bool p_pressed);
-	void _expand_button_toggled(bool p_pressed);
-
-	bool _button_drag_hover(const Vector2 &, const Variant &, Button *p_button, Control *p_control);
+	void _scroll(bool p_right);
+	void _accessibility_action_scroll_right(const Variant &p_data);
+	void _accessibility_action_scroll_left(const Variant &p_data);
+	void _update_buttons();
+	void _update_disabled_buttons();
+	void _update_buttons_icon_and_tooltip();
+	void _update_scroll_container();
 
 protected:
 	void _notification(int p_what);
+	static void _bind_methods();
 
 public:
-	void save_layout_to_config(Ref<ConfigFile> p_config_file, const String &p_section) const;
-	void load_layout_from_config(Ref<ConfigFile> p_config_file, const String &p_section);
+	void set_control(Control *p_control);
+	Control *get_control() const { return control; }
+	bool has_control() const;
 
-	Button *add_item(String p_text, Control *p_item, const Ref<Shortcut> &p_shortcut = nullptr, bool p_at_front = false);
-	void remove_item(Control *p_item);
-	void make_item_visible(Control *p_item, bool p_visible = true, bool p_ignore_lock = false);
-	void move_item_to_end(Control *p_item);
-	void hide_bottom_panel();
-	void toggle_last_opened_bottom_panel();
-	void set_expanded(bool p_expanded);
+	void ensure_control_visible(ObjectID p_id);
 
-	EditorBottomPanel();
+	Button *get_left_button() const;
+	Button *get_right_button() const;
+
+	ScrollContainer *get_scroll_container() const { return scroll_container; }
+
+	EditorScrollBox();
 };

--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -109,7 +109,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 
 	switch (p_location) {
 		case CONTAINER_TOOLBAR: {
-			EditorNode::get_title_bar()->add_child(p_control);
+			EditorNode::get_title_bar_right_hbox()->add_child(p_control);
 		} break;
 
 		case CONTAINER_SPATIAL_EDITOR_MENU: {
@@ -161,7 +161,7 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 
 	switch (p_location) {
 		case CONTAINER_TOOLBAR: {
-			EditorNode::get_title_bar()->remove_child(p_control);
+			EditorNode::get_title_bar_right_hbox()->remove_child(p_control);
 		} break;
 
 		case CONTAINER_SPATIAL_EDITOR_MENU: {

--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -50,6 +50,7 @@
 #include "editor/file_system/editor_file_system.h"
 #include "editor/file_system/editor_paths.h"
 #include "editor/gui/editor_file_dialog.h"
+#include "editor/gui/editor_scroll_box.h"
 #include "editor/gui/editor_spin_slider.h"
 #include "editor/gui/editor_toaster.h"
 #include "editor/import/3d/resource_importer_obj.h"

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -1331,6 +1331,10 @@ void EditorThemeManager::_populate_standard_styles(const Ref<EditorTheme> &p_the
 
 		p_theme->set_constant("outline_size", "FoldableContainer", 0);
 		p_theme->set_constant("h_separation", "FoldableContainer", p_config.separation_margin);
+
+		// EditorScrollBox
+		p_theme->set_icon("arrow_left", "EditorScrollBox", p_theme->get_icon(SNAME("GuiTreeArrowLeft"), EditorStringName(EditorIcons)));
+		p_theme->set_icon("arrow_right", "EditorScrollBox", p_theme->get_icon(SNAME("GuiTreeArrowRight"), EditorStringName(EditorIcons)));
 	}
 
 	// Window and dialogs.


### PR DESCRIPTION
https://github.com/user-attachments/assets/8113c691-19dc-42b6-aae9-5de3d632c9c4

Summary of Changes:
* **EditorScrollBox Extracted for Reuse**:
* * The EditorScrollBox (introduced in https://github.com/godotengine/godot/pull/97878) has been extracted into its own class to allow reuse across the editor. This helps address excessive width issues.

* **Improved Layout in EditorTitleBar**:
* * Refactored the layout using three expanding containers instead of relying on spacer size calculations. This simplifies alignment and makes future layout changes easier:
`[ left_hb                 ] [             center_hb             ] [                 right_hb ]`

* **New Minimum Editor Size**:
* * The minimum size of the editor window is now set to 640×480. This change required adjusting many UI elements to fit within the new constraints. (Most of those adjustments are already done locally).
 
* **Selective Use of EditorScrollBox**:
* * The new EditorScrollBox has been applied to the main menus and screen buttons, but not to right_hb, which includes the EditorRunBar and plugin-specific controls.
Note: it’s currently difficult to keep the main screen buttons centered when many plugins are added to the right container.
 
Requires testing on Android Editor to confirm compatibility and layout integrity on smaller screens.

* Note: The change to the Renderer Button shown in the demo video is not included in this PR. That change is part of https://github.com/godotengine/godot/pull/109357, and is shown in the video only to demonstrate the final result when both PRs are merged.

* Note: The Pause and Stop button changes shown in the video have been removed from this PR. They will be moved to a separate PR if needed.