### PR TITLE
[MSDF] Fix outline bleed out at small sizes.

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -611,7 +611,7 @@ void main() {
 		if (outline_thickness > 0.0) {
 			float cr = clamp(outline_thickness, 0.0, (px_range / 2.0) - 1.0) / px_range;
 			d = min(d, msdf_sample.a);
-			float a = clamp((d - 0.5 + cr) * px_size + 0.5, 0.0, 1.0);
+			float a = clamp((d - 0.5 + cr) * px_size, 0.0, 1.0);
 			color.a = a * color.a;
 		} else {
 			float a = clamp((d - 0.5) * px_size + 0.5, 0.0, 1.0);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1641,7 +1641,7 @@ void fragment() {)";
 		if (msdf_outline_size > 0.0) {
 			float cr = clamp(msdf_outline_size, 0.0, (msdf_pixel_range / 2.0) - 1.0) / msdf_pixel_range;
 			d = min(d, albedo_tex.a);
-			albedo_tex.a = clamp((d - 0.5 + cr) * px_size + 0.5, 0.0, 1.0);
+			albedo_tex.a = clamp((d - 0.5 + cr) * px_size, 0.0, 1.0);
 		} else {
 			albedo_tex.a = clamp((d - 0.5) * px_size + 0.5, 0.0, 1.0);
 		}

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -518,7 +518,7 @@ void main() {
 		if (outline_thickness > 0) {
 			float cr = clamp(outline_thickness, 0.0, (px_range / 2.0) - 1.0) / px_range;
 			d = min(d, msdf_sample.a);
-			float a = clamp((d - 0.5 + cr) * px_size + 0.5, 0.0, 1.0);
+			float a = clamp((d - 0.5 + cr) * px_size, 0.0, 1.0);
 			color.a = a * color.a;
 		} else {
 			float a = clamp((d - 0.5) * px_size + 0.5, 0.0, 1.0);


### PR DESCRIPTION
Fixes #110126

Partially reverts outline change done #109437, which have no visual effect in most cases, but seems to cause issues at small sizes. This does not affect base font rendering changes, which #109437 is fixing.