### PR TITLE
Fix wrong color for timeline indicator in the light theme

### DIFF
--- a/editor/icons/TimelineIndicator.svg
+++ b/editor/icons/TimelineIndicator.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#fff" d="m3 0h10l-4 4h-2z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="#fefefe" d="m3 0h10l-4 4h-2z"/></svg>


### PR DESCRIPTION
|Before|After|
|-|-|
|<img width="87" height="41" alt="Screenshot_20250916_165255" src="https://github.com/user-attachments/assets/773587c7-5c20-4829-aa79-562fc50e5bdd" />|<img width="87" height="41" alt="Screenshot_20250916_164201" src="https://github.com/user-attachments/assets/f30de166-5ec9-462c-be54-80f4b9862296" />|