### PR TITLE
Don't duplicate PackedScene variants

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -315,6 +315,9 @@ Variant Resource::_duplicate_recursive(const Variant &p_variant, const Duplicate
 			}
 		} break;
 		case Variant::ARRAY: {
+			if (p_usage & PROPERTY_USAGE_NEVER_DUPLICATE) {
+				return p_variant;
+			}
 			const Array &src = p_variant;
 			Array dst;
 			if (src.is_typed()) {
@@ -327,6 +330,9 @@ Variant Resource::_duplicate_recursive(const Variant &p_variant, const Duplicate
 			return dst;
 		} break;
 		case Variant::DICTIONARY: {
+			if (p_usage & PROPERTY_USAGE_NEVER_DUPLICATE) {
+				return p_variant;
+			}
 			const Dictionary &src = p_variant;
 			Dictionary dst;
 			if (src.is_typed()) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -3030,7 +3030,7 @@
 			When duplicating a resource with [method Resource.duplicate], and this flag is set on a property of that resource, the property should always be duplicated, regardless of the [code]subresources[/code] bool parameter.
 		</constant>
 		<constant name="PROPERTY_USAGE_NEVER_DUPLICATE" value="1048576" enum="PropertyUsageFlags" is_bitfield="true">
-			When duplicating a resource with [method Resource.duplicate], and this flag is set on a property of that resource, the property should never be duplicated, regardless of the [code]subresources[/code] bool parameter.
+			When duplicating a resource with [method Resource.duplicate], and this flag is set on a property of that resource, the property should never be duplicated.
 		</constant>
 		<constant name="PROPERTY_USAGE_HIGH_END_GFX" value="2097152" enum="PropertyUsageFlags" is_bitfield="true">
 			The property is only shown in the editor if modern renderers are supported (the Compatibility rendering method is excluded).

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2306,7 +2306,7 @@ void PackedScene::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_get_bundled_scene"), &PackedScene::_get_bundled_scene);
 	ClassDB::bind_method(D_METHOD("get_state"), &PackedScene::get_state);
 
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_bundled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL), "_set_bundled_scene", "_get_bundled_scene");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "_bundled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_NEVER_DUPLICATE), "_set_bundled_scene", "_get_bundled_scene");
 
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_DISABLED);
 	BIND_ENUM_CONSTANT(GEN_EDIT_STATE_INSTANCE);

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -200,19 +200,27 @@ public:
 			} else if (p_a.get_type() == Variant::ARRAY) {
 				const Array &arr_a = p_a;
 				const Array &arr_b = p_b;
-				CHECK(!arr_a.is_same_instance(arr_b));
-				CHECK(arr_a.size() == arr_b.size());
-				for (int i = 0; i < arr_a.size(); i++) {
-					_verify_deep_copied_variants(arr_a[i], arr_b[i]);
+				if (p_property_usage & PROPERTY_USAGE_NEVER_DUPLICATE) {
+					CHECK(arr_a.is_same_instance(arr_b));
+				} else {
+					CHECK(!arr_a.is_same_instance(arr_b));
+					CHECK(arr_a.size() == arr_b.size());
+					for (int i = 0; i < arr_a.size(); i++) {
+						_verify_deep_copied_variants(arr_a[i], arr_b[i]);
+					}
 				}
 			} else if (p_a.get_type() == Variant::DICTIONARY) {
 				const Dictionary &dict_a = p_a;
 				const Dictionary &dict_b = p_b;
-				CHECK(!dict_a.is_same_instance(dict_b));
-				CHECK(dict_a.size() == dict_b.size());
-				for (int i = 0; i < dict_a.size(); i++) {
-					_verify_deep_copied_variants(dict_a.get_key_at_index(i), dict_b.get_key_at_index(i));
-					_verify_deep_copied_variants(dict_a.get_value_at_index(i), dict_b.get_value_at_index(i));
+				if (p_property_usage & PROPERTY_USAGE_NEVER_DUPLICATE) {
+					CHECK(dict_a.is_same_instance(dict_b));
+				} else {
+					CHECK(!dict_a.is_same_instance(dict_b));
+					CHECK(dict_a.size() == dict_b.size());
+					for (int i = 0; i < dict_a.size(); i++) {
+						_verify_deep_copied_variants(dict_a.get_key_at_index(i), dict_b.get_key_at_index(i));
+						_verify_deep_copied_variants(dict_a.get_value_at_index(i), dict_b.get_value_at_index(i));
+					}
 				}
 			} else {
 				CHECK(p_a == p_b);


### PR DESCRIPTION
Fixes #108220

PackedScene keeps all its sub-resources in a Dictionary. There is no way to filter out individual Resources, so skipping everything makes sense I think 🤔 This makes a duplicate of PackedScene effectively the same as original, but PackedScene is mainly used for Node instantiation, not its internals, so this shouldn't cause problems (🤞).

Alternative solution is hard-coding an exception for Script resource somewhere.