### PR TITLE
Fix String.json_escape() to handle ASCII control codes

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4750,7 +4750,7 @@ String String::json_escape() const {
 			escaped += "\\r";
 		} else if (c == '\t') {
 			escaped += "\\t";
-		} else if (c >= 0x00 && c <= 0x1F) {
+		} else if (c <= 0x1F) {
 			// ASCII control characters must be escaped using \uXXXX format.
 			escaped += "\\u";
 			escaped += "00";

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4750,11 +4750,20 @@ String String::json_escape() const {
 			escaped += "\\r";
 		} else if (c == '\t') {
 			escaped += "\\t";
-		} else if (c <= 0x1F) {
-			// ASCII control characters must be escaped using \uXXXX format.
-			escaped += "\\u00";
-			escaped += hex_char_table_upper[(c >> 4) & 0xF];
-			escaped += hex_char_table_upper[c & 0xF];
+		} else if (c <= 0x1F || (c >= 0x7F && c <= 0x9F)) {
+			// ASCII control characters (0x00-0x1F) and C1 control characters (0x7F-0x9F) must be escaped using \uXXXX format.
+			escaped += "\\u";
+			if (c <= 0xFF) {
+				escaped += "00";
+				escaped += hex_char_table_upper[(c >> 4) & 0xF];
+				escaped += hex_char_table_upper[c & 0xF];
+			} else {
+				// For characters > 0xFF
+				escaped += hex_char_table_upper[(c >> 12) & 0xF];
+				escaped += hex_char_table_upper[(c >> 8) & 0xF];
+				escaped += hex_char_table_upper[(c >> 4) & 0xF];
+				escaped += hex_char_table_upper[c & 0xF];
+			}
 		} else {
 			escaped += c;
 		}

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4752,8 +4752,7 @@ String String::json_escape() const {
 			escaped += "\\t";
 		} else if (c >= 0x00 && c <= 0x1F) {
 			// ASCII control characters must be escaped using \uXXXX format
-			escaped += "\\u";
-			escaped += "00";
+			escaped += "\\u00";
 			escaped += hex_char_table_upper[(c >> 4) & 0xF];
 			escaped += hex_char_table_upper[c & 0xF];
 		} else {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4731,7 +4731,6 @@ String String::c_escape_multiline() const {
 
 String String::json_escape() const {
 	String escaped;
-	escaped.reserve(length() * 2);
 	const char32_t *str_data = get_data();
 
 	for (int i = 0; i < length(); i++) {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4730,16 +4730,38 @@ String String::c_escape_multiline() const {
 }
 
 String String::json_escape() const {
-	String escaped = *this;
-	escaped = escaped.replace("\\", "\\\\");
-	escaped = escaped.replace("\b", "\\b");
-	escaped = escaped.replace("\f", "\\f");
-	escaped = escaped.replace("\n", "\\n");
-	escaped = escaped.replace("\r", "\\r");
-	escaped = escaped.replace("\t", "\\t");
-	escaped = escaped.replace("\v", "\\v");
-	escaped = escaped.replace("\"", "\\\"");
-
+	String escaped;
+	escaped.reserve(length() * 2); 
+	const char32_t *str_data = get_data();
+	
+	for (int i = 0; i < length(); i++) {
+		char32_t c = str_data[i];
+		
+		if (c == '\\') {
+			escaped += "\\\\";
+		} else if (c == '"') {
+			escaped += "\\\"";
+		} else if (c == '\b') {
+			escaped += "\\b";
+		} else if (c == '\f') {
+			escaped += "\\f";
+		} else if (c == '\n') {
+			escaped += "\\n";
+		} else if (c == '\r') {
+			escaped += "\\r";
+		} else if (c == '\t') {
+			escaped += "\\t";
+		} else if (c >= 0x00 && c <= 0x1F) {
+			// ASCII control characters must be escaped using \uXXXX format
+			escaped += "\\u";
+			escaped += "00";
+			escaped += hex_char_table_upper[(c >> 4) & 0xF];
+			escaped += hex_char_table_upper[c & 0xF];
+		} else {
+			escaped += c;
+		}
+	}
+	
 	return escaped;
 }
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4731,12 +4731,12 @@ String String::c_escape_multiline() const {
 
 String String::json_escape() const {
 	String escaped;
-	escaped.reserve(length() * 2); 
+	escaped.reserve(length() * 2);
 	const char32_t *str_data = get_data();
-	
+
 	for (int i = 0; i < length(); i++) {
 		char32_t c = str_data[i];
-		
+
 		if (c == '\\') {
 			escaped += "\\\\";
 		} else if (c == '"') {
@@ -4761,7 +4761,7 @@ String String::json_escape() const {
 			escaped += c;
 		}
 	}
-	
+
 	return escaped;
 }
 

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4751,7 +4751,7 @@ String String::json_escape() const {
 		} else if (c == '\t') {
 			escaped += "\\t";
 		} else if (c >= 0x00 && c <= 0x1F) {
-			// ASCII control characters must be escaped using \uXXXX format
+			// ASCII control characters must be escaped using \uXXXX format.
 			escaped += "\\u";
 			escaped += "00";
 			escaped += hex_char_table_upper[(c >> 4) & 0xF];

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1115,10 +1115,10 @@ namespace Godot
                         sb.Append("\\t");
                         break;
                     default:
-                        // ASCII control characters (0x00-0x1F) must be escaped using \uXXXX format.
-                        if (c >= 0x00 && c <= 0x1F)
+                        // ASCII control characters (0x00-0x1F) and C1 control characters (0x7F-0x9F) must be escaped using \uXXXX format.
+                        if (c <= 0x1F || (c >= 0x7F && c <= 0x9F))
                         {
-                            sb.AppendFormat("\\u{0:X4}", (int)c);
+                            sb.AppendFormat(CultureInfo.InvariantCulture, "\\u{0:X4}", (int)c);
                         }
                         else
                         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1087,16 +1087,46 @@ namespace Godot
         /// <returns>The escaped string.</returns>
         public static string JSONEscape(this string instance)
         {
-            var sb = new StringBuilder(instance);
+            var sb = new StringBuilder();
 
-            sb.Replace("\\", "\\\\");
-            sb.Replace("\b", "\\b");
-            sb.Replace("\f", "\\f");
-            sb.Replace("\n", "\\n");
-            sb.Replace("\r", "\\r");
-            sb.Replace("\t", "\\t");
-            sb.Replace("\v", "\\v");
-            sb.Replace("\"", "\\\"");
+            foreach (char c in instance)
+            {
+                switch (c)
+                {
+                    case '\\':
+                        sb.Append("\\\\");
+                        break;
+                    case '"':
+                        sb.Append("\\\"");
+                        break;
+                    case '\b':
+                        sb.Append("\\b");
+                        break;
+                    case '\f':
+                        sb.Append("\\f");
+                        break;
+                    case '\n':
+                        sb.Append("\\n");
+                        break;
+                    case '\r':
+                        sb.Append("\\r");
+                        break;
+                    case '\t':
+                        sb.Append("\\t");
+                        break;
+                    default:
+                        // ASCII control characters (0x00-0x1F) must be escaped using \uXXXX format
+                        if (c >= 0x00 && c <= 0x1F)
+                        {
+                            sb.AppendFormat("\\u{0:X4}", (int)c);
+                        }
+                        else
+                        {
+                            sb.Append(c);
+                        }
+                        break;
+                }
+            }
 
             return sb.ToString();
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/StringExtensions.cs
@@ -1115,7 +1115,7 @@ namespace Godot
                         sb.Append("\\t");
                         break;
                     default:
-                        // ASCII control characters (0x00-0x1F) must be escaped using \uXXXX format
+                        // ASCII control characters (0x00-0x1F) must be escaped using \uXXXX format.
                         if (c >= 0x00 && c <= 0x1F)
                         {
                             sb.AppendFormat("\\u{0:X4}", (int)c);

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -44,7 +44,33 @@ TEST_CASE("[JSON] Stringify single data types") {
 	CHECK(JSON::stringify(12345) == "12345");
 	CHECK(JSON::stringify(0.75) == "0.75");
 	CHECK(JSON::stringify("test") == "\"test\"");
-	CHECK(JSON::stringify("\\\b\f\n\r\t\v\"") == "\"\\\\\\b\\f\\n\\r\\t\\v\\\"\"");
+	CHECK(JSON::stringify("\\\b\f\n\r\t\v\"") == "\"\\\\\\b\\f\\n\\r\\t\\u000B\\\"\"");
+}
+
+TEST_CASE("[JSON] Stringify ASCII control characters") {
+	// Test that ASCII control characters (0x00-0x1F) are properly escaped
+	
+	// Short-form escapes for standard characters
+	CHECK(JSON::stringify("\b") == "\"\\b\"");  // 0x08
+	CHECK(JSON::stringify("\t") == "\"\\t\"");  // 0x09
+	CHECK(JSON::stringify("\n") == "\"\\n\"");  // 0x0A
+	CHECK(JSON::stringify("\f") == "\"\\f\"");  // 0x0C
+	CHECK(JSON::stringify("\r") == "\"\\r\"");  // 0x0D
+	
+	// Key test cases
+	CHECK(JSON::stringify(String::chr(0x00)) == "\"\\u0000\""); // Null
+	CHECK(JSON::stringify(String::chr(0x01)) == "\"\\u0001\""); // Start of heading
+	CHECK(JSON::stringify(String::chr(0x0B)) == "\"\\u000B\""); // Vertical tab
+	CHECK(JSON::stringify(String::chr(0x1F)) == "\"\\u001F\""); // Unit separator
+	
+	// All control characters 0x00-0x1F
+	for (int i = 0; i <= 0x1F; i++) {
+		String result = JSON::stringify(String::chr(i));
+		String expected = (i == 8) ? "\"\\b\"" : (i == 9) ? "\"\\t\"" : (i == 10) ? "\"\\n\"" :
+		                  (i == 12) ? "\"\\f\"" : (i == 13) ? "\"\\r\"" : vformat("\"\\u%04X\"", i);
+		CHECK_MESSAGE(result == expected, vformat("JSON control char 0x%02X failed", i));
+	}
+}
 }
 
 TEST_CASE("[JSON] Stringify arrays") {

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -49,25 +49,28 @@ TEST_CASE("[JSON] Stringify single data types") {
 
 TEST_CASE("[JSON] Stringify ASCII control characters") {
 	// Test that ASCII control characters (0x00-0x1F) are properly escaped
-	
+
 	// Short-form escapes for standard characters
-	CHECK(JSON::stringify("\b") == "\"\\b\"");  // 0x08
-	CHECK(JSON::stringify("\t") == "\"\\t\"");  // 0x09
-	CHECK(JSON::stringify("\n") == "\"\\n\"");  // 0x0A
-	CHECK(JSON::stringify("\f") == "\"\\f\"");  // 0x0C
-	CHECK(JSON::stringify("\r") == "\"\\r\"");  // 0x0D
-	
+	CHECK(JSON::stringify("\b") == "\"\\b\""); // 0x08
+	CHECK(JSON::stringify("\t") == "\"\\t\""); // 0x09
+	CHECK(JSON::stringify("\n") == "\"\\n\""); // 0x0A
+	CHECK(JSON::stringify("\f") == "\"\\f\""); // 0x0C
+	CHECK(JSON::stringify("\r") == "\"\\r\""); // 0x0D
+
 	// Key test cases
 	CHECK(JSON::stringify(String::chr(0x00)) == "\"\\u0000\""); // Null
 	CHECK(JSON::stringify(String::chr(0x01)) == "\"\\u0001\""); // Start of heading
 	CHECK(JSON::stringify(String::chr(0x0B)) == "\"\\u000B\""); // Vertical tab
 	CHECK(JSON::stringify(String::chr(0x1F)) == "\"\\u001F\""); // Unit separator
-	
+
 	// All control characters 0x00-0x1F
 	for (int i = 0; i <= 0x1F; i++) {
 		String result = JSON::stringify(String::chr(i));
-		String expected = (i == 8) ? "\"\\b\"" : (i == 9) ? "\"\\t\"" : (i == 10) ? "\"\\n\"" :
-		                  (i == 12) ? "\"\\f\"" : (i == 13) ? "\"\\r\"" : vformat("\"\\u%04X\"", i);
+		String expected = (i == 8) ? "\"\\b\"" : (i == 9) ? "\"\\t\""
+				: (i == 10)								  ? "\"\\n\""
+				: (i == 12)								  ? "\"\\f\""
+				: (i == 13)								  ? "\"\\r\""
+														  : vformat("\"\\u%04X\"", i);
 		CHECK_MESSAGE(result == expected, vformat("JSON control char 0x%02X failed", i));
 	}
 }

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -74,7 +74,6 @@ TEST_CASE("[JSON] Stringify ASCII control characters") {
 		CHECK_MESSAGE(result == expected, vformat("JSON control char 0x%02X failed", i));
 	}
 }
-}
 
 TEST_CASE("[JSON] Stringify arrays") {
 	CHECK(JSON::stringify(Array()) == "[]");

--- a/tests/core/io/test_json.h
+++ b/tests/core/io/test_json.h
@@ -48,7 +48,7 @@ TEST_CASE("[JSON] Stringify single data types") {
 }
 
 TEST_CASE("[JSON] Stringify ASCII control characters") {
-	// Test that ASCII control characters (0x00-0x1F) are properly escaped
+	// Test that control characters (0x00-0x1F and 0x7F-0x9F) are properly escaped
 
 	// Short-form escapes for standard characters
 	CHECK(JSON::stringify("\b") == "\"\\b\""); // 0x08
@@ -57,13 +57,18 @@ TEST_CASE("[JSON] Stringify ASCII control characters") {
 	CHECK(JSON::stringify("\f") == "\"\\f\""); // 0x0C
 	CHECK(JSON::stringify("\r") == "\"\\r\""); // 0x0D
 
-	// Key test cases
+	// Key test cases for ASCII control characters
 	CHECK(JSON::stringify(String::chr(0x00)) == "\"\\u0000\""); // Null
 	CHECK(JSON::stringify(String::chr(0x01)) == "\"\\u0001\""); // Start of heading
 	CHECK(JSON::stringify(String::chr(0x0B)) == "\"\\u000B\""); // Vertical tab
 	CHECK(JSON::stringify(String::chr(0x1F)) == "\"\\u001F\""); // Unit separator
 
-	// All control characters 0x00-0x1F
+	// Key test cases for C1 control characters
+	CHECK(JSON::stringify(String::chr(0x7F)) == "\"\\u007F\""); // Delete
+	CHECK(JSON::stringify(String::chr(0x80)) == "\"\\u0080\""); // Padding character
+	CHECK(JSON::stringify(String::chr(0x9F)) == "\"\\u009F\""); // Application program command
+
+	// All ASCII control characters (0x00-0x1F)
 	for (int i = 0; i <= 0x1F; i++) {
 		String result = JSON::stringify(String::chr(i));
 		String expected = (i == 8) ? "\"\\b\"" : (i == 9) ? "\"\\t\""
@@ -71,6 +76,13 @@ TEST_CASE("[JSON] Stringify ASCII control characters") {
 				: (i == 12)								  ? "\"\\f\""
 				: (i == 13)								  ? "\"\\r\""
 														  : vformat("\"\\u%04X\"", i);
+		CHECK_MESSAGE(result == expected, vformat("JSON control char 0x%02X failed", i));
+	}
+
+	// All C1 control characters (0x7F-0x9F)
+	for (int i = 0x7F; i <= 0x9F; i++) {
+		String result = JSON::stringify(String::chr(i));
+		String expected = vformat("\"\\u%04X\"", i);
 		CHECK_MESSAGE(result == expected, vformat("JSON control char 0x%02X failed", i));
 	}
 }

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1916,6 +1916,11 @@ TEST_CASE("[String] json_escape") {
 	CHECK(String("\v").json_escape() == "\\u000B"); // vertical tab
 	CHECK(String::chr(0x1F).json_escape() == "\\u001F"); // unit separator
 
+	// C1 control characters also use \uXXXX format
+	CHECK(String::chr(0x7F).json_escape() == "\\u007F"); // Delete
+	CHECK(String::chr(0x80).json_escape() == "\\u0080"); // Padding character
+	CHECK(String::chr(0x9F).json_escape() == "\\u009F"); // Application program command
+
 	// Test all control characters 0x00-0x1F
 	for (int i = 0; i <= 0x1F; i++) {
 		String result = String::chr(i).json_escape();
@@ -1924,6 +1929,13 @@ TEST_CASE("[String] json_escape") {
 				: (i == 12)							  ? "\\f"
 				: (i == 13)							  ? "\\r"
 													  : vformat("\\u%04X", i);
+		CHECK_MESSAGE(result == expected, vformat("Control char 0x%02X failed", i));
+	}
+
+	// Test C1 control characters 0x7F-0x9F
+	for (int i = 0x7F; i <= 0x9F; i++) {
+		String result = String::chr(i).json_escape();
+		String expected = vformat("\\u%04X", i);
 		CHECK_MESSAGE(result == expected, vformat("Control char 0x%02X failed", i));
 	}
 

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1898,6 +1898,37 @@ TEST_CASE("[String] Strip escapes") {
 	CHECK(s.strip_escapes() == "Test Test Test");
 }
 
+TEST_CASE("[String] json_escape") {
+	// Short-form escape sequences
+	CHECK(String("\b").json_escape() == "\\b");
+	CHECK(String("\t").json_escape() == "\\t");
+	CHECK(String("\n").json_escape() == "\\n");
+	CHECK(String("\f").json_escape() == "\\f");
+	CHECK(String("\r").json_escape() == "\\r");
+	
+	// Quotes and backslash
+	CHECK(String("\"").json_escape() == "\\\"");
+	CHECK(String("\\").json_escape() == "\\\\");
+	
+	// ASCII control characters use \uXXXX format
+	CHECK(String::chr(0).json_escape() == "\\u0000");  // null
+	CHECK(String::chr(1).json_escape() == "\\u0001");  // ctrl+a
+	CHECK(String("\v").json_escape() == "\\u000B");    // vertical tab
+	CHECK(String::chr(0x1F).json_escape() == "\\u001F"); // unit separator
+	
+	// Test all control characters 0x00-0x1F
+	for (int i = 0; i <= 0x1F; i++) {
+		String result = String::chr(i).json_escape();
+		String expected = (i == 8) ? "\\b" : (i == 9) ? "\\t" : (i == 10) ? "\\n" : 
+		                  (i == 12) ? "\\f" : (i == 13) ? "\\r" : vformat("\\u%04X", i);
+		CHECK_MESSAGE(result == expected, vformat("Control char 0x%02X failed", i));
+	}
+	
+	// Regular characters and mixed content
+	CHECK(String("Hello World").json_escape() == "Hello World");
+	CHECK(String("Test\u0001\tEnd").json_escape() == "Test\\u0001\\tEnd");
+}
+
 TEST_CASE("[String] Similarity") {
 	String a = "Test";
 	String b = "West";

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1905,25 +1905,28 @@ TEST_CASE("[String] json_escape") {
 	CHECK(String("\n").json_escape() == "\\n");
 	CHECK(String("\f").json_escape() == "\\f");
 	CHECK(String("\r").json_escape() == "\\r");
-	
+
 	// Quotes and backslash
 	CHECK(String("\"").json_escape() == "\\\"");
 	CHECK(String("\\").json_escape() == "\\\\");
-	
+
 	// ASCII control characters use \uXXXX format
-	CHECK(String::chr(0).json_escape() == "\\u0000");  // null
-	CHECK(String::chr(1).json_escape() == "\\u0001");  // ctrl+a
-	CHECK(String("\v").json_escape() == "\\u000B");    // vertical tab
+	CHECK(String::chr(0).json_escape() == "\\u0000"); // null
+	CHECK(String::chr(1).json_escape() == "\\u0001"); // ctrl+a
+	CHECK(String("\v").json_escape() == "\\u000B"); // vertical tab
 	CHECK(String::chr(0x1F).json_escape() == "\\u001F"); // unit separator
-	
+
 	// Test all control characters 0x00-0x1F
 	for (int i = 0; i <= 0x1F; i++) {
 		String result = String::chr(i).json_escape();
-		String expected = (i == 8) ? "\\b" : (i == 9) ? "\\t" : (i == 10) ? "\\n" : 
-		                  (i == 12) ? "\\f" : (i == 13) ? "\\r" : vformat("\\u%04X", i);
+		String expected = (i == 8) ? "\\b" : (i == 9) ? "\\t"
+				: (i == 10)							  ? "\\n"
+				: (i == 12)							  ? "\\f"
+				: (i == 13)							  ? "\\r"
+													  : vformat("\\u%04X", i);
 		CHECK_MESSAGE(result == expected, vformat("Control char 0x%02X failed", i));
 	}
-	
+
 	// Regular characters and mixed content
 	CHECK(String("Hello World").json_escape() == "Hello World");
 	CHECK(String("Test\u0001\tEnd").json_escape() == "Test\\u0001\\tEnd");


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
# Fix String.json_escape() to handle ASCII control codes

## Problem
`String.json_escape()` doesn't properly escape ASCII control characters (0x00-0x1F), producing invalid JSON that violates RFC 8259.

## Solution
- Escape control characters as `\uXXXX` format (e.g., `\u0001`, `\u000B`)
- Keep standard escapes: `\b`, `\t`, `\n`, `\f`, `\r`, `\"`, `\\`  
-  `\v` → `\u000B` (was incorrectly `\\v`)

## Example
```gdscript
# Before (invalid JSON)
"\u0001\u0002\u0003\u0004".json_escape()  # "����" 

# After (valid JSON)  
"\u0001\u0002\u0003\u0004".json_escape()  # "\\u0001\\u0002\\u0003\\u0004"
```

## Changes
- **C++**: `core/string/ustring.cpp` - Rewrote `json_escape()` logic
- **C#**: `modules/mono/.../StringExtensions.cs` - Updated `JSONEscape()` 
- **Tests**: Added comprehensive control character tests

## Breaking Change
Control characters now escape to `\uXXXX` instead of being passed through unescaped. This ensures JSON spec compliance.

Fixes: #109482 


