### PR TITLE
Pattern guard warning fix

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2051,7 +2051,7 @@ void GDScriptAnalyzer::decide_suite_type(GDScriptParser::Node *p_suite, GDScript
 	}
 }
 
-void GDScriptAnalyzer::resolve_suite(GDScriptParser::SuiteNode *p_suite) {
+void GDScriptAnalyzer::resolve_suite(GDScriptParser::SuiteNode *p_suite, bool p_is_root) {
 	for (int i = 0; i < p_suite->statements.size(); i++) {
 		GDScriptParser::Node *stmt = p_suite->statements[i];
 		// Apply annotations.
@@ -2060,7 +2060,7 @@ void GDScriptAnalyzer::resolve_suite(GDScriptParser::SuiteNode *p_suite) {
 			E->apply(parser, stmt, nullptr); // TODO: Provide `p_class`.
 		}
 
-		resolve_node(stmt);
+		resolve_node(stmt, p_is_root);
 		resolve_pending_lambda_bodies();
 		decide_suite_type(p_suite, stmt);
 	}
@@ -2423,7 +2423,7 @@ void GDScriptAnalyzer::resolve_match_branch(GDScriptParser::MatchBranchNode *p_m
 	}
 
 	if (p_match_branch->guard_body) {
-		resolve_suite(p_match_branch->guard_body);
+		resolve_suite(p_match_branch->guard_body, false);
 	}
 
 	resolve_suite(p_match_branch->block);

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -81,7 +81,7 @@ class GDScriptAnalyzer {
 	void resolve_function_signature(GDScriptParser::FunctionNode *p_function, const GDScriptParser::Node *p_source = nullptr, bool p_is_lambda = false);
 	void resolve_function_body(GDScriptParser::FunctionNode *p_function, bool p_is_lambda = false);
 	void resolve_node(GDScriptParser::Node *p_node, bool p_is_root = true);
-	void resolve_suite(GDScriptParser::SuiteNode *p_suite);
+	void resolve_suite(GDScriptParser::SuiteNode *p_suite, bool p_is_root = true);
 	void resolve_assignable(GDScriptParser::AssignableNode *p_assignable, const char *p_kind);
 	void resolve_variable(GDScriptParser::VariableNode *p_variable, bool p_is_local);
 	void resolve_constant(GDScriptParser::ConstantNode *p_constant, bool p_is_local);


### PR DESCRIPTION
This is an attempt to address [#110489](https://github.com/godotengine/godot/issues/110489)

* Added `bool p_is_guard` parameter to `resolve_node`, `reduce_expression`, `resolve_suite` and `reduce_call`
* From `resolve_match_branch` I pass `true` into `resolve_suite` when handling the guard_body
* In reduce_call I don't raise an error if `p_is_guard=true`

Example of warning being called for an unconsumed return as opposed to guard pattern:
<img width="425" height="200" alt="image" src="https://github.com/user-attachments/assets/f8f2fb0c-cfc4-4cbd-a6b1-bbf02770e78b" />

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->


* Fixes #110489.