### PR TITLE
Fix shader compilation errors in Compatibility when using `depth_texture`

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1022,12 +1022,6 @@ uniform highp mat4 world_transform;
 uniform highp uint instance_offset;
 uniform highp uint model_flags;
 
-/* clang-format off */
-
-#GLOBALS
-
-/* clang-format on */
-
 #define LIGHT_BAKE_DISABLED 0u
 #define LIGHT_BAKE_STATIC 1u
 #define LIGHT_BAKE_DYNAMIC 2u
@@ -1267,6 +1261,12 @@ layout(location = 3) out vec4 emission_output_buffer;
 layout(location = 0) out vec4 frag_color;
 
 #endif // !RENDER_MATERIAL
+
+/* clang-format off */
+
+#GLOBALS
+
+/* clang-format on */
 
 vec3 F0(float metallic, float specular, vec3 albedo) {
 	float dielectric = 0.16 * specular * specular;


### PR DESCRIPTION
Globals were defined too early, which means some uniforms were not available at the point they were defined in.

I tested rendering on the MRP as well as many demo projects, and it works as expected.

- This closes https://github.com/godotengine/godot/issues/109553.
