### PR TITLE
Use VHS Circle as the default editor color picker shape

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -572,7 +572,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	set_restart_if_changed("interface/accessibility/accessibility_support", true);
 
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_mode", (int32_t)ColorPicker::MODE_RGB, "RGB,HSV,RAW,OKHSL")
-	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_OKHSL_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,OK HS Rectangle:5,OK HL Rectangle") // `SHAPE_NONE` is 4.
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_VHS_CIRCLE, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle,OKHSL Circle,OK HS Rectangle:5,OK HL Rectangle") // `SHAPE_NONE` is 4.
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/inspector/color_picker_show_intensity", true, "");
 
 	// Theme


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/6688
Closes https://github.com/godotengine/godot-proposals/issues/12554

| VHS Circle | OKHSL Circle |
|---|---|
| <img src=https://github.com/user-attachments/assets/164c7030-a20a-4094-a762-5dcab464cc13 height=300> | <img src=https://github.com/user-attachments/assets/5655156d-6217-47e8-957b-8c0a60a12b65 height=300> |

Rationale: Showing a full white circle by default is suprising. It's tedious having to repeatedly explain to newbies that this isn't a bug, why it's all white, and how to change the shape / default shape.

Showing an HSV circle is more appropriate than an HSL circle since users can edit the color below in RGB or HSV format, whereas they cannot edit the L value.

FYI: the default shape was changed from VHS circle to OKHSL circle in 4.0 (#59786)