### PR TITLE
Fix editor crash caused by `EditorFileSystem::get_singleton` access in theme initialization path

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -3442,7 +3442,7 @@ bool EditorFileSystem::_should_skip_directory(const String &p_path) {
 
 	if (FileAccess::exists(p_path.path_join("project.godot"))) {
 		// Skip if another project inside this.
-		if (EditorFileSystem::get_singleton()->first_scan) {
+		if (EditorFileSystem::get_singleton() == nullptr || EditorFileSystem::get_singleton()->first_scan) {
 			WARN_PRINT_ONCE(vformat("Detected another project.godot at %s. The folder will be ignored.", p_path));
 		}
 		return true;


### PR DESCRIPTION
Fixes #110238 ~, reverts #84797~

```
[0] EditorFileSystem::_should_skip_directory (C:\godot_source\editor\file_system\editor_file_system.cpp:3445)
[1] EditorFileSystem::_scan_new_dir (C:\godot_source\editor\file_system\editor_file_system.cpp:1155)
[2] EditorFileSystem::_load_first_scan_root_dir (C:\godot_source\editor\file_system\editor_file_system.cpp:248)
[3] EditorFileSystem::scan_for_uid (C:\godot_source\editor\file_system\editor_file_system.cpp:256)
[4] ResourceUID::get_id_path (C:\godot_source\core\io\resource_uid.cpp:195)
[5] ResourceLoader::_validate_local_path (C:\godot_source\core\io\resource_loader.cpp:508)
[6] ResourceLoader::_load_start (C:\godot_source\core\io\resource_loader.cpp:568)
[7] ResourceLoader::load (C:\godot_source\core\io\resource_loader.cpp:555)
[8] ThemeDB::initialize_theme (C:\godot_source\scene\theme\theme_db.cpp:65)
[9] Main::setup2 (C:\godot_source\main\main.cpp:3721)
```

Theme gets initialized in `Main::setup2` while `EditorFileSystem` singleton is created later as a child of `EditorNode` in `Main::start` - that's fine as all of the functions in the callstack are static and don't depend on `EditorFileSystem` singleton **except** `EditorFileSystem::_should_skip_directory` when there's `project.godot` present:
```cpp
if (FileAccess::exists(p_path.path_join("project.godot"))) {
  // Skip if another project inside this.
  if (EditorFileSystem::get_singleton()->first_scan) {
	  WARN_PRINT_ONCE(vformat("Detected another project.godot at %s. The folder will be ignored.", p_path));
  }
  return true;
}
```

~This reverts #84797 so maybe a better way would be to move `EditorFileSystem` out of `EditorNode` or to change initialization order.~