### PR TITLE
Disable UNUSED_SIGNAL warning for abstract GDScript classes

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1515,7 +1515,7 @@ void GDScriptAnalyzer::resolve_class_body(GDScriptParser::ClassNode *p_class, co
 			}
 		} else if (member.type == GDScriptParser::ClassNode::Member::SIGNAL) {
 #ifdef DEBUG_ENABLED
-			if (member.signal->usages == 0) {
+			if (member.signal->usages == 0 && !p_class->is_abstract) {
 				parser->push_warning(member.signal->identifier, GDScriptWarning::UNUSED_SIGNAL, member.signal->identifier->name);
 			}
 #endif // DEBUG_ENABLED


### PR DESCRIPTION
Fixes #110758 
Disables the UNUSED_SIGNAL warning for signals declared within an abstract class. 

This warning should be disabled as abstract classes are often not expected to provide complete implementations which would make use of all declared signals.