### PR TITLE
Fix `TileMapLayer` terrain preview icons for transformed alternative tiles

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -3427,11 +3427,9 @@ void TileMapLayerEditorTerrainsPlugin::_update_tiles_list() {
 							icon = atlas_source->get_texture();
 							region = atlas_source->get_tile_texture_region(cell.get_atlas_coords());
 							if (tile_data->get_flip_h()) {
-								region.position.x += region.size.x;
 								region.size.x = -region.size.x;
 							}
 							if (tile_data->get_flip_v()) {
-								region.position.y += region.size.y;
 								region.size.y = -region.size.y;
 							}
 							transpose = tile_data->get_transpose();


### PR DESCRIPTION
The tile terrain preview icon regions were being flipped by negating the region size and moving the region position to the end of the original region (which makes logical sense), but the drawing API expects only the size to be negated, position should be left unchanged. 
It's like that since 4.0 TileMap rework, so could be cherrypicked to all previous 4.x versions.

Fixes #102156.

Before|After
-|-
<img width="1353" height="130" alt="Godot_v4 5-beta5_win64_y677jRdaCr" src="https://github.com/user-attachments/assets/f78e8b87-e211-4b9e-95ff-c505d4800f66" />|<img width="1353" height="130" alt="g4MEo68QV1" src="https://github.com/user-attachments/assets/8f05f3d7-dfbc-41ef-9b5e-57a8af6e63f7" />
