### PR TITLE
Remove duplicate points in SoftBody3D gizmo plugin

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -627,6 +627,14 @@ _ALWAYS_INLINE_ double round(double p_val) {
 _ALWAYS_INLINE_ float round(float p_val) {
 	return std::round(p_val);
 }
+_ALWAYS_INLINE_ float round_to_decimal(const float p_val, const uint8_t precision) {
+	const float factor = pow(10.0F, precision);
+	return round(p_val * factor) / factor;
+}
+_ALWAYS_INLINE_ double round_to_decimal(const double p_val, const uint8_t precision) {
+	const double factor = pow(10.0, precision);
+	return round(p_val * factor) / factor;
+}
 
 _ALWAYS_INLINE_ double wrapf(double p_value, double p_min, double p_max) {
 	double range = p_max - p_min;

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -165,6 +165,7 @@ struct [[nodiscard]] Vector3 {
 	_FORCE_INLINE_ Vector3 sign() const;
 	_FORCE_INLINE_ Vector3 ceil() const;
 	_FORCE_INLINE_ Vector3 round() const;
+	_FORCE_INLINE_ Vector3 round_to_decimal(uint8_t precision) const;
 
 	_FORCE_INLINE_ real_t distance_to(const Vector3 &p_to) const;
 	_FORCE_INLINE_ real_t distance_squared_to(const Vector3 &p_to) const;
@@ -271,6 +272,10 @@ Vector3 Vector3::ceil() const {
 
 Vector3 Vector3::round() const {
 	return Vector3(Math::round(x), Math::round(y), Math::round(z));
+}
+
+Vector3 Vector3::round_to_decimal(uint8_t precision) const {
+	return Vector3(Math::round_to_decimal(x, precision), Math::round_to_decimal(y, precision), Math::round_to_decimal(z, precision));
 }
 
 Vector3 Vector3::lerp(const Vector3 &p_to, real_t p_weight) const {

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -91,6 +91,16 @@
 				Returns [code]true[/code] if vertex is set to pinned.
 			</description>
 		</method>
+		<method name="pin_overlapping_points">
+			<return type="void" />
+			<param index="0" name="point_index" type="int" />
+			<param index="1" name="pinned" type="bool" />
+			<param index="2" name="attachment_path" type="NodePath" default="NodePath(&quot;&quot;)" />
+			<param index="3" name="insert_at" type="int" default="-1" />
+			<description>
+				Sets the pinned state of all the surface vertices overlapping with the provided vertex. When set to [code]true[/code], the optional [param attachment_path] can define a [Node3D] the pinned vertices will be attached to.
+			</description>
+		</method>
 		<method name="remove_collision_exception_with">
 			<return type="void" />
 			<param index="0" name="body" type="Node" />

--- a/editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.cpp
@@ -112,14 +112,23 @@ void SoftBody3DGizmoPlugin::commit_handle(const EditorNode3DGizmo *p_gizmo, int 
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(vformat(is_pinned ? TTR("Remove SoftBody3D pinned point %d") : TTR("Add SoftBody3D pinned point %d"), p_id));
-	undo_redo->add_do_method(soft_body, "set_point_pinned", p_id, !is_pinned);
+	undo_redo->add_do_method(soft_body, "pin_overlapping_points", p_id, !is_pinned);
 	undo_redo->add_do_method(soft_body, "update_gizmos");
-	undo_redo->add_undo_method(soft_body, "set_point_pinned", p_id, is_pinned);
+	undo_redo->add_undo_method(soft_body, "pin_overlapping_points", p_id, is_pinned);
 	undo_redo->add_undo_method(soft_body, "update_gizmos");
 	undo_redo->commit_action();
 }
 
 bool SoftBody3DGizmoPlugin::is_handle_highlighted(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const {
 	SoftBody3D *soft_body = Object::cast_to<SoftBody3D>(p_gizmo->get_node_3d());
-	return soft_body->is_point_pinned(p_id);
+
+	const Vector<int> overlapping_points = soft_body->get_overlapping_points(p_id);
+
+	for (int i = 0; i < overlapping_points.size(); i++) {
+		if (soft_body->is_point_pinned(overlapping_points[i])) {
+			return true;
+		}
+	}
+
+	return false;
 }

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -117,6 +117,27 @@ void MeshInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+void MeshInstance3D::_update_overlapping_vertices() {
+	overlapping_vertices.clear();
+	point_to_position.clear();
+
+	if (mesh.is_null() || mesh->get_surface_count() == 0) {
+		return;
+	}
+
+	int point_index = 0;
+	for (int i = 0; i < mesh->get_surface_count(); i++) {
+		Array arrays = mesh->surface_get_arrays(i);
+		const PackedVector3Array &vertices = arrays[Mesh::ARRAY_VERTEX];
+
+		for (int j = 0; j < vertices.size(); j++, point_index++) {
+			Vector3 coordinates = vertices[j].round_to_decimal(6);
+			overlapping_vertices[coordinates].push_back(point_index);
+			point_to_position[point_index] = coordinates;
+		}
+	}
+}
+
 void MeshInstance3D::set_mesh(const Ref<Mesh> &p_mesh) {
 	if (mesh == p_mesh) {
 		return;
@@ -435,6 +456,7 @@ void MeshInstance3D::_mesh_changed() {
 		}
 	}
 
+	_update_overlapping_vertices();
 	update_gizmos();
 }
 

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -55,6 +55,9 @@ protected:
 	HashMap<StringName, int> blend_shape_properties;
 	Vector<Ref<Material>> surface_override_materials;
 
+	HashMap<Vector3, Vector<int>> overlapping_vertices;
+	HashMap<int, Vector3> point_to_position;
+
 	void _mesh_changed();
 	void _resolve_skeleton_path();
 
@@ -62,6 +65,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	void _update_overlapping_vertices();
 	bool surface_index_0 = false;
 
 	void _notification(int p_what);

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -376,6 +376,7 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &SoftBody3D::apply_central_force);
 
 	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path", "insert_at"), &SoftBody3D::pin_point, DEFVAL(NodePath()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("pin_overlapping_points", "point_index", "pinned", "attachment_path", "insert_at"), &SoftBody3D::pin_overlapping_points, DEFVAL(NodePath()), DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("is_point_pinned", "point_index"), &SoftBody3D::is_point_pinned);
 
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &SoftBody3D::set_ray_pickable);
@@ -716,6 +717,29 @@ void SoftBody3D::pin_point(int p_point_index, bool pin, const NodePath &p_spatia
 	} else {
 		_remove_pinned_point(p_point_index);
 	}
+}
+
+void SoftBody3D::pin_overlapping_points(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path, int p_insert_at) {
+	ERR_FAIL_COND_MSG(!point_to_position.has(p_point_index), vformat("Invalid pin point index: %d", p_point_index));
+
+	const Vector<int> overlapping_points = get_overlapping_points(p_point_index);
+
+	for (int j = 0; j < overlapping_points.size(); ++j) {
+		pin_point(overlapping_points[j], pin, p_spatial_attachment_path, p_insert_at);
+	}
+}
+
+Vector<int> SoftBody3D::get_overlapping_points(int p_point_index) {
+	if (!point_to_position.has(p_point_index)) {
+		return Vector<int>();
+	}
+
+	const Vector3 point_position = point_to_position.get(p_point_index);
+	if (!overlapping_vertices.has(point_position)) {
+		return Vector<int>();
+	}
+
+	return overlapping_vertices.get(point_position);
 }
 
 void SoftBody3D::_pin_point_deferred(int p_point_index, bool pin, const NodePath p_spatial_attachment_path) {

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -183,6 +183,8 @@ public:
 	Vector3 get_point_transform(int p_point_index);
 
 	void pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath(), int p_insert_at = -1);
+	void pin_overlapping_points(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath(), int p_insert_at = -1);
+	Vector<int> get_overlapping_points(int p_point_index);
 	bool is_point_pinned(int p_point_index) const;
 
 	void _pin_point_deferred(int p_point_index, bool pin, const NodePath p_spatial_attachment_path);


### PR DESCRIPTION
Fixes #108149

With the old implementation, all the points were added without checking for duplicates.

<img width="1401" height="835" alt="image" src="https://github.com/user-attachments/assets/a026d8b6-3e09-4047-a61f-6560221df733" />

This also fixes the problem in the linked issue where points were not highlightable, as there were often overlapping points on top.

For reference, in the provided image, it previously displayed that I had ~480 points. With the fix, it is showing the correct number (114).
Just in case, I highlighted all the points on the mesh top-to-bottom (7, excluding the top-most & bottom-most point), and all the points along the circumference (16). 16*7 + 2 = 114, aligning with the resulting number of points.