### PR TITLE
Divide screen texture by luminance multiplier in compatibility

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1423,6 +1423,7 @@ MaterialStorage::MaterialStorage() {
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
 
+		actions.apply_luminance_multiplier = true; // apply luminance multiplier to screen texture
 		actions.check_multiview_samplers = RasterizerGLES3::get_singleton()->is_xr_enabled();
 		actions.global_buffer_array_variable = "global_shader_uniforms";
 		actions.instance_uniform_index_variable = "instance_offset";


### PR DESCRIPTION
Mobile and compatibility both use a luminance multiplier for glow, which has the side effect of making the screen texture dark.

Mobile already worked around this by transparently adding in an extra multiplication when sampling the texture in a shader, but compatibility for some reason didn't.

Fixes #107552