### PR TITLE
OpenXR: Fix ViewportTextures not displaying correct texture (RendererRD)

### DIFF
--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.h
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.h
@@ -71,7 +71,8 @@ private:
 
 	struct SwapchainGraphicsData {
 		bool is_multiview;
-		Vector<RID> texture_rids;
+		LocalVector<RID> texture_rd_rids;
+		LocalVector<RID> texture_rids;
 	};
 
 	EXT_PROTO_XRRESULT_FUNC3(xrGetD3D12GraphicsRequirementsKHR, (XrInstance), p_instance, (XrSystemId), p_system_id, (XrGraphicsRequirementsD3D12KHR *), p_graphics_requirements)

--- a/modules/openxr/extensions/platform/openxr_metal_extension.h
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.h
@@ -60,7 +60,8 @@ private:
 
 	struct SwapchainGraphicsData {
 		bool is_multiview;
-		Vector<RID> texture_rids;
+		LocalVector<RID> texture_rd_rids;
+		LocalVector<RID> texture_rids;
 	};
 
 	bool check_graphics_api_support();

--- a/modules/openxr/extensions/platform/openxr_metal_extension.mm
+++ b/modules/openxr/extensions/platform/openxr_metal_extension.mm
@@ -33,6 +33,7 @@
 #include "../../openxr_util.h"
 
 #import "drivers/metal/rendering_device_driver_metal.h"
+#include "servers/rendering/renderer_rd/storage_rd/texture_storage.h"
 #include "servers/rendering/rendering_server_globals.h"
 
 HashMap<String, bool *> OpenXRMetalExtension::get_requested_extensions() {
@@ -151,6 +152,8 @@ bool OpenXRMetalExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int
 	ERR_FAIL_NULL_V(rendering_server, false);
 	RenderingDevice *rendering_device = rendering_server->get_rendering_device();
 	ERR_FAIL_NULL_V(rendering_device, false);
+	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
+	ERR_FAIL_NULL_V(texture_storage, false);
 
 	uint32_t swapchain_length;
 	XrResult result = xrEnumerateSwapchainImages(p_swapchain, 0, &swapchain_length, nullptr);
@@ -251,12 +254,16 @@ bool OpenXRMetalExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int
 			break;
 	}
 
-	Vector<RID> texture_rids;
+	thread_local LocalVector<RID> texture_rd_rids;
+	thread_local LocalVector<RID> texture_rids;
+
+	texture_rd_rids.reserve(swapchain_length);
+	texture_rids.reserve(swapchain_length);
 
 	// Create Godot texture objects for each entry in our swapchain.
 	for (uint64_t i = 0; i < swapchain_length; i++) {
 		// Note, the formats we sent to render_device are ignored on metal.
-		RID image_rid = rendering_device->texture_create_from_extension(
+		RID texture_rd_rid = rendering_device->texture_create_from_extension(
 				p_array_size == 1 ? RenderingDevice::TEXTURE_TYPE_2D : RenderingDevice::TEXTURE_TYPE_2D_ARRAY,
 				format,
 				samples,
@@ -268,9 +275,15 @@ bool OpenXRMetalExtension::get_swapchain_image_data(XrSwapchain p_swapchain, int
 				p_array_size,
 				1);
 
-		texture_rids.push_back(image_rid);
+		texture_rd_rids.push_back(texture_rd_rid);
+
+		RID texture_rid = texture_storage->texture_allocate();
+		texture_storage->texture_rd_initialize(texture_rid, texture_rd_rid);
+
+		texture_rids.push_back(texture_rid);
 	}
 
+	data->texture_rd_rids = texture_rd_rids;
 	data->texture_rids = texture_rids;
 
 	return true;
@@ -287,11 +300,18 @@ void OpenXRMetalExtension::cleanup_swapchain_graphics_data(void **p_swapchain_gr
 	ERR_FAIL_NULL(rendering_server);
 	RenderingDevice *rendering_device = rendering_server->get_rendering_device();
 	ERR_FAIL_NULL(rendering_device);
+	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
+	ERR_FAIL_NULL(texture_storage);
 
 	for (const RID &texture_rid : data->texture_rids) {
-		rendering_device->free(texture_rid);
+		texture_storage->texture_free(texture_rid);
 	}
 	data->texture_rids.clear();
+
+	for (const RID &texture_rd_rid : data->texture_rd_rids) {
+		rendering_device->free(texture_rd_rid);
+	}
+	data->texture_rd_rids.clear();
 
 	memdelete(data);
 	*p_swapchain_graphics_data = nullptr;
@@ -315,6 +335,6 @@ RID OpenXRMetalExtension::get_texture(void *p_swapchain_graphics_data, int p_ima
 	SwapchainGraphicsData *data = (SwapchainGraphicsData *)p_swapchain_graphics_data;
 	ERR_FAIL_NULL_V(data, RID());
 
-	ERR_FAIL_INDEX_V(p_image_index, data->texture_rids.size(), RID());
+	ERR_FAIL_INDEX_V(p_image_index, (int)data->texture_rids.size(), RID());
 	return data->texture_rids[p_image_index];
 }

--- a/modules/openxr/extensions/platform/openxr_vulkan_extension.h
+++ b/modules/openxr/extensions/platform/openxr_vulkan_extension.h
@@ -70,8 +70,9 @@ private:
 
 	struct SwapchainGraphicsData {
 		bool is_multiview;
-		Vector<RID> texture_rids;
-		Vector<RID> density_map_rids;
+		LocalVector<RID> texture_rd_rids;
+		LocalVector<RID> texture_rids;
+		LocalVector<RID> density_map_rids;
 	};
 
 	bool check_graphics_api_support(XrVersion p_desired_version);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -761,8 +761,8 @@ void TextureStorage::texture_free(RID p_texture) {
 
 	decal_atlas_remove_texture(p_texture);
 
-	for (int i = 0; i < t->proxies.size(); i++) {
-		Texture *p = texture_owner.get_or_null(t->proxies[i]);
+	for (const RID &proxy : t->proxies) {
+		Texture *p = texture_owner.get_or_null(proxy);
 		ERR_CONTINUE(!p);
 		p->proxy_to = RID();
 		p->rd_texture = RID();
@@ -1404,6 +1404,27 @@ void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 	}
 }
 
+void TextureStorage::texture_remap_proxies(RID p_from_texture, RID p_to_texture) {
+	Texture *from_tex = texture_owner.get_or_null(p_from_texture);
+	ERR_FAIL_NULL(from_tex);
+	ERR_FAIL_COND(from_tex->is_proxy);
+	Texture *to_tex = texture_owner.get_or_null(p_to_texture);
+	ERR_FAIL_NULL(to_tex);
+	ERR_FAIL_COND(to_tex->is_proxy);
+
+	if (from_tex == to_tex) {
+		return;
+	}
+
+	// Make a copy, we're about to change this.
+	LocalVector<RID> proxies = from_tex->proxies;
+
+	// Now change them to our new texture.
+	for (const RID &proxy : proxies) {
+		texture_proxy_update(proxy, p_to_texture);
+	}
+}
+
 //these two APIs can be used together or in combination with the others.
 void TextureStorage::texture_2d_placeholder_initialize(RID p_texture) {
 	texture_2d_initialize(p_texture, texture_2d_placeholder);
@@ -1552,8 +1573,8 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 		tex->canvas_texture = nullptr;
 	}
 
-	Vector<RID> proxies_to_update = tex->proxies;
-	Vector<RID> proxies_to_redirect = by_tex->proxies;
+	LocalVector<RID> proxies_to_update = tex->proxies;
+	LocalVector<RID> proxies_to_redirect = by_tex->proxies;
 
 	*tex = *by_tex;
 
@@ -1563,11 +1584,11 @@ void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 		tex->canvas_texture->diffuse = p_texture; //update
 	}
 
-	for (int i = 0; i < proxies_to_update.size(); i++) {
-		texture_proxy_update(proxies_to_update[i], p_texture);
+	for (const RID &proxy : proxies_to_update) {
+		texture_proxy_update(proxy, p_texture);
 	}
-	for (int i = 0; i < proxies_to_redirect.size(); i++) {
-		texture_proxy_update(proxies_to_redirect[i], p_texture);
+	for (const RID &proxy : proxies_to_redirect) {
+		texture_proxy_update(proxy, p_texture);
 	}
 	//delete last, so proxies can be updated
 	texture_owner.free(p_by_texture);
@@ -3272,17 +3293,18 @@ RID TextureStorage::RenderTarget::get_framebuffer() {
 	// this is where our framebuffer cache comes in clutch..
 
 	if (msaa != RS::VIEWPORT_MSAA_DISABLED) {
-		return FramebufferCacheRD::get_singleton()->get_cache_multiview(view_count, color_multisample, overridden.color.is_valid() ? overridden.color : color);
+		return FramebufferCacheRD::get_singleton()->get_cache_multiview(view_count, color_multisample, overridden.color_rd.is_valid() ? overridden.color_rd : color);
 	} else {
-		return FramebufferCacheRD::get_singleton()->get_cache_multiview(view_count, overridden.color.is_valid() ? overridden.color : color);
+		return FramebufferCacheRD::get_singleton()->get_cache_multiview(view_count, overridden.color_rd.is_valid() ? overridden.color_rd : color);
 	}
 }
 
 void TextureStorage::_clear_render_target(RenderTarget *rt) {
 	// clear overrides, we assume these are freed by the object that created them
-	rt->overridden.color = RID();
-	rt->overridden.depth = RID();
-	rt->overridden.velocity = RID();
+	rt->overridden.texture = RID();
+	rt->overridden.color_rd = RID();
+	rt->overridden.depth_rd = RID();
+	rt->overridden.velocity_rd = RID();
 	rt->overridden.cached_slices.clear(); // these are automatically freed when their parent textures are freed so just clear
 
 	// free in reverse dependency order
@@ -3423,9 +3445,9 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 		tex->format = rt->image_format;
 		tex->validated_format = rt->use_hdr ? Image::FORMAT_RGBAH : Image::FORMAT_RGBA8;
 
-		Vector<RID> proxies = tex->proxies; //make a copy, since update may change it
-		for (int i = 0; i < proxies.size(); i++) {
-			texture_proxy_update(proxies[i], rt->texture);
+		LocalVector<RID> proxies = tex->proxies; //make a copy, since update may change it
+		for (const RID &proxy : proxies) {
+			texture_proxy_update(proxy, rt->texture);
 		}
 	}
 }
@@ -3522,6 +3544,10 @@ RID TextureStorage::render_target_get_texture(RID p_render_target) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
+	if (rt->overridden.texture.is_valid()) {
+		return rt->overridden.texture;
+	}
+
 	return rt->texture;
 }
 
@@ -3529,39 +3555,47 @@ void TextureStorage::render_target_set_override(RID p_render_target, RID p_color
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL(rt);
 
-	rt->overridden.color = p_color_texture;
-	rt->overridden.depth = p_depth_texture;
-	rt->overridden.velocity = p_velocity_texture;
-	rt->overridden.velocity_depth = p_velocity_depth_texture;
+	RID was_color_texture = render_target_get_texture(p_render_target);
+
+	rt->overridden.texture = p_color_texture;
+	rt->overridden.color_rd = p_color_texture.is_valid() ? texture_get_rd_texture(p_color_texture) : RID();
+	rt->overridden.depth_rd = p_depth_texture.is_valid() ? texture_get_rd_texture(p_depth_texture) : RID();
+	rt->overridden.velocity_rd = p_velocity_texture.is_valid() ? texture_get_rd_texture(p_velocity_texture) : RID();
+	rt->overridden.velocity_depth_rd = p_velocity_depth_texture.is_valid() ? texture_get_rd_texture(p_velocity_depth_texture) : RID();
+
+	RID new_color_texture = render_target_get_texture(p_render_target);
+	if (was_color_texture.is_valid() && new_color_texture.is_valid()) {
+		texture_remap_proxies(was_color_texture, new_color_texture);
+	}
 }
 
 RID TextureStorage::render_target_get_override_color(RID p_render_target) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	return rt->overridden.color;
+	return rt->overridden.color_rd;
 }
 
 RID TextureStorage::render_target_get_override_depth(RID p_render_target) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	return rt->overridden.depth;
+	return rt->overridden.depth_rd;
 }
 
 RID TextureStorage::render_target_get_override_depth_slice(RID p_render_target, const uint32_t p_layer) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	if (rt->overridden.depth.is_null()) {
+	if (rt->overridden.depth_rd.is_null()) {
 		return RID();
 	} else if (rt->view_count == 1) {
-		return rt->overridden.depth;
+		return rt->overridden.depth_rd;
 	} else {
-		RenderTarget::RTOverridden::SliceKey key(rt->overridden.depth, p_layer);
+		RenderTarget::RTOverridden::SliceKey key(rt->overridden.depth_rd, p_layer);
 
 		if (!rt->overridden.cached_slices.has(key)) {
-			rt->overridden.cached_slices[key] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->overridden.depth, p_layer, 0);
+			rt->overridden.cached_slices[key] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->overridden.depth_rd, p_layer, 0);
 		}
 
 		return rt->overridden.cached_slices[key];
@@ -3572,22 +3606,22 @@ RID TextureStorage::render_target_get_override_velocity(RID p_render_target) con
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	return rt->overridden.velocity;
+	return rt->overridden.velocity_rd;
 }
 
 RID TextureStorage::render_target_get_override_velocity_slice(RID p_render_target, const uint32_t p_layer) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	if (rt->overridden.velocity.is_null()) {
+	if (rt->overridden.velocity_rd.is_null()) {
 		return RID();
 	} else if (rt->view_count == 1) {
-		return rt->overridden.velocity;
+		return rt->overridden.velocity_rd;
 	} else {
-		RenderTarget::RTOverridden::SliceKey key(rt->overridden.velocity, p_layer);
+		RenderTarget::RTOverridden::SliceKey key(rt->overridden.velocity_rd, p_layer);
 
 		if (!rt->overridden.cached_slices.has(key)) {
-			rt->overridden.cached_slices[key] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->overridden.velocity, p_layer, 0);
+			rt->overridden.cached_slices[key] = RD::get_singleton()->texture_create_shared_from_slice(RD::TextureView(), rt->overridden.velocity_rd, p_layer, 0);
 		}
 
 		return rt->overridden.cached_slices[key];
@@ -3598,7 +3632,7 @@ RID TextureStorage::render_target_get_override_velocity_depth(RID p_render_targe
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	return rt->overridden.velocity_depth;
+	return rt->overridden.velocity_depth_rd;
 }
 
 void RendererRD::TextureStorage::render_target_set_render_region(RID p_render_target, const Rect2i &p_render_region) {
@@ -3735,8 +3769,8 @@ RID TextureStorage::render_target_get_rd_texture(RID p_render_target) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, RID());
 
-	if (rt->overridden.color.is_valid()) {
-		return rt->overridden.color;
+	if (rt->overridden.color_rd.is_valid()) {
+		return rt->overridden.color_rd;
 	} else {
 		return rt->color;
 	}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -177,7 +177,7 @@ private:
 		String path;
 
 		RID proxy_to;
-		Vector<RID> proxies;
+		LocalVector<RID> proxies;
 
 		HashSet<RID> lightmap_users;
 
@@ -397,10 +397,13 @@ private:
 
 		// overridden textures
 		struct RTOverridden {
-			RID color;
-			RID depth;
-			RID velocity;
-			RID velocity_depth;
+			RID color_rd;
+			RID depth_rd;
+			RID velocity_rd;
+			RID velocity_depth_rd;
+
+			// texture_rd for our color texture
+			RID texture;
 
 			// In a multiview scenario, which is the most likely where we
 			// override our destination textures, we need to obtain slices
@@ -526,6 +529,7 @@ public:
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
+	void texture_remap_proxies(RID p_from_texture, RID p_to_texture);
 
 	Ref<Image> texture_2d_placeholder;
 	Vector<Ref<Image>> texture_2d_array_placeholder;


### PR DESCRIPTION
This PR fixes the issue that `ViewportTexture` wasn't properly being updated when our render target override function was used and thus preventing the correct texture from being displayed.

This has been a regression from the first Godot 4.0 version as this was working correctly in Godot 3.

While a feature that is only used in PCVR, it has been often requested to fix this.

For compatibility the fix was as easy as updating the proxy texture for our viewport, the same approach used in Godot 3.

For our Vulkan backend for some reason we decided early on to work directly on the rendering device. Our renderer thus had no idea what to do with these textures. 

> [!CAUTION]
> This is a serious breaking change that we need to discuss further in the XR team. There are likely additional changes required.
> We may need to investigate alternatives that are less invasive. 
> As such I've marked this as a milestone for 4.6

> [!WARNING]
> The same issue exists for DX12 and MacOS, the same fix must be applied to these before we can merge this!

Fixes: https://github.com/godotengine/godot/issues/100004