### PR TITLE
GDScript: Enforce Signal Static Typing in `emit` & `emit_signal`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3599,6 +3599,159 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		return;
 	}
 
+#ifdef DEBUG_ENABLED
+	if (p_call->callee && p_call->callee->type == GDScriptParser::Node::SUBSCRIPT && p_call->function_name == SNAME("emit")) {
+		GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_call->callee);
+		reduce_subscript(subscript);
+		StringName signal_name;
+		GDScriptParser::ClassNode *signal_origin = nullptr;
+		StringName signal_origin_native;
+
+		if (subscript->base->type == GDScriptParser::Node::IDENTIFIER) {
+			signal_name = static_cast<GDScriptParser::IdentifierNode *>(subscript->base)->name;
+			signal_origin = parser->current_class;
+		} else if (subscript->base->type == GDScriptParser::Node::SUBSCRIPT) {
+			GDScriptParser::SubscriptNode *inner_subscript = static_cast<GDScriptParser::SubscriptNode *>(subscript->base);
+			reduce_subscript(inner_subscript);
+			signal_name = static_cast<GDScriptParser::IdentifierNode *>(inner_subscript->attribute)->name;
+			signal_origin = inner_subscript->base->get_datatype().class_type;
+			signal_origin_native = inner_subscript->base->get_datatype().native_type;
+		}
+
+		// signal can be from class parent.
+		if (signal_origin != nullptr && !signal_origin->has_member(signal_name)) {
+			if (signal_origin->base_type.kind == GDScriptParser::DataType::NATIVE) {
+				signal_origin_native = signal_origin->base_type.native_type;
+				signal_origin = nullptr;
+			} else {
+				GDScriptParser::ClassNode *parent = signal_origin->base_type.class_type;
+				while (parent != nullptr) {
+					if (parent->has_member(signal_name)) {
+						signal_origin = parent;
+						break;
+					}
+
+					if (parent->base_type.kind == GDScriptParser::DataType::NATIVE && ClassDB::has_signal(parent->base_type.native_type, signal_name)) {
+						signal_origin_native = parent->base_type.native_type;
+						signal_origin = nullptr;
+						break;
+					}
+					parent = parent->base_type.class_type;
+				}
+			}
+		}
+
+		if (signal_origin != nullptr && signal_origin->has_member(signal_name)) {
+			const GDScriptParser::ClassNode::Member &member = signal_origin->get_member(signal_name);
+			if (member.type == GDScriptParser::ClassNode::Member::SIGNAL) {
+				for (int i = 0; i < p_call->arguments.size(); i++) {
+					if (i >= member.signal->parameters.size()) {
+						push_error(vformat(R"*(Signal "%s" expects only %s parameter(s) when emitted.)*", signal_name, itos(member.signal->parameters.size())), p_call);
+						break;
+					}
+
+					GDScriptParser::ExpressionNode *signal_arg_emitted = p_call->arguments[i];
+					GDScriptParser::ParameterNode *signal_param = member.signal->parameters[i];
+					if (signal_arg_emitted->get_datatype().to_string_strict() != "Variant" && !is_type_compatible(signal_param->get_datatype(), signal_arg_emitted->get_datatype())) {
+						push_error(vformat(R"*(Signal "%s" %s parameter is typed as "%s" not "%s".)*", signal_name, itos(i + 1), signal_param->get_datatype().to_string_strict(), signal_arg_emitted->get_datatype().to_string_strict()), p_call);
+					}
+				}
+			}
+		} else {
+			MethodInfo signal_info;
+			if (ClassDB::get_signal(signal_origin_native, signal_name, &signal_info)) {
+				for (int i = 0; i < p_call->arguments.size(); i++) {
+					if (i >= signal_info.arguments.size()) {
+						push_error(vformat(R"*(Signal "%s" expects only %s parameter(s) when emitted.)*", signal_name, itos(signal_info.arguments.size())), p_call);
+						break;
+					}
+
+					GDScriptParser::ExpressionNode *signal_arg_emitted = p_call->arguments[i];
+					PropertyInfo signal_param = signal_info.arguments[i];
+					if (signal_arg_emitted->get_datatype().to_string_strict() != "Variant" && !is_type_compatible(type_from_property(signal_param), signal_arg_emitted->get_datatype())) {
+						push_error(vformat(R"*(Signal "%s" %s parameter is typed as "%s" not "%s".)*", signal_name, itos(i + 1), type_from_property(signal_param).to_string_strict(), signal_arg_emitted->get_datatype().to_string_strict()), p_call);
+					}
+				}
+			}
+		}
+	}
+
+	if (p_call->function_name == SNAME("emit_signal") && p_call->arguments.size() > 0) {
+		StringName signal_name;
+		GDScriptParser::ClassNode *signal_origin = nullptr;
+		StringName signal_origin_native;
+
+		const GDScriptParser::ExpressionNode *signal_arg = p_call->arguments[0];
+		if (signal_arg && signal_arg->is_constant) {
+			signal_name = signal_arg->reduced_value;
+		}
+		if (is_self) {
+			signal_origin = parser->current_class;
+		} else if (p_call->callee->type == GDScriptParser::Node::SUBSCRIPT) {
+			GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_call->callee);
+			reduce_subscript(subscript);
+			signal_origin = subscript->base->get_datatype().class_type;
+			signal_origin_native = subscript->base->get_datatype().native_type;
+		}
+
+		// signal can be from class parent.
+		if (signal_origin != nullptr && !signal_origin->has_member(signal_name)) {
+			if (signal_origin->base_type.kind == GDScriptParser::DataType::NATIVE) {
+				signal_origin_native = signal_origin->base_type.native_type;
+				signal_origin = nullptr;
+			} else {
+				GDScriptParser::ClassNode *parent = signal_origin->base_type.class_type;
+				while (parent != nullptr) {
+					if (parent->has_member(signal_name)) {
+						signal_origin = parent;
+						break;
+					}
+
+					if (parent->base_type.kind == GDScriptParser::DataType::NATIVE && ClassDB::has_signal(parent->base_type.native_type, signal_name)) {
+						signal_origin_native = parent->base_type.native_type;
+						signal_origin = nullptr;
+						break;
+					}
+					parent = parent->base_type.class_type;
+				}
+			}
+		}
+
+		if (signal_origin != nullptr && signal_origin->has_member(signal_name)) {
+			const GDScriptParser::ClassNode::Member &member = signal_origin->get_member(signal_name);
+			if (member.type == GDScriptParser::ClassNode::Member::SIGNAL) {
+				for (int i = 1; i < p_call->arguments.size(); i++) {
+					if (i - 1 >= member.signal->parameters.size()) {
+						push_error(vformat(R"*(Signal "%s" expects only %s parameter(s) when emitted.)*", signal_name, itos(member.signal->parameters.size())), p_call);
+						break;
+					}
+					GDScriptParser::ExpressionNode *signal_arg_emitted = p_call->arguments[i];
+					GDScriptParser::ParameterNode *signal_param = member.signal->parameters[i - 1];
+					if (signal_arg_emitted->get_datatype().to_string_strict() != "Variant" && !is_type_compatible(signal_param->get_datatype(), signal_arg_emitted->get_datatype())) {
+						push_error(vformat(R"*(Signal "%s" %s parameter is typed as "%s" not "%s".)*", signal_name, itos(i + 1), signal_param->get_datatype().to_string_strict(), signal_arg_emitted->get_datatype().to_string_strict()), p_call);
+					}
+				}
+			}
+		} else {
+			MethodInfo signal_info;
+			if (ClassDB::get_signal(signal_origin_native, signal_name, &signal_info)) {
+				for (int i = 1; i < p_call->arguments.size(); i++) {
+					if (i - 1 >= signal_info.arguments.size()) {
+						push_error(vformat(R"*(Signal "%s" expects only %s parameter(s) when emitted.)*", signal_name, itos(signal_info.arguments.size())), p_call);
+						break;
+					}
+
+					GDScriptParser::ExpressionNode *signal_arg_emitted = p_call->arguments[i];
+					PropertyInfo signal_param = signal_info.arguments[i - 1];
+					if (signal_arg_emitted->get_datatype().to_string_strict() != "Variant" && !is_type_compatible(type_from_property(signal_param), signal_arg_emitted->get_datatype())) {
+						push_error(vformat(R"*(Signal "%s" %s parameter is typed as "%s" not "%s".)*", signal_name, itos(i + 1), type_from_property(signal_param).to_string_strict(), signal_arg_emitted->get_datatype().to_string_strict()), p_call);
+					}
+				}
+			}
+		}
+	}
+#endif // DEBUG_ENABLED
+
 	int default_arg_count = 0;
 	BitField<MethodFlags> method_flags = {};
 	GDScriptParser::DataType return_type;

--- a/modules/gdscript/tests/scripts/analyzer/errors/emit_signal.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/emit_signal.gd
@@ -1,0 +1,32 @@
+extends Node
+signal  my_signal(arg1: int)
+
+func _ready():
+
+	var lc = LocalClass.new()
+	# args passed can not be > than signal's params
+	my_signal.emit(1, "placeholder")
+	emit_signal("my_signal",1,"placeholder")
+	child_exiting_tree.emit(Node.new(), "placeholder") # native signal
+	emit_signal("child_exiting_tree",Node.new(), "placeholder") # native signal
+	lc.another_signal.emit(1, "placeholder")
+	lc.emit_signal("another_signal", 1, "placeholder")
+	lc.child_exiting_tree.emit(Node.new(), "placeholder") # native signal
+	lc.emit_signal("child_exiting_tree", Node.new(), "placeholder") # native signal
+
+	# arg type must match signal's param type
+	my_signal.emit(0.1)
+	emit_signal("my_signal", 0.1)
+	child_exiting_tree.emit(Object.new())  # native signal
+	emit_signal("child_exiting_tree", Object .new())
+	lc.another_signal.emit(0.1)
+	lc.emit_signal("another_signal", 0.1)
+	lc.child_exiting_tree.emit(Object.new())  # native signal
+	lc.emit_signal("child_exiting_tree", Object .new())# native signal
+
+	lc.free()
+
+class LocalClass extends Node:
+	signal another_signal(arg1: int)
+	func _ready():
+		another_signal.emit(1)

--- a/modules/gdscript/tests/scripts/analyzer/errors/emit_signal.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/emit_signal.out
@@ -1,0 +1,17 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 8: Signal "my_signal" expects only 1 parameter(s) when emitted.
+>> ERROR at line 9: Signal "my_signal" expects only 1 parameter(s) when emitted.
+>> ERROR at line 10: Signal "child_exiting_tree" expects only 1 parameter(s) when emitted.
+>> ERROR at line 11: Signal "child_exiting_tree" expects only 1 parameter(s) when emitted.
+>> ERROR at line 12: Signal "another_signal" expects only 1 parameter(s) when emitted.
+>> ERROR at line 13: Signal "another_signal" expects only 1 parameter(s) when emitted.
+>> ERROR at line 14: Signal "child_exiting_tree" expects only 1 parameter(s) when emitted.
+>> ERROR at line 15: Signal "child_exiting_tree" expects only 1 parameter(s) when emitted.
+>> ERROR at line 18: Signal "my_signal" 1 parameter is typed as "int" not "float".
+>> ERROR at line 19: Signal "my_signal" 2 parameter is typed as "int" not "float".
+>> ERROR at line 20: Signal "child_exiting_tree" 1 parameter is typed as "Node" not "Object".
+>> ERROR at line 21: Signal "child_exiting_tree" 2 parameter is typed as "Node" not "Object".
+>> ERROR at line 22: Signal "another_signal" 1 parameter is typed as "int" not "float".
+>> ERROR at line 23: Signal "another_signal" 2 parameter is typed as "int" not "float".
+>> ERROR at line 24: Signal "child_exiting_tree" 1 parameter is typed as "Node" not "Object".
+>> ERROR at line 25: Signal "child_exiting_tree" 2 parameter is typed as "Node" not "Object".


### PR DESCRIPTION
Works under the following assumptions:
1. The number of arguments passed to emit or emit_signal must not exceed the number of parameters defined in the signal.
2. The types of arguments passed must match the types of the corresponding signal parameters. (excluding passing Variant)

Encourages more consistent code.

