### PR TITLE
Duplicate 3D nodes when pressing shift during transform

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -310,7 +310,7 @@ private:
 	Vector3 _get_screen_to_space(const Vector3 &p_vector3);
 
 	void _select_region();
-	bool _transform_gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only = false);
+	bool _transform_gizmo_select(const Vector2 &p_screenpos, bool p_highlight_only = false, bool p_duplicate = false);
 	void _transform_gizmo_apply(Node3D *p_node, const Transform3D &p_transform, bool p_local);
 
 	void _nav_pan(Ref<InputEventWithModifiers> p_event, const Vector2 &p_relative);
@@ -381,6 +381,14 @@ private:
 		Variant gizmo_initial_value;
 		bool original_local;
 		bool instant;
+
+		// Tracking duplication data. Sstoring this allows us to decouple the duplication
+		// from creating the undo/redo entry later when committing the transform.
+		bool duplicate;
+		List<Node *> dup_original_selection;
+		HashMap<Node *, NodePath> dup_original_paths;
+		HashMap<Node *, Node *> dup_insertion_siblings;
+		List<Node *> dup_owned_nodes;
 
 		// Numeric blender-style transforms (e.g. 'g5x').
 		// numeric_input tracks the current input value, e.g. 1.23.
@@ -515,7 +523,7 @@ private:
 
 	Transform3D _compute_transform(TransformMode p_mode, const Transform3D &p_original, const Transform3D &p_original_local, Vector3 p_motion, double p_extra, bool p_local, bool p_orthogonal);
 
-	void begin_transform(TransformMode p_mode, bool instant);
+	void begin_transform(TransformMode p_mode, bool p_instant, bool p_duplicate = false);
 	void commit_transform();
 	void apply_transform(Vector3 p_motion, double p_snap);
 	void update_transform(bool p_shift);


### PR DESCRIPTION
Fixes godotengine/godot-proposals#1381

I decided to implement this for `shift` instead of `alt`. The reasoning is that there would be too many conflicts otherwise. Most importantly, `alt` is being used when dragging across the viewport: just left click does a box select, `alt` left click uses the currently active transform tool. So we can not use alt for object duplication, leaving us with `shift` as the modifier for this feature.

The general logic in this PR is:
- `_compute_edit()` is called at the start of all transforms, so that is where we duplicate the nodes before the transform
- `_edit` state data keeps track of the duplication
- `cancel_transform()` removes the duplicated nodes to restore the state before the transform was started
- `commit_transform()` commits the duplicated nodes to history

The object duplication mostly follows the same logic as the normal duplication in the scene tree with a few differences:
- We don't immediately commit the action to undo/redo, instead we keep track of the changes in our `EditData` state object. This allows us to do a rollback in case the transform is cancelled without effecting history. And when a transform is committed the we simply add the duplication to history bundled together with the transform. This leads to a clean history.
- In the context of transforming, it doesn't make sense to abort completely for an illegal operation like duplicating the root node. Instead, we still go on with the transform. We just skip the duplication and show a warning as a toast. This should be more user-friendly than just printing an error and doing nothing.

This PR only implements duplication for spatial gizmos of nodes, it does not make sense for any other kinds of gizmos (like the handles of a physics shape for example).