### PR TITLE
Blend glow before tonemapping and change default to screen.

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -6,8 +6,9 @@
 	<description>
 		Resource for environment nodes (like [WorldEnvironment]) that define multiple environment operations (such as background [Sky] or [Color], ambient light, fog, depth-of-field...). These parameters affect the final render of the scene. The order of these operations is:
 		- Depth of Field Blur
+		- Auto Exposure
 		- Glow
-		- Tonemap (Auto Exposure)
+		- Tonemap
 		- Adjustments
 	</description>
 	<tutorials>
@@ -124,15 +125,15 @@
 		<member name="fog_sun_scatter" type="float" setter="set_fog_sun_scatter" getter="get_fog_sun_scatter" default="0.0">
 			If set above [code]0.0[/code], renders the scene's directional light(s) in the fog color depending on the view angle. This can be used to give the impression that the sun is "piercing" through the fog.
 		</member>
-		<member name="glow_blend_mode" type="int" setter="set_glow_blend_mode" getter="get_glow_blend_mode" enum="Environment.GlowBlendMode" default="2">
+		<member name="glow_blend_mode" type="int" setter="set_glow_blend_mode" getter="get_glow_blend_mode" enum="Environment.GlowBlendMode" default="1">
 			The glow blending mode.
-			[b]Note:[/b] [member glow_blend_mode] has no effect when using the Compatibility rendering method, due to this rendering method using a simpler glow implementation optimized for low-end devices.
+			[b]Note:[/b] The Compatibility renderer always uses [constant GLOW_BLEND_MODE_SCREEN] and [member glow_blend_mode] will have no effect.
 		</member>
 		<member name="glow_bloom" type="float" setter="set_glow_bloom" getter="get_glow_bloom" default="0.0">
 			The bloom's intensity. If set to a value higher than [code]0[/code], this will make glow visible in areas darker than the [member glow_hdr_threshold].
 		</member>
 		<member name="glow_enabled" type="bool" setter="set_glow_enabled" getter="is_glow_enabled" default="false">
-			If [code]true[/code], the glow effect is enabled. This simulates real world eye/camera behavior where bright pixels bleed onto surrounding pixels.
+			If [code]true[/code], the glow effect is enabled. This simulates real world atmosphere and eye/camera behavior by causing bright pixels to bleed onto surrounding pixels.
 			[b]Note:[/b] When using the Mobile rendering method, glow looks different due to the lower dynamic range available in the Mobile rendering method.
 			[b]Note:[/b] When using the Compatibility rendering method, glow uses a different implementation with some properties being unavailable and hidden from the inspector: [code]glow_levels/*[/code], [member glow_normalized], [member glow_strength], [member glow_blend_mode], [member glow_mix], [member glow_map], and [member glow_map_strength]. This implementation is optimized to run on low-end devices and is less flexible as a result.
 		</member>
@@ -145,26 +146,26 @@
 		<member name="glow_hdr_threshold" type="float" setter="set_glow_hdr_bleed_threshold" getter="get_glow_hdr_bleed_threshold" default="1.0">
 			The lower threshold of the HDR glow. When using the Mobile rendering method (which only supports a lower dynamic range up to [code]2.0[/code]), this may need to be below [code]1.0[/code] for glow to be visible. A value of [code]0.9[/code] works well in this case. This value also needs to be decreased below [code]1.0[/code] when using glow in 2D, as 2D rendering is performed in SDR.
 		</member>
-		<member name="glow_intensity" type="float" setter="set_glow_intensity" getter="get_glow_intensity" default="0.8">
+		<member name="glow_intensity" type="float" setter="set_glow_intensity" getter="get_glow_intensity" default="0.3">
 			The overall brightness multiplier of the glow effect. When using the Mobile rendering method (which only supports a lower dynamic range up to [code]2.0[/code]), this should be increased to [code]1.5[/code] to compensate.
 		</member>
-		<member name="glow_levels/1" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_levels/1" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
 			The intensity of the 1st level of glow. This is the most "local" level (least blurry).
 			[b]Note:[/b] [member glow_levels/1] has no effect when using the Compatibility rendering method, due to this rendering method using a simpler glow implementation optimized for low-end devices.
 		</member>
-		<member name="glow_levels/2" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_levels/2" type="float" setter="set_glow_level" getter="get_glow_level" default="0.8">
 			The intensity of the 2nd level of glow.
 			[b]Note:[/b] [member glow_levels/2] has no effect when using the Compatibility rendering method, due to this rendering method using a simpler glow implementation optimized for low-end devices.
 		</member>
-		<member name="glow_levels/3" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
+		<member name="glow_levels/3" type="float" setter="set_glow_level" getter="get_glow_level" default="0.4">
 			The intensity of the 3rd level of glow.
 			[b]Note:[/b] [member glow_levels/3] has no effect when using the Compatibility rendering method, due to this rendering method using a simpler glow implementation optimized for low-end devices.
 		</member>
-		<member name="glow_levels/4" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
+		<member name="glow_levels/4" type="float" setter="set_glow_level" getter="get_glow_level" default="0.1">
 			The intensity of the 4th level of glow.
 			[b]Note:[/b] [member glow_levels/4] has no effect when using the Compatibility rendering method, due to this rendering method using a simpler glow implementation optimized for low-end devices.
 		</member>
-		<member name="glow_levels/5" type="float" setter="set_glow_level" getter="get_glow_level" default="1.0">
+		<member name="glow_levels/5" type="float" setter="set_glow_level" getter="get_glow_level" default="0.0">
 			The intensity of the 5th level of glow.
 			[b]Note:[/b] [member glow_levels/5] has no effect when using the Compatibility rendering method, due to this rendering method using a simpler glow implementation optimized for low-end devices.
 		</member>
@@ -434,19 +435,19 @@
 			[b]Note:[/b] [member tonemap_white] is fixed at a value of [code]16.29[/code], which makes [constant TONE_MAPPER_AGX] unsuitable for use with the Mobile rendering method.
 		</constant>
 		<constant name="GLOW_BLEND_MODE_ADDITIVE" value="0" enum="GlowBlendMode">
-			Additive glow blending mode. Mostly used for particles, glows (bloom), lens flare, bright sources.
+			Adds the glow effect to the scene.
 		</constant>
 		<constant name="GLOW_BLEND_MODE_SCREEN" value="1" enum="GlowBlendMode">
-			Screen glow blending mode. Increases brightness, used frequently with bloom.
+			Adds the glow effect to the scene after modifying the glow influence based on the scene value; dark values will be highly influenced by glow and bright values will not be influenced by glow. This approach avoids bright values becoming overly bright from the glow effect. [member tonemap_white] is used to determine the maximum scene value where the glow should have no influence. When [member tonemap_mode] is set to [constant TONE_MAPPER_LINEAR], a value of [code]1.0[/code] will be used as the maximum scene value.
 		</constant>
 		<constant name="GLOW_BLEND_MODE_SOFTLIGHT" value="2" enum="GlowBlendMode">
-			Soft light glow blending mode. Modifies contrast, exposes shadows and highlights (vivid bloom).
+			Adds the glow effect to the tonemapped image after modifying the glow influence based on the image value; dark values and bright values will not be influenced by glow and mid-range values will be highly influenced by glow. This approach avoids bright values becoming overly bright from the glow effect. The glow will have the largest influence on image values of [code]0.25[/code] and will have no influence when applied to image values greater than [code]1.0[/code].
 		</constant>
 		<constant name="GLOW_BLEND_MODE_REPLACE" value="3" enum="GlowBlendMode">
-			Replace glow blending mode. Replaces all pixels' color by the glow value. This can be used to simulate a full-screen blur effect by tweaking the glow parameters to match the original image's brightness.
+			Replaces all pixels' color by the glow effect. This can be used to simulate a full-screen blur effect by tweaking the glow parameters to match the original image's brightness or to preview glow configuration in the editor.
 		</constant>
 		<constant name="GLOW_BLEND_MODE_MIX" value="4" enum="GlowBlendMode">
-			Mixes the glow with the underlying color to avoid increasing brightness as much while still maintaining a glow effect.
+			Mixes the glow image with the scene image. Best used with [member glow_bloom] to avoid darkening the scene.
 		</constant>
 		<constant name="FOG_MODE_EXPONENTIAL" value="0" enum="FogMode">
 			Use a physically-based fog model defined primarily by fog density.

--- a/drivers/gles3/effects/post_effects.cpp
+++ b/drivers/gles3/effects/post_effects.cpp
@@ -87,7 +87,7 @@ void PostEffects::_draw_screen_triangle() {
 	glBindVertexArray(0);
 }
 
-void PostEffects::post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color, Size2i p_source_size, float p_luminance_multiplier, const Glow::GLOWLEVEL *p_glow_buffers, float p_glow_intensity, uint32_t p_view, bool p_use_multiview, uint64_t p_spec_constants) {
+void PostEffects::post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color, Size2i p_source_size, float p_luminance_multiplier, const Glow::GLOWLEVEL *p_glow_buffers, float p_glow_intensity, float p_srgb_white, uint32_t p_view, bool p_use_multiview, uint64_t p_spec_constants) {
 	glDisable(GL_DEPTH_TEST);
 	glDepthMask(GL_FALSE);
 	glDisable(GL_BLEND);
@@ -124,6 +124,7 @@ void PostEffects::post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuin
 
 		post.shader.version_set_uniform(PostShaderGLES3::PIXEL_SIZE, 1.0 / p_source_size.x, 1.0 / p_source_size.y, post.shader_version, mode, flags);
 		post.shader.version_set_uniform(PostShaderGLES3::GLOW_INTENSITY, p_glow_intensity, post.shader_version, mode, flags);
+		post.shader.version_set_uniform(PostShaderGLES3::SRGB_WHITE, p_srgb_white, post.shader_version, mode, flags);
 	}
 
 	post.shader.version_set_uniform(PostShaderGLES3::VIEW, float(p_view), post.shader_version, mode, flags);

--- a/drivers/gles3/effects/post_effects.h
+++ b/drivers/gles3/effects/post_effects.h
@@ -58,7 +58,7 @@ public:
 	PostEffects();
 	~PostEffects();
 
-	void post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color, Size2i p_source_size, float p_luminance_multiplier, const Glow::GLOWLEVEL *p_glow_buffers, float p_glow_intensity, uint32_t p_view = 0, bool p_use_multiview = false, uint64_t p_spec_constants = 0);
+	void post_copy(GLuint p_dest_framebuffer, Size2i p_dest_size, GLuint p_source_color, Size2i p_source_size, float p_luminance_multiplier, const Glow::GLOWLEVEL *p_glow_buffers, float p_glow_intensity, float p_srgb_white, uint32_t p_view = 0, bool p_use_multiview = false, uint64_t p_spec_constants = 0);
 };
 
 } //namespace GLES3

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2814,6 +2814,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 	float glow_hdr_bleed_threshold = 1.0;
 	float glow_hdr_bleed_scale = 2.0;
 	float glow_hdr_luminance_cap = 12.0;
+	float srgb_white = 1.0;
 	if (p_render_data->environment.is_valid()) {
 		glow_enabled = environment_get_glow_enabled(p_render_data->environment);
 		glow_intensity = environment_get_glow_intensity(p_render_data->environment);
@@ -2821,9 +2822,13 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 		glow_hdr_bleed_threshold = environment_get_glow_hdr_bleed_threshold(p_render_data->environment);
 		glow_hdr_bleed_scale = environment_get_glow_hdr_bleed_scale(p_render_data->environment);
 		glow_hdr_luminance_cap = environment_get_glow_hdr_luminance_cap(p_render_data->environment);
+		srgb_white = environment_get_white(p_render_data->environment);
 	}
 
 	if (glow_enabled) {
+		// Only glow requires srgb_white to be calculated.
+		srgb_white = 1.055 * Math::pow(srgb_white, 1.0f / 2.4f) - 0.055;
+
 		rb->check_glow_buffers();
 	}
 
@@ -2890,7 +2895,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 			}
 
 			// Copy color buffer
-			post_effects->post_copy(fbo_rt, target_size, color, internal_size, p_render_data->luminance_multiplier, glow_buffers, glow_intensity, 0, false, bcs_spec_constants);
+			post_effects->post_copy(fbo_rt, target_size, color, internal_size, p_render_data->luminance_multiplier, glow_buffers, glow_intensity, srgb_white, 0, false, bcs_spec_constants);
 
 			// Copy depth buffer
 			glBindFramebuffer(GL_READ_FRAMEBUFFER, fbo_int);
@@ -2958,7 +2963,7 @@ void RasterizerSceneGLES3::_render_post_processing(const RenderDataGLES3 *p_rend
 
 				glBindFramebuffer(GL_FRAMEBUFFER, fbos[2]);
 				glFramebufferTextureLayer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, write_color, 0, v);
-				post_effects->post_copy(fbos[2], target_size, source_color, internal_size, p_render_data->luminance_multiplier, glow_buffers, glow_intensity, v, true, bcs_spec_constants);
+				post_effects->post_copy(fbos[2], target_size, source_color, internal_size, p_render_data->luminance_multiplier, glow_buffers, glow_intensity, srgb_white, v, true, bcs_spec_constants);
 			}
 
 			// Copy depth

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1247,7 +1247,7 @@ void Environment::_bind_methods() {
 	ADD_GROUP("Tonemap", "tonemap_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tonemap_mode", PROPERTY_HINT_ENUM, "Linear,Reinhard,Filmic,ACES,AgX"), "set_tonemapper", "get_tonemapper");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_exposure", "get_tonemap_exposure");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_tonemap_white", "get_tonemap_white");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "tonemap_white", PROPERTY_HINT_RANGE, "1,16,0.01,or_greater"), "set_tonemap_white", "get_tonemap_white");
 
 	// SSR
 
@@ -1405,7 +1405,7 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_strength", PROPERTY_HINT_RANGE, "0.0,2.0,0.01"), "set_glow_strength", "get_glow_strength");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_mix", PROPERTY_HINT_RANGE, "0.0,1.0,0.001"), "set_glow_mix", "get_glow_mix");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_bloom", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_glow_bloom", "get_glow_bloom");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "glow_blend_mode", PROPERTY_HINT_ENUM, "Additive,Screen,Softlight,Replace,Mix"), "set_glow_blend_mode", "get_glow_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "glow_blend_mode", PROPERTY_HINT_ENUM, "Additive,Screen,Soft Light,Replace,Mix"), "set_glow_blend_mode", "get_glow_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_threshold", PROPERTY_HINT_RANGE, "0.0,4.0,0.01"), "set_glow_hdr_bleed_threshold", "get_glow_hdr_bleed_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_scale", PROPERTY_HINT_RANGE, "0.0,4.0,0.01"), "set_glow_hdr_bleed_scale", "get_glow_hdr_bleed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "glow_hdr_luminance_cap", PROPERTY_HINT_RANGE, "0.0,256.0,0.01"), "set_glow_hdr_luminance_cap", "get_glow_hdr_luminance_cap");
@@ -1572,11 +1572,11 @@ Environment::Environment() {
 	set_camera_feed_id(bg_camera_feed_id);
 
 	glow_levels.resize(7);
-	glow_levels.write[0] = 0.0;
-	glow_levels.write[1] = 0.0;
-	glow_levels.write[2] = 1.0;
-	glow_levels.write[3] = 0.0;
-	glow_levels.write[4] = 1.0;
+	glow_levels.write[0] = 1.0;
+	glow_levels.write[1] = 0.8;
+	glow_levels.write[2] = 0.4;
+	glow_levels.write[3] = 0.1;
+	glow_levels.write[4] = 0.0;
 	glow_levels.write[5] = 0.0;
 	glow_levels.write[6] = 0.0;
 

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -163,11 +163,11 @@ private:
 	bool glow_enabled = false;
 	Vector<float> glow_levels;
 	bool glow_normalize_levels = false;
-	float glow_intensity = 0.8;
+	float glow_intensity = 0.3;
 	float glow_strength = 1.0;
 	float glow_mix = 0.05;
 	float glow_bloom = 0.0;
-	GlowBlendMode glow_blend_mode = GLOW_BLEND_MODE_SOFTLIGHT;
+	GlowBlendMode glow_blend_mode = GLOW_BLEND_MODE_SCREEN;
 	float glow_hdr_bleed_threshold = 1.0;
 	float glow_hdr_bleed_scale = 2.0;
 	float glow_hdr_luminance_cap = 12.0;

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -114,10 +114,10 @@ public:
 			GLOW_MODE_MIX
 		};
 
-		GlowMode glow_mode = GLOW_MODE_ADD;
-		float glow_intensity = 1.0;
+		GlowMode glow_mode = GLOW_MODE_SCREEN;
+		float glow_intensity = 0.3;
 		float glow_map_strength = 0.0f;
-		float glow_levels[7] = { 0.0, 0.0, 1.0, 0.0, 1.0, 0.0, 0.0 };
+		float glow_levels[7] = { 1.0, 0.8, 0.4, 0.1, 0.0, 0.0, 0.0 };
 		Vector2i glow_texture_size;
 		bool glow_use_bicubic_upscale = false;
 		RID glow_texture;

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -393,6 +393,8 @@ vec3 gather_glow(sampler2D tex, vec2 uv) { // sample all selected glow levels
 		glow += GLOW_TEXTURE_SAMPLE(tex, uv, 6).rgb * params.glow_levels[6];
 	}
 
+	glow = glow * params.luminance_multiplier;
+
 	return glow;
 }
 
@@ -402,21 +404,42 @@ vec3 gather_glow(sampler2D tex, vec2 uv) { // sample all selected glow levels
 #define GLOW_MODE_REPLACE 3
 #define GLOW_MODE_MIX 4
 
-vec3 apply_glow(vec3 color, vec3 glow) { // apply glow using the selected blending mode
+// Applies glow using the selected blending mode. Does not handle the mix blend mode.
+vec3 apply_glow(vec3 color, vec3 glow, float white) {
 	if (params.glow_mode == GLOW_MODE_ADD) {
 		return color + glow;
 	} else if (params.glow_mode == GLOW_MODE_SCREEN) {
-		// Needs color clamping.
-		glow.rgb = clamp(glow.rgb, vec3(0.0f), vec3(1.0f));
-		return max((color + glow) - (color * glow), vec3(0.0));
-	} else if (params.glow_mode == GLOW_MODE_SOFTLIGHT) {
-		// Needs color clamping.
-		glow.rgb = clamp(glow.rgb, vec3(0.0f), vec3(1.0f));
-		glow = glow * vec3(0.5f) + vec3(0.5f);
+		// Glow cannot be above 1.0 after normalizing and should be non-negative
+		// to produce expected results. It is possible that glow can be negative
+		// if negative lights were used in the scene.
+		// We clamp to white because glow will be normalized to this range.
+		// Note: white cannot be smaller than the maximum output value.
+		glow.rgb = clamp(glow.rgb, 0.0, white);
 
-		color.r = (glow.r <= 0.5f) ? (color.r - (1.0f - 2.0f * glow.r) * color.r * (1.0f - color.r)) : (((glow.r > 0.5f) && (color.r <= 0.25f)) ? (color.r + (2.0f * glow.r - 1.0f) * (4.0f * color.r * (4.0f * color.r + 1.0f) * (color.r - 1.0f) + 7.0f * color.r)) : (color.r + (2.0f * glow.r - 1.0f) * (sqrt(color.r) - color.r)));
-		color.g = (glow.g <= 0.5f) ? (color.g - (1.0f - 2.0f * glow.g) * color.g * (1.0f - color.g)) : (((glow.g > 0.5f) && (color.g <= 0.25f)) ? (color.g + (2.0f * glow.g - 1.0f) * (4.0f * color.g * (4.0f * color.g + 1.0f) * (color.g - 1.0f) + 7.0f * color.g)) : (color.g + (2.0f * glow.g - 1.0f) * (sqrt(color.g) - color.g)));
-		color.b = (glow.b <= 0.5f) ? (color.b - (1.0f - 2.0f * glow.b) * color.b * (1.0f - color.b)) : (((glow.b > 0.5f) && (color.b <= 0.25f)) ? (color.b + (2.0f * glow.b - 1.0f) * (4.0f * color.b * (4.0f * color.b + 1.0f) * (color.b - 1.0f) + 7.0f * color.b)) : (color.b + (2.0f * glow.b - 1.0f) * (sqrt(color.b) - color.b)));
+		// Normalize to white range.
+		//glow.rgb /= white;
+		//color.rgb /= white;
+		//color.rgb = (color.rgb + glow.rgb) - (color.rgb * glow.rgb);
+		// Expand back to original range.
+		//color.rgb *= white;
+
+		// The following is a mathematically simplified version of the above.
+		color.rgb = color.rgb + glow.rgb - (color.rgb * glow.rgb / white);
+
+		return color;
+	} else if (params.glow_mode == GLOW_MODE_SOFTLIGHT) {
+		// Glow cannot be above 1.0 should be non-negative to produce
+		// expected results. It is possible that glow can be negative
+		// if negative lights were used in the scene.
+		// Note: This approach causes a discontinuity with scene values
+		// at 1.0, but because this glow should have its strongest influence
+		// anchored at 0.25 there is no way around this.
+		glow.rgb = clamp(glow.rgb, 0.0, 1.0);
+
+		color.r = color.r > 1.0 ? color.r : color.r + glow.r * ((color.r <= 0.25f ? ((16.0f * color.r - 12.0f) * color.r + 4.0f) * color.r : sqrt(color.r)) - color.r);
+		color.g = color.g > 1.0 ? color.g : color.g + glow.g * ((color.g <= 0.25f ? ((16.0f * color.g - 12.0f) * color.g + 4.0f) * color.g : sqrt(color.g)) - color.g);
+		color.b = color.b > 1.0 ? color.b : color.b + glow.b * ((color.b <= 0.25f ? ((16.0f * color.b - 12.0f) * color.b + 4.0f) * color.b : sqrt(color.b)) - color.b);
+
 		return color;
 	} else { //replace
 		return glow;
@@ -859,47 +882,56 @@ void main() {
 
 	color.rgb *= exposure;
 
-	// Early Tonemap & SRGB Conversion
+	// Single-pass FXAA and pre-tonemap glow.
+
 #ifndef SUBPASS
 	if (bool(params.flags & FLAG_USE_FXAA)) {
 		// FXAA must be performed before glow to preserve the "bleed" effect of glow.
 		color.rgb = do_fxaa(color.rgb, exposure, uv_interp);
 	}
 
-	if (bool(params.flags & FLAG_USE_GLOW) && params.glow_mode == GLOW_MODE_MIX) {
-		vec3 glow = gather_glow(source_glow, uv_interp) * params.luminance_multiplier;
-		if (params.glow_map_strength > 0.001) {
-			glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
+	if (bool(params.flags & FLAG_USE_GLOW) && params.glow_mode != GLOW_MODE_SOFTLIGHT) {
+		vec3 glow = gather_glow(source_glow, uv_interp);
+		if (params.glow_mode == GLOW_MODE_MIX) {
+			if (params.glow_map_strength > 0.001) {
+				glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
+			}
+			color.rgb = mix(color.rgb, glow, params.glow_intensity);
+		} else {
+			glow = glow * params.glow_intensity;
+			if (params.glow_map_strength > 0.001) {
+				glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
+			}
+			color.rgb = apply_glow(color.rgb, glow, params.white);
 		}
-		color.rgb = mix(color.rgb, glow, params.glow_intensity);
 	}
 #endif
 
+	// Tonemap to lower dynamic range.
+
 	color.rgb = apply_tonemapping(color.rgb, params.white);
+
+	// Additional effects.
+
+#ifndef SUBPASS
+	if (bool(params.flags & FLAG_USE_GLOW) && params.glow_mode == GLOW_MODE_SOFTLIGHT) {
+		// Apply soft light after tonemapping to mitigate the issue of discontinuity
+		// at 1.0 and higher. This makes the issue only appear with HDR output that
+		// can exceed a 1.0 output value.
+		vec3 glow = gather_glow(source_glow, uv_interp);
+		glow = glow * params.glow_intensity;
+		if (params.glow_map_strength > 0.001) {
+			glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
+		}
+		glow = apply_tonemapping(glow, params.white);
+		color.rgb = apply_glow(color.rgb, glow, params.white);
+	}
+#endif
 
 	bool convert_to_srgb = bool(params.flags & FLAG_CONVERT_TO_SRGB);
 	if (convert_to_srgb) {
 		color.rgb = linear_to_srgb(color.rgb); // Regular linear -> SRGB conversion.
 	}
-#ifndef SUBPASS
-	// Glow
-	if (bool(params.flags & FLAG_USE_GLOW) && params.glow_mode != GLOW_MODE_MIX) {
-		vec3 glow = gather_glow(source_glow, uv_interp) * params.glow_intensity * params.luminance_multiplier;
-		if (params.glow_map_strength > 0.001) {
-			glow = mix(glow, texture(glow_map, uv_interp).rgb * glow, params.glow_map_strength);
-		}
-
-		// high dynamic range -> SRGB
-		glow = apply_tonemapping(glow, params.white);
-		if (convert_to_srgb) {
-			glow = linear_to_srgb(glow);
-		}
-
-		color.rgb = apply_glow(color.rgb, glow);
-	}
-#endif
-
-	// Additional effects
 
 	if (bool(params.flags & FLAG_USE_BCS)) {
 		color.rgb = apply_bcs(color.rgb, params.bcs);

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -208,7 +208,13 @@ void RendererEnvironmentStorage::environment_set_tonemap(RID p_env, RS::Environm
 	ERR_FAIL_NULL(env);
 	env->exposure = p_exposure;
 	env->tone_mapper = p_tone_mapper;
-	env->white = p_white;
+	if (p_tone_mapper == RS::ENV_TONE_MAPPER_LINEAR) {
+		env->white = 1.0; // With HDR output, this should be the output max value instead.
+	} else if (p_tone_mapper == RS::ENV_TONE_MAPPER_AGX) {
+		env->white = 16.29;
+	} else {
+		env->white = MAX(1.0, p_white); // Glow with screen blend mode does not work when white < 1.0.
+	}
 }
 
 RS::EnvironmentToneMapper RendererEnvironmentStorage::environment_get_tone_mapper(RID p_env) const {
@@ -471,7 +477,7 @@ Vector<float> RendererEnvironmentStorage::environment_get_glow_levels(RID p_env)
 
 float RendererEnvironmentStorage::environment_get_glow_intensity(RID p_env) const {
 	Environment *env = environment_owner.get_or_null(p_env);
-	ERR_FAIL_NULL_V(env, 0.8);
+	ERR_FAIL_NULL_V(env, 0.3);
 	return env->glow_intensity;
 }
 
@@ -495,7 +501,7 @@ float RendererEnvironmentStorage::environment_get_glow_mix(RID p_env) const {
 
 RS::EnvironmentGlowBlendMode RendererEnvironmentStorage::environment_get_glow_blend_mode(RID p_env) const {
 	Environment *env = environment_owner.get_or_null(p_env);
-	ERR_FAIL_NULL_V(env, RS::ENV_GLOW_BLEND_MODE_SOFTLIGHT);
+	ERR_FAIL_NULL_V(env, RS::ENV_GLOW_BLEND_MODE_SCREEN);
 	return env->glow_blend_mode;
 }
 

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -98,11 +98,11 @@ private:
 		// Glow
 		bool glow_enabled = false;
 		Vector<float> glow_levels;
-		float glow_intensity = 0.8;
+		float glow_intensity = 0.3;
 		float glow_strength = 1.0;
 		float glow_bloom = 0.0;
 		float glow_mix = 0.01;
-		RS::EnvironmentGlowBlendMode glow_blend_mode = RS::ENV_GLOW_BLEND_MODE_SOFTLIGHT;
+		RS::EnvironmentGlowBlendMode glow_blend_mode = RS::ENV_GLOW_BLEND_MODE_SCREEN;
 		float glow_hdr_bleed_threshold = 1.0;
 		float glow_hdr_luminance_cap = 12.0;
 		float glow_hdr_bleed_scale = 2.0;


### PR DESCRIPTION
## Upgrading to Godot 4.6
**This PR changed default values for glow effects. To restore similar behaviour of Godot 4.5 and earlier, please refer to the [migration guide](https://docs.godotengine.org/en/latest/tutorials/migrating/upgrading_to_godot_4.6.html#id3) for the old glow default values.**

- Closes godotengine/godot-proposals#13181
- Closes godotengine/godot-proposals#5142
- Closes godotengine/godot-proposals#12528
- Closes #110670
- Closes #107682 (partially)

This PR supersedes:
- #106962
- #52227
- #110239

This PR is related to:
- #110630

# Rationale and screenshots

Rationale and additional screenshots for this PR can be found in godotengine/godot-proposals#13181.

# Summary

## Mobile and Forward+

Mobile and Forward+ now apply glow before the tonemap function, just like the Compatibility renderer, for all blend modes except for soft light. The `white` parameter is now used to normalize screen blend mode.

Notice how blending before tonemapping gives a softer, more realistic blending of the glow effect without hue shifts and harder edges introduced by blending after tonemapping:

Original scene|Before tonemapping (screen, AgX, 16.29 white)|After tonemapping (screen, AgX, 16.29 white)
-|-|-
<img width="1082" height="1119" alt="original-scene" src="https://github.com/user-attachments/assets/065dfa79-64af-4c96-8faf-c42784fcdd71" /> | <img width="1082" height="1119" alt="before-tonemapping" src="https://github.com/user-attachments/assets/bb6789d3-20b4-4b4d-9fe5-3418eb6bc335" />|<img width="1082" height="1119" alt="after-tonemapping" src="https://github.com/user-attachments/assets/8cc7a3f9-3594-4826-a14e-03a95aa12694" />

## Compatibility

As described in the [proposal](https://github.com/godotengine/godot-proposals/issues/13181), this PR applies glow to nonlinear sRGB encoded values in the Compatibility renderer.

Although blending is performed consistently between HDR 2D enabled and disabled, the result is substantially different. I believe this is related to other glow functions and is independent of the purpose of this PR (glow blending).

As a side effect of the new behaviour, #110670 is fixed.

## Defaults

Previously the screen blend mode was the default for Compatibility and the soft light blend mode was used for Mobile and Forward+. This PR changes the default to be screen for all renderers.

I have also included defaults that were suggested in #52227, so this PR fully supersedes this original PR. (co-author added)

### Future work

With [other upcoming glow changes](https://github.com/godotengine/godot/pull/110077) it might make sense to revisit these to ensure default level values are chosen to match Compatibility behaviour if Compatibility behaviour can be made to look acceptable. Or, if Compatibility can not be made to look as good as the other renderers, new defaults may be needed to better match new glow behaviour in Mobile and Forward+.

# Performance

Blending glow before tonemapping improves performance by removing the need for a second tonemapping operation on glow values. Because glow is blended before tonemapping, tonemapping is applied only once to the final scene that includes the glow effect.

I've added mathematical simplifications and optimizations to the screen and soft light blend functions. Please let me know if you believe these should be in a separate PR instead. The soft light optimization comes from #110239. (co-author added)

To help with the performance impact of branching, specialization constants are likely needed in a followup PR for Mobile and Forward+ renderers.

# Notes for reviewers

1. **Tonemap `white` parameter has been restricted to `1.0` and higher! Previously, you could set `white` to be less than `1.0`, but that does not work with this new glow screen blend mode.**
   - If users want to have a tonemap `white` that is less than `1.0`, they should increase tonemap exposure instead. Decreasing tonemap `white` below `1.0` simply doesn't make sense.
2. Should I avoid changing defaults for intensity and levels until #110077 has been implemented?
3. #110701 can be used to try out this glow PR with HDR support and the new HDR AgX tonemapper.

# Comparisons

## Screen blend mode

Renderer | HDR 2D disabled | HDR 2D enabled
-|-|-
Compatibility | <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/8f3d27ab-bdf2-4194-a7ee-8c14ef1a4cc7" />|<img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/688bb872-c707-4891-825b-059daff648e5" />
Mobile | <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/5dc276ce-a747-455d-ae3f-737b374b0eb0" />| <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/37a5b0a4-1313-4190-9a82-25cc9022c219" />
Forward+ | <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/1af26495-ba87-40f8-a47b-4d5823883945" />| <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/550c8895-dc52-40f7-b42a-814e52bcdb44" />
## Soft light blend mode

Renderer | HDR 2D disabled | HDR 2D enabled
-|-|-
Mobile | <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/c6b5569b-3660-4536-b03a-4264d1d88b2a" />| <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/84b32cdf-5d3a-48f6-9f0d-f505c7737269" />
Forward+ | <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/b4fe100c-b3cf-4cd6-be02-ed428c235632" />| <img width="1154" height="687" alt="image" src="https://github.com/user-attachments/assets/deb86680-6089-4298-ae0c-0d748a637a4d" />