### PR TITLE
Fix tree to update size with scrollbars disabled

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -150,6 +150,7 @@ void TreeItem::_change_tree(Tree *p_tree) {
 			tree->edited_item = nullptr;
 			tree->pressing_for_editor = false;
 		}
+		tree->update_min_size_for_item_change();
 		tree->queue_accessibility_update();
 		tree->queue_redraw();
 	}
@@ -880,6 +881,7 @@ TreeItem *TreeItem::create_child(int p_index) {
 	TreeItem *ti = memnew(TreeItem(tree));
 	if (tree) {
 		ti->cells.resize(tree->columns.size());
+		tree->update_min_size_for_item_change();
 		tree->queue_accessibility_update();
 		tree->queue_redraw();
 	}
@@ -5199,6 +5201,7 @@ void Tree::item_changed(int p_column, TreeItem *p_item) {
 		}
 		p_item->accessibility_row_dirty = true;
 	}
+	update_min_size_for_item_change();
 	queue_accessibility_update();
 	queue_redraw();
 }
@@ -5250,6 +5253,14 @@ void Tree::item_deselected(int p_column, TreeItem *p_item) {
 	p_item->accessibility_row_dirty = true;
 	queue_accessibility_update();
 	queue_redraw();
+}
+
+void Tree::update_min_size_for_item_change() {
+	// Only need to update when any scroll bar is disabled because that's the only time item size
+	// affects tree size.
+	if (!h_scroll_enabled || !v_scroll_enabled) {
+		update_minimum_size();
+	}
 }
 
 void Tree::set_select_mode(SelectMode p_mode) {
@@ -5586,6 +5597,7 @@ void Tree::set_columns(int p_columns) {
 		selected_col = p_columns - 1;
 		selected_button = -1;
 	}
+	update_min_size_for_item_change();
 	queue_accessibility_update();
 	queue_redraw();
 }

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -570,6 +570,7 @@ private:
 	void item_changed(int p_column, TreeItem *p_item);
 	void item_selected(int p_column, TreeItem *p_item);
 	void item_deselected(int p_column, TreeItem *p_item);
+	void update_min_size_for_item_change();
 
 	void propagate_set_columns(TreeItem *p_item);
 


### PR DESCRIPTION
When scrollbars are disabled, tree size is dependent on item sizes, so this adds missing checks for when to resize. The side effect of the bug was that scrollbars could incorrectly appear when items change at runtime.

Fixes #105967
Fixes #106609
Also fixes the root cause of the bugs, so https://github.com/godotengine/godot/pull/106038 will not be needed.

Two things to note about `Tree` and the disable scrollbar properties:
1. Scroll bars are implicitly hidden depending on the minimum size (see `Tree::update_scroll_bars()`)
2. When a scrollbar is disabled, that min size is tied to item size (see `Tree::get_minimum_size()`)

The missing part was updating sizes if any scrollbar is disabled when a change could change content size (modifying items, adding items, removing items, adding columns) so that the `Tree` updates to the new size and keeps scrollbars hidden.

In the original bug report (#105967), starting `scroll_horizontal_enabled` and `scroll_vertical_enabled` `false` meant that there's be no size updates since there's none triggered from item changes, thus scrollbars appear once the content gets too large. The correct sizing behavior is only seen when transitioning from `true` to `false` since that requests a min size update via changing the property.

In the secondary bug report (#106609), `scroll_horizontal_enabled` and `scroll_vertical_enabled` are going from `true` (editor time) to `false` (runtime in the script) so the observed behavior is actually correct when starting `true`. The real issue is that the tree doesn't become super large when starting `false` since starting `false` and going from `true` to `false` should have the same appearance. This was pretty much the same cause as the original issue.

I've also made a small tester for adding/removing items and toggling various settings:
[tree tester.zip](https://github.com/user-attachments/files/21959797/tree.tester.zip)
Note that the tester itself doesn't do proper index checks for things like removing when there are no children to remove. It was just something quick to modify the tree without having to update the script constantly.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
