### PR TITLE
Fix `ResourceLoader.load_threaded_request()` producing partially loaded scripts in some cases

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -61,8 +61,8 @@ class GDScript : public Script {
 	GDCLASS(GDScript, Script);
 	bool tool = false;
 	bool valid = false;
-	bool reloading = false;
 	bool _is_abstract = false;
+	std::atomic<Thread::ID> reloading_thread = 0;
 
 	struct MemberInfo {
 		int index = 0;


### PR DESCRIPTION
Fixes #108054

Allow recursive calls to gdscript->reload() instead of returning OK when reload is called recursively on the same thread even though the script is not (re)loaded properly yet.

This allows resource dependency cycles created by preload() statements, which failed frequently on machines with low core counts.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
