### PR TITLE
Optimize `Animation::_track_update_hash`

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1062,9 +1062,9 @@ Animation::TrackType Animation::get_cache_type(TrackType p_type) {
 }
 
 void Animation::_track_update_hash(int p_track) {
-	NodePath track_path = tracks[p_track]->path;
-	TrackType track_cache_type = get_cache_type(tracks[p_track]->type);
-	tracks[p_track]->thash = StringName(String(track_path.get_concatenated_names()) + String(track_path.get_concatenated_subnames()) + itos(track_cache_type)).hash();
+	const NodePath &track_path = tracks[p_track]->path;
+	const TrackType track_cache_type = get_cache_type(tracks[p_track]->type);
+	tracks[p_track]->thash = HashMapHasherDefault::hash(Pair<const NodePath &, TrackType>(track_path, track_cache_type));
 }
 
 Animation::TypeHash Animation::track_get_type_hash(int p_track) const {


### PR DESCRIPTION
 While I was profiling, I found that `Animation::_track_update_hash` spent significant time allocating due to string concatenation, `NodePath::get_concatenated_names()`,  `NodePath::get_concatenated_subnames()` internals and constructing a `StringName` had some overhead.

I rewrote the method to resolve these issues.