### PR TITLE
Validate theme type name input in Add Theme Type dialog

### DIFF
--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -1334,11 +1334,7 @@ void ThemeItemEditorDialog::_edited_type_edited() {
 	TreeItem *edited_item = edit_type_list->get_selected();
 	const String old_type_name = edited_item->get_metadata(0);
 
-	String new_type_name = edited_item->get_text(0).strip_edges();
-	if (!new_type_name.is_empty()) { // The type name can be empty, unlike the item name.
-		new_type_name = new_type_name.validate_ascii_identifier();
-	}
-
+	const String &new_type_name = Theme::validate_type_name(edited_item->get_text(0));
 	if (old_type_name == new_type_name) {
 		edited_item->set_text(0, old_type_name);
 		return;
@@ -1585,10 +1581,7 @@ void ThemeItemEditorDialog::_item_tree_button_pressed(Object *p_item, int p_colu
 }
 
 void ThemeItemEditorDialog::_add_theme_type() {
-	String new_type_name = edit_add_type_value->get_text().strip_edges();
-	if (!new_type_name.is_empty()) { // The type name can be empty, unlike the item name.
-		new_type_name = new_type_name.validate_ascii_identifier();
-	}
+	const String &new_type_name = Theme::validate_type_name(edit_add_type_value->get_text());
 	edit_add_type_value->clear();
 
 	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
@@ -2254,7 +2247,7 @@ void ThemeTypeDialog::_add_type_options_cbk(int p_index) {
 }
 
 void ThemeTypeDialog::_add_type_dialog_entered(const String &p_value) {
-	_add_type_selected(p_value.strip_edges());
+	_add_type_selected(Theme::validate_type_name(p_value));
 }
 
 void ThemeTypeDialog::_add_type_dialog_activated(int p_index) {
@@ -2890,11 +2883,7 @@ void ThemeTypeEditor::_rename_type_button_cbk() {
 }
 
 void ThemeTypeEditor::_theme_type_rename_dialog_confirmed() {
-	String new_type_name = theme_type_rename_line_edit->get_text().strip_edges();
-	if (!new_type_name.is_empty()) { // The type name can be empty, unlike the item name.
-		new_type_name = new_type_name.validate_ascii_identifier();
-	}
-
+	const String &new_type_name = Theme::validate_type_name(theme_type_rename_line_edit->get_text());
 	if (edited_type == new_type_name) {
 		return;
 	}

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -176,8 +176,10 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 
 // Static helpers.
 bool Theme::is_valid_type_name(const String &p_name) {
-	for (int i = 0; i < p_name.length(); i++) {
-		if (!is_ascii_identifier_char(p_name[i])) {
+	int len = p_name.length();
+	const char32_t *str = p_name.ptr();
+	for (int i = 0; i < len; i++) {
+		if (!is_ascii_identifier_char(str[i])) {
 			return false;
 		}
 	}
@@ -188,12 +190,26 @@ bool Theme::is_valid_item_name(const String &p_name) {
 	if (p_name.is_empty()) {
 		return false;
 	}
-	for (int i = 0; i < p_name.length(); i++) {
-		if (!is_ascii_identifier_char(p_name[i])) {
+	int len = p_name.length();
+	const char32_t *str = p_name.ptr();
+	for (int i = 0; i < len; i++) {
+		if (!is_ascii_identifier_char(str[i])) {
 			return false;
 		}
 	}
 	return true;
+}
+
+String Theme::validate_type_name(const String &p_name) {
+	String type_name = p_name.strip_edges();
+	int len = type_name.length();
+	char32_t *buffer = type_name.ptrw();
+	for (int i = 0; i < len; i++) {
+		if (!is_ascii_identifier_char(buffer[i])) {
+			buffer[i] = '_';
+		}
+	}
+	return type_name;
 }
 
 // Fallback values for theme item types, configurable per theme.

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -116,6 +116,7 @@ protected:
 public:
 	static bool is_valid_type_name(const String &p_name);
 	static bool is_valid_item_name(const String &p_name);
+	static String validate_type_name(const String &p_name);
 
 	void set_default_base_scale(float p_base_scale);
 	float get_default_base_scale() const;


### PR DESCRIPTION
Closes #104297

There are four places where users can provide the name of a theme type:

1. Clicking "+" button in the Theme bottom panel to add a new theme type.
2. Clicking "I" button in the Theme bottom panel to rename an existing theme type.
3. Clicking "+" button in the Manage Theme Items dialog to add a new theme type.
4. Double clicking an theme type list item in the Manage Theme Items dialog to rename an existing theme type.

Currently, place 1 does no check while the others mistakenly prohibit the use of names beginning with numbers.

This PR fixes the validation and adds the missing check in place 1.

p.s. Also optimized `Theme::is_valid_type_name()` and `Theme::is_valid_item_name()`.