### PR TITLE
[4.4] Fix compiling with latest Xcode for macOS 26

### DIFF
--- a/drivers/metal/metal_device_properties.mm
+++ b/drivers/metal/metal_device_properties.mm
@@ -136,6 +136,11 @@ void MetalDeviceProperties::init_features(id<MTLDevice> p_device) {
 	features.mslVersion = SPIRV_CROSS_NAMESPACE::CompilerMSL::Options::make_msl_version(m_maj, m_min)
 
 	switch (features.mslVersionEnum) {
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 260000 || __IPHONE_OS_VERSION_MAX_ALLOWED >= 260000 || __TV_OS_VERSION_MAX_ALLOWED >= 260000
+		case MTLLanguageVersion4_0:
+			setMSLVersion(4, 0);
+			break;
+#endif
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 150000 || __IPHONE_OS_VERSION_MAX_ALLOWED >= 180000 || __TV_OS_VERSION_MAX_ALLOWED >= 180000
 		case MTLLanguageVersion3_2:
 			setMSLVersion(3, 2);


### PR DESCRIPTION
Xcode updated for me last night, and I can't compile Godot 4.4 anymore. This PR fixes it.

Note that this PR is not relevant for 4.3 (this code is not present there) or 4.5 (this code is refactored to not have a hard dependency on these definitions).