### PR TITLE
Expose `get_fading_...` methods for `AnimationNodeStateMachinePlayback`

### DIFF
--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -40,10 +40,34 @@
 				Returns the playback position within the current animation state.
 			</description>
 		</method>
+		<method name="get_fading_from_length" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the playback state length of the node from [method get_fading_from_node]. Returns [code]0[/code] if no animation fade is occurring.
+			</description>
+		</method>
 		<method name="get_fading_from_node" qualifiers="const">
 			<return type="StringName" />
 			<description>
 				Returns the starting state of currently fading animation.
+			</description>
+		</method>
+		<method name="get_fading_from_play_position" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the playback position of the node from [method get_fading_from_node]. Returns [code]0[/code] if no animation fade is occurring.
+			</description>
+		</method>
+		<method name="get_fading_length" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the length of the current fade animation. Returns [code]0[/code] if no animation fade is occurring.
+			</description>
+		</method>
+		<method name="get_fading_position" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the playback position of the current fade animation. Returns [code]0[/code] if no animation fade is occurring.
 			</description>
 		</method>
 		<method name="get_travel_path" qualifiers="const">

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -1474,8 +1474,8 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 				fading_from_node = playback->get_fading_from_node();
 				current_play_pos = playback->get_current_play_pos();
 				current_length = playback->get_current_length();
-				fade_from_current_play_pos = playback->get_fade_from_play_pos();
-				fade_from_length = playback->get_fade_from_length();
+				fade_from_current_play_pos = playback->get_fading_from_play_pos();
+				fade_from_length = playback->get_fading_from_length();
 				fading_time = playback->get_fading_time();
 				fading_pos = playback->get_fading_pos();
 			}

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -334,11 +334,11 @@ float AnimationNodeStateMachinePlayback::get_current_length() const {
 	return current_nti.length;
 }
 
-float AnimationNodeStateMachinePlayback::get_fade_from_play_pos() const {
+float AnimationNodeStateMachinePlayback::get_fading_from_play_pos() const {
 	return fadeing_from_nti.position;
 }
 
-float AnimationNodeStateMachinePlayback::get_fade_from_length() const {
+float AnimationNodeStateMachinePlayback::get_fading_from_length() const {
 	return fadeing_from_nti.length;
 }
 
@@ -1215,6 +1215,10 @@ void AnimationNodeStateMachinePlayback::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_current_play_position"), &AnimationNodeStateMachinePlayback::get_current_play_pos);
 	ClassDB::bind_method(D_METHOD("get_current_length"), &AnimationNodeStateMachinePlayback::get_current_length);
 	ClassDB::bind_method(D_METHOD("get_fading_from_node"), &AnimationNodeStateMachinePlayback::get_fading_from_node);
+	ClassDB::bind_method(D_METHOD("get_fading_from_play_position"), &AnimationNodeStateMachinePlayback::get_fading_from_play_pos);
+	ClassDB::bind_method(D_METHOD("get_fading_from_length"), &AnimationNodeStateMachinePlayback::get_fading_from_length);
+	ClassDB::bind_method(D_METHOD("get_fading_position"), &AnimationNodeStateMachinePlayback::get_fading_pos);
+	ClassDB::bind_method(D_METHOD("get_fading_length"), &AnimationNodeStateMachinePlayback::get_fading_time);
 	ClassDB::bind_method(D_METHOD("get_travel_path"), &AnimationNodeStateMachinePlayback::_get_travel_path);
 
 	ADD_SIGNAL(MethodInfo(SceneStringName(state_started), PropertyInfo(Variant::STRING_NAME, "state")));

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -339,8 +339,8 @@ public:
 	float get_current_play_pos() const;
 	float get_current_length() const;
 
-	float get_fade_from_play_pos() const;
-	float get_fade_from_length() const;
+	float get_fading_from_play_pos() const;
+	float get_fading_from_length() const;
 
 	float get_fading_time() const;
 	float get_fading_pos() const;


### PR DESCRIPTION
This exposes a couple public getter functions from `AnimationNodeStateMachinePlayback`.

Their original PR (#71284) doesn't mention any reason for them not to be exposed, and I could definitely use them!

* `get_fading_from_length`/`get_fading_from_play_position` provide animation state information for the existing `get_fading_from_node`.
* `get_fading_length`/`get_fading_position` provide information of the animation's runtime "blending" state.