### PR TITLE
Fix fixed size flag on StandardMaterial3D when rendering in stereo (reverted)

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1357,7 +1357,7 @@ void vertex() {)";
 	if (flags[FLAG_FIXED_SIZE]) {
 		code += R"(
 	// Fixed Size: Enabled
-	if (PROJECTION_MATRIX[3][3] != 0.0) {
+	if (PROJECTION_MATRIX[2][3] == 0.0) {
 		// Orthogonal matrix; try to do about the same with viewport size.
 		float h = abs(1.0 / (2.0 * PROJECTION_MATRIX[1][1]));
 		// Consistent with vertical FOV (Keep Height).
@@ -1367,7 +1367,7 @@ void vertex() {)";
 		MODELVIEW_MATRIX[2] *= sc;
 	} else {
 		// Scale by depth.
-		float sc = -(MODELVIEW_MATRIX)[3].z;
+		float sc = length((MODELVIEW_MATRIX)[3].xyz);
 		MODELVIEW_MATRIX[0] *= sc;
 		MODELVIEW_MATRIX[1] *= sc;
 		MODELVIEW_MATRIX[2] *= sc;


### PR DESCRIPTION
This PR applies 2 fixes when Label3Ds fixed size flag is used (and assumingly other billboard features) with stereo rendering.

1. The orthogonal check was wrong, in stereo projection `PROJECTION_MATRIX[3][3]` can be non-zero. I changed this to the same check found in `Projection::is_orthogonal` and this seems to work correctly
2. Using just the z component of the position is "good enough" when rendering on desktop, but with stereo rendering your brain gets far more information and perceives the label as bobbing when turning your head. It really stands out. Sadly I can't record it because it's a damn optical illusion that you only see in stereo rendering. Taking the full length provides stability in size and removes this annoying effect.

Fixes https://github.com/godotengine/godot/issues/108188