### PR TITLE
Fix `_validate_property()` in `RetargetModifier3D`

### DIFF
--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -249,7 +249,7 @@ void RetargetModifier3D::remove_child_notify(Node *p_child) {
 
 void RetargetModifier3D::_validate_property(PropertyInfo &p_property) const {
 	if (use_global_pose) {
-		if (p_property.name == "enable_flags") {
+		if (p_property.name == "enable") {
 			p_property.usage = PROPERTY_USAGE_NONE;
 		}
 	}


### PR DESCRIPTION
<img width="663" height="244" alt="image" src="https://github.com/user-attachments/assets/5fbd87ae-2196-4da7-aea0-151c59b3a6ef" />

These flags do nothing when `use global pose` is enabled, so they should only be displayed when `use global pose` is disabled. This is already documented, but only the property name was incorrect. (I have overlooked that change when I changed these props from bool x3 to int at the end of the PR, sorry.)

After fixed:
<img width="656" height="199" alt="image" src="https://github.com/user-attachments/assets/766c9bac-7735-4bd7-9bd0-ca85ffe9f801" />
