### PR TITLE
Fix `Basis.determinant()` doc: uniform scale determinant is `scale^3`

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -74,7 +74,7 @@
 				Returns the [url=https://en.wikipedia.org/wiki/Determinant]determinant[/url] of this basis's matrix. For advanced math, this number can be used to determine a few attributes:
 				- If the determinant is exactly [code]0.0[/code], the basis is not invertible (see [method inverse]).
 				- If the determinant is a negative number, the basis represents a negative scale.
-				[b]Note:[/b] If the basis's scale is the same for every axis, its determinant is always that scale by the power of 2.
+				[b]Note:[/b] If the basis's scale is the same for every axis, its determinant is always that scale by the power of 3.
 			</description>
 		</method>
 		<method name="from_euler" qualifiers="static">


### PR DESCRIPTION
Corrected a documentation mistake in Basis.determinant(). For a uniform scale basis, the determinant is scale^3, not scale^2.

- *Production edit: This closes https://github.com/godotengine/godot-proposals/discussions/13147.*
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->
