### PR TITLE
 Use regularization flag for LODs of deformable objects to improve appearance post deformation

### DIFF
--- a/scene/resources/3d/importer_mesh.cpp
+++ b/scene/resources/3d/importer_mesh.cpp
@@ -341,6 +341,8 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 			}
 		}
 
+		bool deformable = bones.size() > 0 || blend_shapes.size() > 0;
+
 		if (bones.size() > 0 && weights.size() && bone_transform_vector.size() > 0) {
 			Vector3 *vertices_ptrw = vertices.ptrw();
 
@@ -482,7 +484,15 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, Array p_bone_transf
 			PackedInt32Array new_indices;
 			new_indices.resize(index_count);
 
-			const int simplify_options = SurfaceTool::SIMPLIFY_LOCK_BORDER;
+			int simplify_options = 0;
+
+			// Lock geometric boundary in case the mesh is composed of multiple material subsets.
+			simplify_options |= SurfaceTool::SIMPLIFY_LOCK_BORDER;
+
+			if (deformable) {
+				// Improves appearance of deformable objects after deformation by using more regular tessellation.
+				simplify_options |= SurfaceTool::SIMPLIFY_REGULARIZE;
+			}
 
 			size_t new_index_count = SurfaceTool::simplify_with_attrib_func(
 					(unsigned int *)new_indices.ptrw(),


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/84479
Closes https://github.com/godotengine/godot/issues/71141

When generating LODs for meshes that use skinning or blend shapes, we now use the new regularization option (available as of meshoptimizer 0.25). This results in the simplifier taking the distance along the original surface into account when computing simplification error, which biases the results to have a more uniform tessellation, accounting for deformation that is unknown at import time. This fixes two instances of severe LOD degradation (above) after a re-import; it also helps more regular character meshes in certain cases, for example here's a before-after on a mesh with a cape that was simplified too much previously (LOD selection exaggerated via project settings, ~same number of triangles before/after):

before | after
----------|--------
<img width="2790" height="1611" alt="image" src="https://github.com/user-attachments/assets/05779560-d2a5-4c26-81a2-8ed75336071a" /> | <img width="2790" height="1611" alt="image" src="https://github.com/user-attachments/assets/e2245eff-4eb0-4844-bb24-62a155f6f5c9" />
<img width="2790" height="1611" alt="image" src="https://github.com/user-attachments/assets/ca843ea8-84dd-4154-8b83-dd79bb8b6d8e" /> | <img width="2790" height="1611" alt="image" src="https://github.com/user-attachments/assets/a03c770e-8b01-4301-ab9f-781e21d0883f" />