### PR TITLE
Popup: Reset state on visibility change

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -78,6 +78,8 @@ void Popup::_notification(int p_what) {
 			if (!is_in_edited_scene_root()) {
 				if (is_visible()) {
 					_initialize_visible_parents();
+					popped_up = true;
+					hide_reason = HIDE_REASON_NONE;
 				} else {
 					_deinitialize_visible_parents();
 					if (hide_reason == HIDE_REASON_NONE) {
@@ -85,15 +87,6 @@ void Popup::_notification(int p_what) {
 					}
 					emit_signal(SNAME("popup_hide"));
 					popped_up = false;
-				}
-			}
-		} break;
-
-		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
-			if (!is_in_edited_scene_root()) {
-				if (has_focus()) {
-					popped_up = true;
-					hide_reason = HIDE_REASON_NONE;
 				}
 			}
 		} break;


### PR DESCRIPTION
Fixes #109817.

The original logic was never called for certain platforms, leaving the hide reason unset and causing weird semi-random issues with the few users of that internal API, such as when renaming nodes in the scene tree editor.

---

On a related note, it looks like there's a general inconsistency on what happens to the focus of a window with `FLAG_POPUP`. The documentation says that when this flag is enabled the window will "exclusively receive all input, without stealing focus from its parent" yet, due to IME issues, focus requests got eventually added to [Windows](https://github.com/godotengine/godot/pull/77977), [MacOS](https://github.com/godotengine/godot/pull/78029), and [X11](https://github.com/godotengine/godot/pull/72497), although from the ticket above it looks like focus events might still not be sent properly for the latter either.

That said I'm still reasonably sure, judging from the users of `hide_reason` and `popped_up`, that the intent of the `NOTIFICATION_WM_WINDOW_FOCUS_IN` handler was indeed to reset everything each time the window shows up and not only when it gets keyboard focus.