### PR TITLE
Fix `move_and_slide` forcing synchronization with physics thread

### DIFF
--- a/doc/classes/PhysicsDirectBodyState2D.xml
+++ b/doc/classes/PhysicsDirectBodyState2D.xml
@@ -232,6 +232,12 @@
 		<member name="center_of_mass_local" type="Vector2" setter="" getter="get_center_of_mass_local">
 			The body's center of mass position in the body's local coordinate system.
 		</member>
+		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer">
+			The body's collision layer.
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask">
+			The body's collision mask.
+		</member>
 		<member name="inverse_inertia" type="float" setter="" getter="get_inverse_inertia">
 			The inverse of the inertia of the body.
 		</member>

--- a/doc/classes/PhysicsDirectBodyState2DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState2DExtension.xml
@@ -94,6 +94,16 @@
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.center_of_mass_local] and its respective getter.
 			</description>
 		</method>
+		<method name="_get_collision_layer" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_collision_mask" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_constant_force" qualifiers="virtual required const">
 			<return type="Vector2" />
 			<description>
@@ -267,6 +277,18 @@
 			<param index="0" name="velocity" type="float" />
 			<description>
 				Implement to override the behavior of [member PhysicsDirectBodyState2D.angular_velocity] and its respective setter.
+			</description>
+		</method>
+		<method name="_set_collision_layer" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_collision_mask" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="mask" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="_set_constant_force" qualifiers="virtual required">

--- a/doc/classes/PhysicsDirectBodyState3D.xml
+++ b/doc/classes/PhysicsDirectBodyState3D.xml
@@ -232,6 +232,12 @@
 		<member name="center_of_mass_local" type="Vector3" setter="" getter="get_center_of_mass_local">
 			The body's center of mass position in the body's local coordinate system.
 		</member>
+		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer">
+			The body's collision layer.
+		</member>
+		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask">
+			The body's collision mask.
+		</member>
 		<member name="inverse_inertia" type="Vector3" setter="" getter="get_inverse_inertia">
 			The inverse of the inertia of the body.
 		</member>

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -82,6 +82,16 @@
 			<description>
 			</description>
 		</method>
+		<method name="_get_collision_layer" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_collision_mask" qualifiers="virtual required const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="_get_constant_force" qualifiers="virtual required const">
 			<return type="Vector3" />
 			<description>
@@ -237,6 +247,18 @@
 		<method name="_set_angular_velocity" qualifiers="virtual required">
 			<return type="void" />
 			<param index="0" name="velocity" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_collision_layer" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_collision_mask" qualifiers="virtual required">
+			<return type="void" />
+			<param index="0" name="mask" type="int" />
 			<description>
 			</description>
 		</method>

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.cpp
@@ -166,6 +166,22 @@ bool GodotPhysicsDirectBodyState2D::is_sleeping() const {
 	return !body->is_active();
 }
 
+void GodotPhysicsDirectBodyState2D::set_collision_layer(uint32_t p_layer) {
+	body->set_collision_layer(p_layer);
+}
+
+uint32_t GodotPhysicsDirectBodyState2D::get_collision_layer() const {
+	return body->get_collision_layer();
+}
+
+void GodotPhysicsDirectBodyState2D::set_collision_mask(uint32_t p_mask) {
+	body->set_collision_mask(p_mask);
+}
+
+uint32_t GodotPhysicsDirectBodyState2D::get_collision_mask() const {
+	return body->get_collision_mask();
+}
+
 int GodotPhysicsDirectBodyState2D::get_contact_count() const {
 	return body->contact_count;
 }

--- a/modules/godot_physics_2d/godot_body_direct_state_2d.h
+++ b/modules/godot_physics_2d/godot_body_direct_state_2d.h
@@ -81,6 +81,12 @@ public:
 	virtual void set_sleep_state(bool p_enable) override;
 	virtual bool is_sleeping() const override;
 
+	virtual void set_collision_layer(uint32_t p_layer) override;
+	virtual uint32_t get_collision_layer() const override;
+
+	virtual void set_collision_mask(uint32_t p_mask) override;
+	virtual uint32_t get_collision_mask() const override;
+
 	virtual int get_contact_count() const override;
 
 	virtual Vector2 get_contact_local_position(int p_contact_idx) const override;

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.cpp
@@ -174,6 +174,22 @@ bool GodotPhysicsDirectBodyState3D::is_sleeping() const {
 	return !body->is_active();
 }
 
+void GodotPhysicsDirectBodyState3D::set_collision_layer(uint32_t p_layer) {
+	body->set_collision_layer(p_layer);
+}
+
+uint32_t GodotPhysicsDirectBodyState3D::get_collision_layer() const {
+	return body->get_collision_layer();
+}
+
+void GodotPhysicsDirectBodyState3D::set_collision_mask(uint32_t p_mask) {
+	body->set_collision_mask(p_mask);
+}
+
+uint32_t GodotPhysicsDirectBodyState3D::get_collision_mask() const {
+	return body->get_collision_mask();
+}
+
 int GodotPhysicsDirectBodyState3D::get_contact_count() const {
 	return body->contact_count;
 }

--- a/modules/godot_physics_3d/godot_body_direct_state_3d.h
+++ b/modules/godot_physics_3d/godot_body_direct_state_3d.h
@@ -84,6 +84,12 @@ public:
 	virtual void set_sleep_state(bool p_sleep) override;
 	virtual bool is_sleeping() const override;
 
+	virtual void set_collision_layer(uint32_t p_layer) override;
+	virtual uint32_t get_collision_layer() const override;
+
+	virtual void set_collision_mask(uint32_t p_mask) override;
+	virtual uint32_t get_collision_mask() const override;
+
 	virtual int get_contact_count() const override;
 
 	virtual Vector3 get_contact_local_position(int p_contact_idx) const override;

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.cpp
@@ -162,6 +162,22 @@ void JoltPhysicsDirectBodyState3D::set_sleep_state(bool p_enabled) {
 	body->set_is_sleeping(p_enabled);
 }
 
+void JoltPhysicsDirectBodyState3D::set_collision_layer(uint32_t p_layer) {
+	body->set_collision_layer(p_layer);
+}
+
+uint32_t JoltPhysicsDirectBodyState3D::get_collision_layer() const {
+	return body->get_collision_layer();
+}
+
+void JoltPhysicsDirectBodyState3D::set_collision_mask(uint32_t p_mask) {
+	body->set_collision_mask(p_mask);
+}
+
+uint32_t JoltPhysicsDirectBodyState3D::get_collision_mask() const {
+	return body->get_collision_mask();
+}
+
 int JoltPhysicsDirectBodyState3D::get_contact_count() const {
 	return body->get_contact_count();
 }

--- a/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.h
+++ b/modules/jolt_physics/objects/jolt_physics_direct_body_state_3d.h
@@ -90,6 +90,12 @@ public:
 	virtual void set_sleep_state(bool p_enabled) override;
 	virtual bool is_sleeping() const override;
 
+	virtual void set_collision_layer(uint32_t p_layer) override;
+	virtual uint32_t get_collision_layer() const override;
+
+	virtual void set_collision_mask(uint32_t p_mask) override;
+	virtual uint32_t get_collision_mask() const override;
+
 	virtual int get_contact_count() const override;
 
 	virtual Vector3 get_contact_local_position(int p_contact_idx) const override;

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -30,6 +30,10 @@
 
 #include "character_body_2d.h"
 
+#ifndef DISABLE_DEPRECATED
+#include "servers/extensions/physics_server_2d_extension.h"
+#endif
+
 // So, if you pass 45 as limit, avoid numerical precision errors when angle is 45.
 #define FLOOR_ANGLE_THRESHOLD 0.01
 
@@ -416,10 +420,25 @@ void CharacterBody2D::_set_collision_direction(const PhysicsServer2D::MotionResu
 }
 
 void CharacterBody2D::_set_platform_data(const PhysicsServer2D::MotionResult &p_result) {
+	PhysicsDirectBodyState2D *bs = PhysicsServer2D::get_singleton()->body_get_direct_state(p_result.collider);
+	if (bs == nullptr) {
+		return;
+	}
+
 	platform_rid = p_result.collider;
 	platform_object_id = p_result.collider_id;
 	platform_velocity = p_result.collider_velocity;
-	platform_layer = PhysicsServer2D::get_singleton()->body_get_collision_layer(platform_rid);
+
+#ifndef DISABLE_DEPRECATED
+	// Try to accommodate for any physics extensions that have yet to implement `PhysicsDirectBodyState2D::get_collision_layer`.
+	PhysicsDirectBodyState2DExtension *bs_ext = Object::cast_to<PhysicsDirectBodyState2DExtension>(bs);
+	if (bs_ext != nullptr && !GDVIRTUAL_IS_OVERRIDDEN_PTR(bs_ext, _get_collision_layer)) {
+		platform_layer = PhysicsServer2D::get_singleton()->body_get_collision_layer(p_result.collider);
+	} else
+#endif
+	{
+		platform_layer = bs->get_collision_layer();
+	}
 }
 
 const Vector2 &CharacterBody2D::get_velocity() const {

--- a/servers/extensions/physics_server_2d_extension.cpp
+++ b/servers/extensions/physics_server_2d_extension.cpp
@@ -92,6 +92,12 @@ void PhysicsDirectBodyState2DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_set_sleep_state, "enabled");
 	GDVIRTUAL_BIND(_is_sleeping);
 
+	GDVIRTUAL_BIND(_set_collision_layer, "layer");
+	GDVIRTUAL_BIND(_get_collision_layer);
+
+	GDVIRTUAL_BIND(_set_collision_mask, "mask");
+	GDVIRTUAL_BIND(_get_collision_mask);
+
 	GDVIRTUAL_BIND(_get_contact_count);
 
 	GDVIRTUAL_BIND(_get_contact_local_position, "contact_idx");

--- a/servers/extensions/physics_server_2d_extension.h
+++ b/servers/extensions/physics_server_2d_extension.h
@@ -86,6 +86,12 @@ public:
 	EXBIND1(set_sleep_state, bool)
 	EXBIND0RC(bool, is_sleeping)
 
+	EXBIND1(set_collision_layer, uint32_t);
+	EXBIND0RC(uint32_t, get_collision_layer);
+
+	EXBIND1(set_collision_mask, uint32_t);
+	EXBIND0RC(uint32_t, get_collision_mask);
+
 	EXBIND0RC(int, get_contact_count)
 
 	EXBIND1RC(Vector2, get_contact_local_position, int)

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -96,6 +96,12 @@ void PhysicsDirectBodyState3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_set_sleep_state, "enabled");
 	GDVIRTUAL_BIND(_is_sleeping);
 
+	GDVIRTUAL_BIND(_set_collision_layer, "layer");
+	GDVIRTUAL_BIND(_get_collision_layer);
+
+	GDVIRTUAL_BIND(_set_collision_mask, "mask");
+	GDVIRTUAL_BIND(_get_collision_mask);
+
 	GDVIRTUAL_BIND(_get_contact_count);
 
 	GDVIRTUAL_BIND(_get_contact_local_position, "contact_idx");

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -88,6 +88,12 @@ public:
 	EXBIND1(set_sleep_state, bool)
 	EXBIND0RC(bool, is_sleeping)
 
+	EXBIND1(set_collision_layer, uint32_t);
+	EXBIND0RC(uint32_t, get_collision_layer);
+
+	EXBIND1(set_collision_mask, uint32_t);
+	EXBIND0RC(uint32_t, get_collision_mask);
+
 	EXBIND0RC(int, get_contact_count)
 
 	EXBIND1RC(Vector3, get_contact_local_position, int)

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -114,6 +114,12 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sleep_state", "enabled"), &PhysicsDirectBodyState2D::set_sleep_state);
 	ClassDB::bind_method(D_METHOD("is_sleeping"), &PhysicsDirectBodyState2D::is_sleeping);
 
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &PhysicsDirectBodyState2D::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("get_collision_layer"), &PhysicsDirectBodyState2D::get_collision_layer);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &PhysicsDirectBodyState2D::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &PhysicsDirectBodyState2D::get_collision_mask);
+
 	ClassDB::bind_method(D_METHOD("get_contact_count"), &PhysicsDirectBodyState2D::get_contact_count);
 
 	ClassDB::bind_method(D_METHOD("get_contact_local_position", "contact_idx"), &PhysicsDirectBodyState2D::get_contact_local_position);
@@ -142,6 +148,8 @@ void PhysicsDirectBodyState2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_velocity"), "set_angular_velocity", "get_angular_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "linear_velocity"), "set_linear_velocity", "get_linear_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sleeping"), "set_sleep_state", "is_sleeping");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer"), "set_collision_layer", "get_collision_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask"), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM2D, "transform"), "set_transform", "get_transform");
 }
 

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -88,6 +88,12 @@ public:
 	virtual void set_sleep_state(bool p_enable) = 0;
 	virtual bool is_sleeping() const = 0;
 
+	virtual void set_collision_layer(uint32_t p_layer) = 0;
+	virtual uint32_t get_collision_layer() const = 0;
+
+	virtual void set_collision_mask(uint32_t p_mask) = 0;
+	virtual uint32_t get_collision_mask() const = 0;
+
 	virtual int get_contact_count() const = 0;
 
 	virtual Vector2 get_contact_local_position(int p_contact_idx) const = 0;

--- a/servers/physics_server_2d_dummy.h
+++ b/servers/physics_server_2d_dummy.h
@@ -79,6 +79,12 @@ public:
 	virtual void set_sleep_state(bool p_enable) override {}
 	virtual bool is_sleeping() const override { return false; }
 
+	virtual void set_collision_layer(uint32_t p_layer) override {}
+	virtual uint32_t get_collision_layer() const override { return 0; }
+
+	virtual void set_collision_mask(uint32_t p_mask) override {}
+	virtual uint32_t get_collision_mask() const override { return 0; }
+
 	virtual int get_contact_count() const override { return 0; }
 
 	virtual Vector2 get_contact_local_position(int p_contact_idx) const override { return Vector2(); }

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -138,6 +138,12 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sleep_state", "enabled"), &PhysicsDirectBodyState3D::set_sleep_state);
 	ClassDB::bind_method(D_METHOD("is_sleeping"), &PhysicsDirectBodyState3D::is_sleeping);
 
+	ClassDB::bind_method(D_METHOD("set_collision_layer", "layer"), &PhysicsDirectBodyState3D::set_collision_layer);
+	ClassDB::bind_method(D_METHOD("get_collision_layer"), &PhysicsDirectBodyState3D::get_collision_layer);
+
+	ClassDB::bind_method(D_METHOD("set_collision_mask", "mask"), &PhysicsDirectBodyState3D::set_collision_mask);
+	ClassDB::bind_method(D_METHOD("get_collision_mask"), &PhysicsDirectBodyState3D::get_collision_mask);
+
 	ClassDB::bind_method(D_METHOD("get_contact_count"), &PhysicsDirectBodyState3D::get_contact_count);
 
 	ClassDB::bind_method(D_METHOD("get_contact_local_position", "contact_idx"), &PhysicsDirectBodyState3D::get_contact_local_position);
@@ -168,6 +174,8 @@ void PhysicsDirectBodyState3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "angular_velocity"), "set_angular_velocity", "get_angular_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "linear_velocity"), "set_linear_velocity", "get_linear_velocity");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "sleeping"), "set_sleep_state", "is_sleeping");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer"), "set_collision_layer", "get_collision_layer");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask"), "set_collision_mask", "get_collision_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::TRANSFORM3D, "transform"), "set_transform", "get_transform");
 }
 

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -91,6 +91,12 @@ public:
 	virtual void set_sleep_state(bool p_sleep) = 0;
 	virtual bool is_sleeping() const = 0;
 
+	virtual void set_collision_layer(uint32_t p_layer) = 0;
+	virtual uint32_t get_collision_layer() const = 0;
+
+	virtual void set_collision_mask(uint32_t p_mask) = 0;
+	virtual uint32_t get_collision_mask() const = 0;
+
 	virtual int get_contact_count() const = 0;
 
 	virtual Vector3 get_contact_local_position(int p_contact_idx) const = 0;

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -81,6 +81,12 @@ public:
 	virtual void set_sleep_state(bool p_sleep) override {}
 	virtual bool is_sleeping() const override { return false; }
 
+	virtual void set_collision_layer(uint32_t p_layer) override {}
+	virtual uint32_t get_collision_layer() const override { return 0; }
+
+	virtual void set_collision_mask(uint32_t p_mask) override {}
+	virtual uint32_t get_collision_mask() const override { return 0; }
+
 	virtual int get_contact_count() const override { return 0; }
 
 	virtual Vector3 get_contact_local_position(int p_contact_idx) const override { return Vector3(); }


### PR DESCRIPTION
Fixes #94205.

This fixes the physics thread synchronization (when using `physics/*d/run_on_separate_thread`) that ends up happening in `move_and_slide` whenever we collide with something, which happens due to physics server getters (like `body_get_collision_layer` in this case) being forced to wait for the result from the physics thread.

Now instead we expose the collision layer (and mask) through `PhysicsDirectBodyState*D` and access it directly without any thread synchronization, which should be safe to do during physics processing once #109591 is merged.

Note that #109591 is not necessarily a must-have for this, but more of a nice-to-have, as we're already using `PhysicsDirectBodyState*D` in other places in `move_and_slide`, that expose us to worse race conditions than this.