### PR TITLE
Remove duplicate #if defined

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -502,13 +502,13 @@ bool OS::has_feature(const String &p_feature) {
 	if (sizeof(void *) == 4 && p_feature == "32") {
 		return true;
 	}
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 #if defined(MACOS_ENABLED)
 	if (p_feature == "universal") {
 		return true;
 	}
 #endif
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	if (p_feature == "x86_64") {
 		return true;
 	}
@@ -522,11 +522,6 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
 #if defined(__aarch64__) || defined(_M_ARM64)
-#if defined(MACOS_ENABLED)
-	if (p_feature == "universal") {
-		return true;
-	}
-#endif
 	if (p_feature == "arm64") {
 		return true;
 	}


### PR DESCRIPTION
MACOS_ENABLED is the same under both sections so just raise it out of if conditions

In OS.has_feature the "universal" feature occurs 2 times 
1. Under x86/x64 section in https://github.com/godotengine/godot/blob/17fb6e3bd06f6425ad9ec0d93718ce8f848fc3fc/core/os/os.cpp#L507
2. Under arm section in https://github.com/godotengine/godot/blob/17fb6e3bd06f6425ad9ec0d93718ce8f848fc3fc/core/os/os.cpp#L525

Considering it doesn't really differ between those 2 sections(I guess it's really universal hehe) I assume it can be raised out the conditions(most likely right before x86/x64 section) to be a standalone #if defined
This doesn't improve or break anything, at most reduces amount of lines by a little bit and makes has_feature slightly more readble
