### PR TITLE
[macOS] Fix keyboard mapping init in embedded display server.

### DIFF
--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3721,8 +3721,6 @@ bool DisplayServerMacOS::mouse_process_popups(bool p_close) {
 }
 
 DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowMode p_mode, VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, Context p_context, int64_t p_parent_window, Error &r_error) {
-	KeyMappingMacOS::initialize();
-
 	Input::get_singleton()->set_event_dispatch_function(_dispatch_input_events);
 
 	r_error = OK;

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -302,6 +302,8 @@ void DisplayServerMacOSBase::show_emoji_and_symbol_picker() const {
 }
 
 DisplayServerMacOSBase::DisplayServerMacOSBase() {
+	KeyMappingMacOS::initialize();
+
 	// Init TTS
 	bool tts_enabled = GLOBAL_GET("audio/general/text_to_speech");
 	if (tts_enabled) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110074