### PR TITLE
Add helper methods to convert right-to-left `Rect2i` and `Point2i` in `Tree`'s `draw_item`

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2027,6 +2027,20 @@ int Tree::get_item_height(TreeItem *p_item) const {
 	return height;
 }
 
+Point2i Tree::convert_rtl_position(const Point2i &pos, int width) const {
+	if (cache.rtl) {
+		return Point2i(get_size().width - pos.x - width, pos.y);
+	}
+	return pos;
+}
+
+Rect2i Tree::convert_rtl_rect(const Rect2i &rect) const {
+	if (cache.rtl) {
+		return Rect2i(Point2i(get_size().width - rect.position.x - rect.size.x, rect.position.y), rect.size);
+	}
+	return rect;
+}
+
 void Tree::draw_item_rect(const TreeItem::Cell &p_cell, const Rect2i &p_rect, const Color &p_color, const Color &p_icon_color, int p_ol_size, const Color &p_ol_color) const {
 	ERR_FAIL_COND(theme_cache.font.is_null());
 
@@ -2321,9 +2335,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				if (p_item->cells[0].selected || is_row_hovered) {
 					const Rect2 content_rect = _get_content_rect();
 					Rect2i row_rect = Rect2i(Point2i(content_rect.position.x, item_rect.position.y), Size2i(content_rect.size.x, item_rect.size.y));
-					if (rtl) {
-						row_rect.position.x = get_size().width - row_rect.position.x - row_rect.size.x;
-					}
+					row_rect = convert_rtl_rect(row_rect);
 
 					if (p_item->cells[0].selected) {
 						if (is_row_hovered) {
@@ -2350,10 +2362,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			if (select_mode != SELECT_ROW) {
-				Rect2i r = cell_rect;
-				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
-				}
+				Rect2i r = convert_rtl_rect(cell_rect);
 
 				// Cell hover.
 				if (is_cell_hovered && !p_item->cells[i].selected && !drop_mode_flags) {
@@ -2370,9 +2379,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 
 				if (select_mode != SELECT_ROW) {
 					p_item->set_meta("__focus_rect", Rect2(r.position, r.size));
-					if (rtl) {
-						r.position.x = get_size().width - r.position.x - r.size.x;
-					}
+					r = convert_rtl_rect(r);
 					if (p_item->cells[i].selected) {
 						if (is_cell_hovered) {
 							if (has_focus(true)) {
@@ -2394,10 +2401,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			if (theme_cache.draw_guides) {
-				Rect2 r = cell_rect;
-				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
-				}
+				Rect2 r = convert_rtl_rect(cell_rect);
 				RenderingServer::get_singleton()->canvas_item_add_line(ci, Point2i(r.position.x, r.position.y + r.size.height), r.position + r.size, theme_cache.guide_color, 1);
 			}
 
@@ -2407,9 +2411,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					r.position.x = p_draw_ofs.x;
 					r.size.x = item_width + ofs;
 				}
-				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
-				}
+				r = convert_rtl_rect(r);
 				if (p_item->cells[i].custom_bg_outline) {
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y, r.size.x, 1), p_item->cells[i].bg_color);
 					RenderingServer::get_singleton()->canvas_item_add_rect(ci, Rect2(r.position.x, r.position.y + r.size.y - 1, r.size.x, 1), p_item->cells[i].bg_color);
@@ -2421,10 +2423,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			if (drop_mode_flags && drop_mode_over) {
-				Rect2 r = cell_rect;
-				if (rtl) {
-					r.position.x = get_size().width - r.position.x - r.size.x;
-				}
+				Rect2 r = convert_rtl_rect(cell_rect);
 				if (drop_mode_over == p_item) {
 					if (drop_mode_section == 0 || drop_mode_section == -1) {
 						// Line above.
@@ -2464,9 +2463,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				update_item_cell(p_item, i);
 			}
 
-			if (rtl) {
-				item_rect.position.x = get_size().width - item_rect.position.x - item_rect.size.x;
-			}
+			item_rect = convert_rtl_rect(item_rect);
 
 			Point2i text_pos = item_rect.position;
 			text_pos.y += Math::floor((item_rect.size.y - p_item->cells[i].text_buf->get_size().y) * 0.5);
@@ -2637,10 +2634,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				bool should_draw_hovered = !drop_mode_flags && cache.hover_item == p_item && cache.hover_column == i && cache.hover_button_index_in_column == j && !p_item->cells[i].buttons[j].disabled;
 
 				if (should_draw_pressed || should_draw_hovered) {
-					Point2 od = button_ofs;
-					if (rtl) {
-						od.x = get_size().width - od.x - button_size.x;
-					}
+					Point2 od = convert_rtl_position(button_ofs, button_size.x);
 					if (should_draw_pressed && should_draw_hovered) {
 						theme_cache.button_pressed->draw(get_canvas_item(), Rect2(od.x, od.y, button_size.width, MAX(button_size.height, label_h)));
 					} else {
@@ -2648,19 +2642,14 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 					}
 				}
 				if (selected_item == p_item && selected_col == i && selected_button == j) {
-					Point2 od = button_ofs;
-					if (rtl) {
-						od.x = get_size().width - od.x - button_size.x;
-					}
+					Point2 od = convert_rtl_position(button_ofs, button_size.x);
 					theme_cache.button_hover->draw(get_canvas_item(), Rect2(od.x, od.y, button_size.width, MAX(button_size.height, label_h)));
 				}
 
 				button_ofs.y += (label_h - button_size.height) / 2;
 				button_ofs += theme_cache.button_pressed->get_offset();
 
-				if (rtl) {
-					button_ofs.x = get_size().width - button_ofs.x - button_texture->get_width();
-				}
+				button_ofs = convert_rtl_position(button_ofs, button_texture->get_width());
 				button_texture->draw(ci, button_ofs, p_item->cells[i].buttons[j].disabled ? Color(1, 1, 1, 0.5) : p_item->cells[i].buttons[j].color);
 				item_width_with_buttons -= button_size.width + theme_cache.button_margin;
 			}
@@ -2672,9 +2661,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			if (select_mode == SELECT_MULTI && selected_item == p_item && selected_col == i) {
-				if (is_layout_rtl()) {
-					cell_rect.position.x = get_size().width - cell_rect.position.x - cell_rect.size.x;
-				}
+				cell_rect = convert_rtl_rect(cell_rect);
 				if (has_focus(true)) {
 					theme_cache.cursor->draw(ci, cell_rect);
 				} else {
@@ -2689,7 +2676,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			Ref<Texture2D> arrow;
 
 			if (p_item->collapsed) {
-				if (is_layout_rtl()) {
+				if (rtl) {
 					arrow = theme_cache.arrow_collapsed_mirrored;
 				} else {
 					arrow = theme_cache.arrow_collapsed;
@@ -2710,9 +2697,9 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			if (arrow_draw_size.width > 0) {
+				apos = convert_rtl_position(apos, arrow_draw_size.width);
 				Point2 src_pos = Point2();
 				if (rtl) {
-					apos.x = get_size().width - apos.x - arrow_draw_size.width;
 					src_pos = Point2(arrow_full_size.width - arrow_draw_size.width, 0);
 				}
 				Rect2 arrow_rect = Rect2(apos, arrow_draw_size);
@@ -2768,10 +2755,8 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				int more_prev_ofs = 0;
 
 				if (root_pos.y + line_width >= 0) {
-					if (rtl) {
-						root_pos.x = get_size().width - root_pos.x;
-						parent_pos.x = get_size().width - parent_pos.x;
-					}
+					root_pos = convert_rtl_position(root_pos);
+					parent_pos = convert_rtl_position(parent_pos);
 					float parent_bottom_y = root_pos.y + parent_line_width * 0.5 + parent_line_pixel_shift;
 
 					// Order of parts on this bend: the horizontal line first, then the vertical line.

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -548,6 +548,8 @@ private:
 
 	int compute_item_height(TreeItem *p_item) const;
 	int get_item_height(TreeItem *p_item) const;
+	Point2i convert_rtl_position(const Point2i &pos, int width = 0) const;
+	Rect2i convert_rtl_rect(const Rect2i &Rect2) const;
 	void _update_all();
 	void update_column(int p_col);
 	void update_item_cell(TreeItem *p_item, int p_col) const;


### PR DESCRIPTION
A small simplification. I've also removed calls to `is_layout_rtl` inside `draw_item`, since there is an `rtl` flag in the beginning of the method.