### PR TITLE
Change AnimationLibrary serialization to avoid using Dictionary

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -69,10 +69,7 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 			al = get_animation_library(StringName());
 		}
 		al->add_animation(which, anim);
-	} else if (name.begins_with("libraries")) {
-#else
-	if (name.begins_with("libraries")) {
-#endif // DISABLE_DEPRECATED
+	} else if (name == "libraries") {
 		Dictionary d = p_value;
 		while (animation_libraries.size()) {
 			remove_animation_library(animation_libraries[0].name);
@@ -82,10 +79,28 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 			add_animation_library(kv.key, lib);
 		}
 		emit_signal(SNAME("animation_libraries_updated"));
-
+	} else if (name.begins_with("libraries/")) {
+		String which = name.get_slicec('/', 1);
+		if (has_animation_library(which)) {
+			remove_animation_library(which);
+		}
+		add_animation_library(which, p_value);
+		emit_signal(SNAME("animation_libraries_updated"));
 	} else {
 		return false;
 	}
+#else
+	if (name.begins_with("libraries/")) {
+		String which = name.get_slicec('/', 1);
+		if (has_animation_library(which)) {
+			remove_animation_library(which);
+		}
+		add_animation_library(which, p_value);
+		emit_signal(SNAME("animation_libraries_updated"));
+	} else {
+		return false;
+	}
+#endif // DISABLE_DEPRECATED
 
 	return true;
 }
@@ -93,12 +108,13 @@ bool AnimationMixer::_set(const StringName &p_name, const Variant &p_value) {
 bool AnimationMixer::_get(const StringName &p_name, Variant &r_ret) const {
 	String name = p_name;
 
-	if (name.begins_with("libraries")) {
-		Dictionary d;
-		for (const AnimationLibraryData &lib : animation_libraries) {
-			d[lib.name] = lib.library;
+	if (name.begins_with("libraries/")) {
+		String which = name.get_slicec('/', 1);
+		if (has_animation_library(which)) {
+			r_ret = get_animation_library(which);
+		} else {
+			return false;
 		}
-		r_ret = d;
 	} else {
 		return false;
 	}
@@ -111,7 +127,10 @@ uint32_t AnimationMixer::_get_libraries_property_usage() const {
 }
 
 void AnimationMixer::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::DICTIONARY, PNAME("libraries"), PROPERTY_HINT_DICTIONARY_TYPE, "StringName;AnimationLibrary", _get_libraries_property_usage()));
+	for (uint32_t i = 0; i < animation_libraries.size(); i++) {
+		const String path = vformat("libraries/%s", animation_libraries[i].name);
+		p_list->push_back(PropertyInfo(Variant::OBJECT, path, PROPERTY_HINT_RESOURCE_TYPE, "AnimationLibrary", _get_libraries_property_usage()));
+	}
 }
 
 void AnimationMixer::_validate_property(PropertyInfo &p_property) const {


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/110484

Regardless of whether AnimationLibrary was imported, Dictionary was treating it as a sub_resource. This PR parses and serializes AnimationLibrary into a single path.

Prev:
<img width="690" height="233" alt="image" src="https://github.com/user-attachments/assets/68c5719d-03b3-492c-93e8-8053eb32bc2d" />

<img width="544" height="121" alt="image" src="https://github.com/user-attachments/assets/e19b10fe-8996-4e3e-bdf6-12a33d593cd5" />

After fix:
<img width="720" height="144" alt="image" src="https://github.com/user-attachments/assets/1ab80730-a859-4663-b3ab-593154cb76e4" />

<img width="536" height="60" alt="image" src="https://github.com/user-attachments/assets/a0931645-66d3-4980-b332-68952536c349" />

However, it does not affect AnimationLibraries from old projects that have already been built-in unless you re-import the gltf and rearrange it in the tscn. In other words, this change only affects newly imported gltf files and maybe does not affect past projects.　However, since this still constitutes a change in behavior, I marked it as breaking compatibility.

Combined with https://github.com/godotengine/godot/pull/110487, this should significantly improve the safety of imported GlobalAnimationLibraries.