### PR TITLE
Fix mobile renderer motion vectors

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -433,7 +433,7 @@ void vertex_shader(in vec3 vertex,
 	float roughness_highp = 1.0;
 
 #ifdef USE_DOUBLE_PRECISION
-	mat4 modelview = scene_data.view_matrix * model_matrix;
+	mat4 modelview = view_matrix * model_matrix;
 
 	// We separate the basis from the origin because the basis is fine with single point precision.
 	// Then we combine the translations from the model matrix and the view matrix using emulated doubles.
@@ -448,14 +448,14 @@ void vertex_shader(in vec3 vertex,
 
 	// Overwrite the translation part of modelview with improved precision.
 	vec3 temp_precision; // Will be ignored.
-	modelview[3].xyz = double_add_vec3(model_origin, model_precision, scene_data.inv_view_matrix[3].xyz, view_precision, temp_precision);
-	modelview[3].xyz = mat3(scene_data.view_matrix) * modelview[3].xyz;
+	modelview[3].xyz = double_add_vec3(model_origin, model_precision, inv_view_matrix[3].xyz, view_precision, temp_precision);
+	modelview[3].xyz = mat3(view_matrix) * modelview[3].xyz;
 #else
-	mat4 modelview = scene_data.view_matrix * model_matrix;
+	mat4 modelview = view_matrix * model_matrix;
 #endif
-	mat3 modelview_normal = mat3(scene_data.view_matrix) * model_normal_matrix;
-	mat4 read_view_matrix = scene_data.view_matrix;
-	vec2 read_viewport_size = scene_data.viewport_size;
+	mat3 modelview_normal = mat3(view_matrix) * model_normal_matrix;
+	mat4 read_view_matrix = view_matrix;
+	vec2 read_viewport_size = viewport_size;
 
 	{
 #CODE : VERTEX


### PR DESCRIPTION
#106951 added references to `scene_data` in the `vertex_shader()` function, which causes the matrices there to always use current frame data and never previous frame data, breaking motion vectors in the mobile renderer.

This PR fixes that. 🙂