### PR TITLE
Fix infinite loop in GLTFDocument::_convert_animation_node_track

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -7782,9 +7782,12 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 			while (true) {
 				Vector3 scale;
 				Error err = p_godot_animation->try_scale_track_interpolate(p_godot_anim_track_index, time, &scale);
-				ERR_CONTINUE(err != OK);
-				p_gltf_node_track.scale_track.values.push_back(scale);
-				p_gltf_node_track.scale_track.times.push_back(time);
+				if (err == OK) {
+					p_gltf_node_track.scale_track.values.push_back(scale);
+					p_gltf_node_track.scale_track.times.push_back(time);
+				} else {
+					ERR_PRINT(vformat("Error interpolating animation %s scale track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+				}
 				if (last) {
 					break;
 				}
@@ -7817,9 +7820,12 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 			while (true) {
 				Vector3 scale;
 				Error err = p_godot_animation->try_position_track_interpolate(p_godot_anim_track_index, time, &scale);
-				ERR_CONTINUE(err != OK);
-				p_gltf_node_track.position_track.values.push_back(scale);
-				p_gltf_node_track.position_track.times.push_back(time);
+				if (err == OK) {
+					p_gltf_node_track.position_track.values.push_back(scale);
+					p_gltf_node_track.position_track.times.push_back(time);
+				} else {
+					ERR_PRINT(vformat("Error interpolating animation %s position track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+				}
 				if (last) {
 					break;
 				}
@@ -7852,9 +7858,12 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 			while (true) {
 				Quaternion rotation;
 				Error err = p_godot_animation->try_rotation_track_interpolate(p_godot_anim_track_index, time, &rotation);
-				ERR_CONTINUE(err != OK);
-				p_gltf_node_track.rotation_track.values.push_back(rotation);
-				p_gltf_node_track.rotation_track.times.push_back(time);
+				if (err == OK) {
+					p_gltf_node_track.rotation_track.values.push_back(rotation);
+					p_gltf_node_track.rotation_track.times.push_back(time);
+				} else {
+					ERR_PRINT(vformat("Error interpolating animation %s value rotation track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+				}
 				if (last) {
 					break;
 				}
@@ -7894,9 +7903,12 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 					while (true) {
 						Vector3 position;
 						Error err = p_godot_animation->try_position_track_interpolate(p_godot_anim_track_index, time, &position);
-						ERR_CONTINUE(err != OK);
-						p_gltf_node_track.position_track.values.push_back(position);
-						p_gltf_node_track.position_track.times.push_back(time);
+						if (err == OK) {
+							p_gltf_node_track.position_track.values.push_back(position);
+							p_gltf_node_track.position_track.times.push_back(time);
+						} else {
+							ERR_PRINT(vformat("Error interpolating animation %s value position track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+						}
 						if (last) {
 							break;
 						}
@@ -7927,9 +7939,12 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 					while (true) {
 						Quaternion rotation;
 						Error err = p_godot_animation->try_rotation_track_interpolate(p_godot_anim_track_index, time, &rotation);
-						ERR_CONTINUE(err != OK);
-						p_gltf_node_track.rotation_track.values.push_back(rotation);
-						p_gltf_node_track.rotation_track.times.push_back(time);
+						if (err == OK) {
+							p_gltf_node_track.rotation_track.values.push_back(rotation);
+							p_gltf_node_track.rotation_track.times.push_back(time);
+						} else {
+							ERR_PRINT(vformat("Error interpolating animation %s value rotation track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+						}
 						if (last) {
 							break;
 						}
@@ -7970,9 +7985,12 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 					while (true) {
 						Vector3 scale;
 						Error err = p_godot_animation->try_scale_track_interpolate(p_godot_anim_track_index, time, &scale);
-						ERR_CONTINUE(err != OK);
-						p_gltf_node_track.scale_track.values.push_back(scale);
-						p_gltf_node_track.scale_track.times.push_back(time);
+						if (err == OK) {
+							p_gltf_node_track.scale_track.values.push_back(scale);
+							p_gltf_node_track.scale_track.times.push_back(time);
+						} else {
+							ERR_PRINT(vformat("Error interpolating animation %s scale track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+						}
 						if (last) {
 							break;
 						}
@@ -8015,17 +8033,22 @@ bool GLTFDocument::_convert_animation_node_track(Ref<GLTFState> p_state, GLTFAni
 						Quaternion rotation;
 						Vector3 scale;
 						Error err = p_godot_animation->try_position_track_interpolate(p_godot_anim_track_index, time, &position);
-						ERR_CONTINUE(err != OK);
-						err = p_godot_animation->try_rotation_track_interpolate(p_godot_anim_track_index, time, &rotation);
-						ERR_CONTINUE(err != OK);
-						err = p_godot_animation->try_scale_track_interpolate(p_godot_anim_track_index, time, &scale);
-						ERR_CONTINUE(err != OK);
-						p_gltf_node_track.position_track.values.push_back(position);
-						p_gltf_node_track.position_track.times.push_back(time);
-						p_gltf_node_track.rotation_track.values.push_back(rotation);
-						p_gltf_node_track.rotation_track.times.push_back(time);
-						p_gltf_node_track.scale_track.values.push_back(scale);
-						p_gltf_node_track.scale_track.times.push_back(time);
+						if (err == OK) {
+							err = p_godot_animation->try_rotation_track_interpolate(p_godot_anim_track_index, time, &rotation);
+							if (err == OK) {
+								err = p_godot_animation->try_scale_track_interpolate(p_godot_anim_track_index, time, &scale);
+							}
+						}
+						if (err == OK) {
+							p_gltf_node_track.position_track.values.push_back(position);
+							p_gltf_node_track.position_track.times.push_back(time);
+							p_gltf_node_track.rotation_track.values.push_back(rotation);
+							p_gltf_node_track.rotation_track.times.push_back(time);
+							p_gltf_node_track.scale_track.values.push_back(scale);
+							p_gltf_node_track.scale_track.times.push_back(time);
+						} else {
+							ERR_PRINT(vformat("Error interpolating animation %s transform track %d at time %f", p_godot_animation->get_name(), p_godot_anim_track_index, time));
+						}
 						if (last) {
 							break;
 						}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
There were several uses of ERR_CONTINUE in `while(true)` loops before the iterator was updated and checked, which meant that if err != OK, it would loop forever. This fixes it so that it just prints an error message and doesn't push the track data if there's an error.