### PR TITLE
Correctly reset StateMachine opacity when a node is played or renamed

### DIFF
--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -163,6 +163,7 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 		selected_transition_to = StringName();
 		selected_transition_index = -1;
 		selected_node = StringName();
+		connected_nodes.clear();
 
 		for (int i = node_rects.size() - 1; i >= 0; i--) { //inverse to draw order
 			if (node_rects[i].play.has_point(mb->get_position())) { //edit name


### PR DESCRIPTION
Fixes edge cases I missed in #98402, where if a transition line or node is selected, and then a node's play button is pressed, node opacity isn't correctly reset. This also happens when renaming nodes. Hoping this makes it to 4.4.2.

<img width="830" height="230" alt="statemachine-play-highlight-bug" src="https://github.com/user-attachments/assets/560260b3-d18a-4d64-be0e-da4f7772a3c3" />
