### PR TITLE
Minor optimizations in Delaunay3D and GI.

### DIFF
--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -225,7 +225,7 @@ public:
 				points[i] = Vector3(Vector3i((src_points[i] - rect.position) / longest_axis * QUANTIZATION_MAX)) / QUANTIZATION_MAX;
 			}
 
-			const real_t delta_max = Math::sqrt(2.0) * 100.0;
+			const real_t delta_max = Math::SQRT2 * 100.0;
 			Vector3 center = Vector3(0.5, 0.5, 0.5);
 
 			// The larger the root simplex is, the more likely it is that the
@@ -262,6 +262,7 @@ public:
 
 		AHashMap<Triangle, uint32_t, TriangleHasher> triangles_inserted;
 		LocalVector<Triangle> triangles;
+		const Vector3 scale = proportions * ACCEL_GRID_SIZE;
 
 		for (uint32_t i = 0; i < point_count; i++) {
 			bool unique = true;
@@ -275,7 +276,7 @@ public:
 				continue;
 			}
 
-			Vector3i grid_pos = Vector3i(points[i] * proportions * ACCEL_GRID_SIZE);
+			Vector3i grid_pos = Vector3i(points[i] * scale);
 			grid_pos = grid_pos.clampi(0, ACCEL_GRID_SIZE - 1);
 
 			for (List<Simplex *>::Element *E = acceleration_grid[grid_pos.x][grid_pos.y][grid_pos.z].front(); E;) {
@@ -331,8 +332,8 @@ public:
 
 					const real_t radius2 = Math::sqrt(double(new_simplex->circum_r2)) + 0.0001;
 					Vector3 extents = Vector3(radius2, radius2, radius2);
-					Vector3i from = Vector3i((center - extents) * proportions * ACCEL_GRID_SIZE);
-					Vector3i to = Vector3i((center + extents) * proportions * ACCEL_GRID_SIZE);
+					Vector3i from = Vector3i((center - extents) * scale);
+					Vector3i to = Vector3i((center + extents) * scale);
 					from = from.clampi(0, ACCEL_GRID_SIZE - 1);
 					to = to.clampi(0, ACCEL_GRID_SIZE - 1);
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -1743,7 +1743,7 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 		Vector3 offset = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[cascade].position)) * cascades[cascade].cell_size * Vector3(1.0, 1.0 / y_mult, 1.0);
 		Vector3 probe_size = cascades[cascade].cell_size * (cascade_size / SDFGI::PROBE_DIVISOR) * Vector3(1.0, 1.0 / y_mult, 1.0);
 		Vector3 ray_from = gi->sdfgi_debug_probe_pos;
-		Vector3 ray_to = gi->sdfgi_debug_probe_pos + gi->sdfgi_debug_probe_dir * cascades[cascade].cell_size * Math::sqrt(3.0) * cascade_size;
+		Vector3 ray_to = gi->sdfgi_debug_probe_pos + gi->sdfgi_debug_probe_dir * cascades[cascade].cell_size * Math::SQRT3 * cascade_size;
 		float sphere_radius = 0.2;
 		float closest_dist = 1e20;
 		gi->sdfgi_debug_probe_enabled = false;

--- a/tests/scene/test_path_follow_3d.h
+++ b/tests/scene/test_path_follow_3d.h
@@ -236,7 +236,7 @@ TEST_CASE("[SceneTree][PathFollow3D] Progress out of range") {
 }
 
 TEST_CASE("[SceneTree][PathFollow3D] Calculate forward vector") {
-	const real_t dist_cube_100 = 100 * Math::sqrt(3.0);
+	const real_t dist_cube_100 = 100 * Math::SQRT3;
 	Ref<Curve3D> curve;
 	curve.instantiate();
 	curve->add_point(Vector3(0, 0, 0));


### PR DESCRIPTION
- Replaced `Math::sqrt(2.0)` and `Math::sqrt(3.0)` with `Math::SQRT2` and `Math::SQRT3` constants.
- Moved scale computation out of loop to avoid redundant multiplications.
