### PR TITLE
Pause physics command queue during physics processing

### DIFF
--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -35,6 +35,10 @@
 #include "core/templates/command_queue_mt.h"
 #include "servers/physics_server_2d.h"
 
+#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread)
+#define ASYNC_COND_PUSH_AND_RET (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
+#define ASYNC_COND_PUSH_AND_SYNC (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
+
 #ifdef DEBUG_SYNC
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));
 #else
@@ -58,10 +62,12 @@ class PhysicsServer2DWrapMT : public PhysicsServer2D {
 	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool exit = false;
 	bool create_thread = false;
+	SafeFlag doing_sync;
 
 	void _assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id);
 	void _thread_exit();
 	void _thread_loop();
+	void _thread_sync();
 
 public:
 #define ServerName PhysicsServer2D

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -42,8 +42,15 @@ void PhysicsServer3DWrapMT::_thread_exit() {
 void PhysicsServer3DWrapMT::_thread_loop() {
 	while (!exit) {
 		WorkerThreadPool::get_singleton()->yield();
-		command_queue.flush_all();
+
+		if (!doing_sync.is_set()) {
+			command_queue.flush_all();
+		}
 	}
+}
+
+void PhysicsServer3DWrapMT::_thread_sync() {
+	doing_sync.set();
 }
 
 /* EVENT QUEUING */
@@ -58,7 +65,7 @@ void PhysicsServer3DWrapMT::step(real_t p_step) {
 
 void PhysicsServer3DWrapMT::sync() {
 	if (create_thread) {
-		command_queue.sync();
+		command_queue.push_and_sync(this, &PhysicsServer3DWrapMT::_thread_sync);
 	} else {
 		command_queue.flush_all(); // Flush all pending from other threads.
 	}
@@ -71,6 +78,10 @@ void PhysicsServer3DWrapMT::flush_queries() {
 
 void PhysicsServer3DWrapMT::end_sync() {
 	physics_server_3d->end_sync();
+
+	if (create_thread) {
+		doing_sync.clear();
+	}
 }
 
 void PhysicsServer3DWrapMT::init() {

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -36,6 +36,10 @@
 #include "core/templates/command_queue_mt.h"
 #include "servers/physics_server_3d.h"
 
+#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread)
+#define ASYNC_COND_PUSH_AND_RET (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
+#define ASYNC_COND_PUSH_AND_SYNC (Thread::get_caller_id() != server_thread && !(doing_sync.is_set() && Thread::is_main_thread()))
+
 #ifdef DEBUG_SYNC
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));
 #else
@@ -59,11 +63,13 @@ class PhysicsServer3DWrapMT : public PhysicsServer3D {
 	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool exit = false;
 	bool create_thread = false;
+	SafeFlag doing_sync;
 
 	void _assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id);
 	void _thread_exit();
 	void _thread_step(real_t p_delta);
 	void _thread_loop();
+	void _thread_sync();
 
 public:
 #define ServerName PhysicsServer3D

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -109,6 +109,9 @@ public:
 #endif
 
 #define WRITE_ACTION redraw_request();
+#define ASYNC_COND_PUSH (Thread::get_caller_id() != server_thread)
+#define ASYNC_COND_PUSH_AND_RET (Thread::get_caller_id() != server_thread)
+#define ASYNC_COND_PUSH_AND_SYNC (Thread::get_caller_id() != server_thread)
 
 #ifdef DEBUG_SYNC
 #define SYNC_DEBUG print_line("sync on: " + String(__FUNCTION__));

--- a/servers/server_wrap_mt_common.h
+++ b/servers/server_wrap_mt_common.h
@@ -41,7 +41,7 @@
 
 #define FUNC0R(m_r, m_type)                                                     \
 	virtual m_r m_type() override {                                             \
-		if (Thread::get_caller_id() != server_thread) {                         \
+		if (ASYNC_COND_PUSH_AND_RET) {                                          \
 			m_r ret;                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
 			SYNC_DEBUG                                                          \
@@ -56,7 +56,7 @@
 #define FUNCRIDSPLIT(m_type)                                                        \
 	virtual RID m_type##_create() override {                                        \
 		RID ret = server_name->m_type##_allocate();                                 \
-		if (Thread::get_caller_id() != server_thread) {                             \
+		if (ASYNC_COND_PUSH) {                                                      \
 			command_queue.push(server_name, &ServerName::m_type##_initialize, ret); \
 		} else {                                                                    \
 			server_name->m_type##_initialize(ret);                                  \
@@ -73,7 +73,7 @@
 #define FUNC0RC(m_r, m_type)                                                    \
 	virtual m_r m_type() const override {                                       \
 		WRITE_ACTION                                                            \
-		if (Thread::get_caller_id() != server_thread) {                         \
+		if (ASYNC_COND_PUSH_AND_RET) {                                          \
 			m_r ret;                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret); \
 			SYNC_DEBUG                                                          \
@@ -88,7 +88,7 @@
 #define FUNC0(m_type)                                             \
 	virtual void m_type() override {                              \
 		WRITE_ACTION                                              \
-		if (Thread::get_caller_id() != server_thread) {           \
+		if (ASYNC_COND_PUSH) {                                    \
 			command_queue.push(server_name, &ServerName::m_type); \
 		} else {                                                  \
 			command_queue.flush_if_pending();                     \
@@ -98,7 +98,7 @@
 
 #define FUNC0C(m_type)                                            \
 	virtual void m_type() const override {                        \
-		if (Thread::get_caller_id() != server_thread) {           \
+		if (ASYNC_COND_PUSH) {                                    \
 			command_queue.push(server_name, &ServerName::m_type); \
 		} else {                                                  \
 			command_queue.flush_if_pending();                     \
@@ -109,7 +109,7 @@
 #define FUNC0S(m_type)                                                     \
 	virtual void m_type() override {                                       \
 		WRITE_ACTION                                                       \
-		if (Thread::get_caller_id() != server_thread) {                    \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
 			SYNC_DEBUG                                                     \
 			MAIN_THREAD_SYNC_CHECK                                         \
@@ -121,7 +121,7 @@
 
 #define FUNC0SC(m_type)                                                    \
 	virtual void m_type() const override {                                 \
-		if (Thread::get_caller_id() != server_thread) {                    \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type); \
 			SYNC_DEBUG                                                     \
 			MAIN_THREAD_SYNC_CHECK                                         \
@@ -136,7 +136,7 @@
 #define FUNC1R(m_r, m_type, m_arg1)                                                 \
 	virtual m_r m_type(m_arg1 p1) override {                                        \
 		WRITE_ACTION                                                                \
-		if (Thread::get_caller_id() != server_thread) {                             \
+		if (ASYNC_COND_PUSH_AND_RET) {                                              \
 			m_r ret;                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1); \
 			SYNC_DEBUG                                                              \
@@ -150,7 +150,7 @@
 
 #define FUNC1RC(m_r, m_type, m_arg1)                                                \
 	virtual m_r m_type(m_arg1 p1) const override {                                  \
-		if (Thread::get_caller_id() != server_thread) {                             \
+		if (ASYNC_COND_PUSH_AND_RET) {                                              \
 			m_r ret;                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1); \
 			SYNC_DEBUG                                                              \
@@ -165,7 +165,7 @@
 #define FUNC1S(m_type, m_arg1)                                                 \
 	virtual void m_type(m_arg1 p1) override {                                  \
 		WRITE_ACTION                                                           \
-		if (Thread::get_caller_id() != server_thread) {                        \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                        \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
 			SYNC_DEBUG                                                         \
 			MAIN_THREAD_SYNC_CHECK                                             \
@@ -177,7 +177,7 @@
 
 #define FUNC1SC(m_type, m_arg1)                                                \
 	virtual void m_type(m_arg1 p1) const override {                            \
-		if (Thread::get_caller_id() != server_thread) {                        \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                        \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1); \
 			SYNC_DEBUG                                                         \
 			MAIN_THREAD_SYNC_CHECK                                             \
@@ -190,7 +190,7 @@
 #define FUNC1(m_type, m_arg1)                                         \
 	virtual void m_type(m_arg1 p1) override {                         \
 		WRITE_ACTION                                                  \
-		if (Thread::get_caller_id() != server_thread) {               \
+		if (ASYNC_COND_PUSH) {                                        \
 			command_queue.push(server_name, &ServerName::m_type, p1); \
 		} else {                                                      \
 			command_queue.flush_if_pending();                         \
@@ -200,7 +200,7 @@
 
 #define FUNC1C(m_type, m_arg1)                                        \
 	virtual void m_type(m_arg1 p1) const override {                   \
-		if (Thread::get_caller_id() != server_thread) {               \
+		if (ASYNC_COND_PUSH) {                                        \
 			command_queue.push(server_name, &ServerName::m_type, p1); \
 		} else {                                                      \
 			command_queue.flush_if_pending();                         \
@@ -211,7 +211,7 @@
 #define FUNC2R(m_r, m_type, m_arg1, m_arg2)                                             \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2) override {                                 \
 		WRITE_ACTION                                                                    \
-		if (Thread::get_caller_id() != server_thread) {                                 \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                  \
 			m_r ret;                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2); \
 			SYNC_DEBUG                                                                  \
@@ -225,7 +225,7 @@
 
 #define FUNC2RC(m_r, m_type, m_arg1, m_arg2)                                            \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2) const override {                           \
-		if (Thread::get_caller_id() != server_thread) {                                 \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                  \
 			m_r ret;                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2); \
 			SYNC_DEBUG                                                                  \
@@ -240,7 +240,7 @@
 #define FUNC2S(m_type, m_arg1, m_arg2)                                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) override {                           \
 		WRITE_ACTION                                                               \
-		if (Thread::get_caller_id() != server_thread) {                            \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                            \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
 			SYNC_DEBUG                                                             \
 			MAIN_THREAD_SYNC_CHECK                                                 \
@@ -252,7 +252,7 @@
 
 #define FUNC2SC(m_type, m_arg1, m_arg2)                                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) const override {                     \
-		if (Thread::get_caller_id() != server_thread) {                            \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                            \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2); \
 			SYNC_DEBUG                                                             \
 			MAIN_THREAD_SYNC_CHECK                                                 \
@@ -265,7 +265,7 @@
 #define FUNC2(m_type, m_arg1, m_arg2)                                     \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) override {                  \
 		WRITE_ACTION                                                      \
-		if (Thread::get_caller_id() != server_thread) {                   \
+		if (ASYNC_COND_PUSH) {                                            \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2); \
 		} else {                                                          \
 			command_queue.flush_if_pending();                             \
@@ -275,7 +275,7 @@
 
 #define FUNC2C(m_type, m_arg1, m_arg2)                                    \
 	virtual void m_type(m_arg1 p1, m_arg2 p2) const override {            \
-		if (Thread::get_caller_id() != server_thread) {                   \
+		if (ASYNC_COND_PUSH) {                                            \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2); \
 		} else {                                                          \
 			command_queue.flush_if_pending();                             \
@@ -286,7 +286,7 @@
 #define FUNC3R(m_r, m_type, m_arg1, m_arg2, m_arg3)                                         \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override {                          \
 		WRITE_ACTION                                                                        \
-		if (Thread::get_caller_id() != server_thread) {                                     \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                      \
 			m_r ret;                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3); \
 			SYNC_DEBUG                                                                      \
@@ -300,7 +300,7 @@
 
 #define FUNC3RC(m_r, m_type, m_arg1, m_arg2, m_arg3)                                        \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override {                    \
-		if (Thread::get_caller_id() != server_thread) {                                     \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                      \
 			m_r ret;                                                                        \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3); \
 			SYNC_DEBUG                                                                      \
@@ -315,7 +315,7 @@
 #define FUNC3S(m_type, m_arg1, m_arg2, m_arg3)                                         \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override {                    \
 		WRITE_ACTION                                                                   \
-		if (Thread::get_caller_id() != server_thread) {                                \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
 			SYNC_DEBUG                                                                 \
 			MAIN_THREAD_SYNC_CHECK                                                     \
@@ -327,7 +327,7 @@
 
 #define FUNC3SC(m_type, m_arg1, m_arg2, m_arg3)                                        \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override {              \
-		if (Thread::get_caller_id() != server_thread) {                                \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3); \
 			SYNC_DEBUG                                                                 \
 			MAIN_THREAD_SYNC_CHECK                                                     \
@@ -340,7 +340,7 @@
 #define FUNC3(m_type, m_arg1, m_arg2, m_arg3)                                 \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) override {           \
 		WRITE_ACTION                                                          \
-		if (Thread::get_caller_id() != server_thread) {                       \
+		if (ASYNC_COND_PUSH) {                                                \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3); \
 		} else {                                                              \
 			command_queue.flush_if_pending();                                 \
@@ -350,7 +350,7 @@
 
 #define FUNC3C(m_type, m_arg1, m_arg2, m_arg3)                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3) const override {     \
-		if (Thread::get_caller_id() != server_thread) {                       \
+		if (ASYNC_COND_PUSH) {                                                \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3); \
 		} else {                                                              \
 			command_queue.flush_if_pending();                                 \
@@ -361,7 +361,7 @@
 #define FUNC4R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                     \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override {                   \
 		WRITE_ACTION                                                                            \
-		if (Thread::get_caller_id() != server_thread) {                                         \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                          \
 			m_r ret;                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                          \
@@ -375,7 +375,7 @@
 
 #define FUNC4RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                    \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override {             \
-		if (Thread::get_caller_id() != server_thread) {                                         \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                          \
 			m_r ret;                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                          \
@@ -390,7 +390,7 @@
 #define FUNC4S(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                     \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override {             \
 		WRITE_ACTION                                                                       \
-		if (Thread::get_caller_id() != server_thread) {                                    \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                     \
 			MAIN_THREAD_SYNC_CHECK                                                         \
@@ -402,7 +402,7 @@
 
 #define FUNC4SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                                    \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override {       \
-		if (Thread::get_caller_id() != server_thread) {                                    \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 			SYNC_DEBUG                                                                     \
 			MAIN_THREAD_SYNC_CHECK                                                         \
@@ -415,7 +415,7 @@
 #define FUNC4(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) override {    \
 		WRITE_ACTION                                                              \
-		if (Thread::get_caller_id() != server_thread) {                           \
+		if (ASYNC_COND_PUSH) {                                                    \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4); \
 		} else {                                                                  \
 			command_queue.flush_if_pending();                                     \
@@ -425,7 +425,7 @@
 
 #define FUNC4C(m_type, m_arg1, m_arg2, m_arg3, m_arg4)                               \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4) const override { \
-		if (Thread::get_caller_id() != server_thread) {                              \
+		if (ASYNC_COND_PUSH) {                                                       \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4);    \
 		} else {                                                                     \
 			command_queue.flush_if_pending();                                        \
@@ -436,7 +436,7 @@
 #define FUNC5R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) {                     \
 		WRITE_ACTION                                                                                \
-		if (Thread::get_caller_id() != server_thread) {                                             \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                              \
 			m_r ret;                                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5); \
 			SYNC_DEBUG                                                                              \
@@ -450,7 +450,7 @@
 
 #define FUNC5RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override {      \
-		if (Thread::get_caller_id() != server_thread) {                                             \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                              \
 			m_r ret;                                                                                \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5); \
 			SYNC_DEBUG                                                                              \
@@ -465,7 +465,7 @@
 #define FUNC5S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) override {      \
 		WRITE_ACTION                                                                           \
-		if (Thread::get_caller_id() != server_thread) {                                        \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                        \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5); \
 			SYNC_DEBUG                                                                         \
 			MAIN_THREAD_SYNC_CHECK                                                             \
@@ -477,7 +477,7 @@
 
 #define FUNC5SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                 \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                         \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                         \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);  \
 			SYNC_DEBUG                                                                          \
 			MAIN_THREAD_SYNC_CHECK                                                              \
@@ -490,7 +490,7 @@
 #define FUNC5(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                             \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) override { \
 		WRITE_ACTION                                                                      \
-		if (Thread::get_caller_id() != server_thread) {                                   \
+		if (ASYNC_COND_PUSH) {                                                            \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);     \
 		} else {                                                                          \
 			command_queue.flush_if_pending();                                             \
@@ -500,7 +500,7 @@
 
 #define FUNC5C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5)                                  \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                         \
+		if (ASYNC_COND_PUSH) {                                                                  \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5);           \
 		} else {                                                                                \
 			command_queue.flush_if_pending();                                                   \
@@ -511,7 +511,7 @@
 #define FUNC6R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                             \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) {              \
 		WRITE_ACTION                                                                                    \
-		if (Thread::get_caller_id() != server_thread) {                                                 \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                                  \
 			m_r ret;                                                                                    \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6); \
 			SYNC_DEBUG                                                                                  \
@@ -525,7 +525,7 @@
 
 #define FUNC6RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                              \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                   \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                                    \
 			m_r ret;                                                                                      \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6);   \
 			SYNC_DEBUG                                                                                    \
@@ -540,7 +540,7 @@
 #define FUNC6S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                               \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) override { \
 		WRITE_ACTION                                                                                 \
-		if (Thread::get_caller_id() != server_thread) {                                              \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                              \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);   \
 			SYNC_DEBUG                                                                               \
 			MAIN_THREAD_SYNC_CHECK                                                                   \
@@ -552,7 +552,7 @@
 
 #define FUNC6SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                                    \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                    \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);         \
 			SYNC_DEBUG                                                                                     \
 			MAIN_THREAD_SYNC_CHECK                                                                         \
@@ -565,7 +565,7 @@
 #define FUNC6(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) override { \
 		WRITE_ACTION                                                                                 \
-		if (Thread::get_caller_id() != server_thread) {                                              \
+		if (ASYNC_COND_PUSH) {                                                                       \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);            \
 		} else {                                                                                     \
 			command_queue.flush_if_pending();                                                        \
@@ -575,7 +575,7 @@
 
 #define FUNC6C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6)                                     \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                    \
+		if (ASYNC_COND_PUSH) {                                                                             \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6);                  \
 		} else {                                                                                           \
 			command_queue.flush_if_pending();                                                              \
@@ -586,7 +586,7 @@
 #define FUNC7R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                            \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) override { \
 		WRITE_ACTION                                                                                           \
-		if (Thread::get_caller_id() != server_thread) {                                                        \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                                         \
 			m_r ret;                                                                                           \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7);    \
 			SYNC_DEBUG                                                                                         \
@@ -600,7 +600,7 @@
 
 #define FUNC7RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                 \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                              \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                                               \
 			m_r ret;                                                                                                 \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7);          \
 			SYNC_DEBUG                                                                                               \
@@ -615,7 +615,7 @@
 #define FUNC7S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                  \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) override { \
 		WRITE_ACTION                                                                                            \
-		if (Thread::get_caller_id() != server_thread) {                                                         \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                         \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);          \
 			SYNC_DEBUG                                                                                          \
 			MAIN_THREAD_SYNC_CHECK                                                                              \
@@ -627,7 +627,7 @@
 
 #define FUNC7SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                       \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                               \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                               \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                \
 			SYNC_DEBUG                                                                                                \
 			MAIN_THREAD_SYNC_CHECK                                                                                    \
@@ -640,7 +640,7 @@
 #define FUNC7(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                   \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) override { \
 		WRITE_ACTION                                                                                            \
-		if (Thread::get_caller_id() != server_thread) {                                                         \
+		if (ASYNC_COND_PUSH) {                                                                                  \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                   \
 		} else {                                                                                                \
 			command_queue.flush_if_pending();                                                                   \
@@ -650,7 +650,7 @@
 
 #define FUNC7C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7)                                        \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                               \
+		if (ASYNC_COND_PUSH) {                                                                                        \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7);                         \
 		} else {                                                                                                      \
 			command_queue.flush_if_pending();                                                                         \
@@ -661,7 +661,7 @@
 #define FUNC8R(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                               \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) override { \
 		WRITE_ACTION                                                                                                      \
-		if (Thread::get_caller_id() != server_thread) {                                                                   \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                                                    \
 			m_r ret;                                                                                                      \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7, p8);           \
 			SYNC_DEBUG                                                                                                    \
@@ -675,7 +675,7 @@
 
 #define FUNC8RC(m_r, m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                    \
 	virtual m_r m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                                         \
+		if (ASYNC_COND_PUSH_AND_RET) {                                                                                          \
 			m_r ret;                                                                                                            \
 			command_queue.push_and_ret(server_name, &ServerName::m_type, &ret, p1, p2, p3, p4, p5, p6, p7, p8);                 \
 			SYNC_DEBUG                                                                                                          \
@@ -690,7 +690,7 @@
 #define FUNC8S(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                     \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) override { \
 		WRITE_ACTION                                                                                                       \
-		if (Thread::get_caller_id() != server_thread) {                                                                    \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                                    \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                 \
 			SYNC_DEBUG                                                                                                     \
 			MAIN_THREAD_SYNC_CHECK                                                                                         \
@@ -702,7 +702,7 @@
 
 #define FUNC8SC(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                          \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                                          \
+		if (ASYNC_COND_PUSH_AND_SYNC) {                                                                                          \
 			command_queue.push_and_sync(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                       \
 			SYNC_DEBUG                                                                                                           \
 			MAIN_THREAD_SYNC_CHECK                                                                                               \
@@ -715,7 +715,7 @@
 #define FUNC8(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                      \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) override { \
 		WRITE_ACTION                                                                                                       \
-		if (Thread::get_caller_id() != server_thread) {                                                                    \
+		if (ASYNC_COND_PUSH) {                                                                                             \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                          \
 		} else {                                                                                                           \
 			command_queue.flush_if_pending();                                                                              \
@@ -725,7 +725,7 @@
 
 #define FUNC8C(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8)                                           \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8) const override { \
-		if (Thread::get_caller_id() != server_thread) {                                                                          \
+		if (ASYNC_COND_PUSH) {                                                                                                   \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8);                                \
 		} else {                                                                                                                 \
 			command_queue.flush_if_pending();                                                                                    \
@@ -736,7 +736,7 @@
 #define FUNC9(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9)                                         \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9) override { \
 		WRITE_ACTION                                                                                                                  \
-		if (Thread::get_caller_id() != server_thread) {                                                                               \
+		if (ASYNC_COND_PUSH) {                                                                                                        \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9);                                 \
 		} else {                                                                                                                      \
 			command_queue.flush_if_pending();                                                                                         \
@@ -747,7 +747,7 @@
 #define FUNC10(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10)                                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10) override { \
 		WRITE_ACTION                                                                                                                               \
-		if (Thread::get_caller_id() != server_thread) {                                                                                            \
+		if (ASYNC_COND_PUSH) {                                                                                                                     \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10);                                         \
 		} else {                                                                                                                                   \
 			command_queue.flush_if_pending();                                                                                                      \
@@ -758,7 +758,7 @@
 #define FUNC11(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11)                                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11) override { \
 		WRITE_ACTION                                                                                                                                            \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                         \
+		if (ASYNC_COND_PUSH) {                                                                                                                                  \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11);                                                 \
 		} else {                                                                                                                                                \
 			command_queue.flush_if_pending();                                                                                                                   \
@@ -769,7 +769,7 @@
 #define FUNC12(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12)                                                    \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12) override { \
 		WRITE_ACTION                                                                                                                                                         \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                      \
+		if (ASYNC_COND_PUSH) {                                                                                                                                               \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12);                                                         \
 		} else {                                                                                                                                                             \
 			command_queue.flush_if_pending();                                                                                                                                \
@@ -780,7 +780,7 @@
 #define FUNC13(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13)                                                        \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13) override { \
 		WRITE_ACTION                                                                                                                                                                      \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                                   \
+		if (ASYNC_COND_PUSH) {                                                                                                                                                            \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13);                                                                 \
 		} else {                                                                                                                                                                          \
 			command_queue.flush_if_pending();                                                                                                                                             \
@@ -791,7 +791,7 @@
 #define FUNC14(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14)                                                            \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13, m_arg14 p14) override { \
 		WRITE_ACTION                                                                                                                                                                                   \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                                                \
+		if (ASYNC_COND_PUSH) {                                                                                                                                                                         \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14);                                                                         \
 		} else {                                                                                                                                                                                       \
 			command_queue.flush_if_pending();                                                                                                                                                          \
@@ -802,7 +802,7 @@
 #define FUNC15(m_type, m_arg1, m_arg2, m_arg3, m_arg4, m_arg5, m_arg6, m_arg7, m_arg8, m_arg9, m_arg10, m_arg11, m_arg12, m_arg13, m_arg14, m_arg15)                                                                \
 	virtual void m_type(m_arg1 p1, m_arg2 p2, m_arg3 p3, m_arg4 p4, m_arg5 p5, m_arg6 p6, m_arg7 p7, m_arg8 p8, m_arg9 p9, m_arg10 p10, m_arg11 p11, m_arg12 p12, m_arg13 p13, m_arg14 p14, m_arg15 p15) override { \
 		WRITE_ACTION                                                                                                                                                                                                \
-		if (Thread::get_caller_id() != server_thread) {                                                                                                                                                             \
+		if (ASYNC_COND_PUSH) {                                                                                                                                                                                      \
 			command_queue.push(server_name, &ServerName::m_type, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15);                                                                                 \
 		} else {                                                                                                                                                                                                    \
 			command_queue.flush_if_pending();                                                                                                                                                                       \


### PR DESCRIPTION
Fixes #109554.

> [!WARNING]
> This change is a bit crude and will likely be a performance regression for some projects that rely on the `physics/*d/run_on_separate_thread` project setting, but I'm not sure how else to fix this race condition, other than to somehow introduce synchronization between `PhysicsServer*DWrapMT`, `PhysicsDirectSpaceState*D` and `PhysicsDirectBodyState*D`, which has its own complications/downsides.

What this does is make it so that `PhysicsServer*DWrapMT::sync` and `PhysicsServer*DWrapMT::end_sync` (called [here](https://github.com/godotengine/godot/blob/8aa37cab8950351d96f541581abdc42136283f24/main/main.cpp#L4738) and [here](https://github.com/godotengine/godot/blob/8aa37cab8950351d96f541581abdc42136283f24/main/main.cpp#L4777) in the main loop) actually "pauses" and "unpauses" the asynchronous processing of commands in the command queue of `PhysicsServer*DWrapMT`, thereby ~~effectively disabling `physics/*d/run_on_separate_thread` during the physics processing part of the main loop~~.

EDIT: It's probably more fair to say that we are _deferring_ `physics/*d/run_on_separate_thread` with this change now, since we're still offloading non-read/non-sync tasks to the physics thread, but until after the physics processing is done.

This would mean that we resolve the (apparently long-standing) race conditions between `PhysicsServer*DWrapMT::_thread_loop` and `PhysicsDirectSpaceState*D` (and `PhysicsDirectBodyState*D` as well) while preserving the ability for users to freely perform physics queries in parallel as much as they want[^1] from any thread[^2] when `physics/*d/run_on_separate_thread` is enabled.

Note however that much of the benefit from `physics/*d/run_on_separate_thread` comes from doing the actual physics step asynchronously, which would still be the case, as that happens after `PhysicsServer*DWrapMT::end_sync`.

[^1]: Only as long as it's done during physics processing, but this is already being enforced [here](https://github.com/godotengine/godot/blob/8aa37cab8950351d96f541581abdc42136283f24/modules/godot_physics_3d/godot_physics_server_3d.cpp#L194), albeit not very rigorously.
[^2]: You're technically only allowed to fetch `PhysicsDirectSpaceState*D` from the main thread, as seen [here](https://github.com/godotengine/godot/blob/8aa37cab8950351d96f541581abdc42136283f24/servers/physics_server_3d_wrap_mt.h#L115), but there's nothing stopping you from caching the instance and using it from multiple threads, which should be fine for that class specifically, since physics queries should (at least in theory) all be read-only.