### PR TITLE
Fix drag and drop `@export` variable assignment when script has errors

### DIFF
--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -186,6 +186,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 		ObjectID obj_id;
 		String variable_name;
 		Variant value;
+		String class_name;
 	};
 
 	LocalVector<DraggedExport> pending_dragged_exports;


### PR DESCRIPTION
Closes #110735

Might be a bit slow with a combination of long file system paths(string comparision), lots of errors and adding a lot of export variables at once, but that's a *very* extreme case. Although if anyone has an idea on how to do this better in terms of time complexity, feel free to suggest changes. But overall should work fine.