### PR TITLE
Tweak the enum visual order for Sort Scripts By editor setting

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -815,7 +815,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/script_list/script_temperature_history_size", 15);
 	_initial_set("text_editor/script_list/highlight_scene_scripts", true);
 	_initial_set("text_editor/script_list/group_help_pages", true);
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/script_list/sort_scripts_by", 0, "Name,Path,None");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/script_list/sort_scripts_by", 0, "None:2,Name:0,Path:1");
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/script_list/list_script_names_as", 0, "Name,Parent Directory And Name,Full Path");
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "text_editor/external/exec_path", "", "");
 	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_PLACEHOLDER_TEXT, "text_editor/external/exec_flags", "{file}", "Call flags with placeholders: {project}, {file}, {col}, {line}.");


### PR DESCRIPTION
**None** is now displayed first to match the typical pattern where the "simplest"/least advanced option is first (even if it's not the default).

This is a purely visual change and doesn't affect the underlying enum or existing settings.

It's likely many other enum project/editor settings benefit from this too, so if you like the idea, I can go through other settings and see if there's anything to change. This would remain fully backwards-compatible too.

- See https://github.com/godotengine/godot-proposals/discussions/13191#discussioncomment-14421828, where I noticed the None option being last (which looked odd).

## Preview

<img width="682" height="133" alt="image" src="https://github.com/user-attachments/assets/356af99f-0848-4802-b764-7dcf3bb18211" />
