### PR TITLE
Change our vertex tangent to read in as float on MeshDataTool to avoid crashes

### DIFF
--- a/scene/resources/mesh_data_tool.cpp
+++ b/scene/resources/mesh_data_tool.cpp
@@ -84,9 +84,9 @@ Error MeshDataTool::create_from_surface(const Ref<ArrayMesh> &p_mesh, int p_surf
 		nr = arrays[Mesh::ARRAY_NORMAL].operator Vector<Vector3>().ptr();
 	}
 
-	const real_t *ta = nullptr;
+	const float *ta = nullptr;
 	if (arrays[Mesh::ARRAY_TANGENT].get_type() != Variant::NIL) {
-		ta = arrays[Mesh::ARRAY_TANGENT].operator Vector<real_t>().ptr();
+		ta = arrays[Mesh::ARRAY_TANGENT].operator Vector<float>().ptr();
 	}
 
 	const Vector2 *uv = nullptr;


### PR DESCRIPTION
Fixes: #110279

While the RenderingServer does have support for PACKED_FLOAT64_ARRAY, this matches how we read vertex weights in the MeshDataTool, which has the same consideration and was changed to float in the original `precision=double` [commit](https://github.com/godotengine/godot/commit/430ad75#diff-4198ccea029f3c9868be7d446b23724747e9f9624a3fcb5576203bc21b305303)
