### PR TITLE
Metal: Enable Intel support

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -197,7 +197,7 @@ opts.Add(BoolVariable("xaudio2", "Enable the XAudio2 audio driver on supported p
 opts.Add(BoolVariable("vulkan", "Enable the Vulkan rendering driver", True))
 opts.Add(BoolVariable("opengl3", "Enable the OpenGL/GLES3 rendering driver", True))
 opts.Add(BoolVariable("d3d12", "Enable the Direct3D 12 rendering driver on supported platforms", False))
-opts.Add(BoolVariable("metal", "Enable the Metal rendering driver on supported platforms (Apple arm64 only)", False))
+opts.Add(BoolVariable("metal", "Enable the Metal rendering driver on supported platforms (Apple arm64/x86_64)", False))
 opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loader dynamically", True))
 opts.Add(BoolVariable("accesskit", "Use AccessKit C SDK", True))
 opts.Add(("accesskit_sdk_path", "Path to the AccessKit C SDK", ""))

--- a/drivers/metal/metal_device_properties.mm
+++ b/drivers/metal/metal_device_properties.mm
@@ -63,6 +63,7 @@
 
 #if (TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED < 140000) || (TARGET_OS_IPHONE && __IPHONE_OS_VERSION_MAX_ALLOWED < 170000)
 #define MTLGPUFamilyApple9 (MTLGPUFamily)1009
+#define MTLGPUFamilyMetal3 (MTLGPUFamily)5001
 #endif
 
 API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0), visionos(1.0))
@@ -79,12 +80,22 @@ void MetalDeviceProperties::init_features(id<MTLDevice> p_device) {
 	features = {};
 
 	features.highestFamily = MTLGPUFamilyApple1;
+#ifndef __x86_64__
+	// On Apple Silicon, we check for Apple family GPUs.
 	for (MTLGPUFamily family = MTLGPUFamilyApple9; family >= MTLGPUFamilyApple1; --family) {
 		if ([p_device supportsFamily:family]) {
 			features.highestFamily = family;
 			break;
 		}
 	}
+#else
+	// For Intel-based Macs, we don't have any Apple family GPUs.
+	// Use the "Metal3" family instead.
+	MTLGPUFamily family = MTLGPUFamilyMetal3;
+	if ([p_device supportsFamily:family]) {
+			features.highestFamily = family;
+	}
+#endif
 
 	if (@available(macOS 11, iOS 16.4, tvOS 16.4, *)) {
 		features.supportsBCTextureCompression = p_device.supportsBCTextureCompression;
@@ -113,13 +124,25 @@ void MetalDeviceProperties::init_features(id<MTLDevice> p_device) {
 		}
 	}
 
-	features.layeredRendering = [p_device supportsFamily:MTLGPUFamilyApple5];
-	features.multisampleLayeredRendering = [p_device supportsFamily:MTLGPUFamilyApple7];
-	features.tessellationShader = [p_device supportsFamily:MTLGPUFamilyApple3];
-	features.imageCubeArray = [p_device supportsFamily:MTLGPUFamilyApple3];
-	features.quadPermute = [p_device supportsFamily:MTLGPUFamilyApple4];
-	features.simdPermute = [p_device supportsFamily:MTLGPUFamilyApple6];
-	features.simdReduction = [p_device supportsFamily:MTLGPUFamilyApple7];
+#ifdef __x86_64__
+	// The only option we have on Intel is MTLGPUFamilyMetal3; just enable everything.
+	features.layeredRendering = true;
+    features.multisampleLayeredRendering = true;
+    features.tessellationShader = true;
+    features.imageCubeArray = true;
+    features.quadPermute = true;
+    features.simdPermute = true;
+    features.simdReduction = true;
+#else // Apple silicon
+    features.layeredRendering = [p_device supportsFamily:MTLGPUFamilyApple5];
+    features.multisampleLayeredRendering = [p_device supportsFamily:MTLGPUFamilyApple7];
+    features.tessellationShader = [p_device supportsFamily:MTLGPUFamilyApple3];
+    features.imageCubeArray = [p_device supportsFamily:MTLGPUFamilyApple3];
+    features.quadPermute = [p_device supportsFamily:MTLGPUFamilyApple4];
+    features.simdPermute = [p_device supportsFamily:MTLGPUFamilyApple6];
+    features.simdReduction = [p_device supportsFamily:MTLGPUFamilyApple7];
+#endif
+
 	features.argument_buffers_tier = p_device.argumentBuffersSupport;
 	features.supports_image_atomic_32_bit = [p_device supportsFamily:MTLGPUFamilyApple6];
 	features.supports_image_atomic_64_bit = [p_device supportsFamily:MTLGPUFamilyApple9] || ([p_device supportsFamily:MTLGPUFamilyApple8] && [p_device supportsFamily:MTLGPUFamilyMac2]);
@@ -155,9 +178,11 @@ void MetalDeviceProperties::init_limits(id<MTLDevice> p_device) {
 
 	// FST: https://developer.apple.com/metal/Metal-Feature-Set-Tables.pdf
 
+	const bool supportsFamilyMetal3 = [p_device supportsFamily:MTLGPUFamilyMetal3];
+
 	// FST: Maximum number of layers per 1D texture array, 2D texture array, or 3D texture.
 	limits.maxImageArrayLayers = 2048;
-	if ([p_device supportsFamily:MTLGPUFamilyApple3]) {
+	if ([p_device supportsFamily:MTLGPUFamilyApple3] || supportsFamilyMetal3) {
 		// FST: Maximum 2D texture width and height.
 		limits.maxFramebufferWidth = 16384;
 		limits.maxFramebufferHeight = 16384;
@@ -194,7 +219,7 @@ void MetalDeviceProperties::init_limits(id<MTLDevice> p_device) {
 	limits.maxColorAttachments = 8;
 
 	// Maximum number of textures the device can access, per stage, from an argument buffer.
-	if ([p_device supportsFamily:MTLGPUFamilyApple6]) {
+	if ([p_device supportsFamily:MTLGPUFamilyApple6] || supportsFamilyMetal3) {
 		limits.maxTexturesPerArgumentBuffer = 1'000'000;
 	} else if ([p_device supportsFamily:MTLGPUFamilyApple4]) {
 		limits.maxTexturesPerArgumentBuffer = 96;
@@ -203,14 +228,14 @@ void MetalDeviceProperties::init_limits(id<MTLDevice> p_device) {
 	}
 
 	// Maximum number of samplers the device can access, per stage, from an argument buffer.
-	if ([p_device supportsFamily:MTLGPUFamilyApple6]) {
+	if ([p_device supportsFamily:MTLGPUFamilyApple6] || supportsFamilyMetal3) {
 		limits.maxSamplersPerArgumentBuffer = 1024;
 	} else {
 		limits.maxSamplersPerArgumentBuffer = 16;
 	}
 
 	// Maximum number of buffers the device can access, per stage, from an argument buffer.
-	if ([p_device supportsFamily:MTLGPUFamilyApple6]) {
+	if ([p_device supportsFamily:MTLGPUFamilyApple6] || supportsFamilyMetal3) {
 		limits.maxBuffersPerArgumentBuffer = std::numeric_limits<uint64_t>::max();
 	} else if ([p_device supportsFamily:MTLGPUFamilyApple4]) {
 		limits.maxBuffersPerArgumentBuffer = 96;
@@ -263,7 +288,7 @@ void MetalDeviceProperties::init_limits(id<MTLDevice> p_device) {
 
 	limits.maxPerStageBufferCount = 31;
 	limits.maxPerStageSamplerCount = 16;
-	if ([p_device supportsFamily:MTLGPUFamilyApple6]) {
+	if ([p_device supportsFamily:MTLGPUFamilyApple6] || supportsFamilyMetal3) {
 		limits.maxPerStageTextureCount = 128;
 	} else if ([p_device supportsFamily:MTLGPUFamilyApple4]) {
 		limits.maxPerStageTextureCount = 96;

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -97,6 +97,12 @@
 #define MTLVertexFormatFloatRGB9E5 MTLVertexFormatInvalid
 #endif
 
+#ifdef __x86_64__
+// HACK: Some demos with R16Uint textures crash (at least on my AMD GPU).
+// TODO: Fix this probably.
+#define MTLPixelFormatR16Uint MTLVertexFormatInvalid
+#endif
+
 template <typename T>
 void clear(T *p_val, size_t p_count = 1) {
 	memset(p_val, 0, sizeof(T) * p_count);
@@ -380,7 +386,11 @@ void PixelFormats::initDataFormatCapabilities() {
 	addDataFormatDesc(R16_SNORM, R16Snorm, Invalid, ShortNormalized, Short2Normalized, 1, 1, 2, ColorFloat);
 	addDataFormatDesc(R16_USCALED, Invalid, Invalid, UShort, UShort2, 1, 1, 2, ColorFloat);
 	addDataFormatDesc(R16_SSCALED, Invalid, Invalid, Short, Short2, 1, 1, 2, ColorFloat);
+#ifndef __x86_64__
+    // HACK: Some demos with R16Uint textures crash (at least on my AMD GPU).
+	// TODO: Fix this probably.
 	addDataFormatDesc(R16_UINT, R16Uint, Invalid, UShort, UShort2, 1, 1, 2, ColorUInt16);
+#endif
 	addDataFormatDesc(R16_SINT, R16Sint, Invalid, Short, Short2, 1, 1, 2, ColorInt16);
 	addDataFormatDesc(R16_SFLOAT, R16Float, Invalid, Half, Half2, 1, 1, 2, ColorFloat);
 
@@ -613,7 +623,11 @@ void PixelFormats::initMTLPixelFormatCapabilities() {
 	// Ordinary 16-bit pixel formats
 	addMTLPixelFormatDesc(R16Unorm, Color16, RFWCMB);
 	addMTLPixelFormatDesc(R16Snorm, Color16, RFWCMB);
+#ifndef __x86_64__
+	// HACK: Some demos with R16Uint textures crash (at least on my AMD GPU).
+	// TODO: Fix this probably.
 	addMTLPixelFormatDesc(R16Uint, Color16, RWCM);
+#endif
 	addMTLPixelFormatDesc(R16Sint, Color16, RWCM);
 	addMTLPixelFormatDesc(R16Float, Color16, All);
 

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -100,7 +100,7 @@
 #ifdef __x86_64__
 // HACK: Some demos with R16Uint textures crash (at least on my AMD GPU).
 // TODO: Fix this probably.
-#define MTLPixelFormatR16Uint MTLVertexFormatInvalid
+#define MTLPixelFormatR16Uint MTLPixelFormatInvalid
 #endif
 
 template <typename T>

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -386,11 +386,7 @@ void PixelFormats::initDataFormatCapabilities() {
 	addDataFormatDesc(R16_SNORM, R16Snorm, Invalid, ShortNormalized, Short2Normalized, 1, 1, 2, ColorFloat);
 	addDataFormatDesc(R16_USCALED, Invalid, Invalid, UShort, UShort2, 1, 1, 2, ColorFloat);
 	addDataFormatDesc(R16_SSCALED, Invalid, Invalid, Short, Short2, 1, 1, 2, ColorFloat);
-#ifndef __x86_64__
-    // HACK: Some demos with R16Uint textures crash (at least on my AMD GPU).
-	// TODO: Fix this probably.
 	addDataFormatDesc(R16_UINT, R16Uint, Invalid, UShort, UShort2, 1, 1, 2, ColorUInt16);
-#endif
 	addDataFormatDesc(R16_SINT, R16Sint, Invalid, Short, Short2, 1, 1, 2, ColorInt16);
 	addDataFormatDesc(R16_SFLOAT, R16Float, Invalid, Half, Half2, 1, 1, 2, ColorFloat);
 
@@ -623,11 +619,7 @@ void PixelFormats::initMTLPixelFormatCapabilities() {
 	// Ordinary 16-bit pixel formats
 	addMTLPixelFormatDesc(R16Unorm, Color16, RFWCMB);
 	addMTLPixelFormatDesc(R16Snorm, Color16, RFWCMB);
-#ifndef __x86_64__
-	// HACK: Some demos with R16Uint textures crash (at least on my AMD GPU).
-	// TODO: Fix this probably.
 	addMTLPixelFormatDesc(R16Uint, Color16, RWCM);
-#endif
 	addMTLPixelFormatDesc(R16Sint, Color16, RWCM);
 	addMTLPixelFormatDesc(R16Float, Color16, All);
 

--- a/drivers/metal/rendering_context_driver_metal.mm
+++ b/drivers/metal/rendering_context_driver_metal.mm
@@ -32,6 +32,10 @@
 
 #import "rendering_device_driver_metal.h"
 
+#if (TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED >= 140000) || (TARGET_OS_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= 170000)
+#define MTLGPUFamilyMetal3 (MTLGPUFamily)5001
+#endif
+
 @protocol MTLDeviceEx <MTLDevice>
 #if TARGET_OS_OSX && __MAC_OS_X_VERSION_MAX_ALLOWED < 130300
 - (void)setShouldMaximizeConcurrentCompilation:(BOOL)v;
@@ -60,8 +64,11 @@ Error RenderingContextDriverMetal::initialize() {
 	device.workarounds = Workarounds();
 
 	MetalDeviceProperties props(metal_device);
-	int version = (int)props.features.highestFamily - (int)MTLGPUFamilyApple1 + 1;
-	device.name = vformat("%s (Apple%d)", metal_device.name.UTF8String, version);
+	if (props.features.highestFamily == MTLGPUFamilyMetal3) {
+		device.name = vformat("%s (Metal3)", metal_device.name.UTF8String);
+	} else {
+		device.name = vformat("%s (Apple%d)", metal_device.name.UTF8String, (int)props.features.highestFamily - (int)MTLGPUFamilyApple1 + 1);
+	}
 
 	return OK;
 }

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -2898,6 +2898,9 @@ static MetalDeviceProfile device_profile_from_properties(MetalDeviceProperties *
 		case MTLGPUFamilyApple9:
 			res.gpu = DP::GPU::Apple9;
 			break;
+		case MTLGPUFamilyMetal3:
+			res.gpu = DP::GPU::Metal3;
+			break;
 		default: {
 			// Programming error if the default case is hit.
 			CRASH_NOW_MSG("Unsupported GPU family");

--- a/drivers/metal/rendering_shader_container_metal.h
+++ b/drivers/metal/rendering_shader_container_metal.h
@@ -64,6 +64,7 @@ struct MetalDeviceProfile {
 		Apple7,
 		Apple8,
 		Apple9,
+		Metal3
 	};
 
 	enum class ArgumentBuffersTier : uint32_t {

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -255,9 +255,9 @@ def configure(env: "SConsEnvironment"):
 
     env.Append(LINKFLAGS=["-rpath", "@executable_path/../Frameworks", "-rpath", "@executable_path"])
 
-    if env["metal"] and env["arch"] != "arm64":
-        print_warning("Target architecture '{}' does not support the Metal rendering driver".format(env["arch"]))
-        env["metal"] = False
+    #if env["metal"] and env["arch"] != "arm64":
+    #    print_warning("Target architecture '{}' does not support the Metal rendering driver".format(env["arch"]))
+    #    env["metal"] = False
 
     if env["metal"]:
         env.AppendUnique(CPPDEFINES=["METAL_ENABLED", "RD_ENABLED"])

--- a/platform/macos/display_server_embedded.mm
+++ b/platform/macos/display_server_embedded.mm
@@ -69,6 +69,7 @@ DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, W
 
 #if defined(RD_ENABLED)
 #if defined(VULKAN_ENABLED)
+/*
 #if defined(__x86_64__)
 	bool fallback_to_vulkan = GLOBAL_GET("rendering/rendering_device/fallback_to_vulkan");
 	if (!fallback_to_vulkan) {
@@ -80,6 +81,7 @@ DisplayServerEmbedded::DisplayServerEmbedded(const String &p_rendering_driver, W
 		OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
 	}
 #endif
+*/
 	if (rendering_driver == "vulkan") {
 		rendering_context = memnew(RenderingContextDriverVulkanMacOS);
 	}

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -3850,6 +3850,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 
 #if defined(RD_ENABLED)
 #if defined(VULKAN_ENABLED)
+/*
 #if defined(__x86_64__)
 	bool fallback_to_vulkan = GLOBAL_GET("rendering/rendering_device/fallback_to_vulkan");
 	if (!fallback_to_vulkan) {
@@ -3861,6 +3862,7 @@ DisplayServerMacOS::DisplayServerMacOS(const String &p_rendering_driver, WindowM
 		OS::get_singleton()->set_current_rendering_driver_name(rendering_driver);
 	}
 #endif
+ */
 	if (rendering_driver == "vulkan") {
 		rendering_context = memnew(RenderingContextDriverVulkanMacOS);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This PR adds Intel support for the Metal backend on macOS. It's based on PR #96158.
This is not complete as there is some cleanup I have to do with the code.
There is also currently an error that happens when opening some projects:
```
_mtlValidateArgumentsForTextureViewOnDevice:1855: failed assertion Texture Creation
texture view pixelFormat (MTLPixelFormatInvalid) not castable.
source texture pixelFormat (MTLPixelFormatR16Uint) not compatible with texture view pixelFormat (MTLPixelFormatInvalid).
```
For right now (until someone can help me), I have commented this out using ifdefs. (see the // HACK comments)
This causes the projects that crash to run, but there are some graphical issues and console spam about invalid uniforms.

Screenshots:
<img width="1296" height="190" alt="Screenshot 2025-08-31 at 7 41 04 PM" src="https://github.com/user-attachments/assets/5e9be13b-f4ab-49f8-a3f4-b7536c6dc56a" />
<img width="1920" height="1080" alt="Screenshot 2025-08-31 at 7 46 34 PM" src="https://github.com/user-attachments/assets/3853c1cc-c533-4aa5-b432-c0b70fdb1199" />
<img width="1920" height="1080" alt="Screenshot 2025-08-31 at 8 23 39 PM" src="https://github.com/user-attachments/assets/d9eed10f-251d-4ee0-b643-8225aacf6179" />
<img width="1920" height="1080" alt="Screenshot 2025-08-31 at 7 32 52 PM" src="https://github.com/user-attachments/assets/4d80d0c2-89a1-4bb7-b9fd-5e87aef5a710" />
<img width="1165" height="725" alt="Screenshot 2025-08-31 at 9 00 39 PM" src="https://github.com/user-attachments/assets/d8b55c83-c1ed-4bc7-b1e8-c0d5563edae9" />

Graphical glitches:
<img width="1920" height="1080" alt="Screenshot 2025-08-31 at 8 39 30 PM" src="https://github.com/user-attachments/assets/85ae6a5a-855b-4522-a023-ada1bcf250d8" />
