### PR TITLE
Unify file header fourCC checks

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -227,7 +227,7 @@ Ref<FileAccess> FileAccess::open_encrypted_pass(const String &p_path, ModeFlags 
 Ref<FileAccess> FileAccess::open_compressed(const String &p_path, ModeFlags p_mode_flags, CompressionMode p_compress_mode) {
 	Ref<FileAccessCompressed> fac;
 	fac.instantiate();
-	fac->configure("GCPF", (Compression::Mode)p_compress_mode);
+	fac->configure(FileAccessCompressed::FOURCC_DEFAULT, (Compression::Mode)p_compress_mode);
 	Error err = fac->open_internal(p_path, p_mode_flags);
 	last_file_open_error = err;
 	if (err) {

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -35,6 +35,12 @@
 
 class FileAccessCompressed : public FileAccess {
 	GDSOFTCLASS(FileAccessCompressed, FileAccess);
+
+public:
+	static constexpr uint32_t FOURCC_DEFAULT = make_fourcc("GCPF");
+	static constexpr uint32_t FOURCC_INTERNAL = make_fourcc("GCMP");
+
+private:
 	Compression::Mode cmode = Compression::MODE_ZSTD;
 	bool writing = false;
 	uint64_t write_pos = 0;
@@ -59,14 +65,14 @@ class FileAccessCompressed : public FileAccess {
 	Vector<ReadBlock> read_blocks;
 	uint64_t read_total = 0;
 
-	String magic = "GCMP";
+	uint32_t magic = FOURCC_INTERNAL;
 	mutable Vector<uint8_t> buffer;
 	Ref<FileAccess> f;
 
 	void _close();
 
 public:
-	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
+	void configure(uint32_t p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -76,8 +76,7 @@ Error FileAccessEncrypted::open_and_parse(Ref<FileAccess> p_base, const Vector<u
 		key = p_key;
 
 		if (use_magic) {
-			uint32_t magic = p_base->get_32();
-			ERR_FAIL_COND_V(magic != ENCRYPTED_HEADER_MAGIC, ERR_FILE_UNRECOGNIZED);
+			ERR_FAIL_COND_V(p_base->get_32() != FOURCC, ERR_FILE_UNRECOGNIZED);
 		}
 
 		unsigned char md5d[16];
@@ -157,7 +156,7 @@ void FileAccessEncrypted::_close() {
 		ctx.set_encode_key(key.ptrw(), 256);
 
 		if (use_magic) {
-			file->store_32(ENCRYPTED_HEADER_MAGIC);
+			file->store_32(FOURCC);
 		}
 
 		file->store_buffer(hash, 16);

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -33,12 +33,13 @@
 #include "core/crypto/crypto_core.h"
 #include "core/io/file_access.h"
 
-#define ENCRYPTED_HEADER_MAGIC 0x43454447
-
 class FileAccessEncrypted : public FileAccess {
 	GDSOFTCLASS(FileAccessEncrypted, FileAccess);
 
 public:
+	// Godot Encrypted.
+	static constexpr uint32_t FOURCC = make_fourcc("GDEC");
+
 	enum Mode : int32_t {
 		MODE_READ,
 		MODE_WRITE_AES256,

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -197,7 +197,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	// Search for the header at the start offset - standalone PCK file.
 	f->seek(p_offset);
 	uint32_t magic = f->get_32();
-	if (magic == PACK_HEADER_MAGIC) {
+	if (magic == PackedSourcePCK::FOURCC) {
 		pck_header_found = true;
 	}
 
@@ -214,7 +214,7 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 			for (int i = 0; i < 8; i++) {
 				f->seek(pck_off);
 				magic = f->get_32();
-				if (magic == PACK_HEADER_MAGIC) {
+				if (magic == PackedSourcePCK::FOURCC) {
 #ifdef DEBUG_ENABLED
 					print_verbose("PCK header found in executable pck section, loading from offset 0x" + String::num_int64(pck_off - 4, 16));
 #endif
@@ -237,12 +237,12 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		f->seek(f->get_position() - 4);
 		magic = f->get_32();
 
-		if (magic == PACK_HEADER_MAGIC) {
+		if (magic == PackedSourcePCK::FOURCC) {
 			f->seek(f->get_position() - 12);
 			uint64_t ds = f->get_64();
 			f->seek(f->get_position() - ds - 8);
 			magic = f->get_32();
-			if (magic == PACK_HEADER_MAGIC) {
+			if (magic == PackedSourcePCK::FOURCC) {
 #ifdef DEBUG_ENABLED
 				print_verbose("PCK header found at the end of executable, loading from offset 0x" + String::num_int64(f->get_position() - 4, 16));
 #endif

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -36,9 +36,6 @@
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
 
-// Godot's packed file magic header ("GDPC" in ASCII).
-#define PACK_HEADER_MAGIC 0x43504447
-
 #define PACK_FORMAT_VERSION_V2 2
 #define PACK_FORMAT_VERSION_V3 3
 
@@ -150,6 +147,9 @@ public:
 
 class PackedSourcePCK : public PackSource {
 public:
+	// Godot Pack.
+	static constexpr uint32_t FOURCC = make_fourcc("GDPC");
+
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file) override;
 };

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -65,6 +65,9 @@ class Image : public Resource {
 	GDCLASS(Image, Resource);
 
 public:
+	// Godot Image.
+	static constexpr uint32_t FOURCC = make_fourcc("GDIM");
+
 	enum {
 		MAX_WIDTH = (1 << 24), // Force a limit somehow.
 		MAX_HEIGHT = (1 << 24), // Force a limit somehow.

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -149,11 +149,7 @@ Ref<Resource> ResourceFormatLoaderImage::load(const String &p_path, const String
 		return Ref<Resource>();
 	}
 
-	uint8_t header[4] = { 0, 0, 0, 0 };
-	f->get_buffer(header, 4);
-
-	bool unrecognized = header[0] != 'G' || header[1] != 'D' || header[2] != 'I' || header[3] != 'M';
-	if (unrecognized) {
+	if (f->get_32() != Image::FOURCC) {
 		if (r_error) {
 			*r_error = ERR_FILE_UNRECOGNIZED;
 		}

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -89,7 +89,7 @@ Error PCKPacker::pck_start(const String &p_pck_path, int p_alignment, const Stri
 
 	alignment = p_alignment;
 
-	file->store_32(PACK_HEADER_MAGIC);
+	file->store_32(PackedSourcePCK::FOURCC);
 	file->store_32(PACK_FORMAT_VERSION);
 	file->store_32(GODOT_VERSION_MAJOR);
 	file->store_32(GODOT_VERSION_MINOR);

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -93,6 +93,9 @@ class ResourceLoaderBinary {
 	HashMap<String, Ref<Resource>> dependency_cache;
 
 public:
+	static constexpr uint32_t FOURCC_REGULAR = make_fourcc("RSRC");
+	static constexpr uint32_t FOURCC_COMPRESSED = make_fourcc("RSCC");
+
 	Ref<Resource> get_resource();
 	Error load();
 	void set_translation_remapped(bool p_remapped);

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -295,6 +295,10 @@ constexpr T get_num_bits(T x) {
 	return floor_log2(x);
 }
 
+constexpr uint32_t make_fourcc(const char p_sig[5]) {
+	return static_cast<uint32_t>((p_sig[3] << 24U) | (p_sig[2] << 16U) | (p_sig[1] << 8U) | (p_sig[0]));
+}
+
 // Swap 16, 32 and 64 bits value for endianness.
 #if defined(__GNUC__)
 #define BSWAP16(x) __builtin_bswap16(x)

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -537,7 +537,7 @@ String ShaderGLES3::_version_get_sha1(Version *p_version) const {
 }
 
 #ifndef WEB_ENABLED // not supported in webgl
-static const char *shader_file_header = "GLSC";
+static const uint32_t shader_file_header = make_fourcc("GLSC");
 static const uint32_t cache_file_version = 3;
 #endif
 
@@ -558,9 +558,7 @@ bool ShaderGLES3::_load_from_cache(Version *p_version) {
 		return false;
 	}
 
-	char header[5] = {};
-	f->get_buffer((uint8_t *)header, 4);
-	ERR_FAIL_COND_V(header != String(shader_file_header), false);
+	ERR_FAIL_COND_V(f->get_32() != shader_file_header, false);
 
 	uint32_t file_version = f->get_32();
 	if (file_version != cache_file_version) {
@@ -643,7 +641,7 @@ void ShaderGLES3::_save_to_cache(Version *p_version) {
 	Error error;
 	Ref<FileAccess> f = FileAccess::open(path, FileAccess::WRITE, &error);
 	ERR_FAIL_COND(f.is_null());
-	f->store_buffer((const uint8_t *)shader_file_header, 4);
+	f->store_32(shader_file_header);
 	f->store_32(cache_file_version);
 	f->store_32(variant_count);
 

--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1924,7 +1924,7 @@ Dictionary EditorExportPlatform::_save_zip_patch(const Ref<EditorExportPreset> &
 }
 
 bool EditorExportPlatform::_store_header(Ref<FileAccess> p_fd, bool p_enc, bool p_sparse, uint64_t &r_file_base_ofs, uint64_t &r_dir_base_ofs) {
-	p_fd->store_32(PACK_HEADER_MAGIC);
+	p_fd->store_32(PackedSourcePCK::FOURCC);
 	p_fd->store_32(PACK_FORMAT_VERSION);
 	p_fd->store_32(GODOT_VERSION_MAJOR);
 	p_fd->store_32(GODOT_VERSION_MINOR);
@@ -2159,7 +2159,7 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 
 		uint64_t pck_size = f->get_position() - pck_start_pos;
 		f->store_64(pck_size);
-		f->store_32(PACK_HEADER_MAGIC);
+		f->store_32(PackedSourcePCK::FOURCC);
 
 		if (r_embedded_size) {
 			*r_embedded_size = f->get_position() - embed_pos;

--- a/editor/import/resource_importer_image.cpp
+++ b/editor/import/resource_importer_image.cpp
@@ -83,8 +83,7 @@ Error ResourceImporterImage::import(ResourceUID::ID p_source_id, const String &p
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_CREATE, "Cannot create file in path '" + p_save_path + ".image'.");
 
 	//save the header GDIM
-	const uint8_t header[4] = { 'G', 'D', 'I', 'M' };
-	f->store_buffer(header, 4);
+	f->store_32(Image::FOURCC);
 	//SAVE the extension (so it can be recognized by the loader later
 	f->store_pascal_string(p_source_file.get_extension().to_lower());
 	//SAVE the actual image

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -267,11 +267,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 	}
 
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
-	f->store_8('G');
-	f->store_8('S');
-	f->store_8('T');
-	f->store_8('L');
-
+	f->store_32(CompressedTextureLayered::FOURCC);
 	f->store_32(CompressedTextureLayered::FORMAT_VERSION);
 	f->store_32(p_images.size()); // For 2d layers or 3d depth.
 	f->store_32(mode);

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -355,11 +355,7 @@ void ResourceImporterTexture::_save_ctex(const Ref<Image> &p_image, const String
 	Ref<FileAccess> f = FileAccess::open(p_to_path, FileAccess::WRITE);
 	ERR_FAIL_COND(f.is_null());
 
-	// Godot Streamable Texture 2D.
-	f->store_8('G');
-	f->store_8('S');
-	f->store_8('T');
-	f->store_8('2');
+	f->store_32(CompressedTexture2D::FOURCC);
 
 	// Current format version.
 	f->store_32(CompressedTexture2D::FORMAT_VERSION);

--- a/modules/dds/dds_enums.h
+++ b/modules/dds/dds_enums.h
@@ -32,12 +32,10 @@
 
 #include "core/io/image.h"
 
-#define PF_FOURCC(m_s) ((uint32_t)(((m_s)[3] << 24U) | ((m_s)[2] << 16U) | ((m_s)[1] << 8U) | ((m_s)[0])))
-
 // Reference: https://docs.microsoft.com/en-us/windows/win32/direct3ddds/dds-header
 
 enum {
-	DDS_MAGIC = 0x20534444,
+	DDS_MAGIC = make_fourcc("DDS "),
 	DDS_HEADER_SIZE = 124,
 	DDS_PIXELFORMAT_SIZE = 32,
 
@@ -63,17 +61,17 @@ enum {
 };
 
 enum DDSFourCC {
-	DDFCC_DXT1 = PF_FOURCC("DXT1"),
-	DDFCC_DXT2 = PF_FOURCC("DXT2"),
-	DDFCC_DXT3 = PF_FOURCC("DXT3"),
-	DDFCC_DXT4 = PF_FOURCC("DXT4"),
-	DDFCC_DXT5 = PF_FOURCC("DXT5"),
-	DDFCC_ATI1 = PF_FOURCC("ATI1"),
-	DDFCC_BC4U = PF_FOURCC("BC4U"),
-	DDFCC_ATI2 = PF_FOURCC("ATI2"),
-	DDFCC_BC5U = PF_FOURCC("BC5U"),
-	DDFCC_A2XY = PF_FOURCC("A2XY"),
-	DDFCC_DX10 = PF_FOURCC("DX10"),
+	DDFCC_DXT1 = make_fourcc("DXT1"),
+	DDFCC_DXT2 = make_fourcc("DXT2"),
+	DDFCC_DXT3 = make_fourcc("DXT3"),
+	DDFCC_DXT4 = make_fourcc("DXT4"),
+	DDFCC_DXT5 = make_fourcc("DXT5"),
+	DDFCC_ATI1 = make_fourcc("ATI1"),
+	DDFCC_BC4U = make_fourcc("BC4U"),
+	DDFCC_ATI2 = make_fourcc("ATI2"),
+	DDFCC_BC5U = make_fourcc("BC5U"),
+	DDFCC_A2XY = make_fourcc("A2XY"),
+	DDFCC_DX10 = make_fourcc("DX10"),
 	DDFCC_RGBA16 = 36,
 	DDFCC_R16F = 111,
 	DDFCC_RG16F = 112,

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -40,9 +40,7 @@ Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, vformat("Unable to open file: %s.", p_path));
 
-	uint8_t header[4];
-	f->get_buffer(header, 4);
-	if (header[0] != 'G' || header[1] != 'S' || header[2] != 'T' || header[3] != '2') {
+	if (f->get_32() != FOURCC) {
 		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture file is corrupt (Bad header).");
 	}
 
@@ -506,10 +504,7 @@ Image::Format CompressedTexture3D::get_format() const {
 Error CompressedTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, vformat("Unable to open file: %s.", p_path));
-
-	uint8_t header[4];
-	f->get_buffer(header, 4);
-	ERR_FAIL_COND_V(header[0] != 'G' || header[1] != 'S' || header[2] != 'T' || header[3] != 'L', ERR_FILE_UNRECOGNIZED);
+	ERR_FAIL_COND_V_MSG(f->get_32() != FOURCC, ERR_FILE_CORRUPT, "Compressed texture 3D file is corrupt (Bad header).");
 
 	//stored as compressed textures (used for lossless and lossy compression)
 	uint32_t version = f->get_32();
@@ -692,12 +687,7 @@ Error CompressedTextureLayered::_load_data(const String &p_path, Vector<Ref<Imag
 
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(f.is_null(), ERR_CANT_OPEN, vformat("Unable to open file: %s.", p_path));
-
-	uint8_t header[4];
-	f->get_buffer(header, 4);
-	if (header[0] != 'G' || header[1] != 'S' || header[2] != 'T' || header[3] != 'L') {
-		ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, "Compressed texture layered file is corrupt (Bad header).");
-	}
+	ERR_FAIL_COND_V_MSG(f->get_32() != FOURCC, ERR_FILE_CORRUPT, "Compressed texture layered file is corrupt (Bad header).");
 
 	uint32_t version = f->get_32();
 

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -39,6 +39,9 @@ class CompressedTexture2D : public Texture2D {
 	GDCLASS(CompressedTexture2D, Texture2D);
 
 public:
+	// Godot Streamable Texture 2D.
+	static constexpr uint32_t FOURCC = make_fourcc("GST2");
+
 	enum DataFormat {
 		DATA_FORMAT_IMAGE,
 		DATA_FORMAT_PNG,
@@ -121,6 +124,9 @@ class CompressedTextureLayered : public TextureLayered {
 	GDCLASS(CompressedTextureLayered, TextureLayered);
 
 public:
+	// Godot Streamable Texture Layered.
+	static constexpr uint32_t FOURCC = make_fourcc("GSTL");
+
 	enum DataFormat {
 		DATA_FORMAT_IMAGE,
 		DATA_FORMAT_PNG,
@@ -208,6 +214,8 @@ class CompressedTexture3D : public Texture3D {
 	GDCLASS(CompressedTexture3D, Texture3D);
 
 public:
+	static constexpr uint32_t FOURCC = CompressedTextureLayered::FOURCC;
+
 	enum DataFormat {
 		DATA_FORMAT_IMAGE,
 		DATA_FORMAT_PNG,

--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -418,7 +418,7 @@ String ShaderRD::_version_get_sha1(Version *p_version) const {
 	return hash_build.as_string().sha1_text();
 }
 
-static const char *shader_file_header = "GDSC";
+static const uint32_t shader_file_header = make_fourcc("GDSC");
 static const uint32_t cache_file_version = 4;
 
 String ShaderRD::_get_cache_file_relative_path(Version *p_version, int p_group, const String &p_api_name) {
@@ -449,9 +449,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 		return false;
 	}
 
-	char header[5] = { 0, 0, 0, 0, 0 };
-	f->get_buffer((uint8_t *)header, 4);
-	ERR_FAIL_COND_V(header != String(shader_file_header), false);
+	ERR_FAIL_COND_V(f->get_32() != shader_file_header, false);
 
 	uint32_t file_version = f->get_32();
 	if (file_version != cache_file_version) {
@@ -1010,7 +1008,7 @@ PackedByteArray ShaderRD::save_shader_cache_bytes(const LocalVector<int> &p_vari
 	bytes.resize(total_size);
 
 	uint8_t *bytes_ptr = bytes.ptrw();
-	memcpy(bytes_ptr, shader_file_header, 4);
+	memcpy(bytes_ptr, &shader_file_header, 4);
 	bytes_ptr += 4;
 
 	*(uint32_t *)(bytes_ptr) = cache_file_version;


### PR DESCRIPTION
Unifies header magic/signature checks using a new `make_fourCC` function. 
Replaces instances of magic hexadecimal numbers as well as 4-element byte arrays when checking signatures.