### PR TITLE
Add show_plus_sign to SpinBox and use it for ColorPicker intensity value

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1476,7 +1476,12 @@ Error Expression::parse(const String &p_expression, const Vector<String> &p_inpu
 	str_ofs = 0;
 	input_names = p_input_names;
 
-	expression = p_expression;
+	if (p_expression.begins_with("+") || p_expression.begins_with("*") || p_expression.begins_with("/")) {
+		expression = p_expression.substr(1);
+	} else {
+		expression = p_expression;
+	}
+
 	root = _parse_expression();
 
 	if (error_set) {

--- a/doc/classes/SpinBox.xml
+++ b/doc/classes/SpinBox.xml
@@ -56,11 +56,17 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true" keywords="readonly, disabled, enabled">
 			If [code]true[/code], the [SpinBox] will be editable. Otherwise, it will be read only.
 		</member>
+		<member name="keep_editing_on_text_submit" type="bool" setter="set_keep_editing_on_text_submit" getter="is_editing_kept_on_text_submit" default="false">
+			If [code]true[/code], the [LineEdit] will not exit edit mode when text is submitted by pressing [code]ui_text_submit[/code] action (by default: [kbd]Enter[/kbd] or [kbd]Kp Enter[/kbd]).
+		</member>
 		<member name="prefix" type="String" setter="set_prefix" getter="get_prefix" default="&quot;&quot;">
 			Adds the specified prefix string before the numerical value of the [SpinBox].
 		</member>
 		<member name="select_all_on_focus" type="bool" setter="set_select_all_on_focus" getter="is_select_all_on_focus" default="false">
 			If [code]true[/code], the [SpinBox] will select the whole text when the [LineEdit] gains focus. Clicking the up and down arrows won't trigger this behavior.
+		</member>
+		<member name="show_plus_sign" type="bool" setter="set_show_plus_sign" getter="is_showing_plus_sign" default="false">
+			If [code]true[/code], the [SpinBox] will display a leading [code]+[/code] sign for positive numbers. Negative numbers always include their [code]-[/code] sign automatically, so this property only affects how positive values are shown.
 		</member>
 		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" enum="Control.SizeFlags" is_bitfield="true" default="1" />
 		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="1.0" />

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -524,7 +524,6 @@ void ColorPicker::_slider_value_changed() {
 		color_normalized = modes[current_mode]->get_color();
 	}
 	_normalized_apply_intensity_to_color();
-	intensity_value->set_prefix(intensity < 0 ? "" : "+");
 
 	modes[current_mode]->_value_changed();
 
@@ -835,7 +834,6 @@ void ColorPicker::_update_color(bool p_update_sliders) {
 		alpha_slider->set_step(step);
 		alpha_slider->set_value(modes[current_mode]->get_alpha_slider_value());
 		intensity_slider->set_value(intensity);
-		intensity_value->set_prefix(intensity < 0 ? "" : "+");
 	}
 
 	_update_text_value();
@@ -2270,6 +2268,8 @@ ColorPicker::ColorPicker() {
 	intensity_slider->set_step(0.001);
 	intensity_value->set_allow_greater(true);
 	intensity_value->set_custom_arrow_step(1);
+	intensity_value->set_show_plus_sign(true);
+	intensity_value->set_keep_editing_on_text_submit(true);
 
 	hex_hbc = memnew(HBoxContainer);
 	hex_hbc->set_alignment(ALIGNMENT_BEGIN);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -676,6 +676,9 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (!editing) {
+		if (k->is_action("ui_cancel")) {
+			deselect();
+		}
 		return;
 	}
 
@@ -875,7 +878,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	if (k->is_action_pressed("ui_text_submit")) {
 		emit_signal(SceneStringName(text_submitted), text);
 
-		if (editing && !keep_editing_on_text_submit) {
+		if (!keep_editing_on_text_submit) {
 			unedit();
 			emit_signal(SNAME("editing_toggled"), false);
 			if (DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_VIRTUAL_KEYBOARD) && virtual_keyboard_enabled) {
@@ -888,10 +891,8 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	if (k->is_action("ui_cancel")) {
-		if (editing) {
-			unedit();
-			emit_signal(SNAME("editing_toggled"), false);
-		}
+		unedit();
+		emit_signal(SNAME("editing_toggled"), false);
 
 		accept_event();
 		return;
@@ -1611,6 +1612,10 @@ void LineEdit::_notification(int p_what) {
 			if (editing) {
 				unedit();
 				emit_signal(SNAME("editing_toggled"), false);
+			} else {
+				if (deselect_on_focus_loss_enabled) {
+					deselect();
+				}
 			}
 		} break;
 

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -86,9 +86,14 @@ Size2 SpinBox::get_minimum_size() const {
 
 void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	double step = get_step();
-	String value = String::num(get_value(), Math::range_step_decimals(step));
+	const double current_value = get_value();
+	String value = String::num(current_value, Math::range_step_decimals(step));
 	if (is_localizing_numeral_system()) {
 		value = TS->format_number(value);
+	}
+
+	if (show_plus_sign && current_value >= 0.0) {
+		value = "+" + value;
 	}
 
 	if (p_only_update_if_value_changed && value == last_text_value) {
@@ -106,7 +111,7 @@ void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	}
 
 	if (!accepted && update_on_text_changed && !line_edit->get_text().replace_char(',', '.').contains_char('.')) {
-		value = String::num(get_value(), 0);
+		value = String::num(current_value, 0);
 	}
 
 	line_edit->set_text_with_selection(value);
@@ -583,12 +588,37 @@ bool SpinBox::is_select_all_on_focus() const {
 }
 
 void SpinBox::set_editable(bool p_enabled) {
+	if (line_edit->is_editable() == p_enabled) {
+		return;
+	}
+
 	line_edit->set_editable(p_enabled);
 	queue_redraw();
 }
 
 bool SpinBox::is_editable() const {
 	return line_edit->is_editable();
+}
+
+void SpinBox::set_keep_editing_on_text_submit(bool p_enabled) {
+	line_edit->set_keep_editing_on_text_submit(p_enabled);
+}
+
+bool SpinBox::is_editing_kept_on_text_submit() const {
+	return line_edit->is_editing_kept_on_text_submit();
+}
+
+void SpinBox::set_show_plus_sign(bool p_enabled) {
+	if (show_plus_sign == p_enabled) {
+		return;
+	}
+
+	show_plus_sign = p_enabled;
+	_update_text();
+}
+
+bool SpinBox::is_showing_plus_sign() const {
+	return show_plus_sign;
 }
 
 void SpinBox::apply() {
@@ -638,6 +668,10 @@ void SpinBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editable"), &SpinBox::is_editable);
 	ClassDB::bind_method(D_METHOD("set_update_on_text_changed", "enabled"), &SpinBox::set_update_on_text_changed);
 	ClassDB::bind_method(D_METHOD("get_update_on_text_changed"), &SpinBox::get_update_on_text_changed);
+	ClassDB::bind_method(D_METHOD("set_keep_editing_on_text_submit", "enabled"), &SpinBox::set_keep_editing_on_text_submit);
+	ClassDB::bind_method(D_METHOD("is_editing_kept_on_text_submit"), &SpinBox::is_editing_kept_on_text_submit);
+	ClassDB::bind_method(D_METHOD("set_show_plus_sign", "enabled"), &SpinBox::set_show_plus_sign);
+	ClassDB::bind_method(D_METHOD("is_showing_plus_sign"), &SpinBox::is_showing_plus_sign);
 	ClassDB::bind_method(D_METHOD("set_select_all_on_focus", "enabled"), &SpinBox::set_select_all_on_focus);
 	ClassDB::bind_method(D_METHOD("is_select_all_on_focus"), &SpinBox::is_select_all_on_focus);
 	ClassDB::bind_method(D_METHOD("apply"), &SpinBox::apply);
@@ -646,6 +680,8 @@ void SpinBox::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alignment", PROPERTY_HINT_ENUM, "Left,Center,Right,Fill"), "set_horizontal_alignment", "get_horizontal_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "update_on_text_changed"), "set_update_on_text_changed", "get_update_on_text_changed");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_editing_on_text_submit"), "set_keep_editing_on_text_submit", "is_editing_kept_on_text_submit");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "show_plus_sign"), "set_show_plus_sign", "is_showing_plus_sign");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "prefix"), "set_prefix", "get_prefix");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "suffix"), "set_suffix", "get_suffix");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "custom_arrow_step", PROPERTY_HINT_RANGE, "0,10000,0.0001,or_greater"), "set_custom_arrow_step", "get_custom_arrow_step");

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -48,6 +48,7 @@ class SpinBox : public Range {
 	GDCLASS(SpinBox, Range);
 
 	SpinBoxLineEdit *line_edit = nullptr;
+	bool show_plus_sign = false;
 	bool update_on_text_changed = false;
 	bool accepted = true;
 
@@ -175,6 +176,12 @@ public:
 
 	void set_select_all_on_focus(bool p_enabled);
 	bool is_select_all_on_focus() const;
+
+	void set_keep_editing_on_text_submit(bool p_enabled);
+	bool is_editing_kept_on_text_submit() const;
+
+	void set_show_plus_sign(bool p_enabled);
+	bool is_showing_plus_sign() const;
 
 	void apply();
 	void set_custom_arrow_step(const double p_custom_arrow_step);


### PR DESCRIPTION
Also add keep_editing_on_text_submit to Spinbox to make it easier to change values for ColorPicker.


https://github.com/user-attachments/assets/b83bb606-66f8-4a91-b1bc-fd7fff107c90

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13515*