### PR TITLE
Fix `TileMapLayer` tiles displaying incorrectly with `y_sort` based on visibility layer

### DIFF
--- a/servers/rendering/renderer_canvas_cull.h
+++ b/servers/rendering/renderer_canvas_cull.h
@@ -207,7 +207,7 @@ private:
 	void _render_canvas_item_tree(RID p_to_render_target, Canvas::ChildItem *p_child_items, int p_child_item_count, const Transform2D &p_transform, const Rect2 &p_clip_rect, const Color &p_modulate, RendererCanvasRender::Light *p_lights, RendererCanvasRender::Light *p_directional_lights, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, uint32_t p_canvas_cull_mask, RenderingMethod::RenderInfo *r_render_info = nullptr);
 	void _cull_canvas_item(Item *p_canvas_item, const Transform2D &p_parent_xform, const Rect2 &p_clip_rect, const Color &p_modulate, int p_z, RendererCanvasRender::Item **r_z_list, RendererCanvasRender::Item **r_z_last_list, Item *p_canvas_clip, Item *p_material_owner, bool p_is_already_y_sorted, uint32_t p_canvas_cull_mask, const Point2 &p_repeat_size, int p_repeat_times, RendererCanvasRender::Item *p_repeat_source_item);
 
-	void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int p_z);
+	void _collect_ysort_children(RendererCanvasCull::Item *p_canvas_item, RendererCanvasCull::Item *p_material_owner, const Color &p_modulate, RendererCanvasCull::Item **r_items, int &r_index, int &r_ysort_children_count, int p_z, uint32_t p_canvas_cull_mask);
 	int _count_ysort_children(RendererCanvasCull::Item *p_canvas_item);
 	void _mark_ysort_dirty(RendererCanvasCull::Item *ysort_owner);
 


### PR DESCRIPTION
Resolves #75206

These changes address an oversight of the y sorting logic that made it possible for children of CanvasItems that should be culled by `canvas_cull_mask` to still be rendered.

For example, if:
- CanvasItem A had `y_sort_enabled` set to true and `visibility_layer` set to 1
- CanvasItem B was a child of A, had `y_sort_enabled` set to true, and `visibility_layer` set to 2
- CanvasItem C was a child of B and had `visibility_layer` set to 1

CanvasItem C would still render in any and all viewports with layer 1 enabled.

This was due to the fact that the [`child_items`](https://github.com/WesleyClements/godot/blob/707975a4ebed99087e2a94dd162a2a42440af08e/servers/rendering/renderer_canvas_cull.cpp#L435) array included all children, filtered only by `visible`. Since each element in `child_items` is then checked to be culled individually, the parent's `visibility_layer` is completely disregarded.

To resolve this, I added two new parameters to `RendererCanvasCull::_collect_ysort_children`, `r_ysort_children_count` and `p_canvas_cull_mask`. If an item matches (while visible) the `p_canvas_cull_mask`, it is added to `child_items` as before. If it doesn't match (while visible), it skips adding itself to the array and subtracts itself and it's `ysort_children_count` (if it has any) from the length of the array, `r_ysort_children_count`. To avoid having to call `RendererCanvasCull::_count_ysort_children` again to determine the size of the branch being subtracted from the array length, I changed `RendererCanvasCull::_count_ysort_children` to cache the computed `ysort_children_count` all the way down the tree.

While this solution does not resolve the fact that `child_items` is being allocated to be too large, it works as intended.

This fixes the bug with TileMaps/TileMapLayers because each tile is added as a child CanvasItem with `visibility_layer` set to the default of 0xffffffff. Thus, if the TileMapLayer and it's parent both have `y_sort_enabled` set to true but differ in passing the `p_canvas_cull_mask` check, the TileMapLayers children will still be rendered on viewports matching the parent's `visibility_layer`.