### PR TITLE
Add autoload related getter methods in ProjectSettings

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -59,13 +59,12 @@ public:
 	const static PackedStringArray get_unsupported_features(const PackedStringArray &p_project_features);
 #endif // TOOLS_ENABLED
 
+protected:
 	struct AutoloadInfo {
-		StringName name;
 		String path;
-		bool is_singleton = false;
+		bool is_global_variable = false;
 	};
 
-protected:
 	struct VariantContainer {
 		int order = 0;
 		bool persist = false;
@@ -148,6 +147,8 @@ protected:
 
 	void _add_builtin_input_map();
 
+	Vector<String> _get_autoload_list_bind(bool p_global_variable_only) const;
+
 protected:
 	static void _bind_methods();
 
@@ -209,11 +210,12 @@ public:
 
 	bool has_custom_feature(const String &p_feature) const;
 
-	const HashMap<StringName, AutoloadInfo> &get_autoload_list() const;
-	void add_autoload(const AutoloadInfo &p_autoload);
-	void remove_autoload(const StringName &p_autoload);
-	bool has_autoload(const StringName &p_autoload) const;
-	AutoloadInfo get_autoload(const StringName &p_name) const;
+	// Autoloads are edited via `autoload/*` properties.
+	// This class only manages the data for autoloads. It is not responsible for the corresponding nodes.
+	Vector<StringName> get_autoload_list(bool p_singleton_only) const;
+	String get_autoload_path(const StringName &p_name) const;
+	bool is_autoload_global_variable(const StringName &p_name) const;
+	bool has_autoload(const StringName &p_name) const;
 
 	const HashMap<StringName, String> &get_global_groups_list() const;
 	void add_global_group(const StringName &p_name, const String &p_description);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -61,6 +61,20 @@
 				Clears the whole configuration (not recommended, may break things).
 			</description>
 		</method>
+		<method name="get_autoload_list" qualifiers="const">
+			<return type="PackedStringArray" />
+			<param index="0" name="global_variable_only" type="bool" default="true" />
+			<description>
+				Returns an array of autoload names. If [param global_variable_only] is [code]true[/code], only autoloads with global variable enabled are included.
+			</description>
+		</method>
+		<method name="get_autoload_path" qualifiers="const">
+			<return type="String" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns the file path of the autoload with the given [param name]. Prints an error and returns an empty string if the autoload does not exist.
+			</description>
+		</method>
 		<method name="get_global_class_list">
 			<return type="Dictionary[]" />
 			<description>
@@ -145,12 +159,26 @@
 				[/codeblock]
 			</description>
 		</method>
+		<method name="has_autoload" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if there is an autoload with the given name.
+			</description>
+		</method>
 		<method name="has_setting" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="name" type="String" />
 			<description>
 				Returns [code]true[/code] if a configuration value is present.
 				[b]Note:[/b] In order to be be detected, custom settings have to be either defined with [method set_setting], or exist in the [code]project.godot[/code] file. This is especially relevant when using [method set_initial_value].
+			</description>
+		</method>
+		<method name="is_autoload_global_variable" qualifiers="const">
+			<return type="bool" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Returns [code]true[/code] if there is an autoload with the given name and global variable is enabled for it.
 			</description>
 		</method>
 		<method name="load_resource_pack">

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -140,12 +140,8 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 	}
 
 	/* Autoloads. */
-	HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
-	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-		const ProjectSettings::AutoloadInfo &info = E.value;
-		if (info.is_singleton) {
-			highlighter->add_keyword_color(info.name, usertype_color);
-		}
+	for (const StringName &global_variable_name : ProjectSettings::get_singleton()->get_autoload_list(true)) {
+		highlighter->add_keyword_color(global_variable_name, usertype_color);
 	}
 
 	const ScriptLanguage *scr_lang = script_language;

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1344,12 +1344,9 @@ void ScriptTextEditor::_lookup_symbol(const String &p_symbol, int p_row, int p_c
 				goto_line_centered(result.location - 1);
 			}
 		}
-	} else if (ProjectSettings::get_singleton()->has_autoload(p_symbol)) {
+	} else if (ProjectSettings::get_singleton()->is_autoload_global_variable(p_symbol)) {
 		// Check for Autoload scenes.
-		const ProjectSettings::AutoloadInfo &info = ProjectSettings::get_singleton()->get_autoload(p_symbol);
-		if (info.is_singleton) {
-			EditorNode::get_singleton()->load_scene(info.path);
-		}
+		EditorNode::get_singleton()->load_scene(ProjectSettings::get_singleton()->get_autoload_path(p_symbol));
 	} else if (p_symbol.is_relative_path()) {
 		// Every symbol other than absolute path is relative path so keep this condition at last.
 		String path = _get_absolute_path(p_symbol);
@@ -1370,7 +1367,7 @@ void ScriptTextEditor::_validate_symbol(const String &p_symbol) {
 	ScriptLanguage::LookupResult result;
 	String lc_text = code_editor->get_text_editor()->get_text_for_symbol_lookup();
 	Error lc_error = script->get_language()->lookup_code(lc_text, p_symbol, script->get_path(), base, result);
-	bool is_singleton = ProjectSettings::get_singleton()->has_autoload(p_symbol) && ProjectSettings::get_singleton()->get_autoload(p_symbol).is_singleton;
+	bool is_singleton = ProjectSettings::get_singleton()->is_autoload_global_variable(p_symbol);
 	if (lc_error == OK || is_singleton || ScriptServer::is_global_class(p_symbol) || p_symbol.is_resource_file() || p_symbol.begins_with("uid://")) {
 		text_edit->set_symbol_lookup_word_as_valid(true);
 	} else if (p_symbol.is_relative_path()) {

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -589,10 +589,8 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 }
 
 void GDScriptDocGen::generate_docs(GDScript *p_script, const GDP::ClassNode *p_class) {
-	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
-		if (E.value.is_singleton) {
-			singletons[E.value.path] = E.key;
-		}
+	for (const StringName &global_variable_name : ProjectSettings::get_singleton()->get_autoload_list(true)) {
+		singletons[ProjectSettings::get_singleton()->get_autoload_path(global_variable_name)] = global_variable_name;
 	}
 	_generate_docs(p_script, p_class);
 	singletons.clear();
@@ -600,10 +598,8 @@ void GDScriptDocGen::generate_docs(GDScript *p_script, const GDP::ClassNode *p_c
 
 // This method is needed for the editor, since during autocompletion the script is not compiled, only analyzed.
 void GDScriptDocGen::doctype_from_gdtype(const GDType &p_gdtype, String &r_type, String &r_enum, bool p_is_return) {
-	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
-		if (E.value.is_singleton) {
-			singletons[E.value.path] = E.key;
-		}
+	for (const StringName &global_variable_name : ProjectSettings::get_singleton()->get_autoload_list(true)) {
+		singletons[ProjectSettings::get_singleton()->get_autoload_path(global_variable_name)] = global_variable_name;
 	}
 	_doctype_from_gdtype(p_gdtype, r_type, r_enum, p_is_return);
 	singletons.clear();

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -741,11 +741,8 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 	}
 
 	/* Autoloads. */
-	for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : ProjectSettings::get_singleton()->get_autoload_list()) {
-		const ProjectSettings::AutoloadInfo &info = E.value;
-		if (info.is_singleton) {
-			class_names[info.name] = usertype_color;
-		}
+	for (const StringName &global_variable_name : ProjectSettings::get_singleton()->get_autoload_list(true)) {
+		class_names[global_variable_name] = usertype_color;
 	}
 
 	const GDScriptLanguage *gdscript = GDScriptLanguage::get_singleton();

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -419,8 +419,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
 						// If it's an autoload singleton, we postpone to load it at runtime.
 						// This is so one autoload doesn't try to load another before it's compiled.
-						HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
-						if (autoloads.has(identifier) && autoloads[identifier].is_singleton) {
+						if (ProjectSettings::get_singleton()->is_autoload_global_variable(identifier)) {
 							GDScriptCodeGenerator::Address global = codegen.add_temporary(_gdtype_from_datatype(in->get_datatype(), codegen.script));
 							int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
 							gen->write_store_global(global, idx);

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -123,11 +123,8 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 		case CompletionKind::NODE_PATHS: {
 			{
 				// Autoloads.
-				HashMap<StringName, ProjectSettings::AutoloadInfo> autoloads = ProjectSettings::get_singleton()->get_autoload_list();
-
-				for (const KeyValue<StringName, ProjectSettings::AutoloadInfo> &E : autoloads) {
-					const ProjectSettings::AutoloadInfo &info = E.value;
-					suggestions.push_back(quoted("/root/" + String(info.name)));
+				for (const StringName &autoload_name : ProjectSettings::get_singleton()->get_autoload_list(false)) {
+					suggestions.push_back(quoted("/root/" + String(autoload_name)));
 				}
 			}
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/3705
Partially implements https://github.com/godotengine/godot-proposals/issues/4854
Supersedes https://github.com/godotengine/godot/pull/89198

This PR exposes getter methods to scripting.

Autoload nodes are only created on startup. The editor also tracks autoloads nodes for internal uses, so tool scripts should not touch autoloads data stored in `ProjectSettings`. Currently, to reliably edit singletons in the editor via code, `EditorPlugin.{add,remove}_autoload_singleton()` has to be used.

- Interacting with autoloads no longer needs to interact with the `ProjectSettings::AutoloadInfo` struct.
    - `get_autoload_list()` returns a list of autoload names (optionally passing `true` to only get autoloads with global variable enabled, as it's a very common use case in the editor codebase).
    - `has_autoload()` checks whether an autoload exists.
    - `is_autoload_global_variable()` checks whether an autoload exists and enabled global variable.
    - `get_autoload_path()` returns the corresponding script / scene path.
- Removed `ProjectSettings::{add,remove}_autoload()` internal methods.
    - They are just adding / removing an element to / from the `autoloads` map. https://github.com/godotengine/godot/blob/9dde5688a566775df338df8ae7023cb69b6cfe6d/core/config/project_settings.cpp#L1373-L1381
    - Their names give the false impression that it's already possible to add / remove autoloads at runtime, just not exposed.