### PR TITLE
Don't open folders as file in script editor

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -31,11 +31,13 @@
 #include "script_text_editor.h"
 
 #include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
 #include "core/io/json.h"
 #include "core/math/expression.h"
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc/editor_help.h"
+#include "editor/docks/filesystem_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_toaster.h"
@@ -1241,7 +1243,11 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 	if (ScriptServer::is_global_class(p_symbol)) {
 		EditorNode::get_singleton()->load_resource(ScriptServer::get_global_class_path(p_symbol));
 	} else if (p_symbol.is_resource_file() || p_symbol.begins_with("uid://")) {
-		EditorNode::get_singleton()->load_scene_or_resource(p_symbol);
+		if (DirAccess::dir_exists_absolute(p_symbol)) {
+			FileSystemDock::get_singleton()->navigate_to_path(p_symbol);
+		} else {
+			EditorNode::get_singleton()->load_scene_or_resource(p_symbol);
+		}
 	} else if (lc_error == OK) {
 		_goto_line(p_row);
 


### PR DESCRIPTION
When Ctrl+Clicking a folder path in script editor, the editor would try to open it as resource and print an error.