### PR TITLE
Use squared values and functions for comparisons

### DIFF
--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -671,7 +671,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 		for (const Vector3 &vertex : vertices) {
 			int idx = -1;
 			for (uint32_t k = 0; k < mesh.vertices.size(); k++) {
-				if (mesh.vertices[k].distance_to(vertex) < 0.001f) {
+				if (mesh.vertices[k].distance_squared_to(vertex) < 0.000001f) {
 					idx = k;
 					break;
 				}

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -133,13 +133,14 @@ inline bool segment_intersects_sphere(const Vector3 &p_from, const Vector3 &p_to
 
 	real_t sphere_d = normal.dot(sphere_pos);
 
-	real_t ray_distance = sphere_pos.distance_to(normal * sphere_d);
+	const real_t ray_distance_squared = sphere_pos.distance_squared_to(normal * sphere_d);
+	const real_t sphere_radius_squared = p_sphere_radius * p_sphere_radius;
 
-	if (ray_distance >= p_sphere_radius) {
+	if (ray_distance_squared >= sphere_radius_squared) {
 		return false;
 	}
 
-	real_t inters_d2 = p_sphere_radius * p_sphere_radius - ray_distance * ray_distance;
+	real_t inters_d2 = sphere_radius_squared - ray_distance_squared;
 	real_t inters_d = sphere_d;
 
 	if (inters_d2 >= (real_t)CMP_EPSILON) {

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -193,7 +193,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		// Then check point positions.
 		for (int i = 0; i < points.size(); i++) {
-			if (points[i].distance_to(mb->get_position()) < 10 * EDSCALE) {
+			if (points[i].distance_squared_to(mb->get_position()) < (10.0f * EDSCALE) * (10.0f * EDSCALE)) {
 				_set_selected_point(i);
 
 				Ref<AnimationNode> node = blend_space->get_blend_point_node(i);
@@ -239,7 +239,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				continue;
 			}
 
-			if (points[i].distance_to(mb->get_position()) < 10 * EDSCALE) {
+			if (points[i].distance_squared_to(mb->get_position()) < (10.0f * EDSCALE) * (10.0f * EDSCALE)) {
 				making_triangle.push_back(i);
 				if (making_triangle.size() == 3) {
 					//add triangle!

--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -823,12 +823,13 @@ AbstractPolygon2DEditor::Vertex AbstractPolygon2DEditor::get_active_point() cons
 
 AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const Vector2 &p_pos) const {
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 
 	const int n_polygons = _get_polygon_count();
 	const Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_screen_transform();
 
 	PosVertex closest;
-	real_t closest_dist = 1e10;
+	real_t closest_dist_squared = 1e20;
 
 	for (int j = 0; j < n_polygons; j++) {
 		Vector<Vector2> points = _get_polygon(j);
@@ -838,9 +839,9 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const 
 		for (int i = 0; i < n_points; i++) {
 			Vector2 cp = xform.xform(points[i] + offset);
 
-			const real_t dist = cp.distance_to(p_pos);
-			if (dist < closest_dist && dist < grab_threshold) {
-				closest_dist = dist;
+			const real_t dist_squared = cp.distance_squared_to(p_pos);
+			if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+				closest_dist_squared = dist_squared;
 				closest = PosVertex(j, i, cp);
 			}
 		}
@@ -851,6 +852,7 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const 
 
 AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(const Vector2 &p_pos) const {
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 	const real_t eps = grab_threshold * 2;
 	const real_t eps2 = eps * eps;
 
@@ -858,7 +860,7 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 	const Transform2D xform = canvas_item_editor->get_canvas_transform() * _get_node()->get_screen_transform();
 
 	PosVertex closest;
-	real_t closest_dist = 1e10;
+	real_t closest_dist_squared = 1e20;
 
 	for (int j = 0; j < n_polygons; j++) {
 		Vector<Vector2> points = _get_polygon(j);
@@ -876,9 +878,9 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 				continue; //not valid to reuse point
 			}
 
-			const real_t dist = cp.distance_to(p_pos);
-			if (dist < closest_dist && dist < grab_threshold) {
-				closest_dist = dist;
+			const real_t dist_squared = cp.distance_squared_to(p_pos);
+			if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+				closest_dist_squared = dist_squared;
 				closest = PosVertex(j, i, cp);
 			}
 		}

--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -498,7 +498,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 		// Center drag.
 		if (edit_origin_and_center) {
-			real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+			const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 			if (mb->get_button_index() == MouseButton::LEFT) {
 				if (mb->is_meta_pressed() || mb->is_ctrl_pressed() || mb->is_shift_pressed() || mb->is_alt_pressed()) {
@@ -838,9 +838,9 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const 
 		for (int i = 0; i < n_points; i++) {
 			Vector2 cp = xform.xform(points[i] + offset);
 
-			real_t d = cp.distance_to(p_pos);
-			if (d < closest_dist && d < grab_threshold) {
-				closest_dist = d;
+			const real_t dist = cp.distance_to(p_pos);
+			if (dist < closest_dist && dist < grab_threshold) {
+				closest_dist = dist;
 				closest = PosVertex(j, i, cp);
 			}
 		}
@@ -876,9 +876,9 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 				continue; //not valid to reuse point
 			}
 
-			real_t d = cp.distance_to(p_pos);
-			if (d < closest_dist && d < grab_threshold) {
-				closest_dist = d;
+			const real_t dist = cp.distance_to(p_pos);
+			if (dist < closest_dist && dist < grab_threshold) {
+				closest_dist = dist;
 				closest = PosVertex(j, i, cp);
 			}
 		}

--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -476,7 +476,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 				} else {
 					const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
-					if (!_is_line() && wip.size() > 1 && xform.xform(wip[0]).distance_to(xform.xform(cpoint)) < grab_threshold) {
+					if (!_is_line() && wip.size() > 1 && xform.xform(wip[0]).distance_squared_to(xform.xform(cpoint)) < (grab_threshold * grab_threshold)) {
 						//wip closed
 						_wip_close();
 
@@ -506,7 +506,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 				}
 				if (mb->is_pressed() && !center_drag) {
 					Vector2 center_point = xform.xform(_get_geometric_center());
-					if ((gpoint - center_point).length() < grab_threshold) {
+					if ((gpoint - center_point).length_squared() < (grab_threshold * grab_threshold)) {
 						pre_center_move_edit.clear();
 						int n_polygons = _get_polygon_count();
 						for (int i = 0; i < n_polygons; i++) {

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -82,7 +82,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		return false;
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -83,6 +83,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
@@ -98,13 +99,13 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			original_mouse_pos = gpoint;
 
 			for (int i = 0; i < curve->get_point_count(); i++) {
-				real_t dist_to_p = gpoint.distance_to(xform.xform(curve->get_point_position(i)));
-				real_t dist_to_p_out = gpoint.distance_to(xform.xform(curve->get_point_position(i) + curve->get_point_out(i)));
-				real_t dist_to_p_in = gpoint.distance_to(xform.xform(curve->get_point_position(i) + curve->get_point_in(i)));
+				real_t dist_to_p_squared = gpoint.distance_squared_to(xform.xform(curve->get_point_position(i)));
+				real_t dist_to_p_out_squared = gpoint.distance_squared_to(xform.xform(curve->get_point_position(i) + curve->get_point_out(i)));
+				real_t dist_to_p_in_squared = gpoint.distance_squared_to(xform.xform(curve->get_point_position(i) + curve->get_point_in(i)));
 
 				// Check for point movement start (for point + in/out controls).
 				if (mb->get_button_index() == MouseButton::LEFT) {
-					if (mode == MODE_EDIT && !mb->is_shift_pressed() && dist_to_p < grab_threshold) {
+					if (mode == MODE_EDIT && !mb->is_shift_pressed() && dist_to_p_squared < grab_threshold_squared) {
 						// Points can only be moved in edit mode.
 
 						action = ACTION_MOVING_POINT;
@@ -115,7 +116,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 					} else if (mode == MODE_EDIT || mode == MODE_EDIT_CURVE) {
 						control_points_in_range = 0;
 						// In/out controls can be moved in multiple modes.
-						if (dist_to_p_out < grab_threshold && i < (curve->get_point_count() - 1)) {
+						if (dist_to_p_out_squared < grab_threshold_squared && i < (curve->get_point_count() - 1)) {
 							action = ACTION_MOVING_OUT;
 							action_point = i;
 							moving_from = curve->get_point_out(i);
@@ -123,7 +124,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 							orig_in_length = curve->get_point_in(action_point).length();
 							control_points_in_range += 1;
 						}
-						if (dist_to_p_in < grab_threshold && i > 0) {
+						if (dist_to_p_in_squared < grab_threshold_squared && i > 0) {
 							action = ACTION_MOVING_IN;
 							action_point = i;
 							moving_from = curve->get_point_in(i);
@@ -140,7 +141,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 				// Check for point deletion.
 				EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 				if ((mb->get_button_index() == MouseButton::RIGHT && (mode == MODE_EDIT || mode == MODE_CREATE)) || (mb->get_button_index() == MouseButton::LEFT && mode == MODE_DELETE)) {
-					if (dist_to_p < grab_threshold) {
+					if (dist_to_p_squared < grab_threshold_squared) {
 						undo_redo->create_action(TTR("Remove Point from Curve"));
 						undo_redo->add_do_method(curve.ptr(), "remove_point", i);
 						undo_redo->add_undo_method(curve.ptr(), "add_point", curve->get_point_position(i), curve->get_point_in(i), curve->get_point_out(i), i);
@@ -148,7 +149,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
 						undo_redo->commit_action();
 						return true;
-					} else if (dist_to_p_out < grab_threshold) {
+					} else if (dist_to_p_out_squared < grab_threshold_squared) {
 						undo_redo->create_action(TTR("Remove Out-Control from Curve"));
 						undo_redo->add_do_method(curve.ptr(), "set_point_out", i, Vector2());
 						undo_redo->add_undo_method(curve.ptr(), "set_point_out", i, curve->get_point_out(i));
@@ -156,7 +157,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 						undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
 						undo_redo->commit_action();
 						return true;
-					} else if (dist_to_p_in < grab_threshold) {
+					} else if (dist_to_p_in_squared < grab_threshold_squared) {
 						undo_redo->create_action(TTR("Remove In-Control from Curve"));
 						undo_redo->add_do_method(curve.ptr(), "set_point_in", i, Vector2());
 						undo_redo->add_undo_method(curve.ptr(), "set_point_in", i, curve->get_point_in(i));
@@ -345,7 +346,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			// Find edge
 			edge_point = xform.xform(curve->get_closest_point(xform.affine_inverse().xform(mm->get_position())));
 			on_edge = false;
-			if (edge_point.distance_to(gpoint) <= grab_threshold) {
+			if (edge_point.distance_squared_to(gpoint) <= grab_threshold_squared) {
 				on_edge = true;
 			}
 			// However, if near a control point or its in-out handles then not on edge
@@ -353,17 +354,17 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 			for (int i = 0; i < len; i++) {
 				Vector2 pp = curve->get_point_position(i);
 				Vector2 p = xform.xform(pp);
-				if (p.distance_to(gpoint) <= grab_threshold) {
+				if (p.distance_squared_to(gpoint) <= grab_threshold_squared) {
 					on_edge = false;
 					break;
 				}
 				p = xform.xform(pp + curve->get_point_in(i));
-				if (p.distance_to(gpoint) <= grab_threshold) {
+				if (p.distance_squared_to(gpoint) <= grab_threshold_squared) {
 					on_edge = false;
 					break;
 				}
 				p = xform.xform(pp + curve->get_point_out(i));
-				if (p.distance_to(gpoint) <= grab_threshold) {
+				if (p.distance_squared_to(gpoint) <= grab_threshold_squared) {
 					on_edge = false;
 					break;
 				}

--- a/editor/scene/2d/physics/cast_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/cast_2d_editor_plugin.cpp
@@ -76,7 +76,7 @@ bool Cast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
 		Vector2 gpoint = mb->get_position();
 
 		if (mb->is_pressed()) {
-			if (xform.xform(target_position).distance_to(gpoint) < 8) {
+			if (xform.xform(target_position).distance_squared_to(gpoint) < 64.0f) {
 				pressed = true;
 				original_target_position = target_position;
 				original_mouse_pos = gpoint;

--- a/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
@@ -370,7 +370,7 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 		if (mb->get_button_index() == MouseButton::LEFT) {
 			if (mb->is_pressed()) {
 				for (int i = 0; i < handles.size(); i++) {
-					if (xform.xform(handles[i]).distance_to(gpoint) < grab_threshold) {
+					if (xform.xform(handles[i]).distance_squared_to(gpoint) < (grab_threshold * grab_threshold)) {
 						edit_handle = i;
 
 						break;

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -925,6 +925,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					int pc = painted_weights.size();
 					real_t amount = bone_paint_strength->get_value();
 					real_t radius = bone_paint_radius->get_value() * EDSCALE;
+					real_t radius_squared = radius * radius;
 
 					if (selected_action == ACTION_CLEAR_WEIGHT) {
 						amount = -amount;
@@ -935,7 +936,7 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					const Vector2 *rv = editing_points.ptr();
 
 					for (int i = 0; i < pc; i++) {
-						if (mtx.xform(rv[i]).distance_to(bone_paint_pos) < radius) {
+						if (mtx.xform(rv[i]).distance_squared_to(bone_paint_pos) < radius_squared) {
 							w[i] = CLAMP(r[i] + amount, 0, 1);
 						}
 					}

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -96,7 +96,7 @@ Vector<Vector2> expand(const Vector<Vector2> &points, const Rect2i &rect, float 
 	Vector2 prev = Vector2(p2[lasti].x, p2[lasti].y);
 	for (uint64_t i = 0; i < p2.size(); i++) {
 		Vector2 cur = Vector2(p2[i].x, p2[i].y);
-		if (cur.distance_to(prev) > 0.5f) {
+		if (cur.distance_squared_to(prev) > 0.25f) {
 			outPoints.push_back(cur);
 			prev = cur;
 		}

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -96,7 +96,7 @@ Vector<Vector2> expand(const Vector<Vector2> &points, const Rect2i &rect, float 
 	Vector2 prev = Vector2(p2[lasti].x, p2[lasti].y);
 	for (uint64_t i = 0; i < p2.size(); i++) {
 		Vector2 cur = Vector2(p2[i].x, p2[i].y);
-		if (cur.distance_to(prev) > 0.5) {
+		if (cur.distance_to(prev) > 0.5f) {
 			outPoints.push_back(cur);
 			prev = cur;
 		}

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -414,11 +414,11 @@ void GenericTilePolygonEditor::_grab_polygon_point(Vector2 p_pos, const Transfor
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 	r_polygon_index = -1;
 	r_point_index = -1;
-	float closest_distance = grab_threshold + 1.0;
+	real_t closest_distance = grab_threshold + 1.0f;
 	for (unsigned int i = 0; i < polygons.size(); i++) {
 		const Vector<Vector2> &polygon = polygons[i];
 		for (int j = 0; j < polygon.size(); j++) {
-			float distance = p_pos.distance_to(p_polygon_xform.xform(polygon[j]));
+			const real_t distance = p_pos.distance_to(p_polygon_xform.xform(polygon[j]));
 			if (distance < grab_threshold && distance < closest_distance) {
 				r_polygon_index = i;
 				r_point_index = j;

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -514,7 +514,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 		undo_redo = memnew(EditorUndoRedoManager);
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 	hovered_polygon_index = -1;
 	hovered_point_index = -1;

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -412,17 +412,18 @@ void GenericTilePolygonEditor::_advanced_menu_item_pressed(int p_item_pressed) {
 
 void GenericTilePolygonEditor::_grab_polygon_point(Vector2 p_pos, const Transform2D &p_polygon_xform, int &r_polygon_index, int &r_point_index) {
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 	r_polygon_index = -1;
 	r_point_index = -1;
-	real_t closest_distance = grab_threshold + 1.0f;
+	real_t closest_distance_squared = (grab_threshold + 1.0) * (grab_threshold + 1.0);
 	for (unsigned int i = 0; i < polygons.size(); i++) {
 		const Vector<Vector2> &polygon = polygons[i];
 		for (int j = 0; j < polygon.size(); j++) {
-			const real_t distance = p_pos.distance_to(p_polygon_xform.xform(polygon[j]));
-			if (distance < grab_threshold && distance < closest_distance) {
+			const real_t distance_squared = p_pos.distance_squared_to(p_polygon_xform.xform(polygon[j]));
+			if (distance_squared < grab_threshold_squared && distance_squared < closest_distance_squared) {
 				r_polygon_index = i;
 				r_point_index = j;
-				closest_distance = distance;
+				closest_distance_squared = distance_squared;
 			}
 		}
 	}
@@ -515,6 +516,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 	}
 
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 
 	hovered_polygon_index = -1;
 	hovered_point_index = -1;
@@ -582,7 +584,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 				}
 				if (tools_button_group->get_pressed_button() == button_create) {
 					// Create points.
-					if (in_creation_polygon.size() >= 3 && mb->get_position().distance_to(xform.xform(in_creation_polygon[0])) < grab_threshold) {
+					if (in_creation_polygon.size() >= 3 && mb->get_position().distance_squared_to(xform.xform(in_creation_polygon[0])) < grab_threshold_squared) {
 						// Closes and create polygon.
 						if (!multiple_polygon_mode) {
 							clear_polygons();

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -1163,7 +1163,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_gui_input(const Ref<InputEven
 					_update_current_tile_data_editor();
 				}
 			} else if (drag_type == DRAG_TYPE_MAY_POPUP_MENU) {
-				if (Vector2(drag_start_mouse_pos).distance_to(tile_atlas_control->get_local_mouse_position()) > 5.0 * EDSCALE) {
+				if (Vector2(drag_start_mouse_pos).distance_squared_to(tile_atlas_control->get_local_mouse_position()) > (5.0f * EDSCALE) * (5.0f * EDSCALE)) {
 					drag_type = DRAG_TYPE_NONE;
 				}
 			} else if (drag_type >= DRAG_TYPE_RESIZE_TOP_LEFT && drag_type <= DRAG_TYPE_RESIZE_LEFT) {
@@ -1948,7 +1948,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_gui_input(const Ref<In
 		alternative_tiles_control_unscaled->queue_redraw();
 
 		if (drag_type == DRAG_TYPE_MAY_POPUP_MENU) {
-			if (Vector2(drag_start_mouse_pos).distance_to(alternative_tiles_control->get_local_mouse_position()) > 5.0 * EDSCALE) {
+			if (Vector2(drag_start_mouse_pos).distance_squared_to(alternative_tiles_control->get_local_mouse_position()) > (5.0f * EDSCALE) * (5.0f * EDSCALE)) {
 				drag_type = DRAG_TYPE_NONE;
 			}
 		}

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -42,6 +42,7 @@
 #include "servers/rendering/rendering_server.h"
 
 #define HANDLE_HALF_SIZE 9.5
+#define HANDLE_HALF_SIZE_SQUARED (HANDLE_HALF_SIZE * HANDLE_HALF_SIZE)
 
 bool EditorNode3DGizmo::is_editable() const {
 	ERR_FAIL_NULL_V(spatial_node, false);
@@ -606,7 +607,7 @@ void EditorNode3DGizmo::handles_intersect_ray(Camera3D *p_camera, const Vector2 
 		Vector3 hpos = t.xform(secondary_handles[i]);
 		Vector2 p = p_camera->unproject_position(hpos);
 
-		if (p.distance_to(p_point) < HANDLE_HALF_SIZE) {
+		if (p.distance_squared_to(p_point) < HANDLE_HALF_SIZE_SQUARED) {
 			real_t dp = p_camera->get_transform().origin.distance_to(hpos);
 			if (dp < min_d) {
 				min_d = dp;
@@ -630,7 +631,7 @@ void EditorNode3DGizmo::handles_intersect_ray(Camera3D *p_camera, const Vector2 
 		Vector3 hpos = t.xform(handles[i]);
 		Vector2 p = p_camera->unproject_position(hpos);
 
-		if (p.distance_to(p_point) < HANDLE_HALF_SIZE) {
+		if (p.distance_squared_to(p_point) < HANDLE_HALF_SIZE_SQUARED) {
 			real_t dp = p_camera->get_transform().origin.distance_to(hpos);
 			if (dp < min_d) {
 				min_d = dp;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -462,7 +462,7 @@ void ViewportRotationControl::_process_click(int p_index, Vector2 p_position, bo
 
 void ViewportRotationControl::_process_drag(Ref<InputEventWithModifiers> p_event, int p_index, Vector2 p_position, Vector2 p_relative_position) {
 	Point2 mouse_pos = get_local_mouse_position();
-	const bool movement_threshold_passed = original_mouse_pos.distance_to(mouse_pos) > 4 * EDSCALE;
+	const bool movement_threshold_passed = original_mouse_pos.distance_to(mouse_pos) > 4.0f * EDSCALE;
 	if (orbiting_index == p_index && gizmo_activated && movement_threshold_passed) {
 		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
 			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -462,7 +462,7 @@ void ViewportRotationControl::_process_click(int p_index, Vector2 p_position, bo
 
 void ViewportRotationControl::_process_drag(Ref<InputEventWithModifiers> p_event, int p_index, Vector2 p_position, Vector2 p_relative_position) {
 	Point2 mouse_pos = get_local_mouse_position();
-	const bool movement_threshold_passed = original_mouse_pos.distance_to(mouse_pos) > 4.0f * EDSCALE;
+	const bool movement_threshold_passed = original_mouse_pos.distance_squared_to(mouse_pos) > (4.0f * EDSCALE) * (4.0f * EDSCALE);
 	if (orbiting_index == p_index && gizmo_activated && movement_threshold_passed) {
 		if (Input::get_singleton()->get_mouse_mode() == Input::MouseMode::MOUSE_MODE_VISIBLE) {
 			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -542,7 +542,7 @@ void ViewportRotationControl::_update_focus() {
 
 	for (int i = 0; i < axes.size(); i++) {
 		const Axis2D &axis = axes[i];
-		if (mouse_pos.distance_to(axis.screen_point) < AXIS_CIRCLE_RADIUS) {
+		if (mouse_pos.distance_squared_to(axis.screen_point) < AXIS_CIRCLE_RADIUS_SQUARED) {
 			focused_axis = axis.axis;
 		}
 	}
@@ -5312,6 +5312,7 @@ void _insert_rid_recursive(Node *node, HashSet<RID> &rids) {
 
 Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D *p_node) const {
 	const float MAX_DISTANCE = 50.0;
+	const float MAX_DISTANCE_SQUARED = MAX_DISTANCE * MAX_DISTANCE;
 	const float FALLBACK_DISTANCE = 5.0;
 
 	Vector3 world_ray = get_ray(p_pos);
@@ -5372,7 +5373,7 @@ Vector3 Node3DEditorViewport::_get_instance_position(const Point2 &p_pos, Node3D
 	Vector3 intersection;
 	Plane plane(Vector3(0, 1, 0));
 	if (plane.intersects_ray(world_pos, world_ray, &intersection)) {
-		if (is_orthogonal || world_pos.distance_to(intersection) <= MAX_DISTANCE) {
+		if (is_orthogonal || world_pos.distance_squared_to(intersection) <= MAX_DISTANCE_SQUARED) {
 			return intersection;
 		}
 	}

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -368,11 +368,11 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 
 	if (positive) {
 		// Draw axis lines for the positive axes.
-		const Vector2 center = get_size() / 2.0;
+		const Vector2 center = get_size() / 2.0f;
 		const Vector2 diff = p_axis.screen_point - center;
-		const float line_length = MAX(diff.length() - AXIS_CIRCLE_RADIUS - 0.5 * EDSCALE, 0);
+		const real_t line_length = MAX(diff.length() - AXIS_CIRCLE_RADIUS - 0.5f * EDSCALE, 0.0f);
 
-		draw_line(center + diff.limit_length(0.5 * EDSCALE), center + diff.limit_length(line_length), c, 1.5 * EDSCALE, true);
+		draw_line(center + diff.limit_length(0.5f * EDSCALE), center + diff.limit_length(line_length), c, 1.5f * EDSCALE, true);
 
 		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c, true, -1.0, true);
 
@@ -381,12 +381,12 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 		const Ref<Font> &font = get_theme_font(SNAME("rotation_control"), EditorStringName(EditorFonts));
 		const int font_size = get_theme_font_size(SNAME("rotation_control_size"), EditorStringName(EditorFonts));
 		const Size2 char_size = font->get_char_size(axis_name[0], font_size);
-		const Vector2 char_offset = Vector2(-char_size.width / 2.0, char_size.height * 0.25);
+		const Vector2 char_offset = Vector2(-char_size.width / 2.0f, char_size.height * 0.25f);
 		draw_char(font, p_axis.screen_point + char_offset, axis_name, font_size, c_positive_axis);
 	} else {
 		// Draw an outline around the negative axes.
-		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c, true, -1.0, true);
-		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS * 0.8, c.darkened(0.4), true, -1.0, true);
+		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS, c, true, -1.0f, true);
+		draw_circle(p_axis.screen_point, AXIS_CIRCLE_RADIUS * 0.8f, c.darkened(0.4), true, -1.0f, true);
 
 		// Draw the text for the negative axes.
 		const String axis_name = direction == 0 ? "-X" : (direction == 1 ? "-Y" : "-Z");
@@ -396,14 +396,14 @@ void ViewportRotationControl::_draw_axis(const Axis2D &p_axis) {
 		const float font_ascent = font->get_ascent(font_size);
 		const float font_descent = font->get_descent(font_size);
 		const float string_height = font_ascent + font_descent;
-		const Vector2 offset(-string_size.width / 2.0, string_height * 0.25);
+		const Vector2 offset(-string_size.width / 2.0f, string_height * 0.25f);
 		draw_string(font, p_axis.screen_point + offset, axis_name, HORIZONTAL_ALIGNMENT_LEFT, -1.0f, font_size, c_negative_axis);
 	}
 }
 
 void ViewportRotationControl::_get_sorted_axis(Vector<Axis2D> &r_axis) {
-	const Vector2 center = get_size() / 2.0;
-	const real_t radius = get_size().x / 2.0 - AXIS_CIRCLE_RADIUS - 2.0 * EDSCALE;
+	const Vector2 center = get_size() / 2.0f;
+	const real_t radius = get_size().x / 2.0f - AXIS_CIRCLE_RADIUS - 2.0f * EDSCALE;
 	const Basis camera_basis = viewport->view_3d_controller->to_camera_transform().get_basis().inverse();
 
 	for (int i = 0; i < 3; ++i) {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -95,6 +95,7 @@ class ViewportRotationControl : public Control {
 	bool gizmo_activated = false;
 
 	const float AXIS_CIRCLE_RADIUS = 8.0f * EDSCALE;
+	const float AXIS_CIRCLE_RADIUS_SQUARED = AXIS_CIRCLE_RADIUS * AXIS_CIRCLE_RADIUS;
 
 protected:
 	void _notification(int p_what);

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -1195,7 +1195,7 @@ int Path3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_gizmo,
 	if (Path3DEditorPlugin::singleton->curve_edit->is_pressed()) {
 		for (int idx = 0; idx < curve->get_point_count(); ++idx) {
 			const Vector3 pos = path->get_global_transform().xform(curve->get_point_position(idx));
-			if (p_camera->unproject_position(pos).distance_to(p_point) < 20.0f) {
+			if (p_camera->unproject_position(pos).distance_squared_to(p_point) < 400.0f) {
 				ret = idx;
 				break;
 			}

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -658,7 +658,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 						real_t cdist = from.distance_to(to);
 						from = gt.xform(from);
 						to = gt.xform(to);
-						if (cdist > 0) {
+						if (cdist > 0.0f) {
 							const Vector2 segment_a = viewport->point_to_screen(from);
 							const Vector2 segment_b = viewport->point_to_screen(to);
 							Vector2 inters = Geometry2D::get_closest_point_to_segment(mbpos, segment_a, segment_b);
@@ -1194,8 +1194,8 @@ int Path3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_gizmo,
 	int ret = -1;
 	if (Path3DEditorPlugin::singleton->curve_edit->is_pressed()) {
 		for (int idx = 0; idx < curve->get_point_count(); ++idx) {
-			Vector3 pos = path->get_global_transform().xform(curve->get_point_position(idx));
-			if (p_camera->unproject_position(pos).distance_to(p_point) < 20) {
+			const Vector3 pos = path->get_global_transform().xform(curve->get_point_position(idx));
+			if (p_camera->unproject_position(pos).distance_to(p_point) < 20.0f) {
 				ret = idx;
 				break;
 			}

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -601,6 +601,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 	Transform3D it = gt.affine_inverse();
 
 	static const int click_dist = 10; //should make global
+	static const int click_dist_squared = click_dist * click_dist;
 
 	Ref<InputEventMouseButton> mb = p_event;
 
@@ -641,24 +642,24 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 				const Vector3 *r = v3a.ptr();
 				float closest_d = 1e20;
 
-				if (viewport->point_to_screen(gt.xform(c->get_point_position(0))).distance_to(mbpos) < click_dist) {
+				if (viewport->point_to_screen(gt.xform(c->get_point_position(0))).distance_squared_to(mbpos) < click_dist_squared) {
 					return EditorPlugin::AFTER_GUI_INPUT_PASS; //nope, existing
 				}
 
 				for (int i = 0; i < c->get_point_count() - 1; i++) {
 					//find the offset and point index of the place to break up
 					int j = idx;
-					if (viewport->point_to_screen(gt.xform(c->get_point_position(i + 1))).distance_to(mbpos) < click_dist) {
+					if (viewport->point_to_screen(gt.xform(c->get_point_position(i + 1))).distance_squared_to(mbpos) < click_dist_squared) {
 						return EditorPlugin::AFTER_GUI_INPUT_PASS; //nope, existing
 					}
 
 					while (j < rc && c->get_point_position(i + 1) != r[j]) {
 						Vector3 from = r[j];
 						Vector3 to = r[j + 1];
-						real_t cdist = from.distance_to(to);
+						real_t cdist_squared = from.distance_squared_to(to);
 						from = gt.xform(from);
 						to = gt.xform(to);
-						if (cdist > 0.0f) {
+						if (cdist_squared > 0.0f) {
 							const Vector2 segment_a = viewport->point_to_screen(from);
 							const Vector2 segment_b = viewport->point_to_screen(to);
 							Vector2 inters = Geometry2D::get_closest_point_to_segment(mbpos, segment_a, segment_b);
@@ -737,35 +738,35 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 		} else if (mb->is_pressed() && ((mb->get_button_index() == MouseButton::LEFT && curve_del->is_pressed()) || (mb->get_button_index() == MouseButton::RIGHT && curve_edit->is_pressed()))) {
 			const float disk_size = EDITOR_GET("editors/3d_gizmos/gizmo_settings/path3d_tilt_disk_size");
 			for (int i = 0; i < c->get_point_count(); i++) {
-				real_t dist_to_p = viewport->point_to_screen(gt.xform(c->get_point_position(i))).distance_to(mbpos);
-				real_t dist_to_p_out = viewport->point_to_screen(gt.xform(c->get_point_position(i) + c->get_point_out(i))).distance_to(mbpos);
-				real_t dist_to_p_in = viewport->point_to_screen(gt.xform(c->get_point_position(i) + c->get_point_in(i))).distance_to(mbpos);
-				real_t dist_to_p_up = viewport->point_to_screen(gt.xform(c->get_point_position(i) + c->get_point_baked_posture(i, true).get_column(1) * disk_size)).distance_to(mbpos);
+				real_t dist_to_p_squared = viewport->point_to_screen(gt.xform(c->get_point_position(i))).distance_squared_to(mbpos);
+				real_t dist_to_p_out_squared = viewport->point_to_screen(gt.xform(c->get_point_position(i) + c->get_point_out(i))).distance_squared_to(mbpos);
+				real_t dist_to_p_in_squared = viewport->point_to_screen(gt.xform(c->get_point_position(i) + c->get_point_in(i))).distance_squared_to(mbpos);
+				real_t dist_to_p_up_squared = viewport->point_to_screen(gt.xform(c->get_point_position(i) + c->get_point_baked_posture(i, true).get_column(1) * disk_size)).distance_squared_to(mbpos);
 
 				// Find the offset and point index of the place to break up.
 				// Also check for the control points.
-				if (dist_to_p < click_dist) {
+				if (dist_to_p_squared < click_dist_squared) {
 					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 					ur->create_action(TTR("Remove Path Point"));
 					ur->add_do_method(c.ptr(), "remove_point", i);
 					ur->add_undo_method(c.ptr(), "add_point", c->get_point_position(i), c->get_point_in(i), c->get_point_out(i), i);
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
-				} else if (dist_to_p_out < click_dist) {
+				} else if (dist_to_p_out_squared < click_dist_squared) {
 					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 					ur->create_action(TTR("Reset Out-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_out", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_out", i, c->get_point_out(i));
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
-				} else if (dist_to_p_in < click_dist) {
+				} else if (dist_to_p_in_squared < click_dist_squared) {
 					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 					ur->create_action(TTR("Reset In-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_in", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_in", i, c->get_point_in(i));
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
-				} else if (dist_to_p_up < click_dist) {
+				} else if (dist_to_p_up_squared < click_dist_squared) {
 					EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
 					ur->create_action(TTR("Reset Point Tilt"));
 					ur->add_do_method(c.ptr(), "set_point_tilt", i, 0.0f);

--- a/editor/scene/3d/polygon_3d_editor_plugin.cpp
+++ b/editor/scene/3d/polygon_3d_editor_plugin.cpp
@@ -153,6 +153,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 
 		//first check if a point is to be added (segment split)
 		const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 
 		switch (mode) {
 			case MODE_CREATE: {
@@ -167,7 +168,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 						edited_point = 1;
 						return EditorPlugin::AFTER_GUI_INPUT_STOP;
 					} else {
-						if (wip.size() > 1 && p_camera->unproject_position(gt.xform(Vector3(wip[0].x, wip[0].y, depth))).distance_to(gpoint) < grab_threshold) {
+						if (wip.size() > 1 && p_camera->unproject_position(gt.xform(Vector3(wip[0].x, wip[0].y, depth))).distance_squared_to(gpoint) < grab_threshold_squared) {
 							//wip closed
 							_wip_close();
 

--- a/editor/scene/3d/polygon_3d_editor_plugin.cpp
+++ b/editor/scene/3d/polygon_3d_editor_plugin.cpp
@@ -152,7 +152,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 		PackedVector2Array poly = _get_polygon();
 
 		//first check if a point is to be added (segment split)
-		real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 		switch (mode) {
 			case MODE_CREATE: {
@@ -203,9 +203,9 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 							}
 
 							//search edges
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < poly.size(); i++) {
 								const Vector2 segment_a = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 								const Vector2 segment_b = p_camera->unproject_position(gt.xform(Vector3(poly[(i + 1) % poly.size()].x, poly[(i + 1) % poly.size()].y, depth)));
@@ -215,9 +215,9 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 									continue; //not valid to reuse point
 								}
 
-								real_t d = cp.distance_to(gpoint);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(gpoint);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -237,15 +237,15 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 						} else {
 							//look for points to move
 
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < poly.size(); i++) {
 								Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
-								real_t d = cp.distance_to(gpoint);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(gpoint);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -282,15 +282,15 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 					}
 				}
 				if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed() && edited_point == -1) {
-					int closest_idx = -1;
 					Vector2 closest_pos;
 					real_t closest_dist = 1e10;
+					int closest_idx = -1;
 					for (int i = 0; i < poly.size(); i++) {
 						Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
-						real_t d = cp.distance_to(gpoint);
-						if (d < closest_dist && d < grab_threshold) {
-							closest_dist = d;
+						const real_t dist = cp.distance_to(gpoint);
+						if (dist < closest_dist && dist < grab_threshold) {
+							closest_dist = dist;
 							closest_pos = cp;
 							closest_idx = i;
 						}

--- a/editor/scene/3d/polygon_3d_editor_plugin.cpp
+++ b/editor/scene/3d/polygon_3d_editor_plugin.cpp
@@ -205,7 +205,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 
 							//search edges
 							Vector2 closest_pos;
-							real_t closest_dist = 1e10;
+							real_t closest_dist_squared = 1e20;
 							int closest_idx = -1;
 							for (int i = 0; i < poly.size(); i++) {
 								const Vector2 segment_a = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
@@ -216,9 +216,9 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 									continue; //not valid to reuse point
 								}
 
-								const real_t dist = cp.distance_to(gpoint);
-								if (dist < closest_dist && dist < grab_threshold) {
-									closest_dist = dist;
+								const real_t dist_squared = cp.distance_squared_to(gpoint);
+								if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+									closest_dist_squared = dist_squared;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -239,14 +239,14 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 							//look for points to move
 
 							Vector2 closest_pos;
-							real_t closest_dist = 1e10;
+							real_t closest_dist_squared = 1e20;
 							int closest_idx = -1;
 							for (int i = 0; i < poly.size(); i++) {
 								Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
-								const real_t dist = cp.distance_to(gpoint);
-								if (dist < closest_dist && dist < grab_threshold) {
-									closest_dist = dist;
+								const real_t dist_squared = cp.distance_squared_to(gpoint);
+								if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+									closest_dist_squared = dist_squared;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -284,14 +284,14 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 				}
 				if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed() && edited_point == -1) {
 					Vector2 closest_pos;
-					real_t closest_dist = 1e10;
+					real_t closest_dist_squared = 1e20;
 					int closest_idx = -1;
 					for (int i = 0; i < poly.size(); i++) {
 						Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
-						const real_t dist = cp.distance_to(gpoint);
-						if (dist < closest_dist && dist < grab_threshold) {
-							closest_dist = dist;
+						const real_t dist_squared = cp.distance_squared_to(gpoint);
+						if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+							closest_dist_squared = dist_squared;
 							closest_pos = cp;
 							closest_idx = i;
 						}

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1850,6 +1850,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 
 					DragType resize_drag = DRAG_NONE;
 					const real_t radius = select_handle->get_size().width * (1.5f / 2.0f);
+					const real_t radius_squared = radius * radius;
 
 					for (int i = 0; i < 4; i++) {
 						int prev = (i + 3) % 4;
@@ -1858,13 +1859,13 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 						Vector2 ofs = ((endpoints[i] - endpoints[prev]).normalized() + ((endpoints[i] - endpoints[next]).normalized())).normalized();
 						ofs *= (select_handle->get_size().width / 2);
 						ofs += endpoints[i];
-						if (ofs.distance_to(b->get_position()) < radius) {
+						if (ofs.distance_squared_to(b->get_position()) < radius_squared) {
 							resize_drag = dragger[i * 2];
 						}
 
 						ofs = (endpoints[i] + endpoints[next]) / 2;
 						ofs += (endpoints[next] - endpoints[i]).orthogonal().normalized() * (select_handle->get_size().width / 2);
-						if (ofs.distance_to(b->get_position()) < radius) {
+						if (ofs.distance_squared_to(b->get_position()) < radius_squared) {
 							resize_drag = dragger[i * 2 + 1];
 						}
 					}

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1848,7 +1848,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 					};
 
 					DragType resize_drag = DRAG_NONE;
-					real_t radius = (select_handle->get_size().width / 2) * 1.5;
+					const real_t radius = select_handle->get_size().width * (1.5f / 2.0f);
 
 					for (int i = 0; i < 4; i++) {
 						int prev = (i + 3) % 4;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -79,6 +79,7 @@
 #include "servers/rendering/rendering_server.h"
 
 #define DRAG_THRESHOLD (8 * EDSCALE)
+#define DRAG_THRESHOLD_SQUARED (DRAG_THRESHOLD * DRAG_THRESHOLD)
 constexpr real_t SCALE_HANDLE_DISTANCE = 25;
 constexpr real_t MOVE_HANDLE_DISTANCE = 25;
 
@@ -2520,7 +2521,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 		if (can_select) {
 			click = transform.affine_inverse().xform(b->get_position());
 			// Allow selecting on release when performed very small box selection (necessary when Shift is pressed, see below).
-			can_select = b->is_pressed() || (drag_type == DRAG_BOX_SELECTION && click.distance_to(drag_from) <= DRAG_THRESHOLD);
+			can_select = b->is_pressed() || (drag_type == DRAG_BOX_SELECTION && click.distance_squared_to(drag_from) <= DRAG_THRESHOLD_SQUARED);
 		}
 
 		if (can_select) {

--- a/editor/scene/texture/texture_region_editor_plugin.cpp
+++ b/editor/scene/texture/texture_region_editor_plugin.cpp
@@ -387,7 +387,7 @@ void TextureRegionEditor::_texture_overlay_input(const Ref<InputEvent> &p_input)
 
 					for (int i = 0; i < 8; i++) {
 						Vector2 tuv = endpoints[i];
-						if (tuv.distance_to(mb->get_position()) < handle_radius) {
+						if (tuv.distance_squared_to(mb->get_position()) < (handle_radius * handle_radius)) {
 							drag_index = i;
 						}
 					}

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -235,9 +235,10 @@ public:
 
 	_FORCE_INLINE_ void apply_bias_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3(), real_t p_max_delta_av = -1.0) {
 		biased_linear_velocity += p_impulse * _inv_mass;
+		const real_t max_delta_av_squared = p_max_delta_av * p_max_delta_av;
 		if (p_max_delta_av != 0.0) {
 			Vector3 delta_av = _inv_inertia_tensor.xform((p_position - center_of_mass).cross(p_impulse));
-			if (p_max_delta_av > 0 && delta_av.length() > p_max_delta_av) {
+			if (p_max_delta_av > 0 && delta_av.length_squared() > max_delta_av_squared) {
 				delta_av = delta_av.normalized() * p_max_delta_av;
 			}
 			biased_angular_velocity += delta_av;

--- a/modules/godot_physics_3d/godot_body_pair_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_pair_3d.cpp
@@ -205,7 +205,7 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 
 	// Cast a segment from each support point of A in the motion direction.
 	Vector3 segment_hit_local;
-	real_t segment_hit_length = FLT_MAX;
+	real_t segment_hit_length_squared = FLT_MAX;
 	int segment_support_idx = -1;
 	for (int i = 0; i < support_count_A; i++) {
 		supports_A[i] = p_xform_A.xform(supports_A[i]);
@@ -224,10 +224,10 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 		Vector3 rpos, rnorm;
 		int fi = -1;
 		if (p_B->get_shape(p_shape_B)->intersect_segment(local_from, local_to, rpos, rnorm, fi, true)) {
-			const real_t hit_length = local_from.distance_to(rpos);
-			if (hit_length < segment_hit_length) {
+			const real_t hit_length_squared = local_from.distance_squared_to(rpos);
+			if (hit_length_squared < segment_hit_length_squared) {
 				segment_support_idx = i;
-				segment_hit_length = hit_length;
+				segment_hit_length_squared = hit_length_squared;
 				segment_hit_local = rpos;
 			}
 		}

--- a/modules/godot_physics_3d/godot_body_pair_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_pair_3d.cpp
@@ -204,9 +204,9 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 	shape_A_ptr->get_supports(p_xform_A.basis.xform_inv(mnormal).normalized(), max_supports, supports_A, support_count_A, support_type_A);
 
 	// Cast a segment from each support point of A in the motion direction.
-	int segment_support_idx = -1;
-	float segment_hit_length = FLT_MAX;
 	Vector3 segment_hit_local;
+	real_t segment_hit_length = FLT_MAX;
+	int segment_support_idx = -1;
 	for (int i = 0; i < support_count_A; i++) {
 		supports_A[i] = p_xform_A.xform(supports_A[i]);
 
@@ -224,7 +224,7 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 		Vector3 rpos, rnorm;
 		int fi = -1;
 		if (p_B->get_shape(p_shape_B)->intersect_segment(local_from, local_to, rpos, rnorm, fi, true)) {
-			float hit_length = local_from.distance_to(rpos);
+			const real_t hit_length = local_from.distance_to(rpos);
 			if (hit_length < segment_hit_length) {
 				segment_support_idx = i;
 				segment_hit_length = hit_length;

--- a/modules/godot_physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/modules/godot_physics_3d/godot_collision_solver_3d_sat.cpp
@@ -194,7 +194,7 @@ static void _generate_contacts_edge_circle(const Vector3 *p_points_A, int p_poin
 	Vector3 circle_B_line_1 = p_points_B[1] - circle_B_pos;
 	Vector3 circle_B_line_2 = p_points_B[2] - circle_B_pos;
 
-	real_t circle_B_radius = circle_B_line_1.length();
+	real_t circle_B_radius_squared = circle_B_line_1.length_squared();
 	Vector3 circle_B_normal = circle_B_line_1.cross(circle_B_line_2).normalized();
 
 	Plane circle_plane(circle_B_normal, circle_B_pos);
@@ -211,7 +211,7 @@ static void _generate_contacts_edge_circle(const Vector3 *p_points_A, int p_poin
 	real_t dist_sq = dist_vec.length_squared();
 
 	// Point 1 is inside disk, add as contact point.
-	if (dist_sq <= circle_B_radius * circle_B_radius) {
+	if (dist_sq <= circle_B_radius_squared) {
 		contact_points[num_points] = edge_A_1;
 		++num_points;
 	}
@@ -223,7 +223,7 @@ static void _generate_contacts_edge_circle(const Vector3 *p_points_A, int p_poin
 	real_t dist_sq_2 = dist_vec_2.length_squared();
 
 	// Point 2 is inside disk, add as contact point.
-	if (dist_sq_2 <= circle_B_radius * circle_B_radius) {
+	if (dist_sq_2 <= circle_B_radius_squared) {
 		contact_points[num_points] = edge_A_2;
 		++num_points;
 	}
@@ -237,7 +237,7 @@ static void _generate_contacts_edge_circle(const Vector3 *p_points_A, int p_poin
 
 		a = line_length_sq;
 		b = 2.0 * dist_vec.dot(line_vec);
-		c = dist_sq - circle_B_radius * circle_B_radius;
+		c = dist_sq - circle_B_radius_squared;
 
 		// Solve for t.
 		real_t sqrtterm = b * b - 4.0 * a * c;

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -275,7 +275,7 @@ bool GodotSphereShape3D::intersect_segment(const Vector3 &p_begin, const Vector3
 }
 
 bool GodotSphereShape3D::intersect_point(const Vector3 &p_point) const {
-	return p_point.length() < radius;
+	return p_point.length_squared() < (radius * radius);
 }
 
 Vector3 GodotSphereShape3D::get_closest_point_to(const Vector3 &p_point) const {
@@ -599,11 +599,11 @@ bool GodotCapsuleShape3D::intersect_segment(const Vector3 &p_begin, const Vector
 
 bool GodotCapsuleShape3D::intersect_point(const Vector3 &p_point) const {
 	if (Math::abs(p_point.y) < height * 0.5 - radius) {
-		return Vector3(p_point.x, 0, p_point.z).length() < radius;
+		return Vector3(p_point.x, 0, p_point.z).length_squared() < (radius * radius);
 	} else {
 		Vector3 p = p_point;
 		p.y = Math::abs(p.y) - height * 0.5 + radius;
-		return p.length() < radius;
+		return p.length_squared() < (radius * radius);
 	}
 }
 
@@ -613,7 +613,7 @@ Vector3 GodotCapsuleShape3D::get_closest_point_to(const Vector3 &p_point) const 
 
 	const Vector3 p = Geometry3D::get_closest_point_to_segment(p_point, segment_a, segment_b);
 
-	if (p.distance_to(p_point) < radius) {
+	if (p.distance_squared_to(p_point) < (radius * radius)) {
 		return p_point;
 	}
 
@@ -737,7 +737,7 @@ bool GodotCylinderShape3D::intersect_segment(const Vector3 &p_begin, const Vecto
 
 bool GodotCylinderShape3D::intersect_point(const Vector3 &p_point) const {
 	if (Math::abs(p_point.y) < height * 0.5) {
-		return Vector3(p_point.x, 0, p_point.z).length() < radius;
+		return Vector3(p_point.x, 0, p_point.z).length_squared() < (radius * radius);
 	}
 	return false;
 }
@@ -765,7 +765,7 @@ Vector3 GodotCylinderShape3D::get_closest_point_to(const Vector3 &p_point) const
 
 		const Vector3 p = Geometry3D::get_closest_point_to_segment(p_point, segment_a, segment_b);
 
-		if (p.distance_to(p_point) < radius) {
+		if (p.distance_squared_to(p_point) < (radius * radius)) {
 			return p_point;
 		}
 

--- a/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_hinge_joint_3d.cpp
@@ -268,8 +268,8 @@ void GodotHingeJoint3D::solve(real_t p_step) {
 		{
 			//solve orthogonal angular velocity correction
 			real_t relaxation = real_t(1.);
-			real_t len = velrelOrthog.length();
-			if (len > real_t(0.00001)) {
+			real_t len_squared = velrelOrthog.length_squared();
+			if (len_squared > real_t(0.0000000001f)) {
 				Vector3 normal = velrelOrthog.normalized();
 				real_t denom = A->compute_angular_impulse_denominator(normal) +
 						B->compute_angular_impulse_denominator(normal);
@@ -279,8 +279,8 @@ void GodotHingeJoint3D::solve(real_t p_step) {
 
 			//solve angular positional correction
 			Vector3 angularError = -axisA.cross(axisB) * (real_t(1.) / p_step);
-			real_t len2 = angularError.length();
-			if (len2 > real_t(0.00001)) {
+			real_t len2_squared = angularError.length_squared();
+			if (len2_squared > real_t(0.0000000001f)) {
 				Vector3 normal2 = angularError.normalized();
 				real_t denom2 = A->compute_angular_impulse_denominator(normal2) +
 						B->compute_angular_impulse_denominator(normal2);

--- a/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_slider_joint_3d.cpp
@@ -200,16 +200,16 @@ void GodotSliderJoint3D::solve(real_t p_step) {
 	Vector3 angBorthog = angVelB - angVelAroundAxisB;
 	Vector3 velrelOrthog = angAorthog - angBorthog;
 	//solve orthogonal angular velocity correction
-	real_t len = velrelOrthog.length();
-	if (len > real_t(0.00001)) {
+	real_t len_squared = velrelOrthog.length_squared();
+	if (len_squared > real_t(0.0000000001f)) {
 		Vector3 normal = velrelOrthog.normalized();
 		real_t denom = A->compute_angular_impulse_denominator(normal) + B->compute_angular_impulse_denominator(normal);
 		velrelOrthog *= (real_t(1.) / denom) * m_dampingOrthoAng * m_softnessOrthoAng;
 	}
 	//solve angular positional correction
 	Vector3 angularError = axisA.cross(axisB) * (real_t(1.) / p_step);
-	real_t len2 = angularError.length();
-	if (len2 > real_t(0.00001)) {
+	real_t len2_squared = angularError.length_squared();
+	if (len2_squared > real_t(0.0000000001f)) {
 		Vector3 normal2 = angularError.normalized();
 		real_t denom2 = A->compute_angular_impulse_denominator(normal2) + B->compute_angular_impulse_denominator(normal2);
 		angularError *= (real_t(1.) / denom2) * m_restitutionOrthoAng * m_softnessOrthoAng;

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -154,20 +154,20 @@ void MobileVRInterface::set_position_from_sensors() {
 	last_accerometer_data = acc;
 	last_magnetometer_data = magneto;
 
-	if (grav.length() < 0.1f) {
+	if (grav.length_squared() < 0.01f) {
 		// not ideal but use our accelerometer, this will contain shaky user behavior
 		// maybe look into some math but I'm guessing that if this isn't available, it's because we lack the gyro sensor to actually work out
 		// what a stable gravity vector is
 		grav = acc;
-		if (grav.length() > 0.1f) {
+		if (grav.length_squared() > 0.01f) {
 			has_grav = true;
 		};
 	} else {
 		has_grav = true;
 	};
 
-	const bool has_magneto = magneto.length() > 0.1f;
-	if (gyro.length() > 0.1f) {
+	const bool has_magneto = magneto.length_squared() > 0.01f;
+	if (gyro.length_squared() > 0.01f) {
 		/* this can return to 0.0 if the user doesn't move the phone, so once on, it's on */
 		has_gyro = true;
 	};

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -147,27 +147,27 @@ void MobileVRInterface::set_position_from_sensors() {
 	if (sensor_first) {
 		sensor_first = false;
 	} else {
-		acc = scrub(acc, last_accerometer_data, 2, 0.2);
-		magneto = scrub(magneto, last_magnetometer_data, 3, 0.3);
+		acc = scrub(acc, last_accerometer_data, 2, 0.2f);
+		magneto = scrub(magneto, last_magnetometer_data, 3, 0.3f);
 	};
 
 	last_accerometer_data = acc;
 	last_magnetometer_data = magneto;
 
-	if (grav.length() < 0.1) {
+	if (grav.length() < 0.1f) {
 		// not ideal but use our accelerometer, this will contain shaky user behavior
 		// maybe look into some math but I'm guessing that if this isn't available, it's because we lack the gyro sensor to actually work out
 		// what a stable gravity vector is
 		grav = acc;
-		if (grav.length() > 0.1) {
+		if (grav.length() > 0.1f) {
 			has_grav = true;
 		};
 	} else {
 		has_grav = true;
 	};
 
-	bool has_magneto = magneto.length() > 0.1;
-	if (gyro.length() > 0.1) {
+	const bool has_magneto = magneto.length() > 0.1f;
+	if (gyro.length() > 0.1f) {
 		/* this can return to 0.0 if the user doesn't move the phone, so once on, it's on */
 		has_gyro = true;
 	};

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -140,7 +140,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	// make copies of our inputs
 	bool has_grav = false;
 	Vector3 acc = input->get_accelerometer();
-	Vector3 gyro = input->get_gyroscope();
+	const Vector3 gyro = input->get_gyroscope();
 	Vector3 grav = input->get_gravity();
 	Vector3 magneto = scale_magneto(input->get_magnetometer()); // this may be overkill on iOS because we're already getting a calibrated magnetometer reading
 

--- a/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
@@ -236,8 +236,8 @@ void NavMeshQueries2D::map_query_path(NavMap2D *p_map, const Ref<NavigationPathQ
 }
 
 void NavMeshQueries2D::_query_task_find_start_end_positions(NavMeshPathQueryTask2D &p_query_task, const NavMapIteration2D &p_map_iteration) {
-	real_t begin_d = FLT_MAX;
-	real_t end_d = FLT_MAX;
+	real_t begin_d_squared = FLT_MAX;
+	real_t end_d_squared = FLT_MAX;
 
 	const LocalVector<Ref<NavRegionIteration2D>> &regions = p_map_iteration.region_iterations;
 
@@ -258,17 +258,17 @@ void NavMeshQueries2D::_query_task_find_start_end_positions(NavMeshPathQueryTask
 				const Triangle2 triangle(p.vertices[0], p.vertices[point_id - 1], p.vertices[point_id]);
 
 				Vector2 point = triangle.get_closest_point_to(p_query_task.start_position);
-				real_t distance_to_point = point.distance_to(p_query_task.start_position);
-				if (distance_to_point < begin_d) {
-					begin_d = distance_to_point;
+				real_t distance_to_point_squared = point.distance_squared_to(p_query_task.start_position);
+				if (distance_to_point_squared < begin_d_squared) {
+					begin_d_squared = distance_to_point_squared;
 					p_query_task.begin_polygon = &p;
 					p_query_task.begin_position = point;
 				}
 
 				point = triangle.get_closest_point_to(p_query_task.target_position);
-				distance_to_point = point.distance_to(p_query_task.target_position);
-				if (distance_to_point < end_d) {
-					end_d = distance_to_point;
+				distance_to_point_squared = point.distance_squared_to(p_query_task.target_position);
+				if (distance_to_point_squared < end_d_squared) {
+					end_d_squared = distance_to_point_squared;
 					p_query_task.end_polygon = &p;
 					p_query_task.end_position = point;
 				}

--- a/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
+++ b/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
@@ -66,7 +66,7 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 		return false;
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
 
 	Ref<InputEventMouseButton> mb = p_event;

--- a/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
+++ b/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
@@ -67,13 +67,14 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 	}
 
 	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT) {
 		if (mb->is_pressed()) {
 			// Start position
-			if (xform.xform(node->get_start_position()).distance_to(mb->get_position()) < grab_threshold) {
+			if (xform.xform(node->get_start_position()).distance_squared_to(mb->get_position()) < grab_threshold_squared) {
 				start_grabbed = true;
 				original_start_position = node->get_start_position();
 
@@ -83,7 +84,7 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 			}
 
 			// End position
-			if (xform.xform(node->get_end_position()).distance_to(mb->get_position()) < grab_threshold) {
+			if (xform.xform(node->get_end_position()).distance_squared_to(mb->get_position()) < grab_threshold_squared) {
 				end_grabbed = true;
 				original_end_position = node->get_end_position();
 

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -461,6 +461,7 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 		Vector<Vector3> obstacle_vertices = obstacle_node->get_vertices();
 
 		const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		const real_t grab_threshold_squared = grab_threshold * grab_threshold;
 
 		switch (mode) {
 			case MODE_CREATE: {
@@ -514,7 +515,7 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 						edited_point = 1;
 						return EditorPlugin::AFTER_GUI_INPUT_STOP;
 					} else {
-						if (wip_vertices.size() > 1 && p_camera->unproject_position(gt.xform(wip_vertices[0])).distance_to(mouse_position) < grab_threshold) {
+						if (wip_vertices.size() > 1 && p_camera->unproject_position(gt.xform(wip_vertices[0])).distance_squared_to(mouse_position) < grab_threshold_squared) {
 							_wip_close();
 
 							return EditorPlugin::AFTER_GUI_INPUT_STOP;

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -142,7 +142,7 @@ int NavigationObstacle3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DG
 
 	for (int idx = 0; idx < vertices.size(); ++idx) {
 		Vector3 pos = gt.xform(vertices[idx]);
-		if (p_camera->unproject_position(pos).distance_to(p_point) < 20.0f) {
+		if (p_camera->unproject_position(pos).distance_squared_to(p_point) < 400.0f) {
 			return idx;
 		}
 	}

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -142,7 +142,7 @@ int NavigationObstacle3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DG
 
 	for (int idx = 0; idx < vertices.size(); ++idx) {
 		Vector3 pos = gt.xform(vertices[idx]);
-		if (p_camera->unproject_position(pos).distance_to(p_point) < 20) {
+		if (p_camera->unproject_position(pos).distance_to(p_point) < 20.0f) {
 			return idx;
 		}
 	}
@@ -460,7 +460,7 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 		Vector3 cpoint = Vector3(spoint.x, 0.0, spoint.z);
 		Vector<Vector3> obstacle_vertices = obstacle_node->get_vertices();
 
-		real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 		switch (mode) {
 			case MODE_CREATE: {
@@ -478,9 +478,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 								continue; // Skip edge as clicked point is too close to existing vertex.
 							}
 
-							real_t d = cp.distance_to(mouse_position);
-							if (d < closest_dist && d < grab_threshold) {
-								closest_dist = d;
+							const real_t dist = cp.distance_to(mouse_position);
+							if (dist < closest_dist && dist < grab_threshold) {
+								closest_dist = dist;
 								closest_edge_point = cp;
 								closest_idx = i;
 							}
@@ -546,9 +546,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 							}
 
 							//search edges
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < obstacle_vertices.size(); i++) {
 								const Vector2 a = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
 								const Vector2 b = p_camera->unproject_position(gt.xform(obstacle_vertices[(i + 1) % obstacle_vertices.size()]));
@@ -558,9 +558,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 									continue; //not valid to reuse point
 								}
 
-								real_t d = cp.distance_to(mouse_position);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(mouse_position);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -578,15 +578,15 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 								return EditorPlugin::AFTER_GUI_INPUT_STOP;
 							}
 						} else {
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < obstacle_vertices.size(); i++) {
 								Vector2 cp = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
 
-								real_t d = cp.distance_to(mouse_position);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(mouse_position);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -624,13 +624,13 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 
 			case MODE_DELETE: {
 				if (mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-					int closest_idx = -1;
 					real_t closest_dist = 1e10;
+					int closest_idx = -1;
 					for (int i = 0; i < obstacle_vertices.size(); i++) {
 						Vector2 point = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
-						real_t d = point.distance_to(mouse_position);
-						if (d < closest_dist && d < grab_threshold) {
-							closest_dist = d;
+						const real_t dist = point.distance_to(mouse_position);
+						if (dist < closest_dist && dist < grab_threshold) {
+							closest_dist = dist;
 							closest_idx = i;
 						}
 					}

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -469,7 +469,7 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 					if (obstacle_vertices.size() >= 3) {
 						int closest_idx = -1;
 						Vector2 closest_edge_point;
-						real_t closest_dist = 1e10;
+						real_t closest_dist_squared = 1e20;
 						for (int i = 0; i < obstacle_vertices.size(); i++) {
 							const Vector2 a = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
 							const Vector2 b = p_camera->unproject_position(gt.xform(obstacle_vertices[(i + 1) % obstacle_vertices.size()]));
@@ -479,9 +479,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 								continue; // Skip edge as clicked point is too close to existing vertex.
 							}
 
-							const real_t dist = cp.distance_to(mouse_position);
-							if (dist < closest_dist && dist < grab_threshold) {
-								closest_dist = dist;
+							const real_t dist_squared = cp.distance_squared_to(mouse_position);
+							if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+								closest_dist_squared = dist_squared;
 								closest_edge_point = cp;
 								closest_idx = i;
 							}
@@ -548,7 +548,7 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 
 							//search edges
 							Vector2 closest_pos;
-							real_t closest_dist = 1e10;
+							real_t closest_dist_squared = 1e20;
 							int closest_idx = -1;
 							for (int i = 0; i < obstacle_vertices.size(); i++) {
 								const Vector2 a = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
@@ -559,9 +559,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 									continue; //not valid to reuse point
 								}
 
-								const real_t dist = cp.distance_to(mouse_position);
-								if (dist < closest_dist && dist < grab_threshold) {
-									closest_dist = dist;
+								const real_t dist_squared = cp.distance_squared_to(mouse_position);
+								if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+									closest_dist_squared = dist_squared;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -580,14 +580,14 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 							}
 						} else {
 							Vector2 closest_pos;
-							real_t closest_dist = 1e10;
+							real_t closest_dist_squared = 1e20;
 							int closest_idx = -1;
 							for (int i = 0; i < obstacle_vertices.size(); i++) {
 								Vector2 cp = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
 
-								const real_t dist = cp.distance_to(mouse_position);
-								if (dist < closest_dist && dist < grab_threshold) {
-									closest_dist = dist;
+								const real_t dist_squared = cp.distance_squared_to(mouse_position);
+								if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+									closest_dist_squared = dist_squared;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -625,13 +625,13 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 
 			case MODE_DELETE: {
 				if (mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-					real_t closest_dist = 1e10;
+					real_t closest_dist_squared = 1e20;
 					int closest_idx = -1;
 					for (int i = 0; i < obstacle_vertices.size(); i++) {
 						Vector2 point = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
-						const real_t dist = point.distance_to(mouse_position);
-						if (dist < closest_dist && dist < grab_threshold) {
-							closest_dist = dist;
+						const real_t dist_squared = point.distance_squared_to(mouse_position);
+						if (dist_squared < closest_dist_squared && dist_squared < grab_threshold_squared) {
+							closest_dist_squared = dist_squared;
 							closest_idx = i;
 						}
 					}

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2210,7 +2210,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 					pd.last_pressed_position = pd.position;
 				}
 
-				if (old_pd.double_click_begun && mb->is_pressed() && pd.last_button_pressed == old_pd.last_button_pressed && (pd.button_time - old_pd.button_time) < 400 && Vector2(old_pd.last_pressed_position * scale).distance_to(Vector2(pd.last_pressed_position * scale)) < 5) {
+				if (old_pd.double_click_begun && mb->is_pressed() && pd.last_button_pressed == old_pd.last_button_pressed && (pd.button_time - old_pd.button_time) < 400 && Vector2(old_pd.last_pressed_position * scale).distance_to(Vector2(pd.last_pressed_position * scale)) < 5.0f) {
 					pd.double_click_begun = false;
 					mb->set_double_click(true);
 				}
@@ -3270,7 +3270,7 @@ void WaylandThread::_wp_tablet_tool_on_frame(void *data, struct zwp_tablet_tool_
 					td.last_pressed_position = td.position;
 				}
 
-				if (old_td.double_click_begun && mb->is_pressed() && td.last_button_pressed == old_td.last_button_pressed && (td.button_time - old_td.button_time) < 400 && Vector2(td.last_pressed_position * scale).distance_to(Vector2(old_td.last_pressed_position * scale)) < 5) {
+				if (old_td.double_click_begun && mb->is_pressed() && td.last_button_pressed == old_td.last_button_pressed && (td.button_time - old_td.button_time) < 400 && Vector2(td.last_pressed_position * scale).distance_to(Vector2(old_td.last_pressed_position * scale)) < 5.0f) {
 					td.double_click_begun = false;
 					mb->set_double_click(true);
 				}

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -2210,7 +2210,7 @@ void WaylandThread::_wl_pointer_on_frame(void *data, struct wl_pointer *wl_point
 					pd.last_pressed_position = pd.position;
 				}
 
-				if (old_pd.double_click_begun && mb->is_pressed() && pd.last_button_pressed == old_pd.last_button_pressed && (pd.button_time - old_pd.button_time) < 400 && Vector2(old_pd.last_pressed_position * scale).distance_to(Vector2(pd.last_pressed_position * scale)) < 5.0f) {
+				if (old_pd.double_click_begun && mb->is_pressed() && pd.last_button_pressed == old_pd.last_button_pressed && (pd.button_time - old_pd.button_time) < 400 && Vector2(old_pd.last_pressed_position * scale).distance_squared_to(Vector2(pd.last_pressed_position * scale)) < 25.0f) {
 					pd.double_click_begun = false;
 					mb->set_double_click(true);
 				}
@@ -3270,7 +3270,7 @@ void WaylandThread::_wp_tablet_tool_on_frame(void *data, struct zwp_tablet_tool_
 					td.last_pressed_position = td.position;
 				}
 
-				if (old_td.double_click_begun && mb->is_pressed() && td.last_button_pressed == old_td.last_button_pressed && (td.button_time - old_td.button_time) < 400 && Vector2(td.last_pressed_position * scale).distance_to(Vector2(old_td.last_pressed_position * scale)) < 5.0f) {
+				if (old_td.double_click_begun && mb->is_pressed() && td.last_button_pressed == old_td.last_button_pressed && (td.button_time - old_td.button_time) < 400 && Vector2(td.last_pressed_position * scale).distance_squared_to(Vector2(old_td.last_pressed_position * scale)) < 25.0f) {
 					td.double_click_begun = false;
 					mb->set_double_click(true);
 				}

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5372,7 +5372,7 @@ void DisplayServerX11::process_events() {
 					uint64_t diff = OS::get_singleton()->get_ticks_usec() / 1000 - last_click_ms;
 
 					if (mb->get_button_index() == last_click_button_index) {
-						if (diff < 400 && Vector2(last_click_pos).distance_to(Vector2(event.xbutton.x, event.xbutton.y)) < 5) {
+						if (diff < 400 && Vector2(last_click_pos).distance_to(Vector2(event.xbutton.x, event.xbutton.y)) < 5.0f) {
 							last_click_ms = 0;
 							last_click_pos = Point2i(-100, -100);
 							last_click_button_index = MouseButton::NONE;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5372,7 +5372,7 @@ void DisplayServerX11::process_events() {
 					uint64_t diff = OS::get_singleton()->get_ticks_usec() / 1000 - last_click_ms;
 
 					if (mb->get_button_index() == last_click_button_index) {
-						if (diff < 400 && Vector2(last_click_pos).distance_to(Vector2(event.xbutton.x, event.xbutton.y)) < 5.0f) {
+						if (diff < 400 && Vector2(last_click_pos).distance_squared_to(Vector2(event.xbutton.x, event.xbutton.y)) < 25.0f) {
 							last_click_ms = 0;
 							last_click_pos = Point2i(-100, -100);
 							last_click_button_index = MouseButton::NONE;

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -272,7 +272,7 @@ int DisplayServerWeb::_mouse_button_callback(int p_pressed, int p_button, double
 		uint64_t diff = (OS::get_singleton()->get_ticks_usec() / 1000) - ds->last_click_ms;
 
 		if (ev->get_button_index() == ds->last_click_button_index) {
-			if (diff < 400 && Point2(ds->last_click_pos).distance_to(ev->get_position()) < 5) {
+			if (diff < 400 && Point2(ds->last_click_pos).distance_to(ev->get_position()) < 5.0f) {
 				ds->last_click_ms = 0;
 				ds->last_click_pos = Point2(-100, -100);
 				ds->last_click_button_index = MouseButton::NONE;

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -272,7 +272,7 @@ int DisplayServerWeb::_mouse_button_callback(int p_pressed, int p_button, double
 		uint64_t diff = (OS::get_singleton()->get_ticks_usec() / 1000) - ds->last_click_ms;
 
 		if (ev->get_button_index() == ds->last_click_button_index) {
-			if (diff < 400 && Point2(ds->last_click_pos).distance_to(ev->get_position()) < 5.0f) {
+			if (diff < 400 && Point2(ds->last_click_pos).distance_squared_to(ev->get_position()) < 25.0f) {
 				ds->last_click_ms = 0;
 				ds->last_click_pos = Point2(-100, -100);
 				ds->last_click_button_index = MouseButton::NONE;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1037,14 +1037,14 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			Vector2 pos = p.transform[2];
 
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(_seed)) : Vector2();
+			force += p.velocity.length() > 0.0f ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(_seed)) : Vector2();
 			//apply radial acceleration
 			Vector2 org = emission_xform[2];
 			Vector2 diff = pos - org;
-			force += diff.length() > 0.0 ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(_seed)) : Vector2();
+			force += diff.length() > 0.0f ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(_seed)) : Vector2();
 			//apply tangential acceleration;
 			Vector2 yx = Vector2(diff.y, diff.x);
-			force += yx.length() > 0.0 ? (yx * Vector2(-1.0, 1.0)).normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(_seed))) : Vector2();
+			force += yx.length() > 0.0f ? (yx * Vector2(-1.0f, 1.0f)).normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(_seed))) : Vector2();
 			//apply attractor forces
 			p.velocity += force * local_delta;
 			//orbit velocity
@@ -1133,7 +1133,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 		p.color *= p.base_color * p.start_color_rand;
 
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-			if (p.velocity.length() > 0.0) {
+			if (p.velocity.length() > 0.0f) {
 				p.transform.columns[1] = p.velocity;
 			}
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1037,14 +1037,14 @@ void CPUParticles2D::_particles_process(double p_delta) {
 			Vector2 pos = p.transform[2];
 
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0f ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(_seed)) : Vector2();
+			force += p.velocity.length_squared() > 0.0f ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(_seed)) : Vector2();
 			//apply radial acceleration
 			Vector2 org = emission_xform[2];
 			Vector2 diff = pos - org;
-			force += diff.length() > 0.0f ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(_seed)) : Vector2();
+			force += diff.length_squared() > 0.0f ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(_seed)) : Vector2();
 			//apply tangential acceleration;
 			Vector2 yx = Vector2(diff.y, diff.x);
-			force += yx.length() > 0.0f ? (yx * Vector2(-1.0f, 1.0f)).normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(_seed))) : Vector2();
+			force += yx.length_squared() > 0.0f ? (yx * Vector2(-1.0f, 1.0f)).normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(_seed))) : Vector2();
 			//apply attractor forces
 			p.velocity += force * local_delta;
 			//orbit velocity
@@ -1133,7 +1133,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 		p.color *= p.base_color * p.start_color_rand;
 
 		if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-			if (p.velocity.length() > 0.0f) {
+			if (p.velocity.length_squared() > 0.0f) {
 				p.transform.columns[1] = p.velocity;
 			}
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -74,11 +74,11 @@ bool OccluderPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double
 	if (closed) {
 		return Geometry2D::is_point_in_polygon(p_point, Variant(polygon));
 	} else {
-		const real_t d = LINE_GRAB_WIDTH / 2 + p_tolerance;
+		const real_t dist = LINE_GRAB_WIDTH / 2 + p_tolerance;
 		const Vector2 *points = polygon.ptr();
 		for (int i = 0; i < polygon.size() - 1; i++) {
-			Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
-			if (p.distance_to(p_point) <= d) {
+			const Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
+			if (p.distance_to(p_point) <= dist) {
 				return true;
 			}
 		}

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -75,10 +75,11 @@ bool OccluderPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double
 		return Geometry2D::is_point_in_polygon(p_point, Variant(polygon));
 	} else {
 		const real_t dist = LINE_GRAB_WIDTH / 2 + p_tolerance;
+		const real_t dist_squared = dist * dist;
 		const Vector2 *points = polygon.ptr();
 		for (int i = 0; i < polygon.size() - 1; i++) {
-			const Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
-			if (p.distance_to(p_point) <= dist) {
+			Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
+			if (p.distance_squared_to(p_point) <= dist_squared) {
 				return true;
 			}
 		}

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -58,18 +58,19 @@ bool Line2D::_edit_use_rect() const {
 }
 
 bool Line2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
-	const real_t d = _width / 2 + p_tolerance;
+	const real_t dist = _width / 2 + p_tolerance;
+	const real_t dist_squared = dist * dist;
 	const Vector2 *points = _points.ptr();
 	for (int i = 0; i < _points.size() - 1; i++) {
 		Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
-		if (p_point.distance_to(p) <= d) {
+		if (p_point.distance_squared_to(p) <= dist_squared) {
 			return true;
 		}
 	}
 	// Closing segment between the first and last point.
 	if (_closed && _points.size() > 2) {
 		Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[0], points[_points.size() - 1]);
-		if (p_point.distance_to(p) <= d) {
+		if (p_point.distance_squared_to(p) <= dist_squared) {
 			return true;
 		}
 	}

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -683,7 +683,7 @@ bool NavigationAgent2D::is_target_reachable() {
 }
 
 bool NavigationAgent2D::_is_target_reachable() const {
-	return target_desired_distance >= _get_final_position().distance_to(target_position);
+	return _get_final_position().distance_squared_to(target_position) <= (target_desired_distance * target_desired_distance);
 }
 
 bool NavigationAgent2D::is_navigation_finished() {
@@ -760,7 +760,7 @@ void NavigationAgent2D::_update_navigation() {
 			const Vector2 segment_a = navigation_path[navigation_path_index - 1];
 			const Vector2 segment_b = navigation_path[navigation_path_index];
 			Vector2 p = Geometry2D::get_closest_point_to_segment(origin, segment_a, segment_b);
-			if (origin.distance_to(p) >= path_max_distance) {
+			if (origin.distance_squared_to(p) >= (path_max_distance * path_max_distance)) {
 				// To faraway, reload path
 				reload_path = true;
 			}
@@ -849,11 +849,11 @@ void NavigationAgent2D::_move_to_next_waypoint() {
 
 bool NavigationAgent2D::_is_within_waypoint_distance(const Vector2 &p_origin) const {
 	const Vector<Vector2> &navigation_path = navigation_result->get_path();
-	return p_origin.distance_to(navigation_path[navigation_path_index]) < path_desired_distance;
+	return p_origin.distance_squared_to(navigation_path[navigation_path_index]) < (path_desired_distance * path_desired_distance);
 }
 
 bool NavigationAgent2D::_is_within_target_distance(const Vector2 &p_origin) const {
-	return p_origin.distance_to(target_position) < target_desired_distance;
+	return p_origin.distance_squared_to(target_position) < (target_desired_distance * target_desired_distance);
 }
 
 void NavigationAgent2D::_trigger_waypoint_reached() {

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -895,7 +895,7 @@ void NavigationAgent2D::_trigger_waypoint_reached() {
 			if (navlink) {
 				Vector2 link_global_start_position = navlink->get_global_start_position();
 				Vector2 link_global_end_position = navlink->get_global_end_position();
-				if (waypoint.distance_to(link_global_start_position) < waypoint.distance_to(link_global_end_position)) {
+				if (waypoint.distance_squared_to(link_global_start_position) < waypoint.distance_squared_to(link_global_end_position)) {
 					details[SNAME("link_entry_position")] = link_global_start_position;
 					details[SNAME("link_exit_position")] = link_global_end_position;
 				} else {

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -149,7 +149,7 @@ Rect2 NavigationLink2D::_edit_get_rect() const {
 
 bool NavigationLink2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 	Vector2 closest_point = Geometry2D::get_closest_point_to_segment(p_point, get_start_position(), get_end_position());
-	return p_point.distance_to(closest_point) < p_tolerance;
+	return p_point.distance_squared_to(closest_point) < (p_tolerance * p_tolerance);
 }
 #endif // DEBUG_ENABLED
 

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -75,7 +75,7 @@ bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 			const Vector2 segment_b = curve->sample(i, frac);
 
 			Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, segment_a, segment_b);
-			if (p.distance_to(p_point) <= p_tolerance) {
+			if (p.distance_squared_to(p_point) <= (p_tolerance * p_tolerance)) {
 				return true;
 			}
 

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -156,7 +156,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 			// If we hit a ceiling platform, we set the vertical velocity to at least the platform one.
 			if (on_ceiling && result.collider_velocity != Vector2() && result.collider_velocity.dot(up_direction) < 0) {
 				// If ceiling sliding is on, only apply when the ceiling is flat or when the motion is upward.
-				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (result.collision_normal + up_direction).length() < 0.01) {
+				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (result.collision_normal + up_direction).length() < 0.01f) {
 					apply_ceiling_velocity = true;
 					Vector2 ceiling_vertical_velocity = up_direction * up_direction.dot(result.collider_velocity);
 					Vector2 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
@@ -166,7 +166,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				}
 			}
 
-			if (on_floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01) {
+			if (on_floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01f) {
 				Transform2D gt = get_global_transform();
 				if (result.travel.length() <= margin + CMP_EPSILON) {
 					gt.columns[2] -= result.travel;

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -157,7 +157,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 			// If we hit a ceiling platform, we set the vertical velocity to at least the platform one.
 			if (on_ceiling && result.collider_velocity != Vector2() && result.collider_velocity.dot(up_direction) < 0) {
 				// If ceiling sliding is on, only apply when the ceiling is flat or when the motion is upward.
-				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (result.collision_normal + up_direction).length() < 0.01f) {
+				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (result.collision_normal + up_direction).length_squared() < 0.0001f) {
 					apply_ceiling_velocity = true;
 					Vector2 ceiling_vertical_velocity = up_direction * up_direction.dot(result.collider_velocity);
 					Vector2 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
@@ -167,7 +167,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				}
 			}
 
-			if (on_floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01f) {
+			if (on_floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length_squared() < 0.0001f) {
 				Transform2D gt = get_global_transform();
 				if (result.travel.length() <= recovery_tolerance) {
 					gt.columns[2] -= result.travel;

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -121,6 +121,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 	Vector2 motion_slide_up = motion.slide(up_direction);
 
 	Vector2 prev_floor_normal = floor_normal;
+	const real_t recovery_tolerance = margin + CMP_EPSILON;
 
 	platform_rid = RID();
 	platform_object_id = ObjectID();
@@ -160,7 +161,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					apply_ceiling_velocity = true;
 					Vector2 ceiling_vertical_velocity = up_direction * up_direction.dot(result.collider_velocity);
 					Vector2 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
-					if (motion_vertical_velocity.dot(up_direction) > 0 || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
+					if (motion_vertical_velocity.dot(up_direction) > 0.0f || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
 						velocity = ceiling_vertical_velocity + velocity.slide(up_direction);
 					}
 				}
@@ -168,7 +169,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 			if (on_floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01f) {
 				Transform2D gt = get_global_transform();
-				if (result.travel.length() <= margin + CMP_EPSILON) {
+				if (result.travel.length() <= recovery_tolerance) {
 					gt.columns[2] -= result.travel;
 				}
 				set_global_transform(gt);
@@ -188,7 +189,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				// Avoid to move forward on a wall if floor_block_on_wall is true.
 				if (p_was_on_floor && !on_floor && !vel_dir_facing_up) {
 					// If the movement is large the body can be prevented from reaching the walls.
-					if (result.travel.length() <= margin + CMP_EPSILON) {
+					if (result.travel.length() <= recovery_tolerance) {
 						// Cancels the motion.
 						Transform2D gt = get_global_transform();
 						gt.columns[2] -= result.travel;

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -121,7 +121,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 	Vector2 motion_slide_up = motion.slide(up_direction);
 
 	Vector2 prev_floor_normal = floor_normal;
-	const real_t recovery_tolerance = margin + CMP_EPSILON;
+	const real_t recovery_tolerance_squared = (margin + CMP_EPSILON) * (margin + CMP_EPSILON);
 
 	platform_rid = RID();
 	platform_object_id = ObjectID();
@@ -169,7 +169,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 			if (on_floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length_squared() < 0.0001f) {
 				Transform2D gt = get_global_transform();
-				if (result.travel.length() <= recovery_tolerance) {
+				if (result.travel.length_squared() <= recovery_tolerance_squared) {
 					gt.columns[2] -= result.travel;
 				}
 				set_global_transform(gt);
@@ -189,7 +189,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				// Avoid to move forward on a wall if floor_block_on_wall is true.
 				if (p_was_on_floor && !on_floor && !vel_dir_facing_up) {
 					// If the movement is large the body can be prevented from reaching the walls.
-					if (result.travel.length() <= recovery_tolerance) {
+					if (result.travel.length_squared() <= recovery_tolerance_squared) {
 						// Cancels the motion.
 						Transform2D gt = get_global_transform();
 						gt.columns[2] -= result.travel;
@@ -364,7 +364,7 @@ void CharacterBody2D::_apply_floor_snap(bool p_wall_as_floor) {
 			// move_and_collide may stray the object a bit when getting it unstuck.
 			// Canceling this motion should not affect move_and_slide, as previous
 			// calls to move_and_collide already took care of freeing the body.
-			if (result.travel.length() > margin) {
+			if (result.travel.length_squared() > (margin * margin)) {
 				result.travel = up_direction * up_direction.dot(result.travel);
 			} else {
 				result.travel = Vector2();

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -103,11 +103,11 @@ bool PhysicsBody2D::move_and_collide(const PhysicsServer2D::MotionParameters &p_
 			// Check depth of recovery.
 			real_t projected_length = r_result.travel.dot(motion_normal);
 			Vector2 recovery = r_result.travel - motion_normal * projected_length;
-			const real_t recovery_length = recovery.length();
+			const real_t recovery_length_squared = recovery.length_squared();
 			const real_t recovery_max_threshold = p_parameters.margin + precision;
 			// Fixes cases where canceling slide causes the motion to go too deep into the ground,
 			// because we're only taking rest information into account and not general recovery.
-			if (recovery_length < recovery_max_threshold) {
+			if (recovery_length_squared < recovery_max_threshold * recovery_max_threshold) {
 				// Apply adjustment to motion.
 				r_result.travel = motion_normal * projected_length;
 				r_result.remainder = p_parameters.motion - r_result.travel;

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -103,10 +103,11 @@ bool PhysicsBody2D::move_and_collide(const PhysicsServer2D::MotionParameters &p_
 			// Check depth of recovery.
 			real_t projected_length = r_result.travel.dot(motion_normal);
 			Vector2 recovery = r_result.travel - motion_normal * projected_length;
-			real_t recovery_length = recovery.length();
+			const real_t recovery_length = recovery.length();
+			const real_t recovery_max_threshold = p_parameters.margin + precision;
 			// Fixes cases where canceling slide causes the motion to go too deep into the ground,
 			// because we're only taking rest information into account and not general recovery.
-			if (recovery_length < p_parameters.margin + precision) {
+			if (recovery_length < recovery_max_threshold) {
 				// Apply adjustment to motion.
 				r_result.travel = motion_normal * projected_length;
 				r_result.remainder = p_parameters.motion - r_result.travel;

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -238,7 +238,7 @@ void RayCast2D::_draw_debug_shape() {
 	// Draw an arrow indicating where the RayCast is pointing to
 	const real_t max_arrow_size = 6;
 	const real_t line_width = 1.4;
-	bool no_line = target_position.length() < line_width;
+	const bool no_line = target_position.length() < line_width;
 	real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -238,7 +238,7 @@ void RayCast2D::_draw_debug_shape() {
 	// Draw an arrow indicating where the RayCast is pointing to
 	const real_t max_arrow_size = 6;
 	const real_t line_width = 1.4;
-	const bool no_line = target_position.length() < line_width;
+	const bool no_line = target_position.length_squared() < (line_width * line_width);
 	real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -250,7 +250,7 @@ void ShapeCast2D::_notification(int p_what) {
 			if (target_position != Vector2()) {
 				const real_t max_arrow_size = 6;
 				const real_t line_width = 1.4;
-				bool no_line = target_position.length() < line_width;
+				const bool no_line = target_position.length() < line_width;
 				real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 				if (no_line) {

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -250,7 +250,7 @@ void ShapeCast2D::_notification(int p_what) {
 			if (target_position != Vector2()) {
 				const real_t max_arrow_size = 6;
 				const real_t line_width = 1.4;
-				const bool no_line = target_position.length() < line_width;
+				const bool no_line = target_position.length_squared() < (line_width * line_width);
 				real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 				if (no_line) {

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -865,7 +865,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				}
 				// rotate spread to direction
 				Vector3 binormal = Vector3(0.0, 1.0, 0.0).cross(direction_nrm);
-				if (binormal.length_squared() < 0.00000001) {
+				if (binormal.length_squared() < 0.00000001f) {
 					// direction is parallel to Y. Choose Z as the binormal.
 					binormal = Vector3(0.0, 0.0, 1.0);
 				}
@@ -1049,19 +1049,19 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				position.z = 0.0;
 			}
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0 ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(alt_seed)) : Vector3();
+			force += p.velocity.length() > 0.0f ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(alt_seed)) : Vector3();
 			//apply radial acceleration
 			Vector3 org = emission_xform.origin;
 			Vector3 diff = position - org;
-			force += diff.length() > 0.0 ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(alt_seed)) : Vector3();
+			force += diff.length() > 0.0f ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(alt_seed)) : Vector3();
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				Vector2 yx = Vector2(diff.y, diff.x);
 				Vector2 yx2 = (yx * Vector2(-1.0, 1.0)).normalized();
-				force += yx.length() > 0.0 ? Vector3(yx2.x, yx2.y, 0.0) * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
+				force += yx.length() > 0.0f ? Vector3(yx2.x, yx2.y, 0.0f) * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
 
 			} else {
 				Vector3 crossDiff = diff.normalized().cross(gravity.normalized());
-				force += crossDiff.length() > 0.0 ? crossDiff.normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
+				force += crossDiff.length() > 0.0f ? crossDiff.normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
 			}
 			//apply attractor forces
 			p.velocity += force * local_delta;
@@ -1161,7 +1161,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 
 		if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 			if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-				if (p.velocity.length() > 0.0) {
+				if (p.velocity.length() > 0.0f) {
 					p.transform.basis.set_column(1, p.velocity.normalized());
 				} else {
 					p.transform.basis.set_column(1, p.transform.basis.get_column(1));
@@ -1178,7 +1178,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 		} else {
 			//orient particle Y towards velocity
 			if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-				if (p.velocity.length() > 0.0) {
+				if (p.velocity.length() > 0.0f) {
 					p.transform.basis.set_column(1, p.velocity.normalized());
 				} else {
 					p.transform.basis.set_column(1, p.transform.basis.get_column(1).normalized());

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -1049,19 +1049,19 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				position.z = 0.0;
 			}
 			//apply linear acceleration
-			force += p.velocity.length() > 0.0f ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(alt_seed)) : Vector3();
+			force += p.velocity.length_squared() > 0.0f ? p.velocity.normalized() * tex_linear_accel * Math::lerp(parameters_min[PARAM_LINEAR_ACCEL], parameters_max[PARAM_LINEAR_ACCEL], rand_from_seed(alt_seed)) : Vector3();
 			//apply radial acceleration
 			Vector3 org = emission_xform.origin;
 			Vector3 diff = position - org;
-			force += diff.length() > 0.0f ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(alt_seed)) : Vector3();
+			force += diff.length_squared() > 0.0f ? diff.normalized() * (tex_radial_accel)*Math::lerp(parameters_min[PARAM_RADIAL_ACCEL], parameters_max[PARAM_RADIAL_ACCEL], rand_from_seed(alt_seed)) : Vector3();
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				Vector2 yx = Vector2(diff.y, diff.x);
 				Vector2 yx2 = (yx * Vector2(-1.0, 1.0)).normalized();
-				force += yx.length() > 0.0f ? Vector3(yx2.x, yx2.y, 0.0f) * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
+				force += yx.length_squared() > 0.0f ? Vector3(yx2.x, yx2.y, 0.0f) * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
 
 			} else {
 				Vector3 crossDiff = diff.normalized().cross(gravity.normalized());
-				force += crossDiff.length() > 0.0f ? crossDiff.normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
+				force += crossDiff.length_squared() > 0.0f ? crossDiff.normalized() * (tex_tangential_accel * Math::lerp(parameters_min[PARAM_TANGENTIAL_ACCEL], parameters_max[PARAM_TANGENTIAL_ACCEL], rand_from_seed(alt_seed))) : Vector3();
 			}
 			//apply attractor forces
 			p.velocity += force * local_delta;
@@ -1161,7 +1161,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 
 		if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 			if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-				if (p.velocity.length() > 0.0f) {
+				if (p.velocity.length_squared() > 0.0f) {
 					p.transform.basis.set_column(1, p.velocity.normalized());
 				} else {
 					p.transform.basis.set_column(1, p.transform.basis.get_column(1));
@@ -1178,7 +1178,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 		} else {
 			//orient particle Y towards velocity
 			if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
-				if (p.velocity.length() > 0.0f) {
+				if (p.velocity.length_squared() > 0.0f) {
 					p.transform.basis.set_column(1, p.velocity.normalized());
 				} else {
 					p.transform.basis.set_column(1, p.transform.basis.get_column(1).normalized());

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -331,13 +331,13 @@ void GPUParticlesCollisionSDF3D::_find_closest_distance(const Vector3 &p_pos, co
 		if (!p_bvh[p_bvh_cell].bounds.has_point(p_pos)) {
 			//outside, find closest point
 			const Vector3 he = p_bvh[p_bvh_cell].bounds.size * 0.5f;
-			Vector3 center = p_bvh[p_bvh_cell].bounds.position + he;
+			const Vector3 center = p_bvh[p_bvh_cell].bounds.position + he;
 
-			Vector3 rel = (p_pos - center).abs();
-			Vector3 closest = rel.min(he);
-			float d = rel.distance_to(closest);
+			const Vector3 rel = (p_pos - center).abs();
+			const Vector3 closest = rel.min(he);
+			const float dist = rel.distance_to(closest);
 
-			if (d >= r_closest_distance) {
+			if (dist >= r_closest_distance) {
 				pass = false; //already closer than this aabb, discard
 			}
 		}

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -330,7 +330,7 @@ void GPUParticlesCollisionSDF3D::_find_closest_distance(const Vector3 &p_pos, co
 		bool pass = true;
 		if (!p_bvh[p_bvh_cell].bounds.has_point(p_pos)) {
 			//outside, find closest point
-			Vector3 he = p_bvh[p_bvh_cell].bounds.size * 0.5;
+			const Vector3 he = p_bvh[p_bvh_cell].bounds.size * 0.5f;
 			Vector3 center = p_bvh[p_bvh_cell].bounds.position + he;
 
 			Vector3 rel = (p_pos - center).abs();

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -335,9 +335,9 @@ void GPUParticlesCollisionSDF3D::_find_closest_distance(const Vector3 &p_pos, co
 
 			const Vector3 rel = (p_pos - center).abs();
 			const Vector3 closest = rel.min(he);
-			const float dist = rel.distance_to(closest);
+			const float d_squared = rel.distance_squared_to(closest);
 
-			if (dist >= r_closest_distance) {
+			if (d_squared >= (r_closest_distance * r_closest_distance)) {
 				pass = false; //already closer than this aabb, discard
 			}
 		}

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -792,6 +792,7 @@ void LightmapGI::_plot_triangle_into_octree(GenProbesOctree *p_cell, float p_cel
 }
 
 void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, float p_cell_size, const Vector<Vector3> &probe_positions, LocalVector<Vector3> &new_probe_positions, HashMap<Vector3i, bool> &positions_used, const AABB &p_bounds) {
+	const float probe_margin = p_cell_size * 0.5f;
 	for (int i = 0; i < 8; i++) {
 		Vector3i pos = p_cell->offset;
 		if (i & 1) {
@@ -812,7 +813,7 @@ void LightmapGI::_gen_new_positions_from_octree(const GenProbesOctree *p_cell, f
 			const Vector3 *pp = probe_positions.ptr();
 			bool exists = false;
 			for (int j = 0; j < ppcount; j++) {
-				if (pp[j].distance_to(real_pos) < (p_cell_size * 0.5f)) {
+				if (pp[j].distance_squared_to(real_pos) < probe_margin * probe_margin) {
 					exists = true;
 					break;
 				}

--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -619,7 +619,7 @@ bool LookAtModifier3D::is_intersecting_axis(const Vector3 &p_prev, const Vector3
 	// Prevent that the angular velocity does not become too large.
 	// Check that is p_flipping_axis flipped nearby p_check_axis (close than origin_safe_margin) or not. If p_check_plane is true, check two axes of crossed plane.
 	if (p_check_plane) {
-		if (get_projection_vector(p_prev, p_check_axis).length() > origin_safe_margin && get_projection_vector(p_current, p_check_axis).length() > origin_safe_margin) {
+		if (get_projection_vector(p_prev, p_check_axis).length_squared() > (origin_safe_margin * origin_safe_margin) && get_projection_vector(p_current, p_check_axis).length_squared() > (origin_safe_margin * origin_safe_margin)) {
 			return false;
 		}
 	} else if (Math::abs(p_prev[p_check_axis]) > origin_safe_margin && Math::abs(p_current[p_check_axis]) > origin_safe_margin) {

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -965,7 +965,7 @@ void NavigationAgent3D::_trigger_waypoint_reached() {
 			if (navlink) {
 				Vector3 link_global_start_position = navlink->get_global_start_position();
 				Vector3 link_global_end_position = navlink->get_global_end_position();
-				if (waypoint.distance_to(link_global_start_position) < waypoint.distance_to(link_global_end_position)) {
+				if (waypoint.distance_squared_to(link_global_start_position) < waypoint.distance_squared_to(link_global_end_position)) {
 					details[SNAME("link_entry_position")] = link_global_start_position;
 					details[SNAME("link_exit_position")] = link_global_end_position;
 				} else {

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -747,7 +747,7 @@ bool NavigationAgent3D::is_target_reachable() {
 }
 
 bool NavigationAgent3D::_is_target_reachable() const {
-	return target_desired_distance >= _get_final_position().distance_to(target_position);
+	return _get_final_position().distance_squared_to(target_position) <= (target_desired_distance * target_desired_distance);
 }
 
 bool NavigationAgent3D::is_navigation_finished() {
@@ -829,7 +829,7 @@ void NavigationAgent3D::_update_navigation() {
 			segment_a.y -= path_height_offset;
 			segment_b.y -= path_height_offset;
 			Vector3 p = Geometry3D::get_closest_point_to_segment(origin, segment_a, segment_b);
-			if (origin.distance_to(p) >= path_max_distance) {
+			if (origin.distance_squared_to(p) >= (path_max_distance * path_max_distance)) {
 				// To faraway, reload path
 				reload_path = true;
 			}
@@ -919,11 +919,11 @@ void NavigationAgent3D::_move_to_next_waypoint() {
 bool NavigationAgent3D::_is_within_waypoint_distance(const Vector3 &p_origin) const {
 	const Vector<Vector3> &navigation_path = navigation_result->get_path();
 	Vector3 waypoint = navigation_path[navigation_path_index] - Vector3(0, path_height_offset, 0);
-	return p_origin.distance_to(waypoint) < path_desired_distance;
+	return p_origin.distance_squared_to(waypoint) < (path_desired_distance * path_desired_distance);
 }
 
 bool NavigationAgent3D::_is_within_target_distance(const Vector3 &p_origin) const {
-	return p_origin.distance_to(target_position) < target_desired_distance;
+	return p_origin.distance_squared_to(target_position) < (target_desired_distance * target_desired_distance);
 }
 
 void NavigationAgent3D::_trigger_waypoint_reached() {

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -183,7 +183,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 			// If we hit a ceiling platform, we set the vertical velocity to at least the platform one.
 			if (collision_state.ceiling && platform_ceiling_velocity != Vector3() && platform_ceiling_velocity.dot(up_direction) < 0) {
 				// If ceiling sliding is on, only apply when the ceiling is flat or when the motion is upward.
-				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (ceiling_normal + up_direction).length() < 0.01) {
+				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (ceiling_normal + up_direction).length() < 0.01f) {
 					apply_ceiling_velocity = true;
 					Vector3 ceiling_vertical_velocity = up_direction * up_direction.dot(platform_ceiling_velocity);
 					Vector3 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
@@ -193,7 +193,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				}
 			}
 
-			if (collision_state.floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01) {
+			if (collision_state.floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01f) {
 				Transform3D gt = get_global_transform();
 				if (result.travel.length() <= margin + CMP_EPSILON) {
 					gt.origin -= result.travel;
@@ -232,7 +232,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 							// Cancel the motion.
 							Transform3D gt = get_global_transform();
 							real_t travel_total = result.travel.length();
-							real_t cancel_dist_max = MIN(0.1, margin * 20);
+							const real_t cancel_dist_max = MIN(0.1f, margin * 20.0f);
 							if (travel_total <= margin + CMP_EPSILON) {
 								gt.origin -= result.travel;
 								result.travel = Vector3(); // Cancel for constant speed computation.

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -184,7 +184,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 			// If we hit a ceiling platform, we set the vertical velocity to at least the platform one.
 			if (collision_state.ceiling && platform_ceiling_velocity != Vector3() && platform_ceiling_velocity.dot(up_direction) < 0) {
 				// If ceiling sliding is on, only apply when the ceiling is flat or when the motion is upward.
-				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (ceiling_normal + up_direction).length() < 0.01f) {
+				if (!slide_on_ceiling || motion.dot(up_direction) < 0 || (ceiling_normal + up_direction).length_squared() < 0.0001f) {
 					apply_ceiling_velocity = true;
 					Vector3 ceiling_vertical_velocity = up_direction * up_direction.dot(platform_ceiling_velocity);
 					Vector3 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
@@ -194,7 +194,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				}
 			}
 
-			if (collision_state.floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01f) {
+			if (collision_state.floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length_squared() < 0.0001f) {
 				Transform3D gt = get_global_transform();
 				if (result.travel.length() <= recovery_tolerance) {
 					gt.origin -= result.travel;

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -141,7 +141,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 	Vector3 motion = velocity * p_delta;
 	Vector3 motion_slide_up = motion.slide(up_direction);
 	Vector3 prev_floor_normal = floor_normal;
-	const real_t recovery_tolerance = margin + CMP_EPSILON;
+	const real_t recovery_tolerance_squared = (margin + CMP_EPSILON) * (margin + CMP_EPSILON);
 
 	platform_rid = RID();
 	platform_object_id = ObjectID();
@@ -196,7 +196,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 			if (collision_state.floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length_squared() < 0.0001f) {
 				Transform3D gt = get_global_transform();
-				if (result.travel.length() <= recovery_tolerance) {
+				if (result.travel.length_squared() <= recovery_tolerance_squared) {
 					gt.origin -= result.travel;
 				}
 				set_global_transform(gt);
@@ -232,12 +232,13 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						if (p_was_on_floor && !vel_dir_facing_up) {
 							// Cancel the motion.
 							Transform3D gt = get_global_transform();
-							const real_t travel_total = result.travel.length();
+							const real_t travel_total_squared = result.travel.length_squared();
 							const real_t cancel_dist_max = MIN(0.1f, margin * 20.0f);
-							if (travel_total <= recovery_tolerance) {
+							const real_t cancel_dist_max_squared = cancel_dist_max * cancel_dist_max;
+							if (travel_total_squared <= recovery_tolerance_squared) {
 								gt.origin -= result.travel;
 								result.travel = Vector3(); // Cancel for constant speed computation.
-							} else if (travel_total < cancel_dist_max) { // If the movement is large the body can be prevented from reaching the walls.
+							} else if (travel_total_squared < cancel_dist_max_squared) { // If the movement is large the body can be prevented from reaching the walls.
 								gt.origin -= result.travel.slide(up_direction);
 								// Keep remaining motion in sync with amount canceled.
 								motion = motion.slide(up_direction);
@@ -402,6 +403,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 	Vector3 motion = velocity * p_delta;
+	const real_t recovery_tolerance_squared = (margin + CMP_EPSILON) * (margin + CMP_EPSILON);
 
 	platform_rid = RID();
 	platform_object_id = ObjectID();
@@ -432,7 +434,7 @@ void CharacterBody3D::_move_and_slide_floating(double p_delta) {
 
 			if (wall_min_slide_angle != 0 && Math::acos(wall_normal.dot(-velocity.normalized())) < wall_min_slide_angle + FLOOR_ANGLE_THRESHOLD) {
 				motion = Vector3();
-				if (result.travel.length() < margin + CMP_EPSILON) {
+				if (result.travel.length_squared() < recovery_tolerance_squared) {
 					Transform3D gt = get_global_transform();
 					gt.origin -= result.travel;
 					set_global_transform(gt);
@@ -481,7 +483,7 @@ void CharacterBody3D::apply_floor_snap() {
 			// move_and_collide may stray the object a bit when getting it unstuck.
 			// Canceling this motion should not affect move_and_slide, as previous
 			// calls to move_and_collide already took care of freeing the body.
-			if (result.travel.length() > margin) {
+			if (result.travel.length_squared() > (margin * margin)) {
 				result.travel = up_direction * up_direction.dot(result.travel);
 			} else {
 				result.travel = Vector3();

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -141,6 +141,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 	Vector3 motion = velocity * p_delta;
 	Vector3 motion_slide_up = motion.slide(up_direction);
 	Vector3 prev_floor_normal = floor_normal;
+	const real_t recovery_tolerance = margin + CMP_EPSILON;
 
 	platform_rid = RID();
 	platform_object_id = ObjectID();
@@ -187,7 +188,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					apply_ceiling_velocity = true;
 					Vector3 ceiling_vertical_velocity = up_direction * up_direction.dot(platform_ceiling_velocity);
 					Vector3 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
-					if (motion_vertical_velocity.dot(up_direction) > 0 || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
+					if (motion_vertical_velocity.dot(up_direction) > 0.0f || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
 						velocity = ceiling_vertical_velocity + velocity.slide(up_direction);
 					}
 				}
@@ -195,7 +196,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 			if (collision_state.floor && floor_stop_on_slope && (velocity.normalized() + up_direction).length() < 0.01f) {
 				Transform3D gt = get_global_transform();
-				if (result.travel.length() <= margin + CMP_EPSILON) {
+				if (result.travel.length() <= recovery_tolerance) {
 					gt.origin -= result.travel;
 				}
 				set_global_transform(gt);
@@ -219,9 +220,9 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				if (floor_block_on_wall) {
 					// Needs horizontal motion from current motion instead of motion_slide_up
 					// to properly test the angle and avoid standing on slopes
-					Vector3 horizontal_motion = motion.slide(up_direction);
-					Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
-					real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(horizontal_motion.normalized())));
+					const Vector3 horizontal_motion = motion.slide(up_direction);
+					const Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
+					const real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(horizontal_motion.normalized())));
 
 					// Avoid to move forward on a wall if floor_block_on_wall is true.
 					// Applies only when the motion angle is under 90 degrees,
@@ -231,9 +232,9 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						if (p_was_on_floor && !vel_dir_facing_up) {
 							// Cancel the motion.
 							Transform3D gt = get_global_transform();
-							real_t travel_total = result.travel.length();
+							const real_t travel_total = result.travel.length();
 							const real_t cancel_dist_max = MIN(0.1f, margin * 20.0f);
-							if (travel_total <= margin + CMP_EPSILON) {
+							if (travel_total <= recovery_tolerance) {
 								gt.origin -= result.travel;
 								result.travel = Vector3(); // Cancel for constant speed computation.
 							} else if (travel_total < cancel_dist_max) { // If the movement is large the body can be prevented from reaching the walls.
@@ -255,12 +256,12 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						}
 
 						// Apply slide on forward in order to allow only lateral motion on next step.
-						Vector3 forward = wall_normal.slide(up_direction).normalized();
+						const Vector3 forward = wall_normal.slide(up_direction).normalized();
 						motion = motion.slide(forward);
 
 						// Scales the horizontal velocity according to the wall slope.
 						if (vel_dir_facing_up) {
-							Vector3 slide_motion = velocity.slide(result.collisions[0].normal);
+							const Vector3 slide_motion = velocity.slide(result.collisions[0].normal);
 							// Keeps the vertical motion from velocity and add the horizontal motion of the projection.
 							velocity = up_direction * up_direction.dot(velocity) + slide_motion.slide(up_direction);
 						} else {
@@ -283,7 +284,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 						// Allow sliding when the body falls.
 						if (!collision_state.floor && motion.dot(up_direction) < 0) {
-							Vector3 slide_motion = motion.slide(wall_normal);
+							const Vector3 slide_motion = motion.slide(wall_normal);
 							// Test again to allow sliding only if the result goes downwards.
 							// Fixes jittering issues at the bottom of inclined walls.
 							if (slide_motion.dot(up_direction) < 0) {
@@ -301,8 +302,8 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 				// Stop horizontal motion when under wall slide threshold.
 				if (p_was_on_floor && (wall_min_slide_angle > 0.0) && result_state.wall) {
-					Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
-					real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(motion_slide_up.normalized())));
+					const Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
+					const real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(motion_slide_up.normalized())));
 					if (motion_angle < wall_min_slide_angle) {
 						motion = up_direction * motion.dot(up_direction);
 						velocity = up_direction * velocity.dot(up_direction);

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -139,11 +139,11 @@ bool PhysicsBody3D::move_and_collide(const PhysicsServer3D::MotionParameters &p_
 			// Check depth of recovery.
 			real_t projected_length = r_result.travel.dot(motion_normal);
 			Vector3 recovery = r_result.travel - motion_normal * projected_length;
-			const real_t recovery_length = recovery.length();
+			const real_t recovery_length_squared = recovery.length_squared();
 			const real_t recovery_max_threshold = p_parameters.margin + precision;
 			// Fixes cases where canceling slide causes the motion to go too deep into the ground,
 			// because we're only taking rest information into account and not general recovery.
-			if (recovery_length < recovery_max_threshold) {
+			if (recovery_length_squared < recovery_max_threshold * recovery_max_threshold) {
 				// Apply adjustment to motion.
 				r_result.travel = motion_normal * projected_length;
 				r_result.remainder = p_parameters.motion - r_result.travel;

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -139,10 +139,11 @@ bool PhysicsBody3D::move_and_collide(const PhysicsServer3D::MotionParameters &p_
 			// Check depth of recovery.
 			real_t projected_length = r_result.travel.dot(motion_normal);
 			Vector3 recovery = r_result.travel - motion_normal * projected_length;
-			real_t recovery_length = recovery.length();
+			const real_t recovery_length = recovery.length();
+			const real_t recovery_max_threshold = p_parameters.margin + precision;
 			// Fixes cases where canceling slide causes the motion to go too deep into the ground,
 			// because we're only taking rest information into account and not general recovery.
-			if (recovery_length < p_parameters.margin + precision) {
+			if (recovery_length < recovery_max_threshold) {
 				// Apply adjustment to motion.
 				r_result.travel = motion_normal * projected_length;
 				r_result.remainder = p_parameters.motion - r_result.travel;

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -614,7 +614,7 @@ void Voxelizer::_fixup_plot(int p_idx, int p_level) {
 		bake_cells.write[p_idx].normal[2] /= alpha;
 
 		Vector3 n(bake_cells[p_idx].normal[0], bake_cells[p_idx].normal[1], bake_cells[p_idx].normal[2]);
-		if (n.length() < 0.01) {
+		if (n.length() < 0.01f) {
 			//too much fight over normal, zero it
 			bake_cells.write[p_idx].normal[0] = 0;
 			bake_cells.write[p_idx].normal[1] = 0;

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -614,7 +614,7 @@ void Voxelizer::_fixup_plot(int p_idx, int p_level) {
 		bake_cells.write[p_idx].normal[2] /= alpha;
 
 		Vector3 n(bake_cells[p_idx].normal[0], bake_cells[p_idx].normal[1], bake_cells[p_idx].normal[2]);
-		if (n.length() < 0.01f) {
+		if (n.length_squared() < 0.0001f) {
 			//too much fight over normal, zero it
 			bake_cells.write[p_idx].normal[0] = 0;
 			bake_cells.write[p_idx].normal[1] = 0;

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -496,7 +496,7 @@ Vector2 AnimationNodeBlendSpace2D::get_closest_point(const Vector2 &p_point) {
 			const Vector2 segment_a = points[j];
 			const Vector2 segment_b = points[(j + 1) % 3];
 			Vector2 closest_point = Geometry2D::get_closest_point_to_segment(p_point, segment_a, segment_b);
-			if (first || closest_point.distance_to(p_point) < best_point.distance_to(p_point)) {
+			if (first || closest_point.distance_squared_to(p_point) < best_point.distance_squared_to(p_point)) {
 				best_point = closest_point;
 				first = false;
 			}
@@ -590,7 +590,7 @@ AnimationNode::NodeTimeInfo AnimationNodeBlendSpace2D::_process(ProcessState &p_
 				const Vector2 segment_a = points[j];
 				const Vector2 segment_b = points[(j + 1) % 3];
 				Vector2 closest2 = Geometry2D::get_closest_point_to_segment(blend_pos, segment_a, segment_b);
-				if (first || closest2.distance_to(blend_pos) < best_point.distance_to(blend_pos)) {
+				if (first || closest2.distance_squared_to(blend_pos) < best_point.distance_squared_to(blend_pos)) {
 					best_point = closest2;
 					blend_triangle = i;
 					first = false;

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -744,7 +744,7 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 	const Vector2 center = uv_size * 0.5;
 
 	if (is_click && !spinning) {
-		real_t dist = center.distance_to(event_position);
+		const real_t dist = center.distance_to(event_position);
 		if (dist >= center.x * (WHEEL_RADIUS * 2.0f) && dist <= center.x) {
 			spinning = true;
 			if (!wheel_focused) {
@@ -861,13 +861,13 @@ void ColorPickerShapeCircle::update_circle_cursor(const Vector2 &p_color_change_
 		circle_keyboard_joypad_picker_cursor_position = p_center + p_hue_offset;
 	}
 
-	Vector2i potential_cursor_position = circle_keyboard_joypad_picker_cursor_position + p_color_change_vector;
-	real_t potential_new_cursor_distance = p_center.distance_to(potential_cursor_position);
-	real_t dist_pre = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
+	const Vector2i potential_cursor_position = circle_keyboard_joypad_picker_cursor_position + p_color_change_vector;
+	const real_t potential_new_cursor_distance = p_center.distance_to(potential_cursor_position);
+	const real_t dist_pre = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
 	if (color_picker->s < 1 || potential_new_cursor_distance < dist_pre) {
 		circle_keyboard_joypad_picker_cursor_position += p_color_change_vector;
-		real_t dist = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
-		real_t rad = p_center.angle_to_point(circle_keyboard_joypad_picker_cursor_position);
+		const real_t dist = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
+		const real_t rad = p_center.angle_to_point(circle_keyboard_joypad_picker_cursor_position);
 		color_picker->h = ((rad >= 0) ? rad : (Math::TAU + rad)) / Math::TAU;
 		color_picker->s = CLAMP(dist / p_center.x, 0, 1);
 	} else {

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -862,9 +862,9 @@ void ColorPickerShapeCircle::update_circle_cursor(const Vector2 &p_color_change_
 	}
 
 	const Vector2i potential_cursor_position = circle_keyboard_joypad_picker_cursor_position + p_color_change_vector;
-	const real_t potential_new_cursor_distance = p_center.distance_to(potential_cursor_position);
-	const real_t dist_pre = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
-	if (color_picker->s < 1 || potential_new_cursor_distance < dist_pre) {
+	const real_t potential_new_cursor_distance_squared = p_center.distance_squared_to(potential_cursor_position);
+	const real_t dist_pre_squared = p_center.distance_squared_to(circle_keyboard_joypad_picker_cursor_position);
+	if (color_picker->s < 1 || potential_new_cursor_distance_squared < dist_pre_squared) {
 		circle_keyboard_joypad_picker_cursor_position += p_color_change_vector;
 		const real_t dist = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
 		const real_t rad = p_center.angle_to_point(circle_keyboard_joypad_picker_cursor_position);

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -745,7 +745,7 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 
 	if (is_click && !spinning) {
 		real_t dist = center.distance_to(event_position);
-		if (dist >= center.x * WHEEL_RADIUS * 2.0 && dist <= center.x) {
+		if (dist >= center.x * (WHEEL_RADIUS * 2.0f) && dist <= center.x) {
 			spinning = true;
 			if (!wheel_focused) {
 				cursor_editing = true;

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -744,14 +744,15 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 	const Vector2 center = uv_size * 0.5;
 
 	if (is_click && !spinning) {
-		const real_t dist = center.distance_to(event_position);
-		if (dist >= center.x * (WHEEL_RADIUS * 2.0f) && dist <= center.x) {
+		const real_t dist_squared = center.distance_squared_to(event_position);
+		const real_t min_dist_squared = (center.x * (WHEEL_RADIUS * 2.0f)) * (center.x * (WHEEL_RADIUS * 2.0f));
+		if (dist_squared >= min_dist_squared && dist_squared <= (center.x * center.x)) {
 			spinning = true;
 			if (!wheel_focused) {
 				cursor_editing = true;
 				wheel_focused = true;
 			}
-		} else if (dist > center.x) {
+		} else if (dist_squared > (center.x * center.x)) {
 			// Clicked outside the wheel.
 			cancel_event();
 			return;

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -54,6 +54,7 @@
 constexpr int MINIMAP_OFFSET = 12;
 constexpr int MINIMAP_PADDING = 5;
 constexpr int MIN_DRAG_DISTANCE_FOR_VALID_CONNECTION = 20;
+constexpr int MIN_DRAG_DISTANCE_FOR_VALID_CONNECTION_SQUARED = MIN_DRAG_DISTANCE_FOR_VALID_CONNECTION * MIN_DRAG_DISTANCE_FOR_VALID_CONNECTION;
 constexpr int MAX_CONNECTION_LINE_CURVE_TESSELATION_STAGES = 5;
 constexpr int GRID_MINOR_STEPS_PER_MAJOR_LINE = 10;
 constexpr int GRID_MINOR_STEPS_PER_MAJOR_DOT = 5;
@@ -1335,7 +1336,7 @@ void GraphEdit::_top_connection_layer_input(const Ref<InputEvent> &p_ev) {
 		minimap->queue_redraw();
 		callable_mp(this, &GraphEdit::_update_top_connection_layer).call_deferred();
 
-		connecting_valid = just_disconnected || click_pos.distance_to(connecting_to_point / zoom) > MIN_DRAG_DISTANCE_FOR_VALID_CONNECTION;
+		connecting_valid = just_disconnected || click_pos.distance_squared_to(connecting_to_point / zoom) > MIN_DRAG_DISTANCE_FOR_VALID_CONNECTION_SQUARED;
 
 		if (connecting_valid) {
 			Vector2 mpos = mm->get_position() / zoom;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -525,7 +525,8 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				if (selecting_enabled && !text.is_empty()) {
 					const int triple_click_timeout = 600;
 					const int triple_click_tolerance = 5;
-					const bool is_triple_click = !b->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && b->get_position().distance_to(last_dblclk_pos) < triple_click_tolerance;
+					const int triple_click_tolerance_squared = triple_click_tolerance * triple_click_tolerance;
+					const bool is_triple_click = !b->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && b->get_position().distance_squared_to(last_dblclk_pos) < triple_click_tolerance_squared;
 
 					if (is_triple_click) {
 						// Triple-click select all.

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -358,7 +358,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			drag.diff_y += mm->get_relative().y;
 			double diff_y = -0.01 * Math::pow(Math::abs(drag.diff_y), 1.8) * SIGN(drag.diff_y);
 			set_value(CLAMP(drag.base_val + step * diff_y, get_min(), get_max()));
-		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2.0f) {
+		} else if (drag.allowed && drag.capture_pos.distance_squared_to(mm->get_position()) > 4.0f) {
 			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 			drag.enabled = true;
 			drag.base_val = get_value();

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -358,7 +358,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			drag.diff_y += mm->get_relative().y;
 			double diff_y = -0.01 * Math::pow(Math::abs(drag.diff_y), 1.8) * SIGN(drag.diff_y);
 			set_value(CLAMP(drag.base_val + step * diff_y, get_min(), get_max()));
-		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
+		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2.0f) {
 			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 			drag.enabled = true;
 			drag.base_val = get_value();

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2341,7 +2341,8 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				const int triple_click_timeout = 600;
 				const int triple_click_tolerance = 5;
-				bool is_triple_click = (!mb->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && mb->get_position().distance_to(last_dblclk_pos) < triple_click_tolerance);
+				const int triple_click_tolerance_squared = triple_click_tolerance * triple_click_tolerance;
+				bool is_triple_click = (!mb->is_double_click() && (OS::get_singleton()->get_ticks_msec() - last_dblclk) < triple_click_timeout && mb->get_position().distance_squared_to(last_dblclk_pos) < triple_click_tolerance_squared);
 
 				if (!mb->is_double_click() && !is_triple_click) {
 					if (mb->is_alt_pressed()) {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4061,7 +4061,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (rtl) {
 					cpos.x = get_size().width - cpos.x;
 				}
-				if (cpos.distance_to(pressing_pos) > 2.0f) {
+				if (cpos.distance_squared_to(pressing_pos) > 4.0f) {
 					range_drag_enabled = true;
 					range_drag_capture_pos = cpos;
 					range_drag_base = popup_edited_item->get_range(popup_edited_item_col);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4061,7 +4061,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (rtl) {
 					cpos.x = get_size().width - cpos.x;
 				}
-				if (cpos.distance_to(pressing_pos) > 2) {
+				if (cpos.distance_to(pressing_pos) > 2.0f) {
 					range_drag_enabled = true;
 					range_drag_capture_pos = cpos;
 					range_drag_base = popup_edited_item->get_range(popup_edited_item_col);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -57,7 +57,7 @@ bool CanvasItem::_edit_is_selected_on_click(const Point2 &p_point, double p_tole
 	if (_edit_use_rect()) {
 		return _edit_get_rect().has_point(p_point);
 	} else {
-		return p_point.length() < p_tolerance;
+		return p_point.length_squared() < (p_tolerance * p_tolerance);
 	}
 }
 #endif // DEBUG_ENABLED

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2057,7 +2057,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Viewport *section_root = get_section_root_viewport();
 		if (!gui.drag_attempted && gui.mouse_focus && section_root && !section_root->gui.global_dragging && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 			gui.drag_accum += mm->get_relative();
-			float len = gui.drag_accum.length();
+			const real_t len = gui.drag_accum.length();
 			if (len > gui.drag_threshold) {
 				{ // Attempt grab, try parent controls too.
 					CanvasItem *ci = gui.mouse_focus;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2057,8 +2057,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Viewport *section_root = get_section_root_viewport();
 		if (!gui.drag_attempted && gui.mouse_focus && section_root && !section_root->gui.global_dragging && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 			gui.drag_accum += mm->get_relative();
-			const real_t len = gui.drag_accum.length();
-			if (len > gui.drag_threshold) {
+			const real_t len_squared = gui.drag_accum.length_squared();
+			if (len_squared > gui.drag_threshold * gui.drag_threshold) {
 				{ // Attempt grab, try parent controls too.
 					CanvasItem *ci = gui.mouse_focus;
 					while (ci) {

--- a/scene/resources/2d/circle_shape_2d.cpp
+++ b/scene/resources/2d/circle_shape_2d.cpp
@@ -35,7 +35,8 @@
 #include "servers/rendering/rendering_server.h"
 
 bool CircleShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
-	return p_point.length() < get_radius() + p_tolerance;
+	const double detection_radius = get_radius() + p_tolerance;
+	return p_point.length_squared() < detection_radius * detection_radius;
 }
 
 void CircleShape2D::_update_shape() {

--- a/scene/resources/2d/concave_polygon_shape_2d.cpp
+++ b/scene/resources/2d/concave_polygon_shape_2d.cpp
@@ -36,6 +36,7 @@
 #include "servers/rendering/rendering_server.h"
 
 bool ConcavePolygonShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	const double tolerance_squared = p_tolerance * p_tolerance;
 	Vector<Vector2> s = get_segments();
 	int len = s.size();
 	if (len == 0 || (len % 2) == 1) {
@@ -45,7 +46,7 @@ bool ConcavePolygonShape2D::_edit_is_selected_on_click(const Point2 &p_point, do
 	const Vector2 *r = s.ptr();
 	for (int i = 0; i < len; i += 2) {
 		Vector2 closest = Geometry2D::get_closest_point_to_segment(p_point, r[i], r[i + 1]);
-		if (p_point.distance_to(closest) < p_tolerance) {
+		if (p_point.distance_squared_to(closest) < tolerance_squared) {
 			return true;
 		}
 	}

--- a/scene/resources/2d/segment_shape_2d.cpp
+++ b/scene/resources/2d/segment_shape_2d.cpp
@@ -37,7 +37,7 @@
 
 bool SegmentShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
 	Vector2 closest = Geometry2D::get_closest_point_to_segment(p_point, a, b);
-	return p_point.distance_to(closest) < p_tolerance;
+	return p_point.distance_squared_to(closest) < (p_tolerance * p_tolerance);
 }
 
 void SegmentShape2D::_update_shape() {

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -47,7 +47,8 @@ void SeparationRayShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
 	const float max_arrow_size = 6;
 	const float line_width = 1.4;
-	const bool no_line = target_position.length() < line_width;
+	const float line_width_squared = line_width * line_width;
+	const bool no_line = target_position.length_squared() < line_width_squared;
 	float arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -47,7 +47,7 @@ void SeparationRayShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
 	const float max_arrow_size = 6;
 	const float line_width = 1.4;
-	bool no_line = target_position.length() < line_width;
+	const bool no_line = target_position.length() < line_width;
 	float arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {

--- a/scene/resources/2d/world_boundary_shape_2d.cpp
+++ b/scene/resources/2d/world_boundary_shape_2d.cpp
@@ -36,19 +36,20 @@
 #include "servers/rendering/rendering_server.h"
 
 bool WorldBoundaryShape2D::_edit_is_selected_on_click(const Point2 &p_point, double p_tolerance) const {
+	const double tolerance_squared = p_tolerance * p_tolerance;
 	const Vector2 shape_center = distance * normal;
 	// Orthogonal part of the shape editor gizmo (the flat line).
 	const Vector2 ortho_segment_a = shape_center - normal.orthogonal() * 100;
 	const Vector2 ortho_segment_b = shape_center + normal.orthogonal() * 100;
 	const Vector2 ortho_closest = Geometry2D::get_closest_point_to_segment(p_point, ortho_segment_a, ortho_segment_b);
-	if (p_point.distance_to(ortho_closest) < p_tolerance) {
+	if (p_point.distance_squared_to(ortho_closest) < tolerance_squared) {
 		return true;
 	}
 	// Normal part of the shape editor gizmo (the arrow).
 	const Vector2 normal_segment_a = shape_center;
 	const Vector2 normal_segment_b = shape_center + normal * 30;
 	const Vector2 normal_closest = Geometry2D::get_closest_point_to_segment(p_point, normal_segment_a, normal_segment_b);
-	if (p_point.distance_to(normal_closest) < p_tolerance) {
+	if (p_point.distance_squared_to(normal_closest) < tolerance_squared) {
 		return true;
 	}
 	return false;

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4153,11 +4153,12 @@ bool Animation::_float_track_optimize_key(const TKey<float> t0, const TKey<float
 }
 
 bool Animation::_vector2_track_optimize_key(const TKey<Vector2> t0, const TKey<Vector2> t1, const TKey<Vector2> t2, real_t p_allowed_velocity_err, real_t p_allowed_angular_error, real_t p_allowed_precision_error, bool p_is_nearest) {
+	const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 	// Remove overlapping keys.
 	if (Math::is_equal_approx(t0.time, t1.time) || Math::is_equal_approx(t1.time, t2.time)) {
 		return true;
 	}
-	if ((t0.value - t1.value).length() < p_allowed_precision_error && (t1.value - t2.value).length() < p_allowed_precision_error) {
+	if ((t0.value - t1.value).length_squared() < allowed_precision_error_squared && (t1.value - t2.value).length_squared() < allowed_precision_error_squared) {
 		return true;
 	}
 	if (p_is_nearest) {
@@ -4187,11 +4188,12 @@ bool Animation::_vector2_track_optimize_key(const TKey<Vector2> t0, const TKey<V
 }
 
 bool Animation::_vector3_track_optimize_key(const TKey<Vector3> t0, const TKey<Vector3> t1, const TKey<Vector3> t2, real_t p_allowed_velocity_err, real_t p_allowed_angular_error, real_t p_allowed_precision_error, bool p_is_nearest) {
+	const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 	// Remove overlapping keys.
 	if (Math::is_equal_approx(t0.time, t1.time) || Math::is_equal_approx(t1.time, t2.time)) {
 		return true;
 	}
-	if ((t0.value - t1.value).length() < p_allowed_precision_error && (t1.value - t2.value).length() < p_allowed_precision_error) {
+	if ((t0.value - t1.value).length_squared() < allowed_precision_error_squared && (t1.value - t2.value).length_squared() < allowed_precision_error_squared) {
 		return true;
 	}
 	if (p_is_nearest) {
@@ -4222,11 +4224,12 @@ bool Animation::_vector3_track_optimize_key(const TKey<Vector3> t0, const TKey<V
 }
 
 bool Animation::_quaternion_track_optimize_key(const TKey<Quaternion> t0, const TKey<Quaternion> t1, const TKey<Quaternion> t2, real_t p_allowed_velocity_err, real_t p_allowed_angular_error, real_t p_allowed_precision_error, bool p_is_nearest) {
+	const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 	// Remove overlapping keys.
 	if (Math::is_equal_approx(t0.time, t1.time) || Math::is_equal_approx(t1.time, t2.time)) {
 		return true;
 	}
-	if ((t0.value - t1.value).length() < p_allowed_precision_error && (t1.value - t2.value).length() < p_allowed_precision_error) {
+	if ((t0.value - t1.value).length_squared() < allowed_precision_error_squared && (t1.value - t2.value).length_squared() < allowed_precision_error_squared) {
 		return true;
 	}
 	if (p_is_nearest) {
@@ -4281,8 +4284,9 @@ void Animation::_position_track_optimize(int p_idx, real_t p_allowed_velocity_er
 		}
 	}
 
+	const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 	if (tt->positions.size() == 2) {
-		if ((tt->positions[0].value - tt->positions[1].value).length() < p_allowed_precision_error) {
+		if ((tt->positions[0].value - tt->positions[1].value).length_squared() < allowed_precision_error_squared) {
 			tt->positions.remove_at(1);
 		}
 	}
@@ -4311,8 +4315,9 @@ void Animation::_rotation_track_optimize(int p_idx, real_t p_allowed_velocity_er
 		}
 	}
 
+	const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 	if (rt->rotations.size() == 2) {
-		if ((rt->rotations[0].value - rt->rotations[1].value).length() < p_allowed_precision_error) {
+		if ((rt->rotations[0].value - rt->rotations[1].value).length_squared() < allowed_precision_error_squared) {
 			rt->rotations.remove_at(1);
 		}
 	}
@@ -4341,8 +4346,9 @@ void Animation::_scale_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 		}
 	}
 
+	const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 	if (st->scales.size() == 2) {
-		if ((st->scales[0].value - st->scales[1].value).length() < p_allowed_precision_error) {
+		if ((st->scales[0].value - st->scales[1].value).length_squared() < allowed_precision_error_squared) {
 			st->scales.remove_at(1);
 		}
 	}
@@ -4469,6 +4475,7 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 	}
 
 	if (vt->values.size() == 2) {
+		const real_t allowed_precision_error_squared = p_allowed_precision_error * p_allowed_precision_error;
 		bool single_key = false;
 		switch (type) {
 			case Variant::FLOAT: {
@@ -4483,17 +4490,17 @@ void Animation::_value_track_optimize(int p_idx, real_t p_allowed_velocity_err, 
 			case Variant::VECTOR2: {
 				Vector2 val_0 = vt->values[0].value;
 				Vector2 val_1 = vt->values[1].value;
-				single_key = (val_0 - val_1).length() < p_allowed_precision_error;
+				single_key = (val_0 - val_1).length_squared() < allowed_precision_error_squared;
 			} break;
 			case Variant::VECTOR3: {
 				Vector3 val_0 = vt->values[0].value;
 				Vector3 val_1 = vt->values[1].value;
-				single_key = (val_0 - val_1).length() < p_allowed_precision_error;
+				single_key = (val_0 - val_1).length_squared() < allowed_precision_error_squared;
 			} break;
 			case Variant::QUATERNION: {
 				Quaternion val_0 = vt->values[0].value;
 				Quaternion val_1 = vt->values[1].value;
-				single_key = (val_0 - val_1).length() < p_allowed_precision_error;
+				single_key = (val_0 - val_1).length_squared() < allowed_precision_error_squared;
 			} break;
 			default: {
 			} break;

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -439,7 +439,8 @@ static Vector<Vector2> reduce(const Vector<Vector2> &points, const Rect2i &rect,
 
 	Vector2 last = result[result.size() - 1];
 
-	if (last.y > result[0].y && last.distance_to(result[0]) < ep * 0.5f) {
+	const float tolerance_squared = (ep * 0.5f) * (ep * 0.5f);
+	if (last.y > result[0].y && last.distance_squared_to(result[0]) < tolerance_squared) {
 		result.write[0].y = last.y;
 		result.resize(result.size() - 1);
 	}

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -818,9 +818,9 @@ void Curve2D::_bake_segment2d_even_length(RBMap<real_t, Vector2> &r_bake, real_t
 	Vector2 beg = p_a.bezier_interpolate(p_a + p_out, p_b + p_in, p_b, p_begin);
 	Vector2 end = p_a.bezier_interpolate(p_a + p_out, p_b + p_in, p_b, p_end);
 
-	real_t length = beg.distance_to(end);
+	real_t length_squared = beg.distance_squared_to(end);
 
-	if (length > p_length && p_depth < p_max_depth) {
+	if (length_squared > (p_length * p_length) && p_depth < p_max_depth) {
 		real_t mp = (p_begin + p_end) * 0.5;
 		Vector2 mid = p_a.bezier_interpolate(p_a + p_out, p_b + p_in, p_b, mp);
 		r_bake[mp] = mid;
@@ -1535,9 +1535,9 @@ void Curve3D::_bake_segment3d_even_length(RBMap<real_t, Vector3> &r_bake, real_t
 	Vector3 beg = p_a.bezier_interpolate(p_a + p_out, p_b + p_in, p_b, p_begin);
 	Vector3 end = p_a.bezier_interpolate(p_a + p_out, p_b + p_in, p_b, p_end);
 
-	real_t length = beg.distance_to(end);
+	real_t length_squared = beg.distance_squared_to(end);
 
-	if (length > p_length && p_depth < p_max_depth) {
+	if (length_squared > (p_length * p_length) && p_depth < p_max_depth) {
 		real_t mp = (p_begin + p_end) * 0.5;
 		Vector3 mid = p_a.bezier_interpolate(p_a + p_out, p_b + p_in, p_b, mp);
 		r_bake[mp] = mid;


### PR DESCRIPTION
Revival of PR #108358. I looked through each commit, and modified it a little bit, but mostly this is the work of @AThousandShips so I kept the same author on the commits.

Even if the benefits are too negligible to show up on benchmarks, I think this is still worth doing. We don't have to label this PR as performance if the performance difference isn't measurable, we could just call it code hygiene to use the squared functions where applicable because that way we're following the same guideline internally as we recommend to users (["prefer it if you need to compare vectors or need the squared distance for some formula"](https://docs.godotengine.org/en/stable/classes/class_vector2.html#class-vector2-method-length-squared)).

The changes I made on top of ATS's work:
* Remove parenthesis for assignments as noted here https://github.com/godotengine/godot/pull/108358#discussion_r2191014240
* Only make a variable to hold length squared when it's used multiple times, otherwise do an in-place multiply.
* Chance one case of `float` to `real_t` in `godot_body_pair_3d.cpp`, avoids a needless cast in double builds.
* Order variables by size (`Vector2`, then `real_t`, then `int`).
* Add `const` in a few places.
* Rename the commits to say what they do.