### PR TITLE
Implement alternative transparency sorting modes

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -210,6 +210,12 @@
 		<member name="size" type="float" setter="set_size" getter="get_size" default="1.0">
 			The camera's size in meters measured as the diameter of the width or height, depending on [member keep_aspect]. Only applicable in orthogonal and frustum modes.
 		</member>
+		<member name="transparency_sort_axis" type="Vector3" setter="set_transparency_sort_axis" getter="get_transparency_sort_axis" default="Vector3(0, 0, 1)">
+			The axis used when [member transparency_sort_mode] is set to [constant RenderingServer.TRANSPARENCY_SORT_CUSTOM_AXIS].
+		</member>
+		<member name="transparency_sort_mode" type="int" setter="set_transparency_sort_mode" getter="get_transparency_sort_mode" enum="RenderingServer.TransparencySortMode" default="0">
+			The mode this camera uses to sort transparent meshes. See [enum RenderingServer.TransparencySortMode] for possible values.
+		</member>
 		<member name="v_offset" type="float" setter="set_v_offset" getter="get_v_offset" default="0.0">
 			The vertical (Y) offset of the camera viewport.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2776,6 +2776,17 @@
 		<member name="rendering/camera/depth_of_field/depth_of_field_use_jitter" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], jitters DOF samples to make effect slightly blurrier and hide lines created from low sample rates. This can result in a slightly grainy appearance when used with a low number of samples.
 		</member>
+		<member name="rendering/camera/transparency_sort/default_transparency_sort_axis" type="Vector3" setter="" getter="" default="Vector3(0, 0, 1)">
+			Sets the axis used when [member rendering/camera/transparency_sort/default_transparency_sort_mode] is set to [b]CustomAxis[/b].
+			[b]Note:[/b] This property is only read when the project starts. To control the default transparency sorting axis at runtime, call [method RenderingServer.set_default_transparency_sort_axis] instead.
+		</member>
+		<member name="rendering/camera/transparency_sort/default_transparency_sort_mode" type="int" setter="" getter="" default="1">
+			Sets the default mode used to sort transparent meshes on [Camera3D] nodes whose [member Camera3D.transparency_sort_mode] is set to [constant RenderingServer.TRANSPARENCY_SORT_DEFAULT].
+			- [code]Depth[/code]: Sort based on depth. Equivalent to [code]Orthogonal[/code] when camera projection is set to [constant Camera3D.PROJECTION_ORTHOGONAL].
+			- [code]Orthogonal[/code]: Sort based on distance to camera's near plane. Equivalent to [code]Depth[/code] when camera projection is set to [constant Camera3D.PROJECTION_ORTHOGONAL].
+			- [code]CustomAxis[/code]: Sort based on a dot product of the mesh's position and [member rendering/camera/transparency_sort/default_transparency_sort_axis]. For example, when set to the value [code]Vector3(0, 0, 1)[/code] meshes are sorted based on their position on the Z-axis regardless of camera orientation.
+			[b]Note:[/b] This property is only read when the project starts. To control the default transparency sorting mode at runtime, call [method RenderingServer.set_default_transparency_sort_mode] instead.
+		</member>
 		<member name="rendering/driver/depth_prepass/disable_for_vendors" type="String" setter="" getter="" default="&quot;PowerVR,Mali,Adreno,Apple&quot;">
 			Disables [member rendering/driver/depth_prepass/enable] conditionally for certain vendors. By default, disables the depth prepass for mobile devices as mobile devices do not benefit from the depth prepass due to their unique architecture.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -181,6 +181,23 @@
 				Sets [Transform3D] of camera.
 			</description>
 		</method>
+		<method name="camera_set_transparency_sort_axis">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="axis" type="Vector3" />
+			<description>
+				Sets the axis used when transparency sorting mode is set to [constant TRANSPARENCY_SORT_CUSTOM_AXIS]. Equivalent to [member Camera3D.transparency_sort_axis].
+				[b]Note:[/b] The axis set by this function is not used when transparency sorting mode is set to [constant TRANSPARENCY_SORT_DEFAULT]. To change the default axis, see [method set_default_transparency_sort_axis].
+			</description>
+		</method>
+		<method name="camera_set_transparency_sort_mode">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="mode" type="int" enum="RenderingServer.TransparencySortMode" />
+			<description>
+				Sets the mode the camera uses to sort transparent meshes. Equivalent to [member Camera3D.transparency_sort_mode].
+			</description>
+		</method>
 		<method name="camera_set_use_vertical_aspect">
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />
@@ -3443,6 +3460,21 @@
 				Sets the default clear color which is used when a specific clear color has not been selected. See also [method get_default_clear_color].
 			</description>
 		</method>
+		<method name="set_default_transparency_sort_axis">
+			<return type="void" />
+			<param index="0" name="axis" type="Vector3" />
+			<description>
+				Sets the axis used when the default transparency sorting mode is set to [constant TRANSPARENCY_SORT_CUSTOM_AXIS]. Runtime equivalent to [member ProjectSettings.rendering/camera/transparency_sort/default_transparency_sort_axis].
+			</description>
+		</method>
+		<method name="set_default_transparency_sort_mode">
+			<return type="void" />
+			<param index="0" name="mode" type="int" enum="RenderingServer.TransparencySortMode" />
+			<description>
+				Sets the mode used to sort transparent meshes for cameras that use [constant TRANSPARENCY_SORT_DEFAULT]. To change camera's mode, see [method camera_set_transparency_sort_mode] and [member Camera3D.transparency_sort_mode]. Runtime equivalent to [member ProjectSettings.rendering/camera/transparency_sort/default_transparency_sort_mode].
+				[b]Note:[/b] Setting the default mode to [constant TRANSPARENCY_SORT_DEFAULT] is equivalent to setting it to [constant TRANSPARENCY_SORT_DEPTH].
+			</description>
+		</method>
 		<method name="shader_create">
 			<return type="RID" />
 			<description>
@@ -5044,6 +5076,18 @@
 		</constant>
 		<constant name="FOG_VOLUME_SHAPE_MAX" value="5" enum="FogVolumeShape">
 			Represents the size of the [enum FogVolumeShape] enum.
+		</constant>
+		<constant name="TRANSPARENCY_SORT_DEFAULT" value="0" enum="TransparencySortMode">
+			Transparent meshes are sorted by the default mode. If unchanged, the default mode is [constant TRANSPARENCY_SORT_DEPTH]. To change the default mode to other value, see [method set_default_transparency_sort_mode] and [member ProjectSettings.rendering/camera/transparency_sort/default_transparency_sort_mode].
+		</constant>
+		<constant name="TRANSPARENCY_SORT_DEPTH" value="1" enum="TransparencySortMode">
+			Transparent meshes are sorted based on their depth. Equivalent to [constant TRANSPARENCY_SORT_ORTHOGONAL] when camera projection is set to [constant Camera3D.PROJECTION_ORTHOGONAL].
+		</constant>
+		<constant name="TRANSPARENCY_SORT_ORTHOGONAL" value="2" enum="TransparencySortMode">
+			Transparent meshes are sorted based on their distance to camera's near plane. Equivalent to [constant TRANSPARENCY_SORT_DEPTH] when camera projection is set to [constant Camera3D.PROJECTION_ORTHOGONAL].
+		</constant>
+		<constant name="TRANSPARENCY_SORT_CUSTOM_AXIS" value="3" enum="TransparencySortMode">
+			Transparent meshes are sorted based on a dot product of their position and a custom axis. For example, when the axis is set to the value [code]Vector3(0, 0, 1)[/code] meshes are sorted based on their position on the Z-axis regardless of camera orientation. To change the axis, see [method camera_set_transparency_sort_axis], [method set_default_transparency_sort_axis], and [member ProjectSettings.rendering/camera/transparency_sort/default_transparency_sort_axis].
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_BILINEAR" value="0" enum="ViewportScaling3DMode">
 			Use bilinear scaling for the viewport's 3D buffer. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less than [code]1.0[/code] will result in undersampling while values greater than [code]1.0[/code] will result in supersampling. A value of [code]1.0[/code] disables scaling.

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -67,8 +67,9 @@
 			The amount by which the depth of this [VisualInstance3D] will be adjusted when sorting by depth. Uses the same units as the engine (which are typically meters). Adjusting it to a higher value will make the [VisualInstance3D] reliably draw on top of other [VisualInstance3D]s that are otherwise positioned at the same spot. To ensure it always draws on top of other objects around it (not positioned at the same spot), set the value to be greater than the distance between this [VisualInstance3D] and the other nearby [VisualInstance3D]s.
 		</member>
 		<member name="sorting_use_aabb_center" type="bool" setter="set_sorting_use_aabb_center" getter="is_sorting_use_aabb_center">
-			If [code]true[/code], the object is sorted based on the [AABB] center. The object will be sorted based on the global position otherwise.
-			The [AABB] center based sorting is generally more accurate for 3D models. The position based sorting instead allows to better control the drawing order when working with [GPUParticles3D] and [CPUParticles3D].
+			If [code]true[/code], the object is sorted based on the [AABB]. The object will be sorted based on the global position otherwise.
+			The [AABB] based sorting is generally more accurate for 3D models. The position based sorting instead allows to better control the drawing order when working with [GPUParticles3D] and [CPUParticles3D].
+			[b]Note:[/b] Despite the name, [AABB]'s center is only used when camera's projection is set to [constant Camera3D.PROJECTION_PERSPECTIVE] or [constant Camera3D.PROJECTION_FRUSTUM], and its sorting method is set to [constant RenderingServer.TRANSPARENCY_SORT_DEPTH]. Otherwise [AABB]'s support is used. See [method AABB.get_support].
 		</member>
 	</members>
 </class>

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -143,6 +143,9 @@ struct RenderDataGLES3 {
 	/* Shadow data */
 	const RendererSceneRender::RenderShadowData *render_shadows = nullptr;
 	int render_shadow_count = 0;
+
+	RS::TransparencySortMode transparency_sort_mode;
+	Vector3 transparency_sort_axis = Vector3(0, 0, 1);
 };
 
 class RasterizerCanvasGLES3;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -455,7 +455,10 @@ void EditorNode::_update_from_settings() {
 		TranslationServer::get_singleton()->set_fallback_locale(current_fallback_locale);
 		scene_root->propagate_notification(Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED);
 	}
-
+	Vector3 default_transparency_sort_axis = GLOBAL_GET("rendering/camera/transparency_sort/default_transparency_sort_axis");
+	RS::get_singleton()->set_default_transparency_sort_axis(default_transparency_sort_axis);
+	RS::TransparencySortMode default_transparency_sort_mode = RS::TransparencySortMode(int(GLOBAL_GET("rendering/camera/transparency_sort/default_transparency_sort_mode")));
+	RS::get_singleton()->set_default_transparency_sort_mode(default_transparency_sort_mode);
 	RS::DOFBokehShape dof_shape = RS::DOFBokehShape(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_shape")));
 	RS::get_singleton()->camera_attributes_set_dof_blur_bokeh_shape(dof_shape);
 	RS::DOFBlurQuality dof_quality = RS::DOFBlurQuality(int(GLOBAL_GET("rendering/camera/depth_of_field/depth_of_field_bokeh_quality")));

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -130,6 +130,10 @@ void Camera3D::_validate_property(PropertyInfo &p_property) const {
 			if (mode != PROJECTION_FRUSTUM) {
 				p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 			}
+		} else if (p_property.name == "transparency_sort_axis") {
+			if (transparency_sort_mode != RS::TRANSPARENCY_SORT_CUSTOM_AXIS) {
+				p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+			}
 		}
 	}
 
@@ -666,6 +670,10 @@ void Camera3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_cull_mask_value", "layer_number", "value"), &Camera3D::set_cull_mask_value);
 	ClassDB::bind_method(D_METHOD("get_cull_mask_value", "layer_number"), &Camera3D::get_cull_mask_value);
+	ClassDB::bind_method(D_METHOD("set_transparency_sort_mode", "mode"), &Camera3D::set_transparency_sort_mode);
+	ClassDB::bind_method(D_METHOD("get_transparency_sort_mode"), &Camera3D::get_transparency_sort_mode);
+	ClassDB::bind_method(D_METHOD("set_transparency_sort_axis", "axis"), &Camera3D::set_transparency_sort_axis);
+	ClassDB::bind_method(D_METHOD("get_transparency_sort_axis"), &Camera3D::get_transparency_sort_axis);
 
 	//ClassDB::bind_method(D_METHOD("_camera_make_current"),&Camera::_camera_make_current );
 
@@ -684,6 +692,8 @@ void Camera3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "frustum_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_frustum_offset", "get_frustum_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "near", PROPERTY_HINT_RANGE, "0.001,10,0.001,or_greater,exp,suffix:m"), "set_near", "get_near");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "far", PROPERTY_HINT_RANGE, "0.01,4000,0.01,or_greater,exp,suffix:m"), "set_far", "get_far");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "transparency_sort_mode", PROPERTY_HINT_ENUM, "Default,Depth,Orthogonal,CustomAxis"), "set_transparency_sort_mode", "get_transparency_sort_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "transparency_sort_axis", PROPERTY_HINT_NONE), "set_transparency_sort_axis", "get_transparency_sort_axis");
 
 	BIND_ENUM_CONSTANT(PROJECTION_PERSPECTIVE);
 	BIND_ENUM_CONSTANT(PROJECTION_ORTHOGONAL);
@@ -823,6 +833,27 @@ Vector3 Camera3D::get_doppler_tracked_velocity() const {
 	} else {
 		return Vector3();
 	}
+}
+
+void Camera3D::set_transparency_sort_mode(RS::TransparencySortMode p_mode) {
+	if (transparency_sort_mode != p_mode) {
+		transparency_sort_mode = p_mode;
+		notify_property_list_changed();
+		RS::get_singleton()->camera_set_transparency_sort_mode(camera, p_mode);
+	}
+}
+
+RS::TransparencySortMode Camera3D::get_transparency_sort_mode() const {
+	return transparency_sort_mode;
+}
+
+void Camera3D::set_transparency_sort_axis(const Vector3 &p_axis) {
+	transparency_sort_axis = p_axis;
+	RS::get_singleton()->camera_set_transparency_sort_axis(camera, p_axis);
+}
+
+Vector3 Camera3D::get_transparency_sort_axis() const {
+	return transparency_sort_axis;
 }
 
 #ifndef PHYSICS_3D_DISABLED

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -74,6 +74,8 @@ private:
 	real_t v_offset = 0.0;
 	real_t h_offset = 0.0;
 	KeepAspect keep_aspect = KEEP_HEIGHT;
+	RS::TransparencySortMode transparency_sort_mode = RS::TRANSPARENCY_SORT_DEFAULT;
+	Vector3 transparency_sort_axis = Vector3(0, 0, 1);
 
 	RID camera;
 	RID scenario_id;
@@ -205,6 +207,12 @@ public:
 	DopplerTracking get_doppler_tracking() const;
 
 	Vector3 get_doppler_tracked_velocity() const;
+
+	void set_transparency_sort_mode(RS::TransparencySortMode p_mode);
+	RS::TransparencySortMode get_transparency_sort_mode() const;
+
+	void set_transparency_sort_axis(const Vector3 &p_axis);
+	Vector3 get_transparency_sort_axis() const;
 
 #ifndef PHYSICS_3D_DISABLED
 	RID get_pyramid_shape_rid();

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -901,22 +901,22 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 		}
 	}
 
+	Plane sort_plane = near_plane; // Shared by orthogonal and custom axis. Depth uses camera position.
+	if (p_render_data->scene_data->transparency_sort_mode == RS::TRANSPARENCY_SORT_CUSTOM_AXIS) {
+		sort_plane.normal = -p_render_data->scene_data->transparency_sort_axis;
+	}
 	//fill list
 
 	for (int i = 0; i < (int)p_render_data->instances->size(); i++) {
 		GeometryInstanceForwardClustered *inst = static_cast<GeometryInstanceForwardClustered *>((*p_render_data->instances)[i]);
 
-		Vector3 center = inst->transform.origin;
-		if (p_render_data->scene_data->cam_orthogonal) {
-			if (inst->use_aabb_center) {
-				center = inst->transformed_aabb.get_support(-near_plane.normal);
-			}
-			inst->depth = near_plane.distance_to(center) - inst->sorting_offset;
-		} else {
-			if (inst->use_aabb_center) {
-				center = inst->transformed_aabb.position + (inst->transformed_aabb.size * 0.5);
-			}
+		if (p_render_data->scene_data->transparency_sort_mode == RS::TRANSPARENCY_SORT_DEPTH && !p_render_data->scene_data->cam_orthogonal) {
+			Vector3 center = inst->use_aabb_center ? inst->transformed_aabb.get_center() : inst->transform.origin;
 			inst->depth = p_render_data->scene_data->cam_transform.origin.distance_to(center) - inst->sorting_offset;
+		} else {
+			// Intentionally uses support despite the name for compatibility reasons.
+			Vector3 sort_position = inst->use_aabb_center ? inst->transformed_aabb.get_support(-sort_plane.normal) : inst->transform.origin;
+			inst->depth = sort_plane.distance_to(sort_position) - inst->sorting_offset;
 		}
 		uint32_t depth_layer = CLAMP(int(inst->depth * 16 / z_max), 0, 15);
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2015,22 +2015,22 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 		}
 	}
 
+	Plane sort_plane = near_plane; // Shared by orthogonal and custom axis. Depth uses camera position.
+	if (p_render_data->scene_data->transparency_sort_mode == RS::TRANSPARENCY_SORT_CUSTOM_AXIS) {
+		sort_plane.normal = -p_render_data->scene_data->transparency_sort_axis;
+	}
 	//fill list
 
 	for (int i = 0; i < (int)p_render_data->instances->size(); i++) {
 		GeometryInstanceForwardMobile *inst = static_cast<GeometryInstanceForwardMobile *>((*p_render_data->instances)[i]);
 
-		Vector3 center = inst->transform.origin;
-		if (p_render_data->scene_data->cam_orthogonal) {
-			if (inst->use_aabb_center) {
-				center = inst->transformed_aabb.get_support(-near_plane.normal);
-			}
-			inst->depth = near_plane.distance_to(center) - inst->sorting_offset;
-		} else {
-			if (inst->use_aabb_center) {
-				center = inst->transformed_aabb.position + (inst->transformed_aabb.size * 0.5);
-			}
+		if (p_render_data->scene_data->transparency_sort_mode == RS::TRANSPARENCY_SORT_DEPTH && !p_render_data->scene_data->cam_orthogonal) {
+			Vector3 center = inst->use_aabb_center ? inst->transformed_aabb.get_center() : inst->transform.origin;
 			inst->depth = p_render_data->scene_data->cam_transform.origin.distance_to(center) - inst->sorting_offset;
+		} else {
+			// Intentionally uses support despite the name for compatibility reasons.
+			Vector3 sort_position = inst->use_aabb_center ? inst->transformed_aabb.get_support(-sort_plane.normal) : inst->transform.origin;
+			inst->depth = sort_plane.distance_to(sort_position) - inst->sorting_offset;
 		}
 		uint32_t depth_layer = CLAMP(int(inst->depth * 16 / z_max), 0, 15);
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1278,6 +1278,8 @@ void RendererSceneRenderRD::render_scene(const Ref<RenderSceneBuffers> &p_render
 
 		scene_data.z_near = p_camera_data->main_projection.get_z_near();
 		scene_data.z_far = p_camera_data->main_projection.get_z_far();
+		scene_data.transparency_sort_mode = p_camera_data->transparency_sort_mode;
+		scene_data.transparency_sort_axis = p_camera_data->transparency_sort_axis;
 
 		// this should be the same for all cameras..
 		const float lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();

--- a/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_data_rd.h
@@ -67,6 +67,9 @@ public:
 	float z_near = 0.0;
 	float z_far = 0.0;
 
+	RS::TransparencySortMode transparency_sort_mode;
+	Vector3 transparency_sort_axis = Vector3(0, 0, 1);
+
 	float lod_distance_multiplier = 0.0;
 	float screen_mesh_lod_threshold = 0.0;
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -144,8 +144,28 @@ void RendererSceneCull::camera_set_use_vertical_aspect(RID p_camera, bool p_enab
 	camera->vaspect = p_enable;
 }
 
+void RendererSceneCull::camera_set_transparency_sort_mode(RID p_camera, RS::TransparencySortMode p_mode) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	camera->transparency_sort_mode = p_mode;
+}
+
+void RendererSceneCull::camera_set_transparency_sort_axis(RID p_camera, const Vector3 &p_axis) {
+	Camera *camera = camera_owner.get_or_null(p_camera);
+	ERR_FAIL_NULL(camera);
+	camera->transparency_sort_axis = p_axis.normalized();
+}
+
 bool RendererSceneCull::is_camera(RID p_camera) const {
 	return camera_owner.owns(p_camera);
+}
+
+void RendererSceneCull::set_default_transparency_sort_mode(RS::TransparencySortMode p_mode) {
+	default_transparency_sort_mode = p_mode == RS::TRANSPARENCY_SORT_DEFAULT ? RS::TRANSPARENCY_SORT_DEPTH : p_mode;
+}
+
+void RendererSceneCull::set_default_transparency_sort_axis(const Vector3 &p_axis) {
+	default_transparency_sort_axis = p_axis.normalized();
 }
 
 /* OCCLUDER API */
@@ -2613,6 +2633,13 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		taa_frame_count = float(RSG::rasterizer->get_frame_number() % p_jitter_phase_count);
 	}
 
+	RS::TransparencySortMode transparency_sort_mode = camera->transparency_sort_mode;
+	Vector3 transparency_sort_axis = camera->transparency_sort_axis;
+	if (camera->transparency_sort_mode == RS::TRANSPARENCY_SORT_DEFAULT) {
+		transparency_sort_mode = default_transparency_sort_mode;
+		transparency_sort_axis = default_transparency_sort_axis;
+	}
+
 	RendererSceneRender::CameraData camera_data;
 
 	// Setup Camera(s)
@@ -2655,7 +2682,7 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 			} break;
 		}
 
-		camera_data.set_camera(transform, projection, is_orthogonal, is_frustum, vaspect, jitter, taa_frame_count, camera->visible_layers);
+		camera_data.set_camera(transform, projection, is_orthogonal, is_frustum, vaspect, jitter, taa_frame_count, camera->visible_layers, transparency_sort_mode, transparency_sort_axis);
 #ifndef XR_DISABLED
 	} else {
 		XRServer *xr_server = XRServer::get_singleton();
@@ -2688,7 +2715,7 @@ void RendererSceneCull::render_camera(const Ref<RenderSceneBuffers> &p_render_bu
 		}
 
 		if (view_count == 1) {
-			camera_data.set_camera(transforms[0], projections[0], false, false, camera->vaspect, jitter, p_jitter_phase_count, camera->visible_layers);
+			camera_data.set_camera(transforms[0], projections[0], false, false, camera->vaspect, jitter, p_jitter_phase_count, camera->visible_layers, transparency_sort_mode, transparency_sort_axis);
 		} else if (view_count == 2) {
 			camera_data.set_multiview_camera(view_count, transforms, projections, false, false, camera->vaspect);
 		} else {
@@ -4305,6 +4332,9 @@ RendererSceneCull::RendererSceneCull() {
 	bool tighter_caster_culling = GLOBAL_DEF("rendering/lights_and_shadows/tighter_shadow_caster_culling", true);
 	light_culler->set_caster_culling_active(tighter_caster_culling);
 	light_culler->set_light_culling_active(tighter_caster_culling);
+
+	default_transparency_sort_mode = GLOBAL_GET("rendering/camera/transparency_sort/default_transparency_sort_mode");
+	default_transparency_sort_axis = GLOBAL_GET("rendering/camera/transparency_sort/default_transparency_sort_axis");
 }
 
 RendererSceneCull::~RendererSceneCull() {

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -87,6 +87,9 @@ public:
 		RID attributes;
 		RID compositor;
 
+		RS::TransparencySortMode transparency_sort_mode;
+		Vector3 transparency_sort_axis;
+
 		Transform3D transform;
 
 		Camera() {
@@ -98,8 +101,13 @@ public:
 			size = 1.0;
 			offset = Vector2();
 			vaspect = false;
+			transparency_sort_mode = RS::TRANSPARENCY_SORT_DEFAULT;
+			transparency_sort_axis = Vector3(0, 0, 1);
 		}
 	};
+
+	RS::TransparencySortMode default_transparency_sort_mode = RS::TRANSPARENCY_SORT_DEPTH;
+	Vector3 default_transparency_sort_axis = Vector3(0, 0, 1);
 
 	mutable RID_Owner<Camera, true> camera_owner;
 
@@ -115,7 +123,12 @@ public:
 	virtual void camera_set_camera_attributes(RID p_camera, RID p_attributes);
 	virtual void camera_set_compositor(RID p_camera, RID p_compositor);
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable);
+	virtual void camera_set_transparency_sort_mode(RID p_camera, RS::TransparencySortMode p_mode);
+	virtual void camera_set_transparency_sort_axis(RID p_camera, const Vector3 &p_axis);
 	virtual bool is_camera(RID p_camera) const;
+
+	virtual void set_default_transparency_sort_mode(RS::TransparencySortMode p_mode);
+	virtual void set_default_transparency_sort_axis(const Vector3 &p_axis);
 
 	/* OCCLUDER API */
 

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -33,7 +33,7 @@
 /////////////////////////////////////////////////////////////////////////////
 // CameraData
 
-void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect, const Vector2 &p_taa_jitter, float p_taa_frame_count, const uint32_t p_visible_layers) {
+void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect, const Vector2 &p_taa_jitter, float p_taa_frame_count, const uint32_t p_visible_layers, RS::TransparencySortMode p_transparency_sort_mode, Vector3 p_transparency_sort_axis) {
 	view_count = 1;
 	is_orthogonal = p_is_orthogonal;
 	is_frustum = p_is_frustum;
@@ -47,6 +47,9 @@ void RendererSceneRender::CameraData::set_camera(const Transform3D p_transform, 
 	view_projection[0] = p_projection;
 	taa_jitter = p_taa_jitter;
 	taa_frame_count = p_taa_frame_count;
+
+	transparency_sort_mode = p_transparency_sort_mode;
+	transparency_sort_axis = p_transparency_sort_axis;
 }
 
 void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect) {

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -311,7 +311,10 @@ public:
 		Vector2 taa_jitter;
 		float taa_frame_count = 0.0f;
 
-		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF);
+		RS::TransparencySortMode transparency_sort_mode;
+		Vector3 transparency_sort_axis;
+
+		void set_camera(const Transform3D p_transform, const Projection p_projection, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect, const Vector2 &p_taa_jitter = Vector2(), float p_taa_frame_count = 0.0f, uint32_t p_visible_layers = 0xFFFFFFFF, RS::TransparencySortMode p_transparency_sort_mode = RS::TRANSPARENCY_SORT_DEPTH, Vector3 p_transparency_sort_axis = Vector3(0, 0, 1));
 		void set_multiview_camera(uint32_t p_view_count, const Transform3D *p_transforms, const Projection *p_projections, bool p_is_orthogonal, bool p_is_frustum, bool p_vaspect);
 	};
 

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -55,7 +55,12 @@ public:
 	virtual void camera_set_camera_attributes(RID p_camera, RID p_attributes) = 0;
 	virtual void camera_set_compositor(RID p_camera, RID p_compositor) = 0;
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;
+	virtual void camera_set_transparency_sort_mode(RID p_camera, RS::TransparencySortMode p_mode) = 0;
+	virtual void camera_set_transparency_sort_axis(RID p_camera, const Vector3 &p_axis) = 0;
 	virtual bool is_camera(RID p_camera) const = 0;
+
+	virtual void set_default_transparency_sort_mode(RS::TransparencySortMode p_mode) = 0;
+	virtual void set_default_transparency_sort_axis(const Vector3 &p_axis) = 0;
 
 	virtual RID occluder_allocate() = 0;
 	virtual void occluder_initialize(RID p_occluder) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -678,6 +678,11 @@ public:
 	FUNC2(camera_set_camera_attributes, RID, RID)
 	FUNC2(camera_set_compositor, RID, RID)
 	FUNC2(camera_set_use_vertical_aspect, RID, bool)
+	FUNC2(camera_set_transparency_sort_mode, RID, TransparencySortMode)
+	FUNC2(camera_set_transparency_sort_axis, RID, const Vector3 &)
+
+	FUNC1(set_default_transparency_sort_mode, TransparencySortMode)
+	FUNC1(set_default_transparency_sort_axis, const Vector3 &)
 
 	/* OCCLUDER */
 	FUNCRIDSPLIT(occluder)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2817,6 +2817,16 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_camera_attributes", "camera", "effects"), &RenderingServer::camera_set_camera_attributes);
 	ClassDB::bind_method(D_METHOD("camera_set_compositor", "camera", "compositor"), &RenderingServer::camera_set_compositor);
 	ClassDB::bind_method(D_METHOD("camera_set_use_vertical_aspect", "camera", "enable"), &RenderingServer::camera_set_use_vertical_aspect);
+	ClassDB::bind_method(D_METHOD("camera_set_transparency_sort_mode", "camera", "mode"), &RenderingServer::camera_set_transparency_sort_mode);
+	ClassDB::bind_method(D_METHOD("camera_set_transparency_sort_axis", "camera", "axis"), &RenderingServer::camera_set_transparency_sort_axis);
+
+	ClassDB::bind_method(D_METHOD("set_default_transparency_sort_mode", "mode"), &RenderingServer::set_default_transparency_sort_mode);
+	ClassDB::bind_method(D_METHOD("set_default_transparency_sort_axis", "axis"), &RenderingServer::set_default_transparency_sort_axis);
+
+	BIND_ENUM_CONSTANT(TRANSPARENCY_SORT_DEFAULT);
+	BIND_ENUM_CONSTANT(TRANSPARENCY_SORT_DEPTH);
+	BIND_ENUM_CONSTANT(TRANSPARENCY_SORT_ORTHOGONAL);
+	BIND_ENUM_CONSTANT(TRANSPARENCY_SORT_CUSTOM_AXIS);
 
 	/* VIEWPORT */
 
@@ -3670,6 +3680,9 @@ void RenderingServer::init() {
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PROPERTY_HINT_ENUM, "Box (Fast),Hexagon (Average),Circle (Slowest)"), 1);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PROPERTY_HINT_ENUM, "Very Low (Fastest),Low (Fast),Medium (Average),High (Slow)"), 1);
 	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_use_jitter", false);
+
+	GLOBAL_DEF(PropertyInfo(Variant::VECTOR3, "rendering/camera/transparency_sort/default_transparency_sort_axis"), Vector3(0, 0, 1));
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/camera/transparency_sort/default_transparency_sort_mode", PROPERTY_HINT_ENUM, "Depth:1,Orthogonal:2,CustomAxis:3"), 1);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/environment/ssao/quality", PROPERTY_HINT_ENUM, "Very Low (Fast),Low (Fast),Medium (Average),High (Slow),Ultra (Custom)"), 2);
 	GLOBAL_DEF("rendering/environment/ssao/half_size", true);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -920,6 +920,18 @@ public:
 	virtual void camera_set_compositor(RID p_camera, RID p_compositor) = 0;
 	virtual void camera_set_use_vertical_aspect(RID p_camera, bool p_enable) = 0;
 
+	enum TransparencySortMode {
+		TRANSPARENCY_SORT_DEFAULT,
+		TRANSPARENCY_SORT_DEPTH,
+		TRANSPARENCY_SORT_ORTHOGONAL,
+		TRANSPARENCY_SORT_CUSTOM_AXIS,
+	};
+
+	virtual void set_default_transparency_sort_mode(TransparencySortMode p_mode) = 0;
+	virtual void set_default_transparency_sort_axis(const Vector3 &p_axis) = 0;
+	virtual void camera_set_transparency_sort_mode(RID p_camera, TransparencySortMode p_mode) = 0;
+	virtual void camera_set_transparency_sort_axis(RID p_camera, const Vector3 &p_axis) = 0;
+
 	/* VIEWPORT API */
 
 	enum CanvasItemTextureFilter {
@@ -1941,6 +1953,7 @@ VARIANT_ENUM_CAST(RenderingServer::ParticlesEmitFlags);
 VARIANT_ENUM_CAST(RenderingServer::ParticlesCollisionType);
 VARIANT_ENUM_CAST(RenderingServer::ParticlesCollisionHeightfieldResolution);
 VARIANT_ENUM_CAST(RenderingServer::FogVolumeShape);
+VARIANT_ENUM_CAST(RenderingServer::TransparencySortMode);
 VARIANT_ENUM_CAST(RenderingServer::ViewportScaling3DMode);
 VARIANT_ENUM_CAST(RenderingServer::ViewportUpdateMode);
 VARIANT_ENUM_CAST(RenderingServer::ViewportClearMode);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/12967

This pr adds the basic framework to implement alternative heuristics to sort transparent meshes and makes use of it by adding two new sorting modes.

This pr slightly differs from the proposal by adding an extra default sorting mode `TRANSPARENCY_SORT_DEFAULT` and `TRANSPARENCY_SORT_ORTHOGONAL`. The default mode can be changed via a project setting or methods on the `RenderingServer`. 

Unlike was originally mentioned in the proposal, this should play nicely with https://github.com/godotengine/godot/pull/109388, so there's no need to wait for it (it should still be merged since consistent mesh sorting would still benefit projects benefitting from this pr).

## Features implemented ##
New enum `TransparencySortMode` on the `RenderingServer` with 4 options:
- `TRANSPARENCY_SORT_DEFAULT`: Sorted by the default heuristic. (Default heuristic is TRANSPARENCY_SORT_DEPTH if unchanged)
- `TRANSPARENCY_SORT_DEPTH`: Sorted based on depth. (Current behavior)
- `TRANSPARENCY_SORT_ORTHOGRAPHIC`: Sorted based on dot product between a camera normal and a mesh position. (Identical to how orthographic camera sorts, but now possible with perspective cameras)
- `TRANSPARENCY_SORT_CUSTOM_AXIS`: Sorted based on a dot product between a custom `Vector3` axis and a mesh position.

Two new project settings under camera category to interact with the default sorting:
- `rendering/camera/transparency_sort/default_transparency_sort_axis` (default Vector3(0, 0, 1))
- `rendering/camera/transparency_sort/default_transparency_sort_mode` (default 1, i.e. `TRANSPARENCY_SORT_DEPTH`)

Two new `Camera3D` properties to override default sorting (`alpha_sort_axis` is only visible in editor when heuristic is set to sort by axis):
- `transparency_sort_axis` (default Vector3(0, 0, 1))
- `transparency_sort_heuristic` (default RenderingServer.TRANSPARENCY_SORT_DEFAULT)

Four new `RenderingServer` methods to control sorting:
```python
void camera_set_transparency_sort_axis(camera: RID, axis: Vector3)
void camera_set_transparency_sort_mode(camera: RID, mode: TransparencySortMode)
void set_default_transparency_sort_axis(axis: Vector3)
void set_default_transparency_sort_mode(heuristic: TransparencySortMode)
```