### PR TITLE
Fix iOS/visionOS export plugin crash on exit.

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -2893,10 +2893,4 @@ EditorExportPlatformAppleEmbedded::EditorExportPlatformAppleEmbedded(const char 
 }
 
 EditorExportPlatformAppleEmbedded::~EditorExportPlatformAppleEmbedded() {
-#ifdef MACOS_ENABLED
-	quit_request.set();
-	if (check_for_changes_thread.is_started()) {
-		check_for_changes_thread.wait_to_finish();
-	}
-#endif
 }

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -98,6 +98,13 @@ protected:
 		check_for_changes_thread.start(_check_for_changes_poll_thread, this);
 	}
 
+	void _stop_remote_device_poller_thread() {
+		quit_request.set();
+		if (check_for_changes_thread.is_started()) {
+			check_for_changes_thread.wait_to_finish();
+		}
+	}
+
 	int _execute(const String &p_path, const List<String> &p_arguments, std::function<void(const String &)> p_on_data);
 
 private:

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -43,6 +43,9 @@ EditorExportPlatformIOS::EditorExportPlatformIOS() :
 }
 
 EditorExportPlatformIOS::~EditorExportPlatformIOS() {
+#ifdef MACOS_ENABLED
+	_stop_remote_device_poller_thread();
+#endif
 }
 
 void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) const {

--- a/platform/visionos/export/export_plugin.cpp
+++ b/platform/visionos/export/export_plugin.cpp
@@ -43,6 +43,9 @@ EditorExportPlatformVisionOS::EditorExportPlatformVisionOS() :
 }
 
 EditorExportPlatformVisionOS::~EditorExportPlatformVisionOS() {
+#ifdef MACOS_ENABLED
+	_stop_remote_device_poller_thread();
+#endif
 }
 
 void EditorExportPlatformVisionOS::get_export_options(List<ExportOption> *r_options) const {


### PR DESCRIPTION
Device poll thread seems to be rarely crashing during export plugin destruction, seems to have something to do with destructor call order (vtable for the child class disposed before base class destructor is called), since it's crashing with `pure virtual` call error.

```
Thread 0::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x1920f79b8 __ulock_wait + 8
1   libsystem_pthread.dylib       	       0x19213a0b0 _pthread_join + 608
2   Godot                         	       0x107d7474c Thread::wait_to_finish() + 196 (thread_apple.cpp:112)
3   Godot                         	       0x1088b1c9c EditorExportPlatformAppleEmbedded::~EditorExportPlatformAppleEmbedded() + 108 (editor_export_platform_apple_embedded.cpp:2899)
4   Godot                         	       0x108339588 EditorExportPlatformVisionOS::~EditorExportPlatformVisionOS() + 28
5   Godot                         	       0x1083395b4 EditorExportPlatformVisionOS::~EditorExportPlatformVisionOS() + 28
6   Godot                         	       0x10557d62c void memdelete<RefCounted>(RefCounted*) + 52 (memory.h:139)
7   Godot                         	       0x1082ce844 Ref<EditorExportPlatform>::unref() + 68 (ref_counted.h:206)
...

Thread 24 Crashed:
0   libsystem_kernel.dylib        	       0x1920fe388 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x19213788c pthread_kill + 296
2   libsystem_c.dylib             	       0x192040a3c abort + 124
3   libc++abi.dylib               	       0x1920ed384 abort_message + 132
4   libc++abi.dylib               	       0x1920eccb0 __cxa_pure_virtual + 24
5   Godot                         	       0x1088aded4 EditorExportPlatformAppleEmbedded::_check_for_changes_poll_thread(void*) + 720 (editor_export_platform_apple_embedded.cpp:2440)
6   Godot                         	       0x107d74398 Thread::thread_callback(void*) + 64 (thread_apple.cpp:55)
7   libsystem_pthread.dylib       	       0x192137c0c _pthread_start + 136
8   libsystem_pthread.dylib       	       0x192132b80 thread_start + 8
```

Fixes https://github.com/godotengine/godot/issues/110634
Fixes https://github.com/godotengine/godot/issues/111416