### PR TITLE
GDScript: Elide unnecessary copies in `CONSTRUCT_TYPED_*` opcodes

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1805,15 +1805,17 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				const StringName native_type = _global_names_ptr[native_type_idx];
 
 				Array array;
+				array.set_typed(builtin_type, native_type, *script_type);
 				array.resize(argc);
 				for (int i = 0; i < argc; i++) {
-					array[i] = *(instruction_args[i]);
+					// Use .set instead of operator[] to handle type conversion / validation.
+					array.set(i, *(instruction_args[i]));
 				}
 
 				GET_INSTRUCTION_ARG(dst, argc);
 				*dst = Variant(); // Clear potential previous typed array.
 
-				*dst = Array(array, builtin_type, native_type, *script_type);
+				*dst = array;
 
 				ip += 4;
 			}
@@ -1864,18 +1866,20 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				const StringName value_native_type = _global_names_ptr[value_native_type_idx];
 
 				Dictionary dict;
+				dict.set_typed(key_builtin_type, key_native_type, *key_script_type, value_builtin_type, value_native_type, *value_script_type);
 
 				for (int i = 0; i < argc; i++) {
 					GET_INSTRUCTION_ARG(k, i * 2 + 0);
 					GET_INSTRUCTION_ARG(v, i * 2 + 1);
-					dict[*k] = *v;
+					// Use .set instead of operator[] to handle type conversion / validation.
+					dict.set(*k, *v);
 				}
 
 				GET_INSTRUCTION_ARG(dst, argc * 2);
 
 				*dst = Variant(); // Clear potential previous typed dictionary.
 
-				*dst = Dictionary(dict, key_builtin_type, key_native_type, *key_script_type, value_builtin_type, value_native_type, *value_script_type);
+				*dst = dict;
 
 				ip += 6;
 			}

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_array_assign_wrong_to_typed.out
@@ -1,6 +1,5 @@
 GDTEST_RUNTIME_ERROR
 >> ERROR: Method/function failed. Returning: false
->>   Attempted to assign an object into a TypedArray, that does not inherit from 'GDScript'.
->> ERROR: Method/function failed.
->>   Unable to convert array index 0 from "Object" to "Object".
+>>   Attempted to set an object into a TypedArray, that does not inherit from 'GDScript'.
+>> ERROR: Condition "!_p->typed.validate(value, "set")" is true.
 not ok

--- a/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_wrong_to_typed.out
+++ b/modules/gdscript/tests/scripts/runtime/errors/typed_dictionary_assign_wrong_to_typed.out
@@ -1,6 +1,5 @@
 GDTEST_RUNTIME_ERROR
 >> ERROR: Method/function failed. Returning: false
->>   Attempted to assign an object into a TypedDictionary.Key, that does not inherit from 'GDScript'.
->> ERROR: Method/function failed.
->>   Unable to convert key from "Object" to "Object".
+>>   Attempted to set an object into a TypedDictionary.Key, that does not inherit from 'GDScript'.
+>> ERROR: Condition "!_p->typed_key.validate(key, "set")" is true. Returning: false
 not ok


### PR DESCRIPTION
This PR fixes an issue that was noticed by @AdriaandeJongh while looking at the benchmark results used in https://github.com/godotengine/godot/pull/110709

In those benchmark results, the time it took to use initializer-list syntax to create a typed dictionary with 64 entries was 3x as long as the time it took to create an untyped dictionary.

This is because instead of using `set_typed`, both `OPCODE_CONSTRUCT_TYPED_ARRAY` and `OPCODE_CONSTRUCT_TYPED_DICTIONARY` first construct an untyped dictionary, fill it, and use the copy constructor that accepts type parameters to create a typed copy of the dictionary.

By migrating these to use `set_typed` instead, and re-running the benchmark from #110709, the time for typed and untyped dictionaries is effectively identical.