### PR TITLE
Fix AnimationPlayer to use StringName instead of String in the exposed API.

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -64,7 +64,7 @@
 			</description>
 		</method>
 		<method name="get_queue">
-			<return type="PackedStringArray" />
+			<return type="StringName[]" />
 			<description>
 				Returns a list of the animation keys that are currently queued to play.
 			</description>
@@ -280,13 +280,13 @@
 		</method>
 	</methods>
 	<members>
-		<member name="assigned_animation" type="String" setter="set_assigned_animation" getter="get_assigned_animation">
+		<member name="assigned_animation" type="StringName" setter="set_assigned_animation" getter="get_assigned_animation">
 			If playing, the current animation's key, otherwise, the animation last played. When set, this changes the animation, but will not play it unless already playing. See also [member current_animation].
 		</member>
-		<member name="autoplay" type="String" setter="set_autoplay" getter="get_autoplay" default="&quot;&quot;">
+		<member name="autoplay" type="StringName" setter="set_autoplay" getter="get_autoplay" default="&amp;&quot;&quot;">
 			The key of the animation to play when the scene loads.
 		</member>
-		<member name="current_animation" type="String" setter="set_current_animation" getter="get_current_animation" default="&quot;&quot;">
+		<member name="current_animation" type="StringName" setter="set_current_animation" getter="get_current_animation" default="&amp;&quot;&quot;">
 			The key of the currently playing animation. If no animation is playing, the property's value is an empty string. Changing this value does not restart the animation. See [method play] for more information on playing animations.
 			[b]Note:[/b] While this property appears in the Inspector, it's not meant to be edited, and it's not saved in the scene. This property is mainly used to get the currently playing animation, and internally for animation playback tracks. For more information, see [Animation].
 		</member>
@@ -332,7 +332,7 @@
 			</description>
 		</signal>
 		<signal name="current_animation_changed">
-			<param index="0" name="name" type="String" />
+			<param index="0" name="name" type="StringName" />
 			<description>
 				Emitted when [member current_animation] changes.
 			</description>

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -113,7 +113,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 
 			if (player->is_playing()) {
 				{
-					String animname = player->get_assigned_animation();
+					StringName animname = player->get_assigned_animation();
 
 					if (player->has_animation(animname)) {
 						Ref<Animation> anim = player->get_animation(animname);
@@ -229,7 +229,7 @@ void AnimationPlayerEditor::_autoplay_pressed() {
 	if (player->get_autoplay() == current) {
 		//unset
 		undo_redo->create_action(TTR("Toggle Autoplay"));
-		undo_redo->add_do_method(player, "set_autoplay", "");
+		undo_redo->add_do_method(player, "set_autoplay", StringName());
 		undo_redo->add_undo_method(player, "set_autoplay", player->get_autoplay());
 		undo_redo->add_do_method(this, "_animation_player_changed", player);
 		undo_redo->add_undo_method(this, "_animation_player_changed", player);
@@ -238,7 +238,7 @@ void AnimationPlayerEditor::_autoplay_pressed() {
 	} else {
 		//set
 		undo_redo->create_action(TTR("Toggle Autoplay"));
-		undo_redo->add_do_method(player, "set_autoplay", current);
+		undo_redo->add_do_method(player, "set_autoplay", StringName(current));
 		undo_redo->add_undo_method(player, "set_autoplay", player->get_autoplay());
 		undo_redo->add_do_method(this, "_animation_player_changed", player);
 		undo_redo->add_undo_method(this, "_animation_player_changed", player);
@@ -564,8 +564,8 @@ void AnimationPlayerEditor::_animation_remove_confirmed() {
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	undo_redo->create_action(TTR("Remove Animation"));
 	if (player->get_autoplay() == current) {
-		undo_redo->add_do_method(player, "set_autoplay", "");
-		undo_redo->add_undo_method(player, "set_autoplay", current);
+		undo_redo->add_do_method(player, "set_autoplay", StringName());
+		undo_redo->add_undo_method(player, "set_autoplay", StringName(current));
 		// Avoid having the autoplay icon linger around if there is only one animation in the player.
 		undo_redo->add_do_method(this, "_animation_player_changed", player);
 	}
@@ -597,7 +597,7 @@ void AnimationPlayerEditor::_select_anim_by_name(const String &p_anim) {
 }
 
 float AnimationPlayerEditor::_get_editor_step() const {
-	const String current = player->get_assigned_animation();
+	const StringName current = player->get_assigned_animation();
 	const Ref<Animation> anim = player->get_animation(current);
 	ERR_FAIL_COND_V(anim.is_null(), 0.0);
 
@@ -1411,7 +1411,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_timeline_o
 	};
 
 	updating = true;
-	String current = player->get_assigned_animation();
+	StringName current = player->get_assigned_animation();
 	if (current.is_empty() || !player->has_animation(current)) {
 		updating = false;
 		current = "";
@@ -1460,7 +1460,7 @@ void AnimationPlayerEditor::_animation_finished(const String &p_name) {
 	finishing = true;
 }
 
-void AnimationPlayerEditor::_current_animation_changed(const String &p_name) {
+void AnimationPlayerEditor::_current_animation_changed(const StringName &p_name) {
 	if (is_visible_in_tree()) {
 		if (finishing) {
 			finishing = false; // Maybe redundant since it will be false in the AnimationPlayerEditor::_process(), but for safety.

--- a/editor/animation/animation_player_editor_plugin.h
+++ b/editor/animation/animation_player_editor_plugin.h
@@ -206,7 +206,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	void _list_changed();
 	void _animation_finished(const String &p_name);
-	void _current_animation_changed(const String &p_name);
+	void _current_animation_changed(const StringName &p_name);
 	void _update_animation();
 	void _update_player();
 	void _set_controls_disabled(bool p_disabled);

--- a/misc/extension_api_validation/4.5-stable.expected
+++ b/misc/extension_api_validation/4.5-stable.expected
@@ -40,3 +40,17 @@ GH-111117
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/LineEdit/methods/edit': arguments
 
 Optional argument added. Compatibility method registered.
+
+
+GH-110767
+---------
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_assigned_animation/return_value': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_autoplay/return_value': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_current_animation/return_value': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_queue/return_value': type changed value in new API, from "PackedStringArray" to "typedarray::StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/set_assigned_animation/arguments/0': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/set_autoplay/arguments/0': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/set_current_animation/arguments/0': type changed value in new API, from "String" to "StringName".
+Validate extension JSON: Error: Field 'classes/AnimationPlayer/signals/current_animation_changed/arguments/0': type changed value in new API, from "String" to "StringName".
+
+Return types and parameters changed to StringName to improve performance. Compatibility methods registered; No compatibility system for signal arguments.

--- a/scene/animation/animation_player.compat.inc
+++ b/scene/animation/animation_player.compat.inc
@@ -58,6 +58,38 @@ void AnimationPlayer::_seek_bind_compat_80813(double p_time, bool p_update) {
 	seek(p_time, p_update, false);
 }
 
+Vector<String> AnimationPlayer::_get_queue_compat_110767() {
+	Vector<String> queue;
+	for (const Variant &E : get_queue()) {
+		queue.push_back(E);
+	}
+	return queue;
+}
+
+String AnimationPlayer::_get_current_animation_compat_110767() const {
+	return get_current_animation();
+}
+
+void AnimationPlayer::_set_current_animation_compat_110767(const String &p_animation) {
+	set_current_animation(p_animation);
+}
+
+String AnimationPlayer::_get_assigned_animation_compat_110767() const {
+	return get_assigned_animation();
+}
+
+void AnimationPlayer::_set_assigned_animation_compat_110767(const String &p_animation) {
+	set_assigned_animation(p_animation);
+}
+
+String AnimationPlayer::_get_autoplay_compat_110767() const {
+	return get_autoplay();
+}
+
+void AnimationPlayer::_set_autoplay_compat_110767(const String &p_name) {
+	set_autoplay(p_name);
+}
+
 void AnimationPlayer::_bind_compatibility_methods() {
 	ClassDB::bind_method(D_METHOD("set_process_callback", "mode"), &AnimationPlayer::_set_process_callback_bind_compat_80813);
 	ClassDB::bind_method(D_METHOD("get_process_callback"), &AnimationPlayer::_get_process_callback_bind_compat_80813);
@@ -65,6 +97,15 @@ void AnimationPlayer::_bind_compatibility_methods() {
 	ClassDB::bind_method(D_METHOD("get_method_call_mode"), &AnimationPlayer::_get_method_call_mode_bind_compat_80813);
 	ClassDB::bind_method(D_METHOD("set_root", "path"), &AnimationPlayer::_set_root_bind_compat_80813);
 	ClassDB::bind_method(D_METHOD("get_root"), &AnimationPlayer::_get_root_bind_compat_80813);
+
+	ClassDB::bind_compatibility_method(D_METHOD("get_queue"), &AnimationPlayer::_get_queue_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_current_animation"), &AnimationPlayer::_get_current_animation_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("set_current_animation", "animation"), &AnimationPlayer::_set_current_animation_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_assigned_animation"), &AnimationPlayer::_get_assigned_animation_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("set_assigned_animation", "animation"), &AnimationPlayer::_set_assigned_animation_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("get_autoplay"), &AnimationPlayer::_get_autoplay_compat_110767);
+	ClassDB::bind_compatibility_method(D_METHOD("set_autoplay", "name"), &AnimationPlayer::_set_autoplay_compat_110767);
+
 	ClassDB::bind_compatibility_method(D_METHOD("seek", "seconds", "update"), &AnimationPlayer::_seek_bind_compat_80813, DEFVAL(false));
 	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_PHYSICS);
 	BIND_ENUM_CONSTANT(ANIMATION_PROCESS_IDLE);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -365,8 +365,8 @@ void AnimationPlayer::queue(const StringName &p_name) {
 	}
 }
 
-Vector<String> AnimationPlayer::get_queue() {
-	Vector<String> ret;
+TypedArray<StringName> AnimationPlayer::get_queue() {
+	TypedArray<StringName> ret;
 	for (const StringName &E : playback_queue) {
 		ret.push_back(E);
 	}
@@ -579,8 +579,8 @@ bool AnimationPlayer::is_playing() const {
 	return playing;
 }
 
-void AnimationPlayer::set_current_animation(const String &p_animation) {
-	if (p_animation == "[stop]" || p_animation.is_empty()) {
+void AnimationPlayer::set_current_animation(const StringName &p_animation) {
+	if (p_animation == SNAME("[stop]") || p_animation.is_empty()) {
 		stop();
 	} else if (!is_playing()) {
 		play(p_animation);
@@ -592,16 +592,16 @@ void AnimationPlayer::set_current_animation(const String &p_animation) {
 	}
 }
 
-String AnimationPlayer::get_current_animation() const {
-	return (is_playing() ? playback.assigned : "");
+StringName AnimationPlayer::get_current_animation() const {
+	return (is_playing() ? playback.assigned : StringName());
 }
 
-void AnimationPlayer::set_assigned_animation(const String &p_animation) {
+void AnimationPlayer::set_assigned_animation(const StringName &p_animation) {
 	if (is_playing()) {
 		float speed = playback.current.speed_scale;
 		play(p_animation, -1.0, speed, std::signbit(speed));
 	} else {
-		ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation));
+		ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation.operator String()));
 		playback.current.pos = 0;
 		playback.current.from = &animation_set[p_animation];
 		playback.current.start_time = -1;
@@ -611,7 +611,7 @@ void AnimationPlayer::set_assigned_animation(const String &p_animation) {
 	}
 }
 
-String AnimationPlayer::get_assigned_animation() const {
+StringName AnimationPlayer::get_assigned_animation() const {
 	return playback.assigned;
 }
 
@@ -745,7 +745,7 @@ bool AnimationPlayer::has_section() const {
 	return Animation::is_greater_or_equal_approx(playback.current.start_time, 0) || Animation::is_greater_or_equal_approx(playback.current.end_time, 0);
 }
 
-void AnimationPlayer::set_autoplay(const String &p_name) {
+void AnimationPlayer::set_autoplay(const StringName &p_name) {
 	if (is_inside_tree() && !Engine::get_singleton()->is_editor_hint()) {
 		WARN_PRINT("Setting autoplay after the node has been added to the scene has no effect.");
 	}
@@ -753,7 +753,7 @@ void AnimationPlayer::set_autoplay(const String &p_name) {
 	autoplay = p_name;
 }
 
-String AnimationPlayer::get_autoplay() const {
+StringName AnimationPlayer::get_autoplay() const {
 	return autoplay;
 }
 
@@ -1028,7 +1028,7 @@ void AnimationPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "speed_scale", PROPERTY_HINT_RANGE, "-4,4,0.001,or_less,or_greater"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "movie_quit_on_finish"), "set_movie_quit_on_finish_enabled", "is_movie_quit_on_finish_enabled");
 
-	ADD_SIGNAL(MethodInfo(SNAME("current_animation_changed"), PropertyInfo(Variant::STRING, "name")));
+	ADD_SIGNAL(MethodInfo(SNAME("current_animation_changed"), PropertyInfo(Variant::STRING_NAME, "name")));
 	ADD_SIGNAL(MethodInfo(SNAME("animation_changed"), PropertyInfo(Variant::STRING_NAME, "old_name"), PropertyInfo(Variant::STRING_NAME, "new_name")));
 }
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -166,6 +166,14 @@ protected:
 	void _play_compat_84906(const StringName &p_name = StringName(), double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void _play_backwards_compat_84906(const StringName &p_name = StringName(), double p_custom_blend = -1);
 
+	Vector<String> _get_queue_compat_110767();
+	String _get_current_animation_compat_110767() const;
+	void _set_current_animation_compat_110767(const String &p_animation);
+	String _get_assigned_animation_compat_110767() const;
+	void _set_assigned_animation_compat_110767(const String &p_animation);
+	String _get_autoplay_compat_110767() const;
+	void _set_autoplay_compat_110767(const String &p_name);
+
 	static void _bind_compatibility_methods();
 #endif // DISABLE_DEPRECATED
 
@@ -200,23 +208,23 @@ public:
 	void play_section_backwards(const StringName &p_name = StringName(), double p_start_time = -1, double p_end_time = -1, double p_custom_blend = -1);
 	void play_with_capture(const StringName &p_name = StringName(), double p_duration = -1.0, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);
 	void queue(const StringName &p_name);
-	Vector<String> get_queue();
+	TypedArray<StringName> get_queue();
 	void clear_queue();
 	void pause();
 	void stop(bool p_keep_state = false);
 	bool is_playing() const;
-	String get_current_animation() const;
-	void set_current_animation(const String &p_animation);
-	String get_assigned_animation() const;
-	void set_assigned_animation(const String &p_animation);
+	StringName get_current_animation() const;
+	void set_current_animation(const StringName &p_animation);
+	StringName get_assigned_animation() const;
+	void set_assigned_animation(const StringName &p_animation);
 	bool is_valid() const;
 
 	void set_speed_scale(float p_speed);
 	float get_speed_scale() const;
 	float get_playing_speed() const;
 
-	void set_autoplay(const String &p_name);
-	String get_autoplay() const;
+	void set_autoplay(const StringName &p_name);
+	StringName get_autoplay() const;
 
 	void set_movie_quit_on_finish_enabled(bool p_enabled);
 	bool is_movie_quit_on_finish_enabled() const;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

This PR fixes the performance penalty of having to convert to and from `String`↔`StringName` in the exposed `AnimationPlayer` api.