### PR TITLE
Use placeholder instead of value for tooltips of `PROPERTY_HINT_PASSWORD` properties.

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -177,7 +177,11 @@ void EditorPropertyText::_text_changed(const String &p_string) {
 
 	// Set tooltip so that the full text is displayed in a tooltip if hovered.
 	// This is useful when using a narrow inspector, as the text can be trimmed otherwise.
-	text->set_tooltip_text(get_tooltip_string(text->get_text()));
+	if (text->is_secret()) {
+		text->set_tooltip_text(get_tooltip_string(text->get_placeholder()));
+	} else {
+		text->set_tooltip_text(get_tooltip_string(text->get_text()));
+	}
 
 	if (string_name) {
 		emit_changed(get_edited_property(), StringName(p_string));
@@ -192,7 +196,11 @@ void EditorPropertyText::update_property() {
 	if (text->get_text() != s) {
 		int caret = text->get_caret_column();
 		text->set_text(s);
-		text->set_tooltip_text(get_tooltip_string(s));
+		if (text->is_secret()) {
+			text->set_tooltip_text(get_tooltip_string(text->get_placeholder()));
+		} else {
+			text->set_tooltip_text(get_tooltip_string(s));
+		}
 		text->set_caret_column(caret);
 	}
 	text->set_editable(!is_read_only());


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110163

Before:
<img width="746" height="78" alt="Screenshot 2025-09-01 at 16 50 57" src="https://github.com/user-attachments/assets/efaaf657-a3cc-4206-9669-383149a9c8ba" />

After:
<img width="776" height="80" alt="Screenshot 2025-09-01 at 16 44 39" src="https://github.com/user-attachments/assets/15f16b4c-2180-424e-bc80-90edad413a79" />
