### PR TITLE
Correctly hide BlendSpace editor error panel on load

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -801,6 +801,7 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	error_label = memnew(Label);
 	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
 	error_panel->add_child(error_label);
+	error_panel->hide();
 
 	menu = memnew(PopupMenu);
 	add_child(menu);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -1082,6 +1082,7 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 	error_label = memnew(Label);
 	error_label->set_focus_mode(FOCUS_ACCESSIBILITY);
 	error_panel->add_child(error_label);
+	error_panel->hide();
 
 	set_custom_minimum_size(Size2(0, 300 * EDSCALE));
 


### PR DESCRIPTION
For a BlendSpace1D or BlendSpace2D editor, there exists an error panel at the bottom. This error panel isn't correctly hidden on project load, causing a blank panel with no error to be visible on the bottom of the AnimationTree, until an error is first generated and then cleared.

<img width="1645" height="225" alt="blendspace-fix-error-padding" src="https://github.com/user-attachments/assets/c84d6db9-c590-4b2a-8649-a90cb536b11f" />


This PR adds `error_panel->hide()` to both, copying code from `animation_state_machine_editor.cpp`.