### PR TITLE
Use `org.a11y.Status/ScreenReaderEnabled` on Linux.

### DIFF
--- a/platform/linuxbsd/freedesktop_at_spi_monitor.h
+++ b/platform/linuxbsd/freedesktop_at_spi_monitor.h
@@ -40,6 +40,7 @@ private:
 	Thread thread;
 
 	SafeFlag exit_thread;
+	SafeFlag ac_enabled;
 	SafeFlag sr_enabled;
 	SafeFlag supported;
 
@@ -50,7 +51,7 @@ public:
 	~FreeDesktopAtSPIMonitor();
 
 	bool is_supported() { return supported.is_set(); }
-	bool is_active() { return sr_enabled.is_set(); }
+	bool is_active() { return sr_enabled.is_set() && ac_enabled.is_set(); }
 };
 
 #endif // DBUS_ENABLED


### PR DESCRIPTION
This is technically the wrong flag to check, but seems to be what's actually used on a lot of Linux setups, and is working fine with system screen readers.

Probably should be reverted in the future. But since `AccessKit` seems to be still not entirely stable on Linux, it seems like a good idea to be more aggressive with screen reader detection for now. This should prevent unnecessary overhead on Linux. Should still work with default screen readers that are integrated with DE. And if something completely custom is used, it's always possible to use a command line argument or setting to force it on.

Should fix https://github.com/godotengine/godot/issues/109734 and fix https://github.com/godotengine/godot/issues/109732 for users who aren't using screen reader.