### PR TITLE
Work around faulty particle animation frame calculation (Vulkan/OpenGL AMD Windows drivers)

### DIFF
--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -130,9 +130,13 @@ void CanvasItemMaterial::_update_shader() {
 		code += "		particle_frame = clamp(particle_frame, 0.0, particle_total_frames - 1.0);\n";
 		code += "	} else {\n";
 		code += "		particle_frame = mod(particle_frame, particle_total_frames);\n";
-		code += "	}";
+		code += "	}\n";
 		code += "	UV /= vec2(h_frames, v_frames);\n";
-		code += "	UV += vec2(mod(particle_frame, h_frames) / h_frames, floor((particle_frame + 0.5) / h_frames) / v_frames);\n";
+		// Calculating x offset below as `particle_frame / h_frames - frame_row`
+		// instead of `mod(particle_frame, h_frames) / h_frames` or `fract(particle_frame / h_frames)`
+		// as a workaround for faulty results (1.0 instead of 0.0) in some cases for Vulkan/OpenGL AMD Windows drivers (GH-110425).
+		code += "	float frame_row = floor((particle_frame + 0.5) / h_frames);\n";
+		code += "	UV += vec2(particle_frame / h_frames - frame_row, frame_row / v_frames);\n";
 		code += "}\n";
 	}
 


### PR DESCRIPTION
Modifies particle animation frame calculations to work around #110425.

Frame row within the y offset calculation was already calculated like `floor((particle_frame + 0.5) / h_frames)`, I guess that `+ 0.5` was done to work around similar issue as #110425. I've modified the x offset calculation to also use such reliably calculated frame row. Even if `particle_frame / h_frames` will incorrectly return approx `row` instead of exactly `row` for some first frame in a row, the `particle_frame / h_frames - frame_row` will result in approx `0.0` contrary to `1.0` which might be produced by `mod(particle_frame, h_frames) / h_frames` or `fract(particle_frame / h_frames)`.

Before|After
-|-
<img width="479" height="522" alt="c0vbPeWkb1" src="https://github.com/user-attachments/assets/4ca5e982-f38a-40b9-85fd-2edc5f1c50be" />|<img width="378" height="506" alt="godot windows editor dev x86_64_KzcNL9Cp6S" src="https://github.com/user-attachments/assets/4e974ff5-667c-4392-99f6-399df061ee0c" />
