### PR TITLE
Properly inspect old remote selection

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -404,7 +404,8 @@ void EditorDebuggerNode::_notification(int p_what) {
 
 				EditorRunBar::get_singleton()->get_pause_button()->set_disabled(false);
 				// Switch to remote tree view if so desired.
-				auto_switch_remote_scene_tree = (bool)EDITOR_GET("debugger/auto_switch_to_remote_scene_tree");
+				remote_scene_tree->set_new_session();
+				auto_switch_remote_scene_tree = EDITOR_GET("debugger/auto_switch_to_remote_scene_tree");
 				if (auto_switch_remote_scene_tree) {
 					SceneTreeDock::get_singleton()->show_remote_tree();
 				}

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -374,6 +374,16 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		scroll_to_item(scroll_item, false);
 	}
 
+	if (new_session) {
+		// Some nodes may stay selected between sessions.
+		// Make sure the inspector shows them properly.
+		if (!notify_selection_queued) {
+			callable_mp(this, &EditorDebuggerTree::_notify_selection_changed).call_deferred();
+			notify_selection_queued = true;
+		}
+		new_session = false;
+	}
+
 	last_filter = filter;
 	updating_scene_tree = false;
 }

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -60,6 +60,7 @@ private:
 
 	TypedArray<uint64_t> inspected_object_ids;
 	int debugger_id = 0;
+	bool new_session = false;
 	bool updating_scene_tree = false;
 	bool scrolling_to_item = false;
 	bool notify_selection_queued = false;
@@ -91,6 +92,7 @@ public:
 
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 
+	void set_new_session() { new_session = true; }
 	void update_icon_max_width();
 	String get_selected_path();
 	ObjectID get_selected_object();


### PR DESCRIPTION
Fixes #33894

The bug basically boils down to remote tree preserving selection between sessions when node structure happens to match. It's sometimes useful, so I made it work properly instead of removing this behavior.