### PR TITLE
Fix Audio bottom panel going under the taskbar on small displays

### DIFF
--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -168,6 +168,8 @@ class EditorAudioBuses : public VBoxContainer {
 	Timer *save_timer = nullptr;
 	String edited_path;
 
+	void _update_file_label_size();
+
 	void _rebuild_buses();
 	void _update_bus(int p_index);
 	void _update_sends();
@@ -190,6 +192,8 @@ class EditorAudioBuses : public VBoxContainer {
 
 	EditorFileDialog *file_dialog = nullptr;
 	bool new_layout = false;
+
+	bool use_default_editor_size = true;
 
 	void _file_dialog_callback(const String &p_string);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6294,6 +6294,10 @@ bool EditorNode::is_distraction_free_mode_enabled() const {
 	return distraction_free->is_pressed();
 }
 
+void EditorNode::set_center_split_offset(int p_offset) {
+	center_split->set_split_offset(p_offset);
+}
+
 Dictionary EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 	Control *drag_control = memnew(Control);
 	TextureRect *drag_preview = memnew(TextureRect);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -793,6 +793,8 @@ public:
 	void set_distraction_free_mode(bool p_enter);
 	bool is_distraction_free_mode_enabled() const;
 
+	void set_center_split_offset(int p_offset);
+
 	void set_addon_plugin_enabled(const String &p_addon, bool p_enabled, bool p_config_changed = false);
 	bool is_addon_plugin_enabled(const String &p_addon) const;
 


### PR DESCRIPTION
- Addresses https://github.com/godotengine/godot/issues/26835, but only for Audio tab.

- This PR is based on, is a continuation of, and a part of https://github.com/godotengine/godot/pull/102301 (see https://github.com/godotengine/godot/pull/102301#discussion_r1938933381 - I decided to split changes into several PRs for easier review).

https://github.com/user-attachments/assets/5c66ec28-0b74-4e2c-9ab4-d167ca9cfea0