### PR TITLE
Improve plugin autoloads

### DIFF
--- a/editor/plugins/editor_plugin.cpp
+++ b/editor/plugins/editor_plugin.cpp
@@ -71,12 +71,12 @@ void EditorPlugin::remove_custom_type(const String &p_type) {
 
 void EditorPlugin::add_autoload_singleton(const String &p_name, const String &p_path) {
 	if (p_path.begins_with("res://")) {
-		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, p_path);
+		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, p_path, false);
 	} else {
 		const Ref<Script> plugin_script = static_cast<Ref<Script>>(get_script());
 		ERR_FAIL_COND(plugin_script.is_null());
 		const String script_base_path = plugin_script->get_path().get_base_dir();
-		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, script_base_path.path_join(p_path));
+		EditorNode::get_singleton()->get_project_settings()->get_autoload_settings()->autoload_add(p_name, script_base_path.path_join(p_path), false);
 	}
 }
 

--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -448,7 +448,7 @@ void EditorAutoloadSettings::_add_autoload(const String &p_name, const String &p
 	}
 
 	autoload_name = autoload_name.validate_ascii_identifier();
-	autoload_add(autoload_name, p_path);
+	autoload_add(autoload_name, p_path, true);
 }
 
 void EditorAutoloadSettings::update_autoload() {
@@ -759,7 +759,7 @@ void EditorAutoloadSettings::drop_data_fw(const Point2 &p_point, const Variant &
 	undo_redo->commit_action();
 }
 
-bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_path) {
+bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_path, bool p_use_undo) {
 	String name = p_name;
 
 	String error;
@@ -779,6 +779,13 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 	}
 
 	name = "autoload/" + name;
+
+	if (!p_use_undo) {
+		ProjectSettings::get_singleton()->set(name, "*" + p_path);
+		update_autoload();
+		emit_signal(autoload_changed);
+		return true;
+	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 
@@ -803,33 +810,14 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 	return true;
 }
 
-void EditorAutoloadSettings::autoload_remove(const String &p_name) {
-	String name = "autoload/" + p_name;
-
-	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-
-	int order = ProjectSettings::get_singleton()->get_order(name);
-
-	undo_redo->create_action(TTR("Remove Autoload"));
-
-	undo_redo->add_do_property(ProjectSettings::get_singleton(), name, Variant());
-
-	undo_redo->add_undo_property(ProjectSettings::get_singleton(), name, GLOBAL_GET(name));
-	undo_redo->add_undo_method(ProjectSettings::get_singleton(), "set_order", name, order);
-
-	undo_redo->add_do_method(this, "update_autoload");
-	undo_redo->add_undo_method(this, "update_autoload");
-
-	undo_redo->add_do_method(this, "emit_signal", autoload_changed);
-	undo_redo->add_undo_method(this, "emit_signal", autoload_changed);
-
-	undo_redo->commit_action();
+void EditorAutoloadSettings::autoload_remove(const StringName &p_name) {
+	ProjectSettings::get_singleton()->remove_autoload(p_name);
+	update_autoload();
+	emit_signal(autoload_changed);
 }
 
 void EditorAutoloadSettings::_bind_methods() {
 	ClassDB::bind_method("update_autoload", &EditorAutoloadSettings::update_autoload);
-	ClassDB::bind_method("autoload_add", &EditorAutoloadSettings::autoload_add);
-	ClassDB::bind_method("autoload_remove", &EditorAutoloadSettings::autoload_remove);
 
 	ADD_SIGNAL(MethodInfo("autoload_changed"));
 }

--- a/editor/settings/editor_autoload_settings.h
+++ b/editor/settings/editor_autoload_settings.h
@@ -48,7 +48,7 @@ class EditorAutoloadSettings : public VBoxContainer {
 	};
 
 	String path = "res://";
-	String autoload_changed = "autoload_changed";
+	const StringName autoload_changed = "autoload_changed";
 
 	struct AutoloadInfo {
 		String name;
@@ -106,8 +106,8 @@ protected:
 public:
 	void init_autoloads();
 	void update_autoload();
-	bool autoload_add(const String &p_name, const String &p_path);
-	void autoload_remove(const String &p_name);
+	bool autoload_add(const String &p_name, const String &p_path, bool p_use_undo);
+	void autoload_remove(const StringName &p_name);
 
 	EditorAutoloadSettings();
 	~EditorAutoloadSettings();


### PR DESCRIPTION
This PR makes EditorPlugin's `add/remove_autoload_singleton()` no longer create undo action (as discussed in #109825). It doesn't make sense to undo an autoload added by a plugin.

Also applied some general cleanup, like removing unused bound methods.