### PR TITLE
Fix crash when attaching a script without the GDScript module.

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -888,7 +888,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	gc->add_child(memnew(Label(TTR("Language:"))));
 	gc->add_child(language_menu);
 
-	default_language = -1;
+	default_language = ScriptServer::get_language_count() - 1;
 	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 		String lang = ScriptServer::get_language(i)->get_name();
 		language_menu->add_item(lang);


### PR DESCRIPTION
<img width="279" height="221" alt="截屏2025-09-15 23 15 37" src="https://github.com/user-attachments/assets/1a04fb0f-39f3-4650-8ad3-1a639cae991b" />

As shown in the image, when selecting this option, a crash will occur if using a custom build that does not have the GDScript module enabled.

Before the crash, there was an error output which indicated that a certain script selection component in the editor did not have any options selected:
`
[ERROR] core/object/script_language.cpp:228:get_language(): Index p_idx = -1 is out of bounds (_language_count = 1). Index p_idx = -1 is out of bounds (_language_count = 1).
ERROR: Index p_idx = -1 is out of bounds (_language_count = 1).
   at: get_language (core/object/script_language.cpp:228)
`

After testing, my fix PR can resolve this issue (_I have a custom scripting language and did not enable gdscript; after this fix, this Dialog will be able to correctly select my custom scripting language_).