### PR TITLE
Fix for distortions in multi channel signed distance field corners

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -559,8 +559,8 @@ float map_ninepatch_axis(float pixel, float draw_size, float tex_pixel_size, flo
 
 #endif
 
-float msdf_median(float r, float g, float b, float a) {
-	return min(max(min(r, g), min(max(r, g), b)), a);
+float msdf_median(float r, float g, float b) {
+	return max(min(r, g), min(max(r, g), b));
 }
 
 void main() {
@@ -606,7 +606,7 @@ void main() {
 		vec2 msdf_size = vec2(textureSize(color_texture, 0));
 		vec2 dest_size = vec2(1.0) / fwidth(uv);
 		float px_size = max(0.5 * dot((vec2(px_range) / msdf_size), dest_size), 1.0);
-		float d = msdf_median(msdf_sample.r, msdf_sample.g, msdf_sample.b, msdf_sample.a) - 0.5;
+		float d = msdf_median(msdf_sample.r, msdf_sample.g, msdf_sample.b) - 0.5;
 
 		if (outline_thickness > 0.0) {
 			float cr = clamp(outline_thickness, 0.0, px_range / 2.0) / px_range;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1476,8 +1476,8 @@ void vertex() {)";
 
 	if (flags[FLAG_ALBEDO_TEXTURE_MSDF] && !flags[FLAG_UV1_USE_TRIPLANAR]) {
 		code += R"(
-float msdf_median(float r, float g, float b, float a) {
-	return min(max(min(r, g), min(max(r, g), b)), a);
+float msdf_median(float r, float g, float b) {
+    return max(min(r, g), min(max(r, g), b));
 }
 )";
 	}
@@ -1634,7 +1634,7 @@ void fragment() {)";
 		}
 		code += R"(
 		float px_size = max(0.5 * dot(msdf_size, dest_size), 1.0);
-		float d = msdf_median(albedo_tex.r, albedo_tex.g, albedo_tex.b, albedo_tex.a) - 0.5;
+		float d = msdf_median(albedo_tex.r, albedo_tex.g, albedo_tex.b) - 0.5;
 		if (msdf_outline_size > 0.0) {
 			float cr = clamp(msdf_outline_size, 0.0, msdf_pixel_range / 2.0) / msdf_pixel_range;
 			albedo_tex.a = clamp((d + cr) * px_size, 0.0, 1.0);

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -462,8 +462,8 @@ void light_blend_compute(uint light_base, vec4 light_color, inout vec3 color) {
 	}
 }
 
-float msdf_median(float r, float g, float b, float a) {
-	return min(max(min(r, g), min(max(r, g), b)), a);
+float msdf_median(float r, float g, float b) {
+    return max(min(r, g), min(max(r, g), b));
 }
 
 void main() {


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109434

1. We calculate `min(msdf_median_value, true_sdf_value)`
2. We need to avoid discarding the msdf corner information
3. Keeps the sharp corners by only find the median of rgb
4. ~~MSDF outlines is having 0.5 in some cases and not others.~~