### PR TITLE
Fix `CompositorEffect` not setting post-transparent callback on init

### DIFF
--- a/scene/resources/compositor.cpp
+++ b/scene/resources/compositor.cpp
@@ -186,7 +186,7 @@ CompositorEffect::CompositorEffect() {
 	RenderingServer *rs = RenderingServer::get_singleton();
 	if (rs != nullptr) {
 		rid = rs->compositor_effect_create();
-		rs->compositor_effect_set_callback(rid, RenderingServer::CompositorEffectCallbackType(effect_callback_type), Callable(this, "_render_callback"));
+		rs->compositor_effect_set_callback(rid, RenderingServer::CompositorEffectCallbackType(effect_callback_type), callable_mp(this, &CompositorEffect::_call_render_callback));
 	}
 }
 


### PR DESCRIPTION
If `CompositorEffect` is written in gdextension and If callback type is the default `EFFECT_CALLBACK_TYPE_POST_TRANSPARENT`, `CompositorEffect` won't execute the callback unless setting the callback type to the other and then setting it back.

Edit: Tested this issue doesn't happend in gdscript.

`Callable(this, "_render_callback")` is incorrect because `_render_callback` is a virtual method for scripts, not a real method.
