### PR TITLE
PackedScene: Always set node name properly when instantiating

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1410,10 +1410,6 @@ StringName Node::get_name() const {
 	return data.name;
 }
 
-void Node::_set_name_nocheck(const StringName &p_name) {
-	data.name = p_name;
-}
-
 void Node::set_name(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Changing the name to nodes inside the SceneTree is only allowed from the main thread. Use `set_name.call_deferred(new_name)`.");
 	ERR_FAIL_COND(p_name.is_empty());

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -360,7 +360,6 @@ protected:
 
 	void _add_child_nocheck(Node *p_child, const StringName &p_name, InternalMode p_internal_mode = INTERNAL_MODE_DISABLED);
 	void _set_owner_nocheck(Node *p_owner);
-	void _set_name_nocheck(const StringName &p_name);
 
 	void _set_physics_interpolated_client_side(bool p_enable) { data.physics_interpolated_client_side = p_enable; }
 	bool _is_physics_interpolated_client_side() const { return data.physics_interpolated_client_side; }

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -480,12 +480,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						stray_instances.push_back(node); //can't be added, go to stray list
 					}
 				} else {
-					if (Engine::get_singleton()->is_editor_hint()) {
-						//validate name if using editor, to avoid broken
-						node->set_name(snames[n.name]);
-					} else {
-						node->_set_name_nocheck(snames[n.name]);
-					}
+					node->set_name(snames[n.name]);
 				}
 			}
 


### PR DESCRIPTION
Fixes #97525

User code can do anything in `_init()`, so we should call `set_name()` properly.