### PR TITLE
Avoid attempting to load from shader cache when both the user-dir and res-dir are invalid

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -437,7 +437,7 @@ bool ShaderRD::_load_from_cache(Version *p_version, int p_group) {
 		f = FileAccess::open(_get_cache_file_path(p_version, p_group, api_safe_name, true), FileAccess::READ);
 	}
 
-	if (f.is_null()) {
+	if (f.is_null() && shader_cache_res_dir_valid) {
 		f = FileAccess::open(_get_cache_file_path(p_version, p_group, api_safe_name, false), FileAccess::READ);
 	}
 
@@ -539,8 +539,10 @@ void ShaderRD::_compile_version_start(Version *p_version, int p_group) {
 	p_version->dirty = false;
 
 #if ENABLE_SHADER_CACHE
-	if (_load_from_cache(p_version, p_group)) {
-		return;
+	if (shader_cache_user_dir_valid || shader_cache_res_dir_valid) {
+		if (_load_from_cache(p_version, p_group)) {
+			return;
+		}
 	}
 #endif
 
@@ -823,6 +825,7 @@ void ShaderRD::initialize(const Vector<String> &p_variant_defines, const String 
 
 void ShaderRD::_initialize_cache() {
 	shader_cache_user_dir_valid = !shader_cache_user_dir.is_empty();
+	shader_cache_res_dir_valid = !shader_cache_res_dir.is_empty();
 	if (!shader_cache_user_dir_valid) {
 		return;
 	}

--- a/servers/rendering/renderer_rd/shader_rd.h
+++ b/servers/rendering/renderer_rd/shader_rd.h
@@ -142,6 +142,7 @@ private:
 	static bool shader_cache_save_compressed_zstd;
 	static bool shader_cache_save_debug;
 	bool shader_cache_user_dir_valid = false;
+	bool shader_cache_res_dir_valid = false;
 
 	enum StageType {
 		STAGE_TYPE_VERTEX,


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/109659

This is likely a regression from the Shader baker. The shader baker relies on the res-dir, so it can be used even if the user-dir has not been initialized. However, when shader caching is disabled, both the user-dir and the res-dir are invalid, so attempting to read from the res-dir resulted in a crash. 

The main problem comes from here:

https://github.com/godotengine/godot/blob/89f32c6ead3e256740ae27534f6e5214ff9b83b3/servers/rendering/renderer_rd/shader_rd.cpp#L436-L442

If the user dir is false, we fall back on the res dir and just assume it exists and then we crash when creating the file path.

We could just check shader_cache_res_dir_valid in the second if statement. But then we will always get cache miss errors whenever shader caching is disabled

