### PR TITLE
Remove arbitrary limits on BlendSpace editors' visible region

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -294,7 +294,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 
 	blend_space_draw->draw_line(Point2(1, s.height - 1), Point2(s.width - 1, s.height - 1), linecolor, Math::round(EDSCALE));
 
-	if (blend_space->get_min_space() < 0) {
+	if (blend_space->get_min_space() <= 0 && blend_space->get_max_space() >= 0) {
 		float point = 0.0;
 		point = (point - blend_space->get_min_space()) / (blend_space->get_max_space() - blend_space->get_min_space());
 		point *= s.width;
@@ -312,7 +312,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_draw() {
 		if (blend_space->get_snap() > 0) {
 			int prev_idx = -1;
 
-			for (int i = 0; i < s.x; i++) {
+			for (int i = 0; i <= s.x; i++) {
 				float v = blend_space->get_min_space() + i * (blend_space->get_max_space() - blend_space->get_min_space()) / s.x;
 				int idx = int(v / blend_space->get_snap());
 
@@ -413,6 +413,11 @@ void AnimationNodeBlendSpace1DEditor::_config_changed(double) {
 	}
 
 	updating = true;
+
+	constexpr double STEP_UNIT = 0.01;
+	min_value->set_max(max_value->get_value() - STEP_UNIT);
+	max_value->set_min(min_value->get_value() + STEP_UNIT);
+
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Change BlendSpace1D Config"));
 	undo_redo->add_do_method(blend_space.ptr(), "set_max_space", max_value->get_value());
@@ -1033,12 +1038,15 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 
 	edit_hb->add_child(memnew(VSeparator));
 
+	constexpr double STEP_UNIT = 0.01;
+	constexpr double ABS_MAX = 10000;
+
 	edit_hb->add_child(memnew(Label(TTR("Position"))));
 	edit_value = memnew(SpinBox);
 	edit_hb->add_child(edit_value);
-	edit_value->set_min(-1000);
-	edit_value->set_max(1000);
-	edit_value->set_step(0.01);
+	edit_value->set_min(-ABS_MAX);
+	edit_value->set_max(ABS_MAX);
+	edit_value->set_step(STEP_UNIT);
 	edit_value->set_accessibility_name(TTRC("Blend Value"));
 	edit_value->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace1DEditor::_edit_point_pos));
 
@@ -1069,15 +1077,15 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 		bottom_hb->set_h_size_flags(SIZE_EXPAND_FILL);
 
 		min_value = memnew(SpinBox);
-		min_value->set_min(-10000);
-		min_value->set_max(0);
-		min_value->set_step(0.01);
+		min_value->set_min(-ABS_MAX);
+		min_value->set_max(ABS_MAX - STEP_UNIT);
+		min_value->set_step(STEP_UNIT);
 		min_value->set_accessibility_name(TTRC("Min"));
 
 		max_value = memnew(SpinBox);
-		max_value->set_min(0.01);
-		max_value->set_max(10000);
-		max_value->set_step(0.01);
+		max_value->set_min(-ABS_MAX + STEP_UNIT);
+		max_value->set_max(ABS_MAX);
+		max_value->set_step(STEP_UNIT);
 		max_value->set_accessibility_name(TTRC("Max"));
 
 		label_value = memnew(LineEdit);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -539,14 +539,14 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 	blend_space_draw->draw_line(Point2(1, s.height - 1), Point2(s.width - 1, s.height - 1), linecolor, Math::round(EDSCALE));
 
 	blend_space_draw->draw_line(Point2(0, 0), Point2(5 * EDSCALE, 0), linecolor, Math::round(EDSCALE));
-	if (blend_space->get_min_space().y < 0) {
+	if (blend_space->get_min_space().y <= 0 && blend_space->get_max_space().y >= 0) {
 		int y = (blend_space->get_max_space().y / (blend_space->get_max_space().y - blend_space->get_min_space().y)) * s.height;
 		blend_space_draw->draw_line(Point2(0, y), Point2(5 * EDSCALE, y), linecolor, Math::round(EDSCALE));
 		blend_space_draw->draw_string(font, Point2(2 * EDSCALE, y - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
 		blend_space_draw->draw_line(Point2(5 * EDSCALE, y), Point2(s.width, y), linecolor_soft, Math::round(EDSCALE));
 	}
 
-	if (blend_space->get_min_space().x < 0) {
+	if (blend_space->get_min_space().x <= 0 && blend_space->get_max_space().x >= 0) {
 		int x = (-blend_space->get_min_space().x / (blend_space->get_max_space().x - blend_space->get_min_space().x)) * s.width;
 		blend_space_draw->draw_line(Point2(x, s.height - 1), Point2(x, s.height - 5 * EDSCALE), linecolor, Math::round(EDSCALE));
 		blend_space_draw->draw_string(font, Point2(x + 2 * EDSCALE, s.height - 2 * EDSCALE - font->get_height(font_size) + font->get_ascent(font_size)), "0", HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, linecolor);
@@ -558,7 +558,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		if (blend_space->get_snap().x > 0) {
 			int prev_idx = 0;
-			for (int i = 0; i < s.x; i++) {
+			for (int i = 0; i <= s.x; i++) {
 				float v = blend_space->get_min_space().x + i * (blend_space->get_max_space().x - blend_space->get_min_space().x) / s.x;
 				int idx = int(v / blend_space->get_snap().x);
 
@@ -572,7 +572,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_draw() {
 
 		if (blend_space->get_snap().y > 0) {
 			int prev_idx = 0;
-			for (int i = 0; i < s.y; i++) {
+			for (int i = 0; i <= s.y; i++) {
 				float v = blend_space->get_max_space().y - i * (blend_space->get_max_space().y - blend_space->get_min_space().y) / s.y;
 				int idx = int(v / blend_space->get_snap().y);
 
@@ -764,6 +764,13 @@ void AnimationNodeBlendSpace2DEditor::_config_changed(double) {
 	}
 
 	updating = true;
+
+	constexpr double STEP_UNIT = 0.01;
+	min_x_value->set_max(max_x_value->get_value() - STEP_UNIT);
+	max_x_value->set_min(min_x_value->get_value() + STEP_UNIT);
+	min_y_value->set_max(max_y_value->get_value() - STEP_UNIT);
+	max_y_value->set_min(min_y_value->get_value() + STEP_UNIT);
+
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Change BlendSpace2D Config"));
 	undo_redo->add_do_method(blend_space.ptr(), "set_max_space", Vector2(max_x_value->get_value(), max_y_value->get_value()));
@@ -1301,19 +1308,22 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 
 	edit_hb->add_child(memnew(VSeparator));
 
+	constexpr double STEP_UNIT = 0.01;
+	constexpr double ABS_MAX = 10000;
+
 	edit_hb->add_child(memnew(Label(TTR("Position"))));
 	edit_x = memnew(SpinBox);
 	edit_hb->add_child(edit_x);
-	edit_x->set_min(-1000);
-	edit_x->set_step(0.01);
-	edit_x->set_max(1000);
+	edit_x->set_min(-ABS_MAX);
+	edit_x->set_max(ABS_MAX);
+	edit_x->set_step(STEP_UNIT);
 	edit_x->set_accessibility_name(TTRC("Blend X Value"));
 	edit_x->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 	edit_y = memnew(SpinBox);
 	edit_hb->add_child(edit_y);
-	edit_y->set_min(-1000);
-	edit_y->set_step(0.01);
-	edit_y->set_max(1000);
+	edit_y->set_min(-ABS_MAX);
+	edit_y->set_max(ABS_MAX);
+	edit_y->set_step(STEP_UNIT);
 	edit_y->set_accessibility_name(TTRC("Blend Y Value"));
 	edit_y->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_edit_point_pos));
 
@@ -1346,13 +1356,13 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		min_y_value->set_accessibility_name(TTRC("Min Y"));
 		left_vbox->add_child(min_y_value);
 
-		max_y_value->set_max(10000);
-		max_y_value->set_min(0.01);
-		max_y_value->set_step(0.01);
+		max_y_value->set_max(ABS_MAX);
+		max_y_value->set_min(-ABS_MAX + STEP_UNIT);
+		max_y_value->set_step(STEP_UNIT);
 
-		min_y_value->set_min(-10000);
-		min_y_value->set_max(0);
-		min_y_value->set_step(0.01);
+		min_y_value->set_min(-ABS_MAX);
+		min_y_value->set_max(ABS_MAX - STEP_UNIT);
+		min_y_value->set_step(STEP_UNIT);
 	}
 
 	panel = memnew(PanelContainer);
@@ -1385,13 +1395,13 @@ AnimationNodeBlendSpace2DEditor::AnimationNodeBlendSpace2DEditor() {
 		max_x_value->set_accessibility_name(TTRC("Max X"));
 		bottom_vbox->add_child(max_x_value);
 
-		max_x_value->set_max(10000);
-		max_x_value->set_min(0.01);
-		max_x_value->set_step(0.01);
+		max_x_value->set_max(ABS_MAX);
+		max_x_value->set_min(-ABS_MAX + STEP_UNIT);
+		max_x_value->set_step(STEP_UNIT);
 
-		min_x_value->set_min(-10000);
-		min_x_value->set_max(0);
-		min_x_value->set_step(0.01);
+		min_x_value->set_min(-ABS_MAX);
+		min_x_value->set_max(ABS_MAX - STEP_UNIT);
+		min_x_value->set_step(STEP_UNIT);
 	}
 
 	snap_x->connect(SceneStringName(value_changed), callable_mp(this, &AnimationNodeBlendSpace2DEditor::_config_changed));


### PR DESCRIPTION
BlendSpace1D and BlendSpace2D's editors do not allow the min value of their space to be greater than 0, and the max value to be less than 0.01. However, `animation_blend_space_1d.cpp` and `animation_blend_space_2d.cpp` only enforce that the min limit be less than the max limit.

Considering the user's ability to change `value` in BlendSpace1D, and `x` and `y` in BlendSpace2D to anything, one assumes that they should be able to map these BlendSpaces' visible area 1:1 to the range of the specific variable that controls them in their code, even if that range is all negative.

Safeguarding the visibility of 0 so that the user doesn't get disoriented seems to me to be the only reason for this, but that can be rectified by a future PR that adds numbering to grid divisions as well.

Additionally, grid lines are never drawn when at the max edge, that is also fixed here.