### PR TITLE
Remove `RBSet` usage in `RotatedFileLogger::clear_old_backups`

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -116,23 +116,24 @@ void RotatedFileLogger::clear_old_backups() {
 
 	da->list_dir_begin();
 	String f = da->get_next();
-	// backups is a RBSet because it guarantees that iterating on it is done in sorted order.
-	// RotatedFileLogger depends on this behavior to delete the oldest log file first.
-	RBSet<String> backups;
+	// RotatedFileLogger depends on backups being sorted to delete the oldest log file first.
+	// We sort backups before removal.
+	LocalVector<String> backups;
 	while (!f.is_empty()) {
 		if (!da->current_is_dir() && f.begins_with(basename) && f.get_extension() == extension && f != base_path.get_file()) {
-			backups.insert(f);
+			backups.push_back(f);
 		}
 		f = da->get_next();
 	}
 	da->list_dir_end();
 
-	if (backups.size() > max_backups) {
-		// since backups are appended with timestamp and Set iterates them in sorted order,
+	if ((int)backups.size() > max_backups) {
+		// since backups are appended with timestamp, after sorting,
 		// first backups are the oldest
+		backups.sort();
 		int to_delete = backups.size() - max_backups;
-		for (RBSet<String>::Element *E = backups.front(); E && to_delete > 0; E = E->next(), --to_delete) {
-			da->remove(E->get());
+		for (uint32_t i = 0; i < backups.size() && to_delete > 0; i++, --to_delete) {
+			da->remove(backups[i]);
 		}
 	}
 }


### PR DESCRIPTION
The use of `RBSet` here is unnecessary, because we only want an ordered sequence during iteration, which can be fully achieved by explicitly sorting before iteration. The time complexity is the same, and `LocalVector` also has some advantages in terms of cache locality. At the same time, the code’s intent becomes clearer (we need to sort before deletion).

Issues with ordering have caused bugs in the past, and #98216 added unit tests for this. Therefore, as long as CI does not complain, the correctness of this change can be guaranteed.

