### PR TITLE
Fix error when editing a single SoftBody3D pinned point in the editor

### DIFF
--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -705,7 +705,7 @@ void SoftBody3D::apply_central_force(const Vector3 &p_force) {
 }
 
 void SoftBody3D::pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path, int p_insert_at) {
-	ERR_FAIL_COND_MSG(p_insert_at < -1 || p_insert_at >= pinned_points.size(), "Invalid index for pin point insertion position.");
+	ERR_FAIL_COND_MSG(p_insert_at < -1 || p_insert_at > pinned_points.size(), vformat("Invalid index %d for pin point insertion position.", p_insert_at));
 	_pin_point_on_physics_server(p_point_index, pin);
 	if (pin) {
 		_add_pinned_point(p_point_index, p_spatial_attachment_path, p_insert_at);


### PR DESCRIPTION
Simple fix for #97155.
<img width="513" height="55" alt="image" src="https://github.com/user-attachments/assets/0de856b0-a2a9-4d6d-a981-6f274e0a3725" />
Not sure if this is the exact issue, as I've only gotten this error when editing the last element in the list.

I also noticed another PR #97598, but it seems to have been abandoned. My PR doesn't do any additional checks like that PR.
If the provided index is the same as the pinned_points array's size, it appends it to the end. As far as I've tested, there's no issues with this approach.
There's some potentially weird behavior with 0 values, but I think that's by design as the default value set by the editor when adding a new entry is 0, so allowing duplicates there is necessary.