### PR TITLE
Add note to Skeleton3D physical bones deprecated methods

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -215,7 +215,7 @@
 				Returns all bones in the skeleton to their rest poses.
 			</description>
 		</method>
-		<method name="physical_bones_add_collision_exception" deprecated="">
+		<method name="physical_bones_add_collision_exception" deprecated="Use [member PhysicalBoneSimulator3D.physical_bones_add_collision_exception] instead.">
 			<return type="void" />
 			<param index="0" name="exception" type="RID" />
 			<description>
@@ -223,7 +223,7 @@
 				Works just like the [RigidBody3D] node.
 			</description>
 		</method>
-		<method name="physical_bones_remove_collision_exception" deprecated="">
+		<method name="physical_bones_remove_collision_exception" deprecated="Use [member PhysicalBoneSimulator3D.physical_bones_remove_collision_exception] instead.">
 			<return type="void" />
 			<param index="0" name="exception" type="RID" />
 			<description>
@@ -231,7 +231,7 @@
 				Works just like the [RigidBody3D] node.
 			</description>
 		</method>
-		<method name="physical_bones_start_simulation" deprecated="">
+		<method name="physical_bones_start_simulation" deprecated="Use [member PhysicalBoneSimulator3D.physical_bones_start_simulation] instead.">
 			<return type="void" />
 			<param index="0" name="bones" type="StringName[]" default="[]" />
 			<description>
@@ -239,7 +239,7 @@
 				Optionally, a list of bone names can be passed-in, allowing only the passed-in bones to be simulated.
 			</description>
 		</method>
-		<method name="physical_bones_stop_simulation" deprecated="">
+		<method name="physical_bones_stop_simulation" deprecated="Use [member PhysicalBoneSimulator3D.physical_bones_stop_simulation] instead.">
 			<return type="void" />
 			<description>
 				Tells the [PhysicalBone3D] nodes in the Skeleton to stop simulating.


### PR DESCRIPTION
Tell the user to use the PhysicalBoneSimulator3D methods instead of the deprecated Skeleton3D methods for "physical_bones_add_collision_exception", "physical_bones_remove_collision_exception", "physical_bones_start_simulation" and "physical_bones_stop_simulation"

I was trying to get ragdolls to work and was following outdated tutorials that used the methods in Skeleton3D, and I had no idea why it wasn't working at all for me. Having this explained clearly in the docs will hopefully save some people a headache like it did for me.
Other docs and tutorials should probably be updated to specify this too.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
