### PR TITLE
Fix MSDF outline size clamping.

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -609,7 +609,7 @@ void main() {
 		float d = msdf_median(msdf_sample.r, msdf_sample.g, msdf_sample.b);
 
 		if (outline_thickness > 0.0) {
-			float cr = clamp(outline_thickness, 0.0, px_range / 2.0) / px_range;
+			float cr = clamp(outline_thickness, 0.0, (px_range / 2.0) - 1.0) / px_range;
 			d = min(d, msdf_sample.a);
 			float a = clamp((d - 0.5 + cr) * px_size + 0.5, 0.0, 1.0);
 			color.a = a * color.a;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1638,7 +1638,7 @@ void fragment() {)";
 		float px_size = max(0.5 * dot(msdf_size, dest_size), 1.0);
 		float d = msdf_median(albedo_tex.r, albedo_tex.g, albedo_tex.b);
 		if (msdf_outline_size > 0.0) {
-			float cr = clamp(msdf_outline_size, 0.0, msdf_pixel_range / 2.0) / msdf_pixel_range;
+			float cr = clamp(msdf_outline_size, 0.0, (msdf_pixel_range / 2.0) - 1.0) / msdf_pixel_range;
 			d = min(d, albedo_tex.a);
 			albedo_tex.a = clamp((d - 0.5 + cr) * px_size + 0.5, 0.0, 1.0);
 		} else {

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -516,7 +516,7 @@ void main() {
 		float d = msdf_median(msdf_sample.r, msdf_sample.g, msdf_sample.b);
 
 		if (outline_thickness > 0) {
-			float cr = clamp(outline_thickness, 0.0, px_range / 2) / px_range;
+			float cr = clamp(outline_thickness, 0.0, (px_range / 2.0) - 1.0) / px_range;
 			d = min(d, msdf_sample.a);
 			float a = clamp((d - 0.5 + cr) * px_size + 0.5, 0.0, 1.0);
 			color.a = a * color.a;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109757

Max. outline size should be less than a half of pixel range, but it was clamping it to the half of pixel range, resulting in jagged outline (before https://github.com/godotengine/godot/pull/109437) or black background (after) if outline size is over the limit.