### PR TITLE
Improve shader overloaded function error reporting.

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -3865,6 +3865,14 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 	int last_arg_count = 0;
 	bool exists = false;
 	String arg_list = "";
+	bool overload_fail = false;
+	struct OverloadErrorInfo {
+		String arg_list;
+		int index = 0;
+		String func_arg_name;
+		String arg_name;
+	};
+	Vector<OverloadErrorInfo> overload_errors;
 
 	for (int i = 0; i < shader->vfunctions.size(); i++) {
 		if (rname != shader->vfunctions[i].rname) {
@@ -3878,24 +3886,23 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 		}
 
 		FunctionNode *pfunc = shader->vfunctions[i].function;
-		if (arg_list.is_empty()) {
-			for (int j = 0; j < pfunc->arguments.size(); j++) {
-				if (j > 0) {
-					arg_list += ", ";
-				}
-				String func_arg_name;
-				if (pfunc->arguments[j].type == TYPE_STRUCT) {
-					func_arg_name = pfunc->arguments[j].struct_name;
-				} else {
-					func_arg_name = get_datatype_name(pfunc->arguments[j].type);
-				}
-				if (pfunc->arguments[j].array_size > 0) {
-					func_arg_name += "[";
-					func_arg_name += itos(pfunc->arguments[j].array_size);
-					func_arg_name += "]";
-				}
-				arg_list += func_arg_name;
+		arg_list.clear();
+		for (int j = 0; j < pfunc->arguments.size(); j++) {
+			if (j > 0) {
+				arg_list += ", ";
 			}
+			String func_arg_name;
+			if (pfunc->arguments[j].type == TYPE_STRUCT) {
+				func_arg_name = pfunc->arguments[j].struct_name;
+			} else {
+				func_arg_name = get_datatype_name(pfunc->arguments[j].type);
+			}
+			if (pfunc->arguments[j].array_size > 0) {
+				func_arg_name += "[";
+				func_arg_name += itos(pfunc->arguments[j].array_size);
+				func_arg_name += "]";
+			}
+			arg_list += func_arg_name;
 		}
 
 		if (pfunc->arguments.size() != args.size()) {
@@ -3933,9 +3940,17 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 					arg_name += "]";
 				}
 
-				_set_error(vformat(RTR("Invalid argument for \"%s(%s)\" function: argument %d should be %s but is %s."), String(rname), arg_list, j + 1, func_arg_name, arg_name));
 				fail = true;
+				OverloadErrorInfo err_info;
+				err_info.arg_list = arg_list;
+				err_info.index = j + 1;
+				err_info.func_arg_name = func_arg_name;
+				err_info.arg_name = arg_name;
+				overload_errors.push_back(err_info);
+				overload_fail = true;
 				break;
+			} else {
+				overload_fail = false;
 			}
 		}
 
@@ -3970,6 +3985,19 @@ bool ShaderLanguage::_validate_function_call(BlockNode *p_block, const FunctionI
 			}
 			return true;
 		}
+	}
+	if (overload_fail) {
+		String err_str;
+		if (overload_errors.size() == 1) {
+			const OverloadErrorInfo &err_info = overload_errors[0];
+			err_str = vformat("No matching function for \"%s(%s)\" call: argument %d should be %s but is %s.", String(rname), err_info.arg_list, err_info.index, err_info.func_arg_name, err_info.arg_name);
+		} else {
+			err_str = vformat(RTR("No matching function for \"%s\" call:"), String(rname));
+			for (const OverloadErrorInfo &err_info : overload_errors) {
+				err_str += "\n\t" + vformat(RTR("candidate function \"%s(%s)\" not viable, argument %d should be %s but is %s."), String(rname), err_info.arg_list, err_info.index, err_info.func_arg_name, err_info.arg_name);
+			}
+		}
+		_set_error(err_str);
 	}
 
 	if (exists) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109489

- Only show error if all overload fail (instead of setting error o first failed overload and never unsetting it).
- Show all checked candidates if all overloads fail (similar to usual C/C++ compiler errors).

Error with no overloads:
<img width="855" height="459" alt="Screenshot 2025-08-12 at 16 58 02" src="https://github.com/user-attachments/assets/1f8fa58a-14b0-4bdf-8678-1cb9d49957bb" />

Error with overloads:
<img width="855" height="459" alt="Screenshot 2025-08-12 at 16 47 25" src="https://github.com/user-attachments/assets/37589519-c403-4cc0-8f33-c0da5d45d685" />
