### PR TITLE
Improve documentation on `Node.propagate_call()`

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -94,6 +94,7 @@
 			<description>
 				Returns a copy of this [Callable] with one or more arguments bound. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call]. See also [method unbind].
 				[b]Note:[/b] When this method is chained with other similar methods, the order in which the argument list is modified is read from right to left.
+				[b]Note:[/b] When calling methods that use static type hints, parameter types must match, including typed arrays/dictionaries. You may have to create explicitly typed arrays using [Array] and [Dictionary]'s typed constructors, as opposed to using the shorthand [code][][/code] and [code]{}[/code] syntaxes. Otherwise, the method won't be called and an error is printed.
 			</description>
 		</method>
 		<method name="bindv">
@@ -102,6 +103,7 @@
 			<description>
 				Returns a copy of this [Callable] with one or more arguments bound, reading them from an array. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call]. See also [method unbind].
 				[b]Note:[/b] When this method is chained with other similar methods, the order in which the argument list is modified is read from right to left.
+				[b]Note:[/b] When calling methods that use static type hints, parameter types must match, including typed arrays/dictionaries. You may have to create explicitly typed arrays using [Array] and [Dictionary]'s typed constructors, as opposed to using the shorthand [code][][/code] and [code]{}[/code] syntaxes. Otherwise, the method won't be called and an error is printed.
 			</description>
 		</method>
 		<method name="call" qualifiers="vararg const">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -804,6 +804,20 @@
 			<description>
 				Calls the given [param method] name, passing [param args] as arguments, on this node and all of its children, recursively.
 				If [param parent_first] is [code]true[/code], the method is called on this node first, then on all of its children. If [code]false[/code], the children's methods are called first.
+				Example:
+				[codeblocks]
+				[gdscript]
+				# This script is attached to a parent node and all its children.
+
+				func _ready():
+					propagate_call("setup", [15, ["apple", "orange", "pear"]])
+
+				func setup(total_fruits, fruit_names):
+					print("Setting up dispenser with %d fruits: %s" % [total_fruits, fruit_names])
+				[/gdscript]
+				[/codeblocks]
+				To call methods on children without also calling it on the parent, use [method get_children] and a [code]for[/code] loop with [method Object.call] or [method Object.callv] instead.
+				[b]Note:[/b] When calling methods that use static type hints, parameter types must match, including typed arrays/dictionaries. You may have to create explicitly typed arrays using [Array] and [Dictionary]'s typed constructors, as opposed to using the shorthand [code][][/code] and [code]{}[/code] syntaxes. Otherwise, the method won't be called and an error is printed.
 			</description>
 		</method>
 		<method name="propagate_notification">

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -451,6 +451,7 @@
 				node.Call(Node3D.MethodName.Rotate, new Vector3(1f, 0f, 0f), 1.571f);
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] When calling methods that use static type hints, parameter types must match, including typed arrays/dictionaries. You may have to create explicitly typed arrays using [Array] and [Dictionary]'s typed constructors, as opposed to using the shorthand [code][][/code] and [code]{}[/code] syntaxes. Otherwise, the method won't be called and an error is printed.
 				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
@@ -482,6 +483,7 @@
 				# CONNECT_ONE_SHOT makes sure it only gets called once instead of every frame.
 				get_tree().process_frame.connect(callable, CONNECT_ONE_SHOT)
 				[/codeblock]
+				[b]Note:[/b] When calling methods that use static type hints, parameter types must match, including typed arrays/dictionaries. You may have to create explicitly typed arrays using [Array] and [Dictionary]'s typed constructors, as opposed to using the shorthand [code][][/code] and [code]{}[/code] syntaxes. Otherwise, the method won't be called and an error is printed.
 			</description>
 		</method>
 		<method name="callv">
@@ -500,6 +502,7 @@
 				node.Callv(Node3D.MethodName.Rotate, [new Vector3(1f, 0f, 0f), 1.571f]);
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] When calling methods that use static type hints, parameter types must match, including typed arrays/dictionaries. You may have to create explicitly typed arrays using [Array] and [Dictionary]'s typed constructors, as opposed to using the shorthand [code][][/code] and [code]{}[/code] syntaxes. Otherwise, the method won't be called and an error is printed.
 				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>


### PR DESCRIPTION
- Add note on type matching requirements (including typed array/dictionary) for various call methods.

___

- See https://github.com/godotengine/godot-docs-user-notes/discussions/198#discussioncomment-14204081.
