### PR TITLE
Fix DirectInput controllers on game startup

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -58,6 +58,19 @@ JoypadSDL::JoypadSDL() {
 	singleton = this;
 }
 
+#ifdef WINDOWS_ENABLED
+extern "C" {
+HWND SDL_HelperWindow;
+}
+
+// Required for DInput joypads to work
+// TODO: remove this workaround when we update to newer version of SDL
+JoypadSDL::JoypadSDL(HWND p_helper_window) :
+		JoypadSDL() {
+	SDL_HelperWindow = p_helper_window;
+}
+#endif
+
 JoypadSDL::~JoypadSDL() {
 	// Process any remaining input events
 	process_events();
@@ -246,17 +259,6 @@ void JoypadSDL::process_events() {
 		}
 	}
 }
-
-#ifdef WINDOWS_ENABLED
-extern "C" {
-HWND SDL_HelperWindow;
-}
-
-// Required for DInput joypads to work
-void JoypadSDL::setup_sdl_helper_window(HWND p_hwnd) {
-	SDL_HelperWindow = p_hwnd;
-}
-#endif
 
 void JoypadSDL::close_joypad(int p_pad_idx) {
 	int sdl_instance_idx = joypads[p_pad_idx].sdl_instance_idx;

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -39,15 +39,15 @@ typedef struct HWND__ *HWND;
 class JoypadSDL {
 public:
 	JoypadSDL();
+#ifdef WINDOWS_ENABLED
+	JoypadSDL(HWND p_helper_window);
+#endif
 	~JoypadSDL();
 
 	static JoypadSDL *get_singleton();
 
 	Error initialize();
 	void process_events();
-#ifdef WINDOWS_ENABLED
-	void setup_sdl_helper_window(HWND p_hwnd);
-#endif
 
 private:
 	struct Joypad {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7188,10 +7188,8 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	}
 
 #ifdef SDL_ENABLED
-	joypad_sdl = memnew(JoypadSDL());
-	if (joypad_sdl->initialize() == OK) {
-		joypad_sdl->setup_sdl_helper_window(windows[MAIN_WINDOW_ID].hWnd);
-	} else {
+	joypad_sdl = memnew(JoypadSDL(windows[MAIN_WINDOW_ID].hWnd));
+	if (joypad_sdl->initialize() != OK) {
 		ERR_PRINT("Couldn't initialize SDL joypad input driver.");
 		memdelete(joypad_sdl);
 		joypad_sdl = nullptr;


### PR DESCRIPTION
Fixes the problem described here: https://github.com/godotengine/godot/pull/109750#issuecomment-3208611006
Now SDL and DirectInput don't complain when a game starts with a DirectInput controller already connected. Fixes "JoypadSDL::process_events: Error opening gamepad at index 1: IDirectInputDevice8::SetCooperativeLevel() DirectX error 0x80070006"

<details>
<summary>Before this PR</summary>

<img width="1082" height="299" alt="image" src="https://github.com/user-attachments/assets/7cf581e4-02e6-4d6d-9545-0b4ea5e9c961" />
</details>

<details>
<summary>After this PR</summary>

<img width="1256" height="635" alt="image" src="https://github.com/user-attachments/assets/751cdd69-0c06-4dff-b8ea-de02c95bb802" />
</details>

Fixes https://github.com/godotengine/godot/issues/109952