### PR TITLE
Refactor debugging on a device with DAP - now possible with all device types

### DIFF
--- a/editor/export/editor_export.cpp
+++ b/editor/export/editor_export.cpp
@@ -142,8 +142,18 @@ void EditorExport::remove_export_platform(const Ref<EditorExportPlatform> &p_pla
 	should_reload_presets = true;
 }
 
-int EditorExport::get_export_platform_count() {
+int EditorExport::get_export_platform_count() const {
 	return export_platforms.size();
+}
+
+int EditorExport::get_export_platform_index_by_name(const String &p_name) {
+	for (int j = 0; j < get_export_platform_count(); j++) {
+		Ref<EditorExportPlatform> plat = get_export_platform(j);
+		if (!plat.is_null() && plat->get_name().nocasecmp_to(p_name) == 0) {
+			return j;
+		}
+	}
+	return -1;
 }
 
 Ref<EditorExportPlatform> EditorExport::get_export_platform(int p_idx) {

--- a/editor/export/editor_export.h
+++ b/editor/export/editor_export.h
@@ -65,8 +65,14 @@ protected:
 public:
 	static EditorExport *get_singleton() { return singleton; }
 
+	// Encodes a platform/device pair into a single menu/device id and decodes it back.
+	static int encode_platform_device_id(int p_platform_idx, int p_device_idx) { return p_platform_idx * 10000 + p_device_idx; }
+	static int decode_platform_from_id(int p_id) { return p_id / 10000; }
+	static int decode_device_from_id(int p_id) { return p_id % 10000; }
+
 	void add_export_platform(const Ref<EditorExportPlatform> &p_platform);
-	int get_export_platform_count();
+	int get_export_platform_count() const;
+	int get_export_platform_index_by_name(const String &p_name);
 	Ref<EditorExportPlatform> get_export_platform(int p_idx);
 	void remove_export_platform(const Ref<EditorExportPlatform> &p_platform);
 

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -454,7 +454,7 @@ String EditorRunBar::get_playing_scene() const {
 	return run_filename;
 }
 
-Error EditorRunBar::start_native_device(int p_device_id) {
+Error EditorRunBar::start_native_device(int p_device_id) const {
 	return run_native->start_run_native(p_device_id);
 }
 

--- a/editor/run/editor_run_bar.h
+++ b/editor/run/editor_run_bar.h
@@ -121,7 +121,7 @@ public:
 	bool is_playing() const;
 	String get_playing_scene() const;
 
-	Error start_native_device(int p_device_id);
+	Error start_native_device(int p_device_id) const;
 
 	OS::ProcessID has_child_process(OS::ProcessID p_pid) const;
 	void stop_child_process(OS::ProcessID p_pid);

--- a/editor/run/editor_run_native.cpp
+++ b/editor/run/editor_run_native.cpp
@@ -55,20 +55,14 @@ void EditorRunNative::_notification(int p_what) {
 					if (eep.is_null()) {
 						continue;
 					}
-					int platform_idx = -1;
-					for (int j = 0; j < EditorExport::get_singleton()->get_export_platform_count(); j++) {
-						if (eep->get_name() == EditorExport::get_singleton()->get_export_platform(j)->get_name()) {
-							platform_idx = j;
-							break;
-						}
-					}
-					int dc = MIN(eep->get_options_count(), 9000);
+					const int platform_idx = EditorExport::get_singleton()->get_export_platform_index_by_name(eep->get_name());
+					const int device_count = MIN(eep->get_options_count(), 9000);
 					String error;
-					if (dc > 0 && preset->is_runnable()) {
+					if (device_count > 0 && preset->is_runnable()) {
 						popup->add_icon_item(eep->get_run_icon(), eep->get_name(), -1);
 						popup->set_item_disabled(-1, true);
-						for (int j = 0; j < dc; j++) {
-							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), 10000 * platform_idx + j);
+						for (int j = 0; j < device_count; j++) {
+							popup->add_icon_item(eep->get_option_icon(j), eep->get_option_label(j), EditorExport::encode_platform_device_id(platform_idx, j));
 							popup->set_item_tooltip(-1, eep->get_option_tooltip(j));
 							popup->set_item_indent(-1, 2);
 							if (device_shortcut_id <= 4 && eep->is_option_runnable(j)) {
@@ -99,12 +93,10 @@ void EditorRunNative::_confirm_run_native() {
 }
 
 Error EditorRunNative::start_run_native(int p_id) {
-	if (p_id < 0) {
-		return OK;
-	}
+	ERR_FAIL_COND_V(p_id < 0, FAILED);
 
-	int platform = p_id / 10000;
-	int idx = p_id % 10000;
+	const int platform = EditorExport::decode_platform_from_id(p_id);
+	const int idx = EditorExport::decode_device_from_id(p_id);
 	resume_id = p_id;
 
 	if (!EditorNode::get_singleton()->ensure_main_scene(true)) {


### PR DESCRIPTION
One click deploy, debug game on a device with DAP.
Supports all the devices, including Consoles (provided by W4Games).

Fixes https://github.com/godotengine/godot/issues/106969
Required for [RIDER-126274](https://youtrack.jetbrains.com/issue/RIDER-126274), [RIDER-127243](https://youtrack.jetbrains.com/issue/RIDER-127243/Integrate-One-click-deploy-feature)