### PR TITLE
Update links to the contributing section of the docs to the appropriate new sections.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,5 +4,5 @@ Please target the `master` branch in priority.
 Relevant fixes are cherry-picked for stable branches as needed by maintainers.
 
 To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
-https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
+https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 This document summarizes the most important points for people interested in
 contributing to Godot, especially via bug reports or pull requests.
 
-The Godot documentation has a dedicated [Contributing section](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html)
+Godot has a dedicated [Contributing documentation](https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html)
 which details these points and more, and is a recommended read.
 
 ## Table of contents
@@ -55,17 +55,17 @@ Similar rules can be applied when contributing bug fixes - it's always best to
 discuss the implementation in the bug report first if you are not 100% about
 what would be the best fix.
 
-You can refer to the [Pull request review process](https://docs.godotengine.org/en/latest/contributing/workflow/pr_review_guidelines.html)
+You can refer to the [Pull request review process](https://contributing.godotengine.org/en/latest/organization/pull_requests/review_guidelines.html)
 for insights into the intended lifecycle of pull requests. This should help you
 ensure that your pull request fulfills the requirements.
 
 In addition to the following tips, also take a look at the
-[Engine development guide](https://docs.godotengine.org/en/latest/contributing/development/index.html)
+[Engine development guide](https://docs.godotengine.org/en/latest/engine_details/development/index.html)
 for an introduction to developing on Godot.
 
-The [Contributing docs](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html)
-also have important information on the [PR workflow](https://docs.godotengine.org/en/latest/contributing/workflow/pr_workflow.html)
-(with a helpful guide for Git usage), and our [Code style guidelines](https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html)
+The [Contributing docs](https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html)
+also have important information on the [PR workflow](https://contributing.godotengine.org/en/latest/organization/pull_requests/creating_pull_requests.html)
+(with a helpful guide for Git usage), and our [Code style guidelines](https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html)
 which all contributions need to follow.
 
 ### Be mindful of your commits
@@ -84,7 +84,7 @@ stable state, i.e. if your first commit has a bug that you fixed in the second
 commit, try to merge them together before making your pull request. This
 includes fixing build issues or typos, adding documentation, etc.
 
-See our [PR workflow](https://docs.godotengine.org/en/latest/contributing/workflow/pr_workflow.html)
+See our [PR workflow](https://contributing.godotengine.org/en/latest/organization/pull_requests/creating_pull_requests.html)
 documentation for tips on using Git, amending commits and rebasing branches.
 
 This [Git style guide](https://github.com/agis-/git-style-guide) also has some
@@ -145,10 +145,10 @@ scripting APIs, you **must** update the class reference to document those.
 This is to ensure the documentation coverage doesn't decrease as contributions
 are merged.
 
-[Update documentation XML files](https://docs.godotengine.org/en/latest/contributing/documentation/updating_the_class_reference.html)
+[Update documentation XML files](https://contributing.godotengine.org/en/latest/documentation/class_reference.html)
 using your compiled binary, then fill in the descriptions.
 Follow the style guide described in the
-[Documentation writing guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html).
+[Documentation writing guidelines](https://contributing.godotengine.org/en/latest/documentation/guidelines/docs_writing_guidelines.html).
 
 If your pull request modifies parts of the code in a non-obvious way, make sure
 to add comments in the code as well. This helps other people understand the
@@ -174,7 +174,7 @@ applicable.
 Feel free to contribute standalone pull requests to add new tests or improve
 existing tests as well.
 
-See [Unit testing](https://docs.godotengine.org/en/latest/contributing/development/core_and_modules/unit_testing.html)
+See [Unit testing](https://contributing.godotengine.org/en/latest/engine/unit_tests.html)
 for information on writing tests in Godot's C++ codebase.
 
 ## Contributing to Godot translations
@@ -182,7 +182,7 @@ for information on writing tests in Godot's C++ codebase.
 You can contribute to Godot translations on [Hosted Weblate](https://hosted.weblate.org/projects/godot-engine/),
 an open source and web-based translation platform.
 
-Please refer to our [editor and documentation localization guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
+Please refer to our [editor and documentation localization guidelines](https://contributing.godotengine.org/en/latest/documentation/translation/index.html)
 for an overview of the translation resources and what they correspond to.
 
 ## Communicating with developers

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Official binaries for the Godot editor and the export templates can be found
 
 ### Compiling from source
 
-[See the official docs](https://docs.godotengine.org/en/latest/contributing/development/compiling)
+[See the official docs](https://docs.godotengine.org/en/latest/engine_details/development/compiling)
 for compilation instructions for every supported platform.
 
 ## Community and contributing

--- a/doc/classes/ResourceImporterTexture.xml
+++ b/doc/classes/ResourceImporterTexture.xml
@@ -56,7 +56,7 @@
 			Changing this import option only has an effect if a texture is detected as being used in 3D. Changing this to [b]Disabled[/b] then reimporting will not change the existing compress mode on a texture (if it's detected to be used in 3D), but choosing [b]VRAM Compressed[/b] or [b]Basis Universal[/b] will.
 		</member>
 		<member name="editor/convert_colors_with_editor_theme" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], converts the imported image's colors to match [member EditorSettings.interface/theme/icon_and_font_color]. This assumes the image uses the exact same colors as [url=$DOCS_URL/contributing/development/editor/creating_icons.html]Godot's own color palette for editor icons[/url], with the source file designed for a dark editor theme. This should be enabled for editor plugin icons and custom class icons, but should be left disabled otherwise.
+			If [code]true[/code], converts the imported image's colors to match [member EditorSettings.interface/theme/icon_and_font_color]. This assumes the image uses the exact same colors as [url=$DOCS_URL/engine_details/editor/creating_icons.html]Godot's own color palette for editor icons[/url], with the source file designed for a dark editor theme. This should be enabled for editor plugin icons and custom class icons, but should be left disabled otherwise.
 			[b]Note:[/b] Only available for SVG images.
 		</member>
 		<member name="editor/scale_with_editor_scale" type="bool" setter="" getter="" default="false">

--- a/doc/classes/Variant.xml
+++ b/doc/classes/Variant.xml
@@ -80,6 +80,6 @@
 		Modifications to a container will modify all references to it. A [Mutex] should be created to lock it if multi-threaded access is desired.
 	</description>
 	<tutorials>
-		<link title="Variant class introduction">$DOCS_URL/engine_details/development/core_and_modules/variant_class.html</link>
+		<link title="Variant class introduction">$DOCS_URL/engine_details/architecture/variant_class.html</link>
 	</tutorials>
 </class>

--- a/editor/icons/README.md
+++ b/editor/icons/README.md
@@ -3,5 +3,5 @@
 This folder contains all the icons used by Godot editor (except for platform
 icons which are located in their respective platform folder).
 
-See [Editor icons](https://docs.godotengine.org/en/latest/contributing/development/editor/creating_icons.html)
+See [Editor icons](https://docs.godotengine.org/en/latest/engine_details/editor/creating_icons.html)
 in the documentation for details on creating icons for the Godot editor.

--- a/modules/gdscript/tests/README.md
+++ b/modules/gdscript/tests/README.md
@@ -4,7 +4,7 @@ The `scripts/` folder contains integration tests in the form of GDScript files
 and output files.
 
 See the
-[Integration tests for GDScript documentation](https://docs.godotengine.org/en/latest/contributing/development/core_and_modules/unit_testing.html#integration-tests-for-gdscript)
+[Integration tests for GDScript documentation](https://docs.godotengine.org/en/latest/engine_details/architecture/unit_testing.html#integration-tests-for-gdscript)
 for information about creating and running GDScript integration tests.
 
 # GDScript Autocompletion tests

--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -5,7 +5,7 @@ using [Gradle](https://gradle.org/) as a build system.
 
 ## Documentation
 
-- [Compiling for Android](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_android.html)
+- [Compiling for Android](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_android.html)
   - Instructions on building this platform port from source.
 - [Exporting for Android](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_android.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/ios/README.md
+++ b/platform/ios/README.md
@@ -12,7 +12,7 @@ project template used for packaging the iOS export templates.
 
 ## Documentation
 
-- [Compiling for iOS](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_ios.html)
+- [Compiling for iOS](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_ios.html)
   - Instructions on building this platform port from source.
 - [Exporting for iOS](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_ios.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/linuxbsd/README.md
+++ b/platform/linuxbsd/README.md
@@ -7,7 +7,7 @@ used by this platform.
 
 ## Documentation
 
-- [Compiling for Linux/*BSD](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_linuxbsd.html)
+- [Compiling for Linux/*BSD](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_linuxbsd.html)
   - Instructions on building this platform port from source.
 - [Exporting for Linux/*BSD](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_linux.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/macos/README.md
+++ b/platform/macos/README.md
@@ -13,7 +13,7 @@ packaging macOS export templates.
 
 ## Documentation
 
-- [Compiling for macOS](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_macos.html)
+- [Compiling for macOS](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_macos.html)
   - Instructions on building this platform port from source.
 - [Exporting for macOS](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_macos.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/visionos/README.md
+++ b/platform/visionos/README.md
@@ -14,7 +14,7 @@ project template used for packaging the iOS export templates.
 
 The compiling and exporting process is the same as on iOS, but replacing the `ios` parameter by `visionos`.
 
-- [Compiling for iOS](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_ios.html)
+- [Compiling for iOS](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_ios.html)
   - Instructions on building this platform port from source.
 - [Exporting for iOS](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_ios.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/web/README.md
+++ b/platform/web/README.md
@@ -10,7 +10,7 @@ this platform such as the html shell (web page).
 
 ## Documentation
 
-- [Compiling for the Web](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_web.html)
+- [Compiling for the Web](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_web.html)
   - Instructions on building this platform port from source.
 - [Exporting for the Web](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_web.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/windows/README.md
+++ b/platform/windows/README.md
@@ -7,7 +7,7 @@ used by this platform.
 
 ## Documentation
 
-- [Compiling for Windows](https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_windows.html)
+- [Compiling for Windows](https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html)
   - Instructions on building this platform port from source.
 - [Exporting for Windows](https://docs.godotengine.org/en/latest/tutorials/export/exporting_for_windows.html)
   - Instructions on using the compiled export templates to export a project.

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -931,6 +931,6 @@ def check_d3d12_installed(env, suffix):
             "The Direct3D 12 rendering driver requires dependencies to be installed.\n"
             "You can install them by running `python misc\\scripts\\install_d3d12_sdk_windows.py`.\n"
             "See the documentation for more information:\n\t"
-            "https://docs.godotengine.org/en/latest/contributing/development/compiling/compiling_for_windows.html"
+            "https://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_windows.html"
         )
         sys.exit(255)


### PR DESCRIPTION
Follow-up of #110018 and https://github.com/godotengine/godot-docs/pull/11188.

Now that https://github.com/godotengine/godot-docs/pull/11274 is merged, we need to update all the links to the old sections as soon as possible. This is all of the ones i could find.