### PR TITLE
Fix TextServerAdvanced reentrancy mutex ordering deadlock

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -3918,6 +3918,9 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 	if (p_index == 0) {
 		return; // Non visual character, skip.
 	}
+
+	_THREAD_SAFE_METHOD_
+
 	FontAdvanced *fd = _get_font_data(p_font_rid);
 	ERR_FAIL_NULL(fd);
 


### PR DESCRIPTION
This is a single-line PR that addresses a specific deadlock that I ran into. Basically, `TextServerAdvanced` (a Singleton) has its own mutex, but many `TextServerAdvanced` methods also lock the mutex of the `TextAdvanced` they're currently operating on. If one thread attempts to lock these mutex in one order, and another thread in the opposite order. Deadlock.

Thus, if we're going to obtain both of these mutex, then we _must_ make sure we obtain `TextServerAdvanced` first. We must _never_ attempt to obtain the mutex in the opposite order.

That said, it's fine to obtain just one mutex, in which case we need not worry about the order. _Unfortunately_, the hidden/implicit calls to `CommandQueueMT::flush_if_pending()` throw a spanner in the works.

Code that seemingly obtains just the `TextAdvanced` mutex and then exits the scope (i.e. releasing the mutex) does not really operate that way. Instead, `CommandQueueMT::flush_if_pending` is snuck into the code (without any obvious call to the API). This triggers reentrant-like behavior, calling back into `TextServerAdvanced` methods that obtain the `TextServerAdvanced`'s mutex whilst the `TextAdvanced`'s mutex is still held i.e. the locks were obtained in the wrong order.

Stacks showing this deadlock hit in practice:

> `Thread #1`
> __psynch_mutexwait 0x000000019bf01bbc
> _pthread_mutex_firstfit_lock_wait 0x000000019bf3d3f8
> _pthread_mutex_firstfit_lock_slow 0x000000019bf3adbc
> std::recursive_mutex::lock() 0x000000019be778ec
> std::unique_lock::unique_lock[abi:nn190102](std::recursive_mutex &) unique_lock.h:42
> std::unique_lock::unique_lock[abi:nn190102](std::recursive_mutex &) unique_lock.h:41
> MutexLock::MutexLock(const MutexImpl<…> &) mutex.h:77
> MutexLock::MutexLock(const MutexImpl<…> &) mutex.h:77
> **TextServerAdvanced::_free_rid(const RID &) text_server_adv.cpp:395** `<---- Blocked on TextServerAdvanced _thread_safe_ Mutex, held by Thread #9`
> TextServerAdvanced::free_rid(const RID &) text_server_adv.h:755
> TextParagraph::clear() text_paragraph.cpp:351
> Button::_shape(Ref<…>, String) const button.cpp:571
> Button::set_text(const String &) button.cpp:632
> EditorLog::LogFilter::set_message_count(int) editor_log.h:108
> EditorLog::_process_message(const String &, EditorLog::MessageType, bool) editor_log.cpp:240
> EditorLog::add_message(const String &, EditorLog::MessageType) editor_log.cpp:253
> EditorNode::_print_handler_impl(const String &, bool, bool) editor_node.cpp:7296
> EditorNode::_print_handler(void *, const String &, bool, bool) editor_node.cpp:7283
> __print_line(const String &) print_string.cpp:91
> print_line(const Variant &) print_string.h:73
> ShaderRD::_load_from_cache(ShaderRD::Version *, int) shader_rd.cpp:490
> ShaderRD::_compile_version_start(ShaderRD::Version *, int) shader_rd.cpp:542
> ShaderRD::version_set_code(RID, const HashMap<…> &, const String &, const String &, const String &, const Vector<…> &) shader_rd.cpp:638
> RendererCanvasRenderRD::CanvasShaderData::set_code(const String &) renderer_canvas_render_rd.cpp:1607
> RendererRD::MaterialStorage::shader_set_code(RID, const String &) material_storage.cpp:2052
> CommandQueueMT::Command::call_impl<…>(IndexSequence<…>) command_queue_mt.h:69
> CommandQueueMT::Command::call() command_queue_mt.h:62
> CommandQueueMT::_flush() command_queue_mt.h:169
> CommandQueueMT::flush_if_pending() command_queue_mt.h:232
> RenderingServerDefault::canvas_item_add_texture_rect_region(RID, const Rect2 &, RID, const Rect2 &, const Color &, bool, bool) rendering_server_default.h:987
> **TextServerAdvanced::_font_draw_glyph(const RID &, const RID &, long long, const Vector2 &, long long, const Color &, float) const text_server_adv.cpp:4055** `<--- Obtained FontAdvanced Mutex`
> TextServerAdvanced::font_draw_glyph(const RID &, const RID &, long long, const Vector2 &, long long, const Color &, float) const text_server_adv.h:930
> RichTextLabel::_draw_line(RichTextLabel::ItemFrame *, int, const Vector2 &, int, float, const Color &, int, const Color &, const Color &, int, const Vector2 &, int &) rich_text_label.cpp:1390
> RichTextLabel::_notification(int) rich_text_label.cpp:2560
> RichTextLabel::_notification_forwardv(int) rich_text_label.h:44
> Object::_notification_forward(int) object.cpp:931
> Object::notification(int, bool) object.h:890
> CanvasItem::_redraw_callback() canvas_item.cpp:149
> call_with_variant_args_helper<…>(CanvasItem *, void (CanvasItem::*)(), const Variant **, Callable::CallError &, IndexSequence<…>) binder_common.h:223
> call_with_variant_args<…>(CanvasItem *, void (CanvasItem::*)(), const Variant **, int, Callable::CallError &) binder_common.h:337
> CallableCustomMethodPointer::call(const Variant **, int, Variant &, Callable::CallError &) const callable_method_pointer.h:103
> Callable::callp(const Variant **, int, Variant &, Callable::CallError &) const callable.cpp:57
> CallQueue::_call_function(const Callable &, const Variant *, int, bool) message_queue.cpp:220
> CallQueue::flush() message_queue.cpp:268
> SceneTree::physics_process(double) scene_tree.cpp:645
> Main::iteration() main.cpp:4747
> invocation function for block in OS_MacOS_NSApp::start_main() os_macos.mm:1102
> \_\_CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION\_\_ 0x000000019c027be8
> __CFRunLoopDoObservers 0x000000019c027ad4
> __CFRunLoopRun 0x000000019c0271a4
> CFRunLoopRunSpecific 0x000000019c026734
> RunCurrentEventLoopInMode 0x00000001a7595530
> ReceiveNextEventCommon 0x00000001a759b348
> _BlockUntilNextEventMatchingListInModeWithFilter 0x00000001a759b508
> _DPSNextEvent 0x000000019fb9e848
> -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] 0x00000001a0504c24
> -[NSApplication run] 0x000000019fb91874
> OS_MacOS_NSApp::run() os_macos.mm:1056
> main godot_main_macos.mm:126
> start 0x000000019bbc0274
> 
> `Thread #9`
> __psynch_mutexwait 0x000000019bf01bbc
> _pthread_mutex_firstfit_lock_wait 0x000000019bf3d3f8
> _pthread_mutex_firstfit_lock_slow 0x000000019bf3adbc
> std::recursive_mutex::lock() 0x000000019be778ec
> std::unique_lock::unique_lock[abi:nn190102](std::recursive_mutex &) unique_lock.h:42
> std::unique_lock::unique_lock[abi:nn190102](std::recursive_mutex &) unique_lock.h:41
> MutexLock::MutexLock(const MutexImpl<…> &) mutex.h:77
> MutexLock::MutexLock(const MutexImpl<…> &) mutex.h:77
> **TextServerAdvanced::_font_get_ascent(const RID &, long long) const text_server_adv.cpp:2846** `<--- Blocked trying to obtain FontAdvanced mutex`
> TextServerAdvanced::_shape_substr(TextServerAdvanced::ShapedTextDataAdvanced *, const TextServerAdvanced::ShapedTextDataAdvanced *, long long, long long) const text_server_adv.cpp:5335
> **TextServerAdvanced::_shaped_text_substr(const RID &, long long, long long) const text_server_adv.cpp:5160** `<--- TextServerAdvanced _thread_safe_ Mutex obtained`
> TextServerAdvanced::shaped_text_substr(const RID &, long long, long long) const text_server_adv.h:1005
> TextParagraph::_shape_lines() const text_paragraph.cpp:213
> TextParagraph::get_size() const text_paragraph.cpp:587
> RichTextLabel::Line::get_height(float, float) const rich_text_label.h:188
> RichTextLabel::_calculate_line_vertical_offset(const RichTextLabel::Line &) const rich_text_label.cpp:1938
> RichTextLabel::_shape_line(RichTextLabel::ItemFrame *, int, const Ref<…> &, int, int, float, int *) rich_text_label.cpp:684
> RichTextLabel::_process_line_caches() rich_text_label.cpp:3831
> RichTextLabel::_thread_function(void *) rich_text_label.cpp:3599
> WorkerThreadPool::TaskUserData::callback() worker_thread_pool.h:205
> WorkerThreadPool::_process_task(WorkerThreadPool::Task *) worker_thread_pool.cpp:142
> WorkerThreadPool::_thread_function(void *) worker_thread_pool.cpp:218
> Thread::thread_callback(void *) thread_apple.cpp:55
> _pthread_start 0x000000019bf402e4

To fix this particular issue, we require that `TextServerAdvanced::_font_draw_glyph` now obtain the `TextServerAdvanced` mutex before obtaining the `TextAdvanced` mutex.

Admittedly, this PR is a band-aid fix at best. It's addressing just one case of a potentially infinite number of reentrancy issues caused by injected calls to `CommandQueueMT::flush_if_pending`.

Realistically, the way those injected calls to `CommandQueueMT::flush_if_pending` operate is fundamentally unsafe. They're executing essentially arbitrary code, mid-execution of other operations. The queue flushing really ought to be made explicit, and _very_ prominent documentation ought to explain that the method may trigger reentrant-like behavior and thus it's likely unsafe to hold _any_ mutex/locks whilst flushing the command queue.