### PR TITLE
Process skeleton modifiers when the skeleton is marked as dirty

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -295,7 +295,7 @@ void Skeleton3D::_notification(int p_what) {
 #if !defined(DISABLE_DEPRECATED) && !defined(PHYSICS_3D_DISABLED)
 			setup_simulator();
 #endif // _DISABLE_DEPRECATED && PHYSICS_3D_DISABLED
-			update_flags = UPDATE_FLAG_POSE;
+			update_flags |= UPDATE_FLAG_POSE;
 			_notification(NOTIFICATION_UPDATE_SKELETON);
 		} break;
 #ifdef TOOLS_ENABLED
@@ -929,7 +929,7 @@ void Skeleton3D::_make_dirty() {
 		return;
 	}
 	dirty = true;
-	_update_deferred();
+	_update_deferred(modifiers.is_empty() ? UPDATE_FLAG_POSE : (UpdateFlag)(UPDATE_FLAG_POSE | UPDATE_FLAG_MODIFIER));
 }
 
 void Skeleton3D::_update_deferred(UpdateFlag p_update_flag) {


### PR DESCRIPTION
Fixes #109110.

The only place that the default argument of the function is used is in `Skeleton3D::_make_dirty`, so this is just a roundabout way of changing that call. I think it makes more sense to have the full update be the default, though, so I changed it here.

The other change is because the `_make_modifiers_dirty` shortly before does try to add `UPDATE_FLAG_MODIFIER` to `update_flags`, but it ends up getting clobbered afterwards by the direct assignment.

I can't really think of a case where you'd want to skip `_process_modifiers` and display the skeleton without them, to be honest, so perhaps I've misunderstood something about the intent.