### PR TITLE
Clean up some things in shader editor code

### DIFF
--- a/editor/shader/shader_create_dialog.h
+++ b/editor/shader/shader_create_dialog.h
@@ -93,6 +93,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	void _mode_changed(int p_mode = 0);
 	void _browse_path();
 	void _file_selected(const String &p_file);
+	void _refresh_type_icons();
 	String _validate_path(const String &p_path);
 	virtual void ok_pressed() override;
 	void _create_new();

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -41,6 +41,7 @@ class Shader : public Resource {
 	OBJ_SAVE_TYPE(Shader);
 
 public:
+	// Must be kept in sync with the List<String> of shader types in `servers/rendering/shader_types.cpp`.
 	enum Mode {
 		MODE_SPATIAL,
 		MODE_CANVAS_ITEM,

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -30,6 +30,8 @@
 
 #include "shader_types.h"
 
+#include "scene/resources/shader.h"
+
 const HashMap<StringName, ShaderLanguage::FunctionInfo> &ShaderTypes::get_functions(RS::ShaderMode p_mode) const {
 	return shader_modes[p_mode].functions;
 }
@@ -516,11 +518,13 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_FOG].functions["fog"].built_ins["EMISSION"] = ShaderLanguage::TYPE_VEC3;
 	shader_modes[RS::SHADER_FOG].functions["fog"].main_function = true;
 
+	// Must be kept in sync with the Shader::Mode enum.
 	shader_types_list.push_back("spatial");
 	shader_types_list.push_back("canvas_item");
 	shader_types_list.push_back("particles");
 	shader_types_list.push_back("sky");
 	shader_types_list.push_back("fog");
+	DEV_ASSERT(shader_types_list.size() == Shader::MODE_MAX);
 
 	for (const String &type : shader_types_list) {
 		shader_types.insert(type);


### PR DESCRIPTION
This PR has some misc cleanups, such as renaming and organizing things. This is a prerequisite cleanup to PR #64596, I'm opening a separate PR for this change so it can be reviewed and merged in advance of the rest, making the changes in PR #64596 smaller and easier to read later.

* In `shader.h` and `shader_types.cpp`, add comments noting that those need to be kept in sync. EDIT: And also add a DEV_ASSERT to ensure that they are kept in sync as @Calinou suggested.
* In `ShaderEditorPlugin::edit`, rename `si` to `shader_include`, rename `s` to `shader`, add some comments, and check that the object trying to be edited is actually a shader.
* In `ShaderEditorPlugin::_switch_to_editor`, check for null being passed. This will matter once it's possible for shader languages to arbitrarily plug into here, to avoid crashing if those languages have an error.
* In `ShaderEditorPlugin::_make_script_list_context_menu`, make the validation language-agnostic.
* In `ShaderCreateDialog::_validate_path`, rename `p` to `stripped_file_path`, rename `extension` to `file_extension`, and cache the shader type data in a `current_type_data` variable instead of re-getting it every time.
* In `ShaderCreateDialog::_update_language_info`, give `.tres` a higher priority than `.res`, and avoid repeating the non-default-extension parts.
* Move `ShaderCreateDialog` code to get the type icons into a new `_refresh_type_icons` function, and make it language-agnostic. The motivation behind this change is to avoid hard dependencies on specific types, and also to allow re-running this logic later, such as if shader languages are registered later on.

The new `_refresh_type_icons` also fixes a bug where the ShaderInclude icon already present in the engine just wasn't being used by the dialog for some reason. Before, in master:

<img width="400" height="221" alt="Screenshot 2025-08-26 at 6 21 58 PM" src="https://github.com/user-attachments/assets/1f46199a-86c6-408b-8fcc-028b0ddc3b5a" />

After, with this PR:

<img width="400" height="221" alt="Screenshot 2025-08-26 at 6 26 17 PM" src="https://github.com/user-attachments/assets/212655dc-fe1f-4efb-b207-999ddd816eb7" />
