### PR TITLE
Optimize children cache updates and refine special-case handling

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1643,22 +1643,29 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name, InternalM
 	data.children.insert(p_name, p_child);
 
 	p_child->data.internal_mode = p_internal_mode;
+
+	bool can_push_back = false;
 	switch (p_internal_mode) {
 		case INTERNAL_MODE_FRONT: {
 			p_child->data.index = data.internal_children_front_count_cache++;
+			// Safe to push back when ordinary and back children are empty.
+			can_push_back = (data.external_children_count_cache + data.internal_children_back_count_cache) == 0;
 		} break;
 		case INTERNAL_MODE_BACK: {
 			p_child->data.index = data.internal_children_back_count_cache++;
+			// Safe to push back when cache is valid.
+			can_push_back = true;
 		} break;
 		case INTERNAL_MODE_DISABLED: {
 			p_child->data.index = data.external_children_count_cache++;
+			// Safe to push back when back children are empty.
+			can_push_back = data.internal_children_back_count_cache == 0;
 		} break;
 	}
 
 	p_child->data.parent = this;
 
-	if (!data.children_cache_dirty && p_internal_mode == INTERNAL_MODE_DISABLED && data.internal_children_back_count_cache == 0) {
-		// Special case, also add to the cached children array since its cheap.
+	if (!data.children_cache_dirty && can_push_back) {
 		data.children_cache.push_back(p_child);
 	} else {
 		data.children_cache_dirty = true;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -167,7 +167,7 @@ private:
 		Node *parent = nullptr;
 		Node *owner = nullptr;
 		HashMap<StringName, Node *> children;
-		mutable bool children_cache_dirty = true;
+		mutable bool children_cache_dirty = false;
 		mutable LocalVector<Node *> children_cache;
 		HashMap<StringName, Node *> owned_unique_nodes;
 		bool unique_name_in_owner = false;


### PR DESCRIPTION
Previously, the Node children cache was marked dirty in many cases, triggering expensive rebuilds of the entire children array even for simple operations like adding <s>or removing</s> a child at the end. This PR refines the cache invalidation logic to handle several special cases.

Changes:
- Adding children at the end no longer marks the cache dirty unnecessarily if the cache is already valid. (ie. Adding an internal front child while external and back children are empty or adding children normally while back children are empty (current but didn't work since the cache was dirty by default)).

- Changed `children_cache_dirty` default value to `false` so those cases can be handled correctly ie. using `add_child` followed by `get_children` or `get_child_count` will not require rebuilding the cache for special cases.

<s>- Removing the last child no longer marks the cache dirty if the cache is already valid. (ie. Removing the last external child while back children are empty)</s> Needs more work to handle deletion properly.

<s>- Added a way to recover the HashMap from the cache if it's valid and we fail to remove a child if it's name is not found in the HashMap or we return early before marking the cache dirty which will rebuild the same cache again since the child was not removed from the Hashmap. </s> Reverted for now, can be applied later.
