### PR TITLE
Miscellaneous editor optimizations for large scenes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4477,6 +4477,8 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	new_scene->set_scene_instance_state(Ref<SceneState>());
 
 	set_edited_scene(new_scene);
+	// When editor plugins load in, they might use node transforms during their own setup, so make sure they're up to date.
+	get_tree()->flush_transform_notifications();
 
 	String config_file_path = EditorPaths::get_singleton()->get_project_settings_dir().path_join(lpath.get_file() + "-editstate-" + lpath.md5_text() + ".cfg");
 	Ref<ConfigFile> editor_state_cf;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -622,7 +622,6 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 		return;
 	}
 
-	const real_t grab_distance = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 	CanvasItem *ci = Object::cast_to<CanvasItem>(p_node);
 
 	Transform2D xform = p_canvas_xform;
@@ -4149,6 +4148,8 @@ void CanvasItemEditor::_update_editor_settings() {
 	real_t ruler_width_unscaled = EDITOR_GET("editors/2d/ruler_width");
 	ruler_font_size = MAX(get_theme_font_size(SNAME("rulers_size"), EditorStringName(EditorFonts)) * ruler_width_unscaled / 15.0, 8);
 	ruler_width_scaled = MAX(ruler_width_unscaled * EDSCALE, ruler_font_size * 2.0);
+
+	grab_distance = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 }
 
 void CanvasItemEditor::_project_settings_changed() {
@@ -4268,7 +4269,8 @@ void CanvasItemEditor::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (EditorThemeManager::is_generated_theme_outdated() ||
 					EditorSettings::get_singleton()->check_changed_settings_in_group("editors/panning") ||
-					EditorSettings::get_singleton()->check_changed_settings_in_group("editors/2d")) {
+					EditorSettings::get_singleton()->check_changed_settings_in_group("editors/2d") ||
+					EditorSettings::get_singleton()->check_changed_settings_in_group("editors/polygon_editor")) {
 				_update_editor_settings();
 				update_viewport();
 			}

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -259,6 +259,7 @@ private:
 	real_t ruler_width_scaled = 16.0;
 	int ruler_font_size = 8;
 	Point2 node_create_position;
+	real_t grab_distance = 0.0;
 
 	MenuOption last_option;
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -706,7 +706,12 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 		return;
 	}
 
-	TreeItem *item = _find(tree->get_root(), p_node->get_path());
+	TreeItem *item;
+	if (I->value.item && I->value.item->get_metadata(0) == p_node->get_path()) {
+		item = I->value.item;
+	} else {
+		item = _find(tree->get_root(), p_node->get_path());
+	}
 
 	if (!item) {
 		return;


### PR DESCRIPTION
There were a few miscellaneous changes that didn't fit thematically into the other optimization PRs, so I've grouped them here.

#### `editor_node.cpp` transform flushing
The `editor_node.cpp` change is necessary because some editor plugins expect the transforms to be properly set up during the `_load_editor_plugin_states_from_config` call later. 

As a concrete example of an issue, open the `Mesh3DInstance25k.tscn` file. Opening it takes ages because of a convoluted path that triggers an issue in the `DynamicBVH` code. Because the instances all have the same local coordinates, they're initially loaded with identical transforms. They're added to the occlusion culler's dirty instance list, and then during the plugin setup something is `freed` from the culler, causing the dirty list to get processed. However, the transforms have never been propagated between scene loading and now, so everything is inserted at the same location. This triggers an `O(n^2)` edge case in the BVH.

I wouldn't have noticed this issue without it triggering a separate bug. However, both the official plugins and one user plugin end up doing twice as much setup work as they should, because they process the state of the world during the plugin, and then get all the transform updates later. Setting up the transforms properly first seems like the correct thing to be doing, anyways.

[Here's an example of a user plugin running into this issue.](https://github.com/godotengine/godot/issues/94648#issuecomment-2263572842)

I'm not sure this is exactly the right place to put the `flush_transform_notifications` call, it could also be put inside `set_edited_scene`, but I erred on the side of the least impactful change.

#### `canvas_item_editor_plugin` EDITOR_GET removal
When I profiled the delay when selecting canvas items in the editor, literally 60% of the time was spent on this single `EDITOR_GET` call, so I cached it. The delay in question is small, but enough that it felt laggy to me, so I looked into where the time was being spent and found this.

#### `_node_visibility_changed` cache use
Perhaps there's a good reason not to do this, but I couldn't find any issues when testing it. It does dramatically improve the time to update the visibility of large numbers of objects at once.

1. Open `Sprite2D25k.tscn`
2. Select 25000 sprites
3. Toggle the visibility

On `master`, step 3 alone takes ~50 seconds. With this PR, it takes about a half a second.

If you want to test this particular speedup yourself, it'll likely be difficult without also applying #109515 so that large selections are less problematic.

---------------------

All performance tests were run on builds made with the following command: `scons optimize=speed_trace debug_symbols=yes platform=linuxbsd dev_build=no production=yes`.

The test project [editor-optimization-test-scenes.zip](https://github.com/user-attachments/files/21709465/editor-optimization-test-scenes.zip) consists of a series of scenes that each have 25,000 of a common type of node.