### PR TITLE
Allow resizing the length of animations by dragging the timeline

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -304,12 +304,22 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			const int v_separation = get_theme_constant(SNAME("h_separation"), SNAME("AnimationBezierTrackEdit"));
 
 			if (has_focus(true)) {
-				draw_rect(Rect2(Point2(), get_size()), focus_color, false, Math::round(EDSCALE));
+				draw_rect(Rect2(Point2(1, 1), get_size() - Point2(1, 1)), focus_color, false, Math::round(EDSCALE));
+			}
+
+			int right_limit = get_size().width;
+
+			// Unavailable timeline.
+			{
+				int px = (editor->get_current_animation()->get_length() - timeline->get_value()) * timeline->get_zoom_scale() + timeline->get_name_limit();
+				px = MAX(px, timeline->get_name_limit());
+				Rect2 rect = Rect2(px, 0, right_limit - px, get_size().height);
+				if (rect.size.width > 0) {
+					draw_rect(rect, Color(0, 0, 0, 0.2));
+				}
 			}
 
 			draw_line(Point2(limit, 0), Point2(limit, get_size().height), v_line_color, Math::round(EDSCALE));
-
-			int right_limit = get_size().width;
 
 			track_v_scroll_max = v_separation;
 

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -187,6 +187,7 @@ class AnimationTimelineEdit : public Range {
 
 	friend class AnimationBezierTrackEdit;
 	friend class AnimationTrackEditor;
+	friend class AnimationMarkerEdit;
 
 	static constexpr float SCROLL_ZOOM_FACTOR_IN = 1.02f; // Zoom factor per mouse scroll in the animation editor when zooming in. The closer to 1.0, the finer the control.
 	static constexpr float SCROLL_ZOOM_FACTOR_OUT = 0.98f; // Zoom factor when zooming out. Similar to SCROLL_ZOOM_FACTOR_IN but less than 1.0.
@@ -195,6 +196,7 @@ class AnimationTimelineEdit : public Range {
 	bool read_only = false;
 
 	AnimationTrackEdit *track_edit = nullptr;
+	AnimationTrackEditor *editor = nullptr;
 	int name_limit = 0;
 	Range *zoom = nullptr;
 	Range *h_scroll = nullptr;
@@ -225,6 +227,11 @@ class AnimationTimelineEdit : public Range {
 	void _pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event);
 	void _zoom_callback(float p_zoom_factor, Vector2 p_origin, Ref<InputEvent> p_event);
 
+	Rect2 timeline_resize_rect;
+	float timeline_resize_from = 0.0f;
+	float timeline_resize_at = 0.0f;
+	bool resizing_timeline = false;
+
 	bool dragging_timeline = false;
 	bool dragging_hsize = false;
 	float dragging_hsize_from = 0.0f;
@@ -236,6 +243,8 @@ class AnimationTimelineEdit : public Range {
 	bool zoom_callback_occurred = false;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+	void _commit_timeline_resize();
+	void _stop_dragging();
 	void _track_added(int p_track);
 
 	float _get_zoom_scale(double p_zoom_value) const;
@@ -254,6 +263,7 @@ public:
 	virtual Size2 get_minimum_size() const override;
 	void set_animation(const Ref<Animation> &p_animation, bool p_read_only);
 	void set_track_edit(AnimationTrackEdit *p_track_edit);
+	void set_editor(AnimationTrackEditor *p_editor);
 	void set_zoom(Range *p_zoom);
 	Range *get_zoom() const { return zoom; }
 	void auto_fit();

--- a/editor/icons/TimelineHandle.svg
+++ b/editor/icons/TimelineHandle.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="10"><path fill="#fff" d="M 3,0 H 13 L 8,5 Z"/></svg>

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -2069,8 +2069,12 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		// AnimationTimelineEdit.
 		// "primary" is used for integer timeline values, "secondary" for decimals.
 
-		Ref<StyleBoxFlat> style_time_unavailable = EditorThemeManager::make_flat_stylebox(p_config.dark_color_2, 0, 0, 0, 0, 0);
+		Ref<StyleBoxFlat> style_time_unavailable = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3, 0, 0, 0, 0, 0);
 		Ref<StyleBoxFlat> style_time_available = EditorThemeManager::make_flat_stylebox(p_config.font_color * Color(1, 1, 1, 0.2), 0, 0, 0, 0, 0);
+		if (!p_config.dark_theme) {
+			style_time_unavailable = EditorThemeManager::make_flat_stylebox(p_config.font_color * Color(1, 1, 1, 0.2), 0, 0, 0, 0, 0);
+			style_time_available = EditorThemeManager::make_flat_stylebox(p_config.dark_color_3 * Color(1, 1, 1, 0.5), 0, 0, 0, 0, 0);
+		}
 
 		p_theme->set_stylebox("time_unavailable", "AnimationTimelineEdit", style_time_unavailable);
 		p_theme->set_stylebox("time_available", "AnimationTimelineEdit", style_time_available);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -2025,14 +2025,14 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		// "primary" is used for integer timeline values, "secondary" for decimals.
 
 		Ref<StyleBoxFlat> style_time_available = p_config.base_style->duplicate();
-		style_time_available->set_bg_color(p_config.surface_highest_color);
+		style_time_available->set_bg_color(p_config.dark_theme ? p_config.surface_highest_color : p_config.surface_high_color);
 		if (p_config.draw_extra_borders) {
 			style_time_available->set_border_width_all(Math::round(EDSCALE));
-			style_time_available->set_border_color(p_config.extra_border_color_1);
+			style_time_available->set_border_color(p_config.extra_border_color_2);
 		}
 
 		Ref<StyleBoxFlat> style_time_unavailable = p_config.base_style->duplicate();
-		style_time_unavailable->set_bg_color(p_config.surface_high_color);
+		style_time_unavailable->set_bg_color(p_config.dark_theme ? p_config.surface_high_color : p_config.surface_highest_color);
 
 		p_theme->set_stylebox("time_available", "AnimationTimelineEdit", style_time_available);
 		p_theme->set_stylebox("time_unavailable", "AnimationTimelineEdit", style_time_unavailable);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/10030.

[Screencast_20250917_222534.webm](https://github.com/user-attachments/assets/25b34ead-0284-4396-90ae-69cfa1c392a7)

This also fixes the following bugs:
- Timeline components overlapping mode buttons in the tracks.
- Markers drawing outside of bounds.
- Clipped focus in the bezier editor.
- Timeline cursor and track name dragging even if the context menu is open.