### PR TITLE
Fix missing shortcuts for play buttons in SpriteFrames Editor

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -2205,27 +2205,22 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	play_bw_from = memnew(Button);
 	play_bw_from->set_theme_type_variation(SceneStringName(FlatButton));
-	play_bw_from->set_tooltip_text(TTRC("Play selected animation backwards from current pos. (A)"));
 	playback_container->add_child(play_bw_from);
 
 	play_bw = memnew(Button);
 	play_bw->set_theme_type_variation(SceneStringName(FlatButton));
-	play_bw->set_tooltip_text(TTRC("Play selected animation backwards from end. (Shift+A)"));
 	playback_container->add_child(play_bw);
 
 	stop = memnew(Button);
 	stop->set_theme_type_variation(SceneStringName(FlatButton));
-	stop->set_tooltip_text(TTRC("Pause/stop animation playback. (S)"));
 	playback_container->add_child(stop);
 
 	play = memnew(Button);
 	play->set_theme_type_variation(SceneStringName(FlatButton));
-	play->set_tooltip_text(TTRC("Play selected animation from start. (Shift+D)"));
 	playback_container->add_child(play);
 
 	play_from = memnew(Button);
 	play_from->set_theme_type_variation(SceneStringName(FlatButton));
-	play_from->set_tooltip_text(TTRC("Play selected animation from current pos. (D)"));
 	playback_container->add_child(play_from);
 
 	hfc->add_child(memnew(VSeparator));
@@ -2373,6 +2368,11 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	move_up->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_up_pressed));
 	move_down->connect(SceneStringName(pressed), callable_mp(this, &SpriteFramesEditor::_down_pressed));
 
+	play_bw_from->set_shortcut(ED_SHORTCUT("sprite_frames/play_animation_backwards", TTRC("Play Animation Backwards"), Key::A));
+	play_bw->set_shortcut(ED_SHORTCUT("sprite_frames/play_animation_from_end", TTRC("Play Animation Backwards from End"), KeyModifierMask::SHIFT + Key::A));
+	stop->set_shortcut(ED_SHORTCUT("sprite_frames/stop_animation", TTRC("Pause/Stop Animation"), Key::S));
+	play->set_shortcut(ED_SHORTCUT("sprite_frames/play_animation_from_start", TTRC("Play Animation from Start"), KeyModifierMask::SHIFT + Key::D));
+	play_from->set_shortcut(ED_SHORTCUT("sprite_frames/play_animation", TTRC("Play Animation"), Key::D));
 	load->set_shortcut_context(frame_list);
 	load->set_shortcut(ED_SHORTCUT("sprite_frames/load_from_file", TTRC("Add Frame from File"), KeyModifierMask::CMD_OR_CTRL | Key::O));
 	load_sheet->set_shortcut_context(frame_list);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109414


