### PR TITLE
Add information about `emit_particle` in `GPUParticles3D`'s docs

### DIFF
--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -37,6 +37,7 @@
 				Emits a single particle. Whether [param xform], [param velocity], [param color] and [param custom] are applied depends on the value of [param flags]. See [enum EmitFlags].
 				The default ParticleProcessMaterial will overwrite [param color] and use the contents of [param custom] as [code](rotation, age, animation, lifetime)[/code].
 				[b]Note:[/b] [method emit_particle] is only supported on the Forward+ and Mobile rendering methods, not Compatibility.
+				[b]Note:[/b] a custom processing material shader that doesn't modify the transform is required for the EMIT_FLAG_ROTATION_SCALE flag to work correctly.
 			</description>
 		</method>
 		<method name="get_draw_pass_mesh" qualifiers="const">

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -37,7 +37,7 @@
 				Emits a single particle. Whether [param xform], [param velocity], [param color] and [param custom] are applied depends on the value of [param flags]. See [enum EmitFlags].
 				The default ParticleProcessMaterial will overwrite [param color] and use the contents of [param custom] as [code](rotation, age, animation, lifetime)[/code].
 				[b]Note:[/b] [method emit_particle] is only supported on the Forward+ and Mobile rendering methods, not Compatibility.
-				[b]Note:[/b] a custom processing material shader that doesn't modify the transform is required for the EMIT_FLAG_ROTATION_SCALE flag to work correctly.
+				[b]Note:[/b] A custom processing material shader that doesn't modify the transform is required for the [constant EMIT_FLAG_ROTATION_SCALE] flag to work correctly.
 			</description>
 		</method>
 		<method name="get_draw_pass_mesh" qualifiers="const">


### PR DESCRIPTION
I added a short text explaining non-obvious functionality. 