### PR TITLE
GL: Set backbuffer texture filter for screen reading shaders

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -429,9 +429,9 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 					if (!material_screen_texture_cached) {
 						backbuffer_copy = true;
 						back_buffer_rect = Rect2();
-						backbuffer_gen_mipmaps = md->shader_data->uses_screen_texture_mipmaps;
+						backbuffer_gen_mipmaps = md->shader_data->screen_texture_filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP;
 					} else if (!material_screen_texture_mipmaps_cached) {
-						backbuffer_gen_mipmaps = md->shader_data->uses_screen_texture_mipmaps;
+						backbuffer_gen_mipmaps = md->shader_data->screen_texture_filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP;
 					}
 				}
 

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2593,11 +2593,13 @@ void CanvasShaderData::set_code(const String &p_code) {
 	uniforms.clear();
 
 	uses_screen_texture = false;
-	uses_screen_texture_mipmaps = false;
 	uses_sdf = false;
 	uses_time = false;
 	uses_custom0 = false;
 	uses_custom1 = false;
+
+	screen_texture_filter = ShaderLanguage::FILTER_DEFAULT;
+	screen_texture_repeat = ShaderLanguage::REPEAT_DEFAULT;
 
 	if (code.is_empty()) {
 		return; // Just invalid, but no error.
@@ -2635,7 +2637,8 @@ void CanvasShaderData::set_code(const String &p_code) {
 
 	blend_mode = BlendMode(blend_modei);
 	uses_screen_texture = gen_code.uses_screen_texture;
-	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
+	screen_texture_filter = gen_code.screen_texture_filter;
+	screen_texture_repeat = gen_code.screen_texture_repeat;
 
 #if 0
 	print_line("**compiling shader:");
@@ -2704,6 +2707,77 @@ void CanvasMaterialData::update_parameters(const HashMap<StringName, Variant> &p
 	update_parameters_internal(p_parameters, p_uniform_dirty, p_textures_dirty, shader_data->uniforms, shader_data->ubo_offsets.ptr(), shader_data->texture_uniforms, shader_data->default_texture_params, shader_data->ubo_size, false);
 }
 
+static void bind_screen_texture_generic(ShaderLanguage::TextureFilter p_filter, ShaderLanguage::TextureRepeat p_repeat) {
+	GLES3::Config *config = GLES3::Config::get_singleton();
+
+	GLenum pmin = GL_NEAREST;
+	GLenum pmag = GL_NEAREST;
+	GLfloat anisotropy = 1.0f;
+	bool skip = false;
+
+	switch (p_filter) {
+		case ShaderLanguage::FILTER_NEAREST: {
+			pmin = GL_NEAREST;
+			pmag = GL_NEAREST;
+		} break;
+		case ShaderLanguage::FILTER_LINEAR: {
+			pmin = GL_LINEAR;
+			pmag = GL_LINEAR;
+		} break;
+		case ShaderLanguage::FILTER_NEAREST_MIPMAP_ANISOTROPIC: {
+			anisotropy = config->anisotropic_level;
+		};
+			[[fallthrough]];
+		case ShaderLanguage::FILTER_NEAREST_MIPMAP: {
+			pmag = GL_NEAREST;
+			if (config->use_nearest_mip_filter) {
+				pmin = GL_NEAREST_MIPMAP_NEAREST;
+			} else {
+				pmin = GL_NEAREST_MIPMAP_LINEAR;
+			}
+		} break;
+		case ShaderLanguage::FILTER_LINEAR_MIPMAP_ANISOTROPIC: {
+			anisotropy = config->anisotropic_level;
+		};
+			[[fallthrough]];
+		case ShaderLanguage::FILTER_LINEAR_MIPMAP: {
+			pmag = GL_LINEAR;
+			if (config->use_nearest_mip_filter) {
+				pmin = GL_LINEAR_MIPMAP_NEAREST;
+			} else {
+				pmin = GL_LINEAR_MIPMAP_LINEAR;
+			}
+		} break;
+		default: {
+			skip = true;
+		} break;
+	}
+
+	if (!skip) {
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, pmin);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, pmag);
+		if (config->support_anisotropic_filter) {
+			glTexParameterf(GL_TEXTURE_2D, _GL_TEXTURE_MAX_ANISOTROPY_EXT, anisotropy);
+		}
+	}
+
+	GLenum prep = GL_CLAMP_TO_EDGE;
+	switch (p_repeat) {
+		case ShaderLanguage::REPEAT_DISABLE: {
+			prep = GL_CLAMP_TO_EDGE;
+		} break;
+		case ShaderLanguage::REPEAT_ENABLE: {
+			prep = GL_REPEAT;
+		} break;
+		default: {
+			return;
+		} break;
+	}
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, prep);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_R, prep);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, prep);
+}
+
 static void bind_uniforms_generic(const Vector<RID> &p_textures, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, int texture_offset = 0, const RS::CanvasItemTextureFilter *filter_mapping = filter_from_uniform, const RS::CanvasItemTextureRepeat *repeat_mapping = repeat_from_uniform) {
 	const RID *textures = p_textures.ptr();
 	const ShaderCompiler::GeneratedCode::Texture *texture_uniforms = p_texture_uniforms.ptr();
@@ -2736,6 +2810,13 @@ static void bind_uniforms_generic(const Vector<RID> &p_textures, const Vector<Sh
 }
 
 void CanvasMaterialData::bind_uniforms() {
+	if (shader_data->uses_screen_texture) {
+		GLES3::Config *config = GLES3::Config::get_singleton();
+
+		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 4);
+		bind_screen_texture_generic(shader_data->screen_texture_filter, shader_data->screen_texture_repeat);
+	}
+
 	// Bind Material Uniforms
 	glBindBufferBase(GL_UNIFORM_BUFFER, RasterizerCanvasGLES3::MATERIAL_UNIFORM_LOCATION, uniform_buffer);
 
@@ -2922,7 +3003,6 @@ void SceneShaderData::set_code(const String &p_code) {
 	uses_sss = false;
 	uses_transmittance = false;
 	uses_screen_texture = false;
-	uses_screen_texture_mipmaps = false;
 	uses_depth_texture = false;
 	uses_normal_texture = false;
 	uses_bent_normal_texture = false;
@@ -2941,6 +3021,11 @@ void SceneShaderData::set_code(const String &p_code) {
 	uses_custom3 = false;
 	uses_bones = false;
 	uses_weights = false;
+
+	screen_texture_filter = ShaderLanguage::FILTER_DEFAULT;
+	screen_texture_repeat = ShaderLanguage::REPEAT_DEFAULT;
+	depth_texture_filter = ShaderLanguage::FILTER_DEFAULT;
+	depth_texture_repeat = ShaderLanguage::REPEAT_DEFAULT;
 
 	if (code.is_empty()) {
 		return; // Just invalid, but no error.
@@ -3079,11 +3164,15 @@ void SceneShaderData::set_code(const String &p_code) {
 	vertex_input_mask |= uses_weights << RS::ARRAY_WEIGHTS;
 
 	uses_screen_texture = gen_code.uses_screen_texture;
-	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
 	uses_depth_texture = gen_code.uses_depth_texture;
 	uses_normal_texture = gen_code.uses_normal_roughness_texture;
 	uses_vertex_time = gen_code.uses_vertex_time;
 	uses_fragment_time = gen_code.uses_fragment_time;
+
+	screen_texture_filter = gen_code.screen_texture_filter;
+	screen_texture_repeat = gen_code.screen_texture_repeat;
+	depth_texture_filter = gen_code.depth_texture_filter;
+	depth_texture_repeat = gen_code.depth_texture_repeat;
 
 	stencil_enabled = stencil_referencei != -1;
 	stencil_flags = stencil_readi | stencil_writei | stencil_write_depth_faili;
@@ -3202,6 +3291,19 @@ GLES3::MaterialData *GLES3::_create_scene_material_func(ShaderData *p_shader) {
 }
 
 void SceneMaterialData::bind_uniforms() {
+	if (shader_data->uses_screen_texture) {
+		GLES3::Config *config = GLES3::Config::get_singleton();
+
+		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 6);
+		bind_screen_texture_generic(shader_data->screen_texture_filter, shader_data->screen_texture_repeat);
+	}
+	if (shader_data->uses_depth_texture) {
+		GLES3::Config *config = GLES3::Config::get_singleton();
+
+		glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 7);
+		bind_screen_texture_generic(shader_data->depth_texture_filter, shader_data->depth_texture_repeat);
+	}
+
 	// Bind Material Uniforms
 	glBindBufferBase(GL_UNIFORM_BUFFER, SCENE_MATERIAL_UNIFORM_LOCATION, uniform_buffer);
 

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -161,11 +161,13 @@ struct CanvasShaderData : public ShaderData {
 	BlendMode blend_mode;
 
 	bool uses_screen_texture;
-	bool uses_screen_texture_mipmaps;
 	bool uses_sdf;
 	bool uses_time;
 	bool uses_custom0;
 	bool uses_custom1;
+
+	ShaderLanguage::TextureFilter screen_texture_filter;
+	ShaderLanguage::TextureRepeat screen_texture_repeat;
 
 	uint64_t vertex_input_mask;
 
@@ -325,7 +327,6 @@ struct SceneShaderData : public ShaderData {
 	bool uses_sss;
 	bool uses_transmittance;
 	bool uses_screen_texture;
-	bool uses_screen_texture_mipmaps;
 	bool uses_depth_texture;
 	bool uses_normal_texture;
 	bool uses_bent_normal_texture;
@@ -344,6 +345,11 @@ struct SceneShaderData : public ShaderData {
 	bool uses_custom3;
 	bool uses_bones;
 	bool uses_weights;
+
+	ShaderLanguage::TextureFilter screen_texture_filter;
+	ShaderLanguage::TextureRepeat screen_texture_repeat;
+	ShaderLanguage::TextureFilter depth_texture_filter;
+	ShaderLanguage::TextureRepeat depth_texture_repeat;
 
 	uint64_t vertex_input_mask;
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -194,7 +194,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 		depth_test = DEPTH_TEST_ENABLED;
 	}
 	cull_mode = RS::CullMode(cull_modei);
-	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
+	uses_screen_texture_mipmaps = gen_code.screen_texture_filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP;
 	uses_screen_texture = gen_code.uses_screen_texture;
 	uses_depth_texture = gen_code.uses_depth_texture;
 	uses_normal_texture = gen_code.uses_normal_roughness_texture;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -190,7 +190,7 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 	}
 	uses_vertex_time = gen_code.uses_vertex_time;
 	uses_fragment_time = gen_code.uses_fragment_time;
-	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
+	uses_screen_texture_mipmaps = gen_code.screen_texture_filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP;
 	uses_screen_texture = gen_code.uses_screen_texture;
 	uses_depth_texture = gen_code.uses_depth_texture;
 	uses_normal_texture = gen_code.uses_normal_roughness_texture;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1578,7 +1578,7 @@ void RendererCanvasRenderRD::CanvasShaderData::set_code(const String &p_code) {
 		ERR_FAIL_MSG("Shader compilation failed.");
 	}
 
-	uses_screen_texture_mipmaps = gen_code.uses_screen_texture_mipmaps;
+	uses_screen_texture_mipmaps = gen_code.screen_texture_filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP;
 	uses_screen_texture = gen_code.uses_screen_texture;
 
 	pipeline_hash_map.clear_pipelines();

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -927,16 +927,17 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 						StringName name;
 						if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_SCREEN_TEXTURE) {
 							name = "color_buffer";
-							if (u.filter >= ShaderLanguage::FILTER_NEAREST_MIPMAP) {
-								r_gen_code.uses_screen_texture_mipmaps = true;
-							}
 							r_gen_code.uses_screen_texture = true;
+							r_gen_code.screen_texture_filter = u.filter;
+							r_gen_code.screen_texture_repeat = u.repeat;
 						} else if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL_ROUGHNESS_TEXTURE) {
 							name = "normal_roughness_buffer";
 							r_gen_code.uses_normal_roughness_texture = true;
 						} else if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_DEPTH_TEXTURE) {
 							name = "depth_buffer";
 							r_gen_code.uses_depth_texture = true;
+							r_gen_code.depth_texture_filter = u.filter;
+							r_gen_code.depth_texture_repeat = u.repeat;
 						} else {
 							name = _mkid(vnode->name); //texture, use as is
 						}
@@ -1569,8 +1570,8 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 	r_gen_code.uses_fragment_time = false;
 	r_gen_code.uses_vertex_time = false;
 	r_gen_code.uses_global_textures = false;
-	r_gen_code.uses_screen_texture_mipmaps = false;
 	r_gen_code.uses_screen_texture = false;
+	r_gen_code.screen_texture_filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
 	r_gen_code.uses_depth_texture = false;
 	r_gen_code.uses_normal_roughness_texture = false;
 

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -81,10 +81,16 @@ public:
 		bool uses_global_textures = false;
 		bool uses_fragment_time = false;
 		bool uses_vertex_time = false;
-		bool uses_screen_texture_mipmaps = false;
 		bool uses_screen_texture = false;
 		bool uses_depth_texture = false;
 		bool uses_normal_roughness_texture = false;
+
+		// Need to store this information CPU-side for GL.
+		//  Currently only storing screen and depth texture filters as normal-roughness is Forward+ only.
+		ShaderLanguage::TextureFilter screen_texture_filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
+		ShaderLanguage::TextureRepeat screen_texture_repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
+		ShaderLanguage::TextureFilter depth_texture_filter = ShaderLanguage::TextureFilter::FILTER_DEFAULT;
+		ShaderLanguage::TextureRepeat depth_texture_repeat = ShaderLanguage::TextureRepeat::REPEAT_DEFAULT;
 	};
 
 	struct DefaultIdentifierActions {


### PR DESCRIPTION
Fixes #106787

This PR allows texture filter and repeat hints to work on the screen and depth textures in Compatibility mode. Tested in both 2D and 3D shaders.

The old version of this PR was keeping the screen reading textures in the `GeneratedCode`'s texture uniform list, but this led to multiple issues (wrong texture bindings, the screen texture slot appearing in the inspector). Now I'm just saving the screen texture filter to an enum stored in the `GeneratedCode` struct, which rendering backends are free to use how they wish.

Screen texture mipmaps seem to only work in the editor and not at runtime. As far as I'm aware this is an existing bug.

See the MRP for details.