### PR TITLE
JoltPhysics: Fix orphan StringName

### DIFF
--- a/modules/jolt_physics/spaces/jolt_job_system.cpp
+++ b/modules/jolt_physics/spaces/jolt_job_system.cpp
@@ -176,7 +176,7 @@ void JoltJobSystem::post_step() {
 #ifdef DEBUG_ENABLED
 
 void JoltJobSystem::flush_timings() {
-	static const StringName profiler_name("servers");
+	const StringName profiler_name = SNAME("servers");
 
 	EngineDebugger *engine_debugger = EngineDebugger::get_singleton();
 


### PR DESCRIPTION
Fix orphan StringName on exit when using JoltPhysics:
```
...
Orphan StringName: servers (static: 1, total: 2)
StringName: 1 unclaimed string names at exit.
```