### PR TITLE
Revert "MP3: Remove unnecessary memory allocation"

### DIFF
--- a/modules/minimp3/audio_stream_mp3.cpp
+++ b/modules/minimp3/audio_stream_mp3.cpp
@@ -55,7 +55,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 		mp3dec_frame_info_t frame_info;
 		mp3d_sample_t *buf_frame = nullptr;
 
-		int samples_mixed = mp3dec_ex_read_frame(&mp3d, &buf_frame, &frame_info, mp3_stream->channels);
+		int samples_mixed = mp3dec_ex_read_frame(mp3d, &buf_frame, &frame_info, mp3_stream->channels);
 
 		if (samples_mixed) {
 			p_buffer[p_frames - todo] = AudioFrame(buf_frame[0], buf_frame[samples_mixed - 1]);
@@ -68,7 +68,7 @@ int AudioStreamPlaybackMP3::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 
 			if (beat_loop && (int)frames_mixed >= beat_length_frames) {
 				for (int i = 0; i < FADE_SIZE; i++) {
-					samples_mixed = mp3dec_ex_read_frame(&mp3d, &buf_frame, &frame_info, mp3_stream->channels);
+					samples_mixed = mp3dec_ex_read_frame(mp3d, &buf_frame, &frame_info, mp3_stream->channels);
 					loop_fade[i] = AudioFrame(buf_frame[0], buf_frame[samples_mixed - 1]);
 					if (!samples_mixed) {
 						break;
@@ -136,7 +136,7 @@ void AudioStreamPlaybackMP3::seek(double p_time) {
 	}
 
 	frames_mixed = uint32_t(mp3_stream->sample_rate * p_time);
-	mp3dec_ex_seek(&mp3d, (uint64_t)frames_mixed * mp3_stream->channels);
+	mp3dec_ex_seek(mp3d, (uint64_t)frames_mixed * mp3_stream->channels);
 }
 
 void AudioStreamPlaybackMP3::tag_used_streams() {
@@ -182,7 +182,10 @@ Variant AudioStreamPlaybackMP3::get_parameter(const StringName &p_name) const {
 }
 
 AudioStreamPlaybackMP3::~AudioStreamPlaybackMP3() {
-	mp3dec_ex_close(&mp3d);
+	if (mp3d) {
+		mp3dec_ex_close(mp3d);
+		memfree(mp3d);
+	}
 }
 
 Ref<AudioStreamPlayback> AudioStreamMP3::instantiate_playback() {
@@ -195,8 +198,9 @@ Ref<AudioStreamPlayback> AudioStreamMP3::instantiate_playback() {
 
 	mp3s.instantiate();
 	mp3s->mp3_stream = Ref<AudioStreamMP3>(this);
+	mp3s->mp3d = (mp3dec_ex_t *)memalloc(sizeof(mp3dec_ex_t));
 
-	int errorcode = mp3dec_ex_open_buf(&mp3s->mp3d, data.ptr(), data_len, MP3D_SEEK_TO_SAMPLE);
+	int errorcode = mp3dec_ex_open_buf(mp3s->mp3d, data.ptr(), data_len, MP3D_SEEK_TO_SAMPLE);
 
 	mp3s->frames_mixed = 0;
 	mp3s->active = false;
@@ -220,7 +224,7 @@ void AudioStreamMP3::clear_data() {
 void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 	int src_data_len = p_data.size();
 
-	mp3dec_ex_t *mp3d = memnew(mp3dec_ex_t);
+	mp3dec_ex_t *mp3d = (mp3dec_ex_t *)memalloc(sizeof(mp3dec_ex_t));
 	int err = mp3dec_ex_open_buf(mp3d, p_data.ptr(), src_data_len, MP3D_SEEK_TO_SAMPLE);
 	if (err || mp3d->info.hz == 0) {
 		memdelete(mp3d);

--- a/modules/minimp3/audio_stream_mp3.h
+++ b/modules/minimp3/audio_stream_mp3.h
@@ -47,7 +47,7 @@ class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
 
 	bool looping_override = false;
 	bool looping = false;
-	mp3dec_ex_t mp3d = {};
+	mp3dec_ex_t *mp3d = nullptr;
 	uint32_t frames_mixed = 0;
 	bool active = false;
 	int loops = 0;


### PR DESCRIPTION
This reverts https://github.com/godotengine/godot/pull/95999 that caused GCC One Definition Rule (ODR) warnings across translation units when using LTO.

Also:
```c++
// Changed:
mp3dec_ex_t *mp3d = memnew(mp3dec_ex_t);

// To:
mp3dec_ex_t *mp3d = (mp3dec_ex_t *)memalloc(sizeof(mp3dec_ex_t));
```

**Previous Warnings**:
```c++
./thirdparty/minimp3/minimp3_ex.h:88:3: warning: type 'struct mp3dec_ex_t' violates the C++ One Definition Rule [-Wodr]
   88 | } mp3dec_ex_t;
      |   ^
./thirdparty/minimp3/minimp3_ex.h:88:3: note: a different type is defined in another translation unit
   88 | } mp3dec_ex_t;
      |   ^
./thirdparty/minimp3/minimp3_ex.h:82:19: note: the first difference of corresponding definitions is field 'buffer'
   82 |     mp3d_sample_t buffer[MINIMP3_MAX_SAMPLES_PER_FRAME];
      |                   ^
./thirdparty/minimp3/minimp3_ex.h:82:19: note: a field of same name but different type is defined in another translation unit
   82 |     mp3d_sample_t buffer[MINIMP3_MAX_SAMPLES_PER_FRAME];
      |                   ^
./thirdparty/minimp3/minimp3_ex.h:88:3: note: type 'mp3d_sample_t' should match type 'mp3d_sample_t'
   88 | } mp3dec_ex_t;
      |   ^
modules/minimp3/audio_stream_mp3.h:38:7: warning: type 'struct AudioStreamPlaybackMP3' violates the C++ One Definition Rule [-Wodr]
   38 | class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
      |       ^
modules/minimp3/audio_stream_mp3.h:38:7: note: a different type is defined in another translation unit
   38 | class AudioStreamPlaybackMP3 : public AudioStreamPlaybackResampled {
      |       ^
modules/minimp3/audio_stream_mp3.h:49:21: note: the first difference of corresponding definitions is field 'mp3d'
   49 |         mp3dec_ex_t mp3d{};
      |                     ^
modules/minimp3/audio_stream_mp3.h:49:21: note: a field of same name but different type is defined in another translation unit
   49 |         mp3dec_ex_t mp3d{};
      |                     ^
./thirdparty/minimp3/minimp3_ex.h:88:3: note: type 'struct mp3dec_ex_t' itself violates the C++ One Definition Rule
   88 | } mp3dec_ex_t;
      |   ^
modules/minimp3/audio_stream_mp3.h:39:9: warning: type of 'is_class_ptr' does not match original declaration [-Wlto-type-mismatch]
   39 |         GDCLASS(AudioStreamPlaybackMP3, AudioStreamPlaybackResampled);
      |         ^
modules/minimp3/audio_stream_mp3.h:39:9: note: 'is_class_ptr' was previously declared here
   39 |         GDCLASS(AudioStreamPlaybackMP3, AudioStreamPlaybackResampled);
      |         ^
```

<s>Another option is to silence the warnings (Never used elsewhere in the source code):</s>
Edit: It didn't work, the warnings are thrown durning link time.
```c++
#pragma GCC diagnostic push
#pragma GCC diagnostic ignored "-Wodr"
	mp3dec_ex_t mp3d = {};
#pragma GCC diagnostic pop
```