### PR TITLE
Image: Make `fill` method also fill the mipmaps

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -3071,13 +3071,13 @@ void Image::fill(const Color &p_color) {
 	ERR_FAIL_COND_MSG(is_compressed(), "Cannot fill in compressed image formats.");
 
 	uint8_t *dst_data_ptr = data.ptrw();
-
 	int pixel_size = get_format_pixel_size(format);
+	int64_t pixel_count = data.size() / pixel_size;
 
 	// Put first pixel with the format-aware API.
 	_set_color_at_ofs(dst_data_ptr, 0, p_color);
 
-	_repeat_pixel_over_subsequent_memory(dst_data_ptr, pixel_size, width * height);
+	_repeat_pixel_over_subsequent_memory(dst_data_ptr, pixel_size, pixel_count);
 }
 
 void Image::fill_rect(const Rect2i &p_rect, const Color &p_color) {

--- a/tests/core/io/test_image.h
+++ b/tests/core/io/test_image.h
@@ -267,11 +267,15 @@ TEST_CASE("[Image] Modifying pixels of an image") {
 
 	// Fill image with color
 	image2->fill(Color(0.5, 0.5, 0.5, 0.5));
-	for (int y = 0; y < image2->get_height(); y++) {
-		for (int x = 0; x < image2->get_width(); x++) {
-			CHECK_MESSAGE(
-					image2->get_pixel(x, y).r > 0.49,
-					"fill() should colorize all pixels of the image.");
+	for (int m = 0; m < image2->get_mipmap_count(); m++) {
+		Ref<Image> mip_image = image2->get_image_from_mipmap(m);
+
+		for (int y = 0; y < mip_image->get_height(); y++) {
+			for (int x = 0; x < mip_image->get_width(); x++) {
+				CHECK_MESSAGE(
+						mip_image->get_pixel(x, y).r > 0.49,
+						"fill() should colorize all pixels of the image.");
+			}
 		}
 	}
 


### PR DESCRIPTION
Makes the `fill` method also fill the mipmaps of an image. Changes the unit test to account for this case.