### PR TITLE
Add `setup_color_picker()` overload for ColorPickerButton

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -9350,8 +9350,9 @@ AnimationMarkerEdit::AnimationMarkerEdit() {
 	marker_insert_vbox->add_child(_create_hbox_labeled_control(TTR("Marker Name"), marker_insert_new_name));
 	marker_insert_color = memnew(ColorPickerButton);
 	marker_insert_color->set_edit_alpha(false);
-	marker_insert_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(marker_insert_color->get_picker()));
 	marker_insert_vbox->add_child(_create_hbox_labeled_control(TTR("Marker Color"), marker_insert_color));
+	EditorNode::get_singleton()->setup_color_picker(marker_insert_color);
+
 	marker_insert_error_dialog = memnew(AcceptDialog);
 	marker_insert_error_dialog->set_ok_button_text(TTR("Close"));
 	marker_insert_error_dialog->set_title(TTR("Error!"));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4319,6 +4319,10 @@ void EditorNode::setup_color_picker(ColorPicker *p_picker) {
 	palette_file_selected_callback = callable_mp(p_picker, &ColorPicker::_quick_open_palette_file_selected);
 }
 
+void EditorNode::setup_color_picker(ColorPickerButton *p_button) {
+	picker->connect(SNAME("picker_created"), callable_mp(this, &EditorNode::_color_picker_popup_created), CONNECT_ONE_SHOT);
+}
+
 bool EditorNode::is_scene_open(const String &p_path) {
 	for (int i = 0; i < editor_data.get_edited_scene_count(); i++) {
 		if (editor_data.get_scene_path(i) == p_path) {
@@ -6004,6 +6008,11 @@ void EditorNode::run_editor_script(const Ref<Script> &p_script) {
 void EditorNode::_immediate_dialog_confirmed() {
 	immediate_dialog_confirmed = true;
 }
+
+void EditorNode::_color_picker_popup_created(ColorPickerButton *p_button) {
+	p_button->get_popup()->connect("about_to_popup", callable_mp(this, &EditorNode::setup_color_picker).bind(p_button->get_picker()));
+}
+
 bool EditorNode::immediate_confirmation_dialog(const String &p_text, const String &p_ok_text, const String &p_cancel_text, uint32_t p_wrap_width) {
 	ConfirmationDialog *cd = memnew(ConfirmationDialog);
 	cd->set_text(p_text);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -701,6 +701,7 @@ private:
 	void _pick_main_scene_custom_action(const String &p_custom_action_name);
 
 	void _immediate_dialog_confirmed();
+	void _color_picker_popup_created(ColorPickerButton *p_button);
 
 	void _begin_first_scan();
 
@@ -915,6 +916,7 @@ public:
 	bool is_multi_window_enabled() const;
 
 	void setup_color_picker(ColorPicker *p_picker);
+	void setup_color_picker(ColorPickerButton *p_button);
 
 	void request_instantiate_scene(const String &p_path);
 	void request_instantiate_scenes(const Vector<String> &p_files);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -9820,7 +9820,7 @@ void fragment() {
 		sun_color->set_edit_alpha(false);
 		sun_vb->add_margin_child(TTRC("Sun Color"), sun_color);
 		sun_color->connect("color_changed", callable_mp(this, &Node3DEditor::_sun_set_color));
-		sun_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(sun_color->get_picker()));
+		EditorNode::get_singleton()->setup_color_picker(sun_color);
 
 		sun_energy = memnew(EditorSpinSlider);
 		sun_energy->set_max(64.0);
@@ -9868,13 +9868,16 @@ void fragment() {
 		environ_sky_color = memnew(ColorPickerButton);
 		environ_sky_color->set_edit_alpha(false);
 		environ_sky_color->connect("color_changed", callable_mp(this, &Node3DEditor::_environ_set_sky_color));
-		environ_sky_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(environ_sky_color->get_picker()));
 		environ_vb->add_margin_child(TTRC("Sky Color"), environ_sky_color);
+		EditorNode::get_singleton()->setup_color_picker(environ_sky_color);
+
 		environ_ground_color = memnew(ColorPickerButton);
 		environ_ground_color->connect("color_changed", callable_mp(this, &Node3DEditor::_environ_set_ground_color));
 		environ_ground_color->set_edit_alpha(false);
 		environ_ground_color->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(environ_ground_color->get_picker()));
 		environ_vb->add_margin_child(TTRC("Ground Color"), environ_ground_color);
+		EditorNode::get_singleton()->setup_color_picker(environ_ground_color);
+
 		environ_energy = memnew(EditorSpinSlider);
 		environ_energy->set_max(8.0);
 		environ_energy->set_min(0);

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2615,7 +2615,7 @@ void ThemeTypeEditor::_update_type_items() {
 			if (E.value) {
 				item_editor->set_pick_color(edited_theme->get_color(E.key, edited_type));
 				item_editor->connect("color_changed", callable_mp(this, &ThemeTypeEditor::_color_item_changed).bind(E.key));
-				item_editor->get_popup()->connect("about_to_popup", callable_mp(EditorNode::get_singleton(), &EditorNode::setup_color_picker).bind(item_editor->get_picker()));
+				EditorNode::get_singleton()->setup_color_picker(item_editor);
 			} else {
 				item_editor->set_pick_color(ThemeDB::get_singleton()->get_default_theme()->get_color(E.key, edited_type));
 				item_editor->set_disabled(true);


### PR DESCRIPTION
Follow-up to #101570
This PR effectively applies the same changes to other ColorPickerButtons in the editor, but it's done as an overload for `setup_color_picker()`.