### PR TITLE
Remove unused parameter in `__constant_get_enum_name`/`__constant_get_bitfield_name`

### DIFF
--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -75,7 +75,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT(m_constant)                                                          \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
 		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -83,7 +83,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_BITFIELD_FLAG(m_constant)                                                          \
 	{                                                                                                \
-		StringName enum_name = __constant_get_bitfield_name(m_constant, #m_constant);                \
+		StringName enum_name = __constant_get_bitfield_name(m_constant);                             \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant, false, true)); \
 		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -92,7 +92,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 // This just binds enum classes as if they were regular enum constants.
 #define BIND_CORE_ENUM_CLASS_CONSTANT(m_enum, m_prefix, m_member)                                                  \
 	{                                                                                                              \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member, #m_prefix "_" #m_member);                \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                         \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
 		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
@@ -100,7 +100,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_BITFIELD_CLASS_FLAG(m_enum, m_prefix, m_member)                                                               \
 	{                                                                                                                           \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member, #m_prefix "_" #m_member);                         \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                                                  \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member, false, true)); \
 		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                                          \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);                            \
@@ -108,7 +108,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CLASS_CONSTANT_CUSTOM(m_enum, m_name, m_member)                               \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member, #m_name);                  \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                           \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member));   \
 		_global_constants_map[#m_name] = _global_constants.size() - 1;                               \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -116,7 +116,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_BITFIELD_CLASS_FLAG_CUSTOM(m_enum, m_name, m_member)                                          \
 	{                                                                                                           \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member, #m_name);                         \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                                  \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member, false, true)); \
 		_global_constants_map[#m_name] = _global_constants.size() - 1;                                          \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);            \
@@ -124,7 +124,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CLASS_CONSTANT_NO_VAL(m_enum, m_prefix, m_member)                                                 \
 	{                                                                                                                    \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member, #m_prefix "_" #m_member);                      \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                               \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member, true)); \
 		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                                   \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);                     \
@@ -132,7 +132,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant)                                    \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant));            \
 		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -144,7 +144,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT_NO_VAL(m_constant)                                                   \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant, true));        \
 		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -152,7 +152,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant)                             \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant, true));      \
 		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -166,7 +166,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT(m_constant)                                                          \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
 		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -174,7 +174,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_BITFIELD_FLAG(m_constant)                                                          \
 	{                                                                                                \
-		StringName enum_name = __constant_get_bitfield_name(m_constant, #m_constant);                \
+		StringName enum_name = __constant_get_bitfield_name(m_constant);                             \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
 		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -183,7 +183,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 // This just binds enum classes as if they were regular enum constants.
 #define BIND_CORE_ENUM_CLASS_CONSTANT(m_enum, m_prefix, m_member)                                                  \
 	{                                                                                                              \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member, #m_prefix "_" #m_member);                \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                         \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
 		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
@@ -191,7 +191,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_BITFIELD_CLASS_FLAG(m_enum, m_prefix, m_member)                                                  \
 	{                                                                                                              \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member, #m_prefix "_" #m_member);            \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                                     \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
 		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
@@ -199,7 +199,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CLASS_CONSTANT_CUSTOM(m_enum, m_name, m_member)                               \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member, #m_name);                  \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                           \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member));   \
 		_global_constants_map[#m_name] = _global_constants.size() - 1;                               \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -207,7 +207,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_BITFIELD_CLASS_FLAG_CUSTOM(m_enum, m_name, m_member)                               \
 	{                                                                                                \
-		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member, #m_name);              \
+		StringName enum_name = __constant_get_bitfield_name(m_enum::m_member);                       \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_name, (int64_t)m_enum::m_member));   \
 		_global_constants_map[#m_name] = _global_constants.size() - 1;                               \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -215,7 +215,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CLASS_CONSTANT_NO_VAL(m_enum, m_prefix, m_member)                                           \
 	{                                                                                                              \
-		StringName enum_name = __constant_get_enum_name(m_enum::m_member, #m_prefix "_" #m_member);                \
+		StringName enum_name = __constant_get_enum_name(m_enum::m_member);                                         \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_prefix "_" #m_member, (int64_t)m_enum::m_member)); \
 		_global_constants_map[#m_prefix "_" #m_member] = _global_constants.size() - 1;                             \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]);               \
@@ -223,7 +223,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT_CUSTOM(m_custom_name, m_constant)                                    \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant));            \
 		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -235,7 +235,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT_NO_VAL(m_constant)                                                   \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, #m_constant, m_constant));              \
 		_global_constants_map[#m_constant] = _global_constants.size() - 1;                           \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \
@@ -243,7 +243,7 @@ static HashMap<StringName, Vector<_CoreConstant>> _global_enums;
 
 #define BIND_CORE_ENUM_CONSTANT_CUSTOM_NO_VAL(m_custom_name, m_constant)                             \
 	{                                                                                                \
-		StringName enum_name = __constant_get_enum_name(m_constant, #m_constant);                    \
+		StringName enum_name = __constant_get_enum_name(m_constant);                                 \
 		_global_constants.push_back(_CoreConstant(enum_name, m_custom_name, m_constant));            \
 		_global_constants_map[m_custom_name] = _global_constants.size() - 1;                         \
 		_global_enums[enum_name].push_back((_global_constants.ptr())[_global_constants.size() - 1]); \

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -532,10 +532,10 @@ public:
 };
 
 #define BIND_ENUM_CONSTANT(m_constant) \
-	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant, #m_constant), #m_constant, m_constant);
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_enum_name(m_constant), #m_constant, m_constant);
 
 #define BIND_BITFIELD_FLAG(m_constant) \
-	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_bitfield_name(m_constant, #m_constant), #m_constant, m_constant, true);
+	::ClassDB::bind_integer_constant(get_class_static(), __constant_get_bitfield_name(m_constant), #m_constant, m_constant, true);
 
 #define BIND_CONSTANT(m_constant) \
 	::ClassDB::bind_integer_constant(get_class_static(), StringName(), #m_constant, m_constant);

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -205,7 +205,7 @@ inline String enum_qualified_name_to_class_info_name(const String &p_qualified_n
 	};
 
 template <typename T>
-inline StringName __constant_get_enum_name(T param, const String &p_constant) {
+inline StringName __constant_get_enum_name(T param) {
 	return GetTypeInfo<T>::get_class_info().class_name;
 }
 
@@ -230,7 +230,7 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 	};
 
 template <typename T>
-inline StringName __constant_get_bitfield_name(T param, const String &p_constant) {
+inline StringName __constant_get_bitfield_name(T param) {
 	return GetTypeInfo<BitField<T>>::get_class_info().class_name;
 }
 #define CLASS_INFO(m_type) (GetTypeInfo<m_type *>::get_class_info())


### PR DESCRIPTION
Removed unused `String` parameter in `__constant_get_enum_name()` and `__constant_get_bitfield_name()` to avoid creating/destroying extra `Strings`.  Reduces binary size by ~300 KB.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
