### PR TITLE
Physics material presets

### DIFF
--- a/doc/classes/PhysicsMaterial.xml
+++ b/doc/classes/PhysicsMaterial.xml
@@ -9,6 +9,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="preset" type="int" setter="set_preset" getter="get_preset" default="0">
+			Default values for friction and bounce. Approximates real life materials.
+		</member>
 		<member name="absorbent" type="bool" setter="set_absorbent" getter="is_absorbent" default="false">
 			If [code]true[/code], subtracts the bounciness from the colliding object's bounciness instead of adding it.
 		</member>
@@ -23,4 +26,42 @@
 			If [code]true[/code], the physics engine will use the friction of the object marked as "rough" when two objects collide. If [code]false[/code], the physics engine will use the lowest friction of all colliding objects instead. If [code]true[/code] for both colliding objects, the physics engine will use the highest friction.
 		</member>
 	</members>
+	<constants>
+		<constant name="PRESET_GENERIC" value="0" enum="preset">
+			Friction is 0.8 and bounce is 0.8 - approximates a rubber material.
+		</constant>
+		<constant name="PRESET_BRICK" value="1" enum="preset">
+			Friction is 0.6 and bounce is 0.05
+		</constant>
+		<constant name="PRESET_CONCRETE" value="2" enum="preset">
+			Friction is 0.65 and bounce is 0.1
+		</constant>
+		<constant name="PRESET_CERAMIC" value="3" enum="preset">
+			Friction is 0.15 and bounce is 0.7
+		</constant>
+		<constant name="PRESET_GRAVEL" value="4" enum="preset">
+			Friction is 0.7 and bounce is 0.15
+		</constant>
+		<constant name="PRESET_CARPET" value="5" enum="preset">
+			Friction is 0.8 and bounce is 0.05
+		</constant>
+		<constant name="PRESET_GLASS" value="6" enum="preset">
+			Friction is 0.2 and bounce is 0.6
+		</constant>
+		<constant name="PRESET_PLASTER" value="7" enum="preset">
+			Friction is 0.55 and bounce is 0.25
+		</constant>
+		<constant name="PRESET_WOOD" value="8" enum="preset">
+			Friction is 0.45 and bounce is 0.15
+		</constant>
+		<constant name="PRESET_METAL" value="9" enum="preset">
+			Friction is 0.6 and bounce is 0.1
+		</constant>
+		<constant name="PRESET_ROCK" value="10" enum="preset">
+			Friction is 0.7 and bounce is 0.2
+		</constant>
+		<constant name="PRESET_CUSTOM" value="11" enum="preset">
+			No default settings. If changes are made to other presets the [member preset] is changed to [code skip-lint]PRESET_CUSTOM[/code].
+		</constant>
+	</constants>
 </class>

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -152,7 +152,5 @@ void PhysicsMaterial::set_absorbent(bool p_val) {
 
 PhysicsMaterial::PhysicsMaterial() {
 	preset = PRESET_GENERIC;
-	friction = 0.8;
-	bounce = 0.8;
 }
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -151,6 +151,6 @@ void PhysicsMaterial::set_absorbent(bool p_val) {
 }
 
 PhysicsMaterial::PhysicsMaterial() {
-	preset = static_cast<Preset>(PRESET_GENERIC);
+	set_preset(PRESET_GENERIC);
 }
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -32,6 +32,9 @@
 
 #if !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)
 void PhysicsMaterial::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_preset", "preset"), &PhysicsMaterial::set_preset);
+	ClassDB::bind_method(D_METHOD("get_preset"), &PhysicsMaterial::get_preset);
+
 	ClassDB::bind_method(D_METHOD("set_friction", "friction"), &PhysicsMaterial::set_friction);
 	ClassDB::bind_method(D_METHOD("get_friction"), &PhysicsMaterial::get_friction);
 
@@ -48,25 +51,105 @@ void PhysicsMaterial::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rough"), "set_rough", "is_rough");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bounce", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_bounce", "get_bounce");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "absorbent"), "set_absorbent", "is_absorbent");
+
+	BIND_ENUM_CONSTANT(PRESET_GENERIC);
+	BIND_ENUM_CONSTANT(PRESET_BRICK);
+	BIND_ENUM_CONSTANT(PRESET_CONCRETE);
+	BIND_ENUM_CONSTANT(PRESET_CERAMIC);
+	BIND_ENUM_CONSTANT(PRESET_GRAVEL);
+	BIND_ENUM_CONSTANT(PRESET_CARPET);
+	BIND_ENUM_CONSTANT(PRESET_GLASS);
+	BIND_ENUM_CONSTANT(PRESET_PLASTER);
+	BIND_ENUM_CONSTANT(PRESET_WOOD);
+	BIND_ENUM_CONSTANT(PRESET_METAL);
+	BIND_ENUM_CONSTANT(PRESET_ROCK);
+	BIND_ENUM_CONSTANT(PRESET_CUSTOM);
+}
+
+void PhysicsMaterial::set_preset(Preset p_preset) {
+	if (preset == p_preset && p_preset != PRESET_CUSTOM) {
+		return;
+	}
+	preset = static_cast<Preset>(p_preset);
+	switch (p_preset) {
+		case PRESET_GENERIC:
+			friction = 0.8;
+			bounce = 0.8;
+			break;
+		case PRESET_BRICK:
+			friction = 0.6;
+			bounce = 0.05;
+			break;
+		case PRESET_CONCRETE:
+			friction = 0.65;
+			bounce = 0.1;
+			break;
+		case PRESET_CERAMIC:
+			friction = 0.15;
+			bounce = 0.7;
+			break;
+		case PRESET_GRAVEL:
+			friction = 0.7;
+			bounce = 0.15;
+			break;
+		case PRESET_CARPET:
+			friction = 0.8;
+			bounce = 0.05;
+			break;
+		case PRESET_GLASS:
+			friction = 0.2;
+			bounce = 0.6;
+			break;
+		case PRESET_PLASTER:
+			friction = 0.55;
+			bounce = 0.25;
+			break;
+		case PRESET_WOOD:
+			friction = 0.45;
+			bounce = 0.15;
+			break;
+		case PRESET_METAL:
+			friction = 0.6;
+			bounce = 0.1;
+			break;
+		case PRESET_ROCK:
+			friction = 0.7;
+			bounce = 0.2;
+			break;
+		case PRESET_CUSTOM:
+			break;
+		default:
+			set_preset(PRESET_CUSTOM);
+			break;
+	}
+	emit_changed();
 }
 
 void PhysicsMaterial::set_friction(real_t p_val) {
 	friction = p_val;
+	preset = static_cast<Preset>(PRESET_CUSTOM);
 	emit_changed();
 }
 
 void PhysicsMaterial::set_rough(bool p_val) {
 	rough = p_val;
+	preset = static_cast<Preset>(PRESET_CUSTOM);
 	emit_changed();
 }
 
 void PhysicsMaterial::set_bounce(real_t p_val) {
 	bounce = p_val;
+	preset = static_cast<Preset>(PRESET_CUSTOM);
 	emit_changed();
 }
 
 void PhysicsMaterial::set_absorbent(bool p_val) {
 	absorbent = p_val;
+	preset = static_cast<Preset>(PRESET_CUSTOM);
 	emit_changed();
+}
+
+PhysicsMaterial::PhysicsMaterial() {
+	preset = static_cast<Preset>(PRESET_GENERIC);
 }
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -47,6 +47,7 @@ void PhysicsMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_absorbent", "absorbent"), &PhysicsMaterial::set_absorbent);
 	ClassDB::bind_method(D_METHOD("is_absorbent"), &PhysicsMaterial::is_absorbent);
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "preset", PROPERTY_HINT_ENUM, "Generic,Brick,Concrete,Ceramic,Gravel,Carpet,Glass,Plaster,Wood,Metal,Rock,Custom"), "set_preset", "get_preset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "friction", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_friction", "get_friction");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rough"), "set_rough", "is_rough");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bounce", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_bounce", "get_bounce");

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -74,8 +74,8 @@ void PhysicsMaterial::set_preset(Preset p_preset) {
 	preset = static_cast<Preset>(p_preset);
 	switch (p_preset) {
 		case PRESET_GENERIC:
-			friction = 0.8;
-			bounce = 0.8;
+			friction = 1.0;
+			bounce = 0.0;
 			break;
 		case PRESET_BRICK:
 			friction = 0.6;

--- a/scene/resources/physics_material.cpp
+++ b/scene/resources/physics_material.cpp
@@ -151,6 +151,8 @@ void PhysicsMaterial::set_absorbent(bool p_val) {
 }
 
 PhysicsMaterial::PhysicsMaterial() {
-	set_preset(PRESET_GENERIC);
+	preset = PRESET_GENERIC;
+	friction = 0.8;
+	bounce = 0.8;
 }
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)

--- a/scene/resources/physics_material.h
+++ b/scene/resources/physics_material.h
@@ -38,15 +38,35 @@ class PhysicsMaterial : public Resource {
 	OBJ_SAVE_TYPE(PhysicsMaterial);
 	RES_BASE_EXTENSION("phymat");
 
+enum Preset {
+	PRESET_GENERIC,
+	PRESET_BRICK,
+	PRESET_CONCRETE,
+	PRESET_CERAMIC,
+	PRESET_GRAVEL,
+	PRESET_CARPET,
+	PRESET_GLASS,
+	PRESET_PLASTER,
+	PRESET_WOOD,
+	PRESET_METAL,
+	PRESET_ROCK,
+	PRESET_CUSTOM
+};
+
+private:
 	real_t friction = 1.0;
 	bool rough = false;
 	real_t bounce = 0.0;
 	bool absorbent = false;
 
+	Preset preset;
 protected:
 	static void _bind_methods();
 
 public:
+	void set_preset(Preset p_preset);
+	Preset get_preset() const { return preset; }
+
 	void set_friction(real_t p_val);
 	_FORCE_INLINE_ real_t get_friction() const { return friction; }
 
@@ -66,5 +86,9 @@ public:
 	_FORCE_INLINE_ real_t computed_bounce() const {
 		return absorbent ? -bounce : bounce;
 	}
+
+	PhysicsMaterial();
 };
+
+VARIANT_ENUM_CAST(PhysicsMaterial::Preset);
 #endif // !defined(PHYSICS_2D_DISABLED) || !defined(PHYSICS_3D_DISABLED)

--- a/scene/resources/physics_material.h
+++ b/scene/resources/physics_material.h
@@ -38,20 +38,20 @@ class PhysicsMaterial : public Resource {
 	OBJ_SAVE_TYPE(PhysicsMaterial);
 	RES_BASE_EXTENSION("phymat");
 
-enum Preset {
-	PRESET_GENERIC,
-	PRESET_BRICK,
-	PRESET_CONCRETE,
-	PRESET_CERAMIC,
-	PRESET_GRAVEL,
-	PRESET_CARPET,
-	PRESET_GLASS,
-	PRESET_PLASTER,
-	PRESET_WOOD,
-	PRESET_METAL,
-	PRESET_ROCK,
-	PRESET_CUSTOM
-};
+	enum Preset {
+		PRESET_GENERIC,
+		PRESET_BRICK,
+		PRESET_CONCRETE,
+		PRESET_CERAMIC,
+		PRESET_GRAVEL,
+		PRESET_CARPET,
+		PRESET_GLASS,
+		PRESET_PLASTER,
+		PRESET_WOOD,
+		PRESET_METAL,
+		PRESET_ROCK,
+		PRESET_CUSTOM
+	};
 
 private:
 	real_t friction = 1.0;
@@ -60,6 +60,7 @@ private:
 	bool absorbent = false;
 
 	Preset preset;
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Added PhysicsMaterial presets for developers wanting preset values for known materials.

Only known issue is that when PhysicsMaterial is initialized it will consider itself as PRESET_GENERIC but doesn't apply values and is being looked into. Otherwise, switching between presets works and should give a close enough approximation to their declared materials for collisions.

https://github.com/godotengine/godot-proposals/issues/13220