### PR TITLE
Add support for system window menu popup

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1432,6 +1432,11 @@ void DisplayServerWayland::window_start_resize(WindowResizeEdge p_edge, WindowID
 	wayland_thread.window_start_resize(p_edge, p_window);
 }
 
+void DisplayServerWayland::window_show_system_menu(WindowID p_window) {
+	MutexLock mutex_lock(wayland_thread.mutex);
+	wayland_thread.window_show_system_menu(p_window);
+}
+
 void DisplayServerWayland::cursor_set_shape(CursorShape p_shape) {
 	ERR_FAIL_INDEX(p_shape, CURSOR_MAX);
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -321,6 +321,7 @@ public:
 
 	virtual void window_start_drag(WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_start_resize(WindowResizeEdge p_edge, WindowID p_window) override;
+	virtual void window_show_system_menu(WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -3800,6 +3800,22 @@ void WaylandThread::window_start_resize(DisplayServer::WindowResizeEdge p_edge, 
 #endif
 }
 
+void WaylandThread::window_show_system_menu(DisplayServer::WindowID p_window) {
+	ERR_FAIL_COND(!windows.has(p_window));
+
+	WindowState &ws = windows[p_window];
+	SeatState *ss = wl_seat_get_seat_state(wl_seat_current);
+	if (ws.wl_surface && ws.xdg_toplevel) {
+		xdg_toplevel_show_window_menu(ws.xdg_toplevel, wl_seat_current, ss->pointer_data.button_serial, ss->pointer_data.position.x, ss->pointer_data.position.y);
+	}
+
+#ifdef LIBDECOR_ENABLED
+	if (ws.libdecor_frame) {
+		libdecor_frame_show_window_menu(ws.libdecor_frame, wl_seat_current, ss->pointer_data.button_serial, ss->pointer_data.position.x, ss->pointer_data.position.y);
+	}
+#endif
+}
+
 void WaylandThread::window_set_parent(DisplayServer::WindowID p_window_id, DisplayServer::WindowID p_parent_id) {
 	ERR_FAIL_COND(!windows.has(p_window_id));
 	ERR_FAIL_COND(!windows.has(p_parent_id));

--- a/platform/linuxbsd/wayland/wayland_thread.h
+++ b/platform/linuxbsd/wayland/wayland_thread.h
@@ -1033,6 +1033,7 @@ public:
 	WindowState *window_get_state(DisplayServer::WindowID p_window_id);
 
 	void window_start_resize(DisplayServer::WindowResizeEdge p_edge, DisplayServer::WindowID p_window);
+	virtual void window_show_system_menu(WindowID p_window = MAIN_WINDOW_ID) override;
 
 	void window_set_max_size(DisplayServer::WindowID p_window_id, const Size2i &p_size);
 	void window_set_min_size(DisplayServer::WindowID p_window_id, const Size2i &p_size);

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -547,6 +547,7 @@ public:
 
 	virtual void window_start_drag(WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_start_resize(WindowResizeEdge p_edge, WindowID p_window) override;
+	virtual void window_show_system_menu(WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual Error embed_process(WindowID p_window, OS::ProcessID p_pid, const Rect2i &p_rect, bool p_visible, bool p_grab_focus) override;
 	virtual Error request_close_embedded_process(OS::ProcessID p_pid) override;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4354,6 +4354,25 @@ void DisplayServerWindows::window_start_resize(WindowResizeEdge p_edge, WindowID
 	}
 }
 
+void DisplayServerWindows::window_show_system_menu(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
+	ERR_FAIL_COND(!windows.has(p_window));
+	WindowData &wd = windows[p_window];
+	HMENU system_menu = GetSystemMenu(wd.hWnd, false);
+
+	POINT coords;
+	GetCursorPos(&coords);
+
+	// Retrieve menu identifier for later.
+	int menu_ident = TrackPopupMenu(system_menu, TPM_LEFTALIGN | TPM_TOPALIGN, coords.x, coords.y, 0, wd.hWnd, 0);
+
+	if (menu_ident != 0) {
+		SendMessage(wd.hWnd, WM_SYSCOMMAND, menu_ident, 0);
+	}
+
+}
+
 void DisplayServerWindows::set_context(Context p_context) {
 }
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -662,6 +662,7 @@ public:
 
 	virtual void window_start_drag(WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual void window_start_resize(WindowResizeEdge p_edge, WindowID p_window = MAIN_WINDOW_ID) override;
+	virtual void window_show_system_menu(WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -1475,6 +1475,7 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("window_start_drag", "window_id"), &DisplayServer::window_start_drag, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_start_resize", "edge", "window_id"), &DisplayServer::window_start_resize, DEFVAL(MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("window_show_system_menu", "window_id"), &DisplayServer::window_show_system_menu, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("accessibility_should_increase_contrast"), &DisplayServer::accessibility_should_increase_contrast);
 	ClassDB::bind_method(D_METHOD("accessibility_should_reduce_animation"), &DisplayServer::accessibility_should_reduce_animation);

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -539,6 +539,8 @@ public:
 
 	virtual void window_start_resize(WindowResizeEdge p_edge, WindowID p_window = MAIN_WINDOW_ID) {}
 
+	virtual void window_show_system_menu(WindowID p_window = MAIN_WINDOW_ID) {}
+
 	// Accessibility.
 
 	enum AccessibilityMode {


### PR DESCRIPTION
The system window popup menu has been implemented. For applications with custom title bars this can be especially useful, to act similarly to real system bars.

To use, simply execute `DisplayServer.window_show_system_menu()`. 

On Windows, it uses `GetSystemMenu`. On Linux on Wayland, it uses libdecor's implementation, or `xdg_toplevel`'s. On X11 it sends a `_GTK_SHOW_WINDOW_MENU` event, although no GTK is used under the hood.

(excuse the train wallpapers)

Linux (Wayland)

[Screencast_20250919_022019.webm](https://github.com/user-attachments/assets/d587a465-2c20-40be-857c-d635338184c9)

Linux (X11 via XWayland)

[Screencast_20250919_021843.webm](https://github.com/user-attachments/assets/f078ea44-0681-4d2e-884c-37834dc23857)

Windows

https://github.com/user-attachments/assets/64eeff6c-d3bb-4efc-9a40-87392ccc8573

* *Bugsquad edit, closes: https://github.com/godotengine/godot-proposals/issues/13217*