### PR TITLE
Add name info to EditorAutoloadSettings invalid name message

### DIFF
--- a/editor/settings/editor_autoload_settings.cpp
+++ b/editor/settings/editor_autoload_settings.cpp
@@ -95,7 +95,7 @@ void EditorAutoloadSettings::_notification(int p_what) {
 bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, String *r_error) {
 	if (!p_name.is_valid_unicode_identifier()) {
 		if (r_error) {
-			*r_error = TTR("Invalid name.") + " " + TTR("Must be a valid Unicode identifier.");
+			*r_error = TTR("Must be a valid Unicode identifier.");
 		}
 
 		return false;
@@ -103,7 +103,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 
 	if (ClassDB::class_exists(p_name)) {
 		if (r_error) {
-			*r_error = TTR("Invalid name.") + " " + TTR("Must not collide with an existing engine class name.");
+			*r_error = TTR("Must not collide with an existing engine class name.");
 		}
 
 		return false;
@@ -111,7 +111,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 
 	if (ScriptServer::is_global_class(p_name)) {
 		if (r_error) {
-			*r_error = TTR("Invalid name.") + "\n" + TTR("Must not collide with an existing global script class name.");
+			*r_error = TTR("Must not collide with an existing global script class name.");
 		}
 
 		return false;
@@ -119,7 +119,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 
 	if (Variant::get_type_by_name(p_name) < Variant::VARIANT_MAX) {
 		if (r_error) {
-			*r_error = TTR("Invalid name.") + " " + TTR("Must not collide with an existing built-in type name.");
+			*r_error = TTR("Must not collide with an existing built-in type name.");
 		}
 
 		return false;
@@ -128,7 +128,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 	for (int i = 0; i < CoreConstants::get_global_constant_count(); i++) {
 		if (CoreConstants::get_global_constant_name(i) == p_name) {
 			if (r_error) {
-				*r_error = TTR("Invalid name.") + " " + TTR("Must not collide with an existing global constant name.");
+				*r_error = TTR("Must not collide with an existing global constant name.");
 			}
 
 			return false;
@@ -139,7 +139,7 @@ bool EditorAutoloadSettings::_autoload_name_is_valid(const String &p_name, Strin
 		for (const String &keyword : ScriptServer::get_language(i)->get_reserved_words()) {
 			if (keyword == p_name) {
 				if (r_error) {
-					*r_error = TTR("Invalid name.") + " " + TTR("Keyword cannot be used as an Autoload name.");
+					*r_error = TTR("Keyword cannot be used as an Autoload name.");
 				}
 
 				return false;
@@ -780,7 +780,7 @@ bool EditorAutoloadSettings::autoload_add(const String &p_name, const String &p_
 
 	String error;
 	if (!_autoload_name_is_valid(name, &error)) {
-		EditorNode::get_singleton()->show_warning(TTR("Can't add Autoload:") + "\n" + error);
+		EditorNode::get_singleton()->show_warning(TTR("Can't add Autoload:") + "\n" + vformat(TTR("%s is an invalid name."), p_name) + " " + error);
 		return false;
 	}
 


### PR DESCRIPTION
Possibly closes #110258.

Adding direct info about which name caused the error makes sense. Not right after the colon as suggested in the issue since there might be different reasons for Autoload fail. Adding this inside invalid name error seems like a good place, since other cases already include more information:

```cpp
String error;
if (!_autoload_name_is_valid(name, &error)) {
  EditorNode::get_singleton()->show_warning(TTR("Can't add Autoload:") + "\n" + error);
  return false;
}

if (!FileAccess::exists(p_path)) {
  EditorNode::get_singleton()->show_warning(TTR("Can't add Autoload:") + "\n" + vformat(TTR("%s is an invalid path. File does not exist."), p_path));
  return false;
}

if (!p_path.begins_with("res://")) {
  EditorNode::get_singleton()->show_warning(TTR("Can't add Autoload:") + "\n" + vformat(TTR("%s is an invalid path. Not in resource path (res://)."), p_path));
  return false;
}
```

Before:
<img width="520" height="190" alt="obraz" src="https://github.com/user-attachments/assets/7a2e9c69-05e1-401c-9542-98ee08886ef2" />
After:
<img width="535" height="211" alt="obraz" src="https://github.com/user-attachments/assets/90cfd61e-cd82-4c7f-b8f3-305f4191d4d1" />
