### PR TITLE
Add `ConstIterator` conversions for missing container `Iterators`

### DIFF
--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -200,6 +200,7 @@ public:
 		return data[p_index];
 	}
 
+	struct ConstIterator;
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {
 			return *elem_ptr;
@@ -220,6 +221,10 @@ public:
 		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
 		Iterator() {}
 		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
+
+		operator ConstIterator() const {
+			return ConstIterator(elem_ptr);
+		}
 
 	private:
 		T *elem_ptr = nullptr;

--- a/core/templates/rb_map.h
+++ b/core/templates/rb_map.h
@@ -96,6 +96,7 @@ public:
 
 	typedef KeyValue<K, V> ValueType;
 
+	struct ConstIterator;
 	struct Iterator {
 		friend class RBMap<K, V, C, A>;
 
@@ -125,6 +126,10 @@ public:
 		Iterator(Element *p_E) { E = p_E; }
 		Iterator() {}
 		Iterator(const Iterator &p_it) { E = p_it.E; }
+
+		operator ConstIterator() const {
+			return ConstIterator(E);
+		}
 
 	private:
 		Element *E = nullptr;

--- a/core/templates/rb_set.h
+++ b/core/templates/rb_set.h
@@ -83,6 +83,7 @@ public:
 
 	typedef T ValueType;
 
+	struct ConstIterator;
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {
 			return E->get();
@@ -104,6 +105,10 @@ public:
 		Iterator(Element *p_E) { E = p_E; }
 		Iterator() {}
 		Iterator(const Iterator &p_it) { E = p_it.E; }
+
+		operator ConstIterator() const {
+			return ConstIterator(E);
+		}
 
 	private:
 		Element *E = nullptr;

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -256,6 +256,7 @@ public:
 		return false;
 	}
 
+	struct ConstIterator;
 	struct Iterator {
 		_FORCE_INLINE_ T &operator*() const {
 			return *elem_ptr;
@@ -276,6 +277,10 @@ public:
 		Iterator(T *p_ptr) { elem_ptr = p_ptr; }
 		Iterator() {}
 		Iterator(const Iterator &p_it) { elem_ptr = p_it.elem_ptr; }
+
+		operator ConstIterator() const {
+			return ConstIterator(elem_ptr);
+		}
 
 	private:
 		T *elem_ptr = nullptr;


### PR DESCRIPTION
- Closes godotengine/godot-proposals#13036
- GDExtension PR godotengine/godot-cpp#1835

This is more an address of an inconsistency of the iterators, for some container iterators already had a conversion operator but not every container with an `Iterator` struct did, this is rounding out the remainder of the iterators that should. To minimize changes and keep consistency this follows the implementation common among the containers that already performed the conversion. This is mostly just to synchronize for GDExtensions. 