### PR TITLE
Fix Clear option not visible when a Resource's `@export`-ed property is a Script

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -778,10 +778,19 @@ bool EditorResourcePicker::_is_type_valid(const String &p_type_name, const HashS
 }
 
 bool EditorResourcePicker::_is_custom_type_script() const {
-	Ref<Script> resource_as_script = edited_resource;
+	EditorProperty *editor_property = Object::cast_to<EditorProperty>(get_parent());
+	if (!editor_property) {
+		return false;
+	}
 
-	if (resource_as_script.is_valid() && resource_owner && resource_owner->has_meta(SceneStringName(_custom_type_script))) {
-		return true;
+	// Check if the property being edited is 'script'.
+	if (editor_property->get_edited_property() == CoreStringName(script)) {
+		// If there's currently a valid script assigned and the owning Node/Resource also has a custom type script assigned, then
+		// the currently assigned script is either the custom type script itself or an extension of it.
+		Ref<Script> resource_as_script = edited_resource;
+		if (resource_as_script.is_valid() && resource_owner && resource_owner->has_meta(SceneStringName(_custom_type_script))) {
+			return true;
+		}
 	}
 
 	return false;


### PR DESCRIPTION
Closes #110178

Narrows down the criteria to determine if the property being edited with the `EditorResourcePicker` is actually the `Object->script` property.