### PR TITLE
Fix vertical alignment of Inspector category titles

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1678,9 +1678,18 @@ void EditorInspectorCategory::_notification(int p_what) {
 			if (is_layout_rtl()) {
 				ofs = get_size().width - ofs - w;
 			}
-			float text_pos_y = font->get_ascent(font_size) + (get_size().height - font->get_height(font_size)) / 2 + v_margin_offset;
+
+			// Use TextLine so we have access to accurate font metrics. This way,
+			// we can ensure the line is vertically centered regardless of the font used
+			// or its size.
+			Ref<TextLine> tl;
+			tl.instantiate();
+			tl->add_string(label, font, font_size);
+			tl->set_width(w);
+			tl->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_LEFT);
+			float text_pos_y = (get_size().height - tl->get_size().height) / 2 + v_margin_offset;
 			Point2 text_pos = Point2(ofs, text_pos_y).round();
-			draw_string(font, text_pos, label, HORIZONTAL_ALIGNMENT_LEFT, w, font_size, theme_cache.font_color);
+			tl->draw(get_canvas_item(), text_pos, theme_cache.font_color);
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110302

Before:
<img width="114" height="40" alt="Godot_v4 5-beta7_mono_win64_pCvQXk6NKg" src="https://github.com/user-attachments/assets/79bf3d62-3539-447b-8b9f-b92203fd93d3" />

After:
<img width="100" height="44" alt="godot windows editor x86_64_HFoWMlcpEI" src="https://github.com/user-attachments/assets/8f3a93a4-6e6a-4f7c-8dbe-8ca7b1f7bd3e" />
