### PR TITLE
Fix shortcut reset for spatial_editor/tool_select

### DIFF
--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -288,8 +288,6 @@ GameViewDebugger::GameViewDebugger() {
 	ED_SHORTCUT_OVERRIDE("editor/suspend_resume_embedded_project", "macos", KeyModifierMask::META | KeyModifierMask::SHIFT | Key::B);
 
 	ED_SHORTCUT("editor/next_frame_embedded_project", TTRC("Next Frame"), Key::F10);
-
-	ED_SHORTCUT("spatial_editor/tool_select", TTRC("Select Mode"), Key::Q);
 }
 
 ///////


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109538

After:

<img width="912" height="737" alt="Screenshot_20250812_104147" src="https://github.com/user-attachments/assets/6d8e6944-1854-440b-a77f-095a5a8690ba" />

