### PR TITLE
Expose `Thread::is_main_thread()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1526,6 +1526,10 @@ void Thread::set_thread_safety_checks_enabled(bool p_enabled) {
 	set_current_thread_safe_for_nodes(!p_enabled);
 }
 
+bool Thread::is_main_thread() {
+	return ::Thread::is_main_thread();
+}
+
 void Thread::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("start", "callable", "priority"), &Thread::start, DEFVAL(PRIORITY_NORMAL));
 	ClassDB::bind_method(D_METHOD("get_id"), &Thread::get_id);
@@ -1534,6 +1538,7 @@ void Thread::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("wait_to_finish"), &Thread::wait_to_finish);
 
 	ClassDB::bind_static_method("Thread", D_METHOD("set_thread_safety_checks_enabled", "enabled"), &Thread::set_thread_safety_checks_enabled);
+	ClassDB::bind_static_method("Thread", D_METHOD("is_main_thread"), &Thread::is_main_thread);
 
 	BIND_ENUM_CONSTANT(PRIORITY_LOW);
 	BIND_ENUM_CONSTANT(PRIORITY_NORMAL);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -495,6 +495,7 @@ public:
 	Variant wait_to_finish();
 
 	static void set_thread_safety_checks_enabled(bool p_enabled);
+	static bool is_main_thread();
 };
 
 namespace Special {

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -30,6 +30,13 @@
 				To check if a [Thread] is joinable, use [method is_started].
 			</description>
 		</method>
+		<method name="is_main_thread" qualifiers="static">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if the thread this method was called from is the main thread.
+				[b]Note:[/b] This is a static method and isn't associated with a specific [Thread] object.
+			</description>
+		</method>
 		<method name="is_started" qualifiers="const">
 			<return type="bool" />
 			<description>


### PR DESCRIPTION
This PR exposes `Thread::is_main_thread()`, which is already part of Godot's internal API - it's just not exposed to scripts and GDExtension.

I found this while working on a GDExtension that runs some code via `RenderingServer.call_on_render_thread()`, and it would be useful to know if code is running on the main thread (which if "Thread model" is set to "Safe" would be the same as the render thread, so we can't necessarily check via `not RenderingServer.is_on_render_thread()`).

But, also, this is used all over the place in Godot modules, so I think it would be useful to GDExtensions in other circumstances as well.