### PR TITLE
[macOS] Add missing `joypad_sdl->process_events()` for embeddded

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1262,6 +1262,11 @@ void OS_MacOS_Embedded::run() {
 			@autoreleasepool {
 				@try {
 					ds->process_events();
+#ifdef SDL_ENABLED
+					if (joypad_sdl) {
+						joypad_sdl->process_events();
+					}
+#endif
 
 					if (Main::iteration()) {
 						break;


### PR DESCRIPTION
Fixes #110069

`joypad_sdl->process_events();` was called in `OS_MacOS_NSApp::start_main()` 

https://github.com/godotengine/godot/blob/4ebf67c12dcdffcb69242569c118a371a654b6ae/platform/macos/os_macos.mm#L1067-L1100

but not in the new and distinct `OS_MacOS_Embedded::run()`.

https://github.com/godotengine/godot/blob/4ebf67c12dcdffcb69242569c118a371a654b6ae/platform/macos/os_macos.mm#L1233-L1281

This PR fixes that issue.

cc. @Nintorch 