### PR TITLE
Editor: Do not embolden the Main Font if it's variable

### DIFF
--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -286,7 +286,9 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		bold_fc->set_base_font(custom_font);
-		bold_fc->set_variation_embolden(embolden_strength);
+		if (!custom_font->get_supported_variation_list().has(TS->name_to_tag("wght"))) {
+			bold_fc->set_variation_embolden(embolden_strength);
+		}
 	} else {
 		EditorSettings::get_singleton()->set_manually("interface/editor/main_font_bold", "");
 		bold_fc->set_base_font(default_font_bold);
@@ -313,7 +315,9 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 			custom_font->set_fallbacks(fallback_custom);
 		}
 		bold_fc_msdf->set_base_font(custom_font);
-		bold_fc_msdf->set_variation_embolden(embolden_strength);
+		if (!custom_font->get_supported_variation_list().has(TS->name_to_tag("wght"))) {
+			bold_fc_msdf->set_variation_embolden(embolden_strength);
+		}
 	} else {
 		EditorSettings::get_singleton()->set_manually("interface/editor/main_font_bold", "");
 		bold_fc_msdf->set_base_font(default_font_bold_msdf);


### PR DESCRIPTION
Fixes #110426

During #106217's writing I was unaware that if the editor's Main Font Bold was unset, it would take the Main Font and embolden it.

In that situation, the weight would be set to bold and the embolden process would happen at the same time, resulting in a very heavy and blurry font.

This changes so emboldening won't happen if the font is variable, as by default, the bold font will be set to have a bold weight.

- Inter Variable set on both Main Font and Main Font Bold:
<img width="250" height="147" alt="image" src="https://github.com/user-attachments/assets/0f5a39f0-f4b3-425e-9718-d35f25cc5529" />

---
- Inter Variable set on Main Font, Main Font Bold unset, before fix:
<img width="254" height="112" alt="image" src="https://github.com/user-attachments/assets/4a6984d3-d1e7-4de6-a0b1-2f41d6ec12e1" />

---
- Inter Variable set on Main Font, Main Font Bold unset, after fix:
<img width="258" height="148" alt="image" src="https://github.com/user-attachments/assets/b8af29f5-6002-4858-ab97-ee81f0e91650" />
