### PR TITLE
Extend DAP to allow debugging main/current/specific scene/secondary editor and command-line arguments

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -86,6 +86,7 @@ public:
 	Dictionary req_godot_put_msg(const Dictionary &p_params) const;
 
 	// Internal requests
+	Vector<String> _extract_play_arguments(const Dictionary &p_args) const;
 	Dictionary _launch_process(const Dictionary &p_params) const;
 
 	// Events

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -367,7 +367,7 @@ void EditorRunBar::recovery_mode_reload_project() {
 	EditorNode::get_singleton()->trigger_menu_option(EditorNode::PROJECT_RELOAD_CURRENT_PROJECT, false);
 }
 
-void EditorRunBar::play_main_scene(bool p_from_native) {
+void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_play_args) {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
 		return;
@@ -379,7 +379,7 @@ void EditorRunBar::play_main_scene(bool p_from_native) {
 		stop_playing();
 
 		current_mode = RunMode::RUN_MAIN;
-		_run_scene();
+		_run_scene("", p_play_args);
 	}
 }
 
@@ -574,7 +574,7 @@ EditorRunBar::EditorRunBar() {
 	play_button->set_toggle_mode(true);
 	play_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	play_button->set_tooltip_text(TTRC("Run the project's default scene."));
-	play_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::play_main_scene).bind(false));
+	play_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::play_main_scene).bind(false, Vector<String>()));
 
 	ED_SHORTCUT_AND_COMMAND("editor/run_project", TTRC("Run Project"), Key::F5);
 	ED_SHORTCUT_OVERRIDE("editor/run_project", "macos", KeyModifierMask::META | Key::B);

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -113,7 +113,7 @@ public:
 	void recovery_mode_show_dialog();
 	void recovery_mode_reload_project();
 
-	void play_main_scene(bool p_from_native = false);
+	void play_main_scene(bool p_from_native = false, const Vector<String> &p_play_args = Vector<String>());
 	void play_current_scene(bool p_reload = false, const Vector<String> &p_play_args = Vector<String>());
 	void play_custom_scene(const String &p_custom, const Vector<String> &p_play_args = Vector<String>());
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/discussions/12121

Required for https://youtrack.jetbrains.com/issue/RIDER-115995

There is a continuation to this pull request https://github.com/godotengine/godot/pull/109987, which helps with debugging on devices.
