### PR TITLE
Add `XR_META_hand_tracking_microgestures` action paths

### DIFF
--- a/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_interaction_extension.cpp
@@ -33,6 +33,8 @@
 #include "../action_map/openxr_interaction_profile_metadata.h"
 #include "core/config/project_settings.h"
 
+#include <openxr/openxr.h>
+
 OpenXRHandInteractionExtension *OpenXRHandInteractionExtension::singleton = nullptr;
 
 OpenXRHandInteractionExtension *OpenXRHandInteractionExtension::get_singleton() {
@@ -54,6 +56,7 @@ HashMap<String, bool *> OpenXRHandInteractionExtension::get_requested_extensions
 	// We still register our meta data or the action map editor will fail.
 	if (GLOBAL_GET("xr/openxr/extensions/hand_interaction_profile")) {
 		request_extensions[XR_EXT_HAND_INTERACTION_EXTENSION_NAME] = &available;
+		request_extensions[XR_META_HAND_TRACKING_MICROGESTURES_EXTENSION_NAME] = &available;
 	}
 
 	return request_extensions;
@@ -67,31 +70,30 @@ void OpenXRHandInteractionExtension::on_register_metadata() {
 	OpenXRInteractionProfileMetadata *openxr_metadata = OpenXRInteractionProfileMetadata::get_singleton();
 	ERR_FAIL_NULL(openxr_metadata);
 
-	// Hand interaction profile
-	openxr_metadata->register_interaction_profile("Hand interaction", "/interaction_profiles/ext/hand_interaction_ext", XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Grip pose", "/user/hand/left", "/user/hand/left/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Grip pose", "/user/hand/right", "/user/hand/right/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Aim pose", "/user/hand/left", "/user/hand/left/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Aim pose", "/user/hand/right", "/user/hand/right/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Pinch pose", "/user/hand/left", "/user/hand/left/input/pinch_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Pinch pose", "/user/hand/right", "/user/hand/right/input/pinch_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Poke pose", "/user/hand/left", "/user/hand/left/input/poke_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Poke pose", "/user/hand/right", "/user/hand/right/input/poke_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Palm pose", "/user/hand/left", "/user/hand/left/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Palm pose", "/user/hand/right", "/user/hand/right/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
+	// Hand interaction profile.
+	const String profile_path = "/interaction_profiles/ext/hand_interaction_ext";
+	openxr_metadata->register_interaction_profile("Hand interaction", profile_path, XR_EXT_HAND_INTERACTION_EXTENSION_NAME);
+	for (const String user_path : { "/user/hand/left", "/user/hand/right" }) {
+		openxr_metadata->register_io_path(profile_path, "Grip pose", user_path, user_path + "/input/grip/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+		openxr_metadata->register_io_path(profile_path, "Aim pose", user_path, user_path + "/input/aim/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+		openxr_metadata->register_io_path(profile_path, "Pinch pose", user_path, user_path + "/input/pinch_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+		openxr_metadata->register_io_path(profile_path, "Poke pose", user_path, user_path + "/input/poke_ext/pose", "", OpenXRAction::OPENXR_ACTION_POSE);
+		openxr_metadata->register_io_path(profile_path, "Palm pose", user_path, user_path + "/input/palm_ext/pose", XR_EXT_PALM_POSE_EXTENSION_NAME, OpenXRAction::OPENXR_ACTION_POSE);
 
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Pinch", "/user/hand/left", "/user/hand/left/input/pinch_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Pinch", "/user/hand/right", "/user/hand/right/input/pinch_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Pinch ready", "/user/hand/left", "/user/hand/left/input/pinch_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Pinch ready", "/user/hand/right", "/user/hand/right/input/pinch_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Pinch", user_path, user_path + "/input/pinch_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+		openxr_metadata->register_io_path(profile_path, "Pinch ready", user_path, user_path + "/input/pinch_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Aim activate", "/user/hand/left", "/user/hand/left/input/aim_activate_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Aim activate", "/user/hand/right", "/user/hand/right/input/aim_activate_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Aim activate ready", "/user/hand/left", "/user/hand/left/input/aim_activate_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Aim activate ready", "/user/hand/right", "/user/hand/right/input/aim_activate_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Aim activate", user_path, user_path + "/input/aim_activate_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+		openxr_metadata->register_io_path(profile_path, "Aim activate ready", user_path, user_path + "/input/aim_activate_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
 
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Grasp", "/user/hand/left", "/user/hand/left/input/grasp_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Grasp", "/user/hand/right", "/user/hand/right/input/grasp_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Grasp ready", "/user/hand/left", "/user/hand/left/input/grasp_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
-	openxr_metadata->register_io_path("/interaction_profiles/ext/hand_interaction_ext", "Grasp ready", "/user/hand/right", "/user/hand/right/input/grasp_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Grasp", user_path, user_path + "/input/grasp_ext/value", "", OpenXRAction::OPENXR_ACTION_FLOAT);
+		openxr_metadata->register_io_path(profile_path, "Grasp ready", user_path, user_path + "/input/grasp_ext/ready_ext", "", OpenXRAction::OPENXR_ACTION_BOOL);
+
+		// Hand tracking microgestures.
+		openxr_metadata->register_io_path(profile_path, "Swipe left", user_path, user_path + "/input/swipe_left_meta/click", "XR_META_hand_tracking_microgestures", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Swipe right", user_path, user_path + "/input/swipe_right_meta/click", "XR_META_hand_tracking_microgestures", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Swipe forward", user_path, user_path + "/input/swipe_forward_meta/click", "XR_META_hand_tracking_microgestures", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Swipe backward", user_path, user_path + "/input/swipe_backward_meta/click", "XR_META_hand_tracking_microgestures", OpenXRAction::OPENXR_ACTION_BOOL);
+		openxr_metadata->register_io_path(profile_path, "Tap thumb", user_path, user_path + "/input/tap_thumb_meta/click", "XR_META_hand_tracking_microgestures", OpenXRAction::OPENXR_ACTION_BOOL);
+	}
 }


### PR DESCRIPTION
Adds the action paths provided in the [XR_META_hand_tracking_microgestures](https://registry.khronos.org/OpenXR/specs/1.1/html/xrspec.html#XR_META_hand_tracking_microgestures) OpenXR extension, which allows for the detection of thumb swiping/tapping movements.

These action paths are a further extension on top of the hand interaction profile, so I've gated this extension behind the hand interaction profile project setting.