### PR TITLE
Make POT generation use `tooltip_auto_translate_mode`

### DIFF
--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -113,6 +113,32 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 			}
 		}
 
+		// Handle the `tooltip_auto_translate_mode` property separately.
+		String tooltip_text;
+		bool tooltip_auto_translating = auto_translating;
+		for (int j = 0; j < state->get_node_property_count(i); j++) {
+			String property = state->get_node_property_name(i, j);
+			if (property == "tooltip_text") {
+				tooltip_text = (String)state->get_node_property_value(i, j);
+				continue;
+			}
+			if (property == "tooltip_auto_translate_mode") {
+				int mode = (int)state->get_node_property_value(i, j);
+				switch (mode) {
+					case Node::AUTO_TRANSLATE_MODE_ALWAYS: {
+						tooltip_auto_translating = true;
+					} break;
+					case Node::AUTO_TRANSLATE_MODE_DISABLED: {
+						tooltip_auto_translating = false;
+					} break;
+				}
+				continue;
+			}
+		}
+		if (!tooltip_text.is_empty() && tooltip_auto_translating) {
+			r_translations->push_back({ tooltip_text });
+		}
+
 		// Parse the names of children of `TabContainer`s, as they are used for tab titles.
 		if (!tabcontainer_paths.is_empty()) {
 			if (!parent_path.begins_with(tabcontainer_paths[tabcontainer_paths.size() - 1])) {
@@ -208,4 +234,5 @@ PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlug
 	exception_list.insert("LineEdit", { "text" });
 	exception_list.insert("TextEdit", { "text" });
 	exception_list.insert("CodeEdit", { "text" });
+	exception_list.insert("Control", { "tooltip_text" });
 }


### PR DESCRIPTION
Fixes #109278

This PR adds special handling on `tooltip_text` and `tooltip_auto_translate_mode`.