### PR TITLE
Add toki pona

### DIFF
--- a/core/string/locales.h
+++ b/core/string/locales.h
@@ -916,6 +916,7 @@ static const char *language_list[][2] = {
 	{ "tn", "Tswana" },
 	{ "to", "Tongan" },
 	{ "tog", "Nyasa Tonga" },
+	{ "tok", "toki pona" },
 	{ "tpi", "Tok Pisin" },
 	{ "tr", "Turkish" },
 	{ "tru", "Turoyo" },


### PR DESCRIPTION
The editor has supported the toki pona language since ~Commit dda2614, but the locale has not been properly labeled since then, and is not selectable as a targetable locale for projects.

I am aware I already did a similar PR, but it was closed without action (Unless I'm mis remembering, cant find it), and given the language is in the editor now, adding it to the list makes more sense.