### PR TITLE
Fix typo in ScriptLanguageExtension::lookup_code

### DIFF
--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -459,7 +459,7 @@ public:
 		r_result.description = ret.get("description", "");
 		r_result.is_deprecated = ret.get("is_deprecated", false);
 		r_result.deprecated_message = ret.get("deprecated_message", "");
-		r_result.is_deprecated = ret.get("is_deprecated", false);
+		r_result.is_experimental = ret.get("is_experimental", false);
 		r_result.experimental_message = ret.get("experimental_message", "");
 
 		r_result.doc_type = ret.get("doc_type", "");


### PR DESCRIPTION
Fix typo – is_deprecated was being set twice, skipping is_experimental.

Lookup code:

https://github.com/godotengine/godot/blob/8ebf8ae23c095d4185e79602bb18a6952e192b56/core/object/script_language.h#L356-L382

Afterwards it was being accessed by ScriptTextEditor.