### PR TITLE
Fix OptionButton not removing icon when using clear

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -394,6 +394,7 @@ void OptionButton::add_separator(const String &p_text) {
 void OptionButton::clear() {
 	popup->clear();
 	set_text("");
+	set_button_icon(Ref<Texture2D>());
 	current = NONE_SELECTED;
 	_refresh_size_cache();
 }
@@ -410,7 +411,7 @@ void OptionButton::_select(int p_which, bool p_emit) {
 
 		current = NONE_SELECTED;
 		set_text("");
-		set_button_icon(nullptr);
+		set_button_icon(Ref<Texture2D>());
 	} else {
 		ERR_FAIL_INDEX(p_which, popup->get_item_count());
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109754

Before:

[Screencast_20250818_233239.webm](https://github.com/user-attachments/assets/c9993796-b932-44e4-a63f-0aab9c2822c2)


After:

[Screencast_20250818_233434.webm](https://github.com/user-attachments/assets/ea870a8c-e30b-4700-af6f-af13d3504868)
