### PR TITLE
Fix: InputEventJoypadMotion should trigger only once for 3.x

### DIFF
--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -131,6 +131,10 @@ class PopupMenu : public Popup {
 	Control *control;
 	real_t max_height;
 
+	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
+	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
+	float gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
+
 	void _draw_items();
 	void _draw_background();
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "slider.h"
+#include "core/os/input.h"
 #include "core/os/keyboard.h"
 
 Size2 Slider::get_minimum_size() const {
@@ -108,10 +109,21 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 		}
 	}
 
+	Input *input = Input::get_singleton();
+	Ref<InputEventJoypadMotion> joypadmotion_event = p_event;
+	Ref<InputEventJoypadButton> joypadbutton_event = p_event;
+	bool is_joypad_event = (joypadmotion_event.is_valid() || joypadbutton_event.is_valid());
+
 	if (!mm.is_valid() && !mb.is_valid()) {
 		if (p_event->is_action_pressed("ui_left", true)) {
 			if (orientation != HORIZONTAL) {
 				return;
+			}
+			if (is_joypad_event) {
+				if (!input->is_action_just_pressed("ui_left")) {
+					return;
+				}
+				set_process_internal(true);
 			}
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
@@ -119,18 +131,35 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 			if (orientation != HORIZONTAL) {
 				return;
 			}
+			if (is_joypad_event) {
+				if (!input->is_action_just_pressed("ui_right")) {
+					return;
+				}
+				set_process_internal(true);
+			}
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_up", true)) {
 			if (orientation != VERTICAL) {
 				return;
 			}
-
+			if (is_joypad_event) {
+				if (!input->is_action_just_pressed("ui_up")) {
+					return;
+				}
+				set_process_internal(true);
+			}
 			set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
 		} else if (p_event->is_action_pressed("ui_down", true)) {
 			if (orientation != VERTICAL) {
 				return;
+			}
+			if (is_joypad_event) {
+				if (!input->is_action_just_pressed("ui_down")) {
+					return;
+				}
+				set_process_internal(true);
 			}
 			set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
 			accept_event();
@@ -146,6 +175,37 @@ void Slider::_gui_input(Ref<InputEvent> p_event) {
 
 void Slider::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			Input *input = Input::get_singleton();
+
+			if (input->is_action_just_released("ui_left") || input->is_action_just_released("ui_right") || input->is_action_just_released("ui_up") || input->is_action_just_released("ui_down")) {
+				gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
+				set_process_internal(false);
+				return;
+			}
+
+			gamepad_event_delay_ms -= get_process_delta_time();
+			if (gamepad_event_delay_ms <= 0) {
+				gamepad_event_delay_ms = GAMEPAD_EVENT_REPEAT_RATE_MS + gamepad_event_delay_ms;
+				if (orientation == HORIZONTAL) {
+					if (input->is_action_pressed("ui_left")) {
+						set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
+					}
+
+					if (input->is_action_pressed("ui_right")) {
+						set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
+					}
+				} else if (orientation == VERTICAL) {
+					if (input->is_action_pressed("ui_down")) {
+						set_value(get_value() - (custom_step >= 0 ? custom_step : get_step()));
+					}
+
+					if (input->is_action_pressed("ui_up")) {
+						set_value(get_value() + (custom_step >= 0 ? custom_step : get_step()));
+					}
+				}
+			}
+		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			minimum_size_changed();
 			update();

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -49,6 +49,10 @@ class Slider : public Range {
 	bool editable;
 	bool scrollable;
 
+	const float DEFAULT_GAMEPAD_EVENT_DELAY_MS = 0.5;
+	const float GAMEPAD_EVENT_REPEAT_RATE_MS = 1.0 / 20;
+	float gamepad_event_delay_ms = DEFAULT_GAMEPAD_EVENT_DELAY_MS;
+
 protected:
 	void _gui_input(Ref<InputEvent> p_event);
 	void _notification(int p_what);


### PR DESCRIPTION
Fixes #62932 for 3.x branch
Back-port of previous pull request #63168

Both slider and popup_menu has been modified to support joypad motion.