### PR TITLE
Make `editor_description` a metadata

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -663,6 +663,21 @@ void Resource::reset_local_to_scene() {
 Node *(*Resource::_get_local_scene_func)() = nullptr;
 void (*Resource::_update_configuration_warning)() = nullptr;
 
+void Resource::set_editor_description(const String &p_editor_description) {
+	if (p_editor_description == get_editor_description()) {
+		return;
+	}
+	if (p_editor_description.is_empty()) {
+		remove_meta("_editor_description_");
+	} else {
+		set_meta("_editor_description_", p_editor_description);
+	}
+}
+
+String Resource::get_editor_description() const {
+	return get_meta("_editor_description_", String());
+}
+
 void Resource::set_as_translation_remapped(bool p_remapped) {
 	if (remapped_list.in_list() == p_remapped) {
 		return;
@@ -721,6 +736,8 @@ void Resource::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_local_scene"), &Resource::get_local_scene);
 	ClassDB::bind_method(D_METHOD("setup_local_to_scene"), &Resource::setup_local_to_scene);
 	ClassDB::bind_method(D_METHOD("reset_state"), &Resource::reset_state);
+	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Resource::set_editor_description);
+	ClassDB::bind_method(D_METHOD("get_editor_description"), &Resource::get_editor_description);
 
 	ClassDB::bind_method(D_METHOD("set_id_for_path", "path", "id"), &Resource::set_id_for_path);
 	ClassDB::bind_method(D_METHOD("get_id_for_path", "path"), &Resource::get_id_for_path);
@@ -750,6 +767,9 @@ void Resource::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_path", "get_path");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_name"), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "resource_scene_unique_id", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_scene_unique_id", "get_scene_unique_id");
+
+	ADD_GROUP("Resource", "");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR), "set_editor_description", "get_editor_description");
 
 	GDVIRTUAL_BIND(_setup_local_to_scene);
 	GDVIRTUAL_BIND(_get_rid);

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -176,6 +176,9 @@ public:
 
 #endif
 
+	void set_editor_description(const String &p_editor_description);
+	String get_editor_description() const;
+
 	void set_as_translation_remapped(bool p_remapped);
 
 	virtual RID get_rid() const; // Some resources may offer conversion to RID.

--- a/doc/classes/Resource.xml
+++ b/doc/classes/Resource.xml
@@ -153,6 +153,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="editor_description" type="String" setter="set_editor_description" getter="get_editor_description" default="&quot;&quot;">
+			An optional description to the resource.
+		</member>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" default="false">
 			If [code]true[/code], the resource is duplicated for each instance of all scenes using it. At run-time, the resource can be modified in one scene without affecting other instances (see [method PackedScene.instantiate]).
 			[b]Note:[/b] Changing this property at run-time has no effect on already created duplicate resources.

--- a/editor/doc/doc_tools.cpp
+++ b/editor/doc/doc_tools.cpp
@@ -497,7 +497,7 @@ void DocTools::generate(BitField<GenerateFlags> p_flags) {
 				}
 
 				if (properties_from_instance) {
-					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "script" || E.name == "resource_scene_unique_id") {
+					if (E.name == "resource_local_to_scene" || E.name == "resource_name" || E.name == "resource_path" || E.name == "script" || E.name == "resource_scene_unique_id" || E.name == "editor_description") {
 						// Don't include spurious properties from Object property list.
 						continue;
 					}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2616,16 +2616,19 @@ String Node::get_scene_file_path() const {
 
 void Node::set_editor_description(const String &p_editor_description) {
 	ERR_THREAD_GUARD
-	if (data.editor_description == p_editor_description) {
+	if (p_editor_description == get_editor_description()) {
 		return;
 	}
-
-	data.editor_description = p_editor_description;
+	if (p_editor_description.is_empty()) {
+		remove_meta("_editor_description_");
+	} else {
+		set_meta("_editor_description_", p_editor_description);
+	}
 	emit_signal(SNAME("editor_description_changed"), this);
 }
 
 String Node::get_editor_description() const {
-	return data.editor_description;
+	return get_meta("_editor_description_", String());
 }
 
 void Node::set_editable_instance(Node *p_node, bool p_editable) {
@@ -4010,7 +4013,7 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "auto_translate_mode", PROPERTY_HINT_ENUM, "Inherit,Always,Disabled"), "set_auto_translate_mode", "get_auto_translate_mode");
 
 	ADD_GROUP("Editor Description", "editor_");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR), "set_editor_description", "get_editor_description");
 
 	GDVIRTUAL_BIND(_process, "delta");
 	GDVIRTUAL_BIND(_physics_process, "delta");

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -184,7 +184,6 @@ private:
 #ifdef TOOLS_ENABLED
 		NodePath import_path; // Path used when imported, used by scene editors to keep tracking.
 #endif
-		String editor_description;
 
 		Viewport *viewport = nullptr;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13221
Alternate of #110713

This PR:

- Adds `editor_description` to `Resource`.
- Makes `editor_description` backed by a metadata entry named `_editor_description_` instead of a dedicated variable. This way, we save a few bytes for each `Node` / `Resource` created most of the times.