### PR TITLE
[4.3] Install older .NET 6 on Linux CI to fix compiling

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -153,7 +153,9 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           # Targeting the oldest version we want to support to ensure it still builds.
-          dotnet-version: 8.0.100
+          dotnet-version: |
+              6.0.100
+              8.0.100
 
       - name: Compilation
         uses: ./.github/actions/godot-build


### PR DESCRIPTION
This fixes an oversight/regression from PR #105716 that only affects the 4.3 branch.

The changes in this PR match what's already on the 4.2 branch.

Credit to @raulsntos for pointing this out here: https://github.com/godotengine/godot/pull/92131#issuecomment-3229927479

Note that we have to install both, having .NET 6 but not .NET 8 fails:

<img width="1039" height="673" alt="Screenshot 2025-08-27 at 5 01 26 PM" src="https://github.com/user-attachments/assets/f7339588-d569-4c3c-9e6a-1a095e8612ad" />
