### PR TITLE
Add units to RichTextLabel `get_content_height()` and `get_content_width()` documentation 

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -103,7 +103,7 @@
 		<method name="get_content_height" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the height of the content.
+				Returns the height of the content, in pixels.
 				[b]Note:[/b] This method always returns the full content size, and is not affected by [member visible_ratio] and [member visible_characters]. To get the visible content size, use [method get_visible_content_rect].
 				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>
@@ -111,7 +111,7 @@
 		<method name="get_content_width" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the width of the content.
+				Returns the width of the content, in pixels.
 				[b]Note:[/b] This method always returns the full content size, and is not affected by [member visible_ratio] and [member visible_characters]. To get the visible content size, use [method get_visible_content_rect].
 				[b]Note:[/b] If [member threaded] is enabled, this method returns a value for the loaded part of the document. Use [method is_finished] or [signal finished] to determine whether document is fully loaded.
 			</description>


### PR DESCRIPTION
i.e., specify they're in pixels. Literally just adds ", in pixels." to the 2 relevant lines of the XML docs.

This closes godotengine/godot-docs#11185

This is my first PR here, if I've done anything wrong please let me know!

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
