### PR TITLE
Fix favorite folders that are outside of the project being displayed in `FileSystemDock`'s file list

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -991,6 +991,9 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		// Display the favorites.
 		Vector<String> favorites_list = EditorSettings::get_singleton()->get_favorites();
 		for (const String &favorite : favorites_list) {
+			if (!favorite.begins_with("res://")) {
+				continue;
+			}
 			String text;
 			Ref<Texture2D> icon;
 			if (favorite == "res://") {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110406

The same way `_update_tree` does it:

https://github.com/godotengine/godot/blob/2dd26a027a99633231184616d4dd287bbdd1c0a3/editor/docks/filesystem_dock.cpp#L417-L421