### PR TITLE
Increase precision of SpotLight attenuation calculation to avoid driver bug on Intel devices

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -746,12 +746,12 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 	float light_length = length(light_rel_vec);
 	hvec3 light_rel_vec_norm = hvec3(light_rel_vec / light_length);
 	half spot_attenuation = get_omni_attenuation(light_length, spot_lights.data[idx].inv_radius, spot_lights.data[idx].attenuation);
-	hvec3 spot_dir = hvec3(spot_lights.data[idx].direction);
-	half cone_angle = half(spot_lights.data[idx].cone_angle);
-	half scos = max(dot(-light_rel_vec_norm, spot_dir), cone_angle);
+	vec3 spot_dir = spot_lights.data[idx].direction;
+	float cone_angle = spot_lights.data[idx].cone_angle;
+	float scos = max(dot(-vec3(light_rel_vec_norm), spot_dir), cone_angle);
 
 	// This conversion to a highp float is crucial to prevent light leaking due to precision errors.
-	float spot_rim = max(1e-4, float(half(1.0) - scos) / float(half(1.0) - cone_angle));
+	float spot_rim = max(1e-4, (1.0 - scos) / (1.0 - cone_angle));
 	spot_attenuation *= half(1.0 - pow(spot_rim, spot_lights.data[idx].cone_attenuation));
 
 	// Compute size.
@@ -779,7 +779,7 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 			//soft shadow
 
 			//find blocker
-			float z_norm = dot(vec3(spot_dir), -light_rel_vec) * spot_lights.data[idx].inv_radius;
+			float z_norm = dot(spot_dir, -light_rel_vec) * spot_lights.data[idx].inv_radius;
 
 			vec2 shadow_uv = splane.xy * spot_lights.data[idx].atlas_rect.zw + spot_lights.data[idx].atlas_rect.xy;
 
@@ -857,7 +857,7 @@ void light_process_spot(uint idx, vec3 vertex, hvec3 eye_vec, hvec3 normal, vec3
 		shadow_z = 2.0 * z_near * z_far / (z_far + z_near - shadow_z * (z_far - z_near));
 
 		//distance to light plane
-		float z = dot(vec3(spot_dir), -light_rel_vec);
+		float z = dot(spot_dir, -light_rel_vec);
 		transmittance_z = half(z - shadow_z);
 	}
 #endif // !SHADOWS_DISABLED


### PR DESCRIPTION
On at least one intel integrated device (Intel Xe) I get a nasty precision bug when using the mobile renderer

<img width="981" height="819" alt="Screenshot from 2025-09-09 12-00-47" src="https://github.com/user-attachments/assets/08f7ee22-3891-46c5-ab1c-18101178cd7b" />

I have tested on another device and the issue seems to be specific to this GPU. Most likely this is a shader code gen error in the driver (it could also be a bug with how FP16 is handled by Intel integrated GPUs). 

We have two options:
1. Disable FP16 on this device (i.e. maintain a ban list)
2. Avoid FP16 in this situation. 

I opted to avoid FP16 in this situation because I doubt that FP 16 is helping this specific code very much anyway. 

This PR forces us to do 1 dot product, 1 max, operation, and 2 subtract operations in high precision that would normally be done at half precision. It also potentially adds an extra half register for most of this function. I say "potentially" since it's not guaranteed that a given compiler would pack `spot_dir` into a register with another variable anyway. 

As a trade off. This PR avoids 3 conversions from `vec3()` to `hvec3()`, 1 conversion from `float` to `half`, and 2 conversions from `half` to `float`.

Overall profiling doesn't reveal any obvious performance difference. So the impact on performance is inconclusive and likely it is highly device dependent. 

Since the changes are minimal and the performance impact is inconclusive. I think we should go ahead with this PR. It is extremely bad for people to ship games and have them randomly look horrible on certain devices.

_After this PR_

<img width="792" height="769" alt="Screenshot from 2025-09-09 13-16-55" src="https://github.com/user-attachments/assets/09100b77-0478-48ab-94b9-28424a2639a6" />

