### PR TITLE
Fix imported animation warning labeled as Imported Scene

### DIFF
--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -7828,7 +7828,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	imported_anim_warning = memnew(Button);
 	imported_anim_warning->hide();
-	imported_anim_warning->set_text(TTR("Imported Scene"));
+	imported_anim_warning->set_text(TTR("Imported Animation"));
 	imported_anim_warning->set_tooltip_text(TTR("Warning: Editing imported animation"));
 	imported_anim_warning->connect(SceneStringName(pressed), callable_mp(this, &AnimationTrackEditor::_show_imported_anim_warning));
 	bottom_hf->add_child(imported_anim_warning);


### PR DESCRIPTION
This warning is shown when the current animation contains imported tracks.

An animation being imported does not necessarily mean that the scene is imported. For example, it can be a regular scene using an imported AnimationLibrary.