### PR TITLE
Show simple dialog when there are no Resources to duplicate

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -161,8 +161,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 					unique_resources_confirmation->popup_centered();
 				} else {
 					current_option = -1;
-					unique_resources_label->set_text(TTRC("This object has no resources."));
-					unique_resources_confirmation->popup_centered();
+					EditorNode::get_singleton()->show_warning(TTR("This object has no resources to duplicate."));
 				}
 			} else {
 				editor_data->apply_changes_in_editors();


### PR DESCRIPTION
When using Make Sub-Resources Unique option and there are no eligible resources, the editor will show this awkward dialog:
<img width="589" height="365" alt="image" src="https://github.com/user-attachments/assets/e409f958-79af-4fc4-acb5-fa9ecb3b28db" />
This PR replaces it with a simple information:
<img width="300" height="128" alt="image" src="https://github.com/user-attachments/assets/51dcd711-b2ec-4f34-b851-a7be9b9a93ce" />
