### PR TITLE
Fix the UID cache might not be synchronized when copying directories externally

### DIFF
--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -86,7 +86,7 @@ public:
 	Error update_cache();
 	static String get_path_from_cache(Ref<FileAccess> &p_cache_file, const String &p_uid_string);
 
-	void clear();
+	void verify();
 
 	static ResourceUID *get_singleton() { return singleton; }
 


### PR DESCRIPTION
Validate cached entries for uids and purge invalid entries instead of purging all entries, which keeps the uids of files as unchanged as possible.

Automatically assign new UIDs to duplicate new files. This prevents the file path corresponding to the UID in the UID cache from being replaced (from the perspective of the file path, the UID of the file has changed).

Fix #102490.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html
-->

If your project directory has many files, this approach is somewhat inefficient. A more appropriate approach is to use the `EditorFileSystem` cache `filesystem` to track changes to the directory file tree. When a file is deleted, remove the corresponding `uid` using `ResourceUID::remove_id()`. However, the current `EditorFileSystem`'s tracking of files is limited (for example, the handling of directory deletion is too rough), which makes some caches unreliable.
