### PR TITLE
Implement `mipmap_limit` functionality for Texture importers

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,0 +1,41 @@
+/**************************************************************************/
+/*  image.compat.inc                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+Error Image::_generate_mipmaps_bind_compat_108720(bool p_renormalize) {
+	return generate_mipmaps(p_renormalize, -1);
+}
+
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::_generate_mipmaps_bind_compat_108720);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "image.h"
+#include "image.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
@@ -456,15 +457,11 @@ Size2i Image::get_size() const {
 }
 
 bool Image::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
 }
 
 int Image::get_mipmap_count() const {
-	if (mipmaps) {
-		return get_image_required_mipmaps(width, height, format);
-	} else {
-		return 0;
-	}
+	return mipmap_count;
 }
 
 // Using template generates perfectly optimized code due to constant expression reduction and unused variable removal present in all compilers.
@@ -553,13 +550,13 @@ void Image::convert(Format p_new_format) {
 			"Cannot convert to (or from) compressed formats. Use compress() and decompress() instead.");
 
 	// Includes the main image.
-	const int mipmap_count = get_mipmap_count() + 1;
+	const int total_mipmaps = get_mipmap_count() + 1;
 
 	if (!_are_formats_compatible(format, p_new_format)) {
 		// Use put/set pixel which is slower but works with non-byte formats.
-		Image new_img(width, height, mipmaps, p_new_format);
+		Image new_img(width, height, p_new_format, total_mipmaps - 1);
 
-		for (int mip = 0; mip < mipmap_count; mip++) {
+		for (int mip = 0; mip < total_mipmaps; mip++) {
 			Ref<Image> src_mip = get_image_from_mipmap(mip);
 			Ref<Image> new_mip = new_img.get_image_from_mipmap(mip);
 
@@ -582,11 +579,11 @@ void Image::convert(Format p_new_format) {
 	}
 
 	// Convert the formats in an optimized way by removing/adding color channels if necessary.
-	Image new_img(width, height, mipmaps, p_new_format);
+	Image new_img(width, height, p_new_format, total_mipmaps - 1);
 
 	const int conversion_type = format | p_new_format << 8;
 
-	for (int mip = 0; mip < mipmap_count; mip++) {
+	for (int mip = 0; mip < total_mipmaps; mip++) {
 		int64_t mip_offset = 0;
 		int64_t mip_size = 0;
 		int mip_width = 0;
@@ -1166,8 +1163,8 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 		dst2.initialize_data(p_width, p_height, false, format);
 	}
 
-	bool had_mipmaps = mipmaps;
-	if (interpolate_mipmaps && !had_mipmaps) {
+	int had_mipmaps = get_mipmap_count();
+	if (interpolate_mipmaps && !(had_mipmaps > 0)) {
 		generate_mipmaps();
 	}
 	// --
@@ -1424,8 +1421,8 @@ void Image::resize(int p_width, int p_height, Interpolation p_interpolation) {
 		dst._copy_internals_from(dst2);
 	}
 
-	if (had_mipmaps) {
-		dst.generate_mipmaps();
+	if (had_mipmaps > 0) {
+		dst.generate_mipmaps(false, had_mipmaps);
 	}
 
 	_copy_internals_from(dst);
@@ -1489,8 +1486,8 @@ void Image::rotate_90(ClockDirection p_direction) {
 	ERR_FAIL_COND_MSG(width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", width));
 	ERR_FAIL_COND_MSG(height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", height));
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int used_mipmaps = get_mipmap_count();
+	if (used_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1597,8 +1594,8 @@ void Image::rotate_90(ClockDirection p_direction) {
 #undef PREV_INDEX_IN_CYCLE
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (used_mipmaps > 0) {
+		generate_mipmaps(false, used_mipmaps);
 	}
 }
 
@@ -1607,8 +1604,8 @@ void Image::rotate_180() {
 	ERR_FAIL_COND_MSG(width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", width));
 	ERR_FAIL_COND_MSG(height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", height));
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int used_mipmaps = get_mipmap_count();
+	if (used_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1631,16 +1628,16 @@ void Image::rotate_180() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (used_mipmaps > 0) {
+		generate_mipmaps(false, used_mipmaps);
 	}
 }
 
 void Image::flip_y() {
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot flip_y in compressed image formats.");
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int used_mipmaps = get_mipmap_count();
+	if (used_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1661,16 +1658,16 @@ void Image::flip_y() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (used_mipmaps > 0) {
+		generate_mipmaps(false, used_mipmaps);
 	}
 }
 
 void Image::flip_x() {
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot flip_x in compressed image formats.");
 
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int used_mipmaps = get_mipmap_count();
+	if (used_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1691,8 +1688,8 @@ void Image::flip_x() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps();
+	if (used_mipmaps > 0) {
+		generate_mipmaps(false, used_mipmaps);
 	}
 }
 
@@ -1881,7 +1878,7 @@ void Image::shrink_x2() {
 	ERR_FAIL_COND(data.is_empty());
 	Vector<uint8_t> new_data;
 
-	if (mipmaps) {
+	if (has_mipmaps()) {
 		// Just use the lower mipmap as base and copy all.
 		int64_t ofs = get_mipmap_offset(1);
 		int64_t new_size = data.size() - ofs;
@@ -1906,8 +1903,8 @@ void Image::shrink_x2() {
 }
 
 void Image::normalize() {
-	bool used_mipmaps = has_mipmaps();
-	if (used_mipmaps) {
+	int used_mipmaps = get_mipmap_count();
+	if (used_mipmaps > 0) {
 		clear_mipmaps();
 	}
 
@@ -1923,19 +1920,19 @@ void Image::normalize() {
 		}
 	}
 
-	if (used_mipmaps) {
-		generate_mipmaps(true);
+	if (used_mipmaps > 0) {
+		generate_mipmaps(true, used_mipmaps);
 	}
 }
 
-Error Image::generate_mipmaps(bool p_renormalize) {
+Error Image::generate_mipmaps(bool p_renormalize, int p_limit) {
 	ERR_FAIL_COND_V_MSG(is_compressed(), ERR_UNAVAILABLE, "Cannot generate mipmaps from compressed image formats.");
 	ERR_FAIL_COND_V_MSG(format == FORMAT_RGBA4444, ERR_UNAVAILABLE, "Cannot generate mipmaps from RGBA4444 format.");
 	ERR_FAIL_COND_V_MSG(width == 0 || height == 0, ERR_UNCONFIGURED, "Cannot generate mipmaps with width or height equal to 0.");
 
 	int gen_mipmap_count;
 
-	int64_t size = _get_dst_image_size(width, height, format, gen_mipmap_count);
+	int64_t size = _get_dst_image_size(width, height, format, gen_mipmap_count, p_limit);
 	data.resize(size);
 	uint8_t *wp = data.ptrw();
 
@@ -1955,7 +1952,7 @@ Error Image::generate_mipmaps(bool p_renormalize) {
 		prev_h = h;
 	}
 
-	mipmaps = true;
+	mipmap_count = gen_mipmap_count;
 
 	return OK;
 }
@@ -2008,7 +2005,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 
 	int mmcount;
 
-	_get_dst_image_size(width, height, format, mmcount);
+	_get_dst_image_size(width, height, format, mmcount, get_mipmap_count());
 
 	uint8_t *base_ptr = data.ptrw();
 
@@ -2129,7 +2126,7 @@ Error Image::generate_mipmap_roughness(RoughnessChannel p_roughness_channel, con
 }
 
 void Image::clear_mipmaps() {
-	if (!mipmaps) {
+	if (!has_mipmaps()) {
 		return;
 	}
 
@@ -2142,7 +2139,7 @@ void Image::clear_mipmaps() {
 	_get_mipmap_offset_and_size(1, ofs, w, h);
 	data.resize(ofs);
 
-	mipmaps = false;
+	mipmap_count = 0;
 }
 
 bool Image::is_empty() const {
@@ -2171,7 +2168,33 @@ void Image::set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_for
 	initialize_data(p_width, p_height, p_use_mipmaps, p_format, p_data);
 }
 
+Ref<Image> Image::create_empty_partial_mipmaps(int p_width, int p_height, int p_mipmap_limit, Format p_format) {
+	Ref<Image> image;
+	image.instantiate();
+	image->initialize_data(p_width, p_height, p_format, p_mipmap_limit);
+	return image;
+}
+
+Ref<Image> Image::create_from_data_partial_mipmaps(int p_width, int p_height, int p_mipmap_limit, Format p_format, const Vector<uint8_t> &p_data) {
+	Ref<Image> image;
+	image.instantiate();
+	image->initialize_data(p_width, p_height, p_format, p_mipmap_limit, p_data);
+	return image;
+}
+
+void Image::set_data_partial_mipmaps(int p_width, int p_height, int p_mipmap_limit, Format p_format, const Vector<uint8_t> &p_data) {
+	initialize_data(p_width, p_height, p_format, p_mipmap_limit, p_data);
+}
+
 void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
+	initialize_data(p_width, p_height, p_format, p_use_mipmaps ? -1 : 0);
+}
+
+void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+	initialize_data(p_width, p_height, p_format, p_use_mipmaps ? -1 : 0, p_data);
+}
+
+void Image::initialize_data(int p_width, int p_height, Format p_format, int p_mipmap_limit) {
 	ERR_FAIL_COND_MSG(p_width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", p_width));
 	ERR_FAIL_COND_MSG(p_height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", p_height));
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH,
@@ -2183,7 +2206,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm = 0;
-	int64_t size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
+	int64_t size = _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmap_limit);
 	data.resize(size);
 
 	{
@@ -2193,11 +2216,11 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 
 	width = p_width;
 	height = p_height;
-	mipmaps = p_use_mipmaps;
 	format = p_format;
+	mipmap_count = mm;
 }
 
-void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
+void Image::initialize_data(int p_width, int p_height, Format p_format, int p_mipmap_limit, const Vector<uint8_t> &p_data) {
 	ERR_FAIL_COND_MSG(p_width <= 0, vformat("The Image width specified (%d pixels) must be greater than 0 pixels.", p_width));
 	ERR_FAIL_COND_MSG(p_height <= 0, vformat("The Image height specified (%d pixels) must be greater than 0 pixels.", p_height));
 	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH,
@@ -2208,13 +2231,12 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_WIDTH, MAX_HEIGHT, MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
-	int mm;
-	int64_t size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
+	int num_mipmaps;
+	int64_t size = _get_dst_image_size(p_width, p_height, p_format, num_mipmaps, p_mipmap_limit);
 
 	if (unlikely(p_data.size() != size)) {
 		String description_mipmaps = get_format_name(p_format) + " ";
-		if (p_use_mipmaps) {
-			const int num_mipmaps = get_image_required_mipmaps(p_width, p_height, p_format);
+		if (num_mipmaps > 0) {
 			if (num_mipmaps != 1) {
 				description_mipmaps += vformat("with %d mipmaps", num_mipmaps);
 			} else {
@@ -2231,15 +2253,14 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	width = p_width;
 	format = p_format;
 	data = p_data;
-
-	mipmaps = p_use_mipmaps;
+	mipmap_count = num_mipmaps;
 }
 
 void Image::initialize_data(const char **p_xpm) {
 	int size_width = 0;
 	int size_height = 0;
 	int pixelchars = 0;
-	mipmaps = false;
+	mipmap_count = 0;
 	bool has_alpha = false;
 
 	enum Status {
@@ -2630,9 +2651,9 @@ Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_qua
 	return save_webp_buffer_func(Ref<Image>((Image *)this), p_lossy, p_quality);
 }
 
-int64_t Image::get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps) {
+int64_t Image::get_image_data_size(int p_width, int p_height, Format p_format, int p_mipmap_limit) {
 	int mm;
-	return _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmaps ? -1 : 0);
+	return _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmap_limit);
 }
 
 int Image::get_image_required_mipmaps(int p_width, int p_height, Format p_format) {
@@ -2775,7 +2796,7 @@ Error Image::compress_from_channels(CompressMode p_mode, UsedChannels p_channels
 Image::Image(const char **p_xpm) {
 	width = 0;
 	height = 0;
-	mipmaps = false;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
 	initialize_data(p_xpm);
@@ -2784,7 +2805,7 @@ Image::Image(const char **p_xpm) {
 Image::Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
 	width = 0;
 	height = 0;
-	mipmaps = p_use_mipmaps;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
 	initialize_data(p_width, p_height, p_use_mipmaps, p_format);
@@ -2793,10 +2814,28 @@ Image::Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
 Image::Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
 	width = 0;
 	height = 0;
-	mipmaps = p_mipmaps;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
 	initialize_data(p_width, p_height, p_mipmaps, p_format, p_data);
+}
+
+Image::Image(int p_width, int p_height, Format p_format, int p_mipmap_limit) {
+	width = 0;
+	height = 0;
+	mipmap_count = 0;
+	format = FORMAT_L8;
+
+	initialize_data(p_width, p_height, p_format, p_mipmap_limit);
+}
+
+Image::Image(int p_width, int p_height, Format p_format, int p_mipmap_limit, const Vector<uint8_t> &p_data) {
+	width = 0;
+	height = 0;
+	mipmap_count = 0;
+	format = FORMAT_L8;
+
+	initialize_data(p_width, p_height, p_format, p_mipmap_limit, p_data);
 }
 
 Rect2i Image::get_used_rect() const {
@@ -2840,7 +2879,7 @@ Rect2i Image::get_used_rect() const {
 }
 
 Ref<Image> Image::get_region(const Rect2i &p_region) const {
-	Ref<Image> img = memnew(Image(p_region.size.x, p_region.size.y, mipmaps, format));
+	Ref<Image> img = memnew(Image(p_region.size.x, p_region.size.y, has_mipmaps(), format));
 	img->blit_rect(Ref<Image>((Image *)this), p_region, Point2i(0, 0));
 	return img;
 }
@@ -3132,7 +3171,14 @@ void Image::_set_data(const Dictionary &p_data) {
 
 	ERR_FAIL_COND(ddformat == FORMAT_MAX);
 
-	initialize_data(dwidth, dheight, dmipmaps, ddformat, ddata);
+	int mip_count = 0;
+	if (p_data.has("mipmap_count")) {
+		mip_count = int(p_data["mipmap_count"]);
+	} else {
+		mip_count = dmipmaps ? -1 : 0;
+	}
+
+	initialize_data(dwidth, dheight, ddformat, mip_count, ddata);
 }
 
 Dictionary Image::_get_data() const {
@@ -3140,7 +3186,8 @@ Dictionary Image::_get_data() const {
 	d["width"] = width;
 	d["height"] = height;
 	d["format"] = get_format_name(format);
-	d["mipmaps"] = mipmaps;
+	d["mipmap_count"] = mipmap_count;
+	d["mipmaps"] = has_mipmaps();
 	d["data"] = data;
 	return d;
 }
@@ -3153,7 +3200,7 @@ void Image::_copy_internals_from(const Image &p_image) {
 	format = p_image.format;
 	width = p_image.width;
 	height = p_image.height;
-	mipmaps = p_image.mipmaps;
+	mipmap_count = p_image.mipmap_count;
 	data = p_image.data;
 }
 
@@ -3532,7 +3579,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("crop", "width", "height"), &Image::crop);
 	ClassDB::bind_method(D_METHOD("flip_x"), &Image::flip_x);
 	ClassDB::bind_method(D_METHOD("flip_y"), &Image::flip_y);
-	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize"), &Image::generate_mipmaps, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("generate_mipmaps", "renormalize", "limit"), &Image::generate_mipmaps, DEFVAL(false), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("clear_mipmaps"), &Image::clear_mipmaps);
 
 #ifndef DISABLE_DEPRECATED
@@ -3751,7 +3798,7 @@ Ref<Image> Image::get_image_from_mipmap(int p_mipmap) const {
 	image->format = format;
 	image->data = new_data;
 
-	image->mipmaps = false;
+	image->mipmap_count = 0;
 	return image;
 }
 
@@ -4249,7 +4296,7 @@ void Image::renormalize_rgbe9995(uint32_t *p_rgb) {
 Image::Image(const uint8_t *p_mem_png_jpg, int p_len) {
 	width = 0;
 	height = 0;
-	mipmaps = false;
+	mipmap_count = 0;
 	format = FORMAT_L8;
 
 	if (_png_mem_loader_func) {
@@ -4281,7 +4328,7 @@ void Image::copy_internals_from(const Ref<Image> &p_image) {
 	format = p_image->format;
 	width = p_image->width;
 	height = p_image->height;
-	mipmaps = p_image->mipmaps;
+	mipmap_count = p_image->mipmap_count;
 	data = p_image->data;
 }
 

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -1725,16 +1725,12 @@ int64_t Image::_get_dst_image_size(int p_width, int p_height, Format p_format, i
 
 		size += s;
 
-		if (p_mipmaps >= 0) {
-			w = MAX(minw, w >> 1);
-			h = MAX(minh, h >> 1);
-		} else {
-			if (w == minw && h == minh) {
-				break;
-			}
-			w = MAX(minw, w >> 1);
-			h = MAX(minh, h >> 1);
+		if (w == minw && h == minh) {
+			break;
 		}
+
+		w = MAX(minw, w >> 1);
+		h = MAX(minh, h >> 1);
 
 		// Set mipmap size.
 		if (r_mm_width) {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -248,12 +248,18 @@ protected:
 
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _generate_mipmaps_bind_compat_108720(bool p_renormalize = false);
+
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	Format format = FORMAT_L8;
 	Vector<uint8_t> data;
 	int width = 0;
 	int height = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	void _copy_internals_from(const Image &p_image);
 
@@ -324,7 +330,7 @@ public:
 	void flip_y();
 
 	// Generate a mipmap chain of an image (creates an image 1/4 the size, with averaging of 4->1).
-	Error generate_mipmaps(bool p_renormalize = false);
+	Error generate_mipmaps(bool p_renormalize = false, int p_limit = -1);
 
 	Error generate_mipmap_roughness(RoughnessChannel p_roughness_channel, const Ref<Image> &p_normal_map);
 
@@ -334,6 +340,8 @@ public:
 	// Creates new internal image data of a given size and format. Current image will be lost.
 	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format);
 	void initialize_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
+	void initialize_data(int p_width, int p_height, Format p_format, int p_mipmap_limit);
+	void initialize_data(int p_width, int p_height, Format p_format, int p_mipmap_limit, const Vector<uint8_t> &p_data);
 	void initialize_data(const char **p_xpm);
 
 	// Returns true when the image is empty (0,0) in size.
@@ -358,9 +366,15 @@ public:
 	static Ref<Image> create_from_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
 	void set_data(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data);
 
+	static Ref<Image> create_empty_partial_mipmaps(int p_width, int p_height, int p_mipmap_limit, Format p_format);
+	static Ref<Image> create_from_data_partial_mipmaps(int p_width, int p_height, int p_mipmap_limit, Format p_format, const Vector<uint8_t> &p_data);
+	void set_data_partial_mipmaps(int p_width, int p_height, int p_mipmap_limit, Format p_format, const Vector<uint8_t> &p_data);
+
 	Image() = default; // Create an empty image.
 	Image(int p_width, int p_height, bool p_use_mipmaps, Format p_format); // Create an empty image of a specific size and format.
 	Image(int p_width, int p_height, bool p_mipmaps, Format p_format, const Vector<uint8_t> &p_data); // Import an image of a specific size and format from a byte vector.
+	Image(int p_width, int p_height, Format p_format, int p_mipmap_limit);
+	Image(int p_width, int p_height, Format p_format, int p_mipmap_limit, const Vector<uint8_t> &p_data);
 	Image(const uint8_t *p_mem_png_jpg, int p_len = -1); // Import either a png or jpg from a pointer.
 	Image(const char **p_xpm); // Import an XPM image.
 
@@ -374,7 +388,7 @@ public:
 	static int get_format_block_size(Format p_format);
 	static void get_format_min_pixel_size(Format p_format, int &r_w, int &r_h);
 
-	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps = false);
+	static int64_t get_image_data_size(int p_width, int p_height, Format p_format, int p_mipmap_limit = 0);
 	static int get_image_required_mipmaps(int p_width, int p_height, Format p_format);
 	static Size2i get_image_mipmap_size(int p_width, int p_height, Format p_format, int p_mipmap);
 	static int64_t get_image_mipmap_offset(int p_width, int p_height, Format p_format, int p_mipmap);

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -214,8 +214,10 @@
 		<method name="generate_mipmaps">
 			<return type="int" enum="Error" />
 			<param index="0" name="renormalize" type="bool" default="false" />
+			<param index="1" name="limit" type="int" default="-1" />
 			<description>
 				Generates mipmaps for the image. Mipmaps are precalculated lower-resolution copies of the image that are automatically used if the image needs to be scaled down when rendered. They help improve image quality and performance when rendering. This method returns an error if the image is compressed, in a custom format, or if the image's width/height is [code]0[/code]. Enabling [param renormalize] when generating mipmaps for normal map textures will make sure all resulting vector values are normalized.
+				When [param limit] is [code]-1[/code], the entire mipmap chain is generated. Otherwise, only up to [param limit] mipmaps will be generated.
 				It is possible to check if the image has mipmaps by calling [method has_mipmaps] or [method get_mipmap_count]. Calling [method generate_mipmaps] on an image that already has mipmaps will replace existing mipmaps in the image.
 			</description>
 		</method>
@@ -623,7 +625,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{ &quot;data&quot;: PackedByteArray(), &quot;format&quot;: &quot;Lum8&quot;, &quot;height&quot;: 0, &quot;mipmaps&quot;: false, &quot;width&quot;: 0 }">
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{ &quot;data&quot;: PackedByteArray(), &quot;format&quot;: &quot;Lum8&quot;, &quot;height&quot;: 0, &quot;mipmap_count&quot;: 0, &quot;mipmaps&quot;: false, &quot;width&quot;: 0 }">
 			Holds all the image's color data in a given format. See [enum Format] constants.
 		</member>
 	</members>

--- a/doc/classes/ResourceImporterLayeredTexture.xml
+++ b/doc/classes/ResourceImporterLayeredTexture.xml
@@ -56,7 +56,9 @@
 			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
-			Unimplemented. This currently has no effect when changed.
+			Sets the maximal amount of mipmaps for a texture. The smaller the limit, the sharper the texture will appear from a distance. This can help alleviate the overbluring of distant images, especially ones with a low resolution.
+			If set to [code]-1[/code], the full mipmap chain will be generated. If [code]0[/code], no mipmaps will be generated.
+			[b]Note:[/b] This setting is ignored if [member mipmaps/generate] is [code]false[/code].
 		</member>
 		<member name="slices/arrangement" type="int" setter="" getter="" default="1">
 			Controls how the cubemap's texture is internally laid out. When using high-resolution cubemaps, [b]2×3[/b] and [b]3×2[/b] are less prone to exceeding hardware texture size limits compared to [b]1×6[/b] and [b]6×1[/b].

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -71,7 +71,9 @@
 			It's recommended to enable mipmaps in 3D. However, in 2D, this should only be enabled if your project visibly benefits from having mipmaps enabled. If the camera never zooms out significantly, there won't be a benefit to enabling mipmaps but memory usage will increase.
 		</member>
 		<member name="mipmaps/limit" type="int" setter="" getter="" default="-1">
-			Unimplemented. This currently has no effect when changed.
+			Sets the maximal amount of mipmaps for a texture. The smaller the limit, the sharper the texture will appear from a distance. This can help alleviate the overbluring of distant images, especially ones with a low resolution.
+			If set to [code]-1[/code], the full mipmap chain will be generated. If [code]0[/code], no mipmaps will be generated.
+			[b]Note:[/b] This setting is ignored if [member mipmaps/generate] is [code]false[/code].
 		</member>
 		<member name="process/channel_remap/alpha" type="int" setter="" getter="" default="3">
 			Specifies the data source of the output image's alpha channel.

--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -35,6 +35,12 @@
 				Called when the [Texture3D]'s height is queried.
 			</description>
 		</method>
+		<method name="_get_mipmap_count" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+				Called when the amount of mipmaps in the [Texture3D] is queried.
+			</description>
+		</method>
 		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
@@ -75,6 +81,12 @@
 			<return type="int" />
 			<description>
 				Returns the [Texture3D]'s height in pixels. Width is typically represented by the Y axis.
+			</description>
+		</method>
+		<method name="get_mipmap_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the [Texture3D]'s mipmap count.
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">

--- a/doc/classes/TextureLayered.xml
+++ b/doc/classes/TextureLayered.xml
@@ -44,6 +44,12 @@
 				Called when the number of layers in the [TextureLayered] is queried.
 			</description>
 		</method>
+		<method name="_get_mipmap_count" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+				Called when the amount of mipmaps in the [TextureLayered] is queried.
+			</description>
+		</method>
 		<method name="_get_width" qualifiers="virtual required const">
 			<return type="int" />
 			<description>
@@ -85,6 +91,12 @@
 			<return type="int" />
 			<description>
 				Returns the number of referenced [Image]s.
+			</description>
+		</method>
+		<method name="get_mipmap_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the layers' mipmap count.
 			</description>
 		</method>
 		<method name="get_width" qualifiers="const">

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1097,7 +1097,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		// It also allows for reading compressed textures, mipmaps, and more formats.
 		Vector<uint8_t> data;
 
-		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, texture->real_format, texture->mipmaps > 1);
+		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, texture->real_format, texture->mipmaps - 1);
 
 		data.resize(data_size * 2); // Add some memory at the end, just in case for buggy drivers.
 		uint8_t *w = data.ptrw();
@@ -1123,7 +1123,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		data.resize(data_size);
 
 		ERR_FAIL_COND_V(data.is_empty(), Ref<Image>());
-		image = Image::create_from_data(texture->alloc_width, texture->alloc_height, texture->mipmaps > 1, texture->real_format, data);
+		image = Image::create_from_data_partial_mipmaps(texture->alloc_width, texture->alloc_height, texture->mipmaps - 1, texture->real_format, data);
 		if (image->is_empty()) {
 			const String &path_str = texture->path.is_empty() ? "with no path" : vformat("with path '%s'", texture->path);
 			ERR_FAIL_V_MSG(Ref<Image>(), vformat("Texture %s has no data.", path_str));
@@ -1139,7 +1139,7 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 		Vector<uint8_t> data;
 
 		// On web and mobile we always read an RGBA8 image with no mipmaps.
-		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, false);
+		int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, 0);
 
 		data.resize(data_size * 2); // Add some memory at the end, just in case for buggy drivers.
 		uint8_t *w = data.ptrw();
@@ -1214,7 +1214,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 
 	Vector<uint8_t> data;
 
-	int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, false);
+	int64_t data_size = Image::get_image_data_size(texture->alloc_width, texture->alloc_height, Image::FORMAT_RGBA8, 0);
 
 	data.resize(data_size * 2); //add some memory at the end, just in case for buggy drivers
 	uint8_t *w = data.ptrw();
@@ -1269,7 +1269,7 @@ Ref<Image> TextureStorage::texture_2d_layer_get(RID p_texture, int p_layer) cons
 	}
 
 	if (texture->mipmaps > 1) {
-		image->generate_mipmaps();
+		image->generate_mipmaps(false, texture->mipmaps - 1);
 	}
 
 	return image;
@@ -1286,7 +1286,7 @@ Vector<Ref<Image>> TextureStorage::_texture_3d_read_framebuffer(GLES3::Texture *
 	int depth = p_texture->depth;
 
 	for (int mipmap_level = 0; mipmap_level < p_texture->mipmaps; mipmap_level++) {
-		int64_t data_size = Image::get_image_data_size(width, height, Image::FORMAT_RGBA8, false);
+		int64_t data_size = Image::get_image_data_size(width, height, Image::FORMAT_RGBA8, 0);
 		glViewport(0, 0, width, height);
 		glClearColor(0.0, 0.0, 0.0, 0.0);
 		glClear(GL_COLOR_BUFFER_BIT);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -270,10 +270,10 @@ struct Texture {
 					max_lod = 0;
 				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_NEAREST_MIPMAP_NEAREST;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				} else {
 					pmin = GL_NEAREST_MIPMAP_LINEAR;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				}
 			} break;
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
@@ -287,10 +287,10 @@ struct Texture {
 					max_lod = 0;
 				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_LINEAR_MIPMAP_NEAREST;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				} else {
 					pmin = GL_LINEAR_MIPMAP_LINEAR;
-					max_lod = 1000;
+					max_lod = mipmaps - 1;
 				}
 			} break;
 			default: {

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -54,6 +54,7 @@ public:
 
 	int hdr_compression = 0;
 	bool mipmaps = true;
+	int mipmap_limit = -1;
 	bool high_quality = false;
 	Image::UsedChannels used_channels = Image::USED_CHANNELS_RGBA;
 };
@@ -111,7 +112,7 @@ public:
 	virtual void get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset = 0) const override;
 	virtual bool get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const override;
 
-	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2);
+	void _save_tex(Vector<Ref<Image>> p_images, const String &p_to_path, int p_compress_mode, float p_lossy, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, Image::CompressSource p_csource, Image::UsedChannels used_channels, bool p_mipmaps, bool p_force_po2, int p_mipmap_limit);
 
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) override;
 

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -351,7 +351,7 @@ void ResourceImporterTexture::save_to_ctex_format(Ref<FileAccess> f, const Ref<I
 	}
 }
 
-void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
+void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_roughness, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, int p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel) {
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 
@@ -405,7 +405,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 		}
 
 		if (!image->has_mipmaps() || p_force_normal) {
-			image->generate_mipmaps(p_force_normal);
+			image->generate_mipmaps(p_force_normal, p_limit_mipmap);
 		}
 
 	} else {
@@ -712,7 +712,7 @@ Error ResourceImporterTexture::import(ResourceUID::ID p_source_id, const String 
 
 	// Mipmaps.
 	const bool mipmaps = p_options["mipmaps/generate"];
-	const uint32_t mipmap_limit = mipmaps ? uint32_t(p_options["mipmaps/limit"]) : uint32_t(-1);
+	const int mipmap_limit = int(p_options["mipmaps/limit"]);
 
 	// Roughness.
 	const int roughness = p_options["roughness/mode"];

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -86,7 +86,7 @@ protected:
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];
 
-	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, uint32_t p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
+	void _save_ctex(const Ref<Image> &p_image, const String &p_to_path, CompressMode p_compress_mode, float p_lossy_quality, const Image::BasisUniversalPackerParams &p_basisu_params, Image::CompressMode p_vram_compression, bool p_mipmaps, bool p_streamable, bool p_detect_3d, bool p_detect_srgb, bool p_detect_normal, bool p_force_normal, bool p_srgb_friendly, bool p_force_po2_for_compressed, int p_limit_mipmap, const Ref<Image> &p_normal, Image::RoughnessChannel p_roughness_channel);
 	void _save_editor_meta(const Dictionary &p_metadata, const String &p_to_path);
 	Dictionary _load_editor_meta(const String &p_to_path) const;
 

--- a/editor/scene/texture/texture_3d_editor_plugin.cpp
+++ b/editor/scene/texture/texture_3d_editor_plugin.cpp
@@ -172,8 +172,8 @@ void Texture3DEditor::_update_gui() {
 	const String format_name = Image::get_format_name(format);
 
 	if (texture->has_mipmaps()) {
-		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), format);
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true) * texture->get_depth();
+		const int mip_count = texture->get_mipmap_count();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, mip_count) * texture->get_depth();
 
 		info->set_text(vformat(String::utf8("%d×%d×%d %s\n") + TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
 				texture->get_width(),
@@ -184,7 +184,7 @@ void Texture3DEditor::_update_gui() {
 				String::humanize_size(memory)));
 
 	} else {
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, false) * texture->get_depth();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, 0) * texture->get_depth();
 
 		info->set_text(vformat(String::utf8("%d×%d×%d %s\n") + TTR("No Mipmaps") + "\n" + TTR("Memory: %s"),
 				texture->get_width(),

--- a/editor/scene/texture/texture_layered_editor_plugin.cpp
+++ b/editor/scene/texture/texture_layered_editor_plugin.cpp
@@ -205,15 +205,15 @@ void TextureLayeredEditor::_update_gui() {
 	}
 
 	if (texture->has_mipmaps()) {
-		const int mip_count = Image::get_image_required_mipmaps(texture->get_width(), texture->get_height(), format);
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, true) * texture->get_layers();
+		const int mip_count = texture->get_mipmap_count();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, mip_count) * texture->get_layers();
 
 		texture_info += vformat(TTR("%s Mipmaps") + "\n" + TTR("Memory: %s"),
 				mip_count,
 				String::humanize_size(memory));
 
 	} else {
-		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, false) * texture->get_layers();
+		const int memory = Image::get_image_data_size(texture->get_width(), texture->get_height(), format, 0) * texture->get_layers();
 
 		texture_info += vformat(TTR("No Mipmaps") + "\n" + TTR("Memory: %s"),
 				String::humanize_size(memory));

--- a/modules/basis_universal/image_compress_basisu.cpp
+++ b/modules/basis_universal/image_compress_basisu.cpp
@@ -416,7 +416,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 
 		// Create the buffer for transcoded/decompressed data.
 		Vector<uint8_t> out_data;
-		out_data.resize(Image::get_image_data_size(transcoder.get_width(), transcoder.get_height(), image_format, transcoder.get_levels() > 1));
+		out_data.resize(Image::get_image_data_size(transcoder.get_width(), transcoder.get_height(), image_format, transcoder.get_levels() - 1));
 
 		uint8_t *dst = out_data.ptrw();
 		memset(dst, 0, out_data.size());
@@ -436,7 +436,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 			}
 		}
 
-		image = Image::create_from_data(transcoder.get_width(), transcoder.get_height(), transcoder.get_levels() > 1, image_format, out_data);
+		image = Image::create_from_data_partial_mipmaps(transcoder.get_width(), transcoder.get_height(), transcoder.get_levels() - 1, image_format, out_data);
 	} else {
 		basist::basisu_transcoder transcoder;
 		ERR_FAIL_COND_V(!transcoder.validate_header(src_ptr, src_size), image);
@@ -448,7 +448,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 
 		// Create the buffer for transcoded/decompressed data.
 		Vector<uint8_t> out_data;
-		out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels > 1));
+		out_data.resize(Image::get_image_data_size(basisu_info.m_width, basisu_info.m_height, image_format, basisu_info.m_total_levels - 1));
 
 		uint8_t *dst = out_data.ptrw();
 		memset(dst, 0, out_data.size());
@@ -468,7 +468,7 @@ Ref<Image> basis_universal_unpacker_ptr(const uint8_t *p_data, int p_size) {
 			}
 		}
 
-		image = Image::create_from_data(basisu_info.m_width, basisu_info.m_height, basisu_info.m_total_levels > 1, image_format, out_data);
+		image = Image::create_from_data_partial_mipmaps(basisu_info.m_width, basisu_info.m_height, basisu_info.m_total_levels - 1, image_format, out_data);
 	}
 
 	if (needs_ra_rg_swap) {

--- a/modules/bcdec/image_decompress_bcdec.cpp
+++ b/modules/bcdec/image_decompress_bcdec.cpp
@@ -273,7 +273,7 @@ void image_decompress_bcdec(Image *p_image) {
 	}
 
 	int mm_count = p_image->get_mipmap_count();
-	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->get_mipmap_count());
 
 	// Decompressed data.
 	Vector<uint8_t> data;
@@ -291,7 +291,7 @@ void image_decompress_bcdec(Image *p_image) {
 		decompress_image(bcdec_format, rb + src_ofs, wb + dst_ofs, mipmap_w, mipmap_h);
 	}
 
-	p_image->set_data(width, height, p_image->has_mipmaps(), target_format, data);
+	p_image->set_data_partial_mipmaps(width, height, mm_count, target_format, data);
 
 	// Swap channels if the format is using a channel swizzle.
 	if (source_format == Image::FORMAT_DXT5_RA_AS_RG) {

--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -440,11 +440,11 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		dxt1_encoding_table_buffer = compress_rd->storage_buffer_create(1024 * 4, Span(dxt1_encoding_table).reinterpret<uint8_t>());
 	}
 
-	const int mip_count = r_img->get_mipmap_count() + 1;
+	const int mip_count = r_img->get_mipmap_count();
 
 	// Container for the compressed data.
 	Vector<uint8_t> dst_data;
-	dst_data.resize(Image::get_image_data_size(img_width, img_height, dest_format, r_img->has_mipmaps()));
+	dst_data.resize(Image::get_image_data_size(img_width, img_height, dest_format, r_img->get_mipmap_count()));
 	uint8_t *dst_data_ptr = dst_data.ptrw();
 
 	Vector<Vector<uint8_t>> src_images;
@@ -452,7 +452,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	Vector<uint8_t> *src_image_ptr = src_images.ptrw();
 
 	// Compress each mipmap.
-	for (int i = 0; i < mip_count; i++) {
+	for (int i = 0; i < mip_count + 1; i++) {
 		int width, height;
 		Image::get_image_mipmap_offset_and_dimensions(img_width, img_height, dest_format, i, width, height);
 
@@ -691,7 +691,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 	src_images.clear();
 
 	// Set the compressed data to the image.
-	r_img->set_data(img_width, img_height, r_img->has_mipmaps(), dest_format, dst_data);
+	r_img->set_data_partial_mipmaps(img_width, img_height, mip_count, dest_format, dst_data);
 
 	print_verbose(
 			vformat("Betsy: Encoding a %dx%d image with %d mipmaps as %s took %d ms.",

--- a/modules/camera/camera_android.cpp
+++ b/modules/camera/camera_android.cpp
@@ -307,7 +307,7 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 				return;
 			}
 			if (len != data_y.size()) {
-				int64_t size = Image::get_image_data_size(width, height, Image::FORMAT_R8, false);
+				int64_t size = Image::get_image_data_size(width, height, Image::FORMAT_R8, 0);
 				data_y.resize(len > size ? len : size);
 			}
 			memcpy(data_y.ptrw(), data, len);
@@ -319,7 +319,7 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 				return;
 			}
 			if (len != data_uv.size()) {
-				int64_t size = Image::get_image_data_size(width / 2, height / 2, Image::FORMAT_RG8, false);
+				int64_t size = Image::get_image_data_size(width / 2, height / 2, Image::FORMAT_RG8, 0);
 				data_uv.resize(len > size ? len : size);
 			}
 			memcpy(data_uv.ptrw(), data, len);
@@ -335,7 +335,7 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 				return;
 			}
 			if (len != data_y.size()) {
-				int64_t size = Image::get_image_data_size(width, height, Image::FORMAT_RGBA8, false);
+				int64_t size = Image::get_image_data_size(width, height, Image::FORMAT_RGBA8, 0);
 				data_y.resize(len > size ? len : size);
 			}
 			memcpy(data_y.ptrw(), data, len);
@@ -350,7 +350,7 @@ void CameraFeedAndroid::onImage(void *context, AImageReader *p_reader) {
 				return;
 			}
 			if (len != data_y.size()) {
-				int64_t size = Image::get_image_data_size(width, height, Image::FORMAT_RGB8, false);
+				int64_t size = Image::get_image_data_size(width, height, Image::FORMAT_RGB8, 0);
 				data_y.resize(len > size ? len : size);
 			}
 			memcpy(data_y.ptrw(), data, len);

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -186,8 +186,8 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 	}
 
 	Vector<uint8_t> data;
-	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
-	int mm_count = p_image->has_mipmaps() ? Image::get_image_required_mipmaps(w, h, target_format) : 0;
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->get_mipmap_count());
+	int mm_count = p_image->get_mipmap_count();
 	data.resize(target_size);
 	int shift = Image::get_format_pixel_rshift(target_format);
 
@@ -282,7 +282,7 @@ void image_compress_cvtt(Image *p_image, Image::UsedChannels p_channels) {
 	WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_native_group_task(&_digest_job_queue, &job_queue, WorkerThreadPool::get_singleton()->get_thread_count(), -1, true, SNAME("CVTT Compress"));
 	WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
-	p_image->set_data(w, h, p_image->has_mipmaps(), target_format, data);
+	p_image->set_data_partial_mipmaps(w, h, mm_count, target_format, data);
 
 	print_verbose(vformat("CVTT: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
@@ -314,7 +314,7 @@ void image_decompress_cvtt(Image *p_image) {
 	const uint8_t *rb = p_image->get_data().ptr();
 
 	Vector<uint8_t> data;
-	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(w, h, target_format, p_image->get_mipmap_count());
 	int mm_count = p_image->get_mipmap_count();
 	data.resize(target_size);
 
@@ -393,5 +393,5 @@ void image_decompress_cvtt(Image *p_image) {
 		w >>= 1;
 		h >>= 1;
 	}
-	p_image->set_data(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
+	p_image->set_data_partial_mipmaps(p_image->get_width(), p_image->get_height(), mm_count, target_format, data);
 }

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -383,7 +383,7 @@ static Ref<Image> _dds_load_layer(Ref<FileAccess> p_file, DDSFormat p_dds_format
 		}
 	}
 
-	return memnew(Image(p_width, p_height, p_mipmaps > 1, info.format, r_src_data));
+	return memnew(Image(p_width, p_height, info.format, p_mipmaps - 1, r_src_data));
 }
 
 static Vector<Ref<Image>> _dds_load_images(Ref<FileAccess> p_f, DDSFormat p_dds_format, uint32_t p_width, uint32_t p_height, uint32_t p_mipmaps, uint32_t p_pitch, uint32_t p_flags, uint32_t p_layer_count) {

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -162,7 +162,7 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	}
 
 	// Compress image data and (if required) mipmaps.
-	const bool has_mipmaps = r_img->has_mipmaps();
+	const int mip_count = r_img->get_mipmap_count();
 	int width = r_img->get_width();
 	int height = r_img->get_height();
 
@@ -196,12 +196,11 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 
 	// Create the buffer for compressed image data.
 	Vector<uint8_t> dest_data;
-	dest_data.resize(Image::get_image_data_size(width, height, target_format, has_mipmaps));
+	dest_data.resize(Image::get_image_data_size(width, height, target_format, r_img->get_mipmap_count()));
 	uint8_t *dest_write = dest_data.ptrw();
 
 	const uint8_t *src_read = r_img->get_data().ptr();
 
-	const int mip_count = has_mipmaps ? Image::get_image_required_mipmaps(width, height, target_format) : 0;
 	Vector<uint32_t> padded_src;
 
 	for (int i = 0; i < mip_count + 1; i++) {
@@ -301,7 +300,7 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 	}
 
 	// Replace original image with compressed one.
-	r_img->set_data(width, height, has_mipmaps, target_format, dest_data);
+	r_img->set_data_partial_mipmaps(width, height, mip_count, target_format, dest_data);
 
 	print_verbose(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }

--- a/modules/etcpak/image_decompress_etcpak.cpp
+++ b/modules/etcpak/image_decompress_etcpak.cpp
@@ -215,7 +215,7 @@ void _decompress_etc(Image *p_image) {
 	}
 
 	int mm_count = p_image->get_mipmap_count();
-	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->has_mipmaps());
+	int64_t target_size = Image::get_image_data_size(width, height, target_format, p_image->get_mipmap_count());
 
 	// Decompressed data.
 	Vector<uint8_t> data;
@@ -233,7 +233,7 @@ void _decompress_etc(Image *p_image) {
 		decompress_image(etcpak_format, rb + src_ofs, wb + dst_ofs, mipmap_w, mipmap_h);
 	}
 
-	p_image->set_data(p_image->get_width(), p_image->get_height(), p_image->has_mipmaps(), target_format, data);
+	p_image->set_data_partial_mipmaps(p_image->get_width(), p_image->get_height(), mm_count, target_format, data);
 
 	// Swap channels if the format is using a channel swizzle.
 	if (source_format == Image::FORMAT_ETC2_RA_AS_RG) {

--- a/modules/ktx/texture_loader_ktx.cpp
+++ b/modules/ktx/texture_loader_ktx.cpp
@@ -498,7 +498,7 @@ static Ref<Image> load_from_file_access(Ref<FileAccess> f, Error *r_error) {
 		memcpy(src_data.ptrw() + prev_size, ktxTexture_GetData(ktx_texture) + offset, mip_size);
 	}
 
-	Ref<Image> img = memnew(Image(width, height, mipmaps - 1, format, src_data));
+	Ref<Image> img = memnew(Image(width, height, format, mipmaps - 1, src_data));
 	if (srgb) {
 		img->srgb_to_linear();
 	}

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -145,7 +145,7 @@ private:
 	int w = 0;
 	int h = 0;
 	int layers = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	LayeredType layered_type = LayeredType::LAYERED_TYPE_2D_ARRAY;
 
 	virtual void reload_from_file() override;
@@ -163,6 +163,7 @@ public:
 	int get_height() const override;
 	int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;
@@ -232,7 +233,7 @@ private:
 	int w = 0;
 	int h = 0;
 	int d = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	virtual void reload_from_file() override;
 
@@ -248,6 +249,7 @@ public:
 	int get_height() const override;
 	int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual void set_path(const String &p_path, bool p_take_over) override;

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -87,7 +87,7 @@ void ImageTexture::set_image(const Ref<Image> &p_image) {
 	w = p_image->get_width();
 	h = p_image->get_height();
 	format = p_image->get_format();
-	mipmaps = p_image->has_mipmaps();
+	mipmap_count = p_image->get_mipmap_count();
 
 	if (texture.is_null()) {
 		texture = RenderingServer::get_singleton()->texture_2d_create(p_image);
@@ -112,7 +112,7 @@ void ImageTexture::update(const Ref<Image> &p_image) {
 			"The new image dimensions must match the texture size.");
 	ERR_FAIL_COND_MSG(p_image->get_format() != format,
 			"The new image format must match the texture's image format.");
-	ERR_FAIL_COND_MSG(mipmaps != p_image->has_mipmaps(),
+	ERR_FAIL_COND_MSG(mipmap_count != p_image->get_mipmap_count(),
 			"The new image mipmaps configuration must match the texture's image mipmaps configuration");
 
 	RS::get_singleton()->texture_2d_update(texture, p_image);
@@ -258,7 +258,11 @@ int ImageTextureLayered::get_layers() const {
 }
 
 bool ImageTextureLayered::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
+}
+
+int ImageTextureLayered::get_mipmap_count() const {
+	return mipmap_count;
 }
 
 ImageTextureLayered::LayeredType ImageTextureLayered::get_layered_type() const {
@@ -304,14 +308,14 @@ Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 	Image::Format new_format = p_images[0]->get_format();
 	int new_width = p_images[0]->get_width();
 	int new_height = p_images[0]->get_height();
-	bool new_mipmaps = p_images[0]->has_mipmaps();
+	int new_mipmaps = p_images[0]->get_mipmap_count();
 
 	for (int i = 1; i < p_images.size(); i++) {
 		ERR_FAIL_COND_V_MSG(p_images[i]->get_format() != new_format, ERR_INVALID_PARAMETER,
 				"All images must share the same format");
 		ERR_FAIL_COND_V_MSG(p_images[i]->get_width() != new_width || p_images[i]->get_height() != new_height, ERR_INVALID_PARAMETER,
 				"All images must share the same dimensions");
-		ERR_FAIL_COND_V_MSG(p_images[i]->has_mipmaps() != new_mipmaps, ERR_INVALID_PARAMETER,
+		ERR_FAIL_COND_V_MSG(p_images[i]->get_mipmap_count() != new_mipmaps, ERR_INVALID_PARAMETER,
 				"All images must share the usage of mipmaps");
 	}
 
@@ -328,7 +332,7 @@ Error ImageTextureLayered::create_from_images(Vector<Ref<Image>> p_images) {
 	width = new_width;
 	height = new_height;
 	layers = new_layers;
-	mipmaps = new_mipmaps;
+	mipmap_count = new_mipmaps;
 	return OK;
 }
 
@@ -337,7 +341,7 @@ void ImageTextureLayered::update_layer(const Ref<Image> &p_image, int p_layer) {
 	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image.");
 	ERR_FAIL_COND_MSG(p_image->get_format() != format, "Image format must match texture's image format.");
 	ERR_FAIL_COND_MSG(p_image->get_width() != width || p_image->get_height() != height, "Image size must match texture's image size.");
-	ERR_FAIL_COND_MSG(p_image->has_mipmaps() != mipmaps, "Image mipmap configuration must match texture's image mipmap configuration.");
+	ERR_FAIL_COND_MSG(p_image->get_mipmap_count() != mipmap_count, "Image mipmap configuration must match texture's image mipmap configuration.");
 	ERR_FAIL_INDEX_MSG(p_layer, layers, "Layer index is out of bounds.");
 	RS::get_singleton()->texture_2d_update(texture, p_image, p_layer);
 }
@@ -396,7 +400,11 @@ int ImageTexture3D::get_depth() const {
 	return depth;
 }
 bool ImageTexture3D::has_mipmaps() const {
-	return mipmaps;
+	return mipmap_count > 0;
+}
+
+int ImageTexture3D::get_mipmap_count() const {
+	return mipmap_count;
 }
 
 Error ImageTexture3D::_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data) {
@@ -431,7 +439,7 @@ Error ImageTexture3D::create(Image::Format p_format, int p_width, int p_height, 
 	width = p_width;
 	height = p_height;
 	depth = p_depth;
-	mipmaps = p_mipmaps;
+	mipmap_count = p_mipmaps ? Image::get_image_required_mipmaps(width, height, format) : 0;
 
 	return OK;
 }

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -40,7 +40,7 @@ class ImageTexture : public Texture2D {
 
 	mutable RID texture;
 	Image::Format format = Image::FORMAT_L8;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	int w = 0;
 	int h = 0;
 	Size2 size_override;
@@ -95,7 +95,7 @@ class ImageTextureLayered : public TextureLayered {
 	int width = 0;
 	int height = 0;
 	int layers = 0;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	Error _create_from_images(const TypedArray<Image> &p_images);
 
@@ -111,6 +111,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual LayeredType get_layered_type() const override;
 
 	Error create_from_images(Vector<Ref<Image>> p_images);
@@ -133,7 +134,7 @@ class ImageTexture3D : public Texture3D {
 	int width = 1;
 	int height = 1;
 	int depth = 1;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 
 	TypedArray<Image> _get_images() const;
 	void _set_images(const TypedArray<Image> &p_images);
@@ -150,6 +151,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 
 	Error create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data);
 	void update(const Vector<Ref<Image>> &p_data);

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -62,10 +62,10 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 	compression_mode = CompressionMode(decode_uint16(data));
 	DataFormat data_format = DataFormat(decode_uint16(data + 2));
 	format = Image::Format(decode_uint32(data + 4));
-	uint32_t mipmap_count = decode_uint32(data + 8);
+	uint32_t mip_count = decode_uint32(data + 8);
 	size.width = decode_uint32(data + 12);
 	size.height = decode_uint32(data + 16);
-	mipmaps = mipmap_count > 1;
+	mipmap_count = (int)mip_count - 1;
 
 	data += 20;
 	data_size -= 20;
@@ -88,7 +88,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 			Vector<uint8_t> image_data;
 
 			ERR_FAIL_COND(data_size < 4);
-			for (uint32_t i = 0; i < mipmap_count; i++) {
+			for (uint32_t i = 0; i < mip_count; i++) {
 				uint32_t mipsize = decode_uint32(data);
 				data += 4;
 				data_size -= 4;
@@ -106,7 +106,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 				data_size -= mipsize;
 			}
 
-			image.instantiate(size.width, size.height, mipmaps, format, image_data);
+			image.instantiate(size.width, size.height, format, mipmap_count, image_data);
 
 		} break;
 		case COMPRESSION_MODE_BASIS_UNIVERSAL: {
@@ -118,7 +118,7 @@ void PortableCompressedTexture2D::_set_data(const Vector<uint8_t> &p_data) {
 		case COMPRESSION_MODE_ETC2:
 		case COMPRESSION_MODE_BPTC:
 		case COMPRESSION_MODE_ASTC: {
-			image.instantiate(size.width, size.height, mipmaps, format, p_data.slice(20));
+			image.instantiate(size.width, size.height, format, mipmap_count, p_data.slice(20));
 		} break;
 	}
 	ERR_FAIL_COND(image.is_null());

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -63,7 +63,7 @@ private:
 	Vector<uint8_t> compressed_buffer;
 	Size2 size;
 	Size2 size_override;
-	bool mipmaps = false;
+	int mipmap_count = 0;
 	Image::Format format = Image::FORMAT_L8;
 
 	mutable RID texture;

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -161,6 +161,12 @@ bool Texture3D::has_mipmaps() const {
 	return ret;
 }
 
+int Texture3D::get_mipmap_count() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_mipmap_count, ret);
+	return ret;
+}
+
 Vector<Ref<Image>> Texture3D::get_data() const {
 	TypedArray<Image> ret;
 	GDVIRTUAL_CALL(_get_data, ret);
@@ -178,6 +184,7 @@ void Texture3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &Texture3D::get_height);
 	ClassDB::bind_method(D_METHOD("get_depth"), &Texture3D::get_depth);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &Texture3D::has_mipmaps);
+	ClassDB::bind_method(D_METHOD("get_mipmap_count"), &Texture3D::get_mipmap_count);
 	ClassDB::bind_method(D_METHOD("get_data"), &Texture3D::_get_datai);
 	ClassDB::bind_method(D_METHOD("create_placeholder"), &Texture3D::create_placeholder);
 
@@ -186,6 +193,7 @@ void Texture3D::_bind_methods() {
 	GDVIRTUAL_BIND(_get_height);
 	GDVIRTUAL_BIND(_get_depth);
 	GDVIRTUAL_BIND(_has_mipmaps);
+	GDVIRTUAL_BIND(_get_mipmap_count);
 	GDVIRTUAL_BIND(_get_data);
 }
 
@@ -232,6 +240,12 @@ bool TextureLayered::has_mipmaps() const {
 	return ret;
 }
 
+int TextureLayered::get_mipmap_count() const {
+	int ret = 0;
+	GDVIRTUAL_CALL(_get_mipmap_count, ret);
+	return ret;
+}
+
 Ref<Image> TextureLayered::get_layer_data(int p_layer) const {
 	Ref<Image> ret;
 	GDVIRTUAL_CALL(_get_layer_data, p_layer, ret);
@@ -245,6 +259,7 @@ void TextureLayered::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_height"), &TextureLayered::get_height);
 	ClassDB::bind_method(D_METHOD("get_layers"), &TextureLayered::get_layers);
 	ClassDB::bind_method(D_METHOD("has_mipmaps"), &TextureLayered::has_mipmaps);
+	ClassDB::bind_method(D_METHOD("get_mipmap_count"), &TextureLayered::get_mipmap_count);
 	ClassDB::bind_method(D_METHOD("get_layer_data", "layer"), &TextureLayered::get_layer_data);
 
 	BIND_ENUM_CONSTANT(LAYERED_TYPE_2D_ARRAY);
@@ -257,5 +272,6 @@ void TextureLayered::_bind_methods() {
 	GDVIRTUAL_BIND(_get_height);
 	GDVIRTUAL_BIND(_get_layers);
 	GDVIRTUAL_BIND(_has_mipmaps);
+	GDVIRTUAL_BIND(_get_mipmap_count);
 	GDVIRTUAL_BIND(_get_layer_data, "layer_index");
 }

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -91,6 +91,7 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(int, _get_height)
 	GDVIRTUAL0RC_REQUIRED(int, _get_layers)
 	GDVIRTUAL0RC_REQUIRED(bool, _has_mipmaps)
+	GDVIRTUAL0RC_REQUIRED(int, _get_mipmap_count)
 	GDVIRTUAL1RC_REQUIRED(Ref<Image>, _get_layer_data, int)
 public:
 	enum LayeredType {
@@ -105,6 +106,7 @@ public:
 	virtual int get_height() const;
 	virtual int get_layers() const;
 	virtual bool has_mipmaps() const;
+	virtual int get_mipmap_count() const;
 	virtual Ref<Image> get_layer_data(int p_layer) const;
 };
 
@@ -123,6 +125,7 @@ protected:
 	GDVIRTUAL0RC_REQUIRED(int, _get_height)
 	GDVIRTUAL0RC_REQUIRED(int, _get_depth)
 	GDVIRTUAL0RC_REQUIRED(bool, _has_mipmaps)
+	GDVIRTUAL0RC_REQUIRED(int, _get_mipmap_count)
 	GDVIRTUAL0RC_REQUIRED(TypedArray<Image>, _get_data)
 public:
 	virtual Image::Format get_format() const;
@@ -130,6 +133,7 @@ public:
 	virtual int get_height() const;
 	virtual int get_depth() const;
 	virtual bool has_mipmaps() const;
+	virtual int get_mipmap_count() const;
 	virtual Vector<Ref<Image>> get_data() const;
 	virtual Ref<Resource> create_placeholder() const;
 };

--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -159,6 +159,10 @@ bool TextureLayeredRD::has_mipmaps() const {
 	return mipmaps > 1;
 }
 
+int TextureLayeredRD::get_mipmap_count() const {
+	return mipmaps;
+}
+
 RID TextureLayeredRD::get_rid() const {
 	if (texture_rid.is_null()) {
 		// We are in trouble, create something temporary.
@@ -284,6 +288,10 @@ int Texture3DRD::get_depth() const {
 
 bool Texture3DRD::has_mipmaps() const {
 	return mipmaps > 1;
+}
+
+int Texture3DRD::get_mipmap_count() const {
+	return mipmaps;
 }
 
 RID Texture3DRD::get_rid() const {

--- a/scene/resources/texture_rd.h
+++ b/scene/resources/texture_rd.h
@@ -89,6 +89,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_layers() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
@@ -146,6 +147,7 @@ public:
 	virtual int get_height() const override;
 	virtual int get_depth() const override;
 	virtual bool has_mipmaps() const override;
+	virtual int get_mipmap_count() const override;
 	virtual RID get_rid() const override;
 
 	void set_texture_rd_rid(RID p_texture_rd_rid);

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -470,4 +470,30 @@ TEST_CASE("[Image] Convert image") {
 	CHECK_MESSAGE(image2->get_data() == image_data, "Image conversion to invalid type (Image::FORMAT_MAX + 1) should not alter image.");
 }
 
+TEST_CASE("[Image] Partial mipmaps") {
+	Ref<Image> image = memnew(Image(256, 256, Image::FORMAT_RGBA8, 3));
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+
+	image->rotate_90(CLOCKWISE);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+	image->rotate_90(COUNTERCLOCKWISE);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+	image->rotate_180();
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+
+	image->convert(Image::FORMAT_RGBAF);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+
+	image->clear_mipmaps();
+	CHECK_MESSAGE(image->get_mipmap_count() == 0, "The image's mipmap count should be equal to 0.");
+
+	image->generate_mipmaps(false, 1);
+	CHECK_MESSAGE(image->get_mipmap_count() == 1, "The image's mipmap count should be equal to 1.");
+
+	image->convert(Image::FORMAT_RGBA8);
+	image->generate_mipmaps(false, 3);
+	image->compress(Image::COMPRESS_ASTC);
+	CHECK_MESSAGE(image->get_mipmap_count() == 3, "The image's mipmap count should be equal to 3.");
+}
+
 } // namespace TestImage


### PR DESCRIPTION
Depends on #108720
Fixes #63934

Makes the importer respect the previously non-functional `mipmap_limit` property for textures.