### PR TITLE
Fix Resource duplicate calls `ImageTexture::set_image` with an invalid image.

### DIFF
--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -83,7 +83,13 @@ Ref<ImageTexture> ImageTexture::create_from_image(const Ref<Image> &p_image) {
 }
 
 void ImageTexture::set_image(const Ref<Image> &p_image) {
-	ERR_FAIL_COND_MSG(p_image.is_null() || p_image->is_empty(), "Invalid image");
+	if (p_image.is_null() || p_image->is_empty()) {
+		if (image_stored) {
+			ERR_PRINT("Invalid image");
+		}
+		return;
+	}
+
 	w = p_image->get_width();
 	h = p_image->get_height();
 	format = p_image->get_format();
@@ -474,8 +480,13 @@ TypedArray<Image> ImageTexture3D::_get_images() const {
 }
 
 void ImageTexture3D::_set_images(const TypedArray<Image> &p_images) {
-	int new_layers = p_images.size();
-	ERR_FAIL_COND(new_layers == 0);
+	if (p_images.size() == 0) {
+		if (images_stored) {
+			ERR_PRINT("Invalid images");
+		}
+		return;
+	}
+
 	Ref<Image> img_base = p_images[0];
 	ERR_FAIL_COND(img_base.is_null());
 
@@ -504,6 +515,8 @@ void ImageTexture3D::_set_images(const TypedArray<Image> &p_images) {
 
 	Error err = _create(new_format, new_width, new_height, new_depth, new_mipmaps, p_images);
 	ERR_FAIL_COND(err != OK);
+
+	images_stored = true;
 }
 
 void ImageTexture3D::_bind_methods() {

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -134,6 +134,7 @@ class ImageTexture3D : public Texture3D {
 	int height = 1;
 	int depth = 1;
 	bool mipmaps = false;
+	bool images_stored = false;
 
 	TypedArray<Image> _get_images() const;
 	void _set_images(const TypedArray<Image> &p_images);


### PR DESCRIPTION
* Fixes: https://github.com/godotengine/godot/issues/110208