### PR TITLE
Allow inherited methods to be used as property setters/getters

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1453,8 +1453,15 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 				bool has_valid_setter = false;
 
 				if (member.variable->getter_pointer != nullptr) {
-					if (p_class->has_function(member.variable->getter_pointer->name)) {
-						getter_function = p_class->get_member(member.variable->getter_pointer->name).function;
+					GDScriptParser::ClassNode *current_class = p_class;
+					bool found_getter = false;
+					while (current_class != nullptr && !found_getter) {
+						if (current_class->has_function(member.variable->getter_pointer->name)) {
+							getter_function = current_class->get_member(member.variable->getter_pointer->name).function;
+							found_getter = true;
+						} else {
+							current_class = current_class->base_type.class_type;
+						}
 					}
 
 					if (getter_function == nullptr) {
@@ -1483,8 +1490,15 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 				}
 
 				if (member.variable->setter_pointer != nullptr) {
-					if (p_class->has_function(member.variable->setter_pointer->name)) {
-						setter_function = p_class->get_member(member.variable->setter_pointer->name).function;
+					GDScriptParser::ClassNode *current_class = p_class;
+					bool found_setter = false;
+					while (current_class != nullptr && !found_setter) {
+						if (current_class->has_function(member.variable->setter_pointer->name)) {
+							setter_function = current_class->get_member(member.variable->setter_pointer->name).function;
+							found_setter = true;
+						} else {
+							current_class = current_class->base_type.class_type;
+						}
 					}
 
 					if (setter_function == nullptr) {

--- a/modules/gdscript/tests/scripts/analyzer/features/property_getter_class_inheritance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/property_getter_class_inheritance.gd
@@ -1,0 +1,21 @@
+#https://github.com/godotengine/godot/issues/107478
+
+class BaseClass:
+	var base_value = "hello"
+
+	func get_base_value():
+		return base_value
+
+	func get_number():
+		return 42
+
+class DerivedClass extends BaseClass:
+	var inherited_prop:
+		get = get_base_value
+
+	var number_prop:
+		get = get_number
+
+func test():
+	var derived = DerivedClass.new()
+	print(derived.inherited_prop + "\n" + str(derived.number_prop))

--- a/modules/gdscript/tests/scripts/analyzer/features/property_getter_class_inheritance.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/property_getter_class_inheritance.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+hello
+42

--- a/modules/gdscript/tests/scripts/analyzer/features/property_setter_class_inheritance.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/property_setter_class_inheritance.gd
@@ -1,0 +1,20 @@
+#https://github.com/godotengine/godot/issues/107478
+class BaseClass:
+	var base_value = "initial"
+
+	func set_base_value(value):
+		base_value = "set_" + str(value)
+
+	func get_base_value():
+		return base_value
+
+class DerivedClass extends BaseClass:
+	var inherited_prop:
+		get = get_base_value,
+		set = set_base_value
+
+func test():
+	var derived = DerivedClass.new()
+	print(derived.inherited_prop)
+	derived.inherited_prop = "hello"
+	print("\n" + derived.inherited_prop)

--- a/modules/gdscript/tests/scripts/analyzer/features/property_setter_class_inheritance.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/property_setter_class_inheritance.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+initial
+
+set_hello


### PR DESCRIPTION
Fixes [107478](https://github.com/godotengine/godot/issues/107478)
Fixed GDScript getter/setter inheritance resolution bug by modifying  to traverse the entire inheritance chain (not just immediate class) when looking for getter/setter functions,
