### PR TITLE
Use `AncestralClass` to speed up `Object::cast_to` when possible.

### DIFF
--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -54,6 +54,8 @@ class Resource : public RefCounted {
 	GDCLASS(Resource, RefCounted);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::RESOURCE;
+
 	static void register_custom_data_to_otdb() { ClassDB::add_resource_base_extension("res", get_class_static()); }
 	virtual String get_base_extension() const { return "res"; }
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -42,6 +42,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::REF_COUNTED;
+
 	_FORCE_INLINE_ bool is_referenced() const { return refcount_init.get() != 1; }
 	bool init_ref();
 	bool reference(); // returns false if refcount is at zero and didn't get increased

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -140,6 +140,8 @@ protected:
 	}
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::SCRIPT;
+
 	virtual void reload_from_file() override;
 
 	virtual bool can_instantiate() const = 0;

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -55,6 +55,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::NODE_2D;
+
 #ifdef TOOLS_ENABLED
 	virtual Dictionary _edit_get_state() const override;
 	virtual void _edit_set_state(const Dictionary &p_state) override;

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -37,6 +37,8 @@ class Area2D : public CollisionObject2D {
 	GDCLASS(Area2D, CollisionObject2D);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::AREA_2D;
+
 	enum SpaceOverride {
 		SPACE_OVERRIDE_DISABLED,
 		SPACE_OVERRIDE_COMBINE,

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -39,6 +39,8 @@ class CollisionObject2D : public Node2D {
 	GDCLASS(CollisionObject2D, Node2D);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::COLLISION_OBJECT_2D;
+
 	enum DisableMode {
 		DISABLE_MODE_REMOVE,
 		DISABLE_MODE_MAKE_STATIC,

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -70,6 +70,8 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::MESH_INSTANCE_3D;
+
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh() const;
 

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -54,6 +54,8 @@ class Node3D : public Node {
 	friend class SceneTreeFTITests;
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::NODE_3D;
+
 	// Edit mode for the rotation.
 	// THIS MODE ONLY AFFECTS HOW DATA IS EDITED AND SAVED
 	// IT DOES _NOT_ AFFECT THE TRANSFORM LOGIC (see comment in TransformDirty).

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -37,6 +37,8 @@ class CollisionObject3D : public Node3D {
 	GDCLASS(CollisionObject3D, Node3D);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::COLLISION_OBJECT_3D;
+
 	enum DisableMode {
 		DISABLE_MODE_REMOVE,
 		DISABLE_MODE_MAKE_STATIC,

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -49,6 +49,8 @@ protected:
 	Ref<KinematicCollision3D> _move(const Vector3 &p_motion, bool p_test_only = false, real_t p_margin = 0.001, bool p_recovery_as_collision = false, int p_max_collisions = 1);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::PHYSICS_BODY_3D;
+
 	PackedStringArray get_configuration_warnings() const override;
 
 	bool move_and_collide(const PhysicsServer3D::MotionParameters &p_parameters, PhysicsServer3D::MotionResult &r_result, bool p_test_only = false, bool p_cancel_sliding = true);

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -53,6 +53,8 @@ protected:
 
 	GDVIRTUAL0RC(AABB, _get_aabb)
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::VISUAL_INSTANCE_3D;
+
 	enum GetFacesFlags {
 		FACES_SOLID = 1, // solid geometry
 		FACES_ENCLOSING = 2,
@@ -86,6 +88,8 @@ class GeometryInstance3D : public VisualInstance3D {
 	GDCLASS(GeometryInstance3D, VisualInstance3D);
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::GEOMETRY_INSTANCE_3D;
+
 	enum ShadowCastingSetting {
 		SHADOW_CASTING_SETTING_OFF = RS::SHADOW_CASTING_SETTING_OFF,
 		SHADOW_CASTING_SETTING_ON = RS::SHADOW_CASTING_SETTING_ON,

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -50,6 +50,8 @@ class Control : public CanvasItem {
 #endif //TOOLS_ENABLED
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::CONTROL;
+
 	enum Anchor {
 		ANCHOR_BEGIN = 0,
 		ANCHOR_END = 1

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -45,6 +45,8 @@ class CanvasItem : public Node {
 	friend class CanvasLayer;
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::CANVAS_ITEM;
+
 	enum TextureFilter {
 		TEXTURE_FILTER_PARENT_NODE,
 		TEXTURE_FILTER_NEAREST,

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -67,6 +67,8 @@ protected:
 	};
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::NODE;
+
 	// N.B. Any enum stored as a bitfield should be specified as UNSIGNED to work around
 	// some compilers trying to store it as signed, and requiring 1 more bit than necessary.
 	enum ProcessMode : unsigned int {


### PR DESCRIPTION
- Forward-port of https://github.com/godotengine/godot/pull/107844
- Follow-up of https://github.com/godotengine/godot/pull/107462

This implementation is 2x faster (hot access, probably more on cold access) than regular `Object::cast_to`, for classes with corresponding ancestral classes.

It would be possible to "pre-check" the types that derive from any of the ancestral types (e.g. `object && object.has_ancestry(AncestralClass::SPATIAL) && object.is_class_ptr(SpatialSubclass::get_class_ptr_static())`). But that would only accelerate the unhappy path, and only some of the time. The happy path wants to immediately use `is_class_ptr`, so I decided against this micro optimization.

I also made `has_ancestry` a private function. Callers should generally use `derives_from` / `Object::cast_to` instead, which is more resistant to us changing the ancestral classes in the future.

## Benchmark

The benchmarks show a ~2x improvement for cold access. The improvement is likely to be better in reality because we generate more hot situations, and need less cold RAM accesses even in cold situations.

Note that the difference is small in absolute terms, due to `cast_to` already being quite well optimized.

```c++
Object *nav_agent = memnew(NavigationAgent3D);
	Object *node_3D = memnew(Node3D);

	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 1000000000; i++) {
			// Test happy and optimized
			get_ptr_node3d(node_3D);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 1000000000; i++) {
			// Test happy but unoptimized
			get_ptr_navagent(nav_agent);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 1000000000; i++) {
			// Test unhappy but optimized
			get_ptr_node3d(nav_agent);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
	{
		auto t0 = std::chrono::high_resolution_clock::now();
		for (int i = 0; i < 1000000000; i++) {
			// Test unhappy and unoptimized
			get_ptr_navagent(node_3D);
		}
		auto t1 = std::chrono::high_resolution_clock::now();
		std::cout << std::chrono::duration_cast<std::chrono::milliseconds>(t1 - t0).count() << "ms\n";
	}
```

With the helper functions being declared in a separate module (to avoid inlining):

```c++
void *get_ptr_node3d(Object *node) { return Object::cast_to<Node3D>(node); }
void *get_ptr_navagent(Object *node) { return Object::cast_to<NavigationAgent3D>(node); }
```

```
969ms
2256ms
966ms
2257ms
```