### PR TITLE
thorvg: Update to 0.15.16

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1034,7 +1034,7 @@ Files extracted from upstream source:
 ## thorvg
 
 - Upstream: https://github.com/thorvg/thorvg
-- Version: 0.15.13 (c597365b99f27cb46e2a5ac2942da45bb73d5a55, 2025)
+- Version: 0.15.16 (e15069de7afcc5e853edf1561e69d9b8383e2c6c, 2025)
 - License: MIT
 
 Files extracted from upstream source:

--- a/thirdparty/thorvg/inc/config.h
+++ b/thirdparty/thorvg/inc/config.h
@@ -15,5 +15,5 @@
 // For internal debugging:
 //#define THORVG_LOG_ENABLED
 
-#define THORVG_VERSION_STRING "0.15.13"
+#define THORVG_VERSION_STRING "0.15.16"
 #endif

--- a/thirdparty/thorvg/inc/thorvg.h
+++ b/thirdparty/thorvg/inc/thorvg.h
@@ -260,10 +260,14 @@ enum class Type : uint8_t
 
 /**
  * @brief A data structure representing a point in two-dimensional space.
+ *
+ * This structure defines a single point using Cartesian coordinates.
+ * It is typically used for specifying positions or coordinates in 2D graphics.
  */
 struct Point
 {
-    float x, y;
+    float x;  ///< The x-coordinate of the point.
+    float y;  ///< The y-coordinate of the point.
 };
 
 
@@ -453,7 +457,7 @@ public:
      *
      * @return The class type ID of the Paint instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     virtual Type type() const noexcept = 0;
 
@@ -462,7 +466,7 @@ public:
      *
      * This is reserved to specify an paint instance in a scene.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     uint32_t id = 0;
 
@@ -568,7 +572,7 @@ public:
      *
      * @return The class type ID of the Fill instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     virtual Type type() const noexcept = 0;
 
@@ -758,7 +762,7 @@ public:
      *
      * @return The class type ID of the LinearGradient instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     Type type() const noexcept override;
 
@@ -823,7 +827,7 @@ public:
      *
      * @return The class type ID of the LinearGradient instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     Type type() const noexcept override;
 
@@ -1223,7 +1227,7 @@ public:
      *
      * @return The class type ID of the Shape instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     Type type() const noexcept override;
 
@@ -1361,7 +1365,7 @@ public:
      *
      * @return The class type ID of the Picture instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     Type type() const noexcept override;
 
@@ -1461,7 +1465,7 @@ public:
      *
      * @return The class type ID of the Scene instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     Type type() const noexcept override;
 
@@ -1493,13 +1497,22 @@ public:
      * It sets the font name, size and optionally the style.
      *
      * @param[in] name The name of the font. This should correspond to a font available in the canvas.
+     *                 If set to @c nullptr, ThorVG will attempt to select a fallback font available on the system.
      * @param[in] size The size of the font in points. This determines how large the text will appear.
      * @param[in] style The style of the font. It can be used to set the font to 'italic'.
      *                  If not specified, the default style is used. Only 'italic' style is supported currently.
      *
      * @retval Result::InsufficientCondition when the specified @p name cannot be found.
      *
-     * @note Experimental API
+     * @note If the @p name is not specified, ThorVG will select any available font candidate.
+     * @since 1.0
+     *
+     * @code
+     * // Tip for fallback support to use any available font.
+     * if (text->font("Arial", 24) != tvg::Result::Success) {
+     *     text->font(nullptr, 24);
+     * }
+     * @endcode
      */
     Result font(const char* name, float size, const char* style = nullptr) noexcept;
 
@@ -1619,7 +1632,7 @@ public:
      *
      * @return The class type ID of the Text instance.
      *
-     * @since Experimental API
+     * @note Experimental API
      */
     Type type() const noexcept override;
 

--- a/thirdparty/thorvg/src/common/tvgMath.h
+++ b/thirdparty/thorvg/src/common/tvgMath.h
@@ -85,10 +85,17 @@ bool identity(const Matrix* m);
 Matrix operator*(const Matrix& lhs, const Matrix& rhs);
 bool operator==(const Matrix& lhs, const Matrix& rhs);
 
+
+static inline float radian(const Matrix& m)
+{
+    return fabsf(tvg::atan2(m.e21, m.e11));
+}
+
+
 static inline bool rightAngle(const Matrix& m)
 {
-   auto radian = fabsf(tvg::atan2(m.e21, m.e11));
-   if (radian < FLOAT_EPSILON || tvg::equal(radian, MATH_PI2) || tvg::equal(radian, MATH_PI)) return true;
+   auto radian = tvg::radian(m);
+   if (tvg::zero(radian) || tvg::zero(radian - MATH_PI2) || tvg::zero(radian - MATH_PI)) return true;
    return false;
 }
 

--- a/thirdparty/thorvg/src/common/tvgStr.cpp
+++ b/thirdparty/thorvg/src/common/tvgStr.cpp
@@ -229,11 +229,12 @@ char* strAppend(char* lhs, const char* rhs, size_t n)
 
 char* strDirname(const char* path)
 {
-    const char *ptr = strrchr(path, '/');
+    auto ptr = strrchr(path, '/');
 #ifdef _WIN32
-    if (ptr) ptr = strrchr(ptr + 1, '\\');
+    auto ptr2 = strrchr(ptr ? ptr : path, '\\');
+    if (ptr2) ptr = ptr2;
 #endif
-    int len = int(ptr + 1 - path);  // +1 to include '/'
+    auto len = ptr ? size_t(ptr - path + 1) : SIZE_MAX;
     return strDuplicate(path, len);
 }
 

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgLoader.cpp
@@ -393,8 +393,8 @@ static char* _idFromUrl(const char* url)
     ++open;
     --close;
 
-    //trim the rest of the spaces if any
-    while (open < close && *close == ' ') --close;
+    //trim the rest of the spaces and the quote marks if any
+    while (open < close && (*close == ' ' || *close == '\'' || *close == '\"')) --close;
 
     //quick verification
     for (auto id = open; id < close; id++) {
@@ -927,43 +927,6 @@ error:
     }
 
 
-static void _postpone(Array<SvgNodeIdPair>& nodes, SvgNode *node, char* id)
-{
-    nodes.push({node, id});
-}
-
-
-/*
-// TODO - remove?
-static constexpr struct
-{
-    const char* tag;
-    int sz;
-    SvgLengthType type;
-} lengthTags[] = {
-    LENGTH_DEF(%, SvgLengthType::Percent),
-    LENGTH_DEF(px, SvgLengthType::Px),
-    LENGTH_DEF(pc, SvgLengthType::Pc),
-    LENGTH_DEF(pt, SvgLengthType::Pt),
-    LENGTH_DEF(mm, SvgLengthType::Mm),
-    LENGTH_DEF(cm, SvgLengthType::Cm),
-    LENGTH_DEF(in, SvgLengthType::In)
-};
-
-static float _parseLength(const char* str, SvgLengthType* type)
-{
-    float value;
-    int sz = strlen(str);
-
-    *type = SvgLengthType::Px;
-    for (unsigned int i = 0; i < sizeof(lengthTags) / sizeof(lengthTags[0]); i++) {
-        if (lengthTags[i].sz - 1 == sz && !strncmp(lengthTags[i].tag, str, sz)) *type = lengthTags[i].type;
-    }
-    value = svgUtilStrtof(str, nullptr);
-    return value;
-}
-*/
-
 static bool _parseStyleAttr(void* data, const char* key, const char* value);
 static bool _parseStyleAttr(void* data, const char* key, const char* value, bool style);
 
@@ -1215,7 +1178,7 @@ static void _handleCssClassAttr(SvgLoaderData* loader, SvgNode* node, const char
         cssCopyStyleAttr(node, cssNode);
     }
 
-    if (!cssClassFound) _postpone(loader->nodesToStyle, node, *cssClass);
+    if (!cssClassFound) loader->nodesToStyle.push({node, *cssClass});
 }
 
 
@@ -2108,6 +2071,23 @@ static SvgNode* _findParentById(SvgNode* node, char* id, SvgNode* doc)
 }
 
 
+static bool _checkPostponed(SvgNode* node, SvgNode* cloneNode, int depth)
+{
+    if (node == cloneNode) return true;
+
+    if (depth == 512) {
+        TVGERR("SVG", "Infinite recursive call - stopped after %d calls! Svg file may be incorrectly formatted.", depth);
+        return false;
+    }
+
+    for (uint32_t i = 0; i < node->child.count; ++i) {
+        if (_checkPostponed(node->child[i], cloneNode, depth + 1)) return true;
+    }
+
+    return false;
+}
+
+
 static constexpr struct
 {
     const char* tag;
@@ -2149,17 +2129,30 @@ static bool _attrParseUseNode(void* data, const char* key, const char* value)
         nodeFrom = _findNodeById(defs, id);
         if (nodeFrom) {
             if (!_findParentById(node, id, loader->doc)) {
-                _cloneNode(nodeFrom, node, 0);
-                if (nodeFrom->type == SvgNodeType::Symbol) use->symbol = nodeFrom;
+                //Check if none of nodeFrom's children are in the cloneNodes list
+                auto postpone = false;
+                for (auto pair = loader->cloneNodes.head; pair; pair = pair->next) {
+                    if (_checkPostponed(nodeFrom, pair->node, 1)) {
+                        postpone = true;
+                        loader->cloneNodes.back(new((SvgNodeIdPair*)malloc(sizeof(SvgNodeIdPair))) SvgNodeIdPair(node, id));
+                        break;
+                    }
+                }
+                //None of the children of nodeFrom are on the cloneNodes list, so it can be cloned immediately
+                if (!postpone) {
+                    _cloneNode(nodeFrom, node, 0);
+                    if (nodeFrom->type == SvgNodeType::Symbol) use->symbol = nodeFrom;
+                    free(id);
+                }
             } else {
                 TVGLOG("SVG", "%s is ancestor element. This reference is invalid.", id);
+                free(id);
             }
-            free(id);
         } else {
             //some svg export software include <defs> element at the end of the file
             //if so the 'from' element won't be found now and we have to repeat finding
             //after the whole file is parsed
-            _postpone(loader->cloneNodes, node, id);
+            loader->cloneNodes.back(new((SvgNodeIdPair*)malloc(sizeof(SvgNodeIdPair))) SvgNodeIdPair(node, id));
         }
     } else {
         return _attrParseGNode(data, key, value);
@@ -3322,22 +3315,39 @@ static void _cloneNode(SvgNode* from, SvgNode* parent, int depth)
 }
 
 
-static void _clonePostponedNodes(Array<SvgNodeIdPair>* cloneNodes, SvgNode* doc)
+static void _clonePostponedNodes(Inlist<SvgNodeIdPair>* cloneNodes, SvgNode* doc)
 {
-    for (uint32_t i = 0; i < cloneNodes->count; ++i) {
-        auto nodeIdPair = (*cloneNodes)[i];
-        auto defs = _getDefsNode(nodeIdPair.node);
-        auto nodeFrom = _findNodeById(defs, nodeIdPair.id);
-        if (!nodeFrom) nodeFrom = _findNodeById(doc, nodeIdPair.id);
-        if (!_findParentById(nodeIdPair.node, nodeIdPair.id, doc)) {
-            _cloneNode(nodeFrom, nodeIdPair.node, 0);
-            if (nodeFrom && nodeFrom->type == SvgNodeType::Symbol && nodeIdPair.node->type == SvgNodeType::Use) {
-                nodeIdPair.node->node.use.symbol = nodeFrom;
+    auto nodeIdPair = cloneNodes->front();
+    while (nodeIdPair) {
+        if (!_findParentById(nodeIdPair->node, nodeIdPair->id, doc)) {
+            //Check if none of nodeFrom's children are in the cloneNodes list
+            auto postpone = false;
+            auto nodeFrom = _findNodeById(_getDefsNode(nodeIdPair->node), nodeIdPair->id);
+            if (!nodeFrom) nodeFrom = _findNodeById(doc, nodeIdPair->id);
+            if (nodeFrom) {
+                for (auto pair = cloneNodes->head; pair; pair = pair->next) {
+                    if (_checkPostponed(nodeFrom, pair->node, 1)) {
+                        postpone = true;
+                        cloneNodes->back(nodeIdPair);
+                        break;
+                    }
+                }
+            }
+            //Since none of the child nodes of nodeFrom are present in the cloneNodes list, it can be cloned immediately
+            if (!postpone) {
+                _cloneNode(nodeFrom, nodeIdPair->node, 0);
+                if (nodeFrom && nodeFrom->type == SvgNodeType::Symbol && nodeIdPair->node->type == SvgNodeType::Use) {
+                    nodeIdPair->node->node.use.symbol = nodeFrom;
+                }
+                free(nodeIdPair->id);
+                free(nodeIdPair);
             }
         } else {
-            TVGLOG("SVG", "%s is ancestor element. This reference is invalid.", nodeIdPair.id);
+            TVGLOG("SVG", "%s is ancestor element. This reference is invalid.", nodeIdPair->id);
+            free(nodeIdPair->id);
+            free(nodeIdPair);
         }
-        free(nodeIdPair.id);
+        nodeIdPair = cloneNodes->front();
     }
 }
 
@@ -3917,7 +3927,7 @@ void SvgLoader::run(unsigned tid)
         if (loaderData.nodesToStyle.count > 0) cssApplyStyleToPostponeds(loaderData.nodesToStyle, loaderData.cssStyle);
         if (loaderData.cssStyle) cssUpdateStyle(loaderData.doc, loaderData.cssStyle);
 
-        if (loaderData.cloneNodes.count > 0) _clonePostponedNodes(&loaderData.cloneNodes, loaderData.doc);
+        if (!loaderData.cloneNodes.empty()) _clonePostponedNodes(&loaderData.cloneNodes, loaderData.doc);
 
         _updateComposite(loaderData.doc, loaderData.doc);
         if (defs) _updateComposite(loaderData.doc, defs);

--- a/thirdparty/thorvg/src/loaders/svg/tvgSvgLoaderCommon.h
+++ b/thirdparty/thorvg/src/loaders/svg/tvgSvgLoaderCommon.h
@@ -25,6 +25,7 @@
 
 #include "tvgCommon.h"
 #include "tvgArray.h"
+#include "tvgInlist.h"
 
 struct SvgNode;
 struct SvgStyleGradient;
@@ -551,6 +552,8 @@ struct SvgParser
 
 struct SvgNodeIdPair
 {
+    INLIST_ITEM(SvgNodeIdPair);
+    SvgNodeIdPair(SvgNode* n, char* i) : node{n}, id{i} {}
     SvgNode* node;
     char *id;
 };
@@ -579,7 +582,7 @@ struct SvgLoaderData
     Array<SvgStyleGradient*> gradients;
     Array<SvgStyleGradient*> gradientStack; //For stops
     SvgParser* svgParse = nullptr;
-    Array<SvgNodeIdPair> cloneNodes;
+    Inlist<SvgNodeIdPair> cloneNodes;
     Array<SvgNodeIdPair> nodesToStyle;
     Array<char*> images;        //embedded images
     Array<FontFace> fonts;

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwImage.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwImage.cpp
@@ -95,9 +95,9 @@ bool imagePrepare(SwImage* image, const Matrix& transform, const SwBBox& clipReg
 }
 
 
-bool imageGenRle(SwImage* image, const SwBBox& renderRegion, bool antiAlias)
+bool imageGenRle(SwImage* image, const SwBBox& renderRegion, SwMpool* mpool, unsigned tid, bool antiAlias)
 {
-    if ((image->rle = rleRender(image->rle, image->outline, renderRegion, antiAlias))) return true;
+    if ((image->rle = rleRender(image->rle, image->outline, renderRegion, mpool, tid, antiAlias))) return true;
 
     return false;
 }

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMath.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMath.cpp
@@ -245,9 +245,7 @@ void mathSplitCubic(SwPoint* base)
 void mathSplitLine(SwPoint* base)
 {
     base[2] = base[1];
-
-    base[1].x = (base[0].x + base[1].x) >> 1;
-    base[1].y = (base[0].y + base[1].y) >> 1;
+    base[1] = {(base[0].x >> 1) + (base[1].x >> 1), (base[0].y >> 1) + (base[1].y >> 1)};
 }
 
 

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMemPool.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwMemPool.cpp
@@ -24,11 +24,6 @@
 
 
 /************************************************************************/
-/* Internal Class Implementation                                        */
-/************************************************************************/
-
-
-/************************************************************************/
 /* External Class Implementation                                        */
 /************************************************************************/
 
@@ -62,18 +57,9 @@ void mpoolRetStrokeOutline(SwMpool* mpool, unsigned idx)
 }
 
 
-SwOutline* mpoolReqDashOutline(SwMpool* mpool, unsigned idx)
+SwCellPool* mpoolReqCellPool(SwMpool* mpool, unsigned idx)
 {
-    return &mpool->dashOutline[idx];
-}
-
-
-void mpoolRetDashOutline(SwMpool* mpool, unsigned idx)
-{
-    mpool->dashOutline[idx].pts.clear();
-    mpool->dashOutline[idx].cntrs.clear();
-    mpool->dashOutline[idx].types.clear();
-    mpool->dashOutline[idx].closed.clear();
+    return &mpool->cellPool[idx];
 }
 
 
@@ -84,7 +70,8 @@ SwMpool* mpoolInit(uint32_t threads)
     auto mpool = static_cast<SwMpool*>(calloc(1, sizeof(SwMpool)));
     mpool->outline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * allocSize));
     mpool->strokeOutline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * allocSize));
-    mpool->dashOutline = static_cast<SwOutline*>(calloc(1, sizeof(SwOutline) * allocSize));
+    mpool->cellPool = new SwCellPool[allocSize];
+
     mpool->allocSize = allocSize;
 
     return mpool;
@@ -103,11 +90,6 @@ bool mpoolClear(SwMpool* mpool)
         mpool->strokeOutline[i].cntrs.reset();
         mpool->strokeOutline[i].types.reset();
         mpool->strokeOutline[i].closed.reset();
-
-        mpool->dashOutline[i].pts.reset();
-        mpool->dashOutline[i].cntrs.reset();
-        mpool->dashOutline[i].types.reset();
-        mpool->dashOutline[i].closed.reset();
     }
 
     return true;
@@ -122,7 +104,7 @@ bool mpoolTerm(SwMpool* mpool)
 
     free(mpool->outline);
     free(mpool->strokeOutline);
-    free(mpool->dashOutline);
+    delete[](mpool->cellPool);
     free(mpool);
 
     return true;

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwPostEffect.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwPostEffect.cpp
@@ -266,25 +266,87 @@ static void _dropShadowFilter(uint32_t* dst, uint32_t* src, int stride, int w, i
 }
 
 
-static void _dropShadowShift(uint32_t* dst, uint32_t* src, int dstride, int sstride, SwBBox& region, SwPoint& offset, uint8_t opacity, bool direct)
+static void _shift(uint32_t** dst, uint32_t** src, int dstride, int sstride, int wmax, int hmax, const SwBBox& bbox, SwPoint offset, SwSize& size)
 {
-    src += (region.min.y * sstride + region.min.x);
-    dst += (region.min.y * dstride + region.min.x);
+    size.w = bbox.max.x - bbox.min.x;
+    size.h = bbox.max.y - bbox.min.y;
 
-    auto w = region.max.x - region.min.x;
-    auto h = region.max.y - region.min.y;
-    auto translucent = (direct || opacity < 255);
+    //shift
+    if (offset.x < 0) {
+        *src -= offset.x;
+        size.w += offset.x;
+    } else {
+        *dst += offset.x;
+        size.w -= offset.x;
+    }
 
-    //shift offset
-    if (region.min.x + offset.x < 0) src -= offset.x;
-    else dst += offset.x;
+    if (offset.y < 0) {
+        *src -= (offset.y * sstride);
+        size.h += offset.y;
+    } else {
+        *dst += (offset.y * dstride);
+        size.h -= offset.y;
+    }
+}
 
-    if (region.min.y + offset.y < 0) src -= (offset.y * sstride);
-    else dst += (offset.y * dstride);
 
-    for (auto y = 0; y < h; ++y) {
-        if (translucent) rasterTranslucentPixel32(dst, src, w, opacity);
-        else rasterPixel32(dst, src, w, opacity);
+static void _dropShadowNoFilter(uint32_t* dst, uint32_t* src, int dstride, int sstride, int dw, int dh, const SwBBox& bbox, const SwPoint& offset, uint32_t color, uint8_t opacity, bool direct)
+{
+    src += (bbox.min.y * sstride + bbox.min.x);
+    dst += (bbox.min.y * dstride + bbox.min.x);
+
+    SwSize size;
+    _shift(&dst, &src, dstride, sstride, dw, dh, bbox, offset, size);
+
+    for (auto y = 0; y < size.h; ++y) {
+        auto s2 = src;
+        auto d2 = dst;
+        for (int x = 0; x < size.w; ++x, ++d2, ++s2) {
+            auto a = MULTIPLY(opacity, A(*s2));
+            if (!direct || a == 255) *d2 = ALPHA_BLEND(color, a);
+            else *d2 = INTERPOLATE(color, *d2, a);
+        }
+        src += sstride;
+        dst += dstride;
+    }
+}
+
+
+static void _dropShadowNoFilter(SwImage* dimg, SwImage* simg, const SwBBox& bbox, const SwPoint& offset, uint32_t color)
+{
+    int dstride = dimg->stride;
+    int sstride = simg->stride;
+
+    //shadow image
+    _dropShadowNoFilter(dimg->buf32, simg->buf32, dstride, sstride, dimg->w, dimg->h, bbox, offset, color, 255, false);
+
+    //original image
+    auto src = simg->buf32 + (bbox.min.y * sstride + bbox.min.x);
+    auto dst = dimg->buf32 + (bbox.min.y * dstride + bbox.min.x);
+
+    for (auto y = 0; y < (bbox.max.y - bbox.min.y); ++y) {
+        auto s = src;
+        auto d = dst;
+        for (int x = 0; x < (bbox.max.x - bbox.min.x); ++x, ++d, ++s) {
+            *d = *s + ALPHA_BLEND(*d, IA(*s));
+        }
+        src += sstride;
+        dst += dstride;
+    }
+}
+
+
+static void _dropShadowShift(uint32_t* dst, uint32_t* src, int dstride, int sstride, int dw, int dh, const SwBBox& bbox, const SwPoint& offset, uint8_t opacity, bool direct)
+{
+    src += (bbox.min.y * sstride + bbox.min.x);
+    dst += (bbox.min.y * dstride + bbox.min.x);
+
+    SwSize size;
+    _shift(&dst, &src, dstride, sstride, dw, dh, bbox, offset, size);
+
+    for (auto y = 0; y < size.h; ++y) {
+        if (direct) rasterTranslucentPixel32(dst, src, size.w, opacity);
+        else rasterPixel32(dst, src, size.w, opacity);
         src += sstride;
         dst += dstride;
     }
@@ -322,18 +384,14 @@ void effectDropShadowUpdate(RenderEffectDropShadow* params, const Matrix& transf
     rd->extends = _gaussianInit(rd, std::pow(params->sigma * scale, 2), params->quality);
 
     //invalid
-    if (rd->extends == 0 || params->color[3] == 0) {
+    if (params->color[3] == 0) {
         params->valid = false;
         return;
     }
 
     //offset
-    if (params->distance > 0.0f) {
-        auto radian = tvg::deg2rad(90.0f - params->angle);
-        rd->offset = {(SwCoord)(params->distance * cosf(radian)), (SwCoord)(-1.0f * params->distance * sinf(radian))};
-    } else {
-        rd->offset = {0, 0};
-    }
+    auto radian = tvg::deg2rad(90.0f - params->angle) - tvg::radian(transform);
+    rd->offset = {(int32_t)((params->distance * scale) * cosf(radian)), (int32_t)(-1.0f * (params->distance * scale) * sinf(radian))};
 
     params->valid = true;
 }
@@ -364,6 +422,17 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
 
     TVGLOG("SW_ENGINE", "DropShadow region(%ld, %ld, %ld, %ld) params(%f %f %f), level(%d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->angle, params->distance, params->sigma, data->level);
 
+    //no filter required
+    if (data->extends == 0)  {
+        if (direct) {
+            _dropShadowNoFilter(cmp->recoverSfc->buf32, cmp->image.buf32, cmp->recoverSfc->stride, cmp->image.stride, cmp->recoverSfc->w, cmp->recoverSfc->h, bbox, data->offset, color, opacity, direct);
+        } else {
+            _dropShadowNoFilter(buffer[1], &cmp->image, bbox, data->offset, color);
+            std::swap(cmp->image.buf32, buffer[1]->buf32);
+        }
+        return true;
+    }
+
     //saving the original image in order to overlay it into the filtered image.
     _dropShadowFilter(back, front, stride, w, h, bbox, data->kernel[0], color, false);
     std::swap(front, buffer[0]->buf32);
@@ -389,14 +458,14 @@ bool effectDropShadow(SwCompositor* cmp, SwSurface* surface[2], const RenderEffe
 
     //draw to the main surface directly
     if (direct) {
-        _dropShadowShift(cmp->recoverSfc->buf32, cmp->image.buf32, cmp->recoverSfc->stride, stride, bbox, data->offset, opacity, direct);
+        _dropShadowShift(cmp->recoverSfc->buf32, cmp->image.buf32, cmp->recoverSfc->stride, cmp->image.stride, cmp->recoverSfc->w, cmp->recoverSfc->h, bbox, data->offset, opacity, direct);
         std::swap(cmp->image.buf32, buffer[0]->buf32);
         return true;
     }
 
     //draw to the intermediate surface
     rasterClear(surface[1], bbox.min.x, bbox.min.y, w, h);
-    _dropShadowShift(buffer[1]->buf32, cmp->image.buf32, stride, stride, bbox, data->offset, opacity, direct);
+    _dropShadowShift(buffer[1]->buf32, cmp->image.buf32, buffer[1]->stride, cmp->image.stride, buffer[1]->w, buffer[1]->h, bbox, data->offset, opacity, direct);
     std::swap(cmp->image.buf32, buffer[1]->buf32);
 
     //compositing shadow and body
@@ -485,8 +554,6 @@ bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct)
 
     TVGLOG("SW_ENGINE", "Tint region(%ld, %ld, %ld, %ld), param(%d %d %d, %d %d %d, %d)", bbox.min.x, bbox.min.y, bbox.max.x, bbox.max.y, params->black[0], params->black[1], params->black[2], params->white[0], params->white[1], params->white[2], params->intensity);
 
-    /* Tint Formula: (1 - L) * Black + L * White, where the L is Luminance. */
-
     if (direct) {
         auto dbuffer = cmp->recoverSfc->buf32 + (bbox.min.y * cmp->recoverSfc->stride + bbox.min.x);
         auto sbuffer = cmp->image.buf32 + (bbox.min.y * cmp->image.stride + bbox.min.x);
@@ -525,11 +592,6 @@ bool effectTint(SwCompositor* cmp, const RenderEffectTint* params, bool direct)
 
 static uint32_t _trintone(uint32_t s, uint32_t m, uint32_t h, int l)
 {
-    /* Tritone Formula:
-       if (L < 0.5) { (1 - 2L) * Shadow + 2L * Midtone }
-       else { (1 - 2(L - 0.5)) * Midtone + (2(L - 0.5)) * Highlight }
-       Where the L is Luminance. */
-
     if (l < 128) {
         auto a = std::min(l * 2, 255);
         return ALPHA_BLEND(s, 255 - a) + ALPHA_BLEND(m, a);

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRenderer.h
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRenderer.h
@@ -55,6 +55,8 @@ public:
     bool target(pixel_t* data, uint32_t stride, uint32_t w, uint32_t h, ColorSpace cs);
     bool mempool(bool shared);
 
+    SwSurface* request(int channelSize, bool square);
+
     RenderCompositor* target(const RenderRegion& region, ColorSpace cs, CompositionFlag flags) override;
     bool beginComposite(RenderCompositor* cmp, CompositeMethod method, uint8_t opacity) override;
     bool endComposite(RenderCompositor* cmp) override;
@@ -80,7 +82,6 @@ private:
     SwRenderer();
     ~SwRenderer();
 
-    SwSurface* request(int channelSize, bool square);
     RenderData prepareCommon(SwTask* task, const Matrix& transform, const Array<RenderData>& clips, uint8_t opacity, RenderUpdateFlag flags);
 };
 

--- a/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRle.cpp
+++ b/thirdparty/thorvg/src/renderer/sw_engine/tvgSwRle.cpp
@@ -199,19 +199,9 @@
 constexpr auto PIXEL_BITS = 8;   //must be at least 6 bits!
 constexpr auto ONE_PIXEL = (1L << PIXEL_BITS);
 
-using Area = long;
-
 struct Band
 {
     SwCoord min, max;
-};
-
-struct Cell
-{
-    SwCoord x;
-    SwCoord cover;
-    Area area;
-    Cell *next;
 };
 
 struct RleWorker
@@ -227,7 +217,7 @@ struct RleWorker
     Area area;
     SwCoord cover;
 
-    Cell* cells;
+    SwCell* cells;
     ptrdiff_t maxCells;
     ptrdiff_t cellsCnt;
 
@@ -242,11 +232,11 @@ struct RleWorker
     int bandSize;
     int bandShoot;
 
-    void* buffer;
-    long bufferSize;
+    SwCell* buffer;
+    uint32_t bufferSize;
 
-    Cell** yCells;
-    SwCoord yCnt;
+    SwCell** yCells;
+    int32_t yCnt;
 
     bool invalid;
     bool antiAlias;
@@ -282,12 +272,11 @@ static inline SwCoord SUBPIXELS(const SwCoord x)
     return SwCoord(((unsigned long) x) << PIXEL_BITS);
 }
 
-/*
- *  Approximate sqrt(x*x+y*y) using the `alpha max plus beta min'
- *  algorithm.  We use alpha = 1, beta = 3/8, giving us results with a
- *  largest error less than 7% compared to the exact value.
- */
-static inline SwCoord HYPOT(SwPoint pt)
+
+// Approximate sqrt(x*x+y*y) using the `alpha max plus beta min' algorithm.
+// We use alpha = 1, beta = 3/8, giving us results with a largest error
+// less than 7% compared to the exact value.
+static inline int32_t HYPOT(SwPoint pt)
 {
     if (pt.x < 0) pt.x = -pt.x;
     if (pt.y < 0) pt.y = -pt.y;
@@ -295,7 +284,17 @@ static inline SwCoord HYPOT(SwPoint pt)
 }
 
 
-static void _horizLine(RleWorker& rw, SwCoord x, SwCoord y, SwCoord area, SwCoord aCount)
+// Used to prevent integer overflow when calculating the distance between points.
+// This function uses 64-bit arithmetic to safely compute the difference between coordinates.
+static inline uint32_t SAFE_HYPOT(SwPoint& pt1, SwPoint& pt2)
+{
+    auto x = uint32_t(abs(int64_t(pt1.x) - int64_t(pt2.x)));
+    auto y = uint32_t(abs(int64_t(pt1.y) - int64_t(pt2.y)));
+    return (x > y) ? (x + (3 * y >> 3)) : (y + (3 * x >> 3));
+}
+
+
+static void _horizLine(RleWorker& rw, int32_t x, int32_t y, int32_t area, int32_t aCount)
 {
     x += rw.cellMin.x;
     y += rw.cellMin.y;
@@ -401,7 +400,7 @@ static void _sweep(RleWorker& rw)
 }
 
 
-static Cell* _findCell(RleWorker& rw)
+static SwCell* _findCell(RleWorker& rw)
 {
     auto x = rw.cellPos.x;
     if (x > rw.cellXCnt) x = rw.cellXCnt;
@@ -409,7 +408,7 @@ static Cell* _findCell(RleWorker& rw)
     auto pcell = &rw.yCells[rw.cellPos.y];
 
     while(true) {
-        Cell* cell = *pcell;
+        auto cell = *pcell;
         if (!cell || cell->x > x) break;
         if (cell->x == x) return cell;
         pcell = &cell->next;
@@ -529,14 +528,12 @@ static bool _lineTo(RleWorker& rw, const SwPoint& to)
     line[1] = rw.pos;
 
     while (true) {
-        auto diff = line[0] - line[1];
-        auto L = HYPOT(diff);
-
-        if (L > SHRT_MAX) {
+        if (SAFE_HYPOT(line[0], line[1]) > SHRT_MAX) {
             mathSplitLine(line);
             ++line;
             continue;
         }
+        auto diff = line[0] - line[1];
         e1 = TRUNC(line[1]);
         e2 = TRUNC(line[0]);
 
@@ -864,21 +861,25 @@ void _replaceClipSpan(SwRle *rle, SwSpan* clippedSpans, uint32_t size)
 /* External Class Implementation                                        */
 /************************************************************************/
 
-SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegion, bool antiAlias)
+SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegion, SwMpool* mpool, unsigned tid, bool antiAlias)
 {
     if (!outline) return nullptr;
-
-    constexpr auto RENDER_POOL_SIZE = 16384L;
-    constexpr auto BAND_SIZE = 40;
-
-    //TODO: We can preserve several static workers in advance
+  
     RleWorker rw;
-    Cell buffer[RENDER_POOL_SIZE / sizeof(Cell)];
+    auto cellPool = mpoolReqCellPool(mpool, tid);
+    auto reqSize = uint32_t(std::max(renderRegion.w(), renderRegion.h()) * 0.75f) * sizeof(SwCell);  //experimental decision
+
+    // grow by 1.25x and align to multiple of sizeof(SwCell)
+    if (reqSize > cellPool->size) {
+        cellPool->size = ((reqSize + (reqSize >> 2)) / sizeof(SwCell)) * sizeof(SwCell);
+        free(cellPool->buffer);
+        cellPool->buffer = (SwCell*)malloc(cellPool->size);
+    }
 
     //Init Cells
-    rw.buffer = buffer;
-    rw.bufferSize = sizeof(buffer);
-    rw.yCells = reinterpret_cast<Cell**>(buffer);
+    rw.buffer = cellPool->buffer;
+    rw.bufferSize = cellPool->size;
+    rw.yCells = reinterpret_cast<SwCell**>(cellPool->buffer);
     rw.cells = nullptr;
     rw.maxCells = 0;
     rw.cellsCnt = 0;
@@ -890,7 +891,7 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegio
     rw.cellXCnt = rw.cellMax.x - rw.cellMin.x;
     rw.cellYCnt = rw.cellMax.y - rw.cellMin.y;
     rw.outline = const_cast<SwOutline*>(outline);
-    rw.bandSize = rw.bufferSize / (sizeof(Cell) * 2);  //bandSize: 256
+    rw.bandSize = rw.bufferSize / (sizeof(SwCell) * 2);
     rw.bandShoot = 0;
     rw.antiAlias = antiAlias;
 
@@ -898,6 +899,8 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegio
     else rw.rle = rle;
 
     //Generate RLE
+    constexpr auto BAND_SIZE = 40;
+
     Band bands[BAND_SIZE];
     Band* band;
 
@@ -920,16 +923,16 @@ SwRle* rleRender(SwRle* rle, const SwOutline* outline, const SwBBox& renderRegio
         band = bands;
 
         while (band >= bands) {
-            rw.yCells = static_cast<Cell**>(rw.buffer);
+            rw.yCells = reinterpret_cast<SwCell**>(rw.buffer);
             rw.yCnt = band->max - band->min;
 
-            int cellStart = sizeof(Cell*) * (int)rw.yCnt;
-            int cellMod = cellStart % sizeof(Cell);
+            int cellStart = sizeof(SwCell*) * (int)rw.yCnt;
+            int cellMod = cellStart % sizeof(SwCell);
 
-            if (cellMod > 0) cellStart += sizeof(Cell) - cellMod;
+            if (cellMod > 0) cellStart += sizeof(SwCell) - cellMod;
 
-            auto cellsMax = reinterpret_cast<Cell*>((char*)rw.buffer + rw.bufferSize);
-            rw.cells = reinterpret_cast<Cell*>((char*)rw.buffer + cellStart);
+            auto cellsMax = reinterpret_cast<SwCell*>((char*)rw.buffer + rw.bufferSize);
+            rw.cells = reinterpret_cast<SwCell*>((char*)rw.buffer + cellStart);
 
             if (rw.cells >= cellsMax) goto reduce_bands;
 

--- a/thirdparty/thorvg/src/renderer/tvgCommon.h
+++ b/thirdparty/thorvg/src/renderer/tvgCommon.h
@@ -56,8 +56,6 @@ using namespace tvg;
 
 enum class FileType { Png = 0, Jpg, Webp, Tvg, Svg, Lottie, Ttf, Raw, Gif, Unknown };
 
-using Size = Point;
-
 #ifdef THORVG_LOG_ENABLED
     constexpr auto ErrorColor = "\033[31m";  //red
     constexpr auto ErrorBgColor = "\033[41m";//bg red

--- a/thirdparty/thorvg/src/renderer/tvgPaint.h
+++ b/thirdparty/thorvg/src/renderer/tvgPaint.h
@@ -74,9 +74,9 @@ namespace tvg
         } tr;
         RenderUpdateFlag renderFlag = RenderUpdateFlag::None;
         BlendMethod blendMethod;
+        uint16_t refCnt = 0;       //reference count
         uint8_t ctxFlag;
         uint8_t opacity;
-        uint8_t refCnt = 0;                              //reference count
 
         Impl(Paint* pnt) : paint(pnt)
         {
@@ -95,7 +95,6 @@ namespace tvg
 
         uint8_t ref()
         {
-            if (refCnt == 255) TVGERR("RENDERER", "Corrupted reference count!");
             return ++refCnt;
         }
 

--- a/thirdparty/thorvg/src/renderer/tvgText.h
+++ b/thirdparty/thorvg/src/renderer/tvgText.h
@@ -40,10 +40,7 @@ struct Text::Impl
     bool italic = false;
     bool changed = false;
 
-    Impl(Text* p) : paint(p), shape(Shape::gen().release())
-    {
-        shape->fill(FillRule::EvenOdd);
-    }
+    Impl(Text* p) : paint(p), shape(Shape::gen().release()) {}
 
     ~Impl()
     {

--- a/thirdparty/thorvg/update-thorvg.sh
+++ b/thirdparty/thorvg/update-thorvg.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-VERSION=0.15.13
+VERSION=0.15.16
 # Uncomment and set a git hash to use specific commit instead of tag.
 #GIT_COMMIT=
 


### PR DESCRIPTION
https://github.com/thorvg/thorvg/releases/tag/v0.15.14
<details open>
<summary>Changes</summary>

- [Core] Corrected an incorrect fill rule option in text rendering.
- [Core] Fixed incorrect calculation in multiple mask applications.
- [Core] Improved radial gradient handling to conform with SVG 1.1 and address edge cases.
- [CPU] Improved the DropShadow effect stability.
- [CPU] Updated the SoftLight blending equation to align with the W3C specification.
- [CPU] Added proper support for zero-size blur in DropShadow effects.
- [CPU] Revised texture clipping logic to correctly support shapes with inner corners.
- [CPU] Fixed an issue where lines were missing when a picture was rotated 90 degrees.
- [GL/ES] Fixed broken clipping behavior.
- [Lottie] Increased the quality level of GaussianBlur and DropShadow from low to medium.
- [Lottie] Adjusted DropShadow distance to match Adobe After Effects behavior.
- [Lottie] Fixed missing offset corners when using miter joins.
- [Lottie] Ensured proper star/polygon closure to prevent artifacts from inaccurate point comparisons.
- [Lottie] Corrected an issue causing inaccurate opacity when using the Repeater property.
- [Lottie] Fixed a specification mismatch when a null layer was applied to layer masking.
- [SVG] Fix the nested use nodes.
- [Additional Notes] Removed Lena resources previously used in ThorVG.

</details>
