### PR TITLE
Emit `scene_changed` event when opening a scene from an empty tab list

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4401,6 +4401,9 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		}
 	} else {
 		EditorUndoRedoManager::get_singleton()->clear_history(editor_data.get_current_edited_scene_history_id(), false);
+
+		Dictionary state = editor_data.restore_edited_scene_state(editor_selection, &editor_history);
+		callable_mp(this, &EditorNode::_set_main_scene_state).call_deferred(state, get_edited_scene()); // Do after everything else is done setting up.
 	}
 
 	dependency_errors.clear();


### PR DESCRIPTION
Fixes #97427 

Not sure if this is the right way to go about it but in my testing it does seem to work perfectly and I couldn't see any issues.

https://github.com/user-attachments/assets/d07d746d-9d3f-4bc7-8c01-bb3380272a68

MRP [scene-changed-test.zip](https://github.com/user-attachments/files/22066206/scene-changed-test.zip)
