### PR TITLE
Fix particles moving when timescale is 0

### DIFF
--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -1120,8 +1120,8 @@ void ParticlesStorage::update_particles() {
 			double delta = RSG::rasterizer->get_frame_delta_time();
 			if (delta > 0.1) { //avoid recursive stalls if fps goes below 10
 				delta = 0.1;
-			} else if (delta <= 0.0) { //unlikely but..
-				delta = 0.001;
+			} else if (delta < 0.0) {
+				delta = 0.0;
 			}
 			double todo = particles->frame_remainder + delta * time_scale;
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -722,8 +722,8 @@ void CPUParticles2D::_update_internal() {
 		double ldelta = delta;
 		if (ldelta > 0.1) { //avoid recursive stalls if fps goes below 10
 			ldelta = 0.1;
-		} else if (ldelta <= 0.0) { //unlikely but..
-			ldelta = 0.001;
+		} else if (ldelta < 0.0) {
+			ldelta = 0.0;
 		}
 		todo = frame_remainder + ldelta;
 

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -693,8 +693,8 @@ void CPUParticles3D::_update_internal() {
 		double ldelta = delta;
 		if (ldelta > 0.1) { //avoid recursive stalls if fps goes below 10
 			ldelta = 0.1;
-		} else if (ldelta <= 0.0) { //unlikely but..
-			ldelta = 0.001;
+		} else if (ldelta < 0.0) {
+			ldelta = 0.0;
 		}
 		todo = frame_remainder + ldelta;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1566,8 +1566,8 @@ void ParticlesStorage::update_particles() {
 			double delta = RendererCompositorRD::get_singleton()->get_frame_delta_time();
 			if (delta > 0.1) { //avoid recursive stalls if fps goes below 10
 				delta = 0.1;
-			} else if (delta <= 0.0) { //unlikely but..
-				delta = 0.001;
+			} else if (delta < 0.0) {
+				delta = 0.0;
 			}
 			todo = particles->frame_remainder + delta * time_scale;
 


### PR DESCRIPTION
### What Changed?

This issue has been in the game engine for a long time now, but has been exasperated with recent changes.  It used to be that when the engine's time_scale was set to 0, the particles would jitter.  Now they continue to move at an extremely slow pace.

## Why this is an issue?

This impacts games that want replay and photo modes.  In the case of our game Blocky Ball OT, we want both.  This is so we and content creators can more easily create cinematic shots for promoting the game.

## Demonstration of issue

Before the fix ❌:

https://github.com/user-attachments/assets/264de656-7d4e-4dc7-a571-9f4abbcb6017


After the fix ✅:

https://github.com/user-attachments/assets/53e8ca7f-e987-4077-a986-cd91fae80d36


## Solution

Fortunately the solution was extremely simple!  It looks like a clamp was set within the particle systems for both cpu and gpu to prevent delta time from reaching 0.  I suspect the original author @pouleyKetchoupp may simply not have forseen a situation in which delta time would ever be 0?  Probably in an attempt to account for systems with extremely high framerates?  But there are indeed situations in which we do want this to be 0 such as replay modes or other creative time based mechanics such as Dishonored's "bend time" mechanic: https://www.youtube.com/watch?v=56sGfIrHTrE

As always, a huge thank you from Lange Studios and me personally for this brilliant engine!