### PR TITLE
Edit groups on multiple nodes

### DIFF
--- a/editor/docks/groups_editor.cpp
+++ b/editor/docks/groups_editor.cpp
@@ -93,6 +93,41 @@ void GroupsEditor::_set_group_checked(const String &p_name, bool p_checked) {
 	ti->set_checked(0, p_checked);
 }
 
+void GroupsEditor::_add_to_group(const StringName &p_name, bool p_persist, const Array &p_nodes) {
+	for (const Variant &v : p_nodes) {
+		Node *node = Object::cast_to<Node>(v.get_validated_object());
+		if (node) {
+			node->add_to_group(p_name, p_persist);
+		}
+	}
+}
+
+void GroupsEditor::_remove_from_group(const StringName &p_name, const Array &p_nodes) {
+	for (const Variant &v : p_nodes) {
+		Node *node = Object::cast_to<Node>(v.get_validated_object());
+		if (node) {
+			node->remove_from_group(p_name);
+		}
+	}
+}
+
+void GroupsEditor::_get_group_mask(const StringName &p_name, Array &r_nodes, bool p_invert) {
+	for (Node *p_node : selection) {
+		if (p_invert != p_node->is_in_group(p_name)) {
+			r_nodes.push_back(p_node);
+		}
+	}
+}
+
+bool GroupsEditor::_can_edit(const StringName &p_group) {
+	for (Node *p_node : selection) {
+		if (!can_edit(p_node, p_group)) {
+			return false;
+		}
+	}
+	return true;
+}
+
 bool GroupsEditor::_has_group(const String &p_name) {
 	return global_groups.has(p_name) || scene_groups.has(p_name);
 }
@@ -102,7 +137,7 @@ void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id, MouseBu
 		return;
 	}
 
-	if (!node) {
+	if (selection.is_empty()) {
 		return;
 	}
 
@@ -177,7 +212,7 @@ void GroupsEditor::_update_tree() {
 		return;
 	}
 
-	if (!node) {
+	if (selection.is_empty()) {
 		return;
 	}
 
@@ -190,7 +225,9 @@ void GroupsEditor::_update_tree() {
 	tree->clear();
 
 	List<Node::GroupInfo> groups;
-	node->get_groups(&groups);
+	for (Node *p_node : selection) {
+		p_node->get_groups(&groups);
+	}
 	groups.sort_custom<_GroupInfoComparator>();
 
 	List<StringName> current_groups;
@@ -219,7 +256,7 @@ void GroupsEditor::_update_tree() {
 
 		TreeItem *item = tree->create_item(local_root);
 		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-		item->set_editable(0, can_edit(node, E));
+		item->set_editable(0, _can_edit(E));
 		item->set_checked(0, current_groups.find(E) != nullptr);
 		item->set_text(0, E);
 		item->set_meta("__local", true);
@@ -250,7 +287,7 @@ void GroupsEditor::_update_tree() {
 
 		TreeItem *item = tree->create_item(global_root);
 		item->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-		item->set_editable(0, can_edit(node, E));
+		item->set_editable(0, _can_edit(E));
 		item->set_checked(0, current_groups.find(E) != nullptr);
 		item->set_text(0, E);
 		item->set_meta("__local", false);
@@ -305,15 +342,18 @@ void GroupsEditor::_cache_scene_groups(const ObjectID &p_id) {
 	}
 }
 
-void GroupsEditor::set_current(Node *p_node) {
-	if (node == p_node) {
+void GroupsEditor::set_selection(const Vector<Node *> &p_nodes) {
+	if (p_nodes.is_empty()) {
+		holder->hide();
+		select_a_node->show();
+		selection.clear();
 		return;
 	}
-	node = p_node;
 
-	if (!node) {
-		return;
-	}
+	selection = p_nodes;
+
+	holder->show();
+	select_a_node->hide();
 
 	if (scene_tree->get_edited_scene_root() != scene_root_node) {
 		scene_root_node = scene_tree->get_edited_scene_root();
@@ -336,8 +376,10 @@ void GroupsEditor::_item_edited() {
 	if (ti->is_checked(0)) {
 		undo_redo->create_action(TTR("Add to Group"));
 
-		undo_redo->add_do_method(node, "add_to_group", name, true);
-		undo_redo->add_undo_method(node, "remove_from_group", name);
+		Array nodes;
+		_get_group_mask(name, nodes, true);
+		undo_redo->add_do_method(this, "_add_to_group", name, true, nodes);
+		undo_redo->add_undo_method(this, "_remove_from_group", name, nodes);
 
 		undo_redo->add_do_method(this, "_set_group_checked", name, true);
 		undo_redo->add_undo_method(this, "_set_group_checked", name, false);
@@ -351,8 +393,10 @@ void GroupsEditor::_item_edited() {
 	} else {
 		undo_redo->create_action(TTR("Remove from Group"));
 
-		undo_redo->add_do_method(node, "remove_from_group", name);
-		undo_redo->add_undo_method(node, "add_to_group", name, true);
+		Array nodes;
+		_get_group_mask(name, nodes, false);
+		undo_redo->add_do_method(this, "_remove_from_group", name, nodes);
+		undo_redo->add_undo_method(this, "_add_to_group", name, true, nodes);
 
 		undo_redo->add_do_method(this, "_set_group_checked", name, false);
 		undo_redo->add_undo_method(this, "_set_group_checked", name, true);
@@ -487,8 +531,10 @@ void GroupsEditor::_confirm_add() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Add to Group"));
 
-	undo_redo->add_do_method(node, "add_to_group", name, true);
-	undo_redo->add_undo_method(node, "remove_from_group", name);
+	Array nodes;
+	_get_group_mask(name, nodes, true);
+	undo_redo->add_do_method(this, "_add_to_group", name, true, nodes);
+	undo_redo->add_undo_method(this, "_remove_from_group", name, nodes);
 
 	bool is_local = !global_group_button->is_pressed();
 	if (is_local) {
@@ -817,6 +863,9 @@ void GroupsEditor::_bind_methods() {
 	ClassDB::bind_method("_rename_scene_group", &GroupsEditor::_rename_scene_group);
 	ClassDB::bind_method("_remove_scene_group", &GroupsEditor::_remove_scene_group);
 	ClassDB::bind_method("_set_group_checked", &GroupsEditor::_set_group_checked);
+
+	ClassDB::bind_method("_add_to_group", &GroupsEditor::_add_to_group);
+	ClassDB::bind_method("_remove_from_group", &GroupsEditor::_remove_from_group);
 }
 
 void GroupsEditor::_node_removed(Node *p_node) {
@@ -832,15 +881,19 @@ void GroupsEditor::_node_removed(Node *p_node) {
 }
 
 GroupsEditor::GroupsEditor() {
-	node = nullptr;
 	scene_tree = SceneTree::get_singleton();
 
 	ED_SHORTCUT("groups_editor/delete", TTRC("Delete"), Key::KEY_DELETE);
 	ED_SHORTCUT("groups_editor/rename", TTRC("Rename"), Key::F2);
 	ED_SHORTCUT_OVERRIDE("groups_editor/rename", "macos", Key::ENTER);
 
+	holder = memnew(VBoxContainer);
+	holder->set_v_size_flags(SIZE_EXPAND_FILL);
+	holder->hide();
+	add_child(holder);
+
 	HBoxContainer *hbc = memnew(HBoxContainer);
-	add_child(hbc);
+	holder->add_child(hbc);
 
 	add = memnew(Button);
 	add->set_theme_type_variation("FlatMenuButton");
@@ -865,11 +918,21 @@ GroupsEditor::GroupsEditor() {
 	tree->connect("button_clicked", callable_mp(this, &GroupsEditor::_modify_group));
 	tree->connect("item_mouse_selected", callable_mp(this, &GroupsEditor::_item_mouse_selected));
 	tree->connect(SceneStringName(gui_input), callable_mp(this, &GroupsEditor::_groups_gui_input));
-	add_child(tree);
+	holder->add_child(tree);
 
 	menu = memnew(PopupMenu);
 	menu->connect(SceneStringName(id_pressed), callable_mp(this, &GroupsEditor::_menu_id_pressed));
 	tree->add_child(menu);
+
+	select_a_node = memnew(Label);
+	select_a_node->set_focus_mode(FOCUS_ACCESSIBILITY);
+	select_a_node->set_text(TTRC("Select one or more nodes to edit their groups."));
+	select_a_node->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
+	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
+	select_a_node->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	select_a_node->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	select_a_node->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	add_child(select_a_node);
 
 	ProjectSettingsEditor::get_singleton()->get_group_settings()->connect("group_changed", callable_mp(this, &GroupsEditor::_update_groups_and_tree));
 }

--- a/editor/docks/groups_editor.h
+++ b/editor/docks/groups_editor.h
@@ -52,7 +52,7 @@ class GroupsEditor : public VBoxContainer {
 	bool groups_dirty = false;
 	bool update_groups_and_tree_queued = false;
 
-	Node *node = nullptr;
+	LocalVector<Node *> selection;
 	Node *scene_root_node = nullptr;
 	SceneTree *scene_tree = nullptr;
 
@@ -73,9 +73,11 @@ class GroupsEditor : public VBoxContainer {
 
 	PopupMenu *menu = nullptr;
 
+	VBoxContainer *holder = nullptr;
 	LineEdit *filter = nullptr;
 	Button *add = nullptr;
 	Tree *tree = nullptr;
+	Label *select_a_node = nullptr;
 
 	HashMap<ObjectID, HashMap<StringName, bool>> scene_groups_cache;
 	HashMap<StringName, bool> scene_groups_for_caching;
@@ -122,6 +124,11 @@ class GroupsEditor : public VBoxContainer {
 
 	void _node_removed(Node *p_node);
 
+	void _add_to_group(const StringName &p_name, bool p_persist, const Array &p_nodes);
+	void _remove_from_group(const StringName &p_name, const Array &p_nodes);
+	void _get_group_mask(const StringName &p_name, Array &r_nodes, bool p_invert);
+	bool _can_edit(const StringName &p_group);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -134,7 +141,7 @@ public:
 		CONVERT_GROUP,
 	};
 
-	void set_current(Node *p_node);
+	void set_selection(const Vector<Node *> &p_nodes);
 
 	GroupsEditor();
 };

--- a/editor/docks/node_dock.cpp
+++ b/editor/docks/node_dock.cpp
@@ -54,15 +54,7 @@ void NodeDock::_save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_
 
 void NodeDock::_load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section) {
 	const int current_tab = p_layout->get_value(p_section, "dock_node_current_tab", 0);
-	if (select_a_node->is_visible()) {
-		if (current_tab == 0) {
-			groups_button->set_pressed_no_signal(false);
-			connections_button->set_pressed_no_signal(true);
-		} else if (current_tab == 1) {
-			groups_button->set_pressed_no_signal(true);
-			connections_button->set_pressed_no_signal(false);
-		}
-	} else if (current_tab == 0) {
+	if (current_tab == 0) {
 		show_connections();
 	} else if (current_tab == 1) {
 		show_groups();
@@ -87,25 +79,9 @@ void NodeDock::update_lists() {
 	connections->update_tree();
 }
 
-void NodeDock::set_node(Node *p_node) {
-	connections->set_node(p_node);
-	groups->set_current(p_node);
-
-	if (p_node) {
-		if (connections_button->is_pressed()) {
-			connections->show();
-		} else {
-			groups->show();
-		}
-
-		mode_hb->show();
-		select_a_node->hide();
-	} else {
-		connections->hide();
-		groups->hide();
-		mode_hb->hide();
-		select_a_node->show();
-	}
+void NodeDock::set_selection(const Vector<Node *> &p_nodes) {
+	connections->set_selection(p_nodes);
+	groups->set_selection(p_nodes);
 }
 
 NodeDock::NodeDock() {
@@ -114,13 +90,11 @@ NodeDock::NodeDock() {
 	set_name("Node");
 	mode_hb = memnew(HBoxContainer);
 	add_child(mode_hb);
-	mode_hb->hide();
 
 	connections_button = memnew(Button);
 	connections_button->set_theme_type_variation(SceneStringName(FlatButton));
 	connections_button->set_text(TTRC("Signals"));
 	connections_button->set_toggle_mode(true);
-	connections_button->set_pressed(true);
 	connections_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	connections_button->set_clip_text(true);
 	mode_hb->add_child(connections_button);
@@ -130,7 +104,6 @@ NodeDock::NodeDock() {
 	groups_button->set_theme_type_variation(SceneStringName(FlatButton));
 	groups_button->set_text(TTRC("Groups"));
 	groups_button->set_toggle_mode(true);
-	groups_button->set_pressed(false);
 	groups_button->set_h_size_flags(SIZE_EXPAND_FILL);
 	groups_button->set_clip_text(true);
 	mode_hb->add_child(groups_button);
@@ -146,15 +119,7 @@ NodeDock::NodeDock() {
 	groups->set_v_size_flags(SIZE_EXPAND_FILL);
 	groups->hide();
 
-	select_a_node = memnew(Label);
-	select_a_node->set_focus_mode(FOCUS_ACCESSIBILITY);
-	select_a_node->set_text(TTRC("Select a single node to edit its signals and groups."));
-	select_a_node->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
-	select_a_node->set_v_size_flags(SIZE_EXPAND_FILL);
-	select_a_node->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	select_a_node->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	select_a_node->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-	add_child(select_a_node);
+	show_connections();
 }
 
 NodeDock::~NodeDock() {

--- a/editor/docks/node_dock.h
+++ b/editor/docks/node_dock.h
@@ -46,8 +46,6 @@ class NodeDock : public VBoxContainer {
 
 	HBoxContainer *mode_hb = nullptr;
 
-	Label *select_a_node = nullptr;
-
 	void _save_layout_to_config(Ref<ConfigFile> p_layout, const String &p_section) const;
 	void _load_layout_from_config(Ref<ConfigFile> p_layout, const String &p_section);
 
@@ -62,7 +60,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_node(Node *p_node);
+	void set_selection(const Vector<Node *> &p_nodes);
 
 	void show_groups();
 	void show_connections();

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1359,7 +1359,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 					undo_redo->add_undo_method(node, "set_scene_file_path", node->get_scene_file_path());
 					_node_replace_owner(node, node, root);
 					_node_strip_signal_inheritance(node);
-					NodeDock::get_singleton()->set_node(node); // Refresh.
+					NodeDock::get_singleton()->set_selection(Vector<Node *>{ node }); // Refresh.
 					undo_redo->add_do_method(scene_tree, "update_tree");
 					undo_redo->add_undo_method(scene_tree, "update_tree");
 					undo_redo->commit_action();
@@ -2859,7 +2859,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	editor_history->cleanup_history();
 	InspectorDock::get_singleton()->call("_prepare_history");
 	InspectorDock::get_singleton()->update(nullptr);
-	NodeDock::get_singleton()->set_node(nullptr);
+	NodeDock::get_singleton()->set_selection(Vector<Node *>{});
 }
 
 void SceneTreeDock::_update_script_button() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2652,7 +2652,7 @@ void EditorNode::push_node_item(Node *p_node) {
 void EditorNode::push_item(Object *p_object, const String &p_property, bool p_inspector_only) {
 	if (!p_object) {
 		InspectorDock::get_inspector_singleton()->edit(nullptr);
-		NodeDock::get_singleton()->set_node(nullptr);
+		NodeDock::get_singleton()->set_selection(Vector<Node *>());
 		SceneTreeDock::get_singleton()->set_selected(nullptr);
 		InspectorDock::get_singleton()->update(nullptr);
 		hide_unused_editors();
@@ -2774,7 +2774,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 	if (!current_obj) {
 		SceneTreeDock::get_singleton()->set_selected(nullptr);
 		InspectorDock::get_inspector_singleton()->edit(nullptr);
-		NodeDock::get_singleton()->set_node(nullptr);
+		NodeDock::get_singleton()->set_selection(Vector<Node *>());
 		InspectorDock::get_singleton()->update(nullptr);
 		EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		hide_unused_editors();
@@ -2808,7 +2808,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		if (!p_skip_inspector_update) {
 			InspectorDock::get_inspector_singleton()->edit(current_res);
 			SceneTreeDock::get_singleton()->set_selected(nullptr);
-			NodeDock::get_singleton()->set_node(nullptr);
+			NodeDock::get_singleton()->set_selection(Vector<Node *>());
 			InspectorDock::get_singleton()->update(nullptr);
 			EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 			ImportDock::get_singleton()->set_edit_path(current_res->get_path());
@@ -2838,7 +2838,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 
 		InspectorDock::get_inspector_singleton()->edit(current_node);
 		if (current_node->is_inside_tree()) {
-			NodeDock::get_singleton()->set_node(current_node);
+			NodeDock::get_singleton()->set_selection(Vector<Node *>{ current_node });
 			SceneTreeDock::get_singleton()->set_selected(current_node);
 			SceneTreeDock::get_singleton()->set_selection({ current_node });
 			InspectorDock::get_singleton()->update(current_node);
@@ -2850,7 +2850,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 				}
 			}
 		} else {
-			NodeDock::get_singleton()->set_node(nullptr);
+			NodeDock::get_singleton()->set_selection(Vector<Node *>());
 			SceneTreeDock::get_singleton()->set_selected(nullptr);
 			InspectorDock::get_singleton()->update(nullptr);
 		}
@@ -2893,7 +2893,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		}
 
 		InspectorDock::get_inspector_singleton()->edit(current_obj);
-		NodeDock::get_singleton()->set_node(nullptr);
+		NodeDock::get_singleton()->set_selection(multi_nodes);
 		SceneTreeDock::get_singleton()->set_selected(selected_node);
 		SceneTreeDock::get_singleton()->set_selection(multi_nodes);
 		InspectorDock::get_singleton()->update(nullptr);

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -230,6 +230,9 @@ class ConnectionsDock : public VBoxContainer {
 		SLOT_MENU_DISCONNECT,
 	};
 
+	VBoxContainer *holder = nullptr;
+	Label *select_a_node = nullptr;
+
 	Node *selected_node = nullptr;
 	ConnectionsDockTree *tree = nullptr;
 
@@ -273,7 +276,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_node(Node *p_node);
+	void set_selection(const Vector<Node *> &p_nodes);
 	void update_tree();
 
 	ConnectionsDock();


### PR DESCRIPTION
This is a suggested fix to proposals [10331](https://github.com/godotengine/godot-proposals/issues/10331) and [7154](https://github.com/godotengine/godot-proposals/issues/7154). Here is a small project to demonstrate the features:

[4.5-dev-test.zip](https://github.com/user-attachments/files/21905234/4.5-dev-test.zip)

I'm open for suggestions on improving this code. This is still my first issue technically. There's definitely some questionable parts of my code that I really don't know enough about the engine to fix. 

# Things to try:

Click around! Make sure:
 - Groups panel and signal panel render correctly and display relevant messages.
 - When selecting multiple nodes, the signal panel should be blanked, while the group panel should display groups as checked if _any_ nodes in your selection are checked. Ideally, I think this could be one of those Apple-style half-checks, but that would be overkill for a small fix like this.
 - When selecting no nodes, panels can still be switched between, but they both appear blank. 

Add and remove stuff from groups! Make sure:
 - When adding a selection to a group, all selected nodes are added.
 - When removing a selection from a group, all selected nodes that were previously in the group are now removed.
 - Both operations should support undo/redo. When undoing a removal of a selection of nodes that was partially in a group, only the nodes originally in the group should be re-added. Without jargon: undoing and redoing should work. Lol.

And that's it! No bugs this time, unlike my last implementation (#108610). The only bug I can think of is a usability bug where ofc the new message boxes for the signal and group panels won't have translations.

# Implementation details:
This is totally a front-end change. `groups_editor.cpp` contains all the meat of the new changes. Now for-loop free, ethically sourced from free-range iterators. A couple new methods replace the points where `groups_editor` previously would interact with its selected node directly.

```
void GroupsEditor::_add_to_group(const StringName &name, bool persist, const Array &nodes) {
	for (const Variant v : nodes) {
		if (v.get_type() == Variant::OBJECT) {
			bool freed;
			Object *obj = v.get_validated_object_with_check(freed);
			if (freed) {
				continue;
			}

			if (Object::cast_to<Node>(obj)) {
				Object::cast_to<Node>(obj)->add_to_group(name, persist);
			}
		}
	}
}

void GroupsEditor::_remove_from_group(const StringName &name, const Array &nodes) {
	for (const Variant v : nodes) {
		if (v.get_type() == Variant::OBJECT) {
			bool freed;
			Object *obj = v.get_validated_object_with_check(freed);
			if (freed) {
				continue;
			}

			if (Object::cast_to<Node>(obj)) {
				Object::cast_to<Node>(obj)->remove_from_group(name);
			}
		}
	}
}

void GroupsEditor::_get_group_mask(const StringName &name, Array &nodes, bool invert) {
	for (Node *p_node : selection) {
		if (invert != p_node->is_in_group(name)) {
			nodes.push_back(p_node);
		}
	}
}

void GroupsEditor::_get_groups(List<Node::GroupInfo> *p_groups) {
	for (Node *p_node : selection) {
		p_node->get_groups(p_groups);
	}
}

bool GroupsEditor::_can_edit(const StringName &E) {
	for (Node *p_node : selection) {
		if (!can_edit(p_node, E)) {
			return false;
		}
	}
	return true;
}
```

That's pretty much the whole thing. It just wraps the node methods in loops over a selection. Note that the actual selection is stored as `Vector<Node *> selection` and converted to Array when passed to these methods so the undo-redo stack will play nice. `_get_groups` and `_can_edit` might have some optimizations I could possibly implement before merging: `_get_groups` doesn't remove duplicate items and I don't really understand the original `can_edit` method. But I'm not sure how to approach those optimizations.

The only "new" method is `_get_group_mask`. When removing a selection from a group, then undoing, it may be incorrect to simply add all the nodes in the old selection back into the group, since only some of them might have been included in the first place. `_get_group_mask` handles the conversion between `Vector<Node *> selection` and an Array, only including the nodes on which the undo-redo stack should operate in the process.

The other half is the changes made to the ui to fit this feature in. I elected not to implement multi-select signal editing because thinking about that gives me a big headache, and also because it's more of a niche use case than multi-select groups in my humble opinion. But `connections_dialog.cpp` still underwent changes, since it can't rely on `node_dock.cpp` anymore to hide it when multiple nodes are selected. Eventually I gave both the signal and group panels there own "`select_a_node`" panel to throw up whenever they don't like the selection.

*Bugsuqad edit:* Closes godotengine/godot-proposals#10331, closes godotengine/godot-proposals#7154
