### PR TITLE
Fix inconsistent internal name of `get_resource_filesystem`

### DIFF
--- a/editor/editor_interface.cpp
+++ b/editor/editor_interface.cpp
@@ -75,7 +75,7 @@ EditorCommandPalette *EditorInterface::get_command_palette() const {
 	return EditorCommandPalette::get_singleton();
 }
 
-EditorFileSystem *EditorInterface::get_resource_file_system() const {
+EditorFileSystem *EditorInterface::get_resource_filesystem() const {
 	return EditorFileSystem::get_singleton();
 }
 
@@ -778,7 +778,7 @@ void EditorInterface::_bind_methods() {
 	// Editor tools.
 
 	ClassDB::bind_method(D_METHOD("get_command_palette"), &EditorInterface::get_command_palette);
-	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_file_system);
+	ClassDB::bind_method(D_METHOD("get_resource_filesystem"), &EditorInterface::get_resource_filesystem);
 	ClassDB::bind_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths);
 	ClassDB::bind_method(D_METHOD("get_resource_previewer"), &EditorInterface::get_resource_previewer);
 	ClassDB::bind_method(D_METHOD("get_selection"), &EditorInterface::get_selection);

--- a/editor/editor_interface.h
+++ b/editor/editor_interface.h
@@ -101,7 +101,7 @@ public:
 	// Editor tools.
 
 	EditorCommandPalette *get_command_palette() const;
-	EditorFileSystem *get_resource_file_system() const;
+	EditorFileSystem *get_resource_filesystem() const;
 	EditorPaths *get_editor_paths() const;
 	EditorResourcePreview *get_resource_previewer() const;
 	EditorSelection *get_selection() const;


### PR DESCRIPTION
The exposed `EditorInterface.get_resource_filesystem()` was named `EditorInterface::get_resource_file_system()` internally for some reason. This PR fixes it by conforming the internal name to the exposed name, preserving compatibility. This also matches `EditorFileSystem::get_filesystem_path`, but mismatches with the new `editor/file_system/` folder.

Alternatively, we could do it the other way by binding an alternate name for this method, but `filesystem` is the dominant name. `filesystem` is used 677 times, while `file_system` is used 181 times. Also, every single instance in the class reference is `filesystem`.

I think I do slightly prefer `file_system`, but at the end of the day, I don't really care which one we use, we just need to be consistent. Without being consistent, GDExtension and module code has to be different for no reason, I will need an `#ifdef` to swap between these two names.