### PR TITLE
Metal: Read `gl_ViewIndex` in tonemapper.glsl for multi-view subpasses

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -834,6 +834,11 @@ vec3 screen_space_dither(vec2 frag_coord, float bit_alignment_diviser) {
 void main() {
 #ifdef SUBPASS
 	// SUBPASS and USE_MULTIVIEW can be combined but in that case we're already reading from the correct layer
+#ifdef USE_MULTIVIEW
+	// In order to ensure the `SpvCapabilityMultiView` is included in the SPIR-V capabilities, gl_ViewIndex must
+	// be read in the shader. Without this, transpilation to Metal fails to include the multi-view variant.
+	uint vi = ViewIndex;
+#endif
 	vec4 color = subpassLoad(input_color);
 #elif defined(USE_MULTIVIEW)
 	vec4 color = textureLod(source_color, vec3(uv_interp, ViewIndex), 0.0f);


### PR DESCRIPTION
This is necessary to ensure the SpvCapabilityMultiView is included in the SPIR-V, informing downstream transpilers, like Metal, that it should enable multi-view capabilities in the generated Metal shader source.


| before | after |
| :---- | :---- |
| <img alt="CleanShot 2025-08-23 at 09 12 59@2x" src="https://github.com/user-attachments/assets/7e5732e8-2744-424d-b4ad-6762f768abed" /> | <img alt="CleanShot 2025-08-23 at 09 13 39@2x" src="https://github.com/user-attachments/assets/3fcfd3a3-7237-4a5f-b08e-0458bcd7523c" /> |

The issue is that if the `gl_ViewIndex` is not accessed, this code isn't executed in the GLSL compiler:

https://github.com/godotengine/godot/blob/940d62907027f388026ba2cac1ac64381af5c78f/thirdparty/glslang/SPIRV/GlslangToSpv.cpp#L911-L914

> [!NOTE]
>
> This happens before any type of optimisation, so _hopefully_ the capability remains in the SPIR-V if SPIR-V optimizer passes are added at a later date. For example, the [`TrimCapabilities`](https://github.com/KhronosGroup/SPIRV-Tools/blob/8a8bb6c89174ed753eb18a438092ee59356efc3c/source/opt/trim_capabilities_pass.h#L77-L112) pass for SPIRV-Tools does **not** strip multi-view capabilities 👍🏻 

If we do add a optimiser passes in the future, we'd want to modify the `reflect_spirv` function, but I'd rather not do this so late in the 4.5 cycle:

```patch
Index: servers/rendering/rendering_device_commons.cpp
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/servers/rendering/rendering_device_commons.cpp b/servers/rendering/rendering_device_commons.cpp
--- a/servers/rendering/rendering_device_commons.cpp	(revision 90c913487595b7f688c0c642e931d9f82b6e85a9)
+++ b/servers/rendering/rendering_device_commons.cpp	(date 1755905011000)
@@ -994,6 +994,13 @@
 			ERR_FAIL_COND_V_MSG(result != SPV_REFLECT_RESULT_SUCCESS, FAILED,
 					"Reflection of SPIR-V shader stage '" + String(SHADER_STAGE_NAMES[p_spirv[i].shader_stage]) + "' failed parsing shader.");
 
+			for (uint32_t j = 0; j < module.capability_count; j++) {
+				if (module.capabilities[j].value == SpvCapabilityMultiView) {
+					r_reflection.has_multiview = true;
+					break;
+				}
+			}
+
 			if (r_reflection.is_compute) {
 				r_reflection.compute_local_size[0] = module.entry_points->local_size.x;
 				r_reflection.compute_local_size[1] = module.entry_points->local_size.y;
```