### PR TITLE
SCons: Fix Windows `silence_msvc` logfile encoding

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -316,7 +316,7 @@ def configure_msvc(env: "SConsEnvironment"):
                 if not caught and (is_cl and re_cl_capture.match(line)) or (not is_cl and re_link_capture.match(line)):
                     caught = True
                     try:
-                        with open(capture_path, "a", encoding=sys.stdout.encoding) as log:
+                        with open(capture_path, "a", encoding=sys.stdout.encoding, errors="replace") as log:
                             log.write(line + "\n")
                     except OSError:
                         print_warning(f'Failed to log captured line: "{line}".')


### PR DESCRIPTION
When building Godot's source code in a Japanese-language Visual Studio 2022 environment, the build failed due to differences in character encoding between CP932 and Unicode.
This commit resolves the issue, allowing the build to complete successfully.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
