### PR TITLE
Allow custom debug monitors to select desired type

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -62,11 +62,16 @@ public:
 		last_perf_time = pt;
 
 		Array custom_monitor_names = performance->call("get_custom_monitor_names");
+		Array custom_monitor_types = performance->call("get_custom_monitor_types");
+
+		Array custom_monitor_data;
+		custom_monitor_data.push_back(custom_monitor_names);
+		custom_monitor_data.push_back(custom_monitor_types);
 
 		uint64_t monitor_modification_time = performance->call("get_monitor_modification_time");
 		if (monitor_modification_time > last_monitor_modification_time) {
 			last_monitor_modification_time = monitor_modification_time;
-			EngineDebugger::get_singleton()->send_message("performance:profile_names", custom_monitor_names);
+			EngineDebugger::get_singleton()->send_message("performance:profile_names", custom_monitor_data);
 		}
 
 		int max = performance->get("MONITOR_MAX");

--- a/doc/classes/Performance.xml
+++ b/doc/classes/Performance.xml
@@ -18,6 +18,7 @@
 			<param index="0" name="id" type="StringName" />
 			<param index="1" name="callable" type="Callable" />
 			<param index="2" name="arguments" type="Array" default="[]" />
+			<param index="3" name="type" type="int" enum="Performance.MonitorType" default="0" />
 			<description>
 				Adds a custom monitor with the name [param id]. You can specify the category of the monitor using slash delimiters in [param id] (for example: [code]"Game/NumberOfNPCs"[/code]). If there is more than one slash delimiter, then the default category is used. The default category is [code]"Custom"[/code]. Prints an error if given [param id] is already present.
 				[codeblocks]
@@ -82,6 +83,12 @@
 			<return type="StringName[]" />
 			<description>
 				Returns the names of active custom monitors in an [Array].
+			</description>
+		</method>
+		<method name="get_custom_monitor_types">
+			<return type="PackedInt32Array" />
+			<description>
+				Returns the [enum MonitorType] values of active custom monitors in an [Array].
 			</description>
 		</method>
 		<method name="get_monitor" qualifiers="const">
@@ -302,6 +309,18 @@
 		</constant>
 		<constant name="MONITOR_MAX" value="59" enum="Monitor">
 			Represents the size of the [enum Monitor] enum.
+		</constant>
+		<constant name="MONITOR_TYPE_QUANTITY" value="0" enum="MonitorType">
+			Monitor output is formatted as an integer value.
+		</constant>
+		<constant name="MONITOR_TYPE_MEMORY" value="1" enum="MonitorType">
+			Monitor output is formatted as computer memory. Submitted values should represent a number of bytes.
+		</constant>
+		<constant name="MONITOR_TYPE_TIME" value="2" enum="MonitorType">
+			Monitor output is formatted as time in milliseconds. Submitted values should represent a time in seconds (not milliseconds).
+		</constant>
+		<constant name="MONITOR_TYPE_PERCENTAGE" value="3" enum="MonitorType">
+			Monitor output is formatted as a percentage. Submitted values should represent a fractional value rather than the percentage directly, e.g. [code]0.5[/code] for [code]50.00%[/code].
 		</constant>
 	</constants>
 </class>

--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -88,6 +88,9 @@ String EditorPerformanceProfiler::_create_label(float p_value, Performance::Moni
 		case Performance::MONITOR_TYPE_TIME: {
 			return TS->format_number(rtos(p_value * 1000).pad_decimals(2)) + " " + TTR("ms");
 		}
+		case Performance::MONITOR_TYPE_PERCENTAGE: {
+			return TS->format_number(rtos(p_value * 100).pad_decimals(2)) + "%";
+		}
 		default: {
 			return TS->format_number(rtos(p_value));
 		}
@@ -317,7 +320,7 @@ void EditorPerformanceProfiler::reset() {
 	monitor_draw->queue_redraw();
 }
 
-void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_names) {
+void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_names, const PackedInt32Array &p_types) {
 	HashMap<StringName, int> names;
 	for (int i = 0; i < p_names.size(); i++) {
 		names.insert("custom:" + p_names[i], Performance::MONITOR_MAX + i);
@@ -340,6 +343,7 @@ void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_name
 		}
 	}
 
+	int index = 0;
 	for (const KeyValue<StringName, int> &E : names) {
 		String name = String(E.key).replace_first("custom:", "");
 		String base = "Custom";
@@ -347,7 +351,9 @@ void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_name
 			base = name.get_slicec('/', 0);
 			name = name.get_slicec('/', 1);
 		}
-		monitors.insert(E.key, Monitor(name, base, E.value, Performance::MONITOR_TYPE_QUANTITY, nullptr));
+		Performance::MonitorType type = Performance::MonitorType(p_types[index]);
+		monitors.insert(E.key, Monitor(name, base, E.value, type, nullptr));
+		index++;
 	}
 
 	_build_monitor_tree();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -912,13 +912,25 @@ void ScriptEditorDebugger::_msg_show_selection_limit_warning(uint64_t p_thread_i
 }
 
 void ScriptEditorDebugger::_msg_performance_profile_names(uint64_t p_thread_id, const Array &p_data) {
+	ERR_FAIL_COND(p_data.size() != 2);
+	Array name_data = p_data[0];
+	Array type_data = p_data[1];
+
 	Vector<StringName> monitors;
-	monitors.resize(p_data.size());
-	for (int i = 0; i < p_data.size(); i++) {
-		ERR_FAIL_COND(p_data[i].get_type() != Variant::STRING_NAME);
-		monitors.set(i, p_data[i]);
+	monitors.resize(name_data.size());
+	for (int i = 0; i < name_data.size(); i++) {
+		ERR_FAIL_COND(name_data[i].get_type() != Variant::STRING_NAME);
+		monitors.set(i, name_data[i]);
 	}
-	performance_profiler->update_monitors(monitors);
+
+	PackedInt32Array types;
+	types.resize(type_data.size());
+	for (int i = 0; i < type_data.size(); i++) {
+		ERR_FAIL_COND(type_data[i].get_type() != Variant::INT);
+		types.set(i, type_data[i]);
+	}
+
+	performance_profiler->update_monitors(monitors, types);
 }
 
 void ScriptEditorDebugger::_msg_filesystem_update_file(uint64_t p_thread_id, const Array &p_data) {

--- a/main/performance.compat.inc
+++ b/main/performance.compat.inc
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_performance_profiler.h                                         */
+/*  performance.compat.inc                                                */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,62 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#ifndef DISABLE_DEPRECATED
 
-#include "core/templates/hash_map.h"
-#include "main/performance.h"
-#include "scene/gui/control.h"
-#include "scene/gui/label.h"
-#include "scene/gui/split_container.h"
-#include "scene/gui/tree.h"
+void Performance::_add_custom_monitor_bind_compat_110433(const StringName &p_id, const Callable &p_callable, const Vector<Variant> &p_args) {
+	add_custom_monitor(p_id, p_callable, p_args, MONITOR_TYPE_QUANTITY);
+}
 
-class EditorPerformanceProfiler : public HSplitContainer {
-	GDCLASS(EditorPerformanceProfiler, HSplitContainer);
+void Performance::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("add_custom_monitor", "id", "callable", "arguments"), &Performance::_add_custom_monitor_bind_compat_110433, DEFVAL(Array()));
+}
 
-private:
-	class Monitor {
-	public:
-		String name;
-		String base;
-		List<float> history;
-		float max = 0.0f;
-		TreeItem *item = nullptr;
-		Performance::MonitorType type = Performance::MONITOR_TYPE_QUANTITY;
-		int frame_index = 0;
-
-		Monitor() {}
-		Monitor(const String &p_name, const String &p_base, int p_frame_index, Performance::MonitorType p_type, TreeItem *p_item);
-		void update_value(float p_value);
-		void reset();
-	};
-
-	HashMap<StringName, Monitor> monitors;
-
-	HashMap<StringName, TreeItem *> base_map;
-	Tree *monitor_tree = nullptr;
-	Control *monitor_draw = nullptr;
-	Label *info_message = nullptr;
-	StringName marker_key;
-	int marker_frame = 0;
-	const int MARGIN = 4;
-	const int POINT_SEPARATION = 5;
-	const int MARKER_MARGIN = 2;
-
-	static String _create_label(float p_value, Performance::MonitorType p_type);
-	void _monitor_select();
-	void _monitor_draw();
-	void _build_monitor_tree();
-	TreeItem *_get_monitor_base(const StringName &p_base_name);
-	TreeItem *_create_monitor_item(const StringName &p_monitor_name, TreeItem *p_base);
-	void _marker_input(const Ref<InputEvent> &p_event);
-
-protected:
-	void _notification(int p_what);
-
-public:
-	void reset();
-	void update_monitors(const Vector<StringName> &p_names, const PackedInt32Array &p_types);
-	void add_profile_frame(const Vector<float> &p_values);
-	List<float> *get_monitor_data(const StringName &p_name);
-	EditorPerformanceProfiler();
-};
+#endif

--- a/main/performance.h
+++ b/main/performance.h
@@ -45,25 +45,17 @@ class Performance : public Object {
 	static Performance *singleton;
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	void _add_custom_monitor_bind_compat_110433(const StringName &p_id, const Callable &p_callable, const Vector<Variant> &p_args);
+	static void _bind_compatibility_methods();
+#endif
+
 	int _get_node_count() const;
 	int _get_orphan_node_count() const;
 
 	double _process_time;
 	double _physics_process_time;
 	double _navigation_process_time;
-
-	class MonitorCall {
-		Callable _callable;
-		Vector<Variant> _arguments;
-
-	public:
-		MonitorCall(Callable p_callable, Vector<Variant> p_arguments);
-		MonitorCall();
-		Variant call(bool &r_error, String &r_error_message);
-	};
-
-	HashMap<StringName, MonitorCall> _monitor_map;
-	uint64_t _monitor_modification_time;
 
 public:
 	enum Monitor {
@@ -135,7 +127,8 @@ public:
 	enum MonitorType {
 		MONITOR_TYPE_QUANTITY,
 		MONITOR_TYPE_MEMORY,
-		MONITOR_TYPE_TIME
+		MONITOR_TYPE_TIME,
+		MONITOR_TYPE_PERCENTAGE,
 	};
 
 	double get_monitor(Monitor p_monitor) const;
@@ -147,17 +140,35 @@ public:
 	void set_physics_process_time(double p_pt);
 	void set_navigation_process_time(double p_pt);
 
-	void add_custom_monitor(const StringName &p_id, const Callable &p_callable, const Vector<Variant> &p_args);
+	void add_custom_monitor(const StringName &p_id, const Callable &p_callable, const Vector<Variant> &p_args, MonitorType p_type = MONITOR_TYPE_QUANTITY);
 	void remove_custom_monitor(const StringName &p_id);
 	bool has_custom_monitor(const StringName &p_id);
 	Variant get_custom_monitor(const StringName &p_id);
 	TypedArray<StringName> get_custom_monitor_names();
+	Vector<int> get_custom_monitor_types();
 
 	uint64_t get_monitor_modification_time();
 
 	static Performance *get_singleton() { return singleton; }
 
 	Performance();
+
+private:
+	class MonitorCall {
+		MonitorType _type = MONITOR_TYPE_QUANTITY;
+		Callable _callable;
+		Vector<Variant> _arguments;
+
+	public:
+		MonitorCall(MonitorType p_type, const Callable &p_callable, const Vector<Variant> &p_arguments);
+		MonitorCall();
+		Variant call(bool &r_error, String &r_error_message);
+		inline MonitorType get_monitor_type() const { return _type; }
+	};
+
+	HashMap<StringName, MonitorCall> _monitor_map;
+	uint64_t _monitor_modification_time;
 };
 
 VARIANT_ENUM_CAST(Performance::Monitor);
+VARIANT_ENUM_CAST(Performance::MonitorType);

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -61,3 +61,10 @@ GH-111439
 Validate extension JSON: Error: Field 'classes/FileDialog/methods/add_filter/arguments': size changed value in new API, from 2 to 3.
 
 Optional argument added. Compatibility method registered.
+
+
+GH-110433
+---------
+Validate extension JSON: Error: Field 'classes/Performance/methods/add_custom_monitor/arguments': size changed value in new API, from 3 to 4.
+
+Optional argument added. Compatibility method registered.


### PR DESCRIPTION
Currently when adding a custom monitor to the debug panel with [`add_custom_monitor`](https://docs.godotengine.org/en/4.4/classes/class_performance.html#class-performance-method-add-custom-monitor), the monitor will always be `MONITOR_TYPE_QUANTITY` and display the monitor value as an integer. This PR allows users to pass in a `MonitorType` so that their custom debug monitors can be better formatted.

I've also added `MONITOR_TYPE_PERCENTAGE` as another option.

**EDIT 2025-9-15:** Here's a screenshot with some example custom monitors added
<img width="880" height="387" alt="image" src="https://github.com/user-attachments/assets/383e4da5-ad6a-4097-b7c3-11ec0370257e" />
