### PR TITLE
Core: Integrate semantic constants in math structs

### DIFF
--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -34,6 +34,10 @@
 #include "core/math/vector3.h"
 
 struct [[nodiscard]] Basis {
+	static const Basis FLIP_X;
+	static const Basis FLIP_Y;
+	static const Basis FLIP_Z;
+
 	Vector3 rows[3] = {
 		Vector3(1, 0, 0),
 		Vector3(0, 1, 0),
@@ -224,7 +228,7 @@ struct [[nodiscard]] Basis {
 
 	operator Quaternion() const { return get_quaternion(); }
 
-	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
+	static Basis looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 
 	Basis(const Quaternion &p_quaternion) { set_quaternion(p_quaternion); }
 	Basis(const Quaternion &p_quaternion, const Vector3 &p_scale) { set_quaternion_scale(p_quaternion, p_scale); }
@@ -246,6 +250,10 @@ private:
 	// Helper method.
 	void _set_diagonal(const Vector3 &p_diag);
 };
+
+inline constexpr Basis Basis::FLIP_X = { { -1, 0, 0 }, { 0, 1, 0 }, { 0, 0, 1 } };
+inline constexpr Basis Basis::FLIP_Y = { { 1, 0, 0 }, { 0, -1, 0 }, { 0, 0, 1 } };
+inline constexpr Basis Basis::FLIP_Z = { { 1, 0, 0 }, { 0, 1, 0 }, { 0, 0, -1 } };
 
 constexpr bool Basis::operator==(const Basis &p_matrix) const {
 	for (int i = 0; i < 3; i++) {

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -35,6 +35,10 @@
 class Variant;
 
 struct [[nodiscard]] Plane {
+	static const Plane PLANE_YZ;
+	static const Plane PLANE_XZ;
+	static const Plane PLANE_XY;
+
 	Vector3 normal;
 	real_t d = 0;
 
@@ -89,6 +93,10 @@ struct [[nodiscard]] Plane {
 	_FORCE_INLINE_ Plane(const Vector3 &p_normal, const Vector3 &p_point);
 	_FORCE_INLINE_ Plane(const Vector3 &p_point1, const Vector3 &p_point2, const Vector3 &p_point3, ClockDirection p_dir = CLOCKWISE);
 };
+
+inline constexpr Plane Plane::PLANE_YZ = { 1, 0, 0, 0 };
+inline constexpr Plane Plane::PLANE_XZ = { 0, 1, 0, 0 };
+inline constexpr Plane Plane::PLANE_XY = { 0, 0, 1, 0 };
 
 bool Plane::is_point_over(const Vector3 &p_point) const {
 	return (normal.dot(p_point) > d);

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -52,6 +52,9 @@ struct [[nodiscard]] Transform2D {
 	// WARNING: Be aware that unlike 3D code, 2D code uses a left-handed coordinate system:
 	// Y-axis points down, and angle is measure from +X to +Y in a clockwise-fashion.
 
+	static const Transform2D FLIP_X;
+	static const Transform2D FLIP_Y;
+
 	Vector2 columns[3] = {
 		{ 1, 0 },
 		{ 0, 1 },
@@ -148,6 +151,9 @@ struct [[nodiscard]] Transform2D {
 
 	Transform2D() = default;
 };
+
+inline constexpr Transform2D Transform2D::FLIP_X = { { -1, 0 }, { 0, 1 }, { 0, 0 } };
+inline constexpr Transform2D Transform2D::FLIP_Y = { { 1, 0 }, { 0, -1 }, { 0, 0 } };
 
 constexpr bool Transform2D::operator==(const Transform2D &p_transform) const {
 	for (int i = 0; i < 3; i++) {

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -36,6 +36,10 @@
 #include "core/templates/vector.h"
 
 struct [[nodiscard]] Transform3D {
+	static const Transform3D FLIP_X;
+	static const Transform3D FLIP_Y;
+	static const Transform3D FLIP_Z;
+
 	Basis basis;
 	Vector3 origin;
 
@@ -51,8 +55,8 @@ struct [[nodiscard]] Transform3D {
 	void rotate(const Vector3 &p_axis, real_t p_angle);
 	void rotate_basis(const Vector3 &p_axis, real_t p_angle);
 
-	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
-	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false) const;
+	void set_look_at(const Vector3 &p_eye, const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
+	Transform3D looking_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false) const;
 
 	void scale(const Vector3 &p_scale);
 	Transform3D scaled(const Vector3 &p_scale) const;
@@ -135,6 +139,10 @@ struct [[nodiscard]] Transform3D {
 			basis(p_xx, p_xy, p_xz, p_yx, p_yy, p_yz, p_zx, p_zy, p_zz),
 			origin(p_ox, p_oy, p_oz) {}
 };
+
+inline constexpr Transform3D Transform3D::FLIP_X = { Basis::FLIP_X };
+inline constexpr Transform3D Transform3D::FLIP_Y = { Basis::FLIP_Y };
+inline constexpr Transform3D Transform3D::FLIP_Z = { Basis::FLIP_Z };
 
 constexpr bool Transform3D::operator==(const Transform3D &p_transform) const {
 	return (basis == p_transform.basis && origin == p_transform.origin);

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -37,7 +37,12 @@ class String;
 struct Vector2i;
 
 struct [[nodiscard]] Vector2 {
-	static const int AXIS_COUNT = 2;
+	static const Vector2 LEFT;
+	static const Vector2 RIGHT;
+	static const Vector2 UP;
+	static const Vector2 DOWN;
+
+	static constexpr int AXIS_COUNT = 2;
 
 	enum Axis {
 		AXIS_X,
@@ -192,6 +197,11 @@ struct [[nodiscard]] Vector2 {
 			x(p_x), y(p_y) {}
 	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
+
+inline constexpr Vector2 Vector2::LEFT = { -1, 0 };
+inline constexpr Vector2 Vector2::RIGHT = { 1, 0 };
+inline constexpr Vector2 Vector2::UP = { 0, -1 };
+inline constexpr Vector2 Vector2::DOWN = { 0, 1 };
 
 _FORCE_INLINE_ Vector2 Vector2::plane_project(real_t p_d, const Vector2 &p_vec) const {
 	return p_vec - *this * (dot(p_vec) - p_d);

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -37,7 +37,12 @@ class String;
 struct Vector2;
 
 struct [[nodiscard]] Vector2i {
-	static const int AXIS_COUNT = 2;
+	static const Vector2i LEFT;
+	static const Vector2i RIGHT;
+	static const Vector2i UP;
+	static const Vector2i DOWN;
+
+	static constexpr int AXIS_COUNT = 2;
 
 	enum Axis {
 		AXIS_X,
@@ -149,6 +154,11 @@ struct [[nodiscard]] Vector2i {
 			x(p_x), y(p_y) {}
 	// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 };
+
+inline constexpr Vector2i Vector2i::LEFT = { -1, 0 };
+inline constexpr Vector2i Vector2i::RIGHT = { 1, 0 };
+inline constexpr Vector2i Vector2i::UP = { 0, -1 };
+inline constexpr Vector2i Vector2i::DOWN = { 0, 1 };
 
 constexpr Vector2i Vector2i::operator+(const Vector2i &p_v) const {
 	return Vector2i(x + p_v.x, y + p_v.y);

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -39,7 +39,20 @@ struct Vector2;
 struct Vector3i;
 
 struct [[nodiscard]] Vector3 {
-	static const int AXIS_COUNT = 3;
+	static const Vector3 LEFT;
+	static const Vector3 RIGHT;
+	static const Vector3 UP;
+	static const Vector3 DOWN;
+	static const Vector3 FORWARD;
+	static const Vector3 BACK;
+	static const Vector3 MODEL_LEFT;
+	static const Vector3 MODEL_RIGHT;
+	static const Vector3 MODEL_TOP;
+	static const Vector3 MODEL_BOTTOM;
+	static const Vector3 MODEL_FRONT;
+	static const Vector3 MODEL_REAR;
+
+	static constexpr int AXIS_COUNT = 3;
 
 	enum Axis {
 		AXIS_X,
@@ -195,6 +208,19 @@ struct [[nodiscard]] Vector3 {
 			x(p_x), y(p_y), z(p_z) {}
 };
 
+inline constexpr Vector3 Vector3::LEFT = { -1, 0, 0 };
+inline constexpr Vector3 Vector3::RIGHT = { 1, 0, 0 };
+inline constexpr Vector3 Vector3::UP = { 0, 1, 0 };
+inline constexpr Vector3 Vector3::DOWN = { 0, -1, 0 };
+inline constexpr Vector3 Vector3::FORWARD = { 0, 0, -1 };
+inline constexpr Vector3 Vector3::BACK = { 0, 0, 1 };
+inline constexpr Vector3 Vector3::MODEL_LEFT = { 1, 0, 0 };
+inline constexpr Vector3 Vector3::MODEL_RIGHT = { -1, 0, 0 };
+inline constexpr Vector3 Vector3::MODEL_TOP = { 0, 1, 0 };
+inline constexpr Vector3 Vector3::MODEL_BOTTOM = { 0, -1, 0 };
+inline constexpr Vector3 Vector3::MODEL_FRONT = { 0, 0, 1 };
+inline constexpr Vector3 Vector3::MODEL_REAR = { 0, 0, -1 };
+
 Vector3 Vector3::cross(const Vector3 &p_with) const {
 	Vector3 ret(
 			(y * p_with.z) - (z * p_with.y),
@@ -334,7 +360,7 @@ Vector3 Vector3::get_any_perpendicular() const {
 	// since it could be a different vector depending on the prior branching code Math::abs(x) <= Math::abs(y) && Math::abs(x) <= Math::abs(z).
 	// However, it would be reasonable to use any of the axes of the basis, as it is simpler to calculate.
 	ERR_FAIL_COND_V_MSG(is_zero_approx(), Vector3(0, 0, 0), "The Vector3 must not be zero.");
-	return cross((Math::abs(x) <= Math::abs(y) && Math::abs(x) <= Math::abs(z)) ? Vector3(1, 0, 0) : Vector3(0, 1, 0)).normalized();
+	return cross((Math::abs(x) <= Math::abs(y) && Math::abs(x) <= Math::abs(z)) ? Vector3::RIGHT : Vector3::UP).normalized();
 }
 
 /* Operators */

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -37,7 +37,14 @@ class String;
 struct Vector3;
 
 struct [[nodiscard]] Vector3i {
-	static const int AXIS_COUNT = 3;
+	static const Vector3i LEFT;
+	static const Vector3i RIGHT;
+	static const Vector3i UP;
+	static const Vector3i DOWN;
+	static const Vector3i FORWARD;
+	static const Vector3i BACK;
+
+	static constexpr int AXIS_COUNT = 3;
 
 	enum Axis {
 		AXIS_X,
@@ -138,6 +145,13 @@ struct [[nodiscard]] Vector3i {
 	constexpr Vector3i(int32_t p_x, int32_t p_y, int32_t p_z) :
 			x(p_x), y(p_y), z(p_z) {}
 };
+
+inline constexpr Vector3i Vector3i::LEFT = { -1, 0, 0 };
+inline constexpr Vector3i Vector3i::RIGHT = { 1, 0, 0 };
+inline constexpr Vector3i Vector3i::UP = { 0, 1, 0 };
+inline constexpr Vector3i Vector3i::DOWN = { 0, -1, 0 };
+inline constexpr Vector3i Vector3i::FORWARD = { 0, 0, -1 };
+inline constexpr Vector3i Vector3i::BACK = { 0, 0, 1 };
 
 int64_t Vector3i::length_squared() const {
 	return x * (int64_t)x + y * (int64_t)y + z * (int64_t)z;

--- a/core/math/vector4.h
+++ b/core/math/vector4.h
@@ -38,7 +38,7 @@ class String;
 struct Vector4i;
 
 struct [[nodiscard]] Vector4 {
-	static const int AXIS_COUNT = 4;
+	static constexpr int AXIS_COUNT = 4;
 
 	enum Axis {
 		AXIS_X,

--- a/core/math/vector4i.h
+++ b/core/math/vector4i.h
@@ -37,7 +37,7 @@ class String;
 struct Vector4;
 
 struct [[nodiscard]] Vector4i {
-	static const int AXIS_COUNT = 4;
+	static constexpr int AXIS_COUNT = 4;
 
 	enum Axis {
 		AXIS_X,

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2368,7 +2368,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Basis, is_equal_approx, sarray("b"), varray());
 	bind_method(Basis, is_finite, sarray(), varray());
 	bind_method(Basis, get_rotation_quaternion, sarray(), varray());
-	bind_static_method(Basis, looking_at, sarray("target", "up", "use_model_front"), varray(Vector3(0, 1, 0), false));
+	bind_static_method(Basis, looking_at, sarray("target", "up", "use_model_front"), varray(Vector3::UP, false));
 	bind_static_method(Basis, from_scale, sarray("scale"), varray());
 	bind_static_method(Basis, from_euler, sarray("euler", "order"), varray((int64_t)EulerOrder::YXZ));
 
@@ -2411,7 +2411,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Transform3D, scaled_local, sarray("scale"), varray());
 	bind_method(Transform3D, translated, sarray("offset"), varray());
 	bind_method(Transform3D, translated_local, sarray("offset"), varray());
-	bind_method(Transform3D, looking_at, sarray("target", "up", "use_model_front"), varray(Vector3(0, 1, 0), false));
+	bind_method(Transform3D, looking_at, sarray("target", "up", "use_model_front"), varray(Vector3::UP, false));
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, is_equal_approx, sarray("xform"), varray());
 	bind_method(Transform3D, is_finite, sarray(), varray());
@@ -2872,19 +2872,19 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(Math::INF, Math::INF, Math::INF));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "DOWN", Vector3::DOWN);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "FORWARD", Vector3::FORWARD);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "BACK", Vector3::BACK);
 
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_LEFT", Vector3(1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_RIGHT", Vector3(-1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_TOP", Vector3(0, 1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_BOTTOM", Vector3(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_FRONT", Vector3(0, 0, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_REAR", Vector3(0, 0, -1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_LEFT", Vector3::MODEL_LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_RIGHT", Vector3::MODEL_RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_TOP", Vector3::MODEL_TOP);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_BOTTOM", Vector3::MODEL_BOTTOM);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_FRONT", Vector3::MODEL_FRONT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "MODEL_REAR", Vector3::MODEL_REAR);
 
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_X", Vector4::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR4, "Axis", "AXIS_Y", Vector4::AXIS_Y);
@@ -2913,12 +2913,12 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "ONE", Vector3i(1, 1, 1));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MIN", Vector3i(INT32_MIN, INT32_MIN, INT32_MIN));
 	_VariantCall::add_variant_constant(Variant::VECTOR3I, "MAX", Vector3i(INT32_MAX, INT32_MAX, INT32_MAX));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "LEFT", Vector3i(-1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "RIGHT", Vector3i(1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i(0, 1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i(0, -1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i(0, 0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i(0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "LEFT", Vector3i::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "RIGHT", Vector3i::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "UP", Vector3i::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "DOWN", Vector3i::DOWN);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "FORWARD", Vector3i::FORWARD);
+	_VariantCall::add_variant_constant(Variant::VECTOR3I, "BACK", Vector3i::BACK);
 
 	_VariantCall::add_enum_constant(Variant::VECTOR2, "Axis", "AXIS_X", Vector2::AXIS_X);
 	_VariantCall::add_enum_constant(Variant::VECTOR2, "Axis", "AXIS_Y", Vector2::AXIS_Y);
@@ -2929,47 +2929,39 @@ static void _register_variant_builtin_constants() {
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ZERO", Vector2(0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ONE", Vector2(1, 1));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(Math::INF, Math::INF));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2(-1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2(1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2(0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "DOWN", Vector2(0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "DOWN", Vector2::DOWN);
 
 	_VariantCall::add_variant_constant(Variant::VECTOR2I, "ZERO", Vector2i(0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2I, "ONE", Vector2i(1, 1));
 	_VariantCall::add_variant_constant(Variant::VECTOR2I, "MIN", Vector2i(INT32_MIN, INT32_MIN));
 	_VariantCall::add_variant_constant(Variant::VECTOR2I, "MAX", Vector2i(INT32_MAX, INT32_MAX));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "LEFT", Vector2i(-1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "RIGHT", Vector2i(1, 0));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "UP", Vector2i(0, -1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2I, "DOWN", Vector2i(0, 1));
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "LEFT", Vector2i::LEFT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "RIGHT", Vector2i::RIGHT);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "UP", Vector2i::UP);
+	_VariantCall::add_variant_constant(Variant::VECTOR2I, "DOWN", Vector2i::DOWN);
 
 	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "IDENTITY", Transform2D());
-	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_X", Transform2D(-1, 0, 0, 1, 0, 0));
-	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_Y", Transform2D(1, 0, 0, -1, 0, 0));
+	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_X", Transform2D::FLIP_X);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM2D, "FLIP_Y", Transform2D::FLIP_Y);
 
-	Transform3D identity_transform;
-	Transform3D flip_x_transform = Transform3D(-1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0);
-	Transform3D flip_y_transform = Transform3D(1, 0, 0, 0, -1, 0, 0, 0, 1, 0, 0, 0);
-	Transform3D flip_z_transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, -1, 0, 0, 0);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "IDENTITY", identity_transform);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_X", flip_x_transform);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Y", flip_y_transform);
-	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Z", flip_z_transform);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "IDENTITY", Transform3D());
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_X", Transform3D::FLIP_X);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Y", Transform3D::FLIP_Y);
+	_VariantCall::add_variant_constant(Variant::TRANSFORM3D, "FLIP_Z", Transform3D::FLIP_Z);
 
-	Basis identity_basis;
-	Basis flip_x_basis = Basis(-1, 0, 0, 0, 1, 0, 0, 0, 1);
-	Basis flip_y_basis = Basis(1, 0, 0, 0, -1, 0, 0, 0, 1);
-	Basis flip_z_basis = Basis(1, 0, 0, 0, 1, 0, 0, 0, -1);
-	_VariantCall::add_variant_constant(Variant::BASIS, "IDENTITY", identity_basis);
-	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_X", flip_x_basis);
-	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Y", flip_y_basis);
-	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Z", flip_z_basis);
+	_VariantCall::add_variant_constant(Variant::BASIS, "IDENTITY", Basis());
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_X", Basis::FLIP_X);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Y", Basis::FLIP_Y);
+	_VariantCall::add_variant_constant(Variant::BASIS, "FLIP_Z", Basis::FLIP_Z);
 
-	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_YZ", Plane(Vector3(1, 0, 0), 0));
-	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XZ", Plane(Vector3(0, 1, 0), 0));
-	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XY", Plane(Vector3(0, 0, 1), 0));
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_YZ", Plane::PLANE_YZ);
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XZ", Plane::PLANE_XZ);
+	_VariantCall::add_variant_constant(Variant::PLANE, "PLANE_XY", Plane::PLANE_XY);
 
-	_VariantCall::add_variant_constant(Variant::QUATERNION, "IDENTITY", Quaternion(0, 0, 0, 1));
+	_VariantCall::add_variant_constant(Variant::QUATERNION, "IDENTITY", Quaternion());
 
 	_VariantCall::add_enum_constant(Variant::PROJECTION, "Planes", "PLANE_NEAR", Projection::PLANE_NEAR);
 	_VariantCall::add_enum_constant(Variant::PROJECTION, "Planes", "PLANE_FAR", Projection::PLANE_FAR);

--- a/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/spring_bone_3d_gizmo_plugin.cpp
@@ -192,29 +192,26 @@ Ref<ArrayMesh> SpringBoneSimulator3DGizmoPlugin::get_joints_mesh(Skeleton3D *p_s
 }
 
 void SpringBoneSimulator3DGizmoPlugin::draw_sphere(Ref<SurfaceTool> &p_surface_tool, const Basis &p_basis, const Vector3 &p_center, float p_radius, const Color &p_color) {
-	static const Vector3 VECTOR3_RIGHT = Vector3(1, 0, 0);
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
-	static const int STEP = 16;
-	static const float SPPI = Math::TAU / (float)STEP;
+	static constexpr int STEP = 16;
+	static constexpr float SPPI = Math::TAU / (float)STEP;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_UP * p_radius)).rotated(p_basis.xform(VECTOR3_RIGHT), SPPI * ((i - 1) % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::UP * p_radius)).rotated(p_basis.xform(Vector3::RIGHT), SPPI * ((i - 1) % STEP))));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_UP * p_radius)).rotated(p_basis.xform(VECTOR3_RIGHT), SPPI * (i % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::UP * p_radius)).rotated(p_basis.xform(Vector3::RIGHT), SPPI * (i % STEP))));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_RIGHT * p_radius)).rotated(p_basis.xform(VECTOR3_FORWARD), SPPI * ((i - 1) % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::RIGHT * p_radius)).rotated(p_basis.xform(Vector3::FORWARD), SPPI * ((i - 1) % STEP))));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_RIGHT * p_radius)).rotated(p_basis.xform(VECTOR3_FORWARD), SPPI * (i % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::RIGHT * p_radius)).rotated(p_basis.xform(Vector3::FORWARD), SPPI * (i % STEP))));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_FORWARD * p_radius)).rotated(p_basis.xform(VECTOR3_UP), SPPI * ((i - 1) % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::FORWARD * p_radius)).rotated(p_basis.xform(Vector3::UP), SPPI * ((i - 1) % STEP))));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(p_center + ((p_basis.xform(VECTOR3_FORWARD * p_radius)).rotated(p_basis.xform(VECTOR3_UP), SPPI * (i % STEP))));
+		p_surface_tool->add_vertex(p_center + ((p_basis.xform(Vector3::FORWARD * p_radius)).rotated(p_basis.xform(Vector3::UP), SPPI * (i % STEP))));
 	}
 }
 
@@ -323,74 +320,68 @@ Ref<ArrayMesh> SpringBoneCollision3DGizmoPlugin::get_collision_mesh(SpringBoneCo
 }
 
 void SpringBoneCollision3DGizmoPlugin::draw_sphere(Ref<SurfaceTool> &p_surface_tool, float p_radius, const Color &p_color) {
-	static const Vector3 VECTOR3_RIGHT = Vector3(1, 0, 0);
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
-	static const int STEP = 16;
-	static const float SPPI = Math::TAU / (float)STEP;
+	static constexpr int STEP = 16;
+	static constexpr float SPPI = Math::TAU / (float)STEP;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((Vector3::UP * p_radius).rotated(Vector3::RIGHT, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((Vector3::UP * p_radius).rotated(Vector3::RIGHT, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * (i % STEP)));
 	}
 }
 
 void SpringBoneCollision3DGizmoPlugin::draw_capsule(Ref<SurfaceTool> &p_surface_tool, float p_radius, float p_height, const Color &p_color) {
-	static const Vector3 VECTOR3_RIGHT = Vector3(1, 0, 0);
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_FORWARD = Vector3(0, 0, 1);
-	static const int STEP = 16;
-	static const int HALF_STEP = 8;
-	static const float SPPI = Math::TAU / (float)STEP;
-	static const float HALF_PI = Math::PI * 0.5;
+	static constexpr int STEP = 16;
+	static constexpr int HALF_STEP = 8;
+	static constexpr float SPPI = (float)Math::TAU / STEP;
+	static constexpr float HALF_PI = (float)Math::PI * 0.5f;
 
-	Vector3 top = VECTOR3_UP * (p_height * 0.5 - p_radius);
+	Vector3 top = Vector3::UP * (p_height * 0.5 - p_radius);
 	Vector3 bottom = -top;
 
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, -HALF_PI + SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::UP * p_radius).rotated(Vector3::RIGHT, -HALF_PI + SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_UP * p_radius).rotated(VECTOR3_RIGHT, -HALF_PI + SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::UP * p_radius).rotated(Vector3::RIGHT, -HALF_PI + SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (VECTOR3_RIGHT * p_radius).rotated(VECTOR3_FORWARD, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex((i - 1 < HALF_STEP ? top : bottom) + (Vector3::RIGHT * p_radius).rotated(Vector3::FORWARD, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(top + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex(top + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(top + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex(top + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * (i % STEP)));
 	}
 	for (int i = 1; i <= STEP; i++) {
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(bottom + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * ((i - 1) % STEP)));
+		p_surface_tool->add_vertex(bottom + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * ((i - 1) % STEP)));
 		p_surface_tool->set_color(p_color);
-		p_surface_tool->add_vertex(bottom + (VECTOR3_FORWARD * p_radius).rotated(VECTOR3_UP, SPPI * (i % STEP)));
+		p_surface_tool->add_vertex(bottom + (Vector3::FORWARD * p_radius).rotated(Vector3::UP, SPPI * (i % STEP)));
 	}
 	LocalVector<Vector3> directions;
 	directions.resize(4);
-	directions[0] = VECTOR3_RIGHT;
-	directions[1] = -VECTOR3_RIGHT;
-	directions[2] = VECTOR3_FORWARD;
-	directions[3] = -VECTOR3_FORWARD;
+	directions[0] = Vector3::RIGHT;
+	directions[1] = Vector3::LEFT;
+	directions[2] = Vector3::FORWARD;
+	directions[3] = Vector3::BACK;
 	for (int i = 0; i < 4; i++) {
 		Vector3 dir = directions[i] * p_radius;
 		p_surface_tool->set_color(p_color);
@@ -400,16 +391,15 @@ void SpringBoneCollision3DGizmoPlugin::draw_capsule(Ref<SurfaceTool> &p_surface_
 }
 
 void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_tool, const Color &p_color) {
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const float HALF_PI = Math::PI * 0.5;
-	static const float ARROW_LENGTH = 0.3;
-	static const float ARROW_HALF_WIDTH = 0.05;
-	static const float ARROW_TOP_HALF_WIDTH = 0.1;
-	static const float ARROW_TOP = 0.5;
-	static const float RECT_SIZE = 1.0;
-	static const int RECT_STEP_COUNT = 9;
-	static const float RECT_HALF_SIZE = RECT_SIZE * 0.5;
-	static const float RECT_STEP = RECT_SIZE / (float)RECT_STEP_COUNT;
+	static constexpr float HALF_PI = (float)Math::PI * 0.5f;
+	static constexpr float ARROW_LENGTH = 0.3f;
+	static constexpr float ARROW_HALF_WIDTH = 0.05f;
+	static constexpr float ARROW_TOP_HALF_WIDTH = 0.1f;
+	static constexpr float ARROW_TOP = 0.5f;
+	static constexpr float RECT_SIZE = 1.0f;
+	static constexpr int RECT_STEP_COUNT = 9;
+	static constexpr float RECT_HALF_SIZE = RECT_SIZE * 0.5f;
+	static constexpr float RECT_STEP = RECT_SIZE / RECT_STEP_COUNT;
 
 	p_surface_tool->set_color(p_color);
 
@@ -424,7 +414,7 @@ void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_to
 	arrow[5] = Vector3(ARROW_HALF_WIDTH, ARROW_LENGTH, 0);
 	arrow[6] = Vector3(ARROW_TOP_HALF_WIDTH, ARROW_LENGTH, 0);
 	for (int i = 0; i < 2; i++) {
-		Basis ma(VECTOR3_UP, HALF_PI * i);
+		Basis ma(Vector3::UP, HALF_PI * i);
 		for (uint32_t j = 0; j < arrow.size(); j++) {
 			Vector3 v1 = arrow[j];
 			Vector3 v2 = arrow[(j + 1) % arrow.size()];
@@ -435,7 +425,7 @@ void SpringBoneCollision3DGizmoPlugin::draw_plane(Ref<SurfaceTool> &p_surface_to
 
 	// Draw dashed line of the rect.
 	for (int i = 0; i < 4; i++) {
-		Basis ma(VECTOR3_UP, HALF_PI * i);
+		Basis ma(Vector3::UP, HALF_PI * i);
 		for (int j = 0; j < RECT_STEP_COUNT; j++) {
 			if (j % 2 == 1) {
 				continue;

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1482,8 +1482,8 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("orthonormalize"), &Node3D::orthonormalize);
 	ClassDB::bind_method(D_METHOD("set_identity"), &Node3D::set_identity);
 
-	ClassDB::bind_method(D_METHOD("look_at", "target", "up", "use_model_front"), &Node3D::look_at, DEFVAL(Vector3(0, 1, 0)), DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up", "use_model_front"), &Node3D::look_at_from_position, DEFVAL(Vector3(0, 1, 0)), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("look_at", "target", "up", "use_model_front"), &Node3D::look_at, DEFVAL(Vector3::UP), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up", "use_model_front"), &Node3D::look_at_from_position, DEFVAL(Vector3::UP), DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node3D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node3D::to_global);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -321,8 +321,8 @@ public:
 	void global_scale(const Vector3 &p_scale);
 	void global_translate(const Vector3 &p_offset);
 
-	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
-	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0), bool p_use_model_front = false);
+	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
+	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;

--- a/scene/3d/spring_bone_collision_capsule_3d.cpp
+++ b/scene/3d/spring_bone_collision_capsule_3d.cpp
@@ -84,10 +84,8 @@ bool SpringBoneCollisionCapsule3D::is_inside() const {
 }
 
 Pair<Vector3, Vector3> SpringBoneCollisionCapsule3D::get_head_and_tail(const Transform3D &p_center) const {
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
-	static const Vector3 VECTOR3_DOWN = Vector3(0, -1, 0);
 	Transform3D tr = get_transform_from_skeleton(p_center);
-	return Pair<Vector3, Vector3>(tr.origin + tr.basis.xform(VECTOR3_UP * (height * 0.5 - radius)), tr.origin + tr.basis.xform(VECTOR3_DOWN * (height * 0.5 - radius)));
+	return Pair<Vector3, Vector3>(tr.origin + tr.basis.xform(Vector3::UP * (height * 0.5 - radius)), tr.origin + tr.basis.xform(Vector3::DOWN * (height * 0.5 - radius)));
 }
 
 void SpringBoneCollisionCapsule3D::_bind_methods() {

--- a/scene/3d/spring_bone_collision_plane_3d.cpp
+++ b/scene/3d/spring_bone_collision_plane_3d.cpp
@@ -31,10 +31,9 @@
 #include "spring_bone_collision_plane_3d.h"
 
 Vector3 SpringBoneCollisionPlane3D::_collide(const Transform3D &p_center, float p_bone_radius, float p_bone_length, const Vector3 &p_current) const {
-	static const Vector3 VECTOR3_UP = Vector3(0, 1, 0);
 	Transform3D tr = get_transform_from_skeleton(p_center);
 	Vector3 pos = tr.origin;
-	Vector3 normal = tr.basis.get_rotation_quaternion().xform(VECTOR3_UP);
+	Vector3 normal = tr.basis.get_rotation_quaternion().xform(Vector3::UP);
 	Vector3 to_vec = p_current - pos;
 	float distance = to_vec.dot(normal) - p_bone_radius;
 	if (distance > 0) {


### PR DESCRIPTION
- (mostly) supersedes #107723

A variation of the above PR which integrates the changes discussed in the core meeting: semantic constants only! As such, this excludes self-explanatory constants (`ZERO`, `ONE`, etc). Opted for a separate PR in case we want to revisit the more broad approach, without compromising the narrower scope which was already given a thumbs-up