### PR TITLE
Remove nearly-unused "default" range hint min/max

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3591,8 +3591,8 @@ bool EditorInspectorDefaultPlugin::parse_property(Object *p_object, const Varian
 struct EditorPropertyRangeHint {
 	bool or_greater = true;
 	bool or_less = true;
-	double min = -99999.0;
-	double max = 99999.0;
+	double min = 0.0;
+	double max = 0.0;
 	double step = 1.0;
 	String suffix;
 	bool exp_range = false;


### PR DESCRIPTION
Partially fixes issue #109852, see also PR #109887.

This is another pre-existing issue, hidden before by the lack of precision in the serialization. When not using an explicit range hint (such as with `@export` instead of `@export_range`), it secretly uses these default values, so it actually *does* use a range hint even when the user doesn't ask for it.

With this default hint, it's offsetting by the minimum value before snapping, which results in an inaccuracy of approximately 5 orders of magnitude (`99999`). Why is it snapping at all? It sets the step size to the default float step.

This PR removes this weird default value, and sets it to `0.0` instead. The default also includes `bool or_greater = true;` and `bool or_less = true;`, so the min/max values aren't actually used, even in master you can still set values beyond `99999`.