### PR TITLE
Fix Reset on Save corrupt poses if scene has multiple Skeletons

### DIFF
--- a/scene/3d/modifier_bone_target_3d.h
+++ b/scene/3d/modifier_bone_target_3d.h
@@ -45,6 +45,9 @@ protected:
 	virtual void _process_modification(double p_delta) override;
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual bool is_processed_on_saving() const override { return true; }
+#endif
 	void set_bone_name(const String &p_bone_name);
 	String get_bone_name() const;
 	void set_bone(int p_bone);

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -317,11 +317,11 @@ void Skeleton3D::_notification(int p_what) {
 			Bone *bonesptr = bones.ptr();
 			int len = bones.size();
 
-			thread_local LocalVector<bool> bone_global_pose_dirty_backup;
+			LocalVector<bool> bone_global_pose_dirty_backup;
 
 			// Process modifiers.
 
-			thread_local LocalVector<BonePoseBackup> bones_backup;
+			LocalVector<BonePoseBackup> bones_backup;
 			_find_modifiers();
 			if (!modifiers.is_empty()) {
 				bones_backup.resize(bones.size());


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/110379

The bug is caused by the use of thread_local without thread guards for Skeleton backup and restore. When multiple Skeletons exist in a scene, this leads to confusion about which Skeleton they are applied to.

Partially revert (modify) #97538. Also includes a fix for an issue where Reset on Save was not applied to ModifierBoneTarget, polluting the git history.