### PR TITLE
Ignore backfaces during Node3D selection

### DIFF
--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -290,7 +290,7 @@ bool TriangleMesh::intersect_segment(const Vector3 &p_begin, const Vector3 &p_en
 	return inters;
 }
 
-bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index, int32_t *r_face_index) const {
+bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index, int32_t *r_face_index, bool p_ignore_backfaces) const {
 	if (!valid) {
 		return false;
 	}
@@ -338,18 +338,23 @@ bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, V
 						Vector3 res;
 
 						if (f3.intersects_ray(p_begin, p_dir, &res)) {
-							real_t nd = n.dot(res);
-							if (nd < d) {
-								d = nd;
-								r_point = res;
-								r_normal = f3.get_plane().get_normal();
-								if (r_surf_index) {
-									*r_surf_index = s.surface_index;
+							Vector3 face_normal = f3.get_plane().get_normal();
+							if (p_ignore_backfaces && p_dir.dot(face_normal) >= 0) {
+								// Skip this triangle.
+							} else {
+								real_t nd = n.dot(res);
+								if (nd < d) {
+									d = nd;
+									r_point = res;
+									r_normal = face_normal;
+									if (r_surf_index) {
+										*r_surf_index = s.surface_index;
+									}
+									if (r_face_index) {
+										*r_face_index = b.face_index;
+									}
+									inters = true;
 								}
-								if (r_face_index) {
-									*r_face_index = b.face_index;
-								}
-								inters = true;
 							}
 						}
 

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -290,7 +290,7 @@ bool TriangleMesh::intersect_segment(const Vector3 &p_begin, const Vector3 &p_en
 	return inters;
 }
 
-bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index, int32_t *r_face_index, bool p_ignore_backfaces) const {
+bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index, int32_t *r_face_index, CullMode p_cull_mode) const {
 	if (!valid) {
 		return false;
 	}
@@ -339,9 +339,17 @@ bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, V
 
 						if (f3.intersects_ray(p_begin, p_dir, &res)) {
 							Vector3 face_normal = f3.get_plane().get_normal();
-							if (p_ignore_backfaces && p_dir.dot(face_normal) >= 0) {
-								// Skip this triangle.
-							} else {
+							real_t dot = p_dir.dot(face_normal);
+							bool is_backface = dot >= 0;
+
+							bool skip_triangle = false;
+							if (p_cull_mode == CULL_BACK && is_backface) {
+								skip_triangle = true;
+							} else if (p_cull_mode == CULL_FRONT && !is_backface) {
+								skip_triangle = true;
+							}
+
+							if (!skip_triangle) {
 								real_t nd = n.dot(res);
 								if (nd < d) {
 									d = nd;

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -85,7 +85,7 @@ private:
 public:
 	bool is_valid() const;
 	bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr) const;
-	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr) const;
+	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr, bool p_ignore_backfaces = false) const;
 	bool inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale = Vector3(1, 1, 1)) const;
 	Vector<Face3> get_faces() const;
 

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -85,7 +85,12 @@ private:
 public:
 	bool is_valid() const;
 	bool intersect_segment(const Vector3 &p_begin, const Vector3 &p_end, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr) const;
-	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr, bool p_ignore_backfaces = false) const;
+	enum CullMode {
+		CULL_BACK = 0,
+		CULL_FRONT = 1,
+		CULL_DISABLED = 2,
+	};
+	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr, CullMode p_cull_mode = CULL_BACK) const;
 	bool inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale = Vector3(1, 1, 1)) const;
 	Vector<Face3> get_faces() const;
 

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -764,7 +764,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 
 		for (Ref<TriangleMesh> collision_mesh : collision_meshes) {
 			if (collision_mesh.is_valid()) {
-				if (collision_mesh->intersect_ray(ray_from, ray_dir, rpos, rnorm)) {
+				if (collision_mesh->intersect_ray(ray_from, ray_dir, rpos, rnorm, nullptr, nullptr, true)) {
 					r_pos = gt.xform(rpos);
 					r_normal = gt.basis.xform(rnorm).normalized();
 					return true;

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -36,7 +36,12 @@
 #include "editor/editor_string_names.h"
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
+#include "modules/csg/csg_shape.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/sprite_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
+#include "scene/resources/material.h"
+#include "scene/resources/mesh.h"
 
 #define HANDLE_HALF_SIZE 9.5
 
@@ -751,6 +756,60 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	}
 
 	if (!collision_meshes.is_empty()) {
+		TriangleMesh::CullMode cull_mode = TriangleMesh::CULL_BACK;
+
+		GeometryInstance3D *geom = Object::cast_to<GeometryInstance3D>(spatial_node);
+		if (geom) {
+			Ref<Material> mat;
+			BaseMaterial3D::CullMode material_cull_mode = BaseMaterial3D::CULL_BACK;
+
+			MeshInstance3D *mesh_inst = Object::cast_to<MeshInstance3D>(spatial_node);
+			if (mesh_inst) {
+				mat = mesh_inst->get_active_material(0);
+			} else {
+				// Override takes precedence.
+				mat = geom->get_material_override();
+				if (!mat.is_valid()) {
+					SpriteBase3D *sprite = Object::cast_to<SpriteBase3D>(spatial_node);
+					if (sprite) {
+						if (sprite->get_draw_flag(SpriteBase3D::FLAG_DOUBLE_SIDED)) {
+							material_cull_mode = BaseMaterial3D::CULL_DISABLED;
+						}
+					} else {
+						// Each CSG shape type has its own get_material() method.
+						CSGPrimitive3D *csg_prim = Object::cast_to<CSGPrimitive3D>(spatial_node);
+						if (csg_prim) {
+#define CHECK_CSG_TYPE(TypeName)                             \
+	if (!mat.is_valid()) {                                   \
+		TypeName *csg = Object::cast_to<TypeName>(csg_prim); \
+		if (csg) {                                           \
+			mat = csg->get_material();                       \
+		}                                                    \
+	}
+
+							CHECK_CSG_TYPE(CSGBox3D)
+							CHECK_CSG_TYPE(CSGSphere3D)
+							CHECK_CSG_TYPE(CSGCylinder3D)
+							CHECK_CSG_TYPE(CSGTorus3D)
+							CHECK_CSG_TYPE(CSGPolygon3D)
+							CHECK_CSG_TYPE(CSGMesh3D)
+
+#undef CHECK_CSG_TYPE
+						}
+					}
+				}
+			}
+
+			if (mat.is_valid()) {
+				Ref<BaseMaterial3D> base_mat = mat;
+				if (base_mat.is_valid()) {
+					material_cull_mode = base_mat->get_cull_mode();
+				}
+			}
+
+			cull_mode = static_cast<TriangleMesh::CullMode>(material_cull_mode);
+		}
+
 		Transform3D gt = spatial_node->get_global_transform();
 
 		if (billboard_handle) {
@@ -764,7 +823,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 
 		for (Ref<TriangleMesh> collision_mesh : collision_meshes) {
 			if (collision_mesh.is_valid()) {
-				if (collision_mesh->intersect_ray(ray_from, ray_dir, rpos, rnorm, nullptr, nullptr, true)) {
+				if (collision_mesh->intersect_ray(ray_from, ray_dir, rpos, rnorm, nullptr, nullptr, cull_mode)) {
 					r_pos = gt.xform(rpos);
 					r_normal = gt.basis.xform(rnorm).normalized();
 					return true;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -2562,7 +2562,7 @@ void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<Select
 				Transform3D gt = geo_instance->get_global_transform();
 				Transform3D ai = gt.affine_inverse();
 				Vector3 point, normal;
-				if (mesh_collision->intersect_ray(ai.xform(pos), ai.basis.xform(ray).normalized(), point, normal)) {
+				if (mesh_collision->intersect_ray(ai.xform(pos), ai.basis.xform(ray).normalized(), point, normal, nullptr, nullptr, true)) {
 					SelectResult res;
 					res.item = Object::cast_to<Node>(obj);
 					res.order = -pos.distance_to(gt.xform(point));

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -54,12 +54,17 @@
 
 #ifndef _3D_DISABLED
 #include "scene/3d/camera_3d.h"
+#include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/sprite_3d.h"
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/3d/physics/collision_object_3d.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
+#include "modules/csg/csg_shape.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/3d/convex_polygon_shape_3d.h"
+#include "scene/resources/material.h"
+#include "scene/resources/mesh.h"
 #include "scene/resources/surface_tool.h"
 #endif // _3D_DISABLED
 
@@ -2559,10 +2564,62 @@ void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<Select
 			Ref<TriangleMesh> mesh_collision = geo_instance->generate_triangle_mesh();
 
 			if (mesh_collision.is_valid()) {
+				TriangleMesh::CullMode cull_mode = TriangleMesh::CULL_BACK;
+
+				Ref<Material> mat;
+				BaseMaterial3D::CullMode material_cull_mode = BaseMaterial3D::CULL_BACK;
+
+				MeshInstance3D *mesh_inst = Object::cast_to<MeshInstance3D>(geo_instance);
+				if (mesh_inst) {
+					mat = mesh_inst->get_active_material(0);
+				} else {
+					// Override takes precedence.
+					mat = geo_instance->get_material_override();
+
+					if (!mat.is_valid()) {
+						SpriteBase3D *sprite = Object::cast_to<SpriteBase3D>(geo_instance);
+						if (sprite) {
+							if (sprite->get_draw_flag(SpriteBase3D::FLAG_DOUBLE_SIDED)) {
+								material_cull_mode = BaseMaterial3D::CULL_DISABLED;
+							}
+						} else {
+							// Each CSG shape type has its own get_material() method.
+							CSGPrimitive3D *csg_prim = Object::cast_to<CSGPrimitive3D>(geo_instance);
+							if (csg_prim) {
+#define CHECK_CSG_TYPE(TypeName)                             \
+	if (!mat.is_valid()) {                                   \
+		TypeName *csg = Object::cast_to<TypeName>(csg_prim); \
+		if (csg) {                                           \
+			mat = csg->get_material();                       \
+		}                                                    \
+	}
+
+								CHECK_CSG_TYPE(CSGBox3D)
+								CHECK_CSG_TYPE(CSGSphere3D)
+								CHECK_CSG_TYPE(CSGCylinder3D)
+								CHECK_CSG_TYPE(CSGTorus3D)
+								CHECK_CSG_TYPE(CSGPolygon3D)
+								CHECK_CSG_TYPE(CSGMesh3D)
+
+#undef CHECK_CSG_TYPE
+							}
+						}
+					}
+				}
+
+				if (mat.is_valid()) {
+					Ref<BaseMaterial3D> base_mat = mat;
+					if (base_mat.is_valid()) {
+						material_cull_mode = base_mat->get_cull_mode();
+					}
+				}
+
+				cull_mode = static_cast<TriangleMesh::CullMode>(material_cull_mode);
+
 				Transform3D gt = geo_instance->get_global_transform();
 				Transform3D ai = gt.affine_inverse();
 				Vector3 point, normal;
-				if (mesh_collision->intersect_ray(ai.xform(pos), ai.basis.xform(ray).normalized(), point, normal, nullptr, nullptr, true)) {
+				if (mesh_collision->intersect_ray(ai.xform(pos), ai.basis.xform(ray).normalized(), point, normal, nullptr, nullptr, cull_mode)) {
 					SelectResult res;
 					res.item = Object::cast_to<Node>(obj);
 					res.order = -pos.distance_to(gt.xform(point));


### PR DESCRIPTION
Closes [#12550](https://github.com/godotengine/godot-proposals/issues/12550).

~~Adds an editor setting `3D > Ignore Backfaces on Selection` that is `true` by default.~~
Adds an optional parameter and an if statement to TriangleMesh's `intersect_ray` function.