### PR TITLE
CI: Update dependency setup on Linux actions

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -111,16 +111,13 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Linux dependencies for tests
-        if: matrix.proj-test
+      - name: Setup dependencies
         run: |
-          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list
-          sudo apt-get install mesa-vulkan-drivers
-
-      # TODO: Figure out somehow how to embed this one.
-      - name: wayland-scanner dependency
-        run: |
-          sudo apt-get install libwayland-bin
+          sudo apt-get update
+          sudo apt-get install libwayland-bin  # TODO: Figure out somehow how to embed this one.
+          if [ "${{ matrix.proj-test }}" == "true" ]; then
+            sudo apt-get install mesa-vulkan-drivers
+          fi
 
       - name: Free disk space on runner
         run: |

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Class reference schema checks
         run: |
-          sudo apt update
-          sudo apt install -y libxml2-utils
+          sudo apt-get update
+          sudo apt-get install libxml2-utils
           xmllint --quiet --noout --schema doc/class.xsd doc/classes/*.xml modules/*/doc_classes/*.xml platform/*/doc_classes/*.xml
 
       - name: Run C compiler on `gdextension_interface.h`


### PR DESCRIPTION
Makes a few modifications to the depedency management for a couple of Linux-based actions:

#### `static_checks.yml`:
- Use `apt-get` instead of `apt`, as the former is meant for CI while the latter is meant for terminals

#### `linux_builds.yml`:
- Consolidate dependency setup to a single step
- Add `sudo apt-get update` for more consistent installs
- No longer remove `microsoft-prod.list`, as the [original issue](microsoft/linux-package-repositories#34) has been fixed