### PR TITLE
Do not set flags when `PopupMenu::set_visible` is called to hide popup.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3247,7 +3247,7 @@ void PopupMenu::set_visible(bool p_visible) {
 			_native_popup(Rect2i(get_position(), get_size()));
 		}
 	} else {
-		if (is_inside_tree()) {
+		if (p_visible && is_inside_tree()) {
 			set_flag(FLAG_POPUP, true);
 			set_flag(FLAG_NO_FOCUS, !is_embedded());
 		}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109149

Some flags can't be set while window is visible, and it only makes sense to do it here when `set_visible` is used to show window.