### PR TITLE
Fix PopupMenu accel position

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -965,7 +965,7 @@ void PopupMenu::_draw_items() {
 			} else {
 				item_ofs.x = display_width - theme_cache.panel_style->get_margin(SIDE_RIGHT) - items[i].accel_text_buf->get_size().x - theme_cache.item_end_padding;
 			}
-			Vector2 text_pos = item_ofs + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
+			Vector2 text_pos = item_ofs + Point2(0, Math::floor((h - items[i].accel_text_buf->get_size().y) / 2.0));
 			if (theme_cache.font_outline_size > 0 && theme_cache.font_outline_color.a > 0) {
 				items[i].accel_text_buf->draw_outline(ci, text_pos, theme_cache.font_outline_size, theme_cache.font_outline_color);
 			}


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109707

Before:
<img width="169" height="147" alt="Screenshot_20250817_223822" src="https://github.com/user-attachments/assets/ba83aebe-859d-4336-8153-026d3a9e44c0" />


After:
<img width="169" height="147" alt="Screenshot_20250817_223742" src="https://github.com/user-attachments/assets/61405ac2-bf54-4d3e-bcfa-d465af5a4868" />
