### PR TITLE
Fix `WindowUtils::copy_and_rename_pdb` regression

### DIFF
--- a/platform/windows/windows_utils.cpp
+++ b/platform/windows/windows_utils.cpp
@@ -180,7 +180,7 @@ Error WindowsUtils::copy_and_rename_pdb(const String &p_dll_path) {
 			ERR_FAIL_COND_V_MSG(original_path_size < min_base_size + suffix_size, FAILED, vformat("The original PDB path size in bytes is too small: '%s'. Expected size: %d or more bytes, but available %d.", pdb_info.path, min_base_size + suffix_size, original_path_size));
 
 			new_pdb_base_name.clear();
-			new_pdb_base_name.append_utf8(utf8_name, original_path_size - suffix_size);
+			new_pdb_base_name.append_utf8(utf8_name.get_data(), original_path_size - suffix_size);
 			new_pdb_base_name[new_pdb_base_name.length() - 1] = '_'; // Restore the last '_'
 			WARN_PRINT(vformat("The original path size of '%s' in bytes was too small to fit the new name, so it was shortened to '%s%d.pdb'.", pdb_info.path, new_pdb_base_name, max_pdb_names - 1));
 		}


### PR DESCRIPTION
Fixes regression of PDB hot reloading by using the correct `String::append_utf8` overload.

This regression was evident from the logs, as the associated warning would always print `~rust_ext_999.pdb` when in fact, it should print `~rust_999.pdb`.

It appears to have been caused by #104556, and likely would have been avoided by warning on narrowing conversions. It is unclear if other usages of `String::append_utf8` are affected, but it seems somewhat likely.

~~While investigating the above issue, I also noticed that the `min_base_size` calculation appeared to be off by one due to accounting for a null terminator unnecessarily. I rewrote the associated logic for clarity, and to resolve that particular issue.~~