### PR TITLE
Double-click BlendSpace points to open their editor

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -136,6 +136,12 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 				Ref<AnimationNode> node = blend_space->get_blend_point_node(i);
 				EditorNode::get_singleton()->push_item(node.ptr(), "", true);
+
+				if (mb->is_double_click() && AnimationTreeEditor::get_singleton()->can_edit(node)) {
+					_open_editor();
+					return;
+				}
+
 				dragging_selected_attempt = true;
 				drag_from = mb->get_position();
 				_update_tool_erase();

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -177,6 +177,12 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 				selected_point = i;
 				Ref<AnimationNode> node = blend_space->get_blend_point_node(i);
 				EditorNode::get_singleton()->push_item(node.ptr(), "", true);
+
+				if (mb->is_double_click() && AnimationTreeEditor::get_singleton()->can_edit(node)) {
+					_open_editor();
+					return;
+				}
+
 				dragging_selected_attempt = true;
 				drag_from = mb->get_position();
 				_update_tool_erase();


### PR DESCRIPTION
This PR is a companion to #109792 in improving cursor functionality for BlendSpace1D and BlendSpace2D in an unobtrusive way. It allows double-clicking a blendpoint to open its editor, as an alternative to the mouse movement needed to reach the Open Editor button in the toolbar, a point of friction unique to BlendSpaces.