### PR TITLE
Add helper methods to construct a vector from a scalar.

### DIFF
--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -995,3 +995,23 @@ Array::ConstIterator &Array::ConstIterator::operator--() {
 // Zero-constructing Variant results in NULL.
 template <>
 struct is_zero_constructible<Variant> : std::true_type {};
+
+// Vector from scalar helpers.
+_ALWAYS_INLINE_ Vector2 vec2_from_scalar(real_t p_scalar) {
+	return Vector2(p_scalar, p_scalar);
+}
+_ALWAYS_INLINE_ Vector2i vec2i_from_scalar(int32_t p_scalar) {
+	return Vector2i(p_scalar, p_scalar);
+}
+_ALWAYS_INLINE_ Vector3 vec3_from_scalar(real_t p_scalar) {
+	return Vector3(p_scalar, p_scalar, p_scalar);
+}
+_ALWAYS_INLINE_ Vector3i vec3i_from_scalar(int32_t p_scalar) {
+	return Vector3i(p_scalar, p_scalar, p_scalar);
+}
+_ALWAYS_INLINE_ Vector4 vec4_from_scalar(real_t p_scalar) {
+	return Vector4(p_scalar, p_scalar, p_scalar, p_scalar);
+}
+_ALWAYS_INLINE_ Vector4i vec4i_from_scalar(int32_t p_scalar) {
+	return Vector4i(p_scalar, p_scalar, p_scalar, p_scalar);
+}

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -2161,7 +2161,7 @@ void TextureStorage::update_texture_atlas() {
 
 		for (int i = 0; i < item_count; i++) {
 			TextureAtlas::Texture *t = texture_atlas.textures.getptr(items[i].texture);
-			t->uv_rect.position = items[i].pos * border + Vector2i(border / 2, border / 2);
+			t->uv_rect.position = items[i].pos * border + vec2i_from_scalar(border / 2);
 			t->uv_rect.size = items[i].pixel_size;
 
 			t->uv_rect.position /= Size2(texture_atlas.size);

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -933,7 +933,7 @@ void AnimationNodeBlendTreeEditor::_inspect_filters(const String &p_which) {
 		return;
 	}
 
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	filter_dialog->popup_centered(vec2_from_scalar(500 * EDSCALE));
 }
 
 void AnimationNodeBlendTreeEditor::_update_editor_settings() {

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -779,7 +779,7 @@ void AnimationPlayerEditor::_edit_animation_blend() {
 		return;
 	}
 
-	blend_editor.dialog->popup_centered(Size2(400, 400) * EDSCALE);
+	blend_editor.dialog->popup_centered(vec2_from_scalar(400 * EDSCALE));
 	_update_animation_blend();
 }
 

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2177,7 +2177,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 					text_color.a *= 0.7;
 				} else if (node) {
 					Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node, "Node");
-					const Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+					const Vector2 icon_size = vec2_from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 
 					icon_rect = Rect2(Point2(ofs, (get_size().height - check->get_height()) / 2).round(), icon->get_size());
 					draw_texture_rect(icon, icon_rect);
@@ -3728,7 +3728,7 @@ AnimationTrackEdit *AnimationTrackEditPlugin::create_animation_track_edit(Object
 void AnimationTrackEditGroup::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+			icon_size = vec2_from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 		} break;
 
 		case NOTIFICATION_ACCESSIBILITY_UPDATE: {

--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -137,7 +137,7 @@ EditorAssetLibraryItem::EditorAssetLibraryItem(bool p_clickable) {
 
 	icon = memnew(TextureButton);
 	icon->set_accessibility_name(TTRC("Open asset details"));
-	icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
+	icon->set_custom_minimum_size(vec2_from_scalar(64 * EDSCALE));
 	hb->add_child(icon);
 
 	VBoxContainer *vb = memnew(VBoxContainer);
@@ -330,7 +330,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	item = memnew(EditorAssetLibraryItem);
 
 	desc_vbox->add_child(item);
-	desc_vbox->set_custom_minimum_size(Size2(440 * EDSCALE, 440 * EDSCALE));
+	desc_vbox->set_custom_minimum_size(vec2_from_scalar(440 * EDSCALE));
 
 	description = memnew(RichTextLabel);
 	desc_vbox->add_child(description);

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2795,7 +2795,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 			p_rt->push_cell();
 			p_rt->set_cell_row_background_color(code_bg_color, Color(code_bg_color, 0.99));
 			p_rt->set_cell_padding(Rect2(0, 10 * EDSCALE, 0, 10 * EDSCALE));
-			p_rt->set_cell_size_override(Vector2(1, 1), Vector2(10, 10) * EDSCALE);
+			p_rt->set_cell_size_override(Vector2(1, 1), vec2_from_scalar(10 * EDSCALE));
 			p_rt->push_meta("^" + codeblock_copy_text, RichTextLabel::META_UNDERLINE_ON_HOVER);
 			p_rt->add_image(p_owner_node->get_editor_theme_icon(SNAME("ActionCopy")), 24 * EDSCALE, 24 * EDSCALE, Color(link_property_color, 0.3), INLINE_ALIGNMENT_BOTTOM_TO, Rect2(), Variant(), false, TTR("Click to copy."));
 			p_rt->pop(); // meta

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -405,7 +405,7 @@ Control *EditorDockManager::_close_window(WindowWrapper *p_wrapper) {
 void EditorDockManager::_open_dock_in_window(Control *p_dock, bool p_show_window, bool p_reset_size) {
 	ERR_FAIL_NULL(p_dock);
 
-	Size2 borders = Size2(4, 4) * EDSCALE;
+	Size2 borders = vec2_from_scalar(4 * EDSCALE);
 	// Remember size and position before removing it from the main window.
 	Size2 dock_size = p_dock->get_size() + borders * 2;
 	Point2 dock_screen_pos = p_dock->get_screen_position();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1488,7 +1488,7 @@ void EditorNode::_viewport_resized() {
 }
 
 void EditorNode::_titlebar_resized() {
-	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(vec2i_from_scalar(title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (gui_base->is_layout_rtl()) ? margin.y : margin.x;

--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -1013,14 +1013,12 @@ QuickOpenResultListItem::QuickOpenResultListItem() {
 	hbc->add_theme_constant_override(SNAME("separation"), 4 * EDSCALE);
 	add_child(hbc);
 
-	const int max_size = 36 * EDSCALE;
-
 	thumbnail = memnew(TextureRect);
 	thumbnail->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	thumbnail->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
 	thumbnail->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
 	thumbnail->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	thumbnail->set_custom_minimum_size(Size2i(max_size, max_size));
+	thumbnail->set_custom_minimum_size(vec2i_from_scalar(int(36 * EDSCALE)));
 	hbc->add_child(thumbnail);
 
 	text_container = memnew(VBoxContainer);
@@ -1097,12 +1095,10 @@ QuickOpenResultGridItem::QuickOpenResultGridItem() {
 	vbc->add_theme_constant_override(SNAME("separation"), 0);
 	add_child(vbc);
 
-	const int max_size = 64 * EDSCALE;
-
 	thumbnail = memnew(TextureRect);
 	thumbnail->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	thumbnail->set_v_size_flags(Control::SIZE_SHRINK_CENTER);
-	thumbnail->set_custom_minimum_size(Size2i(max_size, max_size));
+	thumbnail->set_custom_minimum_size(vec2i_from_scalar(int(64 * EDSCALE)));
 	vbc->add_child(thumbnail);
 
 	name = memnew(HighlightedLabel);

--- a/editor/gui/editor_toaster.cpp
+++ b/editor/gui/editor_toaster.cpp
@@ -279,7 +279,7 @@ void EditorToaster::_draw_button() {
 		default:
 			break;
 	}
-	main_button->draw_circle(Vector2(button_radius * 2, button_radius * 2), button_radius, color);
+	main_button->draw_circle(vec2_from_scalar(button_radius * 2), button_radius, color);
 }
 
 void EditorToaster::_draw_progress(Control *panel) {

--- a/editor/gui/window_wrapper.cpp
+++ b/editor/gui/window_wrapper.cpp
@@ -318,7 +318,7 @@ void WindowWrapper::set_margins_enabled(bool p_enabled) {
 		margins->queue_free();
 		margins = nullptr;
 	} else if (p_enabled && !margins) {
-		Size2 borders = Size2(4, 4) * EDSCALE;
+		Size2 borders = vec2_from_scalar(4 * EDSCALE);
 		margins = memnew(MarginContainer);
 		margins->add_theme_constant_override("margin_right", borders.width);
 		margins->add_theme_constant_override("margin_top", borders.height);
@@ -501,7 +501,7 @@ ScreenSelect::ScreenSelect() {
 	}
 
 	// Create the popup.
-	const Size2 borders = Size2(4, 4) * EDSCALE;
+	const Size2 borders = vec2_from_scalar(4 * EDSCALE);
 
 	popup = memnew(PopupPanel);
 	popup->connect("popup_hide", callable_mp(static_cast<BaseButton *>(this), &ScreenSelect::set_pressed).bind(false));

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -429,7 +429,7 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Impor
 		if (p_options.has(SNAME("primitive/size"))) {
 			box->set_size(p_options[SNAME("primitive/size")].operator Vector3() * p_applied_root_scale);
 		} else {
-			box->set_size(Vector3(2, 2, 2) * p_applied_root_scale);
+			box->set_size(vec3_from_scalar(2 * p_applied_root_scale));
 		}
 
 		Vector<Ref<Shape3D>> shapes;

--- a/editor/import/editor_atlas_packer.cpp
+++ b/editor/import/editor_atlas_packer.cpp
@@ -60,7 +60,7 @@ void EditorAtlasPacker::chart_pack(Vector<Chart> &charts, int &r_width, int &r_h
 
 		Ref<BitMap> src_bitmap;
 		src_bitmap.instantiate();
-		src_bitmap->create((aabb.size + Vector2(divide_by - 1, divide_by - 1)) / divide_by);
+		src_bitmap->create((aabb.size + vec2_from_scalar(divide_by - 1)) / divide_by);
 
 		int w = src_bitmap->get_size().width;
 		int h = src_bitmap->get_size().height;

--- a/editor/inspector/editor_resource_preview.cpp
+++ b/editor/inspector/editor_resource_preview.cpp
@@ -211,7 +211,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 
 		if (r_small_texture.is_null() && r_texture.is_valid() && preview_generators[i]->generate_small_preview_automatically()) {
 			Ref<Image> small_image = r_texture->get_image()->duplicate();
-			Vector2i new_size = Vector2i(1, 1) * small_thumbnail_size;
+			Vector2i new_size = vec2i_from_scalar(small_thumbnail_size);
 			const real_t aspect = small_image->get_size().aspect();
 			if (aspect > 1.0) {
 				new_size.y = MAX(1, new_size.y / aspect);
@@ -226,7 +226,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 				const Vector2i rect_size = rect->get_size();
 				small_image = Image::create_empty(small_thumbnail_size, small_thumbnail_size, false, rect->get_format());
 				// Blit the rectangle in the center of the square.
-				small_image->blit_rect(rect, Rect2i(Vector2i(), rect_size), (Vector2i(1, 1) * small_thumbnail_size - rect_size) / 2);
+				small_image->blit_rect(rect, Rect2i(Vector2i(), rect_size), (vec2i_from_scalar(small_thumbnail_size) - rect_size) / 2);
 			}
 
 			r_small_texture.instantiate();

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -222,7 +222,7 @@ void ProjectListItemControl::set_project_icon(const Ref<Texture2D> &p_icon) {
 	// The default project icon is 128×128 to look crisp on hiDPI displays,
 	// but we want the actual displayed size to be 64×64 on loDPI displays.
 	project_icon->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
-	project_icon->set_custom_minimum_size(Size2(64, 64) * EDSCALE);
+	project_icon->set_custom_minimum_size(vec2_from_scalar(64 * EDSCALE));
 	project_icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 
 	project_icon->set_texture(p_icon);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1254,7 +1254,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files) {
 }
 
 void ProjectManager::_titlebar_resized() {
-	DisplayServer::get_singleton()->window_set_window_buttons_offset(Vector2i(title_bar->get_global_position().y + title_bar->get_size().y / 2, title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
+	DisplayServer::get_singleton()->window_set_window_buttons_offset(vec2i_from_scalar(title_bar->get_global_position().y + title_bar->get_size().y / 2), DisplayServer::MAIN_WINDOW_ID);
 	const Vector3i &margin = DisplayServer::get_singleton()->window_get_safe_title_margins(DisplayServer::MAIN_WINDOW_ID);
 	if (left_menu_spacer) {
 		int w = (root_container->is_layout_rtl()) ? margin.y : margin.x;

--- a/editor/scene/2d/camera_2d_editor_plugin.cpp
+++ b/editor/scene/2d/camera_2d_editor_plugin.cpp
@@ -219,7 +219,7 @@ void Camera2DEditor::_update_hover(const Vector2 &p_mouse_pos) {
 
 	const Rect2 limit_rect = CanvasItemEditor::get_singleton()->get_canvas_transform().xform(selected_camera->get_limit_rect());
 	const float drag_tolerance = 8.0;
-	const Vector2 tolerance_vector = Vector2(1, 1) * drag_tolerance;
+	const Vector2 tolerance_vector = vec2_from_scalar(drag_tolerance);
 
 	hover_type = Drag::NONE;
 	if (Rect2(limit_rect.position - tolerance_vector, tolerance_vector * 2).has_point(p_mouse_pos)) {

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -932,7 +932,7 @@ void Polygon2DEditor::_center_view() {
 	Size2 texture_size;
 	if (node->get_texture().is_valid()) {
 		texture_size = node->get_texture()->get_size();
-		Vector2 zoom_factor = (canvas->get_size() - Vector2(1, 1) * 50 * EDSCALE) / texture_size;
+		Vector2 zoom_factor = (canvas->get_size() - vec2_from_scalar(50 * EDSCALE)) / texture_size;
 		zoom_widget->set_zoom(MIN(zoom_factor.x, zoom_factor.y));
 	} else {
 		zoom_widget->set_zoom(EDSCALE);
@@ -981,7 +981,7 @@ void Polygon2DEditor::_update_zoom_and_pan(bool p_zoom_at_center) {
 		max_corner = max_corner.max(points[i]);
 	}
 	Size2 page_size = canvas->get_size() / draw_zoom;
-	Vector2 margin = Vector2(50, 50) * EDSCALE / draw_zoom;
+	Vector2 margin = vec2_from_scalar(50 * EDSCALE) / draw_zoom;
 	min_corner -= page_size - margin;
 	max_corner += page_size - margin;
 
@@ -1182,7 +1182,7 @@ void Polygon2DEditor::_canvas_draw() {
 		if (weight_r) {
 			Vector2 draw_pos = mtx.xform(uvs[i]);
 			float weight = weight_r[i];
-			canvas->draw_rect(Rect2(draw_pos - Vector2(2, 2) * EDSCALE, Vector2(5, 5) * EDSCALE), Color(weight, weight, weight, 1.0), Math::round(EDSCALE));
+			canvas->draw_rect(Rect2(draw_pos - vec2_from_scalar(2 * EDSCALE), vec2_from_scalar(int(5 * EDSCALE))), Color(weight, weight, weight, 1.0), Math::round(EDSCALE));
 		} else {
 			if (i < uv_draw_max) {
 				canvas->draw_texture(handle, mtx.xform(uvs[i]) - handle->get_size() * 0.5);
@@ -1364,7 +1364,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	canvas_background = memnew(Panel);
 	uv_main_hsc->add_child(canvas_background);
 	canvas_background->set_h_size_flags(SIZE_EXPAND_FILL);
-	canvas_background->set_custom_minimum_size(Size2(200, 200) * EDSCALE);
+	canvas_background->set_custom_minimum_size(vec2_from_scalar(200 * EDSCALE));
 	canvas_background->set_clip_contents(true);
 
 	preview_polygon = memnew(Polygon2D);

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -492,7 +492,7 @@ void Sprite2DEditor::_debug_uv_draw() {
 void Sprite2DEditor::_center_view() {
 	Ref<Texture2D> tex = node->get_texture();
 	ERR_FAIL_COND(tex.is_null());
-	Vector2 zoom_factor = (debug_uv->get_size() - Vector2(1, 1) * 50 * EDSCALE) / tex->get_size();
+	Vector2 zoom_factor = (debug_uv->get_size() - vec2_from_scalar(50 * EDSCALE)) / tex->get_size();
 	zoom_widget->set_zoom(MIN(zoom_factor.x, zoom_factor.y));
 	// Recalculate scroll limits.
 	_update_zoom_and_pan(false);
@@ -533,7 +533,7 @@ void Sprite2DEditor::_update_zoom_and_pan(bool p_zoom_at_center) {
 	Point2 min_corner;
 	Point2 max_corner = tex->get_size();
 	Size2 page_size = debug_uv->get_size() / draw_zoom;
-	Vector2 margin = Vector2(50, 50) * EDSCALE / draw_zoom;
+	Vector2 margin = vec2_from_scalar(50 * EDSCALE) / draw_zoom;
 	min_corner -= page_size - margin;
 	max_corner += page_size - margin;
 

--- a/editor/scene/2d/tiles/atlas_merging_dialog.cpp
+++ b/editor/scene/2d/tiles/atlas_merging_dialog.cpp
@@ -311,7 +311,7 @@ AtlasMergingDialog::AtlasMergingDialog() {
 	// Atlas sources item list.
 	atlas_merging_atlases_list = memnew(ItemList);
 	atlas_merging_atlases_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	atlas_merging_atlases_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	atlas_merging_atlases_list->set_fixed_icon_size(vec2_from_scalar(60 * EDSCALE));
 	atlas_merging_atlases_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	atlas_merging_atlases_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	atlas_merging_atlases_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);

--- a/editor/scene/2d/tiles/tile_data_editors.cpp
+++ b/editor/scene/2d/tiles/tile_data_editors.cpp
@@ -162,7 +162,7 @@ void GenericTilePolygonEditor::_base_control_draw() {
 
 	Transform2D xform;
 	xform.set_origin(base_control->get_size() / 2 + panning);
-	xform.set_scale(Vector2(editor_zoom_widget->get_zoom(), editor_zoom_widget->get_zoom()));
+	xform.set_scale(vec2_from_scalar(editor_zoom_widget->get_zoom()));
 	base_control->draw_set_transform_matrix(xform);
 
 	// Draw fill rect under texture region.
@@ -523,7 +523,7 @@ void GenericTilePolygonEditor::_base_control_gui_input(Ref<InputEvent> p_event) 
 
 	Transform2D xform;
 	xform.set_origin(base_control->get_size() / 2 + panning);
-	xform.set_scale(Vector2(editor_zoom_widget->get_zoom(), editor_zoom_widget->get_zoom()));
+	xform.set_scale(vec2_from_scalar(editor_zoom_widget->get_zoom()));
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
@@ -1280,11 +1280,11 @@ void TileDataDefaultEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform2
 	if (value.get_type() == Variant::BOOL) {
 		Ref<Texture2D> texture = (bool)value ? tile_bool_checked : tile_bool_unchecked;
 		int size = MIN(tile_set->get_tile_size().x, tile_set->get_tile_size().y) / 3;
-		Rect2 rect = p_transform.xform(Rect2(Vector2(-size / 2, -size / 2) - texture_origin, Vector2(size, size)));
+		Rect2 rect = p_transform.xform(Rect2(vec2_from_scalar(-size / 2) - texture_origin, Vector2(size, size)));
 		p_canvas_item->draw_texture_rect(texture, rect);
 	} else if (value.get_type() == Variant::COLOR) {
 		int size = MIN(tile_set->get_tile_size().x, tile_set->get_tile_size().y) / 3;
-		Rect2 rect = p_transform.xform(Rect2(Vector2(-size / 2, -size / 2) - texture_origin, Vector2(size, size)));
+		Rect2 rect = p_transform.xform(Rect2(vec2_from_scalar(-size / 2) - texture_origin, Vector2(size, size)));
 		p_canvas_item->draw_rect(rect, value);
 	} else {
 		Ref<Font> font = TileSetEditor::get_singleton()->get_theme_font(SNAME("bold"), EditorStringName(EditorFonts));
@@ -1872,7 +1872,7 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 		terrain_property_editor->hide();
 	} else {
 		options.clear();
-		Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2(16, 16) * EDSCALE);
+		Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(vec2_from_scalar(16 * EDSCALE));
 		options.push_back(String(TTR("No terrain")) + String(":-1"));
 		for (int i = 0; i < tile_set->get_terrains_count(terrain_set); i++) {
 			String name = tile_set->get_terrain_name(terrain_set, i);

--- a/editor/scene/2d/tiles/tile_map_layer_editor.cpp
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.cpp
@@ -2378,7 +2378,7 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 
 	sources_list = memnew(ItemList);
 	sources_list->set_auto_translate_mode(Node::AUTO_TRANSLATE_MODE_DISABLED);
-	sources_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	sources_list->set_fixed_icon_size(vec2_from_scalar(60 * EDSCALE));
 	sources_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	sources_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	sources_list->set_stretch_ratio(0.25);
@@ -3320,7 +3320,7 @@ void TileMapLayerEditorTerrainsPlugin::_update_terrains_tree() {
 	}
 
 	// Fill in the terrain list.
-	Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(Size2(16, 16) * EDSCALE);
+	Vector<Vector<Ref<Texture2D>>> icons = tile_set->generate_terrains_icons(vec2_from_scalar(16 * EDSCALE));
 	for (int terrain_set_index = 0; terrain_set_index < tile_set->get_terrain_sets_count(); terrain_set_index++) {
 		// Add an item for the terrain set.
 		TreeItem *terrain_set_tree_item = terrains_tree->create_item();
@@ -3504,7 +3504,7 @@ TileMapLayerEditorTerrainsPlugin::TileMapLayerEditorTerrainsPlugin() {
 	terrains_tile_list->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	terrains_tile_list->set_max_columns(0);
 	terrains_tile_list->set_same_column_width(true);
-	terrains_tile_list->set_fixed_icon_size(Size2(32, 32) * EDSCALE);
+	terrains_tile_list->set_fixed_icon_size(vec2_from_scalar(32 * EDSCALE));
 	terrains_tile_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	tilemap_tab_terrains->add_child(terrains_tile_list);
 

--- a/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_atlas_source_editor.cpp
@@ -1007,7 +1007,7 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 				button->add_theme_constant_override("align_to_largest_stylebox", false);
 				button->set_mouse_filter(Control::MOUSE_FILTER_PASS);
 				button->connect(SceneStringName(pressed), callable_mp(this, &TileSetAtlasSourceEditor::_tile_alternatives_create_button_pressed).bind(tile_id));
-				button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), Vector2(texture_region_base_size_min, texture_region_base_size_min)));
+				button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), vec2_from_scalar(texture_region_base_size_min)));
 				button->set_expand_icon(true);
 				alternative_tiles_control->add_child(button);
 

--- a/editor/scene/2d/tiles/tile_set_editor.cpp
+++ b/editor/scene/2d/tiles/tile_set_editor.cpp
@@ -857,7 +857,7 @@ TileSetEditor::TileSetEditor() {
 
 	sources_list = memnew(ItemList);
 	sources_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	sources_list->set_fixed_icon_size(Size2(60, 60) * EDSCALE);
+	sources_list->set_fixed_icon_size(vec2_from_scalar(60 * EDSCALE));
 	sources_list->set_h_size_flags(SIZE_EXPAND_FILL);
 	sources_list->set_v_size_flags(SIZE_EXPAND_FILL);
 	sources_list->set_theme_type_variation("ItemListSecondary");

--- a/editor/scene/3d/bone_map_editor_plugin.cpp
+++ b/editor/scene/3d/bone_map_editor_plugin.cpp
@@ -341,7 +341,7 @@ void BoneMapper::update_group_idx() {
 
 void BoneMapper::_pick_bone(const StringName &p_bone_name) {
 	picker_key_name = p_bone_name;
-	picker->popup_bones_tree(Size2(500, 500) * EDSCALE);
+	picker->popup_bones_tree(vec2_from_scalar(500 * EDSCALE));
 }
 
 void BoneMapper::_apply_picker_selection() {

--- a/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_instance_3d_editor_plugin.cpp
@@ -663,7 +663,7 @@ MeshInstance3DEditor::MeshInstance3DEditor() {
 	debug_uv_dialog->add_child(debug_uv_arc);
 
 	debug_uv = memnew(Control);
-	debug_uv->set_custom_minimum_size(Size2(600, 600) * EDSCALE);
+	debug_uv->set_custom_minimum_size(vec2_from_scalar(600 * EDSCALE));
 	debug_uv->connect(SceneStringName(draw), callable_mp(this, &MeshInstance3DEditor::_debug_uv_draw));
 	debug_uv_arc->add_child(debug_uv);
 

--- a/editor/scene/3d/multimesh_editor_plugin.cpp
+++ b/editor/scene/3d/multimesh_editor_plugin.cpp
@@ -210,7 +210,7 @@ void MultiMeshEditor::_populate() {
 		xform.basis = post_xform * xform.basis;
 		//xform.basis.orthonormalize();
 
-		xform.basis.scale(Vector3(1, 1, 1) * (_scale + Math::random(-_scale_random, _scale_random)));
+		xform.basis.scale(vec3_from_scalar(_scale + Math::random(-_scale_random, _scale_random)));
 
 		multimesh->set_instance_transform(i, xform);
 	}

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -252,7 +252,7 @@ void EditorNode3DGizmo::_update_bvh() {
 	Transform3D transform = spatial_node->get_global_transform();
 
 	float effective_icon_size = selectable_icon_size > 0.0f ? selectable_icon_size : 0.0f;
-	Vector3 icon_size_vector3 = Vector3(effective_icon_size, effective_icon_size, effective_icon_size);
+	Vector3 icon_size_vector3 = vec3_from_scalar(effective_icon_size);
 	AABB aabb(spatial_node->get_position() - icon_size_vector3 * 100.0f, icon_size_vector3 * 200.0f);
 
 	for (const Vector3 &segment_end : collision_segments) {
@@ -315,7 +315,7 @@ void EditorNode3DGizmo::add_vertices(const Vector<Vector3> &p_vertices, const Re
 			md = MAX(0, p_vertices[i].length());
 		}
 		if (md) {
-			mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3(md, md, md) * 2.0));
+			mesh->set_custom_aabb(AABB(vec3_from_scalar(-md), vec3_from_scalar(md * 2.0)));
 		}
 	}
 
@@ -370,11 +370,11 @@ void EditorNode3DGizmo::add_unscaled_billboard(const Ref<Material> &p_material, 
 		md = MAX(0, vs[i].length());
 	}
 	if (md) {
-		mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3(md, md, md) * 2.0));
+		mesh->set_custom_aabb(AABB(vec3_from_scalar(-md), vec3_from_scalar(md * 2.0)));
 	}
 
 	selectable_icon_size = p_scale;
-	mesh->set_custom_aabb(AABB(Vector3(-selectable_icon_size, -selectable_icon_size, -selectable_icon_size) * 100.0f, Vector3(selectable_icon_size, selectable_icon_size, selectable_icon_size) * 200.0f));
+	mesh->set_custom_aabb(AABB(vec3_from_scalar(-selectable_icon_size * 100.0f), vec3_from_scalar(selectable_icon_size * 200.0f)));
 
 	ins.mesh = mesh;
 	if (valid) {
@@ -456,7 +456,7 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 			md = MAX(0, p_handles[i].length());
 		}
 		if (md) {
-			mesh->set_custom_aabb(AABB(Vector3(-md, -md, -md), Vector3(md, md, md) * 2.0));
+			mesh->set_custom_aabb(AABB(vec3_from_scalar(-md), vec3_from_scalar(md * 2.0)));
 		}
 	}
 

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -4281,7 +4281,7 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 			(gizmo_size / Math::abs(dd)) * MAX(1, EDSCALE) *
 			MIN(viewport_base_height, subviewport_container->get_size().height) / viewport_base_height /
 			subviewport_container->get_stretch_shrink();
-	Vector3 scale = Vector3(1, 1, 1) * gizmo_scale;
+	Vector3 scale = vec3_from_scalar(gizmo_scale);
 
 	// if the determinant is zero, we should disable the gizmo from being rendered
 	// this prevents supplying bad values to the renderer and then having to filter it out again
@@ -6001,7 +6001,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	position_control = memnew(ViewportNavigationControl);
 	position_control->set_navigation_mode(Node3DEditorViewport::NAVIGATION_MOVE);
-	position_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
+	position_control->set_custom_minimum_size(vec2_from_scalar(navigation_control_size * EDSCALE));
 	position_control->set_h_size_flags(SIZE_SHRINK_END);
 	position_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
 	position_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
@@ -6012,7 +6012,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	look_control = memnew(ViewportNavigationControl);
 	look_control->set_navigation_mode(Node3DEditorViewport::NAVIGATION_LOOK);
-	look_control->set_custom_minimum_size(Size2(navigation_control_size, navigation_control_size) * EDSCALE);
+	look_control->set_custom_minimum_size(vec2_from_scalar(navigation_control_size * EDSCALE));
 	look_control->set_h_size_flags(SIZE_SHRINK_END);
 	look_control->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -navigation_control_size * EDSCALE);
 	look_control->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -navigation_control_size * EDSCALE);
@@ -6022,7 +6022,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	surface->add_child(look_control);
 
 	rotation_control = memnew(ViewportRotationControl);
-	rotation_control->set_custom_minimum_size(Size2(80, 80) * EDSCALE);
+	rotation_control->set_custom_minimum_size(vec2_from_scalar(80 * EDSCALE));
 	rotation_control->set_h_size_flags(SIZE_SHRINK_END);
 	rotation_control->set_viewport(this);
 	rotation_control->set_focus_mode(FOCUS_CLICK);
@@ -9787,7 +9787,7 @@ Node3DEditor::Node3DEditor() {
 
 		CenterContainer *sun_direction_center = memnew(CenterContainer);
 		sun_direction = memnew(Control);
-		sun_direction->set_custom_minimum_size(Size2(128, 128) * EDSCALE);
+		sun_direction->set_custom_minimum_size(vec2_from_scalar(128 * EDSCALE));
 		sun_direction_center->add_child(sun_direction);
 		sun_vb->add_margin_child(TTRC("Sun Direction"), sun_direction_center);
 		sun_direction->connect(SceneStringName(gui_input), callable_mp(this, &Node3DEditor::_sun_direction_input));

--- a/editor/scene/3d/root_motion_editor_plugin.cpp
+++ b/editor/scene/3d/root_motion_editor_plugin.cpp
@@ -156,7 +156,7 @@ void EditorPropertyRootMotion::_node_assign() {
 	}
 
 	filters->ensure_cursor_is_visible();
-	filter_dialog->popup_centered(Size2(500, 500) * EDSCALE);
+	filter_dialog->popup_centered(vec2_from_scalar(500 * EDSCALE));
 }
 
 void EditorPropertyRootMotion::_node_clear() {

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -3092,14 +3092,14 @@ void CanvasItemEditor::_draw_rulers() {
 	// Subdivisions
 	int major_subdivision = 2;
 	Transform2D major_subdivide;
-	major_subdivide.scale(Size2(1.0 / major_subdivision, 1.0 / major_subdivision));
+	major_subdivide.scale(vec2_from_scalar(1.0 / major_subdivision));
 
 	int minor_subdivision = 5;
 	Transform2D minor_subdivide;
-	minor_subdivide.scale(Size2(1.0 / minor_subdivision, 1.0 / minor_subdivision));
+	minor_subdivide.scale(vec2_from_scalar(1.0 / minor_subdivision));
 
 	// First and last graduations to draw (in the ruler space)
-	Point2 first = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(Point2(ruler_width_scaled, ruler_width_scaled));
+	Point2 first = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(vec2_from_scalar(ruler_width_scaled));
 	Point2 last = (transform * ruler_transform * major_subdivide * minor_subdivide).affine_inverse().xform(viewport->get_size());
 
 	// Draw top ruler
@@ -3142,7 +3142,7 @@ void CanvasItemEditor::_draw_rulers() {
 	}
 
 	// Draw the top left corner
-	viewport->draw_rect(Rect2(Point2(), Size2(ruler_width_scaled, ruler_width_scaled)), graduation_color);
+	viewport->draw_rect(Rect2(Point2(), vec2_from_scalar(ruler_width_scaled)), graduation_color);
 }
 
 void CanvasItemEditor::_draw_grid() {
@@ -3920,7 +3920,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 
 void CanvasItemEditor::_draw_hover() {
 	List<Rect2> previous_rects;
-	Vector2 icon_size = Vector2(1, 1) * get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor));
+	Vector2 icon_size = vec2_from_scalar(get_theme_constant(SNAME("class_icon_size"), EditorStringName(Editor)));
 
 	for (int i = 0; i < hovering_results.size(); i++) {
 		Ref<Texture2D> node_icon = hovering_results[i].icon;
@@ -3979,7 +3979,7 @@ void CanvasItemEditor::_draw_message() {
 			case DRAG_SCALE_X:
 			case DRAG_SCALE_Y:
 			case DRAG_SCALE_BOTH: {
-				Vector2 original_scale = (Math::is_zero_approx(original_transform.get_scale().x) || Math::is_zero_approx(original_transform.get_scale().y)) ? Vector2(CMP_EPSILON, CMP_EPSILON) : original_transform.get_scale();
+				Vector2 original_scale = (Math::is_zero_approx(original_transform.get_scale().x) || Math::is_zero_approx(original_transform.get_scale().y)) ? vec2_from_scalar(CMP_EPSILON) : original_transform.get_scale();
 				Vector2 delta = current_transform.get_scale() / original_scale;
 				if (drag_type == DRAG_SCALE_BOTH) {
 					message = TTR("Scaling:") + String::utf8(" ×(") + FORMAT(delta.x) + ", " + FORMAT(delta.y) + ")";
@@ -4319,7 +4319,7 @@ void CanvasItemEditor::_update_scrollbars() {
 
 	// Move the zoom buttons.
 	Point2 controls_vb_begin = Point2(5, 5);
-	controls_vb_begin += (show_rulers) ? Point2(ruler_width_scaled, ruler_width_scaled) : Point2();
+	controls_vb_begin += (show_rulers) ? vec2_from_scalar(ruler_width_scaled) : Point2();
 	controls_vb->set_begin(controls_vb_begin);
 
 	Size2 hmin = h_scroll->get_minimum_size();

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -450,14 +450,14 @@ EditorSceneTabs::EditorSceneTabs() {
 	add_child(tab_preview_anchor);
 
 	tab_preview_panel = memnew(Panel);
-	tab_preview_panel->set_size(Size2(100, 100) * EDSCALE);
+	tab_preview_panel->set_size(vec2_from_scalar(100 * EDSCALE));
 	tab_preview_panel->hide();
 	tab_preview_panel->set_self_modulate(Color(1, 1, 1, 0.7));
 	tab_preview_anchor->add_child(tab_preview_panel);
 
 	tab_preview = memnew(TextureRect);
 	tab_preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	tab_preview->set_size(Size2(96, 96) * EDSCALE);
-	tab_preview->set_position(Point2(2, 2) * EDSCALE);
+	tab_preview->set_size(vec2_from_scalar(96 * EDSCALE));
+	tab_preview->set_position(vec2_from_scalar(2 * EDSCALE));
 	tab_preview_panel->add_child(tab_preview);
 }

--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -498,7 +498,7 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 // Toolbars controls.
 
 Size2 ControlEditorPopupButton::get_minimum_size() const {
-	Vector2 base_size = Vector2(26, 26) * EDSCALE;
+	Vector2 base_size = vec2_from_scalar(26 * EDSCALE);
 
 	if (arrow_icon.is_null()) {
 		return base_size;
@@ -580,7 +580,7 @@ void ControlEditorPresetPicker::_add_row_button(HBoxContainer *p_row, const int 
 	ERR_FAIL_COND(preset_buttons.has(p_preset));
 
 	Button *b = memnew(Button);
-	b->set_custom_minimum_size(Size2i(36, 36) * EDSCALE);
+	b->set_custom_minimum_size(vec2i_from_scalar(36 * EDSCALE));
 	b->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	b->set_tooltip_text(p_name);
 	b->set_flat(true);

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -938,7 +938,7 @@ void FontPreview::_notification(int p_what) {
 void FontPreview::_bind_methods() {}
 
 Size2 FontPreview::get_minimum_size() const {
-	return Vector2(64, 64) * EDSCALE;
+	return vec2_from_scalar(64 * EDSCALE);
 }
 
 void FontPreview::set_data(const Ref<Font> &p_f) {

--- a/editor/scene/material_editor_plugin.cpp
+++ b/editor/scene/material_editor_plugin.cpp
@@ -221,7 +221,7 @@ MaterialEditor::MaterialEditor() {
 
 	rect_instance = memnew(ColorRect);
 	layout_2d->add_child(rect_instance);
-	rect_instance->set_custom_minimum_size(Size2(150, 150) * EDSCALE);
+	rect_instance->set_custom_minimum_size(vec2_from_scalar(150 * EDSCALE));
 
 	layout_2d->set_visible(false);
 

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -161,7 +161,7 @@ VSRerouteNode::VSRerouteNode() {
 	Label *title_lbl = Object::cast_to<Label>(get_titlebar_hbox()->get_child(0));
 	title_lbl->hide();
 
-	const Size2 size = Size2(32, 32) * EDSCALE;
+	const Size2 size = vec2_from_scalar(32 * EDSCALE);
 
 	Control *slot_area = memnew(Control);
 	slot_area->set_custom_minimum_size(size);
@@ -5595,7 +5595,7 @@ void VisualShaderEditor::_duplicate_nodes() {
 		return;
 	}
 
-	_dup_paste_nodes(type, items, node_connections, Vector2(10, 10) * EDSCALE, true);
+	_dup_paste_nodes(type, items, node_connections, vec2_from_scalar(10 * EDSCALE), true);
 }
 
 void VisualShaderEditor::_copy_nodes(bool p_cut) {
@@ -8386,7 +8386,7 @@ void VisualShaderNodePortPreview::setup(const Ref<VisualShader> &p_shader, Ref<S
 
 Size2 VisualShaderNodePortPreview::get_minimum_size() const {
 	int port_preview_size = EDITOR_GET("editors/visual_editors/visual_shader/port_preview_size");
-	return Size2(port_preview_size, port_preview_size) * EDSCALE;
+	return vec2_from_scalar(port_preview_size * EDSCALE);
 }
 
 void VisualShaderNodePortPreview::_notification(int p_what) {

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -122,7 +122,7 @@ void GodotWorldBoundaryShape2D::set_data(const Variant &p_data) {
 	ERR_FAIL_COND(arr.size() != 2);
 	normal = arr[0];
 	d = arr[1];
-	configure(Rect2(Vector2(-1e15, -1e15), Vector2(1e15 * 2, 1e15 * 2)));
+	configure(Rect2(vec2_from_scalar(-1e15), vec2_from_scalar(1e15 * 2)));
 }
 
 Variant GodotWorldBoundaryShape2D::get_data() const {

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -152,7 +152,7 @@ Vector3 GodotWorldBoundaryShape3D::get_moment_of_inertia(real_t p_mass) const {
 
 void GodotWorldBoundaryShape3D::_setup(const Plane &p_plane) {
 	plane = p_plane;
-	configure(AABB(Vector3(-1e15, -1e15, -1e15), Vector3(1e15 * 2, 1e15 * 2, 1e15 * 2)));
+	configure(AABB(vec3_from_scalar(-1e15), vec3_from_scalar(1e15 * 2)));
 }
 
 void GodotWorldBoundaryShape3D::set_data(const Variant &p_data) {
@@ -294,7 +294,7 @@ Vector3 GodotSphereShape3D::get_moment_of_inertia(real_t p_mass) const {
 
 void GodotSphereShape3D::_setup(real_t p_radius) {
 	radius = p_radius;
-	configure(AABB(Vector3(-radius, -radius, -radius), Vector3(radius * 2.0, radius * 2.0, radius * 2.0)));
+	configure(AABB(vec3_from_scalar(-radius), vec3_from_scalar(radius * 2.0)));
 }
 
 void GodotSphereShape3D::set_data(const Variant &p_data) {

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -297,7 +297,7 @@ void GodotSoftBody3D::apply_nodes_transform(const Transform3D &p_transform) {
 	}
 
 	uint32_t node_count = nodes.size();
-	Vector3 leaf_size = Vector3(collision_margin, collision_margin, collision_margin) * 2.0;
+	Vector3 leaf_size = vec3_from_scalar(collision_margin * 2.0);
 	for (uint32_t node_index = 0; node_index < node_count; ++node_index) {
 		Node &node = nodes[node_index];
 
@@ -560,7 +560,7 @@ bool GodotSoftBody3D::create_from_trimesh(const Vector<int> &p_indices, const Ve
 	// Create nodes from vertices.
 	nodes.resize(node_count);
 	real_t inv_node_mass = node_count * inv_total_mass;
-	Vector3 leaf_size = Vector3(collision_margin, collision_margin, collision_margin) * 2.0;
+	Vector3 leaf_size = vec3_from_scalar(collision_margin * 2.0);
 	for (uint32_t i = 0; i < node_count; ++i) {
 		Node &node = nodes[i];
 		node.s = vertices[i];

--- a/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/modules/godot_physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -322,7 +322,7 @@ bool GodotGeneric6DOFJoint3D::setup(real_t p_timestep) {
 	}
 
 	// Clear accumulated impulses for the next simulation step
-	m_linearLimits.m_accumulatedImpulse = Vector3(real_t(0.), real_t(0.), real_t(0.));
+	m_linearLimits.m_accumulatedImpulse = vec3_from_scalar(real_t(0.));
 	int i;
 	for (i = 0; i < 3; i++) {
 		m_angularLimits[i].m_accumulatedImpulse = real_t(0.);

--- a/modules/godot_physics_3d/joints/godot_jacobian_entry_3d.h
+++ b/modules/godot_physics_3d/joints/godot_jacobian_entry_3d.h
@@ -80,7 +80,7 @@ public:
 			const Basis &world2B,
 			const Vector3 &inertiaInvA,
 			const Vector3 &inertiaInvB) :
-			m_linearJointAxis(Vector3(real_t(0.), real_t(0.), real_t(0.))) {
+			m_linearJointAxis(vec3_from_scalar(real_t(0.))) {
 		m_aJ = world2A.xform(jointAxis);
 		m_bJ = world2B.xform(-jointAxis);
 		m_0MinvJt = inertiaInvA * m_aJ;
@@ -95,7 +95,7 @@ public:
 			const Vector3 &axisInB,
 			const Vector3 &inertiaInvA,
 			const Vector3 &inertiaInvB) :
-			m_linearJointAxis(Vector3(real_t(0.), real_t(0.), real_t(0.))),
+			m_linearJointAxis(vec3_from_scalar(real_t(0.))),
 			m_aJ(axisInA),
 			m_bJ(-axisInB) {
 		m_0MinvJt = inertiaInvA * m_aJ;
@@ -116,7 +116,7 @@ public:
 		m_aJ = world2A.xform(rel_pos1.cross(jointAxis));
 		m_bJ = world2A.xform(rel_pos2.cross(-jointAxis));
 		m_0MinvJt = inertiaInvA * m_aJ;
-		m_1MinvJt = Vector3(real_t(0.), real_t(0.), real_t(0.));
+		m_1MinvJt = vec3_from_scalar(real_t(0.));
 		m_Adiag = massInvA + m_0MinvJt.dot(m_aJ);
 
 		ERR_FAIL_COND(m_Adiag <= real_t(0.0));

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -186,7 +186,7 @@ void GridMapEditor::_menu_option(int p_option) {
 
 		} break;
 		case MENU_OPTION_GRIDMAP_SETTINGS: {
-			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + Size2(50, 50) * EDSCALE);
+			settings_dialog->popup_centered(settings_vbc->get_combined_minimum_size() + vec2_from_scalar(50 * EDSCALE));
 		} break;
 	}
 }

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -684,7 +684,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 		xform.basis = _ortho_bases[c.rot];
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(vec3_from_scalar(cell_scale));
 		if (baked_meshes.is_empty()) {
 			if (mesh_library->get_item_mesh(c.item).is_valid()) {
 				if (!item_id_to_multimesh_item_placements.has(c.item)) {
@@ -1330,7 +1330,7 @@ Array GridMap::get_meshes() const {
 		xform.basis = _ortho_bases[E.value.rot];
 
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(vec3_from_scalar(cell_scale));
 
 		meshes.push_back(xform * mesh_library->get_item_mesh_transform(id));
 		meshes.push_back(mesh);
@@ -1384,7 +1384,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 
 		xform.basis = _ortho_bases[E.value.rot];
 		xform.set_origin(cellpos * cell_size + ofs);
-		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
+		xform.basis.scale(vec3_from_scalar(cell_scale));
 
 		const OctantKey ok = get_octant_key_from_index_key(key);
 

--- a/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
+++ b/modules/jolt_physics/shapes/jolt_world_boundary_shape_3d.cpp
@@ -67,7 +67,7 @@ void JoltWorldBoundaryShape3D::set_data(const Variant &p_data) {
 AABB JoltWorldBoundaryShape3D::get_aabb() const {
 	const float size = JoltProjectSettings::world_boundary_shape_size;
 	const float half_size = size / 2.0f;
-	return AABB(Vector3(-half_size, -half_size, -half_size), Vector3(size, half_size, size));
+	return AABB(vec3_from_scalar(-half_size), Vector3(size, half_size, size));
 }
 
 String JoltWorldBoundaryShape3D::to_string() const {

--- a/modules/openxr/extensions/openxr_render_model_extension.cpp
+++ b/modules/openxr/extensions/openxr_render_model_extension.cpp
@@ -559,7 +559,7 @@ Transform3D OpenXRRenderModelExtension::render_model_get_root_transform(RID p_re
 
 	// Scale our root transform
 	real_t world_scale = xr_server->get_world_scale();
-	Transform3D root_transform = render_model->root_transform.scaled(Vector3(world_scale, world_scale, world_scale));
+	Transform3D root_transform = render_model->root_transform.scaled(vec3_from_scalar(world_scale));
 
 	return xr_server->get_reference_frame() * root_transform;
 }

--- a/platform/web/display_server_web.cpp
+++ b/platform/web/display_server_web.cpp
@@ -905,7 +905,7 @@ void DisplayServerWeb::_ime_callback(int p_type, const String &p_text) {
 			// IME update.
 			if (ds->ime_active && ds->ime_started) {
 				ds->ime_text = p_text;
-				ds->ime_selection = Vector2i(ds->ime_text.length(), ds->ime_text.length());
+				ds->ime_selection = vec2i_from_scalar(ds->ime_text.length());
 				OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_OS_IME_UPDATE);
 			}
 		} break;

--- a/scene/2d/marker_2d.cpp
+++ b/scene/2d/marker_2d.cpp
@@ -64,7 +64,7 @@ void Marker2D::_draw_cross() {
 #ifdef DEBUG_ENABLED
 Rect2 Marker2D::_edit_get_rect() const {
 	real_t extents = get_gizmo_extents();
-	return Rect2(Point2(-extents, -extents), Size2(extents * 2, extents * 2));
+	return Rect2(vec2_from_scalar(-extents), vec2_from_scalar(extents * 2));
 }
 
 bool Marker2D::_edit_use_rect() const {

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -369,8 +369,7 @@ void NavigationObstacle2D::navmesh_parse_source_geometry(const Ref<NavigationPol
 
 	if (obstacle_radius > 0.0) {
 		// Radius defined obstacle should be uniformly scaled from obstacle basis max scale axis.
-		const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
-		const Vector2 uniform_max_scale = Vector2(scaling_max_value, scaling_max_value);
+		const Vector2 uniform_max_scale = vec2_from_scalar((float)safe_scale[safe_scale.max_axis_index()]);
 		const Transform2D obstacle_circle_transform = p_source_geometry_data->root_node_transform * Transform2D(obstacle->get_global_rotation(), uniform_max_scale, 0.0, obstacle->get_global_position());
 
 		Vector<Vector2> obstruction_circle_vertices;

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -127,7 +127,7 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_s
 	}
 
 	set_position(new_ofs);
-	set_scale(Vector2(1, 1) * p_scale * orig_scale);
+	set_scale(vec2_from_scalar(p_scale) * orig_scale);
 
 	_update_mirroring();
 }

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -1082,7 +1082,7 @@ void TileMapLayer::_physics_draw_quadrant_debug(const RID &p_canvas_item, DebugQ
 	rs->mesh_clear(r_debug_quadrant.physics_mesh);
 
 	// Redraw all shapes from the physics quadrants
-	Rect2i covered_cell_area = Rect2i(r_debug_quadrant.quadrant_coords * TILE_MAP_DEBUG_QUADRANT_SIZE, Vector2i(TILE_MAP_DEBUG_QUADRANT_SIZE, TILE_MAP_DEBUG_QUADRANT_SIZE));
+	Rect2i covered_cell_area = Rect2i(r_debug_quadrant.quadrant_coords * TILE_MAP_DEBUG_QUADRANT_SIZE, vec2i_from_scalar(TILE_MAP_DEBUG_QUADRANT_SIZE));
 	Vector2i first_physics_quadrant_coords = _coords_to_quadrant_coords(covered_cell_area.get_position() - Vector2i(1, 1), physics_quadrant_size) + Vector2i(1, 1);
 	Vector2i last_physics_quadrant_coords = _coords_to_quadrant_coords(covered_cell_area.get_end() - Vector2i(1, 1), physics_quadrant_size) + Vector2i(1, 1);
 

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -82,7 +82,7 @@ real_t GPUParticlesCollisionSphere3D::get_radius() const {
 }
 
 AABB GPUParticlesCollisionSphere3D::get_aabb() const {
-	return AABB(Vector3(-radius, -radius, -radius), Vector3(radius * 2, radius * 2, radius * 2));
+	return AABB(vec3_from_scalar(-radius), vec3_from_scalar(radius * 2));
 }
 
 GPUParticlesCollisionSphere3D::GPUParticlesCollisionSphere3D() :
@@ -506,7 +506,7 @@ Ref<Image> GPUParticlesCollisionSDF3D::bake() {
 	params.cells = (float *)cells_data.ptrw();
 	params.size = sdf_size;
 	params.cell_size = cell_size;
-	params.cell_offset = aabb.position + Vector3(cell_size * 0.5, cell_size * 0.5, cell_size * 0.5);
+	params.cell_offset = aabb.position + vec3_from_scalar(cell_size * 0.5);
 	params.bvh = bvh.ptr();
 	params.triangles = faces.ptr();
 	params.thickness = th;
@@ -933,7 +933,7 @@ real_t GPUParticlesAttractorSphere3D::get_radius() const {
 }
 
 AABB GPUParticlesAttractorSphere3D::get_aabb() const {
-	return AABB(Vector3(-radius, -radius, -radius), Vector3(radius * 2, radius * 2, radius * 2));
+	return AABB(vec3_from_scalar(-radius), vec3_from_scalar(radius * 2));
 }
 
 GPUParticlesAttractorSphere3D::GPUParticlesAttractorSphere3D() :

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -627,8 +627,8 @@ void Label3D::_shape() {
 		case StandardMaterial3D::BILLBOARD_ENABLED: {
 			real_t size_new = MAX(Math::abs(aabb.position.x), (aabb.position.x + aabb.size.x));
 			size_new = MAX(size_new, MAX(Math::abs(aabb.position.y), (aabb.position.y + aabb.size.y)));
-			aabb.position = Vector3(-size_new, -size_new, -size_new);
-			aabb.size = Vector3(size_new * 2.0, size_new * 2.0, size_new * 2.0);
+			aabb.position = vec3_from_scalar(-size_new);
+			aabb.size = vec3_from_scalar(size_new * 2.0);
 		} break;
 		case StandardMaterial3D::BILLBOARD_FIXED_Y: {
 			real_t size_new = MAX(Math::abs(aabb.position.x), (aabb.position.x + aabb.size.x));

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -159,7 +159,7 @@ AABB Light3D::get_aabb() const {
 		return AABB(Vector3(-1, -1, -1), Vector3(2, 2, 2));
 
 	} else if (type == RenderingServer::LIGHT_OMNI) {
-		return AABB(Vector3(-1, -1, -1) * param[PARAM_RANGE], Vector3(2, 2, 2) * param[PARAM_RANGE]);
+		return AABB(vec3_from_scalar(-param[PARAM_RANGE]), vec3_from_scalar(param[PARAM_RANGE] * 2));
 
 	} else if (type == RenderingServer::LIGHT_SPOT) {
 		real_t cone_slant_height = param[PARAM_RANGE];
@@ -167,7 +167,7 @@ AABB Light3D::get_aabb() const {
 
 		if (cone_angle_rad > Math::PI / 2.0) {
 			// Just return the AABB of an omni light if the spot angle is above 90 degrees.
-			return AABB(Vector3(-1, -1, -1) * cone_slant_height, Vector3(2, 2, 2) * cone_slant_height);
+			return AABB(vec3_from_scalar(-cone_slant_height), vec3_from_scalar(cone_slant_height * 2));
 		}
 
 		real_t size = Math::sin(cone_angle_rad) * cone_slant_height;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -745,7 +745,7 @@ void LightmapGI::_plot_triangle_into_octree(GenProbesOctree *p_cell, float p_cel
 
 		AABB subcell;
 		subcell.position = Vector3(pos) * p_cell_size;
-		subcell.size = Vector3(half_size, half_size, half_size) * p_cell_size;
+		subcell.size = vec3_from_scalar(half_size * p_cell_size);
 
 		if (!Geometry3D::triangle_box_overlap(subcell.get_center(), subcell.size * 0.5, p_triangle)) {
 			continue;

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -174,7 +174,7 @@ void NavigationObstacle3D::_notification(int p_what) {
 					const Vector3 safe_scale = get_global_basis().get_scale().abs().maxf(0.001);
 					// Agent radius is a scalar value and does not support non-uniform scaling, choose the largest axis.
 					const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
-					const Vector3 uniform_max_scale = Vector3(scaling_max_value, scaling_max_value, scaling_max_value);
+					const Vector3 uniform_max_scale = vec3_from_scalar(scaling_max_value);
 					const Transform3D debug_transform = Transform3D(Basis().scaled(uniform_max_scale), get_global_position());
 
 					RS::get_singleton()->instance_set_transform(fake_agent_radius_debug_instance_rid, debug_transform);
@@ -452,7 +452,7 @@ void NavigationObstacle3D::navmesh_parse_source_geometry(const Ref<NavigationMes
 	if (obstacle_radius > 0.0) {
 		// Radius defined obstacle should be uniformly scaled from obstacle basis max scale axis.
 		const float scaling_max_value = safe_scale[safe_scale.max_axis_index()];
-		const Vector3 uniform_max_scale = Vector3(scaling_max_value, scaling_max_value, scaling_max_value);
+		const Vector3 uniform_max_scale = vec3_from_scalar(scaling_max_value);
 		const Transform3D obstacle_circle_transform = p_source_geometry_data->root_node_transform * Transform3D(Basis().scaled(uniform_max_scale), obstacle->get_global_position());
 
 		Vector<Vector3> obstruction_circle_vertices;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -247,8 +247,8 @@ void SpriteBase3D::draw_texture_rect(Ref<Texture2D> p_texture, Rect2 p_dst_rect,
 		case StandardMaterial3D::BILLBOARD_ENABLED: {
 			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);
 			size_new = MAX(size_new, MAX(Math::abs(final_rect.position.y) * px_size, (final_rect.position.y + final_rect.size.y) * px_size));
-			aabb_new.position = Vector3(-size_new, -size_new, -size_new);
-			aabb_new.size = Vector3(size_new * 2.0, size_new * 2.0, size_new * 2.0);
+			aabb_new.position = vec3_from_scalar(-size_new);
+			aabb_new.size = vec3_from_scalar(size_new * 2.0);
 		} break;
 		case StandardMaterial3D::BILLBOARD_FIXED_Y: {
 			real_t size_new = MAX(Math::abs(final_rect.position.x) * px_size, (final_rect.position.x + final_rect.size.x) * px_size);

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -692,11 +692,11 @@ void Voxelizer::begin_bake(int p_subdiv, const AABB &p_bounds, float p_exposure_
 	}
 
 	Transform3D to_bounds;
-	to_bounds.basis.scale(Vector3(po2_bounds.size[longest_axis], po2_bounds.size[longest_axis], po2_bounds.size[longest_axis]));
+	to_bounds.basis.scale(vec3_from_scalar(po2_bounds.size[longest_axis]));
 	to_bounds.origin = po2_bounds.position;
 
 	Transform3D to_grid;
-	to_grid.basis.scale(Vector3(axis_cell_size[longest_axis], axis_cell_size[longest_axis], axis_cell_size[longest_axis]));
+	to_grid.basis.scale(vec3_from_scalar(axis_cell_size[longest_axis]));
 
 	to_cell_space = to_grid * to_bounds.affine_inverse();
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1355,7 +1355,8 @@ void CodeEdit::_main_gutter_draw_callback(int p_line, int p_gutter, const Rect2 
 			}
 			Rect2 icon_region = p_region;
 			icon_region.position += Point2(padding, padding);
-			icon_region.size -= Point2(padding, padding) * 2;
+
+			icon_region.size -= vec2_from_scalar(padding * 2);
 			theme_cache.breakpoint_icon->draw_rect(ci, icon_region, false, use_color);
 		}
 	}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1677,7 +1677,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 									if (rtl) {
 										coff.x = rect.size.width - table->columns[col].width - coff.x;
 									}
-									Rect2 crect = Rect2(rect.position + coff - frame->padding.position - Vector2(theme_cache.table_h_separation * 0.5, theme_cache.table_h_separation * 0.5).floor(), Size2(table->columns[col].width + theme_cache.table_h_separation, table->rows[row] + theme_cache.table_v_separation) + frame->padding.position + frame->padding.size);
+									Rect2 crect = Rect2(rect.position + coff - frame->padding.position - vec2_from_scalar(theme_cache.table_h_separation * 0.5).floor(), Size2(table->columns[col].width + theme_cache.table_h_separation, table->rows[row] + theme_cache.table_v_separation) + frame->padding.position + frame->padding.size);
 									if (col == col_count - 1) {
 										if (rtl) {
 											crect.size.x = crect.position.x + crect.size.x;
@@ -6517,7 +6517,7 @@ Vector2i RichTextLabel::get_line_range(int p_line) {
 		int lc = main->lines[i].text_buf->get_line_count();
 
 		if (p_line < line_count + lc) {
-			Vector2i char_offset = Vector2i(main->lines[i].char_offset, main->lines[i].char_offset);
+			Vector2i char_offset = vec2i_from_scalar(main->lines[i].char_offset);
 			Vector2i line_range = main->lines[i].text_buf->get_line_range(p_line - line_count);
 			return char_offset + line_range;
 		}

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -219,7 +219,7 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (stretch && shrink > 1) {
 		Transform2D xform;
-		xform.scale(Vector2(1, 1) / shrink);
+		xform.scale(vec2_from_scalar(1 / shrink));
 		_send_event_to_viewports(p_event->xformed_by(xform));
 	} else {
 		_send_event_to_viewports(p_event);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7847,7 +7847,7 @@ void TextEdit::_cut_internal(int p_caret) {
 	if (p_caret == -1) {
 		line_ranges = get_line_ranges_from_carets();
 	} else {
-		line_ranges.push_back(Point2i(get_caret_line(p_caret), get_caret_line(p_caret)));
+		line_ranges.push_back(vec2i_from_scalar(get_caret_line(p_caret)));
 	}
 	int line_offset = 0;
 	for (Point2i line_range : line_ranges) {
@@ -7881,7 +7881,7 @@ void TextEdit::_copy_internal(int p_caret) {
 		// When there are multiple carets on a line, only copy it once.
 		line_ranges = get_line_ranges_from_carets(false, true);
 	} else {
-		line_ranges.push_back(Point2i(get_caret_line(p_caret), get_caret_line(p_caret)));
+		line_ranges.push_back(vec2i_from_scalar(get_caret_line(p_caret)));
 	}
 	for (Point2i line_range : line_ranges) {
 		for (int i = line_range.x; i <= line_range.y; i++) {

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -91,7 +91,7 @@ Transform2D CanvasLayer::get_transform() const {
 Transform2D CanvasLayer::get_final_transform() const {
 	if (is_following_viewport()) {
 		Transform2D follow;
-		follow.scale(Vector2(get_follow_viewport_scale(), get_follow_viewport_scale()));
+		follow.scale(vec2_from_scalar(get_follow_viewport_scale()));
 		if (vp) {
 			follow = vp->get_canvas_transform() * follow;
 		}

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -5548,7 +5548,7 @@ Transform2D SubViewport::get_screen_transform_internal(bool p_absolute_position)
 	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());
 	if (c) {
 		if (c->is_stretch_enabled()) {
-			container_transform.scale(Vector2(c->get_stretch_shrink(), c->get_stretch_shrink()));
+			container_transform.scale(vec2_from_scalar(c->get_stretch_shrink()));
 		}
 		container_transform = c->get_viewport()->get_screen_transform_internal(p_absolute_position) * c->get_global_transform_with_canvas() * container_transform;
 	} else {
@@ -5568,7 +5568,7 @@ Transform2D SubViewport::get_popup_base_transform() const {
 	}
 	Transform2D container_transform;
 	if (c->is_stretch_enabled()) {
-		container_transform.scale(Vector2(c->get_stretch_shrink(), c->get_stretch_shrink()));
+		container_transform.scale(vec2_from_scalar(c->get_stretch_shrink()));
 	}
 	return c->get_screen_transform() * container_transform * get_final_transform();
 }

--- a/scene/resources/2d/circle_shape_2d.cpp
+++ b/scene/resources/2d/circle_shape_2d.cpp
@@ -64,8 +64,8 @@ void CircleShape2D::_bind_methods() {
 
 Rect2 CircleShape2D::get_rect() const {
 	Rect2 rect;
-	rect.position = -Point2(get_radius(), get_radius());
-	rect.size = Point2(get_radius(), get_radius()) * 2.0;
+	rect.position = vec2_from_scalar(-get_radius());
+	rect.size = vec2_from_scalar(get_radius() * 2.0);
 	return rect;
 }
 

--- a/scene/resources/style_box_flat.cpp
+++ b/scene/resources/style_box_flat.cpp
@@ -325,9 +325,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 
 	// Corner radius center points.
 	Vector<Point2> outer_points = {
-		ring_rect.position + Vector2(ring_corner_radius[0], ring_corner_radius[0]) * ring_scale[0], //tl
+		ring_rect.position + vec2_from_scalar(ring_corner_radius[0]) * ring_scale[0], //tl
 		Point2(ring_rect.position.x + ring_rect.size.x - ring_corner_radius[1] * ring_scale[1].x, ring_rect.position.y + ring_corner_radius[1] * ring_scale[1].y), //tr
-		ring_rect.position + ring_rect.size - Vector2(ring_corner_radius[2], ring_corner_radius[2]) * ring_scale[2], //br
+		ring_rect.position + ring_rect.size - vec2_from_scalar(ring_corner_radius[2]) * ring_scale[2], //br
 		Point2(ring_rect.position.x + ring_corner_radius[3] * ring_scale[3].x, ring_rect.position.y + ring_rect.size.y - ring_corner_radius[3] * ring_scale[3].y) //bl
 	};
 
@@ -338,9 +338,9 @@ inline void draw_rounded_rectangle(Vector<Vector2> &verts, Vector<int> &indices,
 	set_corner_scale(style_rect, inner_rect, inner_corner_radius, inner_scale);
 
 	Vector<Point2> inner_points = {
-		inner_rect.position + Vector2(inner_corner_radius[0], inner_corner_radius[0]) * inner_scale[0], //tl
+		inner_rect.position + vec2_from_scalar(inner_corner_radius[0]) * inner_scale[0], //tl
 		Point2(inner_rect.position.x + inner_rect.size.x - inner_corner_radius[1] * inner_scale[1].x, inner_rect.position.y + inner_corner_radius[1] * inner_scale[1].y), //tr
-		inner_rect.position + inner_rect.size - Vector2(inner_corner_radius[2], inner_corner_radius[2]) * inner_scale[2], //br
+		inner_rect.position + inner_rect.size - vec2_from_scalar(inner_corner_radius[2]) * inner_scale[2], //br
 		Point2(inner_rect.position.x + inner_corner_radius[3] * inner_scale[3].x, inner_rect.position.y + inner_rect.size.y - inner_corner_radius[3] * inner_scale[3].y) //bl
 	};
 

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -562,7 +562,7 @@ void GI::SDFGI::create(RID p_env, const Vector3 &p_world_position, uint32_t p_re
 		Vector3 world_position = p_world_position;
 		world_position.y *= y_mult;
 		int32_t probe_cells = cascade_size / SDFGI::PROBE_DIVISOR;
-		Vector3 probe_size = Vector3(1, 1, 1) * cascade.cell_size * probe_cells;
+		Vector3 probe_size = vec3_from_scalar(cascade.cell_size * probe_cells);
 		Vector3i probe_pos = Vector3i((world_position / probe_size + Vector3(0.5, 0.5, 0.5)).floor());
 		cascade.position = probe_pos * probe_cells;
 
@@ -1192,7 +1192,7 @@ void GI::SDFGI::update(RID p_env, const Vector3 &p_world_position) {
 	for (SDFGI::Cascade &cascade : cascades) {
 		cascade.dirty_regions = Vector3i();
 
-		Vector3 probe_half_size = Vector3(1, 1, 1) * cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5;
+		Vector3 probe_half_size = vec3_from_scalar(cascade.cell_size * float(cascade_size / SDFGI::PROBE_DIVISOR) * 0.5);
 		probe_half_size = Vector3(0, 0, 0);
 
 		Vector3 world_position = p_world_position;
@@ -1439,9 +1439,9 @@ int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, V
 		if (c.dirty_regions == SDFGI::Cascade::DIRTY_ALL) {
 			if (dirty_count == p_region) {
 				r_local_offset = Vector3i();
-				r_local_size = Vector3i(1, 1, 1) * cascade_size;
+				r_local_size = vec3i_from_scalar(cascade_size);
 
-				r_bounds.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + c.position)) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+				r_bounds.position = Vector3((vec3i_from_scalar(-int32_t(cascade_size >> 1)) + c.position)) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 				r_bounds.size = Vector3(r_local_size) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 				return i;
 			}
@@ -1451,7 +1451,7 @@ int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, V
 				if (c.dirty_regions[j] != 0) {
 					if (dirty_count == p_region) {
 						Vector3i from = Vector3i(0, 0, 0);
-						Vector3i to = Vector3i(1, 1, 1) * cascade_size;
+						Vector3i to = vec3i_from_scalar(cascade_size);
 
 						if (c.dirty_regions[j] > 0) {
 							//fill from the beginning
@@ -1473,7 +1473,7 @@ int GI::SDFGI::get_pending_region_data(int p_region, Vector3i &r_local_offset, V
 						r_local_offset = from;
 						r_local_size = to - from;
 
-						r_bounds.position = Vector3(from + Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + c.position) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
+						r_bounds.position = Vector3(from + vec3i_from_scalar(-int32_t(cascade_size >> 1)) + c.position) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 						r_bounds.size = Vector3(r_local_size) * c.cell_size * Vector3(1, 1.0 / y_mult, 1);
 
 						return i;
@@ -1493,7 +1493,7 @@ void GI::SDFGI::update_cascades() {
 	int32_t probe_divisor = cascade_size / SDFGI::PROBE_DIVISOR;
 
 	for (uint32_t i = 0; i < cascades.size(); i++) {
-		Vector3 pos = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[i].position)) * cascades[i].cell_size;
+		Vector3 pos = Vector3((vec3i_from_scalar(-int32_t(cascade_size >> 1)) + cascades[i].position)) * cascades[i].cell_size;
 
 		cascade_data[i].offset[0] = pos.x;
 		cascade_data[i].offset[1] = pos.y;
@@ -1740,7 +1740,7 @@ void GI::SDFGI::debug_probes(RID p_framebuffer, const uint32_t p_view_count, con
 
 	if (gi->sdfgi_debug_probe_dir != Vector3()) {
 		uint32_t cascade = 0;
-		Vector3 offset = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[cascade].position)) * cascades[cascade].cell_size * Vector3(1.0, 1.0 / y_mult, 1.0);
+		Vector3 offset = Vector3((vec3i_from_scalar(-int32_t(cascade_size >> 1)) + cascades[cascade].position)) * cascades[cascade].cell_size * Vector3(1.0, 1.0 / y_mult, 1.0);
 		Vector3 probe_size = cascades[cascade].cell_size * (cascade_size / SDFGI::PROBE_DIVISOR) * Vector3(1.0, 1.0 / y_mult, 1.0);
 		Vector3 ray_from = gi->sdfgi_debug_probe_pos;
 		Vector3 ray_to = gi->sdfgi_debug_probe_pos + gi->sdfgi_debug_probe_dir * cascades[cascade].cell_size * Math::sqrt(3.0) * cascade_size;
@@ -1855,7 +1855,7 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 
 	for (uint32_t i = 0; i < sdfgi_data.max_cascades; i++) {
 		SDFGIData::ProbeCascadeData &c = sdfgi_data.cascades[i];
-		Vector3 pos = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascades[i].position)) * cascades[i].cell_size;
+		Vector3 pos = Vector3((vec3i_from_scalar(-int32_t(cascade_size >> 1)) + cascades[i].position)) * cascades[i].cell_size;
 		Vector3 cam_origin = p_transform.origin;
 		cam_origin.y *= y_mult;
 		pos -= cam_origin; //make pos local to camera, to reduce numerical error
@@ -1928,8 +1928,8 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 		}
 
 		AABB cascade_aabb;
-		cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cascade.position)) * cascade.cell_size;
-		cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cascade.cell_size;
+		cascade_aabb.position = Vector3((vec3i_from_scalar(-int32_t(cascade_size >> 1)) + cascade.position)) * cascade.cell_size;
+		cascade_aabb.size = vec3_from_scalar(cascade_size) * cascade.cell_size;
 
 		for (uint32_t j = 0; j < p_render_data->sdfgi_update_data->positional_light_count; j++) {
 			if (idx == SDFGI::MAX_DYNAMIC_LIGHTS) {
@@ -2314,7 +2314,7 @@ void GI::SDFGI::render_region(Ref<RenderSceneBuffersRD> p_render_buffers, int p_
 				push_constant.occlusion_index = i;
 				RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(SDFGIShader::PreprocessPushConstant));
 
-				Vector3i groups = Vector3i(probe_size + 1, probe_size + 1, probe_size + 1) - offset; //if offset, it's one less probe per axis to compute
+				Vector3i groups = vec3i_from_scalar(probe_size + 1) - offset; //if offset, it's one less probe per axis to compute
 				RD::get_singleton()->compute_list_dispatch(compute_list, groups.x, groups.y, groups.z);
 			}
 			RD::get_singleton()->compute_list_add_barrier(compute_list);
@@ -2387,8 +2387,8 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 		{ //fill light buffer
 
 			AABB cascade_aabb;
-			cascade_aabb.position = Vector3((Vector3i(1, 1, 1) * -int32_t(cascade_size >> 1) + cc.position)) * cc.cell_size;
-			cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cc.cell_size;
+			cascade_aabb.position = Vector3((vec3i_from_scalar(-int32_t(cascade_size >> 1)) + cc.position)) * cc.cell_size;
+			cascade_aabb.size = vec3_from_scalar(cascade_size) * cc.cell_size;
 
 			int idx = 0;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1950,8 +1950,8 @@ AABB ParticlesStorage::particles_collision_get_aabb(RID p_particles_collision) c
 		case RS::PARTICLES_COLLISION_TYPE_SPHERE_ATTRACT:
 		case RS::PARTICLES_COLLISION_TYPE_SPHERE_COLLIDE: {
 			AABB aabb;
-			aabb.position = -Vector3(1, 1, 1) * particles_collision->radius;
-			aabb.size = Vector3(2, 2, 2) * particles_collision->radius;
+			aabb.position = vec3_from_scalar(-particles_collision->radius);
+			aabb.size = vec3_from_scalar(particles_collision->radius * 2);
 			return aabb;
 		}
 		default: {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -3147,7 +3147,7 @@ void TextureStorage::update_decal_atlas() {
 
 		for (int i = 0; i < item_count; i++) {
 			DecalAtlas::Texture *t = decal_atlas.textures.getptr(items[i].texture);
-			t->uv_rect.position = items[i].pos * border + Vector2i(border / 2, border / 2);
+			t->uv_rect.position = items[i].pos * border + vec2i_from_scalar(border / 2);
 			t->uv_rect.size = items[i].pixel_size;
 
 			t->uv_rect.position /= Size2(decal_atlas.size);


### PR DESCRIPTION
This implements new helper methods for all vector inside `variant.h` since it already includes all the vector headers.

usage:

```c
// Before
follow.scale(Vector2(get_follow_viewport_scale(), get_follow_viewport_scale()));
// After
follow.scale(vec2_from_scalar(get_follow_viewport_scale()));
```

