### PR TITLE
Prevent `AnimationPlayer::stop` from clearing queue

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -496,10 +496,6 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 	double start = playback.current.get_start_time();
 	double end = playback.current.get_end_time();
 
-	if (!end_reached) {
-		playback_queue.clear();
-	}
-
 	if (c.assigned != name) { // Reset.
 		c.current.pos = p_from_end ? end : start;
 		c.assigned = name;
@@ -784,7 +780,6 @@ void AnimationPlayer::_stop_internal(bool p_reset, bool p_keep_state) {
 		emit_signal(SNAME("current_animation_changed"), "");
 	}
 	_set_process(false);
-	playback_queue.clear();
 	playing = false;
 }
 


### PR DESCRIPTION
Fixes #36279.

Tested this with the given reproduction project. The updated code achieves the desired behavior, but I am not entirely sure this is the right approach. I simply removed the clearing of the playback queue, and that seems to work. I also don't know why it was being cleared in the first place, if someone knows, please let me know!

I'll update as needed, but I think this approach should work.