### PR TITLE
Add NoiseTextureGenerator singleton

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1617,6 +1617,9 @@
 		<member name="NavigationServer3DManager" type="NavigationServer3DManager" setter="" getter="">
 			The [NavigationServer3DManager] singleton.
 		</member>
+		<member name="NoiseTextureGenerator" type="NoiseTextureGenerator" setter="" getter="">
+			The [NoiseTextureGenerator] singleton.
+		</member>
 		<member name="OS" type="OS" setter="" getter="">
 			The [OS] singleton.
 		</member>

--- a/doc/classes/NoiseTextureGenerator.xml
+++ b/doc/classes/NoiseTextureGenerator.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="NoiseTextureGenerator" inherits="Object" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Singleton to facilitate the baking and updating of noise textures.
+	</brief_description>
+	<description>
+		Baking and updating noise textures is a performance costly operation best done behind a loading screen or using background threads.
+		Each bake function is available as a single-threaded version and as an async task version that uses the [WorkerThreadPool].
+
+		The single-threaded version will be executed instant but block the main thread until the baking of the noise image(s) is finished.
+		The async version will use a background thread to do the baking and may take multiple frames until finished and synchronized back with the main thread.
+		Noise textures that finished their bake using async threads are synced on the [signal RenderingServer.frame_pre_draw] signal.
+
+		On platforms that do not support threads (e.g. web) the async functions automatically do a fallback to the single-threaded function equivalent.
+		Be aware of such fallback as spawning or updating noise textures at runtime without thread support can easily impact a projects frame rate.
+
+		Noise textures that are already baking can not be queued again for another bake until the current bake is finished.
+		Use [method is_noise_texture_2d_baking] and [method is_noise_texture_3d_baking] to check the bake state of a noise texture before queuing them.
+		Be aware that most noise textures queue themself automatically for an update when changing their properties but do so deferred with a delay.
+
+		Avoid connecting signals and callbacks to functions that immediately rebake a noise texture on a callback from the generator, or one of the emitted resource changed signals.
+		Such signal spaghetti can cause a deadlock due to often creating an endless loop of baking and signal emit.
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="bake_noise_texture_2d" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="noise_texture" type="NoiseTexture2D" />
+			<description>
+				Bakes the provided [param noise_texture].
+			</description>
+		</method>
+		<method name="bake_noise_texture_2d_async" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="noise_texture" type="NoiseTexture2D" />
+			<param index="1" name="callback" type="Callable" default="Callable()" />
+			<description>
+				Bakes the provided [param noise_texture] as an async task running on a background thread. After the process is finished the optional [param callback] will be called.
+			</description>
+		</method>
+		<method name="bake_noise_texture_3d" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="noise_texture" type="NoiseTexture3D" />
+			<description>
+				Bakes the provided [param noise_texture].
+			</description>
+		</method>
+		<method name="bake_noise_texture_3d_async" qualifiers="static">
+			<return type="void" />
+			<param index="0" name="noise_texture" type="NoiseTexture3D" />
+			<param index="1" name="callback" type="Callable" default="Callable()" />
+			<description>
+				Bakes the provided [param noise_texture] as an async task running on a background thread. After the process is finished the optional [param callback] will be called.
+			</description>
+		</method>
+		<method name="is_noise_texture_2d_baking" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="noise_texture" type="NoiseTexture2D" />
+			<description>
+				Returns [code]true[/code] when the provided noise texture is being baked on a background thread.
+			</description>
+		</method>
+		<method name="is_noise_texture_3d_baking" qualifiers="static">
+			<return type="bool" />
+			<param index="0" name="noise_texture" type="NoiseTexture3D" />
+			<description>
+				Returns [code]true[/code] when the provided noise texture is being baked on a background thread.
+			</description>
+		</method>
+	</methods>
+</class>

--- a/modules/noise/noise_texture_2d.h
+++ b/modules/noise/noise_texture_2d.h
@@ -42,8 +42,6 @@ class NoiseTexture2D : public Texture2D {
 private:
 	Ref<Image> image;
 
-	Thread noise_thread;
-
 	bool first_time = true;
 	bool update_queued = false;
 	bool regen_queued = false;
@@ -64,13 +62,10 @@ private:
 	Ref<Gradient> color_ramp;
 	Ref<Noise> noise;
 
-	void _thread_done(const Ref<Image> &p_image);
-	static void _thread_function(void *p_ud);
+	void _bake_finished();
 
 	void _queue_update();
-	Ref<Image> _generate_texture();
 	void _update_texture();
-	void _set_texture_image(const Ref<Image> &p_image);
 
 	Ref<Image> _modulate_with_gradient(Ref<Image> p_image, Ref<Gradient> p_gradient);
 
@@ -117,6 +112,9 @@ public:
 
 	virtual RID get_rid() const override;
 	virtual bool has_alpha() const override { return false; }
+
+	virtual Ref<Image> bake_noise_data();
+	void set_data(const Ref<Image> &p_data);
 
 	virtual Ref<Image> get_image() const override;
 

--- a/modules/noise/noise_texture_3d.h
+++ b/modules/noise/noise_texture_3d.h
@@ -40,8 +40,6 @@ class NoiseTexture3D : public Texture3D {
 	GDCLASS(NoiseTexture3D, Texture3D);
 
 private:
-	Thread noise_thread;
-
 	bool first_time = true;
 	bool update_queued = false;
 	bool regen_queued = false;
@@ -62,13 +60,10 @@ private:
 
 	Image::Format format = Image::FORMAT_L8;
 
-	void _thread_done(const TypedArray<Image> &p_data);
-	static void _thread_function(void *p_ud);
+	void _bake_finished();
 
 	void _queue_update();
-	TypedArray<Image> _generate_texture();
 	void _update_texture();
-	void _set_texture_data(const TypedArray<Image> &p_data);
 
 	Ref<Image> _modulate_with_gradient(Ref<Image> p_image, Ref<Gradient> p_gradient);
 
@@ -106,6 +101,9 @@ public:
 	virtual bool has_mipmaps() const override;
 
 	virtual RID get_rid() const override;
+
+	virtual Vector<Ref<Image>> bake_noise_data();
+	void set_data(const Vector<Ref<Image>> &p_data);
 
 	virtual Vector<Ref<Image>> get_data() const override;
 	virtual Image::Format get_format() const override;

--- a/modules/noise/noise_texture_generator.cpp
+++ b/modules/noise/noise_texture_generator.cpp
@@ -1,0 +1,322 @@
+/**************************************************************************/
+/*  noise_texture_generator.cpp                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "noise_texture_generator.h"
+
+#include "servers/rendering/rendering_server.h"
+
+NoiseTextureGenerator *NoiseTextureGenerator::singleton = nullptr;
+bool NoiseTextureGenerator::use_threads = true;
+Mutex NoiseTextureGenerator::bake_mutex;
+Mutex NoiseTextureGenerator::generator_task_mutex;
+AHashMap<Ref<NoiseTexture2D>, NoiseTextureGenerator::GeneratorTask2D *> NoiseTextureGenerator::baking_noise_texture_2d;
+AHashMap<WorkerThreadPool::TaskID, NoiseTextureGenerator::GeneratorTask2D *> NoiseTextureGenerator::generator_tasks_2d;
+AHashMap<Ref<NoiseTexture3D>, NoiseTextureGenerator::GeneratorTask3D *> NoiseTextureGenerator::baking_noise_texture_3d;
+AHashMap<WorkerThreadPool::TaskID, NoiseTextureGenerator::GeneratorTask3D *> NoiseTextureGenerator::generator_tasks_3d;
+
+NoiseTextureGenerator *NoiseTextureGenerator::get_singleton() {
+	return singleton;
+}
+
+NoiseTextureGenerator::NoiseTextureGenerator() {
+	singleton = this;
+
+#ifndef THREADS_ENABLED
+	use_threads = false;
+#endif
+}
+
+NoiseTextureGenerator::~NoiseTextureGenerator() {
+}
+
+void NoiseTextureGenerator::bake_noise_texture_2d(Ref<NoiseTexture2D> p_noise_texture) {
+	ERR_FAIL_COND(p_noise_texture.is_null());
+	ERR_FAIL_COND(p_noise_texture->get_noise().is_null());
+
+	if (is_noise_texture_2d_baking(p_noise_texture)) {
+		ERR_FAIL_MSG("NoiseTexture2D is already baking. Wait for current bake to finish. Use 'NoiseTextureGenerator::is_noise_texture_2d_baking()' to check the bake state of a noise 2d texture.");
+		return;
+	}
+
+	Ref<NoiseTexture2D> noise_texture = p_noise_texture;
+	const Ref<Image> noise_data = noise_texture->bake_noise_data();
+	noise_texture->set_data(noise_data);
+}
+
+void NoiseTextureGenerator::bake_noise_texture_2d_async(Ref<NoiseTexture2D> p_noise_texture, const Callable &p_callback) {
+	ERR_FAIL_COND(p_noise_texture.is_null());
+	ERR_FAIL_COND(p_noise_texture->get_noise().is_null());
+
+	if (is_noise_texture_2d_baking(p_noise_texture)) {
+		ERR_FAIL_MSG("NoiseTexture2D is already baking. Wait for current bake to finish. Use 'NoiseTextureGenerator::is_noise_texture_2d_baking()' to check the bake state of a noise 2d texture.");
+		return;
+	}
+
+	if (!use_threads) {
+		bake_noise_texture_2d(p_noise_texture);
+		if (p_callback.is_valid()) {
+			generator_emit_callback(p_callback);
+		}
+		return;
+	}
+
+	bake_mutex.lock();
+	GeneratorTask2D *generator_task = memnew(GeneratorTask2D);
+	baking_noise_texture_2d.insert(p_noise_texture, generator_task);
+	bake_mutex.unlock();
+
+	generator_task->noise_texture = p_noise_texture;
+	generator_task->noise = p_noise_texture->get_noise();
+	generator_task->callback = p_callback;
+	generator_task->status = GeneratorTask2D::TaskStatus::BAKING_STARTED;
+	generator_task->thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NoiseTextureGenerator::generator_noise_texture_2d_thread_bake, generator_task, false, SNAME("NoiseTextureGenerator"));
+	MutexLock generator_task_lock(generator_task_mutex);
+	generator_tasks_2d.insert(generator_task->thread_task_id, generator_task);
+}
+
+void NoiseTextureGenerator::generator_noise_texture_2d_thread_bake(void *p_arg) {
+	GeneratorTask2D *generator_task = static_cast<GeneratorTask2D *>(p_arg);
+
+	Ref<NoiseTexture2D> noise_texture = generator_task->noise_texture;
+	Ref<Image> noise_data = noise_texture->bake_noise_data();
+	generator_task->noise_data = noise_data;
+
+	generator_task->status = GeneratorTask2D::TaskStatus::BAKING_FINISHED;
+}
+
+bool NoiseTextureGenerator::is_noise_texture_2d_baking(Ref<NoiseTexture2D> p_noise_texture) {
+	MutexLock baking_lock(bake_mutex);
+	return baking_noise_texture_2d.has(p_noise_texture);
+}
+
+void NoiseTextureGenerator::sync_2d_tasks() {
+	if (generator_tasks_2d.is_empty()) {
+		return;
+	}
+
+	MutexLock generator_task_lock(generator_task_mutex);
+
+	LocalVector<Callable> finished_callbacks;
+	LocalVector<WorkerThreadPool::TaskID> finished_task_ids;
+
+	for (KeyValue<WorkerThreadPool::TaskID, GeneratorTask2D *> &E : generator_tasks_2d) {
+		if (WorkerThreadPool::get_singleton()->is_task_completed(E.key)) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
+			finished_task_ids.push_back(E.key);
+
+			GeneratorTask2D *generator_task = E.value;
+			DEV_ASSERT(generator_task->status == GeneratorTask2D::TaskStatus::BAKING_FINISHED);
+
+			baking_noise_texture_2d.erase(generator_task->noise_texture);
+			if (generator_task->callback.is_valid()) {
+				finished_callbacks.push_back(generator_task->callback);
+			}
+
+			Ref<NoiseTexture2D> noise_texture = generator_task->noise_texture;
+			Ref<Image> noise_data = generator_task->noise_data;
+
+			noise_texture->set_data(noise_data);
+
+			memdelete(generator_task);
+		}
+	}
+
+	for (WorkerThreadPool::TaskID finished_task_id : finished_task_ids) {
+		generator_tasks_2d.erase(finished_task_id);
+	}
+
+	for (const Callable &callback : finished_callbacks) {
+		generator_emit_callback(callback);
+	}
+}
+
+void NoiseTextureGenerator::bake_noise_texture_3d(Ref<NoiseTexture3D> p_noise_texture) {
+	ERR_FAIL_COND(p_noise_texture.is_null());
+	ERR_FAIL_COND(p_noise_texture->get_noise().is_null());
+
+	if (is_noise_texture_3d_baking(p_noise_texture)) {
+		ERR_FAIL_MSG("NoiseTexture3D is already baking. Wait for current bake to finish. Use 'NoiseTextureGenerator::is_noise_texture_3d_baking()' to check the bake state of a noise 3d texture.");
+		return;
+	}
+
+	Ref<NoiseTexture3D> noise_texture = p_noise_texture;
+	const Vector<Ref<Image>> noise_data = noise_texture->bake_noise_data();
+	noise_texture->set_data(noise_data);
+}
+
+void NoiseTextureGenerator::bake_noise_texture_3d_async(Ref<NoiseTexture3D> p_noise_texture, const Callable &p_callback) {
+	ERR_FAIL_COND(p_noise_texture.is_null());
+	ERR_FAIL_COND(p_noise_texture->get_noise().is_null());
+
+	if (is_noise_texture_3d_baking(p_noise_texture)) {
+		ERR_FAIL_MSG("NoiseTexture3D is already baking. Wait for current bake to finish. Use 'NoiseTextureGenerator::is_noise_texture_3d_baking()' to check the bake state of a noise 3d texture.");
+		return;
+	}
+
+	if (!use_threads) {
+		bake_noise_texture_3d(p_noise_texture);
+		if (p_callback.is_valid()) {
+			generator_emit_callback(p_callback);
+		}
+		return;
+	}
+
+	bake_mutex.lock();
+	GeneratorTask3D *generator_task = memnew(GeneratorTask3D);
+	baking_noise_texture_3d.insert(p_noise_texture, generator_task);
+	bake_mutex.unlock();
+
+	generator_task->noise_texture = p_noise_texture;
+	generator_task->noise = p_noise_texture->get_noise();
+	generator_task->callback = p_callback;
+	generator_task->status = GeneratorTask3D::TaskStatus::BAKING_STARTED;
+	generator_task->thread_task_id = WorkerThreadPool::get_singleton()->add_native_task(&NoiseTextureGenerator::generator_noise_texture_3d_thread_bake, generator_task, false, SNAME("NoiseTextureGenerator"));
+	MutexLock generator_task_lock(generator_task_mutex);
+	generator_tasks_3d.insert(generator_task->thread_task_id, generator_task);
+}
+
+void NoiseTextureGenerator::generator_noise_texture_3d_thread_bake(void *p_arg) {
+	GeneratorTask3D *generator_task = static_cast<GeneratorTask3D *>(p_arg);
+
+	Ref<NoiseTexture3D> noise_texture = generator_task->noise_texture;
+	Vector<Ref<Image>> noise_data = noise_texture->bake_noise_data();
+	generator_task->noise_data = noise_data;
+
+	generator_task->status = GeneratorTask3D::TaskStatus::BAKING_FINISHED;
+}
+
+bool NoiseTextureGenerator::is_noise_texture_3d_baking(Ref<NoiseTexture3D> p_noise_texture) {
+	MutexLock baking_lock(bake_mutex);
+	return baking_noise_texture_3d.has(p_noise_texture);
+}
+
+void NoiseTextureGenerator::sync_3d_tasks() {
+	if (generator_tasks_3d.is_empty()) {
+		return;
+	}
+
+	MutexLock generator_task_lock(generator_task_mutex);
+
+	LocalVector<Callable> finished_callbacks;
+	LocalVector<WorkerThreadPool::TaskID> finished_task_ids;
+
+	for (KeyValue<WorkerThreadPool::TaskID, GeneratorTask3D *> &E : generator_tasks_3d) {
+		if (WorkerThreadPool::get_singleton()->is_task_completed(E.key)) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
+			finished_task_ids.push_back(E.key);
+
+			GeneratorTask3D *generator_task = E.value;
+			DEV_ASSERT(generator_task->status == GeneratorTask3D::TaskStatus::BAKING_FINISHED);
+
+			baking_noise_texture_3d.erase(generator_task->noise_texture);
+			if (generator_task->callback.is_valid()) {
+				finished_callbacks.push_back(generator_task->callback);
+			}
+
+			Ref<NoiseTexture3D> noise_texture = generator_task->noise_texture;
+			Vector<Ref<Image>> noise_data = generator_task->noise_data;
+
+			noise_texture->set_data(noise_data);
+
+			memdelete(generator_task);
+		}
+	}
+
+	for (WorkerThreadPool::TaskID finished_task_id : finished_task_ids) {
+		generator_tasks_3d.erase(finished_task_id);
+	}
+
+	for (const Callable &callback : finished_callbacks) {
+		generator_emit_callback(callback);
+	}
+}
+
+void NoiseTextureGenerator::init() {
+	if (RS::get_singleton() == nullptr) {
+		use_threads = false;
+	}
+
+	if (use_threads) {
+		RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(this, &NoiseTextureGenerator::sync));
+	}
+}
+
+void NoiseTextureGenerator::finish() {
+	if (RS::get_singleton() && RS::get_singleton()->is_connected(SNAME("frame_pre_draw"), callable_mp(this, &NoiseTextureGenerator::sync))) {
+		RS::get_singleton()->disconnect(SNAME("frame_pre_draw"), callable_mp(this, &NoiseTextureGenerator::sync));
+	}
+
+	MutexLock baking_lock(bake_mutex);
+	{
+		MutexLock generator_task_lock(generator_task_mutex);
+
+		baking_noise_texture_2d.clear();
+		baking_noise_texture_3d.clear();
+
+		for (KeyValue<WorkerThreadPool::TaskID, GeneratorTask2D *> &E : generator_tasks_2d) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
+			GeneratorTask2D *generator_task = E.value;
+			memdelete(generator_task);
+		}
+		generator_tasks_2d.clear();
+
+		for (KeyValue<WorkerThreadPool::TaskID, GeneratorTask3D *> &E : generator_tasks_3d) {
+			WorkerThreadPool::get_singleton()->wait_for_task_completion(E.key);
+			GeneratorTask3D *generator_task = E.value;
+			memdelete(generator_task);
+		}
+		generator_tasks_3d.clear();
+	}
+}
+
+void NoiseTextureGenerator::sync() {
+	sync_2d_tasks();
+	sync_3d_tasks();
+}
+
+bool NoiseTextureGenerator::generator_emit_callback(const Callable &p_callback) {
+	ERR_FAIL_COND_V(!p_callback.is_valid(), false);
+
+	Callable::CallError ce;
+	Variant result;
+	p_callback.callp(nullptr, 0, result, ce);
+
+	return ce.error == Callable::CallError::CALL_OK;
+}
+
+void NoiseTextureGenerator::_bind_methods() {
+	ClassDB::bind_static_method("NoiseTextureGenerator", D_METHOD("bake_noise_texture_2d", "noise_texture"), &NoiseTextureGenerator::bake_noise_texture_2d);
+	ClassDB::bind_static_method("NoiseTextureGenerator", D_METHOD("bake_noise_texture_2d_async", "noise_texture", "callback"), &NoiseTextureGenerator::bake_noise_texture_2d_async, DEFVAL(Callable()));
+	ClassDB::bind_static_method("NoiseTextureGenerator", D_METHOD("is_noise_texture_2d_baking", "noise_texture"), &NoiseTextureGenerator::is_noise_texture_2d_baking);
+
+	ClassDB::bind_static_method("NoiseTextureGenerator", D_METHOD("bake_noise_texture_3d", "noise_texture"), &NoiseTextureGenerator::bake_noise_texture_3d);
+	ClassDB::bind_static_method("NoiseTextureGenerator", D_METHOD("bake_noise_texture_3d_async", "noise_texture", "callback"), &NoiseTextureGenerator::bake_noise_texture_3d_async, DEFVAL(Callable()));
+	ClassDB::bind_static_method("NoiseTextureGenerator", D_METHOD("is_noise_texture_3d_baking", "noise_texture"), &NoiseTextureGenerator::is_noise_texture_3d_baking);
+}

--- a/modules/noise/noise_texture_generator.h
+++ b/modules/noise/noise_texture_generator.h
@@ -1,0 +1,116 @@
+/**************************************************************************/
+/*  noise_texture_generator.h                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "noise.h"
+#include "noise_texture_2d.h"
+#include "noise_texture_3d.h"
+
+#include "core/object/worker_thread_pool.h"
+#include "core/templates/a_hash_map.h"
+
+class NoiseTextureGenerator : public Object {
+	GDCLASS(NoiseTextureGenerator, Object);
+
+	static Mutex bake_mutex;
+	static Mutex generator_task_mutex;
+
+	static NoiseTextureGenerator *singleton;
+
+	static bool use_threads;
+
+	struct GeneratorTask2D {
+		enum TaskStatus {
+			BAKING_STARTED,
+			BAKING_FINISHED,
+			BAKING_FAILED,
+			CALLBACK_DISPATCHED,
+			CALLBACK_FAILED,
+		};
+
+		Ref<NoiseTexture2D> noise_texture;
+		Ref<Noise> noise;
+		Callable callback;
+		Ref<Image> noise_data;
+		WorkerThreadPool::TaskID thread_task_id = WorkerThreadPool::INVALID_TASK_ID;
+		GeneratorTask2D::TaskStatus status = GeneratorTask2D::TaskStatus::BAKING_STARTED;
+	};
+
+	static AHashMap<WorkerThreadPool::TaskID, GeneratorTask2D *> generator_tasks_2d;
+	static void generator_noise_texture_2d_thread_bake(void *p_arg);
+	static AHashMap<Ref<NoiseTexture2D>, GeneratorTask2D *> baking_noise_texture_2d;
+	static void sync_2d_tasks();
+
+	struct GeneratorTask3D {
+		enum TaskStatus {
+			BAKING_STARTED,
+			BAKING_FINISHED,
+			BAKING_FAILED,
+			CALLBACK_DISPATCHED,
+			CALLBACK_FAILED,
+		};
+
+		Ref<NoiseTexture3D> noise_texture;
+		Ref<Noise> noise;
+		Callable callback;
+		Vector<Ref<Image>> noise_data;
+		WorkerThreadPool::TaskID thread_task_id = WorkerThreadPool::INVALID_TASK_ID;
+		GeneratorTask3D::TaskStatus status = GeneratorTask3D::TaskStatus::BAKING_STARTED;
+	};
+
+	static AHashMap<WorkerThreadPool::TaskID, GeneratorTask3D *> generator_tasks_3d;
+	static void generator_noise_texture_3d_thread_bake(void *p_arg);
+	static AHashMap<Ref<NoiseTexture3D>, GeneratorTask3D *> baking_noise_texture_3d;
+	static void sync_3d_tasks();
+
+	static bool generator_emit_callback(const Callable &p_callback);
+
+protected:
+	static void _bind_methods();
+
+public:
+	static NoiseTextureGenerator *get_singleton();
+
+	NoiseTextureGenerator();
+	~NoiseTextureGenerator();
+
+	void init();
+	void sync();
+	void finish();
+
+	static bool is_noise_texture_2d_baking(Ref<NoiseTexture2D> p_noise_texture);
+	static void bake_noise_texture_2d(Ref<NoiseTexture2D> p_noise_texture);
+	static void bake_noise_texture_2d_async(Ref<NoiseTexture2D> p_noise_texture, const Callable &p_callback = Callable());
+
+	static bool is_noise_texture_3d_baking(Ref<NoiseTexture3D> p_noise_texture);
+	static void bake_noise_texture_3d(Ref<NoiseTexture3D> p_noise_texture);
+	static void bake_noise_texture_3d_async(Ref<NoiseTexture3D> p_noise_texture, const Callable &p_callback = Callable());
+};


### PR DESCRIPTION
Adds `NoiseTextureGenerator` singleton to facilitate the baking of noise textures using existing threads from the `WorkerThreadPool` when available.

Previously each single `NoiseTexture2D/3D` created its own dedicated `Thread`, which was neither efficient or performant.

This fresh thread creation made it more or less performance impossible to use noise textures at runtime when not hidden behind a loading screen. The thread-spawn alone would cause stutters to no end on all platforms with a higher thread-spawn costs like Windows. Having so many additional threads running next to the actual WorkerThreadPool max thread count caused a lot of thread congestion when many noise textures were used.

This PR removes the dedicated `Thread` from `NoiseTexture2D/3D` and makes them use `WorkerThreadPool` threads to bake noise images. Because this requires additional bookkeeping and thread synchronization work a new `NoiseTextureGenerator` singleton was added.

Note that there is no elegant hook option with the main loop to do thread synchronization for optional modules like the noise module. To solve this I decided to piggyback on the RenderingServer `frame_pre_draw` signal for thread synchronization. The reason I did not pick a SceneTree signal for this (like some other resources and nodes do) is because not every main loop is always a SceneTree, so those signals might not be available at all.

Using the `frame_pre_draw` signal also allows to sync all the noise bakes that users kicked off in script and that might have been finished quickly by the time the RenderingServer starts its own sync and frame thing. This gives less window to run into issues with async baked noise textures being already baked so the duplicated bake attempts get blocked. Keeping the wait window small is important because all the noise resources have this awkward implementation of using the deferred queue for auto updates that users can't really stop from triggering.

Note that this largely copies the bake logic of the navigation mesh generator, except for the new signal and deferred quirks that are specific to the noise module and resources.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
