### PR TITLE
Revert "[Web] Disregard touch events in pointer callbacks"

### DIFF
--- a/platform/web/js/libs/library_godot_input.js
+++ b/platform/web/js/libs/library_godot_input.js
@@ -504,10 +504,6 @@ const GodotInput = {
 		const func = GodotRuntime.get_func(callback);
 		const canvas = GodotConfig.canvas;
 		function move_cb(evt) {
-			if (evt.pointerType == 'touch') {
-				return;
-			}
-
 			const rect = canvas.getBoundingClientRect();
 			const pos = GodotInput.computePosition(evt, rect);
 			// Scale movement
@@ -539,10 +535,6 @@ const GodotInput = {
 		const func = GodotRuntime.get_func(callback);
 		const canvas = GodotConfig.canvas;
 		function button_cb(p_pressed, evt) {
-			if (evt.pointerType == 'touch') {
-				return;
-			}
-
 			const rect = canvas.getBoundingClientRect();
 			const pos = GodotInput.computePosition(evt, rect);
 			const modifiers = GodotInput.getModifiers(evt);
@@ -555,8 +547,8 @@ const GodotInput = {
 				evt.preventDefault();
 			}
 		}
-		GodotEventListeners.add(canvas, 'pointerdown', button_cb.bind(null, 1), false);
-		GodotEventListeners.add(window, 'pointerup', button_cb.bind(null, 0), false);
+		GodotEventListeners.add(canvas, 'mousedown', button_cb.bind(null, 1), false);
+		GodotEventListeners.add(window, 'mouseup', button_cb.bind(null, 0), false);
 	},
 
 	/*


### PR DESCRIPTION
This reverts commit e7e5c2b832a98000b3a0fe5b89ee74c3dfddffbc.

Reverts: https://github.com/godotengine/godot/pull/107837

Fixes: https://github.com/godotengine/godot/issues/109226

The change from mousedownt to pointerdown is what caused the regression since they are not equivalent functions. The original justification was pretty sparse and only considered mouse events:

> Also swapping mousedown to pointerdown and mouseup to pointerup, so pen events are passed as mouse events more consistently.

Since we are so close to release, I think it is best we just revert the PR, then re-attempt the changes from #107837 in 4.6
