### PR TITLE
Fix springbones physics interpolation stutter

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1660,7 +1660,7 @@ void SpringBoneSimulator3D::reset() {
 
 void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSetting *setting) {
 	if (setting->center_from == CENTER_FROM_WORLD_ORIGIN) {
-		setting->cached_center = p_skeleton->get_global_transform();
+		setting->cached_center = p_skeleton->get_global_transform_interpolated();
 	} else if (setting->center_from == CENTER_FROM_NODE) {
 		if (setting->center_node == NodePath()) {
 			setting->cached_center = Transform3D();
@@ -1669,7 +1669,7 @@ void SpringBoneSimulator3D::_init_joints(Skeleton3D *p_skeleton, SpringBone3DSet
 			if (!nd) {
 				setting->cached_center = Transform3D();
 			} else {
-				setting->cached_center = nd->get_global_transform().affine_inverse() * p_skeleton->get_global_transform();
+				setting->cached_center = nd->get_global_transform_interpolated().affine_inverse() * p_skeleton->get_global_transform_interpolated();
 			}
 		}
 	} else {


### PR DESCRIPTION
When using physics interpolation, springbones do not calculate their target transforms using the correct transform. This causes noticeable stuttering when the skeleton's transform is being influenced by physics interpolation.

Before fix:

https://github.com/user-attachments/assets/6f1aa7c2-3114-4faf-8f4a-fd012c43bf5a

After fix:

https://github.com/user-attachments/assets/f998a925-3c52-4c51-9744-b353686f6a24

Demo project: [springbones_stutter_demo_2025-08-27_14-11-43.zip](https://github.com/user-attachments/files/22012462/springbones_stutter_demo_2025-08-27_14-11-43.zip)

