### PR TITLE
Optimize `terrain_fill_connect`

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -570,7 +570,7 @@ void TileMap::set_pattern(int p_layer, const Vector2i &p_position, const Ref<Til
 	TILEMAP_CALL_FOR_LAYER(p_layer, set_pattern, p_position, p_pattern);
 }
 
-HashMap<Vector2i, TileSet::TerrainsPattern> TileMap::terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints) {
+HashMap<Vector2i, TileSet::TerrainsPattern> TileMap::terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const HashSet<TerrainConstraint, TerrainConstraint> &p_constraints) {
 	HashMap<Vector2i, TileSet::TerrainsPattern> err_value;
 	TILEMAP_CALL_FOR_LAYER_V(p_layer, err_value, terrain_fill_constraints, p_to_replace, p_terrain_set, p_constraints);
 }

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -185,7 +185,7 @@ public:
 	void set_pattern(int p_layer, const Vector2i &p_position, const Ref<TileMapPattern> p_pattern);
 
 	// Terrains (Not exposed).
-	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints);
+	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(int p_layer, const Vector<Vector2i> &p_to_replace, int p_terrain_set, const HashSet<TerrainConstraint, TerrainConstraint> &p_constraints);
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_connect(int p_layer, const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true);
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_path(int p_layer, const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true);
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_pattern(int p_layer, const Vector<Vector2i> &p_coords_array, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern, bool p_ignore_empty_terrains = true);

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -60,6 +60,15 @@ public:
 		return base_cell_coords < p_other.base_cell_coords;
 	}
 
+	bool operator==(const TerrainConstraint &p_other) const {
+		return bit == p_other.bit && base_cell_coords == p_other.base_cell_coords;
+	}
+
+	_FORCE_INLINE_ static uint32_t hash(const TerrainConstraint &p_val) {
+		uint32_t h = HashMapHasherDefault::hash(p_val.base_cell_coords);
+		return hash_murmur3_one_32(h, p_val.bit);
+	}
+
 	String to_string() const {
 		return vformat("Constraint {pos:%s, bit:%d, terrain:%d, priority:%d}", base_cell_coords, bit, terrain, priority);
 	}
@@ -491,9 +500,9 @@ private:
 #endif // DEBUG_ENABLED
 
 	// Terrains.
-	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const RBSet<TerrainConstraint> &p_constraints, TileSet::TerrainsPattern p_current_pattern) const;
-	RBSet<TerrainConstraint> _get_terrain_constraints_from_added_pattern(const Vector2i &p_position, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const;
-	RBSet<TerrainConstraint> _get_terrain_constraints_from_painted_cells_list(const RBSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const;
+	TileSet::TerrainsPattern _get_best_terrain_pattern_for_constraints(int p_terrain_set, const Vector2i &p_position, const HashSet<TerrainConstraint, TerrainConstraint> &p_constraints, TileSet::TerrainsPattern p_current_pattern, const RBSet<TileSet::TerrainsPattern> &p_pattern_set) const;
+	HashSet<TerrainConstraint, TerrainConstraint> _get_terrain_constraints_from_added_pattern(const Vector2i &p_position, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern) const;
+	HashSet<TerrainConstraint, TerrainConstraint> _get_terrain_constraints_from_painted_cells_list(const HashSet<Vector2i> &p_painted, int p_terrain_set, bool p_ignore_empty_terrains) const;
 
 	void _tile_set_changed();
 
@@ -534,7 +543,7 @@ public:
 	Rect2 get_rect(bool &r_changed) const;
 
 	// Terrains.
-	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(const Vector<Vector2i> &p_to_replace, int p_terrain_set, const RBSet<TerrainConstraint> &p_constraints) const; // Not exposed.
+	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_constraints(const Vector<Vector2i> &p_to_replace, int p_terrain_set, const HashSet<TerrainConstraint, TerrainConstraint> &p_constraints) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_connect(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_path(const Vector<Vector2i> &p_coords_array, int p_terrain_set, int p_terrain, bool p_ignore_empty_terrains = true) const; // Not exposed.
 	HashMap<Vector2i, TileSet::TerrainsPattern> terrain_fill_pattern(const Vector<Vector2i> &p_coords_array, int p_terrain_set, TileSet::TerrainsPattern p_terrains_pattern, bool p_ignore_empty_terrains = true) const; // Not exposed.


### PR DESCRIPTION
A conglomeration of small tweaks found via XCode Instruments. Further improvements might require a bigger rewrite. Optimizes `terrain_fill_connect` and `terrain_fill_path` primarily through optimizing `terrain_fill_constrain`

Before: **~350ms on average** (as measured in my test harness)
After: **~165ms on average**, 2.1x faster 

Moving to `HashSet` over `RBSet` for the `TerrainConstraint` set: **saves ~70ms**
Moving to `HashSet` from RBSet in other places: **saves ~20ms**
Removing unnecessary `RBMap` for minimization: **saves ~40ms**
Moving `get_terrains_pattern_set` to parent: **saves ~50ms** 

### Sample test code:

```
extends TileMapLayer

var toggle = false

func _process(delta):
  var startTime = Time.get_ticks_msec()
  var points = []
  for i in range(200):
    for j in range(200):
      points.append(
        Vector2i(i, j)
      )
  var allocTime = Time.get_ticks_msec()
  if toggle:
    set_cells_terrain_connect(points, 0, -1, false)
  else:
    set_cells_terrain_connect(points, 0, 0, false)
  toggle = !toggle
  var totalTime = Time.get_ticks_msec()
  print("Alloc time:", allocTime - startTime)
  print("Terrain Calc time:", totalTime - allocTime)
```

Thanks for making it so straightforward to contribute that it's as easy to address the underlying issue as it is to work around it in my game :)

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
