### PR TITLE
OpenXR: Fix ViewportTextures not displaying correct texture (OpenGL)

### DIFF
--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -151,7 +151,7 @@ struct Texture {
 	bool is_render_target = false;
 
 	RID proxy_to;
-	Vector<RID> proxies;
+	LocalVector<RID> proxies;
 
 	String path;
 	int width = 0;
@@ -525,6 +525,7 @@ public:
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
+	void texture_remap_proxies(RID p_from_texture, RID p_to_texture);
 
 	Ref<Image> texture_2d_placeholder;
 	Vector<Ref<Image>> texture_2d_array_placeholder;


### PR DESCRIPTION
This PR applies a fix to the compatibility renderer that makes `ViewportTexture` work properly with an overridden color buffer on the texture.

> [!NOTE]
> This PR extracts the changes to the compatibility renderer from #109955
> As these changes are pretty straight forward, this PR can likely go ahead without waiting on further discussion on the Vulkan changes.

This is functionality that has been broken since the introduction of the compatibility renderer but is a regression from this feature in Godot 3. It comes up in user complaints every few months. It can be worked around at the cost of performance (performing a separate render).

It would be nice to take along in the Godot 4.5 release as the changes are unlikely to have an impact however a cherry pick to 4.5.1 is reasonable.

See https://github.com/godotengine/godot-demo-projects/pull/1144 for a demo of the functionality (requires a PCVR headset).