### PR TITLE
Fix `BoneAttachment3D` getting global transform of external skeleton before it `is_inside_tree()`

### DIFF
--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -301,7 +301,12 @@ void BoneAttachment3D::on_skeleton_update() {
 		if (sk) {
 			if (!override_pose) {
 				if (use_external_skeleton) {
-					set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
+					if (sk->is_inside_tree()) {
+						set_global_transform(sk->get_global_transform() * sk->get_bone_global_pose(bone_idx));
+						// Else, do nothing, the transform will be set when the skeleton enters the tree:
+						// Skeleton3D::_notification(NOTIFICATION_ENTER_TREE) -> calls Skeleton3D::_notification(NOTIFICATION_UPDATE_SKELETON)
+						// -> emits skeleton_updated signal -> connected to BoneAttachment3D::on_skeleton_update()
+					}
 				} else {
 					set_transform(sk->get_bone_global_pose(bone_idx));
 				}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
Fixes #109366

Added `is_inside_tree()` check for external skeletons in BoneAttachment3D.