### PR TITLE
Clearer wording for CanvasLayer follow_viewport

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -45,7 +45,7 @@
 			The custom [Viewport] node assigned to the [CanvasLayer]. If [code]null[/code], uses the default viewport instead.
 		</member>
 		<member name="follow_viewport_enabled" type="bool" setter="set_follow_viewport" getter="is_following_viewport" default="false">
-			If enabled, the [CanvasLayer] maintains its position in world space. If disabled, the [CanvasLayer] stays in a fixed position on the screen.
+			If enabled, the [CanvasLayer] uses the canvas transformation of the viewport. If disabled, the [CanvasLayer] stays in a fixed position on the screen.
 			Together with [member follow_viewport_scale], this can be used for a pseudo-3D effect.
 		</member>
 		<member name="follow_viewport_scale" type="float" setter="set_follow_viewport_scale" getter="get_follow_viewport_scale" default="1.0">


### PR DESCRIPTION
I think saying "maintains its position in world space" is confusing, because with world space I usually mean the global_position of Node2Ds. Let me know if you have other ideas to improve the text.

It took me some time to understand how cameras and viewports work.
Here is the summary of what I learned:

- Every game has a Window at the top of the hierarchy, which inherits Viewport
- A camera does not change position or global_position of anything. It changes the canvas_transform of the Viewport
- Every node that can be rendered inherits CanvasItem
- Every CanvasItem also sets its own canvas_transform
    - If it is in a CanvasLayer, it uses that canvas_transform
    - Else, if it has a parent, it uses that canvas_transform
    - Else, it uses the canvas_transform of the Viewport
    - Source: https://github.com/godotengine/godot/blob/a3b42d85d27668f8992c0779ed3cc82d13db3dd9/scene/main/canvas_item.cpp#L1491