### PR TITLE
fix: relax vswhere command conditions for broader compatibility

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -725,8 +725,6 @@ def get_compiler_version(env):
                 "-prerelease",
                 "-products",
                 "*",
-                "-requires",
-                "Microsoft.Component.MSBuild",
                 "-utf8",
             ]
             version = subprocess.check_output(args, encoding="utf-8").strip()


### PR DESCRIPTION
fixed: #110467
This PR relaxes the overly restrictive conditions in the vswhere command used for Visual Studio detection during Godot 4 builds.

- **Removed MSBuild requirement**: The previous `-requires Microsoft.Component.MSBuild` condition was unnecessarily restrictive as MSBuild is not strictly required for all build scenarios

## vswhere Command Reference
For reference, here are the relevant vswhere options:

```
Visual Studio Locator version 3.1.7+f39851e70f [query version 3.12.2140.44225]
Copyright (C) Microsoft Corporation. All rights reserved.

Usage:  [options]

Options:
  -all           Finds instances in complete, launchable, and incomplete states. By default, only instances
                 in a complete state - no errors or reboot required - are searched.
  -prerelease    Also searches prereleases. By default, only releases are searched.
  -products arg  One or more product IDs to find. Defaults to Community, Professional, and Enterprise.
                 Specify "*" by itself to search all product instances installed.
                 See https://aka.ms/vs/workloads for a list of product IDs.
  -requires arg  One or more workload or component IDs required when finding instances.
                 All specified IDs must be installed unless -requiresAny is specified.
                 You can specify wildcards including "?" to match any one character,
                 or "*" to match zero or more of any characters.
                 See https://aka.ms/vs/workloads for a list of workload and component IDs.
  -requiresAny   Find instances with any one or more workload or components IDs passed to -requires.
  -version arg   A version range for instances to find. Example: [15.0,16.0) will find versions 15.*.
                 See https://aka.ms/vswhere/versions for more information about versions.
  -latest        Return only the newest version and last installed.
  -sort          Sorts the instances from newest version and last installed to oldest.
                 When used with "find", first instances are sorted then files are sorted lexigraphically.
  -legacy        Also searches Visual Studio 2015 and older products. Information is limited.
                 This option cannot be used with either -products or -requires.
  -path          Gets the instance for the current path. Not compatible with any other selection option.
  -format arg    Return information about instances found in a format described below.
  -property arg  The name of a property to return. Defaults to "value" format.
                 Use delimiters ".", "/", or "_" to separate object and property names.
                 Example: "properties.nickname" will return the "nickname" property under "properties".
  -include arg   One or more extra properties to include, as described below.
  -find arg      Returns matching file paths under the installation path. Defaults to "value" format.
                 The following patterns are supported:
                 ?  Matches any one character except "\".
                 *  Matches zero or more characters except "\".
                 ** Searches the current directory and subdirectories for the remaining search pattern.
  -nocolor       Do not print instances formatted with colors. By default, colors suitable for dark-themed
                 terminals (common) are output when printing to a terminal but not to a pipe.
  -nologo        Do not show logo information. Some formats noted below will not show a logo anyway.
  -utf8          Use UTF-8 encoding (recommended for JSON).
  -?, -h, -help  Display this help message.


Extra properties:
  packages       Return an array of packages installed in this instance.
                 Supported only by the "json" and "xml" formats.

Formats:
  json           An array of JSON objects for each instance (no logo).
  text           Colon-delimited properties in separate blocks for each instance (default).
  value          A single property specified by the -property parameter (no logo, no color).
  xml            An XML data set containing instances (no logo).
```