### PR TITLE
Improve editor language selector

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -352,7 +352,7 @@ void EditorPropertyTextEnum::_emit_changed_value(const String &p_string) {
 }
 
 void EditorPropertyTextEnum::_option_selected(int p_which) {
-	_emit_changed_value(option_button->get_item_text(p_which));
+	_emit_changed_value(option_button->get_item_metadata(p_which));
 }
 
 void EditorPropertyTextEnum::_edit_custom_value() {
@@ -414,20 +414,28 @@ void EditorPropertyTextEnum::update_property() {
 	}
 }
 
-void EditorPropertyTextEnum::setup(const Vector<String> &p_options, bool p_string_name, bool p_loose_mode) {
+void EditorPropertyTextEnum::setup(const Vector<String> &p_options, const Vector<String> &p_option_names, bool p_string_name, bool p_loose_mode) {
+	ERR_FAIL_COND(!p_option_names.is_empty() && p_option_names.size() != p_options.size());
+
 	string_name = p_string_name;
 	loose_mode = p_loose_mode;
 
-	options.clear();
+	options = p_options;
 
 	if (loose_mode) {
 		// Add an explicit empty value for clearing the property in the loose mode.
 		option_button->add_item("", options.size() + 1000);
+		option_button->set_item_metadata(-1, String());
 	}
 
+	bool use_option_names = !p_option_names.is_empty();
 	for (int i = 0; i < p_options.size(); i++) {
-		options.append(p_options[i]);
-		option_button->add_item(p_options[i], i);
+		if (use_option_names) {
+			option_button->add_item(p_option_names[i], i);
+		} else {
+			option_button->add_item(p_options[i], i);
+		}
+		option_button->set_item_metadata(-1, options[i]);
 	}
 
 	if (loose_mode) {
@@ -3689,7 +3697,7 @@ static EditorProperty *get_input_action_editor(const String &p_hint_text, bool i
 		}
 	}
 	options.append_array(builtin_options);
-	editor->setup(options, is_string_name, hints.has("loose_mode"));
+	editor->setup(options, Vector<String>(), is_string_name, hints.has("loose_mode"));
 	return editor;
 }
 
@@ -3803,8 +3811,17 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		case Variant::STRING: {
 			if (p_hint == PROPERTY_HINT_ENUM || p_hint == PROPERTY_HINT_ENUM_SUGGESTION) {
 				EditorPropertyTextEnum *editor = memnew(EditorPropertyTextEnum);
-				Vector<String> options = p_hint_text.split(",", false);
-				editor->setup(options, false, (p_hint == PROPERTY_HINT_ENUM_SUGGESTION));
+				Vector<String> options;
+				Vector<String> option_names;
+				if (p_hint_text.begins_with(";")) {
+					for (const String &option : p_hint_text.split(";", false)) {
+						options.append(option.get_slicec('/', 0));
+						option_names.append(option.get_slicec('/', 1));
+					}
+				} else {
+					options = p_hint_text.remove_char(' ').split(",", false);
+				}
+				editor->setup(options, option_names, false, (p_hint == PROPERTY_HINT_ENUM_SUGGESTION));
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_INPUT_NAME) {
 				return get_input_action_editor(p_hint_text, false);
@@ -3959,7 +3976,7 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 			if (p_hint == PROPERTY_HINT_ENUM || p_hint == PROPERTY_HINT_ENUM_SUGGESTION) {
 				EditorPropertyTextEnum *editor = memnew(EditorPropertyTextEnum);
 				Vector<String> options = p_hint_text.split(",", false);
-				editor->setup(options, true, (p_hint == PROPERTY_HINT_ENUM_SUGGESTION));
+				editor->setup(options, Vector<String>(), true, (p_hint == PROPERTY_HINT_ENUM_SUGGESTION));
 				return editor;
 			} else if (p_hint == PROPERTY_HINT_INPUT_NAME) {
 				return get_input_action_editor(p_hint_text, true);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -150,7 +150,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void setup(const Vector<String> &p_options, bool p_string_name = false, bool p_loose_mode = false);
+	void setup(const Vector<String> &p_options, const Vector<String> &p_option_names = {}, bool p_string_name = false, bool p_loose_mode = false);
 	virtual void update_property() override;
 	EditorPropertyTextEnum();
 };

--- a/editor/project_manager/quick_settings_dialog.cpp
+++ b/editor/project_manager/quick_settings_dialog.cpp
@@ -57,7 +57,7 @@ void QuickSettingsDialog::_fetch_setting_values() {
 		for (const PropertyInfo &pi : editor_settings_properties) {
 			if (pi.name == "interface/editor/editor_language") {
 #ifndef ANDROID_ENABLED
-				editor_languages = pi.hint_string.split(",");
+				editor_languages = pi.hint_string.split(";", false);
 #endif
 			} else if (pi.name == "interface/theme/preset") {
 				editor_themes = pi.hint_string.split(",");
@@ -81,10 +81,11 @@ void QuickSettingsDialog::_update_current_values() {
 		const String current_lang = EDITOR_GET("interface/editor/editor_language");
 
 		for (int i = 0; i < editor_languages.size(); i++) {
-			const String &lang_value = editor_languages[i];
+			const String &lang_value = editor_languages[i].get_slicec('/', 0);
 			if (current_lang == lang_value) {
-				language_option_button->set_text(current_lang);
+				language_option_button->set_text(editor_languages[i].get_slicec('/', 1));
 				language_option_button->select(i);
+				break;
 			}
 		}
 	}
@@ -285,10 +286,10 @@ QuickSettingsDialog::QuickSettingsDialog() {
 			language_option_button->connect(SceneStringName(item_selected), callable_mp(this, &QuickSettingsDialog::_language_selected));
 
 			for (int i = 0; i < editor_languages.size(); i++) {
-				const String &lang_value = editor_languages[i];
-				String lang_name = TranslationServer::get_singleton()->get_locale_name(lang_value);
-				language_option_button->add_item(vformat("[%s] %s", lang_value, lang_name), i);
-				language_option_button->set_item_metadata(i, lang_value);
+				const String &lang_code = editor_languages[i].get_slicec('/', 0);
+				const String &lang_name = editor_languages[i].get_slicec('/', 1);
+				language_option_button->add_item(lang_name, i);
+				language_option_button->set_item_metadata(i, lang_code);
 			}
 
 			_add_setting_control(TTRC("Language"), language_option_button);

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -379,7 +379,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Languages */
 
 	{
-		String lang_hint = "en";
+		String lang_hint = ";en/[en] English";
 		String host_lang = OS::get_singleton()->get_locale();
 
 		// Skip locales if Text server lack required features.
@@ -415,8 +415,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 				continue;
 			}
 
-			lang_hint += ",";
-			lang_hint += locale;
+			lang_hint += ";";
+			const String lang_name = TranslationServer::get_singleton()->get_locale_name(locale);
+			lang_hint += vformat("%s/[%s] %s", locale, locale, lang_name);
 
 			int score = TranslationServer::get_singleton()->compare_locales(host_lang, locale);
 			if (score > 0 && score >= best_score) {


### PR DESCRIPTION
Changes raw locale list to proper language list like in Project Manager:
<img width="692" height="673" alt="image" src="https://github.com/user-attachments/assets/1d5858e7-0dca-4725-8ef6-f2d16a7ac3ba" />
It required some modifications to EditorPropertyTextEnum. Not sure if it's the best way to do that.