### PR TITLE
Compatibility: Improve ASTC extension detecting

### DIFF
--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -78,9 +78,10 @@ Config::Config() {
 #endif
 
 	bptc_supported = extensions.has("GL_ARB_texture_compression_bptc") || extensions.has("GL_EXT_texture_compression_bptc");
-	astc_hdr_supported = extensions.has("GL_KHR_texture_compression_astc_hdr");
-	astc_supported = astc_hdr_supported || extensions.has("GL_KHR_texture_compression_astc") || extensions.has("GL_OES_texture_compression_astc") || extensions.has("GL_KHR_texture_compression_astc_ldr") || extensions.has("WEBGL_compressed_texture_astc");
-	astc_layered_supported = extensions.has("GL_KHR_texture_compression_astc_sliced_3d");
+	astc_3d_supported = extensions.has("GL_OES_texture_compression_astc");
+	astc_hdr_supported = astc_3d_supported || extensions.has("GL_KHR_texture_compression_astc_hdr");
+	astc_layered_supported = astc_hdr_supported || extensions.has("GL_KHR_texture_compression_astc_sliced_3d");
+	astc_supported = astc_layered_supported || extensions.has("GL_KHR_texture_compression_astc_ldr") || extensions.has("WEBGL_compressed_texture_astc");
 
 	if (RasterizerGLES3::is_gles_over_gl()) {
 		float_texture_supported = true;

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -80,6 +80,7 @@ public:
 	bool astc_supported = false;
 	bool astc_hdr_supported = false;
 	bool astc_layered_supported = false;
+	bool astc_3d_supported = false;
 	bool srgb_framebuffer_supported = false;
 
 	bool force_vertex_shading = false;


### PR DESCRIPTION
According to https://developer.arm.com/documentation/102162/0430/Using-ASTC-with-graphics-APIs and https://registry.khronos.org/OpenGL/extensions/OES/OES_texture_compression_astc.txt ASTC extensions are packaged in the following 'tiers':

`GL_KHR_texture_compression_astc_ldr` - 2d, LDR only.
`GL_KHR_texture_compression_astc_sliced_3d` - 2d and sliced 3d, LDR only,
`GL_KHR_texture_compression_astc_hdr` - 2d and sliced 3d, LDR and HDR,
`GL_OES_texture_compression_astc` - 2d, sliced 3d, volumetric 3d, LDR and HDR ('full'),

TODO:
- [x] I was unable to find any information regarding `GL_KHR_texture_compression_astc`, so I've decided to remove it. It has been present in the codebase since ASTC was first implemented in the engine, so it needs to be confirmed whether devices actually report it.
- [x] According to https://registry.khronos.org/webgl/extensions/WEBGL_compressed_texture_astc/ `WEBGL_compressed_texture_astc` can support both LDR and HDR profiles, and the function `getSupportedProfiles` may be used to query them.