### PR TITLE
Fix XR tracker name changing at runtime

### DIFF
--- a/scene/3d/xr/xr_body_modifier_3d.cpp
+++ b/scene/3d/xr/xr_body_modifier_3d.cpp
@@ -66,6 +66,10 @@ StringName XRBodyModifier3D::get_body_tracker() const {
 
 void XRBodyModifier3D::set_body_update(BitField<BodyUpdate> p_body_update) {
 	body_update = p_body_update;
+
+	if (is_inside_tree()) {
+		_get_joint_data();
+	}
 }
 
 BitField<XRBodyModifier3D::BodyUpdate> XRBodyModifier3D::get_body_update() const {

--- a/scene/3d/xr/xr_face_modifier_3d.cpp
+++ b/scene/3d/xr/xr_face_modifier_3d.cpp
@@ -504,6 +504,10 @@ void XRFaceModifier3D::_bind_methods() {
 
 void XRFaceModifier3D::set_face_tracker(const StringName &p_tracker_name) {
 	tracker_name = p_tracker_name;
+
+	if (is_inside_tree()) {
+		_get_blend_data();
+	}
 }
 
 StringName XRFaceModifier3D::get_face_tracker() const {

--- a/scene/3d/xr/xr_hand_modifier_3d.cpp
+++ b/scene/3d/xr/xr_hand_modifier_3d.cpp
@@ -50,6 +50,10 @@ void XRHandModifier3D::_bind_methods() {
 
 void XRHandModifier3D::set_hand_tracker(const StringName &p_tracker_name) {
 	tracker_name = p_tracker_name;
+
+	if (is_inside_tree()) {
+		_get_joint_data();
+	}
 }
 
 StringName XRHandModifier3D::get_hand_tracker() const {


### PR DESCRIPTION
I noticed this issue with `XRHandModifier3D` when working on my recent [jam game](https://dsnopek.itch.io/rock-paper-infinity).

`XRHandModifier3D` will work great if you set the `hand_tracker` to the tracker name before it's added to the scene tree, but if you change it later, it will have no effect - it'll just keep using the old tracker.

Looking at `XRBodyModifier3D` and `XRFaceModifier3D`, they appear to have the same problem as well.