### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/modules/camera/config.py
+++ b/modules/camera/config.py
@@ -1,7 +1,7 @@
 def can_build(env, platform):
     import sys
 
-    if sys.platform.startswith("freebsd"):
+    if sys.platform.startswith("freebsd") or sys.platform.startswith("openbsd"):
         return False
     return platform == "macos" or platform == "windows" or platform == "linuxbsd" or platform == "android"
 


### PR DESCRIPTION
Like FreeBSD, OpenBSD cannot build the camera module because it uses interfaces only provided by Linux.