### PR TITLE
CI: Interrupt build actions if cleaning cache

### DIFF
--- a/.github/workflows/cache_cleanup.yml
+++ b/.github/workflows/cache_cleanup.yml
@@ -5,6 +5,10 @@ on:
     types:
       - closed
 
+concurrency:
+  group: ${{ github.workflow }}|${{ github.ref_name }}
+  cancel-in-progress: true
+
 jobs:
   cleanup:
     name: Cleanup PR caches


### PR DESCRIPTION
- Related: #109407

Taking a cue from the above PR, which interrupts PR actions if drafted, this attempts to do the same for an entirely separate action: Cache Cleanup. Because there's zero risk of overlap between the two PR triggers, this means that the concurrency name can be safely reused; as such: starting a cache cleanup will interrupt any in-progress build action for the associated PR