### PR TITLE
Fix `--generate-spirv-debug-info` regression and cache

### DIFF
--- a/drivers/vulkan/rendering_shader_container_vulkan.h
+++ b/drivers/vulkan/rendering_shader_container_vulkan.h
@@ -32,8 +32,13 @@
 
 #include "servers/rendering/rendering_shader_container.h"
 
+#ifdef DEBUG_ENABLED
+#define RENDERING_SHADER_CONTAINER_VULKAN_COMPRESSION 0
+#define RENDERING_SHADER_CONTAINER_VULKAN_SMOLV 0
+#else
 #define RENDERING_SHADER_CONTAINER_VULKAN_COMPRESSION 1
 #define RENDERING_SHADER_CONTAINER_VULKAN_SMOLV 1
+#endif
 
 class RenderingShaderContainerVulkan : public RenderingShaderContainer {
 	GDSOFTCLASS(RenderingShaderContainerVulkan, RenderingShaderContainer);

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -30,6 +30,10 @@
 
 #include "shader_rd.h"
 
+#ifdef DEBUG_ENABLED
+#include "core/config/engine.h"
+#endif
+
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/worker_thread_pool.h"
@@ -158,6 +162,10 @@ void ShaderRD::setup(const char *p_vertex_code, const char *p_fragment_code, con
 	tohash.append(p_fragment_code ? p_fragment_code : "");
 	tohash.append("[Compute]");
 	tohash.append(p_compute_code ? p_compute_code : "");
+#ifdef DEBUG_ENABLED
+	tohash.append("[DebugInfo]");
+	tohash.append(Engine::get_singleton()->is_generate_spirv_debug_info_enabled() ? "1" : "0");
+#endif
 
 	base_sha256 = tohash.as_string().sha256_text();
 }


### PR DESCRIPTION
`--generate-spirv-debug-info` should compile shaders with debug info used for tools like RenderDoc, but it no longer works in master. This is a regression caused by the optimizations in the shader baker changes, as pointed in https://github.com/godotengine/godot/issues/106881#issuecomment-2960091519.

But even with this fixed, `--generate-spirv-debug-info` doesn't work with the shader cache system and has no effect unless we manually delete the cache every time we set or unset it. This PR also fixes it.

*Bugsquad edit: Fixes #106881*