### PR TITLE
Add editor option of using mouse middle button to paste from primary clipboard

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1327,6 +1327,9 @@
 		<member name="text_editor/behavior/general/empty_selection_clipboard" type="bool" setter="" getter="">
 			If [code]true[/code], copying or cutting without a selection is performed on all lines with a caret. Otherwise, copy and cut require a selection.
 		</member>
+		<member name="text_editor/behavior/general/middle_mouse_paste" type="bool" setter="" getter="">
+			If [code]true[/code], on Linux/BSD, press mouse middle button to paste from primary clipboard.
+		</member>
 		<member name="text_editor/behavior/indent/auto_indent" type="bool" setter="" getter="">
 			If [code]true[/code], automatically indents code when pressing the [kbd]Enter[/kbd] key based on blocks above the new line.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -775,6 +775,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Behavior
 	// Behavior: General
 	_initial_set("text_editor/behavior/general/empty_selection_clipboard", true);
+	_initial_set("text_editor/behavior/general/middle_mouse_paste", true, true);
 
 	// Behavior: Navigation
 	_initial_set("text_editor/behavior/navigation/move_caret_on_right_click", true, true);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1169,6 +1169,7 @@ void LineEdit::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint() && !is_part_of_edited_scene()) {
+				set_middle_mouse_paste_enabled(EDITOR_GET("text_editor/behavior/general/middle_mouse_paste"));
 				set_caret_blink_enabled(EDITOR_GET("text_editor/appearance/caret/caret_blink"));
 				set_caret_blink_interval(EDITOR_GET("text_editor/appearance/caret/caret_blink_interval"));
 
@@ -2766,6 +2767,7 @@ PopupMenu *LineEdit::get_menu() const {
 
 void LineEdit::_editor_settings_changed() {
 #ifdef TOOLS_ENABLED
+	set_middle_mouse_paste_enabled(EDITOR_GET("text_editor/behavior/general/middle_mouse_paste"));
 	if (!EditorSettings::get_singleton()->check_changed_settings_in_group("text_editor/appearance/caret")) {
 		return;
 	}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -44,6 +44,10 @@
 #include "scene/main/window.h"
 #include "scene/theme/theme_db.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/settings/editor_settings.h"
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////
 ///                            TEXT                                         ///
 ///////////////////////////////////////////////////////////////////////////////
@@ -730,6 +734,12 @@ void TextEdit::_accessibility_action_scroll_into_view(const Variant &p_data, int
 	}
 }
 
+#ifdef TOOLS_ENABLED
+void TextEdit::_editor_settings_changed() {
+	set_middle_mouse_paste_enabled(EDITOR_GET("text_editor/behavior/general/middle_mouse_paste"));
+}
+#endif
+
 void TextEdit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_EXIT_TREE:
@@ -840,6 +850,14 @@ void TextEdit::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
+#ifdef TOOLS_ENABLED
+			if (Engine::get_singleton()->is_editor_hint() && !is_part_of_edited_scene()) {
+				set_middle_mouse_paste_enabled(EDITOR_GET("text_editor/behavior/general/middle_mouse_paste"));
+				if (!EditorSettings::get_singleton()->is_connected("settings_changed", callable_mp(this, &TextEdit::_editor_settings_changed))) {
+					EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextEdit::_editor_settings_changed));
+				}
+			}
+#endif
 			_update_caches();
 			if (caret_pos_dirty) {
 				callable_mp(this, &TextEdit::_emit_caret_changed).call_deferred();

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -686,6 +686,10 @@ private:
 	void _move_caret_document_end(bool p_select);
 	bool _clear_carets_and_selection();
 
+#ifdef TOOLS_ENABLED
+	void _editor_settings_changed();
+#endif
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();


### PR DESCRIPTION
Implement https://github.com/godotengine/godot-proposals/issues/6450

LineEdit and TextEdit have already implemented switches of middle button paste. This patch adds an option under 'Text Editor/Behavior/General' in Editor Settings to utilize those switches.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
