### PR TITLE
Fix `AudioStreamPlayer3D` `volume_db` not actually changing volume

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1756,6 +1756,10 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF_RST("audio/general/text_to_speech", false);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/2d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
 	GLOBAL_DEF_RST(PropertyInfo(Variant::FLOAT, "audio/general/3d_panning_strength", PROPERTY_HINT_RANGE, "0,2,0.01"), 0.5f);
+	// True by default in order to keep compatibility with 4.6 and lower.
+	// Set to false when creating a new project.
+	// This probably should be false by default for 5.x
+	GLOBAL_DEF_RST(PropertyInfo(Variant::BOOL, "audio/general/3d_volume_db_affects_attenuation"), true);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "audio/general/ios/session_category", PROPERTY_HINT_ENUM, "Ambient,Multi Route,Play and Record,Playback,Record,Solo Ambient"), 0);
 	GLOBAL_DEF("audio/general/ios/mix_with_others", false);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -477,6 +477,10 @@
 			The base strength of the panning effect for all [AudioStreamPlayer3D] nodes. The panning strength can be further scaled on each Node using [member AudioStreamPlayer3D.panning_strength]. A value of [code]0.0[/code] disables stereo panning entirely, leaving only volume attenuation in place. A value of [code]1.0[/code] completely mutes one of the channels if the sound is located exactly to the left (or right) of the listener.
 			The default value of [code]0.5[/code] is tuned for headphones which means that the opposite side channel goes no lower than 50% of the volume of the nearside channel. You may find that you can set this value higher for speakers to have the same effect since both ears can hear from each speaker.
 		</member>
+		<member name="audio/general/3d_volume_db_affects_attenuation" type="bool" setter="" getter="" default="true">
+			When set to [code]true[/code], the [AudioStreamPlayer3D] property [member AudioStreamPlayer3D.volume_db] will offset attenuation instead of directly offsetting the volume of the sound.
+			This defaults to [code]false[/code] for projects created starting in Godot 4.7.
+		</member>
 		<member name="audio/general/default_playback_type" type="int" setter="" getter="" default="0" experimental="" keywords="stream, sample">
 			Specifies the default playback type of the platform.
 			The default value is set to [b]Stream[/b], as most platforms have no issues mixing streams.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8314,6 +8314,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
 	settings["physics/3d/physics_engine"] = "Jolt Physics";
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
+	settings["audio/general/3d_volume_db_affects_attenuation"] = false;
 	return settings;
 }
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -252,7 +252,10 @@ float AudioStreamPlayer3D::_get_attenuation_db(float p_distance) const {
 		}
 	}
 
-	att += internal->volume_db;
+	if (AudioServer::get_singleton()->cached_volume_db_affects_3d_attenuation) {
+		att += internal->volume_db;
+	}
+
 	if (att > max_db) {
 		att = max_db;
 	}
@@ -496,6 +499,10 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 			float tightness = cached_global_panning_strength * 2.0f;
 			tightness *= panning_strength;
 			_calc_output_vol(local_pos.normalized(), tightness, listener_volume_vector);
+		}
+
+		if (!AudioServer::get_singleton()->cached_volume_db_affects_3d_attenuation) {
+			multiplier *= Math::db_to_linear(internal->volume_db);
 		}
 
 		for (AudioFrame &frame : listener_volume_vector) {

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -2137,6 +2137,7 @@ void AudioServer::_bind_methods() {
 
 AudioServer::AudioServer() {
 	singleton = this;
+	cached_volume_db_affects_3d_attenuation = GLOBAL_GET_CACHED(bool, "audio/general/3d_volume_db_affects_attenuation");
 }
 
 AudioServer::~AudioServer() {

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -204,6 +204,7 @@ public:
 	};
 
 	typedef void (*AudioCallback)(void *p_userdata);
+	bool cached_volume_db_affects_3d_attenuation = true;
 
 private:
 	uint64_t mix_time = 0;


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/109423

It seems that `AudioStreamPlayer3D` `volume_db` was being applied in the attenuation function, seemingly shifting the attenuation distance. The attenuation has a volume cap, and is often at that cap. Lowering `volume_db` gave the effect of moving the listener away, which in some cases would lower volume once the volume is low enough or distance far enough where the volume is no longer capped. This would also had an effect where lowering volume would apply attenuation filtering effects. This PR moves `volume_db` out of the attenuation function and applies it only as a volume vector multiplier.

This does not interpolate the value of volume_db over time, so I was worried that there would be clicks and pops. However, I didn't notice any, even when doing sudden dramatic volume shifts on low frequency sounds. I believe something is interpolating the value. I went looking for whatever that was but got quite lost in the weeds, so I decided that it was probably fine.

~~This is a small change with huge consequences that will definitely break compat. Any projects using `AudioStreamPlayer3D` instances that touched `volume_db` will definitely feel the difference.~~ Thanks to [Calinou](https://github.com/Calinou)'s suggestion, this is a project setting that defaults to false but is enabled on newly-made projects, therefore not breaking compat.