### PR TITLE
Fix remote tree max selection warning not showing properly

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -95,10 +95,7 @@ void EditorDebuggerTree::_scene_tree_selection_changed(TreeItem *p_item, int p_c
 		if (inspected_object_ids.size() == (int)EDITOR_GET("debugger/max_node_selection")) {
 			selection_surpassed_limit = true;
 			p_item->deselect(0);
-			return;
-		}
-
-		if (!inspected_object_ids.has(id)) {
+		} else if (!inspected_object_ids.has(id)) {
 			inspected_object_ids.append(id);
 		}
 	} else if (inspected_object_ids.has(id)) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/pull/108297#issuecomment-3159836030.

> Select remote nodes up to the limit, then Ctrl + click one more node. No warning will appear, but when you then try to deselect a node, it will show the missing warning.