### PR TITLE
Document the interaction between Light3D cull mask and GI/volumetric fog

### DIFF
--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -68,6 +68,7 @@
 		</member>
 		<member name="light_cull_mask" type="int" setter="set_cull_mask" getter="get_cull_mask" default="4294967295">
 			The light will affect objects in the selected layers.
+			[b]Note:[/b] The light cull mask is ignored by [VoxelGI], SDFGI, [LightmapGI], and volumetric fog. These will always render lights in a way that ignores the cull mask. See also [member VisualInstance3D.layers].
 		</member>
 		<member name="light_energy" type="float" setter="set_param" getter="get_param" default="1.0">
 			The light's strength multiplier (this is not a physical unit). For [OmniLight3D] and [SpotLight3D], changing this value will only change the light color's intensity, not the light's radius.


### PR DESCRIPTION
I found this while testing https://github.com/godotengine/godot/pull/108219.
