### PR TITLE
Add check `is_inside_tree()` to `SkeletonModifier3D` as base class

### DIFF
--- a/scene/3d/look_at_modifier_3d.cpp
+++ b/scene/3d/look_at_modifier_3d.cpp
@@ -500,10 +500,6 @@ void LookAtModifier3D::_bind_methods() {
 }
 
 void LookAtModifier3D::_process_modification(double p_delta) {
-	if (!is_inside_tree()) {
-		return;
-	}
-
 	Skeleton3D *skeleton = get_skeleton();
 	if (!skeleton || bone < 0 || bone >= skeleton->get_bone_count()) {
 		return;

--- a/scene/3d/modifier_bone_target_3d.cpp
+++ b/scene/3d/modifier_bone_target_3d.cpp
@@ -98,10 +98,6 @@ void ModifierBoneTarget3D::_bind_methods() {
 }
 
 void ModifierBoneTarget3D::_process_modification(double p_delta) {
-	if (!is_inside_tree()) {
-		return;
-	}
-
 	Skeleton3D *skeleton = get_skeleton();
 	if (!skeleton || bone < 0 || bone >= skeleton->get_bone_count()) {
 		return;

--- a/scene/3d/skeleton_modifier_3d.cpp
+++ b/scene/3d/skeleton_modifier_3d.cpp
@@ -117,7 +117,7 @@ real_t SkeletonModifier3D::get_influence() const {
 }
 
 void SkeletonModifier3D::process_modification(double p_delta) {
-	if (!active) {
+	if (!is_inside_tree() || !active) {
 		return;
 	}
 	_process_modification(p_delta);

--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1492,9 +1492,6 @@ void SpringBoneSimulator3D::_find_collisions() {
 }
 
 void SpringBoneSimulator3D::_process_collisions() {
-	if (!is_inside_tree()) {
-		return;
-	}
 	for (const ObjectID &oid : collisions) {
 		Object *t_obj = ObjectDB::get_instance(oid);
 		if (!t_obj) {
@@ -1619,10 +1616,6 @@ void SpringBoneSimulator3D::_set_active(bool p_active) {
 }
 
 void SpringBoneSimulator3D::_process_modification(double p_delta) {
-	if (!is_inside_tree()) {
-		return;
-	}
-
 	Skeleton3D *skeleton = get_skeleton();
 	if (!skeleton) {
 		return;


### PR DESCRIPTION
- Follow up https://github.com/godotengine/godot/pull/104167

Since these checks are also required in the implementation of https://github.com/godotengine/godot/pull/110120 and https://github.com/godotengine/godot/pull/110336, I considered it appropriate to implement them in the base class. Also I believe this has now been made safer through the fix in https://github.com/godotengine/godot/pull/110145.