### PR TITLE
Fix folder color in FileSystem Dock when using light theme

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1080,7 +1080,11 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 					files->set_item_metadata(-1, bd);
 					files->set_item_selectable(-1, false);
-					files->set_item_icon_modulate(-1, editor_is_dark_theme ? inherited_folder_color : inherited_folder_color * ITEM_COLOR_SCALE);
+					if (!editor_is_dark_theme && inherited_folder_color != default_folder_color) {
+						files->set_item_icon_modulate(-1, inherited_folder_color * ITEM_COLOR_SCALE);
+					} else {
+						files->set_item_icon_modulate(-1, inherited_folder_color);
+					}
 				}
 
 				bool reversed = file_sort == FileSortOption::FILE_SORT_NAME_REVERSE;
@@ -1094,7 +1098,10 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 					files->add_item(dname, folder_icon, true);
 					files->set_item_metadata(-1, dpath);
 					Color this_folder_color = has_custom_color ? folder_colors[assigned_folder_colors[dpath]] : inherited_folder_color;
-					files->set_item_icon_modulate(-1, editor_is_dark_theme ? this_folder_color : this_folder_color * ITEM_COLOR_SCALE);
+					if (!editor_is_dark_theme && this_folder_color != default_folder_color) {
+						this_folder_color *= ITEM_COLOR_SCALE;
+					}
+					files->set_item_icon_modulate(-1, this_folder_color);
 
 					if (previous_selection.has(dname)) {
 						files->select(files->get_item_count() - 1, false);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/110054

Before:
<img width="266" height="462" alt="Screenshot_20250828_222906" src="https://github.com/user-attachments/assets/212f74cc-41bd-49ce-9a4e-ef2842410458" />


After:
<img width="266" height="462" alt="Screenshot_20250828_222943" src="https://github.com/user-attachments/assets/1135ca99-fad6-40c6-bd8e-85d7364807f9" />


