### PR TITLE
Move Skeleton3D init process (for dirty flags) into `POST_ENTER_TREE` from `ENTER_TREE`

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -289,12 +289,14 @@ void Skeleton3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_process_changed();
-			_make_dirty();
-			_make_modifiers_dirty();
-			force_update_all_dirty_bones();
 #if !defined(DISABLE_DEPRECATED) && !defined(PHYSICS_3D_DISABLED)
 			setup_simulator();
 #endif // _DISABLE_DEPRECATED && PHYSICS_3D_DISABLED
+		} break;
+		case NOTIFICATION_POST_ENTER_TREE: {
+			_make_dirty();
+			_make_modifiers_dirty();
+			force_update_all_dirty_bones();
 			update_flags |= UPDATE_FLAG_POSE;
 			_notification(NOTIFICATION_UPDATE_SKELETON);
 		} break;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/110095
- Follow up https://github.com/godotengine/godot/pull/109841

Indeed, it doesn't make sense to process the skeleton modifier via update when the SkeletonModifier isn't ready.

But I don't know why Skeleton initialization was done in enter_tree, probably since the early days of 3.x.  This PR moves these initial processes from enter_tree to ready.

However, since this likely affects many projects, please test carefully. cc @fire @precup

For now, the previous initialization issues I recall is below, and I've confirmed they don't recur problems.

- https://github.com/godotengine/godot/issues/97459
- https://github.com/godotengine/godot/issues/97982