### PR TITLE
Fix typo in control node `_make_custom_tooltip` description.

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -204,7 +204,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				[b]Example:[/b] Usa a scene instance as a tooltip:
+				[b]Example:[/b] Use a scene instance as a tooltip:
 				[codeblocks]
 				[gdscript]
 				func _make_custom_tooltip(for_text):


### PR DESCRIPTION
Fixes a minor typo in the control node's _make_custom_tooltip documentation.
