### PR TITLE
Trim -loop & -cycle from animations during Godot 3 to 4 conversion

### DIFF
--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -155,6 +155,9 @@ public:
 	int joypad_button_mappings[23] = { 0, 1, 2, 3, 9, 10, -1 /*L2*/, -1 /*R2*/, 7, 8, 4, 6, 11, 12, 13, 14, 5, 15, 16, 17, 18, 19, 20 };
 	// Entries for L2 and R2 are -1 since they match to joypad axes and no longer to joypad buttons in Godot 4.
 
+	// Animation suffixes.
+	RegEx animation_suffix = RegEx("([\"'])([a-zA-Z0-9_-]+)(-(?:loop|cycle))([\"'])");
+
 	LocalVector<RegEx *> class_regexes;
 
 	RegEx class_temp_tscn = RegEx("\\bTEMP_RENAMED_CLASS.tscn\\b");
@@ -406,6 +409,7 @@ bool ProjectConverter3To4::convert() {
 				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, source_lines);
 				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, source_lines);
 				rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, source_lines);
+				rename_animation_suffixes(source_lines, reg_container);
 
 				custom_rename(source_lines, "\\.shader", ".gdshader");
 
@@ -428,6 +432,7 @@ bool ProjectConverter3To4::convert() {
 				rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, source_lines);
 				rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, source_lines);
 				rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, source_lines);
+				rename_animation_suffixes(source_lines, reg_container);
 
 				custom_rename(source_lines, "\\.shader", ".gdshader");
 
@@ -598,6 +603,7 @@ bool ProjectConverter3To4::validate_conversion() {
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, lines));
+				changed_elements.append_array(check_for_rename_animation_suffixes(lines, reg_container));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with(".tscn")) {
@@ -616,6 +622,7 @@ bool ProjectConverter3To4::validate_conversion() {
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::shaders_renames, reg_container.shaders_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::builtin_types_renames, reg_container.builtin_types_regexes, lines));
 				changed_elements.append_array(check_for_rename_common(RenamesMap3To4::theme_override_renames, reg_container.theme_override_regexes, lines));
+				changed_elements.append_array(check_for_rename_animation_suffixes(lines, reg_container));
 
 				changed_elements.append_array(check_for_custom_rename(lines, "\\.shader", ".gdshader"));
 			} else if (file_name.ends_with(".cs")) {
@@ -2825,6 +2832,43 @@ Vector<String> ProjectConverter3To4::check_for_rename_input_map_scancode(Vector<
 
 					found_renames.append(line_formatter(current_line, strings[3], String::num_int64(key), line));
 				}
+			}
+		}
+		current_line++;
+	}
+	return found_renames;
+}
+
+void ProjectConverter3To4::rename_animation_suffixes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container) {
+	for (SourceLine &source_line : source_lines) {
+		if (source_line.is_comment) {
+			continue;
+		}
+		String &line = source_line.line;
+		if (uint64_t(line.length()) <= maximum_line_length) {
+			TypedArray<RegExMatch> reg_match = reg_container.animation_suffix.search_all(line);
+			for (int i = 0; i < reg_match.size(); ++i) {
+				Ref<RegExMatch> match = reg_match[i];
+				PackedStringArray strings = match->get_strings();
+				String replacement = strings[1] + strings[2] + strings[4];
+				line = line.replace(strings[0], replacement);
+			}
+		}
+	}
+}
+
+Vector<String> ProjectConverter3To4::check_for_rename_animation_suffixes(Vector<String> &lines, const RegExContainer &reg_container) {
+	Vector<String> found_renames;
+	int current_line = 1;
+
+	for (String &line : lines) {
+		if (uint64_t(line.length()) <= maximum_line_length) {
+			TypedArray<RegExMatch> reg_match = reg_container.animation_suffix.search_all(line);
+			for (int i = 0; i < reg_match.size(); ++i) {
+				Ref<RegExMatch> match = reg_match[i];
+				PackedStringArray strings = match->get_strings();
+				String replacement = strings[1] + strings[2] + strings[4];
+				found_renames.append(line_formatter(current_line, strings[0], replacement, line));
 			}
 		}
 		current_line++;

--- a/editor/project_upgrade/project_converter_3_to_4.h
+++ b/editor/project_upgrade/project_converter_3_to_4.h
@@ -79,6 +79,9 @@ class ProjectConverter3To4 {
 	void rename_joypad_buttons_and_axes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_joypad_buttons_and_axes(Vector<String> &lines, const RegExContainer &reg_container);
 
+	void rename_animation_suffixes(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
+	Vector<String> check_for_rename_animation_suffixes(Vector<String> &lines, const RegExContainer &reg_container);
+
 	void custom_rename(Vector<SourceLine> &source_lines, const String &from, const String &to);
 	Vector<String> check_for_custom_rename(Vector<String> &lines, const String &from, const String &to);
 


### PR DESCRIPTION
Closes #75825, closes #62580.

Tested with my very animation-heavy Godot 3 project.