### PR TITLE
Fix cinematic preview causing the editor redraw continuously and aspect ratio not updating in camera preview

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -482,6 +482,8 @@ private:
 	bool previewing_cinema = false;
 	bool _is_node_locked(const Node *p_node) const;
 	void _preview_exited_scene();
+	void _preview_camera_property_changed();
+	void _update_centered_labels();
 	void _toggle_camera_preview(bool);
 	void _toggle_cinema_preview(bool);
 	void _init_gizmo_instance(int p_idx);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/101499

Moves the logic out of notification.

The aspect ratio yellow rectangle updating worked with cinematic preview because of the bug (but didn't work with just regular preview camera), this PR also makes it work with both after the redraw fix by making it driven by the camera properties changing.

https://github.com/user-attachments/assets/722b7270-34b9-4e2f-9885-426663a2f08f

