### PR TITLE
Fix ability to interact with UI elements in 3D viewport when instant transforming

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -572,6 +572,15 @@ void Node3DEditorViewport::_update_navigation_controls_visibility() {
 	look_control->set_visible(show_viewport_navigation_gizmo);
 }
 
+void Node3DEditorViewport::_update_ui_interaction_state() {
+	Control::MouseFilter filter = _edit.instant ? MOUSE_FILTER_IGNORE : MOUSE_FILTER_PASS;
+
+	view_display_menu->set_mouse_filter(filter);
+	rotation_control->set_mouse_filter(filter);
+	position_control->set_mouse_filter(filter);
+	look_control->set_mouse_filter(filter);
+}
+
 bool Node3DEditorViewport::_is_rotation_arc_visible() const {
 	return _edit.mode == TRANSFORM_ROTATE && !Math::is_zero_approx(_edit.accumulated_rotation_angle) && _edit.gizmo_initiated;
 }
@@ -5663,6 +5672,7 @@ void Node3DEditorViewport::begin_transform(TransformMode p_mode, bool instant) {
 				break;
 		}
 		update_transform_gizmo_view();
+		_update_ui_interaction_state();
 		set_process_input(instant);
 		surface->queue_redraw();
 	}
@@ -6141,6 +6151,7 @@ void Node3DEditorViewport::finish_transform() {
 	_edit.children_original_globals.clear();
 	spatial_editor->set_local_coords_enabled(_edit.original_local);
 	spatial_editor->update_transform_gizmo();
+	_update_ui_interaction_state();
 	surface->queue_redraw();
 	set_process_input(false);
 	clicked = ObjectID();

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -404,6 +404,7 @@ private:
 
 	void _view_settings_confirmed(real_t p_interp_delta);
 	void _update_navigation_controls_visibility();
+	void _update_ui_interaction_state();
 	void _draw();
 
 	// These allow tool scripts to set the 3D cursor location by updating the camera transform.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

Prior to this PR you were able to click on Perspective Menu or interact with gizmos such as the rotation gizmo in the top right corner while doing an instant transform, this would also hijack the commit for the transform. 

For those unaware of instant transform shortcuts:

<img width="914" height="118" alt="image" src="https://github.com/user-attachments/assets/da6d342e-fc39-43ae-ad25-a957d8213f4d" />

Video of bug:

https://github.com/user-attachments/assets/1bd5b2de-baf0-408a-b35f-2b26cf709aa3

