### PR TITLE
Fix "possible cyclic resource inclusion" error due to async resource load race condition

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -67,7 +67,32 @@ void Resource::_unblock_emit_changed() {
 void Resource::_resource_path_changed() {
 }
 
-void Resource::set_path(const String &p_path, bool p_take_over) {
+void Resource::_set_path_internal(const String &p_path, bool p_take_over) {
+	if (!path_cache.is_empty()) {
+		ResourceCache::resources.erase(path_cache);
+	}
+
+	path_cache = "";
+
+	Ref<Resource> existing = ResourceCache::get_ref(p_path, false);
+
+	if (existing.is_valid()) {
+		if (p_take_over) {
+			existing->path_cache = String();
+			ResourceCache::resources.erase(p_path);
+		} else {
+			ERR_FAIL_MSG(vformat("Another resource is loaded from path '%s' (possible cyclic resource inclusion).", p_path));
+		}
+	}
+
+	path_cache = p_path;
+
+	if (!path_cache.is_empty()) {
+		ResourceCache::resources[path_cache] = this;
+	}
+}
+
+void Resource::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (path_cache == p_path) {
 		return;
 	}
@@ -76,31 +101,11 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 		p_take_over = false; // Can't take over an empty path
 	}
 
-	{
+	if (p_lock_cache) {
 		MutexLock lock(ResourceCache::lock);
-
-		if (!path_cache.is_empty()) {
-			ResourceCache::resources.erase(path_cache);
-		}
-
-		path_cache = "";
-
-		Ref<Resource> existing = ResourceCache::get_ref(p_path);
-
-		if (existing.is_valid()) {
-			if (p_take_over) {
-				existing->path_cache = String();
-				ResourceCache::resources.erase(p_path);
-			} else {
-				ERR_FAIL_MSG(vformat("Another resource is loaded from path '%s' (possible cyclic resource inclusion).", p_path));
-			}
-		}
-
-		path_cache = p_path;
-
-		if (!path_cache.is_empty()) {
-			ResourceCache::resources[path_cache] = this;
-		}
+		_set_path_internal(p_path, p_take_over);
+	} else {
+		_set_path_internal(p_path, p_take_over);
 	}
 
 	_resource_path_changed();
@@ -837,22 +842,31 @@ bool ResourceCache::has(const String &p_path) {
 	return true;
 }
 
-Ref<Resource> ResourceCache::get_ref(const String &p_path) {
+Ref<Resource> ResourceCache::_get_ref_internal(const String &p_path) {
 	Ref<Resource> ref;
-	{
+	Resource **res = resources.getptr(p_path);
+
+	if (res) {
+		ref = Ref<Resource>(*res);
+	}
+
+	if (res && ref.is_null()) {
+		// This resource is in the process of being deleted, ignore its existence
+		(*res)->path_cache = String();
+		resources.erase(p_path);
+		res = nullptr;
+	}
+
+	return ref;
+}
+
+Ref<Resource> ResourceCache::get_ref(const String &p_path, bool p_lock_cache) {
+	Ref<Resource> ref;
+	if (p_lock_cache) {
 		MutexLock mutex_lock(lock);
-		Resource **res = resources.getptr(p_path);
-
-		if (res) {
-			ref = Ref<Resource>(*res);
-		}
-
-		if (res && ref.is_null()) {
-			// This resource is in the process of being deleted, ignore its existence
-			(*res)->path_cache = String();
-			resources.erase(p_path);
-			res = nullptr;
-		}
+		ref = _get_ref_internal(p_path);
+	} else {
+		ref = _get_ref_internal(p_path);
 	}
 
 	return ref;

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -125,6 +125,8 @@ protected:
 	virtual Ref<Resource> _duplicate(const DuplicateParams &p_params) const;
 	virtual String _to_string() override;
 
+	void _set_path_internal(const String &p_path, bool p_take_over = false);
+
 public:
 	static Node *(*_get_local_scene_func)(); // Used by the editor.
 	static void (*_update_configuration_warning)(); // Used by the editor.
@@ -142,7 +144,7 @@ public:
 	void set_name(const String &p_name);
 	String get_name() const;
 
-	virtual void set_path(const String &p_path, bool p_take_over = false);
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true);
 	String get_path() const;
 	virtual void set_path_cache(const String &p_path); // Set raw path without involving resource cache.
 	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.contains("::") || path_cache.begins_with("local://"); }
@@ -208,9 +210,37 @@ class ResourceCache {
 	static void clear();
 	friend void register_core_types();
 
+protected:
+	static Ref<Resource> _get_ref_internal(const String &p_path);
+
 public:
 	static bool has(const String &p_path);
-	static Ref<Resource> get_ref(const String &p_path);
+	static Ref<Resource> get_ref(const String &p_path, bool p_lock_cache = true);
+	template <typename F>
+	static Ref<Resource> get_ref_or_create(const String &p_path, F create_func) {
+		Ref<Resource> ref;
+		{
+			MutexLock mutex_lock(lock);
+			Resource **res = resources.getptr(p_path);
+
+			if (res) {
+				ref = Ref<Resource>(*res);
+			}
+
+			if (res && ref.is_null()) {
+				// This resource is in the process of being deleted, ignore its existence
+				(*res)->path_cache = String();
+				resources.erase(p_path);
+				res = nullptr;
+			}
+
+			if (!ref.is_valid()) {
+				ref = create_func();
+			}
+		}
+
+		return ref;
+	}
 	static void get_cached_resources(List<Ref<Resource>> *p_resources);
 	static int get_cached_resource_count();
 };

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -139,7 +139,7 @@ public:
 
 	static const int BINARY_MUTEX_TAG = 1;
 
-	static Ref<LoadToken> _load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user = false);
+	static Ref<LoadToken> _load_start(const String &p_path, const String &p_type_hint, LoadThreadMode p_thread_mode, ResourceFormatLoader::CacheMode p_cache_mode, bool p_for_user = false, const String &parent_path = String());
 	static Ref<Resource> _load_complete(LoadToken &p_load_token, Error *r_error);
 
 private:
@@ -167,7 +167,7 @@ private:
 
 	friend class ResourceFormatImporter;
 
-	static Ref<Resource> _load(const String &p_path, const String &p_original_path, const String &p_type_hint, ResourceFormatLoader::CacheMode p_cache_mode, Error *r_error, bool p_use_sub_threads, float *r_progress);
+	static Ref<Resource> _load(const String &p_path, const String &p_original_path, const String &p_type_hint, ResourceFormatLoader::CacheMode p_cache_mode, Error *r_error, bool p_use_sub_threads, float *r_progress, const String &parent_path = String());
 
 	static ResourceLoadedCallback _loaded_callback;
 
@@ -189,6 +189,7 @@ private:
 		Error error = OK;
 		Ref<Resource> resource;
 		HashSet<String> sub_tasks;
+		String parent_path;
 
 		bool awaited : 1; // If it's in the pool, this helps not awaiting from more than one dependent thread.
 		bool need_wait : 1;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1083,9 +1083,9 @@ void GDScript::set_path_cache(const String &p_path) {
 	}
 }
 
-void GDScript::set_path(const String &p_path, bool p_take_over) {
+void GDScript::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (is_root_script()) {
-		Script::set_path(p_path, p_take_over);
+		Script::set_path(p_path, p_take_over, p_lock_cache);
 	}
 
 	String old_path = path;
@@ -1096,7 +1096,7 @@ void GDScript::set_path(const String &p_path, bool p_take_over) {
 	}
 
 	for (KeyValue<StringName, Ref<GDScript>> &kv : subclasses) {
-		kv.value->set_path(p_path, p_take_over);
+		kv.value->set_path(p_path, p_take_over, p_lock_cache);
 	}
 }
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -303,7 +303,7 @@ public:
 	virtual Error reload(bool p_keep_state = false) override;
 
 	virtual void set_path_cache(const String &p_path) override;
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 	String get_script_path() const;
 	Error load_source_code(const String &p_path);
 

--- a/scene/resources/compressed_texture.cpp
+++ b/scene/resources/compressed_texture.cpp
@@ -89,12 +89,12 @@ Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r
 	return OK;
 }
 
-void CompressedTexture2D::set_path(const String &p_path, bool p_take_over) {
+void CompressedTexture2D::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 void CompressedTexture2D::_requested_3d(void *p_ud) {
@@ -492,12 +492,12 @@ String ResourceFormatLoaderCompressedTexture2D::get_resource_type(const String &
 	return "";
 }
 
-void CompressedTexture3D::set_path(const String &p_path, bool p_take_over) {
+void CompressedTexture3D::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 Image::Format CompressedTexture3D::get_format() const {
@@ -676,12 +676,12 @@ String ResourceFormatLoaderCompressedTexture3D::get_resource_type(const String &
 	return "";
 }
 
-void CompressedTextureLayered::set_path(const String &p_path, bool p_take_over) {
+void CompressedTextureLayered::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 Image::Format CompressedTextureLayered::get_format() const {

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -96,7 +96,7 @@ public:
 	int get_height() const override;
 	virtual RID get_rid() const override;
 
-	virtual void set_path(const String &p_path, bool p_take_over) override;
+	virtual void set_path(const String &p_path, bool p_take_over, bool p_lock_cache = true) override;
 
 	virtual void draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
 	virtual void draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false) const override;
@@ -168,7 +168,7 @@ public:
 	virtual bool has_mipmaps() const override;
 	virtual RID get_rid() const override;
 
-	virtual void set_path(const String &p_path, bool p_take_over) override;
+	virtual void set_path(const String &p_path, bool p_take_over, bool p_lock_cache = true) override;
 
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
 
@@ -255,7 +255,7 @@ public:
 	virtual bool has_mipmaps() const override;
 	virtual RID get_rid() const override;
 
-	virtual void set_path(const String &p_path, bool p_take_over) override;
+	virtual void set_path(const String &p_path, bool p_take_over, bool p_lock_cache = true) override;
 
 	virtual Vector<Ref<Image>> get_data() const override;
 

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -204,12 +204,12 @@ void ImageTexture::set_size_override(const Size2i &p_size) {
 	RenderingServer::get_singleton()->texture_set_size_override(texture, w, h);
 }
 
-void ImageTexture::set_path(const String &p_path, bool p_take_over) {
+void ImageTexture::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 void ImageTexture::_bind_methods() {
@@ -345,12 +345,12 @@ RID ImageTextureLayered::get_rid() const {
 	return texture;
 }
 
-void ImageTextureLayered::set_path(const String &p_path, bool p_take_over) {
+void ImageTextureLayered::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RS::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 void ImageTextureLayered::_bind_methods() {
@@ -443,12 +443,12 @@ RID ImageTexture3D::get_rid() const {
 	}
 	return texture;
 }
-void ImageTexture3D::set_path(const String &p_path, bool p_take_over) {
+void ImageTexture3D::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 TypedArray<Image> ImageTexture3D::_get_images() const {

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -74,7 +74,7 @@ public:
 
 	void set_size_override(const Size2i &p_size);
 
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 
 	~ImageTexture();
 };
@@ -113,7 +113,7 @@ public:
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
 
 	virtual RID get_rid() const override;
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 
 	ImageTextureLayered(LayeredType p_layered_type);
 	~ImageTextureLayered();
@@ -152,7 +152,7 @@ public:
 	virtual Vector<Ref<Image>> get_data() const override;
 
 	virtual RID get_rid() const override;
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 
 	ImageTexture3D();
 	~ImageTexture3D();

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -2595,9 +2595,9 @@ Ref<SceneState> PackedScene::get_state() const {
 	return state;
 }
 
-void PackedScene::set_path(const String &p_path, bool p_take_over) {
+void PackedScene::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	state->set_path(p_path);
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 void PackedScene::set_path_cache(const String &p_path) {

--- a/scene/resources/packed_scene.h
+++ b/scene/resources/packed_scene.h
@@ -275,7 +275,7 @@ public:
 
 	virtual void reload_from_file() override;
 
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 	virtual void set_path_cache(const String &p_path) override;
 
 #ifdef TOOLS_ENABLED

--- a/scene/resources/portable_compressed_texture.cpp
+++ b/scene/resources/portable_compressed_texture.cpp
@@ -332,12 +332,12 @@ Size2 PortableCompressedTexture2D::get_size_override() const {
 	return size_override;
 }
 
-void PortableCompressedTexture2D::set_path(const String &p_path, bool p_take_over) {
+void PortableCompressedTexture2D::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
 
-	Resource::set_path(p_path, p_take_over);
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 }
 
 bool PortableCompressedTexture2D::keep_all_compressed_buffers = false;

--- a/scene/resources/portable_compressed_texture.h
+++ b/scene/resources/portable_compressed_texture.h
@@ -100,7 +100,7 @@ public:
 
 	bool is_pixel_opaque(int p_x, int p_y) const override;
 
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 
 	void set_size_override(const Size2 &p_size);
 	Size2 get_size_override() const;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -516,7 +516,7 @@ Error ResourceLoaderText::load() {
 
 		ext_resources[id].path = path;
 		ext_resources[id].type = type;
-		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external);
+		ext_resources[id].load_token = ResourceLoader::_load_start(path, type, use_sub_threads ? ResourceLoader::LOAD_THREAD_DISTRIBUTE : ResourceLoader::LOAD_THREAD_FROM_CURRENT, cache_mode_for_external, false, res_path);
 		if (ext_resources[id].load_token.is_null()) {
 			if (ResourceLoader::get_abort_on_missing_resources()) {
 				error = ERR_FILE_CORRUPT;
@@ -571,6 +571,7 @@ Error ResourceLoaderText::load() {
 
 		Ref<Resource> res;
 		bool do_assign = false;
+		bool do_set_path = false;
 
 		if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && ResourceCache::has(path)) {
 			//reuse existing
@@ -585,13 +586,7 @@ Error ResourceLoaderText::load() {
 		MissingResource *missing_resource = nullptr;
 
 		if (res.is_null()) { //not reuse
-			Ref<Resource> cache = ResourceCache::get_ref(path);
-			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE && cache.is_valid()) { //only if it doesn't exist
-				//cached, do not assign
-				res = cache;
-			} else {
-				//create
-
+			auto create_func = [&]() -> Ref<Resource> {
 				Object *obj = ClassDB::instantiate(type);
 				if (!obj) {
 					if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
@@ -603,7 +598,7 @@ Error ResourceLoaderText::load() {
 						error_text = vformat("Can't create sub resource of type '%s'", type);
 						_printerr();
 						error = ERR_FILE_CORRUPT;
-						return error;
+						return nullptr;
 					}
 				}
 
@@ -612,11 +607,36 @@ Error ResourceLoaderText::load() {
 					error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", type);
 					_printerr();
 					error = ERR_FILE_CORRUPT;
-					return error;
+					return nullptr;
 				}
 
-				res = Ref<Resource>(r);
+				return Ref<Resource>(r);
+			};
+
+			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
+				res = ResourceCache::get_ref_or_create(path, [&]() -> Ref<Resource> {
+					Ref<Resource> new_res = create_func();
+
+					if (!new_res.is_valid()) {
+						return nullptr;
+					}
+
+					new_res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE, false);
+					new_res->set_scene_unique_id(id);
+					do_assign = true;
+					// Don't set the path again below as we already set it here to avoid lock contention
+					do_set_path = false;
+					return new_res;
+				});
+
+				if (!res.is_valid()) {
+					return error;
+				}
+			} else {
+				//create
+				res = create_func();
 				do_assign = true;
+				do_set_path = true;
 			}
 		}
 
@@ -627,7 +647,7 @@ Error ResourceLoaderText::load() {
 		}
 
 		int_resources[id] = res; // Always assign int resources.
-		if (do_assign) {
+		if (do_assign && do_set_path) {
 			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
 				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
 			} else {
@@ -738,31 +758,38 @@ Error ResourceLoaderText::load() {
 			}
 
 			if (resource.is_null()) {
-				Object *obj = ClassDB::instantiate(res_type);
-				if (!obj) {
-					if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
-						missing_resource = memnew(MissingResource);
-						missing_resource->set_original_class(res_type);
-						missing_resource->set_recording_properties(true);
-						obj = missing_resource;
-					} else {
-						error_text = vformat("Can't create sub resource of type '%s'", res_type);
+				cache = ResourceCache::get_ref_or_create(local_path, [&]() -> Ref<Resource> {
+					Object *obj = ClassDB::instantiate(res_type);
+					if (!obj) {
+						if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+							missing_resource = memnew(MissingResource);
+							missing_resource->set_original_class(res_type);
+							missing_resource->set_recording_properties(true);
+							obj = missing_resource;
+						} else {
+							error_text = vformat("Can't create sub resource of type '%s'", res_type);
+							_printerr();
+							error = ERR_FILE_CORRUPT;
+							return nullptr;
+						}
+					}
+
+					Resource *r = Object::cast_to<Resource>(obj);
+					if (!r) {
+						error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", res_type);
 						_printerr();
 						error = ERR_FILE_CORRUPT;
-						return error;
+						return nullptr;
 					}
-				}
 
-				Resource *r = Object::cast_to<Resource>(obj);
-				if (!r) {
-					error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", res_type);
-					_printerr();
-					error = ERR_FILE_CORRUPT;
-					return error;
-				}
-
-				resource = Ref<Resource>(r);
+					return Ref<Resource>(r);
+				});
 			}
+
+			if (cache.is_null()) {
+				return error;
+			}
+			resource = cache;
 		}
 
 		Dictionary missing_resource_properties;

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -68,8 +68,8 @@ void Shader::_recompile() {
 	set_code(get_code());
 }
 
-void Shader::set_path(const String &p_path, bool p_take_over) {
-	Resource::set_path(p_path, p_take_over);
+void Shader::set_path(const String &p_path, bool p_take_over, bool p_lock_cache) {
+	Resource::set_path(p_path, p_take_over, p_lock_cache);
 
 	if (shader_rid.is_valid()) {
 		RS::get_singleton()->shader_set_path_hint(shader_rid, p_path);

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -83,7 +83,7 @@ public:
 	//void set_mode(Mode p_mode);
 	virtual Mode get_mode() const;
 
-	virtual void set_path(const String &p_path, bool p_take_over = false) override;
+	virtual void set_path(const String &p_path, bool p_take_over = false, bool p_lock_cache = true) override;
 	void set_include_path(const String &p_path);
 
 	void set_code(const String &p_code);


### PR DESCRIPTION
This is an especially tricky error to reproduce as are all race conditions.  Fortunately the code locations for where and why it occurs are close together.  I hope I can demonstrate why it occurs and why this fixes it.  I expect this will fix many issues on the backlog that are documented as "strange behavior" that "sometimes" occurs when loading resources or switching scenes.

## Issue:

1. https://github.com/godotengine/godot/blob/876b290332ec6f2e6d173d08162a02aa7e6ca46d/scene/resources/resource_format_text.cpp#L538

    - Here we are checking to see if a ref already exists in the cache.  This is a problem when there are multiple threads running and checking for the cache of the same resource.  There will be multiple cache misses and then multiple threads will attempt to create this missing resource.
    
2. https://github.com/godotengine/godot/blob/876b290332ec6f2e6d173d08162a02aa7e6ca46d/scene/resources/resource_format_text.cpp#L580-L587

After the code in 1 runs, there will be multiple threads q'd up to also call ``set_path`` on the same resource.

## Solution:

This PR does a few things:

1. Introduce a method called ``get_ref_or_create``.  The reason for this is we were calling ``get_ref`` over multiple threads.  The lock is only held for the ``get_ref`` function which resulted in multiple threads incorrectly thinking they should attempt to create a missing resource.  This way the lock is held for the duration of attempting to get the ref or its creation if that ref is missing.
1. Introduces a field that is passed to ``get_ref`` and ``set_path`` indicating whether a lock is already held in resource cache.  This is because ``get_ref`` and ``set_path`` methods are called internally by the resource as well.  We don't want to compete for a lock we already have when we are initializing the resource.
1. Separate the methods from the lock by introducing protected internal methods (built on the above point).

## NOTE 1:

The logic remains the same.  This simply allows for the lock on the resource cache to persist through checking if a resource already exists in the cache and creating it if it doesn't.  In pseudo code form for easier explanation:

```
{
    lock() // lock persists through code block
    does resource exist?
        return existing_resource
    else
        return create_resource()
}
```

The change being we acquire the lock and don't release it until we grab the existing resource or create one because it didn't previously exist.

## Note 2:

This is the reason I opened this PR previously: https://github.com/godotengine/godot/pull/101399

If you notice point 2 of the PR:

```
VisualShader cannot be loaded in parallel via ResourceLoader::load_threaded_request as this causes errors and crashes. I intend to open a separate issue for this.
```

This fixes the error that was causing that crash.  I never did open that issue like I said I would.  Mainly because i thought converting VisualShaders to normal Shaders worked around the issue.  After testing with our users, it turns out that didn't fix it.  It simply reduced the frequency that it occurred.  This PR actually fixes the issue.  And I suspect will fix many others as well.

## Note 3

This should also improve load times (potentially quite significantly) as it will reduce mutex lock contention.

## Edit

Fixed ``resource_format_binary.cpp`` and also introduced the parameter ``p_parent_path`` to ``ResourceLoader::_load``.

``ResourceLoader::_load`` is also running into race conditions here:

https://github.com/godotengine/godot/blob/3c9d03b8755968ae305b8cfebe886c56402cb044/core/io/resource_loader.cpp#L294-L300

These lines work great for a synchronous situation.  However, in an async context, it is not gauranteed that the next task on the stack requires the current task to complete before it can run. It becomes especially problematic if multiple async load requests are made for packed scenes with the same dependencies.  A situation such as this (my particular case) can arise.

Say we have a scene setup such as this:

```
sunglasses.tscn
|-- sunglasses.glb
```

and then I have multiple inherited scenes such as:

```
sunglasses_red.tscn (inherits sunglasses.tscn)
|-- sunglasses.glb
```

```
sunglasses_blue.tscn (inherits sunglasses.tscn)
|-- sunglasses.glb
```

```
sunglasses_green.tscn (inherits sunglasses.tscn)
|-- sunglasses.glb
```

And then I load all 3 asyncronously:

```cs
 ResourceLoader.LoadThreadedRequest("res://sunglasses_red.tscn");
 ResourceLoader.LoadThreadedRequest("res://sunglasses_blue.tscn");
 ResourceLoader.LoadThreadedRequest("res://sunglasses_green.tscn");
 ```

And this is where it gets interesting. A rare (but possible as in my case) situation can arise that results in a stack overflow crash.  It goes like this:

```
"res://sunglasses_red.tscn" gets added to loading tasks
"res://sunglasses.tscn" gets added to loading tasks. Registers with "res://sunglasses_red.tscn" as subtask 
"res://sunglasses.glb" gets added to loading tasks. Registers with "res://sunglasses.tscn" as subtask
loader checks for any q'd load requests
"res://sunglasses_blue.tscn" gets added to loading tasks. Registers with "res://sunglasses.glb" as subtask
"res://sunglasses_blue.tscn" and "res://sunglasses.glb" call each other's load methods recursively until stack overflow
```

The solution:

Pass ``p_parent_path`` to ``ResourceLoader::_load`` so we know for sure who to register subtasks with rather than trying to infer based on the current stack.

## Edit 2

I found a deadlock issue that can occur and included the fix in this PR as well.  It occurs most often when loading visual shaders in parallel.  Fix was moving the ``ResourceCache::get_ref`` call outside of the resource_loader.cpp's thread_load_mutex lock like so:

https://github.com/godotengine/godot/pull/110538/files#diff-b7b3942bb4b4be0cfa3785b77d607a4d8e0c7b7a963a061989e58d384979ebadR575-R578

```
Ref<Resource> existing = nullptr;
if (p_cache_mode == ResourceFormatLoader::CACHE_MODE_REUSE) {
    existing = ResourceCache::get_ref(local_path);
}


{
    MutexLock thread_load_lock(thread_load_mutex);
```

And here is an example of the deadlock this fixes:
(Also note: This can occur even in the existing codebase, but is less likely due to the short lived locking of the simple ``get_ref``.  The ``get_ref_or_create`` holds the lock longer making this issue easier to reproduce.  Hence why I included it as a fix in this PR as well:

``Thread 1`` and ``Worker Thread 4`` are currently in contention in this example:

<img width="674" height="357" alt="image" src="https://github.com/user-attachments/assets/4fc0be03-9437-49eb-bda4-4c6856f0434d" />

Thread 1 currently holds the ``thread_load_mutex``.

<img width="1108" height="294" alt="image" src="https://github.com/user-attachments/assets/adab0997-51dd-4de3-b2a3-275c6fd53d03" />

And is waiting on ``ResourceCache::get_cache`` and its mutex:

<img width="1012" height="223" alt="image" src="https://github.com/user-attachments/assets/cffe684c-5a13-4c07-ba02-044eb3a6905d" />

But ``Worker Thread 4`` currently holds the ``ResourceCache``'s mutex:

<img width="1710" height="850" alt="image" src="https://github.com/user-attachments/assets/d2923d21-5bcd-49a2-b1e2-642272d72948" />

And is now awaiting on the ``thread_load_mutex``:

<img width="1820" height="784" alt="image" src="https://github.com/user-attachments/assets/346085e3-6bf6-4b3f-af68-fc26cc86ebb8" />

Hence the contention occurs.  Calling ``ResourceCache::get_cache`` earlier in ``ResourceLoader::_load_start`` before ``_load_start`` calls ``MutexLock thread_load_lock(thread_load_mutex)`` prevents this contention.  And as far as I can tell, there isn't any downside to doing this either since all the ``ResourceCache::get_cache`` is for is to check for cache hits which will be tested for again later anyways.