### PR TITLE
Improve error messages for lambda functions without a body

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1987,16 +1987,18 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 	}
 	p_function->resolved_body = true;
 
-	if (p_function->is_abstract) {
-		// Abstract functions don't have a body.
-		if (!p_function->body->statements.is_empty()) {
-			push_error(R"(Abstract function cannot have a body.)", p_function->body);
+	if (p_function->body->statements.is_empty()) {
+		// Non-abstract functions must have a body.
+		if (p_function->source_lambda != nullptr) {
+			push_error(R"(A lambda function must have a ":" followed by a body.)", p_function);
+		} else if (!p_function->is_abstract) {
+			push_error(R"(A function must either have a ":" followed by a body, or be marked as "@abstract".)", p_function);
 		}
 		return;
 	} else {
-		// Non-abstract functions must have a body.
-		if (p_function->body->statements.is_empty()) {
-			push_error(R"(A function must either have a ":" followed by a body, or be marked as "@abstract".)", p_function);
+		// Abstract functions must not have a body.
+		if (p_function->is_abstract) {
+			push_error(R"(An abstract function cannot have a body.)", p_function->body);
 			return;
 		}
 	}

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.gd
@@ -37,5 +37,8 @@ class Test4 extends AbstractClass:
 @abstract @abstract class DuplicateAbstract:
 	pass
 
+func holding_some_invalid_lambda(invalid_default_arg = func():):
+	var some_invalid_lambda = (func():)
+
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_methods.out
@@ -2,10 +2,12 @@ GDTEST_ANALYZER_ERROR
 >> ERROR at line 37: "@abstract" annotation can only be used once per class.
 >> ERROR at line 28: "@abstract" annotation can only be used once per function.
 >> ERROR at line 35: "@abstract" annotation cannot be applied to static functions.
+>> ERROR at line 40: A lambda function must have a ":" followed by a body.
+>> ERROR at line 41: A lambda function must have a ":" followed by a body.
 >> ERROR at line 11: Class "Test1" is not abstract but contains abstract methods. Mark the class as "@abstract" or remove "@abstract" from all methods in this class.
 >> ERROR at line 14: Class "Test2" must implement "AbstractClass.some_func()" and other inherited abstract methods or be marked as "@abstract".
 >> ERROR at line 17: Class "Test3" must implement "AbstractClassAgain.some_func()" and other inherited abstract methods or be marked as "@abstract".
 >> ERROR at line 22: Cannot call the parent class' abstract function "some_func()" because it hasn't been defined.
 >> ERROR at line 25: Cannot call the parent class' abstract function "some_func()" because it hasn't been defined.
->> ERROR at line 32: Abstract function cannot have a body.
+>> ERROR at line 32: An abstract function cannot have a body.
 >> ERROR at line 35: A function must either have a ":" followed by a body, or be marked as "@abstract".


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108197, specifically https://github.com/godotengine/godot/issues/108197#issuecomment-3180284512

This PR improves the error message in these cases:

<img width="800" height="300" alt="Screenshot 2025-08-12 at 7 31 58 PM" src="https://github.com/user-attachments/assets/a02673bd-2819-437d-a3ac-8fcf818f9a0b" />
