### PR TITLE
Rework scene restoring

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1064,7 +1064,6 @@
 		</member>
 		<member name="interface/scene_tabs/restore_scenes_on_load" type="bool" setter="" getter="">
 			If [code]true[/code], when a project is loaded, restores scenes that were opened on the last editor session.
-			[b]Note:[/b] With many opened scenes, the editor may take longer to become usable. If starting the editor quickly is necessary, consider setting this to [code]false[/code].
 		</member>
 		<member name="interface/scene_tabs/show_script_button" type="bool" setter="" getter="">
 			If [code]true[/code], show a button next to each scene tab that opens the scene's "dominant" script when clicked. The "dominant" script is the one that is at the highest level in the scene's hierarchy.

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -611,10 +611,6 @@ int EditorData::add_edited_scene(int p_at_pos) {
 		p_at_pos = edited_scene.size();
 	}
 	EditedScene es;
-	es.root = nullptr;
-	es.path = String();
-	es.file_modified_time = 0;
-	es.history_current = -1;
 	es.live_edit_root = NodePath(String("/root"));
 	es.history_id = last_created_scene++;
 
@@ -628,6 +624,16 @@ int EditorData::add_edited_scene(int p_at_pos) {
 		current_edited_scene = 0;
 	}
 	return p_at_pos;
+}
+
+void EditorData::add_dummy_scene(const String &p_path) {
+	int idx = 0;
+	if (edited_scene.size() > 1 || !is_scene_empty(0)) {
+		idx = add_edited_scene(-1);
+	}
+	edited_scene.write[idx].path = p_path;
+	edited_scene.write[idx].file_modified_time = FileAccess::get_modified_time(p_path);
+	edited_scene.write[idx].dummy = true;
 }
 
 void EditorData::move_edited_scene_index(int p_idx, int p_to_idx) {
@@ -821,6 +827,25 @@ String EditorData::get_scene_type(int p_idx) const {
 	return edited_scene[p_idx].root->get_class();
 }
 
+bool EditorData::is_scene_empty(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), true);
+	return !edited_scene[p_idx].dummy && edited_scene[p_idx].path.is_empty() && edited_scene[p_idx].root == nullptr;
+}
+
+bool EditorData::is_scene_dummy(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), false);
+	return edited_scene[p_idx].dummy;
+}
+
+bool EditorData::remove_dummy_flag(int p_idx) {
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), false);
+	if (edited_scene[p_idx].dummy) {
+		edited_scene.write[p_idx].dummy = false;
+		return true;
+	}
+	return false;
+}
+
 void EditorData::move_edited_scene_to_index(int p_idx) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
@@ -849,14 +874,16 @@ Ref<Script> EditorData::get_scene_root_script(int p_idx) const {
 
 String EditorData::get_scene_title(int p_idx, bool p_always_strip_extension) const {
 	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), String());
-	if (!edited_scene[p_idx].root) {
-		return TTR("[empty]");
-	}
-	if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
-		return TTR("[unsaved]");
+	if (!edited_scene[p_idx].dummy) {
+		if (!edited_scene[p_idx].root) {
+			return TTR("[empty]");
+		}
+		if (edited_scene[p_idx].root->get_scene_file_path().is_empty()) {
+			return TTR("[unsaved]");
+		}
 	}
 
-	const String filename = edited_scene[p_idx].root->get_scene_file_path().get_file();
+	const String filename = edited_scene[p_idx].path.get_file();
 	const String basename = filename.get_basename();
 
 	if (p_always_strip_extension) {
@@ -870,7 +897,7 @@ String EditorData::get_scene_title(int p_idx, bool p_always_strip_extension) con
 			continue;
 		}
 
-		if (edited_scene[i].root && basename == edited_scene[i].root->get_scene_file_path().get_file().get_basename()) {
+		if (edited_scene[i].root && basename == edited_scene[i].path.get_file().get_basename()) {
 			return filename;
 		}
 	}
@@ -887,6 +914,11 @@ void EditorData::set_scene_path(int p_idx, const String &p_path) {
 		return;
 	}
 	edited_scene[p_idx].root->set_scene_file_path(p_path);
+}
+
+void EditorData::set_scene_root(int p_idx, Node *p_node) {
+	ERR_FAIL_INDEX(p_idx, edited_scene.size());
+	edited_scene.write[p_idx].root = p_node;
 }
 
 String EditorData::get_scene_path(int p_idx) const {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -116,7 +116,8 @@ public:
 		Dictionary editor_states;
 		List<Node *> selection;
 		Vector<EditorSelectionHistory::HistoryElement> history_stored;
-		int history_current = 0;
+		int history_current = -1;
+		bool dummy = false;
 		Dictionary custom_state;
 		NodePath live_edit_root;
 		int history_id = 0;
@@ -185,8 +186,6 @@ public:
 	void remove_move_array_element_function(const StringName &p_class);
 	Callable get_move_array_element_function(const StringName &p_class) const;
 
-	void save_editor_global_states();
-
 	void add_custom_type(const String &p_type, const String &p_inherits, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon);
 	Variant instantiate_custom_type(const String &p_type, const String &p_inherits);
 	void remove_custom_type(const String &p_type);
@@ -198,6 +197,7 @@ public:
 	void instantiate_object_properties(Object *p_object);
 
 	int add_edited_scene(int p_at_pos);
+	void add_dummy_scene(const String &p_path);
 	void move_edited_scene_index(int p_idx, int p_to_idx);
 	void remove_scene(int p_idx);
 	void set_edited_scene(int p_idx);
@@ -211,7 +211,11 @@ public:
 	String get_scene_title(int p_idx, bool p_always_strip_extension = false) const;
 	String get_scene_path(int p_idx) const;
 	String get_scene_type(int p_idx) const;
+	bool is_scene_empty(int p_idx) const;
+	bool is_scene_dummy(int p_idx) const;
+	bool remove_dummy_flag(int p_idx);
 	void set_scene_path(int p_idx, const String &p_path);
+	void set_scene_root(int p_idx, Node *p_node);
 	Ref<Script> get_scene_root_script(int p_idx) const;
 	void set_scene_modified_time(int p_idx, uint64_t p_time);
 	uint64_t get_scene_modified_time(int p_idx) const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4246,6 +4246,13 @@ void EditorNode::_set_current_scene(int p_idx) {
 }
 
 void EditorNode::_set_current_scene_nocheck(int p_idx) {
+	if (editor_data.remove_dummy_flag(p_idx)) {
+		Error err;
+		Ref<PackedScene> sdata = ResourceLoader::load(editor_data.get_scene_path(p_idx), "", ResourceFormatLoader::CACHE_MODE_REPLACE, &err);
+		Node *new_scene = sdata->instantiate(PackedScene::GEN_EDIT_STATE_MAIN);
+		editor_data.set_scene_root(p_idx, new_scene);
+	}
+
 	// Save the folding in case the scene gets reloaded.
 	if (editor_data.get_scene_path(p_idx) != "" && editor_data.get_edited_scene_root(p_idx)) {
 		editor_folding.save_scene_folding(editor_data.get_edited_scene_root(p_idx), editor_data.get_scene_path(p_idx));
@@ -4345,7 +4352,7 @@ int EditorNode::new_scene() {
 	if (editor_data.get_edited_scene_count() > 1) {
 		for (int i = 0; i < editor_data.get_edited_scene_count() - 1; i++) {
 			bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(editor_data.get_scene_history_id(i));
-			if (!unsaved && editor_data.get_scene_path(i).is_empty() && editor_data.get_edited_scene_root(i) == nullptr) {
+			if (!unsaved && editor_data.is_scene_empty(i)) {
 				editor_data.remove_scene(i);
 				idx--;
 			}
@@ -4529,6 +4536,16 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		_add_to_recent_scenes(lpath);
 	}
 
+	return OK;
+}
+
+Error EditorNode::load_dummy_scene(const String &p_scene) {
+	const String lpath = ProjectSettings::get_singleton()->localize_path(ResourceUID::ensure_path(p_scene));
+	if (!lpath.begins_with("res://")) {
+		show_accept(TTRC("Error loading scene, it must be inside the project path. Use 'Import' to open the scene, then save it inside the project path."), TTRC("OK"));
+		return ERR_FILE_NOT_FOUND;
+	}
+	editor_data.add_dummy_scene(p_scene);
 	return OK;
 }
 
@@ -5867,7 +5884,7 @@ void EditorNode::_load_open_scenes_from_config(Ref<ConfigFile> p_layout) {
 	PackedStringArray scenes = p_layout->get_value(EDITOR_NODE_CONFIG_SECTION, "open_scenes");
 	for (int i = 0; i < scenes.size(); i++) {
 		if (FileAccess::exists(scenes[i])) {
-			load_scene(scenes[i]);
+			load_dummy_scene(scenes[i]);
 		}
 	}
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -839,6 +839,7 @@ public:
 	void fix_dependencies(const String &p_for_file);
 	int new_scene();
 	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_silent_change_tab = false);
+	Error load_dummy_scene(const String &p_scene);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 	Error load_scene_or_resource(const String &p_file, bool p_ignore_broken_deps = false, bool p_change_scene_tab_if_already_open = true);
 

--- a/editor/icons/TempNode.svg
+++ b/editor/icons/TempNode.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><circle cx="8" cy="8" r="5" fill="none" stroke="#e0e0e0" stroke-dasharray="2,2" stroke-opacity=".8" stroke-width="2"/></svg>

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -272,6 +272,12 @@ void EditorSceneTabs::_update_tab_titles() {
 
 	Ref<Texture2D> script_icon = get_editor_theme_icon(SNAME("Script"));
 	for (int i = 0; i < EditorNode::get_editor_data().get_edited_scene_count(); i++) {
+		if (EditorNode::get_editor_data().is_scene_dummy(i)) {
+			scene_tabs->set_tab_icon(i, get_editor_theme_icon("TempNode"));
+			scene_tabs->set_tab_title(i, EditorNode::get_editor_data().get_scene_title(i));
+			continue;
+		}
+
 		Node *type_node = EditorNode::get_editor_data().get_edited_scene_root(i);
 		Ref<Texture2D> icon;
 		if (type_node) {


### PR DESCRIPTION
Changed the way scene restoring works. Instead of loading all scenes, only the current scene is loaded, other scenes are opened as "dummy scenes". They are not being loaded until you switch to them. This makes the editor open fast regardless of how many scenes you had opened when closing.

https://github.com/user-attachments/assets/7210dabd-1307-474d-9bd5-dcd4e7ff8648

As a result, `restore_scenes_on_load` setting became obsolete and I removed it.
Discussion for more context: https://chat.godotengine.org/channel/editor?msg=6MqBpHYC5xdJShs4z
Needs some testing.