### PR TITLE
Speed up signal disconnects in the editor

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1522,6 +1522,18 @@ int Object::get_persistent_signal_connection_count() const {
 	return count;
 }
 
+uint32_t Object::get_signal_connection_flags(const StringName &p_name, const Callable &p_callable) const {
+	OBJ_SIGNAL_LOCK
+	const SignalData *signal_data = signal_map.getptr(p_name);
+	if (signal_data) {
+		const SignalData::Slot *slot = signal_data->slot_map.getptr(p_callable);
+		if (slot) {
+			return slot->conn.flags;
+		}
+	}
+	return 0;
+}
+
 void Object::get_signals_connected_to_this(List<Connection> *p_connections) const {
 	OBJ_SIGNAL_LOCK
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -973,6 +973,7 @@ public:
 	DEBUG_VIRTUAL void get_signal_connection_list(const StringName &p_signal, List<Connection> *p_connections) const;
 	DEBUG_VIRTUAL void get_all_signal_connections(List<Connection> *p_connections) const;
 	DEBUG_VIRTUAL int get_persistent_signal_connection_count() const;
+	DEBUG_VIRTUAL uint32_t get_signal_connection_flags(const StringName &p_name, const Callable &p_callable) const;
 	DEBUG_VIRTUAL void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
 	DEBUG_VIRTUAL Error connect(const StringName &p_signal, const Callable &p_callable, uint32_t p_flags = 0);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -875,6 +875,7 @@ public:
 	virtual void get_signal_connection_list(const StringName &p_signal, List<Connection> *p_connections) const override;
 	virtual void get_all_signal_connections(List<Connection> *p_connections) const override;
 	virtual int get_persistent_signal_connection_count() const override;
+	virtual uint32_t get_signal_connection_flags(const StringName &p_name, const Callable &p_callable) const override;
 	virtual void get_signals_connected_to_this(List<Connection> *p_connections) const override;
 
 	virtual Error connect(const StringName &p_signal, const Callable &p_callable, uint32_t p_flags = 0) override;


### PR DESCRIPTION
In editor builds only, disconnecting signals is O(n) where n is the number of connections to that signal. The O(n) operation can easily be made O(1) by filtering by the relevant signal and connection. 

This is a problem in particular for large numbers of sibling `Controls`, as they all register `item_rect_changed` with their parent node. To see the problem in the test project:
1. Open `MeshInstance.tscn`
2. Open `Label25k.tscn`
3. Attempt to switch back to the `MeshInstance` tab by clicking on it

Without the PR, step 3 hangs the editor for about ~23 seconds on my machine. With the PR, it takes a fraction of a second.

When attempting to switch scenes, the way it frees the nodes causes all the disconnections to happen in sequence, which ends up being O(n^2) on 25,000 nodes. 

The `get_persistent_signal_connection_count` function is currently only used in editor code, isn't exposed to GDScript, and the new definition is backwards compatible with the old one, so I hope it's okay to change.

Here's a flamegraph of the problem occuring during the repro steps:

<img width="3417" height="1255" alt="image" src="https://github.com/user-attachments/assets/41f533b3-5dc2-493a-8b37-1109f07a8e9e" />

---------------------

All performance tests were run on builds made with the following command: `scons optimize=speed_trace debug_symbols=yes platform=linuxbsd dev_build=no production=yes`.

The test project [editor-optimization-test-scenes.zip](https://github.com/user-attachments/files/21709465/editor-optimization-test-scenes.zip) consists of a series of scenes that each have 25,000 of a common type of node.
