### PR TITLE
CI: Ensure draft PRs don't perform actions

### DIFF
--- a/.github/workflows/runner.yml
+++ b/.github/workflows/runner.yml
@@ -1,5 +1,9 @@
 name: 🔗 GHA
-on: [push, pull_request, merge_group]
+on:
+  push:
+  pull_request:
+    types: [opened, reopened, synchronize, converted_to_draft, ready_for_review]
+  merge_group: # Unused.
 
 concurrency:
   group: ${{ github.workflow }}|${{ github.ref_name }}
@@ -9,7 +13,7 @@ jobs:
   # First stage: Only static checks, fast and prevent expensive builds from running.
 
   static-checks:
-    if: ${{ !vars.DISABLE_GODOT_CI || github.run_attempt > 1 }}
+    if: ${{ (!vars.DISABLE_GODOT_CI || github.run_attempt > 1) && !(github.event_name == 'pull_request' && github.event.pull_request.draft) }}
     name: 📊 Static checks
     uses: ./.github/workflows/static_checks.yml
 


### PR DESCRIPTION
Tweaks the runner conditional such that a drafted PR will **not** perform actions. While I don't think it can be completely exempted from attempting to *start* an action, this should ultimately aid in cleaning up the action queue

~~Gonna be converting this to/from a draft to verify that everything works as intended~~ **EDIT:** Functionality verified! This not only prevents actions running on drafts, but it will *stop* a running action if converted to a draft & *starts* running actions when marked as ready for review!

<img width="420" height="309" alt="25-08-07 15-49-22 chrome" src="https://github.com/user-attachments/assets/0a6b1f7b-c34c-48f5-98d7-e88ca5d850a0" />