### PR TITLE
Geometry2D minor optimization

### DIFF
--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -292,14 +292,16 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 	}
 
 	Vector<Vector<Point2>> polypaths;
-	for (PathsD::size_type i = 0; i < paths.size(); ++i) {
+	polypaths.resize(paths.size());
+	for (PathsD::size_type i = 0; i < paths.size(); i++) {
 		const PathD &path = paths[i];
 
 		Vector<Vector2> polypath;
+		polypath.resize(path.size());
 		for (PathsD::size_type j = 0; j < path.size(); ++j) {
-			polypath.push_back(Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
+			polypath.set(j, Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
 		}
-		polypaths.push_back(polypath);
+		polypaths.set(i, polypath);
 	}
 	return polypaths;
 }
@@ -353,14 +355,16 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 	// to attain the desired precision.
 
 	Vector<Vector<Point2>> polypaths;
+	polypaths.resize(paths.size());
 	for (PathsD::size_type i = 0; i < paths.size(); ++i) {
 		const PathD &path = paths[i];
 
 		Vector<Vector2> polypath2;
+		polypath2.resize(path.size());
 		for (PathsD::size_type j = 0; j < path.size(); ++j) {
-			polypath2.push_back(Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
+			polypath2.set(j, Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
 		}
-		polypaths.push_back(polypath2);
+		polypaths.set(i, polypath2);
 	}
 	return polypaths;
 }


### PR DESCRIPTION
```gdscript
@tool
extends Node2D

var a_dict: Dictionary = { "type": "PackedVector2Array", "args": [40.0, 47.0, 65.0, 25.0, 117.0, 43.0, 101.0, 72.0, 171.0, 78.0, 158.0, 111.0, 140.0, 120.0, 69.0, 117.0, 30.0, 123.0, 11.0, 80.0, 44.0, 96.0, 67.0, 95.0, 98.0, 100.0, 108.0, 107.0, 159.0, 101.0, 151.0, 87.0, 131.0, 88.0, 103.0, 83.0, 89.0, 80.0, 85.0, 56.0, 66.0, 60.0, 54.0, 69.0, 34.0, 70.0, 11.0, 60.0, -12.0, 48.0, -14.0, 18.0, -10.0, 8.0, 3.0, -11.0, 22.0, -16.0, 84.0, -19.0, 121.0, -15.0, 150.0, -1.0, 192.0, 12.0, 236.0, -4.0, 297.0, 3.0, 310.0, 32.0, 306.0, 60.0, 277.0, 76.0, 224.0, 53.0, 227.0, 31.0, 213.0, 31.0, 190.0, 40.0, 176.0, 39.0, 164.0, 23.0, 133.0, 11.0, 73.0, -8.0, 52.0, -2.0, 20.0, 22.0, 28.0, 44.0, 34.0, 46.0] }
var b_dict: Dictionary = { "type": "PackedVector2Array", "args": [85.0, -52.0, 55.0, -32.0, 44.0, -23.0, 37.0, 3.0, 44.0, 16.0, 64.0, 7.0, 51.0, 26.0, 46.0, 42.0, 52.0, 55.0, 43.0, 65.0, 34.0, 78.0, 39.0, 93.0, 43.0, 110.0, 44.0, 130.0, 56.0, 144.0, 62.0, 144.0, 82.0, 144.0, 93.0, 151.0, 121.0, 189.0, 195.0, 193.0, 234.0, 169.0, 247.0, 146.0, 236.0, 120.0, 222.0, 132.0, 214.0, 152.0, 189.0, 166.0, 159.0, 169.0, 135.0, 159.0, 113.0, 140.0, 87.0, 120.0, 60.0, 106.0, 62.0, 79.0, 62.0, 69.0, 66.0, 54.0, 75.0, 42.0, 79.0, 24.0, 81.0, 15.0, 87.0, 10.0, 98.0, 12.0, 112.0, 23.0, 117.0, 27.0, 132.0, 34.0, 129.0, 62.0, 122.0, 81.0, 134.0, 102.0, 148.0, 88.0, 150.0, 68.0, 151.0, 65.0, 157.0, 58.0, 170.0, 63.0, 184.0, 74.0, 190.0, 92.0, 190.0, 101.0, 228.0, 107.0, 260.0, 88.0, 251.0, 79.0, 252.0, 46.0, 253.0, 38.0, 216.0, 55.0, 205.0, 69.0, 195.0, 74.0, 182.0, 54.0, 180.0, 43.0, 178.0, 25.0, 194.0, 9.0, 217.0, -5.0, 233.0, -24.0, 232.0, -50.0, 200.0, -26.0, 190.0, -12.0, 179.0, -4.0, 158.0, 3.0, 148.0, 6.0, 135.0, 11.0, 129.0, 11.0, 112.0, 9.0, 98.0, -14.0, 98.0, -25.0, 127.0, -42.0, 124.0, -63.0, 116.0, -67.0] }

func _ready() -> void:
	var a: PackedVector2Array = JSON.to_native(a_dict)
	var b: PackedVector2Array = JSON.to_native(b_dict)
	var time = Time.get_ticks_msec()
	for i in 10000:
		var _p = Geometry2D.merge_polygons(a, b)
	prints("Merge Polygons:", Time.get_ticks_msec() - time, "ms")
	time = Time.get_ticks_msec()
	for i in 10000:
		var _p = Geometry2D.offset_polygon(a, 16.0, Geometry2D.JOIN_ROUND)
	prints("Offset Polygons:", Time.get_ticks_msec() - time, "ms")

```
```YAML
- Before:
  - Merge Polygons: 3538 ms
  - Offset Polygons: 3390 ms

- After:
  - Merge Polygons: 3269 ms
  - Offset Polygons: 3253 ms
```