### PR TITLE
Fix test project silent crash

### DIFF
--- a/misc/scripts/check_ci_log.py
+++ b/misc/scripts/check_ci_log.py
@@ -27,6 +27,7 @@ if (
     or file_contents.find("Segmentation fault (core dumped)") != -1
     or file_contents.find("Aborted (core dumped)") != -1
     or file_contents.find("terminate called without an active exception") != -1
+    or file_contents.find("execution reached the end of a value-returning function without returning a value") != -1
 ):
     print("FATAL ERROR: Godot has been crashed.")
     sys.exit(52)


### PR DESCRIPTION
When this error happens `runtime error: execution reached the end of a value-returning function without returning a value`, the Test Godot project action will crash silently.

Here's an example after applying this change https://github.com/WhalesState/blazium/actions/runs/17578590713/job/49929599734, it's weird that clangd and building with extra warnings didn't even notice that the method may return without a value, and before this change the GH action just crashed and continued like this one https://github.com/WhalesState/blazium/actions/runs/17575475777/job/49919690017.