### PR TITLE
Add missing bone name suggestions in ModifierBoneTarget3D

### DIFF
--- a/scene/3d/modifier_bone_target_3d.cpp
+++ b/scene/3d/modifier_bone_target_3d.cpp
@@ -72,6 +72,19 @@ void ModifierBoneTarget3D::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "influence") {
 		p_property.usage = PROPERTY_USAGE_READ_ONLY;
 	}
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+	if (p_property.name == "bone_name") {
+		Skeleton3D *skeleton = get_skeleton();
+		if (skeleton) {
+			p_property.hint = PROPERTY_HINT_ENUM;
+			p_property.hint_string = skeleton->get_concatenated_bone_names();
+		} else {
+			p_property.hint = PROPERTY_HINT_NONE;
+			p_property.hint_string = "";
+		}
+	}
 }
 
 void ModifierBoneTarget3D::_bind_methods() {


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/106846

I don't know why I forgot this, but it's lacked...

Before:
<img width="667" height="148" alt="image" src="https://github.com/user-attachments/assets/04f7498f-3432-49cc-b913-e9c4a1518b55" />

After:
<img width="672" height="159" alt="image" src="https://github.com/user-attachments/assets/6daa70bc-cdce-4471-b01f-5334d75f9119" />
