### PR TITLE
Use const and float literals around square values

### DIFF
--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -498,7 +498,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 		// Center drag.
 		if (edit_origin_and_center) {
-			real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+			const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 			if (mb->get_button_index() == MouseButton::LEFT) {
 				if (mb->is_meta_pressed() || mb->is_ctrl_pressed() || mb->is_shift_pressed() || mb->is_alt_pressed()) {
@@ -838,9 +838,9 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_point(const 
 		for (int i = 0; i < n_points; i++) {
 			Vector2 cp = xform.xform(points[i] + offset);
 
-			real_t d = cp.distance_to(p_pos);
-			if (d < closest_dist && d < grab_threshold) {
-				closest_dist = d;
+			const real_t dist = cp.distance_to(p_pos);
+			if (dist < closest_dist && dist < grab_threshold) {
+				closest_dist = dist;
 				closest = PosVertex(j, i, cp);
 			}
 		}
@@ -876,9 +876,9 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 				continue; //not valid to reuse point
 			}
 
-			real_t d = cp.distance_to(p_pos);
-			if (d < closest_dist && d < grab_threshold) {
-				closest_dist = d;
+			const real_t dist = cp.distance_to(p_pos);
+			if (dist < closest_dist && dist < grab_threshold) {
+				closest_dist = dist;
 				closest = PosVertex(j, i, cp);
 			}
 		}

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -82,7 +82,7 @@ bool Path2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) {
 		return false;
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -663,7 +663,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_3d_gui_input(Camera3D *p
 						real_t cdist = from.distance_to(to);
 						from = gt.xform(from);
 						to = gt.xform(to);
-						if (cdist > 0) {
+						if (cdist > 0.0f) {
 							const Vector2 segment_a = viewport->point_to_screen(from);
 							const Vector2 segment_b = viewport->point_to_screen(to);
 							Vector2 inters = Geometry2D::get_closest_point_to_segment(mbpos, segment_a, segment_b);
@@ -1200,8 +1200,8 @@ int Path3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_gizmo,
 	int ret = -1;
 	if (Path3DEditorPlugin::singleton->curve_edit->is_pressed()) {
 		for (int idx = 0; idx < curve->get_point_count(); ++idx) {
-			Vector3 pos = path->get_global_transform().xform(curve->get_point_position(idx));
-			if (p_camera->unproject_position(pos).distance_to(p_point) < 20) {
+			const Vector3 pos = path->get_global_transform().xform(curve->get_point_position(idx));
+			if (p_camera->unproject_position(pos).distance_to(p_point) < 20.0f) {
 				ret = idx;
 				break;
 			}

--- a/editor/scene/3d/polygon_3d_editor_plugin.cpp
+++ b/editor/scene/3d/polygon_3d_editor_plugin.cpp
@@ -153,7 +153,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 		PackedVector2Array poly = _get_polygon();
 
 		//first check if a point is to be added (segment split)
-		real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 		switch (mode) {
 			case MODE_CREATE: {
@@ -204,9 +204,9 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 							}
 
 							//search edges
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < poly.size(); i++) {
 								const Vector2 segment_a = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 								const Vector2 segment_b = p_camera->unproject_position(gt.xform(Vector3(poly[(i + 1) % poly.size()].x, poly[(i + 1) % poly.size()].y, depth)));
@@ -216,9 +216,9 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 									continue; //not valid to reuse point
 								}
 
-								real_t d = cp.distance_to(gpoint);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(gpoint);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -238,15 +238,15 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 						} else {
 							//look for points to move
 
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < poly.size(); i++) {
 								Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
-								real_t d = cp.distance_to(gpoint);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(gpoint);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -283,15 +283,15 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_3d_gui_input(Camera3D *p_ca
 					}
 				}
 				if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed() && edited_point == -1) {
-					int closest_idx = -1;
 					Vector2 closest_pos;
 					real_t closest_dist = 1e10;
+					int closest_idx = -1;
 					for (int i = 0; i < poly.size(); i++) {
 						Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
-						real_t d = cp.distance_to(gpoint);
-						if (d < closest_dist && d < grab_threshold) {
-							closest_dist = d;
+						const real_t dist = cp.distance_to(gpoint);
+						if (dist < closest_dist && dist < grab_threshold) {
+							closest_dist = dist;
 							closest_pos = cp;
 							closest_idx = i;
 						}

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1893,7 +1893,7 @@ bool CanvasItemEditor::_gui_input_resize(const Ref<InputEvent> &p_event) {
 					};
 
 					DragType resize_drag = DRAG_NONE;
-					real_t radius = select_handle->get_size().width * (1.5f / 2.0f);
+					const real_t radius = select_handle->get_size().width * (1.5f / 2.0f);
 
 					for (int i = 0; i < 4; i++) {
 						int prev = (i + 3) % 4;

--- a/modules/godot_physics_3d/godot_body_pair_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_pair_3d.cpp
@@ -224,7 +224,7 @@ bool GodotBodyPair3D::_test_ccd(real_t p_step, GodotBody3D *p_A, int p_shape_A, 
 		Vector3 rpos, rnorm;
 		int fi = -1;
 		if (p_B->get_shape(p_shape_B)->intersect_segment(local_from, local_to, rpos, rnorm, fi, true)) {
-			real_t hit_length = local_from.distance_to(rpos);
+			const real_t hit_length = local_from.distance_to(rpos);
 			if (hit_length < segment_hit_length) {
 				segment_support_idx = i;
 				segment_hit_length = hit_length;

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -140,7 +140,7 @@ void MobileVRInterface::set_position_from_sensors() {
 	// make copies of our inputs
 	bool has_grav = false;
 	Vector3 acc = input->get_accelerometer();
-	Vector3 gyro = input->get_gyroscope();
+	const Vector3 gyro = input->get_gyroscope();
 	Vector3 grav = input->get_gravity();
 	Vector3 magneto = scale_magneto(input->get_magnetometer()); // this may be overkill on iOS because we're already getting a calibrated magnetometer reading
 
@@ -166,7 +166,7 @@ void MobileVRInterface::set_position_from_sensors() {
 		has_grav = true;
 	};
 
-	bool has_magneto = magneto.length() > 0.1f;
+	const bool has_magneto = magneto.length() > 0.1f;
 	if (gyro.length() > 0.1f) {
 		/* this can return to 0.0 if the user doesn't move the phone, so once on, it's on */
 		has_gyro = true;

--- a/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
+++ b/modules/navigation_2d/editor/navigation_link_2d_editor_plugin.cpp
@@ -66,7 +66,7 @@ bool NavigationLink2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 		return false;
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_screen_transform();
 
 	Ref<InputEventMouseButton> mb = p_event;

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -142,7 +142,7 @@ int NavigationObstacle3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DG
 
 	for (int idx = 0; idx < vertices.size(); ++idx) {
 		Vector3 pos = gt.xform(vertices[idx]);
-		if (p_camera->unproject_position(pos).distance_to(p_point) < 20) {
+		if (p_camera->unproject_position(pos).distance_to(p_point) < 20.0f) {
 			return idx;
 		}
 	}
@@ -460,7 +460,7 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 		Vector3 cpoint = Vector3(spoint.x, 0.0, spoint.z);
 		Vector<Vector3> obstacle_vertices = obstacle_node->get_vertices();
 
-		real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+		const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 		switch (mode) {
 			case MODE_CREATE: {
@@ -478,9 +478,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 								continue; // Skip edge as clicked point is too close to existing vertex.
 							}
 
-							real_t d = cp.distance_to(mouse_position);
-							if (d < closest_dist && d < grab_threshold) {
-								closest_dist = d;
+							const real_t dist = cp.distance_to(mouse_position);
+							if (dist < closest_dist && dist < grab_threshold) {
+								closest_dist = dist;
 								closest_edge_point = cp;
 								closest_idx = i;
 							}
@@ -546,9 +546,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 							}
 
 							//search edges
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < obstacle_vertices.size(); i++) {
 								const Vector2 a = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
 								const Vector2 b = p_camera->unproject_position(gt.xform(obstacle_vertices[(i + 1) % obstacle_vertices.size()]));
@@ -558,9 +558,9 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 									continue; //not valid to reuse point
 								}
 
-								real_t d = cp.distance_to(mouse_position);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(mouse_position);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -578,15 +578,15 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 								return EditorPlugin::AFTER_GUI_INPUT_STOP;
 							}
 						} else {
-							int closest_idx = -1;
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
+							int closest_idx = -1;
 							for (int i = 0; i < obstacle_vertices.size(); i++) {
 								Vector2 cp = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
 
-								real_t d = cp.distance_to(mouse_position);
-								if (d < closest_dist && d < grab_threshold) {
-									closest_dist = d;
+								const real_t dist = cp.distance_to(mouse_position);
+								if (dist < closest_dist && dist < grab_threshold) {
+									closest_dist = dist;
 									closest_pos = cp;
 									closest_idx = i;
 								}
@@ -624,13 +624,13 @@ EditorPlugin::AfterGUIInput NavigationObstacle3DEditorPlugin::forward_3d_gui_inp
 
 			case MODE_DELETE: {
 				if (mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-					int closest_idx = -1;
 					real_t closest_dist = 1e10;
+					int closest_idx = -1;
 					for (int i = 0; i < obstacle_vertices.size(); i++) {
 						Vector2 point = p_camera->unproject_position(gt.xform(obstacle_vertices[i]));
-						real_t d = point.distance_to(mouse_position);
-						if (d < closest_dist && d < grab_threshold) {
-							closest_dist = d;
+						const real_t dist = point.distance_to(mouse_position);
+						if (dist < closest_dist && dist < grab_threshold) {
+							closest_dist = dist;
 							closest_idx = i;
 						}
 					}

--- a/modules/tilemap/editor/tile_data_editors.cpp
+++ b/modules/tilemap/editor/tile_data_editors.cpp
@@ -421,7 +421,7 @@ void GenericTilePolygonEditor::_grab_polygon_point(Vector2 p_pos, const Transfor
 	for (unsigned int i = 0; i < polygons.size(); i++) {
 		const Vector<Vector2> &polygon = polygons[i];
 		for (int j = 0; j < polygon.size(); j++) {
-			real_t distance = p_pos.distance_to(p_polygon_xform.xform(polygon[j]));
+			const real_t distance = p_pos.distance_to(p_polygon_xform.xform(polygon[j]));
 			if (distance < grab_threshold && distance < closest_distance) {
 				r_polygon_index = i;
 				r_point_index = j;
@@ -519,7 +519,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 		undo_redo = memnew(EditorUndoRedoManager);
 	}
 
-	real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
+	const real_t grab_threshold = EDITOR_GET("editors/polygon_editor/point_grab_radius");
 
 	hovered_polygon_index = -1;
 	hovered_point_index = -1;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -5377,7 +5377,7 @@ void DisplayServerX11::process_events() {
 					uint64_t diff = OS::get_singleton()->get_ticks_usec() / 1000 - last_click_ms;
 
 					if (mb->get_button_index() == last_click_button_index) {
-						if (diff < 400 && Vector2(last_click_pos).distance_to(Vector2(event.xbutton.x, event.xbutton.y)) < 5) {
+						if (diff < 400 && Vector2(last_click_pos).distance_to(Vector2(event.xbutton.x, event.xbutton.y)) < 5.0f) {
 							last_click_ms = 0;
 							last_click_pos = Point2i(-100, -100);
 							last_click_button_index = MouseButton::NONE;

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -272,7 +272,7 @@ int DisplayServerWeb::_mouse_button_callback(int p_pressed, int p_button, double
 		uint64_t diff = (OS::get_singleton()->get_ticks_usec() / 1000) - ds->last_click_ms;
 
 		if (ev->get_button_index() == ds->last_click_button_index) {
-			if (diff < 400 && Point2(ds->last_click_pos).distance_to(ev->get_position()) < 5) {
+			if (diff < 400 && Point2(ds->last_click_pos).distance_to(ev->get_position()) < 5.0f) {
 				ds->last_click_ms = 0;
 				ds->last_click_pos = Point2(-100, -100);
 				ds->last_click_button_index = MouseButton::NONE;

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -74,11 +74,11 @@ bool OccluderPolygon2D::_edit_is_selected_on_click(const Point2 &p_point, double
 	if (closed) {
 		return Geometry2D::is_point_in_polygon(p_point, Variant(polygon));
 	} else {
-		const real_t d = LINE_GRAB_WIDTH / 2 + p_tolerance;
+		const real_t dist = LINE_GRAB_WIDTH / 2 + p_tolerance;
 		const Vector2 *points = polygon.ptr();
 		for (int i = 0; i < polygon.size() - 1; i++) {
-			Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
-			if (p.distance_to(p_point) <= d) {
+			const Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, points[i], points[i + 1]);
+			if (p.distance_to(p_point) <= dist) {
 				return true;
 			}
 		}

--- a/scene/2d/physics/character_body_2d.cpp
+++ b/scene/2d/physics/character_body_2d.cpp
@@ -162,7 +162,7 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					apply_ceiling_velocity = true;
 					Vector2 ceiling_vertical_velocity = up_direction * up_direction.dot(result.collider_velocity);
 					Vector2 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
-					if (motion_vertical_velocity.dot(up_direction) > 0 || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
+					if (motion_vertical_velocity.dot(up_direction) > 0.0f || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
 						velocity = ceiling_vertical_velocity + velocity.slide(up_direction);
 					}
 				}

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -105,7 +105,7 @@ bool PhysicsBody2D::move_and_collide(const PS2DT::MotionParameters &p_parameters
 			// Check depth of recovery.
 			real_t projected_length = r_result.travel.dot(motion_normal);
 			Vector2 recovery = r_result.travel - motion_normal * projected_length;
-			real_t recovery_length = recovery.length();
+			const real_t recovery_length = recovery.length();
 			// Fixes cases where canceling slide causes the motion to go too deep into the ground,
 			// because we're only taking rest information into account and not general recovery.
 			if (recovery_length < p_parameters.margin + precision) {

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -240,7 +240,7 @@ void RayCast2D::_draw_debug_shape() {
 	// Draw an arrow indicating where the RayCast is pointing to
 	const real_t max_arrow_size = 6;
 	const real_t line_width = 1.4;
-	bool no_line = target_position.length() < line_width;
+	const bool no_line = target_position.length() < line_width;
 	real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -251,7 +251,7 @@ void ShapeCast2D::_notification(int p_what) {
 			if (target_position != Vector2()) {
 				const real_t max_arrow_size = 6;
 				const real_t line_width = 1.4;
-				bool no_line = target_position.length() < line_width;
+				const bool no_line = target_position.length() < line_width;
 				real_t arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 				if (no_line) {

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -330,14 +330,14 @@ void GPUParticlesCollisionSDF3D::_find_closest_distance(const Vector3 &p_pos, co
 		bool pass = true;
 		if (!p_bvh[p_bvh_cell].bounds.has_point(p_pos)) {
 			//outside, find closest point
-			Vector3 he = p_bvh[p_bvh_cell].bounds.size * 0.5f;
-			Vector3 center = p_bvh[p_bvh_cell].bounds.position + he;
+			const Vector3 he = p_bvh[p_bvh_cell].bounds.size * 0.5f;
+			const Vector3 center = p_bvh[p_bvh_cell].bounds.position + he;
 
-			Vector3 rel = (p_pos - center).abs();
-			Vector3 closest = rel.min(he);
-			float d = rel.distance_to(closest);
+			const Vector3 rel = (p_pos - center).abs();
+			const Vector3 closest = rel.min(he);
+			const float dist = rel.distance_to(closest);
 
-			if (d >= r_closest_distance) {
+			if (dist >= r_closest_distance) {
 				pass = false; //already closer than this aabb, discard
 			}
 		}

--- a/scene/3d/physics/character_body_3d.cpp
+++ b/scene/3d/physics/character_body_3d.cpp
@@ -187,7 +187,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					apply_ceiling_velocity = true;
 					Vector3 ceiling_vertical_velocity = up_direction * up_direction.dot(platform_ceiling_velocity);
 					Vector3 motion_vertical_velocity = up_direction * up_direction.dot(velocity);
-					if (motion_vertical_velocity.dot(up_direction) > 0 || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
+					if (motion_vertical_velocity.dot(up_direction) > 0.0f || ceiling_vertical_velocity.length_squared() > motion_vertical_velocity.length_squared()) {
 						velocity = ceiling_vertical_velocity + velocity.slide(up_direction);
 					}
 				}
@@ -219,9 +219,9 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 				if (floor_block_on_wall) {
 					// Needs horizontal motion from current motion instead of motion_slide_up
 					// to properly test the angle and avoid standing on slopes
-					Vector3 horizontal_motion = motion.slide(up_direction);
-					Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
-					real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(horizontal_motion.normalized())));
+					const Vector3 horizontal_motion = motion.slide(up_direction);
+					const Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
+					const real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(horizontal_motion.normalized())));
 
 					// Avoid to move forward on a wall if floor_block_on_wall is true.
 					// Applies only when the motion angle is under 90 degrees,
@@ -231,8 +231,8 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						if (p_was_on_floor && !vel_dir_facing_up) {
 							// Cancel the motion.
 							Transform3D gt = get_global_transform();
-							real_t travel_total = result.travel.length();
-							real_t cancel_dist_max = MIN(0.1f, margin * 20.0f);
+							const real_t travel_total = result.travel.length();
+							const real_t cancel_dist_max = MIN(0.1f, margin * 20.0f);
 							if (travel_total <= margin + CMP_EPSILON) {
 								gt.origin -= result.travel;
 								result.travel = Vector3(); // Cancel for constant speed computation.
@@ -255,12 +255,12 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 						}
 
 						// Apply slide on forward in order to allow only lateral motion on next step.
-						Vector3 forward = wall_normal.slide(up_direction).normalized();
+						const Vector3 forward = wall_normal.slide(up_direction).normalized();
 						motion = motion.slide(forward);
 
 						// Scales the horizontal velocity according to the wall slope.
 						if (vel_dir_facing_up) {
-							Vector3 slide_motion = velocity.slide(result.collisions[0].normal);
+							const Vector3 slide_motion = velocity.slide(result.collisions[0].normal);
 							// Keeps the vertical motion from velocity and add the horizontal motion of the projection.
 							velocity = up_direction * up_direction.dot(velocity) + slide_motion.slide(up_direction);
 						} else {
@@ -283,7 +283,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 						// Allow sliding when the body falls.
 						if (!collision_state.floor && motion.dot(up_direction) < 0) {
-							Vector3 slide_motion = motion.slide(wall_normal);
+							const Vector3 slide_motion = motion.slide(wall_normal);
 							// Test again to allow sliding only if the result goes downwards.
 							// Fixes jittering issues at the bottom of inclined walls.
 							if (slide_motion.dot(up_direction) < 0) {
@@ -301,8 +301,8 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 				// Stop horizontal motion when under wall slide threshold.
 				if (p_was_on_floor && (wall_min_slide_angle > 0.0) && result_state.wall) {
-					Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
-					real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(motion_slide_up.normalized())));
+					const Vector3 horizontal_normal = wall_normal.slide(up_direction).normalized();
+					const real_t motion_angle = Math::abs(Math::acos(-horizontal_normal.dot(motion_slide_up.normalized())));
 					if (motion_angle < wall_min_slide_angle) {
 						motion = up_direction * motion.dot(up_direction);
 						velocity = up_direction * velocity.dot(up_direction);

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -139,7 +139,7 @@ bool PhysicsBody3D::move_and_collide(const PS3DT::MotionParameters &p_parameters
 			// Check depth of recovery.
 			real_t projected_length = r_result.travel.dot(motion_normal);
 			Vector3 recovery = r_result.travel - motion_normal * projected_length;
-			real_t recovery_length = recovery.length();
+			const real_t recovery_length = recovery.length();
 			// Fixes cases where canceling slide causes the motion to go too deep into the ground,
 			// because we're only taking rest information into account and not general recovery.
 			if (recovery_length < p_parameters.margin + precision) {

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -744,7 +744,7 @@ void ColorPickerShapeWheel::_wheel_input(const Ref<InputEvent> &p_event) {
 	const Vector2 center = uv_size * 0.5;
 
 	if (is_click && !spinning) {
-		real_t dist = center.distance_to(event_position);
+		const real_t dist = center.distance_to(event_position);
 		if (dist >= center.x * (WHEEL_RADIUS * 2.0f) && dist <= center.x) {
 			spinning = true;
 			if (!wheel_focused) {
@@ -861,13 +861,13 @@ void ColorPickerShapeCircle::update_circle_cursor(const Vector2 &p_color_change_
 		circle_keyboard_joypad_picker_cursor_position = p_center + p_hue_offset;
 	}
 
-	Vector2i potential_cursor_position = circle_keyboard_joypad_picker_cursor_position + p_color_change_vector;
-	real_t potential_new_cursor_distance = p_center.distance_to(potential_cursor_position);
-	real_t dist_pre = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
+	const Vector2i potential_cursor_position = circle_keyboard_joypad_picker_cursor_position + p_color_change_vector;
+	const real_t potential_new_cursor_distance = p_center.distance_to(potential_cursor_position);
+	const real_t dist_pre = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
 	if (color_picker->s < 1 || potential_new_cursor_distance < dist_pre) {
 		circle_keyboard_joypad_picker_cursor_position += p_color_change_vector;
-		real_t dist = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
-		real_t rad = p_center.angle_to_point(circle_keyboard_joypad_picker_cursor_position);
+		const real_t dist = p_center.distance_to(circle_keyboard_joypad_picker_cursor_position);
+		const real_t rad = p_center.angle_to_point(circle_keyboard_joypad_picker_cursor_position);
 		color_picker->h = ((rad >= 0) ? rad : (Math::TAU + rad)) / Math::TAU;
 		color_picker->s = CLAMP(dist / p_center.x, 0, 1);
 	} else {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -358,7 +358,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 			drag.diff_y += mm->get_relative().y;
 			double diff_y = -0.01 * Math::pow(Math::abs(drag.diff_y), 1.8) * SIGN(drag.diff_y);
 			set_value(CLAMP(drag.base_val + step * diff_y, get_min(), get_max()));
-		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2) {
+		} else if (drag.allowed && drag.capture_pos.distance_to(mm->get_position()) > 2.0f) {
 			Input::get_singleton()->set_mouse_mode(Input::MouseMode::MOUSE_MODE_CAPTURED);
 			drag.enabled = true;
 			drag.base_val = get_value();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4184,7 +4184,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 				if (rtl) {
 					cpos.x = get_size().width - cpos.x;
 				}
-				if (cpos.distance_to(pressing_pos) > 2) {
+				if (cpos.distance_to(pressing_pos) > 2.0f) {
 					range_drag_enabled = true;
 					range_drag_capture_pos = cpos;
 					range_drag_base = popup_edited_item->get_range(popup_edited_item_col);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2059,7 +2059,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Viewport *section_root = get_section_root_viewport();
 		if (!gui.drag_attempted && gui.mouse_focus && section_root && !section_root->gui.global_dragging && (mm->get_button_mask().has_flag(MouseButtonMask::LEFT))) {
 			gui.drag_accum += mm->get_relative();
-			real_t len = gui.drag_accum.length();
+			const real_t len = gui.drag_accum.length();
 			if (len > gui.drag_threshold) {
 				{ // Attempt grab, try parent controls too.
 					CanvasItem *ci = gui.mouse_focus;

--- a/scene/resources/2d/separation_ray_shape_2d.cpp
+++ b/scene/resources/2d/separation_ray_shape_2d.cpp
@@ -47,7 +47,7 @@ void SeparationRayShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
 	const float max_arrow_size = 6;
 	const float line_width = 1.4;
-	bool no_line = target_position.length() < line_width;
+	const bool no_line = target_position.length() < line_width;
 	float arrow_size = CLAMP(target_position.length() * 2 / 3, line_width, max_arrow_size);
 
 	if (no_line) {


### PR DESCRIPTION
This PR uses `const` more, uses float literals, renames `d` to `dist`, and a few other small changes in the proximity of square values. This is a follow-up to PR #109800.