### PR TITLE
Fix reflection probes not recreating downsampled textures when mode changes.

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -246,6 +246,7 @@ private:
 	struct ReflectionAtlas {
 		int count = 0;
 		int size = 0;
+		bool update_always = false;
 
 		RID reflection;
 		RID depth_buffer;


### PR DESCRIPTION
This fixes an issue where the size of the downsampled radiance map was not updated properly for reflection probes when changing between scenes, leading to much lower quality visuals if the reflection probe it happens to reuse was created first with the real time mode instead. Viceversa, the real time probe would end up much higher quality than intended if an scene was opened with a probe that used the Update Once method instead.

Both screenshots here were taken with the same scene, the main difference being that a different scene was opened first that had a reflection probe configured in Update Once mode and the other scene was in Update Always mode.

<img width="902" height="766" alt="image" src="https://github.com/user-attachments/assets/db2d3b4f-bfe6-4328-bee1-dc6e9db74b6d" />

<img width="842" height="757" alt="image" src="https://github.com/user-attachments/assets/366e60a3-0b94-4941-9e26-43e21f4fdb54" />
