### PR TITLE
Prevent degenerate case in `DynamicBVH`

### DIFF
--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -67,7 +67,8 @@ void DynamicBVH::_insert_leaf(Node *p_root, Node *p_leaf) {
 			do {
 				p_root = p_root->children[p_leaf->volume.select_by_proximity(
 						p_root->children[0]->volume,
-						p_root->children[1]->volume)];
+						p_root->children[1]->volume,
+						tiebreaker)];
 			} while (!p_root->is_leaf());
 		}
 		Node *prev = p_root->parent;

--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -120,8 +120,14 @@ private:
 			return (Math::abs(d.x) + Math::abs(d.y) + Math::abs(d.z));
 		}
 
-		_FORCE_INLINE_ int select_by_proximity(const Volume &p_a, const Volume &p_b) const {
-			return (get_proximity_to(p_a) < get_proximity_to(p_b) ? 0 : 1);
+		_FORCE_INLINE_ int select_by_proximity(const Volume &p_a, const Volume &p_b, uint32_t &tiebreaker) const {
+			real_t prox_a = get_proximity_to(p_a);
+			real_t prox_b = get_proximity_to(p_b);
+			if (prox_a == prox_b) {
+				tiebreaker *= 1664525U;
+				return (tiebreaker % 48271U) & 1;
+			}
+			return prox_a < prox_b ? 0 : 1;
 		}
 
 		//
@@ -227,6 +233,7 @@ private:
 	int total_leaves = 0;
 	uint32_t opath = 0;
 	uint32_t index = 0;
+	uint32_t tiebreaker = 134775813U;
 
 	enum {
 		ALLOCA_STACK_SIZE = 128


### PR DESCRIPTION
Fixes one of the issues in #107123.
Fixes one of the issues in #94648.

I'm not sure whether this PR will be wanted or not, since this is in core and needs good justification to add any instructions to a common path. The issue is that the BVH's behavior when large numbers of elements with the same centers are added is extremely degenerate, creating a long chain that devolves all of the find, insert, and remove runtimes to `O(n)`, which implies `O(n^2)` for initial construction of the BVH.

For uses of the DynamicBVH that do include this case, the performance benefits of this PR are immense. The first scene that I profiled that I saw this in was #107123, which has all the nodes at the same position, and that obviously benefits greatly. I was curious what would happen with a mix of nodes, so I created a scene with 25k randomly placed meshes and then added 25k meshes at the same spot off camera. This, it turns out, was also bad, and feels much more likely to occur.

When I ran this 25k random, 25k offscreen scene on master, this is what the flamegraph looks like:
<img width="2523" height="1087" alt="image" src="https://github.com/user-attachments/assets/f58ec6b0-5a74-4052-9dab-bdb1291f35d0" />

Note that this isn't the start up flamegraph, this is process, and this is running standalone. 15% of the time is just BVH overhead from the recurring `optimize_incremental` call, and I'm not even doing new insertions or moving anything.

Here's the same project running with this change:
<img width="2519" height="1082" alt="image" src="https://github.com/user-attachments/assets/2bedc7ca-2185-4889-a315-f870d2bc6301" />

The time spent in `DynamicBVH` drops to 0.01%.

Here's the flamegraph for #107123 (smaller `create_child` issue fixed in #109512):
<img width="2489" height="1294" alt="image" src="https://github.com/user-attachments/assets/7f7e39e0-80b7-431c-b51d-e1696da541b8" />

Here's the flamegraph with it fixed:
<img width="2513" height="1280" alt="image" src="https://github.com/user-attachments/assets/4adfdffd-0266-473b-9c84-f900e2561d20" />

I also wrote up some code to just run the BVH outside of a project, and tested that by itself. The benchmark inserts 25,000 nodes into a BVH in a variety of patterns.

#### `master` (25k inserts, 1 trial)
```
Testing no duplicates:
0.0082 seconds
Testing all duplicates:
2.7655 seconds
Testing half duplicates (before random):
1.0074 seconds
Testing half duplicates (after random):
2.7687 seconds
Testing 10% duplicates (half before, half after):
2.3099 seconds
```

#### This PR (25k inserts, 1 trial)
```
Testing no duplicates:
0.0081 seconds
Testing all duplicates:
0.0027 seconds
Testing half duplicates (before random):
0.0062 seconds
Testing half duplicates (after random):
0.0039 seconds
Testing 10% duplicates (half before, half after):
0.0031 seconds
```

This is just one trial, so the accuracy is low, but three orders of magnitude difference gets the point across pretty clearly. Even just 10% of the objects being duplicates can destroy the BVH.

However, this fix isn't free. Users without duplicate AABB centers will end up paying the cost of an extra float comparison per layer of the tree during inserts. I've tested this on two real projects, one test project, and using the above benchmark. These tests have varied between a 0.6% and 1.7% slowdown in insertion times. Real projects I had to rely on profiler data for instead of benchmarks; the BVH was such a small slice I had to run the profiler for an hour to collect enough data to catch the new code getting hit.

For concrete numbers, I ran the `Testing no duplicates` (25k random insertions) benchmark with 10,000 trials for each branch.
- This PR: 671.98 seconds
- `master`: 662.54 seconds
- 671.98 / 662.54 = 1.014 = +1.4%

Personally, I think this is worth it. Given that the BVH isn't a bottleneck on games I've profiled, a <2% slowdown in insertions for it to avoid a potential footgun seems like a trade I'd make.

Adding a lot of identical centers to the BVH may sound odd, but there are a couple of cases I've seen it come up in:
- Rounding of the AABBs to a larger grid to avoid needing to update them every time they move, which ends up making different positions identical. I have this in my game, although I've ended up not using a BVH for it, in the end.
- Many objects spawning in or pooled at one location. Calling `duplicate` a bunch of times is enough to repro this, as in #107123. This can also happen by accident, like with editor scene loading right now, where transforms aren't propagated until after the occlusion culler is flushed due to plugin loading, causing instanced objects to end up all at the same position for less than a frame. [Here's a user unknowingly running into that problem.](https://github.com/godotengine/godot/issues/94648#issuecomment-2245620499)

I wouldn't really expect that I'd have to avoid that, as a user.

The change itself is just the cheapest PRNG I could think of that was random enough on the lowest bit. I added it to the BVH itself instead of using something static because I would expect construction to be deterministic per instance and the cost isn't significant. If anyone knows how to make it cheaper, I'd love to hear. The additional time is almost entirely spent performing the float == check, so I don't think there's really much better to be done.

---------------------

All performance tests were run on builds made with the following command: `scons optimize=speed_trace debug_symbols=yes platform=linuxbsd dev_build=no production=yes`.

The mix of random and duplicate instances scene mentioned earlier is `Mesh3D25kStackedAndRandom.tscn` in this test project: [editor-optimization-test-scenes.zip](https://github.com/user-attachments/files/21709465/editor-optimization-test-scenes.zip)