### PR TITLE
Remove duplicate initialization of scaling values in viewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5412,14 +5412,6 @@ Viewport::Viewport() {
 	// Window tooltip.
 	gui.tooltip_delay = GLOBAL_GET("gui/timers/tooltip_delay_sec");
 
-#ifndef _3D_DISABLED
-	set_scaling_3d_mode((Viewport::Scaling3DMode)(int)GLOBAL_GET("rendering/scaling_3d/mode"));
-	set_scaling_3d_scale(GLOBAL_GET("rendering/scaling_3d/scale"));
-	set_fsr_sharpness((float)GLOBAL_GET("rendering/scaling_3d/fsr_sharpness"));
-	set_texture_mipmap_bias((float)GLOBAL_GET("rendering/textures/default_filters/texture_mipmap_bias"));
-	set_anisotropic_filtering_level((Viewport::AnisotropicFiltering)(int)GLOBAL_GET("rendering/textures/default_filters/anisotropic_filtering_level"));
-#endif // _3D_DISABLED
-
 	set_sdf_oversize(sdf_oversize); // Set to server.
 
 	// Physics interpolation mode for viewports is a special case.


### PR DESCRIPTION
 - Fixes #110115

Since this initialization block within the constructor of Viewport was introduced in #51870, I would like @BastiaanOlij to comment on this if possible, in case there was a specific reason for introducing this form of initialization, so that I don't break any systems I'm not aware of (such as XR). From looking at the git-blame, it seems that other properties were added to this block over time, with the code becoming more concise, but the values are already initialized in the related header. No other values are initialized in this way, in this constructor.

Because it does not seem intentional to have special behavior for these properties, my guess is that it's fine since in practice one would want a viewport in cases like split-screen or VR cases to follow more than just the scaling settings.

Side effects:

  * Prior to this change, modifying the relevant project settings would cause the scene with the viewport to appear as changed, prompting the user to save it if they try to start the project or exit it. Now the project doesn't appear as changed if you modify these properties in the project settings. Not sure what to make of this.
  * Projects that specifically relied on following these 5 settings implicitly from project settings on all subviewports, will break in that now scaling settings will only be applied to the main viewport (consisent with all other properties) unless explicitly set on the SubViewports themselves.