### PR TITLE
Fix crash due to null pointer dereference when moving/renaming folders in `FileSystemDock`

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2032,6 +2032,7 @@ void FileSystemDock::_before_move(HashMap<String, ResourceUID::ID> &r_uids, Hash
 			}
 		} else {
 			EditorFileSystemDirectory *current_folder = EditorFileSystem::get_singleton()->get_filesystem_path(to_move[i].path);
+			ERR_CONTINUE(current_folder == nullptr);
 			List<EditorFileSystemDirectory *> folders;
 			folders.push_back(current_folder);
 			while (folders.front()) {


### PR DESCRIPTION
Fixes crash mentioned at the very end of https://github.com/godotengine/godot/issues/110406

`current_folder` can be null, so we must check it first.