### PR TITLE
Avoid unnecessary conversions when rendering SVG via Image when premultiplied alpha is desired.

### DIFF
--- a/core/io/image.compat.inc
+++ b/core/io/image.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  image_loader_svg.h                                                    */
+/*  image.compat.inc                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,27 +28,19 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/io/image_loader.h"
+Error Image::_load_svg_from_buffer_109947(const Vector<uint8_t> &p_array, float scale) {
+	return load_svg_from_buffer(p_array, scale, false);
+}
 
-class ImageLoaderSVG : public ImageFormatLoader {
-	static HashMap<Color, Color> forced_color_map;
+Error Image::_load_svg_from_string_109947(const String &p_svg_str, float scale) {
+	return load_svg_from_string(p_svg_str, scale, false);
+}
 
-	static void _replace_color_property(const HashMap<Color, Color> &p_color_map, const String &p_prefix, String &r_string);
+void Image::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("load_svg_from_buffer", "buffer", "scale"), &Image::_load_svg_from_buffer_109947, DEFVAL(1.0));
+	ClassDB::bind_compatibility_method(D_METHOD("load_svg_from_string", "svg_str", "scale"), &Image::_load_svg_from_string_109947, DEFVAL(1.0));
+}
 
-	static Ref<Image> load_mem_svg(const uint8_t *p_svg, int p_size, float p_scale, bool p_premult_alpha = false);
-
-public:
-	static void set_forced_color_map(const HashMap<Color, Color> &p_color_map);
-
-	static Error create_image_from_utf8_buffer(Ref<Image> p_image, const uint8_t *p_buffer, int p_buffer_size, float p_scale, bool p_upsample, bool p_output_premult_alpha = false);
-	static Error create_image_from_utf8_buffer(Ref<Image> p_image, const PackedByteArray &p_buffer, float p_scale, bool p_upsample, bool p_output_premult_alpha = false);
-
-	static Error create_image_from_string(Ref<Image> p_image, String p_string, float p_scale, bool p_upsample, const HashMap<Color, Color> &p_color_map);
-
-	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> p_fileaccess, BitField<ImageFormatLoader::LoaderFlags> p_flags, float p_scale) override;
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
-
-	ImageLoaderSVG();
-};
+#endif // DISABLE_DEPRECATED

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "image.h"
+#include "image.compat.inc"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
@@ -3610,8 +3611,8 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("load_ktx_from_buffer", "buffer"), &Image::load_ktx_from_buffer);
 	ClassDB::bind_method(D_METHOD("load_dds_from_buffer", "buffer"), &Image::load_dds_from_buffer);
 
-	ClassDB::bind_method(D_METHOD("load_svg_from_buffer", "buffer", "scale"), &Image::load_svg_from_buffer, DEFVAL(1.0));
-	ClassDB::bind_method(D_METHOD("load_svg_from_string", "svg_str", "scale"), &Image::load_svg_from_string, DEFVAL(1.0));
+	ClassDB::bind_method(D_METHOD("load_svg_from_buffer", "buffer", "scale", "premult_alpha"), &Image::load_svg_from_buffer, DEFVAL(1.0), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("load_svg_from_string", "svg_str", "scale", "premult_alpha"), &Image::load_svg_from_string, DEFVAL(1.0), DEFVAL(false));
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "_set_data", "_get_data");
 
@@ -4112,7 +4113,7 @@ Error Image::load_dds_from_buffer(const Vector<uint8_t> &p_array) {
 	return _load_from_buffer(p_array, _dds_mem_loader_func);
 }
 
-Error Image::load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale) {
+Error Image::load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale, bool p_premult_alpha) {
 	ERR_FAIL_NULL_V_MSG(
 			_svg_scalable_mem_loader_func,
 			ERR_UNAVAILABLE,
@@ -4122,7 +4123,7 @@ Error Image::load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale) {
 
 	ERR_FAIL_COND_V(buffer_size == 0, ERR_INVALID_PARAMETER);
 
-	Ref<Image> image = _svg_scalable_mem_loader_func(p_array.ptr(), buffer_size, scale);
+	Ref<Image> image = _svg_scalable_mem_loader_func(p_array.ptr(), buffer_size, scale, p_premult_alpha);
 	ERR_FAIL_COND_V(image.is_null(), ERR_PARSE_ERROR);
 
 	copy_internals_from(image);
@@ -4130,8 +4131,8 @@ Error Image::load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale) {
 	return OK;
 }
 
-Error Image::load_svg_from_string(const String &p_svg_str, float scale) {
-	return load_svg_from_buffer(p_svg_str.to_utf8_buffer(), scale);
+Error Image::load_svg_from_string(const String &p_svg_str, float scale, bool p_premult_alpha) {
+	return load_svg_from_buffer(p_svg_str.to_utf8_buffer(), scale, p_premult_alpha);
 }
 
 Error Image::load_ktx_from_buffer(const Vector<uint8_t> &p_array) {

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -50,7 +50,7 @@ typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, floa
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
 
 typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_data, int p_size);
-typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale);
+typedef Ref<Image> (*ScalableImageMemLoadFunc)(const uint8_t *p_data, int p_size, float p_scale, bool p_premult_alpha);
 
 typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
@@ -248,6 +248,12 @@ protected:
 
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _load_svg_from_buffer_109947(const Vector<uint8_t> &p_array, float scale);
+	Error _load_svg_from_string_109947(const String &p_svg_str, float scale);
+	static void _bind_compatibility_methods();
+#endif
+
 private:
 	Format format = FORMAT_L8;
 	Vector<uint8_t> data;
@@ -420,8 +426,8 @@ public:
 	Error load_ktx_from_buffer(const Vector<uint8_t> &p_array);
 	Error load_dds_from_buffer(const Vector<uint8_t> &p_array);
 
-	Error load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale = 1.0);
-	Error load_svg_from_string(const String &p_svg_str, float scale = 1.0);
+	Error load_svg_from_buffer(const Vector<uint8_t> &p_array, float scale = 1.0, bool premult_alpha = false);
+	Error load_svg_from_string(const String &p_svg_str, float scale = 1.0, bool premult_alpha = false);
 
 	void convert_rg_to_ra_rgba8();
 	void convert_ra_rgba8_to_rg();

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -388,8 +388,10 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="buffer" type="PackedByteArray" />
 			<param index="1" name="scale" type="float" default="1.0" />
+			<param index="2" name="premult_alpha" type="bool" default="false" />
 			<description>
 				Loads an image from the UTF-8 binary contents of an [b]uncompressed[/b] SVG file ([b].svg[/b]).
+				Set [param premult_alpha] to true to avoid unnecessary conversions, as the underlying SVG renderer (ThorVG) internally uses premultiplied alpha. Use the corresponding blend mode [constant CanvasItemMaterial.BLEND_MODE_PREMULT_ALPHA].
 				[b]Note:[/b] Beware when using compressed SVG files (like [b].svgz[/b]), they need to be [code]decompressed[/code] before loading.
 				[b]Note:[/b] This method is only available in engine builds with the SVG module enabled. By default, the SVG module is enabled, but it can be disabled at build-time using the [code]module_svg_enabled=no[/code] SCons option.
 			</description>
@@ -398,8 +400,10 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="svg_str" type="String" />
 			<param index="1" name="scale" type="float" default="1.0" />
+			<param index="2" name="premult_alpha" type="bool" default="false" />
 			<description>
 				Loads an image from the string contents of an SVG file ([b].svg[/b]).
+				Set [param premult_alpha] to true to avoid unnecessary conversions, as the underlying SVG renderer (ThorVG) internally uses premultiplied alpha. Use the corresponding blend mode [constant CanvasItemMaterial.BLEND_MODE_PREMULT_ALPHA].
 				[b]Note:[/b] This method is only available in engine builds with the SVG module enabled. By default, the SVG module is enabled, but it can be disabled at build-time using the [code]module_svg_enabled=no[/code] SCons option.
 			</description>
 		</method>

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -863,7 +863,7 @@ void EditorAssetLibrary::_image_update(bool p_use_cache, bool p_final, const Pac
 		} else if ((memcmp(&r[0], &bmp_signature[0], 2) == 0) && Image::_bmp_mem_loader_func) {
 			parsed_image = Image::_bmp_mem_loader_func(r, len);
 		} else if (Image::_svg_scalable_mem_loader_func) {
-			parsed_image = Image::_svg_scalable_mem_loader_func(r, len, 1.0);
+			parsed_image = Image::_svg_scalable_mem_loader_func(r, len, 1.0, false);
 		}
 
 		if (parsed_image.is_null()) {

--- a/misc/extension_api_validation/4.4-stable.expected
+++ b/misc/extension_api_validation/4.4-stable.expected
@@ -328,3 +328,9 @@ GH-108825
 Validate extension JSON: Error: Field 'classes/EditorExportPlatformExtension/methods/_get_option_icon/return_value': type changed value in new API, from "ImageTexture" to "Texture2D".
 
 Return type changed to allow returning both ImageTexture and DPITexture. Compatibility method registered.
+
+
+GH-109947
+---------
+Validate extension JSON: Error: Field 'classes/Image/methods/load_svg_from_buffer/arguments': size changed value in new API, from 2 to 3.
+Validate extension JSON: Error: Field 'classes/Image/methods/load_svg_from_string/arguments': size changed value in new API, from 2 to 3.


### PR DESCRIPTION
This adds a `premult_alpha` parameter to `load_svg_from_buffer` and `load_svg_from_string`. 
Setting this to true avoids unnecessary conversions, as the underlying SVG renderer (ThorVG) internally uses premultiplied alpha.

The default of `premult_alpha = false` means ThorVG will internally convert to straight alpha during its post-render phase (`rasterUnpremultiply` via `postRender` via `canvas->draw`)
See https://github.com/thorvg/thorvg/blob/v0.15.x/src/renderer/sw_engine/tvgSwRaster.cpp#L1590

Before this change a user would have to call `Image.premultiply_alpha` in order to use `BLEND_MODE_PREMULT_ALPHA` - resulting in a double conversion.

Sample project with some timing comparisons:
[svgpma.zip](https://github.com/user-attachments/files/21960662/svgpma.zip)
