### PR TITLE
Add one padding frame to QOA buffer for short streams

### DIFF
--- a/scene/resources/audio_stream_wav.cpp
+++ b/scene/resources/audio_stream_wav.cpp
@@ -616,7 +616,7 @@ Ref<AudioStreamPlayback> AudioStreamWAV::instantiate_playback() {
 		uint32_t ffp = qoa_decode_header(data.ptr(), data_bytes, &sample->qoa.desc);
 		ERR_FAIL_COND_V(ffp != 8, Ref<AudioStreamPlaybackWAV>());
 		sample->qoa.frame_len = qoa_max_frame_size(&sample->qoa.desc);
-		int samples_len = (sample->qoa.desc.samples > QOA_FRAME_LEN ? QOA_FRAME_LEN : sample->qoa.desc.samples);
+		int samples_len = sample->qoa.desc.samples > QOA_FRAME_LEN ? QOA_FRAME_LEN : (sample->qoa.desc.samples + 1);
 		int dec_len = sample->qoa.desc.channels * samples_len;
 		sample->qoa.dec.resize(dec_len);
 	}


### PR DESCRIPTION
Fixes #110482.

The issue happens if the WAV file has a baked loop end right at the end of stream, and only if compress mode is set to `FORMAT_QOA`.

I have applied @bruvzg's solution. The padding frame should never be reached unless it's that specific case. Didn't notice any audible pops after this.