### PR TITLE
Move check for sky cubemap array back into the SkyRD initializer

### DIFF
--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -727,6 +727,12 @@ SkyRD::SkyRD() {
 	roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
 	sky_ggx_samples_quality = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
 	sky_use_cubemap_array = GLOBAL_GET("rendering/reflections/sky_reflections/texture_array_reflections");
+#if defined(MACOS_ENABLED) && defined(__x86_64__)
+	if (OS::get_singleton()->get_current_rendering_driver_name() == "vulkan" && RenderingDevice::get_singleton()->get_device_name().contains("Intel")) {
+		// Disable texture array reflections on macOS on Intel GPUs due to driver bugs.
+		sky_use_cubemap_array = false;
+	}
+#endif
 }
 
 void SkyRD::init() {
@@ -951,15 +957,6 @@ void sky() {
 void SkyRD::set_texture_format(RD::DataFormat p_texture_format) {
 	texture_format = p_texture_format;
 }
-
-#if defined(MACOS_ENABLED) && defined(__x86_64__)
-void SkyRD::check_cubemap_array() {
-	if (OS::get_singleton()->get_current_rendering_driver_name() == "vulkan" && RenderingServer::get_singleton()->get_video_adapter_name().contains("Intel")) {
-		// Disable texture array reflections on macOS on Intel GPUs due to driver bugs.
-		sky_use_cubemap_array = false;
-	}
-}
-#endif
 
 SkyRD::~SkyRD() {
 	// cleanup anything created in init...

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -281,9 +281,7 @@ public:
 
 	uint32_t sky_ggx_samples_quality;
 	bool sky_use_cubemap_array;
-#if defined(MACOS_ENABLED) && defined(__x86_64__)
-	void check_cubemap_array();
-#endif
+
 	Sky *dirty_sky_list = nullptr;
 	mutable RID_Owner<Sky, true> sky_owner;
 	int roughness_layers;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -159,11 +159,6 @@ void RendererCompositorRD::initialize() {
 
 		blit.sampler = RD::get_singleton()->sampler_create(RD::SamplerState());
 	}
-#if defined(MACOS_ENABLED) && defined(__x86_64__)
-	if (scene) {
-		scene->get_sky()->check_cubemap_array();
-	}
-#endif
 }
 
 uint64_t RendererCompositorRD::frame = 1;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/110589
Regression from https://github.com/godotengine/godot/pull/103306

This basically removes the changes from https://github.com/godotengine/godot/pull/105424

We need to disable `sky_use_cubemap_array` as early as possible since it can be read from a few places during initialization of the renderer. However, https://github.com/godotengine/godot/pull/103306 caused a crash because it used `RenderingServer::get_singleton()->get_video_adapter_name()` which isn't available until after the `Utilities` class is initialized. However, `Utilities::get_video_adapter_name()` is just a wrapper function for `RenderingDevice::get_device_name()`. 

https://github.com/godotengine/godot/blob/8b4b93a82e13cb1b7ea5fa28b39163a6311a0bb3/servers/rendering/renderer_rd/storage_rd/utilities.cpp#L313-L315

So there is no need to access `Utilities` at all. 

In https://github.com/godotengine/godot/pull/105424 we moved the check until the end of `RendererCompositorRD::initialize()` to ensure the RenderingServer was initialized. That fixed the crash, but it caused the graphical artifacts in https://github.com/godotengine/godot/issues/110589 because `sky_use_cubemap_array` was getting set to false _after_ it had been read during initialization. So all our shaders were compiled thinking that `sky_use_cubemap_array` was true, but then at run time we followed the false path. This is why setting the project setting for `sky_use_cubemap_array` to false made the graphical artifacts go away. 

Since we don't need to rely on `RenderingServer::get_singleton()->get_video_adapter_name()` after all. We can move the check up to `SkyRD()` to ensure that it is done on time. Now the code is simpler, more self contained and doesn't cause a crash. 