### PR TITLE
Add `GDSOFTCLASS` to six inheritors of `Object`

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -1014,6 +1014,8 @@ public:
 };
 
 class EditorPluginList : public Object {
+	GDSOFTCLASS(EditorPluginList, Object);
+
 private:
 	Vector<EditorPlugin *> plugins_list;
 

--- a/editor/scene/2d/tiles/tile_map_layer_editor.h
+++ b/editor/scene/2d/tiles/tile_map_layer_editor.h
@@ -49,6 +49,8 @@ class TileMapLayer;
 class TileMapLayerEditor;
 
 class TileMapLayerSubEditorPlugin : public Object {
+	GDSOFTCLASS(TileMapLayerSubEditorPlugin, Object);
+
 protected:
 	ObjectID edited_tile_map_layer_id;
 	TileMapLayer *_get_edited_layer() const;

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -41,6 +41,8 @@ struct DBusConnection;
 struct DBusMessageIter;
 
 class FreeDesktopPortalDesktop : public Object {
+	GDSOFTCLASS(FreeDesktopPortalDesktop, Object);
+
 private:
 	bool unsupported = false;
 

--- a/platform/linuxbsd/tts_linux.h
+++ b/platform/linuxbsd/tts_linux.h
@@ -45,6 +45,7 @@
 #endif
 
 class TTS_Linux : public Object {
+	GDSOFTCLASS(TTS_Linux, Object);
 	_THREAD_SAFE_CLASS_
 
 	List<DisplayServer::TTSUtterance> queue;

--- a/scene/theme/theme_owner.h
+++ b/scene/theme/theme_owner.h
@@ -39,6 +39,8 @@ class ThemeContext;
 class Window;
 
 class ThemeOwner : public Object {
+	GDSOFTCLASS(ThemeOwner, Object);
+
 	Node *holder = nullptr;
 
 	Control *owner_control = nullptr;

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -67,6 +67,8 @@ public:
 };
 
 class RenderingDeviceCommons : public Object {
+	GDSOFTCLASS(RenderingDeviceCommons, Object);
+
 	////////////////////////////////////////////
 	// PUBLIC STUFF
 	// Exposed by RenderingDevice, and shared


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Further to bug report #110693, specifically a discussion with @Ivorforce [in this comment](https://github.com/godotengine/godot/issues/110693#issuecomment-3315190974), 6 classes were identified that inherit directly from `Object`, but that do not define `GDCLASS` or `GDSOFTCLASS`, and hence may fail static type checks as [in this comment](https://github.com/godotengine/godot/pull/102064#pullrequestreview-3244758763) in my unit testing PR #102064.

This PR adds `GDSOFTCLASS` to each.

They were found using the following `ripgrep` command:

```bash
rg --pcre2 -n -H -o --multiline --multiline-dotall \
  '^(class\s+(\w+)\s*:\s*public\s+Object\s*\{(?:(?!GDCLASS|GDSOFTCLASS).)*?\})' \
  --glob '*.h' --glob '*.cpp' \
  --glob '!*.gen.h' --glob '!test*.h' \
  --glob '!thirdparty/**' --glob '!drivers/**' --glob '!modules/**' \
  --replace '$2'
```