### PR TITLE
Support debugging Godot editor plugins with DAP

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_parser.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.cpp
@@ -184,6 +184,20 @@ Dictionary DebugAdapterParser::req_launch(const Dictionary &p_params) const {
 	return Dictionary();
 }
 
+Vector<String> DebugAdapterParser::_extract_play_arguments(const Dictionary &args) const {
+	Vector<String> play_args;
+	if (args.has("playArgs")) {
+		Variant v = args["playArgs"];
+		if (v.get_type() == Variant::ARRAY) {
+			Array arr = v;
+			for (const Variant &arg : arr) {
+				play_args.push_back(String(arg));
+			}
+		}
+	}
+	return play_args;
+}
+
 Dictionary DebugAdapterParser::_launch_process(const Dictionary &p_params) const {
 	Dictionary args = p_params["arguments"];
 	ScriptEditorDebugger *dbg = EditorDebuggerNode::get_singleton()->get_default_debugger();
@@ -193,7 +207,15 @@ Dictionary DebugAdapterParser::_launch_process(const Dictionary &p_params) const
 
 	String platform_string = args.get("platform", "host");
 	if (platform_string == "host") {
-		EditorRunBar::get_singleton()->play_main_scene();
+		Vector<String> play_args = _extract_play_arguments(args);
+		const String scene = args.get("scene", "main");
+		if (scene == "main") {
+			EditorRunBar::get_singleton()->play_main_scene(false, play_args);
+		} else if (scene == "current") {
+			EditorRunBar::get_singleton()->play_current_scene(false, play_args);
+		} else {
+			EditorRunBar::get_singleton()->play_custom_scene(scene, play_args);
+		}
 	} else {
 		int device = args.get("device", -1);
 		int idx = -1;

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -86,6 +86,7 @@ public:
 	Dictionary req_godot_put_msg(const Dictionary &p_params) const;
 
 	// Internal requests
+	Vector<String> _extract_play_arguments(const Dictionary &args) const;
 	Dictionary _launch_process(const Dictionary &p_params) const;
 
 	// Events

--- a/editor/debugger/debug_adapter/debug_adapter_parser.h
+++ b/editor/debugger/debug_adapter/debug_adapter_parser.h
@@ -88,6 +88,7 @@ public:
 	// Internal requests
 	Vector<String> _extract_play_arguments(const Dictionary &args) const;
 	Dictionary _launch_process(const Dictionary &p_params) const;
+	Dictionary _launch_secondary_editor(const Dictionary &p_params, const Dictionary &args) const;
 
 	// Events
 	Dictionary ev_initialized() const;

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -64,6 +64,7 @@ struct DAPeer : RefCounted {
 	// Internal client info
 	bool attached = false;
 	Dictionary pending_launch;
+	OS::ProcessID secondary_editor_pid = 0;
 
 	Error handle_data();
 	Error send_data();

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -367,7 +367,7 @@ void EditorRunBar::recovery_mode_reload_project() {
 	EditorNode::get_singleton()->trigger_menu_option(EditorNode::PROJECT_RELOAD_CURRENT_PROJECT, false);
 }
 
-void EditorRunBar::play_main_scene(bool p_from_native) {
+void EditorRunBar::play_main_scene(bool p_from_native, const Vector<String> &p_play_args) {
 	if (Engine::get_singleton()->is_recovery_mode_hint()) {
 		EditorToaster::get_singleton()->popup_str(TTR("Recovery Mode is enabled. Disable it to run the project."), EditorToaster::SEVERITY_WARNING);
 		return;
@@ -379,7 +379,7 @@ void EditorRunBar::play_main_scene(bool p_from_native) {
 		stop_playing();
 
 		current_mode = RunMode::RUN_MAIN;
-		_run_scene();
+		_run_scene("", p_play_args);
 	}
 }
 
@@ -574,8 +574,7 @@ EditorRunBar::EditorRunBar() {
 	play_button->set_toggle_mode(true);
 	play_button->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 	play_button->set_tooltip_text(TTRC("Run the project's default scene."));
-	play_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::play_main_scene).bind(false));
-
+	play_button->connect(SceneStringName(pressed), callable_mp(this, &EditorRunBar::play_main_scene).bind(false, Vector<String>()));
 	ED_SHORTCUT_AND_COMMAND("editor/run_project", TTRC("Run Project"), Key::F5);
 	ED_SHORTCUT_OVERRIDE("editor/run_project", "macos", KeyModifierMask::META | Key::B);
 	play_button->set_shortcut(ED_GET_SHORTCUT("editor/run_project"));

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -113,7 +113,7 @@ public:
 	void recovery_mode_show_dialog();
 	void recovery_mode_reload_project();
 
-	void play_main_scene(bool p_from_native = false);
+	void play_main_scene(bool p_from_native = false, const Vector<String> &p_play_args = Vector<String>());
 	void play_current_scene(bool p_reload = false, const Vector<String> &p_play_args = Vector<String>());
 	void play_custom_scene(const String &p_custom, const Vector<String> &p_play_args = Vector<String>());
 


### PR DESCRIPTION
When DAP is used for debugging, GodotEditor plays the DAP server role, so
we need to run a second Godot with the same project and `--remote-debug flags` wire it with DAP server similar way as we do for debugging a Game.

required for https://github.com/JetBrains/godot-support/issues/332
this should follow after the previous PR https://github.com/godotengine/godot/pull/109637

Can be tested with launch.json:
```
        {
            "name": "secondary editor",
            "type": "godot",
            "request": "launch",
            "project": "${workspaceFolder}",
            "debugServer": 6006,
            "platform": "editor",
            "remoteDebugPort": "60133",
        },
```