### PR TITLE
Set language encoding flag when using Pack Project as ZIP

### DIFF
--- a/editor/export/project_zip_packer.cpp
+++ b/editor/export/project_zip_packer.cpp
@@ -72,8 +72,8 @@ void ProjectZIPPacker::_zip_file(const String &p_path, const String &p_base_path
 	data.resize(len);
 	f->get_buffer(data.ptrw(), len);
 
-	String path = p_path.replace_first(p_base_path, "");
-	zipOpenNewFileInZip(p_zip,
+	String path = p_path.trim_prefix(p_base_path);
+	zipOpenNewFileInZip4(p_zip,
 			path.utf8().get_data(),
 			nullptr,
 			nullptr,
@@ -82,7 +82,15 @@ void ProjectZIPPacker::_zip_file(const String &p_path, const String &p_base_path
 			0,
 			nullptr,
 			Z_DEFLATED,
-			Z_DEFAULT_COMPRESSION);
+			Z_DEFAULT_COMPRESSION,
+			0,
+			-MAX_WBITS,
+			DEF_MEM_LEVEL,
+			Z_DEFAULT_STRATEGY,
+			nullptr,
+			0,
+			0x0314, // "version made by", 0x03 - Unix, 0x14 - ZIP specification version 2.0, required to store Unix file permissions
+			1 << 11); // Bit 11 is the language encoding flag. When set, filename and comment fields must be encoded using UTF-8.
 	zipWriteInFileInZip(p_zip, data.ptr(), data.size());
 	zipCloseFileInZip(p_zip);
 }
@@ -101,8 +109,8 @@ void ProjectZIPPacker::_zip_recursive(const String &p_path, const String &p_base
 		if (cur == "." || cur == ".." || cur == project_data_dir_name) {
 			// Skip
 		} else if (dir->current_is_dir()) {
-			String path = cs.replace_first(p_base_path, "") + "/";
-			zipOpenNewFileInZip(p_zip,
+			String path = cs.trim_prefix(p_base_path) + "/";
+			zipOpenNewFileInZip4(p_zip,
 					path.utf8().get_data(),
 					nullptr,
 					nullptr,
@@ -111,7 +119,15 @@ void ProjectZIPPacker::_zip_recursive(const String &p_path, const String &p_base
 					0,
 					nullptr,
 					Z_DEFLATED,
-					Z_DEFAULT_COMPRESSION);
+					Z_DEFAULT_COMPRESSION,
+					0,
+					-MAX_WBITS,
+					DEF_MEM_LEVEL,
+					Z_DEFAULT_STRATEGY,
+					nullptr,
+					0,
+					0x0314, // "version made by", 0x03 - Unix, 0x14 - ZIP specification version 2.0, required to store Unix file permissions
+					1 << 11); // Bit 11 is the language encoding flag. When set, filename and comment fields must be encoded using UTF-8.
 			zipCloseFileInZip(p_zip);
 			_zip_recursive(cs, p_base_path, p_zip);
 		} else {


### PR DESCRIPTION
Similar to #78732

Currently, the zip archive produced by the "Pack Project as ZIP" command does not have its language encoding flag set. Therefore, the filenames inside might not be recognized as UTF-8 on Windows, causing garbled filenames in extracted files.