### PR TITLE
Refactor `_edit_current()` script check

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2918,16 +2918,6 @@ void EditorNode::hide_unused_editors(const Object *p_editing_owner) {
 	}
 }
 
-static bool overrides_external_editor(Object *p_object) {
-	Script *script = Object::cast_to<Script>(p_object);
-
-	if (!script) {
-		return false;
-	}
-
-	return script->get_language()->overrides_external_editor();
-}
-
 void EditorNode::_add_to_history(const Object *p_object, const String &p_property, bool p_inspector_only) {
 	ObjectID id = p_object->get_instance_id();
 	ObjectID history_id = editor_history.get_current();
@@ -3116,15 +3106,17 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 
 		ObjectID editor_owner_id = editor_owner->get_instance_id();
 		if (main_plugin && !skip_main_plugin) {
-			// Special case if use of external editor is true.
-			Resource *current_res = Object::cast_to<Resource>(current_obj);
-			if (main_plugin->get_plugin_name() == "Script" && current_res && !current_res->is_built_in() && (bool(EDITOR_GET("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
+			// Special case if current_obj is a script.
+			Script *current_script = Object::cast_to<Script>(current_obj);
+			if (current_script) {
 				if (!changing_scene) {
-					main_plugin->edit(current_obj);
+					// Only update main editor screen if using in-engine editor.
+					if (current_script->is_built_in() || (!bool(EDITOR_GET("text_editor/external/use_external_editor")) && !current_script->get_language()->overrides_external_editor())) {
+						editor_main_screen->select(plugin_index);
+					}
+
+					main_plugin->edit(current_script);
 				}
-			} else if (Object::cast_to<Script>(current_obj)) {
-				editor_main_screen->select(plugin_index);
-				main_plugin->edit(current_obj);
 			} else if (main_plugin != editor_plugin_screen) {
 				// Unedit previous plugin.
 				editor_plugin_screen->edit(nullptr);


### PR DESCRIPTION
Refactors my other pull request https://github.com/godotengine/godot/pull/109176 as suggested by KoBeWi (not entirely sure if this is how they meant)

I went down git blame history, and found this https://github.com/godotengine/godot/pull/17679 to no longer be relevant.

This https://github.com/godotengine/godot/pull/6962 is still relevant, but I removed the `main_plugin->get_name()` check in favor of just casting `current_obj` to a script, and checking that.

I couldn't quite find a way of testing `current_script->is_built_in()`, but I believe I understood the purpose/logic of it.

Tested it with a dotnet build in a project with both .gd and .cs files, where I enabled/disabled external script and dotnet script settings.