### PR TITLE
Limit the upper range on the `AudioStreamPlayer3D` `volume_db` slider to 24dB

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -880,7 +880,7 @@ void AudioStreamPlayer3D::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "attenuation_model", PROPERTY_HINT_ENUM, "Inverse,Inverse Square,Logarithmic,Disabled"), "set_attenuation_model", "get_attenuation_model");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,80,suffix:dB"), "set_volume_db", "get_volume_db");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24,or_greater,suffix:dB"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_linear", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_volume_linear", "get_volume_linear");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "unit_size", PROPERTY_HINT_RANGE, "0.1,100,0.01,or_greater"), "set_unit_size", "get_unit_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_db", PROPERTY_HINT_RANGE, "-24,6,suffix:dB"), "set_max_db", "get_max_db");


### PR DESCRIPTION
Noticed while making another PR that the `volume_db` slider on `AudioStreamPlayer3D` caps out at +80dB which is likely way higher than anyone needs. Plus, if https://github.com/godotengine/godot/pull/109452 is merged, I could see someone cranking up their volume suddenly and exploding their speakers.

This reduces the maximum value on the `volume_db` slider to 24dB, in line with the other `AudioStreamPlayer` classes. It also allows higher values in case anyone wants to actually do that.

I made this while making https://github.com/godotengine/godot/pull/109452. If that PR is merged, I feel this one should be merged alongside it to make the overall volume-adjusting experience much nicer.