### PR TITLE
CI: Show doctool diffs inside submodules

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -252,7 +252,7 @@ jobs:
           echo "Running --doctool to see if this changes the public API without updating the documentation."
           echo -e "If a diff is shown, it means that your code/doc changes are incomplete and you should update the class reference with --doctool.\n\n"
           ${{ matrix.bin }} --doctool --headless 2>&1 > /dev/null || true
-          git diff --color --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
+          git diff --color --submodule=diff --ignore-submodules=none --exit-code && ! git ls-files --others --exclude-standard | sed -e 's/^/New doc file missing in PR: /' | grep 'xml$'
 
       # Check API backwards compatibility
       - name: Check for GDExtension compatibility – JSON check


### PR DESCRIPTION
In a similar vain to PR #89552, this does not directly alter the behavior for Godot itself, but it means that forks of Godot with submodules do not need to apply a patch to the CI scripts in order for the CI to build with the submodules. The Godot repo itself has no submodules, and therefore this does nothing, there are no downsides for us, but it benefits forks.

In master, doctool diffs in submodules show up like this:

<img width="1000" height="301" alt="Screenshot 2025-09-03 at 6 06 46 PM" src="https://github.com/user-attachments/assets/d47ff432-db5f-4c2c-b51a-d6d047f6d47e" />

Pretty useless, right? We have no clue what's actually wrong. With this PR, the diff shows up like this:

<img width="1200" height="501" alt="Screenshot 2025-09-03 at 6 18 51 PM" src="https://github.com/user-attachments/assets/0c8b5be8-d0a8-4e62-acd3-ac3d310493de" />

Disclaimer: ChatGPT suggested these arguments, I don't have a precise detailed understanding of them myself. But, hey, I've tested this and it works, and it appears straightforward, so I'm confident this is good.

This should be good to cherry-pick to past branches.
