### PR TITLE
[Windows,Linux] [Input] Return the keyboard ID for raw input

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -104,6 +104,60 @@ bool InputEvent::is_action_type() const {
 	return false;
 }
 
+bool InputEvent::assign_device_index(int p_device) {
+	if (device_index.end() != device_index.find(p_device)) {
+		return false;
+	}
+	device_index.insert(p_device, true);
+	for (const auto &[old_device, active] : device_index) {
+		if (!active) {
+			device_index.erase(old_device);
+			break;
+		}
+	}
+	return true;
+}
+
+bool InputEvent::remove_device_index(int p_device) {
+	if (device_index.end() == device_index.find(p_device)) {
+		return false;
+	}
+	device_index[p_device] = false;
+	return true;
+}
+
+void InputEvent::filter_active_devices(Vector<int> p_active_devices) {
+	for (const auto &[current_dev, active] : device_index) {
+		if (!active) {
+			continue;
+		}
+		bool found = false;
+		for (const auto &new_dev : p_active_devices) {
+			found = (new_dev == current_dev);
+			if (found) {
+				break;
+			}
+		}
+		if (!found) {
+			InputEvent::remove_device_index(current_dev);
+		}
+	}
+}
+
+int InputEvent::get_device_index(int p_device) {
+	return device_index.get_index(p_device);
+}
+
+bool InputEvent::set_device_index(int p_device) {
+	InputEvent::assign_device_index(p_device);
+	int index = InputEvent::get_device_index(p_device);
+	if (-1 == index) {
+		return false;
+	}
+	this->set_device(index);
+	return true;
+}
+
 void InputEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_device", "device"), &InputEvent::set_device);
 	ClassDB::bind_method(D_METHOD("get_device"), &InputEvent::get_device);

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -35,6 +35,7 @@
 #include "core/math/transform_2d.h"
 #include "core/os/keyboard.h"
 #include "core/string/ustring.h"
+#include "core/templates/a_hash_map.h"
 #include "core/typedefs.h"
 
 /**
@@ -52,11 +53,12 @@ class Shortcut;
 class InputEvent : public Resource {
 	GDCLASS(InputEvent, Resource);
 
-	int device = 0;
+	int device = -1; // ALL_DEVICES
 
 protected:
 	bool canceled = false;
 	bool pressed = false;
+	static inline AHashMap<int, bool> device_index; // bool is to mark a device ID as inactive, available for overwriting
 
 	static void _bind_methods();
 
@@ -90,6 +92,12 @@ public:
 	virtual bool accumulate(const Ref<InputEvent> &p_event) { return false; }
 
 	virtual InputEventType get_type() const { return InputEventType::INVALID; }
+
+	static bool assign_device_index(int p_device);
+	static bool remove_device_index(int p_device);
+	static void filter_active_devices(Vector<int> p_active_devices);
+	static int get_device_index(int p_device);
+	bool set_device_index(int p_device);
 };
 
 class InputEventFromWindow : public InputEvent {

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -64,6 +64,7 @@ private:
 	HashMap<String, List<Ref<InputEvent>>> default_builtin_with_overrides_cache;
 
 	List<Ref<InputEvent>>::Element *_find_event(Action &p_action, const Ref<InputEvent> &p_event, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
+	Ref<InputEvent> _normalize_event(const Ref<InputEvent> &p_event) const;
 
 	TypedArray<InputEvent> _action_get_events(const StringName &p_action);
 

--- a/core/templates/a_hash_map.cpp
+++ b/core/templates/a_hash_map.cpp
@@ -37,3 +37,4 @@ template class AHashMap<String, int>;
 template class AHashMap<StringName, StringName>;
 template class AHashMap<StringName, Variant>;
 template class AHashMap<StringName, int>;
+template class AHashMap<int, bool>;

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -729,3 +729,4 @@ extern template class AHashMap<String, int>;
 extern template class AHashMap<StringName, StringName>;
 extern template class AHashMap<StringName, Variant>;
 extern template class AHashMap<StringName, int>;
+extern template class AHashMap<int, bool>;

--- a/doc/classes/InputEvent.xml
+++ b/doc/classes/InputEvent.xml
@@ -117,7 +117,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="device" type="int" setter="set_device" getter="get_device" default="0">
+		<member name="device" type="int" setter="set_device" getter="get_device" default="-1">
 			The event's device ID.
 			[b]Note:[/b] [member device] can be negative for special use cases that don't refer to devices physically present on the system. See [constant DEVICE_ID_EMULATION].
 		</member>

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -251,6 +251,7 @@ Ref<InputEventKey> WaylandThread::_seat_state_get_key_event(SeatState *p_ss, xkb
 
 	event->set_pressed(p_pressed);
 	event->set_keycode(keycode);
+	event->set_device_index(p_ss->wl_seat_name);
 	event->set_physical_keycode(physical_keycode);
 	event->set_location(key_location);
 
@@ -739,6 +740,7 @@ void WaylandThread::_wl_registry_on_global(void *data, struct wl_registry *wl_re
 }
 
 void WaylandThread::_wl_registry_on_global_remove(void *data, struct wl_registry *wl_registry, uint32_t name) {
+	InputEventKey::remove_device_index(name);
 	RegistryState *registry = (RegistryState *)data;
 	ERR_FAIL_NULL(registry);
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -270,6 +270,14 @@ bool DisplayServerX11::_refresh_device_info() {
 	int dev_count;
 	XIDeviceInfo *info = XIQueryDevice(x11_display, XIAllDevices, &dev_count);
 
+	// Check which devices no longer remains to filter
+	Vector<int> new_active_devices;
+	for (int i = 0; i < dev_count; ++i) {
+		XIDeviceInfo *dev = &info[i];
+		new_active_devices.append(dev->deviceid);
+	}
+	InputEvent::filter_active_devices(new_active_devices);
+
 	for (int i = 0; i < dev_count; i++) {
 		XIDeviceInfo *dev = &info[i];
 		if (!dev->enabled) {
@@ -3796,7 +3804,7 @@ void DisplayServerX11::_get_key_modifier_state(unsigned int p_x11_state, Ref<Inp
 	state->set_meta_pressed((p_x11_state & Mod4Mask));
 }
 
-void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, bool p_echo) {
+void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, int p_device_id, bool p_echo) {
 	WindowData &wd = windows[p_window];
 	// X11 functions don't know what const is
 	XKeyEvent *xkeyevent = p_event;
@@ -3918,6 +3926,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				k->set_pressed(keypress);
 
 				k->set_keycode(keycode);
+				k->set_device_index(p_device_id);
 				k->set_physical_keycode(physical_keycode);
 				if (!keysym.is_empty()) {
 					k->set_key_label(fix_key_label(keysym[0], keycode));
@@ -3933,6 +3942,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				if (k->get_keycode() == Key::BACKTAB) {
 					//make it consistent across platforms.
 					k->set_keycode(Key::TAB);
+					k->set_device_index(p_device_id);
 					k->set_physical_keycode(Key::TAB);
 					k->set_shift_pressed(true);
 				}
@@ -3998,6 +4008,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 					k->set_pressed(keypress);
 
 					k->set_keycode(keycode);
+					k->set_device_index(p_device_id);
 					k->set_physical_keycode(physical_keycode);
 					if (!keysym.is_empty()) {
 						k->set_key_label(fix_key_label(keysym[0], keycode));
@@ -4015,6 +4026,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 					if (k->get_keycode() == Key::BACKTAB) {
 						//make it consistent across platforms.
 						k->set_keycode(Key::TAB);
+						k->set_device_index(p_device_id);
 						k->set_physical_keycode(Key::TAB);
 						k->set_shift_pressed(true);
 					}
@@ -4116,7 +4128,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 				if (rk == keysym_keycode) {
 					// Consume to next event.
 					++p_event_index;
-					_handle_key_event(p_window, (XKeyEvent *)&peek_event, p_events, p_event_index, true);
+					_handle_key_event(p_window, (XKeyEvent *)&peek_event, p_events, p_event_index, p_device_id, true);
 					return; //ignore current, echo next
 				}
 			}
@@ -4136,6 +4148,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	}
 
 	k->set_keycode(keycode);
+	k->set_device_index(p_device_id);
 	k->set_physical_keycode((Key)physical_keycode);
 	if (!keysym.is_empty()) {
 		k->set_key_label(fix_key_label(keysym[0], keycode));
@@ -4153,6 +4166,7 @@ void DisplayServerX11::_handle_key_event(WindowID p_window, XKeyEvent *p_event, 
 	if (k->get_keycode() == Key::BACKTAB) {
 		//make it consistent across platforms.
 		k->set_keycode(Key::TAB);
+		k->set_device_index(p_device_id);
 		k->set_physical_keycode(Key::TAB);
 		k->set_shift_pressed(true);
 	}
@@ -4803,6 +4817,7 @@ void DisplayServerX11::process_events() {
 
 		bool ime_window_event = false;
 		WindowID window_id = MAIN_WINDOW_ID;
+		static int current_keyboard_id;
 
 		// Assign the event to the relevant window
 		for (const KeyValue<WindowID, WindowData> &E : windows) {
@@ -4824,6 +4839,11 @@ void DisplayServerX11::process_events() {
 					case XI_HierarchyChanged:
 					case XI_DeviceChanged: {
 						_refresh_device_info();
+					} break;
+					case XI_RawKeyPress:
+					case XI_RawKeyRelease: {
+						XIRawEvent *raw_event = (XIRawEvent *)event_data;
+						current_keyboard_id = raw_event->sourceid;
 					} break;
 					case XI_RawMotion: {
 						if (ime_window_event || ignore_events) {
@@ -5477,7 +5497,7 @@ void DisplayServerX11::process_events() {
 
 				// key event is a little complex, so
 				// it will be handled in its own function.
-				_handle_key_event(window_id, &event.xkey, events, event_index);
+				_handle_key_event(window_id, &event.xkey, events, event_index, current_keyboard_id);
 			} break;
 
 			case SelectionNotify:
@@ -7217,6 +7237,8 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		all_master_event_mask.mask = all_master_mask_data;
 		XISetMask(all_master_event_mask.mask, XI_DeviceChanged);
 		XISetMask(all_master_event_mask.mask, XI_RawMotion);
+		XISetMask(all_master_event_mask.mask, XI_RawKeyPress);
+		XISetMask(all_master_event_mask.mask, XI_RawKeyRelease);
 		XISelectEvents(x11_display, DefaultRootWindow(x11_display), &all_master_event_mask, 1);
 	}
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -306,7 +306,7 @@ class DisplayServerX11 : public DisplayServer {
 
 	Point2i center;
 
-	void _handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, bool p_echo = false);
+	void _handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, int p_device_id, bool p_echo = false);
 
 	Atom _process_selection_request_target(Atom p_target, Window p_requestor, Atom p_property, Atom p_selection) const;
 	void _handle_selection_request_event(XSelectionRequestEvent *p_event) const;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4770,6 +4770,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 	WindowID window_id = INVALID_WINDOW_ID;
 	bool window_created = false;
+	static int current_keyboard_handle;
 
 	// Check whether window exists
 	// FIXME this is O(n), where n is the set of currently open windows and subwindows
@@ -5026,6 +5027,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			const BitField<WinKeyModifierMask> &mods = _get_mods();
 			if (raw->header.dwType == RIM_TYPEKEYBOARD) {
+				current_keyboard_handle = (intptr_t)raw->header.hDevice;
 				if (raw->data.keyboard.VKey == VK_SHIFT) {
 					// If multiple Shifts are held down at the same time,
 					// Windows natively only sends a KEYUP for the last one to be released.
@@ -5037,6 +5039,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 							ERR_BREAK(key_event_pos >= KEY_EVENT_BUFFER_SIZE);
 
 							KeyEvent ke;
+							ke.keyboard_handle = current_keyboard_handle;
 							ke.shift = false;
 							ke.altgr = mods.has_flag(WinKeyModifierMask::ALT_GR);
 							ke.alt = mods.has_flag(WinKeyModifierMask::ALT);
@@ -5109,6 +5112,30 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				}
 			}
 			delete[] lpb;
+		} break;
+		case WM_DEVICECHANGE: {
+			UINT device_count = 0;
+			if (GetRawInputDeviceList(NULL, &device_count, sizeof(RAWINPUTDEVICELIST)) != 0) {
+				break;
+			}
+			if (0 == device_count) {
+				break;
+			}
+			PRAWINPUTDEVICELIST device_list = NULL;
+			device_list = (PRAWINPUTDEVICELIST)malloc(sizeof(RAWINPUTDEVICELIST) * device_count);
+			if (NULL == device_list) {
+				break;
+			}
+			device_count = GetRawInputDeviceList(device_list, &device_count, sizeof(RAWINPUTDEVICELIST));
+			if (device_count != (UINT)-1) {
+				// Check which devices no longer remains to filter
+				Vector<int> new_active_devices;
+				for (UINT i = 0; i < device_count; ++i) {
+					new_active_devices.append((intptr_t)device_list[i].hDevice);
+				}
+				InputEvent::filter_active_devices(new_active_devices);
+			}
+			free(device_list);
 		} break;
 		case WT_CSRCHANGE:
 		case WT_PROXIMITY: {
@@ -6006,6 +6033,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			const BitField<WinKeyModifierMask> &mods = _get_mods();
 
 			KeyEvent ke;
+			ke.keyboard_handle = current_keyboard_handle;
 			ke.shift = mods.has_flag(WinKeyModifierMask::SHIFT);
 			ke.alt = mods.has_flag(WinKeyModifierMask::ALT);
 			ke.altgr = mods.has_flag(WinKeyModifierMask::ALT_GR);
@@ -6199,77 +6227,81 @@ void DisplayServerWindows::_process_key_events() {
 		switch (ke.uMsg) {
 			case WM_CHAR: {
 				// Extended keys should only be processed as WM_KEYDOWN message.
-				if (!KeyMappingWindows::is_extended_key(ke.wParam) && ((i == 0 && ke.uMsg == WM_CHAR) || (i > 0 && key_event_buffer[i - 1].uMsg == WM_CHAR))) {
-					static char32_t prev_wc = 0;
-					char32_t unicode = ke.wParam;
-					if ((unicode & 0xfffffc00) == 0xd800) {
-						if (prev_wc != 0) {
-							ERR_PRINT("invalid utf16 surrogate input");
-						}
-						prev_wc = unicode;
-						break; // Skip surrogate.
-					} else if ((unicode & 0xfffffc00) == 0xdc00) {
-						if (prev_wc == 0) {
-							ERR_PRINT("invalid utf16 surrogate input");
-							break; // Skip invalid surrogate.
-						}
-						unicode = (prev_wc << 10UL) + unicode - ((0xd800 << 10UL) + 0xdc00 - 0x10000);
-						prev_wc = 0;
-					} else {
-						prev_wc = 0;
-					}
-					Ref<InputEventKey> k;
-					k.instantiate();
-
-					UINT vk = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK);
-					bool is_oem = (vk >= 0xB8) && (vk <= 0xE6);
-					Key keycode = KeyMappingWindows::get_keysym(vk);
-					Key key_label = keycode;
-					Key physical_keycode = KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24));
-
-					static BYTE keyboard_state[256];
-					memset(keyboard_state, 0, 256);
-					wchar_t chars[256] = {};
-					UINT extended_code = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK_EX);
-					if (!(ke.lParam & (1 << 24)) && ToUnicodeEx(extended_code, (ke.lParam >> 16) & 0xFF, keyboard_state, chars, 255, 4, GetKeyboardLayout(0)) > 0) {
-						String keysym = String::utf16((char16_t *)chars, 255);
-						if (!keysym.is_empty()) {
-							char32_t unicode_value = keysym[0];
-							// For printable ASCII characters (0x20-0x7E), override the original keycode with the character value.
-							if (is_oem && Key::SPACE <= (Key)unicode_value && (Key)unicode_value <= Key::ASCIITILDE) {
-								keycode = fix_keycode(unicode_value, (Key)unicode_value);
-							}
-							key_label = fix_key_label(unicode_value, keycode);
-						}
-					}
-
-					k->set_window_id(ke.window_id);
-					if (keycode != Key::SHIFT) {
-						k->set_shift_pressed(ke.shift);
-					}
-					if (keycode != Key::ALT) {
-						k->set_alt_pressed(ke.alt);
-					}
-					if (keycode != Key::CTRL) {
-						k->set_ctrl_pressed(ke.control);
-					}
-					if (keycode != Key::META) {
-						k->set_meta_pressed(ke.meta);
-					}
-					k->set_pressed(true);
-					k->set_keycode(keycode);
-					k->set_physical_keycode(physical_keycode);
-					k->set_key_label(key_label);
-					k->set_unicode(fix_unicode(unicode));
-					if (k->get_unicode() && ke.altgr && windows[ke.window_id].ime_active) {
-						k->set_alt_pressed(false);
-						k->set_ctrl_pressed(false);
-					}
-
-					Input::get_singleton()->parse_input_event(k);
-				} else {
-					// Do nothing.
+				if (KeyMappingWindows::is_extended_key(ke.wParam)) {
+					break;
 				}
+				// Skip repeated WM_CHAR
+				if (i > 0 && (key_event_buffer[i - 1].uMsg != WM_CHAR)) {
+					break;
+				}
+				static char32_t prev_wc = 0;
+				char32_t unicode = ke.wParam;
+				if ((unicode & 0xfffffc00) == 0xd800) {
+					if (prev_wc != 0) {
+						ERR_PRINT("invalid utf16 surrogate input");
+					}
+					prev_wc = unicode;
+					break; // Skip surrogate.
+				} else if ((unicode & 0xfffffc00) == 0xdc00) {
+					if (prev_wc == 0) {
+						ERR_PRINT("invalid utf16 surrogate input");
+						break; // Skip invalid surrogate.
+					}
+					unicode = (prev_wc << 10UL) + unicode - ((0xd800 << 10UL) + 0xdc00 - 0x10000);
+					prev_wc = 0;
+				} else {
+					prev_wc = 0;
+				}
+				Ref<InputEventKey> k;
+				k.instantiate();
+
+				UINT vk = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK);
+				bool is_oem = (vk >= 0xB8) && (vk <= 0xE6);
+				Key keycode = KeyMappingWindows::get_keysym(vk);
+				Key key_label = keycode;
+				Key physical_keycode = KeyMappingWindows::get_scansym((ke.lParam >> 16) & 0xFF, ke.lParam & (1 << 24));
+
+				static BYTE keyboard_state[256];
+				memset(keyboard_state, 0, 256);
+				wchar_t chars[256] = {};
+				UINT extended_code = MapVirtualKey((ke.lParam >> 16) & 0xFF, MAPVK_VSC_TO_VK_EX);
+				if (!(ke.lParam & (1 << 24)) && ToUnicodeEx(extended_code, (ke.lParam >> 16) & 0xFF, keyboard_state, chars, 255, 4, GetKeyboardLayout(0)) > 0) {
+					String keysym = String::utf16((char16_t *)chars, 255);
+					if (!keysym.is_empty()) {
+						char32_t unicode_value = keysym[0];
+						// For printable ASCII characters (0x20-0x7E), override the original keycode with the character value.
+						if (is_oem && Key::SPACE <= (Key)unicode_value && (Key)unicode_value <= Key::ASCIITILDE) {
+							keycode = fix_keycode(unicode_value, (Key)unicode_value);
+						}
+						key_label = fix_key_label(unicode_value, keycode);
+					}
+				}
+
+				k->set_window_id(ke.window_id);
+				if (keycode != Key::SHIFT) {
+					k->set_shift_pressed(ke.shift);
+				}
+				if (keycode != Key::ALT) {
+					k->set_alt_pressed(ke.alt);
+				}
+				if (keycode != Key::CTRL) {
+					k->set_ctrl_pressed(ke.control);
+				}
+				if (keycode != Key::META) {
+					k->set_meta_pressed(ke.meta);
+				}
+				k->set_pressed(true);
+				k->set_keycode(keycode);
+				k->set_physical_keycode(physical_keycode);
+				k->set_key_label(key_label);
+				k->set_unicode(fix_unicode(unicode));
+				if (k->get_unicode() && ke.altgr && windows[ke.window_id].ime_active) {
+					k->set_alt_pressed(false);
+					k->set_ctrl_pressed(false);
+				}
+
+				Input::get_singleton()->parse_input_event(k);
+
 			} break;
 			case WM_KEYUP:
 			case WM_KEYDOWN: {
@@ -6350,7 +6382,10 @@ void DisplayServerWindows::_process_key_events() {
 
 				k->set_echo((ke.uMsg == WM_KEYDOWN && (ke.lParam & (1 << 30))));
 
-				Input::get_singleton()->parse_input_event(k);
+				// Send raw input
+				Ref<InputEventKey> k_raw = k->duplicate();
+				k_raw->set_device_index(ke.keyboard_handle);
+				Input::get_singleton()->parse_input_event(k_raw);
 
 			} break;
 		}

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -247,6 +247,7 @@ class DisplayServerWindows : public DisplayServer {
 
 	struct KeyEvent {
 		WindowID window_id;
+		int keyboard_handle;
 		bool alt, shift, control, meta, altgr;
 		UINT uMsg;
 		WPARAM wParam;


### PR DESCRIPTION
Based on [#13083](https://github.com/godotengine/godot-proposals/issues/13083)

- Return the keyboard ID from raw input in InputEventKey as `device`
- When adding Input mapping, the Input events's `device` will be normalized to `ALL_DEVICE`, 
- Normalizing to a default `device` value for input map id safer, since raw input's id can change in runtime by unplugging/plugging back the keyboard
- If users wish to separate by keyboard ID, they need to get the event 's `device` to tell which keyboard the event is from, and handle hot-remapping if the ID was changed in runtime
- Added in 2nd commit: The returned `device` is now ordered starting from 0, and registered by plugin/input. Unplugging a keyboard will leave its `device` open for a new keyboard to register to

Test with GDScript:
```
extends Node

func _input(event):
	if event is InputEventKey and event.pressed and not event.echo:
		print("Pressed: ", OS.get_keycode_string(event.keycode), "| ID: ", event.device)
```

<img width="1127" height="586" alt="image" src="https://github.com/user-attachments/assets/db97525b-9dfd-4bf1-80c8-9f20be083440" />



Test with GDExtension:
```
void App::_input(const godot::Ref<godot::InputEvent> &event)
{
    godot::Ref<godot::InputEventKey> key_event = event;
    if (key_event.is_valid()){
        if (key_event->is_pressed() && !key_event->is_echo()) {
            godot::String key_name = godot::OS::get_singleton()->get_keycode_string(key_event->get_keycode());
            std::int64_t keyboard_id = key_event->get_device();
            godot::UtilityFunctions::print("Pressed: ", key_name, " | ID: ", keyboard_id);
        }
    }
}
```
<img width="1000" height="480" alt="image" src="https://github.com/user-attachments/assets/01390f91-2847-41ac-95e8-41c2849481cf" />

<img width="670" height="667" alt="image" src="https://github.com/user-attachments/assets/dc534c77-4323-4d4c-97b4-84dc677336a5" />


Test input mapping:
Tested action created from GDScript, with an event for pressing key right, the action triggered with multiple keyboard ids (0, 1)
```
extends Node2D

func _ready():
	InputMap.add_action("ui_right_custom")
	var event := InputEventKey.new()
	event.physical_keycode = KEY_RIGHT
	event.pressed = true
	event.echo = false
	InputMap.action_add_event("ui_right_custom", event)

func _process(_delta):
	if Input.is_action_pressed("ui_right_custom", false):
		print("GDScript moving right")

func _input(event):
	if event is InputEventKey:
		if not event.echo:
			if event.pressed:
				print("GDScript Pressed: ", OS.get_keycode_string(event.keycode), "| ID: ", event.device)
			else:
				print("GDScript Released: ", OS.get_keycode_string(event.keycode), "| ID: ", event.device)

```
<img width="1228" height="887" alt="image" src="https://github.com/user-attachments/assets/f90496bf-516a-46b1-b123-f8f38bc78f8a" />

Tested with an action from the input map setting
```
extends Node2D

func _process(_delta):
	if Input.is_action_pressed("ui_left_custom", false):
		print("GDScript moving left")

func _input(event):
	if event is InputEventKey:
		if not event.echo:
			if event.pressed:
				print("GDScript Pressed: ", OS.get_keycode_string(event.keycode), "| ID: ", event.device)
			else:
				print("GDScript Released: ", OS.get_keycode_string(event.keycode), "| ID: ", event.device)

```
<img width="913" height="455" alt="image" src="https://github.com/user-attachments/assets/eeb006db-44c3-443b-9fe9-e476b0638067" />

<img width="1247" height="773" alt="image" src="https://github.com/user-attachments/assets/b35a0ca3-4cd9-40da-9e62-258a5972e2b4" />

Test on Linux X11 (Ubuntu 24.04):
<img width="1117" height="793" alt="image" src="https://github.com/user-attachments/assets/6648acc1-65a5-458d-b7b1-543d2ba2ddca" />


- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/13083.*