### PR TITLE
Fix `collision_animatable` property on TileMap

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -505,7 +505,7 @@
 	</methods>
 	<members>
 		<member name="collision_animatable" type="bool" setter="set_collision_animatable" getter="is_collision_animatable" default="false">
-			If enabled, the TileMap will see its collisions synced to the physics tick and change its collision type from static to kinematic. This is required to create TileMap-based moving platform.
+			If enabled, the TileMap will see its movement synced to the physics tick and change its collision type from static to kinematic. This is required to create a TileMap-based moving platform.
 			[b]Note:[/b] Enabling [member collision_animatable] may have a small performance impact, only do it if the TileMap is moving and has colliding tiles.
 		</member>
 		<member name="collision_visibility_mode" type="int" setter="set_collision_visibility_mode" getter="get_collision_visibility_mode" enum="TileMap.VisibilityMode" default="0">

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -98,7 +98,9 @@ protected:
 	bool _property_can_revert(const StringName &p_name) const { return property_helper.property_can_revert(p_name); }
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 
+#ifndef PHYSICS_2D_DISABLED
 	void _notification(int p_what);
+#endif
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1009,24 +1009,22 @@ void TileMapLayer::_physics_quadrants_update_cell(CellData &r_cell_data, SelfLis
 }
 
 void TileMapLayer::_physics_notification(int p_what) {
-	Transform2D gl_transform = get_global_transform();
 	PhysicsServer2D *ps = PhysicsServer2D::get_singleton();
+	bool in_editor = false;
+#ifdef TOOLS_ENABLED
+	in_editor = Engine::get_singleton()->is_editor_hint();
+#endif // TOOLS_ENABLED
 
 	switch (p_what) {
-		case NOTIFICATION_TRANSFORM_CHANGED:
-			// Move the collisison shapes along with the TileMap.
-			if (is_inside_tree() && tile_set.is_valid()) {
-				for (KeyValue<Vector2i, Ref<PhysicsQuadrant>> &kv : physics_quadrant_map) {
-					for (const KeyValue<PhysicsQuadrant::PhysicsBodyKey, PhysicsQuadrant::PhysicsBodyValue> &kvbody : kv.value->bodies) {
-						const RID &body = kvbody.value.body;
-						Transform2D xform(0, tile_set->map_to_local(kv.key));
-						xform = gl_transform * xform;
-						ps->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM, xform);
-					}
-				}
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			// If we have a TileMap parent with collision_animatable = true, then it will move the physics bodies for us instead.
+			if (is_inside_tree() && (in_editor || tile_map_node == nullptr || !tile_map_node->is_collision_animatable())) {
+				// Move the physics bodies along with the TileMap.
+				Transform2D gl_transform = get_global_transform();
+				move_physics_bodies(gl_transform);
 			}
-			break;
-		case NOTIFICATION_ENTER_TREE:
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
 			// Changes in the tree may cause the space to change (e.g. when reparenting to a SubViewport).
 			if (is_inside_tree()) {
 				RID space = get_world_2d()->get_space();
@@ -1038,6 +1036,20 @@ void TileMapLayer::_physics_notification(int p_what) {
 					}
 				}
 			}
+		} break;
+	}
+}
+
+void TileMapLayer::move_physics_bodies(const Transform2D &p_global_transform) {
+	if (tile_set.is_valid()) {
+		for (KeyValue<Vector2i, Ref<PhysicsQuadrant>> &kv : physics_quadrant_map) {
+			for (const KeyValue<PhysicsQuadrant::PhysicsBodyKey, PhysicsQuadrant::PhysicsBodyValue> &kvbody : kv.value->bodies) {
+				const RID &body = kvbody.value.body;
+				Transform2D xform(0, tile_set->map_to_local(kv.key));
+				xform = p_global_transform * xform;
+				PhysicsServer2D::get_singleton()->body_set_state(body, PhysicsServer2D::BODY_STATE_TRANSFORM, xform);
+			}
+		}
 	}
 }
 
@@ -1954,16 +1966,6 @@ void TileMapLayer::_renamed() {
 	emit_signal(CoreStringName(changed));
 }
 
-void TileMapLayer::_update_notify_local_transform() {
-	bool notify = is_using_kinematic_bodies() || is_y_sort_enabled();
-	if (!notify) {
-		if (is_y_sort_enabled()) {
-			notify = true;
-		}
-	}
-	set_notify_local_transform(notify);
-}
-
 void TileMapLayer::_queue_internal_update() {
 	if (pending_update) {
 		return;
@@ -2073,7 +2075,6 @@ void TileMapLayer::_notification(int p_what) {
 			break;
 		}
 		case NOTIFICATION_ENTER_TREE: {
-			_update_notify_local_transform();
 			dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] = true;
 			_queue_internal_update();
 		} break;
@@ -3251,7 +3252,6 @@ void TileMapLayer::set_y_sort_enabled(bool p_y_sort_enabled) {
 	emit_signal(CoreStringName(changed));
 
 	notify_property_list_changed();
-	_update_notify_local_transform();
 }
 
 void TileMapLayer::set_y_sort_origin(int p_y_sort_origin) {

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -488,7 +488,6 @@ private:
 	void _tile_set_changed();
 
 	void _renamed();
-	void _update_notify_local_transform();
 
 	// Internal updates.
 	void _queue_internal_update();
@@ -569,6 +568,7 @@ public:
 	// --- Physics helpers ---
 	bool has_body_rid(RID p_physics_body) const;
 	Vector2i get_coords_for_body_rid(RID p_physics_body) const; // For finding tiles from collision.
+	void move_physics_bodies(const Transform2D &p_global_transform); // For moving platforms.
 #endif // PHYSICS_2D_DISABLED
 
 	// --- Runtime ---


### PR DESCRIPTION
This property used to work once upon a time in 4.1. In addition to setting the physics bodies to kinematic it needs to handle transform changed and internal physics process notifications, like it did in 4.1 here: https://github.com/godotengine/godot/blob/61adafae2f9dace1f094b89ab2aceebd114e1c01/scene/2d/tile_map.cpp#L1525

This PR restores the property to its working state ~~and also adds it to TileMapLayer.~~

P.S. I removed `TileMapLayer::_update_notify_local_transform` because it had no effect: `NOTIFICATION_LOCAL_TRANSFORM_CHANGED` was not handled (and I don't see why those two settings would need it).

Test project: [Godot-Physics-Tests](https://github.com/fabriceci/Godot-Physics-Tests) (one test fails before this PR, it succeeds after).