### PR TITLE
Add texture update partial method

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1071,6 +1071,20 @@
 				[b]Note:[/b] The existing [param texture] requires the [constant TEXTURE_USAGE_CAN_UPDATE_BIT] to be updatable.
 			</description>
 		</method>
+		<method name="texture_update_partial">
+			<return type="int" enum="Error" />
+			<param index="0" name="texture" type="RID" />
+			<param index="1" name="dst_layer" type="int" />
+			<param index="2" name="dst_mipmap" type="int" />
+			<param index="3" name="dst_pos" type="Vector3i" />
+			<param index="4" name="data_dimensions" type="Vector3i" />
+			<param index="5" name="data" type="PackedByteArray" />
+			<description>
+				Updates a part of the data of the texture specified by the [param texture] with the data. The [param data] is assumed to be a texture data with the same data format as the [param texture], and has the dimensions specified by [param data_dimensions] and the mipmaps is [code]1[/code] (no mipmaps).
+				[b]Note:[/b] Updating textures is forbidden during creation of a draw or compute list.
+				[b]Note:[/b] The existing [param texture] requires the [constant TEXTURE_USAGE_CAN_UPDATE_BIT] to be updatable.
+			</description>
+		</method>
 		<method name="uniform_buffer_create">
 			<return type="RID" />
 			<param index="0" name="size_bytes" type="int" />

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3833,6 +3833,22 @@
 			<description>
 			</description>
 		</method>
+		<method name="texture_update_partial">
+			<return type="void" />
+			<param index="0" name="texture" type="RID" />
+			<param index="1" name="image" type="Image" />
+			<param index="2" name="src_rect" type="Rect2i" />
+			<param index="3" name="dst_pos" type="Vector2i" />
+			<param index="4" name="dst_depth" type="int" default="0" />
+			<param index="5" name="dst_mipmap" type="int" default="0" />
+			<param index="6" name="dst_layer" type="int" default="0" />
+			<description>
+				Updates a part of the data of the texture specified by the [param texture] with the data in [param image]. Can be used to update [Texture2D], [TextureLayered], and [Texture3D]. For 2D textures (which only have one depth and one layer), the [param dst_depth] and [param dst_layer] must be [code]0[/code].
+				[b]Note:[/b] The valid update region size is [code]Vector3i(texture_width &gt;&gt; dst_mipmap, texture_height &gt;&gt; dst_mipmap, texture_depth &gt;&gt; dst_mipmap)[/code], make sure the update region is within the bounds.
+				[b]Note:[/b] The [param image] must have the same format as the [param texture] data. To update a compressed texture, [param src_rect] must be [code]Rect2i(0, 0, image.get_width(), image.get_height())[/code]. Otherwise, an error will be printed and the original texture won't be modified.
+				[b]Note:[/b] The mipmaps of [param image] are ignored. Only the first mipmap level is used.
+			</description>
+		</method>
 		<method name="viewport_attach_camera">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -523,6 +523,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
+	virtual void texture_update_partial(RID p_texture, const Ref<Image> &p_image, Rect2i p_src_rect, Vector2i p_dst_pos, int p_dst_depth = 0, int p_dst_mipmap = 0, int p_dst_layer = 0) override;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
 

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -93,6 +93,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override {}
+	virtual void texture_update_partial(RID p_texture, const Ref<Image> &p_image, Rect2i p_src_rect, Vector2i p_dst_pos, int p_dst_depth = 0, int p_dst_mipmap = 0, int p_dst_layer = 0) override {}
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override {}
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override {}
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1319,6 +1319,48 @@ void TextureStorage::texture_2d_update(RID p_texture, const Ref<Image> &p_image,
 	_texture_2d_update(p_texture, p_image, p_layer, false);
 }
 
+void TextureStorage::texture_update_partial(RID p_texture, const Ref<Image> &p_image, Rect2i p_src_rect, Vector2i p_dst_pos, int p_dst_depth, int p_dst_mipmap, int p_dst_layer) {
+	ERR_FAIL_COND(p_image.is_null() || p_image->is_empty());
+
+	Texture *texture = texture_owner.get_or_null(p_texture);
+
+	ERR_FAIL_NULL(texture);
+	ERR_FAIL_COND(p_image.is_null());
+	ERR_FAIL_COND(texture->render_target);
+	ERR_FAIL_COND(texture->format != p_image->get_format());
+
+	int src_x = p_src_rect.position.x;
+	int src_y = p_src_rect.position.y;
+	int src_w = p_src_rect.size.width;
+	int src_h = p_src_rect.size.height;
+
+	ERR_FAIL_COND(src_w <= 0 || src_h <= 0);
+	ERR_FAIL_COND(src_x < 0 || src_y < 0 || src_x + src_w > p_image->get_width() || src_y + src_h > p_image->get_height());
+
+#ifdef TOOLS_ENABLED
+	texture->image_cache_2d.unref();
+#endif
+
+	TextureToRDFormat tf;
+	Ref<Image> validated_img = _validate_texture_format(p_image, tf);
+	Ref<Image> sub_img = validated_img;
+	if (src_x > 0 || src_y > 0 || src_w != validated_img->get_width() || src_h != validated_img->get_height()) {
+		sub_img = validated_img->get_region(p_src_rect);
+	}
+	Vector2i img_size = sub_img->get_size();
+	Vector<uint8_t> data = sub_img->get_data();
+	Span<uint8_t> span = data.span();
+	if (sub_img->has_mipmaps()) {
+		// Only use the data of the first mipmap level.
+		int64_t mip_ofs;
+		int64_t mip_size;
+		sub_img->get_mipmap_offset_and_size(0, mip_ofs, mip_size);
+		span = Span(data.ptr() + mip_ofs, mip_size);
+	}
+
+	RD::get_singleton()->texture_update_partial(texture->rd_texture, p_dst_layer, p_dst_mipmap, Vector3i(p_dst_pos.x, p_dst_pos.y, p_dst_depth), Vector3i(img_size.x, img_size.y, 1), span);
+}
+
 void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) {
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_NULL(tex);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -524,6 +524,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
+	virtual void texture_update_partial(RID p_texture, const Ref<Image> &p_image, Rect2i p_src_rect, Vector2i p_dst_pos, int p_dst_depth = 0, int p_dst_mipmap = 0, int p_dst_layer = 0) override;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1710,6 +1710,146 @@ Error RenderingDevice::texture_update(RID p_texture, uint32_t p_layer, const Vec
 	return OK;
 }
 
+Error RenderingDevice::texture_update_partial(RID p_texture, uint32_t p_dst_layer, uint32_t p_dst_mipmap, Vector3i p_dst_pos, Vector3i p_data_dimensions, Span<uint8_t> p_data) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	ERR_FAIL_COND_V_MSG(draw_list.active || compute_list.active, ERR_INVALID_PARAMETER, "Updating textures is forbidden during creation of a draw or compute list");
+
+	Texture *texture = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_NULL_V(texture, ERR_INVALID_PARAMETER);
+
+	if (texture->owner != RID()) {
+		p_texture = texture->owner;
+		texture = texture_owner.get_or_null(texture->owner);
+		ERR_FAIL_NULL_V(texture, ERR_BUG); // This is a bug.
+	}
+
+	ERR_FAIL_COND_V_MSG(texture->bound, ERR_CANT_ACQUIRE_RESOURCE,
+			"Texture can't be updated while a draw list that uses it as part of a framebuffer is being created. Ensure the draw list is finalized (and that the color/depth texture using it is not set to `RenderingDevice.FINAL_ACTION_CONTINUE`) to update this texture.");
+
+	ERR_FAIL_COND_V_MSG(!(texture->usage_flags & TEXTURE_USAGE_CAN_UPDATE_BIT), ERR_INVALID_PARAMETER, "Texture requires the `RenderingDevice.TEXTURE_USAGE_CAN_UPDATE_BIT` to be set to be updatable.");
+
+	uint32_t layer_count = _texture_layer_count(texture);
+	ERR_FAIL_COND_V(p_dst_layer >= layer_count, ERR_INVALID_PARAMETER);
+
+	uint32_t required_align = _texture_alignment(texture);
+
+	{
+		uint32_t width = MAX(1u, texture->width >> p_dst_mipmap);
+		uint32_t height = MAX(1u, texture->height >> p_dst_mipmap);
+		uint32_t depth = MAX(1u, texture->depth >> p_dst_mipmap);
+		ERR_FAIL_COND_V(p_dst_pos.x < 0 || (uint32_t)(p_dst_pos.x + p_data_dimensions.x) > width, ERR_INVALID_PARAMETER);
+		ERR_FAIL_COND_V(p_dst_pos.y < 0 || (uint32_t)(p_dst_pos.y + p_data_dimensions.y) > height, ERR_INVALID_PARAMETER);
+		ERR_FAIL_COND_V(p_dst_pos.z < 0 || (uint32_t)(p_dst_pos.z + p_data_dimensions.z) > depth, ERR_INVALID_PARAMETER);
+	}
+
+	uint32_t data_width = p_data_dimensions.x;
+	uint32_t data_height = p_data_dimensions.y;
+	uint32_t data_depth = p_data_dimensions.z;
+	ERR_FAIL_COND_V(data_width <= 0 || data_height <= 0 || data_depth <= 0, ERR_INVALID_PARAMETER);
+
+	uint32_t required_size = get_image_format_required_size(texture->format, data_width, data_height, data_depth, 1);
+	ERR_FAIL_COND_V_MSG(p_data.size() != required_size, ERR_INVALID_PARAMETER, vformat("Required size for texture update (%d) does not match data supplied size (%d). The data supplied must be texture data with data_format=%s, width=%d, height=%d, depth=%d and mipmaps=1.", required_size, p_data.size(), RD::data_format_names[texture->format], data_width, data_height, data_depth));
+
+	_check_transfer_worker_texture(texture);
+
+	uint32_t block_w, block_h;
+	get_compressed_image_format_block_dimensions(texture->format, block_w, block_h);
+
+	uint32_t pixel_size = get_image_format_pixel_size(texture->format);
+	uint32_t pixel_rshift = get_compressed_image_format_pixel_rshift(texture->format);
+	uint32_t block_size = get_compressed_image_format_block_byte_size(texture->format);
+
+	uint32_t region_size = texture_upload_region_size_px;
+
+	const uint8_t *read_ptr = p_data.ptr();
+
+	thread_local LocalVector<RDG::RecordedBufferToTextureCopy> command_buffer_to_texture_copies_vector;
+	command_buffer_to_texture_copies_vector.clear();
+
+	// Indicate the texture will get modified for the shared texture fallback.
+	_texture_update_shared_fallback(p_texture, texture, true);
+
+	for (uint32_t z = 0; z < data_depth; z++) {
+		const uint8_t *read_ptr_depth_slice = read_ptr + (required_size / data_depth) * z;
+		for (uint32_t y = 0; y < data_height; y += region_size) {
+			for (uint32_t x = 0; x < data_width; x += region_size) {
+				uint32_t region_w = MIN(region_size, data_width - x);
+				uint32_t region_h = MIN(region_size, data_height - y);
+
+				uint32_t region_pitch = (region_w * pixel_size * block_w) >> pixel_rshift;
+				uint32_t pitch_step = driver->api_trait_get(RDD::API_TRAIT_TEXTURE_DATA_ROW_PITCH_STEP);
+				region_pitch = STEPIFY(region_pitch, pitch_step);
+				uint32_t to_allocate = region_pitch * region_h;
+				uint32_t alloc_offset = 0, alloc_size = 0;
+				StagingRequiredAction required_action;
+				Error err = _staging_buffer_allocate(upload_staging_buffers, to_allocate, required_align, alloc_offset, alloc_size, required_action, false);
+				ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
+
+				if (!command_buffer_to_texture_copies_vector.is_empty() && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL) {
+					if (_texture_make_mutable(texture, p_texture)) {
+						// The texture must be mutable to be used as a copy destination.
+						draw_graph.add_synchronization();
+					}
+
+					// If the staging buffer requires flushing everything, we submit the command early and clear the current vector.
+					draw_graph.add_texture_update(texture->driver_id, texture->draw_tracker, command_buffer_to_texture_copies_vector);
+					command_buffer_to_texture_copies_vector.clear();
+				}
+
+				_staging_buffer_execute_required_action(upload_staging_buffers, required_action);
+
+				uint8_t *write_ptr;
+
+				{ // Map.
+					uint8_t *data_ptr = driver->buffer_map(upload_staging_buffers.blocks[upload_staging_buffers.current].driver_id);
+					ERR_FAIL_NULL_V(data_ptr, ERR_CANT_CREATE);
+					write_ptr = data_ptr;
+					write_ptr += alloc_offset;
+				}
+
+				ERR_FAIL_COND_V(region_w % block_w, ERR_BUG);
+				ERR_FAIL_COND_V(region_h % block_h, ERR_BUG);
+
+				_copy_region_block_or_regular(read_ptr_depth_slice, write_ptr, x, y, data_width, region_w, region_h, block_w, block_h, region_pitch, pixel_size, block_size);
+
+				{ // Unmap.
+					driver->buffer_unmap(upload_staging_buffers.blocks[upload_staging_buffers.current].driver_id);
+				}
+
+				RDD::BufferTextureCopyRegion copy_region;
+				copy_region.buffer_offset = alloc_offset;
+				copy_region.texture_subresources.aspect = texture->read_aspect_flags;
+				copy_region.texture_subresources.mipmap = p_dst_mipmap;
+				copy_region.texture_subresources.base_layer = p_dst_layer;
+				copy_region.texture_subresources.layer_count = 1;
+				copy_region.texture_offset = Vector3i(x + p_dst_pos.x, y + p_dst_pos.y, z + p_dst_pos.z);
+				copy_region.texture_region_size = Vector3i(region_w, region_h, 1);
+
+				RDG::RecordedBufferToTextureCopy buffer_to_texture_copy;
+				buffer_to_texture_copy.from_buffer = upload_staging_buffers.blocks[upload_staging_buffers.current].driver_id;
+				buffer_to_texture_copy.region = copy_region;
+				command_buffer_to_texture_copies_vector.push_back(buffer_to_texture_copy);
+
+				upload_staging_buffers.blocks.write[upload_staging_buffers.current].fill_amount = alloc_offset + alloc_size;
+			}
+		}
+	}
+
+	if (_texture_make_mutable(texture, p_texture)) {
+		// The texture must be mutable to be used as a copy destination.
+		draw_graph.add_synchronization();
+	}
+
+	draw_graph.add_texture_update(texture->driver_id, texture->draw_tracker, command_buffer_to_texture_copies_vector);
+
+	return OK;
+}
+
+Error RenderingDevice::_texture_update_partial_bind(RID p_texture, uint32_t p_dst_layer, uint32_t p_dst_mipmap, Vector3i p_dst_pos, Vector3i p_data_dimensions, const Vector<uint8_t> &p_data) {
+	return texture_update_partial(p_texture, p_dst_layer, p_dst_mipmap, p_dst_pos, p_data_dimensions, p_data.span());
+}
+
 void RenderingDevice::_texture_check_shared_fallback(Texture *p_texture) {
 	if (p_texture->shared_fallback == nullptr) {
 		p_texture->shared_fallback = memnew(Texture::SharedFallback);
@@ -7345,6 +7485,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_create_from_extension", "type", "format", "samples", "usage_flags", "image", "width", "height", "depth", "layers", "mipmaps"), &RenderingDevice::texture_create_from_extension, DEFVAL(1));
 
 	ClassDB::bind_method(D_METHOD("texture_update", "texture", "layer", "data"), &RenderingDevice::texture_update);
+	ClassDB::bind_method(D_METHOD("texture_update_partial", "texture", "dst_layer", "dst_mipmap", "dst_pos", "data_dimensions", "data"), &RenderingDevice::_texture_update_partial_bind);
 	ClassDB::bind_method(D_METHOD("texture_get_data", "texture", "layer"), &RenderingDevice::texture_get_data);
 	ClassDB::bind_method(D_METHOD("texture_get_data_async", "texture", "layer", "callback"), &RenderingDevice::texture_get_data_async);
 
@@ -8108,6 +8249,11 @@ RenderingDevice::~RenderingDevice() {
 RenderingDevice::RenderingDevice() {
 	if (singleton == nullptr) {
 		singleton = this;
+		List<StringName> names;
+		ClassDB::get_enum_constants("RenderingDevice", "DataFormat", &names);
+		for (const StringName &name : names) {
+			data_format_names.push_back(name);
+		}
 	}
 
 	render_thread_id = Thread::get_caller_id();

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -8242,6 +8242,7 @@ RenderingDevice::~RenderingDevice() {
 	finalize();
 
 	if (singleton == this) {
+		data_format_names.clear(); // Avoid orphan StringNames.
 		singleton = nullptr;
 	}
 }

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -72,6 +72,7 @@ public:
 
 private:
 	static RenderingDevice *singleton;
+	static inline LocalVector<StringName> data_format_names;
 
 	RenderingContextDriver *context = nullptr;
 	RenderingDeviceDriver *driver = nullptr;
@@ -211,6 +212,8 @@ public:
 	Vector<uint8_t> buffer_get_data(RID p_buffer, uint32_t p_offset = 0, uint32_t p_size = 0); // This causes stall, only use to retrieve large buffers for saving.
 	Error buffer_get_data_async(RID p_buffer, const Callable &p_callback, uint32_t p_offset = 0, uint32_t p_size = 0);
 	uint64_t buffer_get_device_address(RID p_buffer);
+
+	Error texture_update_partial(RID p_texture, uint32_t p_layer, uint32_t p_mipmap, Vector3i p_dst_pos, Vector3i p_data_size, Span<uint8_t> p_data);
 
 private:
 	/******************/
@@ -398,6 +401,7 @@ public:
 	RID texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers, uint64_t p_mipmaps = 1);
 	RID texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, uint32_t p_mipmaps = 1, TextureSliceType p_slice_type = TEXTURE_SLICE_2D, uint32_t p_layers = 0);
 	Error texture_update(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data);
+	Error _texture_update_partial_bind(RID p_texture, uint32_t p_layer, uint32_t p_mipmap, Vector3i p_dst_pos, Vector3i p_data_size, const Vector<uint8_t> &p_data);
 	Vector<uint8_t> texture_get_data(RID p_texture, uint32_t p_layer); // CPU textures will return immediately, while GPU textures will most likely force a flush
 	Error texture_get_data_async(RID p_texture, uint32_t p_layer, const Callable &p_callback);
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -200,6 +200,7 @@ public:
 	//these go through command queue if they are in another thread
 	FUNC3(texture_2d_update, RID, const Ref<Image> &, int)
 	FUNC2(texture_3d_update, RID, const Vector<Ref<Image>> &)
+	FUNC7(texture_update_partial, RID, const Ref<Image> &, Rect2i, Vector2i, int, int, int)
 	FUNC4(texture_external_update, RID, int, int, uint64_t)
 	FUNC2(texture_proxy_update, RID, RID)
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -74,6 +74,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
+	virtual void texture_update_partial(RID p_texture, const Ref<Image> &p_image, Rect2i p_src_rect, Vector2i p_dst_pos, int p_dst_depth = 0, int p_dst_mipmap = 0, int p_dst_layer = 0) = 0;
 	virtual void texture_external_update(RID p_proxy, int p_width, int p_height, uint64_t p_external_buffer) = 0;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) = 0;
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2274,6 +2274,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("texture_2d_update", "texture", "image", "layer"), &RenderingServer::texture_2d_update);
 	ClassDB::bind_method(D_METHOD("texture_3d_update", "texture", "data"), &RenderingServer::_texture_3d_update);
+	ClassDB::bind_method(D_METHOD("texture_update_partial", "texture", "image", "src_rect", "dst_pos", "dst_depth", "dst_mipmap", "dst_layer"), &RenderingServer::texture_update_partial, DEFVAL(0), DEFVAL(0), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("texture_proxy_update", "texture", "proxy_to"), &RenderingServer::texture_proxy_update);
 
 	ClassDB::bind_method(D_METHOD("texture_2d_placeholder_create"), &RenderingServer::texture_2d_placeholder_create);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -143,6 +143,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
+	virtual void texture_update_partial(RID p_texture, const Ref<Image> &p_image, Rect2i p_src_rect, Vector2i p_dst_pos, int p_dst_depth = 0, int p_dst_mipmap = 0, int p_dst_layer = 0) = 0;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer = 0) = 0;
 	virtual void texture_proxy_update(RID p_texture, RID p_proxy_to) = 0;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13012. Closes #65762.

Supersedes #80164. Unlike it, this has `src_rect` and `depth` parameters. Theoretically this should support 2D, layered, and 3D textures, as well as compressed textures.

Test project: https://github.com/beicause/texture-update-partial-test
TODO:
- [x] test 2D texture and compressed 2D texture
- [x] test mipmaps
- [x] test layered texture
- [x] test 3D texture