### PR TITLE
Allow to inspect scene's sub-resources in FileSystem dock

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1447,6 +1447,68 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	return OK;
 }
 
+bool ResourceFormatLoaderBinary::has_sub_resources(const String &p_path) const {
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(file.is_null(), false, vformat("Resource file \"%s\" not found."));
+
+	uint8_t header[4];
+	file->get_buffer(header, 4);
+	if (header[0] == 'R' && header[1] == 'S' && header[2] == 'C' && header[3] == 'C') {
+		// Compressed.
+		Ref<FileAccessCompressed> fac;
+		fac.instantiate();
+		Error err = fac->open_after_magic(file);
+		ERR_FAIL_COND_V_MSG(err != OK, false, vformat("Cannot open file \"%s\".", p_path));
+		file = fac;
+	} else if (header[0] != 'R' || header[1] != 'S' || header[2] != 'R' || header[3] != 'C') {
+		// Not normal.
+		ERR_FAIL_V_MSG(false, vformat("Unrecognized binary resource file \"%s\".", p_path));
+	}
+
+	bool big_endian = file->get_32();
+	file->get_32(); // use_real64
+
+	file->set_big_endian(big_endian != 0); // Read big endian if saved as big endian.
+
+	uint32_t ver_major = file->get_32();
+	uint32_t ver_minor = file->get_32();
+	uint32_t ver_format = file->get_32();
+
+	if (ver_format > FORMAT_VERSION || ver_major > GODOT_VERSION_MAJOR) {
+		ERR_FAIL_V_MSG(false, vformat("File \"%s\" can't be loaded, as it uses a format version (%d) or engine version (%d.%d) which are not supported by your engine version (%s).", p_path, ver_format, ver_major, ver_minor, GODOT_VERSION_BRANCH));
+	}
+
+	file->seek(file->get_position() + file->get_32()); // Type
+
+	file->get_64(); // importmd_ofs
+	uint32_t flags = file->get_32();
+
+	file->get_64(); // UID
+
+	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_HAS_SCRIPT_CLASS) {
+		file->seek(file->get_position() + file->get_32()); // Script class
+	}
+
+	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {
+		file->get_32();
+	}
+
+	uint32_t string_table_size = file->get_32();
+	for (uint32_t i = 0; i < string_table_size; i++) {
+		file->seek(file->get_position() + file->get_32());
+	}
+
+	uint32_t ext_resources_size = file->get_32();
+	for (uint32_t i = 0; i < ext_resources_size; i++) {
+		file->seek(file->get_position() + file->get_32()); // Type
+		file->seek(file->get_position() + file->get_32()); // Path
+		if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS) {
+			file->get_64(); // UID
+		}
+	}
+	return file->get_32() > 1; // First sub-resource is self.
+}
+
 void ResourceFormatLoaderBinary::get_classes_used(const String &p_path, HashSet<StringName> *r_classes) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_MSG(f.is_null(), vformat("Cannot open file '%s'.", p_path));

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -121,6 +121,7 @@ public:
 	virtual bool has_custom_uid_support() const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) override;
+	virtual bool has_sub_resources(const String &p_path) const override;
 };
 
 class ResourceFormatSaverBinaryInstance {

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1217,6 +1217,16 @@ ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
 	return ResourceUID::INVALID_ID;
 }
 
+bool ResourceLoader::has_sub_resources(const String &p_path) {
+	const String local_path = _validate_local_path(p_path);
+	for (int i = 0; i < loader_count; i++) {
+		if (loader[i]->recognize_path(local_path)) {
+			return loader[i]->has_sub_resources(local_path);
+		}
+	}
+	return false;
+}
+
 bool ResourceLoader::should_create_uid_file(const String &p_path) {
 	const String local_path = _validate_local_path(p_path);
 	if (FileAccess::exists(local_path + ".uid")) {

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -90,6 +90,7 @@ public:
 	virtual bool is_imported(const String &p_path) const { return false; }
 	virtual int get_import_order(const String &p_path) const { return 0; }
 	virtual String get_import_group_file(const String &p_path) const { return ""; } //no group
+	virtual bool has_sub_resources(const String &p_path) const { return false; }
 
 	virtual ~ResourceFormatLoader() {}
 };
@@ -256,6 +257,7 @@ public:
 	static String get_resource_type(const String &p_path);
 	static String get_resource_script_class(const String &p_path);
 	static ResourceUID::ID get_resource_uid(const String &p_path);
+	static bool has_sub_resources(const String &p_path);
 	static bool should_create_uid_file(const String &p_path);
 	static void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
 	static Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -80,15 +80,21 @@ Control *FileSystemTree::make_custom_tooltip(const String &p_text) const {
 	if (!item) {
 		return nullptr;
 	}
-	return FileSystemDock::get_singleton()->create_tooltip_for_path(item->get_metadata(0));
+	if (get_button_id_at_position(get_local_mouse_position()) > -1) {
+		return nullptr;
+	}
+	return FileSystemDock::get_singleton()->create_tooltip_for_path(item->get_metadata(0), item->get_meta(FileSystemDock::get_singleton()->TYPE_META, String()));
 }
 
 Control *FileSystemList::make_custom_tooltip(const String &p_text) const {
+	if (hovered_button > -1) {
+		return nullptr;
+	}
 	int idx = get_item_at_position(get_local_mouse_position(), true);
 	if (idx == -1) {
 		return nullptr;
 	}
-	return FileSystemDock::get_singleton()->create_tooltip_for_path(get_item_metadata(idx));
+	return FileSystemDock::get_singleton()->create_tooltip_for_path(get_item_metadata(idx), FileSystemDock::get_singleton()->list_types[idx]);
 }
 
 void FileSystemList::_line_editor_submit(const String &p_text) {
@@ -105,6 +111,38 @@ void FileSystemList::_line_editor_submit(const String &p_text) {
 
 	emit_signal(SNAME("item_edited"));
 	queue_redraw();
+}
+
+void FileSystemList::gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid()) {
+		if (hovered_button > -1 && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT) {
+			emit_signal("button_clicked", hovered_button);
+			accept_event();
+			return;
+		}
+	}
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid()) {
+		hovered_button = -1;
+
+		for (int i = 0; i < get_item_count(); i++) {
+			if (button_items.has(i) && _get_button_rect(i).has_point(mm->get_position())) {
+				hovered_button = i;
+				accept_event();
+				return;
+			}
+		}
+	}
+	ItemList::gui_input(p_event);
+}
+
+String FileSystemList::get_tooltip(const Point2 &p_pos) const {
+	if (hovered_button > -1) {
+		return TTR("This file has sub-resources.\nClick to inspect.");
+	}
+	return String();
 }
 
 bool FileSystemList::edit_selected() {
@@ -176,6 +214,16 @@ String FileSystemList::get_edit_text() {
 	return line_editor->get_text();
 }
 
+void FileSystemList::add_button(int p_idx) {
+	button_items.insert(p_idx);
+	queue_redraw();
+}
+
+void FileSystemList::clear_buttons() {
+	button_items.clear();
+	queue_redraw();
+}
+
 void FileSystemList::_text_editor_popup_modal_close() {
 	if (popup_edit_committed) {
 		return; // Already processed by _text_editor_popup_modal_close
@@ -188,8 +236,42 @@ void FileSystemList::_text_editor_popup_modal_close() {
 	_line_editor_submit(line_editor->get_text());
 }
 
+Rect2 FileSystemList::_get_button_rect(int p_idx) const {
+	const Rect2 item_rect = get_item_rect(p_idx);
+	Rect2 button_rect;
+	if (get_icon_mode() == ItemList::ICON_MODE_TOP) {
+		button_rect = Rect2(item_rect.position + Vector2(item_rect.size.x, 0), button_icon->get_size());
+	} else {
+		button_rect = Rect2(item_rect.position + Vector2(item_rect.size.x, item_rect.size.y * 0.5 - button_icon->get_height() * 0.5), button_icon->get_size());
+	}
+	button_rect.position.x -= button_icon->get_width();
+	button_rect.position.y -= const_cast<FileSystemList *>(this)->get_v_scroll_bar()->get_value();
+	return button_rect;
+}
+
+void FileSystemList::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			button_icon = get_editor_theme_icon("InspectSubResources");
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			hovered_button = -1;
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			for (int i = 0; i < get_item_count(); i++) {
+				if (button_items.has(i)) {
+					draw_texture_rect(button_icon, _get_button_rect(i));
+				}
+			}
+		} break;
+	}
+}
+
 void FileSystemList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_edited"));
+	ADD_SIGNAL(MethodInfo("button_clicked"));
 }
 
 FileSystemList::FileSystemList() {
@@ -308,6 +390,7 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 			file_info.type = p_dir->get_file_type(i);
 			file_info.icon_path = p_dir->get_file_icon_path(i);
 			file_info.import_broken = !p_dir->get_file_import_is_valid(i);
+			file_info.has_sub_resources = p_dir->get_file_has_sub_resources(i);
 			file_info.modified_time = p_dir->get_file_modified_time(i);
 
 			file_list.push_back(file_info);
@@ -323,6 +406,7 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 			TreeItem *file_item = tree->create_item(subdirectory_item);
 			const String file_metadata = lpath.path_join(file_info.name);
 			file_item->set_text(0, file_info.name);
+			file_item->set_tooltip_text(0, "/f"); // Will be replaced by custom tooltip.
 			file_item->set_structured_text_bidi_override(0, TextServer::STRUCTURED_TEXT_FILE);
 			file_item->set_icon(0, _get_tree_item_icon(!file_info.import_broken, file_info.type, file_info.icon_path));
 			if (da->is_link(file_metadata)) {
@@ -338,6 +422,7 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 				file_item->set_custom_bg_color(0, parent_bg_color);
 			}
 			file_item->set_metadata(0, file_metadata);
+			file_item->set_meta(TYPE_META, file_info.type);
 			file_item->set_accept_children(false);
 			if (!p_select_in_favorites && current_path == file_metadata) {
 				file_item->select(0);
@@ -347,6 +432,10 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 				file_item->set_custom_color(0, get_theme_color(SNAME("accent_color"), EditorStringName(Editor)));
 			}
 			EditorResourcePreview::get_singleton()->queue_resource_preview(file_metadata, callable_mp(this, &FileSystemDock::_tree_thumbnail_done).bind(tree_update_id, file_item->get_instance_id()));
+
+			if (file_info.has_sub_resources && file_info.type == SNAME("PackedScene")) { // TODO: Sub-resource inspecting shouldn't be limited to scenes.
+				file_item->add_button(0, get_editor_theme_icon(SNAME("InspectSubResources")), -1, false, TTR("This file has sub-resources.\nClick to expand."));
+			}
 		}
 	} else {
 		if (lpath.get_base_dir() == current_path.get_base_dir()) {
@@ -724,6 +813,7 @@ void FileSystemDock::_tree_multi_selected(Object *p_item, int p_column, bool p_s
 		current_path = selected->get_metadata(0);
 		// Note: the "Favorites" item also leads to this path.
 	}
+	sub_resource_inspect_path = String();
 
 	// Display the current path.
 	_set_current_path_line_edit_text(current_path);
@@ -781,12 +871,14 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 			if (!p_path.ends_with("/")) {
 				target_path += "/";
 			}
-		} else if (!da->file_exists(p_path)) {
-			ERR_FAIL_MSG(vformat("Cannot navigate to '%s' as it has not been found in the file system!", p_path));
+		} else {
+			target_path = p_path.is_resource_file() ? p_path : p_path.get_slice("::", 0);
+			ERR_FAIL_COND_MSG(!da->file_exists(target_path), vformat("Cannot navigate to '%s' as it has not been found in the file system!", p_path));
 		}
 	}
 
 	current_path = target_path;
+	sub_resource_inspect_path = String();
 	_set_current_path_line_edit_text(current_path);
 	_push_to_history();
 
@@ -1008,6 +1100,8 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	}
 
 	files->clear();
+	files->clear_buttons();
+	list_types.clear();
 
 	_set_current_path_line_edit_text(current_path);
 
@@ -1049,6 +1143,39 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_column_width(0);
 		const int icon_size = get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
 		files->set_fixed_icon_size(Size2(icon_size, icon_size));
+	}
+
+	if (!sub_resource_inspect_path.is_empty()) {
+		// Go back.
+		files->add_item(TTR("Go Back"), get_editor_theme_icon("UndoRedo"));
+		const String base_dir = sub_resource_inspect_path.get_base_dir();
+		files->set_item_metadata(-1, base_dir + (base_dir.ends_with("/") ? "" : "/"));
+		list_types.resize_initialized(1);
+
+		Ref<PackedScene> scene = ResourceLoader::load(sub_resource_inspect_path);
+		ERR_FAIL_COND(scene.is_null());
+
+		const Color sub_resource_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+		Vector<Ref<Resource>> subs = scene->get_state()->get_sub_resources();
+		for (const Ref<Resource> &res : subs) {
+			const Ref<Texture2D> type_icon = _get_tree_item_icon(true, res->get_class(), String());
+
+			String res_name = res->get_name();
+			if (res_name.is_empty()) {
+				res_name = res->get_class();
+			}
+
+			if (use_thumbnails) {
+				files->add_item(res_name, file_thumbnail, true);
+				files->set_item_tag_icon(-1, type_icon);
+			} else {
+				files->add_item(res_name, type_icon, true);
+			}
+			files->set_item_metadata(-1, res->get_path());
+			files->set_item_custom_fg_color(-1, sub_resource_color);
+			list_types.push_back(res->get_class());
+		}
+		return;
 	}
 
 	Ref<Texture2D> folder_icon = (use_thumbnails) ? folder_thumbnail : get_theme_icon(SNAME("folder"), SNAME("FileDialog"));
@@ -1097,6 +1224,7 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 					file_info.type = efd->get_file_type(index);
 					file_info.icon_path = efd->get_file_icon_path(index);
 					file_info.import_broken = !efd->get_file_import_is_valid(index);
+					file_info.has_sub_resources = efd->get_file_has_sub_resources(index);
 					file_info.modified_time = efd->get_file_modified_time(index);
 				} else {
 					file_info.type = "";
@@ -1185,12 +1313,15 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 				file_info.type = efd->get_file_type(i);
 				file_info.icon_path = efd->get_file_icon_path(i);
 				file_info.import_broken = !efd->get_file_import_is_valid(i);
+				file_info.has_sub_resources = efd->get_file_has_sub_resources(i);
 				file_info.modified_time = efd->get_file_modified_time(i);
 
 				file_list.push_back(file_info);
 			}
 		}
 	}
+	// Ensures that array indices match the file items added below.
+	list_types.resize(files->get_item_count());
 
 	// Sort the file list if needed.
 	sort_file_info_list(file_list, file_sort);
@@ -1227,6 +1358,10 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 			files->add_item(fname, type_icon, true);
 			item_index = files->get_item_count() - 1;
 			files->set_item_metadata(item_index, fpath);
+		}
+		list_types.push_back(finfo->type);
+		if (finfo->has_sub_resources && finfo->type == SNAME("PackedScene")) { // TODO: Sub-resource inspecting shouldn't be limited to scenes.
+			files->add_button(item_index);
 		}
 
 		if (fpath == main_scene_path) {
@@ -1364,6 +1499,12 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 				EditorNode::get_singleton()->load_resource(fpath);
 			}
 		} else {
+			if (!fpath.is_resource_file()) {
+				const String scene_path = fpath.get_slice("::", 0);
+				if (!EditorNode::get_singleton()->is_scene_open(scene_path)) {
+					EditorNode::get_singleton()->load_scene(scene_path);
+				}
+			}
 			EditorNode::get_singleton()->load_resource(fpath);
 		}
 	}
@@ -1390,7 +1531,8 @@ void FileSystemDock::_tree_activate_file() {
 }
 
 void FileSystemDock::_file_list_activate_file(int p_idx) {
-	_select_file(files->get_item_metadata(p_idx));
+	const String path = files->get_item_metadata(p_idx);
+	_select_file(path, false, path.ends_with("/"));
 }
 
 void FileSystemDock::_preview_invalidated(const String &p_path) {
@@ -1458,6 +1600,7 @@ void FileSystemDock::_bw_history() {
 
 void FileSystemDock::_update_history() {
 	current_path = history[history_pos];
+	sub_resource_inspect_path = String();
 	_set_current_path_line_edit_text(current_path);
 
 	if (tree->is_visible()) {
@@ -2984,7 +3127,7 @@ String FileSystemDock::get_folder_path_at_mouse_position() const {
 	return fpath.get_base_dir();
 }
 
-Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {
+Control *FileSystemDock::create_tooltip_for_path(const String &p_path, const String &p_type) const {
 	if (p_path == "Favorites") {
 		// No tooltip for the "Favorites" group.
 		return nullptr;
@@ -2993,13 +3136,16 @@ Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {
 		// No tooltip for directory.
 		return nullptr;
 	}
-	ERR_FAIL_COND_V(!FileAccess::exists(p_path), nullptr);
+	ERR_FAIL_COND_V(p_path.is_resource_file() && !FileAccess::exists(p_path), nullptr);
 
-	const String type = ResourceLoader::get_resource_type(p_path);
-	Control *tooltip = EditorResourceTooltipPlugin::make_default_tooltip(p_path);
+	Control *tooltip = EditorResourceTooltipPlugin::make_default_tooltip(p_path, p_type);
+	if (!p_path.is_resource_file()) {
+		// Tooltip plugins don't work with built-in Resources.
+		return tooltip;
+	}
 
 	for (const Ref<EditorResourceTooltipPlugin> &plugin : tooltip_plugins) {
-		if (plugin->handles(type)) {
+		if (plugin->handles(p_type)) {
 			tooltip = plugin->make_tooltip_for_path(p_path, EditorResourcePreview::get_singleton()->get_preview_metadata(p_path), tooltip);
 		}
 	}
@@ -3716,10 +3862,37 @@ void FileSystemDock::_tree_empty_selected() {
 	tree->deselect_all();
 	current_path = "";
 	current_path_line_edit->set_text(current_path);
+	sub_resource_inspect_path = String();
 	if (file_list_vb->is_visible()) {
 		_update_file_list(false);
 	}
 	_update_selection_changed();
+}
+
+void FileSystemDock::_tree_button_clicked(TreeItem *p_item, int p_column, int p_id, MouseButton p_button) {
+	if (p_item->get_first_child()) {
+		p_item->set_collapsed(false);
+		return;
+	}
+
+	Ref<PackedScene> scene = ResourceLoader::load(p_item->get_metadata(0));
+	ERR_FAIL_COND(scene.is_null());
+
+	const Color sub_resource_color = get_theme_color(SNAME("warning_color"), EditorStringName(Editor));
+	Vector<Ref<Resource>> subs = scene->get_state()->get_sub_resources();
+	for (const Ref<Resource> &res : subs) {
+		TreeItem *res_item = p_item->create_child();
+		const String &res_name = res->get_name();
+		if (res_name.is_empty()) {
+			res_item->set_text(0, res->get_class());
+		} else {
+			res_item->set_text(0, res_name);
+		}
+		res_item->set_custom_color(0, sub_resource_color);
+		res_item->set_icon(0, _get_tree_item_icon(true, res->get_class(), ""));
+		res_item->set_metadata(0, res->get_path());
+		res_item->set_meta(TYPE_META, res->get_class());
+	}
 }
 
 void FileSystemDock::_file_list_item_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {
@@ -3791,6 +3964,13 @@ void FileSystemDock::_file_list_empty_clicked(const Vector2 &p_pos, MouseButton 
 	file_list_popup->set_position(files->get_screen_position() + p_pos);
 	file_list_popup->reset_size();
 	file_list_popup->popup();
+}
+
+void FileSystemDock::_file_list_button_clicked(int p_idx) {
+	tree->deselect_all();
+	current_path = files->get_item_metadata(p_idx);
+	sub_resource_inspect_path = current_path;
+	_update_file_list(false);
 }
 
 void FileSystemDock::select_file(const String &p_file) {
@@ -4450,6 +4630,7 @@ FileSystemDock::FileSystemDock() {
 	tree->connect("item_mouse_selected", callable_mp(this, &FileSystemDock::_tree_rmb_select));
 	tree->connect("empty_clicked", callable_mp(this, &FileSystemDock::_tree_empty_click));
 	tree->connect("nothing_selected", callable_mp(this, &FileSystemDock::_tree_empty_selected));
+	tree->connect("button_clicked", callable_mp(this, &FileSystemDock::_tree_button_clicked));
 	tree->connect(SceneStringName(gui_input), callable_mp(this, &FileSystemDock::_tree_gui_input));
 	tree->connect(SceneStringName(mouse_exited), callable_mp(this, &FileSystemDock::_tree_mouse_exited));
 	tree->connect("item_edited", callable_mp(this, &FileSystemDock::_rename_operation_confirm));
@@ -4492,6 +4673,7 @@ FileSystemDock::FileSystemDock() {
 	files->connect(SceneStringName(gui_input), callable_mp(this, &FileSystemDock::_file_list_gui_input));
 	files->connect("multi_selected", callable_mp(this, &FileSystemDock::_file_multi_selected));
 	files->connect("empty_clicked", callable_mp(this, &FileSystemDock::_file_list_empty_clicked));
+	files->connect("button_clicked", callable_mp(this, &FileSystemDock::_file_list_button_clicked));
 	files->connect("item_edited", callable_mp(this, &FileSystemDock::_rename_operation_confirm));
 	files->set_custom_minimum_size(Size2(0, 15 * EDSCALE));
 	files->set_allow_rmb_select(true);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -67,6 +67,10 @@ class FileSystemList : public ItemList {
 	GDCLASS(FileSystemList, ItemList);
 
 	bool popup_edit_committed = true;
+
+	HashSet<int> button_items;
+	int hovered_button = -1;
+
 	VBoxContainer *popup_editor_vb = nullptr;
 	Popup *popup_editor = nullptr;
 	LineEdit *line_editor = nullptr;
@@ -75,18 +79,31 @@ class FileSystemList : public ItemList {
 	void _line_editor_submit(const String &p_text);
 	void _text_editor_popup_modal_close();
 
+	Rect2 _get_button_rect(int p_idx) const;
+
+	Ref<Texture2D> button_icon;
+
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	virtual String get_tooltip(const Point2 &p_pos) const override;
+
 	bool edit_selected();
 	String get_edit_text();
+
+	void add_button(int p_idx);
+	void clear_buttons();
 
 	FileSystemList();
 };
 
 class FileSystemDock : public EditorDock {
 	GDCLASS(FileSystemDock, EditorDock);
+
+	friend class FileSystemList;
 
 public:
 	enum FileListDisplayMode {
@@ -248,6 +265,7 @@ private:
 	int history_max_size;
 
 	String current_path = "res://";
+	String sub_resource_inspect_path;
 	String select_after_scan;
 	String main_scene_path;
 
@@ -263,6 +281,7 @@ private:
 	bool holding_branch = false;
 	Vector<TreeItem *> tree_items_selected_on_drag_begin;
 	PackedInt32Array list_items_selected_on_drag_begin;
+	LocalVector<String> list_types;
 
 	LocalVector<Ref<EditorResourceTooltipPlugin>> tooltip_plugins;
 
@@ -357,8 +376,10 @@ private:
 	void _tree_rmb_select(const Vector2 &p_pos, MouseButton p_button);
 	void _file_list_item_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _file_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _file_list_button_clicked(int p_idx);
 	void _tree_empty_click(const Vector2 &p_pos, MouseButton p_button);
 	void _tree_empty_selected();
+	void _tree_button_clicked(TreeItem *p_item, int p_column, int p_id, MouseButton p_button);
 
 	void _search(EditorFileSystemDirectory *p_path, List<FileInfo> *matches, int p_max_items);
 
@@ -410,6 +431,8 @@ public:
 
 	static Color get_dir_icon_color(const String &p_dir_path, const Color &p_default);
 
+	const StringName TYPE_META = "type";
+
 	const HashMap<String, Color> &get_folder_colors() const;
 	Dictionary get_assigned_folder_colors() const;
 
@@ -450,7 +473,7 @@ public:
 
 	void add_resource_tooltip_plugin(const Ref<EditorResourceTooltipPlugin> &p_plugin);
 	void remove_resource_tooltip_plugin(const Ref<EditorResourceTooltipPlugin> &p_plugin);
-	Control *create_tooltip_for_path(const String &p_path) const;
+	Control *create_tooltip_for_path(const String &p_path, const String &p_type) const;
 
 	FileSystemDock();
 	~FileSystemDock();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1696,7 +1696,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 		OS::get_singleton()->shell_open(ProjectSettings::get_singleton()->globalize_path(p_resource));
 		return OK;
 	}
-	ERR_FAIL_COND_V(res.is_null(), ERR_CANT_OPEN);
+	ERR_FAIL_COND_V_MSG(res.is_null(), ERR_CANT_OPEN, vformat("Can't load resource at \"%s\".", p_resource));
 
 	if (!p_ignore_broken_deps && !dependency_errors.is_empty()) {
 		dependency_error->show(p_resource, dependency_errors);

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -57,8 +57,8 @@ EditorFileSystem *EditorFileSystem::singleton = nullptr;
 int EditorFileSystem::nb_files_total = 0;
 EditorFileSystem::ScannedDirectory *EditorFileSystem::first_scan_root_dir = nullptr;
 
-//the name is the version, to keep compatibility with different versions of Godot
-#define CACHE_FILE_NAME "filesystem_cache10"
+// The name is the version, to keep compatibility with different versions of Godot.
+#define CACHE_FILE_NAME "filesystem_cache11"
 
 int EditorFileSystemDirectory::find_file_index(const String &p_file) const {
 	for (int i = 0; i < files.size(); i++) {
@@ -167,6 +167,11 @@ Vector<String> EditorFileSystemDirectory::get_file_deps(int p_idx) const {
 bool EditorFileSystemDirectory::get_file_import_is_valid(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, files.size(), false);
 	return files[p_idx]->import_valid;
+}
+
+bool EditorFileSystemDirectory::get_file_has_sub_resources(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, files.size(), false);
+	return files[p_idx]->has_sub_resources;
 }
 
 uint64_t EditorFileSystemDirectory::get_file_modified_time(int p_idx) const {
@@ -455,8 +460,8 @@ void EditorFileSystem::_scan_filesystem() {
 
 				} else {
 					// The last section (deps) may contain the same splitter, so limit the maxsplit to 8 to get the complete deps.
-					Vector<String> split = l.split("::", true, 8);
-					ERR_CONTINUE(split.size() < 9);
+					Vector<String> split = l.split("::", true, 9);
+					ERR_CONTINUE(split.size() < 10);
 					String name = split[0];
 					String file;
 
@@ -468,11 +473,12 @@ void EditorFileSystem::_scan_filesystem() {
 					fc.resource_script_class = split[1].get_slicec('/', 1);
 					fc.uid = split[2].to_int();
 					fc.modification_time = split[3].to_int();
-					fc.import_modification_time = split[4].to_int();
-					fc.import_valid = split[5].to_int() != 0;
-					fc.import_group_file = split[6].strip_edges();
+					fc.has_sub_resources = split[4].to_int();
+					fc.import_modification_time = split[5].to_int();
+					fc.import_valid = split[6].to_int() != 0;
+					fc.import_group_file = split[7].strip_edges();
 					{
-						const Vector<String> &slices = split[7].split("<>");
+						const Vector<String> &slices = split[8].split("<>");
 						ERR_CONTINUE(slices.size() < 7);
 						fc.class_info.name = slices[0];
 						fc.class_info.extends = slices[1];
@@ -482,7 +488,7 @@ void EditorFileSystem::_scan_filesystem() {
 						fc.import_md5 = slices[5];
 						fc.import_dest_paths = slices[6].split("<*>");
 					}
-					fc.deps = split[8].strip_edges().split("<>", false);
+					fc.deps = split[9].strip_edges().split("<>", false);
 
 					file_cache[name] = fc;
 				}
@@ -1267,6 +1273,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				fi->uid = fc->uid;
 				fi->deps = fc->deps;
 				fi->modified_time = mt;
+				fi->has_sub_resources = fc->has_sub_resources;
 				fi->import_modified_time = import_mt;
 				fi->import_md5 = fc->import_md5;
 				fi->import_dest_paths = fc->import_dest_paths;
@@ -1332,6 +1339,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				fi->modified_time = mt;
 				fi->deps = fc->deps;
 				fi->import_modified_time = 0;
+				fi->has_sub_resources = fc->has_sub_resources;
 				fi->import_md5 = "";
 				fi->import_dest_paths = Vector<String>();
 				fi->import_valid = true;
@@ -1364,6 +1372,7 @@ void EditorFileSystem::_process_file_system(const ScannedDirectory *p_scan_dir, 
 				fi->uid = ResourceLoader::get_resource_uid(path);
 				fi->class_info = _get_global_script_class(fi->type, path);
 				fi->deps = _get_dependencies(path);
+				fi->has_sub_resources = ResourceLoader::has_sub_resources(path);
 				fi->modified_time = mt;
 				fi->import_modified_time = 0;
 				fi->import_md5 = "";
@@ -1869,6 +1878,7 @@ void EditorFileSystem::_save_filesystem_cache(EditorFileSystemDirectory *p_dir, 
 		cache_string.append(type);
 		cache_string.append(itos(file_info->uid));
 		cache_string.append(itos(file_info->modified_time));
+		cache_string.append(itos(file_info->has_sub_resources));
 		cache_string.append(itos(file_info->import_modified_time));
 		cache_string.append(itos(file_info->import_valid));
 		cache_string.append(file_info->import_group_file);
@@ -2492,6 +2502,7 @@ void EditorFileSystem::update_files(const Vector<String> &p_script_paths) {
 			fi->class_info = _get_global_script_class(type, file);
 			fi->import_group_file = ResourceLoader::get_import_group_file(file);
 			fi->modified_time = FileAccess::get_modified_time(file);
+			fi->has_sub_resources = ResourceLoader::has_sub_resources(file);
 			fi->deps = _get_dependencies(file);
 			fi->import_valid = (type == "TextFile" || type == "OtherFile") ? true : ResourceLoader::is_import_valid(file);
 

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -65,6 +65,7 @@ class EditorFileSystemDirectory : public Object {
 		bool import_valid = false;
 		String import_group_file;
 		Vector<String> deps;
+		bool has_sub_resources = false;
 		bool verified = false; //used for checking changes
 		// This is for script resources only.
 		struct ScriptClassInfo {
@@ -97,6 +98,7 @@ public:
 	StringName get_file_resource_script_class(int p_idx) const;
 	Vector<String> get_file_deps(int p_idx) const;
 	bool get_file_import_is_valid(int p_idx) const;
+	bool get_file_has_sub_resources(int p_idx) const;
 	uint64_t get_file_modified_time(int p_idx) const;
 	uint64_t get_file_import_modified_time(int p_idx) const;
 	String get_file_script_class_name(int p_idx) const; //used for scripts
@@ -220,6 +222,7 @@ class EditorFileSystem : public Node {
 		String import_md5;
 		Vector<String> import_dest_paths;
 		Vector<String> deps;
+		bool has_sub_resources = false;
 		bool import_valid = false;
 		String import_group_file;
 		ScriptClassInfo class_info;

--- a/editor/file_system/file_info.h
+++ b/editor/file_system/file_info.h
@@ -50,6 +50,7 @@ struct FileInfo {
 	StringName type;
 	Vector<String> sources;
 	bool import_broken = false;
+	bool has_sub_resources = false;
 	uint64_t modified_time = 0;
 
 	bool operator<(const FileInfo &p_fi) const {

--- a/editor/icons/InspectSubResources.svg
+++ b/editor/icons/InspectSubResources.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" xml:space="preserve" width="16" height="16"><path fill="#fff" d="M1 1H2V15H1zM3 6H7V10H3zM14 1H15V15H14zM9 6H13V10H9zM2 1H5V2H2zM11 1H14V2H11zM11 14H14V15H11zM2 14H5V15H2z"/></svg>

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -30,7 +30,6 @@
 
 #include "editor_resource_tooltip_plugins.h"
 
-#include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
@@ -56,7 +55,7 @@ void EditorResourceTooltipPlugin::_bind_methods() {
 	GDVIRTUAL_BIND(_make_tooltip_for_path, "path", "metadata", "base");
 }
 
-VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p_resource_path) {
+VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p_resource_path, const String &p_resource_type) {
 	VBoxContainer *vb = memnew(VBoxContainer);
 	vb->add_theme_constant_override("separation", -4 * EDSCALE);
 	{
@@ -64,13 +63,13 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 		vb->add_child(label);
 	}
 
-	ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_resource_path);
-	if (id != ResourceUID::INVALID_ID) {
-		Label *label = memnew(Label(ResourceUID::get_singleton()->id_to_text(id)));
-		vb->add_child(label);
-	}
+	if (p_resource_path.is_resource_file()) {
+		ResourceUID::ID id = EditorFileSystem::get_singleton()->get_file_uid(p_resource_path);
+		if (id != ResourceUID::INVALID_ID) {
+			Label *label = memnew(Label(ResourceUID::get_singleton()->id_to_text(id)));
+			vb->add_child(label);
+		}
 
-	{
 		Ref<FileAccess> f = FileAccess::open(p_resource_path, FileAccess::READ);
 		if (f.is_valid()) {
 			Label *label = memnew(Label(vformat(TTR("Size: %s"), String::humanize_size(f->get_length()))));
@@ -81,13 +80,14 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 			vb->add_child(label);
 			return vb;
 		}
-	}
 
-	if (ResourceLoader::exists(p_resource_path)) {
-		String type = ResourceLoader::get_resource_type(p_resource_path);
-		Label *label = memnew(Label(vformat(TTR("Type: %s"), type)));
+	} else {
+		Label *label = memnew(Label(TTRC("Built-in resource.")));
 		vb->add_child(label);
 	}
+
+	Label *type = memnew(Label(vformat(TTR("Type: %s"), p_resource_type)));
+	vb->add_child(type);
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (da->is_link(p_resource_path)) {

--- a/editor/inspector/editor_resource_tooltip_plugins.h
+++ b/editor/inspector/editor_resource_tooltip_plugins.h
@@ -50,7 +50,7 @@ protected:
 	GDVIRTUAL3RC(Control *, _make_tooltip_for_path, String, Dictionary, Control *)
 
 public:
-	static VBoxContainer *make_default_tooltip(const String &p_resource_path);
+	static VBoxContainer *make_default_tooltip(const String &p_resource_path, const String &p_resource_type);
 	void request_thumbnail(const String &p_path, TextureRect *p_for_control) const;
 
 	virtual bool handles(const String &p_resource_type) const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2283,11 +2283,10 @@ Ref<Resource> SceneState::get_sub_resource(const String &p_path) {
 }
 
 Vector<Ref<Resource>> SceneState::get_sub_resources() {
-	const String path_prefix = get_path() + "::";
 	Vector<Ref<Resource>> sub_resources;
 	for (const Variant &v : variants) {
 		const Ref<Resource> &res = v;
-		if (res.is_valid() && res->get_path().begins_with(path_prefix)) {
+		if (res.is_valid() && res->is_built_in()) {
 			sub_resources.push_back(res);
 		}
 	}

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1605,6 +1605,19 @@ Error ResourceFormatLoaderText::rename_dependencies(const String &p_path, const 
 	return err;
 }
 
+bool ResourceFormatLoaderText::has_sub_resources(const String &p_path) const {
+	Ref<FileAccess> file = FileAccess::open(p_path, FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(file.is_null(), false, vformat("Resource file \"%s\" not found.", p_path));
+
+	while (!file->eof_reached()) {
+		const String line = file->get_line();
+		if (line.begins_with("[sub_resource")) {
+			return true;
+		}
+	}
+	return false;
+}
+
 ResourceFormatLoaderText *ResourceFormatLoaderText::singleton = nullptr;
 
 /*****************************************************************************************************/

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -162,6 +162,7 @@ public:
 	virtual bool has_custom_uid_support() const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;
 	virtual Error rename_dependencies(const String &p_path, const HashMap<String, String> &p_map) override;
+	virtual bool has_sub_resources(const String &p_path) const override;
 
 	ResourceFormatLoaderText() { singleton = this; }
 };


### PR DESCRIPTION
Partially addresses https://github.com/godotengine/godot-proposals/issues/8750 (not sure about the referencing part)

https://github.com/user-attachments/assets/36ac2c3b-420d-4c05-a66b-624561eac7b7

This is mostly proof of concept for now. I display resources by loading every PackedScene in filesystem, so it's not really usable yet :D
Also there are some bugs like not being able to edit sub-resource or display its type if the scene is closed etc. Also for whatever reason, PackedScenes `get_sub_resources()` does not return nested resources.