### PR TITLE
Add a method to get plugin by name

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -103,6 +103,14 @@
 				Returns the [EditorPaths] singleton.
 			</description>
 		</method>
+		<method name="get_editor_plugin">
+			<return type="EditorPlugin" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns an [EditorPlugin] whose [method EditorPlugin._get_plugin_name] is [param name], or [code]null[/code] if no such plugin is found.
+				This method can be useful to obtain instances of some native plugins (like [GridMapEditorPlugin]), or custom plugins.
+			</description>
+		</method>
 		<method name="get_editor_scale" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -103,6 +103,10 @@ EditorUndoRedoManager *EditorInterface::get_editor_undo_redo() const {
 	return EditorUndoRedoManager::get_singleton();
 }
 
+EditorPlugin *EditorInterface::get_editor_plugin(const String &p_name) {
+	return EditorNode::get_editor_data().get_editor_by_name(p_name);
+}
+
 AABB EditorInterface::_calculate_aabb_for_scene(Node *p_node, AABB &p_scene_aabb) {
 	MeshInstance3D *mesh_node = Object::cast_to<MeshInstance3D>(p_node);
 	if (mesh_node && mesh_node->get_mesh().is_valid()) {
@@ -785,6 +789,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_settings"), &EditorInterface::get_editor_settings);
 	ClassDB::bind_method(D_METHOD("get_editor_toaster"), &EditorInterface::get_editor_toaster);
 	ClassDB::bind_method(D_METHOD("get_editor_undo_redo"), &EditorInterface::get_editor_undo_redo);
+	ClassDB::bind_method(D_METHOD("get_editor_plugin", "name"), &EditorInterface::get_editor_plugin);
 
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -108,6 +108,7 @@ public:
 	Ref<EditorSettings> get_editor_settings() const;
 	EditorToaster *get_editor_toaster() const;
 	EditorUndoRedoManager *get_editor_undo_redo() const;
+	EditorPlugin *get_editor_plugin(const String &p_name);
 
 	Vector<Ref<Texture2D>> make_mesh_previews(const Vector<Ref<Mesh>> &p_meshes, Vector<Transform3D> *p_transforms, int p_preview_size);
 	void make_scene_preview(const String &p_path, Node *p_scene, int p_preview_size);

--- a/modules/gridmap/doc_classes/GridMapEditorPlugin.xml
+++ b/modules/gridmap/doc_classes/GridMapEditorPlugin.xml
@@ -5,6 +5,10 @@
 	</brief_description>
 	<description>
 		GridMapEditorPlugin provides access to the [GridMap] editor functionality.
+		You can get instance of this plugin using [method EditorInterface.get_editor_plugin] with name [code]"GridMap"[/code].
+		[codeblock]
+		var gridmap_plugin = EditorInterface.get_editor_plugin("GridMap")
+		[/codeblock]
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Follow-up to #99639
Makes the plugin accessible without using undocumented hacks.