### PR TITLE
Add reverse UID cache

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1184,7 +1184,10 @@ String ResourceLoader::get_resource_script_class(const String &p_path) {
 }
 
 ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {
-	String local_path = _validate_local_path(p_path);
+	const String local_path = _validate_local_path(p_path);
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		return ResourceUID::get_singleton()->get_path_id(local_path);
+	}
 
 	for (int i = 0; i < loader_count; i++) {
 		ResourceUID::ID id = loader[i]->get_resource_uid(local_path);

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -54,7 +54,9 @@ private:
 		bool saved_to_cache = false;
 	};
 
-	HashMap<ID, Cache> unique_ids; //unique IDs and utf8 paths (less memory used)
+	HashMap<ID, Cache> unique_ids; // Unique IDs and utf8 paths (less memory used).
+	bool use_reverse_cache = false;
+	HashMap<CharString, ID> reverse_cache; // Used at runtime.
 	static ResourceUID *singleton;
 
 	uint32_t cache_entries = 0;
@@ -75,6 +77,7 @@ public:
 	void add_id(ID p_id, const String &p_path);
 	void set_id(ID p_id, const String &p_path);
 	String get_id_path(ID p_id) const;
+	ID get_path_id(const String &p_path) const;
 	void remove_id(ID p_id);
 
 	static String uid_to_path(const String &p_uid);
@@ -86,6 +89,7 @@ public:
 	Error update_cache();
 	static String get_path_from_cache(Ref<FileAccess> &p_cache_file, const String &p_uid_string);
 
+	void enable_reverse_cache() { use_reverse_cache = true; }
 	void clear();
 
 	static ResourceUID *get_singleton() { return singleton; }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2201,6 +2201,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions(); // core extensions must be registered after globals setup and before display
 
+	if (!editor) {
+		ResourceUID::get_singleton()->enable_reverse_cache();
+	}
 	ResourceUID::get_singleton()->load_from_cache(true); // Load UUIDs from cache.
 	ProjectSettings::get_singleton()->fix_autoload_paths(); // Handles autoloads saved as UID.
 


### PR DESCRIPTION
Fixes #75617

This PR introduces a reverse UID cache, i.e. HashMap of path -> UID. It's only used at runtime.
The downside is that it basically doubles memory usage of UID cache (not sure how much is that a problem), but the alternative is doing a reverse lookup on the base cache, which would involve iterating every entry; not very efficient.