### PR TITLE
`FindInFiles`: Show the number of matches for each file

### DIFF
--- a/editor/script/find_in_files.h
+++ b/editor/script/find_in_files.h
@@ -226,6 +226,7 @@ private:
 	Button *_close_button = nullptr;
 	ProgressBar *_progress_bar = nullptr;
 	HashMap<String, TreeItem *> _file_items;
+	HashMap<TreeItem *, int> _file_items_results_count;
 	HashMap<TreeItem *, Result> _result_items;
 	bool _with_replace = false;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13225

https://github.com/user-attachments/assets/6e14ce96-dc48-4aa4-a057-d4781cd43d21

Implementation notes:
- The number of file matches is displayed only after the search is completed. This means that information about the number of file matches is not displayed during the search. This can be seen in the video above.
- I used `" (" + vformat(TTRN("%d match", "%d matches", file_matches_count), file_matches_count) + ")"` instead of `vformat(TTRN(" (%d match)", " (%d matches)", file_matches_count), file_matches_count)` to reuse existing translations.