### PR TITLE
Fix Projection values being displayed transposed in the inspector

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2848,20 +2848,20 @@ void EditorPropertyProjection::_set_read_only(bool p_read_only) {
 void EditorPropertyProjection::_value_changed(double val, const String &p_name) {
 	Projection p;
 	p.columns[0][0] = spin[0]->get_value();
-	p.columns[0][1] = spin[1]->get_value();
-	p.columns[0][2] = spin[2]->get_value();
-	p.columns[0][3] = spin[3]->get_value();
-	p.columns[1][0] = spin[4]->get_value();
+	p.columns[1][0] = spin[1]->get_value();
+	p.columns[2][0] = spin[2]->get_value();
+	p.columns[3][0] = spin[3]->get_value();
+	p.columns[0][1] = spin[4]->get_value();
 	p.columns[1][1] = spin[5]->get_value();
-	p.columns[1][2] = spin[6]->get_value();
-	p.columns[1][3] = spin[7]->get_value();
-	p.columns[2][0] = spin[8]->get_value();
-	p.columns[2][1] = spin[9]->get_value();
+	p.columns[2][1] = spin[6]->get_value();
+	p.columns[3][1] = spin[7]->get_value();
+	p.columns[0][2] = spin[8]->get_value();
+	p.columns[1][2] = spin[9]->get_value();
 	p.columns[2][2] = spin[10]->get_value();
-	p.columns[2][3] = spin[11]->get_value();
-	p.columns[3][0] = spin[12]->get_value();
-	p.columns[3][1] = spin[13]->get_value();
-	p.columns[3][2] = spin[14]->get_value();
+	p.columns[3][2] = spin[11]->get_value();
+	p.columns[0][3] = spin[12]->get_value();
+	p.columns[1][3] = spin[13]->get_value();
+	p.columns[2][3] = spin[14]->get_value();
 	p.columns[3][3] = spin[15]->get_value();
 
 	emit_changed(get_edited_property(), p, p_name);
@@ -2873,20 +2873,20 @@ void EditorPropertyProjection::update_property() {
 
 void EditorPropertyProjection::update_using_transform(Projection p_transform) {
 	spin[0]->set_value_no_signal(p_transform.columns[0][0]);
-	spin[1]->set_value_no_signal(p_transform.columns[0][1]);
-	spin[2]->set_value_no_signal(p_transform.columns[0][2]);
-	spin[3]->set_value_no_signal(p_transform.columns[0][3]);
-	spin[4]->set_value_no_signal(p_transform.columns[1][0]);
+	spin[1]->set_value_no_signal(p_transform.columns[1][0]);
+	spin[2]->set_value_no_signal(p_transform.columns[2][0]);
+	spin[3]->set_value_no_signal(p_transform.columns[3][0]);
+	spin[4]->set_value_no_signal(p_transform.columns[0][1]);
 	spin[5]->set_value_no_signal(p_transform.columns[1][1]);
-	spin[6]->set_value_no_signal(p_transform.columns[1][2]);
-	spin[7]->set_value_no_signal(p_transform.columns[1][3]);
-	spin[8]->set_value_no_signal(p_transform.columns[2][0]);
-	spin[9]->set_value_no_signal(p_transform.columns[2][1]);
+	spin[6]->set_value_no_signal(p_transform.columns[2][1]);
+	spin[7]->set_value_no_signal(p_transform.columns[3][1]);
+	spin[8]->set_value_no_signal(p_transform.columns[0][2]);
+	spin[9]->set_value_no_signal(p_transform.columns[1][2]);
 	spin[10]->set_value_no_signal(p_transform.columns[2][2]);
-	spin[11]->set_value_no_signal(p_transform.columns[2][3]);
-	spin[12]->set_value_no_signal(p_transform.columns[3][0]);
-	spin[13]->set_value_no_signal(p_transform.columns[3][1]);
-	spin[14]->set_value_no_signal(p_transform.columns[3][2]);
+	spin[11]->set_value_no_signal(p_transform.columns[3][2]);
+	spin[12]->set_value_no_signal(p_transform.columns[0][3]);
+	spin[13]->set_value_no_signal(p_transform.columns[1][3]);
+	spin[14]->set_value_no_signal(p_transform.columns[2][3]);
 	spin[15]->set_value_no_signal(p_transform.columns[3][3]);
 }
 
@@ -2911,9 +2911,9 @@ void EditorPropertyProjection::setup(const EditorPropertyRangeHint &p_range_hint
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
-		if (i % 4 == 3) {
-			spin[i]->set_suffix(p_range_hint.suffix);
-		}
+		// Projection is inherently unitless, however someone may want to use it as
+		// a generic way to store 16 values, so we'll still respect the suffix.
+		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
 

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -2852,20 +2852,20 @@ void EditorPropertyProjection::_set_read_only(bool p_read_only) {
 void EditorPropertyProjection::_value_changed(double val, const String &p_name) {
 	Projection p;
 	p.columns[0][0] = spin[0]->get_value();
-	p.columns[0][1] = spin[1]->get_value();
-	p.columns[0][2] = spin[2]->get_value();
-	p.columns[0][3] = spin[3]->get_value();
-	p.columns[1][0] = spin[4]->get_value();
+	p.columns[1][0] = spin[1]->get_value();
+	p.columns[2][0] = spin[2]->get_value();
+	p.columns[3][0] = spin[3]->get_value();
+	p.columns[0][1] = spin[4]->get_value();
 	p.columns[1][1] = spin[5]->get_value();
-	p.columns[1][2] = spin[6]->get_value();
-	p.columns[1][3] = spin[7]->get_value();
-	p.columns[2][0] = spin[8]->get_value();
-	p.columns[2][1] = spin[9]->get_value();
+	p.columns[2][1] = spin[6]->get_value();
+	p.columns[3][1] = spin[7]->get_value();
+	p.columns[0][2] = spin[8]->get_value();
+	p.columns[1][2] = spin[9]->get_value();
 	p.columns[2][2] = spin[10]->get_value();
-	p.columns[2][3] = spin[11]->get_value();
-	p.columns[3][0] = spin[12]->get_value();
-	p.columns[3][1] = spin[13]->get_value();
-	p.columns[3][2] = spin[14]->get_value();
+	p.columns[3][2] = spin[11]->get_value();
+	p.columns[0][3] = spin[12]->get_value();
+	p.columns[1][3] = spin[13]->get_value();
+	p.columns[2][3] = spin[14]->get_value();
 	p.columns[3][3] = spin[15]->get_value();
 
 	emit_changed(get_edited_property(), p, p_name);
@@ -2877,20 +2877,20 @@ void EditorPropertyProjection::update_property() {
 
 void EditorPropertyProjection::update_using_transform(Projection p_transform) {
 	spin[0]->set_value_no_signal(p_transform.columns[0][0]);
-	spin[1]->set_value_no_signal(p_transform.columns[0][1]);
-	spin[2]->set_value_no_signal(p_transform.columns[0][2]);
-	spin[3]->set_value_no_signal(p_transform.columns[0][3]);
-	spin[4]->set_value_no_signal(p_transform.columns[1][0]);
+	spin[1]->set_value_no_signal(p_transform.columns[1][0]);
+	spin[2]->set_value_no_signal(p_transform.columns[2][0]);
+	spin[3]->set_value_no_signal(p_transform.columns[3][0]);
+	spin[4]->set_value_no_signal(p_transform.columns[0][1]);
 	spin[5]->set_value_no_signal(p_transform.columns[1][1]);
-	spin[6]->set_value_no_signal(p_transform.columns[1][2]);
-	spin[7]->set_value_no_signal(p_transform.columns[1][3]);
-	spin[8]->set_value_no_signal(p_transform.columns[2][0]);
-	spin[9]->set_value_no_signal(p_transform.columns[2][1]);
+	spin[6]->set_value_no_signal(p_transform.columns[2][1]);
+	spin[7]->set_value_no_signal(p_transform.columns[3][1]);
+	spin[8]->set_value_no_signal(p_transform.columns[0][2]);
+	spin[9]->set_value_no_signal(p_transform.columns[1][2]);
 	spin[10]->set_value_no_signal(p_transform.columns[2][2]);
-	spin[11]->set_value_no_signal(p_transform.columns[2][3]);
-	spin[12]->set_value_no_signal(p_transform.columns[3][0]);
-	spin[13]->set_value_no_signal(p_transform.columns[3][1]);
-	spin[14]->set_value_no_signal(p_transform.columns[3][2]);
+	spin[11]->set_value_no_signal(p_transform.columns[3][2]);
+	spin[12]->set_value_no_signal(p_transform.columns[0][3]);
+	spin[13]->set_value_no_signal(p_transform.columns[1][3]);
+	spin[14]->set_value_no_signal(p_transform.columns[2][3]);
 	spin[15]->set_value_no_signal(p_transform.columns[3][3]);
 }
 
@@ -2915,9 +2915,9 @@ void EditorPropertyProjection::setup(const EditorPropertyRangeHint &p_range_hint
 		}
 		spin[i]->set_allow_greater(true);
 		spin[i]->set_allow_lesser(true);
-		if (i % 4 == 3) {
-			spin[i]->set_suffix(p_range_hint.suffix);
-		}
+		// Projection is inherently unitless, however someone may want to use it as
+		// a generic way to store 16 values, so we'll still respect the suffix.
+		spin[i]->set_suffix(p_range_hint.suffix);
 	}
 }
 


### PR DESCRIPTION
In Godot's internal C++ code, the `[]` operator on Basis (3D) uses rows, but the `[]` operator on Projection uses columns. The inspector code in master was using the same numbers for Projection as it did for Basis, which resulted in the values being displayed as transposed. This PR fixes it by swapping the numbers, and I also threw in a change to preserve the unit just like it already does in Basis (3D) though this is different from Transform3D.

In 3D, the Basis inspector works correctly, as shown in this video:

https://github.com/user-attachments/assets/a0e7d3b5-83f5-464f-947e-20c043b5003f

The Projection inspector is transposed in master, as shown in this video of it affecting the wrong 4D basis vector:

https://github.com/user-attachments/assets/15956305-b227-4d6f-b4a5-36e06106e82f

Simply put: the green-labeled values are supposed to move the green arrow, but the red arrow moved instead.

This PR fixes the issue, as shown in this video:

https://github.com/user-attachments/assets/95a03e7a-3221-4586-b866-15baf85b4480

This is purely a fix to the editor inspectors, there is no change to anywhere else.