### PR TITLE
Support PackedByteArray IO for `ZIPReader` and `ZIPPacker`

### DIFF
--- a/modules/zip/doc_classes/ZIPPacker.xml
+++ b/modules/zip/doc_classes/ZIPPacker.xml
@@ -36,13 +36,28 @@
 				It will fail if there is no open file.
 			</description>
 		</method>
+		<method name="get_buffer" qualifiers="const">
+			<return type="PackedByteArray" />
+			<description>
+				Returns the zip buffer data if opened using [method open_buffer]. Otherwise, returns an empty array.
+				Must be called after [method close].
+			</description>
+		</method>
 		<method name="open">
 			<return type="int" enum="Error" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="append" type="int" enum="ZIPPacker.ZipAppend" default="0" />
 			<description>
 				Opens a zip file for writing at the given path using the specified write mode.
-				This must be called before everything else.
+			</description>
+		</method>
+		<method name="open_buffer">
+			<return type="int" enum="Error" />
+			<param index="0" name="init" type="PackedByteArray" default="PackedByteArray()" />
+			<param index="1" name="append" type="int" enum="ZIPPacker.ZipAppend" default="0" />
+			<description>
+				Opens a zip buffer for writing using the specified write mode.
+				The initial buffer content can be given in [param init], useful for [constant APPEND_CREATEAFTER] and [constant APPEND_ADDINZIP].
 			</description>
 		</method>
 		<method name="start_file">
@@ -50,7 +65,7 @@
 			<param index="0" name="path" type="String" />
 			<description>
 				Starts writing to a file within the archive. Only one file can be written at the same time.
-				Must be called after [method open].
+				Must be called after [method open] or [method open_buffer].
 			</description>
 		</method>
 		<method name="write_file">
@@ -69,13 +84,13 @@
 	</members>
 	<constants>
 		<constant name="APPEND_CREATE" value="0" enum="ZipAppend">
-			Create a new zip archive at the given path.
+			Create a new zip archive.
 		</constant>
 		<constant name="APPEND_CREATEAFTER" value="1" enum="ZipAppend">
-			Append a new zip archive to the end of the already existing file at the given path.
+			Append a new zip archive to the end of the existing content.
 		</constant>
 		<constant name="APPEND_ADDINZIP" value="2" enum="ZipAppend">
-			Add new files to the existing zip archive at the given path.
+			Add new files to the existing zip archive.
 		</constant>
 		<constant name="COMPRESSION_DEFAULT" value="-1" enum="CompressionLevel">
 			Start a file with the default Deflate compression level ([code]6[/code]). This is a good compromise between speed and file size.

--- a/modules/zip/doc_classes/ZIPReader.xml
+++ b/modules/zip/doc_classes/ZIPReader.xml
@@ -58,7 +58,7 @@
 			<param index="1" name="case_sensitive" type="bool" default="true" />
 			<description>
 				Returns [code]true[/code] if the file exists in the loaded zip archive.
-				Must be called after [method open].
+				Must be called after [method open] or [method open_buffer].
 			</description>
 		</method>
 		<method name="get_compression_level">
@@ -73,7 +73,7 @@
 			<return type="PackedStringArray" />
 			<description>
 				Returns the list of names of all files in the loaded archive.
-				Must be called after [method open].
+				Must be called after [method open] or [method open_buffer].
 			</description>
 		</method>
 		<method name="open">
@@ -83,13 +83,20 @@
 				Opens the zip archive at the given [param path] and reads its file index.
 			</description>
 		</method>
+		<method name="open_buffer">
+			<return type="int" enum="Error" />
+			<param index="0" name="buffer" type="PackedByteArray" />
+			<description>
+				Opens the zip archive in the raw [param buffer] and reads its file index.
+			</description>
+		</method>
 		<method name="read_file">
 			<return type="PackedByteArray" />
 			<param index="0" name="path" type="String" />
 			<param index="1" name="case_sensitive" type="bool" default="true" />
 			<description>
 				Loads the whole content of a file in the loaded zip archive into memory and returns it.
-				Must be called after [method open].
+				Must be called after [method open] or [method open_buffer].
 			</description>
 		</method>
 	</methods>

--- a/modules/zip/zip_packer.cpp
+++ b/modules/zip/zip_packer.cpp
@@ -33,8 +33,90 @@
 #include "core/io/zip_io.h"
 #include "core/os/os.h"
 
+// Callback functions for in-memory operations.
+
+void *ZIPPacker::_zipio_mem_open(voidpf p_opaque, const char *p_fname, int p_mode) {
+	ZIPPacker *self = (ZIPPacker *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+	self->sink_cursor = 0;
+	return p_opaque;
+}
+
+uLong ZIPPacker::_zipio_mem_read(voidpf p_opaque, voidpf p_stream, void *p_buf, uLong p_size) {
+	ZIPPacker *self = (ZIPPacker *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	uLong bytes_to_read = MIN(p_size, self->sink.size() - self->sink_cursor);
+	if (bytes_to_read > 0) {
+		memcpy(p_buf, self->sink.ptr() + self->sink_cursor, bytes_to_read);
+		self->sink_cursor += bytes_to_read;
+	}
+	return bytes_to_read;
+}
+
+uLong ZIPPacker::_zipio_mem_write(voidpf p_opaque, voidpf p_stream, const void *p_buf, uLong p_size) {
+	ZIPPacker *self = (ZIPPacker *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	const uLong size_required = self->sink_cursor + p_size;
+	if (size_required > (uint64_t)self->sink.size()) {
+		self->sink.resize(size_required);
+	}
+
+	memcpy(self->sink.ptrw() + self->sink_cursor, p_buf, p_size);
+	self->sink_cursor += p_size;
+
+	return p_size;
+}
+
+long ZIPPacker::_zipio_mem_tell(voidpf p_opaque, voidpf p_stream) {
+	ZIPPacker *self = (ZIPPacker *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+	return self->sink_cursor;
+}
+
+long ZIPPacker::_zipio_mem_seek(voidpf p_opaque, voidpf p_stream, uLong p_offset, int p_origin) {
+	ZIPPacker *self = (ZIPPacker *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	uint64_t new_cursor = self->sink_cursor;
+	switch (p_origin) {
+		case ZLIB_FILEFUNC_SEEK_CUR: {
+			new_cursor += p_offset;
+		} break;
+		case ZLIB_FILEFUNC_SEEK_END: {
+			new_cursor = self->sink.size() + p_offset;
+		} break;
+		case ZLIB_FILEFUNC_SEEK_SET: {
+			new_cursor = p_offset;
+		} break;
+	}
+
+	if (new_cursor > (uint64_t)self->sink.size()) {
+		self->sink.resize(new_cursor);
+	}
+
+	self->sink_cursor = new_cursor;
+	return 0;
+}
+
+int ZIPPacker::_zipio_mem_close(voidpf p_opaque, voidpf p_stream) {
+	ZIPPacker *self = (ZIPPacker *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	self->sink_cursor = 0;
+	// Keep `sink` as-is so that it can be retrieved.
+	return 0;
+}
+
+int ZIPPacker::_zipio_mem_testerror(voidpf p_opaque, voidpf p_stream) {
+	return 0;
+}
+
+// Implementation of ZIPPacker methods.
+
 Error ZIPPacker::open(const String &p_path, ZipAppend p_append) {
-	if (fa.is_valid()) {
+	if (zf) {
 		close();
 	}
 
@@ -43,8 +125,31 @@ Error ZIPPacker::open(const String &p_path, ZipAppend p_append) {
 	return zf != nullptr ? OK : FAILED;
 }
 
+Error ZIPPacker::open_buffer(const Vector<uint8_t> &p_init, ZipAppend p_append) {
+	if (zf) {
+		close();
+	}
+
+	sink = p_init;
+
+	zlib_filefunc_def io;
+	io.opaque = (void *)this;
+	io.zopen_file = _zipio_mem_open;
+	io.zread_file = _zipio_mem_read;
+	io.zwrite_file = _zipio_mem_write;
+	io.ztell_file = _zipio_mem_tell;
+	io.zseek_file = _zipio_mem_seek;
+	io.zclose_file = _zipio_mem_close;
+	io.zerror_file = _zipio_mem_testerror;
+	io.alloc_mem = zipio_alloc;
+	io.free_mem = zipio_free;
+
+	zf = zipOpen2(nullptr, p_append, nullptr, &io);
+	return zf != nullptr ? OK : FAILED;
+}
+
 Error ZIPPacker::close() {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker cannot be closed because it is not open.");
+	ERR_FAIL_NULL_V_MSG(zf, FAILED, "ZIPPacker cannot be closed because it is not open.");
 
 	Error err = zipClose(zf, nullptr) == ZIP_OK ? OK : FAILED;
 	if (err == OK) {
@@ -53,6 +158,11 @@ Error ZIPPacker::close() {
 	}
 
 	return err;
+}
+
+Vector<uint8_t> ZIPPacker::get_buffer() const {
+	ERR_FAIL_COND_V_MSG(zf, PackedByteArray(), "ZIPPacker is still open. Call close() before retrieving the buffer.");
+	return sink;
 }
 
 void ZIPPacker::set_compression_level(int p_compression_level) {
@@ -65,7 +175,7 @@ int ZIPPacker::get_compression_level() const {
 }
 
 Error ZIPPacker::start_file(const String &p_path) {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(zf, FAILED, "ZIPPacker must be opened before use.");
 
 	zip_fileinfo zipfi;
 
@@ -103,19 +213,21 @@ Error ZIPPacker::start_file(const String &p_path) {
 }
 
 Error ZIPPacker::write_file(const Vector<uint8_t> &p_data) {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(zf, FAILED, "ZIPPacker must be opened before use.");
 
 	return zipWriteInFileInZip(zf, p_data.ptr(), p_data.size()) == ZIP_OK ? OK : FAILED;
 }
 
 Error ZIPPacker::close_file() {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPPacker must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(zf, FAILED, "ZIPPacker must be opened before use.");
 
 	return zipCloseFileInZip(zf) == ZIP_OK ? OK : FAILED;
 }
 
 void ZIPPacker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open", "path", "append"), &ZIPPacker::open, DEFVAL(Variant(APPEND_CREATE)));
+	ClassDB::bind_method(D_METHOD("open_buffer", "init", "append"), &ZIPPacker::open_buffer, DEFVAL(PackedByteArray()), DEFVAL(Variant(APPEND_CREATE)));
+	ClassDB::bind_method(D_METHOD("get_buffer"), &ZIPPacker::get_buffer);
 	ClassDB::bind_method(D_METHOD("set_compression_level", "compression_level"), &ZIPPacker::set_compression_level);
 	ClassDB::bind_method(D_METHOD("get_compression_level"), &ZIPPacker::get_compression_level);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "compression_level"), "set_compression_level", "get_compression_level");
@@ -134,11 +246,8 @@ void ZIPPacker::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESSION_BEST);
 }
 
-ZIPPacker::ZIPPacker() {
-}
-
 ZIPPacker::~ZIPPacker() {
-	if (fa.is_valid()) {
+	if (zf) {
 		close();
 	}
 }

--- a/modules/zip/zip_packer.h
+++ b/modules/zip/zip_packer.h
@@ -38,9 +38,22 @@
 class ZIPPacker : public RefCounted {
 	GDCLASS(ZIPPacker, RefCounted);
 
-	Ref<FileAccess> fa;
 	zipFile zf = nullptr;
+
 	int compression_level = Z_DEFAULT_COMPRESSION;
+
+	Ref<FileAccess> fa;
+
+	Vector<uint8_t> sink;
+	uint64_t sink_cursor = 0;
+
+	static void *_zipio_mem_open(voidpf p_opaque, const char *p_fname, int p_mode);
+	static uLong _zipio_mem_read(voidpf p_opaque, voidpf p_stream, void *p_buf, uLong p_size);
+	static uLong _zipio_mem_write(voidpf p_opaque, voidpf p_stream, const void *p_buf, uLong p_size);
+	static long _zipio_mem_tell(voidpf p_opaque, voidpf p_stream);
+	static long _zipio_mem_seek(voidpf p_opaque, voidpf p_stream, uLong p_offset, int p_origin);
+	static int _zipio_mem_close(voidpf p_opaque, voidpf p_stream);
+	static int _zipio_mem_testerror(voidpf p_opaque, voidpf p_stream);
 
 protected:
 	static void _bind_methods();
@@ -60,7 +73,10 @@ public:
 	};
 
 	Error open(const String &p_path, ZipAppend p_append);
+	Error open_buffer(const Vector<uint8_t> &p_init, ZipAppend p_append);
 	Error close();
+
+	Vector<uint8_t> get_buffer() const;
 
 	void set_compression_level(int p_compression_level);
 	int get_compression_level() const;
@@ -69,7 +85,6 @@ public:
 	Error write_file(const Vector<uint8_t> &p_data);
 	Error close_file();
 
-	ZIPPacker();
 	~ZIPPacker();
 };
 

--- a/modules/zip/zip_reader.cpp
+++ b/modules/zip/zip_reader.cpp
@@ -33,8 +33,79 @@
 #include "core/error/error_macros.h"
 #include "core/io/zip_io.h"
 
+// Callback functions for in-memory operations.
+
+void *ZIPReader::_zipio_mem_open(voidpf p_opaque, const char *p_fname, int p_mode) {
+	ZIPReader *self = (ZIPReader *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+	self->source_cursor = 0;
+	return p_opaque;
+}
+
+uLong ZIPReader::_zipio_mem_read(voidpf p_opaque, voidpf p_stream, void *p_buf, uLong p_size) {
+	ZIPReader *self = (ZIPReader *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	uLong bytes_to_read = MIN(p_size, self->source.size() - self->source_cursor);
+	if (bytes_to_read > 0) {
+		memcpy(p_buf, self->source.ptr() + self->source_cursor, bytes_to_read);
+		self->source_cursor += bytes_to_read;
+	}
+	return bytes_to_read;
+}
+
+uLong ZIPReader::_zipio_mem_write(voidpf p_opaque, voidpf p_stream, const void *p_buf, uLong p_size) {
+	return 0; // Writing is not supported in ZIPReader.
+}
+
+long ZIPReader::_zipio_mem_tell(voidpf p_opaque, voidpf p_stream) {
+	ZIPReader *self = (ZIPReader *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+	return self->source_cursor;
+}
+
+long ZIPReader::_zipio_mem_seek(voidpf p_opaque, voidpf p_stream, uLong p_offset, int p_origin) {
+	ZIPReader *self = (ZIPReader *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	uint64_t new_cursor = self->source_cursor;
+	switch (p_origin) {
+		case ZLIB_FILEFUNC_SEEK_CUR: {
+			new_cursor += p_offset;
+		} break;
+		case ZLIB_FILEFUNC_SEEK_END: {
+			new_cursor = self->source.size() + p_offset;
+		} break;
+		case ZLIB_FILEFUNC_SEEK_SET: {
+			new_cursor = p_offset;
+		} break;
+	}
+
+	if (new_cursor > (uint64_t)self->source.size()) {
+		return -1;
+	}
+
+	self->source_cursor = new_cursor;
+	return 0;
+}
+
+int ZIPReader::_zipio_mem_close(voidpf p_opaque, voidpf p_stream) {
+	ZIPReader *self = (ZIPReader *)p_opaque;
+	DEV_ASSERT(self != nullptr);
+
+	self->source_cursor = 0;
+	self->source.clear();
+	return 0;
+}
+
+int ZIPReader::_zipio_mem_testerror(voidpf p_opaque, voidpf p_stream) {
+	return 0;
+}
+
+// Implementation of ZIPReader methods.
+
 Error ZIPReader::open(const String &p_path) {
-	if (fa.is_valid()) {
+	if (uzf) {
 		close();
 	}
 
@@ -43,12 +114,36 @@ Error ZIPReader::open(const String &p_path) {
 	return uzf != nullptr ? OK : FAILED;
 }
 
+Error ZIPReader::open_buffer(const Vector<uint8_t> &p_buffer) {
+	if (uzf) {
+		close();
+	}
+
+	source = p_buffer;
+
+	zlib_filefunc_def io;
+	io.opaque = (void *)this;
+	io.zopen_file = _zipio_mem_open;
+	io.zread_file = _zipio_mem_read;
+	io.zwrite_file = _zipio_mem_write;
+	io.ztell_file = _zipio_mem_tell;
+	io.zseek_file = _zipio_mem_seek;
+	io.zclose_file = _zipio_mem_close;
+	io.zerror_file = _zipio_mem_testerror;
+	io.alloc_mem = zipio_alloc;
+	io.free_mem = zipio_free;
+
+	uzf = unzOpen2(nullptr, &io);
+	return uzf != nullptr ? OK : FAILED;
+}
+
 Error ZIPReader::close() {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), FAILED, "ZIPReader cannot be closed because it is not open.");
+	ERR_FAIL_NULL_V_MSG(uzf, FAILED, "ZIPReader cannot be closed because it is not open.");
 
 	Error err = unzClose(uzf) == UNZ_OK ? OK : FAILED;
 	if (err == OK) {
 		DEV_ASSERT(fa.is_null());
+		DEV_ASSERT(source.is_empty());
 		uzf = nullptr;
 	}
 
@@ -56,7 +151,7 @@ Error ZIPReader::close() {
 }
 
 PackedStringArray ZIPReader::get_files() {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedStringArray(), "ZIPReader must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(uzf, PackedStringArray(), "ZIPReader must be opened before use.");
 
 	unz_global_info gi;
 	int err = unzGetGlobalInfo(uzf, &gi);
@@ -89,7 +184,7 @@ PackedStringArray ZIPReader::get_files() {
 }
 
 PackedByteArray ZIPReader::read_file(const String &p_path, bool p_case_sensitive) {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), PackedByteArray(), "ZIPReader must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(uzf, PackedByteArray(), "ZIPReader must be opened before use.");
 
 	int err = UNZ_OK;
 
@@ -126,7 +221,7 @@ PackedByteArray ZIPReader::read_file(const String &p_path, bool p_case_sensitive
 }
 
 bool ZIPReader::file_exists(const String &p_path, bool p_case_sensitive) {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), false, "ZIPReader must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(uzf, false, "ZIPReader must be opened before use.");
 
 	int cs = p_case_sensitive ? 1 : 2;
 	if (unzLocateFile(uzf, p_path.utf8().get_data(), cs) != UNZ_OK) {
@@ -141,7 +236,7 @@ bool ZIPReader::file_exists(const String &p_path, bool p_case_sensitive) {
 }
 
 int ZIPReader::get_compression_level(const String &p_path, bool p_case_sensitive) {
-	ERR_FAIL_COND_V_MSG(fa.is_null(), -1, "ZIPReader must be opened before use.");
+	ERR_FAIL_NULL_V_MSG(uzf, -1, "ZIPReader must be opened before use.");
 
 	int cs = p_case_sensitive ? 1 : 2;
 	if (unzLocateFile(uzf, p_path.utf8().get_data(), cs) != UNZ_OK) {
@@ -159,16 +254,15 @@ int ZIPReader::get_compression_level(const String &p_path, bool p_case_sensitive
 	return level;
 }
 
-ZIPReader::ZIPReader() {}
-
 ZIPReader::~ZIPReader() {
-	if (fa.is_valid()) {
+	if (uzf) {
 		close();
 	}
 }
 
 void ZIPReader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open", "path"), &ZIPReader::open);
+	ClassDB::bind_method(D_METHOD("open_buffer", "buffer"), &ZIPReader::open_buffer);
 	ClassDB::bind_method(D_METHOD("close"), &ZIPReader::close);
 	ClassDB::bind_method(D_METHOD("get_files"), &ZIPReader::get_files);
 	ClassDB::bind_method(D_METHOD("read_file", "path", "case_sensitive"), &ZIPReader::read_file, DEFVAL(Variant(true)));

--- a/modules/zip/zip_reader.h
+++ b/modules/zip/zip_reader.h
@@ -38,21 +38,36 @@
 class ZIPReader : public RefCounted {
 	GDCLASS(ZIPReader, RefCounted)
 
-	Ref<FileAccess> fa;
 	unzFile uzf = nullptr;
+
+	Ref<FileAccess> fa;
+
+	Vector<uint8_t> source;
+	uint64_t source_cursor = 0;
+
+	static void *_zipio_mem_open(voidpf p_opaque, const char *p_fname, int p_mode);
+	static uLong _zipio_mem_read(voidpf p_opaque, voidpf p_stream, void *p_buf, uLong p_size);
+	static uLong _zipio_mem_write(voidpf p_opaque, voidpf p_stream, const void *p_buf, uLong p_size);
+	static long _zipio_mem_tell(voidpf p_opaque, voidpf p_stream);
+	static long _zipio_mem_seek(voidpf p_opaque, voidpf p_stream, uLong p_offset, int p_origin);
+	static int _zipio_mem_close(voidpf p_opaque, voidpf p_stream);
+	static int _zipio_mem_testerror(voidpf p_opaque, voidpf p_stream);
 
 protected:
 	static void _bind_methods();
 
 public:
 	Error open(const String &p_path);
+	Error open_buffer(const Vector<uint8_t> &p_buffer);
 	Error close();
 
+	// Operations on the ZIP archive.
 	PackedStringArray get_files();
-	PackedByteArray read_file(const String &p_path, bool p_case_sensitive);
-	bool file_exists(const String &p_path, bool p_case_sensitive);
 	int get_compression_level(const String &p_path, bool p_case_sensitive);
 
-	ZIPReader();
+	// Operations on files within the ZIP archive.
+	PackedByteArray read_file(const String &p_path, bool p_case_sensitive);
+	bool file_exists(const String &p_path, bool p_case_sensitive);
+
 	~ZIPReader();
 };


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/8354
Closes https://github.com/godotengine/godot-proposals/issues/8365

This PR adds `open_buffer()` for `ZIPReader` and `ZIPPacker`. The method name is consistent with the one used in `XMLParser`.

For `ZIPPacker`, an array can be given in `open_buffer()` to act as the initial file content. A `get_buffer()` is added to retrieve the resulting file content.