### PR TITLE
Configure SDL assuming we, in fact, have a libc

### DIFF
--- a/drivers/sdl/SDL_build_config_private.h
+++ b/drivers/sdl/SDL_build_config_private.h
@@ -81,6 +81,7 @@
 #define SDL_PLATFORM_UNIX 1
 
 #define HAVE_STDIO_H 1
+#define HAVE_LIBC 1
 #define HAVE_LINUX_INPUT_H 1
 #define HAVE_POLL 1
 


### PR DESCRIPTION
Without this, on Linux and Linux alone, and only if SDL is builtin, the definitions for some libc functions - notably, memset/memcpy - are taken from SDL source (which defines them in `thirdparty/sdl/stdlib/SDL_memcpy.c` et al unless HAVE_LIBC is 1).

This leaves the codegen at the mercy of the compiler and may lead to the optimal implementations of these functions not being selected (e.g. if extended instruction sets like AVX2+ are available). But the main motivation for this is that it's action at a distance that is incredibly surprising - linking in a gamepad support library should not change the implementation of memset/memcpy!

Before https://github.com/godotengine/godot/pull/106218, SDL was not being linked with, and so going back to using memset/memcpy from libc should be safe.

On Zen 4, the SDL implementation - at least when compiled with clang - is, in fact, fine (for example, clang vectorizes the copying loop), but I'm not sure if there's any consequences on other CPUs and it just felt incredibly strange to use memset/memcpy implementations from SDL because of, what I assume, is an accidental misconfiguration. HAVE_LIBC is set to 1 on Windows/macOS.