### PR TITLE
Handle SDL joypad events for connected controllers on game startup (on Windows and Linux)

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -88,6 +88,9 @@ Error JoypadSDL::initialize() {
 		SDL_AddGamepadMappingsFromIO(rw, 1);
 	}
 
+	// Make sure that we handle already connected joypads when the driver is initialized.
+	process_events();
+
 	print_verbose("SDL: Init OK!");
 	return OK;
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109717

Make sure that SDL events are processed when the SDL joypad input driver is initialized, this will allow it to register the connected controllers when the game starts. The registered controllers will then show up in `Input.get_connected_joypads()`.

<details>
<summary>Before this PR</summary>

<img width="1365" height="708" alt="image" src="https://github.com/user-attachments/assets/4e334dc0-2039-4d11-b110-41043a886925" />
</details>

<details>
<summary>After this PR</summary>

<img width="1326" height="669" alt="image" src="https://github.com/user-attachments/assets/76b8d0b0-2fdf-4f27-b37a-d1683bb42cbe" />
</details>

I tested this PR on Windows and I thought this would fix it on all platforms 😅
TODO:
- [x] Fix this PR on macOS (the issue is also reproducible in Godot 4.4.1, so not technically a bug in this PR, I've read somewhere that it's a quirk of Apple's API)
- [x] Check if it fixes the issue on Linux