### PR TITLE
[Windows] Use UNC style long paths for network share paths.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -393,7 +393,7 @@ public:
 		if (!lpw_path) {
 			return S_FALSE;
 		}
-		String path = String::utf16((const char16_t *)lpw_path).replace_char('\\', '/').trim_prefix(R"(\\?\)").simplify_path();
+		String path = String::utf16((const char16_t *)lpw_path).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/').simplify_path();
 		if (!path.begins_with(root.simplify_path())) {
 			return S_FALSE;
 		}
@@ -626,13 +626,13 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 			current_dir_name.resize_uninitialized(str_len + 1);
 			GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
 			if (dir == ".") {
-				dir = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/');
+				dir = String::utf16((const char16_t *)current_dir_name.get_data()).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/');
 			} else {
-				dir = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(dir);
+				dir = String::utf16((const char16_t *)current_dir_name.get_data()).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(dir);
 			}
 		}
 		dir = dir.simplify_path();
-		dir = dir.trim_prefix(R"(\\?\)").replace_char('/', '\\');
+		dir = dir.replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('/', '\\');
 
 		IShellItem *shellitem = nullptr;
 		hr = SHCreateItemFromParsingName((LPCWSTR)dir.utf16().ptr(), nullptr, IID_IShellItem, (void **)&shellitem);
@@ -675,7 +675,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 						PWSTR file_path = nullptr;
 						hr = result->GetDisplayName(SIGDN_FILESYSPATH, &file_path);
 						if (SUCCEEDED(hr)) {
-							file_names.push_back(String::utf16((const char16_t *)file_path).replace_char('\\', '/').trim_prefix(R"(\\?\)"));
+							file_names.push_back(String::utf16((const char16_t *)file_path).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/'));
 							CoTaskMemFree(file_path);
 						}
 						result->Release();
@@ -689,7 +689,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 					PWSTR file_path = nullptr;
 					hr = result->GetDisplayName(SIGDN_FILESYSPATH, &file_path);
 					if (SUCCEEDED(hr)) {
-						file_names.push_back(String::utf16((const char16_t *)file_path).replace_char('\\', '/').trim_prefix(R"(\\?\)"));
+						file_names.push_back(String::utf16((const char16_t *)file_path).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/'));
 						CoTaskMemFree(file_path);
 					}
 					result->Release();

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -55,12 +55,16 @@ static String fix_path(const String &p_path) {
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
 		current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
-		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
+		path = String::utf16((const char16_t *)current_dir_name.get_data()).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
 	}
 	path = path.simplify_path();
 	path = path.replace_char('/', '\\');
-	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
-		path = R"(\\?\)" + path;
+	if (path.size() >= MAX_PATH && !path.begins_with(R"(\\?\)")) {
+		if (path.is_network_share_path()) {
+			path = R"(\\?\UNC\)" + path.trim_prefix("\\\\");
+		} else {
+			path = R"(\\?\)" + path;
+		}
 	}
 	return path;
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -113,12 +113,16 @@ static String fix_path(const String &p_path) {
 		size_t str_len = GetCurrentDirectoryW(0, nullptr);
 		current_dir_name.resize_uninitialized(str_len + 1);
 		GetCurrentDirectoryW(current_dir_name.size(), (LPWSTR)current_dir_name.ptrw());
-		path = String::utf16((const char16_t *)current_dir_name.get_data()).trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
+		path = String::utf16((const char16_t *)current_dir_name.get_data()).replace_first(R"(\\?\UNC\)", "\\\\").trim_prefix(R"(\\?\)").replace_char('\\', '/').path_join(path);
 	}
 	path = path.simplify_path();
 	path = path.replace_char('/', '\\');
-	if (path.size() >= MAX_PATH && !path.is_network_share_path() && !path.begins_with(R"(\\?\)")) {
-		path = R"(\\?\)" + path;
+	if (path.size() >= MAX_PATH && !path.begins_with(R"(\\?\)")) {
+		if (path.is_network_share_path()) {
+			path = R"(\\?\UNC\)" + path.trim_prefix("\\\\");
+		} else {
+			path = R"(\\?\)" + path;
+		}
 	}
 	return path;
 }


### PR DESCRIPTION
Might fix https://github.com/godotengine/godot/issues/110016 (on Windows 11 both styles of path work with WSL).

We use UNC path for local files but were using old style `\\Server\Share\Path\File` for network shares, which (depending on settings and OS version) is affected by 260-character limit. This PR changes network paths to `\\?\UNC\Server\Share\Path\File` style, which should always support 32K characters.