### PR TITLE
Metal: Reduce baked version to MSL 3.1; validate minimum version

### DIFF
--- a/drivers/metal/metal_utils.h
+++ b/drivers/metal/metal_utils.h
@@ -102,3 +102,7 @@ private:
 extern os_log_t LOG_DRIVER;
 // Used for dynamic tracing.
 extern os_log_t LOG_INTERVALS;
+
+_FORCE_INLINE_ static uint32_t make_msl_version(uint32_t major, uint32_t minor = 0, uint32_t patch = 0) {
+	return (major * 10000) + (minor * 100) + patch;
+}

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -1137,6 +1137,11 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 			RDD::ShaderID(),
 			"Shader was generated with argument buffers, but device has limited support");
 
+	uint32_t msl_version = make_msl_version(device_properties->features.mslVersionMajor, device_properties->features.mslVersionMinor);
+	ERR_FAIL_COND_V_MSG(msl_version < mtl_reflection_data.msl_version,
+			RDD::ShaderID(),
+			"Shader was compiled with a newer version of Metal than is available on the device.");
+
 	MTLCompileOptions *options = [MTLCompileOptions new];
 	uint32_t major = mtl_reflection_data.msl_version / 10000;
 	uint32_t minor = (mtl_reflection_data.msl_version / 100) % 100;

--- a/drivers/metal/rendering_shader_container_metal.mm
+++ b/drivers/metal/rendering_shader_container_metal.mm
@@ -79,7 +79,7 @@ const MetalDeviceProfile *MetalDeviceProfile::get_profile(MetalDeviceProfile::Pl
 			} break;
 		}
 		res.features.mslVersionMajor = 3;
-		res.features.mslVersionMinor = 2;
+		res.features.mslVersionMinor = 1;
 	}
 
 	return &profiles.insert(key, res)->value;


### PR DESCRIPTION
Validate the MSL version of the baked shader is <= the current version supported by the OS, and return an error so it is recompiled.

- ~~Closes~~ Related to #109846