### PR TITLE
CI: Bump Ruff version (0.12.0 → 0.13.1)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,9 +34,9 @@ repos:
         stages: [manual] # Not automatically triggered, invoked via `pre-commit run --hook-stage manual clang-tidy`
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.0
+    rev: v0.13.1
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix]
         files: (\.py|SConstruct|SCsub)$
         types_or: [text]


### PR DESCRIPTION
Also updates the pre-commit id from the recently-deprecated `ruff` to `ruff-check`