### PR TITLE
Fix shader baker metal crash

### DIFF
--- a/drivers/metal/rendering_shader_container_metal.h
+++ b/drivers/metal/rendering_shader_container_metal.h
@@ -213,6 +213,7 @@ public:
 private:
 	const MetalDeviceProfile *device_profile = nullptr;
 	bool export_mode = false;
+	String min_os_version;
 
 	Vector<UniformData> mtl_reflection_binding_set_uniforms_data; // compliment to reflection_binding_set_uniforms_data
 	Vector<SpecializationData> mtl_reflection_specialization_data; // compliment to reflection_specialization_data
@@ -224,6 +225,7 @@ public:
 
 	void set_export_mode(bool p_export_mode) { export_mode = p_export_mode; }
 	void set_device_profile(const MetalDeviceProfile *p_device_profile) { device_profile = p_device_profile; }
+	void set_min_os_version(const String &p_min_os_version) { min_os_version = p_min_os_version; }
 
 	struct MetalShaderReflection {
 		Vector<Vector<UniformData>> uniform_sets;
@@ -253,6 +255,7 @@ protected:
 
 class RenderingShaderContainerFormatMetal : public RenderingShaderContainerFormat {
 	bool export_mode = false;
+	String min_os_version;
 
 	const MetalDeviceProfile *device_profile = nullptr;
 
@@ -260,6 +263,7 @@ public:
 	virtual Ref<RenderingShaderContainer> create_container() const override;
 	virtual ShaderLanguageVersion get_shader_language_version() const override;
 	virtual ShaderSpirvVersion get_shader_spirv_version() const override;
-	RenderingShaderContainerFormatMetal(const MetalDeviceProfile *p_device_profile, bool p_export = false);
+	virtual String get_customization_configuration_info() const override;
+	RenderingShaderContainerFormatMetal(const MetalDeviceProfile *p_device_profile, bool p_export = false, const String &p_min_os_version = "");
 	virtual ~RenderingShaderContainerFormatMetal() = default;
 };

--- a/editor/export/shader_baker_export_plugin.cpp
+++ b/editor/export/shader_baker_export_plugin.cpp
@@ -54,7 +54,7 @@ bool ShaderBakerExportPlugin::_is_active(const Vector<String> &p_features) const
 	return RendererSceneRenderRD::get_singleton() != nullptr && RendererRD::MaterialStorage::get_singleton() != nullptr && p_features.has("shader_baker");
 }
 
-bool ShaderBakerExportPlugin::_initialize_container_format(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) {
+bool ShaderBakerExportPlugin::_initialize_container_format(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features, const Ref<EditorExportPreset> &p_preset) {
 	Variant driver_variant = GLOBAL_GET("rendering/rendering_device/driver." + p_platform->get_os_name().to_lower());
 	if (!driver_variant.is_string()) {
 		driver_variant = GLOBAL_GET("rendering/rendering_device/driver");
@@ -67,7 +67,7 @@ bool ShaderBakerExportPlugin::_initialize_container_format(const Ref<EditorExpor
 
 	for (Ref<ShaderBakerExportPluginPlatform> platform : platforms) {
 		if (platform->matches_driver(shader_container_driver)) {
-			shader_container_format = platform->create_shader_container_format(p_platform);
+			shader_container_format = platform->create_shader_container_format(p_platform, get_export_preset());
 			ERR_FAIL_NULL_V_MSG(shader_container_format, false, "Unable to create shader container format for the export platform.");
 			return true;
 		}
@@ -99,7 +99,7 @@ bool ShaderBakerExportPlugin::_begin_customize_resources(const Ref<EditorExportP
 		return false;
 	}
 
-	if (!_initialize_container_format(p_platform, p_features)) {
+	if (!_initialize_container_format(p_platform, p_features, get_export_preset())) {
 		return false;
 	}
 
@@ -121,6 +121,7 @@ bool ShaderBakerExportPlugin::_begin_customize_resources(const Ref<EditorExportP
 	to_hash.append(GODOT_VERSION_HASH);
 	to_hash.append("[Renderer]");
 	to_hash.append(shader_cache_renderer_name);
+	to_hash.append(shader_container_format->get_customization_configuration_info());
 	customization_configuration_hash = to_hash.as_string().hash64();
 
 	BitField<RenderingShaderLibrary::FeatureBits> renderer_features = {};

--- a/editor/export/shader_baker_export_plugin.h
+++ b/editor/export/shader_baker_export_plugin.h
@@ -38,7 +38,7 @@ class ShaderBakerExportPluginPlatform : public RefCounted {
 	GDCLASS(ShaderBakerExportPluginPlatform, RefCounted);
 
 public:
-	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) = 0;
+	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) = 0;
 	virtual bool matches_driver(const String &p_driver) = 0;
 	virtual ~ShaderBakerExportPluginPlatform() {}
 };
@@ -82,7 +82,7 @@ protected:
 
 	virtual String get_name() const override;
 	virtual bool _is_active(const Vector<String> &p_features) const;
-	virtual bool _initialize_container_format(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features);
+	virtual bool _initialize_container_format(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features, const Ref<EditorExportPreset> &p_preset);
 	virtual void _cleanup_container_format();
 	virtual bool _initialize_cache_directory();
 	virtual bool _begin_customize_resources(const Ref<EditorExportPlatform> &p_platform, const Vector<String> &p_features) override;

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.cpp
@@ -34,7 +34,7 @@
 
 #include <windows.h>
 
-RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformD3D12::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) {
+RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformD3D12::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) {
 	if (lib_d3d12 == nullptr) {
 		lib_d3d12 = LoadLibraryW(L"D3D12.dll");
 		ERR_FAIL_NULL_V_MSG(lib_d3d12, nullptr, "Unable to load D3D12.dll.");

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.h
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_d3d12.h
@@ -39,7 +39,7 @@ private:
 	void *lib_d3d12 = nullptr;
 
 public:
-	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) override;
+	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) override;
 	virtual bool matches_driver(const String &p_driver) override;
 	virtual ~ShaderBakerExportPluginPlatformD3D12() override;
 };

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.cpp
@@ -32,18 +32,22 @@
 
 #include "drivers/metal/rendering_shader_container_metal.h"
 
-RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformMetal::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) {
+RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformMetal::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) {
 	const String &os_name = p_platform->get_os_name();
 	const MetalDeviceProfile *profile;
+	String min_os_version;
 
 	if (os_name == U"macOS") {
 		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::macOS, MetalDeviceProfile::GPU::Apple7);
+		// Godot metal doesn't support x86_64 mac so no need to worry about that version
+		min_os_version = p_preset->get("application/min_macos_version_arm64");
 	} else if (os_name == U"iOS") {
 		profile = MetalDeviceProfile::get_profile(MetalDeviceProfile::Platform::iOS, MetalDeviceProfile::GPU::Apple7);
+		min_os_version = p_preset->get("application/min_ios_version");
 	} else {
 		ERR_FAIL_V_MSG(nullptr, vformat("Unsupported platform: %s", os_name));
 	}
-	return memnew(RenderingShaderContainerFormatMetal(profile, true));
+	return memnew(RenderingShaderContainerFormatMetal(profile, true, min_os_version));
 }
 
 bool ShaderBakerExportPluginPlatformMetal::matches_driver(const String &p_driver) {

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.h
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.h
@@ -34,6 +34,6 @@
 
 class ShaderBakerExportPluginPlatformMetal : public ShaderBakerExportPluginPlatform {
 public:
-	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) override;
+	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) override;
 	virtual bool matches_driver(const String &p_driver) override;
 };

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.cpp
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.cpp
@@ -32,7 +32,7 @@
 
 #include "drivers/vulkan/rendering_shader_container_vulkan.h"
 
-RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformVulkan::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) {
+RenderingShaderContainerFormat *ShaderBakerExportPluginPlatformVulkan::create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) {
 	return memnew(RenderingShaderContainerFormatVulkan);
 }
 

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.h
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_vulkan.h
@@ -36,6 +36,6 @@ class ShaderBakerExportPluginPlatformVulkan : public ShaderBakerExportPluginPlat
 	GDCLASS(ShaderBakerExportPluginPlatformVulkan, ShaderBakerExportPluginPlatform);
 
 public:
-	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform) override;
+	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) override;
 	virtual bool matches_driver(const String &p_driver) override;
 };

--- a/servers/rendering/rendering_shader_container.h
+++ b/servers/rendering/rendering_shader_container.h
@@ -154,4 +154,5 @@ public:
 	virtual Ref<RenderingShaderContainer> create_container() const = 0;
 	virtual ShaderLanguageVersion get_shader_language_version() const = 0;
 	virtual ShaderSpirvVersion get_shader_spirv_version() const = 0;
+	virtual String get_customization_configuration_info() const { return ""; }
 };


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/109846

This passes the ``ExportPreset`` to the shader baker so that the it can take into account the export settings when compiling the shaders.  For this particular PR, it passes ``-mios-version-min=`` and ``-mmacosx-version-min=`` to ``xcrun``.  ``xcrun`` is fortunately smart enough to know which version of metal to compile the shaders against when we pass it ``application/min_macos_version_arm64`` and ``application/min_ios_version`` from the export preset.