### PR TITLE
Add `Node::delete_all_children` method for editor.

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -4963,10 +4963,7 @@ void AnimationTrackEditor::_on_filter_updated(const String &p_filter) {
 void AnimationTrackEditor::_update_tracks() {
 	int selected = _get_track_selected();
 
-	while (track_vbox->get_child_count()) {
-		memdelete(track_vbox->get_child(0));
-	}
-
+	track_vbox->delete_all_children();
 	timeline->set_track_edit(nullptr);
 
 	track_edits.clear();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6875,12 +6875,7 @@ void EditorNode::reload_instances_with_path_in_edited_scenes() {
 			bool original_node_scene_instance_load_placeholder = original_node->get_scene_instance_load_placeholder();
 
 			// Delete all the remaining node children.
-			while (original_node->get_child_count()) {
-				Node *child = original_node->get_child(0);
-
-				original_node->remove_child(child);
-				child->queue_free();
-			}
+			original_node->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 			// Update the name to match
 			instantiated_node->set_name(original_node->get_name());

--- a/editor/gui/editor_file_dialog.cpp
+++ b/editor/gui/editor_file_dialog.cpp
@@ -1996,19 +1996,10 @@ void EditorFileDialog::_update_option_controls() {
 	if (!options_dirty) {
 		return;
 	}
+
 	options_dirty = false;
-
-	while (flow_checkbox_options->get_child_count() > 0) {
-		Node *child = flow_checkbox_options->get_child(0);
-		flow_checkbox_options->remove_child(child);
-		child->queue_free();
-	}
-	while (grid_select_options->get_child_count() > 0) {
-		Node *child = grid_select_options->get_child(0);
-		grid_select_options->remove_child(child);
-		child->queue_free();
-	}
-
+	flow_checkbox_options->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
+	grid_select_options->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 	selected_options.clear();
 
 	for (const EditorFileDialog::Option &opt : options) {

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -391,11 +391,7 @@ WindowWrapper::~WindowWrapper() {
 
 void ScreenSelect::_build_advanced_menu() {
 	// Clear old screen list.
-	while (screen_list->get_child_count(false) > 0) {
-		Node *child = screen_list->get_child(0);
-		screen_list->remove_child(child);
-		child->queue_free();
-	}
+	screen_list->delete_all_children(false, DELETE_MODE_QUEUE_FREE);
 
 	// Populate screen list.
 	const real_t height = real_t(get_theme_font_size(SceneStringName(font_size))) * 1.5;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4698,21 +4698,12 @@ void EditorInspector::update_property(const String &p_prop) {
 
 void EditorInspector::_clear(bool p_hide_plugins) {
 	begin_vbox->hide();
-	while (begin_vbox->get_child_count()) {
-		memdelete(begin_vbox->get_child(0));
-	}
-
 	favorites_section->hide();
-	while (favorites_vbox->get_child_count()) {
-		memdelete(favorites_vbox->get_child(0));
-	}
-	while (favorites_groups_vbox->get_child_count()) {
-		memdelete(favorites_groups_vbox->get_child(0));
-	}
 
-	while (main_vbox->get_child_count()) {
-		memdelete(main_vbox->get_child(0));
-	}
+	begin_vbox->delete_all_children();
+	favorites_vbox->delete_all_children();
+	favorites_groups_vbox->delete_all_children();
+	main_vbox->delete_all_children();
 
 	property_selected = StringName();
 	property_focusable = -1;

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -930,9 +930,7 @@ LineEdit *ProjectManager::get_search_box() {
 // Project tag management.
 
 void ProjectManager::_manage_project_tags() {
-	for (int i = 0; i < project_tags->get_child_count(); i++) {
-		project_tags->get_child(i)->queue_free();
-	}
+	project_tags->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 	const ProjectList::Item item = project_list->get_selected_projects()[0];
 	current_project_tags = item.tags;

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4799,11 +4799,7 @@ void Node3DEditorViewport::_create_preview_node(const Vector<String> &files) con
 void Node3DEditorViewport::_remove_preview_node() {
 	set_message("");
 	if (preview_node->get_parent()) {
-		for (int i = preview_node->get_child_count() - 1; i >= 0; i--) {
-			Node *node = preview_node->get_child(i);
-			node->queue_free();
-			preview_node->remove_child(node);
-		}
+		preview_node->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 		EditorNode::get_singleton()->get_scene_root()->remove_child(preview_node);
 	}
 }

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5939,11 +5939,7 @@ void CanvasItemEditorViewport::_remove_preview() {
 		canvas_item_editor->update_viewport();
 	}
 	if (preview_node->get_parent()) {
-		for (int i = preview_node->get_child_count() - 1; i >= 0; i--) {
-			Node *node = preview_node->get_child(i);
-			node->queue_free();
-			preview_node->remove_child(node);
-		}
+		preview_node->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 		EditorNode::get_singleton()->get_scene_root()->remove_child(preview_node);
 
 		label->hide();

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -242,9 +242,7 @@ void EditorPropertyFontMetaOverride::update_property() {
 			vbox->add_child(paginator);
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
-			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
-				property_vbox->get_child(i)->queue_free();
-			}
+			property_vbox->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 		}
 
 		int size = dict.size();
@@ -439,9 +437,7 @@ void EditorPropertyOTVariation::update_property() {
 			vbox->add_child(paginator);
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
-			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
-				property_vbox->get_child(i)->queue_free();
-			}
+			property_vbox->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 		}
 
 		int size = supported.size();
@@ -647,9 +643,7 @@ void EditorPropertyOTFeatures::update_property() {
 			vbox->add_child(paginator);
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
-			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
-				property_vbox->get_child(i)->queue_free();
-			}
+			property_vbox->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 		}
 
 		// Update add menu items.

--- a/editor/scene/gui/theme_editor_plugin.cpp
+++ b/editor/scene/gui/theme_editor_plugin.cpp
@@ -2592,11 +2592,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 	// Colors.
 	{
-		for (int i = color_items_list->get_child_count() - 1; i >= 0; i--) {
-			Node *node = color_items_list->get_child(i);
-			node->queue_free();
-			color_items_list->remove_child(node);
-		}
+		color_items_list->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 		HashMap<StringName, bool> color_items = _get_type_items(edited_type, Theme::DATA_TYPE_COLOR, show_default);
 		for (const KeyValue<StringName, bool> &E : color_items) {
@@ -2621,11 +2617,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 	// Constants.
 	{
-		for (int i = constant_items_list->get_child_count() - 1; i >= 0; i--) {
-			Node *node = constant_items_list->get_child(i);
-			node->queue_free();
-			constant_items_list->remove_child(node);
-		}
+		constant_items_list->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 		HashMap<StringName, bool> constant_items = _get_type_items(edited_type, Theme::DATA_TYPE_CONSTANT, show_default);
 		for (const KeyValue<StringName, bool> &E : constant_items) {
@@ -2654,11 +2646,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 	// Fonts.
 	{
-		for (int i = font_items_list->get_child_count() - 1; i >= 0; i--) {
-			Node *node = font_items_list->get_child(i);
-			node->queue_free();
-			font_items_list->remove_child(node);
-		}
+		font_items_list->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 		HashMap<StringName, bool> font_items = _get_type_items(edited_type, Theme::DATA_TYPE_FONT, show_default);
 		for (const KeyValue<StringName, bool> &E : font_items) {
@@ -2693,11 +2681,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 	// Fonts sizes.
 	{
-		for (int i = font_size_items_list->get_child_count() - 1; i >= 0; i--) {
-			Node *node = font_size_items_list->get_child(i);
-			node->queue_free();
-			font_size_items_list->remove_child(node);
-		}
+		font_size_items_list->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 		HashMap<StringName, bool> font_size_items = _get_type_items(edited_type, Theme::DATA_TYPE_FONT_SIZE, show_default);
 		for (const KeyValue<StringName, bool> &E : font_size_items) {
@@ -2726,11 +2710,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 	// Icons.
 	{
-		for (int i = icon_items_list->get_child_count() - 1; i >= 0; i--) {
-			Node *node = icon_items_list->get_child(i);
-			node->queue_free();
-			icon_items_list->remove_child(node);
-		}
+		icon_items_list->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 		HashMap<StringName, bool> icon_items = _get_type_items(edited_type, Theme::DATA_TYPE_ICON, show_default);
 		for (const KeyValue<StringName, bool> &E : icon_items) {
@@ -2765,11 +2745,7 @@ void ThemeTypeEditor::_update_type_items() {
 
 	// Styleboxes.
 	{
-		for (int i = stylebox_items_list->get_child_count() - 1; i >= 0; i--) {
-			Node *node = stylebox_items_list->get_child(i);
-			node->queue_free();
-			stylebox_items_list->remove_child(node);
-		}
+		stylebox_items_list->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 		if (leading_stylebox.pinned) {
 			HBoxContainer *item_control = _create_property_control(Theme::DATA_TYPE_STYLEBOX, leading_stylebox.item_name, true);

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -472,11 +472,7 @@ void SceneThemeEditorPreview::_reload_scene() {
 		return;
 	}
 
-	for (int i = preview_content->get_child_count() - 1; i >= 0; i--) {
-		Node *node = preview_content->get_child(i);
-		node->queue_free();
-		preview_content->remove_child(node);
-	}
+	preview_content->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 	Node *instance = loaded_scene->instantiate();
 	if (!instance || !Object::cast_to<Control>(instance)) {

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -396,11 +396,7 @@ void OpenXRActionMapEditor::open_action_map(String p_path) {
 }
 
 void OpenXRActionMapEditor::_clear_action_map() {
-	while (actionsets_vb->get_child_count() > 0) {
-		Node *child = actionsets_vb->get_child(0);
-		actionsets_vb->remove_child(child);
-		child->queue_free();
-	}
+	actionsets_vb->delete_all_children(true, DELETE_MODE_QUEUE_FREE);
 
 	for (int i = tabs->get_tab_count() - 1; i >= 0; --i) {
 		// First tab won't be an interaction profile editor, but being thorough..

--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -337,9 +337,7 @@ void OpenXRInteractionProfileEditor::_update_interaction_profile() {
 	PackedStringArray requested_extensions = OpenXRAPI::get_all_requested_extensions();
 
 	// out with the old...
-	while (interaction_profile_hb->get_child_count() > 0) {
-		memdelete(interaction_profile_hb->get_child(0));
-	}
+	interaction_profile_hb->delete_all_children();
 
 	// in with the new...
 

--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -68,9 +68,7 @@ void OpenXRSelectActionDialog::open() {
 	ERR_FAIL_COND(action_map.is_null());
 
 	// Out with the old.
-	while (main_vb->get_child_count() > 0) {
-		memdelete(main_vb->get_child(0));
-	}
+	main_vb->delete_all_children();
 
 	selected_action = "";
 	action_buttons.clear();

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -74,9 +74,7 @@ void OpenXRSelectInteractionProfileDialog::open(PackedStringArray p_do_not_inclu
 	ERR_FAIL_NULL(meta_data);
 
 	// Out with the old.
-	while (main_vb->get_child_count() > 1) {
-		memdelete(main_vb->get_child(1));
-	}
+	main_vb->delete_all_children();
 
 	PackedStringArray requested_extensions = OpenXRAPI::get_all_requested_extensions();
 


### PR DESCRIPTION
I ran a performance comparison between the new internal method introduced in this PR and the traditional approach of using `remove_child` followed by `memdelete` or `queue_free`.

For clarity, Method refers to the new internal method, while Loop refers to the old-style loop for deleting children. I’ve grouped each pair of results for easier comparison:


Benchmark: Time taken to remove 3000 children (with 1000 internal nodes at the front and 1000 internal nodes at the back).

```yaml
Method: Instant free, internal=true: 772 ms
  Loop: Instant free, internal=true: 1684 ms

Method: Queue free, internal=true: 680 ms
  Loop: Queue free, internal=true: 1621 ms

Method: Instant free, internal=false: 403 ms
  Loop: Instant free, internal=false: 911 ms

Method: Queue free, internal=false: 390 ms
  Loop: Queue free, internal=false: 919 ms
```