### PR TITLE
Make `SceneTree` not crash when receiving a notification without a root being set

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -897,6 +897,10 @@ void SceneTree::_main_window_focus_in() {
 }
 
 void SceneTree::_notification(int p_notification) {
+	if (!get_root()) {
+		return;
+	}
+
 	switch (p_notification) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			get_root()->propagate_notification(p_notification);


### PR DESCRIPTION
This fixes (or at least helps with) a crash that is currently stopping the benchmarks server from collecting new results.
This change should be risk free. Since it's effectively blocking our benchmarks, I think it should be merged asap.

The crash log looks as such:

```
 #0  0x000000000252b19f _ZNK4Node32is_accessible_from_caller_threadEv (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x212b19f)
 #1  0x000000000255abd3 _ZN9SceneTree13_notificationEi (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x215abd3)
 #2  0x000000000256755b _ZN9SceneTree22_notification_forwardvEi (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x216755b)
 #3  0x00000000040681a9 _ZN6Object21_notification_forwardEi (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x3c681a9)
 #4  0x0000000000406eb3 _ZN6Object12notificationEib (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x6eb3)
 #5  0x00007fddc36abc30 __restore_rt (libc.so.6 + 0x19c30)
 #6  0x00000000018e91bd _ZN7HashMapI6StringN7DocData8ClassDocE20HashMapHasherDefault24HashMapComparatorDefaultIS0_E21DefaultTypedAllocatorI14HashMapElementIS0_S2_EEEixERKS0_ (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x14e91bd)
 #7  0x00000000018e0330 _ZN8DocTools8generateE8BitFieldINS_13GenerateFlagsEE (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x14e0330)
 #8  0x00000000018f5aed _ZN10EditorHelp20_gen_extensions_docsEv (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x14f5aed)
 #9  0x0000000000e5fe41 _Z29call_with_variant_args_staticIJEJEEvPFvDpT_EPPK7VariantRN8Callable9CallErrorE13IndexSequenceIJXspT0_EEE (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0xa5fe41)
 #10 0x0000000000e5fe64 _Z29call_with_variant_args_staticIJEEvPFvDpT_EPPK7VariantiRN8Callable9CallErrorE (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0xa5fe64)
 #11 0x0000000000e5fe7a _ZNK33CallableCustomStaticMethodPointerIvJEE4callEPPK7VariantiRS1_RN8Callable9CallErrorE (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0xa5fe7a)
 #12 0x0000000003ddebd1 _ZNK8Callable5callpEPPK7VariantiRS0_RNS_9CallErrorE (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x39debd1)
 #13 0x0000000004063b97 _ZN9CallQueue14_call_functionERK8CallablePK7Variantib (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x3c63b97)
 #14 0x0000000004063d3c _ZN9CallQueue5flushEv (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x3c63d3c)
 #15 0x000000000046a366 _ZN4Main7cleanupEb (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x6a366)
 #16 0x0000000000406ba4 main (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x6ba4)
 #17 0x00007fddc36955f5 __libc_start_call_main (libc.so.6 + 0x35f5)
 #18 0x00007fddc36956a8 __libc_start_main@@GLIBC_2.34 (libc.so.6 + 0x36a8)
 #19 0x00000000004069d5 _start (/home/godot/godot-benchmarks/godot/bin/godot.linuxbsd.editor.x86_64 + 0x69d5)
```

I'm inferring from the logs that `SceneTree::_notification` is called without `get_root` being set. This seems unusual, but not necessarily erroneous - I would expect a scene tree that receives a notification without a root being set to handle it gracefully.
