### PR TITLE
[PopupMenu] Add set item font to PopupMenu

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -244,6 +244,13 @@
 				Returns the auto translate mode of the item at the given [param index].
 			</description>
 		</method>
+		<method name="get_item_font" qualifiers="const">
+			<return type="Font" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Gets the [Font] of the item at the given [param index], or returns [code]null[/code] if the font has not been set.
+			</description>
+		</method>
 		<method name="get_item_icon" qualifiers="const">
 			<return type="Texture2D" />
 			<param index="0" name="index" type="int" />
@@ -492,6 +499,15 @@
 			<param index="1" name="disabled" type="bool" />
 			<description>
 				Enables/disables the item at the given [param index]. When it is disabled, it can't be selected and its action can't be invoked.
+			</description>
+		</method>
+		<method name="set_item_font">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="font" type="Font" />
+			<description>
+				Sets the [Font] of the item at the given [param index]. To clear the font setting, set the font to [code]null[/code].
+				[b]Note:[/b] Loading fonts can consume a lot of memory, and will continue taking up memory until the [PopupMenu] is freed. To minimize memory use, try setting fonts at [signal Window.about_to_popup], and reset them to [code]null[/code] at [signal Popup.popup_hide].
 			</description>
 		</method>
 		<method name="set_item_icon">

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1003,7 +1003,7 @@ void PopupMenu::_shape_item(int p_idx) const {
 	if (items.write[p_idx].dirty) {
 		items.write[p_idx].text_buf->clear();
 
-		Ref<Font> font = items[p_idx].separator ? theme_cache.font_separator : theme_cache.font;
+		Ref<Font> font = items[p_idx].separator ? theme_cache.font_separator : (items[p_idx].font.is_null() ? theme_cache.font : items[p_idx].font);
 		int font_size = items[p_idx].separator ? theme_cache.font_separator_size : theme_cache.font_size;
 
 		if (items[p_idx].text_direction == Control::TEXT_DIRECTION_INHERITED) {
@@ -1864,6 +1864,24 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 	_menu_changed();
 }
 
+void PopupMenu::set_item_font(int p_idx, const Ref<Font> &p_font) {
+	if (p_idx < 0) {
+		p_idx += get_item_count();
+	}
+	ERR_FAIL_INDEX(p_idx, items.size());
+	if (items[p_idx].font == p_font) {
+		return;
+	}
+
+	items.write[p_idx].font = p_font;
+	items.write[p_idx].dirty = true;
+
+	_shape_item(p_idx);
+	control->queue_redraw();
+	child_controls_changed();
+	_menu_changed();
+}
+
 void PopupMenu::set_item_text_direction(int p_idx, Control::TextDirection p_text_direction) {
 	if (p_idx < 0) {
 		p_idx += get_item_count();
@@ -2173,6 +2191,11 @@ int PopupMenu::get_item_idx_from_text(const String &text) const {
 	}
 
 	return -1;
+}
+
+Ref<Font> PopupMenu::get_item_font(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, items.size(), Ref<Font>());
+	return items[p_idx].font;
 }
 
 Ref<Texture2D> PopupMenu::get_item_icon(int p_idx) const {
@@ -3023,6 +3046,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_multistate", "index", "state"), &PopupMenu::set_item_multistate);
 	ClassDB::bind_method(D_METHOD("set_item_multistate_max", "index", "max_states"), &PopupMenu::set_item_max_states);
 	ClassDB::bind_method(D_METHOD("set_item_shortcut_disabled", "index", "disabled"), &PopupMenu::set_item_shortcut_disabled);
+	ClassDB::bind_method(D_METHOD("set_item_font", "index", "font"), &PopupMenu::set_item_font);
 
 	ClassDB::bind_method(D_METHOD("toggle_item_checked", "index"), &PopupMenu::toggle_item_checked);
 	ClassDB::bind_method(D_METHOD("toggle_item_multistate", "index"), &PopupMenu::toggle_item_multistate);
@@ -3049,6 +3073,7 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_tooltip", "index"), &PopupMenu::get_item_tooltip);
 	ClassDB::bind_method(D_METHOD("get_item_shortcut", "index"), &PopupMenu::get_item_shortcut);
 	ClassDB::bind_method(D_METHOD("get_item_indent", "index"), &PopupMenu::get_item_indent);
+	ClassDB::bind_method(D_METHOD("get_item_font", "index"), &PopupMenu::get_item_font);
 
 	ClassDB::bind_method(D_METHOD("get_item_multistate_max", "index"), &PopupMenu::get_item_max_states);
 	ClassDB::bind_method(D_METHOD("get_item_multistate", "index"), &PopupMenu::get_item_state);
@@ -3152,6 +3177,7 @@ void PopupMenu::_bind_methods() {
 	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &PopupMenu::set_item_id, &PopupMenu::get_item_id);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &PopupMenu::set_item_disabled, &PopupMenu::is_item_disabled);
 	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &PopupMenu::set_item_as_separator, &PopupMenu::is_item_separator);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "font", PROPERTY_HINT_RESOURCE_TYPE, "Font"), defaults.font, &PopupMenu::set_item_font, &PopupMenu::get_item_font);
 	PropertyListHelper::register_base_helper(&base_property_helper);
 }
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -50,6 +50,7 @@ class PopupMenu : public Popup {
 		Ref<Texture2D> icon;
 		int icon_max_width = 0;
 		Color icon_modulate = Color(1, 1, 1, 1);
+		Ref<Font> font;
 		String text;
 		String xl_text;
 		Ref<TextLine> text_buf;
@@ -310,11 +311,13 @@ public:
 	void set_item_indent(int p_idx, int p_indent);
 	void set_item_max_states(int p_idx, int p_max_states);
 	void set_item_multistate(int p_idx, int p_state);
+	void set_item_font(int p_idx, const Ref<Font> &p_font);
 	void toggle_item_multistate(int p_idx);
 	void set_item_shortcut_disabled(int p_idx, bool p_disabled);
 
 	void toggle_item_checked(int p_idx);
 
+	Ref<Font> get_item_font(int p_idx) const;
 	String get_item_text(int p_idx) const;
 	String get_item_xl_text(int p_idx) const;
 	Control::TextDirection get_item_text_direction(int p_idx) const;


### PR DESCRIPTION
Adds new methods `set_item_font()` and `get_item_font()` to `PopupMenu`.

Works seemlessly if the fonts are set at `about_to_popup` and set to `null` at `popup_hide`. The sample video is setting the fonts at `about_to_popup`. I included a note in the docs about high memory use if you were to set many popup items with different fonts and how to avoid it.


https://github.com/user-attachments/assets/27cef729-ff8a-48ca-8b77-a64b777f5ea9

