### PR TITLE
expand Node.reparent() doc: does not override new parent behavior

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -848,7 +848,7 @@
 			<param index="1" name="keep_global_transform" type="bool" default="true" />
 			<description>
 				Changes the parent of this [Node] to the [param new_parent]. The node needs to already have a parent. The node's [member owner] is preserved if its owner is still reachable from the new location (i.e., the node is still a descendant of the new parent after the operation).
-				If [param keep_global_transform] is [code]true[/code], the node's global transform will be preserved if supported. [Node2D], [Node3D] and [Control] support this argument (but [Control] keeps only position).
+				If [param keep_global_transform] is [code]true[/code], the node's global transform will be preserved if supported. [Node2D], [Node3D] and [Control] support this argument (but [Control] keeps only position). This does not override the behavior of the new parent node (i.e., reparenting a [Control] to a [Container] will still override the position to preserve its layout).
 			</description>
 		</method>
 		<method name="replace_by">


### PR DESCRIPTION
**Why I think this change is necessary**

While using reparent() with keep_global_transform = true, I ran into unexpected behavior when reparenting Control nodes into Containers. 

I initially assumed a Control node would stay in place when reparented into a Container, and that the container would only take over its position during subsequent layout updates. Instead, the container immediately applied its layout rules, overriding the preserved global transform.

This is correct and expected behavior, when we look at the Container documentation. Containers always control their children’s layout. 

However, the current documentation leaves it to the reader to infer from _'if supported'_ that parent nodes may still override transforms. In hindsight, my assumption was wrong, and it makes sense in hindsight, but I don’t think it’s too wild of an assumption to make, especially when animating or interpolating UI elements between containers (a fairly common use case).

This PR adds a minimal clarification to the reparent() method docs:

```
- If [param keep_global_transform] is [code]true[/code], the node's global transform will be preserved if supported. [Node2D], [Node3D] and [Control] support this argument (but [Control] keeps only position).
+ If [param keep_global_transform] is [code]true[/code], the node's global transform will be preserved if supported. [Node2D], [Node3D] and [Control] support this argument (but [Control] keeps only position). This does not override the behavior of the new parent node (i.e., reparenting a [Control] to a [Container] will still override the position to preserve its layout).
```

So I have added;

> This does not override the behavior of the new parent node (i.e., reparenting a [Control] to a [Container] will still override the position to preserve its layout).

This makes it more clear that `keep_global_transform` doesn’t bypass the normal behavior of the new parent node, and might save someone else from the headache I went through.

I tried keeping the change as minimal and generic as possible, only providing my specific issue as an example, and am open for any further changes to the text.

Though this is just a documentation change, I have compiled the engine just in case, and saw that no other files have changed, so, as I understand it from the contribution guide, I believe this `XML` file is all that needs to be altered, and the changes will propagate over to the documentation repository.