### PR TITLE
Organize toggle files button logic in shader editor

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1867,8 +1867,8 @@ void CodeTextEditor::set_code_complete_func(CodeTextEditorCodeCompleteFunc p_cod
 	code_complete_ud = p_ud;
 }
 
-void CodeTextEditor::set_toggle_list_control(Control *p_control) {
-	toggle_files_list = p_control;
+void CodeTextEditor::set_toggle_list_control(Control *p_toggle_list_control) {
+	toggle_files_list = p_toggle_list_control;
 }
 
 void CodeTextEditor::show_toggle_files_button() {

--- a/editor/gui/code_editor.h
+++ b/editor/gui/code_editor.h
@@ -297,7 +297,7 @@ public:
 
 	void validate_script();
 
-	void set_toggle_list_control(Control *p_control);
+	void set_toggle_list_control(Control *p_toggle_list_control);
 	void show_toggle_files_button();
 	void update_toggle_files_button();
 

--- a/editor/shader/shader_editor.h
+++ b/editor/shader/shader_editor.h
@@ -47,5 +47,7 @@ public:
 	virtual void apply_shaders() = 0;
 	virtual bool is_unsaved() const = 0;
 	virtual void save_external_data(const String &p_str = "") = 0;
+	virtual void set_toggle_list_control(Control *p_toggle_list_control) = 0;
+	virtual void update_toggle_files_button() = 0;
 	virtual void validate_script() = 0;
 };

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -151,11 +151,8 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 			}
 		}
 		es.shader_inc = Ref<ShaderInclude>(si);
-		TextShaderEditor *text_shader = memnew(TextShaderEditor);
-		text_shader->get_code_editor()->set_toggle_list_control(shader_list);
-		es.shader_editor = text_shader;
+		es.shader_editor = memnew(TextShaderEditor);
 		es.shader_editor->edit_shader_include(si);
-		shader_tabs->add_child(es.shader_editor);
 	} else {
 		Shader *s = Object::cast_to<Shader>(p_object);
 		for (uint32_t i = 0; i < edited_shaders.size(); i++) {
@@ -169,15 +166,10 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 		es.shader = Ref<Shader>(s);
 		Ref<VisualShader> vs = es.shader;
 		if (vs.is_valid()) {
-			VisualShaderEditor *vs_editor = memnew(VisualShaderEditor);
-			vs_editor->set_toggle_list_control(shader_list);
-			es.shader_editor = vs_editor;
+			es.shader_editor = memnew(VisualShaderEditor);
 		} else {
-			TextShaderEditor *text_shader = memnew(TextShaderEditor);
-			text_shader->get_code_editor()->set_toggle_list_control(shader_list);
-			es.shader_editor = text_shader;
+			es.shader_editor = memnew(TextShaderEditor);
 		}
-		shader_tabs->add_child(es.shader_editor);
 		es.shader_editor->edit_shader(es.shader);
 	}
 
@@ -192,6 +184,9 @@ void ShaderEditorPlugin::edit(Object *p_object) {
 		}
 	}
 
+	// `set_toggle_list_control` must be called before adding the editor to the scene tree.
+	es.shader_editor->set_toggle_list_control(shader_list);
+	shader_tabs->add_child(es.shader_editor);
 	shader_tabs->set_current_tab(shader_tabs->get_tab_count() - 1);
 	edited_shaders.push_back(es);
 	_update_shader_list();
@@ -627,15 +622,9 @@ void ShaderEditorPlugin::_menu_item_pressed(int p_index) {
 			int index = shader_tabs->get_current_tab();
 			if (index != -1) {
 				ERR_FAIL_INDEX(index, (int)edited_shaders.size());
-				TextShaderEditor *editor = Object::cast_to<TextShaderEditor>(edited_shaders[index].shader_editor);
-				if (editor) {
-					editor->get_code_editor()->update_toggle_files_button();
-				} else {
-					VisualShaderEditor *vs_editor = Object::cast_to<VisualShaderEditor>(edited_shaders[index].shader_editor);
-					if (vs_editor) {
-						vs_editor->update_toggle_files_button();
-					}
-				}
+				ShaderEditor *shader_editor = edited_shaders[index].shader_editor;
+				ERR_FAIL_NULL(shader_editor);
+				shader_editor->update_toggle_files_button();
 			}
 		} break;
 	}
@@ -788,7 +777,7 @@ void ShaderEditorPlugin::_switch_to_editor(ShaderEditor *p_editor) {
 	if (file_menu->get_parent() != nullptr) {
 		file_menu->get_parent()->remove_child(file_menu);
 	}
-	if (make_floating->get_parent()) {
+	if (make_floating->get_parent() != nullptr) {
 		make_floating->get_parent()->remove_child(make_floating);
 	}
 	empty_menu->set_visible(false);

--- a/editor/shader/text_shader_editor.cpp
+++ b/editor/shader/text_shader_editor.cpp
@@ -1030,6 +1030,14 @@ void TextShaderEditor::trim_final_newlines() {
 	code_editor->trim_final_newlines();
 }
 
+void TextShaderEditor::set_toggle_list_control(Control *p_toggle_list_control) {
+	code_editor->set_toggle_list_control(p_toggle_list_control);
+}
+
+void TextShaderEditor::update_toggle_files_button() {
+	code_editor->update_toggle_files_button();
+}
+
 void TextShaderEditor::validate_script() {
 	code_editor->_validate_script();
 }

--- a/editor/shader/text_shader_editor.h
+++ b/editor/shader/text_shader_editor.h
@@ -196,6 +196,8 @@ public:
 	virtual void apply_shaders() override;
 	virtual bool is_unsaved() const override;
 	virtual void save_external_data(const String &p_str = "") override;
+	virtual void set_toggle_list_control(Control *p_toggle_list_control) override;
+	virtual void update_toggle_files_button() override;
 	virtual void validate_script() override;
 
 	bool was_compilation_successful() const { return compilation_success; }

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -6461,8 +6461,8 @@ void VisualShaderEditor::_show_shader_preview() {
 	}
 }
 
-void VisualShaderEditor::set_toggle_list_control(Control *p_control) {
-	toggle_files_list = p_control;
+void VisualShaderEditor::set_toggle_list_control(Control *p_toggle_list_control) {
+	toggle_files_list = p_toggle_list_control;
 }
 
 void VisualShaderEditor::_toggle_files_pressed() {

--- a/editor/shader/visual_shader_editor_plugin.h
+++ b/editor/shader/visual_shader_editor_plugin.h
@@ -669,13 +669,13 @@ public:
 
 	void clear_custom_types();
 	void add_custom_type(const String &p_name, const String &p_type, const Ref<Script> &p_script, const String &p_description, int p_return_icon_type, const String &p_category, bool p_highend);
-	void set_toggle_list_control(Control *p_control);
+	virtual void set_toggle_list_control(Control *p_toggle_list_control) override;
 
 	Dictionary get_custom_node_data(Ref<VisualShaderNodeCustom> &p_custom_node);
 	void update_custom_type(const Ref<Resource> &p_resource);
 
 	virtual Size2 get_minimum_size() const override;
-	void update_toggle_files_button();
+	virtual void update_toggle_files_button() override;
 
 	Ref<VisualShader> get_visual_shader() const { return visual_shader; }
 


### PR DESCRIPTION
In the current master, this code is in the toggle files panel case:

```cpp
if (index != -1) {
	ERR_FAIL_INDEX(index, (int)edited_shaders.size());
	TextShaderEditor *editor = Object::cast_to<TextShaderEditor>(edited_shaders[index].shader_editor);
	if (editor) {
		editor->get_code_editor()->update_toggle_files_button();
	} else {
		VisualShaderEditor *vs_editor = Object::cast_to<VisualShaderEditor>(edited_shaders[index].shader_editor);
		if (vs_editor) {
			vs_editor->update_toggle_files_button();
		}
	}
}
```

It's a bit disorganized for the main shader editor code to know about each language, when an abstract function will do:

```cpp
if (index != -1) {
	ERR_FAIL_INDEX(index, (int)edited_shaders.size());
	ShaderEditor *shader_editor = edited_shaders[index].shader_editor;
	ERR_FAIL_NULL(shader_editor);
	shader_editor->update_toggle_files_button();
}
```

This is a prerequisite cleanup to PR #64596, I'm opening a separate PR for this change so it can be reviewed and merged in advance of the rest, making the changes in PR #64596 smaller.