### PR TITLE
[Unix] Fix `execute_with_pipe` closing wrong pipe handle.

### DIFF
--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -795,7 +795,7 @@ Dictionary OS_Unix::execute_with_pipe(const String &p_path, const List<String> &
 
 	Ref<FileAccessUnixPipe> err_pipe;
 	err_pipe.instantiate();
-	err_pipe->open_existing(pipe_err[0], 0, p_blocking);
+	err_pipe->open_existing(pipe_err[0], -1, p_blocking);
 
 	ProcessInfo pi;
 	process_map_mutex.lock();


### PR DESCRIPTION
`0` can be a valid handle in use (see https://github.com/godotengine/godot/pull/108737#pullrequestreview-3097448794 for example, it was closing pipe handle used by `popen` and breaking it).

Fixes https://github.com/godotengine/godot/issues/109652