### PR TITLE
Improve dependency editor warning

### DIFF
--- a/editor/file_system/dependency_editor.h
+++ b/editor/file_system/dependency_editor.h
@@ -43,6 +43,7 @@ class DependencyEditor : public AcceptDialog {
 
 	Tree *tree = nullptr;
 	Button *fixdeps = nullptr;
+	Label *warning_label = nullptr;
 
 	EditorFileDialog *search = nullptr;
 
@@ -58,6 +59,9 @@ class DependencyEditor : public AcceptDialog {
 	void _update_list();
 
 	void _update_file();
+
+protected:
+	void _notification(int p_what);
 
 public:
 	void edit(const String &p_path);


### PR DESCRIPTION
Replaces the annoying warning dialog with a label:
<img width="770" height="501" alt="image" src="https://github.com/user-attachments/assets/ebf24f19-5d6d-431e-9c4a-b3a7fd2772ce" />
