### PR TITLE
Avoid repeated `_copy_on_write()` calls in `Array::resize()`

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -305,8 +305,9 @@ Error Array::resize(int p_new_size) {
 	int old_size = _p->array.size();
 	Error err = _p->array.resize_initialized(p_new_size);
 	if (!err && variant_type != Variant::NIL && variant_type != Variant::OBJECT) {
+		Variant *write = _p->array.ptrw();
 		for (int i = old_size; i < p_new_size; i++) {
-			VariantInternal::initialize(&_p->array.write[i], variant_type);
+			VariantInternal::initialize(&write[i], variant_type);
 		}
 	}
 	return err;


### PR DESCRIPTION
Updated `Array::resize()` to call `ptrw()` once before looping to initialize typed array elements, instead of accessing each through `.write[]`.

This makes `Array.resize()` in gdscript around 2-4x faster for typed arrays, will vary depending on type and size.  Compared with gdscript below:

```gdscript
func _ready() -> void:
	run_test("resize_int")
	run_test("resize_str")

func resize_int():
	var a: Array[int] = []
	for i in 10000:
		a.resize(i)
		a.resize(0)
		
func resize_str():
	var a: Array[String] = []
	for i in 10000:
		a.resize(i)
		a.resize(0)

func run_test(test_name: String):
	var start := Time.get_ticks_msec()
	call(test_name)
	var end := Time.get_ticks_msec()
	print("%s: %dms" % [test_name, end - start])
```

old:
```
resize_int: 319ms
resize_str: 415ms
```

new:
```
resize_int: 72ms
resize_str: 163ms
```

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
