### PR TITLE
Improve and reduce Game window sizing

### DIFF
--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -165,13 +165,10 @@ class GameView : public VBoxContainer {
 	Button *camera_override_button = nullptr;
 	MenuButton *camera_override_menu = nullptr;
 
-	VSeparator *embedding_separator = nullptr;
-	Button *fixed_size_button = nullptr;
-	Button *keep_aspect_button = nullptr;
-	Button *stretch_button = nullptr;
+	HBoxContainer *embedding_hb = nullptr;
 	MenuButton *embed_options_menu = nullptr;
 	Label *game_size_label = nullptr;
-	Panel *panel = nullptr;
+	PanelContainer *panel = nullptr;
 	EmbeddedProcessBase *embedded_process = nullptr;
 	Label *state_label = nullptr;
 
@@ -194,7 +191,6 @@ class GameView : public VBoxContainer {
 	void _node_type_pressed(int p_option);
 	void _select_mode_pressed(int p_option);
 	void _embed_options_menu_menu_id_pressed(int p_id);
-	void _size_mode_button_pressed(int size_mode);
 
 	void _reset_time_scales();
 	void _speed_state_menu_pressed(int p_id);

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1587,9 +1587,11 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
 
 		// Game view.
-		p_theme->set_type_variation("GamePanel", "Panel");
+		p_theme->set_type_variation("GamePanel", "PanelContainer");
 		Ref<StyleBoxFlat> game_panel = p_theme->get_stylebox(SceneStringName(panel), SNAME("Panel"))->duplicate();
 		game_panel->set_corner_radius_all(0);
+		game_panel->set_content_margin_all(0);
+		game_panel->set_draw_center(true);
 		p_theme->set_stylebox(SceneStringName(panel), "GamePanel", game_panel);
 
 		// Main menu.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1576,9 +1576,11 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
 
 		// Game view.
-		p_theme->set_type_variation("GamePanel", "Panel");
+		p_theme->set_type_variation("GamePanel", "PanelContainer");
 		Ref<StyleBoxFlat> game_panel = p_theme->get_stylebox(SceneStringName(panel), SNAME("Panel"))->duplicate();
 		game_panel->set_corner_radius_all(0);
+		game_panel->set_content_margin_all(0);
+		game_panel->set_draw_center(true);
 		p_theme->set_stylebox(SceneStringName(panel), "GamePanel", game_panel);
 
 		// Main menu.


### PR DESCRIPTION
**Editor window minimum size, before:**

<img width="1024" height="600" alt="image" src="https://github.com/user-attachments/assets/b1949172-e4f5-41ab-a65a-c97073d490b3" />



**Editor window minimum size, after:**

<img width="1024" height="600" alt="godot windows editor dev x86_64_Grd95TdifW" src="https://github.com/user-attachments/assets/fb5c2ed0-210c-4e13-a45d-be16e276d4fa" />
<img width="497" height="259" alt="godot windows editor dev x86_64_dSR1TxVUXI" src="https://github.com/user-attachments/assets/e951ea1a-a9b1-459c-a6d0-734a8bc6f8dc" />

Closes https://github.com/godotengine/godot-proposals/issues/12060

1) Now the top bar is `FlowContainer` which means that there will be no issues with width.

2) All embedding options were moved to single submenu and its icon is changed to see the difference between, for example, camera override options.

3) I decided to move `Toggle Selection Visibility` button to the selection buttons section, since they are directly related.

4) `Panel` where game window is placed on run is replaced with `PanelContainer` (there were sizing issues with it and the label inside it).

5) There is a problem that the Floating Game Workspace does not increase the size of the window to the right, as it was before:

https://github.com/user-attachments/assets/b9ad534d-ae98-4ea6-b812-85a1fe0b2dfa

If this is not ok, feel free to suggest how it can be fixed (same is valid for another changes I made).

