### PR TITLE
Add local frame overrides to Generic6DOFJoint3D.

### DIFF
--- a/doc/classes/Generic6DOFJoint3D.xml
+++ b/doc/classes/Generic6DOFJoint3D.xml
@@ -319,6 +319,14 @@
 		</member>
 		<member name="linear_spring_z/stiffness" type="float" setter="set_param_z" getter="get_param_z" default="0.01">
 		</member>
+		<member name="local_frame_a_override/enabled" type="bool" setter="enable_local_frame_a_override" getter="local_frame_a_override_enabled" default="false">
+		</member>
+		<member name="local_frame_a_override/frame" type="Transform3D" setter="set_local_frame_a_override" getter="get_local_frame_a_override" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+		</member>
+		<member name="local_frame_b_override/enabled" type="bool" setter="enable_local_frame_b_override" getter="local_frame_b_override_enabled" default="false">
+		</member>
+		<member name="local_frame_b_override/frame" type="Transform3D" setter="set_local_frame_b_override" getter="get_local_frame_b_override" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
+		</member>
 	</members>
 	<constants>
 		<constant name="PARAM_LINEAR_LOWER_LIMIT" value="0" enum="Param">

--- a/scene/3d/physics/joints/generic_6dof_joint_3d.h
+++ b/scene/3d/physics/joints/generic_6dof_joint_3d.h
@@ -80,6 +80,11 @@ protected:
 	real_t params_z[PARAM_MAX];
 	bool flags_z[FLAG_MAX];
 
+	bool override_local_frame_a = false;
+	Transform3D local_frame_a_override;
+	bool override_local_frame_b = false;
+	Transform3D local_frame_override_b;
+
 	virtual void _configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) override;
 	static void _bind_methods();
 
@@ -101,6 +106,16 @@ public:
 
 	void set_flag_z(Flag p_flag, bool p_enabled);
 	bool get_flag_z(Flag p_flag) const;
+
+	void enable_local_frame_a_override(bool p_enable);
+	bool local_frame_a_override_enabled() const { return override_local_frame_a; }
+	void set_local_frame_a_override(const Transform3D &p_frame);
+	Transform3D get_local_frame_a_override() const { return local_frame_a_override; }
+
+	void enable_local_frame_b_override(bool p_enable);
+	bool local_frame_b_override_enabled() const { return override_local_frame_b; }
+	void set_local_frame_b_override(const Transform3D &p_frame);
+	Transform3D get_local_frame_b_override() const { return local_frame_override_b; }
 
 	Generic6DOFJoint3D();
 };


### PR DESCRIPTION
Allows for the local frame of Nodes A and B to be changed on Generic6DOFJoint3D.

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13051*