### PR TITLE
Add support for @abstract annotation with vars

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -299,21 +299,29 @@
 		<annotation name="@abstract">
 			<return type="void" />
 			<description>
-				Marks a class or a method as abstract.
+				Marks a class, a method, or a variable as abstract.
 				An abstract class is a class that cannot be instantiated directly. Instead, it is meant to be inherited by other classes. Attempting to instantiate an abstract class will result in an error.
 				An abstract method is a method that has no implementation. Therefore, a newline or a semicolon is expected after the function header. This defines a contract that inheriting classes must conform to, because the method signature must be compatible when overriding.
-				Inheriting classes must either provide implementations for all abstract methods, or the inheriting class must be marked as abstract. If a class has at least one abstract method (either its own or an unimplemented inherited one), then it must also be marked as abstract. However, the reverse is not true: an abstract class is allowed to have no abstract methods.
+				An abstract variable is a variable that has no initial value. This defines a contract that inheriting classes must conform to, because the variable must be defined in the inheriting class.
+				Inheriting classes must either provide implementations for all abstract methods and variables, or the inheriting class must be marked as abstract. If a class has at least one abstract method or variable (either its own or an unimplemented inherited one), then it must also be marked as abstract. However, the reverse is not true: an abstract class is allowed to have no abstract methods nor variables.
 				[codeblock]
 				@abstract class Shape:
 					@abstract func draw()
+					@abstract var area
 
 				class Circle extends Shape:
 					func draw():
 						print("Drawing a circle.")
+					
+					var radius = 1.0
+					var area = PI * radius * radius
 
 				class Square extends Shape:
 					func draw():
 						print("Drawing a square.")
+
+					var side_length = 1.0
+					var area = side_length * side_length
 				[/codeblock]
 			</description>
 		</annotation>

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1260,6 +1260,7 @@ public:
 
 		bool exported = false;
 		bool onready = false;
+		bool is_abstract = false;
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.gd
@@ -1,0 +1,38 @@
+@abstract class BaseAbstractVar extends Node:
+	@abstract var a: int
+	@abstract var b: Node2D
+	@abstract var c: Vector2
+
+class ConcreteFulfilled extends BaseAbstractVar:
+	var a = 1
+	var b = Node2D.new()
+	var c = Vector2i.ZERO
+
+class ConcreteOverride extends ConcreteFulfilled:
+	var a = 2
+
+class ConcreteUnfulfilled extends BaseAbstractVar:
+	pass
+
+class ConcreteDeclaresAbstractVar:
+	@abstract var d: String
+
+@abstract class MismatchVar extends BaseAbstractVar:
+	var a: String = "test"
+
+@abstract class DoubleAbstractVar extends BaseAbstractVar:
+	@abstract var a: int
+	@abstract @abstract var d: int
+
+@abstract class ExportAbstractVar extends BaseAbstractVar:
+	@export var a: int
+	@export @abstract var d: int
+	@abstract @export var e: int
+
+@abstract class OnReadyAbstractVar extends BaseAbstractVar:
+	@onready var b: Node2D
+	@onready @abstract var d: Node2D
+	@abstract @onready var e: Node2D
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.out
@@ -1,0 +1,11 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 21: Type mismatch implementing abstract variable "a": expected "int" got "String".
+>> ERROR at line 25: "@abstract" annotation can only be used once per variable.
+>> ERROR at line 28: Cannot implement abstract variable with export annotation
+>> ERROR at line 29: "@abstract" annotation cannot be applied to an exported variable.
+>> ERROR at line 30: Annotation "@export" cannot be applied to an abstract variable.
+>> ERROR at line 33: Cannot implement abstract variable with "@onready" annotation
+>> ERROR at line 34: "@abstract" annotation cannot be applied to an 'onready' variable.
+>> ERROR at line 35: "@onready" annotation cannot be applied to an abstract variable.
+>> ERROR at line 14: Class "ConcreteUnfulfilled" must provide a value for "BaseAbstractVar.a" and other inherited abstract variables or be marked as "@abstract".
+>> ERROR at line 17: Class "ConcreteDeclaresAbstractVar" is not abstract but contains abstract variables. Mark the class as "@abstract" or remove "@abstract" from all variables in this class.

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_variables.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_variables.gd
@@ -1,0 +1,32 @@
+@abstract class A:
+	@abstract var text_1: String
+	@abstract var text_2: String
+
+class B extends A:
+	var text_1 = "text_1b"
+	var text_2 = "text_2b"
+
+class C extends B:
+	var text_1 = "text_1c"
+
+@abstract class D extends A:
+	var text_1 = "text_1d"
+
+class E extends D:
+	var text_2 = "text_2e"
+
+func test():
+	var b:= B.new()
+	print("B text_1= " + b.text_1)
+	print("B text_2= " + b.text_2)
+
+	var c := C.new()
+	print("C text_1= " + c.text_1)
+	print("C text_2= " + c.text_2)
+
+	var e := E.new()
+	print("E text_1= " + e.text_1)
+	print("E text_2= " + e.text_2)
+
+	e.text_1 = "text_1e"
+	print("E text_1= " + e.text_1)

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_variables.out
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_variables.out
@@ -1,0 +1,8 @@
+GDTEST_OK
+B text_1= text_1b
+B text_2= text_2b
+C text_1= text_1c
+C text_2= text_2b
+E text_1= text_1d
+E text_2= text_2e
+E text_1= text_1e


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/13218

Draft for now as dicussion is still underway on the proposal, but should be ready for merge if/when approved. 

Adds support for using the @abstract annotation with variables. 
* Not compatible with exported or @onready. 
* Functions similarly to abstract functions, with multiple overriding and supports static typing.
* Does not support autocompletion at this stage. Does however support error throwing for incomplete inheritors in editor, which should be enough.