### PR TITLE
Fix disconnected ENetPacketPeer not being returned from service()

### DIFF
--- a/modules/enet/enet_connection.cpp
+++ b/modules/enet/enet_connection.cpp
@@ -133,7 +133,6 @@ ENetConnection::EventType ENetConnection::_parse_event(const ENetEvent &p_event,
 			// A peer disconnected.
 			if (p_event.peer->data != nullptr) {
 				Ref<ENetPacketPeer> pp = Ref<ENetPacketPeer>((ENetPacketPeer *)p_event.peer->data);
-				pp->_on_disconnect();
 				peers.erase(pp);
 				r_event.peer = pp;
 				r_event.data = p_event.data;

--- a/modules/enet/enet_packet_peer.cpp
+++ b/modules/enet/enet_packet_peer.cpp
@@ -125,7 +125,10 @@ int ENetPacketPeer::get_remote_port() const {
 }
 
 bool ENetPacketPeer::is_active() const {
-	return peer != nullptr;
+	if (peer) {
+		return peer->state != ENET_PEER_STATE_DISCONNECTED;
+	}
+	return false;
 }
 
 double ENetPacketPeer::get_statistic(PeerStatistic p_stat) {


### PR DESCRIPTION
Fixes #107864 

When a disconnect event is generated from a call to `service()`, the field in the array where the disconnected peer should be is null. 

The original bug report says this occurs during unclean disconnects but I found it will happen during clean disconnects as well. The problem was due to `_on_disconnect()` nulling the peer before it could be returned. Leaving out that line fixes the issue. The destructor for `ENetPacketPeer` should handle freeing the memory used by this peer when it's not needed. I've also modified `is_active()` so that the disconnected peer will still be considered inactive despite not being null.