### PR TITLE
Fix spotlight's shadow peter-panning with volumetric fog

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -559,7 +559,7 @@ void main() {
 							vec4 v = vec4(view_pos, 1.0);
 
 							vec4 splane = (spot_lights.data[light_index].shadow_matrix * v);
-							splane.z -= spot_lights.data[light_index].shadow_bias / (d * spot_lights.data[light_index].inv_radius);
+							splane.z -= spot_lights.data[light_index].shadow_bias;
 							splane /= splane.w;
 
 							vec3 pos = vec3(splane.xy * spot_lights.data[light_index].atlas_rect.zw + spot_lights.data[light_index].atlas_rect.xy, splane.z);


### PR DESCRIPTION
Fixes #104123

Applies the same fix as in #101952 but in the volumetric fog shader.
For reference, here is the rationale quoted from the above PR :

> Prior to this PR, the bias was scaled because the near plane was dynamically adjusted based on the light's range. One unit in clip space represents different depths depending on the near plane setting. The scaling factor was intended to compensate for this, ensuring consistent peter-panning regardless of the light's range.
>
> Now the near plane is fixed since #100319, one unit in clip space represents always the same depth and there is nothing to compensate for anymore - bias can (and must) now be applied as usual as a constant offset.