### PR TITLE
Add debug draw override to editor Game mode

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -925,6 +925,17 @@ EditorDebuggerNode::CameraOverride EditorDebuggerNode::get_camera_override() {
 	return camera_override;
 }
 
+void EditorDebuggerNode::set_debug_draw_override(Viewport::DebugDraw p_override) {
+	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+		dbg->set_debug_draw_override(p_override);
+	});
+	debug_draw_override = p_override;
+}
+
+Viewport::DebugDraw EditorDebuggerNode::get_debug_draw_override() {
+	return debug_draw_override;
+}
+
 void EditorDebuggerNode::add_debugger_plugin(const Ref<EditorDebuggerPlugin> &p_plugin) {
 	ERR_FAIL_COND_MSG(p_plugin.is_null(), "Debugger plugin is null.");
 	ERR_FAIL_COND_MSG(debugger_plugins.has(p_plugin), "Debugger plugin already exists.");

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -33,6 +33,7 @@
 #include "core/object/script_language.h"
 #include "editor/debugger/editor_debugger_server.h"
 #include "editor/docks/editor_dock.h"
+#include "scene/main/viewport.h"
 
 class Button;
 class DebugAdapterParser;
@@ -115,6 +116,7 @@ private:
 	bool debug_mute_audio = false;
 
 	CameraOverride camera_override = OVERRIDE_NONE;
+	Viewport::DebugDraw debug_draw_override = Viewport::DEBUG_DRAW_DISABLED;
 	HashMap<Breakpoint, bool, Breakpoint> breakpoints;
 
 	HashSet<Ref<EditorDebuggerPlugin>> debugger_plugins;
@@ -217,6 +219,9 @@ public:
 
 	void set_camera_override(CameraOverride p_override);
 	CameraOverride get_camera_override();
+
+	void set_debug_draw_override(Viewport::DebugDraw p_override);
+	Viewport::DebugDraw get_debug_draw_override();
 
 	String get_server_uri() const;
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1727,6 +1727,13 @@ void ScriptEditorDebugger::set_camera_override(CameraOverride p_override) {
 	camera_override = p_override;
 }
 
+void ScriptEditorDebugger::set_debug_draw_override(Viewport::DebugDraw p_override) {
+	Array msg = { p_override };
+	_put_msg("scene:override_debug_draw", msg);
+
+	debug_draw_override = p_override;
+}
+
 void ScriptEditorDebugger::set_breakpoint(const String &p_path, int p_line, bool p_enabled) {
 	Array msg = { p_path, p_line, p_enabled };
 	_put_msg("breakpoint", msg, debugging_thread_id != Thread::UNASSIGNED_ID ? debugging_thread_id : Thread::MAIN_ID);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -198,6 +198,7 @@ private:
 	void _send_debug_mute_audio_msg(bool p_mute);
 
 	EditorDebuggerNode::CameraOverride camera_override;
+	Viewport::DebugDraw debug_draw_override;
 
 	void _stack_dump_frame_selected();
 
@@ -373,6 +374,9 @@ public:
 
 	EditorDebuggerNode::CameraOverride get_camera_override() const;
 	void set_camera_override(EditorDebuggerNode::CameraOverride p_override);
+
+	Viewport::DebugDraw get_debug_draw_override() const;
+	void set_debug_draw_override(Viewport::DebugDraw p_override);
 
 	void set_breakpoint(const String &p_path, int p_line, bool p_enabled);
 

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/object/callable_mp.h"
+#include "core/os/os.h"
 #include "core/os/process_id.h"
 #include "core/string/translation_server.h"
 #include "editor/debugger/editor_debugger_node.h"
@@ -46,6 +47,7 @@
 #include "editor/run/editor_run_bar.h"
 #include "editor/run/embedded_process.h"
 #include "editor/run/run_instances_dialog.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
@@ -323,6 +325,11 @@ void GameViewDebugger::report_window_focused(bool p_focused) {
 	}
 }
 
+void GameViewDebugger::set_debug_draw_override(Viewport::DebugDraw p_mode) {
+	debug_draw_override = p_mode;
+	EditorDebuggerNode::get_singleton()->set_debug_draw_override(debug_draw_override);
+}
+
 void GameViewDebugger::reset_camera_2d_position() {
 	for (Ref<EditorDebuggerSession> &I : sessions) {
 		if (I->is_active()) {
@@ -558,6 +565,9 @@ void GameView::_play_pressed() {
 	if (!window_wrapper->get_window_enabled()) {
 		screen_index_before_start = EditorNode::get_singleton()->get_editor_main_screen()->get_selected_index();
 	}
+
+	// Reset debug draw indication to Normal, as it doesn't persist across game restarts.
+	_debug_draw_override_menu_id_pressed(Node3DEditorViewport::VIEW_DISPLAY_NORMAL);
 
 	if (embed_on_play && _get_embed_available() == EMBED_AVAILABLE) {
 		// It's important to disable the low power mode when unfocused because otherwise
@@ -1084,6 +1094,14 @@ void GameView::_camera_override_button_toggled(bool p_pressed) {
 	debugger->set_camera_override(p_pressed);
 }
 
+void GameView::_debug_draw_override_menu_id_pressed(int p_id) {
+	Node3DEditorViewport::select_debug_draw_mode(p_id, debug_draw_override_menu, debug_draw_override_advanced_submenu, callable_mp(this, &GameView::_set_debug_draw_mode));
+}
+
+void GameView::_set_debug_draw_mode(Viewport::DebugDraw p_mode) {
+	debugger->set_debug_draw_override(p_mode);
+}
+
 void GameView::_camera_override_menu_id_pressed(int p_id) {
 	PopupMenu *menu = camera_override_menu->get_popup();
 	if (p_id != CAMERA_RESET_2D && p_id != CAMERA_RESET_3D) {
@@ -1122,6 +1140,44 @@ void GameView::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			select_mode_button[RuntimeNodeSelect::SELECT_MODE_SINGLE]->set_tooltip_text(vformat(TTR("%s+Alt+RMB: Show list of all nodes at position clicked."), keycode_get_string((Key)KeyModifierMask::CMD_OR_CTRL)));
+
+			const int item_count = debug_draw_override_advanced_submenu->get_item_count();
+			for (int i = 0; i < item_count; i++) {
+				const Array item_data = debug_draw_override_advanced_submenu->get_item_metadata(i);
+				if (item_data.is_empty()) {
+					continue;
+				}
+
+				Node3DEditorViewport::SupportedRenderingMethods rendering_methods = item_data[0];
+				String base_tooltip = item_data[1];
+
+				bool disabled = false;
+				String disabled_tooltip;
+				switch (rendering_methods) {
+					case Node3DEditorViewport::SupportedRenderingMethods::ALL:
+						break;
+					case Node3DEditorViewport::SupportedRenderingMethods::FORWARD_PLUS_MOBILE:
+						disabled = OS::get_singleton()->get_current_rendering_method() == "gl_compatibility";
+						disabled_tooltip = TTR("This debug draw mode is not supported when using the Compatibility renderer.");
+						break;
+					case Node3DEditorViewport::SupportedRenderingMethods::FORWARD_PLUS:
+						disabled = OS::get_singleton()->get_current_rendering_method() == "gl_compatibility" || OS::get_singleton()->get_current_rendering_method() == "mobile";
+						disabled_tooltip = TTR("This debug draw mode is not supported when using the Mobile or Compatibility renderer.");
+						break;
+				}
+
+				debug_draw_override_advanced_submenu->set_item_disabled(i, disabled);
+				String tooltip = TTR(base_tooltip);
+				if (disabled) {
+					if (tooltip.is_empty()) {
+						tooltip = disabled_tooltip;
+					} else {
+						tooltip += "\n\n" + disabled_tooltip;
+					}
+				}
+				debug_draw_override_advanced_submenu->set_item_tooltip(i, tooltip);
+			}
+
 			_update_ui();
 		} break;
 
@@ -1153,6 +1209,9 @@ void GameView::_notification(int p_what) {
 
 			_update_speed_state_size();
 			_update_speed_state_color();
+
+			// Debug draw override is mostly relevant for 3D, so use a 3D-colored icon.
+			debug_draw_override_menu->set_button_icon(get_editor_theme_icon(SNAME("MeshInstance3D")));
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -1429,6 +1488,7 @@ void GameView::_feature_profile_changed() {
 		_node_type_pressed(RuntimeNodeSelect::NODE_TYPE_NONE);
 	}
 	node_type_button[RuntimeNodeSelect::NODE_TYPE_3D]->set_visible(is_3d_enabled);
+	debug_draw_override_menu->set_visible(is_3d_enabled);
 }
 
 GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embedded_process, WindowWrapper *p_wrapper) {
@@ -1571,16 +1631,23 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 
 	selection_hb->add_child(memnew(VSeparator));
 
-	HBoxContainer *audio_hb = memnew(HBoxContainer);
-	main_menu_fc->add_child(audio_hb);
+	HBoxContainer *audio_debug_draw_hb = memnew(HBoxContainer);
+	main_menu_fc->add_child(audio_debug_draw_hb);
 
 	debug_mute_audio_button = memnew(Button);
-	audio_hb->add_child(debug_mute_audio_button);
+	audio_debug_draw_hb->add_child(debug_mute_audio_button);
 	debug_mute_audio_button->set_theme_type_variation("FlatButton");
 	debug_mute_audio_button->connect(SceneStringName(pressed), callable_mp(this, &GameView::_debug_mute_audio_button_pressed));
 	debug_mute_audio_button->set_tooltip_text(debug_mute_audio ? TTRC("Unmute game audio.") : TTRC("Mute game audio."));
 
-	audio_hb->add_child(memnew(VSeparator));
+	debug_draw_override_menu = memnew(MenuButton);
+	audio_debug_draw_hb->add_child(debug_draw_override_menu);
+	debug_draw_override_menu->set_flat(false);
+	debug_draw_override_menu->set_theme_type_variation("FlatMenuButtonNoIconTint");
+	debug_draw_override_menu->set_h_size_flags(SIZE_SHRINK_END);
+	debug_draw_override_menu->set_tooltip_text(TTRC("Debug Draw Options"));
+
+	audio_debug_draw_hb->add_child(memnew(VSeparator));
 
 	HBoxContainer *camera_hb = memnew(HBoxContainer);
 	main_menu_fc->add_child(camera_hb);
@@ -1591,6 +1658,19 @@ GameView::GameView(Ref<GameViewDebugger> p_debugger, EmbeddedProcessBase *p_embe
 	camera_override_button->set_theme_type_variation(SceneStringName(FlatButton));
 	camera_override_button->set_tooltip_text(TTRC("Override the in-game camera."));
 	camera_override_button->connect(SceneStringName(toggled), callable_mp(this, &GameView::_camera_override_button_toggled));
+
+	PopupMenu *debug_draw_override_popup = debug_draw_override_menu->get_popup();
+	debug_draw_override_popup->set_hide_on_checkable_item_selection(false);
+	debug_draw_override_popup->connect(SceneStringName(id_pressed), callable_mp(this, &GameView::_debug_draw_override_menu_id_pressed));
+	debug_draw_override_popup->add_radio_check_item(TTRC("Display Normal"), Node3DEditorViewport::VIEW_DISPLAY_NORMAL);
+	debug_draw_override_popup->set_item_checked(debug_draw_override_popup->get_item_index(Node3DEditorViewport::VIEW_DISPLAY_NORMAL), true);
+	debug_draw_override_popup->add_radio_check_item(TTRC("Display Wireframe"), Node3DEditorViewport::VIEW_DISPLAY_WIREFRAME);
+	debug_draw_override_popup->add_radio_check_item(TTRC("Display Overdraw"), Node3DEditorViewport::VIEW_DISPLAY_OVERDRAW);
+	debug_draw_override_popup->add_radio_check_item(TTRC("Display Lighting"), Node3DEditorViewport::VIEW_DISPLAY_LIGHTING);
+	debug_draw_override_popup->add_radio_check_item(TTRC("Display Unshaded"), Node3DEditorViewport::VIEW_DISPLAY_UNSHADED);
+	debug_draw_override_advanced_submenu = Node3DEditorViewport::get_advanced_debug_draw_menu();
+	debug_draw_override_advanced_submenu->connect(SceneStringName(id_pressed), callable_mp(this, &GameView::_debug_draw_override_menu_id_pressed));
+	debug_draw_override_popup->add_submenu_node_item(TTRC("Display Advanced..."), debug_draw_override_advanced_submenu, Node3DEditorViewport::VIEW_DISPLAY_ADVANCED);
 
 	camera_override_menu = memnew(MenuButton);
 	camera_hb->add_child(camera_override_menu);

--- a/editor/run/game_view_plugin.h
+++ b/editor/run/game_view_plugin.h
@@ -54,6 +54,7 @@ private:
 	int select_mode = RuntimeNodeSelect::SELECT_MODE_SINGLE;
 	bool mute_audio = false;
 	EditorDebuggerNode::CameraOverride camera_override_mode = EditorDebuggerNode::OVERRIDE_INGAME;
+	Viewport::DebugDraw debug_draw_override = Viewport::DEBUG_DRAW_DISABLED;
 
 	bool selection_avoid_locked = false;
 	bool selection_prefer_group = false;
@@ -107,6 +108,8 @@ public:
 	void set_camera_manipulate_mode(EditorDebuggerNode::CameraOverride p_mode);
 
 	void report_window_focused(bool p_focused);
+
+	void set_debug_draw_override(Viewport::DebugDraw p_mode);
 
 	void reset_camera_2d_position();
 	void reset_camera_3d_position();
@@ -168,6 +171,7 @@ class GameView : public VBoxContainer {
 	EmbedSizeMode embed_size_mode = SIZE_MODE_FIXED;
 	bool paused = false;
 	Size2 size_paused;
+	Viewport::DebugDraw debug_draw_override = Viewport::DEBUG_DRAW_DISABLED;
 
 	Rect2i floating_window_rect;
 	int floating_window_screen = -1;
@@ -190,6 +194,8 @@ class GameView : public VBoxContainer {
 
 	Button *camera_override_button = nullptr;
 	MenuButton *camera_override_menu = nullptr;
+	MenuButton *debug_draw_override_menu = nullptr;
+	PopupMenu *debug_draw_override_advanced_submenu = nullptr;
 
 	HBoxContainer *embedding_hb = nullptr;
 	MenuButton *game_window_options_menu = nullptr;
@@ -262,6 +268,9 @@ class GameView : public VBoxContainer {
 
 	void _camera_override_button_toggled(bool p_pressed);
 	void _camera_override_menu_id_pressed(int p_id);
+
+	void _debug_draw_override_menu_id_pressed(int p_id);
+	void _set_debug_draw_mode(Viewport::DebugDraw p_mode);
 
 	void _window_close_request();
 	void _update_floating_window_settings();

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4665,87 +4665,98 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 		case VIEW_DISPLAY_DEBUG_OCCLUDERS:
 		case VIEW_DISPLAY_MOTION_VECTORS:
 		case VIEW_DISPLAY_INTERNAL_BUFFER: {
-			static const int display_options[] = {
-				VIEW_DISPLAY_NORMAL,
-				VIEW_DISPLAY_WIREFRAME,
-				VIEW_DISPLAY_OVERDRAW,
-				VIEW_DISPLAY_UNSHADED,
-				VIEW_DISPLAY_LIGHTING,
-				VIEW_DISPLAY_NORMAL_BUFFER,
-				VIEW_DISPLAY_DEBUG_SHADOW_ATLAS,
-				VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS,
-				VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO,
-				VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING,
-				VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION,
-				VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE,
-				VIEW_DISPLAY_DEBUG_SSAO,
-				VIEW_DISPLAY_DEBUG_SSIL,
-				VIEW_DISPLAY_DEBUG_GI_BUFFER,
-				VIEW_DISPLAY_DEBUG_DISABLE_LOD,
-				VIEW_DISPLAY_DEBUG_PSSM_SPLITS,
-				VIEW_DISPLAY_DEBUG_DECAL_ATLAS,
-				VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS,
-				VIEW_DISPLAY_DEBUG_SDFGI,
-				VIEW_DISPLAY_DEBUG_SDFGI_PROBES,
-				VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS,
-				VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS,
-				VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS,
-				VIEW_DISPLAY_DEBUG_CLUSTER_DECALS,
-				VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES,
-				VIEW_DISPLAY_DEBUG_OCCLUDERS,
-				VIEW_DISPLAY_MOTION_VECTORS,
-				VIEW_DISPLAY_INTERNAL_BUFFER,
-				VIEW_MAX
-			};
-			static const Viewport::DebugDraw debug_draw_modes[] = {
-				Viewport::DEBUG_DRAW_DISABLED,
-				Viewport::DEBUG_DRAW_WIREFRAME,
-				Viewport::DEBUG_DRAW_OVERDRAW,
-				Viewport::DEBUG_DRAW_UNSHADED,
-				Viewport::DEBUG_DRAW_LIGHTING,
-				Viewport::DEBUG_DRAW_NORMAL_BUFFER,
-				Viewport::DEBUG_DRAW_SHADOW_ATLAS,
-				Viewport::DEBUG_DRAW_DIRECTIONAL_SHADOW_ATLAS,
-				Viewport::DEBUG_DRAW_VOXEL_GI_ALBEDO,
-				Viewport::DEBUG_DRAW_VOXEL_GI_LIGHTING,
-				Viewport::DEBUG_DRAW_VOXEL_GI_EMISSION,
-				Viewport::DEBUG_DRAW_SCENE_LUMINANCE,
-				Viewport::DEBUG_DRAW_SSAO,
-				Viewport::DEBUG_DRAW_SSIL,
-				Viewport::DEBUG_DRAW_GI_BUFFER,
-				Viewport::DEBUG_DRAW_DISABLE_LOD,
-				Viewport::DEBUG_DRAW_PSSM_SPLITS,
-				Viewport::DEBUG_DRAW_DECAL_ATLAS,
-				Viewport::DEBUG_DRAW_AREA_LIGHT_ATLAS,
-				Viewport::DEBUG_DRAW_SDFGI,
-				Viewport::DEBUG_DRAW_SDFGI_PROBES,
-				Viewport::DEBUG_DRAW_CLUSTER_OMNI_LIGHTS,
-				Viewport::DEBUG_DRAW_CLUSTER_SPOT_LIGHTS,
-				Viewport::DEBUG_DRAW_CLUSTER_AREA_LIGHTS,
-				Viewport::DEBUG_DRAW_CLUSTER_DECALS,
-				Viewport::DEBUG_DRAW_CLUSTER_REFLECTION_PROBES,
-				Viewport::DEBUG_DRAW_OCCLUDERS,
-				Viewport::DEBUG_DRAW_MOTION_VECTORS,
-				Viewport::DEBUG_DRAW_INTERNAL_BUFFER,
-			};
-
-			for (int idx = 0; display_options[idx] != VIEW_MAX; idx++) {
-				int id = display_options[idx];
-				int item_idx = view_display_menu->get_popup()->get_item_index(id);
-				if (item_idx != -1) {
-					view_display_menu->get_popup()->set_item_checked(item_idx, id == p_option);
-				}
-				item_idx = display_submenu->get_item_index(id);
-				if (item_idx != -1) {
-					display_submenu->set_item_checked(item_idx, id == p_option);
-				}
-
-				if (id == p_option) {
-					viewport->set_debug_draw(debug_draw_modes[idx]);
-				}
-			}
+			select_debug_draw_mode(p_option, view_display_menu, display_submenu, callable_mp(this, &Node3DEditorViewport::set_debug_draw_mode));
 		} break;
 	}
+}
+
+void Node3DEditorViewport::select_debug_draw_mode(int p_option, MenuButton *p_view_display_menu, PopupMenu *p_display_submenu, Callable p_callable) {
+	static const int display_options[] = {
+		VIEW_DISPLAY_NORMAL,
+		VIEW_DISPLAY_WIREFRAME,
+		VIEW_DISPLAY_OVERDRAW,
+		VIEW_DISPLAY_UNSHADED,
+		VIEW_DISPLAY_LIGHTING,
+		VIEW_DISPLAY_NORMAL_BUFFER,
+		VIEW_DISPLAY_DEBUG_SHADOW_ATLAS,
+		VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS,
+		VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO,
+		VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING,
+		VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION,
+		VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE,
+		VIEW_DISPLAY_DEBUG_SSAO,
+		VIEW_DISPLAY_DEBUG_SSIL,
+		VIEW_DISPLAY_DEBUG_GI_BUFFER,
+		VIEW_DISPLAY_DEBUG_DISABLE_LOD,
+		VIEW_DISPLAY_DEBUG_PSSM_SPLITS,
+		VIEW_DISPLAY_DEBUG_DECAL_ATLAS,
+		VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS,
+		VIEW_DISPLAY_DEBUG_SDFGI,
+		VIEW_DISPLAY_DEBUG_SDFGI_PROBES,
+		VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS,
+		VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS,
+		VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS,
+		VIEW_DISPLAY_DEBUG_CLUSTER_DECALS,
+		VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES,
+		VIEW_DISPLAY_DEBUG_OCCLUDERS,
+		VIEW_DISPLAY_MOTION_VECTORS,
+		VIEW_DISPLAY_INTERNAL_BUFFER,
+		VIEW_MAX
+	};
+	static const Viewport::DebugDraw debug_draw_modes[] = {
+		Viewport::DEBUG_DRAW_DISABLED,
+		Viewport::DEBUG_DRAW_WIREFRAME,
+		Viewport::DEBUG_DRAW_OVERDRAW,
+		Viewport::DEBUG_DRAW_UNSHADED,
+		Viewport::DEBUG_DRAW_LIGHTING,
+		Viewport::DEBUG_DRAW_NORMAL_BUFFER,
+		Viewport::DEBUG_DRAW_SHADOW_ATLAS,
+		Viewport::DEBUG_DRAW_DIRECTIONAL_SHADOW_ATLAS,
+		Viewport::DEBUG_DRAW_VOXEL_GI_ALBEDO,
+		Viewport::DEBUG_DRAW_VOXEL_GI_LIGHTING,
+		Viewport::DEBUG_DRAW_VOXEL_GI_EMISSION,
+		Viewport::DEBUG_DRAW_SCENE_LUMINANCE,
+		Viewport::DEBUG_DRAW_SSAO,
+		Viewport::DEBUG_DRAW_SSIL,
+		Viewport::DEBUG_DRAW_GI_BUFFER,
+		Viewport::DEBUG_DRAW_DISABLE_LOD,
+		Viewport::DEBUG_DRAW_PSSM_SPLITS,
+		Viewport::DEBUG_DRAW_DECAL_ATLAS,
+		Viewport::DEBUG_DRAW_AREA_LIGHT_ATLAS,
+		Viewport::DEBUG_DRAW_SDFGI,
+		Viewport::DEBUG_DRAW_SDFGI_PROBES,
+		Viewport::DEBUG_DRAW_CLUSTER_OMNI_LIGHTS,
+		Viewport::DEBUG_DRAW_CLUSTER_SPOT_LIGHTS,
+		Viewport::DEBUG_DRAW_CLUSTER_AREA_LIGHTS,
+		Viewport::DEBUG_DRAW_CLUSTER_DECALS,
+		Viewport::DEBUG_DRAW_CLUSTER_REFLECTION_PROBES,
+		Viewport::DEBUG_DRAW_OCCLUDERS,
+		Viewport::DEBUG_DRAW_MOTION_VECTORS,
+		Viewport::DEBUG_DRAW_INTERNAL_BUFFER,
+	};
+
+	for (int idx = 0; display_options[idx] != VIEW_MAX; idx++) {
+		int id = display_options[idx];
+		int item_idx = p_view_display_menu->get_popup()->get_item_index(id);
+		if (item_idx != -1) {
+			p_view_display_menu->get_popup()->set_item_checked(item_idx, id == p_option);
+		}
+		item_idx = p_display_submenu->get_item_index(id);
+		if (item_idx != -1) {
+			p_display_submenu->set_item_checked(item_idx, id == p_option);
+		}
+
+		if (id == p_option) {
+			// Call the provided callable to set the debug draw mode.
+			// The game view relies on the debugger protocol to set the debug draw mode,
+			// so we can't pass a Viewport instance directly.
+			p_callable.call(debug_draw_modes[idx]);
+		}
+	}
+}
+
+void Node3DEditorViewport::set_debug_draw_mode(Viewport::DebugDraw p_mode) {
+	viewport->set_debug_draw(p_mode);
 }
 
 void Node3DEditorViewport::_preview_exited_scene() {
@@ -6706,9 +6717,72 @@ void Node3DEditorViewport::_set_lock_view_rotation(bool p_lock_rotation) {
 }
 
 void Node3DEditorViewport::_add_advanced_debug_draw_mode_item(PopupMenu *p_popup, const String &p_name, int p_value, SupportedRenderingMethods p_rendering_methods, const String &p_tooltip) {
-	display_submenu->add_radio_check_item(p_name, p_value);
+	p_popup->add_radio_check_item(p_name, p_value);
 	Array item_data = { p_rendering_methods, p_tooltip };
-	display_submenu->set_item_metadata(-1, item_data); // Tooltip is assigned in NOTIFICATION_TRANSLATION_CHANGED.
+	p_popup->set_item_metadata(-1, item_data); // Tooltip is assigned in NOTIFICATION_TRANSLATION_CHANGED.
+}
+
+PopupMenu *Node3DEditorViewport::get_advanced_debug_draw_menu() {
+	PopupMenu *display_submenu = memnew(PopupMenu);
+	display_submenu->set_hide_on_checkable_item_selection(false);
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Splits"), VIEW_DISPLAY_DEBUG_PSSM_SPLITS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Displays directional shadow splits in different colors to make adjusting split thresholds easier. \nRed: 1st split (closest to the camera), Green: 2nd split, Blue: 3rd split, Yellow: 4th split (furthest from the camera)"));
+	display_submenu->add_separator();
+	// TRANSLATORS: "Normal" as in "normal vector", not "normal life".
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Normal Buffer"), VIEW_DISPLAY_NORMAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS);
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Shadow Atlas"), VIEW_DISPLAY_DEBUG_SHADOW_ATLAS, SupportedRenderingMethods::ALL,
+			TTRC("Displays the shadow atlas used for positional (omni/spot) shadow mapping.\nRequires a visible OmniLight3D or SpotLight3D node with shadows enabled to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Map"), VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS, SupportedRenderingMethods::ALL,
+			TTRC("Displays the shadow map used for directional shadow mapping.\nRequires a visible DirectionalLight3D node with shadows enabled to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Decal Atlas"), VIEW_DISPLAY_DEBUG_DECAL_ATLAS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE);
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("AreaLight3D Atlas"), VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE);
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Lighting"), VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Albedo"), VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Emission"), VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SDFGI Cascades"), VIEW_DISPLAY_DEBUG_SDFGI, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires SDFGI to be enabled in Environment to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SDFGI Probes"), VIEW_DISPLAY_DEBUG_SDFGI_PROBES, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires SDFGI to be enabled in Environment to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Scene Luminance"), VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Displays the scene luminance computed from the 3D buffer. This is used for Auto Exposure calculation.\nRequires Auto Exposure to be enabled in CameraAttributes to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SSAO"), VIEW_DISPLAY_DEBUG_SSAO, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Displays the screen-space ambient occlusion buffer. Requires SSAO to be enabled in Environment to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SSIL"), VIEW_DISPLAY_DEBUG_SSIL, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Displays the screen-space indirect lighting buffer. Requires SSIL to be enabled in Environment to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI/SDFGI Buffer"), VIEW_DISPLAY_DEBUG_GI_BUFFER, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Requires SDFGI or VoxelGI to be enabled to have a visible effect."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Disable Mesh LOD"), VIEW_DISPLAY_DEBUG_DISABLE_LOD, SupportedRenderingMethods::ALL,
+			TTRC("Renders all meshes with their highest level of detail regardless of their distance from the camera."));
+	display_submenu->add_separator();
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("OmniLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one OmniLight3D. Warmer colors are used to indicate tiles affected by more lights."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SpotLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one SpotLight3D. Warmer colors are used to indicate tiles affected by more lights."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("AreaLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one AreaLight3D. Warmer colors are used to indicate tiles affected by more lights."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Decal Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_DECALS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one Decal."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("ReflectionProbe Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Highlights tiles of pixels that are affected by at least one ReflectionProbe."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Occlusion Culling Buffer"), VIEW_DISPLAY_DEBUG_OCCLUDERS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Represents occluders with black pixels. Requires occlusion culling to be enabled to have a visible effect."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Motion Vectors"), VIEW_DISPLAY_MOTION_VECTORS, SupportedRenderingMethods::FORWARD_PLUS,
+			TTRC("Represents motion vectors with colored lines in the direction of motion. Gray dots represent areas with no per-pixel motion."));
+	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Internal Buffer"), VIEW_DISPLAY_INTERNAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
+			TTRC("Shows the scene rendered in linear colorspace before any tonemapping or post-processing."));
+
+	return display_submenu;
 }
 
 void Node3DEditorViewport::_load_viewport_inputs() {
@@ -6815,64 +6889,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/view_display_unshaded", TTRC("Display Unshaded")), VIEW_DISPLAY_UNSHADED);
 	view_display_menu->get_popup()->set_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_DISPLAY_NORMAL), true);
 
-	display_submenu = memnew(PopupMenu);
-	display_submenu->set_hide_on_checkable_item_selection(false);
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Splits"), VIEW_DISPLAY_DEBUG_PSSM_SPLITS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
-			TTRC("Displays directional shadow splits in different colors to make adjusting split thresholds easier. \nRed: 1st split (closest to the camera), Green: 2nd split, Blue: 3rd split, Yellow: 4th split (furthest from the camera)"));
-	display_submenu->add_separator();
-	// TRANSLATORS: "Normal" as in "normal vector", not "normal life".
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Normal Buffer"), VIEW_DISPLAY_NORMAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS);
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Shadow Atlas"), VIEW_DISPLAY_DEBUG_SHADOW_ATLAS, SupportedRenderingMethods::ALL,
-			TTRC("Displays the shadow atlas used for positional (omni/spot) shadow mapping.\nRequires a visible OmniLight3D or SpotLight3D node with shadows enabled to have a visible effect."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Directional Shadow Map"), VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS, SupportedRenderingMethods::ALL,
-			TTRC("Displays the shadow map used for directional shadow mapping.\nRequires a visible DirectionalLight3D node with shadows enabled to have a visible effect."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Decal Atlas"), VIEW_DISPLAY_DEBUG_DECAL_ATLAS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE);
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("AreaLight3D Atlas"), VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE);
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Lighting"), VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Albedo"), VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI Emission"), VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Requires a visible VoxelGI node that has been baked to have a visible effect."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SDFGI Cascades"), VIEW_DISPLAY_DEBUG_SDFGI, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Requires SDFGI to be enabled in Environment to have a visible effect."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SDFGI Probes"), VIEW_DISPLAY_DEBUG_SDFGI_PROBES, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Left-click a SDFGI probe to display its occlusion information (white = not occluded, red = fully occluded).\nRequires SDFGI to be enabled in Environment to have a visible effect."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Scene Luminance"), VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
-			TTRC("Displays the scene luminance computed from the 3D buffer. This is used for Auto Exposure calculation.\nRequires Auto Exposure to be enabled in CameraAttributes to have a visible effect."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SSAO"), VIEW_DISPLAY_DEBUG_SSAO, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Displays the screen-space ambient occlusion buffer. Requires SSAO to be enabled in Environment to have a visible effect."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SSIL"), VIEW_DISPLAY_DEBUG_SSIL, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Displays the screen-space indirect lighting buffer. Requires SSIL to be enabled in Environment to have a visible effect."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("VoxelGI/SDFGI Buffer"), VIEW_DISPLAY_DEBUG_GI_BUFFER, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Requires SDFGI or VoxelGI to be enabled to have a visible effect."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Disable Mesh LOD"), VIEW_DISPLAY_DEBUG_DISABLE_LOD, SupportedRenderingMethods::ALL,
-			TTRC("Renders all meshes with their highest level of detail regardless of their distance from the camera."));
-	display_submenu->add_separator();
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("OmniLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Highlights tiles of pixels that are affected by at least one OmniLight3D."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("SpotLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Highlights tiles of pixels that are affected by at least one SpotLight3D."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("AreaLight3D Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Highlights tiles of pixels that are affected by at least one AreaLight3D."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Decal Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_DECALS, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Highlights tiles of pixels that are affected by at least one Decal."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("ReflectionProbe Cluster"), VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Highlights tiles of pixels that are affected by at least one ReflectionProbe."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Occlusion Culling Buffer"), VIEW_DISPLAY_DEBUG_OCCLUDERS, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
-			TTRC("Represents occluders with black pixels. Requires occlusion culling to be enabled to have a visible effect."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Motion Vectors"), VIEW_DISPLAY_MOTION_VECTORS, SupportedRenderingMethods::FORWARD_PLUS,
-			TTRC("Represents motion vectors with colored lines in the direction of motion. Gray dots represent areas with no per-pixel motion."));
-	_add_advanced_debug_draw_mode_item(display_submenu, TTRC("Internal Buffer"), VIEW_DISPLAY_INTERNAL_BUFFER, SupportedRenderingMethods::FORWARD_PLUS_MOBILE,
-			TTRC("Shows the scene rendered in linear colorspace before any tonemapping or post-processing."));
+	display_submenu = Node3DEditorViewport::get_advanced_debug_draw_menu();
 	view_display_menu->get_popup()->add_submenu_node_item(TTRC("Display Advanced..."), display_submenu, VIEW_DISPLAY_ADVANCED);
 
 	view_display_menu->get_popup()->add_separator();

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -115,6 +115,8 @@ class Node3DEditorViewport : public Control {
 	friend class Node3DEditor;
 	friend class ViewportNavigationControl;
 	friend class ViewportRotationControl;
+
+public:
 	enum {
 		VIEW_TOP,
 		VIEW_BOTTOM,
@@ -140,38 +142,38 @@ class Node3DEditorViewport : public Control {
 		VIEW_FRAME_TIME,
 
 		// < Keep in sync with menu.
-		VIEW_DISPLAY_NORMAL,
-		VIEW_DISPLAY_WIREFRAME,
-		VIEW_DISPLAY_OVERDRAW,
-		VIEW_DISPLAY_LIGHTING,
-		VIEW_DISPLAY_UNSHADED,
-		VIEW_DISPLAY_ADVANCED,
+		VIEW_DISPLAY_NORMAL = 100,
+		VIEW_DISPLAY_WIREFRAME = 101,
+		VIEW_DISPLAY_OVERDRAW = 102,
+		VIEW_DISPLAY_LIGHTING = 103,
+		VIEW_DISPLAY_UNSHADED = 104,
+		VIEW_DISPLAY_ADVANCED = 105,
 		// Advanced menu:
-		VIEW_DISPLAY_DEBUG_PSSM_SPLITS,
-		VIEW_DISPLAY_NORMAL_BUFFER,
-		VIEW_DISPLAY_DEBUG_SHADOW_ATLAS,
-		VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS,
-		VIEW_DISPLAY_DEBUG_DECAL_ATLAS,
-		VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS,
-		VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO,
-		VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING,
-		VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION,
-		VIEW_DISPLAY_DEBUG_SDFGI,
-		VIEW_DISPLAY_DEBUG_SDFGI_PROBES,
-		VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE,
-		VIEW_DISPLAY_DEBUG_SSAO,
-		VIEW_DISPLAY_DEBUG_SSIL,
-		VIEW_DISPLAY_DEBUG_GI_BUFFER,
-		VIEW_DISPLAY_DEBUG_DISABLE_LOD,
-		VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS,
-		VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS,
-		VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS,
-		VIEW_DISPLAY_DEBUG_CLUSTER_DECALS,
-		VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES,
-		VIEW_DISPLAY_DEBUG_OCCLUDERS,
-		VIEW_DISPLAY_MOTION_VECTORS,
-		VIEW_DISPLAY_INTERNAL_BUFFER,
-		VIEW_DISPLAY_MAX,
+		VIEW_DISPLAY_DEBUG_PSSM_SPLITS = 106,
+		VIEW_DISPLAY_NORMAL_BUFFER = 107,
+		VIEW_DISPLAY_DEBUG_SHADOW_ATLAS = 108,
+		VIEW_DISPLAY_DEBUG_DIRECTIONAL_SHADOW_ATLAS = 109,
+		VIEW_DISPLAY_DEBUG_DECAL_ATLAS = 110,
+		VIEW_DISPLAY_DEBUG_AREA_LIGHT_ATLAS = 111,
+		VIEW_DISPLAY_DEBUG_VOXEL_GI_ALBEDO = 112,
+		VIEW_DISPLAY_DEBUG_VOXEL_GI_LIGHTING = 113,
+		VIEW_DISPLAY_DEBUG_VOXEL_GI_EMISSION = 114,
+		VIEW_DISPLAY_DEBUG_SDFGI = 115,
+		VIEW_DISPLAY_DEBUG_SDFGI_PROBES = 116,
+		VIEW_DISPLAY_DEBUG_SCENE_LUMINANCE = 117,
+		VIEW_DISPLAY_DEBUG_SSAO = 118,
+		VIEW_DISPLAY_DEBUG_SSIL = 119,
+		VIEW_DISPLAY_DEBUG_GI_BUFFER = 120,
+		VIEW_DISPLAY_DEBUG_DISABLE_LOD = 121,
+		VIEW_DISPLAY_DEBUG_CLUSTER_OMNI_LIGHTS = 122,
+		VIEW_DISPLAY_DEBUG_CLUSTER_SPOT_LIGHTS = 123,
+		VIEW_DISPLAY_DEBUG_CLUSTER_AREA_LIGHTS = 124,
+		VIEW_DISPLAY_DEBUG_CLUSTER_DECALS = 125,
+		VIEW_DISPLAY_DEBUG_CLUSTER_REFLECTION_PROBES = 126,
+		VIEW_DISPLAY_DEBUG_OCCLUDERS = 127,
+		VIEW_DISPLAY_MOTION_VECTORS = 128,
+		VIEW_DISPLAY_INTERNAL_BUFFER = 129,
+		VIEW_DISPLAY_MAX = 130,
 		// > Keep in sync with menu.
 
 		VIEW_LOCK_ROTATION,
@@ -180,7 +182,13 @@ class Node3DEditorViewport : public Control {
 		VIEW_MAX
 	};
 
-public:
+	// Supported rendering methods for advanced debug draw mode items.
+	enum SupportedRenderingMethods {
+		ALL,
+		FORWARD_PLUS,
+		FORWARD_PLUS_MOBILE,
+	};
+
 	static constexpr int32_t GIZMO_BASE_LAYER = 27;
 	static constexpr int32_t GIZMO_EDIT_LAYER = 26;
 	static constexpr int32_t GIZMO_GRID_LAYER = 25;
@@ -497,15 +505,8 @@ private:
 	void register_shortcut_action(const String &p_path, const String &p_name, Key p_keycode, bool p_physical = false);
 	void shortcut_changed_callback(const Ref<Shortcut> p_shortcut, const String &p_shortcut_path);
 
-	// Supported rendering methods for advanced debug draw mode items.
-	enum SupportedRenderingMethods {
-		ALL,
-		FORWARD_PLUS,
-		FORWARD_PLUS_MOBILE,
-	};
-
 	void _set_lock_view_rotation(bool p_lock_rotation);
-	void _add_advanced_debug_draw_mode_item(PopupMenu *p_popup, const String &p_name, int p_value, SupportedRenderingMethods p_rendering_methods = SupportedRenderingMethods::ALL, const String &p_tooltip = "");
+	static void _add_advanced_debug_draw_mode_item(PopupMenu *p_popup, const String &p_name, int p_value, SupportedRenderingMethods p_rendering_methods = SupportedRenderingMethods::ALL, const String &p_tooltip = "");
 
 protected:
 	void _notification(int p_what);
@@ -515,6 +516,10 @@ public:
 	void update_surface() { surface->queue_redraw(); }
 	void update_transform_gizmo_view();
 	void update_transform_gizmo_highlight();
+
+	static PopupMenu *get_advanced_debug_draw_menu();
+	static void select_debug_draw_mode(int p_option, MenuButton *p_view_display_menu, PopupMenu *p_display_submenu, Callable p_callable);
+	void set_debug_draw_mode(Viewport::DebugDraw p_mode);
 
 	void set_can_preview(Camera3D *p_preview);
 	void switch_preview_camera(Camera3D *p_new_camera);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -284,6 +284,13 @@ Error SceneDebugger::_msg_override_cameras(const Array &p_args) {
 	return OK;
 }
 
+Error SceneDebugger::_msg_override_debug_draw(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
+	Viewport::DebugDraw debug_draw = p_args[0];
+	SceneTree::get_singleton()->get_root()->set_debug_draw(debug_draw);
+	return OK;
+}
+
 Error SceneDebugger::_msg_set_object_property(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.size() < 3, ERR_INVALID_DATA);
 	_set_object_property(p_args[0], p_args[1], p_args[2]);
@@ -624,6 +631,7 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["hdr_output_request_state"] = _msg_hdr_output_request_state;
 	message_handlers["hdr_output_toggle_requested"] = _msg_hdr_output_toggle_requested;
 	message_handlers["override_cameras"] = _msg_override_cameras;
+	message_handlers["override_debug_draw"] = _msg_override_debug_draw;
 	message_handlers["transform_camera_2d"] = _msg_transform_camera_2d;
 #ifndef _3D_DISABLED
 	message_handlers["transform_camera_3d"] = _msg_transform_camera_3d;

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -86,6 +86,7 @@ private:
 	static Error _msg_hdr_output_request_state(const Array &p_args);
 	static Error _msg_hdr_output_toggle_requested(const Array &p_args);
 	static Error _msg_override_cameras(const Array &p_args);
+	static Error _msg_override_debug_draw(const Array &p_args);
 	static Error _msg_set_object_property(const Array &p_args);
 	static Error _msg_set_object_property_field(const Array &p_args);
 	static Error _msg_reload_cached_files(const Array &p_args);


### PR DESCRIPTION
This allows overriding the debug draw mode used in the root viewport.

For example, this can be used to temporarily view the running project in wireframe/overdraw mode, which can be used to better diagnose certain issues.

Note that certain debug draw modes have no effect in Mobile/Compatibility due to renderer limitations, but this limitation is already present in the editor. Since we reuse the 3D editor's code for the advanced menu, all the tooltips and disabled items according to the current renderer are still in place.

- This closes https://github.com/godotengine/godot-proposals/issues/12866.

## Preview

https://github.com/user-attachments/assets/14777a5a-46cc-4c4c-a8a3-7ee8f97d5579

## TODO

- [ ] Fix wireframe mode not working in Compatibility unless you call `RenderingServer.set_debug_generate_wireframes(true)` early enough in the project's lifecycle.
  - We could call this method automatically on startup when game embedding is enabled. Note that it has an impact on loading times and VRAM utilization, so maybe it should be an opt-in project setting.
