### PR TITLE
[RTL] Fix text around `visible_characters` boundary being added twice to the buffer.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -593,10 +593,11 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 					String second = tx.substr(remaining_characters, -1);
 					l.text_buf->add_string(first, font, font_size, lang, it->rid);
 					l.text_buf->add_string(second, font, font_size, lang, it->rid);
+				} else {
+					l.text_buf->add_string(tx, font, font_size, lang, it->rid);
 				}
 				remaining_characters -= tx.length();
 
-				l.text_buf->add_string(tx, font, font_size, lang, it->rid);
 				txt += tx;
 				l.char_count += tx.length();
 			} break;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109696 Fixes #109697