### PR TITLE
Android: Ensure proper cleanup of the fragment

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotActivity.kt
@@ -98,7 +98,16 @@ abstract class GodotActivity : FragmentActivity(), GodotHost {
 		} else {
 			Log.v(TAG, "Creating new Godot fragment instance.")
 			godotFragment = initGodotInstance()
-			supportFragmentManager.beginTransaction().replace(R.id.godot_fragment_container, godotFragment!!).setPrimaryNavigationFragment(godotFragment).commitNowAllowingStateLoss()
+
+			val transaction = supportFragmentManager.beginTransaction()
+			if (currentFragment != null) {
+				Log.v(TAG, "Removing existing fragment before replacement.")
+				transaction.remove(currentFragment)
+			}
+
+			transaction.replace(R.id.godot_fragment_container, godotFragment!!)
+				.setPrimaryNavigationFragment(godotFragment)
+				.commitNowAllowingStateLoss()
 		}
 	}
 

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotFragment.java
@@ -126,6 +126,11 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 
 	@Override
 	public void onDetach() {
+		if (godotContainerLayout != null && godotContainerLayout.getParent() != null) {
+			Log.d(TAG, "Cleaning up Godot container layout during detach.");
+			((ViewGroup)godotContainerLayout.getParent()).removeView(godotContainerLayout);
+		}
+
 		super.onDetach();
 		parentHost = null;
 	}
@@ -233,11 +238,21 @@ public class GodotFragment extends Fragment implements IDownloaderClient, GodotH
 			return downloadingExpansionView;
 		}
 
+		if (godotContainerLayout != null && godotContainerLayout.getParent() != null) {
+			Log.w(TAG, "Godot container layout already has a parent, removing it.");
+			((ViewGroup)godotContainerLayout.getParent()).removeView(godotContainerLayout);
+		}
+
 		return godotContainerLayout;
 	}
 
 	@Override
 	public void onDestroy() {
+		if (godotContainerLayout != null && godotContainerLayout.getParent() != null) {
+			Log.w(TAG, "Removing Godot container layout from parent during destruction.");
+			((ViewGroup)godotContainerLayout.getParent()).removeView(godotContainerLayout);
+		}
+
 		godot.onDestroy(this);
 		super.onDestroy();
 	}


### PR DESCRIPTION
Make sure the Android fragment is cleaned up properly. Possible solution for the "child already has a parent" errors in https://github.com/godotengine/godot/issues/109235, where users report that the game starts only for the first time, requiring a device restart to work again.
<details>
<summary>Specific error from the issue</summary>

```
java.lang.RuntimeException: Unable to start activity ComponentInfo{pn.games.exsignal/com.godot.game.GodotApp}: java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2957)
	at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3032)
	at android.app.ActivityThread.-wrap11(Unknown Source)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1696)
	at android.os.Handler.dispatchMessage(Handler.java:105)
	at android.os.Looper.loop(Looper.java:164)
	at android.app.ActivityThread.main(ActivityThread.java:6942)
	at java.lang.reflect.Method.invoke(Native Method)
Caused by: java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
	at android.view.ViewGroup.addViewInner(ViewGroup.java:5122)
	at android.view.ViewGroup.addView(ViewGroup.java:4953)
	at android.view.ViewGroup.addView(ViewGroup.java:4893)
	at androidx.fragment.app.FragmentStateManager.addViewToContainer(FragmentStateManager.java:901)
	at androidx.fragment.app.FragmentStateManager.createView(FragmentStateManager.java:585)
	at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:286)
	at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:114)
	at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1685)
	at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3319)
	at androidx.fragment.app.FragmentManager.dispatchActivityCreated(FragmentManager.java:3237)
	at androidx.fragment.app.FragmentController.dispatchActivityCreated(FragmentController.java:263)
	at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:350)
	at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1341)
	at android.app.Activity.performStart(Activity.java:7200)
	at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2920)

#0. AdIdClientAutoDisconnectThread
	at java.lang.Object.wait(Native Method)
	at java.lang.Thread.parkFor$(Thread.java:2135)
	at sun.misc.Unsafe.park(Unsafe.java:358)
	at java.util.concurrent.locks.LockSupport.parkNanos(LockSupport.java:230)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedNanos(AbstractQueuedSynchronizer.java:1061)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.tryAcquireSharedNanos(AbstractQueuedSynchronizer.java:1352)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:278)
	at com.google.android.gms.ads.identifier.zzb.run(com.google.android.gms:play-services-ads-identifier@@18.2.0:1)
```

</details>