### PR TITLE
Metal: Ensure correct output texture format selection

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -255,11 +255,20 @@ void RenderSceneBuffersRD::ensure_mfx(RendererRD::MFXSpatialEffect *p_effect) {
 	if (mfx_spatial_context) {
 		return;
 	}
+
+	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
+	RenderingDevice *rd = RD::get_singleton();
+
+	// Determine the output format of the render target.
+	RID dest = texture_storage->render_target_get_rd_texture(render_target);
+	RD::TextureFormat tf = rd->texture_get_format(dest);
+	RD::DataFormat output_format = tf.format;
+
 	RendererRD::MFXSpatialEffect::CreateParams params = {
 		.input_size = internal_size,
 		.output_size = target_size,
 		.input_format = base_data_format,
-		.output_format = RD::DATA_FORMAT_R8G8B8A8_UNORM,
+		.output_format = output_format,
 	};
 
 	mfx_spatial_context = p_effect->create_context(params);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1352,6 +1352,7 @@ void RendererViewport::viewport_set_use_hdr_2d(RID p_viewport, bool p_use_hdr_2d
 	}
 	viewport->use_hdr_2d = p_use_hdr_2d;
 	RSG::texture_storage->render_target_set_use_hdr(viewport->render_target, p_use_hdr_2d);
+	_configure_3d_render_buffers(viewport);
 }
 
 bool RendererViewport::viewport_is_using_hdr_2d(RID p_viewport) const {


### PR DESCRIPTION
Ensure the correct output texture format is selected when creating the MetalFX Spatial Shader context.

| before | after |
| :---- | :---- |
| <img width="500px" alt="metalfx_spatial" src="https://github.com/user-attachments/assets/b7f9f78f-6e93-4495-be46-4a6b7c132ac9" /> | <img width="530px" alt="metalfx_spatial_after" src="https://github.com/user-attachments/assets/206c9d0e-6fdd-48f0-a056-1d631a529b70" /> |

> [!NOTE]
>
> Also verified with tps-demo and @Calinou's additions to allow selecting MetalFX upscalers.