### PR TITLE
Expose some `EditorInspector` customization

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -14,12 +14,30 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="collapse_all_folding">
+			<return type="void" />
+			<description>
+				Collapse all foldable groups.
+			</description>
+		</method>
 		<method name="edit">
 			<return type="void" />
 			<param index="0" name="object" type="Object" />
 			<description>
 				Shows the properties of the given [param object] in this inspector for editing. To clear the inspector, call this method with [code]null[/code].
 				[b]Note:[/b] If you want to edit an object in the editor's main inspector, use the [code]edit_*[/code] methods in [EditorInterface] instead.
+			</description>
+		</method>
+		<method name="expand_all_folding">
+			<return type="void" />
+			<description>
+				Expand all foldable groups.
+			</description>
+		</method>
+		<method name="expand_revertable">
+			<return type="void" />
+			<description>
+				Expand all foldable groups that have revertable properties in them.
 			</description>
 		</method>
 		<method name="get_edited_object">
@@ -45,6 +63,64 @@
 			<param index="6" name="wide" type="bool" default="false" />
 			<description>
 				Creates a property editor that can be used by plugin UI to edit the specified property of an [param object].
+			</description>
+		</method>
+		<method name="set_autoclear">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				Sets whether checkable properties, such as theme overrides, should have their value cleared/reverted when unchecked.
+			</description>
+		</method>
+		<method name="set_filter">
+			<return type="void" />
+			<param index="0" name="line_edit" type="LineEdit" />
+			<description>
+				Assigns a [LineEdit] control to use as the filter input, which will cause the inspector to update when [signal LineEdit.text_changed] is emitted.
+			</description>
+		</method>
+		<method name="set_hide_metadata">
+			<return type="void" />
+			<param index="0" name="hide" type="bool" />
+			<description>
+				Sets whether to hide the controls that deal with adding metadata properties to the object being edited by the inspector.
+			</description>
+		</method>
+		<method name="set_hide_script">
+			<return type="void" />
+			<param index="0" name="hide" type="bool" />
+			<description>
+				Sets whether to hide the controls that deal with assigning a script to the object being edited by the inspector.
+			</description>
+		</method>
+		<method name="set_show_categories">
+			<return type="void" />
+			<param index="0" name="show_standard" type="bool" />
+			<param index="1" name="show_custom" type="bool" />
+			<description>
+				Sets whether to show categories. [param show_standard] will show the standard class categories. [param show_custom] will show custom categories, like the ones added with [constant PROPERTY_USAGE_CATEGORY] or [annotation @GDScript.@export_category].
+			</description>
+		</method>
+		<method name="set_use_doc_hints">
+			<return type="void" />
+			<param index="0" name="enable" type="bool" />
+			<description>
+				Sets whether to show documentation tooltips.
+			</description>
+		</method>
+		<method name="set_use_filter">
+			<return type="void" />
+			<param index="0" name="use_filter" type="bool" />
+			<description>
+				Sets whether to use the filter text provided by the filter input assigned by [method set_filter].
+			</description>
+		</method>
+		<method name="set_use_folding">
+			<return type="void" />
+			<param index="0" name="use_folding" type="bool" />
+			<param index="1" name="update_tree" type="bool" default="true" />
+			<description>
+				Sets whether to allow folding any foldable groups.
 			</description>
 		</method>
 	</methods>
@@ -97,7 +173,7 @@
 			<param index="1" name="checked" type="bool" />
 			<description>
 				Emitted when a boolean property is toggled in the inspector.
-				[b]Note:[/b] This signal is never emitted if the internal [code]autoclear[/code] property enabled. Since this property is always enabled in the editor inspector, this signal is never emitted by the editor itself.
+				[b]Note:[/b] This signal is never emitted if the [code]autoclear[/code] property (set using [method set_autoclear]) is enabled. Since this property is always enabled in the editor inspector, this signal is never emitted by the editor itself.
 			</description>
 		</signal>
 		<signal name="resource_selected">

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4835,8 +4835,8 @@ void EditorInspector::set_use_filter(bool p_use) {
 	update_tree();
 }
 
-void EditorInspector::register_text_enter(Node *p_line_edit) {
-	search_box = Object::cast_to<LineEdit>(p_line_edit);
+void EditorInspector::register_text_enter(LineEdit *p_line_edit) {
+	search_box = p_line_edit;
 	if (search_box) {
 		search_box->connect(SceneStringName(text_changed), callable_mp(this, &EditorInspector::update_tree).unbind(1));
 	}
@@ -5671,6 +5671,18 @@ void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 	ClassDB::bind_method("get_selected_path", &EditorInspector::get_selected_path);
 	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);
+
+	ClassDB::bind_method(D_METHOD("set_autoclear", "enable"), &EditorInspector::set_autoclear);
+	ClassDB::bind_method(D_METHOD("set_show_categories", "show_standard", "show_custom"), &EditorInspector::set_show_categories);
+	ClassDB::bind_method(D_METHOD("set_use_doc_hints", "enable"), &EditorInspector::set_use_doc_hints);
+	ClassDB::bind_method(D_METHOD("set_hide_script", "hide"), &EditorInspector::set_hide_script);
+	ClassDB::bind_method(D_METHOD("set_hide_metadata", "hide"), &EditorInspector::set_hide_metadata);
+	ClassDB::bind_method(D_METHOD("set_use_filter", "use_filter"), &EditorInspector::set_use_filter);
+	ClassDB::bind_method(D_METHOD("set_filter", "line_edit"), &EditorInspector::register_text_enter);
+	ClassDB::bind_method(D_METHOD("set_use_folding", "use_folding", "update_tree"), &EditorInspector::set_use_folding, DEFVAL(true));
+	ClassDB::bind_method("collapse_all_folding", &EditorInspector::collapse_all_folding);
+	ClassDB::bind_method("expand_all_folding", &EditorInspector::expand_all_folding);
+	ClassDB::bind_method("expand_revertable", &EditorInspector::expand_revertable);
 
 	ClassDB::bind_static_method("EditorInspector", D_METHOD("instantiate_property_editor", "object", "type", "path", "hint", "hint_text", "usage", "wide"), &EditorInspector::instantiate_property_editor, DEFVAL(false));
 

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -810,7 +810,7 @@ public:
 	void set_hide_metadata(bool p_hide);
 
 	void set_use_filter(bool p_use);
-	void register_text_enter(Node *p_line_edit);
+	void register_text_enter(LineEdit *p_line_edit);
 
 	void set_use_folding(bool p_use_folding, bool p_update_tree = true);
 	bool is_using_folding();


### PR DESCRIPTION
Fixes godotengine/godot-proposals#12755.

This exposes a somewhat arbitrary set of methods from `EditorInspector`, to allow for easily creating your own `EditorInspector` from scripts, that looks and feels like the `EditorInspector` found in `InspectorDock`.

The list of exposed methods is as follows:

- `set_autoclear`
- `set_show_categories`
- `set_use_doc_hints`
- `set_hide_script`
- `set_hide_metadata`
- `set_use_filter`
- `register_text_enter` (as `set_filter`)
- `set_use_folding`
- `collapse_all_folding`
- `expand_all_folding`
- `expand_revertable`

Note that this is mostly (with the exception of `register_text_enter`) exposing stuff as they're named/designed in C++. There might very well be some argument for renaming/refactoring some of this stuff before exposing them, such as:

1. Maybe exposing `set_autoclear` as `set_auto_revert`.
2. Maybe splitting up `set_show_categories` into `set_show_standard_categories` and `set_show_custom_categories`.
3. Maybe exposing `set_use_doc_hints` as `set_use_doc_tooltips`.
4. Maybe exposing `set_hide_script` as `set_show_script_controls`.
5. Maybe exposing `set_hide_metadata` as `set_show_metadata_controls`.
6. Maybe adding getters as well and exposing the applicable ones as actual properties.

Also note that to achieve better parity with the `EditorInspector` found in `InspectorDock`, we would ideally expose `set_property_name_style` and `set_use_settings_name_style` as well, but I wasn't sure how to best expose `EditorPropertyNameProcessor::Style` without also needing to expose `EditorPropertyNameProcessor`, which seemed undesirable.