### PR TITLE
SCons: Use gnu++20 in metal driver

### DIFF
--- a/drivers/metal/SCsub
+++ b/drivers/metal/SCsub
@@ -36,7 +36,7 @@ env_metal.drivers_sources += thirdparty_obj
 # Enable C++20 for the Objective-C++ Metal code, which uses C++20 concepts.
 if "-std=gnu++17" in env_metal["CXXFLAGS"]:
     env_metal["CXXFLAGS"].remove("-std=gnu++17")
-env_metal.Append(CXXFLAGS=["-std=c++20"])
+env_metal.Append(CXXFLAGS=["-std=gnu++20"])
 
 # Enable module support
 env_metal.Append(CCFLAGS=["-fmodules", "-fcxx-modules"])


### PR DESCRIPTION
~~While I lack a macOS environment to test, I'm very confident in this being the fix to #105933. Designated initializers being a C99 extension stopped being the case in C++20, which the metal driver uses. However, the way this was implemented in that driver was inconsistent, as it replaced the standard with the generic C++ standard instead of the GNU equivalent; this meant that it couldn't use the extension supporting a mix of styles~~

Scope altered to simply fix the erroneous assignment of gnu++ to c++