### PR TITLE
Fix incorrect `blend_position` values in BlendSpace editor after dragging point

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -167,7 +167,6 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 				undo_redo->add_undo_method(this, "_update_edited_point_pos");
 				undo_redo->commit_action();
 				updating = false;
-				_update_edited_point_pos();
 			}
 
 			dragging_selected_attempt = false;

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -262,7 +262,6 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				undo_redo->add_undo_method(this, "_update_edited_point_pos");
 				undo_redo->commit_action();
 				updating = false;
-				_update_edited_point_pos();
 			}
 		}
 		dragging_selected_attempt = false;


### PR DESCRIPTION
There is a bug that affects both `BlendSpace1D` and `BlendSpace2D`'s editors. When a blend point is dragged, the blend_position editor above the space is correct during the drag, but is twice the transformation once the mouse is released.

https://github.com/user-attachments/assets/07c1578a-dec7-4cd0-bd69-e4bfa620de05

By removing a redundant call to `_update_edited_point_pos()` in the mouse release function, this is fixed.