### PR TITLE
Replace some `RBSet` with `HashSet`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1292,7 +1292,7 @@ RBSet<GDScript *> GDScript::get_must_clear_dependencies() {
 	RBSet<GDScript *> must_clear_dependencies;
 	HashMap<GDScript *, RBSet<GDScript *>> all_dependencies = get_all_dependencies();
 
-	RBSet<GDScript *> cant_clear;
+	HashSet<GDScript *> cant_clear;
 	for (KeyValue<GDScript *, RBSet<GDScript *>> &E : all_dependencies) {
 		if (dependencies.has(E.key)) {
 			continue;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -843,7 +843,7 @@ PackedStringArray TileMap::get_configuration_warnings() const {
 	warnings.push_back(RTR("The TileMap node is deprecated as it is superseded by the use of multiple TileMapLayer nodes.\nTo convert a TileMap to a set of TileMapLayer nodes, open the TileMap bottom panel with this node selected, click the toolbox icon in the top-right corner and choose \"Extract TileMap layers as individual TileMapLayer nodes\"."));
 
 	// Retrieve the set of Z index values with a Y-sorted layer.
-	RBSet<int> y_sorted_z_index;
+	HashSet<int> y_sorted_z_index;
 	for (const TileMapLayer *layer : layers) {
 		if (layer->is_y_sort_enabled()) {
 			y_sorted_z_index.insert(layer->get_z_index());

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -29,7 +29,7 @@
 /**************************************************************************/
 
 #include "resource_preloader.h"
-#include "core/templates/rb_set.h"
+
 void ResourcePreloader::_set_resources(const Array &p_data) {
 	resources.clear();
 
@@ -54,17 +54,19 @@ Array ResourcePreloader::_get_resources() const {
 	arr.resize(resources.size());
 	names.resize(resources.size());
 
-	RBSet<String> sorted_names;
-
+	String *ptrw = names.ptrw();
+	int i = 0;
 	for (const KeyValue<StringName, Ref<Resource>> &E : resources) {
-		sorted_names.insert(E.key);
+		ptrw[i] = E.key;
+		i++;
 	}
 
-	int i = 0;
-	for (const String &E : sorted_names) {
-		names.set(i, E);
-		arr[i] = resources[E];
-		i++;
+	names.sort();
+
+	Array::Iterator it = arr.begin();
+	for (const String &E : names) {
+		*it = resources[E];
+		++it;
 	}
 
 	return Array{ names, arr };

--- a/scene/resources/particle_process_material.cpp
+++ b/scene/resources/particle_process_material.cpp
@@ -36,7 +36,7 @@ Mutex ParticleProcessMaterial::dirty_materials_mutex;
 SelfList<ParticleProcessMaterial>::List ParticleProcessMaterial::dirty_materials;
 Mutex ParticleProcessMaterial::shader_map_mutex;
 HashMap<ParticleProcessMaterial::MaterialKey, ParticleProcessMaterial::ShaderData, ParticleProcessMaterial::MaterialKey> ParticleProcessMaterial::shader_map;
-RBSet<String> ParticleProcessMaterial::min_max_properties;
+HashSet<String> ParticleProcessMaterial::min_max_properties;
 ParticleProcessMaterial::ShaderNames *ParticleProcessMaterial::shader_names = nullptr;
 
 void ParticleProcessMaterial::init_shaders() {

--- a/scene/resources/particle_process_material.h
+++ b/scene/resources/particle_process_material.h
@@ -150,7 +150,7 @@ private:
 
 	static Mutex shader_map_mutex;
 	static HashMap<MaterialKey, ShaderData, MaterialKey> shader_map;
-	static RBSet<String> min_max_properties;
+	static HashSet<String> min_max_properties;
 
 	MaterialKey current_key;
 	RID shader_rid;

--- a/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_hash_map_rd.h
@@ -45,7 +45,7 @@ private:
 	RBMap<uint32_t, RID> hash_map;
 	LocalVector<Pair<uint32_t, RID>> compiled_queue;
 	Mutex compiled_queue_mutex;
-	RBSet<uint32_t> compilation_set;
+	HashSet<uint32_t> compilation_set;
 	HashMap<uint32_t, WorkerThreadPool::TaskID> compilation_tasks;
 	Mutex local_mutex;
 

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -148,7 +148,7 @@ private:
 		List<Branch> branches;
 		Branch *current_branch = nullptr;
 		int condition_depth = 0;
-		RBSet<String> includes;
+		HashSet<String> includes;
 		List<uint64_t> cyclic_include_hashes; // Holds code hash of includes.
 		int include_depth = 0;
 		String current_filename;


### PR DESCRIPTION
While reading the implementation of `RBSet`, I came across #60999. Out of curiosity, I went through all current uses of `RBSet` in the codebase and found some places where it could be replaced with a `HashSet`. I’m not sure why they still use `RBSet` even though they don’t depend on iteration order—perhaps a later PR made changes, or it was simply overlooked—but I haven’t found anything that would prevent migrating them to `HashSet`.

