### PR TITLE
Fix `AudioStreamPlaylist` not updating `stream_count` when calling `set_list_stream()`

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -113,6 +113,9 @@ StringName AudioStreamInteractive::get_clip_name(int p_clip) const {
 void AudioStreamInteractive::set_clip_stream(int p_clip, const Ref<AudioStream> &p_stream) {
 	ERR_FAIL_INDEX(p_clip, MAX_CLIPS);
 	AudioServer::get_singleton()->lock();
+	if (p_clip >= clip_count) {
+		clip_count = p_clip + 1;
+	}
 	if (clips[p_clip].stream.is_valid()) {
 		version++;
 	}

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -50,11 +50,19 @@ void AudioStreamPlaylist::set_list_stream(int p_stream_index, Ref<AudioStream> p
 	ERR_FAIL_INDEX(p_stream_index, MAX_STREAMS);
 
 	AudioServer::get_singleton()->lock();
+	if (p_stream_index >= stream_count) {
+		stream_count = p_stream_index + 1;
+	}
 	audio_streams[p_stream_index] = p_stream;
 	for (AudioStreamPlaybackPlaylist *E : playbacks) {
 		E->_update_playback_instances();
 	}
 	AudioServer::get_singleton()->unlock();
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		notify_property_list_changed();
+	}
+#endif
 }
 
 Ref<AudioStream> AudioStreamPlaylist::get_list_stream(int p_stream_index) const {

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -53,11 +53,19 @@ void AudioStreamSynchronized::set_sync_stream(int p_stream_index, Ref<AudioStrea
 	ERR_FAIL_INDEX(p_stream_index, MAX_STREAMS);
 
 	AudioServer::get_singleton()->lock();
+	if (p_stream_index >= stream_count) {
+		stream_count = p_stream_index + 1;
+	}
 	audio_streams[p_stream_index] = p_stream;
 	for (AudioStreamPlaybackSynchronized *E : playbacks) {
 		E->_update_playback_instances();
 	}
 	AudioServer::get_singleton()->unlock();
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		notify_property_list_changed();
+	}
+#endif
 }
 
 Ref<AudioStream> AudioStreamSynchronized::get_sync_stream(int p_stream_index) const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/103386. This bug also affected `AudioStreamSynchronized` and `AudioStreamInteractive`, so I updated them too.

Also, `AudioStreamPlaylist` and `AudioStreamSynchronized` will now update the inspector after calling `set_list_stream()`/`set_sync_stream()` from the editor (e.g. from a tool script) in order to display newly added streams, similar to how `AudioStreamInteractive` does it.