### PR TITLE
Deprecate `gdextension_string_name_new_with_*`

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1048,6 +1048,7 @@ static GDExtensionInt gdextension_string_resize(GDExtensionStringPtr p_self, GDE
 	return (*self).resize_uninitialized(p_length);
 }
 
+#ifndef DISABLE_DEPRECATED
 static void gdextension_string_name_new_with_latin1_chars(GDExtensionUninitializedStringNamePtr r_dest, const char *p_contents, GDExtensionBool p_is_static) {
 	memnew_placement(r_dest, StringName(p_contents, static_cast<bool>(p_is_static)));
 }
@@ -1061,6 +1062,7 @@ static void gdextension_string_name_new_with_utf8_chars_and_len(GDExtensionUnini
 	String tmp = String::utf8(p_contents, p_size);
 	memnew_placement(r_dest, StringName(tmp));
 }
+#endif
 
 static GDExtensionInt gdextension_xml_parser_open_buffer(GDExtensionObjectPtr p_instance, const uint8_t *p_buffer, size_t p_size) {
 	XMLParser *xml = (XMLParser *)p_instance;
@@ -1770,9 +1772,11 @@ void gdextension_setup_interface() {
 	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_wcstr);
 	REGISTER_INTERFACE_FUNC(string_operator_plus_eq_c32str);
 	REGISTER_INTERFACE_FUNC(string_resize);
+#ifndef DISABLE_DEPRECATED
 	REGISTER_INTERFACE_FUNC(string_name_new_with_latin1_chars);
 	REGISTER_INTERFACE_FUNC(string_name_new_with_utf8_chars);
 	REGISTER_INTERFACE_FUNC(string_name_new_with_utf8_chars_and_len);
+#endif
 	REGISTER_INTERFACE_FUNC(xml_parser_open_buffer);
 	REGISTER_INTERFACE_FUNC(file_access_store_buffer);
 	REGISTER_INTERFACE_FUNC(file_access_get_buffer);

--- a/core/extension/gdextension_interface.h
+++ b/core/extension/gdextension_interface.h
@@ -1968,6 +1968,7 @@ typedef GDExtensionInt (*GDExtensionInterfaceStringResize)(GDExtensionStringPtr 
 /**
  * @name string_name_new_with_latin1_chars
  * @since 4.2
+ * @deprecated in Godot 4.6. Construct StringName from String instead.
  *
  * Creates a StringName from a Latin-1 encoded C string.
  *
@@ -1987,6 +1988,7 @@ typedef void (*GDExtensionInterfaceStringNameNewWithLatin1Chars)(GDExtensionUnin
 /**
  * @name string_name_new_with_utf8_chars
  * @since 4.2
+ * @deprecated in Godot 4.6. Construct StringName from String instead.
  *
  * Creates a StringName from a UTF-8 encoded C string.
  *
@@ -1998,6 +2000,7 @@ typedef void (*GDExtensionInterfaceStringNameNewWithUtf8Chars)(GDExtensionUninit
 /**
  * @name string_name_new_with_utf8_chars_and_len
  * @since 4.2
+ * @deprecated in Godot 4.6. Construct StringName from String instead.
  *
  * Creates a StringName from a UTF-8 encoded string with a given number of characters.
  *


### PR DESCRIPTION
Deprecate `gdextension_string_name_new_with_*`, prefer to construct StringName from String.

Rationales: https://github.com/godotengine/godot/pull/78580#issuecomment-3305457363. TLDR it doesn't provide much performance improvement.

And I think we should not expose `p_static` parameter. `p_static=true` currently only accepts latin1 string and requires the StringName has a static lifetime, which can be confusing and easily misused (e.g. https://github.com/godot-rust/gdext/issues/1306, cc @Bromeon ), because there are two ways for users:
1. cache StringName in a static variable and make sure them are nerver released. And make sure all static StringNames are created with `p_static=true`, not copied from other StringNames.
2. cache StringName themselves. If it's static, explicitly destroy it on uninitialization.

In my opinion 2 is better. If you use a more complex static HashMap/Vector cache, clearing it during uninitialization would be less error-prone than using `p_static=true`.