### PR TITLE
ColorPicker: Fix preset button order after calling `add_preset()`

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1196,7 +1196,14 @@ void ColorPicker::add_preset(const Color &p_color) {
 	if (e) {
 		presets.move_to_back(e);
 
-		preset_container->move_child(preset_group->get_pressed_button(), preset_container->get_child_count() - 1);
+		for (int i = 1; i < preset_container->get_child_count(); i++) {
+			ColorPresetButton *current_btn = Object::cast_to<ColorPresetButton>(preset_container->get_child(i));
+			if (current_btn && p_color == current_btn->get_preset_color()) {
+				preset_container->move_child(current_btn, preset_container->get_child_count() - 1);
+				current_btn->set_pressed(true);
+				break;
+			}
+		}
 	} else {
 		presets.push_back(p_color);
 


### PR DESCRIPTION
It's expected that calling `add_preset()` always makes that color the last preset. If that color is already added, the preset button is moved to the end of the list.

Currently, the code assumes the `color` to add is always the same as the current selected preset. But it's not always the case. It may also produce an error if `add_preset()` is called with no preset button selected.

https://github.com/user-attachments/assets/19945bb0-e345-4c46-a128-3f5d4dec6e8a
