### PR TITLE
Prevent JNI Variant conversion stack overflow

### DIFF
--- a/platform/android/jni_utils.h
+++ b/platform/android/jni_utils.h
@@ -44,11 +44,11 @@ struct jvalret {
 	jvalret() { obj = nullptr; }
 };
 
-jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_arg, bool force_jobject = false);
+jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_arg, bool force_jobject = false, int p_depth = 0);
 
 String _get_class_name(JNIEnv *env, jclass cls, bool *array);
 
-Variant _jobject_to_variant(JNIEnv *env, jobject obj);
+Variant _jobject_to_variant(JNIEnv *env, jobject obj, int p_depth = 0);
 
 Variant::Type get_jni_type(const String &p_type);
 


### PR DESCRIPTION
While I was testing a plugin with Godot on Android, I triggered a stack overflow by trying to convert a Variant with cyclic references. This PR prevents crashes by adding a call depth guard, similar to how it's handled in other places in the codebase.