### PR TITLE
[macOS] Use `productCategory` instead of `vendorName` for joypad name in SDL

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -973,6 +973,7 @@ Patches:
 - `0004-errno-include.patch` (GH-108354)
 - `0005-fix-libudev-dbus.patch` (GH-108373)
 - `0006-fix-cs-environ.patch` (GH-109283)
+- `0007-macos-joypad-name.patch` (GH-110500)
 
 The SDL source code folder includes `hidapi` library inside of folder `thirdparty/sdl/hidapi/`.
 Its version and license is described in this file under `hidapi`.

--- a/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
+++ b/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
@@ -300,9 +300,15 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
      * struct, and ARC doesn't work with structs. */
     device->controller = (__bridge GCController *)CFBridgingRetain(controller);
 
-    if (controller.vendorName) {
-        name = controller.vendorName.UTF8String;
-    }
+	if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
+		if (controller.productCategory) {
+		    name = controller.productCategory.UTF8String;
+		}
+	} else {
+		if (controller.vendorName) {
+		    name = controller.vendorName.UTF8String;
+		}
+	}
 
     if (!name) {
         name = "MFi Gamepad";

--- a/thirdparty/sdl/patches/0007-macos-joypad-name.patch
+++ b/thirdparty/sdl/patches/0007-macos-joypad-name.patch
@@ -1,0 +1,25 @@
+diff --git a/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m b/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
+index 811a9f1ae7..2ba2cbeae6 100644
+--- a/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
++++ b/thirdparty/sdl/joystick/apple/SDL_mfijoystick.m
+@@ -300,9 +300,15 @@ static bool IOS_AddMFIJoystickDevice(SDL_JoystickDeviceItem *device, GCControlle
+      * struct, and ARC doesn't work with structs. */
+     device->controller = (__bridge GCController *)CFBridgingRetain(controller);
+ 
+-    if (controller.vendorName) {
+-        name = controller.vendorName.UTF8String;
+-    }
++	if (@available(macOS 10.15, iOS 13.0, tvOS 13.0, *)) {
++		if (controller.productCategory) {
++		    name = controller.productCategory.UTF8String;
++		}
++	} else {
++		if (controller.vendorName) {
++		    name = controller.vendorName.UTF8String;
++		}
++	}
+ 
+     if (!name) {
+         name = "MFi Gamepad";
+-- 
+2.51.0


### PR DESCRIPTION
This PR updates the apple sdl driver to use `productCategory` for the controller name instead of `vendorName` when available. This was already updated before the switch to sdl was made so this PR merely pulls those changes into our sdl implementation.

Please see https://github.com/godotengine/godot/pull/104894 for more details.