### PR TITLE
Booleanize values before logical operators

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1276,6 +1276,14 @@ bool Expression::_execute(const Array &p_inputs, Object *p_instance, Expression:
 				}
 			}
 
+			if (op->op == Variant::OP_AND || op->op == Variant::OP_OR ||
+					op->op == Variant::OP_XOR) {
+				a = a.booleanize();
+				b = b.booleanize();
+			} else if (op->op == Variant::OP_NOT) {
+				a = a.booleanize();
+			}
+
 			bool valid = true;
 			Variant::evaluate(op->op, a, b, r_ret, valid);
 			if (!valid) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3111,7 +3111,18 @@ void GDScriptAnalyzer::reduce_binary_op(GDScriptParser::BinaryOpNode *p_binary_o
 		p_binary_op->is_constant = true;
 		if (p_binary_op->variant_op < Variant::OP_MAX) {
 			bool valid = false;
-			Variant::evaluate(p_binary_op->variant_op, p_binary_op->left_operand->reduced_value, p_binary_op->right_operand->reduced_value, p_binary_op->reduced_value, valid);
+
+			Variant left_value = p_binary_op->left_operand->reduced_value;
+			Variant right_value = p_binary_op->right_operand->reduced_value;
+
+			if (p_binary_op->variant_op == Variant::OP_AND || p_binary_op->variant_op == Variant::OP_OR ||
+					p_binary_op->variant_op == Variant::OP_XOR) {
+				left_value = left_value.booleanize();
+				right_value = right_value.booleanize();
+			}
+
+			Variant::evaluate(p_binary_op->variant_op, left_value, right_value, p_binary_op->reduced_value, valid);
+
 			if (!valid) {
 				if (p_binary_op->reduced_value.get_type() == Variant::STRING) {
 					push_error(vformat(R"(%s in operator %s.)", p_binary_op->reduced_value, Variant::get_operator_name(p_binary_op->variant_op)), p_binary_op);


### PR DESCRIPTION
This is an attempt to fix https://github.com/godotengine/godot/issues/108813

Issue:
Inconsistent behavior when using logical operators on constants/literals and on variants:

```
print(42 and "hello") # Error: Invalid operands to operator or, int and String

var a = 42
var b = "hello"
print(a and b) # prints "true"
```

Solution:
- Values are boolenized before calling `Variant::evaluate` in both `expression.cpp` and `gdscript_analyzer.cpp`
- Booleanize both values when operators are `AND`, `OR`, `XOR`
- Booleanize only first value if operator is `NOT`
- For other operators, values are left as is.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
