### PR TITLE
Small `Tree` optimization

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2219,13 +2219,14 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 	int htotal = 0;
 
-	int label_h = 0;
+	r_self_height = compute_item_height(p_item);
+	int label_h = r_self_height + theme_cache.v_separation;
 	bool rtl = cache.rtl;
 
 	// Draw label, if height fits.
 	bool skip = (p_item == root && hide_root);
 
-	if (!skip) {
+	if (!skip && p_pos.y + label_h - theme_cache.offset.y >= 0) {
 		// Draw separation.
 
 		ERR_FAIL_COND_V(theme_cache.font.is_null(), -1);
@@ -2299,13 +2300,6 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			p_item->cells.write[i].text_buf->set_width(text_width);
-
-			r_self_height = compute_item_height(p_item);
-			label_h = r_self_height + theme_cache.v_separation;
-
-			if (p_pos.y + label_h - theme_cache.offset.y < 0) {
-				continue; // No need to draw.
-			}
 
 			Rect2i item_rect = Rect2i(Point2i(ofs, p_pos.y) - theme_cache.offset + p_draw_ofs, Size2i(item_width, label_h));
 			Rect2i cell_rect = item_rect;


### PR DESCRIPTION
`draw_item` is recalculating the height of an item on drawing every cell, when the result is always the same. This is done to skip drawing cells if they are out of visible `y` positions due to scrolling. However, the loop can be entirely avoided by calculating it before, once, and skipping the cell drawing.

I did a rudimentary test with a scene with only a `Tree` and this code:
```gdscript
extends Tree

func _ready() -> void:
	create_item()
	var item : TreeItem
	for i in 50000:
		item = create_item()
		item.set_text(0, "Tree")
	scroll_to_item(item)
	

func _process(_delta: float) -> void:
	queue_redraw()
	print(Performance.get_monitor(Performance.TIME_FPS));
```

The `fps` stabilized around 24/25 with this PR, while on `master` it was around 18/19, with these specs:
 - Windows 11 (build 26100) - Multi-window, 2 monitors - Vulkan (Forward+) - dedicated NVIDIA GeForce RTX 4070 (NVIDIA; 32.0.15.6094) - 13th Gen Intel(R) Core(TM) i5-13500 (20 threads) - 31.78 GiB memory