### PR TITLE
JSON optimization for packed arrays

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -839,9 +839,13 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 
 			ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
 
+			args.resize(dict.size() * 2);
+			Array::Iterator itr = args.begin();
 			for (const KeyValue<Variant, Variant> &kv : dict) {
-				args.push_back(_from_native(kv.key, p_full_objects, p_depth + 1));
-				args.push_back(_from_native(kv.value, p_full_objects, p_depth + 1));
+				*itr = _from_native(kv.key, p_full_objects, p_depth + 1);
+				++itr;
+				*itr = _from_native(kv.value, p_full_objects, p_depth + 1);
+				++itr;
 			}
 
 			return ret;
@@ -867,8 +871,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 
 			ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
 
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(_from_native(arr[i], p_full_objects, p_depth + 1));
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const Variant &V : arr) {
+				*itr = _from_native(V, p_full_objects, p_depth + 1);
+				++itr;
 			}
 
 			return ret;
@@ -878,8 +885,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedByteArray arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const uint8_t &V : arr) {
+				*itr = V;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -888,8 +898,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedInt32Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const int32_t &V : arr) {
+				*itr = V;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -898,8 +911,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedInt64Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const int64_t &V : arr) {
+				*itr = V;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -908,8 +924,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedFloat32Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const float &V : arr) {
+				*itr = V;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -918,8 +937,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedFloat64Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const double &V : arr) {
+				*itr = V;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -928,8 +950,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedStringArray arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+			args.resize(arr.size());
+			Array::Iterator itr = args.begin();
+			for (const String &V : arr) {
+				*itr = V;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -938,10 +963,13 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector2Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				Vector2 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
+			args.resize(arr.size() * 2);
+			Array::Iterator itr = args.begin();
+			for (const Vector2 &V : arr) {
+				*itr = V.x;
+				++itr;
+				*itr = V.y;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -950,11 +978,15 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector3Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				Vector3 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
-				args.push_back(v.z);
+			args.resize(arr.size() * 3);
+			Array::Iterator itr = args.begin();
+			for (const Vector3 &V : arr) {
+				*itr = V.x;
+				++itr;
+				*itr = V.y;
+				++itr;
+				*itr = V.z;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -963,12 +995,17 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedColorArray arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				Color v = arr[i];
-				args.push_back(v.r);
-				args.push_back(v.g);
-				args.push_back(v.b);
-				args.push_back(v.a);
+			args.resize(arr.size() * 4);
+			Array::Iterator itr = args.begin();
+			for (const Color &V : arr) {
+				*itr = V.r;
+				++itr;
+				*itr = V.g;
+				++itr;
+				*itr = V.b;
+				++itr;
+				*itr = V.a;
+				++itr;
 			}
 
 			RETURN_ARGS;
@@ -977,12 +1014,17 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector4Array arr = p_variant;
 
 			Array args;
-			for (int i = 0; i < arr.size(); i++) {
-				Vector4 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
-				args.push_back(v.z);
-				args.push_back(v.w);
+			args.resize(arr.size() * 4);
+			Array::Iterator itr = args.begin();
+			for (const Vector4 &V : arr) {
+				*itr = V.x;
+				++itr;
+				*itr = V.y;
+				++itr;
+				*itr = V.z;
+				++itr;
+				*itr = V.w;
+				++itr;
 			}
 
 			RETURN_ARGS;


### PR DESCRIPTION
(Each test was run with an array size of **10,000,000** elements.)

### Benchmark Results

| TYPE              | AFTER   | BEFORE  |
|-------------------|---------|---------|
| PackedColorArray  | 1941 ms | 15567 ms |
| PackedVector4Array| 2004 ms | 15301 ms |
| PackedVector3Array| 1519 ms | 11715 ms |
| PackedVector2Array| 1116 ms | 7914 ms  |
| Array[Vector2i]   | 62238 ms| 62099 ms |
| PackedInt32Array  | 410 ms  | 3980 ms  |
| PackedInt64Array  | 410 ms  | 4146 ms  |
| PackedFloat32Array| 516 ms  | 4032 ms  |
| PackedFloat64Array| 516 ms  | 4076 ms  |
| PackedStringArray | 1120 ms | 6930 ms  |
| PackedByteArray   | 531 ms  | 4140 ms  |
| Dictionary        | 34861 ms| 46733 ms |
