### PR TITLE
[Docs] Mention 'build version' in iOS, macOS, and visionOS export docs

### DIFF
--- a/platform/ios/doc_classes/EditorExportPlatformIOS.xml
+++ b/platform/ios/doc_classes/EditorExportPlatformIOS.xml
@@ -64,7 +64,8 @@
 			Can be overridden with the environment variable [code]GODOT_APPLE_PLATFORM_PROVISIONING_PROFILE_UUID_RELEASE[/code].
 		</member>
 		<member name="application/short_version" type="String" setter="" getter="">
-			Application version visible to the user, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). Falls back to [member ProjectSettings.application/config/version] if left empty.
+			Application version visible to the user. Can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). Falls back to [member ProjectSettings.application/config/version] if left empty.
+			[b]Note:[/b] This value is used for the [i]Identity &gt; Version[/i] value in the generated Xcode project.
 		</member>
 		<member name="application/signature" type="String" setter="" getter="">
 			A four-character creator code that is specific to the bundle. Optional.
@@ -73,7 +74,8 @@
 			Supported device family.
 		</member>
 		<member name="application/version" type="String" setter="" getter="">
-			Machine-readable application version, in the [code]major.minor.patch[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). This must be incremented on every new release pushed to the App Store.
+			Machine-readable application version in the [code]major.minor.patch[/code] format. Can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). This must be incremented with every new release pushed to the App Store. Falls back to [member ProjectSettings.application/config/version] if left empty.
+			[b]Note:[/b] This value is used for the [i]Identity &gt; Build[/i] value in the generated Xcode project.
 		</member>
 		<member name="architectures/arm64" type="bool" setter="" getter="">
 			If [code]true[/code], [code]arm64[/code] binaries are included into exported project.

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -45,13 +45,15 @@
 			Minimum version of macOS required for this application to run on Intel Macs, in the [code]major.minor.patch[/code] or [code]major.minor[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]).
 		</member>
 		<member name="application/short_version" type="String" setter="" getter="">
-			Application version visible to the user, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). Falls back to [member ProjectSettings.application/config/version] if left empty.
+			Application version visible to the user. Can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). Falls back to [member ProjectSettings.application/config/version] if left empty.
+			[b]Note:[/b] This value is used for the [i]Identity &gt; Version[/i] value in the generated Xcode project.
 		</member>
 		<member name="application/signature" type="String" setter="" getter="">
 			A four-character creator code that is specific to the bundle. Optional.
 		</member>
 		<member name="application/version" type="String" setter="" getter="">
-			Machine-readable application version, in the [code]major.minor.patch[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). This must be incremented on every new release pushed to the App Store.
+			Machine-readable application version in the [code]major.minor.patch[/code] format. Can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). This must be incremented with every new release pushed to the App Store. Falls back to [member ProjectSettings.application/config/version] if left empty.
+			[b]Note:[/b] This value is used for the [i]Identity &gt; Build[/i] value in the generated Xcode project.
 		</member>
 		<member name="binary_format/architecture" type="String" setter="" getter="">
 			Application executable architecture.

--- a/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
+++ b/platform/visionos/doc_classes/EditorExportPlatformVisionOS.xml
@@ -63,13 +63,15 @@
 			Can be overridden with the environment variable [code]GODOT_APPLE_PLATFORM_PROVISIONING_PROFILE_UUID_RELEASE[/code].
 		</member>
 		<member name="application/short_version" type="String" setter="" getter="">
-			Application version visible to the user, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). Falls back to [member ProjectSettings.application/config/version] if left empty.
+			Application version visible to the user. Can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). Falls back to [member ProjectSettings.application/config/version] if left empty.
+			[b]Note:[/b] This value is used for the [i]Identity &gt; Version[/i] value in the generated Xcode project.
 		</member>
 		<member name="application/signature" type="String" setter="" getter="">
 			A four-character creator code that is specific to the bundle. Optional.
 		</member>
 		<member name="application/version" type="String" setter="" getter="">
-			Machine-readable application version, in the [code]major.minor.patch[/code] format, can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). This must be incremented on every new release pushed to the App Store.
+			Machine-readable application version in the [code]major.minor.patch[/code] format. Can only contain numeric characters ([code]0-9[/code]) and periods ([code].[/code]). This must be incremented with every new release pushed to the App Store. Falls back to [member ProjectSettings.application/config/version] if left empty.
+			[b]Note:[/b] This value is used for the [i]Identity &gt; Build[/i] value in the generated Xcode project.
 		</member>
 		<member name="architectures/arm64" type="bool" setter="" getter="">
 			If [code]true[/code], [code]arm64[/code] binaries are included into exported project.


### PR DESCRIPTION
My iOS project in Xcode had the version numbers twice, both in the Version and Build fields:
<img width="458" height="182" alt="Screenshot 2025-08-13 at 16 37 46" src="https://github.com/user-attachments/assets/096e5b4f-dc5a-4f1e-a099-824fc0a8f8d0" />

I went down an unnecessary rabbit hole to find out which of the two variables in Godot's iOS / macOS / visionOS export templates would address what field. This PR simply name drops 'build version' in the export template's version variable that will be applied to the Build number visible in Xcode.