### PR TITLE
Fix `--dump-extension-api-with-docs` indentation

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -96,7 +96,7 @@ static String fix_doc_description(const String &p_bbcode) {
 	// Based on what EditorHelp does.
 
 	return p_bbcode.dedent()
-			.remove_chars("\t\r")
+			.remove_chars("\r")
 			.strip_edges();
 }
 


### PR DESCRIPTION
xml codeblock indentation was changed from spaces to tabs but the tabs were being replaced with empty strings when exported with --dump-extension-api-with-docs, this is small change so that tab characters are no longer replaced.

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/110555*