### PR TITLE
Rephrase `Logger` documentation to be more explicit about thread-safety

### DIFF
--- a/doc/classes/Logger.xml
+++ b/doc/classes/Logger.xml
@@ -23,7 +23,7 @@
 				Called when an error is logged. The error provides the [param function], [param file], and [param line] that it originated from, as well as either the [param code] that generated the error or a [param rationale].
 				The type of error provided by [param error_type] is described in the [enum ErrorType] enumeration.
 				Additionally, [param script_backtraces] provides backtraces for each of the script languages. These will only contain stack frames in editor builds and debug builds by default. To enable them for release builds as well, you need to enable [member ProjectSettings.debug/settings/gdscript/always_track_call_stacks].
-				[b]Warning:[/b] This function may be called from multiple different threads, so you may need to do your own locking.
+				[b]Warning:[/b] This method will be called from threads other than the main thread, possibly at the same time, so you will need to have some kind of thread-safety in your implementation of it, like a [Mutex].
 				[b]Note:[/b] [param script_backtraces] will not contain any captured variables, due to its prohibitively high cost. To get those you will need to capture the backtraces yourself, from within the [Logger] virtual methods, using [method Engine.capture_script_backtraces].
 			</description>
 		</method>
@@ -33,7 +33,7 @@
 			<param index="1" name="error" type="bool" />
 			<description>
 				Called when a message is logged. If [param error] is [code]true[/code], then this message was meant to be sent to [code]stderr[/code].
-				[b]Warning:[/b] This function may be called from multiple different threads, so you may need to do your own locking.
+				[b]Warning:[/b] This method will be called from threads other than the main thread, possibly at the same time, so you will need to have some kind of thread-safety in your implementation of it, like a [Mutex].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The current phrasing (as written by me) of the thread-safety warning for `Logger._log_message` and `Logger._log_error` is perhaps a bit too timid and arguably makes thread-safety sound optional, which it very much is not. Threads spun up by the engine internally can emit errors, which will invoke these callbacks from said threads, meaning any and all implementations of `Logger` are subject to race conditions unless accommodated for.

I was/am a little bit tempted to throw in a scary "or you can crash the entire process" just to really drive home the point, but maybe that's excessive?