### PR TITLE
Use correct screen-space to ndc equation in Compatibility refraction

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1813,7 +1813,8 @@ void fragment() {)";
 	float ref_amount = 1.0 - albedo.a * albedo_tex.a;
 
 	float refraction_depth_tex = textureLod(depth_texture, ref_ofs, 0.0).r;
-	vec4 refraction_view_pos = INV_PROJECTION_MATRIX * vec4(SCREEN_UV * 2.0 - 1.0, refraction_depth_tex, 1.0);
+	vec4 ndc = OUTPUT_IS_SRGB ? vec4(vec3(SCREEN_UV, refraction_depth_tex) * 2.0 - 1.0, 1.0) : vec4(SCREEN_UV * 2.0 - 1.0, refraction_depth_tex, 1.0);
+	vec4 refraction_view_pos = INV_PROJECTION_MATRIX * ndc;
 	refraction_view_pos.xyz /= refraction_view_pos.w;
 
 	// If the depth buffer is lower then the model's Z position, use the refracted UV, otherwise use the normal screen UV.


### PR DESCRIPTION
Converting from screen-space coordinates to ndcs use a different equation in OpenGL as compared to Vulkan. This incorrect equation breaks refraction in Compatibility.

Closes https://github.com/godotengine/godot/issues/106213