### PR TITLE
Implement screen-space based selection outline as default alternative to AABB

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -518,6 +518,12 @@
 		<member name="editors/3d/selection_box_color" type="Color" setter="" getter="">
 			The color to use for the selection box that surrounds selected nodes in the 3D editor viewport.
 		</member>
+		<member name="editors/3d/selection_outline_enabled" type="bool" setter="" getter="">
+			If [code]true[/code], draws screen-space selection outlines for selected objects in the 3D editor viewport. If [code]false[/code], selection is displayed using 3D selection boxes.
+		</member>
+		<member name="editors/3d/selection_outline_thickness" type="float" setter="" getter="">
+			The outline thickness in screen pixels.
+		</member>
 		<member name="editors/3d/show_gizmo_during_rotation" type="int" setter="" getter="">
 			If checked, the transform gizmo remains visible during rotation in that transform mode.
 		</member>

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -884,6 +884,7 @@ EditorNode3DGizmo::EditorNode3DGizmo() {
 	billboard_handle = false;
 	hidden = false;
 	selected = false;
+	highlighted = false;
 	spatial_node = nullptr;
 	gizmo_plugin = nullptr;
 	selectable_icon_size = -1.0f;
@@ -1019,13 +1020,14 @@ Ref<StandardMaterial3D> EditorNode3DGizmoPlugin::get_material(const String &p_na
 		return materials[p_name][0];
 	}
 
-	int index = (p_gizmo->is_selected() ? 1 : 0) + (p_gizmo->is_editable() ? 2 : 0);
+	bool is_active = p_gizmo->is_selected() || p_gizmo->is_highlighted();
+	int index = (is_active ? 1 : 0) + (p_gizmo->is_editable() ? 2 : 0);
 
 	Ref<StandardMaterial3D> mat = materials[p_name][index];
 
 	bool on_top_mat = mat->get_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST);
 
-	if (!on_top_mat && current_state == ON_TOP && p_gizmo->is_selected()) {
+	if (!on_top_mat && current_state == ON_TOP && is_active) {
 		mat = mat->duplicate();
 		mat->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
 	}

--- a/editor/scene/3d/node_3d_editor_gizmos.h
+++ b/editor/scene/3d/node_3d_editor_gizmos.h
@@ -55,6 +55,7 @@ class EditorNode3DGizmo : public Node3DGizmo {
 	};
 
 	bool selected;
+	bool highlighted;
 
 	Vector<Vector3> collision_segments;
 	LocalVector<Ref<TriangleMesh>> collision_meshes;
@@ -122,6 +123,8 @@ public:
 
 	void set_selected(bool p_selected) { selected = p_selected; }
 	bool is_selected() const { return selected; }
+	void set_highlighted(bool p_highlighted) { highlighted = p_highlighted; }
+	bool is_highlighted() const { return highlighted; }
 
 	void set_node_3d(Node3D *p_node);
 	Node3D *get_node_3d() const { return spatial_node; }

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -91,7 +91,9 @@
 #include "editor/translations/editor_translation_preview_menu.h"
 #include "scene/3d/audio_stream_player_3d.h"
 #include "scene/3d/camera_3d.h"
+#include "scene/3d/cpu_particles_3d.h"
 #include "scene/3d/decal.h"
+#include "scene/3d/gpu_particles_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
@@ -106,9 +108,12 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/subviewport_container.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/3d/sky_material.h"
+#include "scene/resources/environment.h"
 #include "scene/resources/packed_scene.h"
+#include "scene/resources/shader.h"
 #include "scene/resources/sky.h"
 #include "scene/resources/surface_tool.h"
 #include "servers/rendering/rendering_server.h"
@@ -2995,6 +3000,9 @@ void Node3DEditorViewport::_cursor_interpolated() {
 	look_control->queue_redraw();
 	surface->queue_redraw();
 	spatial_editor->update_grid();
+	if (spatial_editor->outline_enabled) {
+		_queue_update_outline();
+	}
 }
 
 void Node3DEditorViewport::_freelook_changed() {
@@ -3179,6 +3187,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		case NOTIFICATION_RESIZED: {
 			callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view).call_deferred();
+			selection_buffer_viewport->set_size(viewport->get_size());
+			if (spatial_editor->outline_enabled) {
+				callable_mp(this, &Node3DEditorViewport::_update_outline).call_deferred();
+			}
 		} break;
 
 		case NOTIFICATION_PROCESS: {
@@ -3284,34 +3296,16 @@ void Node3DEditorViewport::_notification(int p_what) {
 				se->last_xform_dirty = false;
 				se->last_xform = t;
 
-				se->aabb = new_aabb;
-
-				Transform3D t_offset = t;
-
-				// apply AABB scaling before item's global transform
-				{
-					const Vector3 offset(0.005, 0.005, 0.005);
-					Basis aabb_s;
-					aabb_s.scale(se->aabb.size + offset);
-					t.translate_local(se->aabb.position - offset / 2);
-					t.basis = t.basis * aabb_s;
-				}
-				{
-					const Vector3 offset(0.01, 0.01, 0.01);
-					Basis aabb_s;
-					aabb_s.scale(se->aabb.size + offset);
-					t_offset.translate_local(se->aabb.position - offset / 2);
-					t_offset.basis = t_offset.basis * aabb_s;
-				}
-
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance, t);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_offset, t_offset);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
-				RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
+				_update_selected_item_aabb(sp);
 			}
 
 			if (changed || (spatial_editor->is_gizmo_visible() && !exist)) {
 				spatial_editor->update_transform_gizmo();
+			}
+
+			if (changed) {
+				// This is only triggered in the first viewport since the cache will be already updated for the rest.
+				spatial_editor->update_outlines_all_viewports();
 			}
 
 			if (message_time > 0) {
@@ -3505,6 +3499,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 			surface->connect(SceneStringName(focus_exited), callable_mp(this, &Node3DEditorViewport::_surface_focus_exit));
 
 			_init_gizmo_instance(index);
+			if (spatial_editor->outline_enabled) {
+				callable_mp(this, &Node3DEditorViewport::_queue_update_outline).call_deferred();
+			}
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -4188,6 +4185,8 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 					preview_camera->show();
 				}
 			}
+
+			_queue_update_outline();
 		} break;
 		case VIEW_GIZMOS: {
 			int idx = view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS);
@@ -4201,6 +4200,9 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			camera->set_cull_mask(layers);
 			view_display_menu->get_popup()->set_item_checked(idx, current);
 
+			gizmos_visible = current;
+
+			_queue_update_outline();
 		} break;
 		case VIEW_TRANSFORM_GIZMO: {
 			int idx = view_display_menu->get_popup()->get_item_index(VIEW_TRANSFORM_GIZMO);
@@ -4536,6 +4538,8 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 
 		surface->queue_redraw();
 	}
+
+	_queue_update_outline();
 }
 
 void Node3DEditorViewport::_toggle_pilot_preview(bool p_activate) {
@@ -4823,6 +4827,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 		int idx = view_display_menu->get_popup()->get_item_index(VIEW_GIZMOS);
 		if (view_display_menu->get_popup()->is_item_checked(idx) != gizmos) {
 			_menu_option(VIEW_GIZMOS);
+			_queue_update_outline();
 		}
 	}
 	if (p_state.has("transform_gizmo")) {
@@ -6353,7 +6358,6 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	c->add_child(viewport);
 	surface = memnew(Control);
 	SET_DRAG_FORWARDING_CD(surface, Node3DEditorViewport);
-	add_child(surface);
 	surface->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	surface->set_clip_contents(true);
 	camera = memnew(Camera3D);
@@ -6736,9 +6740,26 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	_update_name();
 
 	EditorNode::get_singleton()->register_hdr_viewport(viewport);
+
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditorViewport::update_transform_gizmo_view));
+	_init_outline();
+	add_child(surface);
+
+	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &Node3DEditorViewport::_update_outline));
 }
 
 Node3DEditorViewport::~Node3DEditorViewport() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+
+	for (const KeyValue<ObjectID, OutlineCacheEntry> &E : outline_cache) {
+		for (const RID &instance : E.value.instances) {
+			if (instance.is_valid()) {
+				rs->free_rid(instance);
+			}
+		}
+	}
+	outline_cache.clear();
+
 	memdelete(ruler);
 }
 
@@ -7003,6 +7024,14 @@ void Node3DEditor::update_all_gizmos(Node *p_node) {
 	_update_all_gizmos(p_node);
 }
 
+void Node3DEditor::update_outlines_all_viewports() {
+	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
+		if (viewports[i]->is_visible_in_tree()) {
+			viewports[i]->_queue_update_outline();
+		}
+	}
+}
+
 Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	Node3D *sp = Object::cast_to<Node3D>(p_what);
 	if (!sp) {
@@ -7054,6 +7083,469 @@ Object *Node3DEditor::_get_editor_data(Object *p_what) {
 	RS::get_singleton()->instance_geometry_set_flag(si->sbox_instance_xray_offset, RSE::INSTANCE_FLAG_USE_BAKED_LIGHT, false);
 
 	return si;
+}
+
+void Node3DEditorViewport::_init_outline() {
+	selection_buffer_viewport = memnew(SubViewport);
+	selection_buffer_viewport->set_size(viewport->get_size());
+	selection_buffer_viewport->set_update_mode(SubViewport::UPDATE_DISABLED);
+	selection_buffer_viewport->set_clear_mode(SubViewport::CLEAR_MODE_ALWAYS);
+	selection_buffer_viewport->set_use_hdr_2d(false);
+	selection_buffer_viewport->set_default_canvas_item_texture_filter(Viewport::DEFAULT_CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
+	selection_buffer_viewport->set_world_3d(memnew(World3D));
+	selection_buffer_viewport->set_transparent_background(true);
+
+	selection_buffer_viewport->set_msaa_3d(Viewport::MSAA_2X);
+
+	add_child(selection_buffer_viewport);
+
+	selection_buffer_camera = memnew(Camera3D);
+	selection_buffer_camera->set_cull_mask(1 << SELECTION_OUTLINE_LAYER);
+	selection_buffer_viewport->add_child(selection_buffer_camera);
+	selection_buffer_camera->make_current();
+
+	_create_outline_shaders();
+	_create_outline_compositor();
+}
+
+void Node3DEditorViewport::_create_outline_shaders() {
+	selection_buffer_shader.instantiate();
+	// Encode presence in R, active in G to distinguish active vs selected in post.
+	selection_buffer_shader->set_code(R"(
+shader_type spatial;
+render_mode unshaded, cull_disabled;
+
+uniform float object_present = 0.0;
+uniform float color_code = 0.0;
+
+void fragment() {
+	ALBEDO = vec3(object_present, color_code, 0.0);
+}
+)");
+}
+
+static Ref<ShaderMaterial> _make_selection_material(const Ref<Shader> &p_shader, bool p_active) {
+	Ref<ShaderMaterial> mat;
+	mat.instantiate();
+	mat->set_shader(p_shader);
+	mat->set_shader_parameter("object_present", 1.0f);
+	mat->set_shader_parameter("color_code", p_active ? 1.0f : 0.0f);
+	return mat;
+}
+
+void Node3DEditorViewport::_create_outline_compositor() {
+	outline_compositor = memnew(TextureRect);
+	outline_compositor->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	outline_compositor->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
+	outline_compositor->set_stretch_mode(TextureRect::STRETCH_SCALE);
+	outline_compositor->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
+
+	Ref<Shader> edge_shader;
+	edge_shader.instantiate();
+	// 8-neighbor edge detection.
+	edge_shader->set_code(R"(
+shader_type canvas_item;
+
+uniform vec4 outline_color : source_color = vec4(1.0, 0.5, 0.0, 1.0);
+uniform vec4 active_outline_color : source_color = vec4(1.5, 0.75, 0.0, 1.0);
+uniform float outline_width : hint_range(0.5, 5.0) = 1.0;
+
+void fragment() {
+	vec2 size = vec2(textureSize(TEXTURE, 0));
+	vec2 pixel = outline_width / size;
+
+	vec2 center_rg = texture(TEXTURE, UV).rg;
+	float center_present = center_rg.r;
+	float center_active = center_rg.g;
+
+	vec2 left_rg   = texture(TEXTURE, UV + vec2(-pixel.x, 0.0)).rg;
+	vec2 right_rg  = texture(TEXTURE, UV + vec2(pixel.x, 0.0)).rg;
+	vec2 top_rg    = texture(TEXTURE, UV + vec2(0.0, -pixel.y)).rg;
+	vec2 bottom_rg = texture(TEXTURE, UV + vec2(0.0, pixel.y)).rg;
+	vec2 tl_rg = texture(TEXTURE, UV + vec2(-pixel.x, -pixel.y)).rg;
+	vec2 tr_rg = texture(TEXTURE, UV + vec2(pixel.x, -pixel.y)).rg;
+	vec2 bl_rg = texture(TEXTURE, UV + vec2(-pixel.x, pixel.y)).rg;
+	vec2 br_rg = texture(TEXTURE, UV + vec2(pixel.x, pixel.y)).rg;
+
+	float active_threshold = 0.25;
+	bool center_is_active = center_present > 0.0 && center_active >= active_threshold;
+	bool center_is_selected = center_present > 0.0 && center_active < active_threshold;
+	bool center_is_background = center_present <= 0.0;
+	bool has_edge = false;
+	bool edge_has_active = false;
+
+	vec2 neighbors[8] = vec2[8](left_rg, right_rg, top_rg, bottom_rg, tl_rg, tr_rg, bl_rg, br_rg);
+	for (int i = 0; i < 8; i++) {
+		float neighbor_present = neighbors[i].r;
+		float neighbor_active = neighbors[i].g;
+		bool neighbor_is_active = neighbor_present > 0.0 && neighbor_active >= active_threshold;
+		bool neighbor_is_selected = neighbor_present > 0.0 && neighbor_active < active_threshold;
+		bool neighbor_is_background = neighbor_present <= 0.0;
+
+		if ((center_is_background && neighbor_present > 0.0) ||
+			(neighbor_is_background && center_present > 0.0) ||
+			(center_is_active && neighbor_is_selected) ||
+			(center_is_selected && neighbor_is_active)) {
+			has_edge = true;
+			if (neighbor_is_active || center_is_active) {
+				edge_has_active = true;
+			}
+		}
+	}
+
+	if (has_edge) {
+		COLOR = edge_has_active ? active_outline_color : outline_color;
+	} else {
+		COLOR = vec4(0.0);
+	}
+}
+)");
+
+	Ref<ShaderMaterial> edge_material;
+	edge_material.instantiate();
+	edge_material->set_shader(edge_shader);
+	outline_compositor->set_material(edge_material);
+	add_child(outline_compositor);
+	outline_compositor->set_visible(false);
+}
+
+void Node3DEditorViewport::_update_outline_material(Ref<ShaderMaterial> p_material) {
+	ERR_FAIL_COND(p_material.is_null());
+
+	Color outline_color = EDITOR_GET("editors/3d/selection_box_color");
+	Color active_outline_color = EDITOR_GET("editors/3d/active_selection_box_color");
+	float thickness = EDITOR_GET("editors/3d/selection_outline_thickness");
+
+	p_material->set_shader_parameter("outline_color", outline_color);
+	p_material->set_shader_parameter("active_outline_color", active_outline_color);
+	p_material->set_shader_parameter("outline_width", thickness * EDSCALE);
+}
+
+void Node3DEditorViewport::_create_selection_buffer_instances(Node3D *p_node, bool p_is_active, RID p_scenario) {
+	ERR_FAIL_NULL(p_node);
+
+	List<GeometryInstance3D *> geometry_instances;
+	_find_geometry_instances_recursive(p_node, geometry_instances);
+	if (geometry_instances.is_empty()) {
+		_clear_cached_outline_for_node(p_node);
+		return;
+	}
+
+	if (selection_buffer_material_active.is_null()) {
+		selection_buffer_material_active = _make_selection_material(selection_buffer_shader, true);
+	}
+	if (selection_buffer_material_selected.is_null()) {
+		selection_buffer_material_selected = _make_selection_material(selection_buffer_shader, false);
+	}
+	Ref<ShaderMaterial> id_mat = p_is_active ? selection_buffer_material_active : selection_buffer_material_selected;
+
+	ObjectID node_id = p_node->get_instance_id();
+	if (!active_outline_instances.has(node_id)) {
+		active_outline_instances[node_id] = Vector<RID>();
+	}
+
+	if (outline_cache.has(node_id)) {
+		OutlineCacheEntry &entry = outline_cache[node_id];
+
+		bool geometry_valid = (entry.instances.size() == geometry_instances.size());
+		if (geometry_valid && entry.base_rids.size() == geometry_instances.size()) {
+			int i = 0;
+			for (GeometryInstance3D *geom_inst : geometry_instances) {
+				if (geom_inst->get_base() != entry.base_rids[i]) {
+					geometry_valid = false;
+					break;
+				}
+				i++;
+			}
+		} else {
+			geometry_valid = false;
+		}
+
+		if (geometry_valid) {
+			RenderingServer *rs = RenderingServer::get_singleton();
+
+			bool is_newly_outlined = !entry.is_visible;
+			bool active_status_changed = entry.is_active != p_is_active;
+
+			int i = 0;
+			for (GeometryInstance3D *geom_inst : geometry_instances) {
+				RID instance = entry.instances[i];
+
+				rs->instance_set_transform(instance, geom_inst->get_global_transform());
+
+				if (active_status_changed) {
+					rs->instance_geometry_set_material_override(instance, id_mat->get_rid());
+				}
+
+				if (is_newly_outlined) {
+					rs->instance_set_visible(instance, true);
+				}
+
+				active_outline_instances[node_id].push_back(instance);
+				i++;
+			}
+
+			entry.is_active = p_is_active;
+			entry.is_visible = true;
+			return;
+		}
+
+		RenderingServer *rs = RenderingServer::get_singleton();
+		for (const RID &instance : entry.instances) {
+			if (instance.is_valid()) {
+				rs->free_rid(instance);
+			}
+		}
+		outline_cache.erase(node_id);
+	}
+
+	RenderingServer *rs = RenderingServer::get_singleton();
+	OutlineCacheEntry new_entry;
+
+	for (GeometryInstance3D *geom_inst : geometry_instances) {
+		RID base = geom_inst->get_base();
+		if (!base.is_valid()) {
+			continue;
+		}
+
+		RID instance = rs->instance_create2(base, p_scenario);
+		rs->instance_set_transform(instance, geom_inst->get_global_transform());
+		rs->instance_geometry_set_material_override(instance, id_mat->get_rid());
+		rs->instance_set_layer_mask(instance, 1 << SELECTION_OUTLINE_LAYER);
+		rs->instance_geometry_set_cast_shadows_setting(instance, RSE::SHADOW_CASTING_SETTING_OFF);
+		rs->instance_set_visible(instance, true);
+
+		MeshInstance3D *mesh_inst = Object::cast_to<MeshInstance3D>(geom_inst);
+		if (mesh_inst) {
+			Ref<SkinReference> skin_ref = mesh_inst->get_skin_reference();
+			if (skin_ref.is_valid()) {
+				rs->instance_attach_skeleton(instance, skin_ref->get_skeleton());
+				new_entry.has_skeleton = true;
+			}
+		}
+
+		active_outline_instances[node_id].push_back(instance);
+		new_entry.instances.push_back(instance);
+		new_entry.base_rids.push_back(base);
+	}
+
+	new_entry.is_active = p_is_active;
+	new_entry.is_visible = true;
+	outline_cache[node_id] = new_entry;
+}
+
+void Node3DEditorViewport::_hide_aabb_instances(const HashMap<ObjectID, Object *> &p_selection) {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	for (const KeyValue<ObjectID, Object *> &E : p_selection) {
+		Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
+		if (!sp || !sp->is_inside_tree()) {
+			continue;
+		}
+		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(sp);
+		if (!se) {
+			continue;
+		}
+
+		rs->instance_set_visible(se->sbox_instance, false);
+		rs->instance_set_visible(se->sbox_instance_offset, false);
+		rs->instance_set_visible(se->sbox_instance_xray, false);
+		rs->instance_set_visible(se->sbox_instance_xray_offset, false);
+	}
+}
+
+void Node3DEditorViewport::_update_outline() {
+	EditorSelection *es = EditorNode::get_singleton()->get_editor_selection();
+	ERR_FAIL_NULL(es);
+
+	const HashMap<ObjectID, Object *> &selection = es->get_selection();
+	bool should_show_outline = spatial_editor->outline_enabled && gizmos_visible && !previewing_cinema && !previewing;
+
+	RenderingServer *rs = RenderingServer::get_singleton();
+
+	if (selection.is_empty() || !should_show_outline) {
+		_clear_outline();
+		outline_compositor->set_visible(false);
+		rs->viewport_set_update_mode(selection_buffer_viewport->get_viewport_rid(), RSE::VIEWPORT_UPDATE_DISABLED);
+
+		return;
+	}
+
+	_sync_selection_buffer_camera();
+
+	Node3D *active_node = spatial_editor->get_active_node();
+	RID scenario = selection_buffer_viewport->get_world_3d()->get_scenario();
+	if (!active_node && !selection.is_empty()) {
+		active_node = ObjectDB::get_instance<Node3D>(selection.begin()->key);
+	}
+
+	HashSet<ObjectID> selected_nodes;
+	for (const KeyValue<ObjectID, Object *> &E : selection) {
+		Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
+		if (sp && sp->is_inside_tree()) {
+			selected_nodes.insert(sp->get_instance_id());
+		}
+	}
+
+	for (KeyValue<ObjectID, OutlineCacheEntry> &E : outline_cache) {
+		if (E.value.is_visible && !selected_nodes.has(E.key)) {
+			for (const RID &instance : E.value.instances) {
+				if (instance.is_valid()) {
+					rs->instance_set_visible(instance, false);
+				}
+			}
+			E.value.is_visible = false;
+		}
+	}
+
+	active_outline_instances.clear();
+
+	for (const KeyValue<ObjectID, Object *> &E : selection) {
+		Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
+		if (!sp || !sp->is_inside_tree()) {
+			continue;
+		}
+		_create_selection_buffer_instances(sp, (sp == active_node), scenario);
+	}
+
+	// Use continuous viewport update for skeletal meshes so outlines follow bone animation.
+	selection_has_skeleton = false;
+	for (const ObjectID &node_id : selected_nodes) {
+		if (outline_cache.has(node_id) && outline_cache[node_id].has_skeleton) {
+			selection_has_skeleton = true;
+			break;
+		}
+	}
+
+	rs->viewport_set_update_mode(
+			selection_buffer_viewport->get_viewport_rid(),
+			selection_has_skeleton ? RSE::VIEWPORT_UPDATE_ALWAYS : RSE::VIEWPORT_UPDATE_ONCE);
+
+	outline_compositor->set_texture(selection_buffer_viewport->get_texture());
+	Ref<ShaderMaterial> mat = outline_compositor->get_material();
+	if (mat.is_valid()) {
+		_update_outline_material(mat);
+	}
+	outline_compositor->set_visible(true);
+	_hide_aabb_instances(selection);
+}
+
+void Node3DEditorViewport::_queue_update_outline() {
+	if (outline_update_pending) {
+		return;
+	}
+	outline_update_pending = true;
+	callable_mp(this, &Node3DEditorViewport::_deferred_update_outline).call_deferred();
+}
+
+void Node3DEditorViewport::_deferred_update_outline() {
+	outline_update_pending = false;
+	_update_outline();
+}
+
+void Node3DEditorViewport::_sync_selection_buffer_camera() {
+	selection_buffer_camera->set_global_transform(camera->get_global_transform());
+	selection_buffer_camera->set_fov(camera->get_fov());
+	selection_buffer_camera->set_near(camera->get_near());
+	selection_buffer_camera->set_far(camera->get_far());
+	selection_buffer_camera->set_projection(camera->get_projection());
+	selection_buffer_camera->set_size(camera->get_size());
+	selection_buffer_camera->set_frustum_offset(camera->get_frustum_offset());
+}
+
+void Node3DEditorViewport::_update_selected_item_aabb(Node3D *p_node) {
+	ERR_FAIL_NULL(p_node);
+
+	Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(p_node);
+	ERR_FAIL_NULL(se);
+	Transform3D t = p_node->get_global_gizmo_transform();
+	if (!t.is_finite()) {
+		return;
+	}
+	AABB new_aabb = _calculate_spatial_bounds(p_node);
+	se->aabb = new_aabb;
+	Transform3D t_offset = t;
+	{
+		const Vector3 offset(0.005, 0.005, 0.005);
+		Basis aabb_s;
+		aabb_s.scale(se->aabb.size + offset);
+		t.translate_local(se->aabb.position - offset / 2);
+		t.basis = t.basis * aabb_s;
+	}
+	{
+		const Vector3 offset(0.01, 0.01, 0.01);
+		Basis aabb_s;
+		aabb_s.scale(se->aabb.size + offset);
+		t_offset.translate_local(se->aabb.position - offset / 2);
+		t_offset.basis = t_offset.basis * aabb_s;
+	}
+	bool show_aabb = !spatial_editor->outline_enabled;
+	RenderingServer::get_singleton()->instance_set_visible(se->sbox_instance, show_aabb);
+	RenderingServer::get_singleton()->instance_set_visible(se->sbox_instance_offset, show_aabb);
+	RenderingServer::get_singleton()->instance_set_visible(se->sbox_instance_xray, show_aabb);
+	RenderingServer::get_singleton()->instance_set_visible(se->sbox_instance_xray_offset, show_aabb);
+	if (show_aabb) {
+		RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance, t);
+		RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_offset, t_offset);
+		RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray, t);
+		RenderingServer::get_singleton()->instance_set_transform(se->sbox_instance_xray_offset, t_offset);
+	}
+}
+
+void Node3DEditorViewport::_clear_outline() {
+	RenderingServer *rs = RenderingServer::get_singleton();
+	for (const KeyValue<ObjectID, Vector<RID>> &E : active_outline_instances) {
+		ObjectID node_id = E.key;
+
+		if (outline_cache.has(node_id)) {
+			OutlineCacheEntry &entry = outline_cache[node_id];
+			for (const RID &instance : entry.instances) {
+				if (instance.is_valid()) {
+					rs->instance_set_visible(instance, false);
+				}
+			}
+			entry.is_visible = false;
+		} else {
+			for (const RID &instance : E.value) {
+				if (instance.is_valid()) {
+					rs->free_rid(instance);
+				}
+			}
+		}
+	}
+	active_outline_instances.clear();
+}
+
+void Node3DEditorViewport::_clear_cached_outline_for_node(Node3D *p_node) {
+	ERR_FAIL_NULL(p_node);
+	ObjectID node_id = p_node->get_instance_id();
+
+	if (outline_cache.has(node_id)) {
+		RenderingServer *rs = RenderingServer::get_singleton();
+		OutlineCacheEntry &entry = outline_cache[node_id];
+		for (const RID &instance : entry.instances) {
+			if (instance.is_valid()) {
+				rs->free_rid(instance);
+			}
+		}
+		outline_cache.erase(node_id);
+	}
+}
+
+void Node3DEditorViewport::_find_geometry_instances_recursive(Node *p_node, List<GeometryInstance3D *> &r_list) {
+	ERR_FAIL_NULL(p_node);
+
+	if (Object::cast_to<GPUParticles3D>(p_node) || Object::cast_to<CPUParticles3D>(p_node)) {
+		return;
+	}
+
+	GeometryInstance3D *geom_instance = Object::cast_to<GeometryInstance3D>(p_node);
+	if (geom_instance && geom_instance->is_visible_in_tree() && geom_instance->get_base().is_valid()) {
+		r_list.push_back(geom_instance);
+	}
+
+	for (int i = 0; i < p_node->get_child_count(); i++) {
+		_find_geometry_instances_recursive(p_node->get_child(i), r_list);
+	}
 }
 
 void Node3DEditor::_generate_selection_boxes() {
@@ -8752,6 +9244,10 @@ void Node3DEditor::_selection_changed() {
 
 	const HashMap<ObjectID, Object *> &selection = editor_selection->get_selection();
 
+	active_node = nullptr;
+
+	update_outlines_all_viewports();
+
 	for (const KeyValue<ObjectID, Object *> &E : selection) {
 		Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
 		if (!sp) {
@@ -8764,6 +9260,7 @@ void Node3DEditor::_selection_changed() {
 		}
 
 		if (sp == editor_selection->get_top_selected_node_list().back()->get()) {
+			active_node = sp;
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance, active_selection_box->get_rid());
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_xray, active_selection_box_xray->get_rid());
 			RenderingServer::get_singleton()->instance_set_base(se->sbox_instance_offset, active_selection_box->get_rid());
@@ -8777,21 +9274,11 @@ void Node3DEditor::_selection_changed() {
 	}
 
 	if (selected && editor_selection->get_top_selected_node_list().size() != 1) {
-		Vector<Ref<Node3DGizmo>> gizmos = selected->get_gizmos();
-		for (int i = 0; i < gizmos.size(); i++) {
-			Ref<EditorNode3DGizmo> seg = gizmos[i];
-			if (seg.is_null()) {
-				continue;
-			}
-			seg->set_selected(false);
-		}
-
 		Node3DEditorSelectedItem *se = editor_selection->get_node_editor_data<Node3DEditorSelectedItem>(selected);
 		if (se) {
 			se->gizmo.unref();
 			se->subgizmos.clear();
 		}
-		selected->update_gizmos();
 		selected = nullptr;
 	}
 
@@ -8808,6 +9295,24 @@ void Node3DEditor::_selection_changed() {
 	}
 
 	update_transform_gizmo();
+
+	HashSet<ObjectID> all_nodes_to_update(previous_selection);
+
+	for (const KeyValue<ObjectID, Object *> &E : selection) {
+		all_nodes_to_update.insert(E.key);
+	}
+
+	for (const ObjectID &id : all_nodes_to_update) {
+		Node3D *node = ObjectDB::get_instance<Node3D>(id);
+		if (node) {
+			_update_gizmo_selection_state(node);
+		}
+	}
+
+	previous_selection.clear();
+	for (const KeyValue<ObjectID, Object *> &E : selection) {
+		previous_selection.insert(E.key);
+	}
 }
 
 void Node3DEditor::refresh_dirty_gizmos() {
@@ -9223,6 +9728,22 @@ void Node3DEditor::_notification(int p_what) {
 					active_selection_box_mat->set_albedo(active_selection_box_color);
 					active_selection_box_mat_xray->set_albedo(active_selection_box_color * Color(1, 1, 1, 0.15));
 				}
+				outline_enabled = EDITOR_GET("editors/3d/selection_outline_enabled");
+				update_outlines_all_viewports();
+				{
+					EditorSelection *es = EditorNode::get_singleton()->get_editor_selection();
+					if (es) {
+						const HashMap<ObjectID, Object *> &selection = es->get_selection();
+						for (const KeyValue<ObjectID, Object *> &E : selection) {
+							Node3D *sp = ObjectDB::get_instance<Node3D>(E.key);
+							if (!sp) {
+								continue;
+							}
+							viewports[0]->_update_selected_item_aabb(sp);
+						}
+					}
+				}
+				update_transform_gizmo();
 
 				// Update grid color by rebuilding grid.
 				_finish_grid();
@@ -9389,13 +9910,38 @@ void Node3DEditor::move_control_to_right_panel(Control *p_control) {
 	add_control_to_right_panel(p_control);
 }
 
+void Node3DEditor::_update_gizmo_selection_state(Node3D *p_node) {
+	ERR_FAIL_NULL(p_node);
+
+	bool is_selected = editor_selection->is_selected(p_node);
+	bool is_single_selection = editor_selection->get_top_selected_node_list().size() == 1;
+	bool should_be_selected = is_selected && is_single_selection;
+	bool should_be_highlighted = is_selected && !is_single_selection;
+
+	Vector<Ref<Node3DGizmo>> gizmos = p_node->get_gizmos();
+	for (int i = 0; i < gizmos.size(); i++) {
+		Ref<EditorNode3DGizmo> seg = gizmos[i];
+		if (seg.is_null()) {
+			continue;
+		}
+		seg->set_selected(should_be_selected);
+		seg->set_highlighted(should_be_highlighted);
+	}
+	if (!gizmos.is_empty()) {
+		p_node->update_gizmos();
+	}
+}
+
 void Node3DEditor::_request_gizmo(Object *p_obj) {
 	Node3D *sp = Object::cast_to<Node3D>(p_obj);
 	if (!sp) {
 		return;
 	}
 
-	bool is_selected = (sp == selected);
+	bool is_selected = editor_selection->is_selected(sp);
+	bool is_single_selection = editor_selection->get_top_selected_node_list().size() == 1;
+
+	sp->clear_gizmos();
 
 	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
 	if (edited_scene && (sp == edited_scene || (sp->get_owner() && edited_scene->is_ancestor_of(sp)))) {
@@ -9405,9 +9951,11 @@ void Node3DEditor::_request_gizmo(Object *p_obj) {
 			if (seg.is_valid()) {
 				sp->add_gizmo(seg);
 
-				if (is_selected != seg->is_selected()) {
-					seg->set_selected(is_selected);
-				}
+				bool should_be_selected = is_selected && is_single_selection;
+				bool should_be_highlighted = is_selected && !is_single_selection;
+
+				seg->set_selected(should_be_selected);
+				seg->set_highlighted(should_be_highlighted);
 			}
 		}
 		if (!sp->get_gizmos().is_empty()) {
@@ -9556,6 +10104,13 @@ void Node3DEditor::_node_removed(Node *p_node) {
 			if (directional_light_count == 0) {
 				_update_preview_environment();
 			}
+		}
+	}
+
+	Node3D *sp = Object::cast_to<Node3D>(p_node);
+	if (sp) {
+		for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
+			viewports[i]->_clear_cached_outline_for_node(sp);
 		}
 	}
 
@@ -10295,6 +10850,8 @@ Node3DEditor::Node3DEditor() {
 		viewports[i]->set_custom_minimum_size(Size2(39, 39));
 		viewport_base->add_viewport(viewports[i], i);
 	}
+
+	outline_enabled = EDITOR_GET("editors/3d/selection_outline_enabled");
 
 	/* SNAP DIALOG */
 

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -62,11 +62,13 @@ class RichTextLabel;
 class SplitContainer;
 class SubViewport;
 class SubViewportContainer;
+class TextureRect;
 class VSeparator;
 class VSplitContainer;
 class ViewportNavigationControl;
 class WorldEnvironment;
 class MeshInstance3D;
+class GeometryInstance3D;
 
 class ViewportRotationControl : public Control {
 	GDCLASS(ViewportRotationControl, Control);
@@ -115,6 +117,9 @@ class Node3DEditorViewport : public Control {
 	friend class Node3DEditor;
 	friend class ViewportNavigationControl;
 	friend class ViewportRotationControl;
+
+	static constexpr uint32_t SELECTION_OUTLINE_LAYER = 20;
+
 	enum {
 		VIEW_TOP,
 		VIEW_BOTTOM,
@@ -231,6 +236,26 @@ private:
 	Control *surface = nullptr;
 	SubViewport *viewport = nullptr;
 	Camera3D *camera = nullptr;
+
+	SubViewport *selection_buffer_viewport = nullptr;
+	Camera3D *selection_buffer_camera = nullptr;
+	TextureRect *outline_compositor = nullptr;
+	Ref<Shader> selection_buffer_shader;
+	Ref<ShaderMaterial> selection_buffer_material_active;
+	Ref<ShaderMaterial> selection_buffer_material_selected;
+	struct OutlineCacheEntry {
+		Vector<RID> instances;
+		Vector<RID> base_rids;
+		bool is_active = false;
+		bool has_skeleton = false;
+		bool is_visible = false;
+	};
+
+	HashMap<ObjectID, OutlineCacheEntry> outline_cache;
+	HashMap<ObjectID, Vector<RID>> active_outline_instances;
+	bool outline_update_pending = false;
+	bool selection_has_skeleton = false;
+
 	bool transforming = false;
 	bool transform_gizmo_visible = true;
 	bool collision_reposition = false;
@@ -428,6 +453,7 @@ private:
 	bool previewing_cinema = false;
 	int times_focused_consecutively = 0;
 	bool pilot_preview_enabled = false;
+	bool gizmos_visible = true;
 	bool _is_node_locked(const Node *p_node) const;
 	void _preview_exited_scene();
 	void _preview_camera_property_changed();
@@ -488,6 +514,21 @@ private:
 
 	void _set_lock_view_rotation(bool p_lock_rotation);
 	void _add_advanced_debug_draw_mode_item(PopupMenu *p_popup, const String &p_name, int p_value, SupportedRenderingMethods p_rendering_methods = SupportedRenderingMethods::ALL, const String &p_tooltip = "");
+
+	void _init_outline();
+	void _create_outline_shaders();
+	void _create_outline_compositor();
+	void _queue_update_outline();
+	void _deferred_update_outline();
+	void _update_outline();
+	void _update_outline_material(Ref<ShaderMaterial> p_material);
+	void _create_selection_buffer_instances(Node3D *p_node, bool p_is_active, RID p_scenario);
+	void _hide_aabb_instances(const HashMap<ObjectID, Object *> &p_selection);
+	void _sync_selection_buffer_camera();
+	void _clear_outline();
+	void _clear_cached_outline_for_node(Node3D *p_node);
+	void _find_geometry_instances_recursive(Node *p_node, List<GeometryInstance3D *> &r_list);
+	void _update_selected_item_aabb(Node3D *p_node);
 
 protected:
 	void _notification(int p_what);
@@ -798,6 +839,7 @@ private:
 	Ref<Environment> viewport_environment;
 
 	Node3D *selected = nullptr;
+	Node3D *active_node = nullptr;
 
 	Node3DEditorViewport *freelook_viewport = nullptr;
 
@@ -807,6 +849,8 @@ private:
 	void _clear_subgizmo_selection(Object *p_obj = nullptr);
 
 	bool gizmos_dirty = false;
+	HashSet<ObjectID> previous_selection;
+	void _update_gizmo_selection_state(Node3D *p_node);
 
 	static Node3DEditor *singleton;
 
@@ -917,6 +961,8 @@ protected:
 public:
 	static Node3DEditor *get_singleton() { return singleton; }
 
+	bool outline_enabled = true;
+
 	static Size2i get_camera_viewport_size(Camera3D *p_camera);
 
 	Vector3 snap_point(Vector3 p_target, Vector3 p_start = Vector3(0, 0, 0)) const;
@@ -952,6 +998,7 @@ public:
 	void update_transform_gizmo();
 	void update_all_gizmos(Node *p_node = nullptr);
 	void update_gizmo_opacity();
+	void update_outlines_all_viewports();
 	void snap_selected_nodes_to_floor();
 	void select_gizmo_highlight_axis(int p_axis);
 	void set_custom_camera(Node *p_camera) { custom_camera = p_camera; }
@@ -975,6 +1022,7 @@ public:
 
 	VSplitContainer *get_shader_split();
 
+	Node3D *get_active_node() const { return active_node; }
 	Node3D *get_single_selected_node() { return selected; }
 	bool is_current_selected_gizmo(const EditorNode3DGizmo *p_gizmo);
 	bool is_subgizmo_selected(int p_id);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -895,8 +895,14 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_BASIC(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/secondary_grid_color", Color(0.38, 0.38, 0.38, 0.5), "")
 
 	// Use a similar color to the 2D editor selection.
-	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/selection_box_color", Color(1.0, 0.5, 0), "", PROPERTY_USAGE_DEFAULT)
-	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/active_selection_box_color", Color(1.5, 0.75, 0, 1.0), "", PROPERTY_USAGE_DEFAULT)
+	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/selection_box_color", Color(1.0, 0.5, 0), "")
+	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d/active_selection_box_color", Color(1.5, 0.75, 0, 1.0), "")
+
+	// Screen-space selection outline
+	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "editors/3d/selection_outline_enabled", true, "")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "editors/3d/selection_outline_thickness", 1.0, "0.5,10.0,0.1")
+
+	// Gizmos
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/instantiated", Color(0.7, 0.7, 0.7, 0.6), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/joint", Color(0.5, 0.8, 1), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING_USAGE(Variant::COLOR, PROPERTY_HINT_NONE, "editors/3d_gizmos/gizmo_colors/aabb", Color(0.28, 0.8, 0.82), "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Closes: https://github.com/godotengine/godot-proposals/issues/11990
Closes: https://github.com/godotengine/godot-proposals/issues/2795

Begins to Address: https://github.com/godotengine/godot/issues/109223#issuecomment-3173070375

Full disclosure I'm not a rendering expert by any means. 

I tried a stencil-buffer approach as suggested in the first linked proposal, but it ended up being complex and I couldn't get it working quite right especially when trying to select instantiated scenes with several complex meshes and handling an `active node` (https://github.com/godotengine/godot/pull/102176). I think we would need to expose the stencil buffer as a post-process texture to get ideal results which is way beyond my skills set, so I opted to implement something more simple which is just do some post processing in screen-space with a color buffer. 

Reverting back to using AABB is done by checking the enable button in 3D editor settings.

They also have their own color settings to maintain compatibility. 

<img width="1087" height="298" alt="image" src="https://github.com/user-attachments/assets/a07f9011-3b1f-4f8b-8d19-392d92e1e0d5" />


TODO:
- [x] Documentation
- [x] Remove opacity editor setting, the color setting can handle this themselves
- [x] Evaluate any performance impact and optimize
- [x] ~Runtime Selection (Probably a separate PR and also I'm just not familiar with runtime stuff in general)~ (not in this PR)
- [x] Keep evaluating a stencil-based solution?

https://github.com/user-attachments/assets/83d40082-92d4-476d-8c3f-ce6c955b7676

