### PR TITLE
Don't display "File exists, it will be reused." message when loading is disabled in Shader/ScriptCreateDialog

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -626,7 +626,7 @@ void ScriptCreateDialog::_update_dialog() {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTR("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
 	}
 
-	if (validation_panel->is_valid() && !is_new_script_created) {
+	if (validation_panel->is_valid() && !is_new_script_created && load_enabled) {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTR("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
 	}
 
@@ -673,7 +673,7 @@ void ScriptCreateDialog::_update_dialog() {
 	parent_search_button->set_disabled(!is_new_file);
 	parent_browse_button->set_disabled(!is_new_file || !can_inherit_from_file);
 	template_inactive_message = "";
-	String button_text = is_new_file ? TTR("Create") : TTR("Load");
+	String button_text = (is_new_file || !load_enabled) ? TTR("Create") : TTR("Load");
 	set_ok_button_text(button_text);
 
 	if (is_new_file) {

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -500,7 +500,7 @@ void ShaderCreateDialog::_update_dialog() {
 	}
 	if (!is_built_in && !path_error.is_empty()) {
 		validation_panel->set_message(MSG_ID_PATH, path_error, EditorValidationPanel::MSG_ERROR);
-	} else if (validation_panel->is_valid() && !is_new_shader_created) {
+	} else if (validation_panel->is_valid() && !is_new_shader_created && load_enabled) {
 		validation_panel->set_message(MSG_ID_SHADER, TTR("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
 	}
 	if (!built_in_enabled) {


### PR DESCRIPTION
Currently, when you try to create a new script or a shader using the filesystem dock, the dialog will display two confusing messages if the file already exists:

<img width="486" height="416" alt="image" src="https://github.com/user-attachments/assets/fc4c8d20-3a4b-4d7c-b598-1657e57a6e84" />

This PR makes "File exists, it will be reused." message not appear if `load_enabled` is `false`. It also makes the OK button always say "Create" if loading is disabled (only in `ScriptCreateDialog`, shader dialog handles this correctly).