### PR TITLE
Expose EditorNode3DGizmo::is_selected in GDScript.

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -214,5 +214,11 @@
 				Sets the reference [Node3D] node for the gizmo. [param node] must inherit from [Node3D].
 			</description>
 		</method>
+		<method name="is_selected">
+			<return type="bool"/>
+			<description>
+				Returns [code]true[/code] if the gizmo is currently selected. Can be used to only show some gizmos when the node is selected during [method _redraw].
+			</description>
+		</method>
 	</methods>
 </class>

--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -194,7 +194,7 @@
 			</description>
 		</method>
 		<method name="is_selected" qualifiers="const">
-			<return type="bool"/>
+			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the gizmo is currently selected. Can be used to only show some gizmos when the node is selected during [method _redraw].
 			</description>

--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -193,6 +193,12 @@
 				Returns a list of the currently selected subgizmos. Can be used to highlight selected elements during [method _redraw].
 			</description>
 		</method>
+		<method name="is_selected" qualifiers="const">
+			<return type="bool"/>
+			<description>
+				Returns [code]true[/code] if the gizmo is currently selected. Can be used to only show some gizmos when the node is selected during [method _redraw].
+			</description>
+		</method>
 		<method name="is_subgizmo_selected" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="id" type="int" />
@@ -212,12 +218,6 @@
 			<param index="0" name="node" type="Node" />
 			<description>
 				Sets the reference [Node3D] node for the gizmo. [param node] must inherit from [Node3D].
-			</description>
-		</method>
-		<method name="is_selected">
-			<return type="bool"/>
-			<description>
-				Returns [code]true[/code] if the gizmo is currently selected. Can be used to only show some gizmos when the node is selected during [method _redraw].
 			</description>
 		</method>
 	</methods>

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -867,6 +867,7 @@ void EditorNode3DGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hidden", "hidden"), &EditorNode3DGizmo::set_hidden);
 	ClassDB::bind_method(D_METHOD("is_subgizmo_selected", "id"), &EditorNode3DGizmo::is_subgizmo_selected);
 	ClassDB::bind_method(D_METHOD("get_subgizmo_selection"), &EditorNode3DGizmo::get_subgizmo_selection);
+	ClassDB::bind_method(D_METHOD("is_selected"), &EditorNode3DGizmo::is_selected);
 
 	GDVIRTUAL_BIND(_redraw);
 	GDVIRTUAL_BIND(_get_handle_name, "id", "secondary");


### PR DESCRIPTION
I noticed that the `is_selected` method on `EditorNode3DGizmo`  is not properly exposed in GDScript. This function is important to be able to make proper gizmo plugins that only show when the node is selected.

This PR aims to fix this by exposing `is_selected` in GDScript. I didn't add bindings for `set_selected` as I assumed it is only used internally and cannot be successfully called from user code. But I could add bindings for that function as well if needed.

I'm interested to know if there are any way to workaround this issue for current versions of Godot (`4.4.1` or `4.5-rc2`).