### PR TITLE
Fix Editor window resizing for RTL languages

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2024,7 +2024,6 @@ SceneTree::SceneTree() {
 	root->set_name("root");
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		root->set_wrap_controls(true);
 		root->set_auto_translate_mode(Node::AUTO_TRANSLATE_MODE_ALWAYS);
 	} else {
 		root->set_auto_translate_mode(GLOBAL_GET("internationalization/rendering/root_node_auto_translate") ? Node::AUTO_TRANSLATE_MODE_ALWAYS : Node::AUTO_TRANSLATE_MODE_DISABLED);


### PR DESCRIPTION
This line has no effect in both RTL and LTR languages, all it does is that it prevents the window from being resized down when it start with Arabic language, i have added a comment to the issue to reproduce it, i was able to reproduce it on Fedora and Windows 10.

* Fixes: https://github.com/godotengine/godot/issues/97983