### PR TITLE
Don't use `alloca()` in `Object::emit_signalp()` to prevent stack overflow

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1212,8 +1212,13 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 		return ERR_CANT_ACQUIRE_RESOURCE; //no emit, signals blocked
 	}
 
-	Callable *slot_callables = nullptr;
-	uint32_t *slot_flags = nullptr;
+	constexpr int MAX_SLOTS_ON_STACK = 5;
+	// Don't default initialize the Callable objects on the stack, just reserve the space - we'll memnew_placement() them later.
+	alignas(Callable) uint8_t slot_callable_stack[sizeof(Callable) * MAX_SLOTS_ON_STACK];
+	uint32_t slot_flags_stack[MAX_SLOTS_ON_STACK];
+
+	Callable *slot_callables = (Callable *)slot_callable_stack;
+	uint32_t *slot_flags = slot_flags_stack;
 	uint32_t slot_count = 0;
 
 	{
@@ -1234,11 +1239,13 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 		// which is needed in certain edge cases; e.g., https://github.com/godotengine/godot/issues/73889.
 		Ref<RefCounted> rc = Ref<RefCounted>(Object::cast_to<RefCounted>(this));
 
+		if (s->slot_map.size() > MAX_SLOTS_ON_STACK) {
+			slot_callables = (Callable *)memalloc(sizeof(Callable) * s->slot_map.size());
+			slot_flags = (uint32_t *)memalloc(sizeof(uint32_t) * s->slot_map.size());
+		}
+
 		// Ensure that disconnecting the signal or even deleting the object
 		// will not affect the signal calling.
-		slot_callables = (Callable *)alloca(sizeof(Callable) * s->slot_map.size());
-		slot_flags = (uint32_t *)alloca(sizeof(uint32_t) * s->slot_map.size());
-
 		for (const KeyValue<Callable, SignalData::Slot> &slot_kv : s->slot_map) {
 			memnew_placement(&slot_callables[slot_count], Callable(slot_kv.value.conn.callable));
 			slot_flags[slot_count] = slot_kv.value.conn.flags;
@@ -1306,6 +1313,11 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 
 	for (uint32_t i = 0; i < slot_count; ++i) {
 		slot_callables[i].~Callable();
+	}
+
+	if (slot_callables != (Callable *)slot_callable_stack) {
+		memfree(slot_callables);
+		memfree(slot_flags);
 	}
 
 	return err;


### PR DESCRIPTION
This fixes the core part of https://github.com/godotengine/godot/issues/109464

We should still investigate _why_ we end up with a signal with 1000s of connections, and fix that too. But since we don't enforce any limit on the number of connections, we shouldn't leave this trap in core that could allow developers to overflow the stack.

Per our discussion at the last core team meeting, I've removed `alloca()` entirely, and always reserve space on the stack for 5 items. I don't know if this is the optimal number of items - it would be very interesting to gather some data from the Godot editor, and see the mean and median number of connections. However, as you'll see in the benchmarks below, there is so little difference with this PR for a "normal" number of items, that 5 may be OK?

## Benchmarks

I used this GDScript:

<details>
<summary>main.gd</summary>

```gdscript
extends Node2D

var emission_count := 0

signal my_test_signal()

func connect_to_signal_x_times(p_x: int) -> void:
	# First, remove all existing connections.
	var old_conns := my_test_signal.get_connections()
	for conn in old_conns:
		my_test_signal.disconnect(conn['callable'])

	# Now connect X times.
	for i in p_x:
		# This ensures it's a unique Callable each time.
		var cb = func(_a: int):
			emission_count += 1
		my_test_signal.connect(cb.bind(i))

	# Make sure we actually have as many connections as we asked for.
	var new_conns := my_test_signal.get_connections()
	assert(new_conns.size() == p_x)

func do_test(p_x: int) -> void:
	connect_to_signal_x_times(p_x)
	emission_count = 0

	var start_time := Time.get_ticks_usec()
	my_test_signal.emit()
	var duration: float = Time.get_ticks_usec() - start_time

	# Make sure it actually emitted the desired number of times.
	assert(emission_count == p_x)

	print("With ", p_x, " connection(s), emission took ", duration / 1000.0, " ms")

func _ready() -> void:
	do_test(1)
	do_test(2)
	do_test(3)
	do_test(4)
	do_test(5)
	do_test(6)
	do_test(7)
	do_test(8)
	do_test(9)
	do_test(10)
	do_test(25)
	do_test(50)
	do_test(75)
	do_test(100)
	do_test(1000)
	do_test(10000)
	do_test(100000)
```
</details>

I ran the script 3-5 times to ensure that the numbers it gave were about the same each time, and then just took the numbers from the last run that I did.

### No optimizations (`scons dev_build=yes optimize=none lto=none`)

**Before PR (de463e0):**

```
With 1 connection(s), emission took 0.003 ms
With 2 connection(s), emission took 0.002 ms
With 3 connection(s), emission took 0.002 ms
With 4 connection(s), emission took 0.003 ms
With 5 connection(s), emission took 0.003 ms
With 6 connection(s), emission took 0.004 ms
With 7 connection(s), emission took 0.005 ms
With 8 connection(s), emission took 0.006 ms
With 9 connection(s), emission took 0.005 ms
With 10 connection(s), emission took 0.007 ms
With 25 connection(s), emission took 0.014 ms
With 50 connection(s), emission took 0.027 ms
With 75 connection(s), emission took 0.039 ms
With 100 connection(s), emission took 0.051 ms
With 1000 connection(s), emission took 0.521 ms
With 10000 connection(s), emission took 5.517 ms
With 100000 connection(s), emission took 58.14 ms
```

**After PR:**

```
With 1 connection(s), emission took 0.003 ms
With 2 connection(s), emission took 0.002 ms
With 3 connection(s), emission took 0.004 ms
With 4 connection(s), emission took 0.003 ms
With 5 connection(s), emission took 0.004 ms
With 6 connection(s), emission took 0.004 ms
With 7 connection(s), emission took 0.005 ms
With 8 connection(s), emission took 0.005 ms
With 9 connection(s), emission took 0.006 ms
With 10 connection(s), emission took 0.007 ms
With 25 connection(s), emission took 0.015 ms
With 50 connection(s), emission took 0.028 ms
With 75 connection(s), emission took 0.05 ms
With 100 connection(s), emission took 0.065 ms
With 1000 connection(s), emission took 0.653 ms
With 10000 connection(s), emission took 5.62 ms
With 100000 connection(s), emission took 87.998 ms
```

### With optimizations (`scons production=yes`)

**Before PR (de463e0):**

```
With 1 connection(s), emission took 0.002 ms
With 2 connection(s), emission took 0.001 ms
With 3 connection(s), emission took 0.0 ms
With 4 connection(s), emission took 0.001 ms
With 5 connection(s), emission took 0.0 ms
With 6 connection(s), emission took 0.001 ms
With 7 connection(s), emission took 0.0 ms
With 8 connection(s), emission took 0.0 ms
With 9 connection(s), emission took 0.001 ms
With 10 connection(s), emission took 0.001 ms
With 25 connection(s), emission took 0.002 ms
With 50 connection(s), emission took 0.004 ms
With 75 connection(s), emission took 0.006 ms
With 100 connection(s), emission took 0.007 ms
With 1000 connection(s), emission took 0.077 ms
With 10000 connection(s), emission took 0.887 ms
With 100000 connection(s), emission took 12.948 ms
```

**After PR:**

```
With 1 connection(s), emission took 0.001 ms
With 2 connection(s), emission took 0.001 ms
With 3 connection(s), emission took 0.0 ms
With 4 connection(s), emission took 0.001 ms
With 5 connection(s), emission took 0.001 ms
With 6 connection(s), emission took 0.001 ms
With 7 connection(s), emission took 0.001 ms
With 8 connection(s), emission took 0.001 ms
With 9 connection(s), emission took 0.001 ms
With 10 connection(s), emission took 0.001 ms
With 25 connection(s), emission took 0.002 ms
With 50 connection(s), emission took 0.004 ms
With 75 connection(s), emission took 0.014 ms
With 100 connection(s), emission took 0.019 ms
With 1000 connection(s), emission took 0.149 ms
With 10000 connection(s), emission took 0.958 ms
With 100000 connection(s), emission took 42.72 ms
```

### Conclusions

With unoptimized builds, there's no real performance difference until 100k connections.

With the optimized builds, there is a performance difference starting around 75 connections, where it takes about 2x the time. However, 10k connections seems to be only slightly slower (this is reproducible across all the runs I did), and it's only really drastically slower starting at 100k connections.
