### PR TITLE
Fix CXX version retrieval for windows mingw

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -740,9 +740,14 @@ def get_compiler_version(env):
     # Not using -dumpversion as some GCC distros only return major, and
     # Clang used to return hardcoded 4.2.1: # https://reviews.llvm.org/D56803
     try:
-        version = subprocess.check_output(
-            shlex.split(env.subst(env["CXX"]), posix=False) + ["--version"], shell=(os.name == "nt"), encoding="utf-8"
-        ).strip()
+        cxx_path = env.subst(env["CXX"])
+        if os.name == "nt":
+            cmd = [cxx_path, "--version"]
+            version = subprocess.check_output(cmd, shell=False, encoding="utf-8").strip()
+        else:
+            version = subprocess.check_output(
+                shlex.split(cxx_path) + ["--version"], shell=False, encoding="utf-8"
+            ).strip()
     except (subprocess.CalledProcessError, OSError):
         print_warning("Couldn't parse CXX environment variable to infer compiler version.")
         return update_compiler_version_cache(ret)


### PR DESCRIPTION
When compiling on Windows using `use_mingw=yes` this breaks the CXX version detection. Before the fix it prints
```
"'C:Usersjhondoemingw64binx86_64-w64-mingw32-g++' is not recognized as an internal or external command,
operable program or batch file.
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
