### PR TITLE
Move `search_in_file_extensions` to EditorSettings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -645,8 +645,20 @@ void ProjectSettings::_convert_to_last_version(int p_from_version) {
 			set_setting("application/boot_splash/fullsize", Variant());
 		}
 	}
+	// Automatically adds overrides for project settings that were changed to editor settings.
+	_handle_editor_setting_compat("editor/script/search_in_file_extensions", "text_editor/behavior/general/find_in_file_extensions");
 #endif // DISABLE_DEPRECATED
 }
+
+#ifndef DISABLE_DEPRECATED
+void ProjectSettings::_handle_editor_setting_compat(const String &p_original_setting, const String &p_new_setting) {
+	ProjectSettings *ps = ProjectSettings::get_singleton();
+	if (ps->has_setting(p_original_setting)) {
+		ps->set_editor_setting_override(p_new_setting, ps->get_setting(p_original_setting));
+		ps->set_setting(p_original_setting, Variant());
+	}
+}
+#endif
 
 /*
  * This method is responsible for loading a project.godot file and/or data file

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -144,6 +144,9 @@ protected:
 #endif // TOOLS_ENABLED
 
 	void _convert_to_last_version(int p_from_version);
+#ifndef DISABLE_DEPRECATED
+	void _handle_editor_setting_compat(const String &p_original_setting, const String &p_new_setting);
+#endif
 
 	bool load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset);
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1532,6 +1532,9 @@
 		<member name="text_editor/behavior/general/empty_selection_clipboard" type="bool" setter="" getter="">
 			If [code]true[/code], copying or cutting without a selection is performed on all lines with a caret. Otherwise, copy and cut require a selection.
 		</member>
+		<member name="text_editor/behavior/general/find_in_file_extensions" type="PackedStringArray" setter="" getter="">
+			Text-based file extensions to include in the editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
+		</member>
 		<member name="text_editor/behavior/indent/auto_indent" type="bool" setter="" getter="">
 			If [code]true[/code], automatically indents code when pressing the [kbd]Enter[/kbd] key based on blocks above the new line.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1203,9 +1203,6 @@
 			prime-run %command%
 			[/codeblock]
 		</member>
-		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="">
-			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
-		</member>
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
 		</member>

--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -40,6 +40,7 @@
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_command_palette.h"
+#include "editor/settings/editor_settings.h"
 #include "editor/shader/shader_editor_plugin.h"
 #include "editor/shader/text_shader_editor.h"
 #include "editor/themes/editor_scale.h"
@@ -465,21 +466,28 @@ HashSet<String> FindInFilesDialog::get_excludes() const {
 void FindInFilesDialog::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
-			if (is_visible()) {
-				// Extensions might have changed in the meantime, we clean them and instance them again.
-				for (int i = 0; i < filters_container->get_child_count(); i++) {
-					filters_container->get_child(i)->queue_free();
+			if (is_visible() && extensions_dirty) {
+				// Refresh extension checkboxes when the settings changed.
+				for (Node *child : filters_container->iterate_children()) {
+					child->queue_free();
 				}
-				Array exts = GLOBAL_GET("editor/script/search_in_file_extensions");
-				for (int i = 0; i < exts.size(); ++i) {
+				const PackedStringArray extensions = EDITOR_GET("text_editor/behavior/general/find_in_file_extensions");
+				for (const String &ext : extensions) {
 					CheckBox *cb = memnew(CheckBox);
-					cb->set_text(exts[i]);
-					if (!filters_preferences.has(exts[i])) {
-						filters_preferences[exts[i]] = true;
+					cb->set_text(ext);
+					if (!filters_preferences.has(ext)) {
+						filters_preferences[ext] = true;
 					}
-					cb->set_pressed(filters_preferences[exts[i]]);
+					cb->set_pressed(filters_preferences[ext]);
 					filters_container->add_child(cb);
 				}
+				extensions_dirty = false;
+			}
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			if (EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/behavior/general/find_in_file_extensions")) {
+				extensions_dirty = true;
 			}
 		} break;
 	}
@@ -679,7 +687,7 @@ FindInFilesDialog::FindInFilesDialog() {
 
 	Label *filter_label = memnew(Label);
 	filter_label->set_text(TTRC("Filters:"));
-	filter_label->set_tooltip_text(TTRC("Include the files with the following extensions. Add or remove them in ProjectSettings."));
+	filter_label->set_tooltip_text(TTRC("Include the files with the following extensions. Add or remove them in EditorSettings:\n\"text_editor/behavior/general/find_in_file_extensions\"."));
 	filter_label->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 	gc->add_child(filter_label);
 

--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -103,6 +103,7 @@ class FindInFilesDialog : public AcceptDialog {
 
 	String _validate_filter_wildcard(const String &p_expression) const;
 
+	bool extensions_dirty = true;
 	bool replace_mode = false;
 	LineEdit *search_text_line_edit = nullptr;
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -827,6 +827,16 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Behavior: General
 	_initial_set("text_editor/behavior/general/empty_selection_clipboard", true);
 
+	PackedStringArray extensions;
+	if (ClassDB::class_exists("GDScript")) {
+		extensions.push_back("gd");
+	}
+	if (ClassDB::class_exists("CSharpScript")) {
+		extensions.push_back("cs");
+	}
+	extensions.push_back("gdshader");
+	_initial_set("text_editor/behavior/general/find_in_file_extensions", extensions);
+
 	// Behavior: Navigation
 	_initial_set("text_editor/behavior/navigation/move_caret_on_right_click", true, true);
 	_initial_set("text_editor/behavior/navigation/scroll_past_end_of_file", false, true);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -3807,15 +3807,6 @@ Error Main::setup2(bool p_show_boot_logo) {
 			}
 		}
 	}
-
-	PackedStringArray extensions;
-	extensions.push_back("gd");
-	if (ClassDB::class_exists("CSharpScript")) {
-		extensions.push_back("cs");
-	}
-	extensions.push_back("gdshader");
-	GLOBAL_DEF_NOVAL(PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions"), extensions); // Note: should be defined after Scene level modules init to see .NET.
-
 	OS::get_singleton()->benchmark_end_measure("Startup", "Scene");
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
Similar to #107405, this moves `search_in_file_extensions` to EditorSettings and also does a small cleanup for this setting.

Likely supersedes #49047 and closes https://github.com/godotengine/godot-proposals/issues/2766 (I didn't test though)