### PR TITLE
Add default param value to `EditorExportPlatform::get_forced_export_files`

### DIFF
--- a/doc/classes/EditorExportPlatform.xml
+++ b/doc/classes/EditorExportPlatform.xml
@@ -121,7 +121,7 @@
 		</method>
 		<method name="get_forced_export_files" qualifiers="static">
 			<return type="PackedStringArray" />
-			<param index="0" name="preset" type="EditorExportPreset" />
+			<param index="0" name="preset" type="EditorExportPreset" default="null" />
 			<description>
 				Returns array of core file names that always should be exported regardless of preset config.
 			</description>

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -2530,7 +2530,7 @@ void EditorExportPlatform::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_internal_export_files", "preset", "debug"), &EditorExportPlatform::get_internal_export_files);
 
-	ClassDB::bind_static_method("EditorExportPlatform", D_METHOD("get_forced_export_files", "preset"), &EditorExportPlatform::get_forced_export_files);
+	ClassDB::bind_static_method("EditorExportPlatform", D_METHOD("get_forced_export_files", "preset"), &EditorExportPlatform::get_forced_export_files, DEFVAL(Ref<EditorExportPreset>()));
 
 	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_NONE);
 	BIND_ENUM_CONSTANT(EXPORT_MESSAGE_INFO);


### PR DESCRIPTION
Add default parameter value to a new parameter added in 4.5 to `EditorExportPlatform::get_forced_export_files` so we can avoid breaking compatibility for GDScript.

C# and GDExtension use the registered compat method so they don't need this to avoid breaking compatibility.

- Follow-up to #71542
