### PR TITLE
Add `FileAccess.store_{buffer,string}_as_file()`

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -874,6 +874,19 @@ String FileAccess::get_file_as_string(const String &p_path, Error *r_error) {
 	return ret;
 }
 
+Error FileAccess::store_buffer_as_file(const Vector<uint8_t> &p_buffer, const String &p_path) {
+	Error err;
+	Ref<FileAccess> f = FileAccess::open(p_path, WRITE, &err);
+	if (f.is_null()) {
+		ERR_FAIL_V_MSG(err, vformat("Can't open file from path '%s'.", p_path));
+	}
+	return f->store_buffer(p_buffer) ? OK : ERR_FILE_CANT_WRITE;
+}
+
+Error FileAccess::store_string_as_file(const String &p_string, const String &p_path) {
+	return store_buffer_as_file(p_string.to_utf8_buffer(), p_path);
+}
+
 String FileAccess::get_md5(const String &p_file) {
 	Ref<FileAccess> f = FileAccess::open(p_file, READ);
 	if (f.is_null()) {
@@ -965,6 +978,8 @@ void FileAccess::_bind_methods() {
 
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_file_as_bytes", "path"), &FileAccess::_get_file_as_bytes);
 	ClassDB::bind_static_method("FileAccess", D_METHOD("get_file_as_string", "path"), &FileAccess::_get_file_as_string);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("store_buffer_as_file", "buffer", "path"), &FileAccess::store_buffer_as_file);
+	ClassDB::bind_static_method("FileAccess", D_METHOD("store_string_as_file", "string", "path"), &FileAccess::store_string_as_file);
 
 	ClassDB::bind_method(D_METHOD("resize", "length"), &FileAccess::resize);
 	ClassDB::bind_method(D_METHOD("flush"), &FileAccess::flush);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -268,6 +268,9 @@ public:
 	static PackedByteArray _get_file_as_bytes(const String &p_path) { return get_file_as_bytes(p_path, &last_file_open_error); }
 	static String _get_file_as_string(const String &p_path) { return get_file_as_string(p_path, &last_file_open_error); }
 
+	static Error store_buffer_as_file(const Vector<uint8_t> &p_buffer, const String &p_path);
+	static Error store_string_as_file(const String &p_string, const String &p_path);
+
 	template <typename T>
 	static void make_default(AccessType p_access) {
 		create_func[p_access] = _create_builtin<T>;

--- a/doc/classes/FileAccess.xml
+++ b/doc/classes/FileAccess.xml
@@ -489,6 +489,14 @@
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
 			</description>
 		</method>
+		<method name="store_buffer_as_file" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="buffer" type="PackedByteArray" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Stores the given array of bytes as the whole content of the file at [param path]. Returns [constant OK] on success.
+			</description>
+		</method>
 		<method name="store_csv_line">
 			<return type="bool" />
 			<param index="0" name="values" type="PackedStringArray" />
@@ -555,6 +563,14 @@
 				Stores [param string] in the file without a newline character ([code]\n[/code]), encoding the text as UTF-8. This advances the file cursor by the length of the string in UTF-8 encoded bytes, which may be different from [method String.length] which counts the number of UTF-32 codepoints. Returns [code]true[/code] if the operation is successful.
 				[b]Note:[/b] This method is intended to be used to write text files. The string is stored as a UTF-8 encoded buffer without string length or terminating zero, which means that it can't be loaded back easily. If you want to store a retrievable string in a binary file, consider using [method store_pascal_string] instead. For retrieving strings from a text file, you can use [code]get_buffer(length).get_string_from_utf8()[/code] (if you know the length) or [method get_as_text].
 				[b]Note:[/b] If an error occurs, the resulting value of the file position indicator is indeterminate.
+			</description>
+		</method>
+		<method name="store_string_as_file" qualifiers="static">
+			<return type="int" enum="Error" />
+			<param index="0" name="string" type="String" />
+			<param index="1" name="path" type="String" />
+			<description>
+				Stores [param string] as the whole content of the file at [param path], encoding the text as UTF-8. Returns [constant OK] on success.
 			</description>
 		</method>
 		<method name="store_var">


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/discussions/13110

These two static methods are the opposite of `FileAccess.get_file_as_{buffer,string}()`. The "store" vs "get" naming is consistent with the non-static version.

The parameters follow the same order as `ResourceSaver.save()` (as the order was discussed and swapped in 4.0), and are also in the same order as mentioned in the method name.