### PR TITLE
Redraw shape controls when ColorPicker theme changes

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -129,6 +129,9 @@ void ColorPicker::_notification(int p_what) {
 				for (ColorPickerShape *shape : shapes) {
 					if (shape->is_initialized) {
 						shape->update_theme();
+						for (Control *c : shape->controls) {
+							c->queue_redraw();
+						}
 					}
 					shape_popup->set_item_icon(i, shape->get_icon());
 					i++;


### PR DESCRIPTION
ColorPicker doesn't redraw everything properly when setting theme overrides.

https://github.com/user-attachments/assets/faadb88e-99b3-4323-9275-44179a865973

