### PR TITLE
Speed up deletion via the Scene Tree Dock in large trees

### DIFF
--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -152,7 +152,7 @@ class SceneTreeEditor : public Control {
 	void _tree_process_mode_changed();
 
 	void _move_node_children(HashMap<Node *, CachedNode>::Iterator &p_I);
-	void _move_node_item(TreeItem *p_parent, HashMap<Node *, CachedNode>::Iterator &p_I);
+	void _move_node_item(TreeItem *p_parent, HashMap<Node *, CachedNode>::Iterator &p_I, TreeItem *p_correct_prev = nullptr);
 
 	void _node_child_order_changed(Node *p_node);
 	void _node_editor_state_changed(Node *p_node);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -895,7 +895,7 @@ TreeItem *TreeItem::create_child(int p_index) {
 	} else {
 		int idx = 0;
 		if (!children_cache.is_empty()) {
-			idx = MIN(children_cache.size() - 1, p_index);
+			idx = MIN(int(children_cache.size()) - 1, p_index);
 			item_next = children_cache[idx];
 			item_prev = item_next->prev;
 		}
@@ -920,7 +920,7 @@ TreeItem *TreeItem::create_child(int p_index) {
 			if (ti->next) {
 				children_cache.insert(p_index, ti);
 			} else {
-				children_cache.append(ti);
+				children_cache.push_back(ti);
 			}
 		}
 	} else {
@@ -957,7 +957,7 @@ void TreeItem::add_child(TreeItem *p_item) {
 	last_child = p_item;
 
 	if (!children_cache.is_empty()) {
-		children_cache.append(p_item);
+		children_cache.push_back(p_item);
 	}
 
 	validate_cache();
@@ -1111,15 +1111,15 @@ TreeItem *TreeItem::get_child(int p_index) {
 	if (p_index < 0) {
 		p_index += children_cache.size();
 	}
-	ERR_FAIL_INDEX_V(p_index, children_cache.size(), nullptr);
+	ERR_FAIL_INDEX_V(p_index, (int)children_cache.size(), nullptr);
 
-	return children_cache.get(p_index);
+	return children_cache[p_index];
 }
 
 int TreeItem::get_visible_child_count() {
 	_create_children_cache();
 	int visible_count = 0;
-	for (int i = 0; i < children_cache.size(); i++) {
+	for (uint32_t i = 0; i < children_cache.size(); i++) {
 		if (children_cache[i]->is_visible()) {
 			visible_count += 1;
 		}
@@ -1175,7 +1175,7 @@ void TreeItem::validate_cache() const {
 		return;
 	}
 	TreeItem *scan = parent->first_child;
-	int index = 0;
+	uint32_t index = 0;
 	while (scan) {
 		DEV_ASSERT(parent->children_cache[index] == scan);
 		++index;
@@ -1265,7 +1265,7 @@ void TreeItem::move_after(TreeItem *p_item) {
 		// If the cache is empty, it has not been built but there
 		// are items in the tree (note p_item != nullptr,) so we cannot update it.
 		if (!parent->children_cache.is_empty()) {
-			parent->children_cache.append(this);
+			parent->children_cache.push_back(this);
 		}
 	}
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -150,7 +150,7 @@ private:
 	TreeItem *first_child = nullptr;
 	TreeItem *last_child = nullptr;
 
-	Vector<TreeItem *> children_cache;
+	LocalVector<TreeItem *> children_cache;
 	bool is_root = false; // For tree root.
 	Tree *tree = nullptr; // Tree (for reference).
 
@@ -169,7 +169,7 @@ private:
 		if (children_cache.is_empty()) {
 			TreeItem *c = first_child;
 			while (c) {
-				children_cache.append(c);
+				children_cache.push_back(c);
 				c = c->next;
 			}
 		}
@@ -201,7 +201,7 @@ private:
 		}
 		if (parent) {
 			if (!parent->children_cache.is_empty()) {
-				parent->children_cache.remove_at(get_index());
+				parent->children_cache.erase(this);
 			}
 			if (parent->first_child == this) {
 				parent->first_child = next;


### PR DESCRIPTION
If you open `Label25k.tscn` in the test project below, and then attempt to delete one of the elements by selecting it in the scene tree dock and then pressing delete, it takes ~12 seconds for me without this PR. With this PR, it's less than half a second.

Here's the flamegraph showing the problem:
<img width="2530" height="1294" alt="image" src="https://github.com/user-attachments/assets/7ab528fe-4585-4f0d-861b-cc8c38b28739" />

The `SceneTreeEditor` change take the performance from terrible to usable, getting the time down to under a second by itself.

The `Tree` `Vector` -> `LocalVector` change only makes hundreds of ms worth of difference, but that's enough to bring it from usable to pretty good. It's the less important of the two, if it's objectionable.

---------------------

All performance tests were run on builds made with the following command: `scons optimize=speed_trace debug_symbols=yes platform=linuxbsd dev_build=no production=yes`

The test project [editor-optimization-test-scenes.zip](https://github.com/user-attachments/files/21709465/editor-optimization-test-scenes.zip) consists of a series of scenes that each have 25,000 of a common type of node.