### PR TITLE
Fix renaming scenes files not updating placeholder paths

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -232,6 +232,10 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 			if (next_tag.fields.has("instance_placeholder")) {
 				String path = next_tag.fields["instance_placeholder"];
+				// TODO: In the next opportunity to break compatibility, remove the check and always expect a UID.
+				if (path.begins_with("uid://")) {
+					path = ResourceUID::get_singleton()->uid_to_path(path);
+				}
 
 				int path_v = packed_scene->get_state()->add_value(path);
 
@@ -1966,7 +1970,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 			NodePath path = state->get_node_path(i, true);
 			NodePath owner = state->get_node_owner_path(i);
 			Ref<PackedScene> instance = state->get_node_instance(i);
-			String instance_placeholder = state->get_node_instance_placeholder(i);
+			String instance_placeholder = ResourceUID::get_singleton()->path_to_uid(state->get_node_instance_placeholder(i));
 			Vector<StringName> groups = state->get_node_groups(i);
 			Vector<String> deferred_node_paths = state->get_node_deferred_nodepath_properties(i);
 


### PR DESCRIPTION
Fix achieved by saving the placeholder paths as UIDs, while still converting them to pure paths internally to not break compatibility with `InstancePlaceholder.get_instance_path()`.

Fixes #37818.

I know there are other PRs that close this issue, but their scope is larger, and don't seem to be currently maintained. Also, not sure if they don't break compatibility with the function above.