### PR TITLE
Optimize animation performance

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -116,6 +116,12 @@ bool NodePath::operator==(const NodePath &p_path) const {
 		return false;
 	}
 
+	if (data->hash_cache_valid && p_path.data->hash_cache_valid) {
+		if (data->hash_cache != p_path.data->hash_cache) {
+			return false;
+		}
+	}
+
 	if (data->absolute != p_path.data->absolute) {
 		return false;
 	}

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -331,6 +331,22 @@ public:
 		return nullptr;
 	}
 
+	TValue &get_value_ref_or_add_default(const TKey &p_key, bool &r_was_added) {
+		uint32_t element_idx = 0;
+		uint32_t meta_idx = 0;
+		uint32_t hash = _hash(p_key);
+		bool exists = _lookup_idx_with_hash(p_key, element_idx, meta_idx, hash);
+
+		if (exists) {
+			r_was_added = false;
+			return _elements[element_idx].value;
+		} else {
+			r_was_added = true;
+			element_idx = _insert_element(p_key, TValue(), hash);
+			return _elements[element_idx].value;
+		}
+	}
+
 	bool has(const TKey &p_key) const {
 		uint32_t _idx = 0;
 		uint32_t meta_idx = 0;
@@ -584,17 +600,8 @@ public:
 	}
 
 	TValue &operator[](const TKey &p_key) {
-		uint32_t element_idx = 0;
-		uint32_t meta_idx = 0;
-		uint32_t hash = _hash(p_key);
-		bool exists = _lookup_idx_with_hash(p_key, element_idx, meta_idx, hash);
-
-		if (exists) {
-			return _elements[element_idx].value;
-		} else {
-			element_idx = _insert_element(p_key, TValue(), hash);
-			return _elements[element_idx].value;
-		}
+		bool dummy;
+		return get_value_ref_or_add_default(p_key, dummy);
 	}
 
 	/* Insert */

--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -77,12 +77,12 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 			animations_to_add.clear();
 
 			LocalVector<StringName> classes;
-			ClassDB::get_inheriters_from_class("AnimationRootNode", classes);
+			ClassDB::get_inheriters_from_class(SNAME("AnimationRootNode"), classes);
 			classes.sort_custom<StringName::AlphCompare>();
 
 			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
 
-			List<StringName> names;
+			LocalVector<StringName> names;
 			tree->get_animation_list(&names);
 
 			for (const StringName &E : names) {

--- a/editor/animation/animation_blend_space_1d_editor.h
+++ b/editor/animation/animation_blend_space_1d_editor.h
@@ -94,7 +94,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 
 	PopupMenu *menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
-	Vector<String> animations_to_add;
+	Vector<StringName> animations_to_add;
 	float add_point_pos = 0.0f;
 	Vector<real_t> points;
 

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -126,7 +126,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 			menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
 
-			List<StringName> names;
+			LocalVector<StringName> names;
 			tree->get_animation_list(&names);
 			for (const StringName &E : names) {
 				animations_menu->add_icon_item(get_editor_theme_icon(SNAME("Animation")), E);

--- a/editor/animation/animation_blend_space_2d_editor.h
+++ b/editor/animation/animation_blend_space_2d_editor.h
@@ -99,7 +99,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 
 	PopupMenu *menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
-	Vector<String> animations_to_add;
+	Vector<StringName> animations_to_add;
 	Vector2 add_point_pos;
 	Vector<Vector2> points;
 

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -104,6 +104,7 @@ class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	void _node_changed(const StringName &p_node_name);
 
 	String current_node_rename_text;
+	bool graph_update_queued;
 	bool updating;
 
 	void _connection_request(const String &p_from, int p_from_index, const String &p_to, int p_to_index);
@@ -166,6 +167,7 @@ public:
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
 
 	void update_graph();
+	void update_graph_immediately();
 
 	AnimationNodeBlendTreeEditor();
 };

--- a/editor/animation/animation_library_editor.cpp
+++ b/editor/animation/animation_library_editor.cpp
@@ -374,7 +374,7 @@ void AnimationLibraryEditor::_load_files(const PackedStringArray &p_paths) {
 					continue;
 				}
 
-				List<StringName> libs;
+				LocalVector<StringName> libs;
 				mixer->get_animation_library_list(&libs);
 				bool is_already_added = false;
 				for (const StringName &K : libs) {
@@ -684,7 +684,7 @@ void AnimationLibraryEditor::update_tree() {
 	Color ss_color = get_theme_color(SNAME("prop_subsection"), EditorStringName(Editor));
 
 	TreeItem *root = tree->create_item();
-	List<StringName> libs;
+	LocalVector<StringName> libs;
 	Vector<uint64_t> collapsed_lib_ids = _load_mixer_libs_folding();
 
 	mixer->get_animation_library_list(&libs);
@@ -951,7 +951,7 @@ String AnimationLibraryEditor::_get_mixer_signature() const {
 	String signature = String();
 
 	// Get all libraries sorted for consistency
-	List<StringName> libs;
+	LocalVector<StringName> libs;
 	mixer->get_animation_library_list(&libs);
 	libs.sort_custom<StringName::AlphCompare>();
 

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -811,9 +811,9 @@ void AnimationPlayerEditor::_update_animation_blend() {
 
 	blend_editor.tree->clear();
 
-	String current = animation->get_item_text(animation->get_selected());
+	StringName current = animation->get_item_text(animation->get_selected());
 
-	List<StringName> anims;
+	LocalVector<StringName> anims;
 	player->get_animation_list(&anims);
 	TreeItem *root = blend_editor.tree->create_item();
 	updating_blends = true;
@@ -1020,7 +1020,7 @@ void AnimationPlayerEditor::_update_player() {
 		return;
 	}
 
-	List<StringName> libraries;
+	LocalVector<StringName> libraries;
 	player->get_animation_library_list(&libraries);
 
 	int active_idx = -1;
@@ -1144,7 +1144,7 @@ void AnimationPlayerEditor::_update_name_dialog_library_dropdown() {
 		}
 	}
 
-	List<StringName> libraries;
+	LocalVector<StringName> libraries;
 	player->get_animation_library_list(&libraries);
 	library->clear();
 
@@ -1478,7 +1478,7 @@ void AnimationPlayerEditor::_current_animation_changed(const String &p_name) {
 		}
 
 		// Determine the read-only status of the animation's library and the libraries as a whole.
-		List<StringName> libraries;
+		LocalVector<StringName> libraries;
 		player->get_animation_library_list(&libraries);
 
 		bool current_animation_library_is_readonly = false;

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -616,7 +616,7 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	animations_menu->clear();
 	animations_to_add.clear();
 
-	List<StringName> animation_names;
+	LocalVector<StringName> animation_names;
 	tree->get_animation_list(&animation_names);
 	menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
 	if (animation_names.is_empty()) {
@@ -777,7 +777,7 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = animations_to_add[p_index].validate_node_name();
+	String base_name = String(animations_to_add[p_index]).validate_node_name();
 	int base = 1;
 	String name = base_name;
 	while (state_machine->has_node(name)) {

--- a/editor/animation/animation_state_machine_editor.h
+++ b/editor/animation/animation_state_machine_editor.h
@@ -144,7 +144,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	PopupMenu *state_machine_menu = nullptr;
 	PopupMenu *end_menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
-	Vector<String> animations_to_add;
+	Vector<StringName> animations_to_add;
 	Vector<String> nodes_to_connect;
 
 	Vector2 add_node_pos;

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -645,7 +645,7 @@ void AnimationTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) const
 			if (root_path) {
 				AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(root_path->get_node_or_null(animation->track_get_path(track)));
 				if (ap) {
-					List<StringName> anims;
+					LocalVector<StringName> anims;
 					ap->get_animation_list(&anims);
 					for (const StringName &E : anims) {
 						if (!animations.is_empty()) {
@@ -1251,7 +1251,7 @@ void AnimationMultiTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) 
 				if (root_path) {
 					AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(root_path->get_node_or_null(animation->track_get_path(first_track)));
 					if (ap) {
-						List<StringName> anims;
+						LocalVector<StringName> anims;
 						ap->get_animation_list(&anims);
 						for (const StringName &anim : anims) {
 							if (!animations.is_empty()) {
@@ -4130,7 +4130,7 @@ void AnimationTrackEditor::_animation_track_remove_request(int p_track, Ref<Anim
 					if (reset->track_get_path(i) == p_from_animation->track_get_path(p_track)) {
 						// Check if the reset track isn't used by other animations.
 						bool used = false;
-						List<StringName> animation_list;
+						LocalVector<StringName> animation_list;
 						player->get_animation_list(&animation_list);
 
 						for (const StringName &anim_name : animation_list) {
@@ -7423,7 +7423,7 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 		} break;
 		case EDIT_CLEAN_UP_ANIMATION_CONFIRM: {
 			if (cleanup_all->is_pressed()) {
-				List<StringName> names;
+				LocalVector<StringName> names;
 				AnimationPlayerEditor::get_singleton()->get_player()->get_animation_list(&names);
 				for (const StringName &E : names) {
 					_cleanup_animation(AnimationPlayerEditor::get_singleton()->get_player()->get_animation(E));

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -245,7 +245,7 @@ Vector<String> AnimationTreeEditor::get_animation_list() {
 		return Vector<String>();
 	}
 
-	List<StringName> anims;
+	LocalVector<StringName> anims;
 	tree->get_animation_list(&anims);
 	Vector<String> ret;
 	for (const StringName &E : anims) {

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1925,7 +1925,7 @@ bool SceneTreeDock::_has_tracks_to_delete(Node *p_node, List<Node *> &p_to_delet
 	if (ap) {
 		Node *root = ap->get_node(ap->get_root_node());
 		if (root && !p_to_delete.find(root)) {
-			List<StringName> anims;
+			LocalVector<StringName> anims;
 			ap->get_animation_list(&anims);
 
 			for (const StringName &E : anims) {
@@ -2180,7 +2180,7 @@ void SceneTreeDock::perform_node_renames(Node *p_base, HashMap<Node *, NodePath>
 		}
 
 		if (!points_to_other_animation_player) {
-			List<StringName> anims;
+			LocalVector<StringName> anims;
 			mixer->get_animation_list(&anims);
 			Node *root = mixer->get_node(mixer->get_root_node());
 

--- a/editor/import/3d/post_import_plugin_skeleton_renamer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_renamer.cpp
@@ -95,7 +95,7 @@ void PostImportPluginSkeletonRenamer::_internal_process(InternalImportCategory p
 		TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 		while (nodes.size()) {
 			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-			List<StringName> anims;
+			LocalVector<StringName> anims;
 			ap->get_animation_list(&anims);
 			for (const StringName &name : anims) {
 				Ref<Animation> anim = ap->get_animation(name);
@@ -208,7 +208,7 @@ void PostImportPluginSkeletonRenamer::internal_process(InternalImportCategory p_
 			TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 			while (nodes.size()) {
 				AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-				List<StringName> anims;
+				LocalVector<StringName> anims;
 				ap->get_animation_list(&anims);
 				for (const StringName &name : anims) {
 					Ref<Animation> anim = ap->get_animation(name);

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -167,7 +167,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 				while (nodes.size()) {
 					AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-					List<StringName> anims;
+					LocalVector<StringName> anims;
 					ap->get_animation_list(&anims);
 					for (const StringName &name : anims) {
 						Ref<Animation> anim = ap->get_animation(name);
@@ -235,7 +235,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 			TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 			while (nodes.size()) {
 				AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-				List<StringName> anims;
+				LocalVector<StringName> anims;
 				ap->get_animation_list(&anims);
 				for (const StringName &name : anims) {
 					if (String(name).contains_char('/')) {
@@ -398,7 +398,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 				while (nodes.size()) {
 					AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-					List<StringName> anims;
+					LocalVector<StringName> anims;
 					ap->get_animation_list(&anims);
 					for (const StringName &name : anims) {
 						Ref<Animation> anim = ap->get_animation(name);
@@ -569,7 +569,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 					String general_skeleton_pathname = UNIQUE_NODE_PREFIX + profile_skeleton->get_name();
 					while (nodes.size()) {
 						AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-						List<StringName> anims;
+						LocalVector<StringName> anims;
 						ap->get_animation_list(&anims);
 						for (const StringName &name : anims) {
 							Ref<Animation> anim = ap->get_animation(name);
@@ -704,7 +704,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				while (nodes.size()) {
 					AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
 					ERR_CONTINUE(!ap);
-					List<StringName> anims;
+					LocalVector<StringName> anims;
 					ap->get_animation_list(&anims);
 					for (const StringName &name : anims) {
 						Ref<Animation> anim = ap->get_animation(name);
@@ -836,7 +836,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 			TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 			while (nodes.size()) {
 				AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-				List<StringName> anims;
+				LocalVector<StringName> anims;
 				ap->get_animation_list(&anims);
 				for (const StringName &name : anims) {
 					Ref<Animation> anim = ap->get_animation(name);

--- a/editor/import/3d/post_import_plugin_skeleton_track_organizer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_track_organizer.cpp
@@ -69,7 +69,7 @@ void PostImportPluginSkeletonTrackOrganizer::internal_process(InternalImportCate
 		TypedArray<Node> nodes = p_base_scene->find_children("*", "AnimationPlayer");
 		while (nodes.size()) {
 			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(nodes.pop_back());
-			List<StringName> anims;
+			LocalVector<StringName> anims;
 			ap->get_animation_list(&anims);
 
 			Ref<AnimationLibrary> unmapped_al;

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -615,7 +615,7 @@ void _populate_scalable_nodes_collection(Node *p_node, ScalableNodeCollection &p
 	}
 	AnimationPlayer *animation_player = Object::cast_to<AnimationPlayer>(p_node);
 	if (animation_player) {
-		List<StringName> animation_list;
+		LocalVector<StringName> animation_list;
 		animation_player->get_animation_list(&animation_list);
 
 		for (const StringName &E : animation_list) {
@@ -701,7 +701,7 @@ Node *ResourceImporterScene::_pre_fix_node(Node *p_node, Node *p_root, HashMap<R
 
 		bool nodes_were_renamed = r_node_renames.size() != 0;
 
-		List<StringName> anims;
+		LocalVector<StringName> anims;
 		ap->get_animation_list(&anims);
 		for (const StringName &E : anims) {
 			Ref<Animation> anim = ap->get_animation(E);
@@ -1078,7 +1078,7 @@ Node *ResourceImporterScene::_pre_fix_animations(Node *p_node, Node *p_root, con
 
 	if (Object::cast_to<AnimationPlayer>(p_node)) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
-		List<StringName> anims;
+		LocalVector<StringName> anims;
 		ap->get_animation_list(&anims);
 
 		AnimationImportTracks import_tracks_mode[TRACK_CHANNEL_MAX] = {
@@ -1126,7 +1126,7 @@ Node *ResourceImporterScene::_post_fix_animations(Node *p_node, Node *p_root, co
 
 	if (Object::cast_to<AnimationPlayer>(p_node)) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
-		List<StringName> anims;
+		LocalVector<StringName> anims;
 		ap->get_animation_list(&anims);
 
 		if (p_remove_immutable_tracks) {
@@ -1503,10 +1503,10 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 				for (int node_i = 0; node_i < children.size(); node_i++) {
 					AnimationPlayer *anim_player = cast_to<AnimationPlayer>(children[node_i]);
 					ERR_CONTINUE(anim_player == nullptr);
-					List<StringName> anim_list;
+					LocalVector<StringName> anim_list;
 					anim_player->get_animation_list(&anim_list);
 					if (anim_list.size() == 1) {
-						selected_animation_name = anim_list.front()->get();
+						selected_animation_name = anim_list[0];
 					}
 					rest_animation = anim_player->get_animation(selected_animation_name);
 					if (rest_animation.is_valid()) {
@@ -1863,7 +1863,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 		}
 
 		if (post_importer_plugins.size()) {
-			List<StringName> anims;
+			LocalVector<StringName> anims;
 			ap->get_animation_list(&anims);
 			for (const StringName &name : anims) {
 				if (p_animation_data.has(name)) {
@@ -2088,7 +2088,7 @@ void ResourceImporterScene::_create_slices(AnimationPlayer *ap, Ref<Animation> a
 }
 
 void ResourceImporterScene::_optimize_animations(AnimationPlayer *anim, float p_max_vel_error, float p_max_ang_error, int p_prc_error) {
-	List<StringName> anim_names;
+	LocalVector<StringName> anim_names;
 	anim->get_animation_list(&anim_names);
 	for (const StringName &E : anim_names) {
 		Ref<Animation> a = anim->get_animation(E);
@@ -2097,7 +2097,7 @@ void ResourceImporterScene::_optimize_animations(AnimationPlayer *anim, float p_
 }
 
 void ResourceImporterScene::_compress_animations(AnimationPlayer *anim, int p_page_size_kb) {
-	List<StringName> anim_names;
+	LocalVector<StringName> anim_names;
 	anim->get_animation_list(&anim_names);
 	for (const StringName &E : anim_names) {
 		Ref<Animation> a = anim->get_animation(E);
@@ -2808,7 +2808,7 @@ void ResourceImporterScene::_copy_meta(Object *p_src_object, Object *p_dst_objec
 }
 
 void ResourceImporterScene::_optimize_track_usage(AnimationPlayer *p_player, AnimationImportTracks *p_track_actions) {
-	List<StringName> anims;
+	LocalVector<StringName> anims;
 	p_player->get_animation_list(&anims);
 	Node *parent = p_player->get_parent();
 	ERR_FAIL_NULL(parent);
@@ -3323,10 +3323,10 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		for (int i = 0; i < scene->get_child_count(); i++) {
 			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(scene->get_child(i));
 			if (ap) {
-				List<StringName> libs;
+				LocalVector<StringName> libs;
 				ap->get_animation_library_list(&libs);
 				if (libs.size()) {
-					library = ap->get_animation_library(libs.front()->get());
+					library = ap->get_animation_library(libs[0]);
 					break;
 				}
 			}

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -477,7 +477,7 @@ void SceneImportSettingsDialog::_fill_scene(Node *p_node, TreeItem *p_parent_ite
 	AnimationPlayer *anim_node = Object::cast_to<AnimationPlayer>(p_node);
 	if (anim_node) {
 		Vector<String> animation_list;
-		List<StringName> animations;
+		LocalVector<StringName> animations;
 		anim_node->get_animation_list(&animations);
 		for (const StringName &E : animations) {
 			_fill_animation(scene_tree, anim_node->get_animation(E), E, item);

--- a/editor/scene/3d/root_motion_editor_plugin.cpp
+++ b/editor/scene/3d/root_motion_editor_plugin.cpp
@@ -66,7 +66,7 @@ void EditorPropertyRootMotion::_node_assign() {
 
 	HashSet<String> paths;
 	{
-		List<StringName> animations;
+		LocalVector<StringName> animations;
 		mixer->get_animation_list(&animations);
 
 		for (const StringName &E : animations) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5343,7 +5343,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> p_state) {
 	}
 	for (int32_t player_i = 0; player_i < p_state->animation_players.size(); player_i++) {
 		AnimationPlayer *animation_player = p_state->animation_players[player_i];
-		List<StringName> animations;
+		LocalVector<StringName> animations;
 		animation_player->get_animation_list(&animations);
 		for (const StringName &animation_name : animations) {
 			_convert_animation(p_state, animation_player, animation_name);

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -80,10 +80,10 @@ protected:
 	virtual void _animation_node_removed(const ObjectID &p_oid, const StringName &p_node) override;
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	void add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index = -1);
 	void set_blend_point_position(int p_point, float p_position);
@@ -112,7 +112,7 @@ public:
 	void set_use_sync(bool p_sync);
 	bool is_using_sync() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	String get_caption() const override;
 
 	Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -93,10 +93,10 @@ protected:
 	virtual void _animation_node_removed(const ObjectID &p_oid, const StringName &p_node) override;
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	void add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index = -1);
 	void set_blend_point_position(int p_point, const Vector2 &p_position);
@@ -127,7 +127,7 @@ public:
 	void set_y_label(const String &p_label);
 	String get_y_label() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	Vector2 get_closest_point(const Vector2 &p_point);

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -56,16 +56,16 @@ public:
 		PLAY_MODE_BACKWARD
 	};
 
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual NodeTimeInfo get_node_time_info() const override; // Wrapper of get_parameter().
+	virtual NodeTimeInfo get_node_time_info(AnimationNodeInstance &instance, ProcessState &p_process_state) const override; // Wrapper of get_parameter().
 
 	static Vector<String> (*get_editable_animation_list)();
 
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	void set_animation(const StringName &p_name);
 	StringName get_animation() const;
@@ -73,8 +73,8 @@ public:
 	void set_play_mode(PlayMode p_play_mode);
 	PlayMode get_play_mode() const;
 
-	void set_backward(bool p_backward);
-	bool is_backward() const;
+	void set_backward(AnimationNodeInstance &p_instance, ProcessState &p_process_state, bool p_backward);
+	bool is_backward(AnimationNodeInstance &p_instance, ProcessState &p_process_state) const;
 
 	void set_advance_on_start(bool p_advance_on_start);
 	bool is_advance_on_start() const;
@@ -160,7 +160,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
@@ -193,7 +193,7 @@ public:
 	bool is_loop_broken_at_end() const;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeOneShot();
 };
@@ -207,13 +207,13 @@ class AnimationNodeAdd2 : public AnimationNodeSync {
 	StringName add_amount = PNAME("add_amount");
 
 public:
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeAdd2();
 };
@@ -224,13 +224,13 @@ class AnimationNodeAdd3 : public AnimationNodeSync {
 	StringName add_amount = PNAME("add_amount");
 
 public:
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeAdd3();
 };
@@ -241,11 +241,11 @@ class AnimationNodeBlend2 : public AnimationNodeSync {
 	StringName blend_amount = PNAME("blend_amount");
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	virtual bool has_filter() const override;
 	AnimationNodeBlend2();
@@ -257,12 +257,12 @@ class AnimationNodeBlend3 : public AnimationNodeSync {
 	StringName blend_amount = PNAME("blend_amount");
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	AnimationNodeBlend3();
 };
 
@@ -272,13 +272,13 @@ class AnimationNodeSub2 : public AnimationNodeSync {
 	StringName sub_amount = PNAME("sub_amount");
 
 public:
-	void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
 	virtual bool has_filter() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeSub2();
 };
@@ -289,12 +289,12 @@ class AnimationNodeTimeScale : public AnimationNode {
 	StringName scale = PNAME("scale");
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeTimeScale();
 };
@@ -309,12 +309,12 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
 	virtual String get_caption() const override;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	void set_explicit_elapse(bool p_enable);
 	bool is_explicit_elapse() const;
@@ -354,7 +354,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
@@ -384,7 +384,7 @@ public:
 	void set_allow_transition_to_self(bool p_enable);
 	bool is_allow_transition_to_self() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	AnimationNodeTransition();
 };
@@ -394,7 +394,7 @@ class AnimationNodeOutput : public AnimationNode {
 
 public:
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	AnimationNodeOutput();
 };
 
@@ -440,18 +440,20 @@ public:
 		//no need to check for cycles due to tree topology
 	};
 
-	void add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position = Vector2());
+	void add_node(const StringName &p_name, const Ref<AnimationNode> &p_node, const Vector2 &p_position = Vector2());
 	Ref<AnimationNode> get_node(const StringName &p_name) const;
+	const Ref<AnimationNode> &get_node_or_null(const StringName &p_name) const;
 	void remove_node(const StringName &p_name);
 	void rename_node(const StringName &p_name, const StringName &p_new_name);
 	bool has_node(const StringName &p_name) const;
+	const StringName &get_node_name(const AnimationNode &p_node) const;
 	StringName get_node_name(const Ref<AnimationNode> &p_node) const;
 	Vector<StringName> get_node_connection_array(const StringName &p_name) const;
 
 	void set_node_position(const StringName &p_node, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_node) const;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	void connect_node(const StringName &p_input_node, int p_input_index, const StringName &p_output_node);
 	void disconnect_node(const StringName &p_node, int p_input_index);
@@ -466,7 +468,7 @@ public:
 	void get_node_connections(List<NodeConnection> *r_connections) const;
 
 	virtual String get_caption() const override;
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	LocalVector<StringName> get_node_list() const;
 	TypedArray<StringName> get_node_list_as_typed_array() const;

--- a/scene/animation/animation_node_extension.cpp
+++ b/scene/animation/animation_node_extension.cpp
@@ -30,7 +30,7 @@
 
 #include "animation_node_extension.h"
 
-AnimationNode::NodeTimeInfo AnimationNodeExtension::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+AnimationNode::NodeTimeInfo AnimationNodeExtension::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
 	PackedFloat32Array r_ret;
 
 	GDVIRTUAL_CALL(

--- a/scene/animation/animation_node_extension.h
+++ b/scene/animation/animation_node_extension.h
@@ -36,7 +36,7 @@ class AnimationNodeExtension : public AnimationNode {
 	GDCLASS(AnimationNodeExtension, AnimationNode);
 
 public:
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 
 	static bool is_looping(const PackedFloat32Array &p_node_info);
 	static double get_remaining_time(const PackedFloat32Array &p_node_info, bool p_break_loop = false);

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -192,7 +192,7 @@ AnimationNodeStateMachineTransition::AnimationNodeStateMachineTransition() {
 
 ////////////////////////////////////////////////////////
 
-void AnimationNodeStateMachinePlayback::_set_current(AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
+void AnimationNodeStateMachinePlayback::_set_current(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
 	current = p_state;
 	if (current == StringName()) {
 		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
@@ -200,7 +200,7 @@ void AnimationNodeStateMachinePlayback::_set_current(AnimationNodeStateMachine *
 		return;
 	}
 
-	AnimationTree *tree = p_state_machine->process_state ? p_state_machine->process_state->tree : nullptr;
+	AnimationTree *tree = p_process_state.tree;
 	Ref<AnimationNodeStateMachine> anodesm = p_state_machine->find_node_by_path(current);
 	if (anodesm.is_null()) {
 		group_start_transition = Ref<AnimationNodeStateMachineTransition>();
@@ -354,9 +354,9 @@ bool _is_grouped_state_machine(const Ref<AnimationNodeStateMachine> p_node) {
 	return p_node.is_valid() && p_node->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED;
 }
 
-void AnimationNodeStateMachinePlayback::_clear_fading(AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
+void AnimationNodeStateMachinePlayback::_clear_fading(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state) {
 	if (!p_state.is_empty() && !_is_grouped_state_machine(p_state_machine->get_node(p_state))) {
-		_signal_state_change(p_state_machine->get_animation_tree(), p_state, false);
+		_signal_state_change(p_process_state.tree, p_state, false);
 	}
 	fading_from = StringName();
 	fadeing_from_nti = AnimationNode::NodeTimeInfo();
@@ -373,8 +373,8 @@ void AnimationNodeStateMachinePlayback::_signal_state_change(AnimationTree *p_an
 	emit_signal(p_started ? SceneStringName(state_started) : SceneStringName(state_finished), p_state);
 }
 
-void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
-	List<AnimationNode::ChildNode> child_nodes;
+void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only) {
+	LocalVector<AnimationNode::ChildNode> child_nodes;
 	p_state_machine->get_child_nodes(&child_nodes);
 	for (const AnimationNode::ChildNode &child_node : child_nodes) {
 		Ref<AnimationNodeStateMachine> anodesm = child_node.node;
@@ -386,9 +386,9 @@ void AnimationNodeStateMachinePlayback::_clear_path_children(AnimationTree *p_tr
 				playback = playback->duplicate();
 			}
 			playback->path.clear();
-			playback->_clear_path_children(p_tree, anodesm.ptr(), p_test_only);
+			playback->_clear_path_children(p_process_state, p_tree, anodesm.ptr(), p_test_only);
 			if (current != child_node.name) {
-				playback->_start(anodesm.ptr()); // Can restart.
+				playback->_start(p_process_state, anodesm.ptr()); // Can restart.
 			}
 		}
 	}
@@ -421,7 +421,7 @@ void AnimationNodeStateMachinePlayback::_start_children(AnimationTree *p_tree, A
 	}
 }
 
-bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_travel_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only) {
 	if (p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 		return false; // This function must be fired only by the top state machine, do nothing in child state machine.
 	}
@@ -448,7 +448,7 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 				playback = playback->duplicate();
 			}
 			if (!playback->is_playing()) {
-				playback->_start(anodesm.ptr());
+				playback->_start(p_process_state, anodesm.ptr());
 			}
 			ChildStateMachineInfo child_info;
 			child_info.playback = playback;
@@ -471,18 +471,18 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 						child_playback = child_playback->duplicate();
 					}
 					child_playback->_travel_main(SceneStringName(End));
-					child_found_route &= child_playback->_travel(p_tree, child_anodesm.ptr(), false, p_test_only);
+					child_found_route &= child_playback->_travel(p_process_state, p_tree, child_anodesm.ptr(), false, p_test_only);
 					child_path += "/" + child_playback->get_current_node();
 				}
 				// Force restart target state machine.
-				playback->_start(anodesm.ptr());
+				playback->_start(p_process_state, anodesm.ptr());
 			}
 			is_parent_same_state = is_current_same_state;
 
 			bool is_deepest_state = i == temp_path.size() - 1;
 			child_info.is_reset = is_deepest_state ? reset_request_on_teleport : false;
 			playback->_travel_main(temp_path[i], child_info.is_reset);
-			if (playback->_make_travel_path(p_tree, anodesm.ptr(), is_deepest_state ? p_is_allow_transition_to_self : false, child_info.path, p_test_only)) {
+			if (playback->_make_travel_path(p_process_state, p_tree, anodesm.ptr(), is_deepest_state ? p_is_allow_transition_to_self : false, child_info.path, p_test_only)) {
 				found_route &= child_found_route;
 			} else {
 				child_info.path.push_back(temp_path[i]);
@@ -511,16 +511,16 @@ bool AnimationNodeStateMachinePlayback::_travel_children(AnimationTree *p_tree, 
 	return found_route;
 }
 
-void AnimationNodeStateMachinePlayback::_start(AnimationNodeStateMachine *p_state_machine) {
+void AnimationNodeStateMachinePlayback::_start(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine) {
 	playing = true;
-	_set_current(p_state_machine, start_request != StringName() ? start_request : SceneStringName(Start));
+	_set_current(p_process_state, p_state_machine, start_request != StringName() ? start_request : SceneStringName(Start));
 	teleport_request = true;
 	stop_request = false;
 	start_request = StringName();
 }
 
-bool AnimationNodeStateMachinePlayback::_travel(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only) {
-	return _make_travel_path(p_tree, p_state_machine, p_is_allow_transition_to_self, path, p_test_only);
+bool AnimationNodeStateMachinePlayback::_travel(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only) {
+	return _make_travel_path(p_process_state, p_tree, p_state_machine, p_is_allow_transition_to_self, path, p_test_only);
 }
 
 String AnimationNodeStateMachinePlayback::_validate_path(AnimationNodeStateMachine *p_state_machine, const String &p_path) {
@@ -541,12 +541,12 @@ String AnimationNodeStateMachinePlayback::_validate_path(AnimationNodeStateMachi
 	return target;
 }
 
-bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only) {
 	StringName travel = travel_request;
 	travel_request = StringName();
 
 	if (!playing) {
-		_start(p_state_machine);
+		_start(p_process_state, p_state_machine);
 	}
 
 	ERR_FAIL_COND_V(!p_state_machine->states.has(travel), false);
@@ -678,13 +678,13 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 					playback = playback->duplicate();
 				}
 				if (i > 0) {
-					playback->_start(anodesm.ptr());
+					playback->_start(p_process_state, anodesm.ptr());
 				}
 				if (i >= new_path.size()) {
 					break; // Tracing has been finished, needs to break.
 				}
 				playback->_travel_main(SceneStringName(End));
-				if (!playback->_travel(p_tree, anodesm.ptr(), false, p_test_only)) {
+				if (!playback->_travel(p_process_state, p_tree, anodesm.ptr(), false, p_test_only)) {
 					found_route = false;
 					break;
 				}
@@ -705,8 +705,8 @@ bool AnimationNodeStateMachinePlayback::_make_travel_path(AnimationTree *p_tree,
 	}
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	AnimationNode::NodeTimeInfo nti = _process(p_state_machine, p_playback_info, p_test_only);
+AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+	AnimationNode::NodeTimeInfo nti = _process(p_process_state, p_instance, p_state_machine, p_playback_info, p_test_only);
 	start_request = StringName();
 	next_request = false;
 	stop_request = false;
@@ -714,8 +714,8 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::process(Animation
 	return nti;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	AnimationTree *tree = p_state_machine->process_state->tree;
+AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
+	AnimationTree *tree = p_process_state.tree;
 
 	double p_time = p_playback_info.time;
 	double p_delta = p_playback_info.delta;
@@ -728,9 +728,9 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 			// Restart state machine.
 			if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
 				path.clear();
-				_clear_path_children(tree, p_state_machine, p_test_only);
+				_clear_path_children(p_process_state, tree, p_state_machine, p_test_only);
 			}
-			_start(p_state_machine);
+			_start(p_process_state, p_state_machine);
 			reset_request = true;
 		} else {
 			// Reset current state.
@@ -754,7 +754,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 	// Process start/travel request.
 	if (start_request != StringName() || travel_request != StringName()) {
 		if (p_state_machine->get_state_machine_type() != AnimationNodeStateMachine::STATE_MACHINE_TYPE_GROUPED) {
-			_clear_path_children(tree, p_state_machine, p_test_only);
+			_clear_path_children(p_process_state, tree, p_state_machine, p_test_only);
 		}
 	}
 
@@ -768,7 +768,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		}
 		// Teleport to start.
 		if (p_state_machine->states.has(start_request)) {
-			_start(p_state_machine);
+			_start(p_process_state, p_state_machine);
 		} else {
 			StringName node = start_request;
 			ERR_FAIL_V_MSG(AnimationNode::NodeTimeInfo(), "No such node: '" + node + "'");
@@ -783,10 +783,10 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		StringName temp_travel_request = travel_request; // For the case that can't travel.
 		// Process children.
 		Vector<StringName> new_path;
-		bool can_travel = _make_travel_path(tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
+		bool can_travel = _make_travel_path(p_process_state, tree, p_state_machine, travel_path.size() <= 1 ? p_state_machine->is_allow_transition_to_self() : false, new_path, p_test_only);
 		if (travel_path.size()) {
 			if (can_travel) {
-				can_travel = _travel_children(tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
+				can_travel = _travel_children(p_process_state, tree, p_state_machine, travel_target, p_state_machine->is_allow_transition_to_self(), travel_path[0] == current, p_test_only);
 			} else {
 				_start_children(tree, p_state_machine, travel_target, p_test_only);
 			}
@@ -800,7 +800,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 			if (p_state_machine->states.has(temp_travel_request)) {
 				path.clear();
 				if (current != temp_travel_request || reset_request_on_teleport) {
-					_set_current(p_state_machine, temp_travel_request);
+					_set_current(p_process_state, p_state_machine, temp_travel_request);
 					reset_request = reset_request_on_teleport;
 					teleport_request = true;
 				}
@@ -823,15 +823,15 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		pi.seeked = true;
 		pi.is_external_seeking = false;
 		pi.weight = 0;
-		current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true);
+		current_nti = p_state_machine->blend_node(p_process_state, p_instance, p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true);
 		// Don't process first node if not necessary, instead process next node.
-		_transition_to_next_recursive(tree, p_state_machine, p_delta, p_test_only);
+		_transition_to_next_recursive(p_process_state, p_instance, tree, p_state_machine, p_delta, p_test_only);
 	}
 
 	// Check current node existence.
 	if (!p_state_machine->states.has(current)) {
 		playing = false; // Current does not exist.
-		_set_current(p_state_machine, StringName());
+		_set_current(p_process_state, p_state_machine, StringName());
 		return AnimationNode::NodeTimeInfo();
 	}
 
@@ -873,7 +873,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 		pi.time = 0;
 		pi.seeked = true;
 	}
-	current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+	current_nti = p_state_machine->blend_node(p_process_state, p_instance, p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 	// Cross-fade process.
 	if (fading_from != StringName()) {
@@ -892,16 +892,16 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 			pi.time = 0;
 			pi.seeked = true;
 		}
-		fadeing_from_nti = p_state_machine->blend_node(p_state_machine->states[fading_from].node, fading_from, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
+		fadeing_from_nti = p_state_machine->blend_node(p_process_state, p_instance, p_state_machine->states[fading_from].node, fading_from, pi, AnimationNode::FILTER_IGNORE, true, p_test_only); // Blend values must be more than CMP_EPSILON to process discrete keys in edge.
 
 		if (Animation::is_greater_or_equal_approx(fading_pos, fading_time)) {
 			// Finish fading.
-			_clear_fading(p_state_machine, fading_from);
+			_clear_fading(p_process_state, p_state_machine, fading_from);
 		}
 	}
 
 	// Find next and see when to transition.
-	bool will_end = _transition_to_next_recursive(tree, p_state_machine, p_delta, p_test_only) || current == SceneStringName(End);
+	bool will_end = _transition_to_next_recursive(p_process_state, p_instance, tree, p_state_machine, p_delta, p_test_only) || current == SceneStringName(End);
 
 	// Predict remaining time.
 	if (will_end || ((p_state_machine->get_state_machine_type() == AnimationNodeStateMachine::STATE_MACHINE_TYPE_NESTED) && !p_state_machine->has_transition_from(current))) {
@@ -919,7 +919,7 @@ AnimationNode::NodeTimeInfo AnimationNodeStateMachinePlayback::_process(Animatio
 	return current_nti;
 }
 
-bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only) {
 	_reset_request_for_fading_from = false;
 
 	AnimationMixer::PlaybackInfo pi;
@@ -928,9 +928,9 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 	Vector<StringName> transition_path;
 	transition_path.push_back(current);
 	while (true) {
-		next = _find_next(p_tree, p_state_machine);
+		next = _find_next(p_process_state, p_tree, p_state_machine);
 
-		if (!_can_transition_to_next(p_tree, p_state_machine, next, p_test_only)) {
+		if (!_can_transition_to_next(p_process_state, p_tree, p_state_machine, next, p_test_only)) {
 			break; // Finish transition.
 		}
 
@@ -954,9 +954,9 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 				pi.seeked = true;
 				pi.is_external_seeking = false;
 				pi.weight = 0;
-				p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
+				p_state_machine->blend_node(p_process_state, p_instance, p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
 			}
-			_clear_fading(p_state_machine, current);
+			_clear_fading(p_process_state, p_state_machine, current);
 			fading_time = 0;
 			fading_pos = 0;
 		}
@@ -967,7 +967,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		}
 
 		// Update current status.
-		_set_current(p_state_machine, next.node);
+		_set_current(p_process_state, p_state_machine, next.node);
 		current_curve = next.curve;
 
 		if (current == SceneStringName(End)) {
@@ -984,7 +984,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 			pi.seeked = true;
 			pi.is_external_seeking = false;
 			pi.weight = 0;
-			p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
+			p_state_machine->blend_node(p_process_state, p_instance, p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, p_test_only);
 		}
 
 		// Just get length to find next recursive.
@@ -992,7 +992,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 		pi.is_external_seeking = false;
 		pi.weight = 0;
 		pi.seeked = next.is_reset;
-		current_nti = p_state_machine->blend_node(p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
+		current_nti = p_state_machine->blend_node(p_process_state, p_instance, p_state_machine->states[current].node, current, pi, AnimationNode::FILTER_IGNORE, true, true); // Just retrieve remain length, don't process.
 
 		// Fading must be processed.
 		if (fading_time) {
@@ -1003,7 +1003,7 @@ bool AnimationNodeStateMachinePlayback::_transition_to_next_recursive(AnimationT
 	return next.node == SceneStringName(End);
 }
 
-bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only) {
+bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only) {
 	if (p_next.node == StringName()) {
 		return false;
 	}
@@ -1022,7 +1022,7 @@ bool AnimationNodeStateMachinePlayback::_can_transition_to_next(AnimationTree *p
 			}
 			playback->_next_main();
 			// Then, fading should end.
-			_clear_fading(p_state_machine, fading_from);
+			_clear_fading(p_process_state, p_state_machine, fading_from);
 			fading_pos = 0;
 		} else {
 			return true;
@@ -1063,7 +1063,7 @@ Ref<AnimationNodeStateMachineTransition> AnimationNodeStateMachinePlayback::_che
 	return p_transition.transition;
 }
 
-AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const {
+AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_find_next(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const {
 	NextInfo next;
 	if (path.size()) {
 		for (int i = 0; i < p_state_machine->transitions.size(); i++) {
@@ -1092,7 +1092,7 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 			if (ref_transition->get_advance_mode() == AnimationNodeStateMachineTransition::ADVANCE_MODE_DISABLED) {
 				continue;
 			}
-			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(anodesm, ref_transition) || bypass)) {
+			if (p_state_machine->transitions[i].from == current && (_check_advance_condition(p_process_state, anodesm, ref_transition) || bypass)) {
 				if (ref_transition->get_priority() <= priority_best) {
 					priority_best = ref_transition->get_priority();
 					auto_advance_to = i;
@@ -1116,19 +1116,22 @@ AnimationNodeStateMachinePlayback::NextInfo AnimationNodeStateMachinePlayback::_
 	return next;
 }
 
-bool AnimationNodeStateMachinePlayback::_check_advance_condition(const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
+bool AnimationNodeStateMachinePlayback::_check_advance_condition(AnimationNode::ProcessState &p_process_state, const Ref<AnimationNodeStateMachine> state_machine, const Ref<AnimationNodeStateMachineTransition> transition) const {
 	if (transition->get_advance_mode() != AnimationNodeStateMachineTransition::ADVANCE_MODE_AUTO) {
 		return false;
 	}
 
 	StringName advance_condition_name = transition->get_advance_condition_name();
 
-	if (advance_condition_name != StringName() && !bool(state_machine->get_parameter(advance_condition_name))) {
+	// I am too lazy to forward this all the way down, sorry for double lookup.
+	AnimationNodeInstance &instance = p_process_state.tree->get_node_instance(state_machine->get_instance_id());
+
+	if (advance_condition_name != StringName() && !bool(instance.get_parameter(advance_condition_name))) {
 		return false;
 	}
 
 	if (transition->expression.is_valid()) {
-		AnimationTree *tree_base = state_machine->get_animation_tree();
+		AnimationTree *tree_base = p_process_state.tree;
 		ERR_FAIL_NULL_V(tree_base, false);
 
 		NodePath advance_expression_base_node_path = tree_base->get_advance_expression_base_node();
@@ -1232,7 +1235,7 @@ AnimationNodeStateMachinePlayback::AnimationNodeStateMachinePlayback() {
 
 ///////////////////////////////////////////////////////
 
-void AnimationNodeStateMachine::get_parameter_list(List<PropertyInfo> *r_list) const {
+void AnimationNodeStateMachine::get_parameter_list(LocalVector<PropertyInfo> *r_list) const {
 	AnimationNode::get_parameter_list(r_list);
 	r_list->push_back(PropertyInfo(Variant::OBJECT, playback, PROPERTY_HINT_RESOURCE_TYPE, "AnimationNodeStateMachinePlayback", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ALWAYS_DUPLICATE)); // Don't store this object in .tres, it always needs to be made as unique object.
 	List<StringName> advance_conditions;
@@ -1370,7 +1373,7 @@ StringName AnimationNodeStateMachine::get_node_name(const Ref<AnimationNode> &p_
 	ERR_FAIL_V(StringName());
 }
 
-void AnimationNodeStateMachine::get_child_nodes(List<ChildNode> *r_child_nodes) {
+void AnimationNodeStateMachine::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 	Vector<StringName> nodes;
 
 	for (const KeyValue<StringName, State> &E : states) {
@@ -1631,16 +1634,17 @@ Vector2 AnimationNodeStateMachine::get_graph_offset() const {
 	return graph_offset;
 }
 
-AnimationNode::NodeTimeInfo AnimationNodeStateMachine::_process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only) {
-	Ref<AnimationNodeStateMachinePlayback> playback_new = get_parameter(playback);
+AnimationNode::NodeTimeInfo AnimationNodeStateMachine::_process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only) {
+	Ref<AnimationNodeStateMachinePlayback> playback_new = p_instance.get_parameter(playback);
 	ERR_FAIL_COND_V(playback_new.is_null(), AnimationNode::NodeTimeInfo());
-	playback_new->_set_base_path(node_state.get_base_path());
+
+	playback_new->_set_base_path(p_instance.base_path);
 	playback_new->_set_grouped(state_machine_type == STATE_MACHINE_TYPE_GROUPED);
 	if (p_test_only) {
 		playback_new = playback_new->duplicate(); // Don't process original when testing.
 	}
 
-	return playback_new->process(this, p_playback_info, p_test_only);
+	return playback_new->process(p_process_state, p_instance, this, p_playback_info, p_test_only);
 }
 
 String AnimationNodeStateMachine::get_caption() const {

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -163,7 +163,7 @@ protected:
 	virtual void reset_state() override;
 
 public:
-	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual void get_parameter_list(LocalVector<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 	virtual bool is_parameter_read_only(const StringName &p_parameter) const override;
 
@@ -180,7 +180,7 @@ public:
 	void set_node_position(const StringName &p_name, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_name) const;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(LocalVector<ChildNode> *r_child_nodes) override;
 
 	bool has_transition(const StringName &p_from, const StringName &p_to) const;
 	bool has_transition_from(const StringName &p_from) const;
@@ -211,7 +211,7 @@ public:
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;
 
-	virtual NodeTimeInfo _process(const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only = false) override;
+	virtual NodeTimeInfo _process(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const AnimationMixer::PlaybackInfo &p_playback_info, bool p_test_only = false) override;
 	virtual String get_caption() const override;
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name) const override;
@@ -288,32 +288,32 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 	bool is_grouped = false;
 
-	void _clear_fading(AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
+	void _clear_fading(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
 	void _signal_state_change(AnimationTree *p_animation_tree, const StringName &p_state, bool p_started);
 	void _travel_main(const StringName &p_state, bool p_reset_on_teleport = true);
 	void _start_main(const StringName &p_state, bool p_reset = true);
 	void _next_main();
 	void _stop_main();
 
-	bool _make_travel_path(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only);
+	bool _make_travel_path(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, Vector<StringName> &r_path, bool p_test_only);
 	String _validate_path(AnimationNodeStateMachine *p_state_machine, const String &p_path);
-	bool _travel(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only);
-	void _start(AnimationNodeStateMachine *p_state_machine);
+	bool _travel(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_is_allow_transition_to_self, bool p_test_only);
+	void _start(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine);
 
-	void _clear_path_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
-	bool _travel_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only);
+	void _clear_path_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, bool p_test_only);
+	bool _travel_children(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_is_allow_transition_to_self, bool p_is_parent_same_state, bool p_test_only);
 	void _start_children(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const String &p_path, bool p_test_only);
 
-	AnimationNode::NodeTimeInfo process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
-	AnimationNode::NodeTimeInfo _process(AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
+	AnimationNode::NodeTimeInfo process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
+	AnimationNode::NodeTimeInfo _process(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationNodeStateMachine *p_state_machine, const AnimationMixer::PlaybackInfo p_playback_info, bool p_test_only);
 
-	bool _check_advance_condition(const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
-	bool _transition_to_next_recursive(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only);
-	NextInfo _find_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
+	bool _check_advance_condition(AnimationNode::ProcessState &p_process_state, const Ref<AnimationNodeStateMachine> p_state_machine, const Ref<AnimationNodeStateMachineTransition> p_transition) const;
+	bool _transition_to_next_recursive(AnimationNode::ProcessState &p_process_state, AnimationNodeInstance &p_instance, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, double p_delta, bool p_test_only);
+	NextInfo _find_next(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine) const;
 	Ref<AnimationNodeStateMachineTransition> _check_group_transition(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, const AnimationNodeStateMachine::Transition &p_transition, Ref<AnimationNodeStateMachine> &r_state_machine, bool &r_bypass) const;
-	bool _can_transition_to_next(AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only);
+	bool _can_transition_to_next(AnimationNode::ProcessState &p_process_state, AnimationTree *p_tree, AnimationNodeStateMachine *p_state_machine, NextInfo p_next, bool p_test_only);
 
-	void _set_current(AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
+	void _set_current(AnimationNode::ProcessState &p_process_state, AnimationNodeStateMachine *p_state_machine, const StringName &p_state);
 	void _set_grouped(bool p_is_grouped);
 	void _set_base_path(const String &p_base_path);
 	Ref<AnimationNodeStateMachinePlayback> _get_parent_playback(AnimationTree *p_tree) const;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -279,20 +279,20 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 		playback.blend.clear();
 		return;
 	}
-	List<List<Blend>::Element *> to_erase;
-	for (List<Blend>::Element *E = c.blend.front(); E; E = E->next()) {
-		Blend &b = E->get();
+	LocalVector<int> to_erase;
+	for (uint32_t i = 0; i < c.blend.size(); i++) {
+		Blend &b = c.blend[i];
 		b.blend_left = MAX(0, b.blend_left - Math::abs(speed_scale * p_delta) / b.blend_time);
 		if (Animation::is_less_or_equal_approx(b.blend_left, 0)) {
-			to_erase.push_back(E);
+			to_erase.push_back(i);
 			b.blend_left = CMP_EPSILON; // May want to play last frame.
 		}
 		// Note: There may be issues if an animation event triggers an animation change while this blend is active,
 		// so it is best to use "deferred" calls instead of "immediate" for animation events that can trigger new animations.
 		_process_playback_data(b.data, p_delta, b.blend_left, false, false, false);
 	}
-	for (List<Blend>::Element *&E : to_erase) {
-		c.blend.erase(E);
+	for (int i = to_erase.size() - 1; i >= 0; i--) {
+		c.blend.remove_at(to_erase[i]);
 	}
 }
 
@@ -330,9 +330,9 @@ void AnimationPlayer::_blend_post_process() {
 		// If the method track changes current animation, the animation is not finished.
 		if (tmp_from == playback.current.from->animation->get_instance_id()) {
 			if (playback_queue.size()) {
-				String old = playback.assigned;
+				const StringName &old = playback.assigned;
 				play(playback_queue.front()->get());
-				String new_name = playback.assigned;
+				const StringName &new_name = playback.assigned;
 				playback_queue.pop_front();
 				if (end_notify) {
 					emit_signal(SceneStringName(animation_changed), old, new_name);
@@ -409,9 +409,10 @@ void AnimationPlayer::play_section_with_markers(const StringName &p_name, const 
 		name = playback.assigned;
 	}
 
-	ERR_FAIL_COND_MSG(!animation_set.has(name), vformat("Animation not found: %s.", name));
+	AnimationData *ad = animation_set.getptr(name);
+	ERR_FAIL_NULL_MSG(ad, vformat("Animation not found: %s.", name));
 
-	Ref<Animation> animation = animation_set[name].animation;
+	const Ref<Animation> &animation = ad->animation;
 
 	ERR_FAIL_COND_MSG(p_start_marker == p_end_marker && p_start_marker, vformat("Start marker and end marker cannot be the same marker: %s.", p_start_marker));
 	ERR_FAIL_COND_MSG(p_start_marker && !animation->has_marker(p_start_marker), vformat("Marker %s not found in animation: %s.", p_start_marker, name));
@@ -457,12 +458,12 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 		} else if (blend_times.has(bk)) {
 			blend_time = blend_times[bk];
 		} else {
-			bk.from = "*";
+			bk.from = SNAME("*");
 			if (blend_times.has(bk)) {
 				blend_time = blend_times[bk];
 			} else {
 				bk.from = c.current.from->name;
-				bk.to = "*";
+				bk.to = SNAME("*");
 
 				if (blend_times.has(bk)) {
 					blend_time = blend_times[bk];
@@ -650,8 +651,9 @@ void AnimationPlayer::seek_internal(double p_time, bool p_update, bool p_update_
 	playback.current.pos = p_time;
 	if (!playback.current.from) {
 		if (playback.assigned) {
-			ERR_FAIL_COND_MSG(!animation_set.has(playback.assigned), vformat("Animation not found: %s.", playback.assigned));
-			playback.current.from = &animation_set[playback.assigned];
+			AnimationData *ad = animation_set.getptr(playback.assigned);
+			ERR_FAIL_NULL_MSG(ad, vformat("Animation not found: %s.", playback.assigned));
+			playback.current.from = ad;
 		}
 		if (!playback.current.from) {
 			return; // There is no animation.
@@ -794,10 +796,11 @@ void AnimationPlayer::animation_set_next(const StringName &p_animation, const St
 }
 
 StringName AnimationPlayer::animation_get_next(const StringName &p_animation) const {
-	if (!animation_next_set.has(p_animation)) {
+	const StringName *next = animation_next_set.getptr(p_animation);
+	if (!next) {
 		return StringName();
 	}
-	return animation_next_set[p_animation];
+	return *next;
 }
 
 void AnimationPlayer::set_default_blend_time(double p_default) {
@@ -828,8 +831,8 @@ double AnimationPlayer::get_blend_time(const StringName &p_animation1, const Str
 	bk.from = p_animation1;
 	bk.to = p_animation2;
 
-	if (blend_times.has(bk)) {
-		return blend_times[bk];
+	if (const double *blend_time = blend_times.getptr(bk)) {
+		return *blend_time;
 	} else {
 		return 0;
 	}
@@ -872,7 +875,7 @@ Tween::EaseType AnimationPlayer::get_auto_capture_ease_type() const {
 void AnimationPlayer::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	const String pf = p_function;
 	if (p_idx == 0 && (pf == "play" || pf == "play_backwards" || pf == "has_animation" || pf == "queue")) {
-		List<StringName> al;
+		LocalVector<StringName> al;
 		get_animation_list(&al);
 		for (const StringName &name : al) {
 			r_options->push_back(String(name).quote());
@@ -885,7 +888,7 @@ void AnimationPlayer::get_argument_options(const StringName &p_function, int p_i
 void AnimationPlayer::_animation_removed(const StringName &p_name, const StringName &p_library) {
 	AnimationMixer::_animation_removed(p_name, p_library);
 
-	StringName name = p_library == StringName() ? p_name : StringName(String(p_library) + "/" + String(p_name));
+	const StringName &name = p_library == StringName() ? p_name : StringName(String(p_library) + "/" + String(p_name));
 
 	if (!animation_set.has(name)) {
 		return; // No need to update because not the one from the library being used.
@@ -894,17 +897,16 @@ void AnimationPlayer::_animation_removed(const StringName &p_name, const StringN
 	_animation_set_cache_update();
 
 	// Erase blends if needed
-	List<BlendKey> to_erase;
+	LocalVector<BlendKey> to_erase;
 	for (const KeyValue<BlendKey, double> &E : blend_times) {
-		BlendKey bk = E.key;
+		const BlendKey &bk = E.key;
 		if (bk.from == name || bk.to == name) {
 			to_erase.push_back(bk);
 		}
 	}
 
-	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const BlendKey &bk : to_erase) {
+		blend_times.erase(bk);
 	}
 }
 
@@ -912,7 +914,7 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 	AnimationMixer::_rename_animation(p_from_name, p_to_name);
 
 	// Rename autoplay or blends if needed.
-	List<BlendKey> to_erase;
+	LocalVector<BlendKey> to_erase;
 	HashMap<BlendKey, double, BlendKey> to_insert;
 	for (const KeyValue<BlendKey, double> &E : blend_times) {
 		BlendKey bk = E.key;
@@ -933,9 +935,8 @@ void AnimationPlayer::_rename_animation(const StringName &p_from_name, const Str
 		}
 	}
 
-	while (to_erase.size()) {
-		blend_times.erase(to_erase.front()->get());
-		to_erase.pop_front();
+	for (const BlendKey &bk : to_erase) {
+		blend_times.erase(bk);
 	}
 
 	while (to_insert.size()) {

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -94,7 +94,7 @@ private:
 		bool seeked = false;
 		bool internal_seeked = false;
 		bool started = false;
-		List<Blend> blend;
+		LocalVector<Blend> blend;
 	} playback;
 
 	struct BlendKey {

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -277,7 +277,7 @@ private:
 	_FORCE_INLINE_ T _interpolate(const LocalVector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward = false) const;
 
 	template <typename T>
-	_FORCE_INLINE_ void _track_get_key_indices_in_range(const LocalVector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool p_is_backward) const;
+	_FORCE_INLINE_ void _track_get_key_indices_in_range(const LocalVector<T> &p_array, double from_time, double to_time, LocalVector<int> *r_indices, bool p_is_backward) const;
 
 	double length = 1.0;
 	real_t step = DEFAULT_STEP;
@@ -365,7 +365,7 @@ private:
 	bool _fetch_compressed_by_index(uint32_t p_compressed_track, int p_index, Vector3i &r_value, double &r_time) const;
 	int _get_compressed_key_count(uint32_t p_compressed_track) const;
 	template <uint32_t COMPONENTS>
-	void _get_compressed_key_indices_in_range(uint32_t p_compressed_track, double p_time, double p_delta, List<int> *r_indices) const;
+	void _get_compressed_key_indices_in_range(uint32_t p_compressed_track, double p_time, double p_delta, LocalVector<int> *r_indices) const;
 	_FORCE_INLINE_ Quaternion _uncompress_quaternion(const Vector3i &p_value) const;
 	_FORCE_INLINE_ Vector3 _uncompress_pos_scale(uint32_t p_compressed_track, const Vector3i &p_value) const;
 	_FORCE_INLINE_ float _uncompress_blend_shape(const Vector3i &p_value) const;
@@ -513,7 +513,7 @@ public:
 
 	void copy_track(int p_track, Ref<Animation> p_to_animation);
 
-	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE) const;
+	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, LocalVector<int> *r_indices, Animation::LoopedFlag p_looped_flag = Animation::LOOPED_FLAG_NONE) const;
 
 	void add_marker(const StringName &p_name, double p_time);
 	void remove_marker(const StringName &p_name);
@@ -527,7 +527,7 @@ public:
 	void set_marker_color(const StringName &p_name, const Color &p_color);
 
 	void set_length(real_t p_length);
-	real_t get_length() const;
+	_FORCE_INLINE_ real_t get_length() const { return length; }
 
 	void set_loop_mode(LoopMode p_loop_mode);
 	LoopMode get_loop_mode() const;
@@ -542,6 +542,7 @@ public:
 
 	// Helper functions for Variant.
 	static bool is_variant_interpolatable(const Variant p_value);
+	static bool needs_type_cast(const Variant &p_from, const Variant &p_to);
 	static bool validate_type_match(const Variant &p_from, Variant &r_to);
 
 	static Variant cast_to_blendwise(const Variant p_value);


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

---
Before this patch (2dd26a027a99633231184616d4dd287bbdd1c0a3).

FPS: high 192, low 185, median 188.5
MSPF: high 5.40, low 5.20, median 5.30

~After this patch.~ (Benchmarks no longer accurate)

~FPS: high 234, low 229, median 231~
~MSPF:  high 4.36, low 4.27, median 4.32~

---
Here is the test project I used, I ran it from the command line with `--headless --print-fps`, and the engine was compiled with `scons compiledb=yes debug_symbols=yes production=yes`
[Mrp.zip](https://github.com/user-attachments/files/22307048/Mrp.zip)


Changes:
- Replaced `List<>` usages with `LocalVector<>`.
- Updated many variables to use `&`, to avoid copies.
- Changed many function parameters/returns from by-value to `const &` (to avoid copies and ref counting overhead)
- Use single-lookup (e.g. `has_node()+get_node()` changed to  `get_node_or_null()`), same for HashMaps.
- Added `SNAME` when needed.
- `AnimationNodeBlendTreeEditor` now queues (and merges) `update_graph` calls at the end of the frame.
- Large structs like `AnimationMixer::PlaybackInfo` are now passed by `const &` instead of copied.
- `AnimationNode::_blend_node` now uses preallocated `StringName`s.
- `AnimationTree` is now safe to use with `Node::process_thread_group` 
- Misc optimizations and improvements
