### PR TITLE
Add option to `BoneConstraint3D` to make reference target allow to set `Node3D`

### DIFF
--- a/doc/classes/BoneConstraint3D.xml
+++ b/doc/classes/BoneConstraint3D.xml
@@ -52,6 +52,21 @@
 				This bone will be only referenced and not modified by this modifier.
 			</description>
 		</method>
+		<method name="get_reference_node" qualifiers="const">
+			<return type="NodePath" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the reference node path of the setting at [param index].
+				This node will be only referenced and not modified by this modifier.
+			</description>
+		</method>
+		<method name="get_reference_type" qualifiers="const">
+			<return type="int" enum="BoneConstraint3D.ReferenceType" />
+			<param index="0" name="index" type="int" />
+			<description>
+				Returns the reference target type of the setting at [param index]. See also [enum ReferenceType].
+			</description>
+		</method>
 		<method name="get_setting_count" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -100,6 +115,23 @@
 				This bone will be only referenced and not modified by this modifier.
 			</description>
 		</method>
+		<method name="set_reference_node">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="node" type="NodePath" />
+			<description>
+				Sets the reference node path of the setting at [param index] to [param node].
+				This node will be only referenced and not modified by this modifier.
+			</description>
+		</method>
+		<method name="set_reference_type">
+			<return type="void" />
+			<param index="0" name="index" type="int" />
+			<param index="1" name="type" type="int" enum="BoneConstraint3D.ReferenceType" />
+			<description>
+				Sets the reference target type of the setting at [param index] to [param type]. See also [enum ReferenceType].
+			</description>
+		</method>
 		<method name="set_setting_count">
 			<return type="void" />
 			<param index="0" name="count" type="int" />
@@ -108,4 +140,13 @@
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="REFERENCE_TYPE_BONE" value="0" enum="ReferenceType">
+			The reference target is a bone. In this case, the reference target spaces is local space.
+		</constant>
+		<constant name="REFERENCE_TYPE_NODE" value="1" enum="ReferenceType">
+			The reference target is a [Node3D]. In this case, the reference target spaces is model space.
+			In other words, the reference target's coordinates are treated as if it were placed directly under [Skeleton3D] which parent of the [BoneConstraint3D].
+		</constant>
+	</constants>
 </class>

--- a/doc/classes/ConvertTransformModifier3D.xml
+++ b/doc/classes/ConvertTransformModifier3D.xml
@@ -14,6 +14,7 @@
 		- Extract reference pose absolutely and add it to the apply bone's pose.
 		[b]Not Relative + Not Additive:[/b]
 		- Extract reference pose absolutely and the apply bone's pose is replaced with it.
+		[b]Note:[/b] Relative option is available only in the case [method BoneConstraint3D.get_reference_type] is [constant BoneConstraint3D.REFERENCE_TYPE_BONE]. See also [enum BoneConstraint3D.ReferenceType].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CopyTransformModifier3D.xml
+++ b/doc/classes/CopyTransformModifier3D.xml
@@ -14,6 +14,7 @@
 		- Extract reference pose absolutely and add it to the apply bone's pose.
 		[b]Not Relative + Not Additive:[/b]
 		- Extract reference pose absolutely and the apply bone's pose is replaced with it.
+		[b]Note:[/b] Relative option is available only in the case [method BoneConstraint3D.get_reference_type] is [constant BoneConstraint3D.REFERENCE_TYPE_BONE]. See also [enum BoneConstraint3D.ReferenceType].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/3d/aim_modifier_3d.cpp
+++ b/scene/3d/aim_modifier_3d.cpp
@@ -37,7 +37,7 @@ bool AimModifier3D::_set(const StringName &p_path, const Variant &p_value) {
 	if (path.begins_with("settings/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(which, settings.size(), false);
+		ERR_FAIL_INDEX_V(which, (int)settings.size(), false);
 
 		if (what == "forward_axis") {
 			set_forward_axis(which, static_cast<BoneAxis>((int)p_value));
@@ -60,7 +60,7 @@ bool AimModifier3D::_get(const StringName &p_path, Variant &r_ret) const {
 	if (path.begins_with("settings/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(which, settings.size(), false);
+		ERR_FAIL_INDEX_V(which, (int)settings.size(), false);
 
 		if (what == "forward_axis") {
 			r_ret = (int)get_forward_axis(which);
@@ -80,7 +80,7 @@ bool AimModifier3D::_get(const StringName &p_path, Variant &r_ret) const {
 void AimModifier3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	BoneConstraint3D::get_property_list(p_list);
 
-	for (int i = 0; i < settings.size(); i++) {
+	for (uint32_t i = 0; i < settings.size(); i++) {
 		String path = "settings/" + itos(i) + "/";
 		int rotation_usage = is_using_euler(i) ? PROPERTY_USAGE_DEFAULT : PROPERTY_USAGE_NONE;
 
@@ -93,7 +93,7 @@ void AimModifier3D::_get_property_list(List<PropertyInfo> *p_list) const {
 
 PackedStringArray AimModifier3D::get_configuration_warnings() const {
 	PackedStringArray warnings = BoneConstraint3D::get_configuration_warnings();
-	for (int i = 0; i < settings.size(); i++) {
+	for (uint32_t i = 0; i < settings.size(); i++) {
 		if (is_using_euler(i) && get_axis_from_bone_axis(get_forward_axis(i)) == get_primary_rotation_axis(i)) {
 			warnings.push_back(vformat(RTR("Forward axis and primary rotation axis must not be parallel in setting %s."), itos(i)));
 		}
@@ -103,24 +103,24 @@ PackedStringArray AimModifier3D::get_configuration_warnings() const {
 }
 
 void AimModifier3D::_validate_setting(int p_index) {
-	settings.write[p_index] = memnew(AimModifier3DSetting);
+	settings[p_index] = memnew(AimModifier3DSetting);
 }
 
 void AimModifier3D::set_forward_axis(int p_index, BoneAxis p_axis) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	setting->forward_axis = p_axis;
 	update_configuration_warnings();
 }
 
 SkeletonModifier3D::BoneAxis AimModifier3D::get_forward_axis(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), BONE_AXIS_PLUS_Y);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), BONE_AXIS_PLUS_Y);
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	return setting->forward_axis;
 }
 
 void AimModifier3D::set_use_euler(int p_index, bool p_enabled) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	setting->use_euler = p_enabled;
 	notify_property_list_changed();
@@ -128,32 +128,32 @@ void AimModifier3D::set_use_euler(int p_index, bool p_enabled) {
 }
 
 bool AimModifier3D::is_using_euler(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), false);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	return setting->use_euler;
 }
 
 void AimModifier3D::set_primary_rotation_axis(int p_index, Vector3::Axis p_axis) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	setting->primary_rotation_axis = p_axis;
 	update_configuration_warnings();
 }
 
 Vector3::Axis AimModifier3D::get_primary_rotation_axis(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), Vector3::AXIS_X);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), Vector3::AXIS_X);
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	return setting->primary_rotation_axis;
 }
 
 void AimModifier3D::set_use_secondary_rotation(int p_index, bool p_enabled) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	setting->use_secondary_rotation = p_enabled;
 }
 
 bool AimModifier3D::is_using_secondary_rotation(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), false);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), false);
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 	return setting->use_secondary_rotation;
 }
@@ -171,16 +171,28 @@ void AimModifier3D::_bind_methods() {
 	ADD_ARRAY_COUNT("Settings", "setting_count", "set_setting_count", "get_setting_count", "settings/");
 }
 
-void AimModifier3D::_process_constraint(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) {
+void AimModifier3D::_process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) {
 	if (p_apply_bone == p_reference_bone) {
 		ERR_PRINT_ONCE_ED(vformat("In setting %s, the reference bone must not be same with the apply bone.", itos(p_index)));
 		return;
 	}
+	Vector3 reference_origin = p_skeleton->get_bone_global_pose(p_reference_bone).origin;
+	_process_aim(p_index, p_skeleton, p_apply_bone, reference_origin, p_amount);
+}
 
+void AimModifier3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
+	Node3D *nd = Object::cast_to<Node3D>(get_node_or_null(p_reference_node));
+	if (!nd) {
+		return;
+	}
+	Vector3 reference_origin = nd->get_global_transform_interpolated().origin - p_skeleton->get_global_transform_interpolated().origin;
+	_process_aim(p_index, p_skeleton, p_apply_bone, reference_origin, p_amount);
+}
+
+void AimModifier3D::_process_aim(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, Vector3 p_target, float p_amount) {
 	AimModifier3DSetting *setting = static_cast<AimModifier3DSetting *>(settings[p_index]);
 
 	// Prepare forward_vector and rest.
-	Vector3 reference_origin = p_skeleton->get_bone_global_pose(p_reference_bone).origin;
 	Transform3D src_bone_rest = p_skeleton->get_bone_rest(p_apply_bone);
 	Transform3D bone_rest_space;
 	int parent_bone = p_skeleton->get_bone_parent(p_apply_bone);
@@ -190,7 +202,7 @@ void AimModifier3D::_process_constraint(int p_index, Skeleton3D *p_skeleton, int
 		bone_rest_space = p_skeleton->get_bone_global_pose(parent_bone);
 		bone_rest_space.translate_local(src_bone_rest.origin);
 	}
-	Vector3 forward_vector = bone_rest_space.basis.get_rotation_quaternion().xform_inv(reference_origin - bone_rest_space.origin);
+	Vector3 forward_vector = bone_rest_space.basis.get_rotation_quaternion().xform_inv(p_target - bone_rest_space.origin);
 	if (forward_vector.is_zero_approx()) {
 		return;
 	}

--- a/scene/3d/aim_modifier_3d.h
+++ b/scene/3d/aim_modifier_3d.h
@@ -51,7 +51,9 @@ protected:
 
 	static void _bind_methods();
 
-	virtual void _process_constraint(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
+	virtual void _process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
+	virtual void _process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) override;
+	virtual void _process_aim(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, Vector3 p_target, float p_amount);
 	virtual void _validate_setting(int p_index) override;
 
 public:

--- a/scene/3d/bone_constraint_3d.cpp
+++ b/scene/3d/bone_constraint_3d.cpp
@@ -36,10 +36,12 @@ bool BoneConstraint3D::_set(const StringName &p_path, const Variant &p_value) {
 	if (path.begins_with("settings/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(which, settings.size(), false);
+		ERR_FAIL_INDEX_V(which, (int)settings.size(), false);
 
 		if (what == "amount") {
 			set_amount(which, p_value);
+		} else if (what == "reference_type") {
+			set_reference_type(which, static_cast<ReferenceType>((int)p_value));
 		} else if (what == "apply_bone_name") {
 			set_apply_bone_name(which, p_value);
 		} else if (what == "reference_bone_name") {
@@ -48,6 +50,8 @@ bool BoneConstraint3D::_set(const StringName &p_path, const Variant &p_value) {
 			set_apply_bone(which, p_value);
 		} else if (what == "reference_bone") {
 			set_reference_bone(which, p_value);
+		} else if (what == "reference_node") {
+			set_reference_node(which, p_value);
 		} else {
 			return false;
 		}
@@ -61,10 +65,12 @@ bool BoneConstraint3D::_get(const StringName &p_path, Variant &r_ret) const {
 	if (path.begins_with("settings/")) {
 		int which = path.get_slicec('/', 1).to_int();
 		String what = path.get_slicec('/', 2);
-		ERR_FAIL_INDEX_V(which, settings.size(), false);
+		ERR_FAIL_INDEX_V(which, (int)settings.size(), false);
 
 		if (what == "amount") {
 			r_ret = get_amount(which);
+		} else if (what == "reference_type") {
+			r_ret = (int)get_reference_type(which);
 		} else if (what == "apply_bone_name") {
 			r_ret = get_apply_bone_name(which);
 		} else if (what == "reference_bone_name") {
@@ -73,6 +79,8 @@ bool BoneConstraint3D::_get(const StringName &p_path, Variant &r_ret) const {
 			r_ret = get_apply_bone(which);
 		} else if (what == "reference_bone") {
 			r_ret = get_reference_bone(which);
+		} else if (what == "reference_node") {
+			r_ret = get_reference_node(which);
 		} else {
 			return false;
 		}
@@ -87,23 +95,46 @@ void BoneConstraint3D::get_property_list(List<PropertyInfo> *p_list) const {
 		enum_hint = skeleton->get_concatenated_bone_names();
 	}
 
-	for (int i = 0; i < settings.size(); i++) {
+	LocalVector<PropertyInfo> props;
+
+	for (uint32_t i = 0; i < settings.size(); i++) {
 		String path = "settings/" + itos(i) + "/";
-		p_list->push_back(PropertyInfo(Variant::FLOAT, path + "amount", PROPERTY_HINT_RANGE, "0,1,0.001"));
-		p_list->push_back(PropertyInfo(Variant::STRING, path + "apply_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
-		p_list->push_back(PropertyInfo(Variant::INT, path + "apply_bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
-		p_list->push_back(PropertyInfo(Variant::STRING, path + "reference_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
-		p_list->push_back(PropertyInfo(Variant::INT, path + "reference_bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+		props.push_back(PropertyInfo(Variant::FLOAT, path + "amount", PROPERTY_HINT_RANGE, "0,1,0.001"));
+		props.push_back(PropertyInfo(Variant::STRING, path + "apply_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
+		props.push_back(PropertyInfo(Variant::INT, path + "apply_bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+		props.push_back(PropertyInfo(Variant::INT, path + "reference_type", PROPERTY_HINT_ENUM, "Bone,Node"));
+		props.push_back(PropertyInfo(Variant::STRING, path + "reference_bone_name", PROPERTY_HINT_ENUM_SUGGESTION, enum_hint));
+		props.push_back(PropertyInfo(Variant::INT, path + "reference_bone", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+		props.push_back(PropertyInfo(Variant::NODE_PATH, path + "reference_node", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node3D"));
+	}
+
+	for (PropertyInfo &p : props) {
+		_validate_dynamic_prop(p);
+		p_list->push_back(p);
+	}
+}
+
+void BoneConstraint3D::_validate_dynamic_prop(PropertyInfo &p_property) const {
+	PackedStringArray split = p_property.name.split("/");
+	if (split.size() > 2 && split[0] == "settings") {
+		int which = split[1].to_int();
+		if (split[2].begins_with("reference_bone") && get_reference_type(which) != REFERENCE_TYPE_BONE) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+		if (split[2].begins_with("reference_node") && get_reference_type(which) != REFERENCE_TYPE_NODE) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
 	}
 }
 
 void BoneConstraint3D::set_setting_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
 
-	int delta = p_count - settings.size();
+	int delta = p_count - (int)settings.size();
 	if (delta < 0) {
 		for (int i = delta; i < 0; i++) {
-			memdelete(settings[settings.size() + i]);
+			memdelete(settings[(int)settings.size() + i]);
+			settings[(int)settings.size() + i] = nullptr;
 		}
 	}
 	settings.resize(p_count);
@@ -119,11 +150,11 @@ void BoneConstraint3D::set_setting_count(int p_count) {
 }
 
 int BoneConstraint3D::get_setting_count() const {
-	return settings.size();
+	return (int)settings.size();
 }
 
 void BoneConstraint3D::_validate_setting(int p_index) {
-	settings.write[p_index] = memnew(BoneConstraint3DSetting);
+	settings[p_index] = memnew(BoneConstraint3DSetting);
 }
 
 void BoneConstraint3D::clear_settings() {
@@ -131,17 +162,17 @@ void BoneConstraint3D::clear_settings() {
 }
 
 void BoneConstraint3D::set_amount(int p_index, float p_amount) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->amount = p_amount;
 }
 
 float BoneConstraint3D::get_amount(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), 0.0);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), 0.0);
 	return settings[p_index]->amount;
 }
 
 void BoneConstraint3D::set_apply_bone_name(int p_index, const String &p_bone_name) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->apply_bone_name = p_bone_name;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
@@ -150,12 +181,12 @@ void BoneConstraint3D::set_apply_bone_name(int p_index, const String &p_bone_nam
 }
 
 String BoneConstraint3D::get_apply_bone_name(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), String());
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
 	return settings[p_index]->apply_bone_name;
 }
 
 void BoneConstraint3D::set_apply_bone(int p_index, int p_bone) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->apply_bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
@@ -169,12 +200,23 @@ void BoneConstraint3D::set_apply_bone(int p_index, int p_bone) {
 }
 
 int BoneConstraint3D::get_apply_bone(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), -1);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), -1);
 	return settings[p_index]->apply_bone;
 }
 
+void BoneConstraint3D::set_reference_type(int p_index, ReferenceType p_type) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	settings[p_index]->reference_type = p_type;
+	notify_property_list_changed();
+}
+
+BoneConstraint3D::ReferenceType BoneConstraint3D::get_reference_type(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), REFERENCE_TYPE_BONE);
+	return settings[p_index]->reference_type;
+}
+
 void BoneConstraint3D::set_reference_bone_name(int p_index, const String &p_bone_name) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->reference_bone_name = p_bone_name;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
@@ -183,12 +225,12 @@ void BoneConstraint3D::set_reference_bone_name(int p_index, const String &p_bone
 }
 
 String BoneConstraint3D::get_reference_bone_name(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), String());
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), String());
 	return settings[p_index]->reference_bone_name;
 }
 
 void BoneConstraint3D::set_reference_bone(int p_index, int p_bone) {
-	ERR_FAIL_INDEX(p_index, settings.size());
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
 	settings[p_index]->reference_bone = p_bone;
 	Skeleton3D *sk = get_skeleton();
 	if (sk) {
@@ -202,8 +244,18 @@ void BoneConstraint3D::set_reference_bone(int p_index, int p_bone) {
 }
 
 int BoneConstraint3D::get_reference_bone(int p_index) const {
-	ERR_FAIL_INDEX_V(p_index, settings.size(), -1);
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), -1);
 	return settings[p_index]->reference_bone;
+}
+
+void BoneConstraint3D::set_reference_node(int p_index, const NodePath &p_node) {
+	ERR_FAIL_INDEX(p_index, (int)settings.size());
+	settings[p_index]->reference_node = p_node;
+}
+
+NodePath BoneConstraint3D::get_reference_node(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, (int)settings.size(), NodePath());
+	return settings[p_index]->reference_node;
 }
 
 void BoneConstraint3D::_bind_methods() {
@@ -213,18 +265,25 @@ void BoneConstraint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_apply_bone_name", "index"), &BoneConstraint3D::get_apply_bone_name);
 	ClassDB::bind_method(D_METHOD("set_apply_bone", "index", "bone"), &BoneConstraint3D::set_apply_bone);
 	ClassDB::bind_method(D_METHOD("get_apply_bone", "index"), &BoneConstraint3D::get_apply_bone);
+	ClassDB::bind_method(D_METHOD("set_reference_type", "index", "type"), &BoneConstraint3D::set_reference_type);
+	ClassDB::bind_method(D_METHOD("get_reference_type", "index"), &BoneConstraint3D::get_reference_type);
 	ClassDB::bind_method(D_METHOD("set_reference_bone_name", "index", "bone_name"), &BoneConstraint3D::set_reference_bone_name);
 	ClassDB::bind_method(D_METHOD("get_reference_bone_name", "index"), &BoneConstraint3D::get_reference_bone_name);
 	ClassDB::bind_method(D_METHOD("set_reference_bone", "index", "bone"), &BoneConstraint3D::set_reference_bone);
 	ClassDB::bind_method(D_METHOD("get_reference_bone", "index"), &BoneConstraint3D::get_reference_bone);
+	ClassDB::bind_method(D_METHOD("set_reference_node", "index", "node"), &BoneConstraint3D::set_reference_node);
+	ClassDB::bind_method(D_METHOD("get_reference_node", "index"), &BoneConstraint3D::get_reference_node);
 
 	ClassDB::bind_method(D_METHOD("set_setting_count", "count"), &BoneConstraint3D::set_setting_count);
 	ClassDB::bind_method(D_METHOD("get_setting_count"), &BoneConstraint3D::get_setting_count);
 	ClassDB::bind_method(D_METHOD("clear_setting"), &BoneConstraint3D::clear_settings);
+
+	BIND_ENUM_CONSTANT(REFERENCE_TYPE_BONE);
+	BIND_ENUM_CONSTANT(REFERENCE_TYPE_NODE);
 }
 
 void BoneConstraint3D::_validate_bone_names() {
-	for (int i = 0; i < settings.size(); i++) {
+	for (int i = 0; i < (int)settings.size(); i++) {
 		// Prior bone name.
 		if (!settings[i]->apply_bone_name.is_empty()) {
 			set_apply_bone_name(i, settings[i]->apply_bone_name);
@@ -246,27 +305,38 @@ void BoneConstraint3D::_process_modification(double p_delta) {
 		return;
 	}
 
-	for (int i = 0; i < settings.size(); i++) {
-		int apply_bone = settings[i]->apply_bone;
-		if (apply_bone < 0) {
-			continue;
-		}
-
-		int reference_bone = settings[i]->reference_bone;
-		if (reference_bone < 0) {
-			continue;
-		}
-
+	for (int i = 0; i < (int)settings.size(); i++) {
 		float amount = settings[i]->amount;
 		if (amount <= 0) {
 			continue;
 		}
 
-		_process_constraint(i, skeleton, apply_bone, reference_bone, amount);
+		int apply_bone = settings[i]->apply_bone;
+		if (apply_bone < 0) {
+			continue;
+		}
+
+		if (settings[i]->reference_type == REFERENCE_TYPE_BONE) {
+			int reference_bone = settings[i]->reference_bone;
+			if (reference_bone < 0) {
+				continue;
+			}
+			_process_constraint_by_bone(i, skeleton, apply_bone, reference_bone, amount);
+		} else {
+			NodePath pt = settings[i]->reference_node;
+			if (pt.is_empty()) {
+				continue;
+			}
+			_process_constraint_by_node(i, skeleton, apply_bone, pt, amount);
+		}
 	}
 }
 
-void BoneConstraint3D::_process_constraint(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) {
+void BoneConstraint3D::_process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) {
+	//
+}
+
+void BoneConstraint3D::_process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) {
 	//
 }
 

--- a/scene/3d/bone_constraint_3d.h
+++ b/scene/3d/bone_constraint_3d.h
@@ -36,18 +36,27 @@ class BoneConstraint3D : public SkeletonModifier3D {
 	GDCLASS(BoneConstraint3D, SkeletonModifier3D);
 
 public:
+	enum ReferenceType {
+		REFERENCE_TYPE_BONE,
+		REFERENCE_TYPE_NODE,
+	};
+
 	struct BoneConstraint3DSetting {
 		float amount = 1.0;
 
 		String apply_bone_name;
 		int apply_bone = -1;
 
+		ReferenceType reference_type = REFERENCE_TYPE_BONE;
+
 		String reference_bone_name;
 		int reference_bone = -1;
+
+		NodePath reference_node;
 	};
 
 protected:
-	Vector<BoneConstraint3DSetting *> settings;
+	LocalVector<BoneConstraint3DSetting *> settings;
 
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
@@ -55,13 +64,15 @@ protected:
 	// Define get_property_list() instead of _get_property_list()
 	// to merge child class properties into parent class array inspector.
 	void get_property_list(List<PropertyInfo> *p_list) const; // Will be called by child classes.
+	void _validate_dynamic_prop(PropertyInfo &p_property) const;
 
 	virtual void _validate_bone_names() override;
 	static void _bind_methods();
 
 	virtual void _process_modification(double p_delta) override;
 
-	virtual void _process_constraint(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount);
+	virtual void _process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount);
+	virtual void _process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount);
 	virtual void _validate_setting(int p_index);
 
 public:
@@ -73,10 +84,16 @@ public:
 	void set_apply_bone(int p_index, int p_bone);
 	int get_apply_bone(int p_index) const;
 
+	void set_reference_type(int p_index, ReferenceType p_type);
+	ReferenceType get_reference_type(int p_index) const;
+
 	void set_reference_bone_name(int p_index, const String &p_bone_name);
 	String get_reference_bone_name(int p_index) const;
 	void set_reference_bone(int p_index, int p_bone);
 	int get_reference_bone(int p_index) const;
+
+	void set_reference_node(int p_index, const NodePath &p_node);
+	NodePath get_reference_node(int p_index) const;
 
 	void set_setting_count(int p_count);
 	int get_setting_count() const;
@@ -85,3 +102,5 @@ public:
 
 	~BoneConstraint3D();
 };
+
+VARIANT_ENUM_CAST(BoneConstraint3D::ReferenceType);

--- a/scene/3d/convert_transform_modifier_3d.h
+++ b/scene/3d/convert_transform_modifier_3d.h
@@ -55,16 +55,26 @@ public:
 
 		bool relative = true;
 		bool additive = false;
+
+		bool is_relative() {
+			if (reference_type == REFERENCE_TYPE_NODE) {
+				return false;
+			}
+			return relative;
+		}
 	};
 
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _validate_dynamic_prop(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
-	virtual void _process_constraint(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
+	virtual void _process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
+	virtual void _process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) override;
+	virtual void _process_convert(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const Transform3D &p_destination, float p_amount);
 	virtual void _validate_setting(int p_index) override;
 
 public:

--- a/scene/3d/copy_transform_modifier_3d.h
+++ b/scene/3d/copy_transform_modifier_3d.h
@@ -54,18 +54,29 @@ public:
 		BitField<TransformFlag> copy_flags = TRANSFORM_FLAG_ALL;
 		BitField<AxisFlag> axis_flags = AXIS_FLAG_ALL;
 		BitField<AxisFlag> invert_flags = 0;
+
 		bool relative = true;
 		bool additive = false;
+
+		bool is_relative() {
+			if (reference_type == REFERENCE_TYPE_NODE) {
+				return false;
+			}
+			return relative;
+		}
 	};
 
 protected:
 	bool _get(const StringName &p_path, Variant &r_ret) const;
 	bool _set(const StringName &p_path, const Variant &p_value);
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _validate_dynamic_prop(PropertyInfo &p_property) const;
 
 	static void _bind_methods();
 
-	virtual void _process_constraint(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
+	virtual void _process_constraint_by_bone(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, int p_reference_bone, float p_amount) override;
+	virtual void _process_constraint_by_node(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const NodePath &p_reference_node, float p_amount) override;
+	virtual void _process_copy(int p_index, Skeleton3D *p_skeleton, int p_apply_bone, const Transform3D &p_destination, float p_amount);
 	virtual void _validate_setting(int p_index) override;
 
 public:


### PR DESCRIPTION
Allows setting a Node3D as the reference target for BoneConstraint3Ds.

- AimModifier3D
  - Works as a lightweight LookAtModifier allowing settings to be applied to multiple bones, but no advance options (limitation, timebased interpolation, origin setting)
  - It can be used for applications where you want to align the plane of the IK rotation
- Copy/ConvertTransformModifier3D
  - Allows to transfer transforms in ModelSpace, which is useful for matching the tip bone of IK chain with IK target

The video below is a demo combined with IK #110120

https://github.com/user-attachments/assets/3121c4ca-a702-4346-9aeb-827e1bc7697c

Other minor changes:
- Vector to LocalVector
- Add a defensive code on memdelete

Project file:
[ik_test_match_target.zip](https://github.com/user-attachments/files/22245449/ik_test_match_target.zip)
(require to merge both #110120 and this PR)