### PR TITLE
Add Thread.finished signal

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1472,6 +1472,7 @@ void Thread::_start_func(void *ud) {
 	if (t.is_valid()) {
 		t->ret = ret;
 		t->running.clear();
+		t->call_deferred("emit_signal", SNAME("finished"));
 	} else {
 		// We could print a warning here, but the Thread object will be eventually destroyed
 		// noticing wait_to_finish() hasn't been called on it, and it will print a warning itself.
@@ -1532,6 +1533,8 @@ void Thread::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_started"), &Thread::is_started);
 	ClassDB::bind_method(D_METHOD("is_alive"), &Thread::is_alive);
 	ClassDB::bind_method(D_METHOD("wait_to_finish"), &Thread::wait_to_finish);
+
+	ADD_SIGNAL(MethodInfo("finished"));
 
 	ClassDB::bind_static_method("Thread", D_METHOD("set_thread_safety_checks_enabled", "enabled"), &Thread::set_thread_safety_checks_enabled);
 

--- a/doc/classes/Thread.xml
+++ b/doc/classes/Thread.xml
@@ -69,6 +69,13 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="finished">
+			<description>
+				Emitted when the [Thread] finishes running. Serves as a way to notify the user that [method wait_to_finish] can be called safely without blocking the main thread.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 		<constant name="PRIORITY_LOW" value="0" enum="Priority">
 			A thread running with lower priority than normally.


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Adds a `Thread.finished` signal so a function can wait for a thread to finish.

The intended usecase is in a script like this, with a thread completing work in the background. After the thread has finished, it sends a signal to the main thread, which can then rejoin the thread without hanging the main loop.
```gdscript
extends Node

var thread = Thread.new()

func _ready():
	thread.start(func(): OS.delay_msec(1000))
	print("Thread started!")
	
	await thread.finished
	
	print("Thread finished!")
	thread.wait_to_finish()
```