### PR TITLE
Fix rounding error in clustered vertex light culling

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -529,7 +529,9 @@ void vertex_shader(vec3 vertex_input,
 	vec2 clip_pos = clamp((gl_Position.xy / gl_Position.w) * 0.5 + 0.5, 0.0, 1.0);
 #endif
 
-	uvec2 cluster_pos = uvec2(clip_pos / scene_data.screen_pixel_size) >> implementation_data.cluster_shift;
+	uvec2 screen_size = uvec2(1.0 / scene_data.screen_pixel_size);
+	uvec2 screen_pixel = clamp(uvec2(clip_pos * vec2(screen_size)), uvec2(0), screen_size - uvec2(1));
+	uvec2 cluster_pos = screen_pixel >> implementation_data.cluster_shift;
 	uint cluster_offset = (implementation_data.cluster_width * cluster_pos.y + cluster_pos.x) * (implementation_data.max_cluster_element_count_div_32 + 32);
 	uint cluster_z = uint(clamp((-vertex_interp.z / scene_data.z_far) * 32.0, 0.0, 31.0));
 


### PR DESCRIPTION
Looks like there was a rounding error when calculating what clustered light tile to use for off-screen vertices - I've just moved some more of the logic to integer precision to make it a bit more consistent with per-pixel lighting.

Before:

https://github.com/user-attachments/assets/3526bf99-ac63-4ab0-95d6-9fac1a048e6d

After:

https://github.com/user-attachments/assets/785a7d6d-a462-4f48-9244-d21248fdf84e

- Fixes https://github.com/godotengine/godot/issues/98440
- Fixes https://github.com/godotengine/godot/issues/105063