### PR TITLE
Apply fix_alpha_edges after rendering svg in SVGTexture

### DIFF
--- a/scene/resources/svg_texture.cpp
+++ b/scene/resources/svg_texture.cpp
@@ -196,6 +196,7 @@ RID SVGTexture::_load_at_scale(double p_scale, bool p_set_size) const {
 	if (err != OK) {
 		return RID();
 	}
+	img->fix_alpha_edges();
 #else
 	img = Image::create_empty(Math::round(16 * p_scale * base_scale), Math::round(16 * p_scale * base_scale), false, Image::FORMAT_RGBA8);
 #endif


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109714

Before:
<img width="998" height="769" alt="beta5" src="https://github.com/user-attachments/assets/9e7289a8-e035-44fe-9fb9-8bff9ced0115" />

After:
<img width="999" height="820" alt="withFix" src="https://github.com/user-attachments/assets/959af6ba-b389-4eca-b2c6-477cffcc1b9a" />
