### PR TITLE
AnimationTree: Fix `libraries` is stored

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -106,8 +106,12 @@ bool AnimationMixer::_get(const StringName &p_name, Variant &r_ret) const {
 	return true;
 }
 
+uint32_t AnimationMixer::_get_libraries_property_usage() const {
+	return PROPERTY_USAGE_DEFAULT;
+}
+
 void AnimationMixer::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries"), PROPERTY_HINT_DICTIONARY_TYPE, "StringName;AnimationLibrary"));
+	p_list->push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries"), PROPERTY_HINT_DICTIONARY_TYPE, "StringName;AnimationLibrary", _get_libraries_property_usage()));
 }
 
 void AnimationMixer::_validate_property(PropertyInfo &p_property) const {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -338,6 +338,7 @@ protected:
 
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
+	virtual uint32_t _get_libraries_property_usage() const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
 	virtual void _validate_property(PropertyInfo &p_property) const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -899,14 +899,22 @@ void AnimationTree::_setup_animation_player() {
 	clear_caches();
 }
 
-void AnimationTree::_validate_property(PropertyInfo &p_property) const {
+// `libraries` is a dynamic property, so we can't use `_validate_property` to change it.
+uint32_t AnimationTree::_get_libraries_property_usage() const {
 	if (!animation_player.is_empty()) {
-		if (Engine::get_singleton()->is_editor_hint() && (p_property.name == "root_node" || p_property.name.begins_with("libraries"))) {
-			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
-		}
+		return PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_READ_ONLY;
+	}
+	return PROPERTY_USAGE_DEFAULT;
+}
 
-		if (p_property.name.begins_with("libraries")) {
-			p_property.usage &= ~PROPERTY_USAGE_STORAGE;
+void AnimationTree::_validate_property(PropertyInfo &p_property) const {
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	if (!animation_player.is_empty()) {
+		if (p_property.name == "root_node") {
+			p_property.usage |= PROPERTY_USAGE_READ_ONLY;
 		}
 	}
 }

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -312,6 +312,7 @@ private:
 
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
+	virtual uint32_t _get_libraries_property_usage() const override;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	virtual void _validate_property(PropertyInfo &p_property) const override;
 	void _notification(int p_what);


### PR DESCRIPTION
Fix #110237

`libraries` is a dynamic property, so we can't use `_validate_property` to change it. But before #106622 it seems still to be validated because `_validate_property` is called in `AnimationMixer::_get_property_list`
