### PR TITLE
Add static method `from_scalar` to vector 2/3 types.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3401,7 +3401,7 @@ void Image::adjust_bcs(float p_brightness, float p_contrast, float p_saturation)
 		rgb *= p_brightness;
 		rgb = Vector3(0.5, 0.5, 0.5).lerp(rgb, p_contrast);
 		float center = (rgb.x + rgb.y + rgb.z) / 3.0;
-		rgb = Vector3(center, center, center).lerp(rgb, p_saturation);
+		rgb = Vector3::from_scalar(center).lerp(rgb, p_saturation);
 		c.r = rgb.x;
 		c.g = rgb.y;
 		c.b = rgb.z;

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -216,7 +216,7 @@ public:
 			}
 
 			real_t longest_axis = rect.size[rect.get_longest_axis_index()];
-			proportions = Vector3(longest_axis, longest_axis, longest_axis) / rect.size;
+			proportions = Vector3::from_scalar(longest_axis) / rect.size;
 
 			for (uint32_t i = 0; i < point_count; i++) {
 				// Scale points to the unit cube to better utilize R128 precision
@@ -329,8 +329,7 @@ public:
 					center.y = double(new_simplex->circum_center_y);
 					center.z = double(new_simplex->circum_center_z);
 
-					const real_t radius2 = Math::sqrt(double(new_simplex->circum_r2)) + 0.0001;
-					Vector3 extents = Vector3(radius2, radius2, radius2);
+					Vector3 extents = Vector3::from_scalar(Math::sqrt(double(new_simplex->circum_r2)) + 0.0001);
 					Vector3i from = Vector3i((center - extents) * proportions * ACCEL_GRID_SIZE);
 					Vector3i to = Vector3i((center + extents) * proportions * ACCEL_GRID_SIZE);
 					from = from.clampi(0, ACCEL_GRID_SIZE - 1);

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -162,6 +162,7 @@ struct [[nodiscard]] Vector2 {
 
 	real_t angle() const;
 	static Vector2 from_angle(real_t p_angle);
+	_FORCE_INLINE_ constexpr static Vector2 from_scalar(real_t p_scalar) noexcept { return Vector2(p_scalar, p_scalar); }
 
 	_FORCE_INLINE_ Vector2 abs() const {
 		return Vector2(Math::abs(x), Math::abs(y));

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -128,6 +128,8 @@ struct [[nodiscard]] Vector2i {
 	constexpr bool operator==(const Vector2i &p_vec2) const;
 	constexpr bool operator!=(const Vector2i &p_vec2) const;
 
+	_FORCE_INLINE_ constexpr static Vector2i from_scalar(int32_t p_scalar) noexcept { return Vector2i(p_scalar, p_scalar); }
+
 	int64_t length_squared() const;
 	double length() const;
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -189,6 +189,8 @@ struct [[nodiscard]] Vector3 {
 	explicit operator String() const;
 	operator Vector3i() const;
 
+	_FORCE_INLINE_ constexpr static Vector3 from_scalar(real_t p_scalar) noexcept { return Vector3(p_scalar, p_scalar, p_scalar); }
+
 	constexpr Vector3() :
 			x(0), y(0), z(0) {}
 	constexpr Vector3(real_t p_x, real_t p_y, real_t p_z) :

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -133,6 +133,8 @@ struct [[nodiscard]] Vector3i {
 	explicit operator String() const;
 	operator Vector3() const;
 
+	_FORCE_INLINE_ constexpr static Vector3i from_scalar(int32_t p_scalar) noexcept { return Vector3i(p_scalar, p_scalar, p_scalar); }
+
 	constexpr Vector3i() :
 			x(0), y(0), z(0) {}
 	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2878,7 +2878,7 @@ static void _register_variant_builtin_constants() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(Math::INF, Math::INF, Math::INF));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3::from_scalar(Math::INF));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
@@ -2918,8 +2918,8 @@ static void _register_variant_builtin_constants() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ZERO", Vector3i(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ONE", Vector3i(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MIN", Vector3i(INT32_MIN, INT32_MIN, INT32_MIN));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MAX", Vector3i(INT32_MAX, INT32_MAX, INT32_MAX));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MIN", Vector3i::from_scalar(INT32_MIN));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MAX", Vector3i::from_scalar(INT32_MAX));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "LEFT", Vector3i(-1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "RIGHT", Vector3i(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i(0, 1, 0));

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2012,6 +2012,7 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector2, maxf, sarray("with"), varray());
 
 	bind_static_method(Vector2, from_angle, sarray("angle"), varray());
+	bind_static_method(Vector2, from_scalar, sarray("scalar"), varray());
 
 	/* Vector2i */
 
@@ -2032,6 +2033,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector2i, mini, sarray("with"), varray());
 	bind_method(Vector2i, max, sarray("with"), varray());
 	bind_method(Vector2i, maxi, sarray("with"), varray());
+
+	bind_static_method(Vector2i, from_scalar, sarray("scalar"), varray());
 
 	/* Rect2 */
 
@@ -2117,7 +2120,9 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector3, minf, sarray("with"), varray());
 	bind_method(Vector3, max, sarray("with"), varray());
 	bind_method(Vector3, maxf, sarray("with"), varray());
+
 	bind_static_method(Vector3, octahedron_decode, sarray("uv"), varray());
+	bind_static_method(Vector3, from_scalar, sarray("scalar"), varray());
 
 	/* Vector3i */
 
@@ -2137,6 +2142,8 @@ static void _register_variant_builtin_methods_math() {
 	bind_method(Vector3i, mini, sarray("with"), varray());
 	bind_method(Vector3i, max, sarray("with"), varray());
 	bind_method(Vector3i, maxi, sarray("with"), varray());
+
+	bind_static_method(Vector3i, from_scalar, sarray("scalar"), varray());
 
 	/* Vector4 */
 

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -220,6 +220,13 @@
 				[b]Note:[/b] The length of the returned [Vector2] is [i]approximately[/i] [code]1.0[/code], but is is not guaranteed to be exactly [code]1.0[/code] due to floating-point precision issues. Call [method normalized] on the returned [Vector2] if you require a unit vector.
 			</description>
 		</method>
+		<method name="from_scalar" qualifiers="static">
+			<return type="Vector2" />
+			<param index="0" name="scalar" type="float" />
+			<description>
+				Returns a [Vector2] with all components set to the given scalar value. This is a convenient shorthand for writing Vector2(scalar, scalar).
+			</description>
+		</method>
 		<method name="is_equal_approx" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="to" type="Vector2" />

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -87,6 +87,13 @@
 				Returns the distance between this vector and [param to].
 			</description>
 		</method>
+		<method name="from_scalar" qualifiers="static">
+			<return type="Vector2i" />
+			<param index="0" name="scalar" type="int" />
+			<description>
+				Returns a [Vector2i] with all components set to the given scalar value. This is a convenient shorthand for writing Vector2i(scalar, scalar).
+			</description>
+		</method>
 		<method name="length" qualifiers="const" keywords="size">
 			<return type="float" />
 			<description>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -182,6 +182,13 @@
 				Returns a new vector with all components rounded down (towards negative infinity).
 			</description>
 		</method>
+		<method name="from_scalar" qualifiers="static">
+			<return type="Vector3" />
+			<param index="0" name="scalar" type="float" />
+			<description>
+				Returns a [Vector3] with all components set to the given scalar value. This is a convenient shorthand for writing Vector3(scalar, scalar, scalar).
+			</description>
+		</method>
 		<method name="inverse" qualifiers="const">
 			<return type="Vector3" />
 			<description>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -82,6 +82,13 @@
 				Returns the distance between this vector and [param to].
 			</description>
 		</method>
+		<method name="from_scalar" qualifiers="static">
+			<return type="Vector3i" />
+			<param index="0" name="scalar" type="int" />
+			<description>
+				Returns a [Vector3i] with all components set to the given scalar value. This is a convenient shorthand for writing Vector3i(scalar, scalar, scalar).
+			</description>
+		</method>
 		<method name="length" qualifiers="const" keywords="size">
 			<return type="float" />
 			<description>

--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5897,7 +5897,7 @@ Error RenderingDeviceDriverD3D12::_check_capabilities() {
 			if (options6.VariableShadingRateTier >= D3D12_VARIABLE_SHADING_RATE_TIER_2) {
 				fsr_capabilities.primitive_supported = true;
 				fsr_capabilities.attachment_supported = true;
-				fsr_capabilities.min_texel_size = Size2i(options6.ShadingRateImageTileSize, options6.ShadingRateImageTileSize);
+				fsr_capabilities.min_texel_size = Size2i::from_scalar(options6.ShadingRateImageTileSize);
 				fsr_capabilities.max_texel_size = Size2i(8, 8);
 			}
 		}

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -355,7 +355,7 @@ AABB LightStorage::light_get_aabb(RID p_light) const {
 		};
 		case RS::LIGHT_OMNI: {
 			float r = light->param[RS::LIGHT_PARAM_RANGE];
-			return AABB(-Vector3(r, r, r), Vector3(r, r, r) * 2);
+			return AABB(Vector3::from_scalar(-r), Vector3::from_scalar(r * 2));
 		};
 		case RS::LIGHT_DIRECTIONAL: {
 			return AABB();

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -812,7 +812,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 
 	if (atlas->render_buffers.is_null()) {
 		atlas->render_buffers.instantiate();
-		atlas->render_buffers->configure_for_probe(Size2i(atlas->size, atlas->size));
+		atlas->render_buffers->configure_for_probe(Size2i::from_scalar(atlas->size));
 	}
 
 	// First we check if our atlas is initialized.

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1990,7 +1990,7 @@ void TextureStorage::update_texture_atlas() {
 
 		for (int i = 0; i < item_count; i++) {
 			TextureAtlas::Texture *t = texture_atlas.textures.getptr(items[i].texture);
-			t->uv_rect.position = items[i].pos * border + Vector2i(border / 2, border / 2);
+			t->uv_rect.position = items[i].pos * border + Vector2i::from_scalar(border / 2);
 			t->uv_rect.size = items[i].pixel_size;
 
 			t->uv_rect.position /= Size2(texture_atlas.size);

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -933,7 +933,7 @@ void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
 		return;
 	}
 
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	filter_dialog->popup_centered(Size2::from_scalar(500 * EDSCALE));
 }
 
 void AnimationNodeBlendTreeEditor::_update_editor_settings() {

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -779,7 +779,7 @@ void AnimationPlayerEditor::_edit_animation_blend() {
 		return;
 	}
 
-	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
+	blend_editor.dialog->popup_centered(Size2::from_scalar(400 * EDSCALE));
 	_update_animation_blend();
 }
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2177,7 +2177,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 					text_color.a *= 0.7;
 				} else if (node) {
 					Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node, "Node");
-					const Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+					const Vector2 icon_size = Vector2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 
 					icon_rect = Rect2(Point2(ofs, (get_size().height - check->get_height()) / 2).round(), icon->get_size());
 					draw_texture_rect(icon, icon_rect);
@@ -3728,7 +3728,7 @@ AnimationTrackEdit *AnimationTrackEditPlugin::create_animation_track_edit(Object
 void AnimationTrackEditGroup::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+			icon_size = Vector2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -137,7 +137,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem(bool p_clickable) {
 
 	icon = memnew(TextureButton);
 	icon->set_accessibility_name(TTRC("Open asset details"));
-	icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
+	icon->set_custom_minimum_size(Size2::from_scalar(64 * EDSCALE));
 	hb->add_child(icon);
 
 	VBoxContainer *vb = memnew(VBoxContainer);
@@ -330,7 +330,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	item = memnew(EditorAssetLibraryItem);
 
 	desc_vbox->add_child(item);
-	desc_vbox->set_custom_minimum_size(Size2(440 * EDSCALE, 440 * EDSCALE));
+	desc_vbox->set_custom_minimum_size(Size2::from_scalar(440 * EDSCALE));
 
 	description = memnew(RichTextLabel);
 	desc_vbox->add_child(description);

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -414,12 +414,11 @@ Variant EditorDebuggerTree::get_drag_data(const Point2 &p_point) {
 	}
 
 	String path = selected->get_text(0);
-	const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	TextureRect *tf = memnew(TextureRect);
 	tf->set_texture(selected->get_icon(0));
-	tf->set_custom_minimum_size(Size2(icon_size, icon_size));
+	tf->set_custom_minimum_size(Size2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor))));
 	tf->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 	tf->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	hb->add_child(tf);

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2795,7 +2795,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->push_cell();
 			p_rt->set_cell_row_background_color(code_bg_color, Color(code_bg_color, 0.99));
 			p_rt->set_cell_padding(Rect2(0, 10 * EDSCALE, 0, 10 * EDSCALE));
-			p_rt->set_cell_size_override(Vector2(1, 1), Vector2(10, 10) * EDSCALE);
+			p_rt->set_cell_size_override(Vector2(1, 1), Vector2::from_scalar(10 * EDSCALE));
 			p_rt->push_meta("^" + codeblock_copy_text, RichTextLabel::META_UNDERLINE_ON_HOVER);
 			p_rt->add_image(p_owner_node->get_editor_theme_icon(SNAME("ActionCopy")), 24 * EDSCALE, 24 * EDSCALE, Color(link_property_color, 0.3), INLINE_ALIGNMENT_BOTTOM_TO, Rect2(), Variant(), false, TTR("Click to copy."));
 			p_rt->pop(); // meta

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -405,7 +405,7 @@ Control *EditorDockManager::_close_window(WindowWrapper *p_wrapper) {
 void EditorDockManager::_open_dock_in_window(Control *p_dock, bool p_show_window, bool p_reset_size) {
 	ERR_FAIL_NULL(p_dock);
 
-	Size2 borders = Size2(4, 4) * EDSCALE;
+	Size2 borders = Size2::from_scalar(4 * EDSCALE);
 	// Remember size and position before removing it from the main window.
 	Size2 dock_size = p_dock->get_size() + borders * 2;
 	Point2 dock_screen_pos = p_dock->get_screen_position();

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -959,9 +959,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_column_width(thumbnail_size * 3 / 2);
 		files->set_max_text_lines(2);
 		files->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
-
-		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-		files->set_fixed_tag_icon_size(Size2(icon_size, icon_size));
+		files->set_fixed_tag_icon_size(Size2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor))));
 
 		if (thumbnail_size < 64) {
 			folder_thumbnail = get_editor_theme_icon(SNAME("FolderMediumThumb"));
@@ -978,8 +976,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_max_columns(1);
 		files->set_max_text_lines(1);
 		files->set_fixed_column_width(0);
-		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-		files->set_fixed_icon_size(Size2(icon_size, icon_size));
+		files->set_fixed_icon_size(Size2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor))));
 	}
 
 	Ref<Texture2D> folder_icon = (use_thumbnails) ? folder_thumbnail : get_theme_icon(SNAME("folder"), SNAME("FileDialog"));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1488,7 +1488,7 @@ void EditorNode::_viewport_resized() {
 }
 
 void EditorNode::_titlebar_resized() {
-	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i::from_scalar(title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (gui_base->is_layout_rtl()) ? margin.y : margin.x;

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -1013,14 +1013,12 @@ QuickOpenResultListItem::QuickOpenResultListItem() {
 	hbc->add_theme_constant_override(SNAME("separation"), 4 * EDSCALE);
 	add_child(hbc);
 
-	const int max_size = 36 * EDSCALE;
-
 	thumbnail = memnew(TextureRect);
 	thumbnail->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	thumbnail->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	thumbnail->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	thumbnail->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	thumbnail->set_custom_minimum_size(Size2i(max_size, max_size));
+	thumbnail->set_custom_minimum_size(Size2i::from_scalar(36 * EDSCALE));
 	hbc->add_child(thumbnail);
 
 	text_container = memnew(VBoxContainer);
@@ -1097,12 +1095,10 @@ QuickOpenResultGridItem::QuickOpenResultGridItem() {
 	vbc->add_theme_constant_override(SNAME("separation"), 0);
 	add_child(vbc);
 
-	const int max_size = 64 * EDSCALE;
-
 	thumbnail = memnew(TextureRect);
 	thumbnail->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	thumbnail->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
-	thumbnail->set_custom_minimum_size(Size2i(max_size, max_size));
+	thumbnail->set_custom_minimum_size(Size2i::from_scalar(64 * EDSCALE));
 	vbc->add_child(thumbnail);
 
 	name = memnew(HighlightedLabel);

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -279,7 +279,7 @@ void EditorToaster::_draw_button() {
 		default:
 			break;
 	}
-	main_button->draw_circle(Vector2(button_radius * 2, button_radius * 2), button_radius, color);
+	main_button->draw_circle(Vector2::from_scalar(button_radius * 2), button_radius, color);
 }
 
 void EditorToaster::_draw_progress(Control *panel) {

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -318,7 +318,7 @@ void WindowWrapper::set_margins_enabled(bool p_enabled) {
 		margins->queue_free();
 		margins = nullptr;
 	} else if (p_enabled && !margins) {
-		Size2 borders = Size2(4, 4) * EDSCALE;
+		Size2 borders = Size2::from_scalar(4 * EDSCALE);
 		margins = memnew(MarginContainer);
 		margins->add_theme_constant_override("margin_right", borders.width);
 		margins->add_theme_constant_override("margin_top", borders.height);
@@ -501,7 +501,7 @@ ScreenSelect::ScreenSelect() {
 	}
 
 	// Create the popup.
-	const Size2 borders = Size2(4, 4) * EDSCALE;
+	const Size2 borders = Size2::from_scalar(4 * EDSCALE);
 
 	popup = memnew(PopupPanel);
 	popup->connect("popup_hide", callable_mp(static_cast<BaseButton *>(this), &ScreenSelect::set_pressed).bind(false));

--- a/editor/import/3d/collada.cpp
+++ b/editor/import/3d/collada.cpp
@@ -53,7 +53,7 @@ String Collada::Effect::get_texture_path(const String &p_source, Collada &p_stat
 Transform3D Collada::get_root_transform() const {
 	Transform3D unit_scale_transform;
 #ifndef COLLADA_IMPORT_SCALE_SCENE
-	unit_scale_transform.scale(Vector3(state.unit_scale, state.unit_scale, state.unit_scale));
+	unit_scale_transform.scale(Vector3::from_scalar(state.unit_scale));
 #endif
 	return unit_scale_transform;
 }

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -3159,7 +3159,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	}
 	if (Object::cast_to<Node3D>(scene)) {
 		Node3D *scene_3d = Object::cast_to<Node3D>(scene);
-		Vector3 scale = Vector3(root_scale, root_scale, root_scale);
+		Vector3 scale = Vector3::from_scalar(root_scale);
 		if (apply_root) {
 			_apply_permanent_scale_to_descendants(scene, scale);
 		} else {

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -429,7 +429,7 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Impor
 		if (p_options.has(SNAME("primitive/size"))) {
 			box->set_size(p_options[SNAME("primitive/size")].operator Vector3() * p_applied_root_scale);
 		} else {
-			box->set_size(Vector3(2, 2, 2) * p_applied_root_scale);
+			box->set_size(Vector3::from_scalar(2 * p_applied_root_scale));
 		}
 
 		Vector<Ref<Shape3D>> shapes;

--- a/editor/import/editor_atlas_packer.cpp
+++ b/editor/import/editor_atlas_packer.cpp
@@ -60,7 +60,7 @@ void EditorAtlasPacker::chart_pack(Vector<Chart> &charts, int &r_width, int &r_h
 
 		Ref<BitMap> src_bitmap;
 		src_bitmap.instantiate();
-		src_bitmap->create((aabb.size + Vector2(divide_by - 1, divide_by - 1)) / divide_by);
+		src_bitmap->create((aabb.size + Vector2::from_scalar(divide_by - 1)) / divide_by);
 
 		int w = src_bitmap->get_size().width;
 		int h = src_bitmap->get_size().height;

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -216,7 +216,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 
 		if (r_small_texture.is_null() && r_texture.is_valid() && preview_generators[i]->generate_small_preview_automatically()) {
 			Ref<Image> small_image = r_texture->get_image()->duplicate();
-			Vector2i new_size = Vector2i(1, 1) * small_thumbnail_size;
+			Vector2i new_size = Vector2i::from_scalar(small_thumbnail_size);
 			const real_t aspect = small_image->get_size().aspect();
 			if (aspect > 1.0) {
 				new_size.y = MAX(1, new_size.y / aspect);
@@ -231,7 +231,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 				const Vector2i rect_size = rect->get_size();
 				small_image = Image::create_empty(small_thumbnail_size, small_thumbnail_size, false, rect->get_format());
 				// Blit the rectangle in the center of the square.
-				small_image->blit_rect(rect, Rect2i(Vector2i(), rect_size), (Vector2i(1, 1) * small_thumbnail_size - rect_size) / 2);
+				small_image->blit_rect(rect, Rect2i(Vector2i(), rect_size), (Vector2i::from_scalar(small_thumbnail_size) - rect_size) / 2);
 			}
 
 			r_small_texture.instantiate();

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -222,7 +222,7 @@ void ProjectListItemControl::set_project_icon(const Ref<Texture2D> &p_icon) {
 	// The default project icon is 128×128 to look crisp on hiDPI displays,
 	// but we want the actual displayed size to be 64×64 on loDPI displays.
 	project_icon->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
-	project_icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
+	project_icon->set_custom_minimum_size(Size2::from_scalar(64 * EDSCALE));
 	project_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 
 	project_icon->set_texture(p_icon);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1253,7 +1253,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
-	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i::from_scalar(title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;

--- a/editor/scene/2d/camera_2d_editor_plugin.cpp
+++ b/editor/scene/2d/camera_2d_editor_plugin.cpp
@@ -219,7 +219,7 @@ void Camera2DEditor::_update_hover(const Vector2 &p_mouse_pos) {
 
 	const Rect2 limit_rect = CanvasItemEditor::get_singleton()->get_canvas_transform().xform(selected_camera->get_limit_rect());
 	const float drag_tolerance = 8.0;
-	const Vector2 tolerance_vector = Vector2(1, 1) * drag_tolerance;
+	const Vector2 tolerance_vector = Vector2::from_scalar(drag_tolerance);
 
 	hover_type = Drag::NONE;
 	if (Rect2(limit_rect.position - tolerance_vector, tolerance_vector * 2).has_point(p_mouse_pos)) {

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -922,7 +922,7 @@ void Polygon2DEditor::_center_view() {
 	Size2 texture_size;
 	if (node->get_texture().is_valid()) {
 		texture_size = node->get_texture()->get_size();
-		Vector2 zoom_factor = (canvas->get_size() - Vector2(1, 1) * 50 * EDSCALE) / texture_size;
+		Vector2 zoom_factor = (canvas->get_size() - Vector2::from_scalar(50 * EDSCALE)) / texture_size;
 		zoom_widget->set_zoom(MIN(zoom_factor.x, zoom_factor.y));
 	} else {
 		zoom_widget->set_zoom(EDSCALE);
@@ -971,7 +971,7 @@ void Polygon2DEditor::_update_zoom_and_pan(bool p_zoom_at_center) {
 		max_corner = max_corner.max(points[i]);
 	}
 	Size2 page_size = canvas->get_size() / draw_zoom;
-	Vector2 margin = Vector2(50, 50) * EDSCALE / draw_zoom;
+	Vector2 margin = Vector2::from_scalar(50 * EDSCALE) / draw_zoom;
 	min_corner -= page_size - margin;
 	max_corner += page_size - margin;
 
@@ -1172,7 +1172,7 @@ void Polygon2DEditor::_canvas_draw() {
 		if (weight_r) {
 			Vector2 draw_pos = mtx.xform(uvs[i]);
 			float weight = weight_r[i];
-			canvas->draw_rect(Rect2(draw_pos - Vector2(2, 2) * EDSCALE, Vector2(5, 5) * EDSCALE), Color(weight, weight, weight, 1.0), Math::round(EDSCALE));
+			canvas->draw_rect(Rect2(draw_pos - Vector2::from_scalar(2 * EDSCALE), Vector2::from_scalar(5 * EDSCALE)), Color(weight, weight, weight, 1.0), Math::round(EDSCALE));
 		} else {
 			if (i < uv_draw_max) {
 				canvas->draw_texture(handle, mtx.xform(uvs[i]) - handle->get_size() * 0.5);
@@ -1354,7 +1354,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	canvas_background = memnew(Panel);
 	uv_main_hsc->add_child(canvas_background);
 	canvas_background->set_h_size_flags(SIZE_EXPAND_FILL);
-	canvas_background->set_custom_minimum_size(Size2(200, 200) * EDSCALE);
+	canvas_background->set_custom_minimum_size(Size2::from_scalar(200 * EDSCALE));
 	canvas_background->set_clip_contents(true);
 
 	preview_polygon = memnew(Polygon2D);

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -492,7 +492,7 @@ void Sprite2DEditor::_debug_uv_draw() {
 void Sprite2DEditor::_center_view() {
 	Ref<Texture2D> tex = node->get_texture();
 	ERR_FAIL_COND(tex.is_null());
-	Vector2 zoom_factor = (debug_uv->get_size() - Vector2(1, 1) * 50 * EDSCALE) / tex->get_size();
+	Vector2 zoom_factor = (debug_uv->get_size() - Vector2::from_scalar(50 * EDSCALE)) / tex->get_size();
 	zoom_widget->set_zoom(MIN(zoom_factor.x, zoom_factor.y));
 	// Recalculate scroll limits.
 	_update_zoom_and_pan(false);
@@ -533,7 +533,7 @@ void Sprite2DEditor::_update_zoom_and_pan(bool p_zoom_at_center) {
 	Point2 min_corner;
 	Point2 max_corner = tex->get_size();
 	Size2 page_size = debug_uv->get_size() / draw_zoom;
-	Vector2 margin = Vector2(50, 50) * EDSCALE / draw_zoom;
+	Vector2 margin = Vector2::from_scalar(50 * EDSCALE) / draw_zoom;
 	min_corner -= page_size - margin;
 	max_corner += page_size - margin;
 

--- a/editor/scene/2d/tiles/atlas_merging_dialog.cpp
+++ b/editor/scene/2d/tiles/atlas_merging_dialog.cpp
@@ -311,7 +311,7 @@ AtlasMergingDialog::AtlasMergingDialog() {
 	// Atlas sources item list.
 	atlas_merging_atlases_list = memnew(ItemList);
 	atlas_merging_atlases_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	atlas_merging_atlases_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	atlas_merging_atlases_list->set_fixed_icon_size(Size2::from_scalar(60 * EDSCALE));
 	atlas_merging_atlases_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	atlas_merging_atlases_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	atlas_merging_atlases_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -162,7 +162,7 @@ void GenericTilePolygonEditor::_base_control_draw() {
 
 	Transform2D xform;
 	xform.set_origin(base_control->get_size() / 2 + panning);
-	xform.set_scale(Vector2(editor_zoom_widget->get_zoom(), editor_zoom_widget->get_zoom()));
+	xform.set_scale(Vector2::from_scalar(editor_zoom_widget->get_zoom()));
 	base_control->draw_set_transform_matrix(xform);
 
 	// Draw fill rect under texture region.
@@ -523,7 +523,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 
 	Transform2D xform;
 	xform.set_origin(base_control->get_size() / 2 + panning);
-	xform.set_scale(Vector2(editor_zoom_widget->get_zoom(), editor_zoom_widget->get_zoom()));
+	xform.set_scale(Vector2::from_scalar(editor_zoom_widget->get_zoom()));
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
@@ -1280,11 +1280,11 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 	if (value.get_type() == Variant::BOOL) {
 		Ref<Texture2D> texture = (bool)value ? tile_bool_checked : tile_bool_unchecked;
 		int size = MIN(tile_set->get_tile_size().x, tile_set->get_tile_size().y) / 3;
-		Rect2 rect = p_transform.xform(Rect2(Vector2(-size / 2, -size / 2) - texture_origin, Vector2(size, size)));
+		Rect2 rect = p_transform.xform(Rect2(Vector2::from_scalar(-size / 2) - texture_origin, Vector2(size, size)));
 		p_canvas_item->draw_texture_rect(texture, rect);
 	} else if (value.get_type() == Variant::COLOR) {
 		int size = MIN(tile_set->get_tile_size().x, tile_set->get_tile_size().y) / 3;
-		Rect2 rect = p_transform.xform(Rect2(Vector2(-size / 2, -size / 2) - texture_origin, Vector2(size, size)));
+		Rect2 rect = p_transform.xform(Rect2(Vector2::from_scalar(-size / 2) - texture_origin, Vector2(size, size)));
 		p_canvas_item->draw_rect(rect, value);
 	} else {
 		Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), EditorStringName(EditorFonts));
@@ -1872,7 +1872,7 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 		terrain_property_editor->hide();
 	} else {
 		options.clear();
-		Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2(16, 16) * EDSCALE);
+		Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2::from_scalar(16 * EDSCALE));
 		options.push_back(String(TTR("No terrain")) + String(":-1"));
 		for (int i = 0; i < tile_set->get_terrains_count(terrain_set); i++) {
 			String name = tile_set->get_terrain_name(terrain_set, i);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -459,8 +459,7 @@ void TileMapLayerEditorTilesPlugin::_update_scenes_collection_view() {
 	}
 
 	// Icon size update.
-	int int_size = int(EDITOR_GET("filesystem/file_dialog/thumbnail_size")) * EDSCALE;
-	scene_tiles_list->set_fixed_icon_size(Vector2(int_size, int_size));
+	scene_tiles_list->set_fixed_icon_size(Vector2::from_scalar(int(EDITOR_GET("filesystem/file_dialog/thumbnail_size")) * EDSCALE));
 }
 
 void TileMapLayerEditorTilesPlugin::_scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, const Variant &p_ud) {
@@ -2382,7 +2381,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 
 	sources_list = memnew(ItemList);
 	sources_list->set_auto_translate_mode(Node::AUTO_TRANSLATE_MODE_DISABLED);
-	sources_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	sources_list->set_fixed_icon_size(Size2::from_scalar(60 * EDSCALE));
 	sources_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	sources_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	sources_list->set_stretch_ratio(0.25);
@@ -3324,7 +3323,7 @@ void TileMapLayerEditorTerrainsPlugin::_update_terrains_tree() {
 	}
 
 	// Fill in the terrain list.
-	Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2(16, 16) * EDSCALE);
+	Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2::from_scalar(16 * EDSCALE));
 	for (int terrain_set_index = 0; terrain_set_index < tile_set->get_terrain_sets_count(); terrain_set_index++) {
 		// Add an item for the terrain set.
 		TreeItem *terrain_set_tree_item = terrains_tree->create_item();
@@ -3508,7 +3507,7 @@ TileMapLayerEditorTerrainsPlugin::TileMapLayerEditorTerrainsPlugin() {
 	terrains_tile_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	terrains_tile_list->set_max_columns(0);
 	terrains_tile_list->set_same_column_width(true);
-	terrains_tile_list->set_fixed_icon_size(Size2(32, 32) * EDSCALE);
+	terrains_tile_list->set_fixed_icon_size(Size2::from_scalar(32 * EDSCALE));
 	terrains_tile_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	tilemap_tab_terrains->add_child(terrains_tile_list);
 

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -1007,7 +1007,7 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 				button->add_theme_constant_override("align_to_largest_stylebox", false);
 				button->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 				button->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_alternatives_create_button_pressed).bind(tile_id));
-				button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), Vector2(texture_region_base_size_min, texture_region_base_size_min)));
+				button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), Vector2::from_scalar(texture_region_base_size_min)));
 				button->set_expand_icon(true);
 				alternative_tiles_control->add_child(button);
 

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -857,7 +857,7 @@ TileSetEditor::TileSetEditor() {
 
 	sources_list = memnew(ItemList);
 	sources_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	sources_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	sources_list->set_fixed_icon_size(Size2::from_scalar(60 * EDSCALE));
 	sources_list->set_h_size_flags(SIZE_EXPAND_FILL);
 	sources_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	sources_list->set_theme_type_variation("ItemListSecondary");

--- a/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -349,8 +349,7 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 	}
 
 	// Icon size update.
-	int int_size = int(EDITOR_GET("filesystem/file_dialog/thumbnail_size")) * EDSCALE;
-	scene_tiles_list->set_fixed_icon_size(Vector2(int_size, int_size));
+	scene_tiles_list->set_fixed_icon_size(Vector2::from_scalar(int(EDITOR_GET("filesystem/file_dialog/thumbnail_size")) * EDSCALE));
 }
 
 void TileSetScenesCollectionSourceEditor::_notification(int p_what) {

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -81,9 +81,7 @@ void TilesEditorUtils::_thread() {
 			pattern_preview_queue.pop_front();
 			pattern_preview_mutex.unlock();
 
-			int thumbnail_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
-			thumbnail_size *= EDSCALE;
-			Vector2 thumbnail_size2 = Vector2(thumbnail_size, thumbnail_size);
+			Vector2 thumbnail_size2 = Vector2::from_scalar(int(EDITOR_GET("filesystem/file_dialog/thumbnail_size")) * EDSCALE);
 
 			if (item.pattern.is_valid() && !item.pattern->is_empty()) {
 				// Generate the pattern preview

--- a/editor/scene/3d/bone_map_editor_plugin.cpp
+++ b/editor/scene/3d/bone_map_editor_plugin.cpp
@@ -341,7 +341,7 @@ void BoneMapper::update_group_idx() {
 
 void BoneMapper::_pick_bone(const StringName &p_bone_name) {
 	picker_key_name = p_bone_name;
-	picker->popup_bones_tree(Size2(500, 500) * EDSCALE);
+	picker->popup_bones_tree(Size2::from_scalar(500 * EDSCALE));
 }
 
 void BoneMapper::_apply_picker_selection() {

--- a/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/marker_3d_gizmo_plugin.cpp
@@ -110,7 +110,7 @@ int Marker3DGizmoPlugin::get_priority() const {
 void Marker3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Marker3D *marker = Object::cast_to<Marker3D>(p_gizmo->get_node_3d());
 	const real_t extents = marker->get_gizmo_extents();
-	const Transform3D xform(Basis::from_scale(Vector3(extents, extents, extents)));
+	const Transform3D xform(Basis::from_scale(Vector3::from_scalar(extents)));
 
 	p_gizmo->clear();
 	p_gizmo->add_mesh(pos3d_mesh, Ref<Material>(), xform);

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -663,7 +663,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	debug_uv_dialog->add_child(debug_uv_arc);
 
 	debug_uv = memnew(Control);
-	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
+	debug_uv->set_custom_minimum_size(Size2::from_scalar(600 * EDSCALE));
 	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
 	debug_uv_arc->add_child(debug_uv);
 

--- a/editor/scene/3d/multimesh_editor_plugin.cpp
+++ b/editor/scene/3d/multimesh_editor_plugin.cpp
@@ -210,7 +210,7 @@ void MultiMeshEditor::_populate() {
 		xform.basis = post_xform * xform.basis;
 		//xform.basis.orthonormalize();
 
-		xform.basis.scale(Vector3(1, 1, 1) * (_scale + Math::random(-_scale_random, _scale_random)));
+		xform.basis.scale(Vector3::from_scalar(_scale + Math::random(-_scale_random, _scale_random)));
 
 		multimesh->set_instance_transform(i, xform);
 	}

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -252,7 +252,7 @@ void EditorNode3DGizmo::_update_bvh() {
 	Transform3D transform = spatial_node->get_global_transform();
 
 	float effective_icon_size = selectable_icon_size > 0.0f ? selectable_icon_size : 0.0f;
-	Vector3 icon_size_vector3 = Vector3(effective_icon_size, effective_icon_size, effective_icon_size);
+	Vector3 icon_size_vector3 = Vector3::from_scalar(effective_icon_size);
 	AABB aabb(spatial_node->get_position() - icon_size_vector3 * 100.0f, icon_size_vector3 * 200.0f);
 
 	for (const Vector3 &segment_end : collision_segments) {
@@ -315,7 +315,7 @@ void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Re
 			md = MAX(0, p_vertices[i].length());
 		}
 		if (md) {
-			mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3(md, md, md) * 2.0));
+			mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3::from_scalar(md * 2.0)));
 		}
 	}
 
@@ -370,11 +370,11 @@ void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, 
 		md = MAX(0, vs[i].length());
 	}
 	if (md) {
-		mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3(md, md, md) * 2.0));
+		mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3::from_scalar(md * 2.0)));
 	}
 
 	selectable_icon_size = p_scale;
-	mesh->set_custom_aabb(AABB(Vector3(-selectable_icon_size, -selectable_icon_size, -selectable_icon_size) * 100.0f, Vector3(selectable_icon_size, selectable_icon_size, selectable_icon_size) * 200.0f));
+	mesh->set_custom_aabb(AABB(Vector3::from_scalar(-selectable_icon_size * 100.0f), Vector3::from_scalar(selectable_icon_size * 200.0f)));
 
 	ins.mesh = mesh;
 	if (valid) {
@@ -456,7 +456,7 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 			md = MAX(0, p_handles[i].length());
 		}
 		if (md) {
-			mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3(md, md, md) * 2.0));
+			mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3::from_scalar(md * 2.0)));
 		}
 	}
 

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4281,7 +4281,7 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 			(gizmo_size / Math::abs(dd)) * MAX(1, EDSCALE) *
 			MIN(viewport_base_height, subviewport_container->get_size().height) / viewport_base_height /
 			subviewport_container->get_stretch_shrink();
-	Vector3 scale = Vector3(1, 1, 1) * gizmo_scale;
+	Vector3 scale = Vector3::from_scalar(gizmo_scale);
 
 	// if the determinant is zero, we should disable the gizmo from being rendered
 	// this prevents supplying bad values to the renderer and then having to filter it out again
@@ -6000,7 +6000,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	position_control = memnew(ViewportNavigationControl);
 	position_control->set_navigation_mode(Node3DEditorViewport::NAVIGATION_MOVE);
-	position_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
+	position_control->set_custom_minimum_size(Size2::from_scalar(navigation_control_size * EDSCALE));
 	position_control->set_h_size_flags(SIZE_SHRINK_END);
 	position_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
 	position_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
@@ -6011,7 +6011,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	look_control = memnew(ViewportNavigationControl);
 	look_control->set_navigation_mode(Node3DEditorViewport::NAVIGATION_LOOK);
-	look_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
+	look_control->set_custom_minimum_size(Size2::from_scalar(navigation_control_size * EDSCALE));
 	look_control->set_h_size_flags(SIZE_SHRINK_END);
 	look_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -navigation_control_size * EDSCALE);
 	look_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
@@ -6021,7 +6021,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->add_child(look_control);
 
 	rotation_control = memnew(ViewportRotationControl);
-	rotation_control->set_custom_minimum_size(Size2(80, 80) * EDSCALE);
+	rotation_control->set_custom_minimum_size(Size2::from_scalar(80 * EDSCALE));
 	rotation_control->set_h_size_flags(SIZE_SHRINK_END);
 	rotation_control->set_viewport(this);
 	rotation_control->set_focus_mode(FOCUS_CLICK);
@@ -9752,7 +9752,7 @@ Node3DEditor::Node3DEditor() {
 
 		CenterContainer *sun_direction_center = memnew(CenterContainer);
 		sun_direction = memnew(Control);
-		sun_direction->set_custom_minimum_size(Size2(128, 128) * EDSCALE);
+		sun_direction->set_custom_minimum_size(Size2::from_scalar(128 * EDSCALE));
 		sun_direction_center->add_child(sun_direction);
 		sun_vb->add_margin_child(TTRC("Sun Direction"), sun_direction_center);
 		sun_direction->connect(SceneStringName(gui_input), callable_mp(this, &Node3DEditor::_sun_direction_input));

--- a/editor/scene/3d/root_motion_editor_plugin.cpp
+++ b/editor/scene/3d/root_motion_editor_plugin.cpp
@@ -156,7 +156,7 @@ void EditorPropertyRootMotion::_node_assign() {
 	}
 
 	filters->ensure_cursor_is_visible();
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	filter_dialog->popup_centered(Size2::from_scalar(500 * EDSCALE));
 }
 
 void EditorPropertyRootMotion::_node_clear() {

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -2004,7 +2004,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				drag_type = DRAG_SCALE_BOTH;
 
 				if (show_transformation_gizmos) {
-					Size2 scale_factor = Size2(SCALE_HANDLE_DISTANCE, SCALE_HANDLE_DISTANCE);
+					Size2 scale_factor = Size2::from_scalar(SCALE_HANDLE_DISTANCE);
 					Rect2 x_handle_rect = Rect2(scale_factor.x * EDSCALE, -5 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE);
 					if (x_handle_rect.has_point(simple_xform.affine_inverse().xform(b->get_position()))) {
 						drag_type = DRAG_SCALE_X;
@@ -2180,7 +2180,7 @@ bool CanvasItemEditor::_gui_input_move(const Ref<InputEvent> &p_event) {
 					Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
 
 					if (show_transformation_gizmos) {
-						Size2 move_factor = Size2(MOVE_HANDLE_DISTANCE, MOVE_HANDLE_DISTANCE);
+						Size2 move_factor = Size2::from_scalar(MOVE_HANDLE_DISTANCE);
 						Rect2 x_handle_rect = Rect2(move_factor.x * EDSCALE, -5 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE);
 						if (x_handle_rect.has_point(simple_xform.affine_inverse().xform(b->get_position()))) {
 							drag_type = DRAG_MOVE_X;
@@ -3089,14 +3089,14 @@ void CanvasItemEditor::_draw_rulers() {
 	// Subdivisions
 	int major_subdivision = 2;
 	Transform2D major_subdivide;
-	major_subdivide.scale(Size2(1.0 / major_subdivision, 1.0 / major_subdivision));
+	major_subdivide.scale(Size2::from_scalar(1.0 / major_subdivision));
 
 	int minor_subdivision = 5;
 	Transform2D minor_subdivide;
-	minor_subdivide.scale(Size2(1.0 / minor_subdivision, 1.0 / minor_subdivision));
+	minor_subdivide.scale(Size2::from_scalar(1.0 / minor_subdivision));
 
 	// First and last graduations to draw (in the ruler space)
-	Point2 first = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(Point2(ruler_width_scaled, ruler_width_scaled));
+	Point2 first = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(Point2::from_scalar(ruler_width_scaled));
 	Point2 last = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(viewport->get_size());
 
 	// Draw top ruler
@@ -3139,7 +3139,7 @@ void CanvasItemEditor::_draw_rulers() {
 	}
 
 	// Draw the top left corner
-	viewport->draw_rect(Rect2(Point2(), Size2(ruler_width_scaled, ruler_width_scaled)), graduation_color);
+	viewport->draw_rect(Rect2(Point2(), Size2::from_scalar(ruler_width_scaled)), graduation_color);
 }
 
 void CanvasItemEditor::_draw_grid() {
@@ -3710,7 +3710,7 @@ void CanvasItemEditor::_draw_selection() {
 			Transform2D unscaled_transform = (xform * ci->get_transform().affine_inverse() * ci->_edit_get_transform()).orthonormalized();
 			Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
 
-			Size2 move_factor = Size2(MOVE_HANDLE_DISTANCE, MOVE_HANDLE_DISTANCE);
+			Size2 move_factor = Size2::from_scalar(MOVE_HANDLE_DISTANCE);
 			viewport->draw_set_transform_matrix(simple_xform);
 
 			Vector<Point2> points = {
@@ -3744,7 +3744,7 @@ void CanvasItemEditor::_draw_selection() {
 			Transform2D unscaled_transform = (xform * ci->get_transform().affine_inverse() * edit_transform).orthonormalized();
 			Transform2D simple_xform = viewport->get_transform() * unscaled_transform;
 
-			Size2 scale_factor = Size2(SCALE_HANDLE_DISTANCE, SCALE_HANDLE_DISTANCE);
+			Size2 scale_factor = Size2::from_scalar(SCALE_HANDLE_DISTANCE);
 			bool uniform = Input::get_singleton()->is_key_pressed(Key::SHIFT);
 			Point2 offset = (simple_xform.affine_inverse().xform(drag_to) - simple_xform.affine_inverse().xform(drag_from)) * zoom;
 
@@ -3917,7 +3917,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 
 void CanvasItemEditor::_draw_hover() {
 	List<Rect2> previous_rects;
-	Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+	Vector2 icon_size = Vector2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 
 	for (int i = 0; i < hovering_results.size(); i++) {
 		Ref<Texture2D> node_icon = hovering_results[i].icon;
@@ -3976,7 +3976,7 @@ void CanvasItemEditor::_draw_message() {
 			case DRAG_SCALE_X:
 			case DRAG_SCALE_Y:
 			case DRAG_SCALE_BOTH: {
-				Vector2 original_scale = (Math::is_zero_approx(original_transform.get_scale().x) || Math::is_zero_approx(original_transform.get_scale().y)) ? Vector2(CMP_EPSILON, CMP_EPSILON) : original_transform.get_scale();
+				Vector2 original_scale = (Math::is_zero_approx(original_transform.get_scale().x) || Math::is_zero_approx(original_transform.get_scale().y)) ? Vector2::from_scalar(CMP_EPSILON) : original_transform.get_scale();
 				Vector2 delta = current_transform.get_scale() / original_scale;
 				if (drag_type == DRAG_SCALE_BOTH) {
 					message = TTR("Scaling:") + String::utf8(" ×(") + FORMAT(delta.x) + ", " + FORMAT(delta.y) + ")";
@@ -4313,7 +4313,7 @@ void CanvasItemEditor::_update_scrollbars() {
 
 	// Move the zoom buttons.
 	Point2 controls_vb_begin = Point2(5, 5);
-	controls_vb_begin += (show_rulers) ? Point2(ruler_width_scaled, ruler_width_scaled) : Point2();
+	controls_vb_begin += (show_rulers) ? Point2::from_scalar(ruler_width_scaled) : Point2();
 	controls_vb->set_begin(controls_vb_begin);
 
 	Size2 hmin = h_scroll->get_minimum_size();

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -452,14 +452,14 @@ EditorSceneTabs::EditorSceneTabs() {
 	add_child(tab_preview_anchor);
 
 	tab_preview_panel = memnew(Panel);
-	tab_preview_panel->set_size(Size2(100, 100) * EDSCALE);
+	tab_preview_panel->set_size(Size2::from_scalar(100 * EDSCALE));
 	tab_preview_panel->hide();
 	tab_preview_panel->set_self_modulate(Color(1, 1, 1, 0.7));
 	tab_preview_anchor->add_child(tab_preview_panel);
 
 	tab_preview = memnew(TextureRect);
 	tab_preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	tab_preview->set_size(Size2(96, 96) * EDSCALE);
-	tab_preview->set_position(Point2(2, 2) * EDSCALE);
+	tab_preview->set_size(Size2::from_scalar(96 * EDSCALE));
+	tab_preview->set_position(Point2::from_scalar(2 * EDSCALE));
 	tab_preview_panel->add_child(tab_preview);
 }

--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -498,7 +498,7 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 // Toolbars controls.
 
 Size2 ControlEditorPopupButton::get_minimum_size() const {
-	Vector2 base_size = Vector2(26, 26) * EDSCALE;
+	Vector2 base_size = Vector2::from_scalar(26 * EDSCALE);
 
 	if (arrow_icon.is_null()) {
 		return base_size;
@@ -580,7 +580,7 @@ void ControlEditorPresetPicker::_add_row_button(HBoxContainer *p_row, const int 
 	ERR_FAIL_COND(preset_buttons.has(p_preset));
 
 	Button *b = memnew(Button);
-	b->set_custom_minimum_size(Size2i(36, 36) * EDSCALE);
+	b->set_custom_minimum_size(Size2i::from_scalar(36 * EDSCALE));
 	b->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	b->set_tooltip_text(p_name);
 	b->set_flat(true);

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -938,7 +938,7 @@ void FontPreview::_notification(int p_what) {
 void FontPreview::_bind_methods() {}
 
 Size2 FontPreview::get_minimum_size() const {
-	return Vector2(64, 64) * EDSCALE;
+	return Vector2::from_scalar(64 * EDSCALE);
 }
 
 void FontPreview::set_data(const Ref<Font> &p_f) {

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -221,7 +221,7 @@ MaterialEditor::MaterialEditor() {
 
 	rect_instance = memnew(ColorRect);
 	layout_2d->add_child(rect_instance);
-	rect_instance->set_custom_minimum_size(Size2(150, 150) * EDSCALE);
+	rect_instance->set_custom_minimum_size(Size2::from_scalar(150 * EDSCALE));
 
 	layout_2d->set_visible(false);
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1840,8 +1840,7 @@ Variant SceneTreeEditor::get_drag_data_fw(const Point2 &p_point, Control *p_from
 		if (i < list_max) {
 			HBoxContainer *hb = memnew(HBoxContainer);
 			TextureRect *tf = memnew(TextureRect);
-			int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
-			tf->set_custom_minimum_size(Size2(icon_size, icon_size));
+			tf->set_custom_minimum_size(Size2::from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor))));
 			tf->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 			tf->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 			tf->set_texture(icons[i]);

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -1439,7 +1439,7 @@ void SpriteFramesEditor::_zoom_out() {
 void SpriteFramesEditor::_zoom_reset() {
 	thumbnail_zoom = MAX(1.0f, EDSCALE);
 	frame_list->set_fixed_column_width(thumbnail_default_size * 3 / 2);
-	frame_list->set_fixed_icon_size(Size2(thumbnail_default_size, thumbnail_default_size));
+	frame_list->set_fixed_icon_size(Size2::from_scalar(thumbnail_default_size));
 }
 
 void SpriteFramesEditor::_update_library(bool p_skip_selector) {

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -160,7 +160,7 @@ VSRerouteNode::VSRerouteNode() {
 	Label *title_lbl = Object::cast_to<Label>(get_titlebar_hbox()->get_child(0));
 	title_lbl->hide();
 
-	const Size2 size = Size2(32, 32) * EDSCALE;
+	const Size2 size = Size2::from_scalar(32 * EDSCALE);
 
 	Control *slot_area = memnew(Control);
 	slot_area->set_custom_minimum_size(size);
@@ -5591,7 +5591,7 @@ void VisualShaderEditor::_duplicate_nodes() {
 		return;
 	}
 
-	_dup_paste_nodes(type, items, node_connections, Vector2(10, 10) * EDSCALE, true);
+	_dup_paste_nodes(type, items, node_connections, Vector2::from_scalar(10 * EDSCALE), true);
 }
 
 void VisualShaderEditor::_copy_nodes(bool p_cut) {
@@ -8376,7 +8376,7 @@ void VisualShaderNodePortPreview::setup(const Ref<VisualShader> &p_shader, Ref<S
 
 Size2 VisualShaderNodePortPreview::get_minimum_size() const {
 	int port_preview_size = EDITOR_GET("editors/visual_editors/visual_shader/port_preview_size");
-	return Size2(port_preview_size, port_preview_size) * EDSCALE;
+	return Size2::from_scalar(port_preview_size * EDSCALE);
 }
 
 void VisualShaderNodePortPreview::_notification(int p_what) {

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -122,7 +122,7 @@ void GodotWorldBoundaryShape2D::set_data(const Variant &p_data) {
 	ERR_FAIL_COND(arr.size() != 2);
 	normal = arr[0];
 	d = arr[1];
-	configure(Rect2(Vector2(-1e15, -1e15), Vector2(1e15 * 2, 1e15 * 2)));
+	configure(Rect2(Vector2(-1e15, -1e15), Vector2::from_scalar(1e15 * 2)));
 }
 
 Variant GodotWorldBoundaryShape2D::get_data() const {

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -152,7 +152,7 @@ Vector3 GodotWorldBoundaryShape3D::get_moment_of_inertia(real_t p_mass) const {
 
 void GodotWorldBoundaryShape3D::_setup(const Plane &p_plane) {
 	plane = p_plane;
-	configure(AABB(Vector3(-1e15, -1e15, -1e15), Vector3(1e15 * 2, 1e15 * 2, 1e15 * 2)));
+	configure(AABB(Vector3::from_scalar(-1e15), Vector3::from_scalar(1e15 * 2)));
 }
 
 void GodotWorldBoundaryShape3D::set_data(const Variant &p_data) {
@@ -294,7 +294,7 @@ Vector3 GodotSphereShape3D::get_moment_of_inertia(real_t p_mass) const {
 
 void GodotSphereShape3D::_setup(real_t p_radius) {
 	radius = p_radius;
-	configure(AABB(Vector3(-radius, -radius, -radius), Vector3(radius * 2.0, radius * 2.0, radius * 2.0)));
+	configure(AABB(Vector3::from_scalar(-radius), Vector3::from_scalar(radius * 2.0)));
 }
 
 void GodotSphereShape3D::set_data(const Variant &p_data) {

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -297,7 +297,7 @@ void GodotSoftBody3D::apply_nodes_transform(const Transform3D &p_transform) {
 	}
 
 	uint32_t node_count = nodes.size();
-	Vector3 leaf_size = Vector3(collision_margin, collision_margin, collision_margin) * 2.0;
+	Vector3 leaf_size = Vector3::from_scalar(collision_margin * 2.0);
 	for (uint32_t node_index = 0; node_index < node_count; ++node_index) {
 		Node &node = nodes[node_index];
 
@@ -560,7 +560,7 @@ bool GodotSoftBody3D::create_from_trimesh(const Vector<int> &p_indices, const Ve
 	// Create nodes from vertices.
 	nodes.resize(node_count);
 	real_t inv_node_mass = node_count * inv_total_mass;
-	Vector3 leaf_size = Vector3(collision_margin, collision_margin, collision_margin) * 2.0;
+	Vector3 leaf_size = Vector3::from_scalar(collision_margin * 2.0);
 	for (uint32_t i = 0; i < node_count; ++i) {
 		Node &node = nodes[i];
 		node.s = vertices[i];

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -322,7 +322,7 @@ bool GodotGeneric6DOFJoint3D::setup(real_t p_timestep) {
 	}
 
 	// Clear accumulated impulses for the next simulation step
-	m_linearLimits.m_accumulatedImpulse = Vector3(real_t(0.), real_t(0.), real_t(0.));
+	m_linearLimits.m_accumulatedImpulse = Vector3::from_scalar(real_t(0.));
 	int i;
 	for (i = 0; i < 3; i++) {
 		m_angularLimits[i].m_accumulatedImpulse = real_t(0.);

--- a/modules/godot_physics_3d/joints/godot_jacobian_entry_3d.h
+++ b/modules/godot_physics_3d/joints/godot_jacobian_entry_3d.h
@@ -80,7 +80,7 @@ public:
 			const Basis &world2B,
 			const Vector3 &inertiaInvA,
 			const Vector3 &inertiaInvB) :
-			m_linearJointAxis(Vector3(real_t(0.), real_t(0.), real_t(0.))) {
+			m_linearJointAxis(Vector3::from_scalar(real_t(0.))) {
 		m_aJ = world2A.xform(jointAxis);
 		m_bJ = world2B.xform(-jointAxis);
 		m_0MinvJt = inertiaInvA * m_aJ;
@@ -95,7 +95,7 @@ public:
 			const Vector3 &axisInB,
 			const Vector3 &inertiaInvA,
 			const Vector3 &inertiaInvB) :
-			m_linearJointAxis(Vector3(real_t(0.), real_t(0.), real_t(0.))),
+			m_linearJointAxis(Vector3::from_scalar(real_t(0.))),
 			m_aJ(axisInA),
 			m_bJ(-axisInB) {
 		m_0MinvJt = inertiaInvA * m_aJ;
@@ -116,7 +116,7 @@ public:
 		m_aJ = world2A.xform(rel_pos1.cross(jointAxis));
 		m_bJ = world2A.xform(rel_pos2.cross(-jointAxis));
 		m_0MinvJt = inertiaInvA * m_aJ;
-		m_1MinvJt = Vector3(real_t(0.), real_t(0.), real_t(0.));
+		m_1MinvJt = Vector3::from_scalar(real_t(0.));
 		m_Adiag = massInvA + m_0MinvJt.dot(m_aJ);
 
 		ERR_FAIL_COND(m_Adiag <= real_t(0.0));

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -186,7 +186,7 @@ void GridMapEditor::_menu_option(int p_option) {
 
 		} break;
 		case MENU_OPTION_GRIDMAP_SETTINGS: {
-			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + Size2(50, 50) * EDSCALE);
+			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + Size2::from_scalar(50 * EDSCALE));
 		} break;
 	}
 }

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -684,7 +684,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 		xform.basis = _ortho_bases[c.rot];
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(Vector3::from_scalar(cell_scale));
 		if (baked_meshes.is_empty()) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
 				if (!item_id_to_multimesh_item_placements.has(c.item)) {
@@ -1330,7 +1330,7 @@ Array GridMap::get_meshes() const {
 		xform.basis = _ortho_bases[E.value.rot];
 
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(Vector3::from_scalar(cell_scale));
 
 		meshes.push_back(xform * mesh_library->get_item_mesh_transform(id));
 		meshes.push_back(mesh);
@@ -1384,7 +1384,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 
 		xform.basis = _ortho_bases[E.value.rot];
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(Vector3::from_scalar(cell_scale));
 
 		const OctantKey ok = get_octant_key_from_index_key(key);
 

--- a/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
@@ -67,7 +67,7 @@ void JoltWorldBoundaryShape3D::set_data(const Variant &p_data) {
 AABB JoltWorldBoundaryShape3D::get_aabb() const {
 	const float size = JoltProjectSettings::world_boundary_shape_size;
 	const float half_size = size / 2.0f;
-	return AABB(Vector3(-half_size, -half_size, -half_size), Vector3(size, half_size, size));
+	return AABB(Vector3::from_scalar(-half_size), Vector3(size, half_size, size));
 }
 
 String JoltWorldBoundaryShape3D::to_string() const {

--- a/modules/openxr/extensions/openxr_render_model_extension.cpp
+++ b/modules/openxr/extensions/openxr_render_model_extension.cpp
@@ -568,7 +568,7 @@ Transform3D OpenXRRenderModelExtension::render_model_get_root_transform(RID p_re
 
 	// Scale our root transform
 	real_t world_scale = xr_server->get_world_scale();
-	Transform3D root_transform = render_model->root_transform.scaled(Vector3(world_scale, world_scale, world_scale));
+	Transform3D root_transform = render_model->root_transform.scaled(Vector3::from_scalar(world_scale));
 
 	return xr_server->get_reference_frame() * root_transform;
 }

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -905,7 +905,7 @@ void DisplayServerWeb::_ime_callback(int p_type, const String &p_text) {
 			// IME update.
 			if (ds->ime_active && ds->ime_started) {
 				ds->ime_text = p_text;
-				ds->ime_selection = Vector2i(ds->ime_text.length(), ds->ime_text.length());
+				ds->ime_selection = Vector2i::from_scalar(ds->ime_text.length());
 				OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 			}
 		} break;

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -54,7 +54,7 @@ Rect2 OccluderPolygon2D::_edit_get_rect() const {
 			if (polygon.is_empty()) {
 				item_rect = Rect2();
 			} else {
-				Vector2 d = Vector2(LINE_GRAB_WIDTH, LINE_GRAB_WIDTH);
+				Vector2 d = Vector2::from_scalar(LINE_GRAB_WIDTH);
 				item_rect = Rect2(polygon[0] - d, 2 * d);
 				for (int i = 1; i < polygon.size(); i++) {
 					item_rect.expand_to(polygon[i] - d);

--- a/scene/2d/marker_2d.cpp
+++ b/scene/2d/marker_2d.cpp
@@ -64,7 +64,7 @@ void Marker2D::_draw_cross() {
 #ifdef DEBUG_ENABLED
 Rect2 Marker2D::_edit_get_rect() const {
 	real_t extents = get_gizmo_extents();
-	return Rect2(Point2(-extents, -extents), Size2(extents * 2, extents * 2));
+	return Rect2(Point2::from_scalar(-extents), Size2::from_scalar(extents * 2));
 }
 
 bool Marker2D::_edit_use_rect() const {

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -369,8 +369,7 @@ void NavigationObstacle2D::navmesh_parse_source_geometry(const Ref<NavigationPol
 
 	if (obstacle_radius > 0.0) {
 		// Radius defined obstacle should be uniformly scaled from obstacle basis max scale axis.
-		const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
-		const Vector2 uniform_max_scale = Vector2(scaling_max_value, scaling_max_value);
+		const Vector2 uniform_max_scale = Vector2::from_scalar(safe_scale[safe_scale.max_axis_index()]);
 		const Transform2D obstacle_circle_transform = p_source_geometry_data->root_node_transform * Transform2D(obstacle->get_global_rotation(), uniform_max_scale, 0.0, obstacle->get_global_position());
 
 		Vector<Vector2> obstruction_circle_vertices;

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -127,7 +127,7 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_s
 	}
 
 	set_position(new_ofs);
-	set_scale(Vector2(1, 1) * p_scale * orig_scale);
+	set_scale(Vector2::from_scalar(p_scale) * orig_scale);
 
 	_update_mirroring();
 }

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1078,7 +1078,7 @@ void TileMapLayer::_physics_draw_quadrant_debug(const RID &p_canvas_item, DebugQ
 	rs->mesh_clear(r_debug_quadrant.physics_mesh);
 
 	// Redraw all shapes from the physics quadrants
-	Rect2i covered_cell_area = Rect2i(r_debug_quadrant.quadrant_coords * TILE_MAP_DEBUG_QUADRANT_SIZE, Vector2i(TILE_MAP_DEBUG_QUADRANT_SIZE, TILE_MAP_DEBUG_QUADRANT_SIZE));
+	Rect2i covered_cell_area = Rect2i(r_debug_quadrant.quadrant_coords * TILE_MAP_DEBUG_QUADRANT_SIZE, Vector2i::from_scalar(TILE_MAP_DEBUG_QUADRANT_SIZE));
 	Vector2i first_physics_quadrant_coords = _coords_to_quadrant_coords(covered_cell_area.get_position() - Vector2i(1, 1), physics_quadrant_size) + Vector2i(1, 1);
 	Vector2i last_physics_quadrant_coords = _coords_to_quadrant_coords(covered_cell_area.get_end() - Vector2i(1, 1), physics_quadrant_size) + Vector2i(1, 1);
 

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -82,7 +82,7 @@ real_t GPUParticlesCollisionSphere3D::get_radius() const {
 }
 
 AABB GPUParticlesCollisionSphere3D::get_aabb() const {
-	return AABB(Vector3(-radius, -radius, -radius), Vector3(radius * 2, radius * 2, radius * 2));
+	return AABB(Vector3::from_scalar(-radius), Vector3::from_scalar(radius * 2));
 }
 
 GPUParticlesCollisionSphere3D::GPUParticlesCollisionSphere3D() :
@@ -506,7 +506,7 @@ Ref<Image> GPUParticlesCollisionSDF3D::bake() {
 	params.cells = (float *)cells_data.ptrw();
 	params.size = sdf_size;
 	params.cell_size = cell_size;
-	params.cell_offset = aabb.position + Vector3(cell_size * 0.5, cell_size * 0.5, cell_size * 0.5);
+	params.cell_offset = aabb.position + Vector3::from_scalar(cell_size * 0.5);
 	params.bvh = bvh.ptr();
 	params.triangles = faces.ptr();
 	params.thickness = th;
@@ -933,7 +933,7 @@ real_t GPUParticlesAttractorSphere3D::get_radius() const {
 }
 
 AABB GPUParticlesAttractorSphere3D::get_aabb() const {
-	return AABB(Vector3(-radius, -radius, -radius), Vector3(radius * 2, radius * 2, radius * 2));
+	return AABB(Vector3::from_scalar(-radius), Vector3::from_scalar(radius * 2));
 }
 
 GPUParticlesAttractorSphere3D::GPUParticlesAttractorSphere3D() :

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -627,8 +627,8 @@ void Label3D::_shape() {
 		case StandardMaterial3D::BILLBOARD_ENABLED: {
 			real_t size_new = MAX(Math::abs(aabb.position.x), (aabb.position.x + aabb.size.x));
 			size_new = MAX(size_new, MAX(Math::abs(aabb.position.y), (aabb.position.y + aabb.size.y)));
-			aabb.position = Vector3(-size_new, -size_new, -size_new);
-			aabb.size = Vector3(size_new * 2.0, size_new * 2.0, size_new * 2.0);
+			aabb.position = Vector3::from_scalar(-size_new);
+			aabb.size = Vector3::from_scalar(size_new * 2.0);
 		} break;
 		case StandardMaterial3D::BILLBOARD_FIXED_Y: {
 			real_t size_new = MAX(Math::abs(aabb.position.x), (aabb.position.x + aabb.size.x));

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -159,7 +159,7 @@ AABB Light3D::get_aabb() const {
 		return AABB(Vector3(-1, -1, -1), Vector3(2, 2, 2));
 
 	} else if (type == RenderingServer::LIGHT_OMNI) {
-		return AABB(Vector3(-1, -1, -1) * param[PARAM_RANGE], Vector3(2, 2, 2) * param[PARAM_RANGE]);
+		return AABB(Vector3::from_scalar(-param[PARAM_RANGE]), Vector3::from_scalar(param[PARAM_RANGE] * 2));
 
 	} else if (type == RenderingServer::LIGHT_SPOT) {
 		real_t cone_slant_height = param[PARAM_RANGE];
@@ -167,7 +167,7 @@ AABB Light3D::get_aabb() const {
 
 		if (cone_angle_rad > Math::PI / 2.0) {
 			// Just return the AABB of an omni light if the spot angle is above 90 degrees.
-			return AABB(Vector3(-1, -1, -1) * cone_slant_height, Vector3(2, 2, 2) * cone_slant_height);
+			return AABB(Vector3::from_scalar(-cone_slant_height), Vector3::from_scalar(cone_slant_height * 2));
 		}
 
 		real_t size = Math::sin(cone_angle_rad) * cone_slant_height;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -745,7 +745,7 @@ void LightmapGI::_plot_triangle_into_octree(GenProbesOctree *p_cell, float p_cel
 
 		AABB subcell;
 		subcell.position = Vector3(pos) * p_cell_size;
-		subcell.size = Vector3(half_size, half_size, half_size) * p_cell_size;
+		subcell.size = Vector3::from_scalar(half_size * p_cell_size);
 
 		if (!Geometry3D::triangle_box_overlap(subcell.get_center(), subcell.size * 0.5, p_triangle)) {
 			continue;

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -676,7 +676,7 @@ float LookAtModifier3D::remap_damped(float p_from, float p_to, float p_damp_thre
 	double inv_to = 1.0 / p_to;
 	double end_x = limit * inv_to;
 	double position = abs_value * inv_to;
-	Vector2 start = Vector2(p_damp_threshold, p_damp_threshold);
+	Vector2 start = Vector2::from_scalar(p_damp_threshold);
 	Vector2 mid = Vector2(1.0, 1.0);
 	Vector2 end = Vector2(end_x, 1.0);
 	value = get_bspline_y(start, mid, end, position);

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -174,7 +174,7 @@ void NavigationObstacle3D::_notification(int p_what) {
 					const Vector3 safe_scale = get_global_basis().get_scale().abs().maxf(0.001);
 					// Agent radius is a scalar value and does not support non-uniform scaling, choose the largest axis.
 					const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
-					const Vector3 uniform_max_scale = Vector3(scaling_max_value, scaling_max_value, scaling_max_value);
+					const Vector3 uniform_max_scale = Vector3::from_scalar(scaling_max_value);
 					const Transform3D debug_transform = Transform3D(Basis().scaled(uniform_max_scale), get_global_position());
 
 					RS::get_singleton()->instance_set_transform(fake_agent_radius_debug_instance_rid, debug_transform);
@@ -452,7 +452,7 @@ void NavigationObstacle3D::navmesh_parse_source_geometry(const Ref<NavigationMes
 	if (obstacle_radius > 0.0) {
 		// Radius defined obstacle should be uniformly scaled from obstacle basis max scale axis.
 		const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
-		const Vector3 uniform_max_scale = Vector3(scaling_max_value, scaling_max_value, scaling_max_value);
+		const Vector3 uniform_max_scale = Vector3::from_scalar(scaling_max_value);
 		const Transform3D obstacle_circle_transform = p_source_geometry_data->root_node_transform * Transform3D(Basis().scaled(uniform_max_scale), obstacle->get_global_position());
 
 		Vector<Vector3> obstruction_circle_vertices;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -247,8 +247,8 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		case StandardMaterial3D::BILLBOARD_ENABLED: {
 			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);
 			size_new = MAX(size_new, MAX(Math::abs(final_rect.position.y) * px_size, (final_rect.position.y + final_rect.size.y) * px_size));
-			aabb_new.position = Vector3(-size_new, -size_new, -size_new);
-			aabb_new.size = Vector3(size_new * 2.0, size_new * 2.0, size_new * 2.0);
+			aabb_new.position = Vector3::from_scalar(-size_new);
+			aabb_new.size = Vector3::from_scalar(size_new * 2.0);
 		} break;
 		case StandardMaterial3D::BILLBOARD_FIXED_Y: {
 			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -692,11 +692,11 @@ void Voxelizer::begin_bake(int p_subdiv, const AABB &p_bounds, float p_exposure_
 	}
 
 	Transform3D to_bounds;
-	to_bounds.basis.scale(Vector3(po2_bounds.size[longest_axis], po2_bounds.size[longest_axis], po2_bounds.size[longest_axis]));
+	to_bounds.basis.scale(Vector3::from_scalar(po2_bounds.size[longest_axis]));
 	to_bounds.origin = po2_bounds.position;
 
 	Transform3D to_grid;
-	to_grid.basis.scale(Vector3(axis_cell_size[longest_axis], axis_cell_size[longest_axis], axis_cell_size[longest_axis]));
+	to_grid.basis.scale(Vector3::from_scalar(axis_cell_size[longest_axis]));
 
 	to_cell_space = to_grid * to_bounds.affine_inverse();
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -2483,7 +2483,7 @@ void RuntimeNodeSelect::_reset_camera_2d() {
 
 void RuntimeNodeSelect::_update_view_2d() {
 	Transform2D transform = Transform2D();
-	transform.scale_basis(Size2(view_2d_zoom, view_2d_zoom));
+	transform.scale_basis(Size2::from_scalar(view_2d_zoom));
 	transform.columns[2] = -view_2d_offset * view_2d_zoom;
 
 	SceneTree::get_singleton()->get_root()->set_canvas_transform_override(transform);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1354,7 +1354,7 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 			}
 			Rect2 icon_region = p_region;
 			icon_region.position += Point2(padding, padding);
-			icon_region.size -= Point2(padding, padding) * 2;
+			icon_region.size -= Point2::from_scalar(padding * 2);
 			theme_cache.breakpoint_icon->draw_rect(get_canvas_item(), icon_region, false, use_color);
 		}
 	}

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -772,7 +772,7 @@ void FileDialog::update_file_list() {
 		file_list->set_fixed_column_width(theme_cache.thumbnail_size * 3 / 2);
 		file_list->set_max_text_lines(2);
 		file_list->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
-		file_list->set_fixed_icon_size(Size2(theme_cache.thumbnail_size, theme_cache.thumbnail_size));
+		file_list->set_fixed_icon_size(Size2::from_scalar(theme_cache.thumbnail_size));
 	} else {
 		file_list->set_icon_mode(ItemList::ICON_MODE_LEFT);
 		file_list->set_max_columns(1);

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -209,7 +209,7 @@ void GraphEditMinimap::_bind_methods() {
 GraphEditMinimap::GraphEditMinimap(GraphEdit *p_edit) {
 	ge = p_edit;
 
-	minimap_padding = Vector2(MINIMAP_PADDING, MINIMAP_PADDING);
+	minimap_padding = Vector2::from_scalar(MINIMAP_PADDING);
 	minimap_offset = minimap_padding + _convert_from_graph_position(graph_padding);
 }
 
@@ -917,7 +917,7 @@ Rect2 GraphEdit::_compute_shrinked_frame_rect(const GraphFrame *p_frame) {
 	const Size2 titlebar_size = p_frame->get_titlebar_size();
 
 	min_point -= Size2(autoshrink_margin, MAX(autoshrink_margin, titlebar_size.y));
-	max_point += Size2(autoshrink_margin, autoshrink_margin);
+	max_point += Size2::from_scalar(autoshrink_margin);
 
 	return Rect2(min_point, max_point - min_point);
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1676,7 +1676,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 									if (rtl) {
 										coff.x = rect.size.width - table->columns[col].width - coff.x;
 									}
-									Rect2 crect = Rect2(rect.position + coff - frame->padding.position - Vector2(theme_cache.table_h_separation * 0.5, theme_cache.table_h_separation * 0.5).floor(), Size2(table->columns[col].width + theme_cache.table_h_separation, table->rows[row] + theme_cache.table_v_separation) + frame->padding.position + frame->padding.size);
+									Rect2 crect = Rect2(rect.position + coff - frame->padding.position - Vector2::from_scalar(theme_cache.table_h_separation * 0.5).floor(), Size2(table->columns[col].width + theme_cache.table_h_separation, table->rows[row] + theme_cache.table_v_separation) + frame->padding.position + frame->padding.size);
 									if (col == col_count - 1) {
 										if (rtl) {
 											crect.size.x = crect.position.x + crect.size.x;
@@ -6516,7 +6516,7 @@ Vector2i RichTextLabel::get_line_range(int p_line) {
 		int lc = main->lines[i].text_buf->get_line_count();
 
 		if (p_line < line_count + lc) {
-			Vector2i char_offset = Vector2i(main->lines[i].char_offset, main->lines[i].char_offset);
+			Vector2i char_offset = Vector2i::from_scalar(main->lines[i].char_offset);
 			Vector2i line_range = main->lines[i].text_buf->get_line_range(p_line - line_count);
 			return char_offset + line_range;
 		}

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -219,7 +219,7 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (stretch && shrink > 1) {
 		Transform2D xform;
-		xform.scale(Vector2(1, 1) / shrink);
+		xform.scale(Vector2::from_scalar(1 / shrink));
 		_send_event_to_viewports(p_event->xformed_by(xform));
 	} else {
 		_send_event_to_viewports(p_event);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7828,7 +7828,7 @@ void TextEdit::_cut_internal(int p_caret) {
 	if (p_caret == -1) {
 		line_ranges = get_line_ranges_from_carets();
 	} else {
-		line_ranges.push_back(Point2i(get_caret_line(p_caret), get_caret_line(p_caret)));
+		line_ranges.push_back(Point2i::from_scalar(get_caret_line(p_caret)));
 	}
 	int line_offset = 0;
 	for (Point2i line_range : line_ranges) {
@@ -7862,7 +7862,7 @@ void TextEdit::_copy_internal(int p_caret) {
 		// When there are multiple carets on a line, only copy it once.
 		line_ranges = get_line_ranges_from_carets(false, true);
 	} else {
-		line_ranges.push_back(Point2i(get_caret_line(p_caret), get_caret_line(p_caret)));
+		line_ranges.push_back(Point2i::from_scalar(get_caret_line(p_caret)));
 	}
 	for (Point2i line_range : line_ranges) {
 		for (int i = line_range.x; i <= line_range.y; i++) {

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -91,7 +91,7 @@ Transform2D CanvasLayer::get_transform() const {
 Transform2D CanvasLayer::get_final_transform() const {
 	if (is_following_viewport()) {
 		Transform2D follow;
-		follow.scale(Vector2(get_follow_viewport_scale(), get_follow_viewport_scale()));
+		follow.scale(Vector2::from_scalar(get_follow_viewport_scale()));
 		if (vp) {
 			follow = vp->get_canvas_transform() * follow;
 		}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5488,7 +5488,7 @@ Transform2D SubViewport::get_screen_transform_internal(bool p_absolute_position)
 	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());
 	if (c) {
 		if (c->is_stretch_enabled()) {
-			container_transform.scale(Vector2(c->get_stretch_shrink(), c->get_stretch_shrink()));
+			container_transform.scale(Vector2::from_scalar(c->get_stretch_shrink()));
 		}
 		container_transform = c->get_viewport()->get_screen_transform_internal(p_absolute_position) * c->get_global_transform_with_canvas() * container_transform;
 	} else {
@@ -5508,7 +5508,7 @@ Transform2D SubViewport::get_popup_base_transform() const {
 	}
 	Transform2D container_transform;
 	if (c->is_stretch_enabled()) {
-		container_transform.scale(Vector2(c->get_stretch_shrink(), c->get_stretch_shrink()));
+		container_transform.scale(Vector2::from_scalar(c->get_stretch_shrink()));
 	}
 	return c->get_screen_transform() * container_transform * get_final_transform();
 }

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -123,7 +123,7 @@ private:
 	String displayed_title;
 	mutable int current_screen = 0;
 	mutable Point2i position;
-	mutable Size2i size = Size2i(DEFAULT_WINDOW_SIZE, DEFAULT_WINDOW_SIZE);
+	mutable Size2i size = Size2i::from_scalar(DEFAULT_WINDOW_SIZE);
 	mutable Size2i min_size;
 	mutable Size2i max_size;
 	mutable Vector<Vector2> mpath;

--- a/scene/resources/2d/circle_shape_2d.cpp
+++ b/scene/resources/2d/circle_shape_2d.cpp
@@ -64,8 +64,8 @@ void CircleShape2D::_bind_methods() {
 
 Rect2 CircleShape2D::get_rect() const {
 	Rect2 rect;
-	rect.position = -Point2(get_radius(), get_radius());
-	rect.size = Point2(get_radius(), get_radius()) * 2.0;
+	rect.position = -Point2::from_scalar(get_radius());
+	rect.size = Point2::from_scalar(get_radius() * 2.0);
 	return rect;
 }
 

--- a/scene/resources/2d/tile_set.cpp
+++ b/scene/resources/2d/tile_set.cpp
@@ -3473,7 +3473,7 @@ void TileSet::_compatibility_conversion() {
 			} break;
 			case COMPATIBILITY_TILE_MODE_ATLAS_TILE: {
 				atlas_source->set_margins(ctd->region.get_position());
-				atlas_source->set_separation(Vector2i(ctd->autotile_spacing, ctd->autotile_spacing));
+				atlas_source->set_separation(Vector2i::from_scalar(ctd->autotile_spacing));
 				atlas_source->set_texture_region_size(ctd->autotile_tile_size);
 
 				Size2i atlas_size = ctd->region.get_size() / (ctd->autotile_tile_size + atlas_source->get_separation());

--- a/scene/resources/immediate_mesh.h
+++ b/scene/resources/immediate_mesh.h
@@ -74,7 +74,7 @@ class ImmediateMesh : public Mesh {
 	Vector<uint8_t> surface_vertex_create_cache;
 	Vector<uint8_t> surface_attribute_create_cache;
 
-	const Vector3 SMALL_VEC3 = Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON);
+	const Vector3 SMALL_VEC3 = Vector3::from_scalar(CMP_EPSILON);
 
 protected:
 	static void _bind_methods();

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -277,10 +277,10 @@ inline void set_corner_scale(const Rect2 &style_rect, const Rect2 &inner_rect, c
 
 	// Corner Radii as Point2s.
 	Point2 pcr[4] = {
-		Point2(corner_radius[0], corner_radius[0]),
-		Point2(corner_radius[1], corner_radius[1]),
-		Point2(corner_radius[2], corner_radius[2]),
-		Point2(corner_radius[3], corner_radius[3]),
+		Point2::from_scalar(corner_radius[0]),
+		Point2::from_scalar(corner_radius[1]),
+		Point2::from_scalar(corner_radius[2]),
+		Point2::from_scalar(corner_radius[3]),
 	};
 
 	// If corner radii are too small, they won't shrink the full amount.
@@ -325,9 +325,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 
 	// Corner radius center points.
 	Vector<Point2> outer_points = {
-		ring_rect.position + Vector2(ring_corner_radius[0], ring_corner_radius[0]) * ring_scale[0], //tl
+		ring_rect.position + Vector2::from_scalar(ring_corner_radius[0]) * ring_scale[0], //tl
 		Point2(ring_rect.position.x + ring_rect.size.x - ring_corner_radius[1] * ring_scale[1].x, ring_rect.position.y + ring_corner_radius[1] * ring_scale[1].y), //tr
-		ring_rect.position + ring_rect.size - Vector2(ring_corner_radius[2], ring_corner_radius[2]) * ring_scale[2], //br
+		ring_rect.position + ring_rect.size - Vector2::from_scalar(ring_corner_radius[2]) * ring_scale[2], //br
 		Point2(ring_rect.position.x + ring_corner_radius[3] * ring_scale[3].x, ring_rect.position.y + ring_rect.size.y - ring_corner_radius[3] * ring_scale[3].y) //bl
 	};
 
@@ -338,9 +338,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 	set_corner_scale(style_rect, inner_rect, inner_corner_radius, inner_scale);
 
 	Vector<Point2> inner_points = {
-		inner_rect.position + Vector2(inner_corner_radius[0], inner_corner_radius[0]) * inner_scale[0], //tl
+		inner_rect.position + Vector2::from_scalar(inner_corner_radius[0]) * inner_scale[0], //tl
 		Point2(inner_rect.position.x + inner_rect.size.x - inner_corner_radius[1] * inner_scale[1].x, inner_rect.position.y + inner_corner_radius[1] * inner_scale[1].y), //tr
-		inner_rect.position + inner_rect.size - Vector2(inner_corner_radius[2], inner_corner_radius[2]) * inner_scale[2], //br
+		inner_rect.position + inner_rect.size - Vector2::from_scalar(inner_corner_radius[2]) * inner_scale[2], //br
 		Point2(inner_rect.position.x + inner_corner_radius[3] * inner_scale[3].x, inner_rect.position.y + inner_rect.size.y - inner_corner_radius[3] * inner_scale[3].y) //bl
 	};
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -138,12 +138,10 @@ void VisualShaderNode::set_input_port_default_value(int p_port, const Variant &p
 			case Variant::VECTOR3: {
 				switch (p_prev_value.get_type()) {
 					case Variant::INT: {
-						float pv = (float)(int)p_prev_value;
-						value = Vector3(pv, pv, pv);
+						value = Vector3::from_scalar((float)(int)p_prev_value);
 					} break;
 					case Variant::FLOAT: {
-						float pv = p_prev_value;
-						value = Vector3(pv, pv, pv);
+						value = Vector3::from_scalar(p_prev_value);
 					} break;
 					case Variant::VECTOR2: {
 						Vector2 pv = p_prev_value;

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -40,7 +40,7 @@
 
 using namespace RendererRD;
 
-const Vector3i GI::SDFGI::Cascade::DIRTY_ALL = Vector3i(0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF);
+const Vector3i GI::SDFGI::Cascade::DIRTY_ALL = Vector3i::from_scalar(0x7FFFFFFF);
 
 GI *GI::singleton = nullptr;
 
@@ -562,7 +562,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 		Vector3 world_position = p_world_position;
 		world_position.y *= y_mult;
 		int32_t probe_cells = cascade_size / SDFGI::PROBE_DIVISOR;
-		Vector3 probe_size = Vector3(1, 1, 1) * cascade.cell_size * probe_cells;
+		Vector3 probe_size = Vector3::from_scalar(cascade.cell_size * probe_cells);
 		Vector3i probe_pos = Vector3i((world_position / probe_size + Vector3(0.5, 0.5, 0.5)).floor());
 		cascade.position = probe_pos * probe_cells;
 
@@ -1192,7 +1192,7 @@ void GI::SDFGI::update(RID p_env, const Vector3 &p_world_position) {
 	for (SDFGI::Cascade &cascade : cascades) {
 		cascade.dirty_regions = Vector3i();
 
-		Vector3 probe_half_size = Vector3(1, 1, 1) * cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5;
+		Vector3 probe_half_size = Vector3::from_scalar(cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5);
 		probe_half_size = Vector3(0, 0, 0);
 
 		Vector3 world_position = p_world_position;
@@ -1439,9 +1439,9 @@ int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, V
 		if (c.dirty_regions == SDFGI::Cascade::DIRTY_ALL) {
 			if (dirty_count == p_region) {
 				r_local_offset = Vector3i();
-				r_local_size = Vector3i(1, 1, 1) * cascade_size;
+				r_local_size = Vector3i::from_scalar(cascade_size);
 
-				r_bounds.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + c.position)) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+				r_bounds.position = Vector3((Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + c.position)) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 				r_bounds.size = Vector3(r_local_size) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 				return i;
 			}
@@ -1451,7 +1451,7 @@ int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, V
 				if (c.dirty_regions[j] != 0) {
 					if (dirty_count == p_region) {
 						Vector3i from = Vector3i(0, 0, 0);
-						Vector3i to = Vector3i(1, 1, 1) * cascade_size;
+						Vector3i to = Vector3i::from_scalar(cascade_size);
 
 						if (c.dirty_regions[j] > 0) {
 							//fill from the beginning
@@ -1473,7 +1473,7 @@ int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, V
 						r_local_offset = from;
 						r_local_size = to - from;
 
-						r_bounds.position = Vector3(from + Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + c.position) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+						r_bounds.position = Vector3(from + Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + c.position) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 						r_bounds.size = Vector3(r_local_size) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 
 						return i;
@@ -1493,7 +1493,7 @@ void GI::SDFGI::update_cascades() {
 	int32_t probe_divisor = cascade_size / SDFGI::PROBE_DIVISOR;
 
 	for (uint32_t i = 0; i < cascades.size(); i++) {
-		Vector3 pos = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[i].position)) * cascades[i].cell_size;
+		Vector3 pos = Vector3((Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + cascades[i].position)) * cascades[i].cell_size;
 
 		cascade_data[i].offset[0] = pos.x;
 		cascade_data[i].offset[1] = pos.y;
@@ -1740,7 +1740,7 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 
 	if (gi->sdfgi_debug_probe_dir != Vector3()) {
 		uint32_t cascade = 0;
-		Vector3 offset = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[cascade].position)) * cascades[cascade].cell_size * Vector3(1.0, 1.0 / y_mult, 1.0);
+		Vector3 offset = Vector3((Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + cascades[cascade].position)) * cascades[cascade].cell_size * Vector3(1.0, 1.0 / y_mult, 1.0);
 		Vector3 probe_size = cascades[cascade].cell_size * (cascade_size / SDFGI::PROBE_DIVISOR) * Vector3(1.0, 1.0 / y_mult, 1.0);
 		Vector3 ray_from = gi->sdfgi_debug_probe_pos;
 		Vector3 ray_to = gi->sdfgi_debug_probe_pos + gi->sdfgi_debug_probe_dir * cascades[cascade].cell_size * Math::sqrt(3.0) * cascade_size;
@@ -1855,7 +1855,7 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 
 	for (uint32_t i = 0; i < sdfgi_data.max_cascades; i++) {
 		SDFGIData::ProbeCascadeData &c = sdfgi_data.cascades[i];
-		Vector3 pos = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[i].position)) * cascades[i].cell_size;
+		Vector3 pos = Vector3((Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + cascades[i].position)) * cascades[i].cell_size;
 		Vector3 cam_origin = p_transform.origin;
 		cam_origin.y *= y_mult;
 		pos -= cam_origin; //make pos local to camera, to reduce numerical error
@@ -1928,8 +1928,8 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 		}
 
 		AABB cascade_aabb;
-		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size;
-		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size;
+		cascade_aabb.position = Vector3((Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + cascade.position)) * cascade.cell_size;
+		cascade_aabb.size = Vector3::from_scalar(cascade_size) * cascade.cell_size;
 
 		for (uint32_t j = 0; j < p_render_data->sdfgi_update_data->positional_light_count; j++) {
 			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {
@@ -2314,7 +2314,7 @@ void GI::SDFGI::render_region(Ref<RenderSceneBuffersRD> p_render_buffers, int p_
 				push_constant.occlusion_index = i;
 				RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDFGIShader::PreprocessPushConstant));
 
-				Vector3i groups = Vector3i(probe_size + 1, probe_size + 1, probe_size + 1) - offset; //if offset, it's one less probe per axis to compute
+				Vector3i groups = Vector3i::from_scalar(probe_size + 1) - offset; //if offset, it's one less probe per axis to compute
 				RD::get_singleton()->compute_list_dispatch(compute_list, groups.x, groups.y, groups.z);
 			}
 			RD::get_singleton()->compute_list_add_barrier(compute_list);
@@ -2387,8 +2387,8 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 		{ //fill light buffer
 
 			AABB cascade_aabb;
-			cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cc.position)) * cc.cell_size;
-			cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cc.cell_size;
+			cascade_aabb.position = Vector3((Vector3i::from_scalar(-int32_t(cascade_size >> 1)) + cc.position)) * cc.cell_size;
+			cascade_aabb.size = Vector3::from_scalar(cascade_size) * cc.cell_size;
 
 			int idx = 0;
 
@@ -3045,7 +3045,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 		int multiplier = dynamic_maps[0].size / MAX(MAX(octree_size.x, octree_size.y), octree_size.z);
 
 		Transform3D oversample_scale;
-		oversample_scale.basis.scale(Vector3(multiplier, multiplier, multiplier));
+		oversample_scale.basis.scale(Vector3::from_scalar(multiplier));
 
 		Transform3D to_cell = oversample_scale * gi->voxel_gi_get_to_cell_xform(probe);
 		Transform3D to_world_xform = transform * to_cell.affine_inverse();

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1357,7 +1357,7 @@ void LightStorage::reflection_atlas_set_size(RID p_ref_atlas, int p_reflection_s
 
 	if (ra->cluster_builder) {
 		// only if we're using our cluster
-		ra->cluster_builder->setup(Size2i(ra->size, ra->size), max_cluster_elements, RID(), RID(), RID());
+		ra->cluster_builder->setup(Size2i::from_scalar(ra->size), max_cluster_elements, RID(), RID(), RID());
 	}
 
 	ra->size = p_reflection_size;
@@ -1550,7 +1550,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		fb.push_back(atlas->depth_buffer);
 		atlas->depth_fb = RD::get_singleton()->framebuffer_create(fb);
 
-		atlas->render_buffers->configure_for_reflections(Size2i(atlas->size, atlas->size));
+		atlas->render_buffers->configure_for_reflections(Size2i::from_scalar(atlas->size));
 	}
 
 	if (rpi->atlas_index == -1) {
@@ -1688,7 +1688,7 @@ ClusterBuilderRD *LightStorage::reflection_probe_instance_get_cluster_builder(RI
 		if (ra->cluster_builder == nullptr) {
 			ra->cluster_builder = memnew(ClusterBuilderRD);
 			ra->cluster_builder->set_shared(p_cluster_builder_shared);
-			ra->cluster_builder->setup(Size2i(ra->size, ra->size), get_max_cluster_elements(), RID(), RID(), RID());
+			ra->cluster_builder->setup(Size2i::from_scalar(ra->size), get_max_cluster_elements(), RID(), RID(), RID());
 		}
 		return ra->cluster_builder;
 	}

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -437,7 +437,7 @@ AABB LightStorage::light_get_aabb(RID p_light) const {
 		};
 		case RS::LIGHT_OMNI: {
 			float r = light->param[RS::LIGHT_PARAM_RANGE];
-			return AABB(-Vector3(r, r, r), Vector3(r, r, r) * 2);
+			return AABB(Vector3::from_scalar(-r), Vector3::from_scalar(r * 2));
 		};
 		case RS::LIGHT_DIRECTIONAL: {
 			return AABB();

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1950,8 +1950,8 @@ AABB ParticlesStorage::particles_collision_get_aabb(RID p_particles_collision) c
 		case RS::PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT:
 		case RS::PARTICLES_COLLISION_TYPE_SPHERE_COLLIDE: {
 			AABB aabb;
-			aabb.position = -Vector3(1, 1, 1) * particles_collision->radius;
-			aabb.size = Vector3(2, 2, 2) * particles_collision->radius;
+			aabb.position = -Vector3::from_scalar(particles_collision->radius);
+			aabb.size = Vector3::from_scalar(particles_collision->radius * 2);
 			return aabb;
 		}
 		default: {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2920,7 +2920,7 @@ void TextureStorage::update_decal_atlas() {
 
 		for (int i = 0; i < item_count; i++) {
 			DecalAtlas::Texture *t = decal_atlas.textures.getptr(items[i].texture);
-			t->uv_rect.position = items[i].pos * border + Vector2i(border / 2, border / 2);
+			t->uv_rect.position = items[i].pos * border + Vector2i::from_scalar(border / 2);
 			t->uv_rect.size = items[i].pixel_size;
 
 			t->uv_rect.position /= Size2(decal_atlas.size);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -65,8 +65,8 @@ class RenderingServer : public Object {
 
 	Array _get_array_from_surface(uint64_t p_format, Vector<uint8_t> p_vertex_data, Vector<uint8_t> p_attrib_data, Vector<uint8_t> p_skin_data, int p_vertex_len, Vector<uint8_t> p_index_data, int p_index_len, const AABB &p_aabb, const Vector4 &p_uv_scale) const;
 
-	const Vector2 SMALL_VEC2 = Vector2(CMP_EPSILON, CMP_EPSILON);
-	const Vector3 SMALL_VEC3 = Vector3(CMP_EPSILON, CMP_EPSILON, CMP_EPSILON);
+	const Vector2 SMALL_VEC2 = Vector2::from_scalar(CMP_EPSILON);
+	const Vector3 SMALL_VEC3 = Vector3::from_scalar(CMP_EPSILON);
 
 	virtual TypedArray<StringName> _global_shader_parameter_get_list() const;
 

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -168,10 +168,10 @@ TEST_CASE("[Vector3] Length methods") {
 TEST_CASE("[Vector3] Limiting methods") {
 	constexpr Vector3 vector = Vector3(10, 10, 10);
 	CHECK_MESSAGE(
-			vector.limit_length().is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
+			vector.limit_length().is_equal_approx(Vector3::from_scalar(Math::SQRT13)),
 			"Vector3 limit_length should work as expected.");
 	CHECK_MESSAGE(
-			vector.limit_length(5).is_equal_approx(5 * Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
+			vector.limit_length(5).is_equal_approx(Vector3::from_scalar(Math::SQRT13 * 5)),
 			"Vector3 limit_length should work as expected.");
 
 	CHECK_MESSAGE(
@@ -196,7 +196,7 @@ TEST_CASE("[Vector3] Normalization methods") {
 			Vector3(1, 1, 0).normalized().is_equal_approx(Vector3(Math::SQRT12, Math::SQRT12, 0)),
 			"Vector3 normalized should work as expected.");
 	CHECK_MESSAGE(
-			Vector3(1, 1, 1).normalized().is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
+			Vector3(1, 1, 1).normalized().is_equal_approx(Vector3::from_scalar(Math::SQRT13)),
 			"Vector3 normalized should work as expected.");
 
 	Vector3 vector = Vector3(3.2, -5.4, 6);
@@ -313,7 +313,7 @@ TEST_CASE("[Vector3] Other methods") {
 			vector.direction_to(Vector3()).is_equal_approx(-vector.normalized()),
 			"Vector3 direction_to should work as expected.");
 	CHECK_MESSAGE(
-			Vector3(1, 1, 1).direction_to(Vector3(2, 2, 2)).is_equal_approx(Vector3(Math::SQRT13, Math::SQRT13, Math::SQRT13)),
+			Vector3(1, 1, 1).direction_to(Vector3(2, 2, 2)).is_equal_approx(Vector3::from_scalar(Math::SQRT13)),
 			"Vector3 direction_to should work as expected.");
 	CHECK_MESSAGE(
 			vector.inverse().is_equal_approx(Vector3(1 / 1.2, 1 / 3.4, 1 / 5.6)),

--- a/tests/scene/test_path_follow_3d.h
+++ b/tests/scene/test_path_follow_3d.h
@@ -279,10 +279,10 @@ TEST_CASE("[SceneTree][PathFollow3D] Calculate forward vector") {
 	CHECK(is_equal_approx(Vector3(0, 0, -1), path_follow_3d->get_transform().get_basis().get_column(2)));
 
 	path_follow_3d->set_progress(400 + 1.5 * dist_cube_100);
-	CHECK(is_equal_approx(Vector3(0.577348, 0.577348, 0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
+	CHECK(is_equal_approx(Vector3::from_scalar(0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
 
 	path_follow_3d->set_progress(400 + 2 * dist_cube_100 - 0.01);
-	CHECK(is_equal_approx(Vector3(0.577348, 0.577348, 0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
+	CHECK(is_equal_approx(Vector3::from_scalar(0.577348), path_follow_3d->get_transform().get_basis().get_column(2)));
 
 	path_follow_3d->set_progress(500 + 2 * dist_cube_100);
 	CHECK(is_equal_approx(Vector3(1, 0, 0), path_follow_3d->get_transform().get_basis().get_column(2)));


### PR DESCRIPTION
Refactors vector initializations by replacing repeated scalar arguments and redundant operations with `from_scalar`, making the code shorter, easier to read, and slightly more efficient.

A shorter, more concise name would be appreciated, such as `fill`, `splat`, or `uniform`.

Use cases:

- **Temporary variable elimination:**
  ```c++
  const real_t radius2 = Math::sqrt(double(new_simplex->circum_r2)) + 0.0001;
  Vector3 extents = Vector3(radius2, radius2, radius2);
  ```
  Changed to:
  ```c++
  Vector3 extents = Vector3::from_scalar(Math::sqrt(double(new_simplex->circum_r2)) + 0.0001);
  ```
- **Line shortening:**
   ```c++
   Size2i(options6.ShadingRateImageTileSize, options6.ShadingRateImageTileSize)
   ```
   Changed to:
   ```c++
   Size2i::from_scalar(options6.ShadingRateImageTileSize)
   ```
- **Redundant operation elimination:**
   ```c++
   Vector2i(border / 2, border / 2)
   Size2(400, 400) * EDSCALE
   ```
   Changed to:
   ```c++
   Vector2i::from_scalar(border / 2)
   Size2::from_scalar(400 * EDSCALE)
   ```
- **Dummy vector scaling elimination:**
  ```c++
  Vector3(1, 1, 1) * cascade.cell_size * probe_cells;
  ```
  Changed to:
  ```c++
  Vector3::from_scalar(cascade.cell_size * probe_cells);
  ```
  
* Here's another implementation using constructors which is much better: https://github.com/godotengine/godot/pull/109687