### PR TITLE
[macOS] Process joypad input directly in the embedded process.

### DIFF
--- a/platform/macos/display_server_embedded.h
+++ b/platform/macos/display_server_embedded.h
@@ -144,11 +144,6 @@ public:
 	virtual Point2i mouse_get_position() const override;
 	virtual BitField<MouseButtonMask> mouse_get_button_state() const override;
 
-	// MARK: - Joystick
-
-	void joy_add(int p_idx, const String &p_name);
-	void joy_del(int p_idx);
-
 	// MARK: - Window
 
 	virtual bool has_feature(Feature p_feature) const override;

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -389,36 +389,8 @@ void DisplayServerEmbedded::window_set_drop_files_callback(const Callable &p_cal
 	// Not supported
 }
 
-void DisplayServerEmbedded::joy_add(int p_idx, const String &p_name) {
-	Joy *joy = joysticks.getptr(p_idx);
-	if (joy == nullptr) {
-		joysticks[p_idx] = Joy(p_name);
-		Input::get_singleton()->joy_connection_changed(p_idx, true, p_name);
-	}
-}
-
-void DisplayServerEmbedded::joy_del(int p_idx) {
-	if (joysticks.erase(p_idx)) {
-		Input::get_singleton()->joy_connection_changed(p_idx, false, String());
-	}
-}
-
 void DisplayServerEmbedded::process_events() {
 	Input *input = Input::get_singleton();
-	for (KeyValue<int, Joy> &kv : joysticks) {
-		uint64_t ts = input->get_joy_vibration_timestamp(kv.key);
-		if (ts > kv.value.timestamp) {
-			kv.value.timestamp = ts;
-			Vector2 strength = input->get_joy_vibration_strength(kv.key);
-			if (strength == Vector2()) {
-				EngineDebugger::get_singleton()->send_message("game_view:joy_stop", { kv.key });
-			} else {
-				float duration = input->get_joy_vibration_duration(kv.key);
-				EngineDebugger::get_singleton()->send_message("game_view:joy_start", { kv.key, duration, strength });
-			}
-		}
-	}
-
 	input->flush_buffered_events();
 }
 

--- a/platform/macos/editor/embedded_game_view_plugin.mm
+++ b/platform/macos/editor/embedded_game_view_plugin.mm
@@ -131,8 +131,6 @@ void GameViewDebuggerMacOS::_init_capture_message_handlers() {
 	parse_message_handlers["game_view:mouse_set_mode"] = &GameViewDebuggerMacOS::_msg_mouse_set_mode;
 	parse_message_handlers["game_view:window_set_ime_active"] = &GameViewDebuggerMacOS::_msg_window_set_ime_active;
 	parse_message_handlers["game_view:window_set_ime_position"] = &GameViewDebuggerMacOS::_msg_window_set_ime_position;
-	parse_message_handlers["game_view:joy_start"] = &GameViewDebuggerMacOS::_msg_joy_start;
-	parse_message_handlers["game_view:joy_stop"] = &GameViewDebuggerMacOS::_msg_joy_stop;
 	parse_message_handlers["game_view:warp_mouse"] = &GameViewDebuggerMacOS::_msg_warp_mouse;
 }
 

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -93,7 +93,6 @@ class EmbeddedProcessMacOS final : public EmbeddedProcessBase {
 
 	void _try_embed_process();
 	void update_embedded_process();
-	void _joy_connection_changed(int p_index, bool p_connected) const;
 
 protected:
 	void _notification(int p_what);

--- a/platform/macos/embedded_debugger.h
+++ b/platform/macos/embedded_debugger.h
@@ -62,8 +62,6 @@ private:
 	Error _msg_win_event(const Array &p_args);
 	Error _msg_notification(const Array &p_args);
 	Error _msg_ime_update(const Array &p_args);
-	Error _msg_joy_add(const Array &p_args);
-	Error _msg_joy_del(const Array &p_args);
 	Error _msg_ds_state(const Array &p_args);
 
 public:

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -75,8 +75,6 @@ void EmbeddedDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["win_event"] = &EmbeddedDebugger::_msg_win_event;
 	parse_message_handlers["notification"] = &EmbeddedDebugger::_msg_notification;
 	parse_message_handlers["ime_update"] = &EmbeddedDebugger::_msg_ime_update;
-	parse_message_handlers["joy_add"] = &EmbeddedDebugger::_msg_joy_add;
-	parse_message_handlers["joy_del"] = &EmbeddedDebugger::_msg_joy_del;
 	parse_message_handlers["ds_state"] = &EmbeddedDebugger::_msg_ds_state;
 }
 
@@ -158,21 +156,6 @@ Error EmbeddedDebugger::_msg_notification(const Array &p_args) {
 	if (OS::get_singleton()->get_main_loop()) {
 		OS::get_singleton()->get_main_loop()->notification(notification);
 	}
-	return OK;
-}
-
-Error EmbeddedDebugger::_msg_joy_add(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 2, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'joy_add' message.");
-	int idx = p_args[0];
-	String name = p_args[1];
-	ds->joy_add(idx, name);
-	return OK;
-}
-
-Error EmbeddedDebugger::_msg_joy_del(const Array &p_args) {
-	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'joy_del' message.");
-	int idx = p_args[0];
-	ds->joy_del(idx);
 	return OK;
 }
 

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1263,6 +1263,11 @@ void OS_MacOS_Embedded::run() {
 				@try {
 					ds->process_events();
 
+#ifdef SDL_ENABLED
+					if (joypad_sdl) {
+						joypad_sdl->process_events();
+					}
+#endif
 					if (Main::iteration()) {
 						break;
 					}


### PR DESCRIPTION
Joypad input is not associated with the window, so there's no reason to run it via IPC, should not change the current behavior, but will prevent issues when new features are added (see https://github.com/godotengine/godot/pull/107967).

Fixes https://github.com/godotengine/godot/issues/110069