### PR TITLE
Range: Only use the snapped value if it is different enough from the entered value

### DIFF
--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -189,12 +189,19 @@ double Range::_calc_value(double p_val, double p_step) const {
 	}
 
 	if (p_step > 0) {
+		double snapped_val;
 		if (Math::abs(shared->min) > p_step * 1e14) {
 			// Min is too big to use for snapping offset, so snap without it.
-			p_val = _snapped_r128(p_val, p_step);
+			snapped_val = _snapped_r128(p_val, p_step);
 		} else {
 			// Subtract min to support cases like min = 0.1, step = 0.2, snaps to 0.1, 0.3, 0.5, etc.
-			p_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;
+			snapped_val = _snapped_r128(p_val - shared->min, p_step) + shared->min;
+		}
+		// Only use the snapped value if it is different enough from the original value.
+		// Otherwise, prefer the user's input to avoid precision issues due to snapping.
+		// Use a stricter tolerance than the auto-calculated one in `Math::is_equal_approx()`.
+		if (!Math::is_equal_approx(p_val, snapped_val, 1e-14)) {
+			p_val = snapped_val;
 		}
 	}
 


### PR DESCRIPTION
Fixes #109838 (not a regression fix this time, this PR is actually an improvement over what Godot has ever had before)

@jan-kapoli commented (but deleted their comment?) asking why we are snapping at all. Well, the reason why is because this is the behavior of Range. However, that still raises a good point. If the value is already good, we shouldn't need to snap it. This PR checks if the value is approximately equal to the snapped value, and uses the original value. This now works correctly even for values and step sizes down to `1e-7`:

<img width="900" height="351" alt="Screenshot 2025-09-01 at 12 22 25 PM" src="https://github.com/user-attachments/assets/a0416334-da1b-469b-8e21-717549934adc" />

Snapping will still occur if the value is different enough. For example, with a step size of `0.0000001`, if you enter `0.000000101`, this gets converted to `9.999999999994822e-08` instead of `0.0000001`, but `0.0000001` gets preserved as the closest possible float to `0.0000001` (and therefore serialized as `1e-7`).

The behavior in this PR may be slightly worse if you don't trust the user's input, allowing the value to be up to `1e-14` away from the snapped value rather than force-snapping to within `1e-15` or `1e-16` of the best value. However, I think this is a very minor problem (only slightly worse than the imprecision `double` already provides), and has the benefit that if you do trust the user's input and expect that the value the user entered is *probably* already good, this helps.