### PR TITLE
OpenXR: Prevent adding/removing extension wrappers after session start

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1792,10 +1792,14 @@ void OpenXRAPI::set_xr_interface(OpenXRInterface *p_xr_interface) {
 }
 
 void OpenXRAPI::register_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper) {
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_COND_MSG(openxr_api && openxr_api->instance != XR_NULL_HANDLE, "Cannot register OpenXR extension wrappers after the OpenXR instance has been created.");
 	registered_extension_wrappers.push_back(p_extension_wrapper);
 }
 
 void OpenXRAPI::unregister_extension_wrapper(OpenXRExtensionWrapper *p_extension_wrapper) {
+	OpenXRAPI *openxr_api = OpenXRAPI::get_singleton();
+	ERR_FAIL_COND_MSG(openxr_api && openxr_api->instance != XR_NULL_HANDLE, "Cannot unregister OpenXR extension wrappers after the OpenXR instance has been created.");
 	registered_extension_wrappers.erase(p_extension_wrapper);
 }
 
@@ -3711,26 +3715,32 @@ bool OpenXRAPI::trigger_haptic_pulse(RID p_action, RID p_tracker, float p_freque
 }
 
 void OpenXRAPI::register_composition_layer_provider(OpenXRExtensionWrapper *p_extension) {
+	ERR_FAIL_COND_MSG(running, "Cannot register OpenXR composition layer providers while the session is running.");
 	composition_layer_providers.append(p_extension);
 }
 
 void OpenXRAPI::unregister_composition_layer_provider(OpenXRExtensionWrapper *p_extension) {
+	ERR_FAIL_COND_MSG(running, "Cannot unregister OpenXR composition layer providers while the session is running.");
 	composition_layer_providers.erase(p_extension);
 }
 
 void OpenXRAPI::register_projection_views_extension(OpenXRExtensionWrapper *p_extension) {
+	ERR_FAIL_COND_MSG(running, "Cannot register OpenXR projection views extensions while the session is running.");
 	projection_views_extensions.append(p_extension);
 }
 
 void OpenXRAPI::unregister_projection_views_extension(OpenXRExtensionWrapper *p_extension) {
+	ERR_FAIL_COND_MSG(running, "Cannot unregister OpenXR projection views extensions while the session is running.");
 	projection_views_extensions.erase(p_extension);
 }
 
 void OpenXRAPI::register_frame_info_extension(OpenXRExtensionWrapper *p_extension) {
+	ERR_FAIL_COND_MSG(running, "Cannot register OpenXR frame info extensions while the session is running.");
 	frame_info_extensions.append(p_extension);
 }
 
 void OpenXRAPI::unregister_frame_info_extension(OpenXRExtensionWrapper *p_extension) {
+	ERR_FAIL_COND_MSG(running, "Cannot unregister OpenXR frame info extensions while the session is running.");
 	frame_info_extensions.erase(p_extension);
 }
 


### PR DESCRIPTION
This is _related_ to my work on improving XR when Godot is rendering on a separate thread, but not entirely.

It is thread unsafe to add/remove extension wrappers from any of these `Vector<T>`s because both the render and main thread loop over them, especially in `OpenXRAPI::end_frame()` which runs on the render thread and can't have data change out from under it.

However, it's just unsafe in general to add/remove extension wrappers from these lists after an OpenXR session has started, even in a single-threaded context, because the state of all our OpenXR resources will get inconsistent if an extension wrapper runs some of its `on_*()` methods, but not all of them.

This PR aims to fix that!

There's two groups of extension lists:

- The main list (modified by `OpenXRAPI::register_extension_wrapper()` and `::unregister_extension_wrapper()`). This is the strictest case: we can't add or remove anything from this list after the OpenXR instance has been created (so, even before the session).
- All the other lists, which are only used in `OpenXRAPI::end_frame()`. Those can't have any changes after the session has actually started (so, not just after the session has been created, but after the state has changed to `XR_SESSION_STATE_READY`). This is important because some pre-existing extensions add themselves to those lists right after the session is created (and remove themselves after the session is destroyed), and we need to not break them

I've tested this with the `XR_FB_passthrough` extension support from godot_openxr_vendors (which uses the `composition_layer_providers` list), and all seems good. But it could still use some testing with other extensions that use the other lists to make sure this doesn't break any of them.