### PR TITLE
Meta: Move /editor/scene folder from `core` to `docks` codeowner.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,12 +56,11 @@
 /editor/icons/                                @godotengine/usability
 /editor/import/                               @godotengine/import
 /editor/inspector/                            @godotengine/docks
-/editor/scene/                                @godotengine/core
 /editor/scene/2d/                             @godotengine/2d-editor
 /editor/scene/2d/physics                      @godotengine/2d-editor @godotengine/physics
 /editor/scene/3d/                             @godotengine/3d-editor
 /editor/scene/3d/physics                      @godotengine/3d-editor @godotengine/physics
-/editor/scene/gui/                            @godotengine/usability @godotengine/gui-nodes
+/editor/scene/gui/                            @godotengine/gui-nodes
 /editor/themes/                               @godotengine/usability @godotengine/gui-nodes
 /editor/translations/                         @godotengine/usability
 


### PR DESCRIPTION
The folder `/editor/scene` contains UI elements, gizmos and dialogues for the editor that pertain to scene editing. This is editor related expertise, whereas core is more concerned with data structures, architecture, and low level processes.

I would argue that, from a top down view, the editor is a user of the core library, and owns UI that edits core types.
From a code review perspective, I've been observing incoming pull requests for `/editor/scene` and feel that they require a different kind of expertise compared to other core related PRs.

This was changed in https://github.com/godotengine/godot/pull/104696.
The folder `/scene` contains core data structures and should stay with the `core` team.

(tagging fellow core maintainers and our editor expert KoBeWi for their perspective)