### PR TITLE
Simplify the Quick Open logic in ColorPicker

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3826,11 +3826,6 @@ void EditorNode::_update_file_menu_opened() {
 	_update_undo_redo_allowed();
 }
 
-void EditorNode::_palette_quick_open_dialog() {
-	quick_open_color_palette->popup_dialog({ "ColorPalette" }, palette_file_selected_callback);
-	quick_open_color_palette->set_title(TTRC("Quick Open Color Palette..."));
-}
-
 void EditorNode::replace_resources_in_object(Object *p_object, const Vector<Ref<Resource>> &p_source_resources, const Vector<Ref<Resource>> &p_target_resource) {
 	List<PropertyInfo> pi;
 	p_object->get_property_list(&pi);
@@ -4313,10 +4308,7 @@ void EditorNode::setup_color_picker(ColorPicker *p_picker) {
 	p_picker->set_color_mode((ColorPicker::ColorModeType)default_color_mode);
 	p_picker->set_picker_shape((ColorPicker::PickerShapeType)picker_shape);
 	p_picker->set_edit_intensity(show_intensity);
-
-	p_picker->set_quick_open_callback(callable_mp(this, &EditorNode::_palette_quick_open_dialog));
 	p_picker->set_palette_saved_callback(callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::update_file));
-	palette_file_selected_callback = callable_mp(p_picker, &ColorPicker::_quick_open_palette_file_selected);
 }
 
 bool EditorNode::is_scene_open(const String &p_path) {
@@ -8747,9 +8739,6 @@ EditorNode::EditorNode() {
 
 	quick_open_dialog = memnew(EditorQuickOpenDialog);
 	gui_base->add_child(quick_open_dialog);
-
-	quick_open_color_palette = memnew(EditorQuickOpenDialog);
-	gui_base->add_child(quick_open_color_palette);
 
 	_update_recent_scenes();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -261,7 +261,6 @@ private:
 	EditorPluginList *editor_plugins_force_input_forwarding = nullptr;
 	EditorPluginList *editor_plugins_force_over = nullptr;
 	EditorPluginList *editor_plugins_over = nullptr;
-	EditorQuickOpenDialog *quick_open_color_palette = nullptr;
 	EditorResourcePreview *resource_preview = nullptr;
 	EditorSelection *editor_selection = nullptr;
 	EditorSettingsDialog *editor_settings_dialog = nullptr;
@@ -561,7 +560,6 @@ private:
 	void _tool_menu_option(int p_idx);
 	void _export_as_menu_option(int p_idx);
 	void _update_file_menu_opened();
-	void _palette_quick_open_dialog();
 
 	void _remove_plugin_from_enabled(const String &p_name);
 	void _plugin_over_edit(EditorPlugin *p_plugin, Object *p_object);

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -54,6 +54,11 @@
 #include "scene/theme/theme_db.h"
 #include "thirdparty/misc/ok_color_shader.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
+#include "editor/gui/editor_quick_open_dialog.h"
+#endif // TOOLS_ENABLED
+
 static inline bool is_color_overbright(const Color &color) {
 	return (color.r > 1.0) || (color.g > 1.0) || (color.b > 1.0);
 }
@@ -630,10 +635,6 @@ void ColorPicker::set_editor_settings(Object *p_editor_settings) {
 
 	_update_presets();
 	_update_recent_presets();
-}
-
-void ColorPicker::set_quick_open_callback(const Callable &p_file_selected) {
-	quick_open_callback = p_file_selected;
 }
 
 void ColorPicker::set_palette_saved_callback(const Callable &p_palette_saved) {
@@ -1776,12 +1777,10 @@ void ColorPicker::_options_menu_cbk(int p_which) {
 
 #ifdef TOOLS_ENABLED
 		case MenuOption::MENU_QUICKLOAD:
-			if (quick_open_callback.is_valid()) {
-				file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
-				quick_open_callback.call_deferred();
-			}
+			EditorNode::get_singleton()->get_quick_open_dialog()->popup_dialog({ "ColorPalette" }, callable_mp(this, &ColorPicker::_quick_open_palette_file_selected));
 			break;
 #endif // TOOLS_ENABLED
+
 		case MenuOption::MENU_CLEAR: {
 			PackedColorArray colors = get_presets();
 			for (Color c : colors) {

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -237,7 +237,6 @@ private:
 	void _req_permission();
 
 #ifdef TOOLS_ENABLED
-	Callable quick_open_callback;
 	Callable palette_saved_callback;
 #endif // TOOLS_ENABLED
 
@@ -423,7 +422,6 @@ protected:
 public:
 #ifdef TOOLS_ENABLED
 	void set_editor_settings(Object *p_editor_settings);
-	void set_quick_open_callback(const Callable &p_file_selected);
 	void set_palette_saved_callback(const Callable &p_palette_saved);
 
 	void _quick_open_palette_file_selected(const String &p_path);


### PR DESCRIPTION
The current implementation is rather complicated, calling back and forth between `ColorPicker` and `EditorNode`.

The refactoring of the Quick Open dialog were merged near the time this feature was merged. Nowadays we have a centralized way to quick open.