### PR TITLE
Add debanding to SMAA and apply debanding before spatial upscalers.

### DIFF
--- a/servers/rendering/renderer_rd/effects/smaa.cpp
+++ b/servers/rendering/renderer_rd/effects/smaa.cpp
@@ -181,6 +181,11 @@ void SMAA::process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_source_colo
 
 	smaa.blend_push_constant.inv_size[0] = inv_size.x;
 	smaa.blend_push_constant.inv_size[1] = inv_size.y;
+	if (debanding_mode == DEBANDING_MODE_8_BIT) {
+		smaa.blend_push_constant.flags |= SMAA_BLEND_FLAG_USE_8_BIT_DEBANDING;
+	} else if (debanding_mode == DEBANDING_MODE_10_BIT) {
+		smaa.blend_push_constant.flags |= SMAA_BLEND_FLAG_USE_10_BIT_DEBANDING;
+	}
 
 	RID linear_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 

--- a/servers/rendering/renderer_rd/effects/smaa.h
+++ b/servers/rendering/renderer_rd/effects/smaa.h
@@ -59,7 +59,7 @@ private:
 	struct SMAAEdgePushConstant {
 		float inv_size[2];
 		float threshold;
-		float reserved;
+		float pad;
 	};
 
 	struct SMAAWeightPushConstant {
@@ -71,7 +71,13 @@ private:
 
 	struct SMAABlendPushConstant {
 		float inv_size[2];
-		float reserved[2];
+		uint32_t flags;
+		float pad;
+	};
+
+	enum SMAABlendFlags {
+		SMAA_BLEND_FLAG_USE_8_BIT_DEBANDING = (1 << 0),
+		SMAA_BLEND_FLAG_USE_10_BIT_DEBANDING = (1 << 1),
 	};
 
 	struct SMAAEffect {
@@ -103,6 +109,13 @@ public:
 
 	void allocate_render_targets(Ref<RenderSceneBuffersRD> p_render_buffers);
 	void process(Ref<RenderSceneBuffersRD> p_render_buffers, RID p_source_color, RID p_dst_framebuffer);
+
+	enum DebandingMode {
+		DEBANDING_MODE_DISABLED,
+		DEBANDING_MODE_8_BIT,
+		DEBANDING_MODE_10_BIT,
+	};
+	DebandingMode debanding_mode = DEBANDING_MODE_DISABLED;
 };
 
 } // namespace RendererRD

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -113,6 +113,14 @@ protected:
 	void _post_process_subpass(RID p_source_texture, RID p_framebuffer, const RenderDataRD *p_render_data);
 	void _disable_clear_request(const RenderDataRD *p_render_data);
 
+	_FORCE_INLINE_ bool _is_8bit_data_format(RD::DataFormat p_data_format) {
+		return p_data_format >= RD::DATA_FORMAT_R8_UNORM && p_data_format <= RD::DATA_FORMAT_A8B8G8R8_SRGB_PACK32;
+	}
+
+	_FORCE_INLINE_ bool _is_10bit_data_format(RD::DataFormat p_data_format) {
+		return p_data_format >= RD::DATA_FORMAT_A2R10G10B10_UNORM_PACK32 && p_data_format <= RD::DATA_FORMAT_A2B10G10R10_SINT_PACK32;
+	}
+
 	// needed for a single argument calls (material and uv2)
 	PagedArrayPool<RenderGeometryInstance *> cull_argument_pool;
 	PagedArray<RenderGeometryInstance *> cull_argument; //need this to exist

--- a/servers/rendering/renderer_rd/shaders/effects/smaa_blending.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/smaa_blending.glsl
@@ -34,7 +34,7 @@ layout(location = 1) out vec4 offset;
 
 layout(push_constant, std430) uniform Params {
 	vec2 inv_size;
-	vec2 reserved;
+	vec2 pad;
 }
 params;
 
@@ -62,9 +62,13 @@ layout(set = 1, binding = 0) uniform sampler2D blend_tex;
 
 layout(location = 0) out vec4 out_color;
 
+#define FLAG_USE_8_BIT_DEBANDING (1 << 0)
+#define FLAG_USE_10_BIT_DEBANDING (1 << 1)
+
 layout(push_constant, std430) uniform Params {
 	vec2 inv_size;
-	vec2 reserved;
+	uint flags;
+	float pad;
 }
 params;
 
@@ -95,6 +99,22 @@ void SMAAMovc(bvec4 cond, inout vec4 variable, vec4 value) {
 	SMAAMovc(cond.zw, variable.zw, value.zw);
 }
 
+// From https://alex.vlachos.com/graphics/Alex_Vlachos_Advanced_VR_Rendering_GDC2015.pdf
+// and https://www.shadertoy.com/view/MslGR8 (5th one starting from the bottom)
+// NOTE: `frag_coord` is in pixels (i.e. not normalized UV).
+// This dithering must be applied after encoding changes (linear/nonlinear) have been applied
+// as the final step before quantization from floating point to integer values.
+vec3 screen_space_dither(vec2 frag_coord, float bit_alignment_diviser) {
+	// Iestyn's RGB dither (7 asm instructions) from Portal 2 X360, slightly modified for VR.
+	// Removed the time component to avoid passing time into this shader.
+	vec3 dither = vec3(dot(vec2(171.0, 231.0), frag_coord));
+	dither.rgb = fract(dither.rgb / vec3(103.0, 71.0, 97.0));
+
+	// Subtract 0.5 to avoid slightly brightening the whole viewport.
+	// Use a dither strength of 100% rather than the 37.5% suggested by the original source.
+	return (dither.rgb - 0.5) / bit_alignment_diviser;
+}
+
 void main() {
 	vec4 a;
 	a.x = texture(blend_tex, offset.xy).a;
@@ -119,5 +139,12 @@ void main() {
 		out_color.rgb += blending_weight.y * textureLinear(color_tex, blending_coord.zw);
 		out_color.rgb = linear_to_srgb(out_color.rgb);
 		out_color.a = texture(color_tex, tex_coord).a;
+	}
+	if (bool(params.flags & FLAG_USE_8_BIT_DEBANDING)) {
+		// Divide by 255 to align to 8-bit quantization.
+		out_color.rgb += screen_space_dither(gl_FragCoord.xy, 255.0);
+	} else if (bool(params.flags & FLAG_USE_10_BIT_DEBANDING)) {
+		// Divide by 1023 to align to 10-bit quantization.
+		out_color.rgb += screen_space_dither(gl_FragCoord.xy, 1023.0);
 	}
 }


### PR DESCRIPTION
Fixes #109531

This PR should bring debanding back to a state where it is equivalent or better than the Godot 4.4.1 behaviour in all cases. To do this, SMAA now has debanding support built-in, which allows debanding to correctly be applied directly before quantization to integer values.

This approach means the debanding dithering is applied twice to a very similar 10 bit buffer when using the Mobile rendering method with HDR 2D enabled and SMAA enabled. This makes the dithering noise more visible than necessary, but it doesn't worthwhile to add in even more logic for this very specific scenario. This is not an issue when the scene buffer and swapchain buffer have different formats, like in Forward+ or Mobile with HDR 2D disabled: in these cases, if two debanding passes happen, the first debanding will be applied to 10 bit linear and the second debanding will be applied to 8 bit nonlinear, which is the ideal behaviour.

For spatial upscaling (FSR 1.0 and MetalFX (Spatial)), behaviour similar to Godot 4.4.1 has been reintroduced: the debanding pattern will be applied prematurely and spatial upscaling will be applied afterwards. This creates suboptimal results, as noted in the comments of this PR, but for the sake of maintaining the "better than nothing" approach of Godot 4.4.1, I think this is a reasonable compromise for now.

In the future we can look at introducing a full new pass that applies debanding after spatial scaling.

Finally, I have changed the "reserved" push constant names to "pad" in SMAA, since these appear to be padding and are not actually meant to be reserved for anything in particular.