### PR TITLE
Improve tile source tooltips

### DIFF
--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -183,6 +183,7 @@ void TileMapLayerEditorTilesPlugin::_update_tile_set_sources_list() {
 	}
 	sources_list->set_meta("old_source", old_source);
 	sources_list->clear();
+	sources_list->tile_set = Ref<TileSet>();
 
 	TileMapLayer *edited_layer = _get_edited_layer();
 	if (!edited_layer) {
@@ -193,6 +194,7 @@ void TileMapLayerEditorTilesPlugin::_update_tile_set_sources_list() {
 	if (tile_set.is_null()) {
 		return;
 	}
+	sources_list->tile_set = tile_set;
 
 	if (!tile_set->has_source(old_source)) {
 		old_source = -1;
@@ -2380,20 +2382,11 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 	p->set_item_checked(TilesEditorUtils::SOURCE_SORT_ID, true);
 	sources_bottom_actions->add_child(source_sort_button);
 
-	sources_list = memnew(ItemList);
-	sources_list->set_auto_translate_mode(Node::AUTO_TRANSLATE_MODE_DISABLED);
-	sources_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
-	sources_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	sources_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	sources_list->set_stretch_ratio(0.25);
-	sources_list->set_custom_minimum_size(Size2(70, 0) * EDSCALE);
-	sources_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
-	sources_list->set_theme_type_variation("ItemListSecondary");
+	sources_list = memnew(TileSetSourceItemList);
 	sources_list->connect(SceneStringName(item_selected), callable_mp(this, &TileMapLayerEditorTilesPlugin::_update_source_display).unbind(1));
 	sources_list->connect(SceneStringName(item_selected), callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::set_sources_lists_current));
 	sources_list->connect("item_activated", callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::display_tile_set_editor_panel).unbind(1));
 	sources_list->connect(SceneStringName(visibility_changed), callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::synchronize_sources_list).bind(sources_list, source_sort_button));
-	sources_list->add_user_signal(MethodInfo("sort_request"));
 	sources_list->connect("sort_request", callable_mp(this, &TileMapLayerEditorTilesPlugin::_update_tile_set_sources_list));
 	split_container_left_side->add_child(sources_list);
 	split_container_left_side->add_child(sources_bottom_actions);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -47,6 +47,7 @@
 
 class TileMapLayer;
 class TileMapLayerEditor;
+class TileSetSourceItemList;
 
 class TileMapLayerSubEditorPlugin : public Object {
 protected:
@@ -176,7 +177,7 @@ private:
 	Label *missing_source_label = nullptr;
 	Label *invalid_source_label = nullptr;
 
-	ItemList *sources_list = nullptr;
+	TileSetSourceItemList *sources_list = nullptr;
 	MenuButton *source_sort_button = nullptr;
 
 	Ref<Texture2D> missing_atlas_texture_icon;

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -728,6 +728,7 @@ void TileSetEditor::edit(Ref<TileSet> p_tile_set) {
 
 	// Change the edited object.
 	tile_set = p_tile_set;
+	sources_list->tile_set = p_tile_set;
 
 	// Read-only status is false by default
 	read_only = new_read_only_state;
@@ -855,18 +856,11 @@ TileSetEditor::TileSetEditor() {
 	p->add_radio_check_item(TTR("Sort by Name (Descending)"), TilesEditorUtils::SOURCE_SORT_NAME_REVERSE);
 	p->set_item_checked(TilesEditorUtils::SOURCE_SORT_ID, true);
 
-	sources_list = memnew(ItemList);
-	sources_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	sources_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
-	sources_list->set_h_size_flags(SIZE_EXPAND_FILL);
-	sources_list->set_v_size_flags(SIZE_EXPAND_FILL);
-	sources_list->set_theme_type_variation("ItemListSecondary");
+	sources_list = memnew(TileSetSourceItemList);
 	sources_list->connect(SceneStringName(item_selected), callable_mp(this, &TileSetEditor::_source_selected));
 	sources_list->connect(SceneStringName(item_selected), callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::set_sources_lists_current));
 	sources_list->connect(SceneStringName(visibility_changed), callable_mp(TilesEditorUtils::get_singleton(), &TilesEditorUtils::synchronize_sources_list).bind(sources_list, source_sort_button));
-	sources_list->add_user_signal(MethodInfo("sort_request"));
 	sources_list->connect("sort_request", callable_mp(this, &TileSetEditor::_update_sources_list).bind(-1));
-	sources_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	SET_DRAG_FORWARDING_CDU(sources_list, TileSetEditor);
 	split_container_left_side->add_child(sources_list);
 

--- a/editor/scene/2d/tiles/tile_set_editor.h
+++ b/editor/scene/2d/tiles/tile_set_editor.h
@@ -43,6 +43,7 @@ class HBoxContainer;
 class SplitContainer;
 class EditorFileDialog;
 class EditorInspectorPlugin;
+class TileSetSourceItemList;
 
 class TileSetEditor : public MarginContainer {
 	GDCLASS(TileSetEditor, MarginContainer);
@@ -76,7 +77,7 @@ private:
 	MenuButton *sources_add_button = nullptr;
 	MenuButton *source_sort_button = nullptr;
 	MenuButton *sources_advanced_menu_button = nullptr;
-	ItemList *sources_list = nullptr;
+	TileSetSourceItemList *sources_list = nullptr;
 	Ref<Texture2D> missing_texture_texture;
 	void _source_selected(int p_source_index);
 	void _source_delete_pressed();

--- a/editor/scene/2d/tiles/tiles_editor_plugin.cpp
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.cpp
@@ -327,6 +327,32 @@ TilesEditorUtils::~TilesEditorUtils() {
 	singleton = nullptr;
 }
 
+String TileSetSourceItemList::get_tooltip(const Point2 &p_pos) const {
+	int idx = get_item_at_position(p_pos);
+	if (tile_set.is_null() || idx == -1) {
+		return ItemList::get_tooltip(p_pos);
+	}
+	idx = get_item_metadata(idx);
+
+	Ref<TileSetAtlasSource> atlas = tile_set->get_source(idx);
+	if (atlas.is_valid() && atlas->get_texture().is_valid()) {
+		return vformat(TTR("Source ID: %d\nTexture path: %s"), idx, atlas->get_texture()->get_path());
+	}
+	return vformat(TTR("Source ID: %d"), idx);
+}
+
+TileSetSourceItemList::TileSetSourceItemList() {
+	set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	set_h_size_flags(SIZE_EXPAND_FILL);
+	set_v_size_flags(SIZE_EXPAND_FILL);
+	set_stretch_ratio(0.25);
+	set_custom_minimum_size(Size2(70, 0) * EDSCALE);
+	set_theme_type_variation("ItemListSecondary");
+	set_texture_filter(TEXTURE_FILTER_NEAREST);
+	set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
+	add_user_signal(MethodInfo("sort_request"));
+}
+
 void TileMapEditorPlugin::_tile_map_layer_changed() {
 	if (tile_map_changed_needs_update) {
 		return;

--- a/editor/scene/2d/tiles/tiles_editor_plugin.h
+++ b/editor/scene/2d/tiles/tiles_editor_plugin.h
@@ -107,6 +107,17 @@ public:
 	~TilesEditorUtils();
 };
 
+class TileSetSourceItemList : public ItemList {
+	GDCLASS(TileSetSourceItemList, ItemList);
+
+public:
+	Ref<TileSet> tile_set;
+
+	virtual String get_tooltip(const Point2 &p_pos) const override;
+
+	TileSetSourceItemList();
+};
+
 class TileMapEditorPlugin : public EditorPlugin {
 	GDCLASS(TileMapEditorPlugin, EditorPlugin);
 


### PR DESCRIPTION
It annoyed me that there is no easy way to check tile source's ID in the editor. This PR makes it appear in source's tooltip, and also if it's atlas source with a texture, it shows full texture path:
<img width="394" height="126" alt="image" src="https://github.com/user-attachments/assets/8a1a9a9f-1c13-4c56-b6a9-b3e2c90eb0d2" />
This required adding a custom ItemList sub-class, so I also moved some initialization code.