### PR TITLE
Ensure the AnimationPlayer emits `animation_finished` for every animation

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -52,6 +52,8 @@ public:
 private:
 	AHashMap<StringName, StringName> animation_next_set; // For auto advance.
 
+	StringName finished_anim;
+
 	float speed_scale = 1.0;
 	double default_blend_time = 0.0;
 


### PR DESCRIPTION
Fixes #27509

Tested this with a small script similar to the one in the issue. An `animation_finished` is now emitted every time it should.