### PR TITLE
GLTF: Allow controlling how external data is handled on export

### DIFF
--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1046,7 +1046,7 @@ GLTFImageIndex FBXDocument::_parse_image_save_image(Ref<FBXState> p_state, const
 	return p_state->images.size() - 1;
 }
 
-Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_path) {
+Error FBXDocument::_parse_images(Ref<FBXState> p_state) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 
 	const ufbx_scene *fbx_scene = p_state->scene.get();
@@ -1057,8 +1057,8 @@ Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_pat
 		if (path.is_absolute_path()) {
 			path = path.get_file();
 		}
-		if (!p_base_path.is_empty()) {
-			path = p_base_path.path_join(path);
+		if (!p_state->base_path.is_empty()) {
+			path = p_state->base_path.path_join(path);
 		}
 		path = path.simplify_path();
 		Vector<uint8_t> data;
@@ -2015,7 +2015,7 @@ void FBXDocument::_process_mesh_instances(Ref<FBXState> p_state, Node *p_scene_r
 	}
 }
 
-Error FBXDocument::_parse(Ref<FBXState> p_state, const String &p_path, Ref<FileAccess> p_file) {
+Error FBXDocument::_parse(Ref<FBXState> p_state, Ref<FileAccess> p_file) {
 	p_state->scene.reset();
 
 	Error err = ERR_INVALID_DATA;
@@ -2106,7 +2106,7 @@ Error FBXDocument::_parse(Ref<FBXState> p_state, const String &p_path, Ref<FileA
 		}
 	}
 
-	err = _parse_fbx_state(p_state, p_path);
+	err = _parse_fbx_state(p_state);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	return OK;
@@ -2170,7 +2170,7 @@ Error FBXDocument::append_from_buffer(const PackedByteArray &p_bytes, const Stri
 	file_access.instantiate();
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
 	state->base_path = p_base_path.get_base_dir();
-	err = _parse(state, state->base_path, file_access);
+	err = _parse(state, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());
@@ -2180,7 +2180,7 @@ Error FBXDocument::append_from_buffer(const PackedByteArray &p_bytes, const Stri
 	return OK;
 }
 
-Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state, const String &p_search_path) {
+Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state) {
 	Error err;
 
 	// Abort parsing if the scene is not loaded.
@@ -2196,7 +2196,7 @@ Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state, const String &p_searc
 
 	if (!p_state->discard_meshes_and_materials) {
 		/* PARSE IMAGES */
-		err = _parse_images(p_state, p_search_path);
+		err = _parse_images(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
@@ -2260,7 +2260,7 @@ Error FBXDocument::append_from_file(const String &p_path, Ref<GLTFState> p_state
 	if (p_state == Ref<FBXState>()) {
 		p_state.instantiate();
 	}
-	state->filename = p_path.get_file().get_basename();
+	state->filename = p_path.get_file();
 	state->use_named_skin_binds = p_flags & GLTFDocument::ImportFlags::IMPORT_FLAG_USE_NAMED_SKIN_BINDS;
 	state->discard_meshes_and_materials = p_flags & GLTFDocument::ImportFlags::IMPORT_FLAG_DISCARD_MESHES_AND_MATERIALS;
 	Error err;
@@ -2272,7 +2272,7 @@ Error FBXDocument::append_from_file(const String &p_path, Ref<GLTFState> p_state
 		base_path = p_path.get_base_dir();
 	}
 	state->base_path = base_path;
-	err = _parse(p_state, base_path, file);
+	err = _parse(p_state, file);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());

--- a/modules/fbx/fbx_document.cpp
+++ b/modules/fbx/fbx_document.cpp
@@ -1048,7 +1048,7 @@ GLTFImageIndex FBXDocument::_parse_image_save_image(Ref<FBXState> p_state, const
 	return p_state->images.size() - 1;
 }
 
-Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_path) {
+Error FBXDocument::_parse_images(Ref<FBXState> p_state) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 
 	const ufbx_scene *fbx_scene = p_state->scene.get();
@@ -1059,8 +1059,8 @@ Error FBXDocument::_parse_images(Ref<FBXState> p_state, const String &p_base_pat
 		if (path.is_absolute_path()) {
 			path = path.get_file();
 		}
-		if (!p_base_path.is_empty()) {
-			path = p_base_path.path_join(path);
+		if (!p_state->base_path.is_empty()) {
+			path = p_state->base_path.path_join(path);
 		}
 		path = path.simplify_path();
 		Vector<uint8_t> data;
@@ -2018,7 +2018,7 @@ void FBXDocument::_process_mesh_instances(Ref<FBXState> p_state, Node *p_scene_r
 	}
 }
 
-Error FBXDocument::_parse(Ref<FBXState> p_state, const String &p_path, Ref<FileAccess> p_file) {
+Error FBXDocument::_parse(Ref<FBXState> p_state, Ref<FileAccess> p_file) {
 	p_state->scene.reset();
 
 	Error err = ERR_INVALID_DATA;
@@ -2109,7 +2109,7 @@ Error FBXDocument::_parse(Ref<FBXState> p_state, const String &p_path, Ref<FileA
 		}
 	}
 
-	err = _parse_fbx_state(p_state, p_path);
+	err = _parse_fbx_state(p_state);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	return OK;
@@ -2173,7 +2173,7 @@ Error FBXDocument::append_from_buffer(const PackedByteArray &p_bytes, const Stri
 	file_access.instantiate();
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
 	state->base_path = p_base_path.get_base_dir();
-	err = _parse(state, state->base_path, file_access);
+	err = _parse(state, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());
@@ -2183,7 +2183,7 @@ Error FBXDocument::append_from_buffer(const PackedByteArray &p_bytes, const Stri
 	return OK;
 }
 
-Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state, const String &p_search_path) {
+Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state) {
 	Error err;
 
 	// Abort parsing if the scene is not loaded.
@@ -2199,7 +2199,7 @@ Error FBXDocument::_parse_fbx_state(Ref<FBXState> p_state, const String &p_searc
 
 	if (!p_state->discard_meshes_and_materials) {
 		/* PARSE IMAGES */
-		err = _parse_images(p_state, p_search_path);
+		err = _parse_images(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
@@ -2263,7 +2263,7 @@ Error FBXDocument::append_from_file(const String &p_path, Ref<GLTFState> p_state
 	if (p_state == Ref<FBXState>()) {
 		p_state.instantiate();
 	}
-	state->filename = p_path.get_file().get_basename();
+	state->filename = p_path.get_file();
 	state->use_named_skin_binds = p_flags & GLTFDocument::ImportFlags::IMPORT_FLAG_USE_NAMED_SKIN_BINDS;
 	state->discard_meshes_and_materials = p_flags & GLTFDocument::ImportFlags::IMPORT_FLAG_DISCARD_MESHES_AND_MATERIALS;
 	Error err;
@@ -2275,7 +2275,7 @@ Error FBXDocument::append_from_file(const String &p_path, Ref<GLTFState> p_state
 		base_path = p_path.get_base_dir();
 	}
 	state->base_path = base_path;
-	err = _parse(p_state, base_path, file);
+	err = _parse(p_state, file);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());

--- a/modules/fbx/fbx_document.h
+++ b/modules/fbx/fbx_document.h
@@ -78,7 +78,7 @@ private:
 	Error _parse_meshes(Ref<FBXState> p_state);
 	Ref<Image> _parse_image_bytes_into_image(Ref<FBXState> p_state, const Vector<uint8_t> &p_bytes, const String &p_filename, int p_index);
 	GLTFImageIndex _parse_image_save_image(Ref<FBXState> p_state, const Vector<uint8_t> &p_bytes, const String &p_file_extension, int p_index, Ref<Image> p_image);
-	Error _parse_images(Ref<FBXState> p_state, const String &p_base_path);
+	Error _parse_images(Ref<FBXState> p_state);
 	Error _parse_materials(Ref<FBXState> p_state);
 	Error _parse_skins(Ref<FBXState> p_state);
 	Error _parse_animations(Ref<FBXState> p_state);
@@ -95,11 +95,11 @@ private:
 	Error _parse_lights(Ref<FBXState> p_state);
 
 public:
-	Error _parse_fbx_state(Ref<FBXState> p_state, const String &p_search_path);
+	Error _parse_fbx_state(Ref<FBXState> p_state);
 	void _process_mesh_instances(Ref<FBXState> p_state, Node *p_scene_root);
 	void _generate_scene_node(Ref<FBXState> p_state, const GLTFNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root);
 	void _generate_skeleton_bone_node(Ref<FBXState> p_state, const GLTFNodeIndex p_node_index, Node *p_scene_parent, Node *p_scene_root);
 	void _import_animation(Ref<FBXState> p_state, AnimationPlayer *p_animation_player,
 			const GLTFAnimationIndex p_index, const bool p_trimming, const bool p_remove_immutable_tracks);
-	Error _parse(Ref<FBXState> p_state, const String &p_path, Ref<FileAccess> p_file);
+	Error _parse(Ref<FBXState> p_state, Ref<FileAccess> p_file);
 };

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -169,6 +169,12 @@
 				Returns an array of unique node names. This is used in both the import process and export process.
 			</description>
 		</method>
+		<method name="is_text_file" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if [member filename] indicates this is a text-based glTF file, meaning that it ends with [code]".gltf"[/code] (case insensitive). Returns [code]false[/code] with any other extension or for an empty filename (indicating this is a byte array in memory).
+			</description>
+		</method>
 		<method name="set_accessors">
 			<return type="void" />
 			<param index="0" name="accessors" type="GLTFAccessor[]" />
@@ -286,6 +292,13 @@
 				Sets the unique node names in the state. This is used in both the import process and export process.
 			</description>
 		</method>
+		<method name="should_separate_resource_files" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if resource files, such as images, should be separated into their own files. Returns [code]false[/code] if they should be embedded in the glTF file. This is determined by the [member external_data_mode] property.
+				Extensions should call this method to determine if they should save their resources in separate files. For example, the [code]KHR_audio_emitter[/code] extension should use this to determine if it should save audio files in separate files such as [code].mp3[/code] files, or if it should embed them in the glTF file in buffer views. For example, any extension handling images should use this to determine if they should save images in separate files such as [code].png[/code] files, or if they should embed them in the glTF file in buffer views.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="bake_fps" type="float" setter="set_bake_fps" getter="get_bake_fps" default="30.0">
@@ -300,6 +313,12 @@
 			The copyright string in the asset header of the glTF file. This is set during import if present and export if non-empty. See the glTF asset header documentation for more information.
 		</member>
 		<member name="create_animations" type="bool" setter="set_create_animations" getter="get_create_animations" default="true">
+		</member>
+		<member name="external_data_mode" type="int" setter="set_external_data_mode" getter="get_external_data_mode" enum="GLTFState.ExternalDataMode" default="0">
+			When exporting a glTF file, this determines where external data, such as images and binary buffers, should be stored.
+			The default value is [constant EXTERNAL_DATA_MODE_AUTOMATIC], which automatically determines if data should be embedded or separated based on the file extension used, embedding for [code].glb[/code] files and separating for [code].gltf[/code] files. If you want different behavior, you can set this to one of the [enum ExternalDataMode] values.
+			Saving resources like images to their own files can be useful for destinations where you need access to these files separately. For example, if the exported glTF is added to the [code]res://[/code] folder of a Godot project, the default behavior of the Godot editor is to extract embedded images to their own files so they can be imported and compressed into GPU-optimized formats.
+			Extensions should respect this setting by calling [method should_separate_resource_files] to determine if they should save their resources in separate files.
 		</member>
 		<member name="filename" type="String" setter="set_filename" getter="get_filename" default="&quot;&quot;">
 			The file name associated with this glTF data. If it ends with [code].gltf[/code], this is text-based glTF, otherwise this is binary GLB. This will be set during import when appending from a file, and will be set during export when writing to a file. If writing to a buffer, this will be an empty string.
@@ -331,6 +350,29 @@
 		</member>
 	</members>
 	<constants>
+		<constant name="EXTERNAL_DATA_MODE_AUTOMATIC" value="0" enum="ExternalDataMode">
+			When exporting a glTF file, automatically determines if data should be embedded or separated based on the file extension used and if [member base_path] is valid. With this option, exporting a [code].gltf[/code] file with a valid [member base_path] will behave like [constant EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES]. If exporting a [code].glb[/code] file, exporting to an in-memory buffer, or exporting with [member base_path] set to an empty string, this will behave like [constant EXTERNAL_DATA_MODE_EMBED_EVERYTHING].
+			This option is suitable for most use cases. It behaves like Blender's "glTF Binary (.glb)" export option for [code].glb[/code] files, and like Blender's "glTF Separate (.gltf + .bin + textures)" export option for [code].gltf[/code] files.
+		</constant>
+		<constant name="EXTERNAL_DATA_MODE_EMBED_EVERYTHING" value="1" enum="ExternalDataMode">
+			When exporting a glTF file, embeds all data in the glTF file, including images and binary buffers. For [code].glb[/code] files, this will use the binary blob chunk at the end of the file to store the data in buffer 0 (if present). For all other buffers, such as buffers in [code].gltf[/code] files, the data will be embedded as a base64-encoded string in the JSON of the buffer.
+			This option is useful when you want a single self-contained file. It behaves like Blender's "glTF Binary (.glb)" export option for [code].glb[/code] files, and like Blender's "glTF Embedded (.gltf)" export option for [code].gltf[/code] files.
+			[b]Note:[/b] This usually results in a single self-contained file, but this is not guaranteed. The glTF binary ([code].glb[/code]) format has a maximum file size of 4 GiB, so if the data exceeds that size, the buffer will be forced to save as a separate file.
+		</constant>
+		<constant name="EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES" value="2" enum="ExternalDataMode">
+			When exporting a glTF file, separates all files that can be saved in their own file formats into their own files, and also save all raw binary blobs, such as glTF buffers, into separate [code].bin[/code] files.
+			This option is useful when having the glTF file's contents spread out over multiple files is desired, resulting in maximum human readability. It behaves like Blender's "glTF Separate (.gltf + .bin + textures)" export option.
+			Extensions should respect this setting by calling [method should_separate_resource_files] to determine if they should save their resources in separate files.
+		</constant>
+		<constant name="EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS" value="3" enum="ExternalDataMode">
+			When exporting a glTF file, separates all raw binary blobs, such as glTF buffers, into separate [code].bin[/code] files. Resources that can be saved in their own file formats, such as images, are embedded within glTF buffers, and are stored in the [code].bin[/code] files.
+			This option is useful if you need efficient storage of binary data while also keeping the number of files low. In the typical case, this option will result in only two files: the glTF file and a single [code].bin[/code] file next to it.
+		</constant>
+		<constant name="EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES" value="4" enum="ExternalDataMode">
+			When exporting a glTF file, separates all resources that can be saved in their own file formats into their own files, such as images. This option does not separate buffers, meaning that binary blob data without a file type, such as mesh data, animation data, skin/skeleton data, and so on, are still embedded in the glTF file.
+			This option is useful if the exported glTF file is intended to be added to the project folder in a game engine, so that the game engine can import the resources files separately, and optionally use them separately. Otherwise, game engines may extract embedded resources to their own files, resulting in duplicate data in the project folder.
+			Extensions should respect this setting by calling [method should_separate_resource_files] to determine if they should save their resources in separate files.
+		</constant>
 		<constant name="HANDLE_BINARY_IMAGE_MODE_DISCARD_TEXTURES" value="0" enum="HandleBinaryImageMode">
 			When importing a glTF file with embedded binary images, discards all images and uses untextured materials in their place. Images stored as separate files in the [code]res://[/code] folder are not affected by this; those will be used as Godot imported them.
 		</constant>

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -113,6 +113,7 @@ void SceneExporterGLTFPlugin::_export_scene_as_gltf() {
 	Ref<GLTFState> state;
 	state.instantiate();
 	state->set_copyright(_export_settings->get_copyright());
+	state->set_external_data_mode(_export_settings->get_external_data_mode());
 	int32_t flags = 0;
 	flags |= EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
 	state->set_bake_fps(_export_settings->get_bake_fps());

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -112,6 +112,7 @@ void SceneExporterGLTFPlugin::_export_scene_as_gltf() {
 	Ref<GLTFState> state;
 	state.instantiate();
 	state->set_copyright(_export_settings->get_copyright());
+	state->set_external_data_mode(_export_settings->get_external_data_mode());
 	int32_t flags = 0;
 	flags |= EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
 	state->set_bake_fps(_export_settings->get_bake_fps());

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
@@ -267,6 +267,10 @@ void EditorSceneExporterGLTFSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bake_fps"), &EditorSceneExporterGLTFSettings::get_bake_fps);
 	ClassDB::bind_method(D_METHOD("set_bake_fps", "bake_fps"), &EditorSceneExporterGLTFSettings::set_bake_fps);
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_fps", PROPERTY_HINT_RANGE, "0.001,120,0.0001,or_greater"), "set_bake_fps", "get_bake_fps");
+
+	ClassDB::bind_method(D_METHOD("get_external_data_mode"), &EditorSceneExporterGLTFSettings::get_external_data_mode);
+	ClassDB::bind_method(D_METHOD("set_external_data_mode", "external_data_mode"), &EditorSceneExporterGLTFSettings::set_external_data_mode);
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "external_data_mode", PROPERTY_HINT_ENUM, "Automatic,Embed Everything,Separate All Files,Separate Binary Blobs,Separate Resource Files"), "set_external_data_mode", "get_external_data_mode");
 }
 
 double EditorSceneExporterGLTFSettings::get_bake_fps() const {

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.h
@@ -40,6 +40,7 @@ class EditorSceneExporterGLTFSettings : public RefCounted {
 
 	String _copyright;
 	double _bake_fps = 30.0;
+	GLTFState::ExternalDataMode _external_data_mode = GLTFState::EXTERNAL_DATA_MODE_AUTOMATIC;
 
 protected:
 	static void _bind_methods();
@@ -59,4 +60,7 @@ public:
 
 	double get_bake_fps() const;
 	void set_bake_fps(const double p_bake_fps);
+
+	GLTFState::ExternalDataMode get_external_data_mode() const { return _external_data_mode; }
+	void set_external_data_mode(GLTFState::ExternalDataMode p_external_data_mode) { _external_data_mode = p_external_data_mode; }
 };

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -678,86 +678,65 @@ static inline bool _all_buffers_empty(const Vector<Vector<uint8_t>> &p_buffers, 
 	return true;
 }
 
-Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
-
-	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
+Error GLTFDocument::_encode_buffers(Ref<GLTFState> p_state) {
+	const int64_t buffer_count = p_state->buffers.size();
+	print_verbose("glTF: Total buffers: " + itos(buffer_count));
+	if (buffer_count == 0 || _all_buffers_empty(p_state->buffers)) {
 		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
 		return OK;
 	}
-	Array buffers;
-	Dictionary first_buffer;
-
-	first_buffer["byteLength"] = p_state->buffers[0].size();
-	buffers.push_back(first_buffer);
-
-	for (GLTFBufferIndex i = 1; i < p_state->buffers.size(); i++) {
-		const Vector<uint8_t> &buffer_data = p_state->buffers[i];
-		Dictionary gltf_buffer;
-		if (buffer_data.is_empty()) {
-			if (i < p_state->buffers.size() - 1 && !_all_buffers_empty(p_state->buffers, i + 1)) {
+	Array buffer_dicts;
+	buffer_dicts.resize(buffer_count);
+	const bool should_separate = p_state->should_separate_binary_blobs();
+	// Check if the buffer at index 0 should be used as a GLB buffer.
+	GLTFBufferIndex loop_start_index;
+	if (should_separate || p_state->is_text_file()) {
+		loop_start_index = 0; // Encode all buffers with URIs, don't use a GLB buffer.
+	} else {
+		loop_start_index = 1; // Encode buffers starting at index 1 with URIs, use buffer 0 as a GLB buffer.
+		const PackedByteArray buffer_data = p_state->buffers[0];
+		const int64_t buffer_byte_length = buffer_data.size();
+		if (buffer_byte_length == 0) {
+			// If this buffer is empty and the others were too, this would've returned at the top of the function.
+			ERR_PRINT("glTF export: Buffer 0 is empty, but there are non-empty subsequent buffers. Writing it anyway to preserve buffer indices.");
+		}
+		Dictionary first_gltf_buffer_dict;
+		first_gltf_buffer_dict["byteLength"] = buffer_byte_length;
+		buffer_dicts[0] = first_gltf_buffer_dict;
+	}
+	// Encode the rest of the buffers.
+	for (GLTFBufferIndex buffer_index = loop_start_index; buffer_index < buffer_count; buffer_index++) {
+		const PackedByteArray &buffer_data = p_state->buffers[buffer_index];
+		const int64_t buffer_byte_length = buffer_data.size();
+		Dictionary gltf_buffer_dict;
+		gltf_buffer_dict["byteLength"] = buffer_byte_length;
+		if (buffer_byte_length == 0) {
+			if (buffer_index < buffer_count - 1 && !_all_buffers_empty(p_state->buffers, buffer_index + 1)) {
 				// Have to push back an empty buffer to avoid changing the buffer index, even though this is against spec.
-				WARN_PRINT("glTF: Buffer " + itos(i) + " is empty, but there are non-empty subsequent buffers.");
-				gltf_buffer["byteLength"] = 0;
-				buffers.push_back(gltf_buffer);
+				WARN_PRINT("glTF: Buffer " + itos(buffer_index) + " is empty, but there are non-empty subsequent buffers.");
+				buffer_dicts[buffer_index] = gltf_buffer_dict;
 			}
 			continue;
 		}
-		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
-		const String bin_path = p_state->base_path.path_join(bin_filename);
-		Error err;
-		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
-		if (file.is_null()) {
-			return err;
-		}
-		file->create(FileAccess::ACCESS_RESOURCES);
-		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = bin_filename;
-		gltf_buffer["byteLength"] = buffer_data.size();
-		buffers.push_back(gltf_buffer);
-	}
-	p_state->json["buffers"] = buffers;
-
-	return OK;
-}
-
-Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
-
-	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
-		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
-		return OK;
-	}
-	Array buffers;
-
-	for (GLTFBufferIndex i = 0; i < p_state->buffers.size(); i++) {
-		const Vector<uint8_t> &buffer_data = p_state->buffers[i];
-		Dictionary gltf_buffer;
-		if (buffer_data.is_empty()) {
-			if (i < p_state->buffers.size() - 1 && !_all_buffers_empty(p_state->buffers, i + 1)) {
-				// Have to push back an empty buffer to avoid changing the buffer index, even though this is against spec.
-				WARN_PRINT("glTF: Buffer " + itos(i) + " is empty, but there are non-empty subsequent buffers.");
-				gltf_buffer["byteLength"] = 0;
-				buffers.push_back(gltf_buffer);
+		if (should_separate) {
+			// Encode the buffer as a separate file.
+			const String bin_filename = p_state->filename.get_basename() + itos(buffer_index) + ".bin";
+			const String bin_path = p_state->base_path.path_join(bin_filename);
+			Error err;
+			Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
+			if (file.is_null()) {
+				return err;
 			}
-			continue;
+			file->store_buffer(buffer_data.ptr(), buffer_byte_length);
+			gltf_buffer_dict["uri"] = bin_filename;
+		} else {
+			// Encode the buffer as a base64 data URI.
+			const String base64_data = CryptoCore::b64_encode_str(buffer_data.ptr(), buffer_byte_length);
+			gltf_buffer_dict["uri"] = "data:application/octet-stream;base64," + base64_data;
 		}
-		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
-		const String bin_path = p_state->base_path.path_join(bin_filename);
-		Error err;
-		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
-		if (file.is_null()) {
-			return err;
-		}
-		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = bin_filename;
-		gltf_buffer["byteLength"] = buffer_data.size();
-		buffers.push_back(gltf_buffer);
+		buffer_dicts[buffer_index] = gltf_buffer_dict;
 	}
-	if (!buffers.is_empty()) {
-		p_state->json["buffers"] = buffers;
-	}
-
+	p_state->json["buffers"] = buffer_dicts;
 	return OK;
 }
 
@@ -766,6 +745,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state) {
 		return OK;
 	}
 
+	p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_EMBED_EVERYTHING);
 	const Array &buffers = p_state->json["buffers"];
 	for (GLTFBufferIndex i = 0; i < buffers.size(); i++) {
 		const Dictionary &buffer = buffers[i];
@@ -787,6 +767,9 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state) {
 				ERR_FAIL_COND_V_MSG(!FileAccess::exists(uri), ERR_FILE_NOT_FOUND, "glTF: Binary file not found: " + uri);
 				buffer_data = FileAccess::get_file_as_bytes(uri);
 				ERR_FAIL_COND_V_MSG(buffer_data.is_empty(), ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
+				// Infer the external data mode on import in case the user wishes to round-trip the glTF file back out of Godot later.
+				// This may be modified later by the code in `GLTFDocument::_parse_images`.
+				p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS);
 			}
 
 			ERR_FAIL_COND_V(!buffer.has("byteLength"), ERR_PARSE_ERROR);
@@ -2100,7 +2083,7 @@ Dictionary GLTFDocument::_serialize_image(Ref<GLTFState> p_state, Ref<Image> p_i
 		ERR_FAIL_COND_V_MSG(p_image->is_compressed(), image_dict, "glTF: Image was compressed, but could not be decompressed.");
 	}
 
-	if (p_state->filename.to_lower().ends_with("gltf")) {
+	if (p_state->should_separate_resource_files()) {
 		String relative_texture_dir = "textures";
 		String full_texture_dir = p_state->base_path.path_join(relative_texture_dir);
 		Ref<DirAccess> da = DirAccess::open(p_state->base_path);
@@ -2381,6 +2364,14 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state) {
 				uri = uri.uri_file_decode();
 				uri = p_state->base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
 				resource_uri = uri.simplify_path();
+				// Infer the external data mode on import in case the user wishes to round-trip the glTF file back out of Godot later,
+				// or if the user needs to know how the original glTF file stored its data before importing it for some reason.
+				// This code runs after the similar code in `GLTFDocument::_parse_buffers()`, so it checks for the values set there.
+				if (p_state->get_external_data_mode() == GLTFState::EXTERNAL_DATA_MODE_EMBED_EVERYTHING) {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES);
+				} else if (p_state->get_external_data_mode() == GLTFState::EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS) {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES);
+				}
 				// ResourceLoader will rely on the file extension to use the relevant loader.
 				// The spec says that if mimeType is defined, it should take precedence (e.g.
 				// there could be a `.png` image which is actually JPEG), but there's no easy
@@ -6799,14 +6790,16 @@ Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {
 }
 
 Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
-	Error err = FAILED;
-	if (p_state->filename.to_lower().ends_with("glb")) {
-		err = _encode_buffer_glb(p_state);
-		ERR_FAIL_COND_V(err != OK, err);
-		const String gltf_path = p_state->base_path.path_join(p_state->filename);
-		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
-		ERR_FAIL_COND_V(file.is_null(), FAILED);
-
+	const String gltf_path = p_state->base_path.path_join(p_state->filename);
+	Error err = _encode_buffers(p_state);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "glTF: Failed to encode buffers for file: " + gltf_path);
+	Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
+	ERR_FAIL_COND_V(file.is_null(), FAILED);
+	if (p_state->is_text_file()) {
+		String json = JSON::stringify(p_state->json, "", true, true);
+		file->store_string(json);
+	} else {
+		// Serialize binary glTF (GLB) file.
 		constexpr uint64_t header_size = 12;
 		constexpr uint64_t chunk_header_size = 8;
 		constexpr uint32_t magic = 0x46546C67; // The byte sequence "glTF" as little-endian.
@@ -6820,14 +6813,19 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
 		uint64_t total_file_length = header_size + chunk_header_size + text_chunk_length;
 		uint64_t binary_data_length = 0;
 		uint64_t binary_chunk_length = 0;
-		if (p_state->buffers.size() > 0) {
+		if (p_state->buffers.size() > 0 && !p_state->should_separate_binary_blobs()) {
 			binary_data_length = p_state->buffers[0].size();
 			binary_chunk_length = ((binary_data_length + 3) & (~3));
 			const uint64_t file_length_with_buffer = total_file_length + chunk_header_size + binary_chunk_length;
 			// Check if the file length with the buffer is greater than glTF's maximum of 4 GiB.
 			// If it is, we can't write the buffer into the file, but can write it separately.
 			if (unlikely(file_length_with_buffer > (uint64_t)UINT32_MAX)) {
-				err = _encode_buffer_bins(p_state);
+				if (p_state->get_external_data_mode() == GLTFState::EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES) {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES);
+				} else {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS);
+				}
+				err = _encode_buffers(p_state);
 				ERR_FAIL_COND_V(err != OK, err);
 				// Since the buffer bins were re-encoded, we need to re-convert the JSON to string.
 				json_string = JSON::stringify(p_state->json, "", true, true);
@@ -6865,15 +6863,6 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
 				file->store_8(0);
 			}
 		}
-	} else {
-		err = _encode_buffer_bins(p_state);
-		ERR_FAIL_COND_V(err != OK, err);
-		const String gltf_path = p_state->base_path.path_join(p_state->filename);
-		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
-		ERR_FAIL_COND_V(file.is_null(), FAILED);
-
-		String json = JSON::stringify(p_state->json, "", true, true);
-		file->store_string(json);
 	}
 	return err;
 }
@@ -7017,7 +7006,7 @@ HashSet<String> GLTFDocument::get_supported_gltf_extensions_hashset() {
 }
 
 PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err) {
-	Error err = _encode_buffer_glb(p_state);
+	Error err = _encode_buffers(p_state);
 	if (r_err) {
 		*r_err = err;
 	}
@@ -7036,13 +7025,13 @@ PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Erro
 	uint64_t total_file_length = header_size + chunk_header_size + text_chunk_length;
 	ERR_FAIL_COND_V(total_file_length > (uint64_t)UINT32_MAX, PackedByteArray());
 	uint64_t binary_data_length = 0;
-	if (p_state->buffers.size() > 0) {
+	if (p_state->buffers.size() > 0 && !p_state->should_separate_binary_blobs()) {
 		binary_data_length = p_state->buffers[0].size();
 		const uint64_t file_length_with_buffer = total_file_length + chunk_header_size + binary_data_length;
 		total_file_length = file_length_with_buffer;
 	}
 	ERR_FAIL_COND_V_MSG(total_file_length > (uint64_t)UINT32_MAX, PackedByteArray(),
-			"glTF: File size exceeds glTF Binary's maximum of 4 GiB. Cannot serialize as a single GLB in-memory buffer.");
+			"glTF: File size exceeds glTF Binary's maximum of 4 GiB. Cannot serialize as a single GLB byte array in memory.");
 	const uint32_t binary_chunk_length = binary_data_length;
 
 	Ref<StreamPeerBuffer> buffer;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -242,29 +242,6 @@ Error GLTFDocument::_serialize_scenes(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-Error GLTFDocument::_parse_json(const String &p_path, Ref<GLTFState> p_state) {
-	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ, &err);
-	if (file.is_null()) {
-		return err;
-	}
-
-	Vector<uint8_t> array;
-	array.resize(file->get_length());
-	file->get_buffer(array.ptrw(), array.size());
-	String text = String::utf8((const char *)array.ptr(), array.size());
-
-	JSON json;
-	err = json.parse(text);
-	if (err != OK) {
-		_err_print_error("", p_path.utf8().get_data(), json.get_error_line(), json.get_error_message().utf8().get_data(), false, ERR_HANDLER_SCRIPT);
-		return err;
-	}
-	p_state->json = json.get_data();
-
-	return OK;
-}
-
 Error GLTFDocument::_parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state) {
 	ERR_FAIL_COND_V(p_file.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
@@ -701,7 +678,7 @@ static inline bool _all_buffers_empty(const Vector<Vector<uint8_t>> &p_buffers, 
 	return true;
 }
 
-Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path) {
+Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state) {
 	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
@@ -726,16 +703,16 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 			}
 			continue;
 		}
-		String filename = p_path.get_basename().get_file() + itos(i) + ".bin";
-		String path = p_path.get_base_dir() + "/" + filename;
+		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
+		const String bin_path = p_state->base_path.path_join(bin_filename);
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
 		if (file.is_null()) {
 			return err;
 		}
 		file->create(FileAccess::ACCESS_RESOURCES);
 		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = filename;
+		gltf_buffer["uri"] = bin_filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
 		buffers.push_back(gltf_buffer);
 	}
@@ -744,7 +721,7 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 	return OK;
 }
 
-Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path) {
+Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state) {
 	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
@@ -765,15 +742,15 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 			}
 			continue;
 		}
-		String filename = p_path.get_basename().get_file() + itos(i) + ".bin";
-		String path = p_path.get_base_dir() + "/" + filename;
+		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
+		const String bin_path = p_state->base_path.path_join(bin_filename);
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
 		if (file.is_null()) {
 			return err;
 		}
 		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = filename;
+		gltf_buffer["uri"] = bin_filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
 		buffers.push_back(gltf_buffer);
 	}
@@ -784,7 +761,7 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 	return OK;
 }
 
-Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_path) {
+Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state) {
 	if (!p_state->json.has("buffers")) {
 		return OK;
 	}
@@ -804,9 +781,9 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 				}
 				buffer_data = _parse_base64_uri(uri);
 			} else { // Relative path to an external image file.
-				ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
+				ERR_FAIL_COND_V(p_state->base_path.is_empty(), ERR_INVALID_PARAMETER);
 				uri = uri.uri_file_decode();
-				uri = p_base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
+				uri = p_state->base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
 				ERR_FAIL_COND_V_MSG(!FileAccess::exists(uri), ERR_FILE_NOT_FOUND, "glTF: Binary file not found: " + uri);
 				buffer_data = FileAccess::get_file_as_bytes(uri);
 				ERR_FAIL_COND_V_MSG(buffer_data.is_empty(), ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
@@ -2148,6 +2125,8 @@ Dictionary GLTFDocument::_serialize_image(Ref<GLTFState> p_state, Ref<Image> p_i
 		}
 		image_dict["uri"] = relative_texture_dir.path_join(image_file_name).uri_encode();
 	} else {
+		// Else, such as if this is a `.glb`, a byte array in memory, or an
+		// embedded `.gltf`, we need to serialize the image into a buffer view.
 		GLTFBufferViewIndex bvi;
 
 		Ref<GLTFBufferView> bv;
@@ -2338,7 +2317,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 	p_state->source_images.push_back(p_image);
 }
 
-Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_path) {
+Error GLTFDocument::_parse_images(Ref<GLTFState> p_state) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	if (!p_state->json.has("images")) {
 		return OK;
@@ -2398,9 +2377,9 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 					mime_type = uri.substr(5, uri.find(";base64") - 5);
 				}
 			} else { // Relative path to an external image file.
-				ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
+				ERR_FAIL_COND_V(p_state->base_path.is_empty(), ERR_INVALID_PARAMETER);
 				uri = uri.uri_file_decode();
-				uri = p_base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
+				uri = p_state->base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
 				resource_uri = uri.simplify_path();
 				// ResourceLoader will rely on the file extension to use the relevant loader.
 				// The spec says that if mimeType is defined, it should take precedence (e.g.
@@ -6716,7 +6695,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p
 	}
 }
 
-Error GLTFDocument::_parse(Ref<GLTFState> p_state, const String &p_path, Ref<FileAccess> p_file) {
+Error GLTFDocument::_parse(Ref<GLTFState> p_state, Ref<FileAccess> p_file) {
 	Error err;
 	if (p_file.is_null()) {
 		return FAILED;
@@ -6756,7 +6735,7 @@ Error GLTFDocument::_parse(Ref<GLTFState> p_state, const String &p_path, Ref<Fil
 		}
 	}
 
-	err = _parse_gltf_state(p_state, p_path);
+	err = _parse_gltf_state(p_state);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	return OK;
@@ -6819,12 +6798,13 @@ Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path) {
+Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
 	Error err = FAILED;
-	if (p_path.to_lower().ends_with("glb")) {
-		err = _encode_buffer_glb(p_state, p_path);
+	if (p_state->filename.to_lower().ends_with("glb")) {
+		err = _encode_buffer_glb(p_state);
 		ERR_FAIL_COND_V(err != OK, err);
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		const String gltf_path = p_state->base_path.path_join(p_state->filename);
+		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V(file.is_null(), FAILED);
 
 		constexpr uint64_t header_size = 12;
@@ -6847,7 +6827,7 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 			// Check if the file length with the buffer is greater than glTF's maximum of 4 GiB.
 			// If it is, we can't write the buffer into the file, but can write it separately.
 			if (unlikely(file_length_with_buffer > (uint64_t)UINT32_MAX)) {
-				err = _encode_buffer_bins(p_state, p_path);
+				err = _encode_buffer_bins(p_state);
 				ERR_FAIL_COND_V(err != OK, err);
 				// Since the buffer bins were re-encoded, we need to re-convert the JSON to string.
 				json_string = JSON::stringify(p_state->json, "", true, true);
@@ -6886,9 +6866,10 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 			}
 		}
 	} else {
-		err = _encode_buffer_bins(p_state, p_path);
+		err = _encode_buffer_bins(p_state);
 		ERR_FAIL_COND_V(err != OK, err);
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		const String gltf_path = p_state->base_path.path_join(p_state->filename);
+		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V(file.is_null(), FAILED);
 
 		String json = JSON::stringify(p_state->json, "", true, true);
@@ -7036,7 +7017,7 @@ HashSet<String> GLTFDocument::get_supported_gltf_extensions_hashset() {
 }
 
 PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err) {
-	Error err = _encode_buffer_glb(p_state, "");
+	Error err = _encode_buffer_glb(p_state);
 	if (r_err) {
 		*r_err = err;
 	}
@@ -7151,11 +7132,11 @@ Error GLTFDocument::_parse_asset_header(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state, const String &p_search_path) {
+Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state) {
 	Error err;
 
 	/* PARSE BUFFERS */
-	err = _parse_buffers(p_state, p_search_path);
+	err = _parse_buffers(p_state);
 	ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 	/* PARSE BUFFER VIEWS */
@@ -7180,7 +7161,7 @@ Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state, const String &p_se
 
 	if (!p_state->discard_meshes_and_materials) {
 		/* PARSE IMAGES */
-		err = _parse_images(p_state, p_search_path);
+		err = _parse_images(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
@@ -7255,7 +7236,7 @@ Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_
 	if (err != OK) {
 		return err;
 	}
-	err = _serialize_file(p_state, p_path);
+	err = _serialize_file(p_state);
 	if (err != OK) {
 		return Error::FAILED;
 	}
@@ -7371,7 +7352,7 @@ Error GLTFDocument::append_from_buffer(const PackedByteArray &p_bytes, const Str
 	file_access.instantiate();
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
 	p_state->set_base_path(p_base_path.get_base_dir());
-	err = _parse(p_state, p_state->base_path, file_access);
+	err = _parse(p_state, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());
@@ -7399,7 +7380,7 @@ Error GLTFDocument::append_from_file(const String &p_path, Ref<GLTFState> p_stat
 		base_path = p_path.get_base_dir();
 	}
 	p_state->set_base_path(base_path);
-	err = _parse(p_state, base_path, file);
+	err = _parse(p_state, file);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -678,86 +678,65 @@ static inline bool _all_buffers_empty(const Vector<Vector<uint8_t>> &p_buffers, 
 	return true;
 }
 
-Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
-
-	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
+Error GLTFDocument::_encode_buffers(Ref<GLTFState> p_state) {
+	const int64_t buffer_count = p_state->buffers.size();
+	print_verbose("glTF: Total buffers: " + itos(buffer_count));
+	if (buffer_count == 0 || _all_buffers_empty(p_state->buffers)) {
 		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
 		return OK;
 	}
-	Array buffers;
-	Dictionary first_buffer;
-
-	first_buffer["byteLength"] = p_state->buffers[0].size();
-	buffers.push_back(first_buffer);
-
-	for (GLTFBufferIndex i = 1; i < p_state->buffers.size(); i++) {
-		const Vector<uint8_t> &buffer_data = p_state->buffers[i];
-		Dictionary gltf_buffer;
-		if (buffer_data.is_empty()) {
-			if (i < p_state->buffers.size() - 1 && !_all_buffers_empty(p_state->buffers, i + 1)) {
+	Array buffer_dicts;
+	buffer_dicts.resize(buffer_count);
+	const bool should_separate = p_state->should_separate_binary_blobs();
+	// Check if the buffer at index 0 should be used as a GLB buffer.
+	GLTFBufferIndex loop_start_index;
+	if (should_separate || p_state->is_text_file()) {
+		loop_start_index = 0; // Encode all buffers with URIs, don't use a GLB buffer.
+	} else {
+		loop_start_index = 1; // Encode buffers starting at index 1 with URIs, use buffer 0 as a GLB buffer.
+		const PackedByteArray buffer_data = p_state->buffers[0];
+		const int64_t buffer_byte_length = buffer_data.size();
+		if (buffer_byte_length == 0) {
+			// If this buffer is empty and the others were too, this would've returned at the top of the function.
+			ERR_PRINT("glTF export: Buffer 0 is empty, but there are non-empty subsequent buffers. Writing it anyway to preserve buffer indices.");
+		}
+		Dictionary first_gltf_buffer_dict;
+		first_gltf_buffer_dict["byteLength"] = buffer_byte_length;
+		buffer_dicts[0] = first_gltf_buffer_dict;
+	}
+	// Encode the rest of the buffers.
+	for (GLTFBufferIndex buffer_index = loop_start_index; buffer_index < buffer_count; buffer_index++) {
+		const PackedByteArray &buffer_data = p_state->buffers[buffer_index];
+		const int64_t buffer_byte_length = buffer_data.size();
+		Dictionary gltf_buffer_dict;
+		gltf_buffer_dict["byteLength"] = buffer_byte_length;
+		if (buffer_byte_length == 0) {
+			if (buffer_index < buffer_count - 1 && !_all_buffers_empty(p_state->buffers, buffer_index + 1)) {
 				// Have to push back an empty buffer to avoid changing the buffer index, even though this is against spec.
-				WARN_PRINT("glTF: Buffer " + itos(i) + " is empty, but there are non-empty subsequent buffers.");
-				gltf_buffer["byteLength"] = 0;
-				buffers.push_back(gltf_buffer);
+				WARN_PRINT("glTF: Buffer " + itos(buffer_index) + " is empty, but there are non-empty subsequent buffers.");
+				buffer_dicts[buffer_index] = gltf_buffer_dict;
 			}
 			continue;
 		}
-		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
-		const String bin_path = p_state->base_path.path_join(bin_filename);
-		Error err;
-		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
-		if (file.is_null()) {
-			return err;
-		}
-		file->create(FileAccess::ACCESS_RESOURCES);
-		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = bin_filename;
-		gltf_buffer["byteLength"] = buffer_data.size();
-		buffers.push_back(gltf_buffer);
-	}
-	p_state->json["buffers"] = buffers;
-
-	return OK;
-}
-
-Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state) {
-	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
-
-	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
-		ERR_FAIL_COND_V_MSG(!p_state->buffer_views.is_empty(), ERR_INVALID_DATA, "glTF: Buffer views are present, but buffers are empty.");
-		return OK;
-	}
-	Array buffers;
-
-	for (GLTFBufferIndex i = 0; i < p_state->buffers.size(); i++) {
-		const Vector<uint8_t> &buffer_data = p_state->buffers[i];
-		Dictionary gltf_buffer;
-		if (buffer_data.is_empty()) {
-			if (i < p_state->buffers.size() - 1 && !_all_buffers_empty(p_state->buffers, i + 1)) {
-				// Have to push back an empty buffer to avoid changing the buffer index, even though this is against spec.
-				WARN_PRINT("glTF: Buffer " + itos(i) + " is empty, but there are non-empty subsequent buffers.");
-				gltf_buffer["byteLength"] = 0;
-				buffers.push_back(gltf_buffer);
+		if (should_separate) {
+			// Encode the buffer as a separate file.
+			const String bin_filename = p_state->filename.get_basename() + itos(buffer_index) + ".bin";
+			const String bin_path = p_state->base_path.path_join(bin_filename);
+			Error err;
+			Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
+			if (file.is_null()) {
+				return err;
 			}
-			continue;
+			file->store_buffer(buffer_data.ptr(), buffer_byte_length);
+			gltf_buffer_dict["uri"] = bin_filename;
+		} else {
+			// Encode the buffer as a base64 data URI.
+			const String base64_data = CryptoCore::b64_encode_str(buffer_data.ptr(), buffer_byte_length);
+			gltf_buffer_dict["uri"] = "data:application/octet-stream;base64," + base64_data;
 		}
-		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
-		const String bin_path = p_state->base_path.path_join(bin_filename);
-		Error err;
-		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
-		if (file.is_null()) {
-			return err;
-		}
-		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = bin_filename;
-		gltf_buffer["byteLength"] = buffer_data.size();
-		buffers.push_back(gltf_buffer);
+		buffer_dicts[buffer_index] = gltf_buffer_dict;
 	}
-	if (!buffers.is_empty()) {
-		p_state->json["buffers"] = buffers;
-	}
-
+	p_state->json["buffers"] = buffer_dicts;
 	return OK;
 }
 
@@ -766,6 +745,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state) {
 		return OK;
 	}
 
+	p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_EMBED_EVERYTHING);
 	const Array &buffers = p_state->json["buffers"];
 	for (GLTFBufferIndex i = 0; i < buffers.size(); i++) {
 		const Dictionary &buffer = buffers[i];
@@ -787,6 +767,9 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state) {
 				ERR_FAIL_COND_V_MSG(!FileAccess::exists(uri), ERR_FILE_NOT_FOUND, "glTF: Binary file not found: " + uri);
 				buffer_data = FileAccess::get_file_as_bytes(uri);
 				ERR_FAIL_COND_V_MSG(buffer_data.is_empty(), ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
+				// Infer the external data mode on import in case the user wishes to round-trip the glTF file back out of Godot later.
+				// This may be modified later by the code in `GLTFDocument::_parse_images`.
+				p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS);
 			}
 
 			ERR_FAIL_COND_V(!buffer.has("byteLength"), ERR_PARSE_ERROR);
@@ -2087,7 +2070,7 @@ Dictionary GLTFDocument::_serialize_image(Ref<GLTFState> p_state, Ref<Image> p_i
 		ERR_FAIL_COND_V_MSG(p_image->is_compressed(), image_dict, "glTF: Image was compressed, but could not be decompressed.");
 	}
 
-	if (p_state->filename.to_lower().ends_with("gltf")) {
+	if (p_state->should_separate_resource_files()) {
 		String relative_texture_dir = "textures";
 		String full_texture_dir = p_state->base_path.path_join(relative_texture_dir);
 		Ref<DirAccess> da = DirAccess::open(p_state->base_path);
@@ -2368,6 +2351,14 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state) {
 				uri = uri.uri_file_decode();
 				uri = p_state->base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
 				resource_uri = uri.simplify_path();
+				// Infer the external data mode on import in case the user wishes to round-trip the glTF file back out of Godot later,
+				// or if the user needs to know how the original glTF file stored its data before importing it for some reason.
+				// This code runs after the similar code in `GLTFDocument::_parse_buffers()`, so it checks for the values set there.
+				if (p_state->get_external_data_mode() == GLTFState::EXTERNAL_DATA_MODE_EMBED_EVERYTHING) {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES);
+				} else if (p_state->get_external_data_mode() == GLTFState::EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS) {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES);
+				}
 				// ResourceLoader will rely on the file extension to use the relevant loader.
 				// The spec says that if mimeType is defined, it should take precedence (e.g.
 				// there could be a `.png` image which is actually JPEG), but there's no easy
@@ -6786,14 +6777,16 @@ Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {
 }
 
 Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
-	Error err = FAILED;
-	if (p_state->filename.to_lower().ends_with("glb")) {
-		err = _encode_buffer_glb(p_state);
-		ERR_FAIL_COND_V(err != OK, err);
-		const String gltf_path = p_state->base_path.path_join(p_state->filename);
-		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
-		ERR_FAIL_COND_V(file.is_null(), FAILED);
-
+	const String gltf_path = p_state->base_path.path_join(p_state->filename);
+	Error err = _encode_buffers(p_state);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "glTF: Failed to encode buffers for file: " + gltf_path);
+	Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
+	ERR_FAIL_COND_V(file.is_null(), FAILED);
+	if (p_state->is_text_file()) {
+		String json = JSON::stringify(p_state->json, "", true, true);
+		file->store_string(json);
+	} else {
+		// Serialize binary glTF (GLB) file.
 		constexpr uint64_t header_size = 12;
 		constexpr uint64_t chunk_header_size = 8;
 		constexpr uint32_t magic = 0x46546C67; // The byte sequence "glTF" as little-endian.
@@ -6807,14 +6800,19 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
 		uint64_t total_file_length = header_size + chunk_header_size + text_chunk_length;
 		uint64_t binary_data_length = 0;
 		uint64_t binary_chunk_length = 0;
-		if (p_state->buffers.size() > 0) {
+		if (p_state->buffers.size() > 0 && !p_state->should_separate_binary_blobs()) {
 			binary_data_length = p_state->buffers[0].size();
 			binary_chunk_length = ((binary_data_length + 3) & (~3));
 			const uint64_t file_length_with_buffer = total_file_length + chunk_header_size + binary_chunk_length;
 			// Check if the file length with the buffer is greater than glTF's maximum of 4 GiB.
 			// If it is, we can't write the buffer into the file, but can write it separately.
 			if (unlikely(file_length_with_buffer > (uint64_t)UINT32_MAX)) {
-				err = _encode_buffer_bins(p_state);
+				if (p_state->get_external_data_mode() == GLTFState::EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES) {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES);
+				} else {
+					p_state->set_external_data_mode(GLTFState::EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS);
+				}
+				err = _encode_buffers(p_state);
 				ERR_FAIL_COND_V(err != OK, err);
 				// Since the buffer bins were re-encoded, we need to re-convert the JSON to string.
 				json_string = JSON::stringify(p_state->json, "", true, true);
@@ -6852,15 +6850,6 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
 				file->store_8(0);
 			}
 		}
-	} else {
-		err = _encode_buffer_bins(p_state);
-		ERR_FAIL_COND_V(err != OK, err);
-		const String gltf_path = p_state->base_path.path_join(p_state->filename);
-		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
-		ERR_FAIL_COND_V(file.is_null(), FAILED);
-
-		String json = JSON::stringify(p_state->json, "", true, true);
-		file->store_string(json);
 	}
 	return err;
 }
@@ -7004,7 +6993,7 @@ HashSet<String> GLTFDocument::get_supported_gltf_extensions_hashset() {
 }
 
 PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err) {
-	Error err = _encode_buffer_glb(p_state);
+	Error err = _encode_buffers(p_state);
 	if (r_err) {
 		*r_err = err;
 	}
@@ -7023,13 +7012,13 @@ PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Erro
 	uint64_t total_file_length = header_size + chunk_header_size + text_chunk_length;
 	ERR_FAIL_COND_V(total_file_length > (uint64_t)UINT32_MAX, PackedByteArray());
 	uint64_t binary_data_length = 0;
-	if (p_state->buffers.size() > 0) {
+	if (p_state->buffers.size() > 0 && !p_state->should_separate_binary_blobs()) {
 		binary_data_length = p_state->buffers[0].size();
 		const uint64_t file_length_with_buffer = total_file_length + chunk_header_size + binary_data_length;
 		total_file_length = file_length_with_buffer;
 	}
 	ERR_FAIL_COND_V_MSG(total_file_length > (uint64_t)UINT32_MAX, PackedByteArray(),
-			"glTF: File size exceeds glTF Binary's maximum of 4 GiB. Cannot serialize as a single GLB in-memory buffer.");
+			"glTF: File size exceeds glTF Binary's maximum of 4 GiB. Cannot serialize as a single GLB byte array in memory.");
 	const uint32_t binary_chunk_length = binary_data_length;
 
 	Ref<StreamPeerBuffer> buffer;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -242,29 +242,6 @@ Error GLTFDocument::_serialize_scenes(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-Error GLTFDocument::_parse_json(const String &p_path, Ref<GLTFState> p_state) {
-	Error err;
-	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ, &err);
-	if (file.is_null()) {
-		return err;
-	}
-
-	Vector<uint8_t> array;
-	array.resize(file->get_length());
-	file->get_buffer(array.ptrw(), array.size());
-	String text = String::utf8((const char *)array.ptr(), array.size());
-
-	JSON json;
-	err = json.parse(text);
-	if (err != OK) {
-		_err_print_error("", p_path.utf8().get_data(), json.get_error_line(), json.get_error_message().utf8().get_data(), false, ERR_HANDLER_SCRIPT);
-		return err;
-	}
-	p_state->json = json.get_data();
-
-	return OK;
-}
-
 Error GLTFDocument::_parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state) {
 	ERR_FAIL_COND_V(p_file.is_null(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
@@ -701,7 +678,7 @@ static inline bool _all_buffers_empty(const Vector<Vector<uint8_t>> &p_buffers, 
 	return true;
 }
 
-Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path) {
+Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state) {
 	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
@@ -726,16 +703,16 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 			}
 			continue;
 		}
-		String filename = p_path.get_basename().get_file() + itos(i) + ".bin";
-		String path = p_path.get_base_dir() + "/" + filename;
+		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
+		const String bin_path = p_state->base_path.path_join(bin_filename);
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
 		if (file.is_null()) {
 			return err;
 		}
 		file->create(FileAccess::ACCESS_RESOURCES);
 		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = filename;
+		gltf_buffer["uri"] = bin_filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
 		buffers.push_back(gltf_buffer);
 	}
@@ -744,7 +721,7 @@ Error GLTFDocument::_encode_buffer_glb(Ref<GLTFState> p_state, const String &p_p
 	return OK;
 }
 
-Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path) {
+Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state) {
 	print_verbose("glTF: Total buffers: " + itos(p_state->buffers.size()));
 
 	if (p_state->buffers.is_empty() || _all_buffers_empty(p_state->buffers)) {
@@ -765,15 +742,15 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 			}
 			continue;
 		}
-		String filename = p_path.get_basename().get_file() + itos(i) + ".bin";
-		String path = p_path.get_base_dir() + "/" + filename;
+		const String bin_filename = p_state->filename.get_basename() + itos(i) + ".bin";
+		const String bin_path = p_state->base_path.path_join(bin_filename);
 		Error err;
-		Ref<FileAccess> file = FileAccess::open(path, FileAccess::WRITE, &err);
+		Ref<FileAccess> file = FileAccess::open(bin_path, FileAccess::WRITE, &err);
 		if (file.is_null()) {
 			return err;
 		}
 		file->store_buffer(buffer_data.ptr(), buffer_data.size());
-		gltf_buffer["uri"] = filename;
+		gltf_buffer["uri"] = bin_filename;
 		gltf_buffer["byteLength"] = buffer_data.size();
 		buffers.push_back(gltf_buffer);
 	}
@@ -784,7 +761,7 @@ Error GLTFDocument::_encode_buffer_bins(Ref<GLTFState> p_state, const String &p_
 	return OK;
 }
 
-Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_path) {
+Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state) {
 	if (!p_state->json.has("buffers")) {
 		return OK;
 	}
@@ -804,9 +781,9 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> p_state, const String &p_base_
 				}
 				buffer_data = _parse_base64_uri(uri);
 			} else { // Relative path to an external image file.
-				ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
+				ERR_FAIL_COND_V(p_state->base_path.is_empty(), ERR_INVALID_PARAMETER);
 				uri = uri.uri_file_decode();
-				uri = p_base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
+				uri = p_state->base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
 				ERR_FAIL_COND_V_MSG(!FileAccess::exists(uri), ERR_FILE_NOT_FOUND, "glTF: Binary file not found: " + uri);
 				buffer_data = FileAccess::get_file_as_bytes(uri);
 				ERR_FAIL_COND_V_MSG(buffer_data.is_empty(), ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
@@ -2135,6 +2112,8 @@ Dictionary GLTFDocument::_serialize_image(Ref<GLTFState> p_state, Ref<Image> p_i
 		}
 		image_dict["uri"] = relative_texture_dir.path_join(image_file_name).uri_encode();
 	} else {
+		// Else, such as if this is a `.glb`, a byte array in memory, or an
+		// embedded `.gltf`, we need to serialize the image into a buffer view.
 		GLTFBufferViewIndex bvi;
 
 		Ref<GLTFBufferView> bv;
@@ -2325,7 +2304,7 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 	p_state->source_images.push_back(p_image);
 }
 
-Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_path) {
+Error GLTFDocument::_parse_images(Ref<GLTFState> p_state) {
 	ERR_FAIL_COND_V(p_state.is_null(), ERR_INVALID_PARAMETER);
 	if (!p_state->json.has("images")) {
 		return OK;
@@ -2385,9 +2364,9 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> p_state, const String &p_base_p
 					mime_type = uri.substr(5, uri.find(";base64") - 5);
 				}
 			} else { // Relative path to an external image file.
-				ERR_FAIL_COND_V(p_base_path.is_empty(), ERR_INVALID_PARAMETER);
+				ERR_FAIL_COND_V(p_state->base_path.is_empty(), ERR_INVALID_PARAMETER);
 				uri = uri.uri_file_decode();
-				uri = p_base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
+				uri = p_state->base_path.path_join(uri).replace_char('\\', '/'); // Fix for Windows.
 				resource_uri = uri.simplify_path();
 				// ResourceLoader will rely on the file extension to use the relevant loader.
 				// The spec says that if mimeType is defined, it should take precedence (e.g.
@@ -6703,7 +6682,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p
 	}
 }
 
-Error GLTFDocument::_parse(Ref<GLTFState> p_state, const String &p_path, Ref<FileAccess> p_file) {
+Error GLTFDocument::_parse(Ref<GLTFState> p_state, Ref<FileAccess> p_file) {
 	Error err;
 	if (p_file.is_null()) {
 		return FAILED;
@@ -6743,7 +6722,7 @@ Error GLTFDocument::_parse(Ref<GLTFState> p_state, const String &p_path, Ref<Fil
 		}
 	}
 
-	err = _parse_gltf_state(p_state, p_path);
+	err = _parse_gltf_state(p_state);
 	ERR_FAIL_COND_V(err != OK, err);
 
 	return OK;
@@ -6806,12 +6785,13 @@ Error GLTFDocument::_serialize_asset_header(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path) {
+Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state) {
 	Error err = FAILED;
-	if (p_path.to_lower().ends_with("glb")) {
-		err = _encode_buffer_glb(p_state, p_path);
+	if (p_state->filename.to_lower().ends_with("glb")) {
+		err = _encode_buffer_glb(p_state);
 		ERR_FAIL_COND_V(err != OK, err);
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		const String gltf_path = p_state->base_path.path_join(p_state->filename);
+		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V(file.is_null(), FAILED);
 
 		constexpr uint64_t header_size = 12;
@@ -6834,7 +6814,7 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 			// Check if the file length with the buffer is greater than glTF's maximum of 4 GiB.
 			// If it is, we can't write the buffer into the file, but can write it separately.
 			if (unlikely(file_length_with_buffer > (uint64_t)UINT32_MAX)) {
-				err = _encode_buffer_bins(p_state, p_path);
+				err = _encode_buffer_bins(p_state);
 				ERR_FAIL_COND_V(err != OK, err);
 				// Since the buffer bins were re-encoded, we need to re-convert the JSON to string.
 				json_string = JSON::stringify(p_state->json, "", true, true);
@@ -6873,9 +6853,10 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 			}
 		}
 	} else {
-		err = _encode_buffer_bins(p_state, p_path);
+		err = _encode_buffer_bins(p_state);
 		ERR_FAIL_COND_V(err != OK, err);
-		Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+		const String gltf_path = p_state->base_path.path_join(p_state->filename);
+		Ref<FileAccess> file = FileAccess::open(gltf_path, FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V(file.is_null(), FAILED);
 
 		String json = JSON::stringify(p_state->json, "", true, true);
@@ -7023,7 +7004,7 @@ HashSet<String> GLTFDocument::get_supported_gltf_extensions_hashset() {
 }
 
 PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err) {
-	Error err = _encode_buffer_glb(p_state, "");
+	Error err = _encode_buffer_glb(p_state);
 	if (r_err) {
 		*r_err = err;
 	}
@@ -7138,11 +7119,11 @@ Error GLTFDocument::_parse_asset_header(Ref<GLTFState> p_state) {
 	return OK;
 }
 
-Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state, const String &p_search_path) {
+Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state) {
 	Error err;
 
 	/* PARSE BUFFERS */
-	err = _parse_buffers(p_state, p_search_path);
+	err = _parse_buffers(p_state);
 	ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 	/* PARSE BUFFER VIEWS */
@@ -7167,7 +7148,7 @@ Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state, const String &p_se
 
 	if (!p_state->discard_meshes_and_materials) {
 		/* PARSE IMAGES */
-		err = _parse_images(p_state, p_search_path);
+		err = _parse_images(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
@@ -7239,7 +7220,7 @@ Error GLTFDocument::write_to_filesystem(Ref<GLTFState> p_state, const String &p_
 	p_state->set_base_path(p_path.get_base_dir());
 	p_state->filename = p_path.get_file();
 	RETURN_IF_ERROR(_serialize(p_state));
-	Error err = _serialize_file(p_state, p_path);
+	Error err = _serialize_file(p_state);
 	if (err != OK) {
 		return Error::FAILED;
 	}
@@ -7355,7 +7336,7 @@ Error GLTFDocument::append_from_buffer(const PackedByteArray &p_bytes, const Str
 	file_access.instantiate();
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
 	p_state->set_base_path(p_base_path.get_base_dir());
-	err = _parse(p_state, p_state->base_path, file_access);
+	err = _parse(p_state, file_access);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());
@@ -7383,7 +7364,7 @@ Error GLTFDocument::append_from_file(const String &p_path, Ref<GLTFState> p_stat
 		base_path = p_path.get_base_dir();
 	}
 	p_state->set_base_path(base_path);
-	err = _parse(p_state, base_path, file);
+	err = _parse(p_state, file);
 	ERR_FAIL_COND_V(err != OK, err);
 	for (Ref<GLTFDocumentExtension> ext : document_extensions) {
 		ERR_CONTINUE(ext.is_null());

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -139,10 +139,9 @@ private:
 			StandardMaterial3D::TextureFilter p_filter_mode, bool p_repeats);
 	Ref<GLTFTextureSampler> _get_sampler_for_texture(Ref<GLTFState> p_state,
 			const GLTFTextureIndex p_texture);
-	Error _parse_json(const String &p_path, Ref<GLTFState> p_state);
 	Error _parse_glb(Ref<FileAccess> p_file, Ref<GLTFState> p_state);
 	void _compute_node_heights(Ref<GLTFState> p_state);
-	Error _parse_buffers(Ref<GLTFState> p_state, const String &p_base_path);
+	Error _parse_buffers(Ref<GLTFState> p_state);
 	Error _parse_buffer_views(Ref<GLTFState> p_state);
 	Error _parse_accessors(Ref<GLTFState> p_state);
 	template <typename T>
@@ -164,7 +163,7 @@ private:
 	Error _serialize_lights(Ref<GLTFState> p_state);
 	Ref<Image> _parse_image_bytes_into_image(Ref<GLTFState> p_state, const Vector<uint8_t> &p_bytes, const String &p_mime_type, int p_index, String &r_file_extension);
 	void _parse_image_save_image(Ref<GLTFState> p_state, const Vector<uint8_t> &p_bytes, const String &p_resource_uri, const String &p_file_extension, int p_index, Ref<Image> p_image);
-	Error _parse_images(Ref<GLTFState> p_state, const String &p_base_path);
+	Error _parse_images(Ref<GLTFState> p_state);
 	Error _parse_textures(Ref<GLTFState> p_state);
 	Error _parse_texture_samplers(Ref<GLTFState> p_state);
 	Error _parse_materials(Ref<GLTFState> p_state);
@@ -206,13 +205,13 @@ private:
 	Error _serialize_nodes(Ref<GLTFState> p_state);
 	Error _serialize_scenes(Ref<GLTFState> p_state);
 	String interpolation_to_string(const GLTFAnimation::Interpolation p_interp);
-	Error _encode_buffer_bins(Ref<GLTFState> p_state, const String &p_path);
-	Error _encode_buffer_glb(Ref<GLTFState> p_state, const String &p_path);
+	Error _encode_buffer_bins(Ref<GLTFState> p_state);
+	Error _encode_buffer_glb(Ref<GLTFState> p_state);
 	PackedByteArray _serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err);
 	Dictionary _serialize_texture_transform_uv1(const Ref<BaseMaterial3D> &p_material);
 	Dictionary _serialize_texture_transform_uv2(const Ref<BaseMaterial3D> &p_material);
 	Error _serialize_asset_header(Ref<GLTFState> p_state);
-	Error _serialize_file(Ref<GLTFState> p_state, const String p_path);
+	Error _serialize_file(Ref<GLTFState> p_state);
 	Error _serialize_gltf_extensions(Ref<GLTFState> p_state) const;
 
 public:
@@ -241,7 +240,7 @@ public:
 	virtual Error write_to_filesystem(Ref<GLTFState> p_state, const String &p_path);
 
 public:
-	Error _parse_gltf_state(Ref<GLTFState> p_state, const String &p_search_path);
+	Error _parse_gltf_state(Ref<GLTFState> p_state);
 	Error _parse_asset_header(Ref<GLTFState> p_state);
 	Error _parse_gltf_extensions(Ref<GLTFState> p_state);
 	void _process_mesh_instances(Ref<GLTFState> p_state, Node *p_scene_root);
@@ -302,7 +301,7 @@ public:
 	void _convert_animation(Ref<GLTFState> p_state, AnimationPlayer *p_animation_player, const String &p_animation_track_name);
 
 	Error _serialize(Ref<GLTFState> p_state);
-	Error _parse(Ref<GLTFState> p_state, const String &p_path, Ref<FileAccess> p_file);
+	Error _parse(Ref<GLTFState> p_state, Ref<FileAccess> p_file);
 };
 
 VARIANT_ENUM_CAST(GLTFDocument::RootNodeMode);

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -205,8 +205,7 @@ private:
 	Error _serialize_nodes(Ref<GLTFState> p_state);
 	Error _serialize_scenes(Ref<GLTFState> p_state);
 	String interpolation_to_string(const GLTFAnimation::Interpolation p_interp);
-	Error _encode_buffer_bins(Ref<GLTFState> p_state);
-	Error _encode_buffer_glb(Ref<GLTFState> p_state);
+	Error _encode_buffers(Ref<GLTFState> p_state);
 	PackedByteArray _serialize_glb_buffer(Ref<GLTFState> p_state, Error *r_err);
 	Dictionary _serialize_texture_transform_uv1(const Ref<BaseMaterial3D> &p_material);
 	Dictionary _serialize_texture_transform_uv2(const Ref<BaseMaterial3D> &p_material);

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -72,6 +72,10 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_base_path", "base_path"), &GLTFState::set_base_path);
 	ClassDB::bind_method(D_METHOD("get_filename"), &GLTFState::get_filename);
 	ClassDB::bind_method(D_METHOD("set_filename", "filename"), &GLTFState::set_filename);
+	ClassDB::bind_method(D_METHOD("is_text_file"), &GLTFState::is_text_file);
+	ClassDB::bind_method(D_METHOD("get_external_data_mode"), &GLTFState::get_external_data_mode);
+	ClassDB::bind_method(D_METHOD("set_external_data_mode", "mode"), &GLTFState::set_external_data_mode);
+	ClassDB::bind_method(D_METHOD("should_separate_resource_files"), &GLTFState::should_separate_resource_files);
 	ClassDB::bind_method(D_METHOD("get_root_nodes"), &GLTFState::get_root_nodes);
 	ClassDB::bind_method(D_METHOD("set_root_nodes", "root_nodes"), &GLTFState::set_root_nodes);
 	ClassDB::bind_method(D_METHOD("get_textures"), &GLTFState::get_textures_bind);
@@ -135,8 +139,15 @@ void GLTFState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "create_animations"), "set_create_animations", "get_create_animations"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "import_as_skeleton_bones"), "set_import_as_skeleton_bones", "get_import_as_skeleton_bones"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "animations", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_animations", "get_animations"); // Vector<Ref<GLTFAnimation>>
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "external_data_mode", PROPERTY_HINT_ENUM, "Automatic,Embed Everything,Separate All Files,Separate Binary Blobs,Separate Resource Files"), "set_external_data_mode", "get_external_data_mode"); // enum
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "handle_binary_image_mode", PROPERTY_HINT_ENUM, "Discard All Textures,Extract Textures,Embed as Basis Universal,Embed as Uncompressed"), "set_handle_binary_image_mode", "get_handle_binary_image_mode"); // enum
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bake_fps", PROPERTY_HINT_RANGE, "0.001,120,0.0001,or_greater"), "set_bake_fps", "get_bake_fps");
+
+	BIND_ENUM_CONSTANT(EXTERNAL_DATA_MODE_AUTOMATIC);
+	BIND_ENUM_CONSTANT(EXTERNAL_DATA_MODE_EMBED_EVERYTHING);
+	BIND_ENUM_CONSTANT(EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES);
+	BIND_ENUM_CONSTANT(EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS);
+	BIND_ENUM_CONSTANT(EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES);
 
 	BIND_ENUM_CONSTANT(HANDLE_BINARY_IMAGE_MODE_DISCARD_TEXTURES);
 	BIND_ENUM_CONSTANT(HANDLE_BINARY_IMAGE_MODE_EXTRACT_TEXTURES);
@@ -443,6 +454,35 @@ void GLTFState::set_filename(const String &p_filename) {
 	if (extract_prefix.is_empty()) {
 		extract_prefix = p_filename.get_basename();
 	}
+}
+
+bool GLTFState::is_text_file() const {
+	return filename.to_lower().ends_with(".gltf");
+}
+
+bool GLTFState::should_separate_binary_blobs() const {
+	if (external_data_mode == EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES || external_data_mode == EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS) {
+		ERR_FAIL_COND_V_MSG(base_path.is_empty(), false, "glTF: No base path is set, cannot separate binary blob files.");
+		return true;
+	}
+	if (external_data_mode == EXTERNAL_DATA_MODE_EMBED_EVERYTHING || external_data_mode == EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES) {
+		return false;
+	}
+	// EXTERNAL_DATA_MODE_AUTOMATIC embeds everything for binary files (.glb, .vrm),
+	// byte arrays in memory (no extension), and when there is no base path set,
+	// but separates for text files (.gltf) when the base path is valid.
+	return is_text_file() && !base_path.is_empty();
+}
+
+bool GLTFState::should_separate_resource_files() const {
+	if (external_data_mode == EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES || external_data_mode == EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES) {
+		ERR_FAIL_COND_V_MSG(base_path.is_empty(), false, "glTF: No base path is set, cannot separate resource files.");
+		return true;
+	}
+	if (external_data_mode == EXTERNAL_DATA_MODE_EMBED_EVERYTHING || external_data_mode == EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS) {
+		return false;
+	}
+	return is_text_file() && !base_path.is_empty();
 }
 
 Variant GLTFState::get_additional_data(const StringName &p_extension_name) const {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -52,6 +52,13 @@ class GLTFState : public Resource {
 	friend class GLTFNode;
 
 public:
+	enum ExternalDataMode {
+		EXTERNAL_DATA_MODE_AUTOMATIC,
+		EXTERNAL_DATA_MODE_EMBED_EVERYTHING,
+		EXTERNAL_DATA_MODE_SEPARATE_ALL_FILES,
+		EXTERNAL_DATA_MODE_SEPARATE_BINARY_BLOBS,
+		EXTERNAL_DATA_MODE_SEPARATE_RESOURCE_FILES,
+	};
 	enum HandleBinaryImageMode {
 		HANDLE_BINARY_IMAGE_MODE_DISCARD_TEXTURES = 0,
 		HANDLE_BINARY_IMAGE_MODE_EXTRACT_TEXTURES,
@@ -79,6 +86,7 @@ protected:
 	bool force_disable_compression = false;
 	bool import_as_skeleton_bones = false;
 
+	ExternalDataMode external_data_mode = ExternalDataMode::EXTERNAL_DATA_MODE_AUTOMATIC;
 	HandleBinaryImageMode handle_binary_image_mode = HANDLE_BINARY_IMAGE_MODE_EXTRACT_TEXTURES;
 
 	Vector<Ref<GLTFNode>> nodes;
@@ -255,6 +263,12 @@ public:
 
 	String get_filename() const;
 	void set_filename(const String &p_filename);
+	bool is_text_file() const;
+
+	ExternalDataMode get_external_data_mode() const { return external_data_mode; }
+	void set_external_data_mode(ExternalDataMode p_external_data_mode) { external_data_mode = p_external_data_mode; }
+	bool should_separate_binary_blobs() const;
+	bool should_separate_resource_files() const;
 
 	PackedInt32Array get_root_nodes() const;
 	void set_root_nodes(const PackedInt32Array &p_root_nodes);
@@ -326,4 +340,5 @@ public:
 	void set_additional_data(const StringName &p_extension_name, Variant p_additional_data);
 };
 
+VARIANT_ENUM_CAST(GLTFState::ExternalDataMode);
 VARIANT_ENUM_CAST(GLTFState::HandleBinaryImageMode);


### PR DESCRIPTION
Draft because this PR depends on https://github.com/godotengine/godot/pull/120519

---

In master, Godot gives you 2 options for exporting, determined only by file type:

* Exporting a `.glb` file embeds binary data into a self-contained file (so long as it fits in the 4 GiB limit).
  * This is equivalent to Blender's "glTF Binary (.glb)" export option.
* Exporting a `.gltf` file separates out all data into files, such as images into image files, and buffers into `.bin` files.
  * This is equivalent to Blender's "glTF Separate (.gltf + .bin + textures)" export option.

However, there are more possibilities available than just those two. Blender offers another option called "glTF Embedded (.gltf)" which embeds all data into a text-based `.gltf`. This PR allows doing that with the "Embed Everything" option. Still... there are more possibilities than just those three, so this PR adds a comprehensive enum:

<img width="510" height="299" alt="Screenshot 2025-08-08 at 2 36 30 AM" src="https://github.com/user-attachments/assets/b76ce2d8-9946-4afa-b16d-c14d263b54ae" />

The default option is "Automatic", which behaves the same as the current behavior in master.

---

* Automatic
  * When exporting a glTF file, automatically determines if data should be embedded or separated based on the file extension used and if `base_path` is valid. With this option, exporting a `.gltf` file with a valid [member base_path] will behave like "Separate All Files". If exporting a `.glb` file, exporting to an in-memory buffer, or exporting with `base_path` set to an empty string, this will behave like "Embed Everything".
  * This option is suitable for most use cases. It behaves like Blender's "glTF Binary (.glb)" export option for `.glb` files, and like Blender's "glTF Separate (.gltf + .bin + textures)" export option for `.gltf` files.
* Embed Everything
  * When exporting a glTF file, embeds all data in the glTF file, including images and binary buffers. For `.glb` files, this will use the binary blob chunk at the end of the file to store the data in buffer 0 (if present). For all other buffers, such as buffers in `.gltf` files, the data will be embedded as a base64-encoded string in the JSON of the buffer.
  * This option is useful when you want a single self-contained file. It behaves like Blender's "glTF Binary (.glb)" export option for `.glb` files, and like Blender's "glTF Embedded (.gltf)" export option for `.gltf` files.
* Separate All Files
  * When exporting a glTF file, separates all files that can be saved in their own file formats into their own files, and also save all raw binary blobs, such as glTF buffers, into separate `.bin` files.
  * This option is useful when having the glTF file's contents spread out over multiple files is desired, resulting in maximum human readability. It behaves like Blender's "glTF Separate (.gltf + .bin + textures)" export option.
* Separate Binary Blobs
  * When exporting a glTF file, separates all raw binary blobs, such as glTF buffers, into separate `.bin` files. Resources that can be saved in their own file formats, such as images, are embedded within glTF buffers, and are stored in the `.bin` files.
  * This option is useful if you need efficient storage of binary data while also keeping the number of files low. In the typical case, this option will result in only two files: the glTF file and a single `.bin` file next to it.
* Separate Resource Files
  * When exporting a glTF file, separates all resources that can be saved in their own file formats into their own files, such as images. This option does not separate buffers, meaning that binary blob data without a file type, such as mesh data, animation data, skin/skeleton data, and so on, are still embedded in the glTF file.
  * This option is useful if the exported glTF file is intended to be added to the project folder in a game engine, so that the game engine can import the resources files separately, and optionally use them separately. Otherwise, game engines may extract embedded resources to their own files, resulting in duplicate data in the project folder.

---

For example, the options would look like this:
```
Embed Everything
file.gltf/glb (contains file.bin and texture.png)

Separate All Files
file.gltf/glb
file.bin
texture.png

Separate Binary Blobs
file.gltf/glb
file.bin (contains texture.png)

Separate Resource Files
file.gltf/glb (contains file.bin)
texture.png
```

---

Effectively, this enum serves to answer two questions:
* Should resource files, like images, be embedded in the buffers, or separated out into their own files?
* Should binary blobs, like buffers, be embedded into the glTF file, or separated out into their own files?

Extensions should respect these options by calling `GLTFState.should_separate_resource_files()` to determine if they should save their resources in separate files.

---

Test project: [gltf_export_external_data_mode.zip](https://github.com/user-attachments/files/21693272/gltf_export_external_data_mode.zip)

In the test project, each folder contains the same test cube exported with different choices for the enum. The `glb/automatic/` and `glb/embed_everything/` folders are equivalent, and the `gltf/automatic/` and `gltf/separate_all_files/` folders are equivalent, but are included for completeness.