### PR TITLE
Fix screen_orientation not being assigned on ios

### DIFF
--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -662,6 +662,7 @@ void DisplayServerAppleEmbedded::screen_set_orientation(DisplayServer::ScreenOri
 	int screen_count = get_screen_count();
 	ERR_FAIL_INDEX(p_screen, screen_count);
 
+	screen_orientation = p_orientation;
 	if (@available(iOS 16.0, *)) {
 		[GDTAppDelegateService.viewController setNeedsUpdateOfSupportedInterfaceOrientations];
 	}


### PR DESCRIPTION
Fixes issue: https://github.com/godotengine/godot/issues/107231

Introduced by commit: https://github.com/godotengine/godot/commit/2d93e004b9b5f6d9f7a56bb43baae0cb1de27443

Here is a link to the file diff: https://github.com/godotengine/godot/commit/2d93e004b9b5f6d9f7a56bb43baae0cb1de27443#diff-02e997eae7e3917de38375685775ae983ff69c3776158596f36058d7771ae3b4R658

<img width="1541" height="306" alt="image" src="https://github.com/user-attachments/assets/f6d97fef-f8ae-4ef7-acff-bfbcc4657240" />


As you can see, @bruvzg accidentally deleted the assignment when the error check was added:

```mm
screen_orientation = p_orientation;
```

Hence, it never rotates when the device rotates!  In fact, iOS shouldn't respect any setting and is likely landscape only at the moment.  Which means vertical orientation is likely also broken.  This should be a blocker on the 4.5 release imo.

As always, thanks for the awesome engine and let me know if you need any changes to the PR.  Much love from Lange Studios (and me personally)! :)