### PR TITLE
[3.x] Process TTS callback on the main thread to avoid speech-dispatcher deadlock

### DIFF
--- a/platform/x11/tts_linux.h
+++ b/platform/x11/tts_linux.h
@@ -41,7 +41,8 @@
 
 #include "speechd-so_wrap.h"
 
-class TTS_Linux {
+class TTS_Linux : public Object {
+	GDCLASS(TTS_Linux, Object);
 	_THREAD_SAFE_CLASS_
 
 	List<OS::TTSUtterance> queue;
@@ -58,6 +59,11 @@ class TTS_Linux {
 	static void speech_event_index_mark(size_t p_msg_id, size_t p_client_id, SPDNotificationType p_type, char *p_index_mark);
 
 	static TTS_Linux *singleton;
+
+protected:
+	static void _bind_methods();
+	void _speech_event(size_t p_msg_id, size_t p_client_id, int p_type);
+	void _speech_index_mark(size_t p_msg_id, size_t p_client_id, int p_type, const String &p_index_mark);
 
 public:
 	static TTS_Linux *get_singleton();


### PR DESCRIPTION
Backport of @bruvzg's work in #73671.

In 3.6.1 stable without this change, calls to OS.tts_speak() that are non-interrupting made while an utterance is being spoken will cause the application to hang the next time OS.tts_speak() or OS.tts_stop() are called.

Repro steps with the following test case: [3.6_tts_test.zip](https://github.com/user-attachments/files/22308921/3.6_tts_test.zip)
1. Click Speak (wait) twice in quick succession before the first utterance completes
2. Click any other button