### PR TITLE
Enable objects stored as dictionary keys to be selected in inspector.

### DIFF
--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -1345,6 +1345,7 @@ void EditorPropertyDictionary::update_property() {
 					}
 					new_prop->set_read_only(true);
 					new_prop->set_selectable(false);
+					new_prop->connect(SNAME("object_id_selected"), callable_mp(this, &EditorPropertyDictionary::_object_id_selected));
 					new_prop->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
 					new_prop->set_draw_background(false);
 					new_prop->set_use_folding(is_using_folding());


### PR DESCRIPTION
Resolves #109873

Enable objects stored as dictionary keys to be selected in inspector. New behavior matches existing behavior for objects stored as dictionary values.