### PR TITLE
Fix peers stopping replication on deleting node they spawned with MultiplayerSpawner

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -283,7 +283,7 @@ Error SceneReplicationInterface::on_replication_stop(Object *p_obj, Variant p_co
 	for (KeyValue<int, PeerInfo> &E : peers_info) {
 		E.value.sync_nodes.erase(sid);
 		E.value.last_watch_usecs.erase(sid);
-		if (sync->get_net_id()) {
+		if (sync->get_net_id() && uint32_t(E.key) == tobj.remote_peer) {
 			E.value.recv_sync_ids.erase(sync->get_net_id());
 		}
 	}


### PR DESCRIPTION
When multiple peers had multiplayer authority over a MultiplayerSpawner and spawned nodes that used a MultiplayerSynchronizer that were later deleted, these peers would stop syncing random nodes from other peers because the net_id of said spawned nodes was not unique over all peers. The net_id was the only criteria that was looked at to stop syncing the node.

This commit fixes this by also looking at the peer the node came from.

Fixes #109432