### PR TITLE
Free TileMapLayer debug quadrant meshes when clearing

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -72,6 +72,9 @@ void TileMapLayer::_debug_update(bool p_force_cleanup) {
 			if (debug_quadrant->canvas_item.is_valid()) {
 				rs->free(debug_quadrant->canvas_item);
 			}
+			if (debug_quadrant->physics_mesh.is_valid()) {
+				rs->free(debug_quadrant->physics_mesh);
+			}
 		}
 		debug_quadrant_map.clear();
 		_debug_was_cleaned_up = true;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes #109718