### PR TITLE
Move file modified asterisk indicator to front of file name/path

### DIFF
--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -711,7 +711,7 @@ void ImportDock::_property_edited(const StringName &p_prop) {
 void ImportDock::_set_dirty(bool p_dirty) {
 	if (p_dirty) {
 		// Add a dirty marker to notify the user that they should reimport the selected resource to see changes.
-		import->set_text(TTR("Reimport") + " (*)");
+		import->set_text("*" + TTR("Reimport"));
 		import->add_theme_color_override(SceneStringName(font_color), get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
 		import->set_tooltip_text(TTRC("You have pending changes that haven't been applied yet. Click Reimport to apply changes made to the import options.\nSelecting another resource in the FileSystem dock without clicking Reimport first will discard changes made in the Import dock."));
 	} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -360,7 +360,7 @@ void EditorNode::_update_title() {
 	}
 	if (unsaved_cache) {
 		// Display the "modified" mark before anything else so that it can always be seen in the OS task bar.
-		title = vformat("(*) %s", title);
+		title = vformat("*%s", title);
 	}
 	DisplayServer::get_singleton()->window_set_title(title + String(" - ") + GODOT_VERSION_NAME);
 	if (project_title) {

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -280,12 +280,13 @@ void EditorSceneTabs::_update_tab_titles() {
 		scene_tabs->set_tab_icon(i, icon);
 
 		bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(EditorNode::get_editor_data().get_scene_history_id(i));
-		scene_tabs->set_tab_title(i, disambiguated_scene_names[i] + (unsaved ? "(*)" : ""));
+		scene_tabs->set_tab_title(i, (unsaved ? "*" : "") + disambiguated_scene_names[i]);
+		scene_tabs->set_tab_tooltip(i, full_path_names[i]);
 
 		if (NativeMenu::get_singleton()->has_feature(NativeMenu::FEATURE_GLOBAL_MENU)) {
 			RID dock_rid = NativeMenu::get_singleton()->get_system_menu(NativeMenu::DOCK_MENU_ID);
 			int global_menu_index = scene_tabs->get_tab_metadata(i);
-			NativeMenu::get_singleton()->set_item_text(dock_rid, global_menu_index, EditorNode::get_editor_data().get_scene_title(i) + (unsaved ? "(*)" : ""));
+			NativeMenu::get_singleton()->set_item_text(dock_rid, global_menu_index, (unsaved ? "*" : "") + EditorNode::get_editor_data().get_scene_title(i));
 			NativeMenu::get_singleton()->set_item_tag(dock_rid, global_menu_index, i);
 		}
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2275,14 +2275,14 @@ void ScriptEditor::_update_script_names() {
 		if (se) {
 			Ref<Texture2D> icon = se->get_theme_icon();
 			String path = se->get_edited_resource()->get_path();
-			bool saved = !path.is_empty();
+			bool is_stored_on_disk = !path.is_empty();
 			String name = se->get_name();
 			Ref<Script> scr = se->get_edited_resource();
 
 			_ScriptEditorItemData sd;
 			sd.icon = icon;
 			sd.name = name;
-			sd.tooltip = saved ? path : TTR("Unsaved file.");
+			sd.tooltip = is_stored_on_disk ? path : TTR("Unsaved file.");
 			sd.index = i;
 			sd.used = used.has(se->get_edited_resource());
 			sd.category = 0;
@@ -2318,7 +2318,7 @@ void ScriptEditor::_update_script_names() {
 					sd.name = path;
 				} break;
 			}
-			if (!saved) {
+			if (!is_stored_on_disk) {
 				sd.name = se->get_name();
 			}
 
@@ -2348,7 +2348,7 @@ void ScriptEditor::_update_script_names() {
 	Vector<String> disambiguated_script_names;
 	Vector<String> full_script_paths;
 	for (int j = 0; j < sedata.size(); j++) {
-		String name = sedata[j].name.replace("(*)", "");
+		String name = sedata[j].name.replace("*", "");
 		ScriptListName script_display = (ScriptListName)(int)EDITOR_GET("text_editor/script_list/list_script_names_as");
 		switch (script_display) {
 			case DISPLAY_NAME: {
@@ -2368,8 +2368,8 @@ void ScriptEditor::_update_script_names() {
 	EditorNode::disambiguate_filenames(full_script_paths, disambiguated_script_names);
 
 	for (int j = 0; j < sedata.size(); j++) {
-		if (sedata[j].name.ends_with("(*)")) {
-			sedata.write[j].name = disambiguated_script_names[j] + "(*)";
+		if (sedata[j].name.begins_with("*")) {
+			sedata.write[j].name = "*" + disambiguated_script_names[j];
 		} else {
 			sedata.write[j].name = disambiguated_script_names[j];
 		}
@@ -4693,7 +4693,7 @@ String ScriptEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
 
 			int i = 1;
 			for (const String &E : unsaved_built_in_scripts) {
-				message.write[i] = E.trim_suffix("(*)");
+				message.write[i] = E.trim_prefix("*");
 				i++;
 			}
 			return String("\n").join(message);
@@ -4705,7 +4705,7 @@ String ScriptEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
 
 	int i = 1;
 	for (const String &E : unsaved_scripts) {
-		message.write[i] = E.trim_suffix("(*)");
+		message.write[i] = E.trim_prefix("*");
 		i++;
 	}
 	return String("\n").join(message);

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -795,7 +795,7 @@ String ScriptTextEditor::get_name() {
 	}
 
 	if (is_unsaved()) {
-		name += "(*)";
+		name = "*" + name;
 	}
 
 	return name;

--- a/editor/script/text_editor.cpp
+++ b/editor/script/text_editor.cpp
@@ -82,7 +82,7 @@ String TextEditor::get_name() {
 	}
 
 	if (is_unsaved()) {
-		name += "(*)";
+		name = "*" + name;
 	}
 
 	return name;

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -86,7 +86,7 @@ void ShaderEditorPlugin::_update_shader_list() {
 		// TODO: Handle visual shaders too.
 
 		if (unsaved) {
-			text += "(*)";
+			text = "*" + text;
 		}
 
 		String _class = shader->get_class();
@@ -320,7 +320,7 @@ String ShaderEditorPlugin::get_unsaved_status(const String &p_for_scene) const {
 				if (unsaved_shaders.is_empty()) {
 					unsaved_shaders.append(TTR("Save changes to the following shaders(s) before quitting?"));
 				}
-				unsaved_shaders.append(edited_shaders[i].name.trim_suffix("(*)"));
+				unsaved_shaders.append(edited_shaders[i].name.trim_prefix("*"));
 			}
 		}
 	}


### PR DESCRIPTION
Unifies way of marking files as modified across the whole editor:

- use prefix since that's more visible in width-constrained scenarios
- get rid of parenthesis around asterisk symbol and extra space between asterisk and file name
- get rid of file modified symbol on tooltips, unify to show full path instead

Closes https://github.com/godotengine/godot-proposals/issues/13188

I was on a fence if I should report that as a bug or improvement proposal, or just create the PR since it's kinda obvious change, but I've ultimately decided for going the proposal way. Since they're usually left open for unspecified amount of time, I'm contributing a default solution in advance - I'll of course modify it to reflect further decisions, if necessary.

EDIT: pointed out changes in cleaner manner