### PR TITLE
Add rerasterization on `SVGTexture::set_size_override()`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4122,7 +4122,7 @@ Error Image::load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale) {
 
 	ERR_FAIL_COND_V(buffer_size == 0, ERR_INVALID_PARAMETER);
 
-	Ref<Image> image = _svg_scalable_mem_loader_func(p_array.ptr(), buffer_size, scale);
+	Ref<Image> image = _svg_scalable_mem_loader_func(p_array.ptr(), buffer_size, scale, Size2(), nullptr);
 	ERR_FAIL_COND_V(image.is_null(), ERR_PARSE_ERROR);
 
 	copy_internals_from(image);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -50,7 +50,7 @@ typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, floa
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
 
 typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_data, int p_size);
-typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale);
+typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale, const Size2 &p_custom_dimensions, Size2 *r_base_size);
 
 typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const bool p_lossy, const float p_quality);

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -863,7 +863,7 @@ void EditorAssetLibrary::_image_update(bool p_use_cache, bool p_final, const Pac
 		} else if ((memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {
 			parsed_image = Image::_bmp_mem_loader_func(r, len);
 		} else if (Image::_svg_scalable_mem_loader_func) {
-			parsed_image = Image::_svg_scalable_mem_loader_func(r, len, 1.0);
+			parsed_image = Image::_svg_scalable_mem_loader_func(r, len, 1.0, Size2(), nullptr);
 		}
 
 		if (parsed_image.is_null()) {

--- a/modules/svg/image_loader_svg.h
+++ b/modules/svg/image_loader_svg.h
@@ -37,15 +37,15 @@ class ImageLoaderSVG : public ImageFormatLoader {
 
 	static void _replace_color_property(const HashMap<Color, Color> &p_color_map, const String &p_prefix, String &r_string);
 
-	static Ref<Image> load_mem_svg(const uint8_t *p_svg, int p_size, float p_scale);
+	static Ref<Image> load_mem_svg(const uint8_t *p_svg, int p_size, float p_scale, const Size2 &p_custom_dimensions = Size2(), Size2 *r_base_size = nullptr);
 
 public:
 	static void set_forced_color_map(const HashMap<Color, Color> &p_color_map);
 
-	static Error create_image_from_utf8_buffer(Ref<Image> p_image, const uint8_t *p_buffer, int p_buffer_size, float p_scale, bool p_upsample);
-	static Error create_image_from_utf8_buffer(Ref<Image> p_image, const PackedByteArray &p_buffer, float p_scale, bool p_upsample);
+	static Error create_image_from_utf8_buffer(Ref<Image> p_image, const uint8_t *p_buffer, int p_buffer_size, float p_scale, bool p_upsample, const Size2 &p_custom_dimensions = Size2(), Size2 *r_base_size = nullptr);
+	static Error create_image_from_utf8_buffer(Ref<Image> p_image, const PackedByteArray &p_buffer, float p_scale, bool p_upsample, const Size2 &p_custom_dimensions = Size2(), Size2 *r_base_size = nullptr);
 
-	static Error create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
+	static Error create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map, const Size2 &p_custom_dimensions = Size2(), Size2 *r_base_size = nullptr);
 
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/scene/resources/svg_texture.h
+++ b/scene/resources/svg_texture.h
@@ -61,7 +61,7 @@ class SVGTexture : public Texture2D {
 
 	void _remove_scale(double p_scale);
 	RID _ensure_scale(double p_scale) const;
-	RID _load_at_scale(double p_scale, bool p_set_size) const;
+	RID _load_at_scale(double p_scale, bool p_set_size, const Size2i &p_custom_dimensions = Size2i()) const;
 	void _update_texture();
 	void _clear();
 
@@ -96,6 +96,7 @@ public:
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
 	virtual void draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = true) const override;
 
+	Size2i get_size_override() const { return size_override; }
 	void set_size_override(const Size2i &p_size);
 	bool is_pixel_opaque(int p_x, int p_y) const override;
 


### PR DESCRIPTION
This adds rerasterization on `SVGTexture::set_size_override()`. It also adds `SVGTexture::get_size_override()`.

## Why it's needed for 4.5

This PR is kinda critical for SVGTexture (IMHO needed for 4.5 as it's a new feature), as it adds a way to rerender the SVG to any size needed. Without this, when setting `SVGTexture::set_size_override()`, it only stretched the rendered texture, making it blurry (defeating the nice thing about SVGs).

### Context

I created this PR in the context of writing the `SVGTexture` feature for the release page. While discussing with @bruvzg who implemented the initial PR, he told me that SVGTextures were only re-resterised with viewport oversampling (i.e. when the UI scales with the viewport stretch mode set to `canvas_items`.[^1]

This makes the rendering of a SVG file highly dependent on its native size. And from experience, the native size is often arbitrary, due to its vector-based nature.

So without this PR:
- There's no way to set an arbitrary size that doesn't follow the initial aspect ratio.
- The only way to set it to an arbitrary size (that follow the aspect ratio) is to adjust the `base_scale` property to be the result of the wanted size divided by the original size. This is kinda awkward and this makes you lose the usage of the `base_scale` property to just multiply the value at will.

[^1]: This makes it really hard to explain: "yeah, you can use SVG files now, but only at their specified size"