### PR TITLE
Fix "SpriteFrames" editor not fully hiding the bottom panel

### DIFF
--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -1611,7 +1611,6 @@ void SpriteFramesEditor::edit(Ref<SpriteFrames> p_frames) {
 	if (p_frames.is_null()) {
 		frames.unref();
 		_remove_sprite_node();
-		hide();
 		return;
 	}
 


### PR DESCRIPTION
Fixes #80756.

This was a funny one. First, let me explain how bottom panel hiding works:

When the editor thinks a bottom plugin should hide, it first tells the plugin to edit nothing (`nullptr`) and then tells it to hide with `PluginName->make_visible(false)`. That function doesn't hide the editor directly, instead calling `EditorNode::get_bottom_panel()->hide_bottom_panel()`, which will cycle through all visible bottom editors and hide them, **_and only if visible editors where found_** it would be able to hide the panel itself.

The PR #72783, back in 2023, made so that the "SpriteFrames" editor hid itself from the get go if made to edit nothing. You could think that this was the cause of the regression, but it wasn't, because at the time `make_visible()` was called **_before_** the editors were told to edit nothing. When was the ordered changed to the one we have now? In #104318, two years later, which funnily enough, already predicted that it could break certain plugins.

Finally, this PR makes so that the "SpriteFrames" editor doesn't hide itself when nothing is edit anymore. From my tests, it doesn't reintroduce the bug that the first PR fixed.