### PR TITLE
GDExtension: Update warning about `gdextension_special_compat_hashes.cpp` to prevent confusion

### DIFF
--- a/core/extension/gdextension_special_compat_hashes.cpp
+++ b/core/extension/gdextension_special_compat_hashes.cpp
@@ -63,7 +63,7 @@ bool GDExtensionSpecialCompatHashes::get_legacy_hashes(const StringName &p_class
 			if (p_check_valid) {
 				MethodBind *mb = ClassDB::get_method_with_compatibility(p_class, p_method, mapping.current_hash);
 				if (!mb) {
-					WARN_PRINT(vformat("Compatibility hash %d for %s::%s() mapped to non-existent hash %d. Please update gdextension_special_compat_hashes.cpp.", mapping.legacy_hash, p_class, p_method, mapping.current_hash));
+					WARN_PRINT(vformat("Compatibility hash %d for %s::%s() mapped to non-existent hash %d in gdextension_special_compat_hashes.cpp.", mapping.legacy_hash, p_class, p_method, mapping.current_hash));
 					continue;
 				}
 			}


### PR DESCRIPTION
If there's an invalid hash in the list of hashes in `gdextension_special_compat_hashes.cpp`, it'll print a warning like this:

```
 Compatibility hash 2865980031 for Performance::add_custom_monitor() mapped to non-existent hash 4099036814. Please update gdextension_special_compat_hashes.cpp.
```

Due to the poor wording on my part (I wrote that message!) this has led a few people to think they needed update `gdextension_special_compat_hashes.cpp` to account for their changes, rather than add a compatibility method (which is what they actually should do in 99.9% of cases).

This PR attempts to reword this message to eliminate the confusion.
