### PR TITLE
Expand completion confirmation to handle completion in `Shift` selection mode

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -2327,6 +2327,7 @@ void CodeEdit::confirm_code_completion(bool p_replace) {
 			continue;
 		}
 		int caret_line = get_caret_line(i);
+		p_replace = (has_selection(i)) ? true : p_replace;
 
 		const String &insert_text = code_completion_options[code_completion_current_selected].insert_text;
 		const String &display_text = code_completion_options[code_completion_current_selected].display;


### PR DESCRIPTION
It is related to this issue: #110393
I am not sure what are all the use cases of this completion function, so I think it requires some testing.
I tested it with additional `()` and `(`  while applying completion and it seems to be working fine.