### PR TITLE
VisualShaderEditor: Merge continuous input port default value change actions

### DIFF
--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -3337,7 +3337,7 @@ void VisualShaderEditor::_port_edited(const StringName &p_property, const Varian
 	ERR_FAIL_COND(vsn.is_null());
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	undo_redo->create_action(TTR("Set Input Default Port"));
+	undo_redo->create_action(vformat(TTR("Set Input Port Default: %s"), vsn->get_input_port_name(editing_port)), UndoRedo::MERGE_ENDS);
 
 	Ref<VisualShaderNodeCustom> custom = Object::cast_to<VisualShaderNodeCustom>(vsn.ptr());
 	if (custom.is_valid()) {


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13064

This PR specifies `MERGE_ENDS` when creating the undo-redo action and updates the action name to be more descriptive.