### PR TITLE
Core: Optimize Array usage with preallocation and indexed assignment

### DIFF
--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -157,8 +157,9 @@ static Array array_from_info(const char *const *info_list) {
 
 static Array array_from_info_count(const char *const *info_list, int info_count) {
 	Array arr;
+	arr.resize(info_count);
 	for (int i = 0; i < info_count; i++) {
-		arr.push_back(String::utf8(info_list[i]));
+		arr.set(i, String::utf8(info_list[i]));
 	}
 	return arr;
 }
@@ -176,22 +177,24 @@ Dictionary Engine::get_author_info() const {
 
 TypedArray<Dictionary> Engine::get_copyright_info() const {
 	TypedArray<Dictionary> components;
+	components.resize(COPYRIGHT_INFO_COUNT);
 	for (int component_index = 0; component_index < COPYRIGHT_INFO_COUNT; component_index++) {
 		const ComponentCopyright &cp_info = COPYRIGHT_INFO[component_index];
 		Dictionary component_dict;
 		component_dict["name"] = String::utf8(cp_info.name);
 		Array parts;
+		parts.resize(cp_info.part_count);
 		for (int i = 0; i < cp_info.part_count; i++) {
 			const ComponentCopyrightPart &cp_part = cp_info.parts[i];
 			Dictionary part_dict;
 			part_dict["files"] = array_from_info_count(cp_part.files, cp_part.file_count);
 			part_dict["copyright"] = array_from_info_count(cp_part.copyright_statements, cp_part.copyright_count);
 			part_dict["license"] = String::utf8(cp_part.license);
-			parts.push_back(part_dict);
+			parts.set(i, part_dict);
 		}
 		component_dict["parts"] = parts;
 
-		components.push_back(component_dict);
+		components.set(component_index, component_dict);
 	}
 	return components;
 }

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1423,8 +1423,10 @@ void ProjectSettings::save_scene_groups_cache() {
 			continue;
 		}
 		Array list;
+		list.resize(E.value.size());
+		int idx = 0;
 		for (const StringName &group : E.value) {
-			list.push_back(group);
+			list.set(idx++, group);
 		}
 		cf->set_value(E.key, "groups", list);
 	}
@@ -1518,10 +1520,12 @@ void ProjectSettings::_add_builtin_input_map() {
 
 		for (KeyValue<String, List<Ref<InputEvent>>> &E : builtins) {
 			Array events;
+			events.resize(E.value.size());
+			int idx = 0;
 
 			// Convert list of input events into array
 			for (const Ref<InputEvent> &event : E.value) {
-				events.push_back(event);
+				events.set(idx++, event);
 			}
 
 			Dictionary action;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -79,8 +79,11 @@ Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &
 	List<String> exts;
 	::ResourceLoader::get_recognized_extensions_for_type(p_type, &exts);
 	Vector<String> ret;
+	ret.resize(exts.size());
+	int idx = 0;
+
 	for (const String &E : exts) {
-		ret.push_back(E);
+		ret.set(idx++, E);
 	}
 
 	return ret;
@@ -103,8 +106,11 @@ PackedStringArray ResourceLoader::get_dependencies(const String &p_path) {
 	::ResourceLoader::get_dependencies(p_path, &deps);
 
 	PackedStringArray ret;
+	ret.resize(deps.size());
+	int idx = 0;
+
 	for (const String &E : deps) {
-		ret.push_back(E);
+		ret.set(idx++, E);
 	}
 
 	return ret;
@@ -175,8 +181,11 @@ Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_r
 	List<String> exts;
 	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
 	Vector<String> ret;
+	ret.resize(exts.size());
+	int idx = 0;
+
 	for (const String &E : exts) {
-		ret.push_back(E);
+		ret.set(idx++, E);
 	}
 	return ret;
 }
@@ -505,8 +514,11 @@ Vector<String> OS::get_video_adapter_driver_info() const {
 Vector<String> OS::get_cmdline_args() {
 	List<String> cmdline = ::OS::get_singleton()->get_cmdline_args();
 	Vector<String> cmdlinev;
+	cmdlinev.resize(cmdline.size());
+	int idx = 0;
+
 	for (const String &E : cmdline) {
-		cmdlinev.push_back(E);
+		cmdlinev.set(idx++, E);
 	}
 
 	return cmdlinev;
@@ -515,8 +527,11 @@ Vector<String> OS::get_cmdline_args() {
 Vector<String> OS::get_cmdline_user_args() {
 	List<String> cmdline = ::OS::get_singleton()->get_cmdline_user_args();
 	Vector<String> cmdlinev;
+	cmdlinev.resize(cmdline.size());
+	int idx = 0;
+
 	for (const String &E : cmdline) {
-		cmdlinev.push_back(E);
+		cmdlinev.set(idx++, E);
 	}
 
 	return cmdlinev;
@@ -538,8 +553,11 @@ bool OS::is_restart_on_exit_set() const {
 Vector<String> OS::get_restart_on_exit_arguments() const {
 	List<String> args = ::OS::get_singleton()->get_restart_on_exit_arguments();
 	Vector<String> args_vector;
+	args_vector.resize(args.size());
+	int idx = 0;
+
 	for (const String &arg : args) {
-		args_vector.push_back(arg);
+		args_vector.set(idx++, arg);
 	}
 
 	return args_vector;
@@ -966,9 +984,10 @@ TypedArray<PackedVector2Array> Geometry2D::decompose_polygon_in_convex(const Vec
 	Vector<Vector<Point2>> decomp = ::Geometry2D::decompose_polygon_in_convex(p_polygon);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(decomp.size());
 
-	for (int i = 0; i < decomp.size(); ++i) {
-		ret.push_back(decomp[i]);
+	for (int i = 0; i < decomp.size(); i++) {
+		ret.set(i, decomp[i]);
 	}
 	return ret;
 }
@@ -977,9 +996,10 @@ TypedArray<PackedVector2Array> Geometry2D::merge_polygons(const Vector<Vector2> 
 	Vector<Vector<Point2>> polys = ::Geometry2D::merge_polygons(p_polygon_a, p_polygon_b);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -988,9 +1008,10 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polygons(const Vector<Vector2> &
 	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polygons(p_polygon_a, p_polygon_b);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -999,9 +1020,10 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polygons(const Vector<Vecto
 	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polygons(p_polygon_a, p_polygon_b);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -1010,9 +1032,10 @@ TypedArray<PackedVector2Array> Geometry2D::exclude_polygons(const Vector<Vector2
 	Vector<Vector<Point2>> polys = ::Geometry2D::exclude_polygons(p_polygon_a, p_polygon_b);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -1021,9 +1044,10 @@ TypedArray<PackedVector2Array> Geometry2D::clip_polyline_with_polygon(const Vect
 	Vector<Vector<Point2>> polys = ::Geometry2D::clip_polyline_with_polygon(p_polyline, p_polygon);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -1032,9 +1056,10 @@ TypedArray<PackedVector2Array> Geometry2D::intersect_polyline_with_polygon(const
 	Vector<Vector<Point2>> polys = ::Geometry2D::intersect_polyline_with_polygon(p_polyline, p_polygon);
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -1043,9 +1068,10 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polygon(const Vector<Vector2> 
 	Vector<Vector<Point2>> polys = ::Geometry2D::offset_polygon(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type));
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -1054,9 +1080,10 @@ TypedArray<PackedVector2Array> Geometry2D::offset_polyline(const Vector<Vector2>
 	Vector<Vector<Point2>> polys = ::Geometry2D::offset_polyline(p_polygon, p_delta, ::Geometry2D::PolyJoinType(p_join_type), ::Geometry2D::PolyEndType(p_end_type));
 
 	TypedArray<PackedVector2Array> ret;
+	ret.resize(polys.size());
 
-	for (int i = 0; i < polys.size(); ++i) {
-		ret.push_back(polys[i]);
+	for (int i = 0; i < polys.size(); i++) {
+		ret.set(i, polys[i]);
 	}
 	return ret;
 }
@@ -1065,8 +1092,9 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	Dictionary ret;
 
 	Vector<Size2i> rects;
+	rects.resize(p_rects.size());
 	for (int i = 0; i < p_rects.size(); i++) {
-		rects.push_back(p_rects[i]);
+		rects.set(i, p_rects[i]);
 	}
 
 	Vector<Point2i> result;
@@ -1075,8 +1103,9 @@ Dictionary Geometry2D::make_atlas(const Vector<Size2> &p_rects) {
 	::Geometry2D::make_atlas(rects, result, size);
 
 	Vector<Point2> r_result;
+	r_result.resize(result.size());
 	for (int i = 0; i < result.size(); i++) {
-		r_result.push_back(result[i]);
+		r_result.set(i, result[i]);
 	}
 
 	ret["points"] = r_result;
@@ -1160,7 +1189,7 @@ Vector<Vector3> Geometry3D::compute_convex_mesh_points(const TypedArray<Plane> &
 	Vector<Plane> planes_vec;
 	int size = p_planes.size();
 	planes_vec.resize(size);
-	for (int i = 0; i < size; ++i) {
+	for (int i = 0; i < size; i++) {
 		planes_vec.set(i, p_planes[i]);
 	}
 	Variant ret = ::Geometry3D::compute_convex_mesh_points(planes_vec.ptr(), size);
@@ -1624,9 +1653,11 @@ TypedArray<Dictionary> ClassDB::class_get_signal_list(const StringName &p_class,
 	List<MethodInfo> signals;
 	::ClassDB::get_signal_list(p_class, &signals, p_no_inheritance);
 	TypedArray<Dictionary> ret;
+	ret.resize(signals.size());
+	int idx = 0;
 
 	for (const MethodInfo &E : signals) {
-		ret.push_back(E.operator Dictionary());
+		ret.set(idx++, E.operator Dictionary());
 	}
 
 	return ret;
@@ -1636,8 +1667,11 @@ TypedArray<Dictionary> ClassDB::class_get_property_list(const StringName &p_clas
 	List<PropertyInfo> plist;
 	::ClassDB::get_property_list(p_class, &plist, p_no_inheritance);
 	TypedArray<Dictionary> ret;
+	ret.resize(plist.size());
+	int idx = 0;
+
 	for (const PropertyInfo &E : plist) {
-		ret.push_back(E.operator Dictionary());
+		ret.set(idx++, E.operator Dictionary());
 	}
 
 	return ret;
@@ -1689,14 +1723,16 @@ TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class,
 	List<MethodInfo> methods;
 	::ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
 	TypedArray<Dictionary> ret;
+	ret.resize(methods.size());
+	int idx = 0;
 
 	for (const MethodInfo &E : methods) {
 #ifdef DEBUG_ENABLED
-		ret.push_back(E.operator Dictionary());
+		ret.set(idx++, E.operator Dictionary());
 #else
 		Dictionary dict;
 		dict["name"] = E.name;
-		ret.push_back(dict);
+		ret.set(idx++, dict);
 #endif // DEBUG_ENABLED
 	}
 
@@ -1997,8 +2033,11 @@ Vector<String> Engine::get_singleton_list() const {
 	List<::Engine::Singleton> singletons;
 	::Engine::get_singleton()->get_singletons(&singletons);
 	Vector<String> ret;
+	ret.resize(singletons.size());
+	int idx = 0;
+
 	for (const ::Engine::Singleton &E : singletons) {
-		ret.push_back(E.name);
+		ret.set(idx++, E.name);
 	}
 	return ret;
 }

--- a/core/extension/gdextension.cpp
+++ b/core/extension/gdextension.cpp
@@ -639,9 +639,10 @@ void GDExtension::_register_extension_class_signal(GDExtensionClassLibraryPtr p_
 
 	MethodInfo s;
 	s.name = signal_name;
+	s.arguments.resize(p_argument_count);
 	for (int i = 0; i < p_argument_count; i++) {
 		PropertyInfo arg(p_argument_info[i]);
-		s.arguments.push_back(arg);
+		s.arguments.set(i, arg);
 	}
 	ClassDB::add_signal(class_name, s);
 }

--- a/core/extension/gdextension_library_loader.cpp
+++ b/core/extension/gdextension_library_loader.cpp
@@ -183,8 +183,10 @@ Error GDExtensionLibraryLoader::open_library(const String &p_path) {
 
 	Vector<String> abs_dependencies_paths;
 	if (!library_dependencies.is_empty()) {
+		abs_dependencies_paths.resize(library_dependencies.size());
+		int idx = 0;
 		for (const SharedObject &dependency : library_dependencies) {
-			abs_dependencies_paths.push_back(ProjectSettings::get_singleton()->globalize_path(dependency.path));
+			abs_dependencies_paths.set(idx++, ProjectSettings::get_singleton()->globalize_path(dependency.path));
 		}
 	}
 

--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -224,8 +224,10 @@ bool GDExtensionManager::is_extension_loaded(const String &p_path) const {
 
 Vector<String> GDExtensionManager::get_loaded_extensions() const {
 	Vector<String> ret;
+	ret.resize(gdextension_map.size());
+	int idx = 0;
 	for (const KeyValue<String, Ref<GDExtension>> &E : gdextension_map) {
-		ret.push_back(E.key);
+		ret.set(idx++, E.key);
 	}
 	return ret;
 }

--- a/core/input/shortcut.cpp
+++ b/core/input/shortcut.cpp
@@ -41,10 +41,11 @@ void Shortcut::set_events(const Array &p_events) {
 }
 
 void Shortcut::set_events_list(const List<Ref<InputEvent>> *p_events) {
-	events.clear();
+	events.resize(p_events->size());
+	int idx = 0;
 
 	for (const Ref<InputEvent> &ie : *p_events) {
-		events.push_back(ie);
+		events.set(idx++, ie);
 	}
 }
 

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -131,6 +131,7 @@ void FileAccessCompressed::_close() {
 		}
 
 		Vector<int> block_sizes;
+		block_sizes.resize(bc);
 		for (uint32_t i = 0; i < bc; i++) {
 			uint32_t bl = i == (bc - 1) ? write_max % block_size : block_size;
 			uint8_t *bp = &write_ptr[i * block_size];
@@ -141,7 +142,7 @@ void FileAccessCompressed::_close() {
 			ERR_FAIL_COND_MSG(compressed_size < 0, "FileAccessCompressed: Error compressing data.");
 
 			f->store_buffer(cblock.ptr(), (uint64_t)compressed_size);
-			block_sizes.push_back(compressed_size);
+			block_sizes.set(i, compressed_size);
 		}
 
 		f->seek(16); //ok write block sizes

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -149,8 +149,10 @@ PackedStringArray IP::resolve_hostname_addresses(const String &p_hostname, Type 
 	}
 
 	PackedStringArray result;
+	result.resize(res.size());
+	int idx = 0;
 	for (const IPAddress &E : res) {
-		result.push_back(String(E));
+		result.set(idx++, String(E));
 	}
 	return result;
 }
@@ -255,11 +257,13 @@ void IP::clear_cache(const String &p_hostname) {
 }
 
 PackedStringArray IP::_get_local_addresses() const {
-	PackedStringArray addresses;
 	List<IPAddress> ip_addresses;
 	get_local_addresses(&ip_addresses);
+	PackedStringArray addresses;
+	addresses.resize(ip_addresses.size());
+	int idx = 0;
 	for (const IPAddress &E : ip_addresses) {
-		addresses.push_back(String(E));
+		addresses.set(idx++, String(E));
 	}
 
 	return addresses;

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -839,9 +839,11 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 
 			ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
 
+			args.resize(dict.size() * 2);
+			int idx = 0;
 			for (const KeyValue<Variant, Variant> &kv : dict) {
-				args.push_back(_from_native(kv.key, p_full_objects, p_depth + 1));
-				args.push_back(_from_native(kv.value, p_full_objects, p_depth + 1));
+				args.set(idx++, _from_native(kv.key, p_full_objects, p_depth + 1));
+				args.set(idx++, _from_native(kv.value, p_full_objects, p_depth + 1));
 			}
 
 			return ret;
@@ -867,8 +869,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 
 			ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
 
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(_from_native(arr[i], p_full_objects, p_depth + 1));
+				args.set(i, _from_native(arr[i], p_full_objects, p_depth + 1));
 			}
 
 			return ret;
@@ -878,8 +881,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedByteArray arr = p_variant;
 
 			Array args;
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+				args.set(i, arr[i]);
 			}
 
 			RETURN_ARGS;
@@ -888,8 +892,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedInt32Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+				args.set(i, arr[i]);
 			}
 
 			RETURN_ARGS;
@@ -898,8 +903,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedInt64Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+				args.set(i, arr[i]);
 			}
 
 			RETURN_ARGS;
@@ -908,8 +914,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedFloat32Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+				args.set(i, arr[i]);
 			}
 
 			RETURN_ARGS;
@@ -918,8 +925,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedFloat64Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+				args.set(i, arr[i]);
 			}
 
 			RETURN_ARGS;
@@ -928,8 +936,9 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedStringArray arr = p_variant;
 
 			Array args;
+			args.resize(arr.size());
 			for (int i = 0; i < arr.size(); i++) {
-				args.push_back(arr[i]);
+				args.set(i, arr[i]);
 			}
 
 			RETURN_ARGS;
@@ -938,10 +947,12 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector2Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size() * 2);
+			int idx = 0;
 			for (int i = 0; i < arr.size(); i++) {
 				Vector2 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
+				args.set(idx++, v.x);
+				args.set(idx++, v.y);
 			}
 
 			RETURN_ARGS;
@@ -950,11 +961,13 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector3Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size() * 3);
+			int idx = 0;
 			for (int i = 0; i < arr.size(); i++) {
 				Vector3 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
-				args.push_back(v.z);
+				args.set(idx++, v.x);
+				args.set(idx++, v.y);
+				args.set(idx++, v.z);
 			}
 
 			RETURN_ARGS;
@@ -963,12 +976,14 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedColorArray arr = p_variant;
 
 			Array args;
+			args.resize(arr.size() * 4);
+			int idx = 0;
 			for (int i = 0; i < arr.size(); i++) {
 				Color v = arr[i];
-				args.push_back(v.r);
-				args.push_back(v.g);
-				args.push_back(v.b);
-				args.push_back(v.a);
+				args.set(idx++, v.r);
+				args.set(idx++, v.g);
+				args.set(idx++, v.b);
+				args.set(idx++, v.a);
 			}
 
 			RETURN_ARGS;
@@ -977,12 +992,14 @@ Variant JSON::_from_native(const Variant &p_variant, bool p_full_objects, int p_
 			const PackedVector4Array arr = p_variant;
 
 			Array args;
+			args.resize(arr.size() * 4);
+			int idx = 0;
 			for (int i = 0; i < arr.size(); i++) {
 				Vector4 v = arr[i];
-				args.push_back(v.x);
-				args.push_back(v.y);
-				args.push_back(v.z);
-				args.push_back(v.w);
+				args.set(idx++, v.x);
+				args.set(idx++, v.y);
+				args.set(idx++, v.z);
+				args.set(idx++, v.w);
 			}
 
 			RETURN_ARGS;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -361,8 +361,6 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 		} break;
 
 		case VARIANT_NODE_PATH: {
-			Vector<StringName> names;
-			Vector<StringName> subnames;
 			bool absolute;
 
 			int name_count = f->get_16();
@@ -373,11 +371,16 @@ Error ResourceLoaderBinary::parse_variant(Variant &r_v) {
 				subname_count += 1; // has a property field, so we should count it as well
 			}
 
+			Vector<StringName> names;
+			names.resize(name_count);
 			for (int i = 0; i < name_count; i++) {
-				names.push_back(_get_string());
+				names.set(i, _get_string());
 			}
+
+			Vector<StringName> subnames;
+			subnames.resize(subname_count);
 			for (uint32_t i = 0; i < subname_count; i++) {
-				subnames.push_back(_get_string());
+				subnames.set(i, _get_string());
 			}
 
 			NodePath np = NodePath(names, subnames, absolute);

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1543,8 +1543,10 @@ Vector<String> ResourceLoader::list_directory(const String &p_directory) {
 	}
 
 	Vector<String> ret;
+	ret.resize(files_found.size());
+	int idx = 0;
 	for (const String &f : files_found) {
-		ret.push_back(f);
+		ret.set(idx++, f);
 	}
 
 	return ret;

--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -207,9 +207,11 @@ bool AStar3D::has_point(int64_t p_id) const {
 
 PackedInt64Array AStar3D::get_point_ids() {
 	PackedInt64Array point_list;
+	point_list.resize(points.size());
+	int idx = 0;
 
 	for (KeyValue<int64_t, Point *> &kv : points) {
-		point_list.push_back(kv.key);
+		point_list.set(idx++, kv.key);
 	}
 
 	return point_list;
@@ -220,9 +222,11 @@ Vector<int64_t> AStar3D::get_point_connections(int64_t p_id) {
 	ERR_FAIL_COND_V_MSG(!p_entry, Vector<int64_t>(), vformat("Can't get point's connections. Point with id: %d doesn't exist.", p_id));
 
 	Vector<int64_t> point_list;
+	point_list.resize((*p_entry)->neighbors.size());
+	int idx = 0;
 
 	for (KeyValue<int64_t, Point *> &kv : (*p_entry)->neighbors) {
-		point_list.push_back(kv.key);
+		point_list.set(idx++, kv.key);
 	}
 
 	return point_list;

--- a/core/math/a_star_grid_2d.cpp
+++ b/core/math/a_star_grid_2d.cpp
@@ -614,6 +614,8 @@ TypedArray<Dictionary> AStarGrid2D::get_point_data_in_region(const Rect2i &p_reg
 	const int32_t end_y = inter_region.get_end().y - region.position.y;
 
 	TypedArray<Dictionary> data;
+	data.resize((end_y - start_y) * (end_x - start_x));
+	int idx = 0;
 
 	for (int32_t y = start_y; y < end_y; y++) {
 		for (int32_t x = start_x; x < end_x; x++) {
@@ -624,7 +626,7 @@ TypedArray<Dictionary> AStarGrid2D::get_point_data_in_region(const Rect2i &p_reg
 			dict["position"] = p.pos;
 			dict["solid"] = _get_solid_unchecked(p.id);
 			dict["weight_scale"] = p.weight_scale;
-			data.push_back(dict);
+			data.set(idx++, dict);
 		}
 	}
 

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -245,6 +245,7 @@ public:
 			//create root simplex
 			Simplex *root = memnew(Simplex(point_count + 0, point_count + 1, point_count + 2, point_count + 3));
 			root->SE = simplex_list.push_back(root);
+			root->grid_positions.reserve(ACCEL_GRID_SIZE * ACCEL_GRID_SIZE * ACCEL_GRID_SIZE);
 
 			for (uint32_t i = 0; i < ACCEL_GRID_SIZE; i++) {
 				for (uint32_t j = 0; j < ACCEL_GRID_SIZE; j++) {

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -292,14 +292,16 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 	}
 
 	Vector<Vector<Point2>> polypaths;
+	polypaths.resize(paths.size());
 	for (PathsD::size_type i = 0; i < paths.size(); ++i) {
 		const PathD &path = paths[i];
 
 		Vector<Vector2> polypath;
+		polypath.resize(path.size());
 		for (PathsD::size_type j = 0; j < path.size(); ++j) {
-			polypath.push_back(Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
+			polypath.set(j, Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
 		}
-		polypaths.push_back(polypath);
+		polypaths.set(i, polypath);
 	}
 	return polypaths;
 }
@@ -353,14 +355,16 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 	// to attain the desired precision.
 
 	Vector<Vector<Point2>> polypaths;
+	polypaths.resize(paths.size());
 	for (PathsD::size_type i = 0; i < paths.size(); ++i) {
 		const PathD &path = paths[i];
 
 		Vector<Vector2> polypath2;
+		polypath2.resize(path.size());
 		for (PathsD::size_type j = 0; j < path.size(); ++j) {
-			polypath2.push_back(Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
+			polypath2.set(j, Point2(static_cast<real_t>(path[j].x), static_cast<real_t>(path[j].y)));
 		}
-		polypaths.push_back(polypath2);
+		polypaths.set(i, polypath2);
 	}
 	return polypaths;
 }

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -745,19 +745,22 @@ Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height
 	Vector<Plane> planes;
 
 	const double sides_step = Math::TAU / p_sides;
+	planes.resize(p_sides + 2);
+	int idx = 0;
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
 		normal[(p_axis + 1) % 3] = Math::cos(i * sides_step);
 		normal[(p_axis + 2) % 3] = Math::sin(i * sides_step);
 
-		planes.push_back(Plane(normal, p_radius));
+		planes.set(idx++, Plane(normal, p_radius));
 	}
 
 	Vector3 axis;
 	axis[p_axis] = 1.0;
+	real_t half_height = p_height * 0.5f;
 
-	planes.push_back(Plane(axis, p_height * 0.5f));
-	planes.push_back(Plane(-axis, p_height * 0.5f));
+	planes.set(idx++, Plane(axis, half_height));
+	planes.set(idx++, Plane(-axis, half_height));
 
 	return planes;
 }
@@ -776,17 +779,19 @@ Vector<Plane> Geometry3D::build_sphere_planes(real_t p_radius, int p_lats, int p
 	axis_neg[p_axis] = -1.0;
 
 	const double lon_step = Math::TAU / p_lons;
+	planes.resize(p_lons * (1 + 2 * p_lats));
+	int idx = 0;
 	for (int i = 0; i < p_lons; i++) {
 		Vector3 normal;
 		normal[(p_axis + 1) % 3] = Math::cos(i * lon_step);
 		normal[(p_axis + 2) % 3] = Math::sin(i * lon_step);
 
-		planes.push_back(Plane(normal, p_radius));
+		planes.set(idx++, Plane(normal, p_radius));
 
 		for (int j = 1; j <= p_lats; j++) {
 			Vector3 plane_normal = normal.lerp(axis, j / (real_t)p_lats).normalized();
-			planes.push_back(Plane(plane_normal, p_radius));
-			planes.push_back(Plane(plane_normal * axis_neg, p_radius));
+			planes.set(idx++, Plane(plane_normal, p_radius));
+			planes.set(idx++, Plane(plane_normal * axis_neg, p_radius));
 		}
 	}
 
@@ -807,18 +812,20 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 	axis_neg[p_axis] = -1.0;
 
 	const double sides_step = Math::TAU / p_sides;
+	planes.resize(p_sides * (1 + 2 * p_lats));
+	int idx = 0;
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
 		normal[(p_axis + 1) % 3] = Math::cos(i * sides_step);
 		normal[(p_axis + 2) % 3] = Math::sin(i * sides_step);
 
-		planes.push_back(Plane(normal, p_radius));
+		planes.set(idx++, Plane(normal, p_radius));
 
 		for (int j = 1; j <= p_lats; j++) {
 			Vector3 plane_normal = normal.lerp(axis, j / (real_t)p_lats).normalized();
 			Vector3 position = axis * p_height * 0.5f + plane_normal * p_radius;
-			planes.push_back(Plane(plane_normal, position));
-			planes.push_back(Plane(plane_normal * axis_neg, position * axis_neg));
+			planes.set(idx++, Plane(plane_normal, position));
+			planes.set(idx++, Plane(plane_normal * axis_neg, position * axis_neg));
 		}
 	}
 

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -867,8 +867,9 @@ static MethodInfo info_from_bind(MethodBind *p_method) {
 	minfo.name = p_method->get_name();
 	minfo.id = p_method->get_method_id();
 
+	minfo.arguments.resize(p_method->get_argument_count());
 	for (int i = 0; i < p_method->get_argument_count(); i++) {
-		minfo.arguments.push_back(p_method->get_argument_info(i));
+		minfo.arguments.set(i, p_method->get_argument_info(i));
 	}
 
 	minfo.return_val = p_method->get_return_info();
@@ -2096,11 +2097,16 @@ void ClassDB::add_extension_class_virtual_method(const StringName &p_class, cons
 	mi.return_val = PropertyInfo(p_method_info->return_value);
 	mi.return_val_metadata = p_method_info->return_value_metadata;
 	mi.flags = p_method_info->method_flags;
-	for (int i = 0; i < (int)p_method_info->argument_count; i++) {
+
+	const int size = p_method_info->argument_count;
+	arg_names.resize(size);
+	mi.arguments.resize(size);
+	mi.arguments_metadata.resize(size);
+	for (int i = 0; i < size; i++) {
 		PropertyInfo arg(p_method_info->arguments[i]);
-		mi.arguments.push_back(arg);
-		mi.arguments_metadata.push_back(p_method_info->arguments_metadata[i]);
-		arg_names.push_back(arg.name);
+		mi.arguments.set(i, arg);
+		mi.arguments_metadata.set(i, p_method_info->arguments_metadata[i]);
+		arg_names.set(i, arg.name);
 	}
 
 	add_virtual_method(p_class, mi, true, arg_names);

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -38,8 +38,9 @@ uint32_t MethodBind::get_hash() const {
 	MethodInfo mi;
 	mi.return_val = get_return_info();
 	mi.flags = get_hint_flags();
+	mi.arguments.resize(get_argument_count());
 	for (int i = 0; i < get_argument_count(); i++) {
-		mi.arguments.push_back(get_argument_info(i));
+		mi.arguments.set(i, get_argument_info(i));
 	}
 	mi.default_arguments = default_arguments;
 

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -122,8 +122,10 @@ Vector<String> TranslationPO::_get_message_list() const {
 	get_message_list(&msgs);
 
 	Vector<String> v;
+	v.resize(msgs.size());
+	int idx = 0;
 	for (const StringName &E : msgs) {
-		v.push_back(E);
+		v.set(idx++, E);
 	}
 
 	return v;
@@ -255,11 +257,11 @@ void TranslationPO::add_plural_message(const StringName &p_src_text, const Vecto
 
 	if (map_id_str.has(p_src_text)) {
 		WARN_PRINT(vformat("Double translations for \"%s\" under the same context \"%s\" for locale %s.\nThere should only be one unique translation for a given string under the same context.", p_src_text, p_context, get_locale()));
-		map_id_str[p_src_text].clear();
 	}
 
+	map_id_str[p_src_text].resize(p_plural_xlated_texts.size());
 	for (int i = 0; i < p_plural_xlated_texts.size(); i++) {
-		map_id_str[p_src_text].push_back(p_plural_xlated_texts[i]);
+		map_id_str[p_src_text].set(i, p_plural_xlated_texts[i]);
 	}
 }
 

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -576,8 +576,10 @@ Array Signal::get_connections() const {
 	obj->get_signal_connection_list(name, &connections);
 
 	Array arr;
+	arr.resize(connections.size());
+	int idx = 0;
 	for (const Object::Connection &E : connections) {
-		arr.push_back(E);
+		arr.set(idx++, E);
 	}
 	return arr;
 }

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1656,13 +1656,15 @@ String Variant::stringify(int recursion_count) const {
 			String str("{ ");
 
 			Vector<_VariantStrPair> pairs;
+			pairs.resize(d.size());
+			int idx = 0;
 
 			for (const KeyValue<Variant, Variant> &kv : d) {
 				_VariantStrPair sp;
 				sp.key = stringify_variant_clean(kv.key, recursion_count);
 				sp.value = stringify_variant_clean(kv.value, recursion_count);
 
-				pairs.push_back(sp);
+				pairs.set(idx++, sp);
 			}
 
 			for (int i = 0; i < pairs.size(); i++) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1300,6 +1300,7 @@ struct VariantBuiltInMethodInfo {
 			mi.flags |= METHOD_FLAG_STATIC;
 		}
 
+		mi.arguments.resize(argument_count);
 		for (int i = 0; i < argument_count; i++) {
 			PropertyInfo pi;
 #ifdef DEBUG_ENABLED
@@ -1311,7 +1312,7 @@ struct VariantBuiltInMethodInfo {
 			if (pi.type == Variant::NIL) {
 				pi.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 			}
-			mi.arguments.push_back(pi);
+			mi.arguments.set(i, pi);
 		}
 
 		mi.default_arguments = default_arguments;

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -332,12 +332,12 @@ void Variant::get_constructor_list(Type p_type, List<MethodInfo> *r_list) {
 
 	for (int i = 0; i < get_constructor_count(p_type); i++) {
 		int ac = get_constructor_argument_count(p_type, i);
-		mi.arguments.clear();
+		mi.arguments.resize(ac);
 		for (int j = 0; j < ac; j++) {
 			PropertyInfo arg;
 			arg.name = get_constructor_argument_name(p_type, i, j);
 			arg.type = get_constructor_argument_type(p_type, i, j);
-			mi.arguments.push_back(arg);
+			mi.arguments.set(j, arg);
 		}
 		r_list->push_back(mi);
 	}

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1427,12 +1427,14 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		}                                                                                                        \
 		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
 			Vector<Variant> args;                                                                                \
+			args.resize(p_argcount);                                                                             \
 			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
+				args.set(i, PtrToArg<Variant>::convert(p_args[i]));                                              \
 			}                                                                                                    \
 			Vector<const Variant *> argsp;                                                                       \
+			argsp.resize(p_argcount);                                                                            \
 			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
+				argsp.set(i, &args[i]);                                                                          \
 			}                                                                                                    \
 			Variant r;                                                                                           \
 			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
@@ -1472,12 +1474,14 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		}                                                                                                        \
 		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
 			Vector<Variant> args;                                                                                \
+			args.resize(p_argcount);                                                                             \
 			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
+				args.set(i, PtrToArg<Variant>::convert(p_args[i]));                                              \
 			}                                                                                                    \
 			Vector<const Variant *> argsp;                                                                       \
+			argsp.resize(p_argcount);                                                                            \
 			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
+				argsp.set(i, &args[i]);                                                                          \
 			}                                                                                                    \
 			Variant r;                                                                                           \
 			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
@@ -1517,12 +1521,14 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 		}                                                                                                        \
 		static void ptrcall(void *ret, const void **p_args, int p_argcount) {                                    \
 			Vector<Variant> args;                                                                                \
+			args.resize(p_argcount);                                                                             \
 			for (int i = 0; i < p_argcount; i++) {                                                               \
-				args.push_back(PtrToArg<Variant>::convert(p_args[i]));                                           \
+				args.set(i, PtrToArg<Variant>::convert(p_args[i]));                                              \
 			}                                                                                                    \
 			Vector<const Variant *> argsp;                                                                       \
+			argsp.resize(p_argcount);                                                                            \
 			for (int i = 0; i < p_argcount; i++) {                                                               \
-				argsp.push_back(&args[i]);                                                                       \
+				argsp.set(i, &args[i]);                                                                          \
 			}                                                                                                    \
 			Variant r;                                                                                           \
 			validated_call(&r, (const Variant **)argsp.ptr(), p_argcount);                                       \
@@ -1854,11 +1860,12 @@ MethodInfo Variant::get_utility_function_info(const StringName &p_name) {
 		if (bfi->is_vararg) {
 			info.flags |= METHOD_FLAG_VARARG;
 		}
+		info.arguments.resize(bfi->argnames.size());
 		for (int i = 0; i < bfi->argnames.size(); ++i) {
 			PropertyInfo arg;
 			arg.type = bfi->get_arg_type(i);
 			arg.name = bfi->argnames[i];
-			info.arguments.push_back(arg);
+			info.arguments.set(i, arg);
 		}
 	}
 	return info;


### PR DESCRIPTION
This PR replaces many `push_back` calls on Array types in the core folder with a pattern that uses preallocation (resize) + indexed assignment (set) when the final size of the array is known in advance.

If benchmarking is preferred, we can break this down into smaller PRs for each set of changes. Alternatively, we can review the whole set together and decide whether to merge as is.

### Changes in this PR:

- [x] core/io/json.cpp -> https://github.com/godotengine/godot/pull/109898
- [x] core/math/geometry_2d.cpp -> https://github.com/godotengine/godot/pull/109897
- [ ] core/config/engine.cpp
- [ ] core/config/project_settings.cpp
- [ ] core/core_bind.cpp
- [ ] core/extension/gdextension.cpp
- [ ] core/extension/gdextension_library_loader.cpp
- [ ] core/extension/gdextension_manager.cpp
- [ ] core/input/shortcut.cpp
- [ ] core/io/file_access_compressed.cpp
- [ ] core/io/ip.cpp
- [ ] core/io/marshalls.cpp
- [ ] core/io/remote_filesystem_client.cpp
- [ ] core/io/resource_format_binary.cpp
- [ ] core/io/resource_loader.cpp
- [ ] core/math/a_star.cpp
- [ ] core/math/a_star_grid_2d.cpp
- [ ] core/math/delaunay_3d.h
- [ ] core/math/geometry_3d.cpp
- [ ] core/object/class_db.cpp
- [ ] core/object/method_bind.cpp
- [ ] core/string/translation_po.cpp
- [ ] core/variant/callable.cpp
- [ ] core/variant/variant.cpp
- [ ] core/variant/variant_call.cpp
- [ ] core/variant/variant_construct.cpp
- [ ] core/variant/variant_utility.cpp