### PR TITLE
[3.x] Fix Line breaking may not work correctly when using color tags with specific font

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -361,12 +361,6 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 				int ascent = font->get_ascent();
 				int descent = font->get_descent();
 
-				// Each BBCode tag is drawn individually, so we have to add the character spacing manually.
-				int spacing_char = 0;
-				if (visible_characters != 0) {
-					spacing_char = font->get_spacing_char();
-				}
-
 				Color color;
 				Color font_color_shadow;
 				bool underline = false;
@@ -453,6 +447,12 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 
 						end++;
 					}
+					// Each BBCode tag is drawn individually, so we have to add the character spacing manually.
+					int spacing_char = 0;
+					if (visible_characters != 0) {
+						spacing_char = font->get_spacing_char();
+					}
+
 					CHECK_HEIGHT(fh);
 					ENSURE_WIDTH(w + spacing_char);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/108890
Made sure that https://github.com/godotengine/godot/issues/34130 is still fixed and does not regress.

The fix is simple: 
Since we are running the code in a while loop, we need to assign the `spacing_char` always and may reset it to `0` when we are in a new blank line (created by `ENSURE_WIDTH`).

https://github.com/user-attachments/assets/04dd1e70-bb15-4357-98c6-7ef257c06152

cc @lawnjelly 