### PR TITLE
Fix `AudioStreamPlaylist` goes to next stream at wrong time if `AudioServer.playback_speed_scale != 1.0`

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -262,6 +262,7 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 	}
 
 	double time_dec = (1.0 / AudioServer::get_singleton()->get_mix_rate());
+	time_dec *= p_rate_scale * AudioServer::get_singleton()->get_playback_speed_scale();
 	double fade_dec = (1.0 / playlist->fade_time) / AudioServer::get_singleton()->get_mix_rate();
 
 	int todo = p_frames;
@@ -269,9 +270,9 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 	while (todo) {
 		int to_mix = MIN(todo, MIX_BUFFER_SIZE);
 
-		playback[play_order[play_index]]->mix(mix_buffer, 1.0, to_mix);
+		playback[play_order[play_index]]->mix(mix_buffer, p_rate_scale, to_mix);
 		if (fade_index != -1) {
-			playback[fade_index]->mix(fade_buffer, 1.0, to_mix);
+			playback[fade_index]->mix(fade_buffer, p_rate_scale, to_mix);
 		}
 
 		offset += time_dec * to_mix;
@@ -337,7 +338,7 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 
 				if (restart) {
 					playback[idx]->start(0); // No loop, just cold-restart.
-					playback[idx]->mix(mix_buffer + i, 1.0, to_mix - i); // Fill rest of mix buffer
+					playback[idx]->mix(mix_buffer + i, p_rate_scale, to_mix - i); // Fill rest of mix buffer
 				}
 
 				// Update fade todo.


### PR DESCRIPTION
#109113
Adjusted AudioStreamPlaylist’s mix routine to multiply the time decrement by both p_rate_scale and AudioServer::playback_speed_scale, and passed the rate scale through to sub-stream mixing

Ensured restart logic mixes the new stream with the appropriate rate scale, preventing timing gaps or premature transitions

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
