### PR TITLE
CI: Ensure prettier/clearer sanitizer output

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -11,8 +11,10 @@ env:
   GODOT_CPP_BRANCH: 4.4
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
-  TSAN_OPTIONS: suppressions=${{ github.workspace }}/misc/error_suppressions/tsan.txt
-  UBSAN_OPTIONS: suppressions=${{ github.workspace }}/misc/error_suppressions/ubsan.txt
+  ASAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/asan.txt
+  LSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/lsan.txt
+  TSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/tsan.txt
+  UBSAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/ubsan.txt
 
 jobs:
   build-linux:

--- a/misc/error_suppressions/asan.txt
+++ b/misc/error_suppressions/asan.txt
@@ -1,0 +1,5 @@
+# Supported suppression types are:
+# - interceptor_name
+# - interceptor_via_fun
+# - interceptor_via_lib
+# - odr_violation

--- a/misc/error_suppressions/lsan.txt
+++ b/misc/error_suppressions/lsan.txt
@@ -1,0 +1,2 @@
+# Supported suppression types are:
+# - leak

--- a/misc/error_suppressions/tsan.txt
+++ b/misc/error_suppressions/tsan.txt
@@ -1,9 +1,9 @@
 # See the below link for an explanation of this file's format
 # https://github.com/google/sanitizers/wiki/ThreadSanitizerSuppressions
 
-deadlock:tests/core/templates/test_command_queue.h
 deadlock:modules/text_server_adv/text_server_adv.cpp
 deadlock:modules/text_server_fb/text_server_fb.cpp
+deadlock:tests/core/templates/test_command_queue.h
 race:modules/navigation_2d/nav_map_2d.cpp
 race:modules/navigation_3d/nav_map_3d.cpp
 race:thirdparty/thorvg/src/loaders/external_jpg/tvgJpgLoader.cpp

--- a/misc/error_suppressions/ubsan.txt
+++ b/misc/error_suppressions/ubsan.txt
@@ -1,11 +1,21 @@
+# See the below link for an explanation of this file's format
+# https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html#available-checks
+
+bounds:thirdparty/harfbuzz/src/hb-open-type.hh
+bounds:thirdparty/harfbuzz/src/OT/Layout/GPOS/../../../hb-ot-layout-gsubgpos.hh
+bounds:thirdparty/harfbuzz/src/OT/Layout/GSUB/LigatureSet.hh
+bounds:thirdparty/harfbuzz/src/OT/name/../../hb-open-type.hh
+bounds:thirdparty/icu4c/common/rbbi.cpp
 enum:thirdparty/glslang/SPIRV/spirv.hpp
 float-divide-by-zero:thirdparty/amd-fsr2/ffx_fsr2.cpp
 float-divide-by-zero:thirdparty/misc/ok_color.h
 float-divide-by-zero:thirdparty/rvo2/rvo2_2d/Agent2d.cpp
 float-divide-by-zero:thirdparty/thorvg/src/renderer/sw_engine/tvgSwFill.cpp
+float-divide-by-zero:thirdparty/thorvg/src/renderer/tvgText.h
 function:thirdparty/embree/common/sys/thread.cpp
 function:thirdparty/embree/kernels/common/accel.h
 function:thirdparty/xatlas/xatlas.cpp
+implicit-integer-sign-change:MachineIndependent/glslang.y
 implicit-integer-sign-change:thirdparty/basis_universal/encoder/jpgd.cpp
 implicit-integer-sign-change:thirdparty/basis_universal/transcoder/basisu_astc_helpers.h
 implicit-integer-sign-change:thirdparty/embree/common/lexers/../sys/ref.h
@@ -13,11 +23,12 @@ implicit-integer-sign-change:thirdparty/embree/common/lexers/tokenstream.cpp
 implicit-integer-sign-change:thirdparty/embree/common/sys/sysinfo.cpp
 implicit-integer-sign-change:thirdparty/embree/common/tasking/taskschedulerinternal.cpp
 implicit-integer-sign-change:thirdparty/embree/common/tasking/taskschedulerinternal.h
-implicit-integer-sign-change:thirdparty/embree/kernels/bvh/../common/../builders/primref.h
 implicit-integer-sign-change:thirdparty/embree/kernels/bvh/../common/../../common/sys/../math/../simd/vfloat4_sse2.h
 implicit-integer-sign-change:thirdparty/embree/kernels/bvh/../common/../../common/sys/../math/../simd/vuint4_sse2.h
+implicit-integer-sign-change:thirdparty/embree/kernels/bvh/../common/../builders/primref.h
 implicit-integer-sign-change:thirdparty/embree/kernels/bvh/../common/vector.h
 implicit-integer-sign-change:thirdparty/embree/kernels/bvh/../geometry/triangle.h
+implicit-integer-sign-change:thirdparty/etcpak/ProcessDxtc.cpp
 implicit-integer-sign-change:thirdparty/glslang/glslang/MachineIndependent/ParseHelper.cpp
 implicit-integer-sign-change:thirdparty/glslang/glslang/MachineIndependent/preprocessor/PpScanner.cpp
 implicit-integer-sign-change:thirdparty/glslang/glslang/MachineIndependent/preprocessor/PpTokens.cpp
@@ -26,6 +37,7 @@ implicit-integer-sign-change:thirdparty/glslang/SPIRV/hex_float.h
 implicit-integer-sign-change:thirdparty/harfbuzz/src/hb-algs.hh
 implicit-integer-sign-change:thirdparty/harfbuzz/src/hb-buffer.hh
 implicit-integer-sign-change:thirdparty/harfbuzz/src/hb-cache.hh
+implicit-integer-sign-change:thirdparty/harfbuzz/src/hb-face.cc
 implicit-integer-sign-change:thirdparty/harfbuzz/src/hb-face.hh
 implicit-integer-sign-change:thirdparty/harfbuzz/src/hb-ot-layout-gsubgpos.hh
 implicit-integer-sign-change:thirdparty/harfbuzz/src/OT/Layout/GDEF/../../../hb-cache.hh
@@ -39,14 +51,20 @@ implicit-integer-sign-change:thirdparty/icu4c/common/unicode/unistr.h
 implicit-integer-sign-change:thirdparty/icu4c/common/unistr.cpp
 implicit-integer-sign-change:thirdparty/icu4c/common/uresbund.cpp
 implicit-integer-sign-change:thirdparty/icu4c/common/ustrtrns.cpp
+implicit-integer-sign-change:thirdparty/libjpeg-turbo/src/jcdctmgr.c
+implicit-integer-sign-change:thirdparty/libjpeg-turbo/src/jdarith.c
+implicit-integer-sign-change:thirdparty/libjpeg-turbo/src/jdhuff.c
 implicit-integer-sign-change:thirdparty/libogg/bitwise.c
 implicit-integer-sign-change:thirdparty/libvorbis/info.c
 implicit-integer-sign-change:thirdparty/libvorbis/sharedbook.c
+implicit-integer-sign-change:thirdparty/manifold/src/impl.h
 implicit-integer-sign-change:thirdparty/mbedtls/library/base64.c
 implicit-integer-sign-change:thirdparty/misc/smolv.cpp
 implicit-integer-sign-change:thirdparty/recastnavigation/Recast/Include/Recast.h
 implicit-integer-sign-change:thirdparty/recastnavigation/Recast/Source/RecastMesh.cpp
+implicit-integer-sign-change:thirdparty/sdl/SDL_guid.c
 implicit-integer-sign-change:thirdparty/spirv-reflect/spirv_reflect.c
+implicit-integer-sign-change:thirdparty/thorvg/src/common/tvgCompressor.cpp
 implicit-integer-sign-change:thirdparty/thorvg/src/renderer/sw_engine/tvgSwRaster.cpp
 implicit-integer-sign-change:thirdparty/tinyexr/tinyexr.h
 implicit-integer-sign-change:thirdparty/vulkan/vk_mem_alloc.h


### PR DESCRIPTION
- Related #109616

Essentially a subsection of the above PR, focusing exclusively on making our existing sanitizer as clean/pretty as possible. As part of that, this suppresses new thirdparty notices that cropped up, which should've been accounted for previously and thus makes this a bugfix. Adding new tests and/or actual code changes are out-of-scope for 4.5