### PR TITLE
[4.4] VariantParser: Fix reading negated identifiers for forwards compatibility with 4.5

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -148,7 +148,8 @@ const char *VariantParser::tk_name[TK_MAX] = {
 static double stor_fix(const String &p_str) {
 	if (p_str == "inf") {
 		return INFINITY;
-	} else if (p_str == "inf_neg") {
+	} else if (p_str == "-inf" || p_str == "inf_neg") {
+		// -inf included for forward compatibility.
 		return -INFINITY;
 	} else if (p_str == "nan") {
 		return NAN;
@@ -411,22 +412,19 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 				if (cchar <= 32) {
 					break;
 				}
-
-				if (cchar == '-' || (cchar >= '0' && cchar <= '9')) {
+				StringBuffer<> token_text;
+				if (cchar == '-') {
+					token_text += '-';
+					cchar = p_stream->get_char();
+				}
+				if (cchar >= '0' && cchar <= '9') {
 					//a number
-
-					StringBuffer<> num;
 #define READING_SIGN 0
 #define READING_INT 1
 #define READING_DEC 2
 #define READING_EXP 3
 #define READING_DONE 4
 					int reading = READING_INT;
-
-					if (cchar == '-') {
-						num += '-';
-						cchar = p_stream->get_char();
-					}
 
 					char32_t c = cchar;
 					bool exp_sign = false;
@@ -474,7 +472,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 						if (reading == READING_DONE) {
 							break;
 						}
-						num += c;
+						token_text += c;
 						c = p_stream->get_char();
 					}
 
@@ -483,17 +481,16 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 					r_token.type = TK_NUMBER;
 
 					if (is_float) {
-						r_token.value = num.as_double();
+						r_token.value = token_text.as_double();
 					} else {
-						r_token.value = num.as_int();
+						r_token.value = token_text.as_int();
 					}
 					return OK;
 				} else if (is_ascii_alphabet_char(cchar) || is_underscore(cchar)) {
-					StringBuffer<> id;
 					bool first = true;
 
 					while (is_ascii_alphabet_char(cchar) || is_underscore(cchar) || (!first && is_digit(cchar))) {
-						id += cchar;
+						token_text += cchar;
 						cchar = p_stream->get_char();
 						first = false;
 					}
@@ -501,7 +498,7 @@ Error VariantParser::get_token(Stream *p_stream, Token &r_token, int &line, Stri
 					p_stream->saved = cchar;
 
 					r_token.type = TK_IDENTIFIER;
-					r_token.value = id.as_string();
+					r_token.value = token_text.as_string();
 					return OK;
 				} else {
 					r_err_str = "Unexpected character";
@@ -699,7 +696,8 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			value = Variant();
 		} else if (id == "inf") {
 			value = INFINITY;
-		} else if (id == "inf_neg") {
+		} else if (id == "-inf" || id == "inf_neg") {
+			// -inf included for forward compatibility.
 			value = -INFINITY;
 		} else if (id == "nan") {
 			value = NAN;


### PR DESCRIPTION
This PR backports the negative identifier reading fix from PR #101618, and provides support for reading `-inf`. This provides forwards compatibility with files saved in Godot 4.5 in the Godot 4.4 branch.

This can be further cherry-picked to 4.3 and 4.2 if desired.