### PR TITLE
SCons: Fix `dlltool` on Windows MinGW builds

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -603,10 +603,10 @@ def CommandNoCache(env, target, sources, command, **args):
     return result
 
 
-def Run(env, function):
+def Run(env, function, comstr="$GENCOMSTR"):
     from SCons.Script import Action
 
-    return Action(function, "$GENCOMSTR")
+    return Action(function, comstr)
 
 
 def detect_darwin_toolchain_path(env):

--- a/platform/windows/SCsub
+++ b/platform/windows/SCsub
@@ -74,11 +74,7 @@ env.add_source_files(sources, common_win)
 sources += res_obj
 
 if env["accesskit"] and not env.msvc:
-    env["BUILDERS"]["DEF"].emitter = redirect_emitter
-    def_file = "uiautomationcore." + env["arch"] + ".def"
-    def_target = "libuiautomationcore." + env["arch"] + ".a"
-    def_obj = env.DEF(def_target, def_file)
-    sources += def_obj
+    sources += env.DEFLIB("uiautomationcore")
 
 prog = env.add_program("#bin/godot", sources, PROGSUFFIX=env["PROGSUFFIX"])
 arrange_program_clean(prog)


### PR DESCRIPTION
While attempting to replicate #95512, I was repeatedly halted at the start of compilation by the define library refusing to cooperate. This replaces the previous implementation with a much more "SCons" way of doing things, which guarantees that a proper executable is obtained regardless of which MinGW setup is used

Additionally expands the `env.Run` function to accept optional command string, because we can't just call `env.Action` for some reason
