### PR TITLE
Add `reserve()` to `Dictionary`, apply to constructors on GDScript VM

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -299,6 +299,12 @@ void Dictionary::_ref(const Dictionary &p_from) const {
 	_p = p_from._p;
 }
 
+void Dictionary::reserve(int p_new_capacity) {
+	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
+	ERR_FAIL_COND_MSG(p_new_capacity < 0, "New capacity must be non-negative.");
+	_p->variant_map.reserve(p_new_capacity);
+}
+
 void Dictionary::clear() {
 	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
 	_p->variant_map.clear();
@@ -607,6 +613,7 @@ Dictionary Dictionary::recursive_duplicate(bool p_deep, ResourceDeepDuplicateMod
 		return n;
 	}
 
+	n.reserve(_p->variant_map.size());
 	if (p_deep) {
 		bool is_call_chain_end = recursion_count == 0;
 

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -74,6 +74,7 @@ public:
 
 	int size() const;
 	bool is_empty() const;
+	void reserve(int p_new_capacity);
 	void clear();
 	void sort();
 	void merge(const Dictionary &p_dictionary, bool p_overwrite = false);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1829,7 +1829,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				int argc = _code_ptr[ip + 1];
 				Dictionary dict;
-
+				dict.reserve(argc);
 				for (int i = 0; i < argc; i++) {
 					GET_INSTRUCTION_ARG(k, i * 2 + 0);
 					GET_INSTRUCTION_ARG(v, i * 2 + 1);
@@ -1867,7 +1867,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				Dictionary dict;
 				dict.set_typed(key_builtin_type, key_native_type, *key_script_type, value_builtin_type, value_native_type, *value_script_type);
-
+				dict.reserve(argc);
 				for (int i = 0; i < argc; i++) {
 					GET_INSTRUCTION_ARG(k, i * 2 + 0);
 					GET_INSTRUCTION_ARG(v, i * 2 + 1);


### PR DESCRIPTION
`HashMap` has a `reserve()` function, so I thought: why not expose it to `Dictionary` considering `CowData`/`Vector`'s `reserve()` is exposed to `Array`? There is a lot of places within the engine we could use it to reduce bottleneck.

Additionally, implementing is quite simple since all needed is to call the `HashMap`'s own `reserve()`, much like how `clear()` in `Dictionary` is mostly a wrapper to its internal `HashMap`'s `clear()`.

While looking for a candidate for a stress test, I noticed in the GDScript VM that the constructor for both untyped and typed `Dictionary` uses a for loop with known final size, so that was possibly the best one. The test I wrote consists in declaring a `Dictionary` with 63 elements mid-function 2²¹ times.

<details>
<summary><strong>Script</strong></summary>
<br>

```gdscript
extends Node


func _ready() -> void:
	benchmark_untyped()
	benchmark_typed()


func benchmark_untyped() -> void:
	var time_start := Time.get_ticks_usec()
	for i in pow(2, 21):
		var x := {
			1: 1,
			2: 2,
			3: 4,
			4: 8,
			5: 16,
			6: 32,
			7: 64,
			8: 128,
			9: 256,
			10: 512,
			11: 1024,
			12: 2048,
			13: 4096,
			14: 8192,
			15: 16384,
			16: 32768,
			17: 65536,
			18: 131072,
			19: 262144,
			20: 524288,
			21: 1048576,
			22: 2097152,
			23: 4194304,
			24: 8388608,
			25: 16777216,
			26: 33554432,
			27: 67108864,
			28: 134217728,
			29: 268435456,
			30: 536870912,
			31: 1073741824,
			32: 2147483648,
			33: 4294967296,
			34: 8589934592,
			35: 17179869184,
			36: 34359738368,
			37: 68719476736,
			38: 137438953472,
			39: 274877906944,
			40: 549755813888,
			41: 1099511627776,
			42: 2199023255552,
			43: 4398046511104,
			44: 8796093022208,
			45: 17592186044416,
			46: 35184372088832,
			47: 70368744177664,
			48: 140737488355328,
			49: 281474976710656,
			50: 562949953421312,
			51: 1125899906842624,
			52: 2251799813685248,
			53: 4503599627370496,
			54: 9007199254740992,
			55: 18014398509481984,
			56: 36028797018963968,
			57: 72057594037927936,
			58: 144115188075855872,
			59: 288230376151711744,
			60: 576460752303423488,
			61: 1152921504606846976,
			62: 2305843009213693952,
			63: 4611686018427387904,
		}
	var time_end := Time.get_ticks_usec()
	print("time untyped: %dms" % ((time_end - time_start) / 1000))


func benchmark_typed() -> void:
	var time_start := Time.get_ticks_usec()
	for i in pow(2, 21):
		var x: Dictionary[int, int] = {
			1: 1,
			2: 2,
			3: 4,
			4: 8,
			5: 16,
			6: 32,
			7: 64,
			8: 128,
			9: 256,
			10: 512,
			11: 1024,
			12: 2048,
			13: 4096,
			14: 8192,
			15: 16384,
			16: 32768,
			17: 65536,
			18: 131072,
			19: 262144,
			20: 524288,
			21: 1048576,
			22: 2097152,
			23: 4194304,
			24: 8388608,
			25: 16777216,
			26: 33554432,
			27: 67108864,
			28: 134217728,
			29: 268435456,
			30: 536870912,
			31: 1073741824,
			32: 2147483648,
			33: 4294967296,
			34: 8589934592,
			35: 17179869184,
			36: 34359738368,
			37: 68719476736,
			38: 137438953472,
			39: 274877906944,
			40: 549755813888,
			41: 1099511627776,
			42: 2199023255552,
			43: 4398046511104,
			44: 8796093022208,
			45: 17592186044416,
			46: 35184372088832,
			47: 70368744177664,
			48: 140737488355328,
			49: 281474976710656,
			50: 562949953421312,
			51: 1125899906842624,
			52: 2251799813685248,
			53: 4503599627370496,
			54: 9007199254740992,
			55: 18014398509481984,
			56: 36028797018963968,
			57: 72057594037927936,
			58: 144115188075855872,
			59: 288230376151711744,
			60: 576460752303423488,
			61: 1152921504606846976,
			62: 2305843009213693952,
			63: 4611686018427387904,
		}
	var time_end := Time.get_ticks_usec()
	print("time typed: %dms" % ((time_end - time_start) / 1000))
```

</details>

I made two template release builds, with and without this PR, and ran the script.

Before:
```
time untyped: 4858ms
time typed: 5390ms
```

After
```
time untyped: 4420ms
time typed: 4810ms
```

There are countless places where `reserve()` could be used, so this is just a beginning.