### PR TITLE
Use `language` command line argument to override editor locale.

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -50,6 +50,7 @@
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/project_manager/engine_update_label.h"
 #include "editor/translations/editor_translation.h"
+#include "main/main.h"
 #include "modules/regex/regex.h"
 #include "scene/gui/color_picker.h"
 #include "scene/main/node.h"
@@ -79,7 +80,7 @@ bool EditorSettings::_set(const StringName &p_name, const Variant &p_value) {
 		emit_signal(SNAME("settings_changed"));
 
 		if (p_name == SNAME("interface/editor/editor_language")) {
-			setup_language();
+			setup_language(false);
 		}
 	}
 	return true;
@@ -1289,7 +1290,7 @@ void EditorSettings::create() {
 
 		print_verbose("EditorSettings: Load OK!");
 
-		singleton->setup_language();
+		singleton->setup_language(true);
 		singleton->setup_network();
 		singleton->load_favorites_and_recent_dirs();
 		singleton->update_text_editor_themes_list();
@@ -1316,13 +1317,19 @@ fail:
 	singleton->set_path(config_file_path, true);
 	singleton->save_changed_setting = true;
 	singleton->_load_defaults(extra_config);
-	singleton->setup_language();
+	singleton->setup_language(true);
 	singleton->setup_network();
 	singleton->update_text_editor_themes_list();
 }
 
-void EditorSettings::setup_language() {
+void EditorSettings::setup_language(bool p_initial_setup) {
 	String lang = _EDITOR_GET("interface/editor/editor_language");
+	if (p_initial_setup) {
+		String lang_ov = Main::get_locale_override();
+		if (!lang_ov.is_empty()) {
+			lang = lang_ov;
+		}
+	}
 
 	if (lang == "en") {
 		TranslationServer::get_singleton()->set_locale(lang);

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -138,7 +138,7 @@ public:
 	static String get_newest_settings_path();
 
 	static void create();
-	void setup_language();
+	void setup_language(bool p_initial_setup);
 	void setup_network();
 	static void save();
 	static void destroy();

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1094,7 +1094,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				arg == "--display-driver" ||
 				arg == "--rendering-method" ||
 				arg == "--rendering-driver" ||
-				arg == "--xr-mode") {
+				arg == "--xr-mode" ||
+				arg == "-l" ||
+				arg == "--language") {
 			if (N) {
 				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(arg);
 				forwardable_cli_arguments[CLI_SCOPE_TOOL].push_back(N->get());
@@ -3840,6 +3842,10 @@ void Main::setup_boot_logo() {
 
 String Main::get_rendering_driver_name() {
 	return rendering_driver;
+}
+
+String Main::get_locale_override() {
+	return locale;
 }
 
 // everything the main loop needs to know about frame timings

--- a/main/main.h
+++ b/main/main.h
@@ -71,6 +71,7 @@ public:
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
 	static Error setup2(bool p_show_boot_logo = true); // The thread calling setup2() will effectively become the main thread.
 	static String get_rendering_driver_name();
+	static String get_locale_override();
 	static void setup_boot_logo();
 #ifdef TESTS_ENABLED
 	static Error test_setup();


### PR DESCRIPTION
`language` argument was used for running projects, but was completely ignored by editor/pm. Argument is only applied during initial load and is not used when changing locale from the editor settings.

Fixes https://github.com/godotengine/godot/issues/110273