### PR TITLE
Show symlink target in the resource tooltip.

### DIFF
--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -81,6 +81,12 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 		Label *label = memnew(Label(vformat(TTR("Type: %s"), type)));
 		vb->add_child(label);
 	}
+
+	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	if (da->is_link(p_resource_path)) {
+		Label *link = memnew(Label(vformat(TTR("Link to: %s"), da->read_link(p_resource_path))));
+		vb->add_child(link);
+	}
 	return vb;
 }
 


### PR DESCRIPTION
It was already shown in the default file system view tooltips, but tooltips are overridden for the resource type files.

<img width="341" height="295" alt="Screenshot 2025-08-11 at 16 12 48" src="https://github.com/user-attachments/assets/a48826ff-e19a-4cdc-ba67-c190a02f5dc1" />
