### PR TITLE
Fix exported variable type mismatch after script change

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -821,7 +821,6 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 				}
 			}
 		}
-
 #endif
 	}
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -36,6 +36,10 @@
 #include "core/debugger/script_debugger.h"
 #include "core/io/resource_loader.h"
 
+#if TOOLS_ENABLED
+#include "editor/editor_node.h"
+#endif
+
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count = 0;
 bool ScriptServer::languages_ready = false;
@@ -804,6 +808,21 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 				values[n] = p_values[n];
 			}
 		}
+
+#if TOOLS_ENABLED
+		if (values.has(n) && E.type == Variant::OBJECT) {
+			if (!E.hint_string.is_empty()) {
+				Object *obj = Object::cast_to<Object>(values[n]);
+				if (obj) {
+					if (!EditorNode::get_singleton()->is_object_of_custom_type(obj, E.hint_string) && !obj->is_class(E.hint_string)) {
+						values[n] = Variant();
+						WARN_PRINT(vformat("Exported variable type mismatch (expected \"%s\", got \"%s\"). Removing the node from variable \"%s\".", E.hint_string, obj->get_class(), n));
+					}
+				}
+			}
+		}
+
+#endif
 	}
 
 	properties = p_properties;


### PR DESCRIPTION
Fixes: #68015 


https://github.com/user-attachments/assets/4e130cd8-b49a-4e67-9b9f-9760ec74a470

Definitely not the best. This does have support for both C# and GDScript exported variables. I've done testing and it works for custom classes too. Inside `PlaceHolderScriptInstance::update` we check if the value of the exported variable would be an object or not and then if the exported variable does have a value: we compare it with the new expected variables type and reset the value if not appropriate. There may still be some edge cases I haven't accounted for, but I wasn't able to find any during testing.

I'm open for any constructive criticism or feedback. Thank you.

EDIT: I intend to redo this pull-request. Turning into a draft