### PR TITLE
Fix uniforms break particle shaders after conversion from a `ParticleProcessMaterial` (reverted)

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -374,6 +374,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 				Variant default_value = RenderingServer::get_singleton()->shader_get_parameter_default(shader->get_rid(), pi.name);
 				param_cache.insert(pi.name, default_value);
 				remap_cache.insert(info.name, pi.name);
+				RS::get_singleton()->material_set_param(_get_material(), pi.name, default_value);
 			}
 			groups[last_group][last_subgroup].push_back(info);
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

This fixes #101456. 

The issue is that when a ShaderMaterial is changed and there is a variable with the same name but a different type, the value used when running the shader becomes null (or zero depending on the type) but in the inspector the default value for that variable is shown (which is expected). There is a more detailed explanation in the issue.

This one-line change fixes the issue, but I'm not exactly sure the ramifications it will cause, so let me know. 
