### PR TITLE
Optimize tree size computation and the scene tree dock filter

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -972,6 +972,17 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 }
 
 bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_selected) {
+	TreeItem *last_selected = nullptr;
+	bool result = _update_filter_helper(p_parent, p_scroll_to_selected, last_selected);
+	if (p_scroll_to_selected && last_selected) {
+		// Scrolling to the first selected in the _update_filter call above followed by the last
+		// selected here is enough to frame all selected items as well as possible.
+		callable_mp(tree, &Tree::scroll_to_item).call_deferred(last_selected, false);
+	}
+	return result;
+}
+
+bool SceneTreeEditor::_update_filter_helper(TreeItem *p_parent, bool p_scroll_to_selected, TreeItem *&r_last_selected) {
 	if (!p_parent) {
 		p_parent = tree->get_root();
 		filter_term_warning.clear();
@@ -1026,7 +1037,8 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 	bool keep_for_children = false;
 	for (TreeItem *child = p_parent->get_first_child(); child; child = child->get_next()) {
 		// Always keep if at least one of the children are kept.
-		keep_for_children = _update_filter(child, p_scroll_to_selected) || keep_for_children;
+		// Only scroll if we haven't already found a child to scroll to.
+		keep_for_children = _update_filter_helper(child, p_scroll_to_selected && !keep_for_children, r_last_selected) || keep_for_children;
 	}
 
 	if (!is_root) {
@@ -1099,9 +1111,13 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 	if (editor_selection) {
 		Node *n = get_node(p_parent->get_metadata(0));
 		if (selectable) {
-			if (p_scroll_to_selected && n && editor_selection->is_selected(n)) {
-				// Needs to be deferred to account for possible root visibility change.
-				callable_mp(tree, &Tree::scroll_to_item).call_deferred(p_parent, false);
+			if (n && editor_selection->is_selected(n)) {
+				if (p_scroll_to_selected) {
+					// Needs to be deferred to account for possible root visibility change.
+					callable_mp(tree, &Tree::scroll_to_item).call_deferred(p_parent, false);
+				} else {
+					r_last_selected = p_parent;
+				}
 			}
 		} else if (n) {
 			editor_selection->remove_node(n);

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -146,6 +146,7 @@ class SceneTreeEditor : public Control {
 
 	void _test_update_tree();
 	bool _update_filter(TreeItem *p_parent = nullptr, bool p_scroll_to_selected = false);
+	bool _update_filter_helper(TreeItem *p_parent, bool p_scroll_to_selected, TreeItem *&r_last_selected);
 	bool _node_matches_class_term(const Node *p_item_node, const String &p_term);
 	bool _item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms);
 	void _tree_changed();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2008,7 +2008,8 @@ int Tree::compute_item_height(TreeItem *p_item) const {
 	for (int i = 0; i < columns.size(); i++) {
 		height = MAX(height, p_item->get_minimum_size(i).y);
 	}
-	int item_min_height = MAX(theme_cache.font->get_height(theme_cache.font_size), p_item->get_custom_minimum_height());
+	int font_height = cache.font_height != -1 ? cache.font_height : theme_cache.font->get_height(theme_cache.font_size);
+	int item_min_height = MAX(font_height, p_item->get_custom_minimum_height());
 	if (height < item_min_height) {
 		height = item_min_height;
 	}
@@ -5024,7 +5025,8 @@ void Tree::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_DRAW: {
-			v_scroll->set_custom_step(theme_cache.font->get_height(theme_cache.font_size));
+			int font_height = cache.font_height != -1 ? cache.font_height : theme_cache.font->get_height(theme_cache.font_size);
+			v_scroll->set_custom_step(font_height);
 
 			update_scrollbars();
 			RID ci = get_canvas_item();
@@ -5120,6 +5122,7 @@ void Tree::_notification(int p_what) {
 }
 
 void Tree::_update_all() {
+	cache.font_height = theme_cache.font->get_height(theme_cache.font_size);
 	for (int i = 0; i < columns.size(); i++) {
 		update_column(i);
 	}

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -688,6 +688,7 @@ private:
 		int hover_button_index_in_column = -1;
 
 		bool rtl = false;
+		int font_height = -1;
 	} cache;
 
 	int _get_title_button_height() const;


### PR DESCRIPTION
These are fixes for the last issues I've encountered related to large node counts in the editor. You can trigger them in a variety of ways, but they all come back to either:
- updating the filter causes `O(m*n)` behavior where n is the current selection size and m is the number of items in the tree
- calculating font height so many times that the constant factors on it overwhelm the runtime

For the filter issue, here are two ways to see the problem:
- Attempt to type in the Scene Tree dock's filter while a large (5k+) number of nodes are selected. This can take upwards of a minute per letter typed for large enough selections.
- Make a large selection, switch to an arbitrary other scene's tab, and then attempt to switch back. Switching scenes updates the filter, which will lag the editor out and dominate the scene switch time.

The core of the issue is that when updating the filter, it attempts to scroll to every selected item in turn. This seems equivalent to scrolling to the first item and them scrolling to the last item, so that's what this PR updates it to do, instead. Since scrolling to an item is `O(m)` on the number of items, that cuts an `O(m*n)` algorithm (which is `O(m^2)` with a large enough selection) down to just `O(m)`.

For the font height calculation:
This commonly triggers any time that you redraw the scene tree and whenever you mouse over the scene tree, since it checks what your mouse is over. This doesn't seem like it should be that expensive, but it turns out it is, and the difference in responsiveness of the Scene Tree dock with it cached is massive. You can very obviously see a visual difference just by opening a scene with 20k+ nodes and trying to scroll around and interact with the Scene Tree dock.

One thing I'm nore sure of: this PR assumes that `font` and `font_size` in `theme_cache` only change when the theme changes. This is fine as far as I know, but I'm not exactly sure how `theme_cache` works, so I wanted to call it out. If this isn't safe to cache on the longer term, it still seems worth caching on a per frame basis somehow.

-----------------------------------------------------------------

It's data time!
Typing "Label" into a filter with 25k items that all match and 1 item selected: 1.5s before, 1.5s after
Typing "Label" into a filter with 25k items that all match and 1k items selected: 74s before, 1.5s after
Here's a flamegraph of the before, stuck in the `scroll_to_selected` swamp, which itself is mostly spent getting font heights:
<img width="2521" height="818" alt="image" src="https://github.com/user-attachments/assets/9872b075-a945-416e-8b00-84b0b40f0961" />

Switching to a scene with 100k items, 1 item selected: 5.5s before, 4.9s after
Switching to a scene with 100k items, 1k items selected: manually killed 10 minutes in before, 4.9s after
Here's a flamegraph that might give you deja vu:
<img width="2498" height="817" alt="image" src="https://github.com/user-attachments/assets/f5faf529-9164-41a1-aec0-2ede7a6a243d" />

The font height calculation can seen as a problem just scrolling through and clicking around a large Scene Tree dock, here's me doing that for a little bit:
Before
<img width="2506" height="1011" alt="image" src="https://github.com/user-attachments/assets/509f4c0a-55d7-4d28-8092-97401157f3ec" />

After
<img width="2514" height="1009" alt="image" src="https://github.com/user-attachments/assets/67592ee2-fd52-46f0-b83d-37f78b0920e5" />

I also recorded a little video of the difference. Pretty clear how impactful this is.
Before
https://imgur.com/g7VQimY
After
https://imgur.com/mdmfZWA

-----------------------------------------------------------------

All of the data in this PR was collected on builds built with `scons optimize=speed_trace production=yes debug_symbols=yes platform=linuxbsd dev_build=no use_llvm=yes`. The before numbers aren't actually from `master`, they're from `master` with my other editor performance PRs cherry-picked on, as well. The other, existing performance problems make these tests difficult to run without them. The sample project I've been using to test is 
[editor-optimization-test-scenes.zip](https://github.com/user-attachments/files/22454375/editor-optimization-test-scenes.zip).


With this PR and my other optimization PRs applied, I'm able to work reasonably comfortably on a scene with 100,000 nodes in it!