### PR TITLE
Fix JSON modification out of sync

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -540,8 +540,22 @@ Error JSON::_parse_object(Dictionary &object, const char32_t *p_str, int &index,
 }
 
 void JSON::set_data(const Variant &p_data) {
+	if (data == p_data) {
+		return;
+	}
 	data = p_data;
+
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint() && get_path().get_extension().nocasecmp_to("json") == 0) {
+		// Synchronize changes made in the inspector to the internal editor. Only for json files.
+		text = JSON::stringify(data, "\t", false, true);
+	} else {
+		text.clear();
+	}
+#else
 	text.clear();
+#endif
+	emit_changed();
 }
 
 Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_str, int &r_err_line) {
@@ -575,13 +589,53 @@ Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_st
 	return err;
 }
 
+#ifdef TOOLS_ENABLED
+Error JSON::copy_from(const Ref<Resource> &p_resource) {
+	Ref<JSON> json = p_resource;
+	ERR_FAIL_COND_V(json.is_null(), ERR_INVALID_PARAMETER);
+	if (get_class() != json->get_class()) {
+		return ERR_INVALID_PARAMETER;
+	}
+
+	_block_emit_changed();
+
+	reset_state(); // May want to reset state.
+
+	List<PropertyInfo> pi;
+	json->get_property_list(&pi);
+
+	for (const PropertyInfo &E : pi) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE)) {
+			continue;
+		}
+		if (E.name == "resource_path") {
+			continue; // Do not change path.
+		}
+
+		set(E.name, json->get(E.name));
+	}
+
+	if (Engine::get_singleton()->is_editor_hint() && get_path().get_extension().nocasecmp_to("json") == 0) {
+		text = json->text; // Prevent text inconsistencies.
+	}
+
+	_unblock_emit_changed();
+
+	return OK;
+}
+#endif // TOOLS_ENABLED
+
 Error JSON::parse(const String &p_json_string, bool p_keep_text) {
+	Variant prev_data = data;
 	Error err = _parse_string(p_json_string, data, err_str, err_line);
 	if (err == Error::OK) {
 		err_line = 0;
 	}
 	if (p_keep_text) {
 		text = p_json_string;
+	}
+	if (prev_data != data) {
+		emit_changed();
 	}
 	return err;
 }

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -86,6 +86,10 @@ protected:
 	static void _bind_methods();
 
 public:
+#ifdef TOOLS_ENABLED
+	Error copy_from(const Ref<Resource> &p_resource) override;
+#endif
+
 	Error parse(const String &p_json_string, bool p_keep_text = false);
 	String get_parsed_text() const;
 

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -178,6 +178,9 @@ String Resource::get_scene_unique_id() const {
 }
 
 void Resource::set_name(const String &p_name) {
+	if (name == p_name) {
+		return;
+	}
 	name = p_name;
 	emit_changed();
 }

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -948,9 +948,14 @@ void ScriptEditor::_close_current_tab(bool p_save, bool p_history_back) {
 }
 
 void ScriptEditor::_close_discard_current_tab(const String &p_str) {
-	Ref<Script> scr = _get_current_script();
-	if (scr.is_valid()) {
-		scr->reload_from_file();
+	ScriptEditorBase *current = _get_current_editor();
+	if (current) {
+		Ref<Resource> current_res = current->get_edited_resource();
+		Ref<Script> scr = current_res;
+		Ref<JSON> json = current_res;
+		if (scr.is_valid() || json.is_valid()) {
+			current_res->reload_from_file();
+		}
 	}
 	_close_tab(tab_container->get_current_tab(), false);
 	erase_tab_confirm->hide();

--- a/editor/script/text_editor.cpp
+++ b/editor/script/text_editor.cpp
@@ -109,7 +109,9 @@ void TextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 
 	Ref<JSON> json_file = edited_res;
 	if (json_file.is_valid()) {
+		json_file->reload_from_file(); // Ignore possible unsaved changes.
 		code_editor->get_text_editor()->set_text(json_file->get_parsed_text());
+		json_file->connect_changed(callable_mp(this, &TextEditor::_update_text));
 	}
 
 	code_editor->get_text_editor()->clear_undo_history();
@@ -188,6 +190,19 @@ void TextEditor::reload_text() {
 	_validate_script();
 }
 
+void TextEditor::_update_text() {
+	if (parsing) {
+		// The changed signal emitted while parsing in the text editor.
+		parsing = false; // Block only once to allow the user's combo to be triggered.
+		return;
+	}
+	Ref<JSON> json = edited_res;
+	if (json.is_valid()) {
+		code_editor->get_text_editor()->set_text(json->get_parsed_text());
+		_validate_script();
+	}
+}
+
 void TextEditor::_validate_script() {
 	emit_signal(SNAME("name_changed"));
 	emit_signal(SNAME("edited_script_changed"));
@@ -199,6 +214,7 @@ void TextEditor::_validate_script() {
 		te->set_line_background_color(code_editor->get_error_pos().x, Color(0, 0, 0, 0));
 		code_editor->set_error("");
 
+		parsing = true;
 		if (json_file->parse(te->get_text(), true) != OK) {
 			code_editor->set_error(json_file->get_error_message().replace("[", "[lb]"));
 			code_editor->set_error_pos(json_file->get_error_line(), 0);
@@ -250,6 +266,7 @@ void TextEditor::apply_code() {
 
 	Ref<JSON> json_file = edited_res;
 	if (json_file.is_valid()) {
+		parsing = true;
 		json_file->parse(code_editor->get_text_editor()->get_text(), true);
 	}
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();

--- a/editor/script/text_editor.h
+++ b/editor/script/text_editor.h
@@ -93,6 +93,9 @@ private:
 		EDIT_EMOJI_AND_SYMBOL,
 	};
 
+	bool parsing = false;
+	void _update_text(); // For resources that allow editing in the inspector and internal editor.
+
 protected:
 	void _edit_option(int p_op);
 	void _make_context_menu(bool p_selection, bool p_can_fold, bool p_is_folded, Vector2 p_position);


### PR DESCRIPTION
A json file can be modified in three places: the inspector, the internal editor, and the external editor.

Make sure that modifying the JSON in one place is synchronized to the other two.

Fix #104943, supersede #105134.

Note: Opening a json file in the internal editor will automatically reload from the file. This will discard any unsaved changes in the Inspector. To restore these unsaved changes, **undo and then redo** them in the Inspector.

https://github.com/user-attachments/assets/627d0823-ff07-47a0-8f4d-527c93110d72




<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
