### PR TITLE
Android: Add method to set root window color at runtime

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -2261,6 +2261,14 @@
 				Makes the window specified by [param window_id] request attention, which is materialized by the window title and taskbar entry blinking until the window is focused. This usually has no visible effect if the window is currently focused. The exact behavior varies depending on the operating system.
 			</description>
 		</method>
+		<method name="window_set_color">
+			<return type="void" />
+			<param index="0" name="color" type="Color" />
+			<description>
+				Sets the background color of the root window.
+				[b]Note:[/b] This method is implemented only on Android.
+			</description>
+		</method>
 		<method name="window_set_current_screen">
 			<return type="void" />
 			<param index="0" name="screen" type="int" />

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -690,6 +690,9 @@ void EditorNode::_update_theme(bool p_skip_creation) {
 	editor_dock_manager->update_tab_styles();
 	editor_dock_manager->update_docks_menu();
 	editor_dock_manager->set_tab_icon_max_width(theme->get_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
+#ifdef ANDROID_ENABLED
+	DisplayServer::get_singleton()->window_set_color(theme->get_color(SNAME("background"), EditorStringName(Editor)));
+#endif
 }
 
 Ref<Texture2D> EditorNode::_get_editor_theme_native_menu_icon(const StringName &p_name, bool p_global_menu, bool p_dark_mode) const {

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -297,6 +297,9 @@ void ProjectManager::_update_theme(bool p_skip_creation) {
 			asset_library->add_theme_style_override(SceneStringName(panel), memnew(StyleBoxEmpty));
 		}
 	}
+#ifdef ANDROID_ENABLED
+	DisplayServer::get_singleton()->window_set_color(theme->get_color(SNAME("background"), EditorStringName(Editor)));
+#endif
 }
 
 Button *ProjectManager::_add_main_view(MainViewTab p_id, const String &p_name, const Ref<Texture2D> &p_icon, Control *p_view_control) {

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -626,6 +626,12 @@ bool DisplayServerAndroid::can_any_window_draw() const {
 	return true;
 }
 
+void DisplayServerAndroid::window_set_color(const Color &p_color) {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_NULL(godot_java);
+	godot_java->set_window_color(p_color);
+}
+
 void DisplayServerAndroid::process_events() {
 	Input::get_singleton()->flush_buffered_events();
 }

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -220,6 +220,8 @@ public:
 	virtual void window_set_vsync_mode(DisplayServer::VSyncMode p_vsync_mode, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual DisplayServer::VSyncMode window_get_vsync_mode(WindowID p_vsync_mode) const override;
 
+	virtual void window_set_color(const Color &p_color) override;
+
 	virtual void process_events() override;
 
 	void process_accelerometer(const Vector3 &p_accelerometer);

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.kt
@@ -260,16 +260,7 @@ class Godot private constructor(val context: Context) {
 					useImmersive.set(true)
 					newArgs.add(commandLine[i])
 				} else if (commandLine[i] == "--background_color") {
-					val colorStr = commandLine[i + 1]
-					try {
-						backgroundColor = colorStr.toColorInt()
-						Log.d(TAG, "background color = $backgroundColor")
-					} catch (e: java.lang.IllegalArgumentException) {
-						Log.d(TAG, "Failed to parse background color: $colorStr")
-					}
-					runOnHostThread {
-						getActivity()?.window?.decorView?.setBackgroundColor(backgroundColor)
-					}
+					setWindowColor(commandLine[i + 1])
 				} else if (commandLine[i] == "--use_apk_expansion") {
 					useApkExpansion = true
 				} else if (hasExtra && commandLine[i] == "--apk_expansion_md5") {
@@ -489,6 +480,21 @@ class Godot private constructor(val context: Context) {
 			background.color
 		} else {
 			backgroundColor
+		}
+	}
+
+	fun setWindowColor(colorStr: String) {
+		val color = try {
+			colorStr.toColorInt()
+		} catch (e: java.lang.IllegalArgumentException) {
+			Log.w(TAG, "Failed to parse background color: $colorStr", e)
+			return
+		}
+		val decorView = getActivity()?.window?.decorView ?: return
+		runOnHostThread {
+			decorView.setBackgroundColor(color)
+			backgroundColor = color
+			setSystemBarsAppearance()
 		}
 	}
 

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -85,6 +85,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_instance) {
 	_verify_apk = p_env->GetMethodID(godot_class, "nativeVerifyApk", "(Ljava/lang/String;)I");
 	_enable_immersive_mode = p_env->GetMethodID(godot_class, "nativeEnableImmersiveMode", "(Z)V");
 	_is_in_immersive_mode = p_env->GetMethodID(godot_class, "isInImmersiveMode", "()Z");
+	_set_window_color = p_env->GetMethodID(godot_class, "setWindowColor", "(Ljava/lang/String;)V");
 	_on_editor_workspace_selected = p_env->GetMethodID(godot_class, "nativeOnEditorWorkspaceSelected", "(Ljava/lang/String;)V");
 	_get_activity = p_env->GetMethodID(godot_class, "getActivity", "()Landroid/app/Activity;");
 }
@@ -584,6 +585,16 @@ bool GodotJavaWrapper::is_in_immersive_mode() {
 		return env->CallBooleanMethod(godot_instance, _is_in_immersive_mode);
 	} else {
 		return false;
+	}
+}
+
+void GodotJavaWrapper::set_window_color(const Color &p_color) {
+	if (_set_window_color) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL(env);
+		String color = "#" + p_color.to_html(false);
+		jstring jStrColor = env->NewStringUTF(color.utf8().get_data());
+		env->CallVoidMethod(godot_instance, _set_window_color, jStrColor);
 	}
 }
 

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -81,6 +81,7 @@ private:
 	jmethodID _verify_apk = nullptr;
 	jmethodID _enable_immersive_mode = nullptr;
 	jmethodID _is_in_immersive_mode = nullptr;
+	jmethodID _set_window_color = nullptr;
 	jmethodID _on_editor_workspace_selected = nullptr;
 	jmethodID _get_activity = nullptr;
 
@@ -136,6 +137,8 @@ public:
 
 	void enable_immersive_mode(bool p_enabled);
 	bool is_in_immersive_mode();
+
+	void set_window_color(const Color &p_color);
 
 	void on_editor_workspace_selected(const String &p_workspace);
 };

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1476,6 +1476,8 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_start_drag", "window_id"), &DisplayServer::window_start_drag, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_start_resize", "edge", "window_id"), &DisplayServer::window_start_resize, DEFVAL(MAIN_WINDOW_ID));
 
+	ClassDB::bind_method(D_METHOD("window_set_color", "color"), &DisplayServer::window_set_color);
+
 	ClassDB::bind_method(D_METHOD("accessibility_should_increase_contrast"), &DisplayServer::accessibility_should_increase_contrast);
 	ClassDB::bind_method(D_METHOD("accessibility_should_reduce_animation"), &DisplayServer::accessibility_should_reduce_animation);
 	ClassDB::bind_method(D_METHOD("accessibility_should_reduce_transparency"), &DisplayServer::accessibility_should_reduce_transparency);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -525,6 +525,8 @@ public:
 
 	virtual void window_start_drag(WindowID p_window = MAIN_WINDOW_ID) {}
 
+	virtual void window_set_color(const Color &p_color) {}
+
 	enum WindowResizeEdge {
 		WINDOW_EDGE_TOP_LEFT,
 		WINDOW_EDGE_TOP,


### PR DESCRIPTION
- This PR adds a method to set the root window background color at runtime.
- The second commit uses this method to make the Android editor’s root window color match the editor background color.
---

What I mean by "root window" here?

The root window is the one on which the Godot app is rendered. It’s only visible in areas where Godot  doesn’t render, the status bar, navigation bar, and display cutouts.

https://github.com/godotengine/godot/pull/108557 added an export option to set this background color at export time. However, there are valid reasons to want to change it at runtime. For example, I want to change it dynamically based on the app’s theme color.

~Currently, it’s already possible to change this color at runtime using `JavaClassWrapper` and `AndroidRuntime`. Since I was already adding a method to change it for the Editor, I figured it made sense to expose it as well. That’s the only reason.~

<details><summary>Example to set it via JavaClassWrapper</summary>

```
func set_system_bar_color(color: Color, override_appearance := false) -> void:
	if not android_runtime:
		return
	
	var activity = android_runtime.getActivity()
	var callable = func ():
		var window = activity.getWindow()
		var decorView = window.getDecorView()
		decorView.setBackgroundColor(color.to_argb32())
		
		if (is_light_system_bars != (color.get_luminance() > 0.45)) or override_appearance:
			is_light_system_bars = color.get_luminance() > 0.45
			var WindowInsetsControllerCompat = JavaClassWrapper.wrap("androidx.core.view.WindowInsetsControllerCompat")
			var controller = WindowInsetsControllerCompat.call("<init>", window, window.getDecorView())
			controller.setAppearanceLightNavigationBars(is_light_system_bars)
			controller.setAppearanceLightStatusBars(is_light_system_bars)
	
	activity.runOnUiThread(android_runtime.createRunnableFromGodotCallable(callable))
```
</details> 

Update: It's not trivial to do this via JavaClassWrapper. See https://github.com/godotengine/godot/issues/109667