### PR TITLE
Allow trailing comma in `preload`

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3595,6 +3595,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_preload(ExpressionNode *p_
 
 	pop_completion_call();
 
+	// Allow trailing comma.
+	match(GDScriptTokenizer::Token::COMMA);
+
 	pop_multiline();
 	consume(GDScriptTokenizer::Token::PARENTHESIS_CLOSE, R"*(Expected ")" after preload path.)*");
 	complete_extents(preload);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/110773

I wanted to add a test, but I don't know how to test `preload`, it complains that the file I am trying to load doesn't exist (which makes sense, to be fair)