### PR TITLE
Web: Fix clipboard text encoding in `update_clipboard_callback`

### DIFF
--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -1004,7 +1004,7 @@ Vector<String> DisplayServerWeb::get_rendering_drivers_func() {
 
 // Clipboard
 void DisplayServerWeb::update_clipboard_callback(const char *p_text) {
-	String text = p_text;
+	String text = String::utf8(p_text);
 
 #ifdef PROXY_TO_PTHREAD_ENABLED
 	if (!Thread::is_main_thread()) {


### PR DESCRIPTION
Web only.
Replaces direct assignment with String::utf8 to ensure clipboard text is correctly interpreted as UTF-8.

Fixes #108591 