### PR TITLE
[GraphEdit] Do not scale popup menus in the graph elements when zoomed.

### DIFF
--- a/doc/classes/GraphElement.xml
+++ b/doc/classes/GraphElement.xml
@@ -19,6 +19,9 @@
 			If [code]true[/code], the user can resize the GraphElement.
 			[b]Note:[/b] Dragging the handle will only emit the [signal resize_request] and [signal resize_end] signals, the GraphElement needs to be resized manually.
 		</member>
+		<member name="scaling_menus" type="bool" setter="set_scaling_menus" getter="is_scaling_menus" default="false">
+			If [code]true[/code], [PopupMenu]s that are descendants of the GraphElement are scaled with the [GraphEdit] zoom.
+		</member>
 		<member name="selectable" type="bool" setter="set_selectable" getter="is_selectable" default="true">
 			If [code]true[/code], the user can select the GraphElement.
 		</member>

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -213,6 +213,14 @@ bool GraphElement::is_selectable() {
 	return selectable;
 }
 
+void GraphElement::set_scaling_menus(bool p_scaling_menus) {
+	scaling_menus = p_scaling_menus;
+}
+
+bool GraphElement::is_scaling_menus() const {
+	return scaling_menus;
+}
+
 void GraphElement::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_resizable", "resizable"), &GraphElement::set_resizable);
 	ClassDB::bind_method(D_METHOD("is_resizable"), &GraphElement::is_resizable);
@@ -226,6 +234,9 @@ void GraphElement::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_selected", "selected"), &GraphElement::set_selected);
 	ClassDB::bind_method(D_METHOD("is_selected"), &GraphElement::is_selected);
 
+	ClassDB::bind_method(D_METHOD("set_scaling_menus", "scaling_menus"), &GraphElement::set_scaling_menus);
+	ClassDB::bind_method(D_METHOD("is_scaling_menus"), &GraphElement::is_scaling_menus);
+
 	ClassDB::bind_method(D_METHOD("set_position_offset", "offset"), &GraphElement::set_position_offset);
 	ClassDB::bind_method(D_METHOD("get_position_offset"), &GraphElement::get_position_offset);
 
@@ -234,6 +245,7 @@ void GraphElement::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "draggable"), "set_draggable", "is_draggable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selectable"), "set_selectable", "is_selectable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "selected"), "set_selected", "is_selected");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scaling_menus"), "set_scaling_menus", "is_scaling_menus");
 
 	ADD_SIGNAL(MethodInfo("node_selected"));
 	ADD_SIGNAL(MethodInfo("node_deselected"));

--- a/scene/gui/graph_element.h
+++ b/scene/gui/graph_element.h
@@ -48,6 +48,8 @@ protected:
 
 	Vector2 position_offset;
 
+	bool scaling_menus = false;
+
 	struct ThemeCache {
 		Ref<Texture2D> resizer;
 	} theme_cache;
@@ -83,6 +85,9 @@ public:
 
 	void set_selectable(bool p_selectable);
 	bool is_selectable();
+
+	void set_scaling_menus(bool p_scaling_menus);
+	bool is_scaling_menus() const;
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/108609

https://github.com/user-attachments/assets/a6a695c3-e53f-4d1f-bedd-5db2e739ea7d

