### PR TITLE
[3.x] Fix `is_visible_in_tree` regression for out of tree

### DIFF
--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -913,14 +913,15 @@ void Spatial::show() {
 
 	data.visible = true;
 
-	if (!is_inside_tree()) {
-		return;
-	}
-
 	bool parent_visible = get_parent_spatial() ? get_parent_spatial()->data.visible_in_tree : true;
 	if (parent_visible) {
 		_propagate_visible_in_tree(true);
 	}
+
+	if (!is_inside_tree()) {
+		return;
+	}
+
 	_propagate_visibility_changed();
 }
 
@@ -931,14 +932,15 @@ void Spatial::hide() {
 
 	data.visible = false;
 
-	if (!is_inside_tree()) {
-		return;
-	}
-
 	bool parent_visible = get_parent_spatial() ? get_parent_spatial()->data.visible_in_tree : true;
 	if (parent_visible) {
 		_propagate_visible_in_tree(false);
 	}
+
+	if (!is_inside_tree()) {
+		return;
+	}
+
 	_propagate_visibility_changed();
 }
 


### PR DESCRIPTION
Fixes small regression from #107324:

The cached `is_visible_in_tree` flag wasn't updated when `Spatials` were hidden or shown out of tree.

While it didn't cause any obvious problems, it was a change to previous behaviour, so is undesirable. Keeping the flag up to date outside the tree is unlikely to cause any performance issues.

## Notes
* Caught this when testing a blob shadows project which set some lights to hidden while out of tree.
* The regression testing code I left in for `DEV_ENABLED` builds did its job.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
