### PR TITLE
Fix texture repeat mode for GLES3 renderer.

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -820,14 +820,6 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		state.canvas_instance_batches[state.current_batch_index].filter = texture_filter;
 	}
 
-	RSE::CanvasItemTextureRepeat texture_repeat = p_item->texture_repeat == RSE::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT ? state.default_repeat : p_item->texture_repeat;
-
-	if (texture_repeat != state.canvas_instance_batches[state.current_batch_index].repeat) {
-		_new_batch(r_batch_broken);
-
-		state.canvas_instance_batches[state.current_batch_index].repeat = texture_repeat;
-	}
-
 	Transform2D base_transform = p_item->final_transform;
 	if (p_item->repeat_source_item && (p_repeat_offset.x || p_repeat_offset.y)) {
 		base_transform.columns[2] += p_item->repeat_source_item->final_transform.basis_xform(p_repeat_offset);
@@ -882,6 +874,7 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		state.canvas_instance_batches[state.current_batch_index].specialization ^= CanvasShaderGLES3::DISABLE_LIGHTING;
 	}
 
+	const RSE::CanvasItemTextureRepeat base_texture_repeat = p_item->texture_repeat == RSE::CANVAS_ITEM_TEXTURE_REPEAT_DEFAULT ? state.default_repeat : p_item->texture_repeat;
 	const Item::Command *c = p_item->commands;
 	while (c) {
 		if (skipping && c->type != Item::Command::TYPE_ANIMATION_SLICE) {
@@ -915,12 +908,21 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 
 		Color blend_color = base_color;
 		GLES3::CanvasShaderData::BlendMode blend_mode = p_blend_mode;
+		RSE::CanvasItemTextureRepeat texture_repeat = base_texture_repeat;
 		if (c->type == Item::Command::TYPE_RECT) {
 			const Item::CommandRect *rect = static_cast<const Item::CommandRect *>(c);
 			if (rect->flags & CANVAS_RECT_LCD) {
 				blend_mode = GLES3::CanvasShaderData::BLEND_MODE_LCD;
 				blend_color = rect->modulate * base_color;
 			}
+
+			if (rect->flags & CANVAS_RECT_TILE) {
+				texture_repeat = RSE::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED;
+			}
+		}
+		if (texture_repeat != state.canvas_instance_batches[state.current_batch_index].repeat) {
+			_new_batch(r_batch_broken);
+			state.canvas_instance_batches[state.current_batch_index].repeat = texture_repeat;
 		}
 
 		if (blend_mode != state.canvas_instance_batches[state.current_batch_index].blend_mode || blend_color != state.canvas_instance_batches[state.current_batch_index].blend_color) {
@@ -932,12 +934,6 @@ void RasterizerCanvasGLES3::_record_item_commands(const Item *p_item, RID p_rend
 		switch (c->type) {
 			case Item::Command::TYPE_RECT: {
 				const Item::CommandRect *rect = static_cast<const Item::CommandRect *>(c);
-
-				if (rect->flags & CANVAS_RECT_TILE && state.canvas_instance_batches[state.current_batch_index].repeat != RSE::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED) {
-					_new_batch(r_batch_broken);
-					state.canvas_instance_batches[state.current_batch_index].repeat = RSE::CanvasItemTextureRepeat::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED;
-				}
-
 				if (rect->texture != state.canvas_instance_batches[state.current_batch_index].tex || state.canvas_instance_batches[state.current_batch_index].command_type != Item::Command::TYPE_RECT) {
 					_new_batch(r_batch_broken);
 					state.canvas_instance_batches[state.current_batch_index].tex = rect->texture;


### PR DESCRIPTION
Before:
<img width="1193" height="630" alt="Screenshot From 2025-08-29 12-56-51" src="https://github.com/user-attachments/assets/68baae5f-06fa-4162-992f-e8c5907488bb" />

After:
<img width="1193" height="630" alt="Screenshot From 2025-08-29 12-56-59" src="https://github.com/user-attachments/assets/4e93a5ff-6b56-4c0e-87ae-15f57118f0f1" />


* Fixes: https://github.com/godotengine/godot/issues/110082