### PR TITLE
Fix SpriteBase3D having artifacts on edges due to texture repeat

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -3038,6 +3038,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, Transparency p_
 	material->set_flag(FLAG_ALBEDO_TEXTURE_MSDF, p_msdf);
 	material->set_flag(FLAG_DISABLE_DEPTH_TEST, p_no_depth);
 	material->set_flag(FLAG_FIXED_SIZE, p_fixed_size);
+	material->set_flag(FLAG_USE_TEXTURE_REPEAT, false);
 	material->set_alpha_antialiasing(p_alpha_antialiasing_mode);
 	material->set_texture_filter(p_filter);
 	if (p_billboard || p_billboard_y) {


### PR DESCRIPTION
Texture repeat is now disabled on SpriteBase3D to avoid artifacts on sprites that have pixels touching the edge.

Note that this does **not** fix artifacts related to sprites viewed at a distance or at oblique angles due to mipmapping. Having some padding is still needed to minimize these issues.

- This closes https://github.com/godotengine/godot-proposals/issues/13044.

**Testing project:** [test-sprite-linear.zip](https://github.com/user-attachments/files/21927932/test-sprite-linear.zip)

## Preview

### Before

<img width="608" height="394" alt="Before" src="https://github.com/user-attachments/assets/0a5fb034-8b42-4778-bc13-66d468a45b66" />

### After
<img width="512" height="384" alt="After" src="https://github.com/user-attachments/assets/6322e8ff-25be-49a5-b934-aea65d91be53" />
