### PR TITLE
Compatibility: Fix backface culling gets ignored when double-sided shadows are used

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3200,7 +3200,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			// Find cull variant.
 			RS::CullMode cull_mode = shader->cull_mode;
 
-			if (p_pass_mode == PASS_MODE_MATERIAL || (surf->flags & GeometryInstanceSurface::FLAG_USES_DOUBLE_SIDED_SHADOWS)) {
+			if (p_pass_mode == PASS_MODE_MATERIAL || (p_pass_mode == PASS_MODE_SHADOW && (surf->flags & GeometryInstanceSurface::FLAG_USES_DOUBLE_SIDED_SHADOWS))) {
 				cull_mode = RS::CULL_MODE_DISABLED;
 			} else {
 				bool mirror = inst->mirror;


### PR DESCRIPTION
Fixes #108941. Looks like the culling mode was always disabled (no matter the render pass) if the material is setup with double-sided shadows:

```cpp
if (p_pass_mode == PASS_MODE_MATERIAL || (surf->flags & GeometryInstanceSurface::FLAG_USES_DOUBLE_SIDED_SHADOWS)) {
				cull_mode = RS::CULL_MODE_DISABLED;
}
```

Looks fixed after adjusting the condition check. 

<img width="1280" height="563" alt="Image" src="https://github.com/user-attachments/assets/600cc70b-16df-4c5e-afec-10d0e61aca2c" />

<img width="1280" height="474" alt="Image" src="https://github.com/user-attachments/assets/862f6ad9-98ba-41ce-a709-35e79d467a19" />


