### PR TITLE
`ThemeEditor` fix to show filename for new/renamed files

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.h
+++ b/editor/scene/gui/theme_editor_plugin.h
@@ -454,6 +454,9 @@ class ThemeEditor : public VBoxContainer {
 	void _theme_edit_button_cbk();
 	void _theme_close_button_cbk();
 	void _scene_closed(const String &p_path);
+	void _resource_saved(const Ref<Resource> &p_resource);
+	void _files_moved(const String &p_old_path, const String &p_new_path);
+	void _update_theme_name(const String &p_name);
 
 	void _add_preview_button_cbk();
 	void _preview_scene_dialog_cbk(const String &p_path);


### PR DESCRIPTION
Updated `ThemeEditor` to set the theme name label when theme file is initially created or renamed.

Fixes #109546

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
