### PR TITLE
Stabilize viewport behavior under FSR2 (fallback to Bilinear)

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1150,7 +1150,7 @@ bool Viewport::_set_size(const Size2i &p_size, const int p_view_count, const Siz
 		new_font_oversampling = font_oversampling_override;
 	}
 
-	Size2i new_size = p_size.maxi(2);
+	Size2i new_size = p_size.clampi(2, 16384);
 	if (size == new_size && view_count == p_view_count && size_allocated == p_allocated && stretch_transform == stretch_transform_new && p_size_2d_override == size_2d_override && new_font_oversampling == font_oversampling) {
 		return false;
 	}

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -217,6 +217,12 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 				scaling_type = RSE::scaling_3d_mode_type(scaling_3d_mode);
 			}
 
+			if (scaling_3d_mode == RSE::VIEWPORT_SCALING_3D_MODE_FSR2 && (MIN(p_viewport->size.width * scaling_3d_scale, p_viewport->size.height * scaling_3d_scale) < 64)) {
+				WARN_PRINT_ONCE("FSR2 is not compatible with viewport dimensions below 64px. Falling back to bilinear 3D resolution scaling.");
+				scaling_3d_mode = RSE::VIEWPORT_SCALING_3D_MODE_BILINEAR;
+				scaling_type = RSE::scaling_3d_mode_type(scaling_3d_mode);
+			}
+
 			if (use_taa && scaling_type == RSE::VIEWPORT_SCALING_3D_TYPE_TEMPORAL) {
 				// Temporal upscalers can't be used with TAA.
 				// Turn it off and prefer using the temporal upscaler.
@@ -224,8 +230,8 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 				use_taa = false;
 			}
 
-			int target_width;
-			int target_height;
+			int target_width = p_viewport->size.width;
+			int target_height = p_viewport->size.height;
 			int render_width;
 			int render_height;
 
@@ -234,23 +240,20 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 				case RSE::VIEWPORT_SCALING_3D_MODE_NEAREST:
 					// Clamp 3D rendering resolution to reasonable values supported on most hardware.
 					// This prevents freezing the engine or outright crashing on lower-end GPUs.
-					target_width = p_viewport->size.width;
-					target_height = p_viewport->size.height;
 					render_width = CLAMP(target_width * scaling_3d_scale, 1, 16384);
 					render_height = CLAMP(target_height * scaling_3d_scale, 1, 16384);
 					break;
 				case RSE::VIEWPORT_SCALING_3D_MODE_METALFX_SPATIAL:
 				case RSE::VIEWPORT_SCALING_3D_MODE_METALFX_TEMPORAL:
 				case RSE::VIEWPORT_SCALING_3D_MODE_FSR:
+					render_width = CLAMP(target_width * scaling_3d_scale, 1.0, 16384.0);
+					render_height = CLAMP(target_height * scaling_3d_scale, 1.0, 16384.0);
+					break;
 				case RSE::VIEWPORT_SCALING_3D_MODE_FSR2:
-					target_width = p_viewport->size.width;
-					target_height = p_viewport->size.height;
-					render_width = MAX(target_width * scaling_3d_scale, 1.0); // target_width / (target_width * scaling)
-					render_height = MAX(target_height * scaling_3d_scale, 1.0);
+					render_width = CLAMP(target_width * scaling_3d_scale, 64.0, 16384.0);
+					render_height = CLAMP(target_height * scaling_3d_scale, 64.0, 16384.0);
 					break;
 				case RSE::VIEWPORT_SCALING_3D_MODE_OFF:
-					target_width = p_viewport->size.width;
-					target_height = p_viewport->size.height;
 					render_width = target_width;
 					render_height = target_height;
 					break;
@@ -259,8 +262,6 @@ void RendererViewport::_configure_3d_render_buffers(Viewport *p_viewport) {
 					WARN_PRINT_ONCE(vformat("Unknown scaling mode: %d. Disabling 3D resolution scaling.", scaling_3d_mode));
 					scaling_3d_mode = RSE::VIEWPORT_SCALING_3D_MODE_OFF;
 					scaling_3d_scale = 1.0;
-					target_width = p_viewport->size.width;
-					target_height = p_viewport->size.height;
 					render_width = target_width;
 					render_height = target_height;
 					break;


### PR DESCRIPTION
- Fixes #105509
- Supersedes #110005 if this version of the fix is preferred, pending comment by maintainers.

Edit - I've closed that one in favor of this one to simplify things - that one still has most of the details if needed, but briefly:
 - this enforces a maximum limit of 16384 for the dimensions of viewports in the inspector (previously only a minimum of 2x2 was enforced, which allowed viewports to grow beyond what is allowed anywhere else in the engine and exceeds most device limits anyway)
 - ensures FSR1 viewports don't fall below 1x1 _after scaling_
 - ensures FSR2 viewports don't fall below 64x64 (also after scaling)
 - ensures viewports can't exceed 16384 on either dimension
   - but I am slightly concerned about not having an error message about this since it likely just crops the buffer silently - user may want to make something like a 2x16384 texture as a LUT or palette using a viewport, which is about as big as a 181x181 texture in data, but now they wouldn't know the viewport is cropped - might do a followup for that...
 - ~correctly switches off temporal antialiasing jitter when falling back to Bilinear.~
   - nvm this was fixed by #110672 5 months ago, this pull request was rebased so it makes no changes in this regard

See [this comment](https://github.com/godotengine/godot/pull/110005#issuecomment-3229898889) for comparisons between FSR2 and Bilinear at 64x64px. With this PR, one can still set a SubViewport to 64x64px using FSR2, just can't go below that without it falling back to Bilinear. The previous PR attempts to resize the SubViewport's internal render size so that it is always of valid dimensions to avoid the crash and error spam reported in #105509 but this may be superfluous as per [Calinou's comment](https://github.com/godotengine/godot/pull/110005#issuecomment-3229824700) and the comparison.

Unlike the previous PR, this one is very unlikely to cause problems to existing projects and I feel it can be backported safely.

~Opened as draft since there may be preference between the two fixes.~

~edit - also, if merged, please fix the typo in the commit message, I don't want to trigger a build just for that... (Stablize -> Stabilize)~ Fixed