### PR TITLE
Clarify that velocity doesn't need delta multiplication in CharacterBody documentation

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -141,6 +141,7 @@
 			<return type="bool" />
 			<description>
 				Moves the body based on [member velocity]. If the body collides with another, it will slide along the other body (by default only on floor) rather than stop immediately. If the other body is a [CharacterBody2D] or [RigidBody2D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
+				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
 				Modifies [member velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
 				The general behavior and available properties change according to the [member motion_mode].
@@ -196,6 +197,7 @@
 		</member>
 		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
 			Current velocity vector in pixels per second, used and modified during calls to [method move_and_slide].
+			This property should not be set to a value multiplied by [code]delta[/code], because this happens internally in [method move_and_slide]. Otherwise, the simulation will run at an incorrect speed.
 		</member>
 		<member name="wall_min_slide_angle" type="float" setter="set_wall_min_slide_angle" getter="get_wall_min_slide_angle" default="0.2617994">
 			Minimum angle (in radians) where the body is allowed to slide when it encounters a wall. The default value equals 15 degrees. This property only affects movement when [member motion_mode] is [constant MOTION_MODE_FLOATING].

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -133,6 +133,7 @@
 			<return type="bool" />
 			<description>
 				Moves the body based on [member velocity]. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [CharacterBody3D] or [RigidBody3D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
+				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
 				Modifies [member velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for more detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
 				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
@@ -187,6 +188,7 @@
 		</member>
 		<member name="velocity" type="Vector3" setter="set_velocity" getter="get_velocity" default="Vector3(0, 0, 0)">
 			Current velocity vector (typically meters per second), used and modified during calls to [method move_and_slide].
+			This property should not be set to a value multiplied by [code]delta[/code], because this happens internally in [method move_and_slide]. Otherwise, the simulation will run at an incorrect speed.
 		</member>
 		<member name="wall_min_slide_angle" type="float" setter="set_wall_min_slide_angle" getter="get_wall_min_slide_angle" default="0.2617994">
 			Minimum angle (in radians) where the body is allowed to slide when it encounters a wall. The default value equals 15 degrees. When [member motion_mode] is [constant MOTION_MODE_GROUNDED], it only affects movement if [member floor_block_on_wall] is [code]true[/code].


### PR DESCRIPTION
## What this PR does

This PR clarifies an ambiguity with how to use `velocity` with `delta` and `move_and_slide()` from the `CharacterBody2D` and `CharacterBody3D` nodes.

## The problem

As it stands, Godot 4's documentation does not specify if `velocity` must be multiplied by `delta`. This confuses developers who aren't familiar with the internals of `move_and_slide()`. This is clarified in [Godot 3's class reference](https://docs.godotengine.org/en/3.6/classes/class_kinematicbody2d.html#class-kinematicbody2d-method-move-and-slide).

### A concrete example of the problem

For instance, recently, a client of mine requested consulting help regarding a bug where enemy speed would vary between machines. My client was confused because he multiplied `CharacterBody3D.velocity` by `delta` in `Node._physics_process`. This is intuitive because all other values that must consistently change every frame should be multiplied by `delta`, but `move_and_slide()` [already does that calculation under the hood](https://github.com/godotengine/godot/blob/3defc856b0f1c727b4346e60615b2b2451916837/scene/3d/physics/character_body_3d.cpp#L42). Multiplying by `delta` again runs the simulation at an incorrect speed.

Before reading the source code, I researched if multiplying by `delta` was necessary. I googled and asked in the Discord servers, and I mostly found info for Godot 3, and information that was either conflicting or unclear. The CharacterBodies' documentation said nothing, and the [PhysicsBody3D class reference](https://docs.godotengine.org/en/latest/classes/class_physicsbody3d.html#class-physicsbody3d-method-move-and-collide) was particularly misleading in specifying that the developer must multiply `motion` by `delta`.

Reading the source code easily answered my question, but source code shouldn't be documentation for casual users and common use cases like moving a `CharacterBody3D` each frame. 

## Conclusion

From my experience and according to Godot 3's documentation, it is important to specify that `velocity` does not need to be multiplied by `delta`.