### PR TITLE
Improve look of some buttons inside the inspector

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -414,6 +414,7 @@ class EditorInspectorSection : public Container {
 		int vertical_separation = 0;
 		int inspector_margin = 0;
 		int indent_size = 0;
+		int key_padding_size = 0;
 
 		Color warning_color;
 		Color prop_subsection;


### PR DESCRIPTION
- Slight increase the horizontal padding.
- Switch the hover effect from "Button" to "FlatButton" style (not noticeable now, but will be in _someone's_ theme. :slightly_smiling_face:).
- ~Fix some properties overlapping the animation key button when the inspector width is very small.~ [1]
- Fix hovering effect staying when the mouse leaves the button vertically in properties that unfold.

|Before|After|
|-|-|
|<img width="313" height="74" alt="Screenshot_20250911_181146" src="https://github.com/user-attachments/assets/9d354c4c-7c4f-40ae-887a-1afc7137617a" />|<img width="313" height="74" alt="Screenshot_20250911_180911" src="https://github.com/user-attachments/assets/a7f46c2e-d908-4a7c-a3ed-3ec81e2aac56" />|

[1] Caused a regression, fixed by #110827. If this is cherry-picked, that PR needs to be as well.