### PR TITLE
Use proper linear sRGB conversions on Compatibility

### DIFF
--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -10,19 +10,18 @@ layout(std140) uniform TonemapData { //ubo:0
 	float saturation;
 };
 
-// This expects 0-1 range input.
 vec3 linear_to_srgb(vec3 color) {
-	//color = clamp(color, vec3(0.0), vec3(1.0));
-	//const vec3 a = vec3(0.055f);
-	//return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
-	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
-	return max(vec3(1.055) * pow(color, vec3(0.416666667)) - vec3(0.055), vec3(0.0));
+	return vec3(
+			color.r <= 0.0031308 ? color.r * 12.92 : 1.055 * pow(color.r, 1.0 / 2.4) - 0.055,
+			color.g <= 0.0031308 ? color.g * 12.92 : 1.055 * pow(color.g, 1.0 / 2.4) - 0.055,
+			color.b <= 0.0031308 ? color.b * 12.92 : 1.055 * pow(color.b, 1.0 / 2.4) - 0.055);
 }
 
-// This expects 0-1 range input, outside that range it behaves poorly.
 vec3 srgb_to_linear(vec3 color) {
-	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
-	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);
+	return vec3(
+			color.r <= 0.04045 ? color.r / 12.92 : pow((color.r + 0.055) / 1.055, 2.4),
+			color.g <= 0.04045 ? color.g / 12.92 : pow((color.g + 0.055) / 1.055, 2.4),
+			color.b <= 0.04045 ? color.b / 12.92 : pow((color.b + 0.055) / 1.055, 2.4));
 }
 
 #ifdef APPLY_TONEMAPPING


### PR DESCRIPTION
I briefly mentioned this in the [rc](https://chat.godotengine.org/channel/rendering/thread/S7gKFGEwsDTo2Racf) but again:

The current approximations for sRGB-linear conversion used on the Compatibility shaders are _rough_. A color may shift as much as ~6.8 values during a roundtrip e.g. `(7, 20, 38)` -> `(0, 16, 36)`. Most of the error is concentrated on the darker values:

<img width="1024" height="64" alt="gardient" src="https://github.com/user-attachments/assets/af183fbc-59a2-43f0-80da-8b6563e2cf42" />
<img width="1024" height="64" alt="gardientWerror" src="https://github.com/user-attachments/assets/026b1503-a125-425a-9190-88f46a93cb80" />
<img width="1024" height="64" alt="gradient_compatibility" src="https://github.com/user-attachments/assets/c3f2361f-9cd8-4f3a-a1bd-ffb5f9d7405b" />

_The result of rendering an 8 bit sRGB gradient on Compatilibity Renderer 3D using Linear tonemapping and no lighting. From top to bottom: gradient, gradient with colors shifted more than 1 value marked with red, absolute error divided by max absolute error._

This is a critical part to get right as the error will compound with every following calculation. At the same time, it is admittedly tempting to approximate the functions as the proper ones are not the simplest. On newer desktops their cost is practically irrelevant, but there are some concerns of what the numbers look like on older/mobile machines as the functions can be called multiple times per pixel.

If at all possible, the proper functions should be used. They're not a good place to skimp on quality, given how big of an impact they have on the final color (technically speaking, only ~76% of colors appear correctly currently). That said, in the event that using the proper functions is simply out of the budget, I did also look at using better approximations. Surprisingly the web didn't seem to offer any, and thus I took a stab at creating couple myself:

<img width="600" height="500" alt="error-waves" src="https://github.com/user-attachments/assets/f6a957e6-bf3a-43bb-84cd-8ee1f1bd4159" />

_Absolute error compared to the proper function for sRGB to linear conversion scaled to the max error of the 3rd degree polynomial approximation currently in use. From top max to min error: 3rd degree, 4th degree, 5th degree, 6th degree polynomial, and 4th degree polynomial with extra division term._
<details>
  <summary>Functions as gdscript</summary>
  
  ```gdscript
# Proper conversion from linear to sRGB; "Ground truth".
func linear_to_srgb(C_lin: float) -> float:
	if (C_lin <= 0.0031308):
		return C_lin * 12.92
	else:
		return 1.055 * pow(C_lin, 1.0 / 2.4) - 0.055

# Proper conversion from sRGB to linear; "Ground truth".
func srgb_to_linear(x: float) -> float:
	if (x <= 0.04045):
		return x / 12.92
	else:
		return pow((x + 0.055) / 1.055, 2.4)

# Error is measured as the maximum absolute difference between approximation and "ground truth".
# Function is specifically sampled at byte range as that is the most important to get right,
# since the function is mainly used after sampling 8 bpc images.
func get_error(approx_func: Callable) -> float:
	var error: float = 0.0
	for i: int in 256:
		var x: float = float(i) / 255.0
		var approx: float = linear_to_srgb(approx_func.call(x))
		var truth:  float = linear_to_srgb(srgb_to_linear(x))
		error = maxf(error, absf(approx - truth) * 255.0)
	return error

# 3rd degree approximation for conversion from sRGB to linear.
# Maximum absolute error: 4.97650843991149
func srgb_to_linear3(x: float) -> float:
	# Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
	return x * (x * (x * 0.305306011 + 0.682171111) + 0.012522878)

# 4th degree approximation for conversion from sRGB to linear.
# Maximum absolute error: 2.42472471929748
func srgb_to_linear4(x: float) -> float:
	const A: float = 0.03663759556202023
	const B: float = 0.5455181222066212
	const C: float = 0.5303844680616453
	const D: float = -0.11254018583177583
	return x * (x * (x * (x * D + C) + B) + A)

# 5th degree approximation for conversion from sRGB to linear.
# Maximum absolute error: 1.62327377372596
func srgb_to_linear5(x: float) -> float:
	const A: float = 0.04663849658753321
	const B: float = 0.4555100218658552
	const C: float = 0.7904079360347088
	const D: float = -0.41256725023533375
	const E: float = 0.1200107957486438
	return x * (x * (x * (x * (x * E + D) + C) + B) + A)

# 6th degree approximation for conversion from sRGB to linear.
# Maximum absolute error: 1.16801796917133
func srgb_to_linear6(x: float) -> float:
	const A: float = 0.053591337996
	const B: float = 0.36512313475
	const C: float = 1.1867196127
	const D: float = -1.1843320904
	const E: float = 0.80834160344
	const F: float = 1.0 - A - B - C - D - E
	return x * (x * (x * (x * (x * (x * F + E) + D) + C) + B) + A)

# 4th degree approximation with error minimization for conversion from sRGB to linear.
# Maximum absolute error: 0.24973327388874
func srgb_to_linear4e(x: float) -> float:
	const A: float = -0.061739930596
	const B: float = 0.40610679064
	const C: float = 0.65166786075
	const D: float = -0.00036823780623
	const E: float = -0.067402137164
	const F: float = 1.0 - A - B - C - D/(1.0 - E) - D/E
	return (((A*x + B)*x + C)*x + F)*x + D/(x - E) + D/E
```
  
</details>

Unfortunately, I didn't quite reach my goal of visually lossless round-trip as even the ~0.25 error isn't quite enough for that. It is however leagues better than the basic polynomials. 

Some notes:
- All functions are constrained to give 0 at 0 and 1 at 1 and be continuous in 0 to 1 range.
- I'm not well versed on the performance of constant arrays; most of the function calls happen after sampling textures, so reading the values from there in those instances might also be an option.
- The methods that I used for curve fitting really don't seem to like the linear part in the beginning - omitting that, they become quite good approximations.

### Help needed ###
- Testing the performance impact on slower/mobile devices.
- If you happen to be knowledgeable of any better approximations or are familiar with curve fitting, I'd gladly see if the current approximations could be improved.
