### PR TITLE
Assign shortcuts to prev/next script buttons

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4461,17 +4461,19 @@ ScriptEditor::ScriptEditor(WindowWrapper *p_wrapper) {
 
 	script_back = memnew(Button);
 	script_back->set_theme_type_variation(SceneStringName(FlatButton));
-	script_back->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_history_back));
-	menu_hb->add_child(script_back);
-	script_back->set_disabled(true);
 	script_back->set_tooltip_text(TTRC("Go to previous edited document."));
+	script_back->set_shortcut(ED_GET_SHORTCUT("script_editor/history_previous"));
+	script_back->set_disabled(true);
+	menu_hb->add_child(script_back);
+	script_back->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_history_back));
 
 	script_forward = memnew(Button);
 	script_forward->set_theme_type_variation(SceneStringName(FlatButton));
-	script_forward->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_history_forward));
-	menu_hb->add_child(script_forward);
-	script_forward->set_disabled(true);
 	script_forward->set_tooltip_text(TTRC("Go to next edited document."));
+	script_forward->set_shortcut(ED_GET_SHORTCUT("script_editor/history_next"));
+	script_forward->set_disabled(true);
+	menu_hb->add_child(script_forward);
+	script_forward->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditor::_history_forward));
 
 	menu_hb->add_child(memnew(VSeparator));
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13045

This makes the shortcuts appear in tooltip, but otherwise there is no change in functionality.

<img width="293" height="113" alt="image" src="https://github.com/user-attachments/assets/20c44105-c267-4793-8543-7fe039f05a5e" />

I also reorganized the code a bit.