### PR TITLE
[Web] Fix `AudioStreamPlayer.get_playback_position()` returning incorrect values for samples

### DIFF
--- a/platform/web/js/libs/audio.position.worklet.js
+++ b/platform/web/js/libs/audio.position.worklet.js
@@ -29,22 +29,28 @@
 /**************************************************************************/
 
 class GodotPositionReportingProcessor extends AudioWorkletProcessor {
+	static get parameterDescriptors() {
+		return [
+			{
+				name: 'reset',
+				defaultValue: 0,
+				minValue: 0,
+				maxValue: 1,
+				automationRate: 'k-rate',
+			},
+		];
+	}
+
 	constructor(...args) {
 		super(...args);
 		this.position = 0;
-
-		this.port.onmessage = (event) => {
-			switch (event?.data?.type) {
-			case 'reset':
-				this.position = 0;
-				break;
-			default:
-				// Do nothing.
-			}
-		};
 	}
 
-	process(inputs, _outputs, _parameters) {
+	process(inputs, _outputs, parameters) {
+		if (parameters['reset'][0] > 0) {
+			this.position = 0;
+		}
+
 		if (inputs.length > 0) {
 			const input = inputs[0];
 			if (input.length > 0) {

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -643,6 +643,7 @@ class SampleNode {
 				'godot-position-reporting-processor'
 			);
 		}
+		this._playbackPosition = this.offset;
 		this._positionWorklet.port.onmessage = (event) => {
 			switch (event.data['type']) {
 			case 'position':
@@ -652,7 +653,11 @@ class SampleNode {
 				// Do nothing.
 			}
 		};
-		this._positionWorklet.port.postMessage('reset');
+
+		const resetParameter = this._positionWorklet.parameters.get('reset');
+		resetParameter.setValueAtTime(1, GodotAudio.ctx.currentTime);
+		resetParameter.setValueAtTime(0, GodotAudio.ctx.currentTime + 1);
+
 		return this._positionWorklet;
 	}
 


### PR DESCRIPTION
This PR changes the way how we reset the audio position position tracking for the Web platform.

Previously, we based the logic around the [`AudioWorkletNode.port`](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletNode/port) message handler setup in the constructor. That handler received "reset" messages and reset the `this.position` to `0`. Unfortunately, it seems that only Firefox truly is compatible with that method.

I pivoted instead to use the native `AudioParam` support in [`AudioWorkletNode.parameters`](https://developer.mozilla.org/en-US/docs/Web/API/AudioWorkletNode/parameters) in order to handle the position reset.

These params are usually for gain or other audio parameters. But I figured that I could send a "reset" value for the exact start frame, and sending a "no reset" value for every other frame. Now, on each processed frame, it checks if the "reset" property is bigger than 0, and if it is, it resets the position.

Fixes #109144 (hopefully)