### PR TITLE
Add the ability to get the angle of a hinge joint.

### DIFF
--- a/doc/classes/HingeJoint3D.xml
+++ b/doc/classes/HingeJoint3D.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_angle" qualifiers="const">
+			<return type="float" />
+			<description>
+				Return the current hinge joint angle.
+			</description>
+		</method>
 		<method name="get_flag" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="flag" type="int" enum="HingeJoint3D.Flag" />

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -802,6 +802,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="hinge_joint_get_angle" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+				Gets the current hinge joint angle.
+			</description>
+		</method>
 		<method name="hinge_joint_get_flag" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -725,6 +725,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="_hinge_joint_get_angle" qualifiers="virtual required const">
+			<return type="float" />
+			<param index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
 		<method name="_hinge_joint_get_flag" qualifiers="virtual required const">
 			<return type="bool" />
 			<param index="0" name="joint" type="RID" />

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1398,6 +1398,14 @@ real_t GodotPhysicsServer3D::hinge_joint_get_param(RID p_joint, HingeJointParam 
 	return hinge_joint->get_param(p_param);
 }
 
+real_t GodotPhysicsServer3D::hinge_joint_get_angle(RID p_joint) const {
+	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, 0);
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, 0);
+	GodotHingeJoint3D *hinge_joint = static_cast<GodotHingeJoint3D *>(joint);
+	return hinge_joint->get_hinge_angle();
+}
+
 void GodotPhysicsServer3D::hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -339,6 +339,7 @@ public:
 
 	virtual void hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) override;
 	virtual real_t hinge_joint_get_param(RID p_joint, HingeJointParam p_param) const override;
+	virtual real_t hinge_joint_get_angle(RID p_joint) const override;
 
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_value) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override;

--- a/modules/jolt_physics/joints/jolt_hinge_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_hinge_joint_3d.cpp
@@ -377,6 +377,13 @@ float JoltHingeJoint3D::get_applied_torque() const {
 	}
 }
 
+real_t JoltHingeJoint3D::get_angle() const {
+	if (JPH::HingeConstraint *constraint = static_cast<JPH::HingeConstraint *>(jolt_ref.GetPtr())) {
+		return constraint->GetCurrentAngle();
+	}
+	return 0.0;
+}
+
 void JoltHingeJoint3D::rebuild() {
 	destroy();
 

--- a/modules/jolt_physics/joints/jolt_hinge_joint_3d.h
+++ b/modules/jolt_physics/joints/jolt_hinge_joint_3d.h
@@ -93,5 +93,7 @@ public:
 	float get_applied_force() const;
 	float get_applied_torque() const;
 
+	real_t get_angle() const;
+
 	virtual void rebuild() override;
 };

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1391,6 +1391,16 @@ real_t JoltPhysicsServer3D::hinge_joint_get_param(RID p_joint, HingeJointParam p
 	return (real_t)hinge_joint->get_param(p_param);
 }
 
+real_t JoltPhysicsServer3D::hinge_joint_get_angle(RID p_joint) const {
+	const JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
+	ERR_FAIL_NULL_V(joint, 0.0);
+
+	ERR_FAIL_COND_V(joint->get_type() != JOINT_TYPE_HINGE, 0.0);
+	const JoltHingeJoint3D *hinge_joint = static_cast<const JoltHingeJoint3D *>(joint);
+
+	return hinge_joint->get_angle();
+}
+
 void JoltPhysicsServer3D::hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) {
 	JoltJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_NULL(joint);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -381,6 +381,7 @@ public:
 
 	virtual void hinge_joint_set_param(RID p_joint, PhysicsServer3D::HingeJointParam p_param, real_t p_value) override;
 	virtual real_t hinge_joint_get_param(RID p_joint, PhysicsServer3D::HingeJointParam p_param) const override;
+	virtual real_t hinge_joint_get_angle(RID p_joint) const override;
 
 	virtual void hinge_joint_set_flag(RID p_joint, PhysicsServer3D::HingeJointFlag p_flag, bool p_enabled) override;
 	virtual bool hinge_joint_get_flag(RID p_joint, PhysicsServer3D::HingeJointFlag p_flag) const override;

--- a/scene/3d/physics/joints/hinge_joint_3d.cpp
+++ b/scene/3d/physics/joints/hinge_joint_3d.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "hinge_joint_3d.h"
+#include "core/error/error_macros.h"
 
 void HingeJoint3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_param", "param", "value"), &HingeJoint3D::set_param);
@@ -36,6 +37,7 @@ void HingeJoint3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_flag", "flag", "enabled"), &HingeJoint3D::set_flag);
 	ClassDB::bind_method(D_METHOD("get_flag", "flag"), &HingeJoint3D::get_flag);
+	ClassDB::bind_method(D_METHOD("get_angle"), &HingeJoint3D::get_angle);
 
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "params/bias", PROPERTY_HINT_RANGE, "0.00,0.99,0.01"), "set_param", "get_param", PARAM_BIAS);
 
@@ -93,6 +95,11 @@ void HingeJoint3D::set_flag(Flag p_flag, bool p_value) {
 bool HingeJoint3D::get_flag(Flag p_flag) const {
 	ERR_FAIL_INDEX_V(p_flag, FLAG_MAX, false);
 	return flags[p_flag];
+}
+
+real_t HingeJoint3D::get_angle() const {
+	ERR_FAIL_COND_V(!is_configured(), 0.0);
+	return PhysicsServer3D::get_singleton()->hinge_joint_get_angle(get_rid());
 }
 
 void HingeJoint3D::_configure_joint(RID p_joint, PhysicsBody3D *body_a, PhysicsBody3D *body_b) {

--- a/scene/3d/physics/joints/hinge_joint_3d.h
+++ b/scene/3d/physics/joints/hinge_joint_3d.h
@@ -67,6 +67,8 @@ public:
 	void set_flag(Flag p_flag, bool p_value);
 	bool get_flag(Flag p_flag) const;
 
+	real_t get_angle() const;
+
 	HingeJoint3D();
 };
 

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -393,6 +393,7 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_hinge_joint_set_param, "joint", "param", "value");
 	GDVIRTUAL_BIND(_hinge_joint_get_param, "joint", "param");
+	GDVIRTUAL_BIND(_hinge_joint_get_angle, "joint");
 
 	GDVIRTUAL_BIND(_hinge_joint_set_flag, "joint", "flag", "enabled");
 	GDVIRTUAL_BIND(_hinge_joint_get_flag, "joint", "flag");

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -500,6 +500,7 @@ public:
 
 	EXBIND3(hinge_joint_set_param, RID, HingeJointParam, real_t)
 	EXBIND2RC(real_t, hinge_joint_get_param, RID, HingeJointParam)
+	EXBIND1RC(real_t, hinge_joint_get_angle, RID)
 
 	EXBIND3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
 	EXBIND2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -952,6 +952,7 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("hinge_joint_set_param", "joint", "param", "value"), &PhysicsServer3D::hinge_joint_set_param);
 	ClassDB::bind_method(D_METHOD("hinge_joint_get_param", "joint", "param"), &PhysicsServer3D::hinge_joint_get_param);
+	ClassDB::bind_method(D_METHOD("hinge_joint_get_angle", "joint"), &PhysicsServer3D::hinge_joint_get_angle);
 
 	ClassDB::bind_method(D_METHOD("hinge_joint_set_flag", "joint", "flag", "enabled"), &PhysicsServer3D::hinge_joint_set_flag);
 	ClassDB::bind_method(D_METHOD("hinge_joint_get_flag", "joint", "flag"), &PhysicsServer3D::hinge_joint_get_flag);

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -701,6 +701,7 @@ public:
 
 	virtual void hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) = 0;
 	virtual real_t hinge_joint_get_param(RID p_joint, HingeJointParam p_param) const = 0;
+	virtual real_t hinge_joint_get_angle(RID p_joint) const = 0;
 
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) = 0;
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const = 0;

--- a/servers/physics_server_3d_dummy.h
+++ b/servers/physics_server_3d_dummy.h
@@ -401,6 +401,7 @@ public:
 
 	virtual void hinge_joint_set_param(RID p_joint, HingeJointParam p_param, real_t p_value) override {}
 	virtual real_t hinge_joint_get_param(RID p_joint, HingeJointParam p_param) const override { return 0; }
+	virtual real_t hinge_joint_get_angle(RID p_joint) const override { return 0; }
 
 	virtual void hinge_joint_set_flag(RID p_joint, HingeJointFlag p_flag, bool p_enabled) override {}
 	virtual bool hinge_joint_get_flag(RID p_joint, HingeJointFlag p_flag) const override { return false; }

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -360,6 +360,7 @@ public:
 
 	FUNC3(hinge_joint_set_param, RID, HingeJointParam, real_t)
 	FUNC2RC(real_t, hinge_joint_get_param, RID, HingeJointParam)
+	FUNC1RC(real_t, hinge_joint_get_angle, RID)
 
 	FUNC3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
 	FUNC2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
What the title says, add this relatively important feature (can be used for things such as detecting when a hinge has nearly hit its limits).

Closes godotengine/godot-proposals#4385 