### PR TITLE
Reset physics interpolation on unhiding 2D nodes

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -95,6 +95,14 @@ void CanvasItem::_handle_visibility_change(bool p_visible) {
 
 	if (p_visible) {
 		queue_redraw();
+
+		if (pending_lerp_reset) {
+			pending_lerp_reset = false;
+
+			if (is_physics_interpolated_and_enabled()) {
+				RenderingServer::get_singleton()->canvas_item_reset_physics_interpolation(canvas_item);
+			}
+		}
 	} else {
 		emit_signal(SceneStringName(hidden));
 	}
@@ -405,8 +413,12 @@ void CanvasItem::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (is_visible_in_tree() && is_physics_interpolated_and_enabled()) {
-				RenderingServer::get_singleton()->canvas_item_reset_physics_interpolation(canvas_item);
+			if (is_visible_in_tree()) {
+				if (is_physics_interpolated_and_enabled()) {
+					RenderingServer::get_singleton()->canvas_item_reset_physics_interpolation(canvas_item);
+				}
+			} else {
+				pending_lerp_reset = true;
 			}
 		} break;
 

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -97,6 +97,7 @@ private:
 	bool visible = true;
 	bool parent_visible_in_tree = false;
 	bool pending_update = false;
+	bool pending_lerp_reset = false;
 	bool top_level = false;
 	bool drawing = false;
 	bool block_transform_notify = false;


### PR DESCRIPTION
Fixes #101192

If a 2D node has its interpolation reset, it will only honor the request if the node is visible, for performance reasons. But if you unhide the node, it will still be using outdated lerp information, which is especially the case if physics interpolation was disabled globally.

This PR simply adds a flag to 2D nodes queueing up the lerp reset if the node is hidden. Once unhidden, it will perform the reset if it was previously requested.