### PR TITLE
Fix nested TileMapLayers highlight rendering in editor

### DIFF
--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -200,6 +200,18 @@ void TileMapLayer::_debug_update(bool p_force_cleanup) {
 
 #endif // DEBUG_ENABLED
 
+Color TileMapLayer::_highlight_color(const Color &p_modulate) const {
+	if (highlight_mode == HIGHLIGHT_MODE_BELOW) {
+		return p_modulate.darkened(0.5);
+	}
+	if (highlight_mode == HIGHLIGHT_MODE_ABOVE) {
+		Color c = p_modulate.darkened(0.5);
+		c.a *= 0.3;
+		return c;
+	}
+	return p_modulate;
+}
+
 /////////////////////////////// Rendering //////////////////////////////////////
 void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 	RenderingServer *rs = RenderingServer::get_singleton();
@@ -208,19 +220,14 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 	bool forced_cleanup = p_force_cleanup || !enabled || tile_set.is_null() || !is_visible_in_tree();
 
 	// ----------- Layer level processing -----------
-	if (!forced_cleanup) {
-		// Modulate the layer.
-		Color layer_modulate = get_modulate();
+	// Modulate the layer.
+	Color layer_modulate = get_self_modulate();
 #ifdef TOOLS_ENABLED
-		if (highlight_mode == HIGHLIGHT_MODE_BELOW) {
-			layer_modulate = layer_modulate.darkened(0.5);
-		} else if (highlight_mode == HIGHLIGHT_MODE_ABOVE) {
-			layer_modulate = layer_modulate.darkened(0.5);
-			layer_modulate.a *= 0.3;
-		}
-#endif // TOOLS_ENABLED
-		rs->canvas_item_set_modulate(get_canvas_item(), layer_modulate);
+	if (!forced_cleanup) {
+		layer_modulate = _highlight_color(layer_modulate);
+		rs->canvas_item_set_self_modulate(get_canvas_item(), layer_modulate);
 	}
+#endif // TOOLS_ENABLED
 
 	// ----------- Quadrants processing -----------
 
@@ -341,7 +348,7 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 						rs->canvas_item_set_light_mask(ci, get_light_mask());
 						rs->canvas_item_set_z_as_relative_to_parent(ci, true);
 						rs->canvas_item_set_z_index(ci, tile_z_index);
-						rs->canvas_item_set_self_modulate(ci, get_self_modulate());
+						rs->canvas_item_set_self_modulate(ci, layer_modulate);
 
 						rs->canvas_item_set_default_texture_filter(ci, RS::CanvasItemTextureFilter(get_texture_filter_in_tree()));
 						rs->canvas_item_set_default_texture_repeat(ci, RS::CanvasItemTextureRepeat(get_texture_repeat_in_tree()));
@@ -416,14 +423,15 @@ void TileMapLayer::_rendering_update(bool p_force_cleanup) {
 		if (dirty.flags[DIRTY_FLAGS_LAYER_LIGHT_MASK] ||
 				dirty.flags[DIRTY_FLAGS_LAYER_TEXTURE_FILTER] ||
 				dirty.flags[DIRTY_FLAGS_LAYER_TEXTURE_REPEAT] ||
-				dirty.flags[DIRTY_FLAGS_LAYER_SELF_MODULATE]) {
+				dirty.flags[DIRTY_FLAGS_LAYER_SELF_MODULATE] ||
+				dirty.flags[DIRTY_FLAGS_LAYER_HIGHLIGHT_MODE]) {
 			for (KeyValue<Vector2i, Ref<RenderingQuadrant>> &kv : rendering_quadrant_map) {
 				Ref<RenderingQuadrant> &rendering_quadrant = kv.value;
 				for (const RID &ci : rendering_quadrant->canvas_items) {
 					rs->canvas_item_set_light_mask(ci, get_light_mask());
 					rs->canvas_item_set_default_texture_filter(ci, RS::CanvasItemTextureFilter(get_texture_filter_in_tree()));
 					rs->canvas_item_set_default_texture_repeat(ci, RS::CanvasItemTextureRepeat(get_texture_repeat_in_tree()));
-					rs->canvas_item_set_self_modulate(ci, get_self_modulate());
+					rs->canvas_item_set_self_modulate(ci, layer_modulate);
 				}
 			}
 		}
@@ -1538,7 +1546,7 @@ void TileMapLayer::_scenes_update(bool p_force_cleanup) {
 			_scenes_clear_cell(kv.value);
 		}
 	} else {
-		if (_scenes_was_cleaned_up || dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE]) {
+		if (_scenes_was_cleaned_up || dirty.flags[DIRTY_FLAGS_TILE_SET] || dirty.flags[DIRTY_FLAGS_LAYER_IN_TREE] || dirty.flags[DIRTY_FLAGS_LAYER_HIGHLIGHT_MODE]) {
 			// Update all cells.
 			for (KeyValue<Vector2i, CellData> &kv : tile_map_layer_data) {
 				_scenes_update_cell(kv.value);
@@ -1598,6 +1606,13 @@ void TileMapLayer::_scenes_update_cell(CellData &r_cell_data) {
 						xform.set_origin(tile_set->map_to_local(r_cell_data.coords));
 						scene_as_node2d->set_transform(xform * scene_as_node2d->get_transform());
 					}
+#ifdef TOOLS_ENABLED
+					RenderingServer *rs = RenderingServer::get_singleton();
+					CanvasItem *scene_as_ci = Object::cast_to<CanvasItem>(scene);
+					if (scene_as_ci) {
+						rs->canvas_item_set_modulate(scene_as_ci->get_canvas_item(), _highlight_color(scene_as_ci->get_modulate()));
+					}
+#endif // TOOLS_ENABLED
 					if (tile_map_node) {
 						// Compatibility with TileMap.
 						tile_map_node->add_child(scene);
@@ -3142,6 +3157,7 @@ void TileMapLayer::set_highlight_mode(HighlightMode p_highlight_mode) {
 		return;
 	}
 	highlight_mode = p_highlight_mode;
+	dirty.flags[DIRTY_FLAGS_LAYER_HIGHLIGHT_MODE] = true;
 	_queue_internal_update();
 }
 

--- a/scene/2d/tile_map_layer.h
+++ b/scene/2d/tile_map_layer.h
@@ -369,6 +369,7 @@ public:
 		DIRTY_FLAGS_LAYER_NAVIGATION_MAP,
 		DIRTY_FLAGS_LAYER_NAVIGATION_VISIBILITY_MODE,
 		DIRTY_FLAGS_LAYER_RUNTIME_UPDATE,
+		DIRTY_FLAGS_LAYER_HIGHLIGHT_MODE,
 
 		DIRTY_FLAGS_LAYER_INDEX_IN_TILE_MAP_NODE, // For compatibility.
 
@@ -450,6 +451,7 @@ private:
 	bool _rendering_was_cleaned_up = false;
 	void _rendering_update(bool p_force_cleanup);
 	void _rendering_notification(int p_what);
+	Color _highlight_color(const Color &p_modulate) const;
 	void _rendering_quadrants_update_cell(CellData &r_cell_data, SelfList<RenderingQuadrant>::List &r_dirty_rendering_quadrant_list);
 	void _rendering_occluders_clear_cell(CellData &r_cell_data);
 	void _rendering_occluders_update_cell(CellData &r_cell_data);


### PR DESCRIPTION
Fixes #110710

Replaces the use of set_modulate in the TileMapLayer highlight rendering to set_self_modulate.

The highlight rendering of TileMapLayer currently uses set_modulate to adjust darkness and alpha of non-selected layers.
When TileMapLayers are nested, as shown in the issue, highlighting a child layer darkens the parents using set_modulate, which also affects children, making them darker.

<img width="769" height="519" alt="image" src="https://github.com/user-attachments/assets/e24887dc-7a98-4015-ad3b-54b41cd68cf0" />

<img width="778" height="515" alt="image" src="https://github.com/user-attachments/assets/924b8361-9a31-4328-be6d-d78df62698a5" />


<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
