### PR TITLE
Fix FileDialog's `root_subfolder` on Windows

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1448,7 +1448,7 @@ void FileDialog::_change_dir(const String &p_new_dir) {
 	} else {
 		String old_dir = dir_access->get_current_dir();
 		dir_access->change_dir(p_new_dir);
-		if (!dir_access->get_current_dir(false).begins_with(root_prefix)) {
+		if (!dir_access->get_current_dir().begins_with(root_prefix)) {
 			dir_access->change_dir(old_dir);
 			return;
 		}


### PR DESCRIPTION
`root_prefix` either contains an empty string or the current root including the drive letter. This means that the previous logic would never ever match since `dir_access->get_current_dir(false)` explicitly excludes the drive letter.

This change removes this boolean parameter so we compare paths in a way that can match.

I've had a look at the implementations for other platforms for `DirAccess::get_current_dir(bool include_drive)` and outside Windows none seem to consider the `include_drive` parameter which makes me believe that this change won't break other platforms.

Fixes https://github.com/godotengine/godot/issues/79513

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
