### PR TITLE
Fix audio bus send OptionButton height

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -222,7 +222,7 @@ void EditorAudioBus::update_send() {
 	send->clear();
 	if (is_master) {
 		send->set_disabled(true);
-		send->set_text(TTR("Speakers"));
+		send->add_item(TTRC("Speakers"));
 	} else {
 		send->set_disabled(false);
 		StringName current_send = AudioServer::get_singleton()->get_bus_send(get_index());


### PR DESCRIPTION
Fixes (partially): https://github.com/godotengine/godot/issues/109661 (The bus dropdown part)

Went with this as a fix as the doc says not to set text manually for OptionButtons.

> Note: The [Button.text](https://docs.godotengine.org/en/stable/classes/class_button.html#class-button-property-text) and [Button.icon](https://docs.godotengine.org/en/stable/classes/class_button.html#class-button-property-icon) properties are set automatically based on the selected item. They shouldn't be changed manually.

After:

<img width="320" height="438" alt="Screenshot_20250818_183559" src="https://github.com/user-attachments/assets/20b3c803-f39c-454d-b1e4-6c80e4c5fa40" />

