### PR TITLE
Fix `GridMap` Move Action Undo/Redo/Cancel

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -138,6 +138,7 @@ class GridMapEditor : public VBoxContainer {
 	};
 
 	LocalVector<ClipboardItem> clipboard_items;
+	bool clipboard_is_move = false;
 
 	Color default_color;
 	Color erase_color;
@@ -196,7 +197,7 @@ class GridMapEditor : public VBoxContainer {
 		MENU_OPTION_CURSOR_CLEAR_ROTATION,
 		MENU_OPTION_PASTE_SELECTS,
 		MENU_OPTION_SELECTION_DUPLICATE,
-		MENU_OPTION_SELECTION_CUT,
+		MENU_OPTION_SELECTION_MOVE,
 		MENU_OPTION_SELECTION_CLEAR,
 		MENU_OPTION_SELECTION_FILL,
 		MENU_OPTION_GRIDMAP_SETTINGS
@@ -236,6 +237,7 @@ class GridMapEditor : public VBoxContainer {
 	void _set_clipboard_data();
 	void _update_paste_indicator();
 	void _do_paste();
+	void _cancel_pending_move();
 	void _show_viewports_transform_gizmo(bool p_value);
 	void _update_selection_transform();
 	void _validate_selection();
@@ -248,7 +250,9 @@ class GridMapEditor : public VBoxContainer {
 	void _floor_mouse_exited();
 
 	void _delete_selection();
+	void _delete_selection_with_undo();
 	void _fill_selection();
+	void _setup_paste_mode();
 
 	bool do_input_action(Camera3D *p_camera, const Point2 &p_point, bool p_click);
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Fixes: https://github.com/godotengine/godot/issues/109860

~~Requires and Includes: https://github.com/godotengine/godot/pull/108743~~

This fix includes having to press undo twice to undo a move action. This now only register a single action into the undo/redo system. 

https://github.com/user-attachments/assets/f30dacc3-3acd-434f-8286-10c13ac8fd94

