### PR TITLE
Make `ScriptExtention::_instance_create` and `_placeholder_instance_create` non-const

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -84,6 +84,11 @@ void ScriptExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_is_placeholder_fallback_enabled);
 
 	GDVIRTUAL_BIND(_get_rpc_config);
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL_BIND_COMPAT(_instance_create_109928, "for_object");
+	GDVIRTUAL_BIND_COMPAT(_placeholder_instance_create_109928, "for_object");
+#endif // DISABLE_DEPRECATED
 }
 
 void ScriptLanguageExtension::_bind_methods() {

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -56,13 +56,13 @@ public:
 	EXBIND1RC(bool, inherits_script, const Ref<Script> &)
 	EXBIND0RC(StringName, get_instance_base_type)
 
-	GDVIRTUAL1RC_REQUIRED(GDExtensionPtr<void>, _instance_create, Object *)
+	GDVIRTUAL1R_REQUIRED(GDExtensionPtr<void>, _instance_create, Object *)
 	virtual ScriptInstance *instance_create(Object *p_this) override {
 		GDExtensionPtr<void> ret = nullptr;
 		GDVIRTUAL_CALL(_instance_create, p_this, ret);
 		return reinterpret_cast<ScriptInstance *>(ret.operator void *());
 	}
-	GDVIRTUAL1RC_REQUIRED(GDExtensionPtr<void>, _placeholder_instance_create, Object *)
+	GDVIRTUAL1R_REQUIRED(GDExtensionPtr<void>, _placeholder_instance_create, Object *)
 	PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) override {
 		GDExtensionPtr<void> ret = nullptr;
 		GDVIRTUAL_CALL(_placeholder_instance_create, p_this, ret);

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -59,15 +59,30 @@ public:
 	GDVIRTUAL1R_REQUIRED(GDExtensionPtr<void>, _instance_create, Object *)
 	virtual ScriptInstance *instance_create(Object *p_this) override {
 		GDExtensionPtr<void> ret = nullptr;
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_instance_create_109928, p_this, ret)) {
+			return reinterpret_cast<ScriptInstance *>(ret.operator void *());
+		}
+#endif
 		GDVIRTUAL_CALL(_instance_create, p_this, ret);
 		return reinterpret_cast<ScriptInstance *>(ret.operator void *());
 	}
 	GDVIRTUAL1R_REQUIRED(GDExtensionPtr<void>, _placeholder_instance_create, Object *)
 	PlaceHolderScriptInstance *placeholder_instance_create(Object *p_this) override {
 		GDExtensionPtr<void> ret = nullptr;
+#ifndef DISABLE_DEPRECATED
+		if (GDVIRTUAL_CALL(_placeholder_instance_create_109928, p_this, ret)) {
+			return reinterpret_cast<PlaceHolderScriptInstance *>(ret.operator void *());
+		}
+#endif
 		GDVIRTUAL_CALL(_placeholder_instance_create, p_this, ret);
 		return reinterpret_cast<PlaceHolderScriptInstance *>(ret.operator void *());
 	}
+
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL1RC_COMPAT(_instance_create_109928, GDExtensionPtr<void>, _instance_create, Object *)
+	GDVIRTUAL1RC_COMPAT(_placeholder_instance_create_109928, GDExtensionPtr<void>, _placeholder_instance_create, Object *)
+#endif // DISABLE_DEPRECATED
 
 	EXBIND1RC(bool, instance_has, const Object *)
 	EXBIND0RC(bool, has_source_code)

--- a/doc/classes/ScriptExtension.xml
+++ b/doc/classes/ScriptExtension.xml
@@ -147,7 +147,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_instance_create" qualifiers="virtual required const">
+		<method name="_instance_create" qualifiers="virtual required">
 			<return type="void*" />
 			<param index="0" name="for_object" type="Object" />
 			<description>
@@ -186,7 +186,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_placeholder_instance_create" qualifiers="virtual required const">
+		<method name="_placeholder_instance_create" qualifiers="virtual required">
 			<return type="void*" />
 			<param index="0" name="for_object" type="Object" />
 			<description>


### PR DESCRIPTION
Fixes #103823.

From my understanding, this is the only change necessary for this to reach godot-cpp and other bindings.
After this is merged, newer generations of `extension_api.json` will be update automatically and godot-cpp and others would pick up the change.

Please let me know if that's not the case and more changes are necessary, either in this repo or godot-cpp.