### PR TITLE
Fix links in `CONTRIBUTING.md` now that contributor doc is on contributing.godotengine.org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 This document summarizes the most important points for people interested in
 contributing to Godot, especially via bug reports or pull requests.
 
-The Godot documentation has a dedicated [Contributing section](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html)
+There is also a dedicated [Godot contributing documentation](https://contributing.godotengine.org/en/latest/index.html)
 which details these points and more, and is a recommended read.
 
 ## Table of contents
@@ -55,18 +55,17 @@ Similar rules can be applied when contributing bug fixes - it's always best to
 discuss the implementation in the bug report first if you are not 100% about
 what would be the best fix.
 
-You can refer to the [Pull request review process](https://docs.godotengine.org/en/latest/contributing/workflow/pr_review_guidelines.html)
-for insights into the intended lifecycle of pull requests. This should help you
-ensure that your pull request fulfills the requirements.
-
 In addition to the following tips, also take a look at the
-[Engine development guide](https://docs.godotengine.org/en/latest/contributing/development/index.html)
-for an introduction to developing on Godot.
-
-The [Contributing docs](https://docs.godotengine.org/en/latest/contributing/how_to_contribute.html)
-also have important information on the [PR workflow](https://docs.godotengine.org/en/latest/contributing/workflow/pr_workflow.html)
-(with a helpful guide for Git usage), and our [Code style guidelines](https://docs.godotengine.org/en/latest/contributing/development/code_style_guidelines.html)
+[Introduction to engine contributions](https://contributing.godotengine.org/en/latest/engine/introduction.html)
+and [Engine contribution guidelines](https://contributing.godotengine.org/en/latest/engine/guidelines/index.html)
 which all contributions need to follow.
+
+The [Contributing docs](https://contributing.godotengine.org/en/latest/organization/how_to_contribute.html)
+also have important information on the [PR workflow](https://contributing.godotengine.org/en/latest/organization/pull_requests/index.html)
+(with a helpful [guide for Git usage](https://contributing.godotengine.org/en/latest/organization/pull_requests/creating_pull_requests.html))
+and the [Pull request review process](https://contributing.godotengine.org/en/latest/organization/pull_requests/review_process.html)
+with insights into the intended lifecycle of pull requests.
+This should help you ensure that your pull request fulfills the requirements.
 
 ### Be mindful of your commits
 
@@ -84,7 +83,7 @@ stable state, i.e. if your first commit has a bug that you fixed in the second
 commit, try to merge them together before making your pull request. This
 includes fixing build issues or typos, adding documentation, etc.
 
-See our [PR workflow](https://docs.godotengine.org/en/latest/contributing/workflow/pr_workflow.html)
+See our [PR workflow](https://contributing.godotengine.org/en/latest/organization/pull_requests/index.html)
 documentation for tips on using Git, amending commits and rebasing branches.
 
 This [Git style guide](https://github.com/agis-/git-style-guide) also has some
@@ -145,10 +144,10 @@ scripting APIs, you **must** update the class reference to document those.
 This is to ensure the documentation coverage doesn't decrease as contributions
 are merged.
 
-[Update documentation XML files](https://docs.godotengine.org/en/latest/contributing/documentation/updating_the_class_reference.html)
+[Update documentation XML files](https://contributing.godotengine.org/en/latest/documentation/class_reference.html)
 using your compiled binary, then fill in the descriptions.
 Follow the style guide described in the
-[Documentation writing guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/docs_writing_guidelines.html).
+[Documentation writing guidelines](https://contributing.godotengine.org/en/latest/documentation/guidelines/index.html).
 
 If your pull request modifies parts of the code in a non-obvious way, make sure
 to add comments in the code as well. This helps other people understand the
@@ -174,7 +173,7 @@ applicable.
 Feel free to contribute standalone pull requests to add new tests or improve
 existing tests as well.
 
-See [Unit testing](https://docs.godotengine.org/en/latest/contributing/development/core_and_modules/unit_testing.html)
+See [Unit testing](https://contributing.godotengine.org/en/latest/engine/unit_tests.html)
 for information on writing tests in Godot's C++ codebase.
 
 ## Contributing to Godot translations
@@ -182,7 +181,7 @@ for information on writing tests in Godot's C++ codebase.
 You can contribute to Godot translations on [Hosted Weblate](https://hosted.weblate.org/projects/godot-engine/),
 an open source and web-based translation platform.
 
-Please refer to our [editor and documentation localization guidelines](https://docs.godotengine.org/en/latest/contributing/documentation/editor_and_docs_localization.html)
+Please refer to our [editor and documentation localization guidelines](https://contributing.godotengine.org/en/latest/documentation/translation/index.html)
 for an overview of the translation resources and what they correspond to.
 
 ## Communicating with developers


### PR DESCRIPTION
I had to rework some of the text since the new contributing.godotengine.org website doesn't seem to be a 1-to-1 equivalence with the old documentation...