### PR TITLE
Editor: Split doc translations to separate .cpp, it's too big

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -49,6 +49,7 @@
 #include "editor/file_system/editor_paths.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/project_manager/engine_update_label.h"
+#include "editor/translations/doc_translation.h"
 #include "editor/translations/editor_translation.h"
 #include "modules/regex/regex.h"
 #include "scene/gui/color_picker.h"

--- a/editor/translations/doc_translation.h
+++ b/editor/translations/doc_translation.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  editor_translation.h                                                  */
+/*  doc_translation.h                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -31,10 +31,5 @@
 #pragma once
 
 #include "core/string/ustring.h"
-#include "core/templates/vector.h"
 
-Vector<String> get_editor_locales();
-void load_editor_translations(const String &p_locale);
-void load_property_translations(const String &p_locale);
-void load_extractable_translations(const String &p_locale);
-Vector<Vector<String>> get_extractable_message_list();
+void load_doc_translations(const String &p_locale);

--- a/editor/translations/editor_translation.cpp
+++ b/editor/translations/editor_translation.cpp
@@ -34,7 +34,6 @@
 #include "core/io/file_access_memory.h"
 #include "core/io/translation_loader_po.h"
 #include "core/string/translation_server.h"
-#include "editor/translations/doc_translations.gen.h"
 #include "editor/translations/editor_translations.gen.h"
 #include "editor/translations/extractable_translations.gen.h"
 #include "editor/translations/property_translations.gen.h"
@@ -106,34 +105,6 @@ void load_property_translations(const String &p_locale) {
 		}
 
 		etl++;
-	}
-}
-
-void load_doc_translations(const String &p_locale) {
-	const Ref<TranslationDomain> domain = TranslationServer::get_singleton()->get_or_add_domain("godot.documentation");
-
-	const DocTranslationList *dtl = _doc_translations;
-	while (dtl->data) {
-		if (dtl->lang == p_locale) {
-			Vector<uint8_t> data;
-			data.resize(dtl->uncomp_size);
-			const int64_t ret = Compression::decompress(data.ptrw(), dtl->uncomp_size, dtl->data, dtl->comp_size, Compression::MODE_DEFLATE);
-			ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
-
-			Ref<FileAccessMemory> fa;
-			fa.instantiate();
-			fa->open_custom(data.ptr(), data.size());
-
-			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
-
-			if (tr.is_valid()) {
-				tr->set_locale(dtl->lang);
-				domain->add_translation(tr);
-				break;
-			}
-		}
-
-		dtl++;
 	}
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -119,7 +119,7 @@
 #include "editor/project_manager/project_manager.h"
 #include "editor/register_editor_types.h"
 #include "editor/settings/editor_settings.h"
-#include "editor/translations/editor_translation.h"
+#include "editor/translations/doc_translation.h"
 
 #if defined(TOOLS_ENABLED) && !defined(NO_EDITOR_SPLASH)
 #include "main/splash_editor.gen.h"


### PR DESCRIPTION
This would crash GCC 14 on Linux x86_32 (tested on Fedora 41 i686):
```
g++ -o bin/obj/editor/translations/editor_translation.linuxbsd.editor.x86_32.o -c -std=gnu++17 -fno-exceptions -ffp-contract=off -flto -pipe -pthread -msse2 -mfpmath=sse -mstackrealign -fno-diagnostics-color -O2 -Wall -Wshadow -Wno-misleading-indentation -Wenum-conversion -DTOOLS_ENABLED -DDEBUG_ENABLED -DNDEBUG -DENGINE_UPDATE_CHECK_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DFONTCONFIG_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -D_REENTRANT -DPULSEAUDIO_ENABLED -DDBUS_ENABLED -DSPEECHD_ENABLED -DXKB_ENABLED -DUDEV_ENABLED -DSDL_ENABLED -DWITH_GZFILEOP -DLINUXBSD_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DX11_ENABLED -DLIBDECOR_ENABLED -DWAYLAND_ENABLED -DACCESSKIT_DYNAMIC -DACCESSKIT_ENABLED -DVULKAN_ENABLED -DRD_ENABLED -DGLES3_ENABLED -DCRASH_HANDLER_ENABLED -DMINIZIP_ENABLED -DBROTLI_ENABLED -DTHREADS_ENABLED -DCLIPPER2_ENABLED -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DVK_USE_PLATFORM_WAYLAND_KHR -DGLAD_ENABLED -DEGL_ENABLED -DGLAD_GLX_NO_X11 -Ithirdparty/accesskit/include -Iplatform/linuxbsd -I. -I/usr/include/freetype2 -I/usr/include/libpng16 -I/usr/include/harfbuzz -I/usr/include/glib-2.0 -I/usr/lib/glib-2.0/include -I/usr/include/sysprof-6 -I/usr/include/webp -I/usr/include/libxml2 -I/usr/include/dbus-1.0 -I/usr/lib/dbus-1.0/include -I/usr/include/speech-dispatcher -I/usr/include/libdecor-0 -isystem thirdparty/glad -isystem thirdparty/volk -isystem thirdparty/vulkan -isystem thirdparty/vulkan/include -isystem thirdparty/clipper2/include editor/translations/editor_translation.cpp
virtual memory exhausted: Cannot allocate memory
scons: *** [bin/obj/editor/translations/editor_translation.linuxbsd.editor.x86_32.o] Error 1
```

It's not caused by LTO or debug symbols or optimization, even with just this I reproduce the crash:
```
g++ -o bin/obj/editor/translations/editor_translation.linuxbsd.editor.x86_32.o -c -Iplatform/linuxbsd -I. editor/translations/editor_translation.cpp
```

Splitting the file is just a stopgap solution, eventually if the translations get bigger we'll have the same problem. But this allows me to update the Godot package on Fedora 41 to 4.5 so I think we can start with this.