### PR TITLE
Fix typo in doc of `text_editor/theme/highlighting/gdscript/string_name_color`

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1578,7 +1578,7 @@
 			The GDScript syntax highlighter text color for node reference literals (e.g. [code]$"Sprite"[/code] and [code]%"Sprite"[/code]]).
 		</member>
 		<member name="text_editor/theme/highlighting/gdscript/string_name_color" type="Color" setter="" getter="">
-			The GDScript syntax highlighter text color for [StringName] literals (e.g. [code]&gt;"example"[/code]).
+			The GDScript syntax highlighter text color for [StringName] literals (e.g. [code]&amp;"example"[/code]).
 		</member>
 		<member name="text_editor/theme/highlighting/keyword_color" type="Color" setter="" getter="">
 			The script editor's non-control flow keyword color (used for keywords like [code]var[/code], [code]func[/code], [code]extends[/code], ...).


### PR DESCRIPTION
Fix the literal example from `>"example"` to `&"example"`, in the *Editor Settings - Text Editor - Theme - GDScript*'s tooltip of *String Name Color*.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
