### PR TITLE
Add `DPITexture::update()`.

### DIFF
--- a/doc/classes/DPITexture.xml
+++ b/doc/classes/DPITexture.xml
@@ -45,6 +45,16 @@
 				Sets SVG source code.
 			</description>
 		</method>
+		<method name="update">
+			<return type="void" />
+			<param index="0" name="source" type="String" />
+			<param index="1" name="scale" type="float" default="1.0" />
+			<param index="2" name="saturation" type="float" default="1.0" />
+			<param index="3" name="color_map" type="Dictionary" default="{}" />
+			<description>
+				Updates the texture with new SVG data.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="base_scale" type="float" setter="set_base_scale" getter="get_base_scale" default="1.0">

--- a/editor/import/resource_importer_svg.cpp
+++ b/editor/import/resource_importer_svg.cpp
@@ -73,9 +73,6 @@ void ResourceImporterSVG::get_import_options(const String &p_path, List<ImportOp
 }
 
 Error ResourceImporterSVG::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
-	Ref<DPITexture> dpi_tex;
-	dpi_tex.instantiate();
-
 	String source = FileAccess::get_file_as_string(p_source_file);
 	ERR_FAIL_COND_V_MSG(source.is_empty(), ERR_CANT_OPEN, vformat("Cannot open file from path \"%s\".", p_source_file));
 
@@ -83,11 +80,7 @@ Error ResourceImporterSVG::import(ResourceUID::ID p_source_id, const String &p_s
 	double saturation = p_options["saturation"];
 	Dictionary color_map = p_options["color_map"];
 
-	dpi_tex->set_base_scale(base_scale);
-	dpi_tex->set_saturation(saturation);
-	dpi_tex->set_color_map(color_map);
-	dpi_tex->set_source(source);
-
+	Ref<DPITexture> dpi_tex = DPITexture::create_from_string(source, base_scale, saturation, color_map);
 	ERR_FAIL_COND_V_MSG(dpi_tex->get_rid().is_null(), ERR_CANT_OPEN, vformat("Failed loading SVG, unsupported or invalid SVG data in \"%s\".", p_source_file));
 
 	int flg = 0;

--- a/scene/resources/dpi_texture.cpp
+++ b/scene/resources/dpi_texture.cpp
@@ -30,15 +30,15 @@
 
 #include "dpi_texture.h"
 
-#include "core/io/image_loader.h"
 #include "scene/main/canvas_item.h"
 #include "scene/main/viewport.h"
 #include "scene/resources/bit_map.h"
-#include "scene/resources/placeholder_textures.h"
 
 #include "modules/modules_enabled.gen.h" // For svg.
 #ifdef MODULE_SVG_ENABLED
 #include "modules/svg/image_loader_svg.h"
+#else
+#include "core/io/image_loader.h"
 #endif
 
 Mutex DPITexture::mutex;
@@ -85,11 +85,17 @@ void DPITexture::unreference_scaling_level(double p_scale) {
 Ref<DPITexture> DPITexture::create_from_string(const String &p_source, float p_scale, float p_saturation, const Dictionary &p_color_map) {
 	Ref<DPITexture> dpi_texture;
 	dpi_texture.instantiate();
-	dpi_texture->set_source(p_source);
-	dpi_texture->set_base_scale(p_scale);
-	dpi_texture->set_saturation(p_saturation);
-	dpi_texture->set_color_map(p_color_map);
+	dpi_texture->update(p_source, p_scale, p_saturation, p_color_map);
 	return dpi_texture;
+}
+
+void DPITexture::update(const String &p_source, float p_scale, float p_saturation, const Dictionary &p_color_map) {
+	_block_emit_changed();
+	set_source(p_source);
+	set_base_scale(p_scale);
+	set_saturation(p_saturation);
+	set_color_map(p_color_map);
+	_unblock_emit_changed();
 }
 
 void DPITexture::set_source(const String &p_source) {
@@ -105,10 +111,10 @@ String DPITexture::get_source() const {
 }
 
 void DPITexture::set_base_scale(float p_scale) {
+	p_scale = MAX(0.01, p_scale);
 	if (base_scale == p_scale) {
 		return;
 	}
-	ERR_FAIL_COND(p_scale <= 0.0);
 
 	base_scale = p_scale;
 	_update_texture();
@@ -119,6 +125,7 @@ float DPITexture::get_base_scale() const {
 }
 
 void DPITexture::set_saturation(float p_saturation) {
+	p_saturation = CLAMP(p_saturation, 0.0, 1.0);
 	if (saturation == p_saturation) {
 		return;
 	}
@@ -196,12 +203,13 @@ RID DPITexture::_load_at_scale(double p_scale, bool p_set_size) const {
 	if (err != OK) {
 		return RID();
 	}
-#else
-	img = Image::create_empty(Math::round(16 * p_scale * base_scale), Math::round(16 * p_scale * base_scale), false, Image::FORMAT_RGBA8);
-#endif
 	if (saturation != 1.0) {
 		img->adjust_bcs(1.0, 1.0, saturation);
 	}
+	img->fix_alpha_edges();
+#else
+	img = Image::create_empty(Math::round(16 * p_scale * base_scale), Math::round(16 * p_scale * base_scale), false, Image::FORMAT_RGBA8);
+#endif
 
 	Size2 current_size = size;
 	if (p_set_size) {
@@ -354,6 +362,7 @@ void DPITexture::set_size_override(const Size2i &p_size) {
 
 void DPITexture::_bind_methods() {
 	ClassDB::bind_static_method("DPITexture", D_METHOD("create_from_string", "source", "scale", "saturation", "color_map"), &DPITexture::create_from_string, DEFVAL(1.0), DEFVAL(1.0), DEFVAL(Dictionary()));
+	ClassDB::bind_method(D_METHOD("update", "source", "scale", "saturation", "color_map"), &DPITexture::update, DEFVAL(1.0), DEFVAL(1.0), DEFVAL(Dictionary()));
 
 	ClassDB::bind_method(D_METHOD("set_source", "source"), &DPITexture::set_source);
 	ClassDB::bind_method(D_METHOD("get_source"), &DPITexture::get_source);

--- a/scene/resources/dpi_texture.h
+++ b/scene/resources/dpi_texture.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/templates/lru.h"
 #include "scene/resources/texture.h"
 
 class BitMap;
@@ -70,6 +69,7 @@ protected:
 
 public:
 	static Ref<DPITexture> create_from_string(const String &p_source, float p_scale = 1.0, float p_saturation = 1.0, const Dictionary &p_color_map = Dictionary());
+	void update(const String &p_source, float p_scale = 1.0, float p_saturation = 1.0, const Dictionary &p_color_map = Dictionary());
 
 	void set_source(const String &p_source);
 	String get_source() const;


### PR DESCRIPTION
Changes:
* Add `DPITexture::update()` method to easily update the texture without emitting changed signal many times.
* Made some changes to avoid errors while updating the texture when some parameters are invalid.

