### PR TITLE
Clear `XRServer#remove_tracker` errors when closing the Godot editor

### DIFF
--- a/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
+++ b/modules/openxr/extensions/openxr_hand_tracking_extension.cpp
@@ -349,7 +349,9 @@ void OpenXRHandTrackingExtension::cleanup_hand_tracking() {
 			hand_trackers[i].is_initialized = false;
 			hand_trackers[i].hand_tracker = XR_NULL_HANDLE;
 
-			XRServer::get_singleton()->remove_tracker(hand_trackers[i].godot_tracker);
+			if (hand_trackers[i].godot_tracker.is_valid()) {
+				XRServer::get_singleton()->remove_tracker(hand_trackers[i].godot_tracker);
+			}
 		}
 	}
 }

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -635,8 +635,10 @@ void OpenXRInterface::free_trackers() {
 		Tracker *tracker = trackers[i];
 
 		openxr_api->tracker_free(tracker->tracker_rid);
-		xr_server->remove_tracker(tracker->controller_tracker);
-		tracker->controller_tracker.unref();
+		if (tracker->controller_tracker.is_valid()) {
+			xr_server->remove_tracker(tracker->controller_tracker);
+			tracker->controller_tracker.unref();
+		}
 
 		memdelete(tracker);
 	}


### PR DESCRIPTION
Addresses the following errors when the Godot editor is closed:
```
XR: Clearing primary interface
ERROR: Condition "p_tracker.is_null()" is true.
   at: remove_tracker (servers/xr_server.cpp:345)
ERROR: Condition "p_tracker.is_null()" is true.
   at: remove_tracker (servers/xr_server.cpp:345)

```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
