### PR TITLE
Update `GODOT_CPP_BRANCH` after Godot v4.5-stable release

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -8,7 +8,7 @@ env:
     dev_mode=yes
     module_text_server_fb_enabled=yes
     "accesskit_sdk_path=${{ github.workspace }}/accesskit-c-0.17.0/"
-  GODOT_CPP_BRANCH: 4.4
+  GODOT_CPP_BRANCH: 4.5
   DOTNET_NOLOGO: true
   DOTNET_CLI_TELEMETRY_OPTOUT: true
   ASAN_OPTIONS: color=always:print_suppressions=1:suppressions=${{ github.workspace }}/misc/error_suppressions/asan.txt


### PR DESCRIPTION
We always use godot-cpp version N-1 in CI.

With the Godot 4.5-stable being released, and the 4.6 dev cycle opening, that version is now 4.5!