### PR TITLE
Create an undo/redo action when pinning a SoftBody3D point in the editor

### DIFF
--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -704,10 +704,6 @@ void SoftBody3D::apply_central_force(const Vector3 &p_force) {
 	PhysicsServer3D::get_singleton()->soft_body_apply_central_force(physics_rid, p_force);
 }
 
-void SoftBody3D::pin_point_toggle(int p_point_index) {
-	pin_point(p_point_index, !(-1 != _has_pinned_point(p_point_index)));
-}
-
 void SoftBody3D::pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path, int p_insert_at) {
 	ERR_FAIL_COND_MSG(p_insert_at < -1 || p_insert_at >= pinned_points.size(), "Invalid index for pin point insertion position.");
 	_pin_point_on_physics_server(p_point_index, pin);

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -182,7 +182,6 @@ public:
 
 	Vector3 get_point_transform(int p_point_index);
 
-	void pin_point_toggle(int p_point_index);
 	void pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath(), int p_insert_at = -1);
 	bool is_point_pinned(int p_point_index) const;
 


### PR DESCRIPTION
Previously, if you pinned a point by clicking on one of the soft body vertex handles, the scene was not marked as modified, and the action could not be undone by hitting Ctrl + Z.

- This salvages https://github.com/godotengine/godot/pull/108291.
  Thanks @simpkins for the original PR :slightly_smiling_face:

## TODO

- [x] Fix gizmos not updating after undo/redo until you hover one of the points with the mouse again.
  - Fixed thanks to https://github.com/godotengine/godot/pull/108291#pullrequestreview-3142109751.
  
  _bugsquad edit: Closes https://github.com/godotengine/godot/issues/106325_