### PR TITLE
Fix preview camera label being visible and errors when editor loads with scene in cinematic preview and camera selected

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3154,11 +3154,11 @@ void Node3DEditorViewport::_notification(int p_what) {
 				if (cam != nullptr && cam != previewing) {
 					//then switch the viewport's camera to the scene's viewport camera
 					if (previewing != nullptr) {
-						previewing->disconnect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+						previewing->disconnect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 						previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
 					}
 					previewing = cam;
-					previewing->connect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+					previewing->connect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 					previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
 					RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), cam->get_camera());
 					surface->queue_redraw();
@@ -4197,13 +4197,17 @@ void Node3DEditorViewport::_toggle_cinema_preview(bool p_activate) {
 
 	if (!previewing_cinema) {
 		if (previewing != nullptr) {
-			previewing->disconnect(SceneStringName(tree_exited), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
+			previewing->disconnect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 			previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
 		}
 
 		previewing = nullptr;
 		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
+
+		preview_camera->disconnect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
 		preview_camera->set_pressed(false);
+		preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
+
 		if (!preview) {
 			preview_camera->hide();
 		} else {
@@ -4455,6 +4459,7 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 		if (previewing_cinema) {
 			_update_centered_labels();
 			surface->queue_redraw();
+			preview_camera->hide();
 		}
 	}
 
@@ -4471,7 +4476,9 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 			surface->queue_redraw();
 			previewing_camera = true;
 			preview_camera->set_pressed(true);
-			preview_camera->show();
+			if (!previewing_cinema) {
+				preview_camera->show();
+			}
 		}
 	}
 	preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Prevents this:

<img width="1187" height="154" alt="image" src="https://github.com/user-attachments/assets/7ebbc9b4-6515-470c-a9d9-22426121f1c9" />

Fixes this error when exiting from `Cinematic Preview`:

`ERROR: Attempt to disconnect a nonexistent connection from 'Camera3D:<Camera3D#2182883654489>'. Signal: 'tree_exited', callable: 'Node3DEditorViewport::_preview_exited_scene'.
  ERROR: editor/plugins/node_3d_editor_plugin.cpp:3979 - Condition "!p_activate && !previewing" is true`