### PR TITLE
Strip empty deps when loading filesystem cache

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -465,7 +465,7 @@ void EditorFileSystem::_scan_filesystem() {
 						fc.import_md5 = slices[5];
 						fc.import_dest_paths = slices[6].split("<*>");
 					}
-					fc.deps = split[8].strip_edges().split("<>");
+					fc.deps = split[8].strip_edges().split("<>", false);
 
 					file_cache[name] = fc;
 				}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109526

Not sure whether this line should receive the same treatment (unrelated to issue above)
https://github.com/godotengine/godot/blob/de463e0241b0b846fdd3ff76ad12fe6fcf62a9e5/editor/file_system/editor_file_system.cpp#L466
