### PR TITLE
Improve `_gui_input` description

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -137,7 +137,7 @@
 			<return type="void" />
 			<param index="0" name="event" type="InputEvent" />
 			<description>
-				Virtual method to be implemented by the user. Override this method to handle and accept inputs on UI elements. See also [method accept_event].
+				Virtual method to be implemented by the user. Override this method to handle and accept inputs on UI elements. The [Control] node first calls the virtual function [method Control._gui_input], allowing you to manually handle the input event before it's processed internally. See also [method accept_event].
 				[b]Example:[/b] Click on the control to print a message:
 				[codeblocks]
 				[gdscript]


### PR DESCRIPTION
Salvages #96999
Closes #47322

I removed the `Note:` part. It should be reworded, but I wasn't sure how. What it's supposed to convey is that e.g. if you attach a script to SpinBox and call `accept_event()` on all InputEventMouse events, it will disable internal mouse handling. Maybe it's not that relevant, I'd add it once someone runs into this issue.