### PR TITLE
Fix filtered objects getting unselected after reselection and certain properties change

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1098,7 +1098,7 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 				// Needs to be deferred to account for possible root visibility change.
 				callable_mp(tree, &Tree::scroll_to_item).call_deferred(p_parent, false);
 			}
-		} else if (n) {
+		} else if (n && !suppress_filter_removal) {
 			editor_selection->remove_node(n);
 			p_parent->deselect(0);
 		}
@@ -1691,8 +1691,12 @@ void SceneTreeEditor::set_marked(Node *p_marked, bool p_selectable, bool p_child
 }
 
 void SceneTreeEditor::set_filter(const String &p_filter) {
+	if (filter != p_filter) {
+		suppress_filter_removal = false;
+	}
 	filter = p_filter;
 	_update_filter(nullptr, true);
+	suppress_filter_removal = true;
 }
 
 String SceneTreeEditor::get_filter() const {

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -184,6 +184,7 @@ class SceneTreeEditor : public Control {
 	bool display_foreign = false;
 	bool tree_dirty = true;
 	bool pending_test_update = false;
+	bool suppress_filter_removal = false;
 	Timer *update_node_tooltip_delay = nullptr;
 
 	static void _bind_methods();


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This is a somewhat weird issue that I can only reliably reproduce in certain circumstances but sometimes can reproduce when just changing transforms for instantiate scenes. The fix is to suppress the filter removal unless the filter changes, to allow reselection without issues.

An example (note the conveyor getting unselected after I change the size property):

https://github.com/user-attachments/assets/721ff05a-1372-422d-a2dc-f68f927c46dd

With this PR the conveyor remains selected. 
