### PR TITLE
Fix the issue preventing installing C# binaries on Android devices with api <= 29

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -388,7 +388,13 @@ ext.shouldUseLegacyPackaging = { ->
         return Boolean.parseBoolean(legacyPackagingFlag)
     }
 
-    // Default behavior for minSdk >= 24
+    if (getExportMinSdkVersion() <= 29) {
+        // Use legacy packaging for compatibility with device running api <= 29.
+        // See https://github.com/godotengine/godot/issues/108842 for reference.
+        return true
+    }
+
+    // Default behavior for minSdk > 29.
     return false
 }
 


### PR DESCRIPTION
From my investigations, it seems that Android devices with api level 29 (Android 10) or lower have issues with installing Godot C# binaries when the export template's native libraries are not compressed.

The fix thus is to enable `useLegacyPackaging` for exports where the min SDK is 29 or lower.

Fixes https://github.com/godotengine/godot/issues/108842
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
