### PR TITLE
Add a debug-only guard to detect concurrent calls of cache updating method.

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -164,6 +164,10 @@ private:
 		Ref<SceneState> instance_state;
 		Ref<SceneState> inherited_state;
 
+#ifdef DEBUG_ENABLED
+		mutable bool updating_cache = false;
+#endif
+
 		Node *parent = nullptr;
 		Node *owner = nullptr;
 		HashMap<StringName, Node *> children;
@@ -264,8 +268,8 @@ private:
 
 	Ref<MultiplayerAPI> multiplayer;
 
-	String _get_tree_string_pretty(const String &p_prefix, bool p_last);
-	String _get_tree_string(const Node *p_node);
+	String _get_tree_string_pretty(const String &p_prefix, bool p_last) const;
+	String _get_tree_string(const Node *p_node) const;
 
 	Node *_get_child_by_name(const StringName &p_name) const;
 


### PR DESCRIPTION
Add a guard to protect the children cache from concurrent calls in debug builds.

This avoids using a single `ERR_FAIL_COND_MSG` macro to allow setting a breakpoint directly on the condition and reporting the full stack trace when it triggers, instead of just throwing the error without enough context to reproduce.

Edit: I’d also prefer to use a crash macro so it works without debug symbols or breakpoints.