### PR TITLE
Return the precise number of decimals

### DIFF
--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -60,16 +60,16 @@ double Math::randfn(double p_mean, double p_deviation) {
 
 int Math::step_decimals(double p_step) {
 	if (p_step <= 0) {
-        return 0;
-    }
-    const double EPSILON = 1e-10;
-    double scaled = p_step;
-    int decimals = 0;
-    while (abs(scaled - round(scaled)) > EPSILON && decimals < 10) {
-        scaled *= 10.0;
-        decimals++;
-    }
-    return decimals;
+		return 0;
+	}
+	const double EPSILON = 1e-10;
+	double scaled = p_step;
+	int decimals = 0;
+	while (abs(scaled - round(scaled)) > EPSILON && decimals < 10) {
+		scaled *= 10.0;
+		decimals++;
+	}
+	return decimals;
 }
 
 // Only meant for editor usage in float ranges, where a step of 0

--- a/core/math/math_funcs.cpp
+++ b/core/math/math_funcs.cpp
@@ -59,29 +59,17 @@ double Math::randfn(double p_mean, double p_deviation) {
 }
 
 int Math::step_decimals(double p_step) {
-	static const int maxn = 10;
-	static const double sd[maxn] = {
-		0.9999, // somehow compensate for floating point error
-		0.09999,
-		0.009999,
-		0.0009999,
-		0.00009999,
-		0.000009999,
-		0.0000009999,
-		0.00000009999,
-		0.000000009999,
-		0.0000000009999
-	};
-
-	double abs = Math::abs(p_step);
-	double decs = abs - (int)abs; // Strip away integer part
-	for (int i = 0; i < maxn; i++) {
-		if (decs >= sd[i]) {
-			return i;
-		}
-	}
-
-	return 0;
+	if (p_step <= 0) {
+        return 0;
+    }
+    const double EPSILON = 1e-10;
+    double scaled = p_step;
+    int decimals = 0;
+    while (abs(scaled - round(scaled)) > EPSILON && decimals < 10) {
+        scaled *= 10.0;
+        decimals++;
+    }
+    return decimals;
 }
 
 // Only meant for editor usage in float ranges, where a step of 0


### PR DESCRIPTION
passing in numbers such as 0.25 return 1 in the old implementation, which means that elements such as the UI slider when using export_range will not display the number to the desired precision.

This fixes https://github.com/godotengine/godot/issues/95725 for me in my custom 4.5 build

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
