### PR TITLE
AudioStreamOggVorbis: only show invalid comment warning in Editor builds

### DIFF
--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -460,14 +460,19 @@ void AudioStreamOggVorbis::maybe_update_info() {
 	}
 
 	Dictionary dictionary;
+	// Comments are required by the Vorbis spec to be structured like env vars, i.e. VAR=VALUE.
+	// This is how tags are stored (artist, album, etc.), and we parse them out for display.
+	// See https://xiph.org/vorbis/doc/v-comment.html
 	for (int i = 0; i < comment.comments; i++) {
 		String c = String::utf8(comment.user_comments[i]);
 		int equals = c.find_char('=');
 
+#ifdef TOOLS_ENABLED
 		if (equals == -1) {
 			WARN_PRINT(vformat(R"(Invalid comment in Ogg Vorbis file "%s", should contain '=': "%s".)", get_path(), c));
 			continue;
 		}
+#endif
 
 		String tag = c.substr(0, equals);
 		String tag_value = c.substr(equals + 1);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
There are a bunch of music editors love to set invalid Vorbis comments in ogg vorbis files that they export (e.g. Sony's likes to write "Sony Ogg Vorbis 1.0 Final"), and this results in a lot of logspam whenever an ogg like this is loaded up. We should really only be emitting a warning about it if tools are enabled.