### PR TITLE
Expose mesh vertex count in SoftBody3D

### DIFF
--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -150,6 +150,9 @@
 		<member name="parent_collision_ignore" type="NodePath" setter="set_parent_collision_ignore" getter="get_parent_collision_ignore" default="NodePath(&quot;&quot;)">
 			[NodePath] to a [CollisionObject3D] this SoftBody3D should avoid clipping.
 		</member>
+		<member name="point_count" type="int" setter="" getter="get_point_count">
+			The number of vertices (points) on the soft body mesh.
+		</member>
 		<member name="pressure_coefficient" type="float" setter="set_pressure_coefficient" getter="get_pressure_coefficient" default="0.0">
 			The pressure coefficient of this soft body. Simulate pressure build-up from inside this body. Higher values increase the strength of this effect.
 		</member>

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -378,6 +378,8 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path", "insert_at"), &SoftBody3D::pin_point, DEFVAL(NodePath()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("is_point_pinned", "point_index"), &SoftBody3D::is_point_pinned);
 
+	ClassDB::bind_method(D_METHOD("get_point_count"), &SoftBody3D::get_point_count);
+
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &SoftBody3D::is_ray_pickable);
 
@@ -395,6 +397,8 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_coefficient", "get_drag_coefficient");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "point_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_point_count");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "disable_mode", PROPERTY_HINT_ENUM, "Remove,KeepActive"), "set_disable_mode", "get_disable_mode");
 
@@ -690,6 +694,16 @@ void SoftBody3D::set_drag_coefficient(real_t p_drag_coefficient) {
 
 Vector3 SoftBody3D::get_point_transform(int p_point_index) {
 	return PhysicsServer3D::get_singleton()->soft_body_get_point_global_position(physics_rid, p_point_index);
+}
+
+int SoftBody3D::get_point_count() const {
+	if (mesh.is_null()) {
+		return 0;
+	}
+
+	const int vertex_count = mesh->surface_get_array_len(0);
+	ERR_FAIL_COND_V(vertex_count < 0, 0);
+	return vertex_count;
 }
 
 void SoftBody3D::apply_impulse(int p_point_index, const Vector3 &p_impulse) {

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -151,6 +151,7 @@ public:
 
 	void set_parent_collision_ignore(const NodePath &p_parent_collision_ignore);
 	const NodePath &get_parent_collision_ignore() const;
+	int get_point_count() const;
 
 	void set_pinned_points_indices(Vector<PinnedPoint> p_pinned_points_indices);
 	Vector<PinnedPoint> get_pinned_points_indices();


### PR DESCRIPTION
I noticed that a lot of SoftBody3D's functionalities are not exposed in the editor.

With this PR, I exposed the already existing bounding box, as well as creating and exposing a separate method for the vertex (point) count.

With the existing point-related methods, you have to specify an index, but as far as I'm aware, there is no way of knowing if the provided index is valid (in bounds) other than running the game and checking for an error:
```
Index p_index = 500 is out of bounds ((int)shared->mesh_to_physics.size() = 480).
  <C++ Source>  modules\jolt_physics\objects\jolt_soft_body_3d.cpp:695 @ JoltSoftBody3D::get_vertex_position()
```