### PR TITLE
make_rst.py: Remove extra blank lines

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2477,6 +2477,10 @@ def format_text_block(
             state,
         )
 
+    # Remove extraneous empty lines.
+    pattern = re.compile(r"(?m)^\n+$")
+    text = pattern.sub("", text).removeprefix("\n").removesuffix("\n")
+
     return text
 
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
This removes most of the consecutive blank lines found in text blocks in RST files (sometimes 3 or 4 of them), and leaves a single one instead. The only place I've noticed to still have extra blank lines is after a deprecated/experimental note, like `Node`'s `NOTIFICATION_MOVED_IN_PARENT`. Code blocks are not modified.

This simply uses a regex in `format_text_block()` to remove consecutive blank lines, and removes one leading and trailing newline as well (the point being that 2 newlines are appended after a block anyway).