### PR TITLE
GDScript: Add support for @abstract annotation with vars

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -782,6 +782,11 @@
 				[/codeblock]
 			</description>
 		</annotation>
+		<annotation name="@override">
+			<return type="void" />
+			<description>
+			</description>
+		</annotation>
 		<annotation name="@rpc">
 			<return type="void" />
 			<param index="0" name="mode" type="String" default="&quot;authority&quot;" />

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -299,21 +299,24 @@
 		<annotation name="@abstract">
 			<return type="void" />
 			<description>
-				Marks a class or a method as abstract.
+				Marks a class, a method, or a variable as abstract.
 				An abstract class is a class that cannot be instantiated directly. Instead, it is meant to be inherited by other classes. Attempting to instantiate an abstract class will result in an error.
-				An abstract method is a method that has no implementation. Therefore, a newline or a semicolon is expected after the function header. This defines a contract that inheriting classes must conform to, because the method signature must be compatible when overriding.
-				Inheriting classes must either provide implementations for all abstract methods, or the inheriting class must be marked as abstract. If a class has at least one abstract method (either its own or an unimplemented inherited one), then it must also be marked as abstract. However, the reverse is not true: an abstract class is allowed to have no abstract methods.
+				An abstract variable is a variable that has no initial value. This defines a contract that inheriting classes must conform to, because the variable must be overridden in the inheriting class to give it an initial value.
+				Inheriting classes must either provide implementations for all abstract methods and variables, or the inheriting class must be marked as abstract. If a class has at least one abstract method or variable (either its own or an unimplemented inherited one), then it must also be marked as abstract. However, the reverse is not true: an abstract class is allowed to have no abstract methods nor variables.
 				[codeblock]
 				@abstract class Shape:
 					@abstract func draw()
+					@abstract var name
 
 				class Circle extends Shape:
 					func draw():
 						print("Drawing a circle.")
+					@override var name = "circle"
 
 				class Square extends Shape:
 					func draw():
 						print("Drawing a square.")
+					@override var name = "square"
 				[/codeblock]
 			</description>
 		</annotation>

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -33,6 +33,7 @@
 #include "../gdscript.h"
 
 #include "core/config/project_settings.h"
+#include "editor/doc/editor_help.h"
 
 HashMap<String, String> GDScriptDocGen::singletons;
 
@@ -522,7 +523,28 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					prop_doc.default_value = docvalue_from_expression(m_var->initializer);
 				}
 
-				prop_doc.overridden = false;
+				if (m_var->is_override) {
+					prop_doc.overridden = true;
+
+					const DocTools *dd = EditorHelp::get_doc_data();
+					if (dd) {
+						HashMap<String, DocData::ClassDoc>::ConstIterator E = dd->class_list.find(doc.inherits);
+						while (E && !E->value.name.is_empty()) {
+							bool found = false;
+							for (const DocData::PropertyDoc &property : E->value.properties) {
+								if (property.name == var_name) {
+									prop_doc.overrides = E->value.name;
+									found = true;
+									break;
+								}
+							}
+							if (found) {
+								break;
+							}
+							E = dd->class_list.find(E->value.inherits);
+						}
+					}
+				}
 
 				doc.properties.push_back(prop_doc);
 			} break;

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -57,11 +57,14 @@ class GDScriptAnalyzer {
 	HashMap<const GDScriptParser::ClassNode *, Ref<GDScriptParserRef>> external_class_parser_cache;
 	bool static_context = false;
 
-	// Tests for detecting invalid overloading of script members
-	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node, const GDScriptParser::Node *p_member);
-	static _FORCE_INLINE_ bool has_member_name_conflict_in_native_type(const StringName &p_name, const StringName &p_native_type_string);
-	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string);
-	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);
+	enum class MemberConflict {
+		NOT_FOUND,
+		OVERRIDE,
+		FOUND,
+	};
+	_FORCE_INLINE_ MemberConflict _check_member_conflict_gdscript(const GDScriptParser::ClassNode *p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type);
+	_FORCE_INLINE_ MemberConflict _check_member_conflict_native(const StringName &p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type);
+	void check_member_conflict(const GDScriptParser::ClassNode *p_class, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::DataType *r_override_type = nullptr);
 
 	void get_class_node_current_scope_classes(GDScriptParser::ClassNode *p_node, List<GDScriptParser::ClassNode *> *p_list, GDScriptParser::Node *p_source);
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2378,7 +2378,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			}
 
 			const GDScriptParser::VariableNode *field = member.variable;
-			if (field->is_static || field->is_override) {
+			if (field->is_static || field->is_override || field->is_abstract) {
 				continue;
 			}
 
@@ -2581,7 +2581,7 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 		}
 
 		const GDScriptParser::VariableNode *field = member.variable;
-		if (!field->is_static) {
+		if (!field->is_static || field->is_abstract) {
 			continue;
 		}
 
@@ -2616,7 +2616,7 @@ GDScriptFunction *GDScriptCompiler::_make_static_initializer(Error &r_error, GDS
 			continue;
 		}
 		const GDScriptParser::VariableNode *field = p_class->members[i].variable;
-		if (!field->is_static) {
+		if (!field->is_static || field->is_abstract) {
 			continue;
 		}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2378,7 +2378,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			}
 
 			const GDScriptParser::VariableNode *field = member.variable;
-			if (field->is_static) {
+			if (field->is_static || field->is_override) {
 				continue;
 			}
 
@@ -2426,14 +2426,19 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 					return nullptr;
 				}
 
-				GDScriptDataType field_type = _gdtype_from_datatype(field->get_datatype(), codegen.script);
-				GDScriptCodeGenerator::Address dst_address(GDScriptCodeGenerator::Address::MEMBER, codegen.script->member_indices[field->identifier->name].index, field_type);
-
-				if (field->use_conversion_assign) {
-					codegen.generator->write_assign_with_conversion(dst_address, src_address);
+				if (_is_class_member_property(codegen, field->identifier->name)) { // `@override var` for a native property.
+					codegen.generator->write_set_member(src_address, field->identifier->name);
 				} else {
-					codegen.generator->write_assign(dst_address, src_address);
+					GDScriptDataType field_type = _gdtype_from_datatype(field->get_datatype(), codegen.script);
+					GDScriptCodeGenerator::Address dst_address(GDScriptCodeGenerator::Address::MEMBER, codegen.script->member_indices[field->identifier->name].index, field_type);
+
+					if (field->use_conversion_assign) {
+						codegen.generator->write_assign_with_conversion(dst_address, src_address);
+					} else {
+						codegen.generator->write_assign(dst_address, src_address);
+					}
 				}
+
 				if (src_address.mode == GDScriptCodeGenerator::Address::TEMPORARY) {
 					codegen.generator->pop_temporary();
 				}
@@ -2890,7 +2895,7 @@ Error GDScriptCompiler::_prepare_compilation(GDScript *p_script, const GDScriptP
 				if (variable->is_static) {
 					minfo.index = p_script->static_variables_indices.size();
 					p_script->static_variables_indices[name] = minfo;
-				} else {
+				} else if (!variable->is_override) {
 					minfo.index = p_script->member_indices.size();
 					p_script->member_indices[name] = minfo;
 					p_script->members.insert(name);

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1260,6 +1260,7 @@ public:
 
 		bool exported = false;
 		bool onready = false;
+		bool is_abstract = false;
 		bool is_override = false;
 		PropertyInfo export_info;
 		int assignments = 0;

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1260,6 +1260,7 @@ public:
 
 		bool exported = false;
 		bool onready = false;
+		bool is_override = false;
 		PropertyInfo export_info;
 		int assignments = 0;
 		bool is_static = false;
@@ -1530,6 +1531,7 @@ private:
 	bool static_unload_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool abstract_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool override_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.gd
@@ -1,0 +1,24 @@
+@abstract class BaseAbstractVar extends Node:
+	@abstract var a: int
+	@abstract var b: Node2D
+	@abstract var c: Vector2
+
+class ConcreteFulfilled extends BaseAbstractVar:
+	@override var a = 1
+	@override var b = Node2D.new()
+	@override var c = Vector2i.ZERO
+
+class ConcreteUnfulfilled extends BaseAbstractVar:
+	pass
+
+class ConcreteDeclaresAbstractVar:
+	@abstract var d: String
+
+@abstract class DoubleAbstractVar:
+	@abstract @abstract var a: int
+
+@abstract class InitializedAbstractVar:
+	@abstract var a: int = 1
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/abstract_variables.out
@@ -1,0 +1,5 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 18: "@abstract" annotation can only be used once per variable.
+>> ERROR at line 21: An abstract variable cannot have an initializer.
+>> ERROR at line 11: Class "ConcreteUnfulfilled" must provide a value for "BaseAbstractVar.a" and other inherited abstract variables or be marked as "@abstract".
+>> ERROR at line 14: Class "ConcreteDeclaresAbstractVar" is not abstract but contains abstract variables. Mark the class as "@abstract" or remove "@abstract" from all variables in this class.

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_base_enum.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_shadows_base_enum.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 5: The member "V" already exists in parent class A.
+>> ERROR at line 5: The member "V" already exists in base class "A".

--- a/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/overload_script_variable.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 3: Member "script" redefined (original in native class 'Node')
+>> ERROR at line 3: The member "script" already exists in base class "Node".

--- a/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/variable_overloads_superclass_function.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 9: The member "overload_me" already exists in parent class A.
+>> ERROR at line 9: The member "overload_me" already exists in base class "A".

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_variables.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_variables.gd
@@ -1,0 +1,35 @@
+@abstract class A:
+	@abstract var text_1: String
+	@abstract var text_2: String
+
+class B extends A:
+	@override var text_1 = "text_1b"
+	@override var text_2 = "text_2b"
+
+class C extends B:
+	@override var text_1 = "text_1c"
+
+@abstract class D extends A:
+	@override var text_1 = "text_1d"
+
+class E extends D:
+	@override var text_2 = "text_2e"
+
+func test():
+	var b:= B.new()
+	print("B text_1= " + b.text_1)
+	print("B text_2= " + b.text_2)
+	print("..")
+
+	var c := C.new()
+	print("C text_1= " + c.text_1)
+	print("C text_2= " + c.text_2)
+	print("..")
+
+	var e := E.new()
+	print("E text_1= " + e.text_1)
+	print("E text_2= " + e.text_2)
+	print("..")
+
+	e.text_1 = "text_1e"
+	print("E text_1= " + e.text_1)

--- a/modules/gdscript/tests/scripts/runtime/features/abstract_variables.out
+++ b/modules/gdscript/tests/scripts/runtime/features/abstract_variables.out
@@ -1,0 +1,11 @@
+GDTEST_OK
+B text_1= text_1b
+B text_2= text_2b
+..
+C text_1= text_1c
+C text_2= text_2b
+..
+E text_1= text_1d
+E text_2= text_2e
+..
+E text_1= text_1e


### PR DESCRIPTION
* requires/includes #93787 
* closes https://github.com/godotengine/godot-proposals/issues/13218

Draft for now as dicussion is still underway on the proposal, but should be ready for merge if/when approved.

Adds support for using the `@abstract` annotation with variables within `@abstract` classes. 
This annotation requires that the variable it is attached to gets given an initial value by child classes using `@override`. 
For more details on `@override`, please check #93787. tldr: `@override` enables the user to specialize an initial value for a variable which is not impacted by the setter. 

This does not automatically make the setter and getter abstract. 

Basic usage example:
```GDScript
@abstract class Animal:
  @abstract var legs: int # Every class that extends animal must give this an initial value

class Cat extends Animal:
  @override var legs: int = 4 # Sets the initial value for Animal.legs to 4

# Stork will be considered incomplete since it doesn't give a value for legs, 
# and will throw an analyzer error (won't let you compile/run). 
class Stork extends Animal:
  var feathers: int = 10000
```

Technically speaking, this requires that the child class defines the initializer for the field, as opposed to the current behavior where the base class is responsible for defining this initializer (which is also optional in GDScript).
This has two benefits:
* The initializer does not go through the setter, meaning its value stored as-is without any chance of being modified
* Makes giving an initial value to the variable a requirement for child class completeness, which is a development safety feature to ensure all child classes define an initial value that is appropriate for their use