### PR TITLE
[4.2] Fix incorrect Vulkan include in vulkan_context.h

### DIFF
--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -40,11 +40,7 @@
 #include "servers/display_server.h"
 #include "servers/rendering/rendering_device.h"
 
-#ifdef USE_VOLK
-#include <volk.h>
-#else
-#include <vulkan/vulkan.h>
-#endif
+#include "drivers/vulkan/godot_vulkan.h"
 
 #include "vulkan_hooks.h"
 


### PR DESCRIPTION
PR #97510 consolidated the Vulkan includes into a lightweight `godot_vulkan.h` header. This was cherry-picked to older branches, but there was a mistake when cherry-picking to 4.2, this one spot was missed. This PR fixes it.

The file being included, `#include "drivers/vulkan/godot_vulkan.h"`, is very similar to the existing code already, but adds `#include <stdint.h>` and `#define VK_NO_STDINT_H`:

```cpp
#ifndef GODOT_VULKAN_H
#define GODOT_VULKAN_H

#ifdef USE_VOLK
#include <volk.h>
#else
#include <stdint.h>
#define VK_NO_STDINT_H
#include <vulkan/vulkan.h>
#endif

#endif // GODOT_VULKAN_H
```

This problem **only affects 4.2**, not 4.3 or later, and not 4.1. In the 4.1 branch, the code already matches the contents of this PR: https://github.com/godotengine/godot/blob/4.1/drivers/vulkan/vulkan_context.h

Without this PR, the iOS platform does not compile in the 4.2 branch with the latest Xcode. With this PR, it compiles.