### PR TITLE
CI: Bump Linux builder to Ubuntu 24.04

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -16,7 +16,7 @@ env:
   GODOT_CPP_BRANCH: 4.5
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  ASAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/asan.txt
+  ASAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/asan.txt:alloc_dealloc_mismatch=0
   LSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/lsan.txt
   TSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/tsan.txt
   UBSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/ubsan.txt
@@ -24,7 +24,7 @@ env:
 jobs:
   build-linux:
     # Stay one LTS before latest to increase portability of Linux artifacts.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:

--- a/misc/error_suppressions/lsan.txt
+++ b/misc/error_suppressions/lsan.txt
@@ -1,2 +1,5 @@
 # Supported suppression types are:
 # - leak
+
+# leak:libfontconfig
+# leak:libvulkan

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -498,6 +498,8 @@ public:
 			return;
 		}
 
+		GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdangling-pointer=") // False positive on GCC 13/14.
+
 		call_level->prev = _call_stack;
 		_call_stack = call_level;
 		call_level->stack = p_stack;
@@ -506,6 +508,8 @@ public:
 		call_level->ip = p_ip;
 		call_level->line = p_line;
 		_call_stack_size++;
+
+		GODOT_GCC_WARNING_POP
 	}
 
 	_FORCE_INLINE_ void exit_function() {


### PR DESCRIPTION
- Subsection of #100749
- Depends on #109573
- Depends on #109960

This integrates the necessary version bump for "proper" C++20 compilation on Linux, but does so in an isolated environment so that those changes can be atomic. Addresses a handful of sanitizer bugs from the newer gcc compiler, though I'll probably need a hand ironing out whatever is causing the `LeakSanitizer` to trigger

Note this necessitated the addition of `alloc_dealloc_mismatch=0` to the asan options, at least temporarily. Without it, the following error occurs on CI:
<details>

```
Run xvfb-run ./bin/godot.linuxbsd.editor.dev.double.x86_64.san --audio-driver Dummy --import --path test_project 2>&1 | tee sanitizers_log.txt || true
Godot Engine v4.5.beta.double.gh-109576.efa3c79d4 (2025-08-25 16:25:30 UTC) - https://godotengine.org
=================================================================
==11582==ERROR: AddressSanitizer: alloc-dealloc-mismatch (operator new vs free) on 0x51900017c580
    #0 0x7fbb82efc4d8 in free ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52
    #1 0x7fbb63a58817  (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x1058817) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #2 0x7fbb63a57f29 in llvm::PassRegistry::registerPass(llvm::PassInfo const&, bool) (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x1057f29) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #3 0x7fbb66da86e1  (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x43a86e1) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #4 0x7fbb822a1ed2  (/lib/x86_64-linux-gnu/libc.so.6+0xa1ed2) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #5 0x7fbb66da861c in llvm::initializeScopInlinerPass(llvm::PassRegistry&) (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x43a861c) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #6 0x7fbb66d5be71 in polly::initializePollyPasses(llvm::PassRegistry&) (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x435be71) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #7 0x7fbb6376500c  (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0xd6500c) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #8 0x7fbb835c471e  (/lib64/ld-linux-x86-64.so.2+0x571e) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #9 0x7fbb835c4823  (/lib64/ld-linux-x86-64.so.2+0x5823) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #10 0x7fbb835c05b1 in _dl_catch_exception (/lib64/ld-linux-x86-64.so.2+0x15b1) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #11 0x7fbb835cbd7b  (/lib64/ld-linux-x86-64.so.2+0xcd7b) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #12 0x7fbb835c051b in _dl_catch_exception (/lib64/ld-linux-x86-64.so.2+0x151b) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #13 0x7fbb835cc163  (/lib64/ld-linux-x86-64.so.2+0xd163) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #14 0x7fbb822981a3  (/lib/x86_64-linux-gnu/libc.so.6+0x981a3) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #15 0x7fbb835c051b in _dl_catch_exception (/lib64/ld-linux-x86-64.so.2+0x151b) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #16 0x7fbb835c0668  (/lib64/ld-linux-x86-64.so.2+0x1668) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #17 0x7fbb82297c82  (/lib/x86_64-linux-gnu/libc.so.6+0x97c82) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #18 0x7fbb8229825e in dlopen (/lib/x86_64-linux-gnu/libc.so.6+0x9825e) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #19 0x7fbb82e7cf08 in dlopen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:6341
    #20 0x7fbb6c8365f4  (/lib/x86_64-linux-gnu/libvulkan.so.1+0x1f5f4) (BuildId: 32e77fd13d177aaa6ceeba4862c3407d9246e422)
    #21 0x7fbb6c841191  (/lib/x86_64-linux-gnu/libvulkan.so.1+0x2a191) (BuildId: 32e77fd13d177aaa6ceeba4862c3407d9246e422)
    #22 0x7fbb6c84b4f1 in vkEnumerateInstanceExtensionProperties (/lib/x86_64-linux-gnu/libvulkan.so.1+0x344f1) (BuildId: 32e77fd13d177aaa6ceeba4862c3407d9246e422)
    #23 0x55aae0832333 in RenderingContextDriverVulkan::_initialize_instance_extensions() (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x5ee0e333) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #24 0x55aae083fc99 in RenderingContextDriverVulkan::initialize() (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x5ee1bc99) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #25 0x55aad2ae662e in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x510c262e) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #26 0x55aad2ac4134 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x510a0134) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #27 0x55aaf052b53e in DisplayServer::create(int, String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x6eb0753e) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #28 0x55aad2e39ae4 in Main::setup2(bool) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x51415ae4) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #29 0x55aad2e31de3 in Main::setup(char const*, int, char**, bool) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x5140dde3) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #30 0x55aad296c498 in main (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x50f48498) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #31 0x7fbb8222a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #32 0x7fbb8222a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #33 0x55aad296c024 in _start (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x50f48024) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)

0x51900017c580 is located 0 bytes inside of 1024-byte region [0x51900017c580,0x51900017c980)
allocated by thread T0 here:
    #0 0x7fbb82efeaf8 in operator new(unsigned long, std::align_val_t) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:107
    #1 0x7fbb63a1ff6f  (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x101ff6f) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #2 0x7fbb63a58817  (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x1058817) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #3 0x7fbb63a57f29 in llvm::PassRegistry::registerPass(llvm::PassInfo const&, bool) (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0x1057f29) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #4 0x7fbb63714124  (/lib/x86_64-linux-gnu/libLLVM.so.19.1+0xd14124) (BuildId: 69e03c77b75fb2179e6db98a0340b327a0456591)
    #5 0x7fbb835c471e  (/lib64/ld-linux-x86-64.so.2+0x571e) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #6 0x7fbb835c4823  (/lib64/ld-linux-x86-64.so.2+0x5823) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #7 0x7fbb835c05b1 in _dl_catch_exception (/lib64/ld-linux-x86-64.so.2+0x15b1) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #8 0x7fbb835cbd7b  (/lib64/ld-linux-x86-64.so.2+0xcd7b) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #9 0x7fbb835c051b in _dl_catch_exception (/lib64/ld-linux-x86-64.so.2+0x151b) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #10 0x7fbb835cc163  (/lib64/ld-linux-x86-64.so.2+0xd163) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #11 0x7fbb822981a3  (/lib/x86_64-linux-gnu/libc.so.6+0x981a3) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #12 0x7fbb835c051b in _dl_catch_exception (/lib64/ld-linux-x86-64.so.2+0x151b) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #13 0x7fbb835c0668  (/lib64/ld-linux-x86-64.so.2+0x1668) (BuildId: 281ac1521b4102509b1c7ac7004db7c1efb81796)
    #14 0x7fbb82297c82  (/lib/x86_64-linux-gnu/libc.so.6+0x97c82) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #15 0x7fbb8229825e in dlopen (/lib/x86_64-linux-gnu/libc.so.6+0x9825e) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #16 0x7fbb82e7cf08 in dlopen ../../../../src/libsanitizer/sanitizer_common/sanitizer_common_interceptors.inc:6341
    #17 0x7fbb6c8365f4  (/lib/x86_64-linux-gnu/libvulkan.so.1+0x1f5f4) (BuildId: 32e77fd13d177aaa6ceeba4862c3407d9246e422)
    #18 0x7fbb6c841191  (/lib/x86_64-linux-gnu/libvulkan.so.1+0x2a191) (BuildId: 32e77fd13d177aaa6ceeba4862c3407d9246e422)
    #19 0x7fbb6c84b4f1 in vkEnumerateInstanceExtensionProperties (/lib/x86_64-linux-gnu/libvulkan.so.1+0x344f1) (BuildId: 32e77fd13d177aaa6ceeba4862c3407d9246e422)
    #20 0x55aae0832333 in RenderingContextDriverVulkan::_initialize_instance_extensions() (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x5ee0e333) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #21 0x55aae083fc99 in RenderingContextDriverVulkan::initialize() (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x5ee1bc99) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #22 0x55aad2ae662e in DisplayServerX11::DisplayServerX11(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x510c262e) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #23 0x55aad2ac4134 in DisplayServerX11::create_func(String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x510a0134) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #24 0x55aaf052b53e in DisplayServer::create(int, String const&, DisplayServer::WindowMode, DisplayServer::VSyncMode, unsigned int, Vector2i const*, Vector2i const&, int, DisplayServer::Context, long, Error&) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x6eb0753e) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #25 0x55aad2e39ae4 in Main::setup2(bool) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x51415ae4) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #26 0x55aad2e31de3 in Main::setup(char const*, int, char**, bool) (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x5140dde3) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #27 0x55aad296c498 in main (/home/runner/work/godot/godot/bin/godot.linuxbsd.editor.dev.double.x86_64.san+0x50f48498) (BuildId: 7b1fa82fcd71a08b610224a7ffeb2f580d39ec6f)
    #28 0x7fbb8222a1c9  (/lib/x86_64-linux-gnu/libc.so.6+0x2a1c9) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)
    #29 0x7fbb8222a28a in __libc_start_main (/lib/x86_64-linux-gnu/libc.so.6+0x2a28a) (BuildId: 282c2c16e7b6600b0b22ea0c99010d2795752b5f)

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch ../../../../src/libsanitizer/asan/asan_malloc_linux.cpp:52 in free
==11582==HINT: if you don't care about these errors you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==11582==ABORTING
FATAL ERROR: An incorrectly used memory was found.
```
</details>