### PR TITLE
Move ColorPicker shaders to ColorPickerShape class

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -52,7 +52,6 @@
 #include "scene/resources/style_box_flat.h"
 #include "scene/resources/style_box_texture.h"
 #include "scene/theme/theme_db.h"
-#include "thirdparty/misc/ok_color_shader.h"
 
 static inline bool is_color_overbright(const Color &color) {
 	return (color.r > 1.0) || (color.g > 1.0) || (color.b > 1.0);
@@ -253,117 +252,6 @@ void ColorPicker::_update_theme_item_cache() {
 	VBoxContainer::_update_theme_item_cache();
 
 	theme_cache.base_scale = get_theme_default_base_scale();
-}
-
-void ColorPicker::init_shaders() {
-	wheel_shader.instantiate();
-	wheel_shader->set_code(R"(
-// ColorPicker wheel shader.
-
-shader_type canvas_item;
-
-uniform float wheel_radius = 0.42;
-
-void fragment() {
-	float x = UV.x - 0.5;
-	float y = UV.y - 0.5;
-	float a = atan(y, x);
-	x += 0.001;
-	y += 0.001;
-	float b = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-	x -= 0.002;
-	float b2 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-	y -= 0.002;
-	float b3 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-	x += 0.002;
-	float b4 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
-
-	COLOR = vec4(clamp((abs(fract(((a - TAU) / TAU) + vec3(3.0, 2.0, 1.0) / 3.0) * 6.0 - 3.0) - 1.0), 0.0, 1.0), (b + b2 + b3 + b4) / 4.00);
-}
-)");
-
-	circle_shader.instantiate();
-	circle_shader->set_code(R"(
-// ColorPicker circle shader.
-
-shader_type canvas_item;
-
-uniform float v = 1.0;
-
-void fragment() {
-	float x = UV.x - 0.5;
-	float y = UV.y - 0.5;
-	float a = atan(y, x);
-	x += 0.001;
-	y += 0.001;
-	float b = float(sqrt(x * x + y * y) < 0.5);
-	x -= 0.002;
-	float b2 = float(sqrt(x * x + y * y) < 0.5);
-	y -= 0.002;
-	float b3 = float(sqrt(x * x + y * y) < 0.5);
-	x += 0.002;
-	float b4 = float(sqrt(x * x + y * y) < 0.5);
-
-	COLOR = vec4(mix(vec3(1.0), clamp(abs(fract(vec3((a - TAU) / TAU) + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - vec3(3.0)) - vec3(1.0), 0.0, 1.0), ((float(sqrt(x * x + y * y)) * 2.0)) / 1.0) * vec3(v), (b + b2 + b3 + b4) / 4.00);
-})");
-
-	circle_ok_color_shader.instantiate();
-	circle_ok_color_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hsl circle shader.
-
-uniform float ok_hsl_l = 1.0;
-
-void fragment() {
-	float x = UV.x - 0.5;
-	float y = UV.y - 0.5;
-	float h = atan(y, x) / (2.0 * M_PI);
-	float s = sqrt(x * x + y * y) * 2.0;
-	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
-	x += 0.001;
-	y += 0.001;
-	float b = float(sqrt(x * x + y * y) < 0.5);
-	x -= 0.002;
-	float b2 = float(sqrt(x * x + y * y) < 0.5);
-	y -= 0.002;
-	float b3 = float(sqrt(x * x + y * y) < 0.5);
-	x += 0.002;
-	float b4 = float(sqrt(x * x + y * y) < 0.5);
-	COLOR = vec4(col, (b + b2 + b3 + b4) / 4.00);
-})");
-
-	rectangle_ok_color_hs_shader.instantiate();
-	rectangle_ok_color_hs_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hs rectangle shader.
-
-uniform float ok_hsl_l = 0.0;
-
-void fragment() {
-	float h = UV.x;
-	float s = 1.0 - UV.y;
-	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
-	COLOR = vec4(col, 1.0);
-})");
-
-	rectangle_ok_color_hl_shader.instantiate();
-	rectangle_ok_color_hl_shader->set_code(OK_COLOR_SHADER + R"(
-// ColorPicker ok color hl rectangle shader.
-
-uniform float ok_hsl_s = 0.0;
-
-void fragment() {
-	float h = UV.x;
-	float l = 1.0 - UV.y;
-	vec3 col = okhsl_to_srgb(vec3(h, ok_hsl_s, l));
-	COLOR = vec4(col, 1.0);
-})");
-}
-
-void ColorPicker::finish_shaders() {
-	wheel_shader.unref();
-	circle_shader.unref();
-	circle_ok_color_shader.unref();
-	rectangle_ok_color_hs_shader.unref();
-	rectangle_ok_color_hl_shader.unref();
 }
 
 void ColorPicker::set_focus_on_line_edit() {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -168,11 +168,6 @@ public:
 	};
 
 private:
-	static inline Ref<Shader> wheel_shader;
-	static inline Ref<Shader> circle_shader;
-	static inline Ref<Shader> circle_ok_color_shader;
-	static inline Ref<Shader> rectangle_ok_color_hs_shader;
-	static inline Ref<Shader> rectangle_ok_color_hl_shader;
 	static inline List<Color> preset_cache;
 	static inline List<Color> recent_preset_cache;
 
@@ -433,9 +428,6 @@ public:
 	GridContainer *get_slider_container();
 	HSlider *get_slider(int idx);
 	Vector<float> get_active_slider_values();
-
-	static void init_shaders();
-	static void finish_shaders();
 
 	void add_mode(ColorMode *p_mode);
 	void add_shape(ColorPickerShape *p_shape);

--- a/scene/gui/color_picker_shape.cpp
+++ b/scene/gui/color_picker_shape.cpp
@@ -32,6 +32,118 @@
 
 #include "scene/gui/margin_container.h"
 #include "scene/resources/material.h"
+#include "thirdparty/misc/ok_color_shader.h"
+
+void ColorPickerShape::init_shaders() {
+	wheel_shader.instantiate();
+	wheel_shader->set_code(R"(
+// ColorPicker wheel shader.
+
+shader_type canvas_item;
+
+uniform float wheel_radius = 0.42;
+
+void fragment() {
+	float x = UV.x - 0.5;
+	float y = UV.y - 0.5;
+	float a = atan(y, x);
+	x += 0.001;
+	y += 0.001;
+	float b = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+	x -= 0.002;
+	float b2 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+	y -= 0.002;
+	float b3 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+	x += 0.002;
+	float b4 = float(sqrt(x * x + y * y) < 0.5) * float(sqrt(x * x + y * y) > wheel_radius);
+
+	COLOR = vec4(clamp((abs(fract(((a - TAU) / TAU) + vec3(3.0, 2.0, 1.0) / 3.0) * 6.0 - 3.0) - 1.0), 0.0, 1.0), (b + b2 + b3 + b4) / 4.00);
+}
+)");
+
+	circle_shader.instantiate();
+	circle_shader->set_code(R"(
+// ColorPicker circle shader.
+
+shader_type canvas_item;
+
+uniform float v = 1.0;
+
+void fragment() {
+	float x = UV.x - 0.5;
+	float y = UV.y - 0.5;
+	float a = atan(y, x);
+	x += 0.001;
+	y += 0.001;
+	float b = float(sqrt(x * x + y * y) < 0.5);
+	x -= 0.002;
+	float b2 = float(sqrt(x * x + y * y) < 0.5);
+	y -= 0.002;
+	float b3 = float(sqrt(x * x + y * y) < 0.5);
+	x += 0.002;
+	float b4 = float(sqrt(x * x + y * y) < 0.5);
+
+	COLOR = vec4(mix(vec3(1.0), clamp(abs(fract(vec3((a - TAU) / TAU) + vec3(1.0, 2.0 / 3.0, 1.0 / 3.0)) * 6.0 - vec3(3.0)) - vec3(1.0), 0.0, 1.0), ((float(sqrt(x * x + y * y)) * 2.0)) / 1.0) * vec3(v), (b + b2 + b3 + b4) / 4.00);
+})");
+
+	circle_ok_color_shader.instantiate();
+	circle_ok_color_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hsl circle shader.
+
+uniform float ok_hsl_l = 1.0;
+
+void fragment() {
+	float x = UV.x - 0.5;
+	float y = UV.y - 0.5;
+	float h = atan(y, x) / (2.0 * M_PI);
+	float s = sqrt(x * x + y * y) * 2.0;
+	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
+	x += 0.001;
+	y += 0.001;
+	float b = float(sqrt(x * x + y * y) < 0.5);
+	x -= 0.002;
+	float b2 = float(sqrt(x * x + y * y) < 0.5);
+	y -= 0.002;
+	float b3 = float(sqrt(x * x + y * y) < 0.5);
+	x += 0.002;
+	float b4 = float(sqrt(x * x + y * y) < 0.5);
+	COLOR = vec4(col, (b + b2 + b3 + b4) / 4.00);
+})");
+
+	rectangle_ok_color_hs_shader.instantiate();
+	rectangle_ok_color_hs_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hs rectangle shader.
+
+uniform float ok_hsl_l = 0.0;
+
+void fragment() {
+	float h = UV.x;
+	float s = 1.0 - UV.y;
+	vec3 col = okhsl_to_srgb(vec3(h, s, ok_hsl_l));
+	COLOR = vec4(col, 1.0);
+})");
+
+	rectangle_ok_color_hl_shader.instantiate();
+	rectangle_ok_color_hl_shader->set_code(OK_COLOR_SHADER + R"(
+// ColorPicker ok color hl rectangle shader.
+
+uniform float ok_hsl_s = 0.0;
+
+void fragment() {
+	float h = UV.x;
+	float l = 1.0 - UV.y;
+	vec3 col = okhsl_to_srgb(vec3(h, ok_hsl_s, l));
+	COLOR = vec4(col, 1.0);
+})");
+}
+
+void ColorPickerShape::finish_shaders() {
+	wheel_shader.unref();
+	circle_shader.unref();
+	circle_ok_color_shader.unref();
+	rectangle_ok_color_hs_shader.unref();
+	rectangle_ok_color_hl_shader.unref();
+}
 
 void ColorPickerShape::_emit_color_changed() {
 	color_picker->emit_signal(SNAME("color_changed"), color_picker->color);
@@ -698,7 +810,7 @@ void ColorPickerShapeWheel::_initialize_controls() {
 
 	Ref<ShaderMaterial> material;
 	material.instantiate();
-	material->set_shader(ColorPicker::wheel_shader);
+	material->set_shader(ColorPickerShape::wheel_shader);
 	material->set_shader_parameter("wheel_radius", WHEEL_RADIUS);
 
 	wheel = memnew(Control);

--- a/scene/gui/color_picker_shape.h
+++ b/scene/gui/color_picker_shape.h
@@ -38,6 +38,12 @@ class ColorPickerShape : public Object {
 	void _emit_color_changed();
 
 protected:
+	static inline Ref<Shader> wheel_shader;
+	static inline Ref<Shader> circle_shader;
+	static inline Ref<Shader> circle_ok_color_shader;
+	static inline Ref<Shader> rectangle_ok_color_hs_shader;
+	static inline Ref<Shader> rectangle_ok_color_hl_shader;
+
 	ColorPicker *color_picker = nullptr;
 	bool is_dragging = false;
 
@@ -67,6 +73,9 @@ public:
 	bool is_initialized = false;
 	bool cursor_editing = false;
 	float echo_multiplier = 1;
+
+	static void init_shaders();
+	static void finish_shaders();
 
 	virtual String get_name() const = 0;
 	virtual Ref<Texture2D> get_icon() const = 0;
@@ -113,7 +122,7 @@ protected:
 	Control *square = nullptr;
 	Control *square_overlay = nullptr;
 	Control *value_slider = nullptr;
-	virtual Ref<Shader> _get_shader() const { return ColorPicker::rectangle_ok_color_hs_shader; }
+	virtual Ref<Shader> _get_shader() const { return ColorPickerShape::rectangle_ok_color_hs_shader; }
 	virtual void _initialize_controls() override;
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
 
@@ -139,7 +148,7 @@ class ColorPickerShapeOKHLRectangle : public ColorPickerShapeOKHSRectangle {
 	GDCLASS(ColorPickerShapeOKHLRectangle, ColorPickerShapeOKHSRectangle);
 
 protected:
-	virtual Ref<Shader> _get_shader() const override { return ColorPicker::rectangle_ok_color_hl_shader; }
+	virtual Ref<Shader> _get_shader() const override { return ColorPickerShape::rectangle_ok_color_hl_shader; }
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
 
 	virtual void _square_draw() override;
@@ -230,7 +239,7 @@ class ColorPickerShapeVHSCircle : public ColorPickerShapeCircle {
 
 protected:
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
-	virtual Ref<Shader> _get_shader() const override { return ColorPicker::circle_shader; }
+	virtual Ref<Shader> _get_shader() const override { return ColorPickerShape::circle_shader; }
 
 	virtual void _circle_input(const Ref<InputEvent> &p_event) override;
 	virtual void _value_slider_input(const Ref<InputEvent> &p_event) override;
@@ -251,7 +260,7 @@ class ColorPickerShapeOKHSLCircle : public ColorPickerShapeCircle {
 
 protected:
 	virtual void _update_cursor(const Vector2 &p_color_change_vector, bool p_is_echo) override;
-	virtual Ref<Shader> _get_shader() const override { return ColorPicker::circle_ok_color_shader; }
+	virtual Ref<Shader> _get_shader() const override { return ColorPickerShape::circle_ok_color_shader; }
 
 	virtual void _circle_input(const Ref<InputEvent> &p_event) override;
 	virtual void _value_slider_input(const Ref<InputEvent> &p_event) override;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -52,6 +52,7 @@
 #include "scene/gui/check_button.h"
 #include "scene/gui/code_edit.h"
 #include "scene/gui/color_picker.h"
+#include "scene/gui/color_picker_shape.h"
 #include "scene/gui/color_rect.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
@@ -1377,7 +1378,7 @@ void register_scene_types() {
 
 	if (RenderingServer::get_singleton()) {
 		// RenderingServer needs to exist for this to succeed.
-		ColorPicker::init_shaders();
+		ColorPickerShape::init_shaders();
 		GraphEdit::init_shaders();
 	}
 
@@ -1439,7 +1440,7 @@ void unregister_scene_types() {
 
 	ParticleProcessMaterial::finish_shaders();
 	CanvasItemMaterial::finish_shaders();
-	ColorPicker::finish_shaders();
+	ColorPickerShape::finish_shaders();
 	GraphEdit::finish_shaders();
 	SceneStringNames::free();
 


### PR DESCRIPTION
I don't know if it was a leftover, but it's only used in `ColorPickerShape`.