### PR TITLE
Docs: `PhysicsShapeQueryParameters3D` fix function used in code example

### DIFF
--- a/doc/classes/PhysicsShapeQueryParameters3D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters3D.xml
@@ -35,7 +35,7 @@
 			The queried shape's [RID] that will be used for collision/intersection queries. Use this over [member shape] if you want to optimize for performance using the Servers API:
 			[codeblocks]
 			[gdscript]
-			var shape_rid = PhysicsServer3D.shape_create(PhysicsServer3D.SHAPE_SPHERE)
+			var shape_rid = PhysicsServer3D.sphere_shape_create()
 			var radius = 2.0
 			PhysicsServer3D.shape_set_data(shape_rid, radius)
 
@@ -48,7 +48,7 @@
 			PhysicsServer3D.free_rid(shape_rid)
 			[/gdscript]
 			[csharp]
-			RID shapeRid = PhysicsServer3D.ShapeCreate(PhysicsServer3D.ShapeType.Sphere);
+			RID shapeRid = PhysicsServer3D.SphereShapeCreate();
 			float radius = 2.0f;
 			PhysicsServer3D.ShapeSetData(shapeRid, radius);
 


### PR DESCRIPTION
At one point the shape creation functions in the `PhysicsServer3D` was changed, but the code sample in `PhysicsShapeQueryParameters3D` was not updated, this PR fixes that.

And I gave a cursory search and I think that was the only place left behind.