### PR TITLE
Fix Range scale overflow

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -44,7 +44,7 @@ double Range::_snapped_r128(double p_value, double p_step) {
 	// R128 is fixed-precision with 64 bits after the decimal point, but double already uses 53 of those,
 	// so a step size finer than 2^-11 will lose precision, and in practice even 1e-3 can be problematic.
 	// By rescaling the value and step, we can shift precision into the higher bits (effectively turning R128 into a makeshift float).
-	const int decimals = 14 - Math::floor(std::log10(MAX(Math::abs(p_value), p_step)));
+	const int decimals = MIN(18, 14 - Math::floor(std::log10(MAX(Math::abs(p_value), p_step))));
 	const double scale = Math::pow(10.0, decimals);
 	p_value *= scale;
 	p_step *= scale;


### PR DESCRIPTION
Fixes the regression noted in #109838

The scale factor introduced in PR #109887 helped with the step size losing precision due to the least significant bits underflowing, but it introduced a new problem: the scale factor itself was overflowing beyond the supported range. We can't go beyond 10^18 because that is the maximum value we can store in R128. Double itself is fine with this value.

<img width="1200" height="151" alt="Screenshot 2025-08-29 at 8 34 08 PM" src="https://github.com/user-attachments/assets/5cc8928d-9461-405f-be5d-00b1ef21fa4f" />

Note that `0.0001` and finer values are serialized with a bunch of `9`s. At least `0.001` and courser values work, which is the editor's default float step, so this should still work seamlessly from the perspective of the majority of users. And, the remaining problem is mostly just a cosmetic issue, unlike this regression which massively altered the value.

If we had 128-bit floats, this code would be a lot more straightforward, with no need for all this clamping to float ourselves into the R128 range, but alas, we don't have that yet and therefore this code will have to do for now.