### PR TITLE
Don't send remote Resources as path

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -279,20 +279,6 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 		const PropertyInfo &pinfo = KV.value.prop.first;
 		Variant var = KV.value.values[remote_objects->remote_object_ids[0]];
 
-		if (pinfo.type == Variant::OBJECT && var.is_string()) {
-			String path = var;
-			if (path.contains("::")) {
-				// Built-in resource.
-				String base_path = path.get_slice("::", 0);
-				Ref<Resource> dependency = ResourceLoader::load(base_path);
-				if (dependency.is_valid()) {
-					remote_dependencies.insert(dependency);
-				}
-			}
-			var = ResourceLoader::load(path);
-			KV.value.values[remote_objects->remote_object_ids[0]] = var;
-		}
-
 		// Always add the property, since props may have been added or removed.
 		remote_objects->prop_list.push_back(pinfo);
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -834,16 +834,13 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 		Array prop = { pi.name, pi.type };
 		PropertyHint hint = pi.hint;
 		String hint_string = pi.hint_string;
-		if (res.is_valid() && !res->get_path().is_empty()) {
-			var = res->get_path();
-		} else { //only send information that can be sent..
-			int len = 0; //test how big is this to encode
-			encode_variant(var, nullptr, len);
-			if (len > p_max_size) { //limit to max size
-				hint = PROPERTY_HINT_OBJECT_TOO_BIG;
-				hint_string = "";
-				var = Variant();
-			}
+		// Only send information that can be sent.
+		int len = 0; // Test how big is this to encode.
+		encode_variant(var, nullptr, len);
+		if (len > p_max_size) { // Limit to max size.
+			hint = PROPERTY_HINT_OBJECT_TOO_BIG;
+			hint_string = "";
+			var = Variant();
 		}
 		prop.push_back(hint);
 		prop.push_back(hint_string);


### PR DESCRIPTION
Scene debugger was serializing Resources as path, unlike other objects. In remote inspector they were deserialized as a local copy of the resource, instead of the remote one. I don't know what was the purpose of this code, it looks like it assumed that if a Resource has path then its remote instance will be the same as the one stored on disk, but that's not true.

Fixes #47237

A side-effect is that resources in remote inspector can no longer be unfolded, they always open in new inspector.

https://github.com/user-attachments/assets/69f84336-2b3e-41fb-8587-e5be471bfcc3

This can be fixed in a follow-up, but if it's not acceptable, I can try to come up with something for this PR.