### PR TITLE
Make `OpenXRCompositionLayer` and its children safe for multithreaded rendering

### DIFF
--- a/modules/openxr/extensions/openxr_composition_layer_extension.cpp
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.cpp
@@ -82,42 +82,96 @@ void OpenXRCompositionLayerExtension::on_session_created(const XrSession p_sessi
 
 void OpenXRCompositionLayerExtension::on_session_destroyed() {
 	OpenXRAPI::get_singleton()->unregister_composition_layer_provider(this);
-
-#ifdef ANDROID_ENABLED
-	free_queued_android_surface_swapchains();
-#endif
 }
 
 void OpenXRCompositionLayerExtension::on_pre_render() {
-#ifdef ANDROID_ENABLED
-	free_queued_android_surface_swapchains();
-#endif
-
-	for (OpenXRViewportCompositionLayerProvider *composition_layer : composition_layers) {
+	for (CompositionLayer *composition_layer : registered_composition_layers) {
 		composition_layer->on_pre_render();
 	}
 }
 
 int OpenXRCompositionLayerExtension::get_composition_layer_count() {
-	return composition_layers.size();
+	return registered_composition_layers.size();
 }
 
 XrCompositionLayerBaseHeader *OpenXRCompositionLayerExtension::get_composition_layer(int p_index) {
-	ERR_FAIL_INDEX_V(p_index, composition_layers.size(), nullptr);
-	return composition_layers[p_index]->get_composition_layer();
+	ERR_FAIL_UNSIGNED_INDEX_V((unsigned int)p_index, registered_composition_layers.size(), nullptr);
+	return registered_composition_layers[p_index]->get_composition_layer();
 }
 
 int OpenXRCompositionLayerExtension::get_composition_layer_order(int p_index) {
-	ERR_FAIL_INDEX_V(p_index, composition_layers.size(), 1);
-	return composition_layers[p_index]->get_sort_order();
+	ERR_FAIL_UNSIGNED_INDEX_V((unsigned int)p_index, registered_composition_layers.size(), 1);
+	return registered_composition_layers[p_index]->sort_order;
 }
 
-void OpenXRCompositionLayerExtension::register_viewport_composition_layer_provider(OpenXRViewportCompositionLayerProvider *p_composition_layer) {
-	composition_layers.push_back(p_composition_layer);
+RID OpenXRCompositionLayerExtension::composition_layer_create(XrCompositionLayerBaseHeader *p_openxr_layer) {
+	RID rid = composition_layer_owner.make_rid();
+	CompositionLayer *layer = composition_layer_owner.get_or_null(rid);
+
+	switch (p_openxr_layer->type) {
+		case XR_TYPE_COMPOSITION_LAYER_QUAD: {
+			layer->composition_layer_quad = *(XrCompositionLayerQuad *)p_openxr_layer;
+		} break;
+		case XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR: {
+			layer->composition_layer_cylinder = *(XrCompositionLayerCylinderKHR *)p_openxr_layer;
+		} break;
+		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
+			layer->composition_layer_equirect = *(XrCompositionLayerEquirect2KHR *)p_openxr_layer;
+		} break;
+		default: {
+			ERR_PRINT(vformat("Invalid OpenXR composition layer type: %s", p_openxr_layer->type));
+			composition_layer_owner.free(rid);
+			return RID();
+		}
+	}
+
+	return rid;
 }
 
-void OpenXRCompositionLayerExtension::unregister_viewport_composition_layer_provider(OpenXRViewportCompositionLayerProvider *p_composition_layer) {
-	composition_layers.erase(p_composition_layer);
+void OpenXRCompositionLayerExtension::composition_layer_free(RID p_layer) {
+	RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_free_rt).bind(p_layer));
+}
+
+void OpenXRCompositionLayerExtension::composition_layer_register(RID p_layer) {
+	RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_register_rt).bind(p_layer));
+}
+
+void OpenXRCompositionLayerExtension::composition_layer_unregister(RID p_layer) {
+	RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_unregister_rt).bind(p_layer));
+}
+
+Ref<JavaObject> OpenXRCompositionLayerExtension::composition_layer_get_android_surface(RID p_layer) {
+	MutexLock lock(composition_layer_mutex);
+	CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);
+	ERR_FAIL_NULL_V(layer, Ref<JavaObject>());
+	return layer->get_android_surface();
+}
+
+void OpenXRCompositionLayerExtension::_composition_layer_free_rt(RID p_layer) {
+	_composition_layer_unregister_rt(p_layer);
+
+	MutexLock lock(composition_layer_mutex);
+	CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);
+	if (layer) {
+		for (OpenXRExtensionWrapper *extension : OpenXRAPI::get_registered_extension_wrappers()) {
+			extension->on_viewport_composition_layer_destroyed(&layer->composition_layer);
+		}
+		layer->free();
+	}
+
+	composition_layer_owner.free(p_layer);
+}
+
+void OpenXRCompositionLayerExtension::_composition_layer_register_rt(RID p_layer) {
+	CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);
+	ERR_FAIL_NULL(layer);
+	registered_composition_layers.push_back(layer);
+}
+
+void OpenXRCompositionLayerExtension::_composition_layer_unregister_rt(RID p_layer) {
+	CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);
+	ERR_FAIL_NULL(layer);
+	registered_composition_layers.erase(layer);
 }
 
 bool OpenXRCompositionLayerExtension::is_available(XrStructureType p_which) {
@@ -156,61 +210,17 @@ bool OpenXRCompositionLayerExtension::create_android_surface_swapchain(XrSwapcha
 
 	return false;
 }
-
-void OpenXRCompositionLayerExtension::free_android_surface_swapchain(XrSwapchain p_swapchain) {
-	android_surface_swapchain_free_queue.push_back(p_swapchain);
-}
-
-void OpenXRCompositionLayerExtension::free_queued_android_surface_swapchains() {
-	for (XrSwapchain swapchain : android_surface_swapchain_free_queue) {
-		xrDestroySwapchain(swapchain);
-	}
-	android_surface_swapchain_free_queue.clear();
-}
 #endif
 
 ////////////////////////////////////////////////////////////////////////////
-// OpenXRViewportCompositionLayerProvider
+// OpenXRCompositionLayerExtension::CompositionLayer
 
-OpenXRViewportCompositionLayerProvider::OpenXRViewportCompositionLayerProvider(XrCompositionLayerBaseHeader *p_composition_layer) {
-	composition_layer = p_composition_layer;
-	openxr_api = OpenXRAPI::get_singleton();
-	composition_layer_extension = OpenXRCompositionLayerExtension::get_singleton();
-}
-
-OpenXRViewportCompositionLayerProvider::~OpenXRViewportCompositionLayerProvider() {
-	for (OpenXRExtensionWrapper *extension : OpenXRAPI::get_registered_extension_wrappers()) {
-		extension->on_viewport_composition_layer_destroyed(composition_layer);
-	}
-
-	if (use_android_surface) {
-		free_swapchain();
-	} else {
-		// This will reset the viewport and free the swapchain too.
-		set_viewport(RID(), Size2i());
-	}
-}
-
-void OpenXRViewportCompositionLayerProvider::set_alpha_blend(bool p_alpha_blend) {
-	if (alpha_blend != p_alpha_blend) {
-		alpha_blend = p_alpha_blend;
-		if (alpha_blend) {
-			composition_layer->layerFlags |= XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-		} else {
-			composition_layer->layerFlags &= ~XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
-		}
-	}
-}
-
-void OpenXRViewportCompositionLayerProvider::set_viewport(RID p_viewport, Size2i p_size) {
+void OpenXRCompositionLayerExtension::CompositionLayer::set_viewport(RID p_viewport, const Size2i &p_size) {
 	ERR_FAIL_COND(use_android_surface);
-
-	RenderingServer *rs = RenderingServer::get_singleton();
-	ERR_FAIL_NULL(rs);
 
 	if (subviewport.viewport != p_viewport) {
 		if (subviewport.viewport.is_valid()) {
-			RID rt = rs->viewport_get_render_target(subviewport.viewport);
+			RID rt = RenderingServer::get_singleton()->viewport_get_render_target(subviewport.viewport);
 			RSG::texture_storage->render_target_set_override(rt, RID(), RID(), RID(), RID());
 		}
 
@@ -225,7 +235,7 @@ void OpenXRViewportCompositionLayerProvider::set_viewport(RID p_viewport, Size2i
 	}
 }
 
-void OpenXRViewportCompositionLayerProvider::set_use_android_surface(bool p_use_android_surface, Size2i p_size) {
+void OpenXRCompositionLayerExtension::CompositionLayer::set_use_android_surface(bool p_use_android_surface, const Size2i &p_size) {
 #ifdef ANDROID_ENABLED
 	if (p_use_android_surface == use_android_surface) {
 		if (use_android_surface && swapchain_size != p_size) {
@@ -241,7 +251,7 @@ void OpenXRViewportCompositionLayerProvider::set_use_android_surface(bool p_use_
 	use_android_surface = p_use_android_surface;
 
 	if (use_android_surface) {
-		if (!composition_layer_extension->is_android_surface_swapchain_available()) {
+		if (!OpenXRCompositionLayerExtension::get_singleton()->is_android_surface_swapchain_available()) {
 			ERR_PRINT_ONCE("OpenXR: Cannot use Android surface for composition layer because the extension isn't available");
 		}
 
@@ -256,56 +266,147 @@ void OpenXRViewportCompositionLayerProvider::set_use_android_surface(bool p_use_
 #endif
 }
 
-#ifdef ANDROID_ENABLED
-void OpenXRViewportCompositionLayerProvider::create_android_surface() {
-	ERR_FAIL_COND(android_surface.swapchain != XR_NULL_HANDLE || android_surface.surface.is_valid());
-	ERR_FAIL_COND(!openxr_api || !openxr_api->is_running());
-
-	void *next_pointer = nullptr;
-	for (OpenXRExtensionWrapper *wrapper : openxr_api->get_registered_extension_wrappers()) {
-		void *np = wrapper->set_android_surface_swapchain_create_info_and_get_next_pointer(extension_property_values, next_pointer);
-		if (np != nullptr) {
-			next_pointer = np;
+void OpenXRCompositionLayerExtension::CompositionLayer::set_alpha_blend(bool p_alpha_blend) {
+	if (alpha_blend != p_alpha_blend) {
+		alpha_blend = p_alpha_blend;
+		if (alpha_blend) {
+			composition_layer.layerFlags |= XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
+		} else {
+			composition_layer.layerFlags &= ~XR_COMPOSITION_LAYER_BLEND_TEXTURE_SOURCE_ALPHA_BIT;
 		}
 	}
+}
 
-	// Check to see if content should be protected.
-	XrSwapchainCreateFlags create_flags = 0;
+void OpenXRCompositionLayerExtension::CompositionLayer::set_transform(const Transform3D &p_transform) {
+	Transform3D reference_frame = XRServer::get_singleton()->get_reference_frame();
+	Transform3D transform = reference_frame.inverse() * p_transform;
+	Quaternion quat(transform.basis.orthonormalized());
 
-	if (protected_content) {
-		create_flags = XR_SWAPCHAIN_CREATE_PROTECTED_CONTENT_BIT;
-	}
-
-	// The XR_FB_android_surface_swapchain_create extension mandates that format, sampleCount,
-	// faceCount, arraySize, and mipCount must be zero.
-	XrSwapchainCreateInfo info = {
-		XR_TYPE_SWAPCHAIN_CREATE_INFO, // type
-		next_pointer, // next
-		create_flags, // createFlags
-		XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, // usageFlags
-		0, // format
-		0, // sampleCount
-		(uint32_t)swapchain_size.x, // width
-		(uint32_t)swapchain_size.y, // height
-		0, // faceCount
-		0, // arraySize
-		0, // mipCount
+	XrPosef pose = {
+		{ (float)quat.x, (float)quat.y, (float)quat.z, (float)quat.w },
+		{ (float)transform.origin.x, (float)transform.origin.y, (float)transform.origin.z }
 	};
 
-	jobject surface;
-	composition_layer_extension->create_android_surface_swapchain(&info, &android_surface.swapchain, &surface);
-
-	swapchain_state.dirty = true;
-
-	if (surface) {
-		android_surface.surface.instantiate(JavaClassWrapper::get_singleton()->wrap("android.view.Surface"), surface);
+	switch (composition_layer.type) {
+		case XR_TYPE_COMPOSITION_LAYER_QUAD: {
+			composition_layer_quad.pose = pose;
+		} break;
+		case XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR: {
+			composition_layer_cylinder.pose = pose;
+		} break;
+		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
+			composition_layer_equirect.pose = pose;
+		} break;
+		default: {
+			ERR_PRINT(vformat("Cannot set transform on unsupported composition layer type: %s", composition_layer.type));
+		}
 	}
 }
-#endif
 
-Ref<JavaObject> OpenXRViewportCompositionLayerProvider::get_android_surface() {
+void OpenXRCompositionLayerExtension::CompositionLayer::set_extension_property_values(const Dictionary &p_property_values) {
+	extension_property_values = p_property_values;
+	extension_property_values_changed = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_min_filter(Filter p_mode) {
+	swapchain_state.min_filter = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_mag_filter(Filter p_mode) {
+	swapchain_state.mag_filter = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_mipmap_mode(MipmapMode p_mode) {
+	swapchain_state.mipmap_mode = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_horizontal_wrap(Wrap p_mode) {
+	swapchain_state.horizontal_wrap = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_vertical_wrap(Wrap p_mode) {
+	swapchain_state.vertical_wrap = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_red_swizzle(Swizzle p_mode) {
+	swapchain_state.red_swizzle = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_green_swizzle(Swizzle p_mode) {
+	swapchain_state.green_swizzle = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_blue_swizzle(Swizzle p_mode) {
+	swapchain_state.blue_swizzle = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_alpha_swizzle(Swizzle p_mode) {
+	swapchain_state.alpha_swizzle = p_mode;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_max_anisotropy(float p_value) {
+	swapchain_state.max_anisotropy = p_value;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_border_color(const Color &p_color) {
+	swapchain_state.border_color = p_color;
+	swapchain_state_is_dirty = true;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_quad_size(const Size2 &p_size) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_QUAD);
+	composition_layer_quad.size = { (float)p_size.x, (float)p_size.y };
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_cylinder_radius(float p_radius) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR);
+	composition_layer_cylinder.radius = p_radius;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_cylinder_aspect_ratio(float p_aspect_ratio) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR);
+	composition_layer_cylinder.aspectRatio = p_aspect_ratio;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_cylinder_central_angle(float p_central_angle) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR);
+	composition_layer_cylinder.centralAngle = p_central_angle;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_equirect_radius(float p_radius) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR);
+	composition_layer_equirect.radius = p_radius;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_equirect_central_horizontal_angle(float p_angle) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR);
+	composition_layer_equirect.centralHorizontalAngle = p_angle;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_equirect_upper_vertical_angle(float p_angle) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR);
+	composition_layer_equirect.upperVerticalAngle = p_angle;
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::set_equirect_lower_vertical_angle(float p_angle) {
+	ERR_FAIL_COND(composition_layer.type != XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR);
+	composition_layer_equirect.lowerVerticalAngle = p_angle;
+}
+
+Ref<JavaObject> OpenXRCompositionLayerExtension::CompositionLayer::get_android_surface() {
 #ifdef ANDROID_ENABLED
 	if (use_android_surface) {
+		MutexLock lock(OpenXRCompositionLayerExtension::get_singleton()->composition_layer_mutex);
 		if (android_surface.surface.is_null()) {
 			create_android_surface();
 		}
@@ -315,14 +416,10 @@ Ref<JavaObject> OpenXRViewportCompositionLayerProvider::get_android_surface() {
 	return Ref<JavaObject>();
 }
 
-void OpenXRViewportCompositionLayerProvider::set_extension_property_values(const Dictionary &p_extension_property_values) {
-	extension_property_values = p_extension_property_values;
-	extension_property_values_changed = true;
-}
-
-void OpenXRViewportCompositionLayerProvider::on_pre_render() {
+void OpenXRCompositionLayerExtension::CompositionLayer::on_pre_render() {
 #ifdef ANDROID_ENABLED
 	if (use_android_surface) {
+		MutexLock lock(OpenXRCompositionLayerExtension::get_singleton()->composition_layer_mutex);
 		if (android_surface.surface.is_null()) {
 			create_android_surface();
 		}
@@ -331,7 +428,7 @@ void OpenXRViewportCompositionLayerProvider::on_pre_render() {
 #endif
 
 	RenderingServer *rs = RenderingServer::get_singleton();
-	ERR_FAIL_NULL(rs);
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 
 	if (subviewport.viewport.is_valid() && openxr_api && openxr_api->is_running()) {
 		RS::ViewportUpdateMode update_mode = rs->viewport_get_update_mode(subviewport.viewport);
@@ -345,19 +442,22 @@ void OpenXRViewportCompositionLayerProvider::on_pre_render() {
 		}
 	}
 
-	if (swapchain_state.dirty) {
+	if (swapchain_state_is_dirty) {
 		update_swapchain_state();
-		swapchain_state.dirty = false;
+		swapchain_state_is_dirty = false;
 	}
 }
 
-XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_composition_layer() {
+XrCompositionLayerBaseHeader *OpenXRCompositionLayerExtension::CompositionLayer::get_composition_layer() {
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	OpenXRCompositionLayerExtension *composition_layer_extension = OpenXRCompositionLayerExtension::get_singleton();
+
 	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
 		// OpenXR not initialized or we're in the editor?
 		return nullptr;
 	}
 
-	if (!composition_layer_extension->is_available(composition_layer->type)) {
+	if (!composition_layer_extension->is_available(composition_layer.type)) {
 		// Selected type is not supported, ignore our layer.
 		return nullptr;
 	}
@@ -375,23 +475,20 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 	}
 
 	// Update the layer struct for the swapchain.
-	switch (composition_layer->type) {
+	switch (composition_layer.type) {
 		case XR_TYPE_COMPOSITION_LAYER_QUAD: {
-			XrCompositionLayerQuad *quad_layer = (XrCompositionLayerQuad *)composition_layer;
-			quad_layer->space = openxr_api->get_play_space();
-			quad_layer->subImage = subimage;
+			composition_layer_quad.space = openxr_api->get_play_space();
+			composition_layer_quad.subImage = subimage;
 		} break;
 
 		case XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR: {
-			XrCompositionLayerCylinderKHR *cylinder_layer = (XrCompositionLayerCylinderKHR *)composition_layer;
-			cylinder_layer->space = openxr_api->get_play_space();
-			cylinder_layer->subImage = subimage;
+			composition_layer_cylinder.space = openxr_api->get_play_space();
+			composition_layer_cylinder.subImage = subimage;
 		} break;
 
 		case XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR: {
-			XrCompositionLayerEquirect2KHR *equirect_layer = (XrCompositionLayerEquirect2KHR *)composition_layer;
-			equirect_layer->space = openxr_api->get_play_space();
-			equirect_layer->subImage = subimage;
+			composition_layer_equirect.space = openxr_api->get_play_space();
+			composition_layer_equirect.subImage = subimage;
 		} break;
 
 		default: {
@@ -404,18 +501,27 @@ XrCompositionLayerBaseHeader *OpenXRViewportCompositionLayerProvider::get_compos
 
 		void *next_pointer = nullptr;
 		for (OpenXRExtensionWrapper *extension : OpenXRAPI::get_registered_extension_wrappers()) {
-			void *np = extension->set_viewport_composition_layer_and_get_next_pointer(composition_layer, extension_property_values, next_pointer);
+			void *np = extension->set_viewport_composition_layer_and_get_next_pointer(&composition_layer, extension_property_values, next_pointer);
 			if (np) {
 				next_pointer = np;
 			}
 		}
-		composition_layer->next = next_pointer;
+		composition_layer.next = next_pointer;
 	}
 
-	return composition_layer;
+	return &composition_layer;
 }
 
-void OpenXRViewportCompositionLayerProvider::update_swapchain_state() {
+void OpenXRCompositionLayerExtension::CompositionLayer::free() {
+	if (use_android_surface) {
+		free_swapchain();
+	} else {
+		// This will reset the viewport and free the swapchain too.
+		set_viewport(RID(), Size2i());
+	}
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::update_swapchain_state() {
 	OpenXRFBUpdateSwapchainExtension *fb_update_swapchain_ext = OpenXRFBUpdateSwapchainExtension::get_singleton();
 	if (!fb_update_swapchain_ext) {
 		return;
@@ -439,11 +545,7 @@ void OpenXRViewportCompositionLayerProvider::update_swapchain_state() {
 	}
 }
 
-OpenXRViewportCompositionLayerProvider::SwapchainState *OpenXRViewportCompositionLayerProvider::get_swapchain_state() {
-	return &swapchain_state;
-}
-
-void OpenXRViewportCompositionLayerProvider::update_swapchain_sub_image(XrSwapchainSubImage &r_subimage) {
+void OpenXRCompositionLayerExtension::CompositionLayer::update_swapchain_sub_image(XrSwapchainSubImage &r_subimage) {
 #ifdef ANDROID_ENABLED
 	if (use_android_surface) {
 		r_subimage.swapchain = android_surface.swapchain;
@@ -463,14 +565,17 @@ void OpenXRViewportCompositionLayerProvider::update_swapchain_sub_image(XrSwapch
 	r_subimage.imageRect.extent.height = swapchain_size.height;
 }
 
-bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p_static_image) {
+bool OpenXRCompositionLayerExtension::CompositionLayer::update_and_acquire_swapchain(bool p_static_image) {
 	ERR_FAIL_COND_V(use_android_surface, false);
+
+	OpenXRCompositionLayerExtension *composition_layer_extension = OpenXRCompositionLayerExtension::get_singleton();
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
 
 	if (openxr_api == nullptr || composition_layer_extension == nullptr) {
 		// OpenXR not initialized or we're in the editor?
 		return false;
 	}
-	if (!composition_layer_extension->is_available(get_openxr_type())) {
+	if (!composition_layer_extension->is_available(composition_layer.type)) {
 		// Selected type is not supported?
 		return false;
 	}
@@ -504,7 +609,7 @@ bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p
 		return false;
 	}
 
-	swapchain_state.dirty = true;
+	swapchain_state_is_dirty = true;
 
 	// Acquire our image so we can start rendering into it,
 	// we can ignore should_render here, ret will be false.
@@ -517,12 +622,21 @@ bool OpenXRViewportCompositionLayerProvider::update_and_acquire_swapchain(bool p
 	return ret;
 }
 
-void OpenXRViewportCompositionLayerProvider::free_swapchain() {
+RID OpenXRCompositionLayerExtension::CompositionLayer::get_current_swapchain_texture() {
+	ERR_FAIL_COND_V(use_android_surface, RID());
+
+	if (OpenXRAPI::get_singleton() == nullptr) {
+		return RID();
+	}
+
+	return subviewport.swapchain_info.get_image();
+}
+
+void OpenXRCompositionLayerExtension::CompositionLayer::free_swapchain() {
 #ifdef ANDROID_ENABLED
 	if (use_android_surface) {
 		if (android_surface.swapchain != XR_NULL_HANDLE) {
-			composition_layer_extension->free_android_surface_swapchain(android_surface.swapchain);
-
+			OpenXRCompositionLayerExtension::get_singleton()->xrDestroySwapchain(android_surface.swapchain);
 			android_surface.swapchain = XR_NULL_HANDLE;
 			android_surface.surface.unref();
 		}
@@ -538,12 +652,48 @@ void OpenXRViewportCompositionLayerProvider::free_swapchain() {
 	swapchain_size = Size2i();
 }
 
-RID OpenXRViewportCompositionLayerProvider::get_current_swapchain_texture() {
-	ERR_FAIL_COND_V(use_android_surface, RID());
+#ifdef ANDROID_ENABLED
+void OpenXRCompositionLayerExtension::CompositionLayer::create_android_surface() {
+	ERR_FAIL_COND(android_surface.swapchain != XR_NULL_HANDLE || android_surface.surface.is_valid());
 
-	if (openxr_api == nullptr) {
-		return RID();
+	void *next_pointer = nullptr;
+	for (OpenXRExtensionWrapper *wrapper : OpenXRAPI::get_registered_extension_wrappers()) {
+		void *np = wrapper->set_android_surface_swapchain_create_info_and_get_next_pointer(extension_property_values, next_pointer);
+		if (np != nullptr) {
+			next_pointer = np;
+		}
 	}
 
-	return subviewport.swapchain_info.get_image();
+	// Check to see if content should be protected.
+	XrSwapchainCreateFlags create_flags = 0;
+
+	if (protected_content) {
+		create_flags = XR_SWAPCHAIN_CREATE_PROTECTED_CONTENT_BIT;
+	}
+
+	// The XR_FB_android_surface_swapchain_create extension mandates that format, sampleCount,
+	// faceCount, arraySize, and mipCount must be zero.
+	XrSwapchainCreateInfo info = {
+		XR_TYPE_SWAPCHAIN_CREATE_INFO, // type
+		next_pointer, // next
+		create_flags, // createFlags
+		XR_SWAPCHAIN_USAGE_SAMPLED_BIT | XR_SWAPCHAIN_USAGE_COLOR_ATTACHMENT_BIT | XR_SWAPCHAIN_USAGE_MUTABLE_FORMAT_BIT, // usageFlags
+		0, // format
+		0, // sampleCount
+		(uint32_t)swapchain_size.x, // width
+		(uint32_t)swapchain_size.y, // height
+		0, // faceCount
+		0, // arraySize
+		0, // mipCount
+	};
+
+	jobject surface;
+	OpenXRCompositionLayerExtension::get_singleton()->create_android_surface_swapchain(&info, &android_surface.swapchain, &surface);
+
+	swapchain_state_is_dirty = true;
+
+	if (surface) {
+		android_surface.surface.instantiate(JavaClassWrapper::get_singleton()->wrap("android.view.Surface"), surface);
+	}
 }
+#endif

--- a/modules/openxr/extensions/openxr_composition_layer_extension.h
+++ b/modules/openxr/extensions/openxr_composition_layer_extension.h
@@ -43,9 +43,28 @@ typedef XrResult(XRAPI_PTR *PFN_xrCreateSwapchainAndroidSurfaceKHR)(XrSession se
 #endif
 
 class JavaObject;
-class OpenXRViewportCompositionLayerProvider;
 
 // This extension provides access to composition layers for displaying 2D content through the XR compositor.
+
+#define OPENXR_LAYER_FUNC1(m_name, m_arg1)                                                                                                                                \
+	void _composition_layer_##m_name##_rt(RID p_layer, m_arg1 p1) {                                                                                                       \
+		CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);                                                                                           \
+		ERR_FAIL_NULL(layer);                                                                                                                                             \
+		layer->m_name(p1);                                                                                                                                                \
+	}                                                                                                                                                                     \
+	void composition_layer_##m_name(RID p_layer, m_arg1 p1) {                                                                                                             \
+		RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_##m_name##_rt).bind(p_layer, p1)); \
+	}
+
+#define OPENXR_LAYER_FUNC2(m_name, m_arg1, m_arg2)                                                                                                                            \
+	void _composition_layer_##m_name##_rt(RID p_layer, m_arg1 p1, m_arg2 p2) {                                                                                                \
+		CompositionLayer *layer = composition_layer_owner.get_or_null(p_layer);                                                                                               \
+		ERR_FAIL_NULL(layer);                                                                                                                                                 \
+		layer->m_name(p1, p2);                                                                                                                                                \
+	}                                                                                                                                                                         \
+	void composition_layer_##m_name(RID p_layer, m_arg1 p1, m_arg2 p2) {                                                                                                      \
+		RenderingServer::get_singleton()->call_on_render_thread(callable_mp(this, &OpenXRCompositionLayerExtension::_composition_layer_##m_name##_rt).bind(p_layer, p1, p2)); \
+	}
 
 // OpenXRCompositionLayerExtension enables the extensions related to this functionality
 class OpenXRCompositionLayerExtension : public OpenXRExtensionWrapper {
@@ -54,52 +73,6 @@ class OpenXRCompositionLayerExtension : public OpenXRExtensionWrapper {
 protected:
 	static void _bind_methods() {}
 
-public:
-	static OpenXRCompositionLayerExtension *get_singleton();
-
-	OpenXRCompositionLayerExtension();
-	virtual ~OpenXRCompositionLayerExtension() override;
-
-	virtual HashMap<String, bool *> get_requested_extensions() override;
-	virtual void on_instance_created(const XrInstance p_instance) override;
-	virtual void on_session_created(const XrSession p_session) override;
-	virtual void on_session_destroyed() override;
-	virtual void on_pre_render() override;
-
-	virtual int get_composition_layer_count() override;
-	virtual XrCompositionLayerBaseHeader *get_composition_layer(int p_index) override;
-	virtual int get_composition_layer_order(int p_index) override;
-
-	void register_viewport_composition_layer_provider(OpenXRViewportCompositionLayerProvider *p_composition_layer);
-	void unregister_viewport_composition_layer_provider(OpenXRViewportCompositionLayerProvider *p_composition_layer);
-
-	bool is_available(XrStructureType p_which);
-	bool is_android_surface_swapchain_available() { return android_surface_ext_available; }
-
-#ifdef ANDROID_ENABLED
-	bool create_android_surface_swapchain(XrSwapchainCreateInfo *p_info, XrSwapchain *r_swapchain, jobject *r_surface);
-	void free_android_surface_swapchain(XrSwapchain p_swapchain);
-#endif
-
-private:
-	static OpenXRCompositionLayerExtension *singleton;
-
-	Vector<OpenXRViewportCompositionLayerProvider *> composition_layers;
-
-	bool cylinder_ext_available = false;
-	bool equirect_ext_available = false;
-	bool android_surface_ext_available = false;
-
-#ifdef ANDROID_ENABLED
-	Vector<XrSwapchain> android_surface_swapchain_free_queue;
-	void free_queued_android_surface_swapchains();
-
-	EXT_PROTO_XRRESULT_FUNC1(xrDestroySwapchain, (XrSwapchain), swapchain)
-	EXT_PROTO_XRRESULT_FUNC4(xrCreateSwapchainAndroidSurfaceKHR, (XrSession), session, (const XrSwapchainCreateInfo *), info, (XrSwapchain *), swapchain, (jobject *), surface)
-#endif
-};
-
-class OpenXRViewportCompositionLayerProvider {
 public:
 	// Must be identical to Filter enum definition in OpenXRCompositionLayer.
 	enum Filter {
@@ -146,79 +119,177 @@ public:
 		Swizzle alpha_swizzle = Swizzle::SWIZZLE_ALPHA;
 		float max_anisotropy = 1.0;
 		Color border_color = { 0.0, 0.0, 0.0, 0.0 };
-		bool dirty = false;
 	};
 
+	static OpenXRCompositionLayerExtension *get_singleton();
+
+	OpenXRCompositionLayerExtension();
+	virtual ~OpenXRCompositionLayerExtension() override;
+
+	virtual HashMap<String, bool *> get_requested_extensions() override;
+	virtual void on_instance_created(const XrInstance p_instance) override;
+	virtual void on_session_created(const XrSession p_session) override;
+	virtual void on_session_destroyed() override;
+	virtual void on_pre_render() override;
+
+	virtual int get_composition_layer_count() override;
+	virtual XrCompositionLayerBaseHeader *get_composition_layer(int p_index) override;
+	virtual int get_composition_layer_order(int p_index) override;
+
+	// The data on p_openxr_layer will be copied - there is no need to keep it valid after this call.
+	RID composition_layer_create(XrCompositionLayerBaseHeader *p_openxr_layer);
+	void composition_layer_free(RID p_layer);
+
+	void composition_layer_register(RID p_layer);
+	void composition_layer_unregister(RID p_layer);
+
+	OPENXR_LAYER_FUNC2(set_viewport, RID, const Size2i &);
+	OPENXR_LAYER_FUNC2(set_use_android_surface, bool, const Size2i &);
+	OPENXR_LAYER_FUNC1(set_sort_order, int);
+	OPENXR_LAYER_FUNC1(set_alpha_blend, bool);
+	OPENXR_LAYER_FUNC1(set_transform, const Transform3D &);
+	OPENXR_LAYER_FUNC1(set_protected_content, bool);
+	OPENXR_LAYER_FUNC1(set_extension_property_values, Dictionary);
+
+	OPENXR_LAYER_FUNC1(set_min_filter, Filter);
+	OPENXR_LAYER_FUNC1(set_mag_filter, Filter);
+	OPENXR_LAYER_FUNC1(set_mipmap_mode, MipmapMode);
+	OPENXR_LAYER_FUNC1(set_horizontal_wrap, Wrap);
+	OPENXR_LAYER_FUNC1(set_vertical_wrap, Wrap);
+	OPENXR_LAYER_FUNC1(set_red_swizzle, Swizzle);
+	OPENXR_LAYER_FUNC1(set_blue_swizzle, Swizzle);
+	OPENXR_LAYER_FUNC1(set_green_swizzle, Swizzle);
+	OPENXR_LAYER_FUNC1(set_alpha_swizzle, Swizzle);
+	OPENXR_LAYER_FUNC1(set_max_anisotropy, float);
+	OPENXR_LAYER_FUNC1(set_border_color, const Color &);
+
+	OPENXR_LAYER_FUNC1(set_quad_size, const Size2 &);
+
+	OPENXR_LAYER_FUNC1(set_cylinder_radius, float);
+	OPENXR_LAYER_FUNC1(set_cylinder_aspect_ratio, float);
+	OPENXR_LAYER_FUNC1(set_cylinder_central_angle, float);
+
+	OPENXR_LAYER_FUNC1(set_equirect_radius, float);
+	OPENXR_LAYER_FUNC1(set_equirect_central_horizontal_angle, float);
+	OPENXR_LAYER_FUNC1(set_equirect_upper_vertical_angle, float);
+	OPENXR_LAYER_FUNC1(set_equirect_lower_vertical_angle, float);
+
+	Ref<JavaObject> composition_layer_get_android_surface(RID p_layer);
+
+	bool is_available(XrStructureType p_which);
+	bool is_android_surface_swapchain_available() { return android_surface_ext_available; }
+
 private:
-	XrCompositionLayerBaseHeader *composition_layer = nullptr;
-	int sort_order = 1;
-	bool alpha_blend = false;
-	Dictionary extension_property_values;
-	bool extension_property_values_changed = true;
+	static OpenXRCompositionLayerExtension *singleton;
 
-	struct {
-		RID viewport;
-		Size2i viewport_size;
-		OpenXRAPI::OpenXRSwapChainInfo swapchain_info;
-		bool static_image = false;
-		bool swapchain_protected_content = false;
-	} subviewport;
+	bool cylinder_ext_available = false;
+	bool equirect_ext_available = false;
+	bool android_surface_ext_available = false;
+
+	void _composition_layer_free_rt(RID p_layer);
+	void _composition_layer_register_rt(RID p_layer);
+	void _composition_layer_unregister_rt(RID p_layer);
 
 #ifdef ANDROID_ENABLED
-	struct {
-		XrSwapchain swapchain = XR_NULL_HANDLE;
-		Ref<JavaObject> surface;
-	} android_surface;
+	bool create_android_surface_swapchain(XrSwapchainCreateInfo *p_info, XrSwapchain *r_swapchain, jobject *r_surface);
+
+	EXT_PROTO_XRRESULT_FUNC1(xrDestroySwapchain, (XrSwapchain), swapchain)
+	EXT_PROTO_XRRESULT_FUNC4(xrCreateSwapchainAndroidSurfaceKHR, (XrSession), session, (const XrSwapchainCreateInfo *), info, (XrSwapchain *), swapchain, (jobject *), surface)
 #endif
 
-	bool use_android_surface = false;
-	bool protected_content = false;
-	Size2i swapchain_size;
+	struct CompositionLayer {
+		union {
+			XrCompositionLayerBaseHeader composition_layer;
+			XrCompositionLayerQuad composition_layer_quad;
+			XrCompositionLayerCylinderKHR composition_layer_cylinder;
+			XrCompositionLayerEquirect2KHR composition_layer_equirect;
+		};
 
-	OpenXRAPI *openxr_api = nullptr;
-	OpenXRCompositionLayerExtension *composition_layer_extension = nullptr;
+		int sort_order = 1;
+		bool alpha_blend = false;
+		Dictionary extension_property_values;
+		bool extension_property_values_changed = true;
 
-	// Only for SubViewports.
-	bool update_and_acquire_swapchain(bool p_static_image);
-	RID get_current_swapchain_texture();
-
-	void update_swapchain_sub_image(XrSwapchainSubImage &r_swapchain_sub_image);
-	void free_swapchain();
-
-	SwapchainState swapchain_state;
+		struct {
+			RID viewport;
+			Size2i viewport_size;
+			OpenXRAPI::OpenXRSwapChainInfo swapchain_info;
+			bool static_image = false;
+			bool swapchain_protected_content = false;
+		} subviewport;
 
 #ifdef ANDROID_ENABLED
-	void create_android_surface();
+		struct {
+			XrSwapchain swapchain = XR_NULL_HANDLE;
+			Ref<JavaObject> surface;
+		} android_surface;
 #endif
 
-public:
-	XrStructureType get_openxr_type() { return composition_layer->type; }
+		bool use_android_surface = false;
+		bool protected_content = false;
+		Size2i swapchain_size;
 
-	void set_sort_order(int p_sort_order) { sort_order = p_sort_order; }
-	int get_sort_order() const { return sort_order; }
+		SwapchainState swapchain_state;
+		bool swapchain_state_is_dirty = false;
 
-	void set_alpha_blend(bool p_alpha_blend);
-	bool get_alpha_blend() const { return alpha_blend; }
+		void set_viewport(RID p_viewport, const Size2i &p_size);
+		void set_use_android_surface(bool p_use_android_surface, const Size2i &p_size);
 
-	void set_viewport(RID p_viewport, Size2i p_size);
-	RID get_viewport() const { return subviewport.viewport; }
+		void set_sort_order(int p_sort_order) { sort_order = p_sort_order; }
+		void set_alpha_blend(bool p_alpha_blend);
+		void set_protected_content(bool p_protected_content) { protected_content = p_protected_content; }
+		void set_transform(const Transform3D &p_transform);
+		void set_extension_property_values(const Dictionary &p_extension_property_values);
 
-	void set_use_android_surface(bool p_enable, Size2i p_size);
-	bool get_use_android_surface() const { return use_android_surface; }
+		void set_min_filter(Filter p_mode);
+		void set_mag_filter(Filter p_mode);
+		void set_mipmap_mode(MipmapMode p_mode);
+		void set_horizontal_wrap(Wrap p_mode);
+		void set_vertical_wrap(Wrap p_mode);
+		void set_red_swizzle(Swizzle p_mode);
+		void set_green_swizzle(Swizzle p_mode);
+		void set_blue_swizzle(Swizzle p_mode);
+		void set_alpha_swizzle(Swizzle p_mode);
+		void set_max_anisotropy(float p_value);
+		void set_border_color(const Color &p_color);
 
-	void set_protected_content(bool p_protected_content) { protected_content = p_protected_content; }
-	bool is_protected_content() const { return protected_content; }
+		void set_quad_size(const Size2 &p_size);
 
-	Ref<JavaObject> get_android_surface();
+		void set_cylinder_radius(float p_radius);
+		void set_cylinder_aspect_ratio(float p_aspect_ratio);
+		void set_cylinder_central_angle(float p_central_angle);
 
-	void set_extension_property_values(const Dictionary &p_property_values);
+		void set_equirect_radius(float p_radius);
+		void set_equirect_central_horizontal_angle(float p_angle);
+		void set_equirect_upper_vertical_angle(float p_angle);
+		void set_equirect_lower_vertical_angle(float p_angle);
 
-	void on_pre_render();
-	XrCompositionLayerBaseHeader *get_composition_layer();
+		Ref<JavaObject> get_android_surface();
+		void on_pre_render();
+		XrCompositionLayerBaseHeader *get_composition_layer();
+		void free();
 
-	void update_swapchain_state();
-	SwapchainState *get_swapchain_state();
+	private:
+		void update_swapchain_state();
+		void update_swapchain_sub_image(XrSwapchainSubImage &r_subimage);
+		bool update_and_acquire_swapchain(bool p_static_image);
+		RID get_current_swapchain_texture();
+		void free_swapchain();
 
-	OpenXRViewportCompositionLayerProvider(XrCompositionLayerBaseHeader *p_composition_layer);
-	~OpenXRViewportCompositionLayerProvider();
+#ifdef ANDROID_ENABLED
+		void create_android_surface();
+#endif
+	};
+
+	Mutex composition_layer_mutex;
+	RID_Owner<CompositionLayer, true> composition_layer_owner;
+	LocalVector<CompositionLayer *> registered_composition_layers;
 };
+
+VARIANT_ENUM_CAST(OpenXRCompositionLayerExtension::Filter);
+VARIANT_ENUM_CAST(OpenXRCompositionLayerExtension::MipmapMode);
+VARIANT_ENUM_CAST(OpenXRCompositionLayerExtension::Wrap);
+VARIANT_ENUM_CAST(OpenXRCompositionLayerExtension::Swizzle);
+
+#undef OPENXR_LAYER_FUNC1
+#undef OPENXR_LAYER_FUNC2

--- a/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
+++ b/modules/openxr/extensions/openxr_fb_update_swapchain_extension.cpp
@@ -122,7 +122,7 @@ bool OpenXRFBUpdateSwapchainExtension::is_android_ext_enabled() const {
 	return fb_swapchain_update_state_android_ext;
 }
 
-void OpenXRFBUpdateSwapchainExtension::update_swapchain_state(XrSwapchain p_swapchain, const OpenXRViewportCompositionLayerProvider::SwapchainState *p_swapchain_state) {
+void OpenXRFBUpdateSwapchainExtension::update_swapchain_state(XrSwapchain p_swapchain, const OpenXRCompositionLayerExtension::SwapchainState *p_swapchain_state) {
 	if (!p_swapchain_state) {
 		return;
 	}
@@ -207,34 +207,34 @@ void OpenXRFBUpdateSwapchainExtension::update_swapchain_surface_size(XrSwapchain
 #endif
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::filter_to_gl(OpenXRViewportCompositionLayerProvider::Filter p_filter, OpenXRViewportCompositionLayerProvider::MipmapMode p_mipmap_mode) {
+uint32_t OpenXRFBUpdateSwapchainExtension::filter_to_gl(OpenXRCompositionLayerExtension::Filter p_filter, OpenXRCompositionLayerExtension::MipmapMode p_mipmap_mode) {
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	switch (p_mipmap_mode) {
-		case OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_DISABLED:
+		case OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_DISABLED:
 			switch (p_filter) {
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_NEAREST:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_NEAREST:
 					return GL_NEAREST;
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_LINEAR:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_LINEAR:
 					return GL_LINEAR;
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_CUBIC:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_CUBIC:
 					return GL_CUBIC_IMG;
 			}
-		case OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_NEAREST:
+		case OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_NEAREST:
 			switch (p_filter) {
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_NEAREST:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_NEAREST:
 					return GL_NEAREST_MIPMAP_NEAREST;
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_LINEAR:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_LINEAR:
 					return GL_LINEAR_MIPMAP_NEAREST;
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_CUBIC:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_CUBIC:
 					return GL_CUBIC_MIPMAP_NEAREST_IMG;
 			}
-		case OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_LINEAR:
+		case OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_LINEAR:
 			switch (p_filter) {
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_NEAREST:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_NEAREST:
 					return GL_NEAREST_MIPMAP_LINEAR;
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_LINEAR:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_LINEAR:
 					return GL_LINEAR_MIPMAP_LINEAR;
-				case OpenXRViewportCompositionLayerProvider::Filter::FILTER_CUBIC:
+				case OpenXRCompositionLayerExtension::Filter::FILTER_CUBIC:
 					return GL_CUBIC_MIPMAP_LINEAR_IMG;
 			}
 	}
@@ -242,104 +242,104 @@ uint32_t OpenXRFBUpdateSwapchainExtension::filter_to_gl(OpenXRViewportCompositio
 	return 0;
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::wrap_to_gl(OpenXRViewportCompositionLayerProvider::Wrap p_wrap) {
+uint32_t OpenXRFBUpdateSwapchainExtension::wrap_to_gl(OpenXRCompositionLayerExtension::Wrap p_wrap) {
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	switch (p_wrap) {
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_CLAMP_TO_BORDER:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_CLAMP_TO_BORDER:
 			return GL_CLAMP_TO_BORDER;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_CLAMP_TO_EDGE:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_CLAMP_TO_EDGE:
 			return GL_CLAMP_TO_EDGE;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_REPEAT:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_REPEAT:
 			return GL_REPEAT;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_MIRRORED_REPEAT:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_MIRRORED_REPEAT:
 			return GL_MIRRORED_REPEAT;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_MIRROR_CLAMP_TO_EDGE:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_MIRROR_CLAMP_TO_EDGE:
 			return GL_CLAMP_TO_EDGE;
 	}
 #endif
 	return 0;
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::swizzle_to_gl(OpenXRViewportCompositionLayerProvider::Swizzle p_swizzle) {
+uint32_t OpenXRFBUpdateSwapchainExtension::swizzle_to_gl(OpenXRCompositionLayerExtension::Swizzle p_swizzle) {
 #ifdef XR_USE_GRAPHICS_API_OPENGL_ES
 	switch (p_swizzle) {
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_RED:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_RED:
 			return GL_RED;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_GREEN:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_GREEN:
 			return GL_GREEN;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_BLUE:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_BLUE:
 			return GL_BLUE;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_ALPHA:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_ALPHA:
 			return GL_ALPHA;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_ZERO:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_ZERO:
 			return GL_ZERO;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_ONE:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_ONE:
 			return GL_ONE;
 	}
 #endif
 	return 0;
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::filter_to_vk(OpenXRViewportCompositionLayerProvider::Filter p_filter) {
+uint32_t OpenXRFBUpdateSwapchainExtension::filter_to_vk(OpenXRCompositionLayerExtension::Filter p_filter) {
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 	switch (p_filter) {
-		case OpenXRViewportCompositionLayerProvider::Filter::FILTER_NEAREST:
+		case OpenXRCompositionLayerExtension::Filter::FILTER_NEAREST:
 			return VK_FILTER_NEAREST;
-		case OpenXRViewportCompositionLayerProvider::Filter::FILTER_LINEAR:
+		case OpenXRCompositionLayerExtension::Filter::FILTER_LINEAR:
 			return VK_FILTER_LINEAR;
-		case OpenXRViewportCompositionLayerProvider::Filter::FILTER_CUBIC:
+		case OpenXRCompositionLayerExtension::Filter::FILTER_CUBIC:
 			return VK_FILTER_CUBIC_EXT;
 	}
 #endif
 	return 0;
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::mipmap_mode_to_vk(OpenXRViewportCompositionLayerProvider::MipmapMode p_mipmap_mode) {
+uint32_t OpenXRFBUpdateSwapchainExtension::mipmap_mode_to_vk(OpenXRCompositionLayerExtension::MipmapMode p_mipmap_mode) {
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 	switch (p_mipmap_mode) {
-		case OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_DISABLED:
+		case OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_DISABLED:
 			return VK_SAMPLER_MIPMAP_MODE_LINEAR;
-		case OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_NEAREST:
+		case OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_NEAREST:
 			return VK_SAMPLER_MIPMAP_MODE_NEAREST;
-		case OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_LINEAR:
+		case OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_LINEAR:
 			return VK_SAMPLER_MIPMAP_MODE_LINEAR;
 	}
 #endif
 	return 0;
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::wrap_to_vk(OpenXRViewportCompositionLayerProvider::Wrap p_wrap) {
+uint32_t OpenXRFBUpdateSwapchainExtension::wrap_to_vk(OpenXRCompositionLayerExtension::Wrap p_wrap) {
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 	switch (p_wrap) {
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_CLAMP_TO_BORDER:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_CLAMP_TO_BORDER:
 			return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_CLAMP_TO_EDGE:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_CLAMP_TO_EDGE:
 			return VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_REPEAT:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_REPEAT:
 			return VK_SAMPLER_ADDRESS_MODE_REPEAT;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_MIRRORED_REPEAT:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_MIRRORED_REPEAT:
 			return VK_SAMPLER_ADDRESS_MODE_MIRRORED_REPEAT;
-		case OpenXRViewportCompositionLayerProvider::Wrap::WRAP_MIRROR_CLAMP_TO_EDGE:
+		case OpenXRCompositionLayerExtension::Wrap::WRAP_MIRROR_CLAMP_TO_EDGE:
 			return VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE;
 	}
 #endif
 	return 0;
 }
 
-uint32_t OpenXRFBUpdateSwapchainExtension::swizzle_to_vk(OpenXRViewportCompositionLayerProvider::Swizzle p_swizzle) {
+uint32_t OpenXRFBUpdateSwapchainExtension::swizzle_to_vk(OpenXRCompositionLayerExtension::Swizzle p_swizzle) {
 #ifdef XR_USE_GRAPHICS_API_VULKAN
 	switch (p_swizzle) {
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_RED:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_RED:
 			return VK_COMPONENT_SWIZZLE_R;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_GREEN:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_GREEN:
 			return VK_COMPONENT_SWIZZLE_G;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_BLUE:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_BLUE:
 			return VK_COMPONENT_SWIZZLE_B;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_ALPHA:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_ALPHA:
 			return VK_COMPONENT_SWIZZLE_A;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_ZERO:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_ZERO:
 			return VK_COMPONENT_SWIZZLE_ZERO;
-		case OpenXRViewportCompositionLayerProvider::Swizzle::SWIZZLE_ONE:
+		case OpenXRCompositionLayerExtension::Swizzle::SWIZZLE_ONE:
 			return VK_COMPONENT_SWIZZLE_ONE;
 	}
 #endif

--- a/modules/openxr/extensions/openxr_fb_update_swapchain_extension.h
+++ b/modules/openxr/extensions/openxr_fb_update_swapchain_extension.h
@@ -62,7 +62,7 @@ public:
 	bool is_enabled() const;
 	bool is_android_ext_enabled() const;
 
-	void update_swapchain_state(XrSwapchain p_swapchain, const OpenXRViewportCompositionLayerProvider::SwapchainState *p_swapchain_state);
+	void update_swapchain_state(XrSwapchain p_swapchain, const OpenXRCompositionLayerExtension::SwapchainState *p_swapchain_state);
 
 	void update_swapchain_surface_size(XrSwapchain p_swapchain, const Size2i &p_size);
 
@@ -76,14 +76,14 @@ private:
 	bool fb_swapchain_update_state_opengles_ext = false;
 	bool fb_swapchain_update_state_android_ext = false;
 
-	uint32_t filter_to_gl(OpenXRViewportCompositionLayerProvider::Filter p_filter, OpenXRViewportCompositionLayerProvider::MipmapMode p_mipmap_mode = OpenXRViewportCompositionLayerProvider::MipmapMode::MIPMAP_MODE_DISABLED);
-	uint32_t wrap_to_gl(OpenXRViewportCompositionLayerProvider::Wrap p_wrap);
-	uint32_t swizzle_to_gl(OpenXRViewportCompositionLayerProvider::Swizzle p_swizzle);
+	uint32_t filter_to_gl(OpenXRCompositionLayerExtension::Filter p_filter, OpenXRCompositionLayerExtension::MipmapMode p_mipmap_mode = OpenXRCompositionLayerExtension::MipmapMode::MIPMAP_MODE_DISABLED);
+	uint32_t wrap_to_gl(OpenXRCompositionLayerExtension::Wrap p_wrap);
+	uint32_t swizzle_to_gl(OpenXRCompositionLayerExtension::Swizzle p_swizzle);
 
-	uint32_t filter_to_vk(OpenXRViewportCompositionLayerProvider::Filter p_filter);
-	uint32_t mipmap_mode_to_vk(OpenXRViewportCompositionLayerProvider::MipmapMode p_mipmap);
-	uint32_t wrap_to_vk(OpenXRViewportCompositionLayerProvider::Wrap p_wrap);
-	uint32_t swizzle_to_vk(OpenXRViewportCompositionLayerProvider::Swizzle p_swizzle);
+	uint32_t filter_to_vk(OpenXRCompositionLayerExtension::Filter p_filter);
+	uint32_t mipmap_mode_to_vk(OpenXRCompositionLayerExtension::MipmapMode p_mipmap);
+	uint32_t wrap_to_vk(OpenXRCompositionLayerExtension::Wrap p_wrap);
+	uint32_t swizzle_to_vk(OpenXRCompositionLayerExtension::Swizzle p_swizzle);
 
 	// OpenXR API call wrappers
 	EXT_PROTO_XRRESULT_FUNC2(xrUpdateSwapchainFB, (XrSwapchain), swapchain, (const XrSwapchainStateBaseHeaderFB *), state);

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -93,7 +93,7 @@ bool OpenXRAPI::OpenXRSwapChainInfo::create(XrSwapchainCreateFlags p_create_flag
 	XrResult result;
 
 	void *next_pointer = nullptr;
-	for (OpenXRExtensionWrapper *wrapper : openxr_api->get_registered_extension_wrappers()) {
+	for (OpenXRExtensionWrapper *wrapper : OpenXRAPI::get_registered_extension_wrappers()) {
 		void *np = wrapper->set_swapchain_create_info_and_get_next_pointer(next_pointer);
 		if (np != nullptr) {
 			next_pointer = np;

--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -30,6 +30,7 @@
 
 #include "openxr_composition_layer.h"
 
+#include "../extensions/openxr_composition_layer_extension.h"
 #include "../openxr_api.h"
 #include "../openxr_interface.h"
 
@@ -48,11 +49,7 @@ static const char *HOLE_PUNCH_SHADER_CODE =
 		"\tALBEDO = vec3(0.0, 0.0, 0.0);\n"
 		"}\n";
 
-OpenXRCompositionLayer::OpenXRCompositionLayer(XrCompositionLayerBaseHeader *p_composition_layer) {
-	composition_layer_base_header = p_composition_layer;
-	openxr_layer_provider = memnew(OpenXRViewportCompositionLayerProvider(composition_layer_base_header));
-	swapchain_state = openxr_layer_provider->get_swapchain_state();
-
+OpenXRCompositionLayer::OpenXRCompositionLayer() {
 	openxr_api = OpenXRAPI::get_singleton();
 	composition_layer_extension = OpenXRCompositionLayerExtension::get_singleton();
 
@@ -65,6 +62,8 @@ OpenXRCompositionLayer::OpenXRCompositionLayer(XrCompositionLayerBaseHeader *p_c
 		openxr_interface->connect("session_begun", callable_mp(this, &OpenXRCompositionLayer::_on_openxr_session_begun));
 		openxr_interface->connect("session_stopping", callable_mp(this, &OpenXRCompositionLayer::_on_openxr_session_stopping));
 	}
+
+	XRServer::get_singleton()->connect("reference_frame_changed", callable_mp(this, &OpenXRCompositionLayer::update_transform));
 
 	set_process_internal(true);
 	set_notify_local_transform(true);
@@ -84,10 +83,8 @@ OpenXRCompositionLayer::~OpenXRCompositionLayer() {
 
 	composition_layer_nodes.erase(this);
 
-	if (openxr_layer_provider != nullptr) {
-		_clear_composition_layer_provider();
-		memdelete(openxr_layer_provider);
-		openxr_layer_provider = nullptr;
+	if (composition_layer_extension && composition_layer.is_valid()) {
+		composition_layer_extension->composition_layer_free(composition_layer);
 	}
 }
 
@@ -219,38 +216,38 @@ void OpenXRCompositionLayer::_remove_fallback_node() {
 	fallback = nullptr;
 }
 
-void OpenXRCompositionLayer::_setup_composition_layer_provider() {
+void OpenXRCompositionLayer::_setup_composition_layer() {
 	if (use_android_surface || layer_viewport) {
 		if (composition_layer_extension) {
-			composition_layer_extension->register_viewport_composition_layer_provider(openxr_layer_provider);
+			composition_layer_extension->composition_layer_register(composition_layer);
 			registered = true;
-		}
 
-		// NOTE: We don't setup/clear when using Android surfaces, so we don't destroy the surface unexpectedly.
-		if (layer_viewport) {
-			// Set our properties on the layer provider, which will create all the necessary resources (ex swap chains).
-			openxr_layer_provider->set_viewport(layer_viewport->get_viewport_rid(), layer_viewport->get_size());
+			// NOTE: We don't setup/clear when using Android surfaces, so we don't destroy the surface unexpectedly.
+			if (layer_viewport) {
+				// Set our properties on the layer provider, which will create all the necessary resources (ex swap chains).
+				composition_layer_extension->composition_layer_set_viewport(composition_layer, layer_viewport->get_viewport_rid(), layer_viewport->get_size());
+			}
 		}
 	}
 }
 
-void OpenXRCompositionLayer::_clear_composition_layer_provider() {
+void OpenXRCompositionLayer::_clear_composition_layer() {
 	if (composition_layer_extension) {
-		composition_layer_extension->unregister_viewport_composition_layer_provider(openxr_layer_provider);
+		composition_layer_extension->composition_layer_unregister(composition_layer);
 		registered = false;
-	}
 
-	// NOTE: We don't setup/clear when using Android surfaces, so we don't destroy the surface unexpectedly.
-	if (!use_android_surface) {
-		// This will reset the viewport and free all the resources (ex swap chains) used by the layer.
-		openxr_layer_provider->set_viewport(RID(), Size2i());
+		// NOTE: We don't setup/clear when using Android surfaces, so we don't destroy the surface unexpectedly.
+		if (!use_android_surface) {
+			// This will reset the viewport and free all the resources (ex swap chains) used by the layer.
+			composition_layer_extension->composition_layer_set_viewport(composition_layer, RID(), Size2i());
+		}
 	}
 }
 
 void OpenXRCompositionLayer::_on_openxr_session_begun() {
 	openxr_session_running = true;
 	if (_should_register()) {
-		_setup_composition_layer_provider();
+		_setup_composition_layer();
 	}
 	if (!fallback && _should_use_fallback_node()) {
 		_create_fallback_node();
@@ -262,7 +259,13 @@ void OpenXRCompositionLayer::_on_openxr_session_stopping() {
 	if (fallback && !_should_use_fallback_node()) {
 		_remove_fallback_node();
 	}
-	_clear_composition_layer_provider();
+	_clear_composition_layer();
+}
+
+void OpenXRCompositionLayer::update_transform() {
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_transform(composition_layer, get_transform());
+	}
 }
 
 void OpenXRCompositionLayer::update_fallback_mesh() {
@@ -271,16 +274,6 @@ void OpenXRCompositionLayer::update_fallback_mesh() {
 
 bool OpenXRCompositionLayer::_should_register() {
 	return !registered && openxr_session_running && is_inside_tree() && is_visible() && is_natively_supported();
-}
-
-XrPosef OpenXRCompositionLayer::get_openxr_pose() {
-	Transform3D reference_frame = XRServer::get_singleton()->get_reference_frame();
-	Transform3D transform = reference_frame.inverse() * get_transform();
-	Quaternion quat(transform.basis.orthonormalized());
-	return {
-		{ (float)quat.x, (float)quat.y, (float)quat.z, (float)quat.w },
-		{ (float)transform.origin.x, (float)transform.origin.y, (float)transform.origin.z }
-	};
 }
 
 bool OpenXRCompositionLayer::is_viewport_in_use(SubViewport *p_viewport) {
@@ -307,7 +300,7 @@ void OpenXRCompositionLayer::set_layer_viewport(SubViewport *p_viewport) {
 
 	layer_viewport = p_viewport;
 	if (_should_register()) {
-		_setup_composition_layer_provider();
+		_setup_composition_layer();
 	}
 
 	if (layer_viewport) {
@@ -320,11 +313,11 @@ void OpenXRCompositionLayer::set_layer_viewport(SubViewport *p_viewport) {
 
 	if (fallback) {
 		_reset_fallback_material();
-	} else if (openxr_session_running && is_visible() && is_inside_tree()) {
+	} else if (openxr_session_running && composition_layer_extension && is_visible() && is_inside_tree()) {
 		if (layer_viewport) {
-			openxr_layer_provider->set_viewport(layer_viewport->get_viewport_rid(), layer_viewport->get_size());
+			composition_layer_extension->composition_layer_set_viewport(composition_layer, layer_viewport->get_viewport_rid(), layer_viewport->get_size());
 		} else {
-			openxr_layer_provider->set_viewport(RID(), Size2i());
+			composition_layer_extension->composition_layer_set_viewport(composition_layer, RID(), Size2i());
 		}
 	}
 }
@@ -338,13 +331,17 @@ void OpenXRCompositionLayer::set_use_android_surface(bool p_use_android_surface)
 	if (use_android_surface) {
 		// It's possible that the layer provider is unregistered here (if previously invisible)
 		set_layer_viewport(nullptr);
-		openxr_layer_provider->set_use_android_surface(true, android_surface_size);
+		if (composition_layer_extension) {
+			composition_layer_extension->composition_layer_set_use_android_surface(composition_layer, true, android_surface_size);
+		}
 		// ...and it may not be set up above because of viewport = null, android surface is false, so set it up again:
 		if (_should_register()) {
-			_setup_composition_layer_provider();
+			_setup_composition_layer();
 		}
 	} else {
-		openxr_layer_provider->set_use_android_surface(false, Size2i());
+		if (composition_layer_extension) {
+			composition_layer_extension->composition_layer_set_use_android_surface(composition_layer, false, Size2i());
+		}
 	}
 
 	notify_property_list_changed();
@@ -360,8 +357,8 @@ void OpenXRCompositionLayer::set_android_surface_size(Size2i p_size) {
 	}
 
 	android_surface_size = p_size;
-	if (use_android_surface) {
-		openxr_layer_provider->set_use_android_surface(true, android_surface_size);
+	if (use_android_surface && composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_use_android_surface(composition_layer, true, android_surface_size);
 	}
 }
 
@@ -397,185 +394,211 @@ bool OpenXRCompositionLayer::get_enable_hole_punch() const {
 }
 
 void OpenXRCompositionLayer::set_sort_order(int p_order) {
-	openxr_layer_provider->set_sort_order(p_order);
+	sort_order = p_order;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_sort_order(composition_layer, p_order);
+	}
 	update_configuration_warnings();
 }
 
 int OpenXRCompositionLayer::get_sort_order() const {
-	return openxr_layer_provider->get_sort_order();
+	return sort_order;
 }
 
 void OpenXRCompositionLayer::set_alpha_blend(bool p_alpha_blend) {
-	openxr_layer_provider->set_alpha_blend(p_alpha_blend);
+	alpha_blend = p_alpha_blend;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_alpha_blend(composition_layer, p_alpha_blend);
+	}
 	if (fallback) {
 		_reset_fallback_material();
 	}
 }
 
 bool OpenXRCompositionLayer::get_alpha_blend() const {
-	return openxr_layer_provider->get_alpha_blend();
+	return alpha_blend;
 }
 
 bool OpenXRCompositionLayer::is_natively_supported() const {
 	if (composition_layer_extension && openxr_api) {
-		return composition_layer_extension->is_available(openxr_layer_provider->get_openxr_type());
+		return composition_layer_extension->is_available(_get_openxr_type());
 	}
 	return false;
 }
 
 void OpenXRCompositionLayer::set_protected_content(bool p_protected_content) {
-	openxr_layer_provider->set_protected_content(p_protected_content);
+	if (protected_content == p_protected_content) {
+		return;
+	}
+	protected_content = p_protected_content;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_protected_content(composition_layer, p_protected_content);
+	}
 }
 
 bool OpenXRCompositionLayer::is_protected_content() const {
-	return openxr_layer_provider->is_protected_content();
+	return protected_content;
 }
 
 void OpenXRCompositionLayer::set_min_filter(Filter p_mode) {
-	if (swapchain_state->min_filter == (OpenXRViewportCompositionLayerProvider::Filter)p_mode) {
+	if (min_filter == p_mode) {
 		return;
 	}
-
-	swapchain_state->min_filter = (OpenXRViewportCompositionLayerProvider::Filter)p_mode;
-	swapchain_state->dirty = true;
+	min_filter = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_min_filter(composition_layer, (OpenXRCompositionLayerExtension::Filter)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Filter OpenXRCompositionLayer::get_min_filter() const {
-	return (OpenXRCompositionLayer::Filter)swapchain_state->min_filter;
+	return min_filter;
 }
 
 void OpenXRCompositionLayer::set_mag_filter(Filter p_mode) {
-	if (swapchain_state->mag_filter == (OpenXRViewportCompositionLayerProvider::Filter)p_mode) {
+	if (mag_filter == p_mode) {
 		return;
 	}
-
-	swapchain_state->mag_filter = (OpenXRViewportCompositionLayerProvider::Filter)p_mode;
-	swapchain_state->dirty = true;
+	mag_filter = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_mag_filter(composition_layer, (OpenXRCompositionLayerExtension::Filter)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Filter OpenXRCompositionLayer::get_mag_filter() const {
-	return (OpenXRCompositionLayer::Filter)swapchain_state->mag_filter;
+	return mag_filter;
 }
 
 void OpenXRCompositionLayer::set_mipmap_mode(MipmapMode p_mode) {
-	if (swapchain_state->mipmap_mode == (OpenXRViewportCompositionLayerProvider::MipmapMode)p_mode) {
+	if (mipmap_mode == p_mode) {
 		return;
 	}
-
-	swapchain_state->mipmap_mode = (OpenXRViewportCompositionLayerProvider::MipmapMode)p_mode;
-	swapchain_state->dirty = true;
+	mipmap_mode = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_mipmap_mode(composition_layer, (OpenXRCompositionLayerExtension::MipmapMode)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::MipmapMode OpenXRCompositionLayer::get_mipmap_mode() const {
-	return (OpenXRCompositionLayer::MipmapMode)swapchain_state->mipmap_mode;
+	return mipmap_mode;
 }
 
 void OpenXRCompositionLayer::set_horizontal_wrap(Wrap p_mode) {
-	if (swapchain_state->horizontal_wrap == (OpenXRViewportCompositionLayerProvider::Wrap)p_mode) {
+	if (horizontal_wrap == p_mode) {
 		return;
 	}
-
-	swapchain_state->horizontal_wrap = (OpenXRViewportCompositionLayerProvider::Wrap)p_mode;
-	swapchain_state->dirty = true;
+	horizontal_wrap = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_horizontal_wrap(composition_layer, (OpenXRCompositionLayerExtension::Wrap)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Wrap OpenXRCompositionLayer::get_horizontal_wrap() const {
-	return (OpenXRCompositionLayer::Wrap)swapchain_state->horizontal_wrap;
+	return horizontal_wrap;
 }
 
 void OpenXRCompositionLayer::set_vertical_wrap(Wrap p_mode) {
-	if (swapchain_state->vertical_wrap == (OpenXRViewportCompositionLayerProvider::Wrap)p_mode) {
+	if (vertical_wrap == p_mode) {
 		return;
 	}
-
-	swapchain_state->vertical_wrap = (OpenXRViewportCompositionLayerProvider::Wrap)p_mode;
-	swapchain_state->dirty = true;
+	vertical_wrap = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_vertical_wrap(composition_layer, (OpenXRCompositionLayerExtension::Wrap)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Wrap OpenXRCompositionLayer::get_vertical_wrap() const {
-	return (OpenXRCompositionLayer::Wrap)swapchain_state->vertical_wrap;
+	return vertical_wrap;
 }
 
 void OpenXRCompositionLayer::set_red_swizzle(Swizzle p_mode) {
-	if (swapchain_state->red_swizzle == (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode) {
+	if (red_swizzle == p_mode) {
 		return;
 	}
-
-	swapchain_state->red_swizzle = (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode;
-	swapchain_state->dirty = true;
+	red_swizzle = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_red_swizzle(composition_layer, (OpenXRCompositionLayerExtension::Swizzle)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Swizzle OpenXRCompositionLayer::get_red_swizzle() const {
-	return (OpenXRCompositionLayer::Swizzle)swapchain_state->red_swizzle;
+	return red_swizzle;
 }
 
 void OpenXRCompositionLayer::set_green_swizzle(Swizzle p_mode) {
-	if (swapchain_state->green_swizzle == (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode) {
+	if (green_swizzle == p_mode) {
 		return;
 	}
-
-	swapchain_state->green_swizzle = (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode;
-	swapchain_state->dirty = true;
+	green_swizzle = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_green_swizzle(composition_layer, (OpenXRCompositionLayerExtension::Swizzle)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Swizzle OpenXRCompositionLayer::get_green_swizzle() const {
-	return (OpenXRCompositionLayer::Swizzle)swapchain_state->green_swizzle;
+	return green_swizzle;
 }
 
 void OpenXRCompositionLayer::set_blue_swizzle(Swizzle p_mode) {
-	if (swapchain_state->blue_swizzle == (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode) {
+	if (blue_swizzle == p_mode) {
 		return;
 	}
-
-	swapchain_state->blue_swizzle = (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode;
-	swapchain_state->dirty = true;
+	blue_swizzle = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_blue_swizzle(composition_layer, (OpenXRCompositionLayerExtension::Swizzle)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Swizzle OpenXRCompositionLayer::get_blue_swizzle() const {
-	return (OpenXRCompositionLayer::Swizzle)swapchain_state->blue_swizzle;
+	return blue_swizzle;
 }
 
 void OpenXRCompositionLayer::set_alpha_swizzle(Swizzle p_mode) {
-	if (swapchain_state->alpha_swizzle == (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode) {
+	if (alpha_swizzle == p_mode) {
 		return;
 	}
-
-	swapchain_state->alpha_swizzle = (OpenXRViewportCompositionLayerProvider::Swizzle)p_mode;
-	swapchain_state->dirty = true;
+	alpha_swizzle = p_mode;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_alpha_swizzle(composition_layer, (OpenXRCompositionLayerExtension::Swizzle)p_mode);
+	}
 }
 
 OpenXRCompositionLayer::Swizzle OpenXRCompositionLayer::get_alpha_swizzle() const {
-	return (OpenXRCompositionLayer::Swizzle)swapchain_state->alpha_swizzle;
+	return alpha_swizzle;
 }
 
 void OpenXRCompositionLayer::set_max_anisotropy(float p_value) {
-	if (swapchain_state->max_anisotropy == p_value) {
+	if (max_anisotropy == p_value) {
 		return;
 	}
-
-	swapchain_state->max_anisotropy = p_value;
-	swapchain_state->dirty = true;
+	max_anisotropy = p_value;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_max_anisotropy(composition_layer, p_value);
+	}
 }
 
 float OpenXRCompositionLayer::get_max_anisotropy() const {
-	return swapchain_state->max_anisotropy;
+	return max_anisotropy;
 }
 
-void OpenXRCompositionLayer::set_border_color(Color p_color) {
-	if (swapchain_state->border_color == p_color) {
+void OpenXRCompositionLayer::set_border_color(const Color &p_color) {
+	if (border_color == p_color) {
 		return;
 	}
-
-	swapchain_state->border_color = p_color;
-	swapchain_state->dirty = true;
+	border_color = p_color;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_border_color(composition_layer, p_color);
+	}
 }
 
 Color OpenXRCompositionLayer::get_border_color() const {
-	return swapchain_state->border_color;
+	return border_color;
 }
 
 Ref<JavaObject> OpenXRCompositionLayer::get_android_surface() {
-	return openxr_layer_provider->get_android_surface();
+	if (composition_layer_extension) {
+		return composition_layer_extension->composition_layer_get_android_surface(composition_layer);
+	}
+	return Ref<JavaObject>();
 }
 
 Vector2 OpenXRCompositionLayer::intersects_ray(const Vector3 &p_origin, const Vector3 &p_direction) const {
@@ -626,7 +649,9 @@ void OpenXRCompositionLayer::_notification(int p_what) {
 			for (OpenXRExtensionWrapper *extension : OpenXRAPI::get_registered_extension_wrappers()) {
 				extension_property_values.merge(extension->get_viewport_composition_layer_extension_property_defaults());
 			}
-			openxr_layer_provider->set_extension_property_values(extension_property_values);
+			if (composition_layer_extension) {
+				composition_layer_extension->composition_layer_set_extension_property_values(composition_layer, extension_property_values);
+			}
 		} break;
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (fallback) {
@@ -640,26 +665,27 @@ void OpenXRCompositionLayer::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_natively_supported() && openxr_session_running && is_inside_tree()) {
 				if (is_visible()) {
-					_setup_composition_layer_provider();
+					_setup_composition_layer();
 				} else {
-					_clear_composition_layer_provider();
+					_clear_composition_layer();
 				}
 			}
 			update_configuration_warnings();
 		} break;
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+			update_transform();
 			update_configuration_warnings();
 		} break;
 		case NOTIFICATION_ENTER_TREE: {
 			if (layer_viewport && is_viewport_in_use(layer_viewport)) {
-				_clear_composition_layer_provider();
+				_clear_composition_layer();
 			} else if (openxr_session_running && is_visible()) {
-				_setup_composition_layer_provider();
+				_setup_composition_layer();
 			}
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			// This will clean up existing resources.
-			_clear_composition_layer_provider();
+			_clear_composition_layer();
 		} break;
 	}
 }
@@ -692,7 +718,9 @@ bool OpenXRCompositionLayer::_get(const StringName &p_property, Variant &r_value
 bool OpenXRCompositionLayer::_set(const StringName &p_property, const Variant &p_value) {
 	extension_property_values[p_property] = p_value;
 
-	openxr_layer_provider->set_extension_property_values(extension_property_values);
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_extension_property_values(composition_layer, extension_property_values);
+	}
 
 	return true;
 }

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -32,7 +32,6 @@
 
 #include <openxr/openxr.h>
 
-#include "../extensions/openxr_composition_layer_extension.h"
 #include "scene/3d/node_3d.h"
 
 class JavaObject;
@@ -40,28 +39,27 @@ class MeshInstance3D;
 class Mesh;
 class OpenXRAPI;
 class OpenXRCompositionLayerExtension;
-class OpenXRViewportCompositionLayerProvider;
 class SubViewport;
 
 class OpenXRCompositionLayer : public Node3D {
 	GDCLASS(OpenXRCompositionLayer, Node3D);
 
 public:
-	// Must be identical to Filter enum definition in OpenXRViewportCompositionLayerProvider.
+	// Must be identical to Filter enum definition in OpenXRCompositionLayerExtension.
 	enum Filter {
 		FILTER_NEAREST,
 		FILTER_LINEAR,
 		FILTER_CUBIC,
 	};
 
-	// Must be identical to MipmapMode enum definition in OpenXRViewportCompositionLayerProvider.
+	// Must be identical to MipmapMode enum definition in OpenXRCompositionLayerExtension.
 	enum MipmapMode {
 		MIPMAP_MODE_DISABLED,
 		MIPMAP_MODE_NEAREST,
 		MIPMAP_MODE_LINEAR,
 	};
 
-	// Must be identical to Wrap enum definition in OpenXRViewportCompositionLayerProvider.
+	// Must be identical to Wrap enum definition in OpenXRCompositionLayerExtension.
 	enum Wrap {
 		WRAP_CLAMP_TO_BORDER,
 		WRAP_CLAMP_TO_EDGE,
@@ -70,7 +68,7 @@ public:
 		WRAP_MIRROR_CLAMP_TO_EDGE,
 	};
 
-	// Must be identical to Swizzle enum definition in OpenXRViewportCompositionLayerProvider.
+	// Must be identical to Swizzle enum definition in OpenXRCompositionLayerExtension.
 	enum Swizzle {
 		SWIZZLE_RED,
 		SWIZZLE_GREEN,
@@ -80,30 +78,42 @@ public:
 		SWIZZLE_ONE,
 	};
 
-private:
-	XrCompositionLayerBaseHeader *composition_layer_base_header = nullptr;
-	OpenXRViewportCompositionLayerProvider *openxr_layer_provider = nullptr;
+protected:
+	RID composition_layer;
 
+private:
 	SubViewport *layer_viewport = nullptr;
 	bool use_android_surface = false;
 	Size2i android_surface_size = Size2i(1024, 1024);
 	bool enable_hole_punch = false;
+	bool alpha_blend = false;
+	int sort_order = 1;
+	bool protected_content = false;
 	MeshInstance3D *fallback = nullptr;
 	bool should_update_fallback_mesh = false;
 	bool openxr_session_running = false;
 	bool registered = false;
-
-	OpenXRViewportCompositionLayerProvider::SwapchainState *swapchain_state = nullptr;
-
 	Dictionary extension_property_values;
+
+	Filter min_filter = FILTER_LINEAR;
+	Filter mag_filter = FILTER_LINEAR;
+	MipmapMode mipmap_mode = MIPMAP_MODE_LINEAR;
+	Wrap horizontal_wrap = WRAP_CLAMP_TO_BORDER;
+	Wrap vertical_wrap = WRAP_CLAMP_TO_BORDER;
+	Swizzle red_swizzle = SWIZZLE_RED;
+	Swizzle green_swizzle = SWIZZLE_GREEN;
+	Swizzle blue_swizzle = SWIZZLE_BLUE;
+	Swizzle alpha_swizzle = SWIZZLE_ALPHA;
+	float max_anisotropy = 1.0;
+	Color border_color = { 0.0, 0.0, 0.0, 0.0 };
 
 	bool _should_use_fallback_node();
 	void _create_fallback_node();
 	void _reset_fallback_material();
 	void _remove_fallback_node();
 
-	void _setup_composition_layer_provider();
-	void _clear_composition_layer_provider();
+	void _setup_composition_layer();
+	void _clear_composition_layer();
 
 protected:
 	OpenXRAPI *openxr_api = nullptr;
@@ -123,15 +133,15 @@ protected:
 	bool _should_register();
 
 	virtual Ref<Mesh> _create_fallback_mesh() = 0;
+	virtual XrStructureType _get_openxr_type() const = 0;
 
+	void update_transform();
 	void update_fallback_mesh();
-
-	XrPosef get_openxr_pose();
 
 	static Vector<OpenXRCompositionLayer *> composition_layer_nodes;
 	bool is_viewport_in_use(SubViewport *p_viewport);
 
-	OpenXRCompositionLayer(XrCompositionLayerBaseHeader *p_composition_layer);
+	OpenXRCompositionLayer();
 
 public:
 	void set_layer_viewport(SubViewport *p_viewport);
@@ -188,7 +198,7 @@ public:
 	void set_max_anisotropy(float p_value);
 	float get_max_anisotropy() const;
 
-	void set_border_color(Color p_color);
+	void set_border_color(const Color &p_color);
 	Color get_border_color() const;
 
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/modules/openxr/scene/openxr_composition_layer_cylinder.h
+++ b/modules/openxr/scene/openxr_composition_layer_cylinder.h
@@ -37,19 +37,6 @@
 class OpenXRCompositionLayerCylinder : public OpenXRCompositionLayer {
 	GDCLASS(OpenXRCompositionLayerCylinder, OpenXRCompositionLayer);
 
-	XrCompositionLayerCylinderKHR composition_layer = {
-		XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR, // type
-		nullptr, // next
-		0, // layerFlags
-		XR_NULL_HANDLE, // space
-		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
-		{}, // subImage
-		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
-		1.0, // radius
-		Math::PI / 2.0, // centralAngle
-		1.0, // aspectRatio
-	};
-
 	float radius = 1.0;
 	float aspect_ratio = 1.0;
 	float central_angle = Math::PI / 2.0;
@@ -58,11 +45,10 @@ class OpenXRCompositionLayerCylinder : public OpenXRCompositionLayer {
 protected:
 	static void _bind_methods();
 
-	void _notification(int p_what);
-
-	void update_transform();
-
 	virtual Ref<Mesh> _create_fallback_mesh() override;
+	virtual XrStructureType _get_openxr_type() const override {
+		return XR_TYPE_COMPOSITION_LAYER_CYLINDER_KHR;
+	}
 
 public:
 	void set_radius(float p_radius);

--- a/modules/openxr/scene/openxr_composition_layer_equirect.cpp
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.cpp
@@ -30,13 +30,28 @@
 
 #include "openxr_composition_layer_equirect.h"
 
+#include "../extensions/openxr_composition_layer_extension.h"
 #include "../openxr_interface.h"
 
 #include "scene/resources/mesh.h"
 
-OpenXRCompositionLayerEquirect::OpenXRCompositionLayerEquirect() :
-		OpenXRCompositionLayer((XrCompositionLayerBaseHeader *)&composition_layer) {
-	XRServer::get_singleton()->connect("reference_frame_changed", callable_mp(this, &OpenXRCompositionLayerEquirect::update_transform));
+OpenXRCompositionLayerEquirect::OpenXRCompositionLayerEquirect() {
+	if (composition_layer_extension) {
+		XrCompositionLayerEquirect2KHR openxr_composition_layer = {
+			XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR, // type
+			nullptr, // next
+			0, // layerFlags
+			XR_NULL_HANDLE, // space
+			XR_EYE_VISIBILITY_BOTH, // eyeVisibility
+			{}, // subImage
+			{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
+			radius, // radius
+			central_horizontal_angle, // centralHorizontalAngle
+			upper_vertical_angle, // upperVerticalAngle
+			-lower_vertical_angle, // lowerVerticalAngle
+		};
+		composition_layer = composition_layer_extension->composition_layer_create((XrCompositionLayerBaseHeader *)&openxr_composition_layer);
+	}
 }
 
 OpenXRCompositionLayerEquirect::~OpenXRCompositionLayerEquirect() {
@@ -120,22 +135,12 @@ Ref<Mesh> OpenXRCompositionLayerEquirect::_create_fallback_mesh() {
 	return mesh;
 }
 
-void OpenXRCompositionLayerEquirect::_notification(int p_what) {
-	switch (p_what) {
-		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
-			update_transform();
-		} break;
-	}
-}
-
-void OpenXRCompositionLayerEquirect::update_transform() {
-	composition_layer.pose = get_openxr_pose();
-}
-
 void OpenXRCompositionLayerEquirect::set_radius(float p_radius) {
 	ERR_FAIL_COND(p_radius <= 0);
 	radius = p_radius;
-	composition_layer.radius = radius;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_equirect_radius(composition_layer, p_radius);
+	}
 	update_fallback_mesh();
 }
 
@@ -146,7 +151,9 @@ float OpenXRCompositionLayerEquirect::get_radius() const {
 void OpenXRCompositionLayerEquirect::set_central_horizontal_angle(float p_angle) {
 	ERR_FAIL_COND(p_angle <= 0);
 	central_horizontal_angle = p_angle;
-	composition_layer.centralHorizontalAngle = central_horizontal_angle;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_equirect_central_horizontal_angle(composition_layer, p_angle);
+	}
 	update_fallback_mesh();
 }
 
@@ -157,7 +164,9 @@ float OpenXRCompositionLayerEquirect::get_central_horizontal_angle() const {
 void OpenXRCompositionLayerEquirect::set_upper_vertical_angle(float p_angle) {
 	ERR_FAIL_COND(p_angle <= 0 || p_angle > (Math::PI / 2.0));
 	upper_vertical_angle = p_angle;
-	composition_layer.upperVerticalAngle = p_angle;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_equirect_upper_vertical_angle(composition_layer, p_angle);
+	}
 	update_fallback_mesh();
 }
 
@@ -168,7 +177,9 @@ float OpenXRCompositionLayerEquirect::get_upper_vertical_angle() const {
 void OpenXRCompositionLayerEquirect::set_lower_vertical_angle(float p_angle) {
 	ERR_FAIL_COND(p_angle <= 0 || p_angle > (Math::PI / 2.0));
 	lower_vertical_angle = p_angle;
-	composition_layer.lowerVerticalAngle = -p_angle;
+	if (composition_layer_extension) {
+		composition_layer_extension->composition_layer_set_equirect_lower_vertical_angle(composition_layer, -p_angle);
+	}
 	update_fallback_mesh();
 }
 

--- a/modules/openxr/scene/openxr_composition_layer_equirect.h
+++ b/modules/openxr/scene/openxr_composition_layer_equirect.h
@@ -37,20 +37,6 @@
 class OpenXRCompositionLayerEquirect : public OpenXRCompositionLayer {
 	GDCLASS(OpenXRCompositionLayerEquirect, OpenXRCompositionLayer);
 
-	XrCompositionLayerEquirect2KHR composition_layer = {
-		XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR, // type
-		nullptr, // next
-		0, // layerFlags
-		XR_NULL_HANDLE, // space
-		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
-		{}, // subImage
-		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
-		1.0, // radius
-		Math::PI / 2.0, // centralHorizontalAngle
-		Math::PI / 4.0, // upperVerticalAngle
-		-Math::PI / 4.0, // lowerVerticalAngle
-	};
-
 	float radius = 1.0;
 	float central_horizontal_angle = Math::PI / 2.0;
 	float upper_vertical_angle = Math::PI / 4.0;
@@ -60,11 +46,10 @@ class OpenXRCompositionLayerEquirect : public OpenXRCompositionLayer {
 protected:
 	static void _bind_methods();
 
-	void _notification(int p_what);
-
-	void update_transform();
-
 	virtual Ref<Mesh> _create_fallback_mesh() override;
+	virtual XrStructureType _get_openxr_type() const override {
+		return XR_TYPE_COMPOSITION_LAYER_EQUIRECT2_KHR;
+	}
 
 public:
 	void set_radius(float p_radius);

--- a/modules/openxr/scene/openxr_composition_layer_quad.h
+++ b/modules/openxr/scene/openxr_composition_layer_quad.h
@@ -37,27 +37,15 @@
 class OpenXRCompositionLayerQuad : public OpenXRCompositionLayer {
 	GDCLASS(OpenXRCompositionLayerQuad, OpenXRCompositionLayer);
 
-	XrCompositionLayerQuad composition_layer = {
-		XR_TYPE_COMPOSITION_LAYER_QUAD, // type
-		nullptr, // next
-		0, // layerFlags
-		XR_NULL_HANDLE, // space
-		XR_EYE_VISIBILITY_BOTH, // eyeVisibility
-		{}, // subImage
-		{ { 0, 0, 0, 0 }, { 0, 0, 0 } }, // pose
-		{ 1.0, 1.0 }, // size
-	};
-
 	Size2 quad_size = Size2(1.0, 1.0);
 
 protected:
 	static void _bind_methods();
 
-	void _notification(int p_what);
-
-	void update_transform();
-
 	virtual Ref<Mesh> _create_fallback_mesh() override;
+	virtual XrStructureType _get_openxr_type() const override {
+		return XR_TYPE_COMPOSITION_LAYER_QUAD;
+	}
 
 public:
 	void set_quad_size(const Size2 &p_size);


### PR DESCRIPTION
Presently, our implementation of OpenXR composition layers is not thread-safe when used with `rendering/driver/threads/thread_model` set to "Separate".

This can lead to crashes. For example, if you run [this fork of the GDQuest TPS demo](https://github.com/dsnopek/gdquest-tps-demo/tree/standalone-vr-slush-multithreaded) and rapidly press the "Y" button (which will toggle visibility of a composition layer with performance info) it will eventually crash. (NOTE: this is easier to reproduce with the OpenGL renderer, but in order to use that on Quest or other Android-based headsets, you'll need to use PR #109080)

**This PR fixes that crash and makes OpenXR composition layers thread-safe in general!**

I've tested this with a litany of demo projects, covering all types of composition layers including using Android surfaces, on both Vulkan and OpenGL, as well as with both single and multi-threaded rendering. Everything seems to be working fine for me!

I tried really hard to not totally rewrite how we handle OpenXR composition layers, and did a couple of earlier iterations that made smaller changes, but I wasn't able to make it fully thread-safe without going all the way to Godot's "server pattern" and using `OpenXRCompositionLayerExtension` as a proxy to the underlying resources using `RID`s. So, unfortunately, the diff is pretty big and not the easiest to review. However, long-term, I think this is a much cleaner and easier-to-maintain design.

~~**NOTE:** This is currently marked as DRAFT because it builds upon PR https://github.com/godotengine/godot/pull/108644. I did this, because that PR was already ready to go, and I don't want to cause merge conflicts for the first-time contributor who made it. :-) I'll take this out of DRAFT after that PR is merged~~