### PR TITLE
ImporterMesh: Validate triangle indices array size is a multiple of 3

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3340,13 +3340,14 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 			Vector<int> indices_vec4_mapping;
 			if (mesh_prim.has("indices")) {
 				indices = _decode_accessor_as_ints(p_state, mesh_prim["indices"], false);
-				const int is = indices.size();
+				const int index_count = indices.size();
 
 				if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
+					ERR_FAIL_COND_V_MSG(index_count % 3 != 0, ERR_PARSE_ERROR, "glTF import: Mesh " + itos(i) + " surface " + itos(j) + " in file " + p_state->filename + " is invalid. Indexed triangle meshes MUST have an index array with a size that is a multiple of 3, but got " + itos(index_count) + " indices.");
 					// Swap around indices, convert ccw to cw for front face.
 
 					int *w = indices.ptrw();
-					for (int k = 0; k < is; k += 3) {
+					for (int k = 0; k < index_count; k += 3) {
 						SWAP(w[k + 1], w[k + 2]);
 					}
 				}
@@ -3355,7 +3356,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				Vector<bool> used_indices;
 				used_indices.resize_initialized(orig_vertex_num);
 				bool *used_w = used_indices.ptrw();
-				for (int idx_i = 0; idx_i < is; idx_i++) {
+				for (int idx_i = 0; idx_i < index_count; idx_i++) {
 					ERR_FAIL_INDEX_V(indices_w[idx_i], orig_vertex_num, ERR_INVALID_DATA);
 					used_w[indices_w[idx_i]] = true;
 				}
@@ -3556,11 +3557,12 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 				// Generate indices because they need to be swapped for CW/CCW.
 				const Vector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
 				ERR_FAIL_COND_V(vertices.is_empty(), ERR_PARSE_ERROR);
-				const int vs = vertices.size();
-				indices.resize(vs);
+				const int vertex_count = vertices.size();
+				ERR_FAIL_COND_V_MSG(vertex_count % 3 != 0, ERR_PARSE_ERROR, "glTF import: Mesh " + itos(i) + " surface " + itos(j) + " in file " + p_state->filename + " is invalid. Non-indexed triangle meshes MUST have a vertex array with a size that is a multiple of 3, but got " + itos(vertex_count) + " vertices.");
+				indices.resize(vertex_count);
 				{
 					int *w = indices.ptrw();
-					for (int k = 0; k < vs; k += 3) {
+					for (int k = 0; k < vertex_count; k += 3) {
 						w[k] = k;
 						w[k + 1] = k + 2;
 						w[k + 2] = k + 1;

--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -322,6 +322,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 		if (index_count == 0) {
 			continue; //no lods if no indices
 		}
+		ERR_FAIL_COND_MSG(index_count % 3 != 0, "ImporterMesh::generate_lods: Indexed triangle meshes MUST have an index array with a size that is a multiple of 3, but got " + itos(index_count) + " indices. Cannot generate LODs for this invalid mesh.");
 
 		const Vector3 *vertices_ptr = vertices.ptr();
 		const int *indices_ptr = indices.ptr();


### PR DESCRIPTION
This PR fixes https://github.com/godotengine/godot/issues/98519. That test file is very invalid, but Godot still shouldn't crash when trying to import it. The cause of the crash was trying to generate LODs on a mesh with an indices array with a size that was not a multiple of 3, which crashes the `meshoptimizer` library which expects a multiple of 3 size (the library already has asserts for this, but those aren't compiled in with Godot). The test file now looks like this when imported:

<img width="1200" height="701" alt="Screenshot 2025-08-16 at 1 04 35 AM" src="https://github.com/user-attachments/assets/f1300b08-8e63-49c5-bd39-3a4269219534" />

Only a single line change in this PR is actually required to prevent the crash, this of code line added to `ImporterMesh::generate_lods`:

```cpp
ERR_FAIL_COND_MSG(index_count % 3 != 0, "ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got " + itos(index_count) + " indices. Cannot generate LODs for this invalid mesh.");
```

Here is the console output with just that single line change:
<details>

```
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 173 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 174 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 175 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 176 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 184 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 185 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 186 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 187 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 195 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 196 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 197 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 198 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 206 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 207 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 208 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 209 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 217 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 218 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 219 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 220 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 228 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 229 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 230 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 231 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 239 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 240 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 241 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 242 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 250 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 251 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 252 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 253 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 261 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 262 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 263 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 264 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 272 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 273 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 274 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 275 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 283 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 284 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 285 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 286 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 294 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 295 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 296 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 297 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 305 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 306 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 307 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 308 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 316 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 317 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 318 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 319 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 327 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 328 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 329 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 330 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 338 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 339 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 340 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 341 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 349 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 350 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 351 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 352 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 360 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 361 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 362 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 363 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 371 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 372 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 373 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 374 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 382 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 383 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 384 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 385 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 393 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 394 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 395 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 396 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 404 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 405 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 406 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 407 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 415 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 416 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 417 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 418 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 426 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 427 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 428 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 429 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 437 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 438 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 439 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 440 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 448 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 449 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 450 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 451 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 497 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 498 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 499 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 500 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 525 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 526 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 527 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 528 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 620 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 620 is out of bounds (vertex_count = 620).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 419 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 419 is out of bounds (vertex_count = 419).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 445 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 433 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 424 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 439 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 521 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 521 is out of bounds (vertex_count = 521).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 646 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 605 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 605 is out of bounds (vertex_count = 605).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 322 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 4834 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 13394 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 13394 is out of bounds (vertex_count = 13394).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 13394 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 13394 is out of bounds (vertex_count = 13394).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 4834 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 13394 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 13394 is out of bounds (vertex_count = 13394).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 4375 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 5699 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 5699 is out of bounds (vertex_count = 5699).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 4375 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 13394 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 13394 is out of bounds (vertex_count = 13394).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 13394 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 13394 is out of bounds (vertex_count = 13394).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 5699 indices. Cannot generate LODs for this invalid mesh.
  ERROR: scene/resources/3d/importer_mesh.cpp:672 - Index index = 5699 is out of bounds (vertex_count = 5699).
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 4834 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 4375 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 1171 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 18391 indices. Cannot generate LODs for this invalid mesh.
  ERROR: ImporterMesh::generate_lods: Indexed triangle meshes MUST have an indices array with a size that is a multiple of 3, but got 484 indices. Cannot generate LODs for this invalid mesh.
```

</details>

However, I also added some code in GLTFDocument to check for invalid meshes, catching the problem earlier, and entirely skips including broken meshes in the scene (rather than just skipping LOD generation for them).

Here is the console output with all the changes in this PR:
<details>

```
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 173 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 174 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 175 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 176 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 184 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 185 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 186 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 187 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 195 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 196 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 197 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 198 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 206 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 207 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 208 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 209 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 217 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 218 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 219 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 220 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 228 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 229 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 230 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 231 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 239 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 240 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 241 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 242 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 250 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 251 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 252 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 253 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 261 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 262 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 263 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 264 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 272 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 273 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 274 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 275 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 283 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 284 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 285 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 286 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 294 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 295 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 296 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 297 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 305 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 306 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 307 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 308 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 316 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 317 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 318 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 319 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 327 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 328 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 329 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 330 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 338 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 339 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 340 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 341 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 349 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 350 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 351 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 352 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 360 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 361 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 362 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 363 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 371 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 372 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 373 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 374 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 382 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 383 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 384 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 385 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 393 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 394 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 395 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 396 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 404 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 405 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 406 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 407 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 415 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 416 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 417 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 418 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 426 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 427 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 428 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 429 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 437 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 438 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 439 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 440 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 448 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 449 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 450 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 451 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 497 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 498 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 499 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 500 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 525 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 526 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 527 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:1053 - glTF import: Invalid accessor count 0 for accessor at index 528 while importing file 'Quarry_Slate'. Accessor count must be greater than 0.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 31 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 620 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 38 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 419 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 40 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 445 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 41 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 433 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 43 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 424 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 44 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 439 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 47 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 521 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 48 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 646 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 49 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 605 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 50 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 322 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 51 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 4834 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 52 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 13394 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 53 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 54 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 13394 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 56 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 4834 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 57 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 58 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 13394 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 59 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 4375 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 60 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 5699 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 61 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 62 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 4375 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 63 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 64 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 13394 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 81 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 82 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 84 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 85 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 90 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 91 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 13394 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 93 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 5699 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 94 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 4834 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 95 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 4375 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 96 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 1171 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 97 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 98 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 99 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 100 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 101 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 103 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 18391 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 112 surface 0 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 484 vertices.
  ERROR: modules/gltf/gltf_document.cpp:3565 - glTF import: Mesh 112 surface 1 in file Quarry_Slate is invalid. Non-indexed triangle meshes MUST have a vertices array with a size that is a multiple of 3, but got 484 vertices.
```

</details>