### PR TITLE
Clamp minimum size of 3D texture view in D3D12.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -2848,7 +2848,7 @@ D3D12_UNORDERED_ACCESS_VIEW_DESC RenderingDeviceDriverD3D12::_make_ranged_uav_fo
 		} break;
 		case D3D12_UAV_DIMENSION_TEXTURE3D: {
 			uav_desc.Texture3D.MipSlice = mip;
-			uav_desc.Texture3D.WSize >>= p_mipmap_offset;
+			uav_desc.Texture3D.WSize = MAX(uav_desc.Texture3D.WSize >> p_mipmap_offset, 1U);
 		} break;
 		default:
 			break;


### PR DESCRIPTION
3D textures that used mipmaps that'd scale the depth of the texture enough to make the bitshift result in a 0 would lead to crashing the driver. Applying the clamp fixes this issue.

*Bugsquad edit:* Fixes https://github.com/godotengine/godot/issues/108552.