### PR TITLE
Add `GDSOFTCLASS` to `NetSocket`

### DIFF
--- a/core/io/net_socket.h
+++ b/core/io/net_socket.h
@@ -34,6 +34,8 @@
 #include "core/object/ref_counted.h"
 
 class NetSocket : public RefCounted {
+	GDSOFTCLASS(NetSocket, RefCounted);
+
 protected:
 	static NetSocket *(*_create)();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Further to bug-report #110693, which is blocking #102064, this PR adds `GDSOFTCLASS` to `NetSocket`.

