### PR TITLE
OpenXR: Safely set environment blend mode when rendering on a separate thread

### DIFF
--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -337,6 +337,7 @@ private:
 		bool has_xr_viewport = false;
 		XrTime predicted_display_time = 0;
 		XrSpace play_space = XR_NULL_HANDLE;
+		XrEnvironmentBlendMode environment_blend_mode = XR_ENVIRONMENT_BLEND_MODE_OPAQUE;
 		double render_target_size_multiplier = 1.0;
 		uint64_t frame = 0;
 		Rect2i render_region;
@@ -363,19 +364,20 @@ private:
 		OpenXRSwapChainInfo main_swapchains[OPENXR_SWAPCHAIN_MAX];
 	} render_state;
 
-	static void _allocate_view_buffers(uint32_t p_view_count, bool p_submit_depth_buffer);
-	static void _set_render_session_running(bool p_is_running);
-	static void _set_render_display_info(XrTime p_predicted_display_time, bool p_should_render);
-	static void _set_render_play_space(uint64_t p_play_space);
-	static void _set_render_state_multiplier(double p_render_target_size_multiplier);
-	static void _set_render_state_render_region(const Rect2i &p_render_region);
+	static void _allocate_view_buffers_rt(uint32_t p_view_count, bool p_submit_depth_buffer);
+	static void _set_render_session_running_rt(bool p_is_running);
+	static void _set_render_display_info_rt(XrTime p_predicted_display_time, bool p_should_render);
+	static void _set_render_play_space_rt(uint64_t p_play_space);
+	static void _set_render_environment_blend_mode_rt(int32_t p_environment_blend_mode);
+	static void _set_render_state_multiplier_rt(double p_render_target_size_multiplier);
+	static void _set_render_state_render_region_rt(const Rect2i &p_render_region);
 
 	_FORCE_INLINE_ void allocate_view_buffers(uint32_t p_view_count, bool p_submit_depth_buffer) {
 		// If we're rendering on a separate thread, we may still be processing the last frame, don't communicate this till we're ready...
 		RenderingServer *rendering_server = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rendering_server);
 
-		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_allocate_view_buffers).bind(p_view_count, p_submit_depth_buffer));
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_allocate_view_buffers_rt).bind(p_view_count, p_submit_depth_buffer));
 	}
 
 	_FORCE_INLINE_ void set_render_session_running(bool p_is_running) {
@@ -383,7 +385,7 @@ private:
 		RenderingServer *rendering_server = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rendering_server);
 
-		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_session_running).bind(p_is_running));
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_session_running_rt).bind(p_is_running));
 	}
 
 	_FORCE_INLINE_ void set_render_display_info(XrTime p_predicted_display_time, bool p_should_render) {
@@ -391,7 +393,7 @@ private:
 		RenderingServer *rendering_server = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rendering_server);
 
-		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_display_info).bind(p_predicted_display_time, p_should_render));
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_display_info_rt).bind(p_predicted_display_time, p_should_render));
 	}
 
 	_FORCE_INLINE_ void set_render_play_space(XrSpace p_play_space) {
@@ -399,7 +401,15 @@ private:
 		RenderingServer *rendering_server = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rendering_server);
 
-		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_play_space).bind(uint64_t(p_play_space)));
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_play_space_rt).bind(uint64_t(p_play_space)));
+	}
+
+	_FORCE_INLINE_ void set_render_environment_blend_mode(XrEnvironmentBlendMode p_mode) {
+		// If we're rendering on a separate thread, we may still be processing the last frame, don't communicate this till we're ready...
+		RenderingServer *rendering_server = RenderingServer::get_singleton();
+		ERR_FAIL_NULL(rendering_server);
+
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_environment_blend_mode_rt).bind((int32_t)p_mode));
 	}
 
 	_FORCE_INLINE_ void set_render_state_multiplier(double p_render_target_size_multiplier) {
@@ -407,14 +417,14 @@ private:
 		RenderingServer *rendering_server = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rendering_server);
 
-		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_multiplier).bind(p_render_target_size_multiplier));
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_multiplier_rt).bind(p_render_target_size_multiplier));
 	}
 
 	_FORCE_INLINE_ void set_render_state_render_region(const Rect2i &p_render_region) {
 		RenderingServer *rendering_server = RenderingServer::get_singleton();
 		ERR_FAIL_NULL(rendering_server);
 
-		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_render_region).bind(p_render_region));
+		rendering_server->call_on_render_thread(callable_mp_static(&OpenXRAPI::_set_render_state_render_region_rt).bind(p_render_region));
 	}
 
 public:


### PR DESCRIPTION
For OpenXR to work safely when Godot is rendering on a separate thread (by setting "Rendering" -> "Driver" -> "Thread Model" to "Safe" in Project Settings), any dynamic values we read from on the render thread need to be either protected by a mutex, or set via `RenderingServer::call_on_render_thread()`

Currently, in `OpenXR::end_frame()` (which runs on the render thread) we're reading from `environment_blend_mode`, which can be set directly on the main thread.

This PR adds a new variable to `render_state` that will be read their instead, and sets it via `RenderingServer::call_on_render_thread()`

I've tested that this works on Quest 3, even for applications that were configured to start in passthrough mode by setting "Environment Blend Mode" to "Alpha" in project settings. They can go from passthrough to passthrough, without having a random opaque frame in-between (at least as far as I could tell :-)). 