### PR TITLE
Avoid unnecessary accessibility calls when accesskit is not supported

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4914,8 +4914,12 @@ bool Main::iteration() {
 		return exit;
 	}
 
+#ifdef ACCESSKIT_ENABLED
 	SceneTree *scene_tree = SceneTree::get_singleton();
 	bool wake_for_events = scene_tree && scene_tree->is_accessibility_enabled();
+#else
+	bool wake_for_events = false;
+#endif // ACCESSKIT_ENABLED
 
 	OS::get_singleton()->add_frame_delay(DisplayServer::get_singleton()->window_can_draw(), wake_for_events);
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4839,6 +4839,7 @@ void Tree::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE:
 		case NOTIFICATION_ACCESSIBILITY_INVALIDATE: {
+#ifdef ACCESSKIT_ENABLED
 			if (root) {
 				_accessibility_clean_info(root);
 			}
@@ -4846,8 +4847,10 @@ void Tree::_notification(int p_what) {
 				col.accessibility_col_element = RID();
 			}
 			accessibility_scroll_element = RID();
+#endif // ACCESSKIT_ENABLED
 		} break;
 
+#ifdef ACCESSKIT_ENABLED
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
@@ -4906,6 +4909,7 @@ void Tree::_notification(int p_what) {
 			DisplayServer::get_singleton()->accessibility_update_set_table_row_count(ae, rows);
 
 		} break;
+#endif // ACCESSKIT_ENABLED
 
 		case NOTIFICATION_FOCUS_ENTER: {
 			if (get_viewport()) {

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -91,6 +91,7 @@ void Node::_notification(int p_notification) {
 			ERR_FAIL_NULL(get_viewport());
 			ERR_FAIL_NULL(data.tree);
 
+#ifdef ACCESSKIT_ENABLED
 			if (data.tree->is_accessibility_supported() && !is_part_of_edited_scene()) {
 				data.tree->_accessibility_force_update();
 				data.tree->_accessibility_notify_change(this);
@@ -100,6 +101,7 @@ void Node::_notification(int p_notification) {
 					data.tree->_accessibility_notify_change(get_window()); // Root node.
 				}
 			}
+#endif // ACCESSKIT_ENABLED
 
 			// Update process mode.
 			if (data.process_mode == PROCESS_MODE_INHERIT) {
@@ -179,6 +181,7 @@ void Node::_notification(int p_notification) {
 			ERR_FAIL_NULL(get_viewport());
 			ERR_FAIL_NULL(data.tree);
 
+#ifdef ACCESSKIT_ENABLED
 			if (data.tree->is_accessibility_supported() && !is_part_of_edited_scene()) {
 				if (data.accessibility_element.is_valid()) {
 					DisplayServer::get_singleton()->accessibility_free_element(data.accessibility_element);
@@ -191,6 +194,7 @@ void Node::_notification(int p_notification) {
 					data.tree->_accessibility_notify_change(get_window()); // Root node.
 				}
 			}
+#endif // ACCESSKIT_ENABLED
 
 			data.tree->nodes_in_tree_count--;
 			orphan_node_count++;
@@ -3685,9 +3689,11 @@ RID Node::get_focused_accessibility_element() const {
 }
 
 void Node::queue_accessibility_update() {
+#ifdef ACCESSKIT_ENABLED
 	if (is_inside_tree() && !is_part_of_edited_scene()) {
 		data.tree->_accessibility_notify_change(this);
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 RID Node::get_accessibility_element() const {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -203,6 +203,7 @@ void SceneTree::flush_transform_notifications() {
 }
 
 bool SceneTree::is_accessibility_enabled() const {
+#ifdef ACCESSKIT_ENABLED
 	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_ACCESSIBILITY_SCREEN_READER)) {
 		return false;
 	}
@@ -213,9 +214,13 @@ bool SceneTree::is_accessibility_enabled() const {
 		return false;
 	}
 	return true;
+#else
+	return false;
+#endif // ACCESSKIT_ENABLED
 }
 
 bool SceneTree::is_accessibility_supported() const {
+#ifdef ACCESSKIT_ENABLED
 	if (!DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_ACCESSIBILITY_SCREEN_READER)) {
 		return false;
 	}
@@ -225,6 +230,9 @@ bool SceneTree::is_accessibility_supported() const {
 		return false;
 	}
 	return true;
+#else
+	return false;
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_accessibility_force_update() {
@@ -232,6 +240,7 @@ void SceneTree::_accessibility_force_update() {
 }
 
 void SceneTree::_accessibility_notify_change(const Node *p_node, bool p_remove) {
+#ifdef ACCESSKIT_ENABLED
 	if (p_node) {
 		if (p_remove) {
 			accessibility_change_queue.erase(p_node->get_instance_id());
@@ -239,9 +248,11 @@ void SceneTree::_accessibility_notify_change(const Node *p_node, bool p_remove) 
 			accessibility_change_queue.insert(p_node->get_instance_id());
 		}
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_process_accessibility_changes(DisplayServer::WindowID p_window_id) {
+#ifdef ACCESSKIT_ENABLED
 	// Process NOTIFICATION_ACCESSIBILITY_UPDATE.
 	Vector<ObjectID> processed;
 	for (const ObjectID &id : accessibility_change_queue) {
@@ -291,9 +302,11 @@ void SceneTree::_process_accessibility_changes(DisplayServer::WindowID p_window_
 	for (const ObjectID &id : processed) {
 		accessibility_change_queue.erase(id);
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_flush_accessibility_changes() {
+#ifdef ACCESSKIT_ENABLED
 	if (is_accessibility_enabled()) {
 		uint64_t time = OS::get_singleton()->get_ticks_msec();
 		if (!accessibility_force_update) {
@@ -307,6 +320,7 @@ void SceneTree::_flush_accessibility_changes() {
 		// Push update to the accessibility driver.
 		DisplayServer::get_singleton()->accessibility_update_if_active(callable_mp(this, &SceneTree::_process_accessibility_changes));
 	}
+#endif // ACCESSKIT_ENABLED
 }
 
 void SceneTree::_flush_ugc() {


### PR DESCRIPTION
Tracked and identified accessibility-related calls that were being executed every frame, even when AccessKit was not supported by the platform or explicitly disabled.

This change prevents propagation of accessibility notifications in those cases, reducing overhead and improving performance.