### PR TITLE
[macOS] Forward application focus events to the embedded process.

### DIFF
--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -40,6 +40,7 @@ class LayerHost final : public Control {
 
 	ScriptEditorDebugger *script_debugger = nullptr;
 	EmbeddedProcessMacOS *process = nullptr;
+	bool window_focused = true;
 
 	struct CustomCursor {
 		Ref<Image> image;

--- a/platform/macos/editor/embedded_process_macos.mm
+++ b/platform/macos/editor/embedded_process_macos.mm
@@ -252,6 +252,10 @@ void LayerHost::_notification(int p_what) {
 				// Restore embedded process mouse mode.
 				ds->mouse_set_mode(process->get_mouse_mode());
 			}
+			if (!window_focused && script_debugger) {
+				script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_FOCUS_IN });
+				window_focused = true;
+			}
 		} break;
 		case NOTIFICATION_MOUSE_EXIT: {
 			DisplayServer *ds = DisplayServer::get_singleton();
@@ -268,6 +272,10 @@ void LayerHost::_notification(int p_what) {
 			if (ds->mouse_get_mode() != DisplayServer::MOUSE_MODE_VISIBLE) {
 				ds->mouse_set_mode(DisplayServer::MOUSE_MODE_VISIBLE);
 			}
+			if (window_focused && script_debugger) {
+				script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_FOCUS_OUT });
+				window_focused = false;
+			}
 		} break;
 		case MainLoop::NOTIFICATION_OS_IME_UPDATE: {
 			if (script_debugger && has_focus()) {
@@ -283,6 +291,28 @@ void LayerHost::_notification(int p_what) {
 				for (int i = 0; i < DisplayServer::CURSOR_MAX; i++) {
 					ds->cursor_set_custom_image(Ref<Resource>(), (DisplayServer::CursorShape)i, Vector2());
 				}
+			}
+		} break;
+		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
+			if (!window_focused && script_debugger) {
+				script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_FOCUS_IN });
+				window_focused = true;
+			}
+		} break;
+		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
+			if (window_focused && script_debugger) {
+				script_debugger->send_message("embed:win_event", { DisplayServer::WINDOW_EVENT_FOCUS_OUT });
+				window_focused = false;
+			}
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_IN: {
+			if (script_debugger) {
+				script_debugger->send_message("embed:notification", { NOTIFICATION_APPLICATION_FOCUS_IN });
+			}
+		} break;
+		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
+			if (script_debugger) {
+				script_debugger->send_message("embed:notification", { NOTIFICATION_APPLICATION_FOCUS_OUT });
 			}
 		} break;
 	}

--- a/platform/macos/embedded_debugger.h
+++ b/platform/macos/embedded_debugger.h
@@ -60,6 +60,7 @@ private:
 	Error _msg_mouse_set_mode(const Array &p_args);
 	Error _msg_event(const Array &p_args);
 	Error _msg_win_event(const Array &p_args);
+	Error _msg_notification(const Array &p_args);
 	Error _msg_ime_update(const Array &p_args);
 	Error _msg_joy_add(const Array &p_args);
 	Error _msg_joy_del(const Array &p_args);

--- a/platform/macos/embedded_debugger.mm
+++ b/platform/macos/embedded_debugger.mm
@@ -73,6 +73,7 @@ void EmbeddedDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["mouse_set_mode"] = &EmbeddedDebugger::_msg_mouse_set_mode;
 	parse_message_handlers["event"] = &EmbeddedDebugger::_msg_event;
 	parse_message_handlers["win_event"] = &EmbeddedDebugger::_msg_win_event;
+	parse_message_handlers["notification"] = &EmbeddedDebugger::_msg_notification;
 	parse_message_handlers["ime_update"] = &EmbeddedDebugger::_msg_ime_update;
 	parse_message_handlers["joy_add"] = &EmbeddedDebugger::_msg_joy_add;
 	parse_message_handlers["joy_del"] = &EmbeddedDebugger::_msg_joy_del;
@@ -148,6 +149,15 @@ Error EmbeddedDebugger::_msg_ime_update(const Array &p_args) {
 	String ime_text = p_args[0];
 	Vector2i ime_selection = p_args[1];
 	ds->update_im_text(ime_selection, ime_text);
+	return OK;
+}
+
+Error EmbeddedDebugger::_msg_notification(const Array &p_args) {
+	ERR_FAIL_COND_V_MSG(p_args.size() != 1, ERR_INVALID_PARAMETER, "Invalid number of arguments for 'notification' message.");
+	int notification = p_args[0];
+	if (OS::get_singleton()->get_main_loop()) {
+		OS::get_singleton()->get_main_loop()->notification(notification);
+	}
 	return OK;
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109633