### PR TITLE
Expand Script class getter's methods with (include_base) to control including the inherited classes in the process

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -71,30 +71,30 @@ Variant Script::_get_property_default_value(const StringName &p_property) {
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_property_list() {
+TypedArray<Dictionary> Script::_get_script_property_list(bool include_base) {
 	TypedArray<Dictionary> ret;
 	List<PropertyInfo> list;
-	get_script_property_list(&list);
+	get_script_property_list(&list, include_base);
 	for (const PropertyInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_method_list() {
+TypedArray<Dictionary> Script::_get_script_method_list(bool include_base) {
 	TypedArray<Dictionary> ret;
 	List<MethodInfo> list;
-	get_script_method_list(&list);
+	get_script_method_list(&list, include_base);
 	for (const MethodInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
 	return ret;
 }
 
-TypedArray<Dictionary> Script::_get_script_signal_list() {
+TypedArray<Dictionary> Script::_get_script_signal_list(bool include_base) {
 	TypedArray<Dictionary> ret;
 	List<MethodInfo> list;
-	get_script_signal_list(&list);
+	get_script_signal_list(&list, include_base);
 	for (const MethodInfo &E : list) {
 		ret.append(E.operator Dictionary());
 	}
@@ -173,9 +173,9 @@ void Script::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("has_script_signal", "signal_name"), &Script::has_script_signal);
 
-	ClassDB::bind_method(D_METHOD("get_script_property_list"), &Script::_get_script_property_list);
-	ClassDB::bind_method(D_METHOD("get_script_method_list"), &Script::_get_script_method_list);
-	ClassDB::bind_method(D_METHOD("get_script_signal_list"), &Script::_get_script_signal_list);
+	ClassDB::bind_method(D_METHOD("get_script_property_list", "include_base"), &Script::_get_script_property_list, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_script_method_list", "include_base"), &Script::_get_script_method_list, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("get_script_signal_list", "include_base"), &Script::_get_script_signal_list, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_script_constant_map"), &Script::_get_script_constant_map);
 	ClassDB::bind_method(D_METHOD("get_property_default_value", "property"), &Script::_get_property_default_value);
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -128,9 +128,9 @@ protected:
 	virtual void _placeholder_erased(PlaceHolderScriptInstance *p_placeholder) {}
 
 	Variant _get_property_default_value(const StringName &p_property);
-	TypedArray<Dictionary> _get_script_property_list();
-	TypedArray<Dictionary> _get_script_method_list();
-	TypedArray<Dictionary> _get_script_signal_list();
+	TypedArray<Dictionary> _get_script_property_list(bool include_base = true);
+	TypedArray<Dictionary> _get_script_method_list(bool include_base = true);
+	TypedArray<Dictionary> _get_script_signal_list(bool include_base = true);
 	Dictionary _get_script_constant_map();
 
 	void _set_debugger_break_language();
@@ -180,13 +180,13 @@ public:
 	virtual ScriptLanguage *get_language() const = 0;
 
 	virtual bool has_script_signal(const StringName &p_signal) const = 0;
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const = 0;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool include_base = true) const = 0;
 
 	virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const = 0;
 
 	virtual void update_exports() {} //editor tool
-	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
+	virtual void get_script_method_list(List<MethodInfo> *p_list, bool include_base = true) const = 0;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool include_base = true) const = 0;
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -139,11 +139,11 @@ public:
 	EXBIND0RC(ScriptLanguage *, get_language)
 	EXBIND1RC(bool, has_script_signal, const StringName &)
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_signal_list, bool)
 
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override {
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool include_base = true) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_signal_list, sl);
+		GDVIRTUAL_CALL(_get_script_signal_list, include_base, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_signals->push_back(MethodInfo::from_dict(sl[i]));
 		}
@@ -165,21 +165,21 @@ public:
 
 	EXBIND0(update_exports)
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_method_list, bool)
 
-	virtual void get_script_method_list(List<MethodInfo> *r_methods) const override {
+	virtual void get_script_method_list(List<MethodInfo> *r_methods, bool include_base = true) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_method_list, sl);
+		GDVIRTUAL_CALL(_get_script_method_list, include_base, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_methods->push_back(MethodInfo::from_dict(sl[i]));
 		}
 	}
 
-	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list)
+	GDVIRTUAL1RC_REQUIRED(TypedArray<Dictionary>, _get_script_property_list, bool)
 
-	virtual void get_script_property_list(List<PropertyInfo> *r_propertys) const override {
+	virtual void get_script_property_list(List<PropertyInfo> *r_propertys, bool include_base = true) const override {
 		TypedArray<Dictionary> sl;
-		GDVIRTUAL_CALL(_get_script_property_list, sl);
+		GDVIRTUAL_CALL(_get_script_property_list, include_base, sl);
 		for (int i = 0; i < sl.size(); i++) {
 			r_propertys->push_back(PropertyInfo::from_dict(sl[i]));
 		}

--- a/doc/classes/Script.xml
+++ b/doc/classes/Script.xml
@@ -72,22 +72,28 @@
 		</method>
 		<method name="get_script_method_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="include_base" type="bool" default="true" />
 			<description>
 				Returns the list of methods in this [Script].
+				[param include_base] defines whether the parent's methods are included or not. This value is propagated.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_method_list].
 			</description>
 		</method>
 		<method name="get_script_property_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="include_base" type="bool" default="true" />
 			<description>
 				Returns the list of properties in this [Script].
+				[param include_base] defines whether the parent's properties are included or not. This value is propagated.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_property_list].
 			</description>
 		</method>
 		<method name="get_script_signal_list">
 			<return type="Dictionary[]" />
+			<param index="0" name="include_base" type="bool" default="true" />
 			<description>
 				Returns the list of user signals defined in this [Script].
+				[param include_base] defines whether the parent's signals are included or not. This value is propagated.
 				[b]Note:[/b] The dictionaries returned by this method are formatted identically to those returned by [method Object.get_signal_list].
 			</description>
 		</method>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -309,8 +309,8 @@ void GDScript::_get_script_method_list(List<MethodInfo> *r_list, bool p_include_
 	}
 }
 
-void GDScript::get_script_method_list(List<MethodInfo> *r_list) const {
-	_get_script_method_list(r_list, true);
+void GDScript::get_script_method_list(List<MethodInfo> *r_list, bool include_base) const {
+	_get_script_method_list(r_list, include_base);
 }
 
 void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const {
@@ -352,8 +352,8 @@ void GDScript::_get_script_property_list(List<PropertyInfo> *r_list, bool p_incl
 	}
 }
 
-void GDScript::get_script_property_list(List<PropertyInfo> *r_list) const {
-	_get_script_property_list(r_list, true);
+void GDScript::get_script_property_list(List<PropertyInfo> *r_list, bool include_base) const {
+	_get_script_property_list(r_list, include_base);
 }
 
 bool GDScript::has_method(const StringName &p_method) const {
@@ -1346,8 +1346,8 @@ void GDScript::_get_script_signal_list(List<MethodInfo> *r_list, bool p_include_
 #endif
 }
 
-void GDScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
+void GDScript::get_script_signal_list(List<MethodInfo> *r_signals, bool include_base) const {
+	_get_script_signal_list(r_signals, include_base);
 }
 
 GDScript *GDScript::_get_gdscript_from_variant(const Variant &p_variant) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -213,9 +213,9 @@ private:
 
 	void _save_orphaned_subclasses(GDScript::ClearData *p_clear_data);
 
-	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base) const;
-	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base) const;
-	void _get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base) const;
+	void _get_script_property_list(List<PropertyInfo> *r_list, bool p_include_base = true) const;
+	void _get_script_method_list(List<MethodInfo> *r_list, bool p_include_base = true) const;
+	void _get_script_signal_list(List<MethodInfo> *r_list, bool p_include_base = true) const;
 
 	GDScript *_get_gdscript_from_variant(const Variant &p_variant);
 	void _collect_function_dependencies(GDScriptFunction *p_func, RBSet<GDScript *> &p_dependencies, const GDScript *p_except);
@@ -277,7 +277,7 @@ public:
 	RBSet<GDScript *> get_must_clear_dependencies();
 
 	virtual bool has_script_signal(const StringName &p_signal) const override;
-	virtual void get_script_signal_list(List<MethodInfo> *r_signals) const override;
+	virtual void get_script_signal_list(List<MethodInfo> *r_signals, bool include_base = true) const override;
 
 	bool is_tool() const override { return tool; }
 	bool is_abstract() const override { return _is_abstract; }
@@ -322,7 +322,7 @@ public:
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
 
-	virtual void get_script_method_list(List<MethodInfo> *p_list) const override;
+	virtual void get_script_method_list(List<MethodInfo> *p_list, bool include_base = true) const override;
 	virtual bool has_method(const StringName &p_method) const override;
 	virtual bool has_static_method(const StringName &p_method) const override;
 
@@ -330,7 +330,7 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
+	virtual void get_script_property_list(List<PropertyInfo> *p_list, bool include_base = true) const override;
 
 	virtual ScriptLanguage *get_language() const override;
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -2513,7 +2513,7 @@ void CSharpScript::set_source_code(const String &p_code) {
 #endif
 }
 
-void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
+void CSharpScript::get_script_method_list(List<MethodInfo> *p_list, bool include_base) const {
 	if (!valid) {
 		return;
 	}
@@ -2523,7 +2523,9 @@ void CSharpScript::get_script_method_list(List<MethodInfo> *p_list) const {
 		for (const CSharpMethodInfo &E : top->methods) {
 			p_list->push_back(E.method_info);
 		}
-
+		if (!include_base) {
+			break;
+		}
 		top = top->base_script.ptr();
 	}
 }
@@ -2700,8 +2702,8 @@ void CSharpScript::_get_script_signal_list(List<MethodInfo> *r_signals, bool p_i
 	}
 }
 
-void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals) const {
-	_get_script_signal_list(r_signals, true);
+void CSharpScript::get_script_signal_list(List<MethodInfo> *r_signals, bool include_base) const {
+	_get_script_signal_list(r_signals, include_base);
 }
 
 bool CSharpScript::inherits_script(const Ref<Script> &p_script) const {
@@ -2729,14 +2731,16 @@ StringName CSharpScript::get_global_name() const {
 	return type_info.is_global_class ? StringName(type_info.class_name) : StringName();
 }
 
-void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
+void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list, bool include_base) const {
 #ifdef TOOLS_ENABLED
 	const CSharpScript *top = this;
 	while (top != nullptr) {
 		for (const PropertyInfo &E : top->exported_members_cache) {
 			r_list->push_back(E);
 		}
-
+		if (!include_base) {
+			break;
+		}
 		top = top->base_script.ptr();
 	}
 #else
@@ -2751,7 +2755,9 @@ void CSharpScript::get_script_property_list(List<PropertyInfo> *r_list) const {
 		for (const PropertyInfo &prop : props) {
 			r_list->push_back(prop);
 		}
-
+		if (!include_base) {
+			break;
+		}
 		top = top->base_script.ptr();
 	}
 #endif

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -219,7 +219,7 @@ private:
 	// Do not use unless you know what you are doing
 	static void update_script_class_info(Ref<CSharpScript> p_script);
 
-	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base) const;
+	void _get_script_signal_list(List<MethodInfo> *r_signals, bool p_include_base = true) const;
 
 protected:
 	static void _bind_methods();
@@ -256,10 +256,10 @@ public:
 	Error reload(bool p_keep_state = false) override;
 
 	bool has_script_signal(const StringName &p_signal) const override;
-	void get_script_signal_list(List<MethodInfo> *r_signals) const override;
+	void get_script_signal_list(List<MethodInfo> *r_signals, bool include_base = true) const override;
 
 	bool get_property_default_value(const StringName &p_property, Variant &r_value) const override;
-	void get_script_property_list(List<PropertyInfo> *r_list) const override;
+	void get_script_property_list(List<PropertyInfo> *r_list, bool include_base = true) const override;
 	void update_exports() override;
 
 	void get_members(HashSet<StringName> *p_members) override;
@@ -281,7 +281,7 @@ public:
 
 	ScriptLanguage *get_language() const override;
 
-	void get_script_method_list(List<MethodInfo> *p_list) const override;
+	void get_script_method_list(List<MethodInfo> *p_list, bool include_base = true) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	MethodInfo get_method_info(const StringName &p_method) const override;


### PR DESCRIPTION
The `Script` getter's methods (`get_script_method_list`, `get_script_property_list`, and `get_script_signal_list`) are expanded with a new parameter (`include_base`) to allow more control and decide whether the parent's methods, properties, or signals should be included in the returned list or not.
Previously, these methods were always considering the inherited properties, methods, and signals, but I needed to disable including the inherited classes for more control in my use case of handling the scripts.