### PR TITLE
Optimize NodePath to String by using cached path

### DIFF
--- a/core/string/node_path.cpp
+++ b/core/string/node_path.cpp
@@ -52,6 +52,7 @@ void NodePath::_update_hash_cache() const {
 void NodePath::prepend_period() {
 	if (data->path.size() && data->path[0].operator String() != ".") {
 		data->path.insert(0, ".");
+		data->concatenated_path = StringName();
 		data->hash_cache_valid = false;
 	}
 }
@@ -179,15 +180,11 @@ NodePath::operator String() const {
 		ret = "/";
 	}
 
-	for (int i = 0; i < data->path.size(); i++) {
-		if (i > 0) {
-			ret += "/";
-		}
-		ret += data->path[i].operator String();
-	}
+	ret += get_concatenated_names();
 
-	for (int i = 0; i < data->subpath.size(); i++) {
-		ret += ":" + data->subpath[i].operator String();
+	String subpath = get_concatenated_subnames();
+	if (!subpath.is_empty()) {
+		ret += ":" + subpath;
 	}
 
 	return ret;
@@ -356,6 +353,7 @@ void NodePath::simplify() {
 			}
 		}
 	}
+	data->concatenated_path = StringName();
 	data->hash_cache_valid = false;
 }
 


### PR DESCRIPTION
Found this problem when I'm working on #110439 (This code doesn't consider absolute path, which maybe wrong):
https://github.com/godotengine/godot/blob/bfa330dd5dc6f4894efc956db1be20e4bc2d0064/scene/resources/animation.cpp#L1067
We can optimize NodePath to String by using the cached concatenated path.

Tested in gdscript
```gdscript
	var t1 := Time.get_ticks_msec()
	var p := NodePath("gsesfs/dawd/fesj/wadfr:dawjjfes:fnsnjk:fasef")
	var s := str(p)
	print(s)
	for i in range(1000000):
		s = str(p)
	print(Time.get_ticks_msec()-t1)
```
Before: 702, After: 373