### PR TITLE
Add Editor Description property to Resources

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -115,6 +115,14 @@ void Resource::set_path_cache(const String &p_path) {
 	GDVIRTUAL_CALL(_set_path_cache, p_path);
 }
 
+void Resource::set_editor_description(const String &p_editor_description) {
+	editor_description = p_editor_description;
+}
+
+String Resource::get_editor_description() const {
+	return editor_description;
+}
+
 static thread_local RandomPCG unique_id_gen = RandomPCG(0);
 
 void Resource::seed_scene_unique_id(uint32_t p_seed) {
@@ -712,6 +720,20 @@ String Resource::get_id_for_path(const String &p_referrer_path) const {
 #endif
 }
 
+void Resource::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "editor_description") {
+		if (is_built_in()) {
+			// For sub resources, we store editor description directly in the property map.
+			// As we don't need to show the tooltip when it is not loaded, this simplifies implementation.
+			p_property.usage |= PROPERTY_USAGE_STORAGE;
+			// Therefore, every resource that can be stored as a sub resource automatically supports editor descriptions,
+			// as they will always be serialized with ResourceSaverText or ResourceSaverBinary, depending on the scene or resource owning them.
+		} else if (!ResourceLoader::has_editor_description_support(get_path())) {
+			p_property.usage = PROPERTY_USAGE_NONE;
+		}
+	}
+}
+
 void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_path", "path"), &Resource::_set_path);
 	ClassDB::bind_method(D_METHOD("take_over_path", "path"), &Resource::_take_over_path);
@@ -730,6 +752,9 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_id_for_path", "path"), &Resource::get_id_for_path);
 
 	ClassDB::bind_method(D_METHOD("is_built_in"), &Resource::is_built_in);
+
+	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Resource::set_editor_description);
+	ClassDB::bind_method(D_METHOD("get_editor_description"), &Resource::get_editor_description);
 
 	ClassDB::bind_static_method("Resource", D_METHOD("generate_scene_unique_id"), &Resource::generate_scene_unique_id);
 	ClassDB::bind_method(D_METHOD("set_scene_unique_id", "id"), &Resource::set_scene_unique_id);
@@ -754,6 +779,9 @@ void Resource::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_path", "get_path");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_name"), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_scene_unique_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_scene_unique_id", "get_scene_unique_id");
+
+	ADD_GROUP("Editor Description", "editor_");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR), "set_editor_description", "get_editor_description");
 
 	GDVIRTUAL_BIND(_setup_local_to_scene);
 	GDVIRTUAL_BIND(_get_rid);

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -79,6 +79,7 @@ private:
 	uint64_t import_last_modified_time = 0;
 	String import_path;
 #endif
+	String editor_description;
 
 	enum EmitChangedState {
 		EMIT_CHANGED_UNBLOCKED,
@@ -106,6 +107,7 @@ private:
 protected:
 	virtual void _resource_path_changed();
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 	void _block_emit_changed();
 	void _unblock_emit_changed();
@@ -145,6 +147,9 @@ public:
 	String get_path() const;
 	virtual void set_path_cache(const String &p_path); // Set raw path without involving resource cache.
 	_FORCE_INLINE_ bool is_built_in() const { return path_cache.is_empty() || path_cache.contains("::") || path_cache.begins_with("local://"); }
+
+	void set_editor_description(const String &p_editor_description);
+	String get_editor_description() const;
 
 	static void seed_scene_unique_id(uint32_t p_seed);
 	static String generate_scene_unique_id();

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -66,6 +66,7 @@ class ResourceLoaderBinary {
 	bool using_named_scene_ids = false;
 	bool using_uids = false;
 	String script_class;
+	String editor_description;
 	bool use_sub_threads = false;
 	float *progress = nullptr;
 	Vector<ExtResource> external_resources;
@@ -102,6 +103,7 @@ public:
 	void open(Ref<FileAccess> p_f, bool p_no_resources = false, bool p_keep_uuid_paths = false);
 	String recognize(Ref<FileAccess> p_f);
 	String recognize_script_class(Ref<FileAccess> p_f);
+	String recognize_editor_description(Ref<FileAccess> p_f);
 	void get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types);
 	void get_classes_used(Ref<FileAccess> p_f, HashSet<StringName> *p_classes);
 
@@ -118,6 +120,8 @@ public:
 	virtual bool handles_type(const String &p_type) const override;
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual String get_resource_script_class(const String &p_path) const override;
+	virtual String get_resource_editor_description(const String &p_path) const override;
+	virtual bool has_editor_description_support() const override;
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes) override;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
@@ -172,6 +176,7 @@ public:
 		FORMAT_FLAG_UIDS = 2,
 		FORMAT_FLAG_REAL_T_IS_DOUBLE = 4,
 		FORMAT_FLAG_HAS_SCRIPT_CLASS = 8,
+		FORMAT_FLAG_HAS_EDITOR_DESCRIPTION = 16,
 
 		// Amount of reserved 32-bit fields in resource header
 		RESERVED_FIELDS = 11

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -111,6 +111,14 @@ String ResourceFormatLoader::get_resource_script_class(const String &p_path) con
 	return ret;
 }
 
+String ResourceFormatLoader::get_resource_editor_description(const String &p_path) const {
+	return String();
+}
+
+bool ResourceFormatLoader::has_editor_description_support() const {
+	return false;
+}
+
 ResourceUID::ID ResourceFormatLoader::get_resource_uid(const String &p_path) const {
 	int64_t uid = ResourceUID::INVALID_ID;
 	if (has_custom_uid_support()) {
@@ -1186,6 +1194,36 @@ String ResourceLoader::get_resource_script_class(const String &p_path) {
 	}
 
 	return "";
+}
+
+String ResourceLoader::get_resource_editor_description(const String &p_path) {
+	const String local_path = _validate_local_path(p_path);
+
+	for (int i = 0; i < loader_count; i++) {
+		if (loader[i]->has_editor_description_support()) {
+			const String result = loader[i]->get_resource_editor_description(local_path);
+			if (!result.is_empty()) {
+				return result;
+			}
+		}
+	}
+
+	return "";
+}
+
+bool ResourceLoader::has_editor_description_support(const String &p_path) {
+	String local_path = _validate_local_path(p_path);
+
+	for (int i = 0; i < loader_count; i++) {
+		if (!loader[i]->recognize_path(local_path)) {
+			continue;
+		}
+		if (loader[i]->has_editor_description_support()) {
+			return true;
+		}
+	}
+
+	return false;
 }
 
 ResourceUID::ID ResourceLoader::get_resource_uid(const String &p_path) {

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -82,6 +82,8 @@ public:
 	virtual void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
 	virtual String get_resource_type(const String &p_path) const;
 	virtual String get_resource_script_class(const String &p_path) const;
+	virtual String get_resource_editor_description(const String &p_path) const;
+	virtual bool has_editor_description_support() const;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const;
 	virtual bool has_custom_uid_support() const;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false);
@@ -243,6 +245,8 @@ public:
 	static void get_classes_used(const String &p_path, HashSet<StringName> *r_classes);
 	static String get_resource_type(const String &p_path);
 	static String get_resource_script_class(const String &p_path);
+	static String get_resource_editor_description(const String &p_path);
+	static bool has_editor_description_support(const String &p_path);
 	static ResourceUID::ID get_resource_uid(const String &p_path);
 	static bool has_custom_uid_support(const String &p_path);
 	static bool should_create_uid_file(const String &p_path);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1823,6 +1823,9 @@ bool Object::editor_is_section_unfolded(const String &p_section) {
 	return editor_section_folding.has(p_section);
 }
 
+bool Object::editor_is_object_or_resource_property(const String &p_name) {
+	return p_name == "script" || p_name == "resource_local_to_scene" || p_name == "resource_name" || p_name == "resource_path" || p_name == "resource_scene_unique_id" || p_name == "editor_description";
+}
 #endif
 
 void Object::clear_internal_resource_paths() {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -1011,6 +1011,7 @@ public:
 	bool editor_is_section_unfolded(const String &p_section);
 	const HashSet<String> &editor_get_section_folding() const { return editor_section_folding; }
 	void editor_clear_section_folding() { editor_section_folding.clear(); }
+	static bool editor_is_object_or_resource_property(const String &p_name);
 #endif
 
 	// Used by script languages to store binding data.

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -153,6 +153,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="editor_description" type="String" setter="set_editor_description" getter="get_editor_description" default="&quot;&quot;">
+			An optional description for the resource. It will be displayed as a tooltip when hovering over the resource in the filesystem dock and the resource picker.
+		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" default="false">
 			If [code]true[/code], the resource is duplicated for each instance of all scenes using it. At run-time, the resource can be modified in one scene without affecting other instances (see [method PackedScene.instantiate]).
 			[b]Note:[/b] Changing this property at run-time has no effect on already created duplicate resources.

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -1951,7 +1951,7 @@ void EditorAnimationMultiTransitionEdit::_get_property_list(List<PropertyInfo> *
 		p_list->push_back(prop_transition_path);
 
 		for (const PropertyInfo &pi : plist) {
-			if (pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene") {
+			if (Object::editor_is_object_or_resource_property(pi.name)) {
 				continue;
 			}
 

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -508,7 +508,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				}
 
 				if (properties_from_instance) {
-					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "script" || E.name == "resource_scene_unique_id") {
+					if (Object::editor_is_object_or_resource_property(E.name)) {
 						// Don't include spurious properties from Object property list.
 						continue;
 					}

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2886,13 +2886,17 @@ Control *FileSystemDock::create_tooltip_for_path(const String &p_path) const {
 	ERR_FAIL_COND_V(!FileAccess::exists(p_path), nullptr);
 
 	const String type = ResourceLoader::get_resource_type(p_path);
-	Control *tooltip = EditorResourceTooltipPlugin::make_default_tooltip(p_path);
-
+	VBoxContainer *default_tooltip = EditorResourceTooltipPlugin::make_default_tooltip(p_path);
+	Control *tooltip = default_tooltip;
+	Dictionary preview_metadata = EditorResourcePreview::get_singleton()->get_preview_metadata(p_path);
 	for (const Ref<EditorResourceTooltipPlugin> &plugin : tooltip_plugins) {
 		if (plugin->handles(type)) {
-			tooltip = plugin->make_tooltip_for_path(p_path, EditorResourcePreview::get_singleton()->get_preview_metadata(p_path), tooltip);
+			tooltip = plugin->make_tooltip_for_path(p_path, preview_metadata, tooltip);
 		}
 	}
+
+	// Editor description tooltip goes last, just like Node's editor description.
+	EditorResourceTooltipPlugin::append_editor_description_tooltip(p_path, default_tooltip);
 	return tooltip;
 }
 

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -108,13 +108,23 @@ void EditorResourcePicker::_update_resource() {
 			if (edited_resource->get_path().is_resource_file()) {
 				resource_path = edited_resource->get_path() + "\n";
 			}
-			assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + class_name);
+			String description = edited_resource->get_editor_description();
+			if (description.is_empty()) {
+				assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + class_name);
+			} else {
+				assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + class_name + "\n\n" + description);
+			}
 
 			// Preview will override the above, so called at the end.
 			EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, callable_mp(this, &EditorResourcePicker::_update_resource_preview).bind(edited_resource->get_instance_id()));
 		}
 	} else if (edited_resource.is_valid()) {
-		assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());
+		String description = edited_resource->get_editor_description();
+		if (description.is_empty()) {
+			assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class());
+		} else {
+			assign_button->set_tooltip_text(resource_path + TTR("Type:") + " " + edited_resource->get_class() + "\n\n" + description);
+		}
 	}
 
 	assign_button->set_disabled(!editable && edited_resource.is_null());

--- a/editor/inspector/editor_resource_tooltip_plugins.cpp
+++ b/editor/inspector/editor_resource_tooltip_plugins.cpp
@@ -88,6 +88,34 @@ VBoxContainer *EditorResourceTooltipPlugin::make_default_tooltip(const String &p
 	return vb;
 }
 
+void EditorResourceTooltipPlugin::append_editor_description_tooltip(const String &p_resource_path, VBoxContainer *p_default_tooltip) {
+	if (!ResourceLoader::exists(p_resource_path)) {
+		return;
+	}
+
+	Ref<Resource> cached_resource = ResourceCache::get_ref(p_resource_path);
+	String editor_description;
+	if (cached_resource.is_valid()) {
+		// Use the editor description in the currently-loaded instance. (Might be unsaved)
+		editor_description = cached_resource->get_editor_description();
+	} else {
+		// Not loaded yet.
+		editor_description = ResourceLoader::get_resource_editor_description(p_resource_path);
+	}
+	if (!editor_description.is_empty()) {
+		String tooltip;
+		const PackedInt32Array boundaries = TS->string_get_word_breaks(editor_description, "", 80);
+		for (int i = 0; i < boundaries.size(); i += 2) {
+			const int start = boundaries[i];
+			const int end = boundaries[i + 1];
+			tooltip += "\n" + editor_description.substr(start, end - start + 1).rstrip("\n");
+		}
+		Label *label = memnew(Label(tooltip));
+		label->set_auto_translate_mode(Node::AUTO_TRANSLATE_MODE_DISABLED);
+		p_default_tooltip->add_child(label);
+	}
+}
+
 void EditorResourceTooltipPlugin::request_thumbnail(const String &p_path, TextureRect *p_for_control) const {
 	ERR_FAIL_NULL(p_for_control);
 	EditorResourcePreview::get_singleton()->queue_resource_preview(p_path, callable_mp(const_cast<EditorResourceTooltipPlugin *>(this), &EditorResourceTooltipPlugin::_thumbnail_ready).bind(p_for_control->get_instance_id()));

--- a/editor/inspector/editor_resource_tooltip_plugins.h
+++ b/editor/inspector/editor_resource_tooltip_plugins.h
@@ -51,6 +51,7 @@ protected:
 
 public:
 	static VBoxContainer *make_default_tooltip(const String &p_resource_path);
+	static void append_editor_description_tooltip(const String &p_resource_path, VBoxContainer *p_default_tooltip);
 	void request_thumbnail(const String &p_path, TextureRect *p_for_control) const;
 
 	virtual bool handles(const String &p_resource_type) const;

--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -99,7 +99,7 @@ class SectionedInspectorFilter : public Object {
 		for (PropertyInfo &pi : pinfo) {
 			int sp = pi.name.find_char('/');
 
-			if (pi.name == "resource_path" || pi.name == "resource_name" || pi.name == "resource_local_to_scene" || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) { //skip resource stuff
+			if (Object::editor_is_object_or_resource_property(pi.name) || pi.name.begins_with("script/") || pi.name.begins_with("_global_script")) { //skip resource stuff
 				continue;
 			}
 
@@ -251,7 +251,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (pi.name.contains_char(':') || pi.name == "script" || pi.name == "resource_name" || pi.name == "resource_path" || pi.name == "resource_local_to_scene" || pi.name.begins_with("_global_script")) {
+		if (pi.name.contains_char(':') || Object::editor_is_object_or_resource_property(pi.name) || pi.name.begins_with("_global_script")) {
 			continue;
 		}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1136,6 +1136,10 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 			script_class = tag.fields["script_class"];
 		}
 
+		if (tag.fields.has("editor_description")) {
+			editor_description = String(tag.fields["editor_description"]).c_unescape();
+		}
+
 		res_type = tag.fields["type"];
 
 	} else {
@@ -1325,6 +1329,44 @@ String ResourceLoaderText::recognize_script_class(Ref<FileAccess> p_f) {
 	return "";
 }
 
+String ResourceLoaderText::recognize_editor_description(Ref<FileAccess> p_f) {
+	error = OK;
+
+	lines = 1;
+	f = p_f;
+
+	stream.f = f;
+
+	ignore_resource_parsing = true;
+
+	VariantParser::Tag tag;
+	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
+
+	if (err) {
+		_printerr();
+		return "";
+	}
+
+	if (tag.fields.has("format")) {
+		int fmt = tag.fields["format"];
+		if (fmt > FORMAT_VERSION) {
+			error_text = "Saved with newer format version";
+			_printerr();
+			return "";
+		}
+	}
+
+	if (tag.name != "gd_resource") {
+		return "";
+	}
+
+	if (tag.fields.has("editor_description")) {
+		return String(tag.fields["editor_description"]).c_unescape();
+	}
+
+	return "";
+}
+
 String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 	error = OK;
 
@@ -1436,6 +1478,7 @@ Ref<Resource> ResourceFormatLoaderText::load(const String &p_path, const String 
 		*r_error = err;
 	}
 	if (err == OK) {
+		loader.get_resource()->set_editor_description(loader.editor_description);
 		return loader.get_resource();
 	} else {
 		return Ref<Resource>();
@@ -1526,6 +1569,27 @@ String ResourceFormatLoaderText::get_resource_script_class(const String &p_path)
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	loader.res_path = loader.local_path;
 	return loader.recognize_script_class(f);
+}
+
+String ResourceFormatLoaderText::get_resource_editor_description(const String &p_path) const {
+	String ext = p_path.get_extension().to_lower();
+	if (ext != "tres") {
+		return String();
+	}
+
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
+	if (f.is_null()) {
+		return String(); // Could not read.
+	}
+
+	ResourceLoaderText loader;
+	loader.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
+	loader.res_path = loader.local_path;
+	return loader.recognize_editor_description(f);
+}
+
+bool ResourceFormatLoaderText::has_editor_description_support() const {
+	return true;
 }
 
 ResourceUID::ID ResourceFormatLoaderText::get_resource_uid(const String &p_path) const {
@@ -1787,6 +1851,10 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 		if (uid != ResourceUID::INVALID_ID) {
 			title += " uid=\"" + ResourceUID::get_singleton()->id_to_text(uid) + "\"";
+		}
+		String editor_description = p_resource->get_editor_description();
+		if (!editor_description.is_empty()) {
+			title += " editor_description=\"" + editor_description.c_escape() + "\"";
 		}
 
 		f->store_string(title);

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -77,6 +77,7 @@ private:
 	int resource_current = 0;
 	String resource_type;
 	String script_class;
+	String editor_description;
 
 	VariantParser::Tag next_tag;
 
@@ -135,6 +136,7 @@ public:
 	void open(Ref<FileAccess> p_f, bool p_skip_first_tag = false);
 	String recognize(Ref<FileAccess> p_f);
 	String recognize_script_class(Ref<FileAccess> p_f);
+	String recognize_editor_description(Ref<FileAccess> p_f);
 	ResourceUID::ID get_uid(Ref<FileAccess> p_f);
 	void get_dependencies(Ref<FileAccess> p_f, List<String> *p_dependencies, bool p_add_types);
 	Error rename_dependencies(Ref<FileAccess> p_f, const String &p_path, const HashMap<String, String> &p_map);
@@ -156,6 +158,8 @@ public:
 
 	virtual String get_resource_type(const String &p_path) const override;
 	virtual String get_resource_script_class(const String &p_path) const override;
+	virtual String get_resource_editor_description(const String &p_path) const override;
+	virtual bool has_editor_description_support() const override;
 	virtual ResourceUID::ID get_resource_uid(const String &p_path) const override;
 	virtual bool has_custom_uid_support() const override;
 	virtual void get_dependencies(const String &p_path, List<String> *p_dependencies, bool p_add_types = false) override;

--- a/tests/core/io/test_json_native.h
+++ b/tests/core/io/test_json_native.h
@@ -101,7 +101,7 @@ TEST_CASE("[JSON][Native] Conversion between native and JSON formats") {
 	res.instantiate();
 
 	// The properties are stored in an array because the order in which they are assigned may be important during initialization.
-	const String res_repr = R"({"type":"Resource","props":["resource_local_to_scene",false,"resource_name","s:","script",null]})";
+	const String res_repr = R"({"type":"Resource","props":["resource_local_to_scene",false,"resource_name","s:","editor_description","s:","script",null]})";
 
 	test(res, res_repr, true);
 	ERR_PRINT_OFF;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Closes https://github.com/godotengine/godot-proposals/issues/13221

This pull request adds the property `editor_description` to Resources. It functions exactly the same as Node's `editor_description`, and also shows the editor description in the resource's tooltip when available.

<img width="1916" height="964" alt="Short editor description" src="https://github.com/user-attachments/assets/7ee05081-ac83-43a2-84d2-e3825712b73d" />

<img width="1910" height="975" alt="Long editor description" src="https://github.com/user-attachments/assets/dfa717e3-bdf3-46e1-ba29-295878bf2897" />