### PR TITLE
Don't emit `scene_changed` when restoring scenes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4296,7 +4296,7 @@ void EditorNode::_set_current_scene_nocheck(int p_idx) {
 	_update_title();
 	callable_mp(scene_tabs, &EditorSceneTabs::update_scene_tabs).call_deferred();
 
-	if (tabs_to_close.is_empty()) {
+	if (tabs_to_close.is_empty() && !restoring_scenes) {
 		callable_mp(this, &EditorNode::_set_main_scene_state).call_deferred(state, get_edited_scene()); // Do after everything else is done setting up.
 	}
 


### PR DESCRIPTION
When start editor and there is multiple scenes open, the editor will emit `scene_changed` signal for every scene - 1. What's worse, the signal is deferred, so the `scene_root` argument of the signal will be the same node for every emission.

This PR prevents that.

Related: https://github.com/godotengine/godot/pull/110135#issuecomment-3264544922