### PR TITLE
Apply MSDF fonts theme to AnimationTreeEditor

### DIFF
--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -40,6 +40,7 @@
 #include "editor/inspector/editor_properties.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "editor/themes/editor_theme_manager.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/grid_container.h"
@@ -1283,6 +1284,23 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 
 	animation_node_inspector_plugin.instantiate();
 	EditorInspector::add_inspector_plugin(animation_node_inspector_plugin);
+
+	vs_msdf_fonts_theme.instantiate();
+	update_theme();
+	graph->set_theme(vs_msdf_fonts_theme);
+}
+
+void AnimationNodeBlendTreeEditor::update_theme() {
+	Ref<Font> label_font = EditorNode::get_singleton()->get_editor_theme()->get_font("main_msdf", EditorStringName(EditorFonts));
+	Ref<Font> label_bold_font = EditorNode::get_singleton()->get_editor_theme()->get_font("main_bold_msdf", EditorStringName(EditorFonts));
+	vs_msdf_fonts_theme->set_font(SceneStringName(font), "Label", label_font);
+	vs_msdf_fonts_theme->set_font(SceneStringName(font), "GraphNodeTitleLabel", label_bold_font);
+	if (!EditorThemeManager::is_dark_theme()) {
+		// Override the color to white for light themes.
+		vs_msdf_fonts_theme->set_color(SceneStringName(font_color), "GraphNodeTitleLabel", Color(1, 1, 1));
+	}
+	vs_msdf_fonts_theme->set_font(SceneStringName(font), "LineEdit", label_font);
+	vs_msdf_fonts_theme->set_font(SceneStringName(font), "Button", label_font);
 }
 
 // EditorPluginAnimationNodeAnimation

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -150,6 +150,9 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 
 	Ref<EditorInspectorPluginAnimationNodeAnimation> animation_node_inspector_plugin;
 
+	// Visual shader specific theme for using MSDF fonts (on AnimationTreeEditor) which reduce aliasing at higher zoom levels.
+	Ref<Theme> vs_msdf_fonts_theme;
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -166,6 +169,7 @@ public:
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 
 	void update_graph();
+	void update_theme();
 
 	AnimationNodeBlendTreeEditor();
 };


### PR DESCRIPTION
This PR is an attempt to address [#91814](https://github.com/godotengine/godot/issues/91814)

As suggested by @Calinou, I based my solution on the approach used in [visual_shader_editor_plugin.cpp](https://github.com/godotengine/godot/blob/71a9948157dc2d5cc71fcb456c9d96656678757d/editor/shader/visual_shader_editor_plugin.cpp).

Changes included:
* Added a local Ref<Theme> object I instantiate in `AnimationTreeEditor`, instantiated in the constructor 
* Populated the theme in a new `update_theme()` function
* Called `update_theme()` from the constructor, immediately after creating the theme, since `AnimationTreeEditor` does not have an `_update_graph` function like in `VisualShaderEditor`
* Applied the theme to `AnimationTreeEditor` itself (`set_theme`) so that all child `AnimationTreeEditorPlugin` inherit it. 
Applying it to the individual plugins also works, but seems redundant.

This replaces the default font with and MSDF font that scale better.

<img width="1319" height="595" alt="MSDF_fix" src="https://github.com/user-attachments/assets/de7372a6-ab30-4f4d-af04-8cec36ad126c" />

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
