### PR TITLE
Defer checking for rendering device support until the new project dialog is opened

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -860,6 +860,23 @@ void ProjectDialog::show_dialog(bool p_reset_name) {
 			set_title(TTRC("Create New Project"));
 			set_ok_button_text(TTRC("Create"));
 
+			if (!rendering_device_checked) {
+				rendering_device_supported = DisplayServer::is_rendering_device_supported();
+
+				if (!rendering_device_supported) {
+					List<BaseButton *> buttons;
+					renderer_button_group->get_buttons(&buttons);
+					for (BaseButton *button : buttons) {
+						if (button->get_meta(SNAME("rendering_method")) == "gl_compatibility") {
+							button->set_pressed(true);
+							break;
+						}
+					}
+				}
+				_renderer_selected();
+				rendering_device_checked = true;
+			}
+
 			name_container->show();
 			install_path_container->hide();
 			renderer_container->show();
@@ -1042,12 +1059,6 @@ ProjectDialog::ProjectDialog() {
 		default_renderer_type = EditorSettings::get_singleton()->get_setting("project_manager/default_renderer");
 	}
 
-	rendering_device_supported = DisplayServer::is_rendering_device_supported();
-
-	if (!rendering_device_supported) {
-		default_renderer_type = "gl_compatibility";
-	}
-
 	Button *rs_button = memnew(CheckBox);
 	rs_button->set_button_group(renderer_button_group);
 	rs_button->set_text(TTRC("Forward+"));
@@ -1106,8 +1117,6 @@ ProjectDialog::ProjectDialog() {
 	rd_not_supported->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	rd_not_supported->set_visible(false);
 	renderer_container->add_child(rd_not_supported);
-
-	_renderer_selected();
 
 	l = memnew(Label);
 	l->set_focus_mode(Control::FOCUS_ACCESSIBILITY);

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -80,6 +80,7 @@ private:
 	HBoxContainer *default_files_container = nullptr;
 	Ref<ButtonGroup> renderer_button_group;
 	bool rendering_device_supported = false;
+	bool rendering_device_checked = false;
 	Label *rd_not_supported = nullptr;
 
 	Label *msg = nullptr;


### PR DESCRIPTION
This can save a lot of time opening the project manager and the information is only ever needed when creating a new project anyway

On my device, this saves between 0.7 seconds when opening the project manager for me. That's down to about 1.1 seconds from 1.8 seconds. For reference, Godot 3.5.3 opens in about 0.9 seconds for me, so this gets us nearly back to that startup time. 