### PR TITLE
[macOS] Set default symbol visibility to hidden.

### DIFF
--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -89,7 +89,7 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.13"])
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
-    env.Append(CCFLAGS=["-fobjc-arc"])
+    env.Append(CCFLAGS=["-fobjc-arc", "-fvisibility=hidden"])
 
     cc_version = get_compiler_version(env)
     cc_version_major = cc_version["apple_major"]


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109910

Doesn't seem to have any effect on how the engine works, everything that requires exposed symbols should set visibility directly. But I would not merge in for 4.5 in the last moment, just in case I have missed some edge case while testing.

Also decreases binary size by 4 MB (stripped release template) - 45 MB (editor with debug symbols) per architecture.