### PR TITLE
Clamp menus at the bottom of the screen.

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -85,6 +85,16 @@ void MenuButton::show_popup() {
 		Transform2D xform = get_viewport()->get_popup_base_transform_native();
 		rect = xform.xform(rect);
 	}
+	Rect2i scr_usable = DisplayServer::get_singleton()->screen_get_usable_rect(get_window()->get_current_screen());
+	Size2i max_size;
+	if (scr_usable.has_area()) {
+		real_t max_h = scr_usable.get_end().y - rect.position.y;
+		real_t max_w = scr_usable.get_end().x - rect.position.x;
+		if (max_h >= 4 * rect.size.height && max_w >= rect.size.width) {
+			max_size = Size2i(max_w, max_h);
+		}
+	}
+	popup->set_max_size(max_size);
 	rect.size.height = 0;
 	popup->set_size(rect.size);
 	if (is_layout_rtl()) {

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3230,6 +3230,10 @@ void PopupMenu::_pre_popup() {
 	set_content_scale_factor(popup_scale);
 	Size2 minsize = get_contents_minimum_size() * popup_scale;
 	minsize.height = Math::ceil(minsize.height); // Ensures enough height at fractional content scales to prevent the v_scroll_bar from showing.
+	real_t max_h = get_max_size().height;
+	if (max_h > 0) {
+		minsize.height = MIN(minsize.height, max_h);
+	}
 	set_min_size(minsize); // `height` is truncated here by the cast to Size2i for Window.min_size.
 	reset_size(); // Shrinkwraps to min size.
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109575

| Before | After |
|---|---|
| <img width="541" height="489" alt="Screenshot 2025-08-26 at 11 22 02" src="https://github.com/user-attachments/assets/b976f5c5-51ee-40db-b3c5-5c635a3f4d56" /> | <img width="541" height="489" alt="Screenshot 2025-08-26 at 11 22 45" src="https://github.com/user-attachments/assets/35d74a40-f24f-4158-8b55-865bb9fd8f19" /> |

