### PR TITLE
Fix/remove error about "Can't update documentation" when saving script

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1768,13 +1768,13 @@ void EditorFileSystem::_notification(int p_what) {
 						// Set first_scan to false before the signals so the function doing_first_scan can return false
 						// in editor_node to start the export if needed.
 						first_scan = false;
+						scanning_changes = false;
+						done_importing = true;
 						ResourceImporter::load_on_startup = nullptr;
 						if (changed) {
 							emit_signal(SNAME("filesystem_changed"));
 						}
 						emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
-						scanning_changes = false; // Changed to false here to prevent recursive triggering of scan thread.
-						done_importing = true;
 					}
 				} else if (!scanning && thread.is_started()) {
 					set_process(false);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3783,8 +3783,6 @@ bool ScriptEditor::_help_tab_goto(const String &p_name, const String &p_desc) {
 }
 
 void ScriptEditor::update_doc(const String &p_name) {
-	ERR_FAIL_COND_MSG(!EditorHelp::has_doc(p_name), vformat("Can't update documentation for \"%s\".", p_name));
-
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		EditorHelp *eh = Object::cast_to<EditorHelp>(tab_container->get_tab_control(i));
 		if (eh && eh->get_class() == p_name) {


### PR DESCRIPTION
Fixes #109426 (maybe).

There are two issues at play here.

1. As talked about in [#109426](https://github.com/godotengine/godot/issues/109426), `EditorHelp::regenerate_script_doc_cache` can find itself stuck in an infinite "loop" of one-shot signal connections, due to `EditorFileSystem::scanning_changes` sometimes being set to `false` *after* emitting its `sources_changed` signal, rather than before, which causes this error to be emitted every single time you save a script file, until you restart the editor.
2. Even with that fixed, something somewhere still causes random one-off emissions of this "Can't update documentation" error that have yet to be tracked down.

I've resolved the first issue by just moving where the `scanning_changes` (and `done_importing`) variable is set in `EditorFileSystem`, so that it's done *before* emitting its `sources_changed` signal.

Note that there is a comment talking about the importance of the current location of `scanning_changes`:

https://github.com/godotengine/godot/blob/0c51ede2434d99d2c80dc87b7df179db66537f1c/editor/file_system/editor_file_system.cpp#L1776

... but when looking at the PR that moved it (#73214) to its current location, I'm not convinced that it necessarily needs to be at the very bottom of this lexical scope. I've also tried reproducing the issue that it meant to resolve (#53871) after moving it up and I have been unable to do so. It is however possible that it's been resolved through other mechanisms since then.

The second issue I "fixed" in a more crude manner, by simply removing the error altogether. The reason for this is that this particular `ERR_FAIL_COND_MSG` seems to be completely redundant, as `ScriptEditor::update_doc` will call `EditorHelp::update_doc`, which already covers this condition, as seen here:

https://github.com/godotengine/godot/blob/0c51ede2434d99d2c80dc87b7df179db66537f1c/editor/doc/editor_help.cpp#L3358-L3363

And seeing as how there have been no reports about this `!doc->class_list.has(edited_class)` error being emitted alongside the `Can't update documentation` error, it would seem to me like these more random one-off `Can't update documentation` errors are likely caused by some harmless race condition that's presumably a non-issue thanks to stuff like the `EditorHelp::_wait_for_thread` call seen in the code above.