### PR TITLE
Fix missing layer provider setup when setting Surface after visibility

### DIFF
--- a/modules/openxr/scene/openxr_composition_layer.cpp
+++ b/modules/openxr/scene/openxr_composition_layer.cpp
@@ -245,7 +245,7 @@ void OpenXRCompositionLayer::_clear_composition_layer_provider() {
 
 void OpenXRCompositionLayer::_on_openxr_session_begun() {
 	openxr_session_running = true;
-	if (is_natively_supported() && is_visible() && is_inside_tree()) {
+	if (_should_register()) {
 		_setup_composition_layer_provider();
 	}
 	if (!fallback && _should_use_fallback_node()) {
@@ -263,6 +263,10 @@ void OpenXRCompositionLayer::_on_openxr_session_stopping() {
 
 void OpenXRCompositionLayer::update_fallback_mesh() {
 	should_update_fallback_mesh = true;
+}
+
+bool OpenXRCompositionLayer::_should_register() {
+	return !registered && openxr_session_running && is_inside_tree() && is_visible() && is_natively_supported();
 }
 
 XrPosef OpenXRCompositionLayer::get_openxr_pose() {
@@ -298,7 +302,7 @@ void OpenXRCompositionLayer::set_layer_viewport(SubViewport *p_viewport) {
 	}
 
 	layer_viewport = p_viewport;
-	if (!registered && is_natively_supported() && openxr_session_running && is_inside_tree() && is_visible()) {
+	if (_should_register()) {
 		_setup_composition_layer_provider();
 	}
 
@@ -328,8 +332,13 @@ void OpenXRCompositionLayer::set_use_android_surface(bool p_use_android_surface)
 
 	use_android_surface = p_use_android_surface;
 	if (use_android_surface) {
+		// It's possible that the layer provider is unregistered here (if previously invisible)
 		set_layer_viewport(nullptr);
 		openxr_layer_provider->set_use_android_surface(true, android_surface_size);
+		// ...and it may not be set up above because of viewport = null, android surface is false, so set it up again:
+		if (_should_register()) {
+			_setup_composition_layer_provider();
+		}
 	} else {
 		openxr_layer_provider->set_use_android_surface(false, Size2i());
 	}

--- a/modules/openxr/scene/openxr_composition_layer.h
+++ b/modules/openxr/scene/openxr_composition_layer.h
@@ -120,6 +120,8 @@ protected:
 	virtual void _on_openxr_session_begun();
 	virtual void _on_openxr_session_stopping();
 
+	bool _should_register();
+
 	virtual Ref<Mesh> _create_fallback_mesh() = 0;
 
 	void update_fallback_mesh();


### PR DESCRIPTION
Fix a bug that prevents setting up the composition layer provider when the Android surface is set **after** updating the layer's visibility.

The following flow works as expected:
```
composition_layer.use_android_surface = true
composition_layer.visible = true
```

But swapping the order to the following breaks setting up the composition layer provider:
```
composition_layer.visible = true
composition_layer.use_android_surface = true
```

This is because of the following:
- When the visibility is updated, `_setup_composition_layer_provider()` is invoked in https://github.com/godotengine/godot/blob/0c51ede2434d99d2c80dc87b7df179db66537f1c/modules/openxr/scene/openxr_composition_layer.cpp#L622
- That call is a no-op because `use_android_surface` and `layer_viewport` are `false` at that point
- When `composition_layer.use_android_surface = true` is invoked, then [`set_use_android_surface`](https://github.com/godotengine/godot/blob/0c51ede2434d99d2c80dc87b7df179db66537f1c/modules/openxr/scene/openxr_composition_layer.cpp#L324) is invoked
- `set_layer_viewport(nullptr)` invoked as part of that flow in https://github.com/godotengine/godot/blob/0c51ede2434d99d2c80dc87b7df179db66537f1c/modules/openxr/scene/openxr_composition_layer.cpp#L331
- That call is a no-op because `layer_viewport = nullptr`
- `set_use_android_surface(...)` completes without the composition layer being set up.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
