### PR TITLE
Add single-object inspect command backwards compatible API for potential regression

### DIFF
--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -1176,6 +1176,16 @@ void DebugAdapterProtocol::on_debug_data(const String &p_msg, const Array &p_dat
 
 			parse_object(remote_obj);
 		}
+#ifndef DISABLE_DEPRECATED
+	} else if (p_msg == "scene:inspect_object") {
+		if (!p_data.is_empty()) {
+			// Legacy single object response format.
+			SceneDebuggerObject remote_obj;
+			remote_obj.deserialize(p_data);
+
+			parse_object(remote_obj);
+		}
+#endif // DISABLE_DEPRECATED
 	} else if (p_msg == "evaluation_return") {
 		// An evaluation was requested from the debuggee; parse it.
 		DebuggerMarshalls::ScriptStackVariable remote_evaluation;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -435,6 +435,17 @@ void ScriptEditorDebugger::_msg_scene_inspect_objects(uint64_t p_thread_id, cons
 	}
 }
 
+#ifndef DISABLE_DEPRECATED
+void ScriptEditorDebugger::_msg_scene_inspect_object(uint64_t p_thread_id, const Array &p_data) {
+	ERR_FAIL_COND(p_data.is_empty());
+	// Legacy compatibility: convert single object response to new format.
+	// p_data is [id, className, properties] - wrap it as first element of array for new handler.
+	Array wrapped_data;
+	wrapped_data.push_back(p_data);
+	_msg_scene_inspect_objects(p_thread_id, wrapped_data);
+}
+#endif // DISABLE_DEPRECATED
+
 void ScriptEditorDebugger::_msg_servers_memory_usage(uint64_t p_thread_id, const Array &p_data) {
 	vmem_tree->clear();
 	TreeItem *root = vmem_tree->create_item();
@@ -952,6 +963,9 @@ void ScriptEditorDebugger::_init_parse_message_handlers() {
 	parse_message_handlers["scene:click_ctrl"] = &ScriptEditorDebugger::_msg_scene_click_ctrl;
 	parse_message_handlers["scene:scene_tree"] = &ScriptEditorDebugger::_msg_scene_scene_tree;
 	parse_message_handlers["scene:inspect_objects"] = &ScriptEditorDebugger::_msg_scene_inspect_objects;
+#ifndef DISABLE_DEPRECATED
+	parse_message_handlers["scene:inspect_object"] = &ScriptEditorDebugger::_msg_scene_inspect_object;
+#endif // DISABLE_DEPRECATED
 	parse_message_handlers["servers:memory_usage"] = &ScriptEditorDebugger::_msg_servers_memory_usage;
 	parse_message_handlers["servers:drawn"] = &ScriptEditorDebugger::_msg_servers_drawn;
 	parse_message_handlers["stack_dump"] = &ScriptEditorDebugger::_msg_stack_dump;

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -203,6 +203,9 @@ private:
 	void _msg_scene_click_ctrl(uint64_t p_thread_id, const Array &p_data);
 	void _msg_scene_scene_tree(uint64_t p_thread_id, const Array &p_data);
 	void _msg_scene_inspect_objects(uint64_t p_thread_id, const Array &p_data);
+#ifndef DISABLE_DEPRECATED
+	void _msg_scene_inspect_object(uint64_t p_thread_id, const Array &p_data);
+#endif // DISABLE_DEPRECATED
 	void _msg_servers_memory_usage(uint64_t p_thread_id, const Array &p_data);
 	void _msg_servers_drawn(uint64_t p_thread_id, const Array &p_data);
 	void _msg_stack_dump(uint64_t p_thread_id, const Array &p_data);

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -167,6 +167,26 @@ Error SceneDebugger::_msg_inspect_objects(const Array &p_args) {
 	return OK;
 }
 
+#ifndef DISABLE_DEPRECATED
+Error SceneDebugger::_msg_inspect_object(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
+	// Legacy compatibility: convert single object ID to new format, then send single object response.
+	Vector<ObjectID> ids;
+	ids.append(ObjectID(p_args[0].operator uint64_t()));
+
+	SceneDebuggerObject obj(ids[0]);
+	if (obj.id.is_null()) {
+		EngineDebugger::get_singleton()->send_message("scene:inspect_object", Array());
+		return OK;
+	}
+
+	Array arr;
+	obj.serialize(arr);
+	EngineDebugger::get_singleton()->send_message("scene:inspect_object", arr);
+	return OK;
+}
+#endif // DISABLE_DEPRECATED
+
 Error SceneDebugger::_msg_clear_selection(const Array &p_args) {
 	RuntimeNodeSelect::get_singleton()->_clear_selection();
 	return OK;
@@ -496,6 +516,9 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["request_scene_tree"] = _msg_request_scene_tree;
 	message_handlers["save_node"] = _msg_save_node;
 	message_handlers["inspect_objects"] = _msg_inspect_objects;
+#ifndef DISABLE_DEPRECATED
+	message_handlers["inspect_object"] = _msg_inspect_object;
+#endif // DISABLE_DEPRECATED
 	message_handlers["clear_selection"] = _msg_clear_selection;
 	message_handlers["suspend_changed"] = _msg_suspend_changed;
 	message_handlers["next_frame"] = _msg_next_frame;

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -83,6 +83,9 @@ private:
 	static Error _msg_request_scene_tree(const Array &p_args);
 	static Error _msg_save_node(const Array &p_args);
 	static Error _msg_inspect_objects(const Array &p_args);
+#ifndef DISABLE_DEPRECATED
+	static Error _msg_inspect_object(const Array &p_args);
+#endif // DISABLE_DEPRECATED
 	static Error _msg_clear_selection(const Array &p_args);
 	static Error _msg_suspend_changed(const Array &p_args);
 	static Error _msg_next_frame(const Array &p_args);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110042 - a regression introduced in https://github.com/godotengine/godot/pull/99680 caused external debuggers using the legacy `scene:inspect_object` command to break. This breaks external debuggers like the vscode godot plugin.

Details:

The `scene:inspect_object` command was replaced with `scene:inspect_objects` (plural) which changed the API from accepting a single object ID to requiring an array of IDs plus a boolean parameter. This broke external debuggers that relied on the original single-object API. Added backward-compatible proxy handlers on both engine and editor sides that convert the legacy single-object format to the new multi-object format internally, ensuring external debuggers continue to work without modification while preserving all new functionality.

Changes:
Engine: Added inspect_object handler that processes single ID and returns single object response
Editor: Added scene:inspect_object response handler that converts single object to array format
Debug Adapter: Added support for legacy single-object response format