### PR TITLE
Add Stretch Modes for Splash Screen

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -43,6 +43,7 @@
 #include "core/variant/typed_array.h"
 #include "core/variant/variant_parser.h"
 #include "core/version.h"
+#include "servers/rendering/rendering_server.h"
 
 #ifdef TOOLS_ENABLED
 #include "modules/modules_enabled.gen.h" // For mono.
@@ -599,6 +600,12 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 				action["events"] = array;
 				E.value.variant = action;
 			}
+		}
+	} else if (p_from_version <= 6) {
+		// Check if we still have legacy boot splash (removed in 4.6), map it to new project setting, then remove legacy setting.
+		if (has_setting("application/boot_splash/fullsize")) {
+			set_setting("application/boot_splash/stretch_mode", RenderingServer::map_scaling_option_to_stretch_mode(get_setting("application/boot_splash/fullsize")));
+			set_setting("application/boot_splash/fullsize", Variant());
 		}
 	}
 #endif // DISABLE_DEPRECATED

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -278,9 +278,6 @@
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>
-		<member name="application/boot_splash/fullsize" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], scale the boot splash image to the full window size (preserving the aspect ratio) when the engine starts. If [code]false[/code], the engine will leave it at the default pixel size.
-		</member>
 		<member name="application/boot_splash/image" type="String" setter="" getter="" default="&quot;&quot;">
 			Path to an image used as the boot splash. If left empty, the default Godot Engine splash will be displayed instead.
 			[b]Note:[/b] Only effective if [member application/boot_splash/show_image] is [code]true[/code].
@@ -292,6 +289,9 @@
 		</member>
 		<member name="application/boot_splash/show_image" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], displays the image specified in [member application/boot_splash/image] when the engine starts. If [code]false[/code], only displays the plain color specified in [member application/boot_splash/bg_color].
+		</member>
+		<member name="application/boot_splash/stretch_mode" type="int" setter="" getter="" default="1">
+			Specifies how the splash image will be stretched. For the original size without stretching, set to disabled. See [enum RenderingServer.SplashStretchMode] constants for more information.
 		</member>
 		<member name="application/boot_splash/use_filter" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], applies linear filtering when scaling the image (recommended for high-resolution artwork). If [code]false[/code], uses nearest-neighbor interpolation (recommended for pixel art).

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3446,14 +3446,24 @@
 				Sets the screen-space roughness limiter parameters, such as whether it should be enabled and its thresholds. Equivalent to [member ProjectSettings.rendering/anti_aliasing/screen_space_roughness_limiter/enabled], [member ProjectSettings.rendering/anti_aliasing/screen_space_roughness_limiter/amount] and [member ProjectSettings.rendering/anti_aliasing/screen_space_roughness_limiter/limit].
 			</description>
 		</method>
-		<method name="set_boot_image">
+		<method name="set_boot_image" deprecated="Use [method set_boot_image_with_stretch] instead.">
 			<return type="void" />
 			<param index="0" name="image" type="Image" />
 			<param index="1" name="color" type="Color" />
 			<param index="2" name="scale" type="bool" />
 			<param index="3" name="use_filter" type="bool" default="true" />
 			<description>
-				Sets a boot image. The color defines the background color. If [param scale] is [code]true[/code], the image will be scaled to fit the screen size. If [param use_filter] is [code]true[/code], the image will be scaled with linear interpolation. If [param use_filter] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
+				Sets a boot image. The [param color] defines the background color. The value of [param scale] indicates if the image will be scaled to fit the screen size. If [param use_filter] is [code]true[/code], the image will be scaled with linear interpolation. If [param use_filter] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
+			</description>
+		</method>
+		<method name="set_boot_image_with_stretch">
+			<return type="void" />
+			<param index="0" name="image" type="Image" />
+			<param index="1" name="color" type="Color" />
+			<param index="2" name="stretch_mode" type="int" enum="RenderingServer.SplashStretchMode" />
+			<param index="3" name="use_filter" type="bool" default="true" />
+			<description>
+				Sets a boot image. The [param color] defines the background color. The value of [param stretch_mode] indicates how the image will be stretched (see [enum SplashStretchMode] for possible values). If [param use_filter] is [code]true[/code], the image will be scaled with linear interpolation. If [param use_filter] is [code]false[/code], the image will be scaled with nearest-neighbor interpolation.
 			</description>
 		</method>
 		<method name="set_debug_generate_wireframes">
@@ -5981,6 +5991,24 @@
 		</constant>
 		<constant name="PIPELINE_SOURCE_MAX" value="5" enum="PipelineSource">
 			Represents the size of the [enum PipelineSource] enum.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_DISABLED" value="0" enum="SplashStretchMode">
+			No stretching is applied.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_KEEP" value="1" enum="SplashStretchMode">
+			Stretches image to fullscreen while preserving aspect ratio.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_KEEP_WIDTH" value="2" enum="SplashStretchMode">
+			Stretches the height of the image based on the width of the screen.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_KEEP_HEIGHT" value="3" enum="SplashStretchMode">
+			Stretches the width of the image based on the height of the screen.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_COVER" value="4" enum="SplashStretchMode">
+			Stretches the image to cover the entire screen while preserving aspect ratio.
+		</constant>
+		<constant name="SPLASH_STRETCH_MODE_IGNORE" value="5" enum="SplashStretchMode">
+			Stretches the image to cover the entire screen but doesn't preserve aspect ratio.
 		</constant>
 		<constant name="FEATURE_SHADERS" value="0" enum="Features" deprecated="This constant has not been used since Godot 3.0.">
 		</constant>

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -463,7 +463,7 @@ void RasterizerGLES3::blit_render_targets_to_screen(DisplayServer::WindowID p_sc
 	}
 }
 
-void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+void RasterizerGLES3::set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter) {
 	if (p_image.is_null() || p_image->is_empty()) {
 		return;
 	}
@@ -481,25 +481,7 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	RID texture = texture_storage->texture_allocate();
 	texture_storage->texture_2d_initialize(texture, p_image);
 
-	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
-	Rect2 screenrect;
-	if (p_scale) {
-		if (win_size.width > win_size.height) {
-			//scale horizontally
-			screenrect.size.y = win_size.height;
-			screenrect.size.x = imgrect.size.x * win_size.height / imgrect.size.y;
-			screenrect.position.x = (win_size.width - screenrect.size.x) / 2;
-
-		} else {
-			//scale vertically
-			screenrect.size.x = win_size.width;
-			screenrect.size.y = imgrect.size.y * win_size.width / imgrect.size.x;
-			screenrect.position.y = (win_size.height - screenrect.size.y) / 2;
-		}
-	} else {
-		screenrect = imgrect;
-		screenrect.position += ((Size2(win_size.width, win_size.height) - screenrect.size) / 2.0).floor();
-	}
+	Rect2 screenrect = RenderingServer::get_splash_stretched_screen_rect(p_image->get_size(), win_size, p_stretch_mode);
 
 #ifdef WINDOWS_ENABLED
 	if (!screen_flipped_y)

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -96,7 +96,7 @@ public:
 	RendererCanvasRender *get_canvas() { return canvas; }
 	RendererSceneRender *get_scene() { return scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
+	void set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true);
 
 	void initialize();
 	void begin_frame(double frame_step);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3681,7 +3681,8 @@ void Main::setup_boot_logo() {
 
 	if (show_logo) { //boot logo!
 		const bool boot_logo_image = GLOBAL_DEF_BASIC("application/boot_splash/show_image", true);
-		const bool boot_logo_scale = GLOBAL_DEF_BASIC("application/boot_splash/fullsize", true);
+
+		const RenderingServer::SplashStretchMode boot_stretch_mode = GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "application/boot_splash/stretch_mode", PROPERTY_HINT_ENUM, "Disabled,Keep,Keep Width,Keep Height,Cover,Ignore"), 1);
 		const bool boot_logo_filter = GLOBAL_DEF_BASIC("application/boot_splash/use_filter", true);
 		String boot_logo_path = GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/boot_splash/image", PROPERTY_HINT_FILE, "*.png"), String());
 
@@ -3721,7 +3722,7 @@ void Main::setup_boot_logo() {
 		boot_bg_color = GLOBAL_DEF_BASIC("application/boot_splash/bg_color", (editor || project_manager) ? boot_splash_editor_bg_color : boot_splash_bg_color);
 #endif
 		if (boot_logo.is_valid()) {
-			RenderingServer::get_singleton()->set_boot_image(boot_logo, boot_bg_color, boot_logo_scale, boot_logo_filter);
+			RenderingServer::get_singleton()->set_boot_image_with_stretch(boot_logo, boot_bg_color, boot_stretch_mode, boot_logo_filter);
 
 		} else {
 #ifndef NO_DEFAULT_BOOT_LOGO
@@ -3735,7 +3736,7 @@ void Main::setup_boot_logo() {
 			MAIN_PRINT("Main: ClearColor");
 			RenderingServer::get_singleton()->set_default_clear_color(boot_bg_color);
 			MAIN_PRINT("Main: Image");
-			RenderingServer::get_singleton()->set_boot_image(splash, boot_bg_color, false);
+			RenderingServer::get_singleton()->set_boot_image_with_stretch(splash, boot_bg_color, RenderingServer::SPLASH_STRETCH_MODE_DISABLED);
 #endif
 		}
 

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -98,9 +98,32 @@ HashMap<String, Variant> EditorExportPlatformIOS::get_custom_project_settings(co
 	switch (image_scale_mode) {
 		case 0: {
 			String logo_path = get_project_setting(p_preset, "application/boot_splash/image");
-			bool is_on = get_project_setting(p_preset, "application/boot_splash/fullsize");
+			RenderingServer::SplashStretchMode stretch_mode = get_project_setting(p_preset, "application/boot_splash/stretch_mode");
 			// If custom logo is not specified, Godot does not scale default one, so we should do the same.
-			value = (is_on && logo_path.length() > 0) ? "scaleAspectFit" : "center";
+			if (logo_path.is_empty()) {
+				value = "center";
+			} else {
+				switch (stretch_mode) {
+					case RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_DISABLED: {
+						value = "center";
+					} break;
+					case RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_KEEP: {
+						value = "scaleAspectFit";
+					} break;
+					case RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
+						value = "scaleAspectFit";
+					} break;
+					case RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
+						value = "scaleAspectFit";
+					} break;
+					case RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_COVER: {
+						value = "scaleAspectFill";
+					} break;
+					case RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_IGNORE: {
+						value = "scaleToFill";
+					} break;
+				}
+			}
 		} break;
 		default: {
 			value = storyboard_image_scale_mode[image_scale_mode - 1];

--- a/platform/web/export/export_plugin.cpp
+++ b/platform/web/export/export_plugin.cpp
@@ -174,7 +174,8 @@ void EditorExportPlatformWeb::_fix_html(Vector<uint8_t> &p_html, const Ref<Edito
 
 	Vector<String> godot_splash_classes;
 	godot_splash_classes.push_back("show-image--" + String(get_project_setting(p_preset, "application/boot_splash/show_image")));
-	godot_splash_classes.push_back("fullsize--" + String(get_project_setting(p_preset, "application/boot_splash/fullsize")));
+	RenderingServer::SplashStretchMode boot_splash_stretch_mode = get_project_setting(p_preset, "application/boot_splash/stretch_mode");
+	godot_splash_classes.push_back("fullsize--" + String(((boot_splash_stretch_mode != RenderingServer::SplashStretchMode::SPLASH_STRETCH_MODE_DISABLED) ? "true" : "false")));
 	godot_splash_classes.push_back("use-filter--" + String(get_project_setting(p_preset, "application/boot_splash/use_filter")));
 	replaces["$GODOT_SPLASH_CLASSES"] = String(" ").join(godot_splash_classes);
 	replaces["$GODOT_SPLASH"] = p_name + ".png";

--- a/servers/rendering/dummy/rasterizer_dummy.h
+++ b/servers/rendering/dummy/rasterizer_dummy.h
@@ -76,6 +76,7 @@ public:
 	RendererCanvasRender *get_canvas() override { return &canvas; }
 	RendererSceneRender *get_scene() override { return &scene; }
 
+	void set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) override {}
 	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) override {}
 
 	void initialize() override {}

--- a/servers/rendering/renderer_compositor.cpp
+++ b/servers/rendering/renderer_compositor.cpp
@@ -45,6 +45,11 @@ RendererCompositor *RendererCompositor::create() {
 	return _create_func();
 }
 
+void RendererCompositor::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+	RenderingServer::SplashStretchMode stretch_mode = RenderingServer::map_scaling_option_to_stretch_mode(p_scale);
+	set_boot_image_with_stretch(p_image, p_color, stretch_mode, p_use_filter);
+}
+
 bool RendererCompositor::is_xr_enabled() const {
 	return xr_enabled;
 }

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -87,7 +87,8 @@ public:
 	virtual RendererCanvasRender *get_canvas() = 0;
 	virtual RendererSceneRender *get_scene() = 0;
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	virtual void set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) = 0;
+	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
 
 	virtual void initialize() = 0;
 	virtual void begin_frame(double frame_step) = 0;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -180,7 +180,7 @@ void RendererCompositorRD::finalize() {
 	RD::get_singleton()->free_rid(blit.sampler);
 }
 
-void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+void RendererCompositorRD::set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter) {
 	if (p_image.is_null() || p_image->is_empty()) {
 		return;
 	}
@@ -215,15 +215,7 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 
 	Size2 window_size = DisplayServer::get_singleton()->window_get_size();
 
-	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
-	Rect2 screenrect;
-	if (p_scale) {
-		screenrect = OS::get_singleton()->calculate_boot_screen_rect(window_size, imgrect.size);
-	} else {
-		screenrect = imgrect;
-		screenrect.position += ((window_size - screenrect.size) / 2.0).floor();
-	}
-
+	Rect2 screenrect = RenderingServer::get_splash_stretched_screen_rect(p_image->get_size(), window_size, p_stretch_mode);
 	screenrect.position /= window_size;
 	screenrect.size /= window_size;
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -119,7 +119,7 @@ public:
 	RendererCanvasRender *get_canvas() { return canvas; }
 	RendererSceneRender *get_scene() { return scene; }
 
-	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter);
+	void set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter);
 
 	void initialize();
 	void begin_frame(double frame_step);

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -1886,6 +1886,63 @@ int RenderingServer::global_shader_uniform_type_get_shader_datatype(GlobalShader
 	}
 }
 
+Rect2 RenderingServer::get_splash_stretched_screen_rect(const Size2 &p_image_size, const Size2 &p_window_size, SplashStretchMode p_stretch_mode) {
+	Size2 imgsize = p_image_size;
+	Rect2 screenrect;
+	switch (p_stretch_mode) {
+		case SplashStretchMode::SPLASH_STRETCH_MODE_DISABLED: {
+			screenrect.size = imgsize;
+			screenrect.position = ((p_window_size - screenrect.size) / 2.0).floor();
+		} break;
+		case SplashStretchMode::SPLASH_STRETCH_MODE_KEEP: {
+			if (p_window_size.width > p_window_size.height) {
+				// Scale horizontally.
+				screenrect.size.y = p_window_size.height;
+				screenrect.size.x = imgsize.width * p_window_size.height / imgsize.height;
+				screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+			} else {
+				// Scale vertically.
+				screenrect.size.x = p_window_size.width;
+				screenrect.size.y = imgsize.height * p_window_size.width / imgsize.width;
+				screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+			}
+		} break;
+		case SplashStretchMode::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
+			// Scale vertically.
+			screenrect.size.x = p_window_size.width;
+			screenrect.size.y = imgsize.height * p_window_size.width / imgsize.width;
+			screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+		} break;
+		case SplashStretchMode::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
+			// Scale horizontally.
+			screenrect.size.y = p_window_size.height;
+			screenrect.size.x = imgsize.width * p_window_size.height / imgsize.height;
+			screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+		} break;
+		case SplashStretchMode::SPLASH_STRETCH_MODE_COVER: {
+			double window_aspect = (double)p_window_size.width / p_window_size.height;
+			double img_aspect = imgsize.width / imgsize.height;
+
+			if (window_aspect > img_aspect) {
+				// Scale vertically.
+				screenrect.size.x = p_window_size.width;
+				screenrect.size.y = imgsize.height * p_window_size.width / imgsize.width;
+				screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+			} else {
+				// Scale horizontally.
+				screenrect.size.y = p_window_size.height;
+				screenrect.size.x = imgsize.width * p_window_size.height / imgsize.height;
+				screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+			}
+		} break;
+		case SplashStretchMode::SPLASH_STRETCH_MODE_IGNORE: {
+			screenrect.size.x = p_window_size.width;
+			screenrect.size.y = p_window_size.height;
+		} break;
+	}
+	return screenrect;
+}
+
 RenderingDevice *RenderingServer::get_rendering_device() const {
 	// Return the rendering device we're using globally.
 	return RenderingDevice::get_singleton();
@@ -3495,7 +3552,10 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_test_texture"), &RenderingServer::get_test_texture);
 	ClassDB::bind_method(D_METHOD("get_white_texture"), &RenderingServer::get_white_texture);
 
+	ClassDB::bind_method(D_METHOD("set_boot_image_with_stretch", "image", "color", "stretch_mode", "use_filter"), &RenderingServer::set_boot_image_with_stretch, DEFVAL(true));
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_boot_image", "image", "color", "scale", "use_filter"), &RenderingServer::set_boot_image, DEFVAL(true));
+#endif
 	ClassDB::bind_method(D_METHOD("get_default_clear_color"), &RenderingServer::get_default_clear_color);
 	ClassDB::bind_method(D_METHOD("set_default_clear_color", "color"), &RenderingServer::set_default_clear_color);
 
@@ -3527,6 +3587,13 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(PIPELINE_SOURCE_DRAW);
 	BIND_ENUM_CONSTANT(PIPELINE_SOURCE_SPECIALIZATION);
 	BIND_ENUM_CONSTANT(PIPELINE_SOURCE_MAX);
+
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_DISABLED);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_KEEP);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_KEEP_WIDTH);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_KEEP_HEIGHT);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_COVER);
+	BIND_ENUM_CONSTANT(SPLASH_STRETCH_MODE_IGNORE);
 
 	ADD_SIGNAL(MethodInfo("frame_pre_draw"));
 	ADD_SIGNAL(MethodInfo("frame_post_draw"));
@@ -3575,6 +3642,13 @@ void RenderingServer::mesh_add_surface_from_planes(RID p_mesh, const Vector<Plan
 	Geometry3D::MeshData mdata = Geometry3D::build_convex_mesh(p_planes);
 	mesh_add_surface_from_mesh_data(p_mesh, mdata);
 }
+
+#ifndef DISABLE_DEPRECATED
+void RenderingServer::set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter) {
+	SplashStretchMode stretch_mode = map_scaling_option_to_stretch_mode(p_scale);
+	set_boot_image_with_stretch(p_image, p_color, stretch_mode, p_use_filter);
+}
+#endif
 
 RID RenderingServer::instance_create2(RID p_base, RID p_scenario) {
 	RID instance = instance_create();

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -1849,7 +1849,23 @@ public:
 	virtual void mesh_add_surface_from_mesh_data(RID p_mesh, const Geometry3D::MeshData &p_mesh_data);
 	virtual void mesh_add_surface_from_planes(RID p_mesh, const Vector<Plane> &p_planes);
 
-	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true) = 0;
+	enum SplashStretchMode {
+		SPLASH_STRETCH_MODE_DISABLED,
+		SPLASH_STRETCH_MODE_KEEP,
+		SPLASH_STRETCH_MODE_KEEP_WIDTH,
+		SPLASH_STRETCH_MODE_KEEP_HEIGHT,
+		SPLASH_STRETCH_MODE_COVER,
+		SPLASH_STRETCH_MODE_IGNORE,
+	};
+
+	virtual void set_boot_image_with_stretch(const Ref<Image> &p_image, const Color &p_color, SplashStretchMode p_stretch_mode, bool p_use_filter = true) = 0;
+	static Rect2 get_splash_stretched_screen_rect(const Size2 &p_image_size, const Size2 &p_window_size, SplashStretchMode p_stretch_mode); // Helper for splash screen
+#ifndef DISABLE_DEPRECATED
+	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true); // Superseded, but left to preserve compat.
+#endif
+	_ALWAYS_INLINE_ static SplashStretchMode map_scaling_option_to_stretch_mode(bool p_scale) {
+		return p_scale ? SplashStretchMode::SPLASH_STRETCH_MODE_KEEP : SplashStretchMode::SPLASH_STRETCH_MODE_DISABLED;
+	}
 	virtual Color get_default_clear_color() = 0;
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 
@@ -2003,6 +2019,7 @@ VARIANT_ENUM_CAST(RenderingServer::CanvasLightShadowFilter);
 VARIANT_ENUM_CAST(RenderingServer::CanvasOccluderPolygonCullMode);
 VARIANT_ENUM_CAST(RenderingServer::GlobalShaderParameterType);
 VARIANT_ENUM_CAST(RenderingServer::RenderingInfo);
+VARIANT_ENUM_CAST(RenderingServer::SplashStretchMode);
 VARIANT_ENUM_CAST(RenderingServer::CanvasTextureChannel);
 VARIANT_ENUM_CAST(RenderingServer::BakeChannels);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -1110,7 +1110,7 @@ public:
 #define ServerName RendererCompositor
 #define server_name RSG::rasterizer
 
-	FUNC4S(set_boot_image, const Ref<Image> &, const Color &, bool, bool)
+	FUNC4S(set_boot_image_with_stretch, const Ref<Image> &, const Color &, RenderingServer::SplashStretchMode, bool)
 
 	/* STATUS INFORMATION */
 


### PR DESCRIPTION
Rework of #56959

Its been a few years since that PR has been modified (originally made for 4.0) so I started again with 4.5, solved any conflicts with the previous one, and made some additions with how new platform specific splash screens are handled.

To rehash, this will replace the `application/boot_splash/fullsize` project setting that can only be toggled on or off in favor of various stretching options that change how the boot image will appear for Godot projects on startup. 

It's a full upgrade because the stretching options include what toggling full size on or off meant previously and with the new options. However, this mostly applies to the editor boot splash and exported desktop platforms because mobile platforms have their own platform-specific approaches for showing boot splashes.

The new setting is called `application/boot_splash/stretch_mode` and the options include:

* *Disabled* (same as toggling the legacy full size project setting off, no stretching applied)
* *Keep* (same as toggling the legacy full size project setting on, stretches while preserving aspect ratio)
* *Keep Width* (stretches width based on height)
* *Keep Height* (stretches height based on the width)
* *Cover* (stretches until it covers the entire screen while preserving aspect ratio)
* *Expand* (stretches until it covers the entire screen but doesn't preserve aspect ratio)

To preserve compatibility, `set_boot_splash` retains the same signature but now routes to a new function `set_boot_splash_with_stretch` which is what's now used for the various renderers. Also, for projects that still have the legacy project setting serialized, a check is done to convert that to the corresponding stretch option.