### PR TITLE
Local particle trails

### DIFF
--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -102,6 +102,9 @@
 		<member name="local_coords" type="bool" setter="set_use_local_coordinates" getter="get_use_local_coordinates" default="false">
 			If [code]true[/code], particles use the parent node's coordinate space (known as local coordinates). This will cause particles to move and rotate along the [GPUParticles2D] node (and its parents) when it is moved or rotated. If [code]false[/code], particles use global coordinates; they will not move or rotate along the [GPUParticles2D] node (and its parents) when it is moved or rotated.
 		</member>
+		<member name="local_trails" type="bool" setter="set_local_trails" getter="get_local_trails" default="false">
+			If [code]true[/code], particles use the parent node's coordinate space (known as local coordinates) for the trail origin. This means the trails will always start from the transform of the [GPUParticles3D] node.
+		</member>
 		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" default="false">
 			If [code]true[/code], only one emission cycle occurs. If set [code]true[/code] during a cycle, emission will stop at the cycle's end.
 		</member>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -133,6 +133,9 @@
 		<member name="local_coords" type="bool" setter="set_use_local_coordinates" getter="get_use_local_coordinates" default="false">
 			If [code]true[/code], particles use the parent node's coordinate space (known as local coordinates). This will cause particles to move and rotate along the [GPUParticles3D] node (and its parents) when it is moved or rotated. If [code]false[/code], particles use global coordinates; they will not move or rotate along the [GPUParticles3D] node (and its parents) when it is moved or rotated.
 		</member>
+		<member name="local_trails" type="bool" setter="set_local_trails" getter="get_local_trails" default="false">
+			If [code]true[/code], particles use the parent node's coordinate space (known as local coordinates) for the trail origin. This means the trails will always start from the transform of the [GPUParticles3D] node.
+		</member>
 		<member name="one_shot" type="bool" setter="set_one_shot" getter="get_one_shot" default="false">
 			If [code]true[/code], only the number of particles equal to [member amount] will be emitted.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3129,6 +3129,14 @@
 				Sets the lifetime of each particle in the system. Equivalent to [member GPUParticles3D.lifetime].
 			</description>
 		</method>
+		<method name="particles_set_local_trails">
+			<return type="void" />
+			<param index="0" name="particles" type="RID" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				Sets the local trails parameter of the particle system. Equivalent to [member GPUParticles3D.local_trails].
+			</description>
+		</method>
 		<method name="particles_set_mode">
 			<return type="void" />
 			<param index="0" name="particles" type="RID" />

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -260,11 +260,20 @@ void ParticlesStorage::particles_set_speed_scale(RID p_particles, double p_scale
 
 	particles->speed_scale = p_scale;
 }
+
 void ParticlesStorage::particles_set_use_local_coordinates(RID p_particles, bool p_enable) {
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL(particles);
 
 	particles->use_local_coords = p_enable;
+	particles->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_PARTICLES);
+}
+
+void ParticlesStorage::particles_set_local_trails(RID p_particles, bool p_enable) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->local_trails = p_enable;
 	particles->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_PARTICLES);
 }
 

--- a/drivers/gles3/storage/particles_storage.h
+++ b/drivers/gles3/storage/particles_storage.h
@@ -162,6 +162,7 @@ private:
 		bool restart_request = false;
 		AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
 		bool use_local_coords = false;
+		bool local_trails = false;
 		bool has_collision_cache = false;
 
 		bool has_sdf_collision = false;
@@ -333,6 +334,7 @@ public:
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) override;
 	virtual void particles_set_speed_scale(RID p_particles, double p_scale) override;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override;
+	virtual void particles_set_local_trails(RID p_particles, bool p_enable) override;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) override;
 	virtual RID particles_get_process_material(RID p_particles) const override;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) override;

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -133,6 +133,15 @@ void GPUParticles2D::set_use_local_coordinates(bool p_enable) {
 	}
 }
 
+void GPUParticles2D::set_local_trails(bool p_enable) {
+	local_trails = p_enable;
+	RS::get_singleton()->particles_set_local_trails(particles, local_trails);
+	set_notify_transform(!p_enable);
+	if (!p_enable && is_inside_tree()) {
+		_update_particle_emission_transform();
+	}
+}
+
 void GPUParticles2D::_update_particle_emission_transform() {
 	Transform2D xf2d = get_global_transform();
 	Transform3D xf;
@@ -294,6 +303,10 @@ Rect2 GPUParticles2D::get_visibility_rect() const {
 }
 
 bool GPUParticles2D::get_use_local_coordinates() const {
+	return local_coords;
+}
+
+bool GPUParticles2D::get_local_trails() const {
 	return local_coords;
 }
 
@@ -867,6 +880,7 @@ void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_randomness_ratio", "ratio"), &GPUParticles2D::set_randomness_ratio);
 	ClassDB::bind_method(D_METHOD("set_visibility_rect", "visibility_rect"), &GPUParticles2D::set_visibility_rect);
 	ClassDB::bind_method(D_METHOD("set_use_local_coordinates", "enable"), &GPUParticles2D::set_use_local_coordinates);
+	ClassDB::bind_method(D_METHOD("set_local_trails", "enable"), &GPUParticles2D::set_local_trails);
 	ClassDB::bind_method(D_METHOD("set_fixed_fps", "fps"), &GPUParticles2D::set_fixed_fps);
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &GPUParticles2D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_interpolate", "enable"), &GPUParticles2D::set_interpolate);
@@ -886,6 +900,7 @@ void GPUParticles2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_randomness_ratio"), &GPUParticles2D::get_randomness_ratio);
 	ClassDB::bind_method(D_METHOD("get_visibility_rect"), &GPUParticles2D::get_visibility_rect);
 	ClassDB::bind_method(D_METHOD("get_use_local_coordinates"), &GPUParticles2D::get_use_local_coordinates);
+	ClassDB::bind_method(D_METHOD("get_local_trails"), &GPUParticles2D::get_local_trails);
 	ClassDB::bind_method(D_METHOD("get_fixed_fps"), &GPUParticles2D::get_fixed_fps);
 	ClassDB::bind_method(D_METHOD("get_fractional_delta"), &GPUParticles2D::get_fractional_delta);
 	ClassDB::bind_method(D_METHOD("get_interpolate"), &GPUParticles2D::get_interpolate);
@@ -958,6 +973,7 @@ void GPUParticles2D::_bind_methods() {
 	ADD_GROUP("Drawing", "");
 	ADD_PROPERTY(PropertyInfo(Variant::RECT2, "visibility_rect", PROPERTY_HINT_NONE, "suffix:px"), "set_visibility_rect", "get_visibility_rect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_coords"), "set_use_local_coordinates", "get_use_local_coordinates");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_trails"), "set_local_trails", "get_local_trails");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "draw_order", PROPERTY_HINT_ENUM, "Index,Lifetime,Reverse Lifetime"), "set_draw_order", "get_draw_order");
 	ADD_GROUP("Trails", "trail_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "trail_enabled", PROPERTY_HINT_GROUP_ENABLE), "set_trail_enabled", "is_trail_enabled");
@@ -1003,6 +1019,7 @@ GPUParticles2D::GPUParticles2D() {
 	set_randomness_ratio(0);
 	set_visibility_rect(Rect2(Vector2(-100, -100), Vector2(200, 200)));
 	set_use_local_coordinates(false);
+	set_local_trails(false);
 	set_draw_order(DRAW_ORDER_LIFETIME);
 	set_speed_scale(1);
 	set_fixed_fps(30);

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -59,6 +59,7 @@ private:
 	double speed_scale = 0.0;
 	Rect2 visibility_rect;
 	bool local_coords = false;
+	bool local_trails = false;
 	int fixed_fps = 0;
 	bool fractional_delta = false;
 	bool interpolate = true;
@@ -120,6 +121,7 @@ public:
 	void set_randomness_ratio(real_t p_ratio);
 	void set_visibility_rect(const Rect2 &p_visibility_rect);
 	void set_use_local_coordinates(bool p_enable);
+	void set_local_trails(bool p_enable);
 	void set_process_material(const Ref<Material> &p_material);
 	void set_speed_scale(double p_scale);
 	void set_collision_base_size(real_t p_ratio);
@@ -143,6 +145,7 @@ public:
 	real_t get_randomness_ratio() const;
 	Rect2 get_visibility_rect() const;
 	bool get_use_local_coordinates() const;
+	bool get_local_trails() const;
 	Ref<Material> get_process_material() const;
 	double get_speed_scale() const;
 

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -146,6 +146,11 @@ void GPUParticles3D::set_use_local_coordinates(bool p_enable) {
 	RS::get_singleton()->particles_set_use_local_coordinates(particles, local_coords);
 }
 
+void GPUParticles3D::set_local_trails(bool p_enable) {
+	local_trails = p_enable;
+	RS::get_singleton()->particles_set_local_trails(particles, local_trails);
+}
+
 void GPUParticles3D::set_process_material(const Ref<Material> &p_material) {
 #ifdef TOOLS_ENABLED
 	if (process_material.is_valid()) {
@@ -218,6 +223,10 @@ AABB GPUParticles3D::get_visibility_aabb() const {
 
 bool GPUParticles3D::get_use_local_coordinates() const {
 	return local_coords;
+}
+
+bool GPUParticles3D::get_local_trails() const {
+	return local_trails;
 }
 
 Ref<Material> GPUParticles3D::get_process_material() const {
@@ -745,6 +754,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_randomness_ratio", "ratio"), &GPUParticles3D::set_randomness_ratio);
 	ClassDB::bind_method(D_METHOD("set_visibility_aabb", "aabb"), &GPUParticles3D::set_visibility_aabb);
 	ClassDB::bind_method(D_METHOD("set_use_local_coordinates", "enable"), &GPUParticles3D::set_use_local_coordinates);
+	ClassDB::bind_method(D_METHOD("set_local_trails", "enable"), &GPUParticles3D::set_local_trails);
 	ClassDB::bind_method(D_METHOD("set_fixed_fps", "fps"), &GPUParticles3D::set_fixed_fps);
 	ClassDB::bind_method(D_METHOD("set_fractional_delta", "enable"), &GPUParticles3D::set_fractional_delta);
 	ClassDB::bind_method(D_METHOD("set_interpolate", "enable"), &GPUParticles3D::set_interpolate);
@@ -762,6 +772,7 @@ void GPUParticles3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_randomness_ratio"), &GPUParticles3D::get_randomness_ratio);
 	ClassDB::bind_method(D_METHOD("get_visibility_aabb"), &GPUParticles3D::get_visibility_aabb);
 	ClassDB::bind_method(D_METHOD("get_use_local_coordinates"), &GPUParticles3D::get_use_local_coordinates);
+	ClassDB::bind_method(D_METHOD("get_local_trails"), &GPUParticles3D::get_local_trails);
 	ClassDB::bind_method(D_METHOD("get_fixed_fps"), &GPUParticles3D::get_fixed_fps);
 	ClassDB::bind_method(D_METHOD("get_fractional_delta"), &GPUParticles3D::get_fractional_delta);
 	ClassDB::bind_method(D_METHOD("get_interpolate"), &GPUParticles3D::get_interpolate);
@@ -839,6 +850,7 @@ void GPUParticles3D::_bind_methods() {
 	ADD_GROUP("Drawing", "");
 	ADD_PROPERTY(PropertyInfo(Variant::AABB, "visibility_aabb", PROPERTY_HINT_NONE, "suffix:m"), "set_visibility_aabb", "get_visibility_aabb");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_coords"), "set_use_local_coordinates", "get_use_local_coordinates");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_trails"), "set_local_trails", "get_local_trails");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "draw_order", PROPERTY_HINT_ENUM, "Index,Lifetime,Reverse Lifetime,View Depth"), "set_draw_order", "get_draw_order");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "transform_align", PROPERTY_HINT_ENUM, "Disabled,Z-Billboard,Y to Velocity,Z-Billboard + Y to Velocity"), "set_transform_align", "get_transform_align");
 	ADD_GROUP("Trails", "trail_");
@@ -894,6 +906,7 @@ GPUParticles3D::GPUParticles3D() {
 	set_trail_lifetime(0.3);
 	set_visibility_aabb(AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8)));
 	set_use_local_coordinates(false);
+	set_local_trails(false);
 	set_draw_passes(1);
 	set_draw_order(DRAW_ORDER_INDEX);
 	set_speed_scale(1);

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -72,6 +72,7 @@ private:
 	double speed_scale = 0.0;
 	AABB visibility_aabb;
 	bool local_coords = false;
+	bool local_trails = false;
 	int fixed_fps = 0;
 	bool fractional_delta = false;
 	bool interpolate = true;
@@ -125,6 +126,7 @@ public:
 	void set_randomness_ratio(real_t p_ratio);
 	void set_visibility_aabb(const AABB &p_aabb);
 	void set_use_local_coordinates(bool p_enable);
+	void set_local_trails(bool p_enable);
 	void set_process_material(const Ref<Material> &p_material);
 	void set_speed_scale(double p_scale);
 	void set_collision_base_size(real_t p_ratio);
@@ -142,6 +144,7 @@ public:
 	real_t get_randomness_ratio() const;
 	AABB get_visibility_aabb() const;
 	bool get_use_local_coordinates() const;
+	bool get_local_trails() const;
 	Ref<Material> get_process_material() const;
 	double get_speed_scale() const;
 	real_t get_collision_base_size() const;

--- a/servers/rendering/dummy/storage/particles_storage.h
+++ b/servers/rendering/dummy/storage/particles_storage.h
@@ -57,6 +57,7 @@ public:
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) override {}
 	virtual void particles_set_speed_scale(RID p_particles, double p_scale) override {}
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override {}
+	virtual void particles_set_local_trails(RID p_particles, bool p_enable) override {}
 	virtual void particles_set_process_material(RID p_particles, RID p_material) override {}
 	virtual RID particles_get_process_material(RID p_particles) const override { return RID(); }
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) override {}

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -184,6 +184,7 @@ layout(push_constant, std430) uniform Params {
 	bool sub_emitter_mode;
 	bool can_emit;
 	bool trail_pass;
+	bool local_trails;
 }
 params;
 
@@ -310,7 +311,10 @@ void main() {
 #ifdef USERDATA6_USED
 			PARTICLE.userdata6 = particles.data[src_idx].userdata6;
 #endif
+		} else if (params.local_trails && bool(PARTICLE.flags & PARTICLE_FLAG_TRAILED)) {
+			PARTICLE.xform = frame_history.data[0].emission_transform; // will set all starts to current node, but they cannot move from there.
 		}
+
 		if (!bool(particles.data[src_idx].flags & PARTICLE_FLAG_ACTIVE)) {
 			// Disable the entire trail if the parent is no longer active.
 			PARTICLE.flags = 0;

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -398,11 +398,20 @@ void ParticlesStorage::particles_set_speed_scale(RID p_particles, double p_scale
 
 	particles->speed_scale = p_scale;
 }
+
 void ParticlesStorage::particles_set_use_local_coordinates(RID p_particles, bool p_enable) {
 	Particles *particles = particles_owner.get_or_null(p_particles);
 	ERR_FAIL_NULL(particles);
 
 	particles->use_local_coords = p_enable;
+	particles->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_PARTICLES);
+}
+
+void ParticlesStorage::particles_set_local_trails(RID p_particles, bool p_enable) {
+	Particles *particles = particles_owner.get_or_null(p_particles);
+	ERR_FAIL_NULL(particles);
+
+	particles->local_trails = p_enable;
 	particles->dependency.changed_notify(Dependency::DEPENDENCY_CHANGED_PARTICLES);
 }
 
@@ -1124,6 +1133,7 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	push_constant.use_fractional_delta = p_particles->fractional_delta;
 	push_constant.sub_emitter_mode = !p_particles->emitting && p_particles->emission_buffer && (p_particles->emission_buffer->particle_count > 0 || p_particles->force_sub_emit);
 	push_constant.trail_pass = false;
+	push_constant.local_trails = p_particles->local_trails;
 
 	p_particles->force_sub_emit = false; //reset
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -171,6 +171,7 @@ private:
 		bool restart_request = false;
 		AABB custom_aabb = AABB(Vector3(-4, -4, -4), Vector3(8, 8, 8));
 		bool use_local_coords = false;
+		bool local_trails = false;
 		bool has_collision_cache = false;
 
 		bool has_sdf_collision = false;
@@ -283,6 +284,10 @@ private:
 			uint32_t sub_emitter_mode;
 			uint32_t can_emit;
 			uint32_t trail_pass;
+			uint32_t local_trails;
+			uint32_t pad1; // Padding required to offset data to multiple of 16 bytes.
+			uint32_t pad2;
+			uint32_t pad3;
 		};
 
 		ParticlesShaderRD shader;
@@ -450,6 +455,7 @@ public:
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) override;
 	virtual void particles_set_speed_scale(RID p_particles, double p_scale) override;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override;
+	virtual void particles_set_local_trails(RID p_particles, bool p_enable) override;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) override;
 	virtual RID particles_get_process_material(RID p_particles) const override;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -589,6 +589,7 @@ public:
 	FUNC2(particles_set_custom_aabb, RID, const AABB &)
 	FUNC2(particles_set_speed_scale, RID, double)
 	FUNC2(particles_set_use_local_coordinates, RID, bool)
+	FUNC2(particles_set_local_trails, RID, bool)
 	FUNC2(particles_set_process_material, RID, RID)
 	FUNC2(particles_set_fixed_fps, RID, int)
 	FUNC2(particles_set_interpolate, RID, bool)

--- a/servers/rendering/storage/particles_storage.h
+++ b/servers/rendering/storage/particles_storage.h
@@ -58,6 +58,7 @@ public:
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) = 0;
 	virtual void particles_set_speed_scale(RID p_particles, double p_scale) = 0;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) = 0;
+	virtual void particles_set_local_trails(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) = 0;
 	virtual RID particles_get_process_material(RID p_particles) const = 0;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2707,6 +2707,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("particles_set_custom_aabb", "particles", "aabb"), &RenderingServer::particles_set_custom_aabb);
 	ClassDB::bind_method(D_METHOD("particles_set_speed_scale", "particles", "scale"), &RenderingServer::particles_set_speed_scale);
 	ClassDB::bind_method(D_METHOD("particles_set_use_local_coordinates", "particles", "enable"), &RenderingServer::particles_set_use_local_coordinates);
+	ClassDB::bind_method(D_METHOD("particles_set_local_trails", "particles", "enable"), &RenderingServer::particles_set_local_trails);
 	ClassDB::bind_method(D_METHOD("particles_set_process_material", "particles", "material"), &RenderingServer::particles_set_process_material);
 	ClassDB::bind_method(D_METHOD("particles_set_fixed_fps", "particles", "fps"), &RenderingServer::particles_set_fixed_fps);
 	ClassDB::bind_method(D_METHOD("particles_set_interpolate", "particles", "enable"), &RenderingServer::particles_set_interpolate);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -788,6 +788,7 @@ public:
 	virtual void particles_set_custom_aabb(RID p_particles, const AABB &p_aabb) = 0;
 	virtual void particles_set_speed_scale(RID p_particles, double p_scale) = 0;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) = 0;
+	virtual void particles_set_local_trails(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) = 0;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) = 0;
 	virtual void particles_set_interpolate(RID p_particles, bool p_enable) = 0;


### PR DESCRIPTION
Based on this feature request: https://github.com/godotengine/godot-proposals/issues/13099

Adding support for local particle trails while using global particles. 

This adds a checkbox for local particle trails - only has an effect when local is not checked.