### PR TITLE
Add `Viewport` mipmap generation support 

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4261,6 +4261,14 @@
 				Practically speaking, this means that the end result of the Viewport will not be clamped to the [code]0-1[/code] range and can be used in 3D rendering without color encoding adjustments. This allows 2D rendering to take advantage of effects requiring high dynamic range (e.g. 2D glow) as well as substantially improves the appearance of effects requiring highly detailed gradients. This setting has the same effect as [member Viewport.use_hdr_2d].
 			</description>
 		</method>
+		<method name="viewport_set_use_mipmaps">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="use_mipmaps" type="bool" />
+			<description>
+				If [code]true[/code], the viewport will generate mipmaps for the output [ViewportTexture]. This has a performance impact, so only enable mipmaps if they are actually needed during rendering.
+			</description>
+		</method>
 		<method name="viewport_set_use_occlusion_culling">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -466,6 +466,9 @@
 			Additionally, 2D rendering will be performed on linear values and will be converted using the appropriate transfer function immediately before blitting to the screen (if the Viewport is attached to the screen).
 			Practically speaking, this means that the end result of the Viewport will not be clamped to the [code]0-1[/code] range and can be used in 3D rendering without color encoding adjustments. This allows 2D rendering to take advantage of effects requiring high dynamic range (e.g. 2D glow) as well as substantially improves the appearance of effects requiring highly detailed gradients.
 		</member>
+		<member name="use_mipmaps" type="bool" setter="set_use_mipmaps" getter="is_using_mipmaps" default="false">
+			If [code]true[/code], the viewport will generate mipmaps for the output [ViewportTexture]. This has a performance impact, so only enable mipmaps if they are actually needed during rendering.
+		</member>
 		<member name="use_occlusion_culling" type="bool" setter="set_use_occlusion_culling" getter="is_using_occlusion_culling" default="false">
 			If [code]true[/code], [OccluderInstance3D] nodes will be usable for occlusion culling in 3D for this viewport. For the root viewport, [member ProjectSettings.rendering/occlusion_culling/use_occlusion_culling] must be set to [code]true[/code] instead.
 			[b]Note:[/b] Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it, and think whether your scene can actually benefit from occlusion culling. Large, open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling. Large open scenes generally benefit more from mesh LOD and visibility ranges ([member GeometryInstance3D.visibility_range_begin] and [member GeometryInstance3D.visibility_range_end]) compared to occlusion culling.

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2323,16 +2323,35 @@ void TextureStorage::_update_render_target_color(RenderTarget *rt) {
 			glGenTextures(1, &rt->color);
 			glBindTexture(texture_target, rt->color);
 
-			if (use_multiview) {
-				glTexImage3D(texture_target, 0, rt->color_internal_format, rt->size.x, rt->size.y, rt->view_count, 0, rt->color_format, rt->color_type, nullptr);
-			} else {
-				glTexImage2D(texture_target, 0, rt->color_internal_format, rt->size.x, rt->size.y, 0, rt->color_format, rt->color_type, nullptr);
+			GLsizei width = rt->size.x;
+			GLsizei height = rt->size.y;
+			uint32_t texture_size_bytes = 0;
+			texture->mipmaps = 0;
+			for (int l = 0; l < 32; l++) {
+				texture->mipmaps += 1;
+				texture_size_bytes += width * height * rt->view_count * rt->color_format_size;
+
+				if (use_multiview) {
+					glTexImage3D(texture_target, l, rt->color_internal_format, width, height, rt->view_count, 0, rt->color_format, rt->color_type, nullptr);
+				} else {
+					glTexImage2D(texture_target, l, rt->color_internal_format, width, height, 0, rt->color_format, rt->color_type, nullptr);
+				}
+
+				if (!rt->use_mipmaps || (width == 1 && height == 1)) {
+					break;
+				}
+
+				width = MAX(1, width >> 1);
+				height = MAX(1, height >> 1);
 			}
 
 			texture->gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
 			texture->gl_set_repeat(RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
 
-			GLES3::Utilities::get_singleton()->texture_allocated_data(rt->color, rt->size.x * rt->size.y * rt->view_count * rt->color_format_size, "Render target color texture");
+			glTexParameteri(texture_target, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+			glTexParameteri(texture_target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+			GLES3::Utilities::get_singleton()->texture_allocated_data(rt->color, texture_size_bytes, "Render target color texture");
 		}
 #ifndef IOS_ENABLED
 		if (use_multiview) {
@@ -3045,6 +3064,25 @@ bool TextureStorage::render_target_is_using_hdr(RID p_render_target) const {
 	return rt->hdr;
 }
 
+void TextureStorage::render_target_set_use_mipmaps(RID p_render_target, bool p_use_mipmaps) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(rt);
+	if (p_use_mipmaps == rt->use_mipmaps) {
+		return;
+	}
+
+	_clear_render_target(rt);
+	rt->use_mipmaps = p_use_mipmaps;
+	_update_render_target_color(rt);
+}
+
+bool TextureStorage::render_target_is_using_mipmaps(RID p_render_target) const {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL_V(rt, false);
+
+	return rt->use_mipmaps;
+}
+
 GLuint TextureStorage::render_target_get_color_internal_format(RID p_render_target) const {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_NULL_V(rt, GL_RGBA8);
@@ -3452,6 +3490,25 @@ void TextureStorage::render_target_sdf_process(RID p_render_target) {
 	glBindFramebuffer(GL_FRAMEBUFFER, system_fbo);
 	glDeleteFramebuffers(1, &temp_fb);
 	glDisable(GL_SCISSOR_TEST);
+}
+
+void TextureStorage::render_target_gen_mipmaps(RID p_render_target) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_NULL(rt);
+
+	if (!rt->use_mipmaps) {
+		return;
+	}
+
+	if (rt->fbo == 0) {
+		_update_render_target_color(rt);
+	}
+
+	Config *config = Config::get_singleton();
+	bool use_multiview = rt->view_count > 1 && config->multiview_supported;
+	GLenum texture_target = use_multiview ? GL_TEXTURE_2D_ARRAY : GL_TEXTURE_2D;
+	glBindTexture(texture_target, rt->color);
+	glGenerateMipmap(texture_target);
 }
 
 void TextureStorage::render_target_copy_to_back_buffer(RID p_render_target, const Rect2i &p_region, bool p_gen_mipmaps) {

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -362,6 +362,7 @@ struct RenderTarget {
 	Size2i velocity_target_size;
 
 	bool hdr = false; // For Compatibility this effects both 2D and 3D rendering!
+	bool use_mipmaps = false;
 	GLuint color_internal_format = GL_RGBA8;
 	GLuint color_format = GL_RGBA;
 	GLuint color_type = GL_UNSIGNED_BYTE;
@@ -667,6 +668,10 @@ public:
 	virtual bool render_target_is_using_hdr(RID p_render_target) const override;
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) override {}
 	virtual bool render_target_is_using_debanding(RID p_render_target) const override { return false; }
+
+	virtual void render_target_set_use_mipmaps(RID p_render_target, bool p_use_mipmaps) override;
+	virtual bool render_target_is_using_mipmaps(RID p_render_target) const override;
+	virtual void render_target_gen_mipmaps(RID p_render_target) override;
 
 	// new
 	void render_target_set_as_unused(RID p_render_target) override {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1079,6 +1079,20 @@ float Viewport::get_oversampling_override() const {
 	return font_oversampling_override;
 }
 
+void Viewport::set_use_mipmaps(bool p_use_mipmaps) {
+	ERR_MAIN_THREAD_GUARD;
+	if (use_mipmaps == p_use_mipmaps) {
+		return;
+	}
+	use_mipmaps = p_use_mipmaps;
+	RS::get_singleton()->viewport_set_use_mipmaps(viewport, p_use_mipmaps);
+}
+
+bool Viewport::is_using_mipmaps() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return use_mipmaps;
+}
+
 bool Viewport::_set_size(const Size2i &p_size, const Size2 &p_size_2d_override, bool p_allocated) {
 	Transform2D stretch_transform_new = Transform2D();
 	float new_font_oversampling = 1.0;
@@ -4948,6 +4962,9 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_texture"), &Viewport::get_texture);
 
+	ClassDB::bind_method(D_METHOD("set_use_mipmaps", "enable"), &Viewport::set_use_mipmaps);
+	ClassDB::bind_method(D_METHOD("is_using_mipmaps"), &Viewport::is_using_mipmaps);
+
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 	ClassDB::bind_method(D_METHOD("set_physics_object_picking", "enable"), &Viewport::set_physics_object_picking);
 	ClassDB::bind_method(D_METHOD("get_physics_object_picking"), &Viewport::get_physics_object_picking);
@@ -5107,6 +5124,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mesh_lod_threshold", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_mesh_lod_threshold", "get_mesh_lod_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_draw", PROPERTY_HINT_ENUM, "Disabled,Unshaded,Lighting,Overdraw,Wireframe,Normal Buffer,VoxelGI Albedo,VoxelGI Lighting,VoxelGI Emission,Shadow Atlas,Directional Shadow Map,Scene Luminance,SSAO,SSIL,Directional Shadow Splits,Decal Atlas,SDFGI Cascades,SDFGI Probes,VoxelGI/SDFGI Buffer,Disable Mesh LOD,OmniLight3D Cluster,SpotLight3D Cluster,Decal Cluster,ReflectionProbe Cluster,Occlusion Culling Buffer,Motion Vectors,Internal Buffer"), "set_debug_draw", "get_debug_draw");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hdr_2d"), "set_use_hdr_2d", "is_using_hdr_2d");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_mipmaps"), "set_use_mipmaps", "is_using_mipmaps");
 
 #ifndef _3D_DISABLED
 	ADD_GROUP("Scaling 3D", "");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -252,6 +252,8 @@ private:
 	Transform2D global_canvas_transform;
 	Transform2D stretch_transform;
 
+	bool use_mipmaps = false;
+
 	Size2i size = Size2i(512, 512);
 	Size2 size_2d_override;
 	bool size_allocated = false;
@@ -581,6 +583,9 @@ public:
 	float get_oversampling_override() const;
 
 	float get_oversampling() const { return font_oversampling; }
+
+	void set_use_mipmaps(bool p_use_mipmaps);
+	bool is_using_mipmaps() const;
 
 	void set_scaling_3d_mode(Scaling3DMode p_scaling_3d_mode);
 	Scaling3DMode get_scaling_3d_mode() const;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -183,6 +183,10 @@ public:
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) override {}
 	virtual bool render_target_is_using_debanding(RID p_render_target) const override { return false; }
 
+	virtual void render_target_set_use_mipmaps(RID p_render_target, bool p_use_mipmaps) override {}
+	virtual bool render_target_is_using_mipmaps(RID p_render_target) const override { return false; }
+	virtual void render_target_gen_mipmaps(RID p_render_target) override {}
+
 	virtual void render_target_request_clear(RID p_render_target, const Color &p_clear_color) override {}
 	virtual bool render_target_is_clear_requested(RID p_render_target) override { return false; }
 	virtual Color render_target_get_clear_request_color(RID p_render_target) override { return Color(); }

--- a/servers/rendering/renderer_rd/effects/copy_effects.cpp
+++ b/servers/rendering/renderer_rd/effects/copy_effects.cpp
@@ -85,6 +85,7 @@ CopyEffects::CopyEffects(bool p_prefer_raster_effects) {
 		copy_modes.push_back("\n#define MODE_SET_COLOR\n");
 		copy_modes.push_back("\n#define MODE_SET_COLOR\n#define DST_IMAGE_8BIT\n");
 		copy_modes.push_back("\n#define MODE_MIPMAP\n");
+		copy_modes.push_back("\n#define MODE_MIPMAP\n#define DST_IMAGE_8BIT\n");
 		copy_modes.push_back("\n#define MODE_LINEARIZE_DEPTH_COPY\n");
 		copy_modes.push_back("\n#define MODE_CUBEMAP_TO_PANORAMA\n");
 		copy_modes.push_back("\n#define MODE_CUBEMAP_ARRAY_TO_PANORAMA\n");
@@ -864,7 +865,7 @@ void CopyEffects::gaussian_glow_raster(RID p_source_rd_texture, RID p_half_textu
 	RD::get_singleton()->draw_list_end();
 }
 
-void CopyEffects::make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size) {
+void CopyEffects::make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size, bool p_8_bit_dst) {
 	ERR_FAIL_COND_MSG(prefer_raster_effects, "Can't use the compute version of the make_mipmap shader with the mobile renderer.");
 
 	UniformSetCacheRD *uniform_set_cache = UniformSetCacheRD::get_singleton();
@@ -885,7 +886,7 @@ void CopyEffects::make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const
 	RD::Uniform u_source_rd_texture(RD::UNIFORM_TYPE_SAMPLER_WITH_TEXTURE, 0, Vector<RID>({ default_sampler, p_source_rd_texture }));
 	RD::Uniform u_dest_texture(RD::UNIFORM_TYPE_IMAGE, 0, p_dest_texture);
 
-	CopyMode mode = COPY_MODE_MIPMAP;
+	CopyMode mode = p_8_bit_dst ? COPY_MODE_MIPMAP_8BIT : COPY_MODE_MIPMAP;
 	RID shader = copy.shader.version_get_shader(copy.shader_version, mode);
 	ERR_FAIL_COND(shader.is_null());
 

--- a/servers/rendering/renderer_rd/effects/copy_effects.h
+++ b/servers/rendering/renderer_rd/effects/copy_effects.h
@@ -115,6 +115,7 @@ private:
 		COPY_MODE_SET_COLOR,
 		COPY_MODE_SET_COLOR_8BIT,
 		COPY_MODE_MIPMAP,
+		COPY_MODE_MIPMAP_8BIT,
 		COPY_MODE_LINEARIZE_DEPTH,
 		COPY_MODE_CUBE_TO_PANORAMA,
 		COPY_MODE_CUBE_ARRAY_TO_PANORAMA,
@@ -338,7 +339,7 @@ public:
 	void gaussian_glow(RID p_source_rd_texture, RID p_back_texture, const Size2i &p_size, float p_strength = 1.0, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_threshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_scale = 1.0);
 	void gaussian_glow_raster(RID p_source_rd_texture, RID p_half_texture, RID p_dest_texture, float p_luminance_multiplier, const Size2i &p_size, float p_strength = 1.0, bool p_first_pass = false, float p_luminance_cap = 16.0, float p_exposure = 1.0, float p_bloom = 0.0, float p_hdr_bleed_threshold = 1.0, float p_hdr_bleed_scale = 1.0, RID p_auto_exposure = RID(), float p_auto_exposure_scale = 1.0);
 
-	void make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size);
+	void make_mipmap(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size, bool p_8_bit_dst = false);
 	void make_mipmap_raster(RID p_source_rd_texture, RID p_dest_texture, const Size2i &p_size);
 
 	void set_color(RID p_dest_texture, const Color &p_color, const Rect2i &p_region, bool p_8bit_dst = false);

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -357,8 +357,11 @@ private:
 		Size2i size;
 		uint32_t view_count;
 		RID color;
+		RID color_mipmap0;
 		Vector<RID> color_slices;
 		RID color_multisample; // Needed when 2D MSAA is enabled.
+		bool use_mipmaps = false;
+		Vector<RID> color_mipmaps;
 
 		RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED; // 2D MSAA mode
 		bool msaa_needs_resolve = false; // 2D MSAA needs resolved
@@ -766,6 +769,10 @@ public:
 	virtual bool render_target_is_using_hdr(RID p_render_target) const override;
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) override;
 	virtual bool render_target_is_using_debanding(RID p_render_target) const override;
+
+	virtual void render_target_set_use_mipmaps(RID p_render_target, bool p_use_mipmaps) override;
+	virtual bool render_target_is_using_mipmaps(RID p_render_target) const override;
+	virtual void render_target_gen_mipmaps(RID p_render_target) override;
 
 	void render_target_copy_to_back_buffer(RID p_render_target, const Rect2i &p_region, bool p_gen_mipmaps);
 	void render_target_clear_back_buffer(RID p_render_target, const Rect2i &p_region, const Color &p_color);

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -723,6 +723,10 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		RSG::texture_storage->render_target_do_msaa_resolve(p_viewport->render_target);
 	}
 
+	if (p_viewport->use_mipmaps) {
+		RSG::texture_storage->render_target_gen_mipmaps(p_viewport->render_target);
+	}
+
 	if (p_viewport->measure_render_time) {
 		String rt_id = "vp_end_" + itos(p_viewport->self.get_id());
 		RSG::utilities->capture_timestamp(rt_id);
@@ -1151,6 +1155,17 @@ void RendererViewport::viewport_set_update_mode(RID p_viewport, RS::ViewportUpda
 	ERR_FAIL_NULL(viewport);
 
 	viewport->update_mode = p_mode;
+}
+
+void RendererViewport::viewport_set_use_mipmaps(RID p_viewport, bool p_use_mipmaps) {
+	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
+	ERR_FAIL_NULL(viewport);
+
+	if (viewport->use_mipmaps != p_use_mipmaps) {
+		viewport->use_mipmaps = p_use_mipmaps;
+
+		RSG::texture_storage->render_target_set_use_mipmaps(viewport->render_target, p_use_mipmaps);
+	}
 }
 
 RS::ViewportUpdateMode RendererViewport::viewport_get_update_mode(RID p_viewport) const {

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -48,6 +48,8 @@ public:
 		// use xr interface to override camera positioning and projection matrices and control output
 		bool use_xr = false;
 
+		bool use_mipmaps = false;
+
 		Size2i internal_size;
 		Size2i size;
 		uint32_t view_count;
@@ -217,6 +219,8 @@ public:
 	void viewport_initialize(RID p_rid);
 
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
+
+	void viewport_set_use_mipmaps(RID p_viewport, bool p_use_mipmaps);
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
 

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2822,6 +2822,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("viewport_create"), &RenderingServer::viewport_create);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_xr", "viewport", "use_xr"), &RenderingServer::viewport_set_use_xr);
+	ClassDB::bind_method(D_METHOD("viewport_set_use_mipmaps", "viewport", "use_mipmaps"), &RenderingServer::viewport_set_use_mipmaps);
 	ClassDB::bind_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::viewport_set_size);
 	ClassDB::bind_method(D_METHOD("viewport_set_active", "viewport", "active"), &RenderingServer::viewport_set_active);
 	ClassDB::bind_method(D_METHOD("viewport_set_parent_viewport", "viewport", "parent_viewport"), &RenderingServer::viewport_set_parent_viewport);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -979,6 +979,7 @@ public:
 	}
 
 	virtual void viewport_set_use_xr(RID p_viewport, bool p_use_xr) = 0;
+	virtual void viewport_set_use_mipmaps(RID p_viewport, bool p_use_mipmaps) = 0;
 	virtual void viewport_set_size(RID p_viewport, int p_width, int p_height) = 0;
 	virtual void viewport_set_active(RID p_viewport, bool p_active) = 0;
 	virtual void viewport_set_parent_viewport(RID p_viewport, RID p_parent_viewport) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -694,6 +694,7 @@ public:
 	FUNCRIDSPLIT(viewport)
 
 	FUNC2(viewport_set_use_xr, RID, bool)
+	FUNC2(viewport_set_use_mipmaps, RID, bool)
 	FUNC3(viewport_set_size, RID, int, int)
 
 	FUNC2(viewport_set_active, RID, bool)

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -161,6 +161,10 @@ public:
 	virtual void render_target_set_use_debanding(RID p_render_target, bool p_use_debanding) = 0;
 	virtual bool render_target_is_using_debanding(RID p_render_target) const = 0;
 
+	virtual void render_target_set_use_mipmaps(RID p_render_target, bool p_use_mipmaps) = 0;
+	virtual bool render_target_is_using_mipmaps(RID p_render_target) const = 0;
+	virtual void render_target_gen_mipmaps(RID p_render_target) = 0;
+
 	virtual void render_target_request_clear(RID p_render_target, const Color &p_clear_color) = 0;
 	virtual bool render_target_is_clear_requested(RID p_render_target) = 0;
 	virtual Color render_target_get_clear_request_color(RID p_render_target) = 0;


### PR DESCRIPTION
Adds an option to the viewport to generate mipmaps after rendering. This is useful with a SubViewport when using the ViewportTexture as a texture in 3d, since mipmaps can be utilized.

The gdscript member `use_mipmaps` is added to the Viewport class. The gdscript method `viewport_set_use_mipmaps` is also added to the RenderingServer. The feature can be used by adding a SubViewport  and toggling on Use Mipmaps.

The option is turned off by default. All rendering functionality is identical to before if the option is left off.

Related:
godotengine/godot-proposals#7576
#23417 (although it specifies 3.x)

* *Bugsquad edit, closes: godotengine/godot-proposals#7576*