### PR TITLE
SCons: Decouple code generators via `argparse`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -140,6 +140,7 @@ env.__class__.module_check_dependencies = methods.module_check_dependencies
 
 env["x86_libtheora_opt_gcc"] = False
 env["x86_libtheora_opt_vc"] = False
+env["PYTHON_BIN"] = sys.executable
 
 # avoid issues when building with different versions of python out of the same directory
 env.SConsignFile(File("#.sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL)).abspath)

--- a/SConstruct
+++ b/SConstruct
@@ -44,26 +44,17 @@ def _helper_module(name, path):
         setattr(parent_module, child_name, child_module)
 
 
-_helper_module("gles3_builders", "gles3_builders.py")
-_helper_module("glsl_builders", "glsl_builders.py")
 _helper_module("methods", "methods.py")
 _helper_module("platform_methods", "platform_methods.py")
+_helper_module("scu_builders", "scu_builders.py")
 _helper_module("version", "version.py")
-_helper_module("core.core_builders", "core/core_builders.py")
-_helper_module("main.main_builders", "main/main_builders.py")
 _helper_module("misc.utility.color", "misc/utility/color.py")
 
 # Local
-import gles3_builders
-import glsl_builders
 import methods
 import scu_builders
 from misc.utility.color import is_stderr_color, print_error, print_info, print_warning
 from platform_methods import architecture_aliases, architectures, compatibility_platform_aliases
-
-if ARGUMENTS.get("target", "editor") == "editor":
-    _helper_module("editor.editor_builders", "editor/editor_builders.py")
-    _helper_module("editor.template_builders", "editor/template_builders.py")
 
 # Scan possible build platforms
 
@@ -140,6 +131,7 @@ env.__class__.module_check_dependencies = methods.module_check_dependencies
 
 env["x86_libtheora_opt_gcc"] = False
 env["x86_libtheora_opt_vc"] = False
+env["PYTHON_BIN"] = sys.executable
 
 # avoid issues when building with different versions of python out of the same directory
 env.SConsignFile(File("#.sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL)).abspath)
@@ -1174,19 +1166,25 @@ env["SHLIBSUFFIX"] = suffix + env["SHLIBSUFFIX"]
 env["OBJPREFIX"] = env["object_prefix"]
 env["SHOBJPREFIX"] = env["object_prefix"]
 
+glsl_emitter = methods.generate_dependency_emitter("glsl_builders.py")
+gles3_emitter = methods.generate_dependency_emitter("gles3_builders.py")
+
 GLSL_BUILDERS = {
     "RD_GLSL": env.Builder(
-        action=env.Run(glsl_builders.build_rd_headers),
+        action=Action("$PYTHON_BIN glsl_builders.py rd_glsl $TARGET $SOURCE", "$GENCOMSTR"),
+        emitters=glsl_emitter,
         suffix="glsl.gen.h",
         src_suffix=".glsl",
     ),
     "GLSL_HEADER": env.Builder(
-        action=env.Run(glsl_builders.build_raw_headers),
+        action=Action("$PYTHON_BIN glsl_builders.py glsl_header $TARGET $SOURCE", "$GENCOMSTR"),
+        emitters=glsl_emitter,
         suffix="glsl.gen.h",
         src_suffix=".glsl",
     ),
     "GLES3_GLSL": env.Builder(
-        action=env.Run(gles3_builders.build_gles3_headers),
+        action=Action("$PYTHON_BIN gles3_builders.py gles3_glsl $TARGET $SOURCE", "$GENCOMSTR"),
+        emitters=gles3_emitter,
         suffix="glsl.gen.h",
         src_suffix=".glsl",
     ),

--- a/core/SCsub
+++ b/core/SCsub
@@ -3,8 +3,6 @@ from misc.utility.scons_hints import *
 
 import os
 
-import core_builders
-
 import methods
 
 Import("env")
@@ -169,60 +167,97 @@ env.core_sources += thirdparty_obj
 env.add_source_files(env.core_sources, "*.cpp")
 
 # Generate disabled classes
-env.CommandNoCache(
-    "disabled_classes.gen.h", env.Value(env.disabled_classes), env.Run(core_builders.disabled_class_builder)
+env.Command(
+    "disabled_classes.gen.h",
+    ["core_builders.py", *env.disabled_classes],
+    env.Run("$PYTHON_BIN ${SOURCES[0]} disabled_classes $TARGET ${SOURCES[1:]}"),
 )
 
 # Generate version info
-env.CommandNoCache(
+version_info = methods.get_version_info(env.module_version_string)
+version_cmd = (
+    "$PYTHON_BIN ${SOURCES[0]} version_info $TARGET --short_name ${SOURCES[1]} --name ${SOURCES[2]} "
+    + "--major ${SOURCES[3]} --minor ${SOURCES[4]} --patch ${SOURCES[5]} --status ${SOURCES[6]} "
+    + "--build ${SOURCES[7]} --website ${SOURCES[9]} --docs_branch ${SOURCES[10]}"
+)
+if version_info["module_config"]:  # Empty string would resolve to "0".
+    version_cmd += " --module_config ${SOURCES[8]}"
+
+env.Command(
     "version_generated.gen.h",
-    env.Value(methods.get_version_info(env.module_version_string)),
-    env.Run(core_builders.version_info_builder),
+    [
+        "core_builders.py",
+        env.Value(version_info["short_name"]),
+        env.Value(version_info["name"]),
+        env.Value(version_info["major"]),
+        env.Value(version_info["minor"]),
+        env.Value(version_info["patch"]),
+        env.Value(version_info["status"]),
+        env.Value(version_info["build"]),
+        env.Value(version_info["module_config"]),
+        env.Value(version_info["website"]),
+        env.Value(version_info["docs_branch"]),
+    ],
+    env.Run(version_cmd),
 )
 
 # Generate version hash
-gen_hash = env.CommandNoCache(
-    "version_hash.gen.cpp", env.Value(methods.get_git_info()), env.Run(core_builders.version_hash_builder)
+git_info = methods.get_git_info()
+git_cmd = "$PYTHON_BIN ${SOURCES[0]} git_info $TARGET --hash ${SOURCES[1]} --timestamp ${SOURCES[2]}"
+gen_hash = env.Command(
+    "version_hash.gen.cpp",
+    ["core_builders.py", env.Value(git_info["git_hash"]), env.Value(git_info["git_timestamp"])],
+    env.Run(git_cmd),
 )
 env.add_source_files(env.core_sources, gen_hash)
 
 # Generate AES256 script encryption key
-encryption_key = os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")
+encryption_cmd = "$PYTHON_BIN ${SOURCES[0]} encryption_key $TARGET"
+encryption_key = os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY", "")
 encryption_key_var = "SCRIPT_AES256_ENCRYPTION_KEY"
-if encryption_key is None:
+if not encryption_key:
     # Fallback to the environment variable used by Godot on export.
     # This allows setting only one environment variable for both compiling and exporting.
-    encryption_key = os.environ.get("GODOT_SCRIPT_ENCRYPTION_KEY")
+    encryption_key = os.environ.get("GODOT_SCRIPT_ENCRYPTION_KEY", "")
     encryption_key_var = "GODOT_SCRIPT_ENCRYPTION_KEY"
 if encryption_key:
     print(
         f"\n*** IMPORTANT: Compiling Godot with custom `{encryption_key_var}` set as environment variable."
         "\n*** Make sure to use templates compiled with this key when exporting a project with encryption.\n"
     )
-gen_encrypt = env.CommandNoCache(
-    "script_encryption_key.gen.cpp",
-    env.Value(encryption_key),
-    env.Run(core_builders.encryption_key_builder),
+    encryption_cmd += " --key ${SOURCES[1]}"
+
+gen_encrypt = env.Command(
+    "script_encryption_key.gen.cpp", ["core_builders.py", env.Value(encryption_key)], env.Run(encryption_cmd)
 )
 env.add_source_files(env.core_sources, gen_encrypt)
 
 # Certificates
-env.CommandNoCache(
+certs_cmd = "$PYTHON_BIN ${SOURCES[0]} certs $TARGET ${SOURCES[1]} ${SOURCES[2]}"
+if env["system_certs_path"]:
+    certs_cmd += " --system ${SOURCES[3]}"
+env.Command(
     "#core/io/certs_compressed.gen.h",
-    ["#thirdparty/certs/ca-bundle.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
-    env.Run(core_builders.make_certs_header),
+    [
+        "core_builders.py",
+        "#thirdparty/certs/ca-bundle.crt",
+        env.Value(env["builtin_certs"]),
+        env.Value(env["system_certs_path"]),
+    ],
+    env.Run(certs_cmd),
 )
 
 # Authors
-env.CommandNoCache("#core/authors.gen.h", "#AUTHORS.md", env.Run(core_builders.make_authors_header))
+authors_cmd = "$PYTHON_BIN ${SOURCES[0]} authors $TARGET ${SOURCES[1]}"
+env.Command("#core/authors.gen.h", ["core_builders.py", "#AUTHORS.md"], env.Run(authors_cmd))
 
 # Donors
-env.CommandNoCache("#core/donors.gen.h", "#DONORS.md", env.Run(core_builders.make_donors_header))
+donors_cmd = "$PYTHON_BIN ${SOURCES[0]} donors $TARGET ${SOURCES[1]}"
+env.Command("#core/donors.gen.h", ["core_builders.py", "#DONORS.md"], env.Run(donors_cmd))
 
 # License
-env.CommandNoCache(
-    "#core/license.gen.h", ["#COPYRIGHT.txt", "#LICENSE.txt"], env.Run(core_builders.make_license_header)
-)
+license_cmd = "$PYTHON_BIN ${SOURCES[0]} license $TARGET ${SOURCES[1]} ${SOURCES[2]}"
+env.Command("#core/license.gen.h", ["core_builders.py", "#LICENSE.txt", "#COPYRIGHT.txt"], env.Run(license_cmd))
 
 # Chain load SCsubs
 SConscript("profiling/SCsub")

--- a/core/SCsub
+++ b/core/SCsub
@@ -3,8 +3,6 @@ from misc.utility.scons_hints import *
 
 import os
 
-import core_builders
-
 import methods
 
 Import("env")
@@ -216,60 +214,99 @@ env.core_sources += thirdparty_obj
 env.add_source_files(env.core_sources, "*.cpp")
 
 # Generate disabled classes
-env.CommandNoCache(
-    "disabled_classes.gen.h", env.Value(env.disabled_classes), env.Run(core_builders.disabled_class_builder)
+env.Command(
+    "disabled_classes.gen.h",
+    ["core_builders.py", *env.disabled_classes],
+    env.Run("$PYTHON_BIN ${SOURCES[0]} disabled_classes $TARGET ${SOURCES[1:]}"),
 )
 
 # Generate version info
-env.CommandNoCache(
+version_info = methods.get_version_info(env.module_version_string)
+version_cmd = (
+    "$PYTHON_BIN ${SOURCES[0]} version_info $TARGET --short_name ${SOURCES[1]} --name ${SOURCES[2]} "
+    + "--major ${SOURCES[3]} --minor ${SOURCES[4]} --patch ${SOURCES[5]} --status ${SOURCES[6]} "
+    + "--build ${SOURCES[7]} --website ${SOURCES[9]} --docs_branch ${SOURCES[10]}"
+)
+if version_info["module_config"]:  # Empty string would resolve to "0".
+    version_cmd += " --module_config ${SOURCES[8]}"
+
+env.Command(
     "version_generated.gen.h",
-    env.Value(methods.get_version_info(env.module_version_string)),
-    env.Run(core_builders.version_info_builder),
+    [
+        "core_builders.py",
+        env.Value(version_info["short_name"]),
+        env.Value(version_info["name"]),
+        env.Value(version_info["major"]),
+        env.Value(version_info["minor"]),
+        env.Value(version_info["patch"]),
+        env.Value(version_info["status"]),
+        env.Value(version_info["build"]),
+        env.Value(version_info["module_config"]),
+        env.Value(version_info["website"]),
+        env.Value(version_info["docs_branch"]),
+    ],
+    env.Run(version_cmd),
 )
 
 # Generate version hash
-gen_hash = env.CommandNoCache(
-    "version_hash.gen.cpp", env.Value(methods.get_git_info()), env.Run(core_builders.version_hash_builder)
+git_info = methods.get_git_info()
+git_cmd = "$PYTHON_BIN ${SOURCES[0]} git_info $TARGET --hash ${SOURCES[1]} --timestamp ${SOURCES[2]}"
+gen_hash = env.Command(
+    "version_hash.gen.cpp",
+    ["core_builders.py", env.Value(git_info["git_hash"]), env.Value(git_info["git_timestamp"])],
+    env.Run(git_cmd),
 )
 env.add_source_files(env.core_sources, gen_hash)
 
 # Generate AES256 script encryption key
-encryption_key = os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY")
+encryption_cmd = "$PYTHON_BIN ${SOURCES[0]} encryption_key $TARGET"
+encryption_key = os.environ.get("SCRIPT_AES256_ENCRYPTION_KEY", "")
 encryption_key_var = "SCRIPT_AES256_ENCRYPTION_KEY"
-if encryption_key is None:
+if not encryption_key:
     # Fallback to the environment variable used by Godot on export.
     # This allows setting only one environment variable for both compiling and exporting.
-    encryption_key = os.environ.get("GODOT_SCRIPT_ENCRYPTION_KEY")
+    encryption_key = os.environ.get("GODOT_SCRIPT_ENCRYPTION_KEY", "")
     encryption_key_var = "GODOT_SCRIPT_ENCRYPTION_KEY"
 if encryption_key:
     print(
         f"\n*** IMPORTANT: Compiling Godot with custom `{encryption_key_var}` set as environment variable."
         "\n*** Make sure to use templates compiled with this key when exporting a project with encryption.\n"
     )
-gen_encrypt = env.CommandNoCache(
-    "script_encryption_key.gen.cpp",
-    env.Value(encryption_key),
-    env.Run(core_builders.encryption_key_builder),
+    encryption_cmd += " --key ${SOURCES[1]}"
+
+gen_encrypt = env.Command(
+    "script_encryption_key.gen.cpp", ["core_builders.py", env.Value(encryption_key)], env.Run(encryption_cmd)
 )
 env.add_source_files(env.core_sources, gen_encrypt)
 
 # Certificates
-env.CommandNoCache(
-    "#core/io/certs_compressed.gen.h",
-    ["#thirdparty/certs/ca-bundle.crt", env.Value(env["builtin_certs"]), env.Value(env["system_certs_path"])],
-    env.Run(core_builders.make_certs_header),
+certs_cmd = "$PYTHON_BIN ${SOURCES[0]} certs $TARGET ${SOURCES[1]}"
+if env["builtin_certs"]:
+    certs_cmd += " --builtin"
+if env["system_certs_path"]:
+    certs_cmd += " --system_certs ${SOURCES[3]}"
+env.Command(
+    "io/certs_compressed.gen.h",
+    [
+        "core_builders.py",
+        "#thirdparty/certs/ca-bundle.crt",
+        env.Value(env["builtin_certs"]),
+        env.Value(env["system_certs_path"]),
+    ],
+    env.Run(certs_cmd),
 )
 
 # Authors
-env.CommandNoCache("#core/authors.gen.h", "#AUTHORS.md", env.Run(core_builders.make_authors_header))
+authors_cmd = "$PYTHON_BIN ${SOURCES[0]} authors $TARGET ${SOURCES[1]}"
+env.Command("authors.gen.h", ["core_builders.py", "#AUTHORS.md"], env.Run(authors_cmd))
 
 # Donors
-env.CommandNoCache("#core/donors.gen.h", "#DONORS.md", env.Run(core_builders.make_donors_header))
+donors_cmd = "$PYTHON_BIN ${SOURCES[0]} donors $TARGET ${SOURCES[1]}"
+env.Command("donors.gen.h", ["core_builders.py", "#DONORS.md"], env.Run(donors_cmd))
 
 # License
-env.CommandNoCache(
-    "#core/license.gen.h", ["#COPYRIGHT.txt", "#LICENSE.txt"], env.Run(core_builders.make_license_header)
-)
+license_cmd = "$PYTHON_BIN ${SOURCES[0]} license $TARGET ${SOURCES[1]} ${SOURCES[2]}"
+env.Command("license.gen.h", ["core_builders.py", "#LICENSE.txt", "#COPYRIGHT.txt"], env.Run(license_cmd))
 
 # Chain load SCsubs
 SConscript("profiling/SCsub")

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -1,24 +1,37 @@
 """Functions used to generate source files during build time"""
 
-from collections import OrderedDict
-from io import TextIOWrapper
+import argparse
+import sys
 
-import methods
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
-# Generate disabled classes
-def disabled_class_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        for c in source[0].read():
+def disabled_classes(target: str, classes: list[str]) -> None:
+    with methods.generated_wrapper(target) as file:
+        for c in classes:
             if cs := c.strip():
                 file.write(f"class {cs}; template <> struct is_class_enabled<{cs}> : std::false_type {{}};\n")
 
 
-# Generate version info
-def version_info_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        file.write(
-            """\
+def version_info(
+    target: str,
+    short_name: str,
+    name: str,
+    major: int,
+    minor: int,
+    patch: int,
+    status: str,
+    build: str,
+    module_config: str,
+    website: str,
+    docs_branch: str,
+) -> None:
+    with methods.generated_wrapper(target) as file:
+        file.write(f"""\
 #define GODOT_VERSION_SHORT_NAME "{short_name}"
 #define GODOT_VERSION_NAME "{name}"
 #define GODOT_VERSION_MAJOR {major}
@@ -30,56 +43,42 @@ def version_info_builder(target, source, env):
 #define GODOT_VERSION_WEBSITE "{website}"
 #define GODOT_VERSION_DOCS_BRANCH "{docs_branch}"
 #define GODOT_VERSION_DOCS_URL "https://docs.godotengine.org/en/" GODOT_VERSION_DOCS_BRANCH
-""".format(**source[0].read())
-        )
+""")
 
 
-def version_hash_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        file.write(
-            """\
+def git_info(target: str, hash: str, timestamp: int) -> None:
+    with methods.generated_wrapper(target) as file:
+        file.write(f"""\
 #include "core/version.h"
 
-const char *const GODOT_VERSION_HASH = "{git_hash}";
-const unsigned long long GODOT_VERSION_TIMESTAMP = {git_timestamp};
-""".format(**source[0].read())
-        )
+const char *const GODOT_VERSION_HASH = "{hash}";
+const unsigned long long GODOT_VERSION_TIMESTAMP = {timestamp};
+""")
 
 
-def encryption_key_builder(target, source, env):
-    src = source[0].read() or "0" * 64
-    try:
-        buffer = bytes.fromhex(src)
-        if len(buffer) != 32:
-            raise ValueError
-    except ValueError:
-        methods.print_error(
-            f'Invalid AES256 encryption key, not 64 hexadecimal characters: "{src}".\n'
-            "Unset `SCRIPT_AES256_ENCRYPTION_KEY` in your environment "
-            "or make sure that it contains exactly 64 hexadecimal characters."
-        )
-        raise
-
-    with methods.generated_wrapper(str(target[0])) as file:
-        file.write(
-            f"""\
-#include <cstdint>
+def encryption_key(target: str, key: bytes) -> None:
+    with methods.generated_wrapper(target) as file:
+        file.write(f"""\
+#include "core/config/project_settings.h"
 
 uint8_t script_encryption_key[32] = {{
-{methods.format_buffer(buffer, 1)}
-}};"""
-        )
+{methods.format_buffer(key, 1)}
+}};
+""")
 
 
-def make_certs_header(target, source, env):
-    buffer = methods.get_buffer(str(source[0]))
-    decomp_size = len(buffer)
-    buffer = methods.compress_buffer(buffer)
+def certs(target: str, certs: str, builtin: bool, system_certs: str) -> None:
+    import zlib
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         # System certs path. Editor will use them if defined. (for package maintainers)
-        file.write('#define _SYSTEM_CERTS_PATH "{}"\n'.format(source[2].read() or ""))
-        if source[1].read():
+        file.write(f'#define _SYSTEM_CERTS_PATH "{system_certs}"\n')
+
+        if builtin:
+            buffer = methods.get_buffer(certs)
+            decomp_size = len(buffer)
+            buffer = zlib.compress(buffer, zlib.Z_BEST_COMPRESSION)
+
             # Defined here and not in env so changing it does not trigger a full rebuild.
             file.write(f"""\
 #define BUILTIN_CERTS_ENABLED
@@ -92,24 +91,25 @@ inline constexpr unsigned char _certs_compressed[] = {{
 """)
 
 
-def make_authors_header(target, source, env):
+def authors(target: str, authors: str) -> None:
     SECTIONS = {
         "Project Founders": "AUTHORS_FOUNDERS",
         "Lead Developer": "AUTHORS_LEAD_DEVELOPERS",
         "Project Manager": "AUTHORS_PROJECT_MANAGERS",
         "Developers": "AUTHORS_DEVELOPERS",
     }
-    buffer = methods.get_buffer(str(source[0]))
+    with open(authors, "rb") as authors_file:
+        buffer = authors_file.read()
     reading = False
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
 
-        def close_section():
+        def close_section() -> None:
             file.write("\tnullptr,\n};\n\n")
 
         for line in buffer.decode().splitlines():
             if line.startswith("    ") and reading:
-                file.write(f'\t"{methods.to_escaped_cstring(line).strip()}",\n')
+                file.write(f"\t{methods.to_raw_cstring(line.strip())},\n")
             elif line.startswith("## "):
                 if reading:
                     close_section()
@@ -123,7 +123,7 @@ def make_authors_header(target, source, env):
             close_section()
 
 
-def make_donors_header(target, source, env):
+def donors(target: str, donors: str) -> None:
     SECTIONS = {
         "Patrons": "DONORS_PATRONS",
         "Platinum sponsors": "DONORS_SPONSORS_PLATINUM",
@@ -134,10 +134,10 @@ def make_donors_header(target, source, env):
         "Platinum members": "DONORS_MEMBERS_PLATINUM",
         "Gold members": "DONORS_MEMBERS_GOLD",
     }
-    buffer = methods.get_buffer(str(source[0]))
+    buffer = methods.get_buffer(donors)
     reading = False
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file, open(donors):
 
         def close_section():
             file.write("\tnullptr,\n};\n\n")
@@ -158,17 +158,16 @@ def make_donors_header(target, source, env):
             close_section()
 
 
-def make_license_header(target, source, env):
-    src_copyright = str(source[0])
-    src_license = str(source[1])
+def license(target: str, license: str, copyright: str) -> None:
+    from typing import TextIO
 
     class LicenseReader:
-        def __init__(self, license_file: TextIOWrapper):
+        def __init__(self, license_file: TextIO) -> None:
             self._license_file = license_file
             self.line_num = 0
             self.current = self.next_line()
 
-        def next_line(self):
+        def next_line(self) -> str:
             line = self._license_file.readline()
             self.line_num += 1
             while line.startswith("#"):
@@ -177,7 +176,7 @@ def make_license_header(target, source, env):
             self.current = line
             return line
 
-        def next_tag(self):
+        def next_tag(self) -> tuple[str, list[str]]:
             if ":" not in self.current:
                 return ("", [])
             tag, line = self.current.split(":", 1)
@@ -186,10 +185,10 @@ def make_license_header(target, source, env):
                 lines.append(self.current.strip())
             return (tag, lines)
 
-    projects = OrderedDict()
+    projects = {}  # type: ignore[var-annotated]
     license_list = []
 
-    with open(src_copyright, "r", encoding="utf-8") as copyright_file:
+    with open(copyright, "r", encoding="utf-8") as copyright_file:
         reader = LicenseReader(copyright_file)
         part = {}
         while reader.current:
@@ -208,7 +207,7 @@ def make_license_header(target, source, env):
                 part = {}
                 reader.next_line()
 
-    data_list = []
+    data_list = []  # type: ignore[var-annotated]
     for project in iter(projects.values()):
         for part in project:
             part["file_index"] = len(data_list)
@@ -216,10 +215,10 @@ def make_license_header(target, source, env):
             part["copyright_index"] = len(data_list)
             data_list += part["Copyright"]
 
-    with open(src_license, "r", encoding="utf-8") as file:
-        license_text = file.read()
+    with open(license, "r", encoding="utf-8") as file_license:
+        license_text = file_license.read()
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         file.write(f"""\
 inline constexpr const char *GODOT_LICENSE_TEXT = {{
 {methods.to_raw_cstring(license_text)}
@@ -275,17 +274,88 @@ struct ComponentCopyright {{
         file.write(f"inline constexpr int LICENSE_COUNT = {len(license_list)};\n")
 
         file.write("inline constexpr const char *LICENSE_NAMES[] = {\n")
-        for license in license_list:
-            file.write(f'\t"{methods.to_escaped_cstring(license[0])}",\n')
+        for item in license_list:
+            file.write(f'\t"{methods.to_escaped_cstring(item[0])}",\n')
         file.write("};\n\n")
 
         file.write("inline constexpr const char *LICENSE_BODIES[] = {\n\n")
-        for license in license_list:
+        for item in license_list:
             to_raw = []
-            for line in license[1:]:
+            for line in item[1:]:
                 if line == ".":
                     to_raw += [""]
                 else:
                     to_raw += [line]
             file.write(f"{methods.to_raw_cstring(to_raw)},\n\n")
         file.write("};\n\n")
+
+
+# Command-Line Arguments
+
+
+def aes256_type(input: str) -> bytes:
+    try:
+        buffer = bytes.fromhex(input)
+        if len(buffer) != 32:
+            raise ValueError
+        return buffer
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid AES256: {input}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    disabled_classes_parser = subparsers.add_parser("disabled_classes")
+    disabled_classes_parser.add_argument("target")
+    disabled_classes_parser.add_argument("classes", nargs="*")
+
+    version_info_parser = subparsers.add_parser("version_info")
+    version_info_parser.add_argument("target")
+    version_info_parser.add_argument("--short_name", default="")
+    version_info_parser.add_argument("--name", default="")
+    version_info_parser.add_argument("--major", type=int, default=0)
+    version_info_parser.add_argument("--minor", type=int, default=0)
+    version_info_parser.add_argument("--patch", type=int, default=0)
+    version_info_parser.add_argument("--status", default="")
+    version_info_parser.add_argument("--build", default="")
+    version_info_parser.add_argument("--module_config", default="")
+    version_info_parser.add_argument("--website", default="")
+    version_info_parser.add_argument("--docs_branch", default="")
+
+    git_info_parser = subparsers.add_parser("git_info")
+    git_info_parser.add_argument("target")
+    git_info_parser.add_argument("--hash", default="")
+    git_info_parser.add_argument("--timestamp", type=int, default=0)
+
+    encryption_key_parser = subparsers.add_parser("encryption_key")
+    encryption_key_parser.add_argument("target")
+    encryption_key_parser.add_argument("--key", type=aes256_type, default="0" * 64)
+
+    certs_parser = subparsers.add_parser("certs")
+    certs_parser.add_argument("target")
+    certs_parser.add_argument("certs")
+    certs_parser.add_argument("builtin", type=bool)
+    certs_parser.add_argument("--system_certs", default="")
+
+    authors_parser = subparsers.add_parser("authors")
+    authors_parser.add_argument("target")
+    authors_parser.add_argument("authors")
+
+    donors_parser = subparsers.add_parser("donors")
+    donors_parser.add_argument("target")
+    donors_parser.add_argument("donors")
+
+    license_parser = subparsers.add_parser("license")
+    license_parser.add_argument("target")
+    license_parser.add_argument("license")
+    license_parser.add_argument("copyright")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/core_builders.py
+++ b/core/core_builders.py
@@ -1,24 +1,37 @@
 """Functions used to generate source files during build time"""
 
-from collections import OrderedDict
-from io import TextIOWrapper
+import argparse
+import sys
 
-import methods
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
-# Generate disabled classes
-def disabled_class_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        for c in source[0].read():
+def disabled_classes(target: str, classes: list[str]) -> None:
+    with methods.generated_wrapper(target) as file:
+        for c in classes:
             if cs := c.strip():
                 file.write(f"class {cs}; template <> struct is_class_enabled<{cs}> : std::false_type {{}};\n")
 
 
-# Generate version info
-def version_info_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        file.write(
-            """\
+def version_info(
+    target: str,
+    short_name: str,
+    name: str,
+    major: int,
+    minor: int,
+    patch: int,
+    status: str,
+    build: str,
+    module_config: str,
+    website: str,
+    docs_branch: str,
+) -> None:
+    with methods.generated_wrapper(target) as file:
+        file.write(f"""\
 #define GODOT_VERSION_SHORT_NAME "{short_name}"
 #define GODOT_VERSION_NAME "{name}"
 #define GODOT_VERSION_MAJOR {major}
@@ -30,56 +43,42 @@ def version_info_builder(target, source, env):
 #define GODOT_VERSION_WEBSITE "{website}"
 #define GODOT_VERSION_DOCS_BRANCH "{docs_branch}"
 #define GODOT_VERSION_DOCS_URL "https://docs.godotengine.org/en/" GODOT_VERSION_DOCS_BRANCH
-""".format(**source[0].read())
-        )
+""")
 
 
-def version_hash_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        file.write(
-            """\
+def git_info(target: str, hash: str, timestamp: int) -> None:
+    with methods.generated_wrapper(target) as file:
+        file.write(f"""\
 #include "core/version.h"
 
-const char *const GODOT_VERSION_HASH = "{git_hash}";
-const unsigned long long GODOT_VERSION_TIMESTAMP = {git_timestamp};
-""".format(**source[0].read())
-        )
+const char *const GODOT_VERSION_HASH = "{hash}";
+const unsigned long long GODOT_VERSION_TIMESTAMP = {timestamp};
+""")
 
 
-def encryption_key_builder(target, source, env):
-    src = source[0].read() or "0" * 64
-    try:
-        buffer = bytes.fromhex(src)
-        if len(buffer) != 32:
-            raise ValueError
-    except ValueError:
-        methods.print_error(
-            f'Invalid AES256 encryption key, not 64 hexadecimal characters: "{src}".\n'
-            "Unset `SCRIPT_AES256_ENCRYPTION_KEY` in your environment "
-            "or make sure that it contains exactly 64 hexadecimal characters."
-        )
-        raise
-
-    with methods.generated_wrapper(str(target[0])) as file:
-        file.write(
-            f"""\
-#include <cstdint>
+def encryption_key(target: str, key: bytes) -> None:
+    with methods.generated_wrapper(target) as file:
+        file.write(f"""\
+#include "core/config/project_settings.h"
 
 uint8_t script_encryption_key[32] = {{
-{methods.format_buffer(buffer, 1)}
-}};"""
-        )
+{methods.format_buffer(key, 1)}
+}};
+""")
 
 
-def make_certs_header(target, source, env):
-    buffer = methods.get_buffer(str(source[0]))
-    decomp_size = len(buffer)
-    buffer = methods.compress_buffer(buffer)
+def certs(target: str, certs: str, builtin: bool, system_certs: str) -> None:
+    import zlib
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         # System certs path. Editor will use them if defined. (for package maintainers)
-        file.write('#define _SYSTEM_CERTS_PATH "{}"\n'.format(source[2].read() or ""))
-        if source[1].read():
+        file.write(f'#define _SYSTEM_CERTS_PATH "{system_certs}"\n')
+
+        if builtin:
+            buffer = methods.get_buffer(certs)
+            decomp_size = len(buffer)
+            buffer = zlib.compress(buffer, zlib.Z_BEST_COMPRESSION)
+
             # Defined here and not in env so changing it does not trigger a full rebuild.
             file.write(f"""\
 #define BUILTIN_CERTS_ENABLED
@@ -92,24 +91,25 @@ inline constexpr unsigned char _certs_compressed[] = {{
 """)
 
 
-def make_authors_header(target, source, env):
+def authors(target: str, authors: str) -> None:
     SECTIONS = {
         "Project Founders": "AUTHORS_FOUNDERS",
         "Lead Developer": "AUTHORS_LEAD_DEVELOPERS",
         "Project Manager": "AUTHORS_PROJECT_MANAGERS",
         "Developers": "AUTHORS_DEVELOPERS",
     }
-    buffer = methods.get_buffer(str(source[0]))
+    with open(authors, "rb") as authors_file:
+        buffer = authors_file.read()
     reading = False
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
 
-        def close_section():
+        def close_section() -> None:
             file.write("\tnullptr,\n};\n\n")
 
         for line in buffer.decode().splitlines():
             if line.startswith("    ") and reading:
-                file.write(f'\t"{methods.to_escaped_cstring(line).strip()}",\n')
+                file.write(f"\t{methods.to_raw_cstring(line.strip())},\n")
             elif line.startswith("## "):
                 if reading:
                     close_section()
@@ -123,7 +123,7 @@ def make_authors_header(target, source, env):
             close_section()
 
 
-def make_donors_header(target, source, env):
+def donors(target: str, donors: str) -> None:
     SECTIONS = {
         "Patrons": "DONORS_PATRONS",
         "Platinum sponsors": "DONORS_SPONSORS_PLATINUM",
@@ -134,10 +134,10 @@ def make_donors_header(target, source, env):
         "Platinum members": "DONORS_MEMBERS_PLATINUM",
         "Gold members": "DONORS_MEMBERS_GOLD",
     }
-    buffer = methods.get_buffer(str(source[0]))
+    buffer = methods.get_buffer(donors)
     reading = False
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file, open(donors):
 
         def close_section():
             file.write("\tnullptr,\n};\n\n")
@@ -158,17 +158,16 @@ def make_donors_header(target, source, env):
             close_section()
 
 
-def make_license_header(target, source, env):
-    src_copyright = str(source[0])
-    src_license = str(source[1])
+def license(target: str, license: str, copyright: str) -> None:
+    from typing import TextIO
 
     class LicenseReader:
-        def __init__(self, license_file: TextIOWrapper):
+        def __init__(self, license_file: TextIO) -> None:
             self._license_file = license_file
             self.line_num = 0
             self.current = self.next_line()
 
-        def next_line(self):
+        def next_line(self) -> str:
             line = self._license_file.readline()
             self.line_num += 1
             while line.startswith("#"):
@@ -177,7 +176,7 @@ def make_license_header(target, source, env):
             self.current = line
             return line
 
-        def next_tag(self):
+        def next_tag(self) -> tuple[str, list[str]]:
             if ":" not in self.current:
                 return ("", [])
             tag, line = self.current.split(":", 1)
@@ -186,10 +185,10 @@ def make_license_header(target, source, env):
                 lines.append(self.current.strip())
             return (tag, lines)
 
-    projects = OrderedDict()
+    projects = {}  # type: ignore[var-annotated]
     license_list = []
 
-    with open(src_copyright, "r", encoding="utf-8") as copyright_file:
+    with open(copyright, "r", encoding="utf-8") as copyright_file:
         reader = LicenseReader(copyright_file)
         part = {}
         while reader.current:
@@ -208,7 +207,7 @@ def make_license_header(target, source, env):
                 part = {}
                 reader.next_line()
 
-    data_list = []
+    data_list = []  # type: ignore[var-annotated]
     for project in iter(projects.values()):
         for part in project:
             part["file_index"] = len(data_list)
@@ -216,10 +215,10 @@ def make_license_header(target, source, env):
             part["copyright_index"] = len(data_list)
             data_list += part["Copyright"]
 
-    with open(src_license, "r", encoding="utf-8") as file:
-        license_text = file.read()
+    with open(license, "r", encoding="utf-8") as file_license:
+        license_text = file_license.read()
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         file.write(f"""\
 inline constexpr const char *GODOT_LICENSE_TEXT = {{
 {methods.to_raw_cstring(license_text)}
@@ -275,17 +274,88 @@ struct ComponentCopyright {{
         file.write(f"inline constexpr int LICENSE_COUNT = {len(license_list)};\n")
 
         file.write("inline constexpr const char *LICENSE_NAMES[] = {\n")
-        for license in license_list:
-            file.write(f'\t"{methods.to_escaped_cstring(license[0])}",\n')
+        for item in license_list:
+            file.write(f'\t"{methods.to_escaped_cstring(item[0])}",\n')
         file.write("};\n\n")
 
         file.write("inline constexpr const char *LICENSE_BODIES[] = {\n\n")
-        for license in license_list:
+        for item in license_list:
             to_raw = []
-            for line in license[1:]:
+            for line in item[1:]:
                 if line == ".":
                     to_raw += [""]
                 else:
                     to_raw += [line]
             file.write(f"{methods.to_raw_cstring(to_raw)},\n\n")
         file.write("};\n\n")
+
+
+# Command-Line Arguments
+
+
+def aes256_type(input: str) -> bytes:
+    try:
+        buffer = bytes.fromhex(input)
+        if len(buffer) != 32:
+            raise ValueError
+        return buffer
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"Invalid AES256: {input}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    disabled_classes_parser = subparsers.add_parser("disabled_classes")
+    disabled_classes_parser.add_argument("target")
+    disabled_classes_parser.add_argument("classes", nargs="*")
+
+    version_info_parser = subparsers.add_parser("version_info")
+    version_info_parser.add_argument("target")
+    version_info_parser.add_argument("--short_name", default="")
+    version_info_parser.add_argument("--name", default="")
+    version_info_parser.add_argument("--major", type=int, default=0)
+    version_info_parser.add_argument("--minor", type=int, default=0)
+    version_info_parser.add_argument("--patch", type=int, default=0)
+    version_info_parser.add_argument("--status", default="")
+    version_info_parser.add_argument("--build", default="")
+    version_info_parser.add_argument("--module_config", default="")
+    version_info_parser.add_argument("--website", default="")
+    version_info_parser.add_argument("--docs_branch", default="")
+
+    git_info_parser = subparsers.add_parser("git_info")
+    git_info_parser.add_argument("target")
+    git_info_parser.add_argument("--hash", default="")
+    git_info_parser.add_argument("--timestamp", type=int, default=0)
+
+    encryption_key_parser = subparsers.add_parser("encryption_key")
+    encryption_key_parser.add_argument("target")
+    encryption_key_parser.add_argument("--key", type=aes256_type, default="0" * 64)
+
+    certs_parser = subparsers.add_parser("certs")
+    certs_parser.add_argument("target")
+    certs_parser.add_argument("certs")
+    certs_parser.add_argument("--builtin", action="store_true")
+    certs_parser.add_argument("--system_certs", default="")
+
+    authors_parser = subparsers.add_parser("authors")
+    authors_parser.add_argument("target")
+    authors_parser.add_argument("authors")
+
+    donors_parser = subparsers.add_parser("donors")
+    donors_parser.add_argument("target")
+    donors_parser.add_argument("donors")
+
+    license_parser = subparsers.add_parser("license")
+    license_parser.add_argument("target")
+    license_parser.add_argument("license")
+    license_parser.add_argument("copyright")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/extension/SCsub
+++ b/core/extension/SCsub
@@ -3,20 +3,16 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-import make_interface_dumper
-import make_interface_header
-import make_wrappers
-
-env.CommandNoCache("ext_wrappers.gen.h", "make_wrappers.py", env.Run(make_wrappers.run))
-env.CommandNoCache(
+env.Command("ext_wrappers.gen.h", ["make_wrappers.py"], env.Run("$PYTHON_BIN ${SOURCES[0]} wrapper $TARGET"))
+env.Command(
     "gdextension_interface_dump.gen.h",
-    ["gdextension_interface.json", "make_interface_dumper.py"],
-    env.Run(make_interface_dumper.run),
+    ["make_interface_dumper.py", "gdextension_interface.json"],
+    env.Run("$PYTHON_BIN ${SOURCES[0]} interface_dumper $TARGET ${SOURCES[1]}"),
 )
-env.CommandNoCache(
+env.Command(
     "gdextension_interface.gen.h",
-    ["gdextension_interface.json", "make_interface_header.py"],
-    env.Run(make_interface_header.run),
+    ["make_interface_header.py", "gdextension_interface.json"],
+    env.Run("$PYTHON_BIN ${SOURCES[0]} interface_header $TARGET ${SOURCES[1]}"),
 )
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/extension/make_interface_dumper.py
+++ b/core/extension/make_interface_dumper.py
@@ -1,12 +1,19 @@
-import methods
+import argparse
+import sys
+
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
-def run(target, source, env):
-    buffer = methods.get_buffer(str(source[0]))
+def interface_dumper(target: str, interface: str) -> None:
+    buffer = methods.get_buffer(interface)
     decomp_size = len(buffer)
     buffer = methods.compress_buffer(buffer)
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         file.write(f"""\
 #ifdef TOOLS_ENABLED
 
@@ -42,3 +49,20 @@ class GDExtensionInterfaceDump {{
 
 #endif // TOOLS_ENABLED
 """)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    interface_dumper_parser = subparsers.add_parser("interface_dumper")
+    interface_dumper_parser.add_argument("target")
+    interface_dumper_parser.add_argument("interface")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/extension/make_interface_header.py
+++ b/core/extension/make_interface_header.py
@@ -1,8 +1,14 @@
+import argparse
 import difflib
 import json
-from collections import OrderedDict
+import sys
 
-import methods
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
+
 
 BASE_TYPES = [
     "void",
@@ -24,18 +30,17 @@ BASE_TYPES = [
 ]
 
 
-def run(target, source, env):
-    filename = str(source[0])
-    buffer = methods.get_buffer(filename)
-    data = json.loads(buffer, object_pairs_hook=OrderedDict)
-    check_formatting(buffer.decode("utf-8"), data, filename)
+def interface_header(target, interface):
+    buffer = methods.get_buffer(interface)
+    data = json.loads(buffer)
+    check_formatting(buffer.decode("utf-8"), data, interface)
     check_allowed_keys(data, ["_copyright", "$schema", "format_version", "types", "interface"])
 
     valid_data_types = {}
     for type in BASE_TYPES:
         valid_data_types[type] = True
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         file.write("""\
 #ifndef __cplusplus
 #include <stddef.h>
@@ -362,3 +367,20 @@ def write_interface(file, interface):
     write_function_type(file, fn)
 
     file.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    interface_header_parser = subparsers.add_parser("interface_header")
+    interface_header_parser.add_argument("target")
+    interface_header_parser.add_argument("interface")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/extension/make_wrappers.py
+++ b/core/extension/make_wrappers.py
@@ -1,3 +1,13 @@
+import sys
+
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
+
+import argparse
+
 proto_mod = """
 #define MODBIND$VER($RETTYPE m_name$ARG) \\
 virtual $RETVAL _##m_name($FUNCARGS) $CONST; \\
@@ -116,10 +126,10 @@ def generate_ex_version(argcount, const=False, returns=False):
     return s
 
 
-def run(target, source, env):
+def wrapper(target: str) -> None:
     max_versions = 12
 
-    txt = "#pragma once"
+    txt = ""
 
     for i in range(max_versions + 1):
         txt += "\n/* Extension Wrapper " + str(i) + " Arguments */\n"
@@ -135,5 +145,21 @@ def run(target, source, env):
         txt += generate_mod_version(i, True, False)
         txt += generate_mod_version(i, True, True)
 
-    with open(str(target[0]), "w", encoding="utf-8", newline="\n") as f:
+    with methods.generated_wrapper(target) as f:
         f.write(txt)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    wrapper_parser = subparsers.add_parser("wrapper")
+    wrapper_parser.add_argument("target")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/input/SCsub
+++ b/core/input/SCsub
@@ -3,18 +3,16 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-import input_builders
-
 # Order matters here. Higher index controller database files write on top of lower index database files.
 controller_databases = [
     "gamecontrollerdb.txt",
     "godotcontrollerdb.txt",
 ]
 
-gensource = env.CommandNoCache(
+gensource = env.Command(
     "default_controller_mappings.gen.cpp",
-    controller_databases,
-    env.Run(input_builders.make_default_controller_mappings),
+    ["input_builders.py"] + controller_databases,
+    env.Run("$PYTHON_BIN ${SOURCES[0]} default_controller_mappings $TARGET ${SOURCES[1:]}"),
 )
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/input/input_builders.py
+++ b/core/input/input_builders.py
@@ -1,14 +1,21 @@
 """Functions used to generate source files during build time"""
 
-from collections import OrderedDict
+from __future__ import annotations
 
-import methods
+import argparse
+import sys
+
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
-def make_default_controller_mappings(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
+def default_controller_mappings(target: str, mapping_files: list[str]) -> None:
+    with methods.generated_wrapper(target) as file:
         file.write("""\
-#include "core/input/default_controller_mappings.h"
+#include "default_controller_mappings.h"
 
 #include "core/typedefs.h"
 
@@ -24,8 +31,8 @@ def make_default_controller_mappings(target, source, env):
         }
 
         # ensure mappings have a consistent order
-        platform_mappings = OrderedDict()
-        for src_path in map(str, source):
+        platform_mappings: dict[str, dict[str, str]] = {}
+        for src_path in mapping_files:
             with open(src_path, "r", encoding="utf-8") as f:
                 mapping_file_lines = f.readlines()
 
@@ -63,3 +70,20 @@ def make_default_controller_mappings(target, source, env):
             file.write(f"#endif // {variable}_ENABLED\n")
 
         file.write("\tnullptr\n};\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    default_controller_mappings_parser = subparsers.add_parser("default_controller_mappings")
+    default_controller_mappings_parser.add_argument("target")
+    default_controller_mappings_parser.add_argument("mapping_files", nargs="*")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/object/SCsub
+++ b/core/object/SCsub
@@ -3,8 +3,6 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-import make_virtuals
-
-env.CommandNoCache("gdvirtual.gen.h", "make_virtuals.py", env.Run(make_virtuals.run))
+env.Command("gdvirtual.gen.h", ["make_virtuals.py"], env.Run("$PYTHON_BIN ${SOURCES[0]} virtuals $TARGET"))
 
 env.add_source_files(env.core_sources, "*.cpp")

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -1,3 +1,13 @@
+import argparse
+import sys
+
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
+
+
 script_call = """ScriptInstance *_script_instance = ((Object *)(this))->get_script_instance();\\
 		if (_script_instance) {\\
 			Callable::CallError ce;\\
@@ -190,12 +200,10 @@ def generate_version(argcount, const=False, returns=False, required=False, compa
     return s
 
 
-def run(target, source, env):
+def virtuals(target: str) -> None:
     max_versions = 12
 
-    txt = """/* THIS FILE IS GENERATED DO NOT EDIT */
-#pragma once
-
+    txt = """\
 // IWYU pragma: begin_keep
 #include "core/object/script_instance.h"
 #include "core/variant/method_ptrcall.h"
@@ -228,5 +236,21 @@ void _gdvirtual_set_method_info_args(MethodInfo &p_method_info) {
         txt += generate_version(i, True, False, False, True)
         txt += generate_version(i, True, True, False, True)
 
-    with open(str(target[0]), "w", encoding="utf-8", newline="\n") as f:
+    with methods.generated_wrapper(target) as f:
         f.write(txt)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    virtuals_parser = subparsers.add_parser("virtuals")
+    virtuals_parser.add_argument("target")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -5,8 +5,6 @@ from misc.utility.scons_hints import *
 
 import pathlib
 
-import profiling_builders
-
 Import("env")
 
 env.add_source_files(env.core_sources, "*.cpp")
@@ -104,13 +102,22 @@ elif env["profiler_path"]:
     print("profiler is required if profiler_path is set. Aborting.")
     Exit(255)
 
-env.CommandNoCache(
+profiling_cmd = "$PYTHON_BIN ${SOURCES[0]} profiling $TARGET ${SOURCES[1]}"
+if env["profiler_sample_callstack"]:
+    profiling_cmd += " --sample_callstack"
+if env["profiler_track_memory"]:
+    profiling_cmd += " --track_memory"
+if env["profiler_record_on_demand"]:
+    profiling_cmd += " --record_on_demand"
+
+env.Command(
     "profiling.gen.h",
     [
+        "profiling_builders.py",
         env.Value(env["profiler"]),
         env.Value(env["profiler_sample_callstack"]),
         env.Value(env["profiler_track_memory"]),
         env.Value(env["profiler_record_on_demand"]),
     ],
-    env.Run(profiling_builders.profiler_gen_builder),
+    env.Run(profiling_cmd),
 )

--- a/core/profiling/profiling_builders.py
+++ b/core/profiling/profiling_builders.py
@@ -1,21 +1,48 @@
 """Functions used to generate source files during build time"""
 
-import methods
+import argparse
+import sys
+
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
-def profiler_gen_builder(target, source, env):
-    with methods.generated_wrapper(str(target[0])) as file:
-        if env["profiler"] == "tracy":
+def profiling(target: str, profiler: str, sample_callstack: bool, track_memory: bool, record_on_demand: bool) -> None:
+    with methods.generated_wrapper(target) as file:
+        if profiler == "tracy":
             file.write("#define GODOT_USE_TRACY\n")
-            if env["profiler_sample_callstack"]:
+            if sample_callstack:
                 file.write("#define TRACY_CALLSTACK 62\n")
-            if env["profiler_track_memory"]:
+            if track_memory:
                 file.write("#define GODOT_PROFILER_TRACK_MEMORY\n")
-            if env["profiler_record_on_demand"]:
+            if record_on_demand:
                 file.write("#define TRACY_ON_DEMAND\n")
-        if env["profiler"] == "perfetto":
+        if profiler == "perfetto":
             file.write("#define GODOT_USE_PERFETTO\n")
-        if env["profiler"] == "instruments":
+        if profiler == "instruments":
             file.write("#define GODOT_USE_INSTRUMENTS\n")
-            if env["profiler_sample_callstack"]:
+            if sample_callstack:
                 file.write("#define INSTRUMENTS_SAMPLE_CALLSTACKS\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    profiling_parser = subparsers.add_parser("profiling")
+    profiling_parser.add_argument("target")
+    profiling_parser.add_argument("profiler")
+    profiling_parser.add_argument("--sample_callstack", action="store_true")
+    profiling_parser.add_argument("--track_memory", action="store_true")
+    profiling_parser.add_argument("--record_on_demand", action="store_true")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -1,5 +1,6 @@
 """Functions used to generate source files during build time"""
 
+import argparse
 import os.path
 
 from methods import generated_wrapper, print_error, to_raw_cstring
@@ -243,13 +244,13 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
     return header_data
 
 
-def build_gles3_header(filename: str, shader: str) -> None:
+def gles3_glsl(target: str, shader: str) -> None:
     include_file_in_gles3_header(shader, header_data := GLES3HeaderStruct(), 0)
     out_file_class = (
         os.path.basename(shader).replace(".glsl", "").title().replace("_", "").replace(".", "") + "ShaderGLES3"
     )
 
-    with generated_wrapper(filename) as file:
+    with generated_wrapper(target) as file:
         defspec = 0
         defvariant = ""
 
@@ -569,7 +570,18 @@ protected:
 """)
 
 
-def build_gles3_headers(target, source, env):
-    env.NoCache(target)
-    for src in source:
-        build_gles3_header(f"{src}.gen.h", str(src))
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    gles3_glsl_parser = subparsers.add_parser("gles3_glsl")
+    gles3_glsl_parser.add_argument("target")
+    gles3_glsl_parser.add_argument("shader")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -1,5 +1,6 @@
 """Functions used to generate source files during build time"""
 
+import argparse
 import os.path
 
 from methods import generated_wrapper, print_error, to_raw_cstring
@@ -189,11 +190,11 @@ def build_rd_header_lines_for_raytracing_stage(lines, stage: str):
 """
 
 
-def build_rd_header(filename: str, shader: str) -> None:
+def rd_glsl(target: str, shader: str) -> None:
     include_file_in_rd_header(shader, header_data := RDHeaderStruct(), 0)
     class_name = os.path.basename(shader).replace(".glsl", "").title().replace("_", "").replace(".", "") + "ShaderRD"
 
-    with generated_wrapper(filename) as file:
+    with generated_wrapper(target) as file:
         file.write(f"""\
 #include "servers/rendering/renderer_rd/shader_rd.h"
 
@@ -244,12 +245,6 @@ public:
 """)
 
 
-def build_rd_headers(target, source, env):
-    env.NoCache(target)
-    for src in source:
-        build_rd_header(f"{src}.gen.h", str(src))
-
-
 class RAWHeaderStruct:
     def __init__(self):
         self.code = ""
@@ -272,10 +267,10 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
             line = fs.readline()
 
 
-def build_raw_header(filename: str, shader: str) -> None:
+def glsl_header(target: str, shader: str) -> None:
     include_file_in_raw_header(shader, header_data := RAWHeaderStruct(), 0)
 
-    with generated_wrapper(filename) as file:
+    with generated_wrapper(target) as file:
         file.write(f"""\
 static const char {os.path.basename(shader).replace(".glsl", "_shader_glsl")}[] = {{
 {to_raw_cstring(header_data.code)}
@@ -283,7 +278,22 @@ static const char {os.path.basename(shader).replace(".glsl", "_shader_glsl")}[] 
 """)
 
 
-def build_raw_headers(target, source, env):
-    env.NoCache(target)
-    for src in source:
-        build_raw_header(f"{src}.gen.h", str(src))
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    rd_glsl_parser = subparsers.add_parser("rd_glsl")
+    rd_glsl_parser.add_argument("target")
+    rd_glsl_parser.add_argument("shader")
+
+    glsl_header_parser = subparsers.add_parser("glsl_header")
+    glsl_header_parser.add_argument("target")
+    glsl_header_parser.add_argument("shader")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/main/SCsub
+++ b/main/SCsub
@@ -3,8 +3,6 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-import main_builders
-
 env.main_sources = []
 
 env_main = env.Clone()
@@ -17,23 +15,23 @@ if env["steamapi"] and env.editor_build:
 if env["tests"]:
     env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
 
-env_main.CommandNoCache(
-    "#main/splash.gen.h",
-    "#main/splash.png",
-    env.Run(main_builders.make_splash),
+env_main.Command(
+    "splash.gen.h",
+    ["main_builders.py", "splash.png"],
+    env.Run("$PYTHON_BIN ${SOURCES[0]} splash $TARGET ${SOURCES[1]}"),
 )
 
 if env_main.editor_build and not env_main["no_editor_splash"]:
-    env_main.CommandNoCache(
-        "#main/splash_editor.gen.h",
-        "#main/splash_editor.png",
-        env.Run(main_builders.make_splash_editor),
+    env_main.Command(
+        "splash_editor.gen.h",
+        ["main_builders.py", "splash_editor.png"],
+        env.Run("$PYTHON_BIN ${SOURCES[0]} splash_editor $TARGET ${SOURCES[1]}"),
     )
 
-env_main.CommandNoCache(
-    "#main/app_icon.gen.h",
-    "#main/app_icon.png",
-    env.Run(main_builders.make_app_icon),
+env_main.Command(
+    "app_icon.gen.h",
+    ["main_builders.py", "app_icon.png"],
+    env.Run("$PYTHON_BIN ${SOURCES[0]} app_icon $TARGET ${SOURCES[1]}"),
 )
 
 lib = env_main.add_library("main", env.main_sources)

--- a/main/main_builders.py
+++ b/main/main_builders.py
@@ -1,12 +1,19 @@
 """Functions used to generate source files during build time"""
 
-import methods
+import argparse
+import sys
+
+try:
+    sys.path.insert(0, "./")
+    import methods
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
-def make_splash(target, source, env):
-    buffer = methods.get_buffer(str(source[0]))
+def splash(target: str, image: str) -> None:
+    buffer = methods.get_buffer(image)
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         # Use a neutral gray color to better fit various kinds of projects.
         file.write(f"""\
 #include "core/math/color.h"
@@ -18,10 +25,10 @@ inline constexpr const unsigned char boot_splash_png[] = {{
 """)
 
 
-def make_splash_editor(target, source, env):
-    buffer = methods.get_buffer(str(source[0]))
+def splash_editor(target: str, image: str) -> None:
+    buffer = methods.get_buffer(image)
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         # The editor splash background color is taken from the default editor theme's background color.
         # This helps achieve a visually "smoother" transition between the splash screen and the editor.
         file.write(f"""\
@@ -34,13 +41,38 @@ inline constexpr const unsigned char boot_splash_editor_png[] = {{
 """)
 
 
-def make_app_icon(target, source, env):
-    buffer = methods.get_buffer(str(source[0]))
+def app_icon(target: str, image: str) -> None:
+    buffer = methods.get_buffer(image)
 
-    with methods.generated_wrapper(str(target[0])) as file:
+    with methods.generated_wrapper(target) as file:
         # Use a neutral gray color to better fit various kinds of projects.
         file.write(f"""\
 inline constexpr const unsigned char app_icon_png[] = {{
 {methods.format_buffer(buffer, 1)}
 }};
 """)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    splash_parser = subparsers.add_parser("splash")
+    splash_parser.add_argument("target")
+    splash_parser.add_argument("image")
+
+    splash_editor_parser = subparsers.add_parser("splash_editor")
+    splash_editor_parser.add_argument("target")
+    splash_editor_parser.add_argument("image")
+
+    app_icon_parser = subparsers.add_parser("app_icon")
+    app_icon_parser.add_argument("target")
+    app_icon_parser.add_argument("image")
+
+    args = vars(parser.parse_args())
+    command = globals().get(args.pop("command"), {})
+    command(**args)
+
+
+if __name__ == "__main__":
+    main()

--- a/methods.py
+++ b/methods.py
@@ -166,55 +166,14 @@ def get_version_info(module_version_string="", silent=False):
 
 
 def get_git_info():
-    os.chdir(base_folder)
-
-    # Parse Git hash if we're in a Git repo.
     git_hash = ""
-    git_folder = ".git"
-
-    if os.path.isfile(".git"):
-        with open(".git", "r", encoding="utf-8") as file:
-            module_folder = file.readline().strip()
-        if module_folder.startswith("gitdir: "):
-            git_folder = module_folder[8:]
-
-    if os.path.isfile(os.path.join(git_folder, "HEAD")):
-        with open(os.path.join(git_folder, "HEAD"), "r", encoding="utf8") as file:
-            head = file.readline().strip()
-        if head.startswith("ref: "):
-            ref = head[5:]
-            # If this directory is a Git worktree instead of a root clone.
-            parts = git_folder.split("/")
-            if len(parts) > 2 and parts[-2] == "worktrees":
-                git_folder = "/".join(parts[0:-2])
-            head = os.path.join(git_folder, ref)
-            packedrefs = os.path.join(git_folder, "packed-refs")
-            if os.path.isfile(head):
-                with open(head, "r", encoding="utf-8") as file:
-                    git_hash = file.readline().strip()
-            elif os.path.isfile(packedrefs):
-                # Git may pack refs into a single file. This code searches .git/packed-refs file for the current ref's hash.
-                # https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-pack-refs.html
-                for line in open(packedrefs, "r", encoding="utf-8").read().splitlines():
-                    if line.startswith("#"):
-                        continue
-                    (line_hash, line_ref) = line.split(" ")
-                    if ref == line_ref:
-                        git_hash = line_hash
-                        break
-        else:
-            git_hash = head
-
-    # Get the UNIX timestamp of the build commit.
     git_timestamp = 0
-    if os.path.exists(".git"):
-        try:
-            git_timestamp = subprocess.check_output(
-                ["git", "log", "-1", "--pretty=format:%ct", "--no-show-signature", git_hash], encoding="utf-8"
-            )
-        except (subprocess.CalledProcessError, OSError):
-            # `git` not found in PATH.
-            pass
+
+    try:
+        git_hash = subprocess.check_output(["git", "log", "-1", "--pretty=format:%H"], encoding="utf-8")
+        git_timestamp = int(subprocess.check_output(["git", "log", "-1", "--pretty=format:%ct"], encoding="utf-8"))
+    except (subprocess.CalledProcessError, OSError):
+        pass  # `git` not found in PATH.
 
     return {
         "git_hash": git_hash,

--- a/methods.py
+++ b/methods.py
@@ -14,8 +14,8 @@ from io import StringIO
 from pathlib import Path
 from typing import Generator, TextIO, cast
 
+import platform_methods
 from misc.utility.color import print_error, print_info, print_warning
-from platform_methods import detect_arch
 
 # Get the "Godot" folder name ahead of time
 base_folder = Path(__file__).resolve().parent
@@ -111,6 +111,14 @@ def redirect_emitter(target, source, env):
     return redirected_targets, source
 
 
+def generate_dependency_emitter(dependencies):
+    def _generated_dependency_emitter(target, source, env):
+        env.Depends(target, dependencies)
+        return target, source
+
+    return _generated_dependency_emitter
+
+
 def disable_warnings(self):
     # 'self' is the environment
     if self.msvc and not using_clang(self):
@@ -166,55 +174,14 @@ def get_version_info(module_version_string="", silent=False):
 
 
 def get_git_info():
-    os.chdir(base_folder)
-
-    # Parse Git hash if we're in a Git repo.
     git_hash = ""
-    git_folder = ".git"
-
-    if os.path.isfile(".git"):
-        with open(".git", "r", encoding="utf-8") as file:
-            module_folder = file.readline().strip()
-        if module_folder.startswith("gitdir: "):
-            git_folder = module_folder[8:]
-
-    if os.path.isfile(os.path.join(git_folder, "HEAD")):
-        with open(os.path.join(git_folder, "HEAD"), "r", encoding="utf8") as file:
-            head = file.readline().strip()
-        if head.startswith("ref: "):
-            ref = head[5:]
-            # If this directory is a Git worktree instead of a root clone.
-            parts = git_folder.split("/")
-            if len(parts) > 2 and parts[-2] == "worktrees":
-                git_folder = "/".join(parts[0:-2])
-            head = os.path.join(git_folder, ref)
-            packedrefs = os.path.join(git_folder, "packed-refs")
-            if os.path.isfile(head):
-                with open(head, "r", encoding="utf-8") as file:
-                    git_hash = file.readline().strip()
-            elif os.path.isfile(packedrefs):
-                # Git may pack refs into a single file. This code searches .git/packed-refs file for the current ref's hash.
-                # https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-pack-refs.html
-                for line in open(packedrefs, "r", encoding="utf-8").read().splitlines():
-                    if line.startswith("#"):
-                        continue
-                    (line_hash, line_ref) = line.split(" ")
-                    if ref == line_ref:
-                        git_hash = line_hash
-                        break
-        else:
-            git_hash = head
-
-    # Get the UNIX timestamp of the build commit.
     git_timestamp = 0
-    if os.path.exists(".git"):
-        try:
-            git_timestamp = subprocess.check_output(
-                ["git", "log", "-1", "--pretty=format:%ct", "--no-show-signature", git_hash], encoding="utf-8"
-            )
-        except (subprocess.CalledProcessError, OSError):
-            # `git` not found in PATH.
-            pass
+
+    try:
+        git_hash = subprocess.check_output(["git", "log", "-1", "--pretty=format:%H"], encoding="utf-8")
+        git_timestamp = int(subprocess.check_output(["git", "log", "-1", "--pretty=format:%ct"], encoding="utf-8"))
+    except (subprocess.CalledProcessError, OSError):
+        pass  # `git` not found in PATH.
 
     return {
         "git_hash": git_hash,
@@ -1087,7 +1054,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     platform = env["platform"]
     target = env["target"]
     arch = env["arch"]
-    host_arch = detect_arch()
+    host_arch = platform_methods.detect_arch()
 
     host_platform = "windows"
     if (

--- a/tests/python_build/validate_builders.py
+++ b/tests/python_build/validate_builders.py
@@ -11,32 +11,32 @@ from typing import Any, Callable
 
 sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "../../"))
 
-from gles3_builders import build_gles3_header
-from glsl_builders import build_raw_header, build_rd_header
+from gles3_builders import gles3_glsl
+from glsl_builders import glsl_header, rd_glsl
 
 FUNC_PATH_KWARGS: list[tuple[Callable[..., None], str, dict[str, Any]]] = [
     (
-        build_gles3_header,
+        gles3_glsl,
         "tests/python_build/fixtures/gles3/vertex_fragment.out",
         {"shader": "tests/python_build/fixtures/gles3/vertex_fragment.glsl"},
     ),
     (
-        build_raw_header,
+        glsl_header,
         "tests/python_build/fixtures/glsl/compute.out",
         {"shader": "tests/python_build/fixtures/glsl/compute.glsl"},
     ),
     (
-        build_raw_header,
+        glsl_header,
         "tests/python_build/fixtures/glsl/vertex_fragment.out",
         {"shader": "tests/python_build/fixtures/glsl/vertex_fragment.glsl"},
     ),
     (
-        build_rd_header,
+        rd_glsl,
         "tests/python_build/fixtures/rd_glsl/compute.out",
         {"shader": "tests/python_build/fixtures/rd_glsl/compute.glsl"},
     ),
     (
-        build_rd_header,
+        rd_glsl,
         "tests/python_build/fixtures/rd_glsl/vertex_fragment.out",
         {"shader": "tests/python_build/fixtures/rd_glsl/vertex_fragment.glsl"},
     ),


### PR DESCRIPTION
- Related godotengine/godot-proposals#11613

This is one potential avenue for decoupling the code generators, which involves keeping the original structure and syntax largely the same, but making the commands be passed via `argparse`. There's some serious codesmell with this approach, but I'm unsure how much of that is from the implementation itself, versus how our existing generator scripts are laid out. In either case, I wanted to get this out now so that there can be potential discussion on if this is what we wanna move forward with, or if other avenues should be explored instead

**EDIT:** In light of #119647, I've decided that this is indeed the best route forward. This can either be put aside to merge once more areas are finalized, or this can be considered isolated to just "core" & consequently ready to merge as-is