### PR TITLE
Add EditorScenePostImportPlugin::get_option_values

### DIFF
--- a/doc/classes/EditorScenePostImportPlugin.xml
+++ b/doc/classes/EditorScenePostImportPlugin.xml
@@ -101,6 +101,12 @@
 				Query the value of an option. This function can only be called from those querying visibility, or processing.
 			</description>
 		</method>
+		<method name="get_option_values" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns all available options and their values. This function can only be called from those querying visibility, or processing.
+			</description>
+		</method>
 	</methods>
 	<constants>
 		<constant name="INTERNAL_IMPORT_CATEGORY_NODE" value="0" enum="InternalImportCategory">

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -148,6 +148,22 @@ void EditorScenePostImport::init(const String &p_source_file) {
 
 ///////////////////////////////////////////////////////
 
+Dictionary EditorScenePostImportPlugin::get_option_values() const {
+	ERR_FAIL_COND_V_MSG(current_options == nullptr && current_options_dict == nullptr, Dictionary(), "get_option_value called from a function where option values are not available.");
+	Dictionary ret;
+	if (current_options_dict) {
+		for (const KeyValue<Variant, Variant> &kv : *current_options_dict) {
+			ret[kv.key] = kv.value;
+		}
+	}
+	if (current_options) {
+		for (const KeyValue<StringName, Variant> &kv : *current_options) {
+			ret[kv.key] = kv.value;
+		}
+	}
+	return ret;
+}
+
 Variant EditorScenePostImportPlugin::get_option_value(const StringName &p_name) const {
 	ERR_FAIL_COND_V_MSG(current_options == nullptr && current_options_dict == nullptr, Variant(), "get_option_value called from a function where option values are not available.");
 	ERR_FAIL_COND_V_MSG(current_options && !current_options->has(p_name), Variant(), "get_option_value called with unexisting option argument: " + String(p_name));
@@ -224,6 +240,7 @@ void EditorScenePostImportPlugin::post_process(Node *p_scene, const HashMap<Stri
 
 void EditorScenePostImportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_option_value", "name"), &EditorScenePostImportPlugin::get_option_value);
+	ClassDB::bind_method(D_METHOD("get_option_values"), &EditorScenePostImportPlugin::get_option_values);
 
 	ClassDB::bind_method(D_METHOD("add_import_option", "name", "value"), &EditorScenePostImportPlugin::add_import_option);
 	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorScenePostImportPlugin::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -133,6 +133,7 @@ protected:
 
 public:
 	Variant get_option_value(const StringName &p_name) const;
+	Dictionary get_option_values() const;
 	void add_import_option(const String &p_name, const Variant &p_default_value);
 	void add_import_option_advanced(Variant::Type p_type, const String &p_name, const Variant &p_default_value, PropertyHint p_hint = PROPERTY_HINT_NONE, const String &p_hint_string = String(), int p_usage_flags = PROPERTY_USAGE_DEFAULT);
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-proposals/issues/13068

In `EditorScenePostImportPlugin` we can currently retrieve option values with `get_option_value` but have no way of determining what the available options are. This PR adds a `get_option_values` method that returns the options Dictionary.

Sample project: 
[importertest2.zip](https://github.com/user-attachments/files/21986417/importertest2.zip)

Double click on the gltf in project root and hit import. You'll see an output print of `get_option_values()`.