### PR TITLE
Expand `LineEdit` with metadata name in `AddMetadataDialog`

### DIFF
--- a/editor/inspector/add_metadata_dialog.cpp
+++ b/editor/inspector/add_metadata_dialog.cpp
@@ -46,6 +46,7 @@ AddMetadataDialog::AddMetadataDialog() {
 	add_meta_name = memnew(LineEdit);
 	add_meta_name->set_accessibility_name(TTRC("Name:"));
 	add_meta_name->set_custom_minimum_size(Size2(200 * EDSCALE, 1));
+	add_meta_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(add_meta_name);
 	hbc->add_child(memnew(Label(TTR("Type:"))));
 


### PR DESCRIPTION
Fixes the inability to view the full metadata name when creating new metadata if the name is too long.
It's really a small change, but even one line of code makes a difference. 😄 

**Before:**

https://github.com/user-attachments/assets/2f541b66-2c49-4bf3-81ad-23f74e53ef95

**After:**

https://github.com/user-attachments/assets/1f8723e9-9b10-4ce3-8108-da520db884e7