### PR TITLE
Use vertex shader workaround for Mali GXX GPUs for glow shader

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/blur_raster.glsl
@@ -11,9 +11,22 @@ layout(location = 0) out vec2 uv_interp;
 /* clang-format on */
 
 void main() {
-	vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
-	gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
-	uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+	// old code, ARM driver bug on Mali-GXXx GPUs and Vulkan API 1.3.xxx
+	// https://github.com/godotengine/godot/pull/92817#issuecomment-2168625982
+	//vec2 base_arr[3] = vec2[](vec2(-1.0, -1.0), vec2(-1.0, 3.0), vec2(3.0, -1.0));
+	//gl_Position = vec4(base_arr[gl_VertexIndex], 0.0, 1.0);
+	//uv_interp = clamp(gl_Position.xy, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
+
+	vec2 vertex_base;
+	if (gl_VertexIndex == 0) {
+		vertex_base = vec2(-1.0, -1.0);
+	} else if (gl_VertexIndex == 1) {
+		vertex_base = vec2(-1.0, 3.0);
+	} else {
+		vertex_base = vec2(3.0, -1.0);
+	}
+	gl_Position = vec4(vertex_base, 0.0, 1.0);
+	uv_interp = clamp(vertex_base, vec2(0.0, 0.0), vec2(1.0, 1.0)) * 2.0; // saturate(x) * 2.0
 }
 
 /* clang-format off */


### PR DESCRIPTION
Fixes part of https://github.com/godotengine/godot/issues/98531

This applies the same workaround from https://github.com/godotengine/godot/pull/92817 to the glow shader. For whatever reason the devices we tested didn't trigger the compiler bug in this shader. But I have at least once device (Google Pixel 7) that triggers this bug. So it seems it is needed here too.

This is a really safe change, so let's sneak it into the 4.5 release