### PR TITLE
Add indicator to linked resources

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -161,8 +161,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 					unique_resources_confirmation->popup_centered();
 				} else {
 					current_option = -1;
-					unique_resources_label->set_text(TTRC("This object has no resources."));
-					unique_resources_confirmation->popup_centered();
+					EditorNode::get_singleton()->show_warning(TTR("This object has no resources to duplicate."));
 				}
 			} else {
 				editor_data->apply_changes_in_editors();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1641,7 +1641,7 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 	saving_resources_in_path.erase(p_resource);
 
 	_resource_saved(p_resource, path);
-
+	clear_node_reference(p_resource); // // Check if Resource is saved to disk to potentially remove it from resource_count
 	emit_signal(SNAME("resource_saved"), p_resource);
 	editor_data.notify_resource_saved(p_resource);
 }
@@ -1741,6 +1741,161 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	}
 	file->set_title(TTR("Save Resource As..."));
 	file->popup_file_dialog();
+}
+
+bool EditorNode::is_resource_internal_to_scene(Ref<Resource> p_resource) {
+	bool inside_scene = !get_edited_scene() || get_edited_scene()->get_scene_file_path() == p_resource->get_path().get_slice("::", 0);
+	return inside_scene || p_resource->get_path().is_empty();
+}
+
+void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> &r_list, bool p_subresources, bool p_allow_external) {
+	Variant::Type type = p_variant.get_type();
+	if (type == Variant::OBJECT && p_variant.get_validated_object() == nullptr) {
+		return;
+	}
+
+	if (type != Variant::OBJECT && type != Variant::ARRAY && type != Variant::DICTIONARY) {
+		return;
+	}
+
+	if (type == Variant::ARRAY) {
+		Array arr = p_variant;
+		for (const Variant &v : arr) {
+			Ref<Resource> res = v;
+			if (res.is_valid()) {
+				if (p_allow_external) {
+					r_list.push_back(res);
+				} else if (is_resource_internal_to_scene(res)) {
+					r_list.push_back(res);
+				}
+			}
+			gather_resources(v, r_list, p_subresources, p_allow_external);
+		}
+		return;
+	}
+
+	if (type == Variant::DICTIONARY) {
+		Dictionary dict = p_variant;
+		for (const KeyValue<Variant, Variant> &kv : dict) {
+			Ref<Resource> res_key = kv.key;
+			Ref<Resource> res_value = kv.value;
+			if (res_key.is_valid()) {
+				if (p_allow_external) {
+					r_list.push_back(res_key);
+				} else if (is_resource_internal_to_scene(res_key)) {
+					r_list.push_back(res_key);
+				}
+			}
+			if (res_value.is_valid()) {
+				if (p_allow_external) {
+					r_list.push_back(res_value);
+				} else if (is_resource_internal_to_scene(res_value)) {
+					r_list.push_back(res_value);
+				}
+			}
+			gather_resources(kv.key, r_list, p_subresources, p_allow_external);
+			gather_resources(kv.value, r_list, p_subresources, p_allow_external);
+		}
+		return;
+	}
+
+	List<PropertyInfo> pinfo;
+	p_variant.get_property_list(&pinfo);
+
+	for (const PropertyInfo &E : pinfo) {
+		if (!(E.usage & PROPERTY_USAGE_EDITOR) || E.name == "script") {
+			continue;
+		}
+
+		Variant property_value = p_variant.get(E.name);
+		Variant::Type property_type = property_value.get_type();
+
+		if (property_type == Variant::ARRAY || property_type == Variant::DICTIONARY) {
+			gather_resources(property_value, r_list, p_subresources, p_allow_external);
+			continue;
+		}
+
+		Ref<Resource> res = property_value;
+		if (res.is_null()) {
+			continue;
+		}
+		if (!p_allow_external) {
+			if (!res->is_built_in() || res->get_path().get_slice("::", 0) != get_edited_scene()->get_scene_file_path()) {
+				if (!res->get_path().is_empty()) {
+					continue;
+				}
+			}
+		}
+		r_list.push_back(res);
+		if (p_subresources) {
+			gather_resources(res, r_list, p_subresources, p_allow_external);
+		}
+	}
+}
+
+void EditorNode::update_resource_count(Node *p_node, bool p_remove) {
+	if (!get_edited_scene()) {
+		return;
+	}
+
+	List<Ref<Resource>> res_list;
+	gather_resources(p_node, res_list, true);
+
+	for (Ref<Resource> &R : res_list) {
+		List<Node *>::Element *E = resource_count[R].find(p_node);
+		if (E) {
+			if (p_remove) {
+				resource_count[R].erase(E);
+			}
+		} else {
+			resource_count[R].push_back(p_node);
+		}
+	}
+
+	emit_signal(SNAME("resource_counter_changed"));
+}
+
+int EditorNode::get_resource_count(Ref<Resource> p_res) {
+	List<Node *> *L = resource_count.getptr(p_res);
+	return L ? L->size() : 0;
+}
+
+List<Node *> EditorNode::get_resource_node_list(Ref<Resource> p_res) {
+	List<Node *> *L = resource_count.getptr(p_res);
+	return L == nullptr ? List<Node *>() : *L;
+}
+
+void EditorNode::update_node_reference(const Variant &p_value, Node *p_node, bool p_remove) {
+	List<Ref<Resource>> list;
+	Ref<Resource> res = p_value;
+	gather_resources(p_value, list, true); //Gather all Resources and their SubResources to remove p_node from their lists.
+
+	if (res.is_valid() && is_resource_internal_to_scene(res)) {
+		// Avoid external Resources from being added in.
+		list.push_back(res);
+	}
+
+	for (Ref<Resource> &R : list) {
+		if (!p_remove) {
+			resource_count[R].push_back(p_node);
+		} else {
+			List<Node *>::Element *E = resource_count[R].find(p_node);
+			if (E) {
+				resource_count[R].erase(E);
+			}
+		}
+	}
+	emit_signal(SNAME("resource_counter_changed"));
+}
+
+void EditorNode::clear_node_reference(Ref<Resource> p_res) {
+	if (is_resource_internal_to_scene(p_res)) {
+		return;
+	}
+	List<Node *> *node_list = resource_count.getptr(p_res);
+	if (node_list != nullptr) {
+		node_list->clear();
+	}
 }
 
 void EditorNode::_menu_option(int p_option) {
@@ -4311,6 +4466,7 @@ void EditorNode::_set_current_scene_nocheck(int p_idx) {
 
 	Node *old_scene = get_editor_data().get_edited_scene_root();
 
+	resource_count.clear();
 	editor_selection->clear();
 	SceneTreeDock::get_singleton()->clear_previous_node_selection();
 	editor_data.set_edited_scene(p_idx);
@@ -7362,6 +7518,8 @@ void EditorNode::_bind_methods() {
 
 	ClassDB::bind_method("stop_child_process", &EditorNode::stop_child_process);
 
+	ClassDB::bind_method(D_METHOD("update_node_reference", "value", "node", "remove"), &EditorNode::update_node_reference, DEFVAL(false));
+
 	ADD_SIGNAL(MethodInfo("request_help_search"));
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));
 	ADD_SIGNAL(MethodInfo("resource_saved", PropertyInfo(Variant::OBJECT, "obj")));
@@ -7369,6 +7527,7 @@ void EditorNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("scene_changed"));
 	ADD_SIGNAL(MethodInfo("scene_closed", PropertyInfo(Variant::STRING, "path")));
 	ADD_SIGNAL(MethodInfo("preview_locale_changed"));
+	ADD_SIGNAL(MethodInfo("resource_counter_changed"));
 }
 
 static Node *_resource_get_edited_scene() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -465,6 +465,7 @@ private:
 
 	Ref<Resource> saving_resource;
 	HashSet<Ref<Resource>> saving_resources_in_path;
+	HashMap<Ref<Resource>, List<Node *>> resource_count; // Keeps track of linked Resources from a Scene.
 
 	uint64_t update_spinner_step_msec = 0;
 	uint64_t update_spinner_step_frame = 0;
@@ -809,6 +810,13 @@ public:
 	void save_resource_in_path(const Ref<Resource> &p_resource, const String &p_path);
 	void save_resource(const Ref<Resource> &p_resource);
 	void save_resource_as(const Ref<Resource> &p_resource, const String &p_at_path = String());
+	bool is_resource_internal_to_scene(Ref<Resource> p_resource);
+	void gather_resources(const Variant &p_variant, List<Ref<Resource>> &r_list, bool p_subresources = false, bool p_allow_external = false);
+	void update_resource_count(Node *p_node, bool p_remove = false);
+	void update_node_reference(const Variant &p_value, Node *p_node, bool p_remove = false);
+	void clear_node_reference(Ref<Resource> p_res);
+	int get_resource_count(Ref<Resource> p_res);
+	List<Node *> get_resource_node_list(Ref<Resource> p_res);
 
 	void show_about() { _menu_option_confirm(HELP_ABOUT, false); }
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5170,11 +5170,22 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		undo_redo->add_do_property(object, p_name, p_value);
 		bool valid = false;
 		Variant value = object->get(p_name, &valid);
+		Variant::Type type = p_value.get_type();
 		if (valid) {
 			if (Object::cast_to<Control>(object) && (p_name == "anchors_preset" || p_name == "layout_mode")) {
 				undo_redo->add_undo_method(object, "_edit_set_state", Object::cast_to<Control>(object)->_edit_get_state());
 			} else {
 				undo_redo->add_undo_property(object, p_name, value);
+			}
+			// We'll use Editor Selection to get the currently edited Node.
+			Node *N = Object::cast_to<Node>(object);
+			if (N && (type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
+				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
+				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
+				// Perhaps an inefficient way of updating the resource count.
+				// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
+				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, true);
+				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", value, N, false);
 			}
 		}
 
@@ -5224,7 +5235,20 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		}
 
 		Resource *r = Object::cast_to<Resource>(object);
+
 		if (r) {
+			//Setting a Subresource. Since there's possibly multiple Nodes referencing 'r', we need to link them to the Subresource.
+			List<Node *> shared_nodes = EditorNode::get_singleton()->get_resource_node_list(r);
+			for (Node *N : shared_nodes) {
+				if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
+					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
+					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
+					// Perhaps an inefficient way of updating the resource count.
+					// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
+					undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, true);
+					undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", value, N, false);
+				}
+			}
 			if (String(p_name) == "resource_local_to_scene") {
 				bool prev = object->get(p_name);
 				bool next = p_value;

--- a/editor/inspector/editor_resource_picker.h
+++ b/editor/inspector/editor_resource_picker.h
@@ -55,6 +55,7 @@ class EditorResourcePicker : public HBoxContainer {
 	mutable HashSet<StringName> allowed_types_with_convert;
 
 	Button *assign_button = nullptr;
+	Button *make_unique_button = nullptr;
 	TextureRect *preview_rect = nullptr;
 	Button *edit_button = nullptr;
 	Button *quick_load_button = nullptr;
@@ -102,6 +103,7 @@ class EditorResourcePicker : public HBoxContainer {
 
 	void _button_draw();
 	void _button_input(const Ref<InputEvent> &p_event);
+	void _on_unique_button_pressed();
 
 	String _get_owner_path() const;
 	String _get_resource_type(const Ref<Resource> &p_resource) const;
@@ -117,6 +119,8 @@ class EditorResourcePicker : public HBoxContainer {
 	void _ensure_resource_menu();
 	void _gather_resources_to_duplicate(const Ref<Resource> p_resource, TreeItem *p_item, const String &p_property_name = "") const;
 	void _duplicate_selected_resources();
+	bool _is_uniqueness_enabled(bool p_check_recursive = false);
+	Ref<Resource> _has_parent_resource();
 
 protected:
 	virtual void _update_resource();

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -335,6 +335,8 @@ void SceneTreeEditor::_update_node_subtree(Node *p_node, TreeItem *p_parent, boo
 		is_new = true;
 	}
 
+	EditorNode::get_singleton()->update_resource_count(p_node);
+
 	if (!(p_force || I->value.dirty)) {
 		// Nothing to do.
 		return;
@@ -897,7 +899,6 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 	if (p_node != get_scene_node() && !get_scene_node()->is_ancestor_of(p_node)) {
 		return;
 	}
-
 	node_cache.remove(p_node);
 	_update_if_clean();
 }
@@ -968,7 +969,6 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 			}
 			node_cache.current_pinned_node = pinned_node;
 		}
-
 		_update_node_subtree(get_scene_node(), nullptr, node_cache.force_update);
 		_compute_hash(get_scene_node(), last_hash);
 
@@ -1225,7 +1225,6 @@ void SceneTreeEditor::_compute_hash(Node *p_node, uint64_t &hash) {
 void SceneTreeEditor::_reset() {
 	// Stop any waiting change to tooltip.
 	update_node_tooltip_delay->stop();
-
 	tree->clear();
 	node_cache.clear();
 }
@@ -2473,6 +2472,9 @@ void SceneTreeEditor::NodeCache::remove(Node *p_node, bool p_recursive) {
 
 	HashMap<Node *, CachedNode>::Iterator I = cache.find(p_node);
 	if (I) {
+		if (editor->is_scene_tree_dock) {
+			EditorNode::get_singleton()->update_resource_count(I->key, true);
+		}
 		if (p_recursive) {
 			int cc = p_node->get_child_count(false);
 


### PR DESCRIPTION
Attempts to somewhat implement
 https://github.com/godotengine/godot-proposals/issues/904 , https://github.com/godotengine/godot-proposals/issues/9603 , https://github.com/godotengine/godot-proposals/issues/10319#issue-2437124230


## Feature

Adds an indicator to tells whether a resource is shared.  The button's tooltip shows the number of times a Resource was shared, along with whether there are subresources to be made unique:
<br />

![showtime](https://github.com/user-attachments/assets/b4dddada-eb7d-447b-9a23-e032eac21f64)


Left Click on the Icon makes Resources Unique. Right Click - Recursive

## Implementation

For this feature, after a lot of trial and error, I settled for reduz's approach of using a 
`HashMap` to track how many times a  Resource is referenced by a Node within a Scene. 
 - If a Resource is referenced more than once, you can make it unique (recursively or not). 
 - If there's only one instance of a Resource, it's already unique, so `make_unique` and `make_unique_recursive` is disabled.

> [!NOTE]
>Duplicating built-in SubResources is also disabled if the 'Parent' Resource wasn't previously made unique. This is because Making a SubResource unique does not matter if the parent isn't also duplicated. See https://github.com/godotengine/godot/pull/109458#issuecomment-3190607935 **(gradient example)**

-  **External** Resources are not added to the `HashMap` — since we can't for certain indicate how many of them there are.
Outside from that, I would separate this feature into two parts:

### SceneTree Operations
---

In the Scene tree, you can add, delete, duplicate and paste nodes. Each time you do these operations, `update_resource_count` collects built-in non-empty Resources and add them to the HashMap, along with their respective Node. So basically you update the Resource counter each time you do these operations.

---

### Inspector Operations

Each time you made a _revelvant_ change to a property that holds a Resource (e.g Made a Resource unique, added a resource to an Array, etc), you update the Resource counter like above, inserting the Resource and its Node in the HashMap. 

> [!NOTE]
>When setting Subresources in the inspector (if not external), they should have the same number of References as the parent. So if Reference `A` is referenced by 3 Nodes, if you add a SubResource  `B`, it should also be linked to 3 Nodes.

It uses a much "simpler" version of `update_resource_count` (although they could be merged but it would make using this API much more cumbersome for the Inspector and SceneTree). `update_node_reference` collects the Resources found withing a  _single_ property and either removes or adds to the HashMap. That way you're only dealing with a specific property is being set and not touching what's already added.

In short, The inspector part was the most tricky, as I did have to fix all the edge cases found when making unique, setting or removing Resources . As of 09/28, it's pretty clean all things considered. Using strictly `update_node_reference` and tweaking some pre existing code made it much cleaner than it previously was.

## To-Do List

The following is a to-do list of everything that should be dealt with. There are some things left undetermined on how they should work, so I added **Waiting for Input** right after the task.

- [x] Display a warning indicator for sub resources as to why they can't be duplicated  _(**Waiting on review for input**)_
- [x] ~Move `Make Unique `and `Make Unique recursive ` funcionality to Icons _(**Waiting on review for input**)_~ Edit: NVM, moving functionality to icons hasnt been well supported by users in previous attempts by other PRs
- [x] Hashmaps clears and updates itself when Nodes are Added/Removed from a scene 
- [x] Disable `make_unique` if there's only copy of the Resource or It's a subresource
- [x] Update Hashmap through other means, such as using Resource Picker
- [x] Counter not updating once you've done an operation.
- [x] Track Subresources
- [x] Bulk-Setting Node's Resources does not add them to hashmap.
- [x] Duplicated Arrays full of Resources do not increase counter for some reason.
- [x] External SubResources made unique should be included in the Hashmap, pointing to the parent's Nodes.
- [x] Find better way of knowing whether a resource is external or not
- [x] ~~History mismatch when undo-redoing packed scenes if they're open on the editor. _**(Waiting on review for input)**_~~ Seems to have fixed itself
- [x] Empty Resources/Sub resources using the wrong icon (fixes itself after saving)
- [x] Arrays (probly Dictionaries too) don't update counter when making unique
- [x]  `Inconsistent Redo` error might happen??
- [x] Fix edge case when saving to disk/deleting resource from disk
- [x] Dictionaries with Resources as Keys don't show an icon
- [x] Edge Case with SubResources not showing the correct amount after adding them to a Resource already referenced by multiple nodes

## Test Project
Added a test project so people interested in this feature can test it. It's a pretty dynamic feature though, so please toy around it and report any weird behavior!
[indicator-test.zip](https://github.com/user-attachments/files/22394474/indicator-test.zip)

