### PR TITLE
Set `_is_queued_for_deletion` back to `false` when cancelling `Object` deletion

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -262,6 +262,9 @@ bool Object::_predelete() {
 }
 
 void Object::cancel_free() {
+	if (_predelete_ok) {
+		_is_queued_for_deletion = false;
+	}
 	_predelete_ok = false;
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110061

Modified code from the linked issue:

```gdscript
class ObjectClass extends Object:
	func _notification(what: int) -> void:
		if what == NOTIFICATION_PREDELETE:
			cancel_free()
			print("predelete is_queued_for_deletion(): ", is_queued_for_deletion())

func _ready() -> void:
	var object := ObjectClass.new()
	get_tree().queue_delete(object)
	object.cancel_free()
	print("ready1 is_queued_for_deletion(): ", object.is_queued_for_deletion())
	
	await get_tree().create_timer(1.0).timeout
	print("ready2 is_queued_for_deletion(): ", object.is_queued_for_deletion())
```

Current master:
```
ready1 is_queued_for_deletion(): true
predelete is_queued_for_deletion(): true
ready2 is_queued_for_deletion(): true
```

This PR:
```
ready1 is_queued_for_deletion(): true
predelete is_queued_for_deletion(): false
ready2 is_queued_for_deletion(): false
```