### PR TITLE
Fix imported images not being saved as external resources when used as sub-resources 

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2171,6 +2171,12 @@ void Image::set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_for
 	initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_data);
 }
 
+#ifdef TOOLS_ENABLED
+bool Image::is_data_equel(const Ref<Image> &p_image) const {
+	return p_image.is_valid() && format == p_image->format && width == p_image->width && height == p_image->height && mipmaps == p_image->mipmaps && data == p_image->data;
+}
+#endif
+
 void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
 	ERR_FAIL_COND_MSG(p_width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", p_width));
 	ERR_FAIL_COND_MSG(p_height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", p_height));

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -358,6 +358,10 @@ public:
 	static Ref<Image> create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
 	void set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
 
+#ifdef TOOLS_ENABLED
+	bool is_data_equel(const Ref<Image> &p_image) const;
+#endif
+
 	Image() = default; // Create an empty image.
 	Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format); // Create an empty image of a specific size and format.
 	Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data); // Import an image of a specific size and format from a byte vector.

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2079,7 +2079,12 @@ void ResourceFormatSaverBinaryInstance::_find_resources(const Variant &p_variant
 						Ref<Resource> sres = value;
 						if (sres.is_valid()) {
 							resource_set.insert(sres);
-							saved_resources.push_back(sres);
+							if (sres->is_built_in()) {
+								saved_resources.push_back(sres);
+							} else { // It may be imported.
+								int idx = external_resources.size();
+								external_resources[res] = idx;
+							}
 						} else {
 							_find_resources(value);
 						}

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -89,6 +89,10 @@ void ImageTexture::set_image(const Ref<Image> &p_image) {
 	format = p_image->get_format();
 	mipmaps = p_image->has_mipmaps();
 
+#ifdef TOOLS_ENABLED
+	image_path = p_image->get_path();
+#endif
+
 	if (texture.is_null()) {
 		texture = RenderingServer::get_singleton()->texture_2d_create(p_image);
 	} else {
@@ -125,11 +129,24 @@ void ImageTexture::update(const Ref<Image> &p_image) {
 }
 
 Ref<Image> ImageTexture::get_image() const {
+	Ref<Image> image;
 	if (image_stored) {
-		return RenderingServer::get_singleton()->texture_2d_get(texture);
-	} else {
-		return Ref<Image>();
+		image = RenderingServer::get_singleton()->texture_2d_get(texture);
+
+#ifdef TOOLS_ENABLED
+		if (image.is_valid() && !image_path.is_empty()) {
+			Ref<Image> source = ResourceCache::get_ref(image_path);
+			if (source.is_null()) {
+				source = ResourceLoader::load(image_path);
+			}
+			if (image != source && image->is_data_equel(source)) {
+				image = source; // Use the source Image to prevent the same data from being saved multiple times.
+			}
+		}
+#endif
 	}
+
+	return image;
 }
 
 int ImageTexture::get_width() const {

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -47,6 +47,10 @@ class ImageTexture : public Texture2D {
 	mutable Ref<BitMap> alpha_cache;
 	bool image_stored = false;
 
+#ifdef TOOLS_ENABLED
+	String image_path;
+#endif
+
 protected:
 	virtual void reload_from_file() override;
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1646,7 +1646,12 @@ void ResourceFormatSaverTextInstance::_find_resources(const Variant &p_variant, 
 						Ref<Resource> sres = v;
 						if (sres.is_valid()) {
 							resource_set.insert(sres);
-							saved_resources.push_back(sres);
+							if (sres->is_built_in()) {
+								saved_resources.push_back(sres);
+							} else { // It may be imported.
+								String id = itos(external_resources.size() + 1) + "_" + Resource::generate_scene_unique_id();
+								external_resources[sres] = id;
+							}
 						} else {
 							_find_resources(v);
 						}


### PR DESCRIPTION
Previously, image assets could be imported as either `Image` or `Texture` types. When imported as an `Image`, dragging and dropping it onto the Texture property in the Inspector would automatically convert it to an `ImageTexture`.

Finally, the `Image` is converted into **pure data** and saved in `TextureStorage`. When trying to fetch the `Image` in the `ImageTexture`, the `Image` is usually newly generated, which loses the `path` property.

When saving the edited scene or the resource being edited in the Inspector, even if the `Image` was imported (an external resource), its data might be embedded in the saved file.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

If the image data has not changed, the PR will try to return the source image instead of the newly generated image when call `ImageTexture::get_image()`.  

When saving, it will check whether the resource with `PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT` enabled (mainly `Image`) is an external (imported) resource. If it is an external resource, it will be saved as an external resource. This helps eliminate possible noise in git.

Fix #109479.