### PR TITLE
OpenXR: Update to OpenXR 1.1.52

### DIFF
--- a/modules/openxr/SCsub
+++ b/modules/openxr/SCsub
@@ -86,9 +86,11 @@ if env["builtin_openxr"]:
 
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/api_layer_interface.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_core.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_init_data.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_instance.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger_recorders.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_logger.cpp")
+        env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/loader_properties.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/manifest_file.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/runtime_interface.cpp")
         env_thirdparty.add_source_files(khrloader_obj, thirdparty_dir + "/src/loader/xr_generated_loader.cpp")

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -864,7 +864,7 @@ Files extracted from the upstream source:
 ## openxr
 
 - Upstream: https://github.com/KhronosGroup/OpenXR-SDK
-- Version: 1.1.49 (977f6675bc0057d5a54ed290cb5c71c699b1c0ab, 2025)
+- Version: 1.1.52 (a664705dee0b1041096d1e21b539bf9fb2489f00, 2025)
 - License: Apache 2.0
 
 Files extracted from upstream source:

--- a/thirdparty/openxr/include/openxr/openxr.h
+++ b/thirdparty/openxr/include/openxr/openxr.h
@@ -26,7 +26,7 @@ extern "C" {
     ((((major) & 0xffffULL) << 48) | (((minor) & 0xffffULL) << 32) | ((patch) & 0xffffffffULL))
 
 // OpenXR current version number.
-#define XR_CURRENT_API_VERSION XR_MAKE_VERSION(1, 1, 49)
+#define XR_CURRENT_API_VERSION XR_MAKE_VERSION(1, 1, 52)
 
 // OpenXR 1.0 version number
 #define XR_API_VERSION_1_0 XR_MAKE_VERSION(1, 0, XR_VERSION_PATCH(XR_CURRENT_API_VERSION))
@@ -255,6 +255,13 @@ typedef enum XrResult {
     XR_ERROR_SPACE_NETWORK_TIMEOUT_FB = -1000169002,
     XR_ERROR_SPACE_NETWORK_REQUEST_FAILED_FB = -1000169003,
     XR_ERROR_SPACE_CLOUD_STORAGE_DISABLED_FB = -1000169004,
+    XR_ERROR_SPACE_INSUFFICIENT_RESOURCES_META = -1000259000,
+    XR_ERROR_SPACE_STORAGE_AT_CAPACITY_META = -1000259001,
+    XR_ERROR_SPACE_INSUFFICIENT_VIEW_META = -1000259002,
+    XR_ERROR_SPACE_PERMISSION_INSUFFICIENT_META = -1000259003,
+    XR_ERROR_SPACE_RATE_LIMITED_META = -1000259004,
+    XR_ERROR_SPACE_TOO_DARK_META = -1000259005,
+    XR_ERROR_SPACE_TOO_BRIGHT_META = -1000259006,
     XR_ERROR_PASSTHROUGH_COLOR_LUT_BUFFER_SIZE_MISMATCH_META = -1000266000,
     XR_ENVIRONMENT_DEPTH_NOT_AVAILABLE_META = 1000291000,
     XR_ERROR_RENDER_MODEL_ID_INVALID_EXT = -1000300000,
@@ -275,6 +282,12 @@ typedef enum XrResult {
     XR_ERROR_SCENE_CAPTURE_FAILURE_BD = -1000392000,
     XR_ERROR_SPACE_NOT_LOCATABLE_EXT = -1000429000,
     XR_ERROR_PLANE_DETECTION_PERMISSION_DENIED_EXT = -1000429001,
+    XR_ERROR_MISMATCHING_TRACKABLE_TYPE_ANDROID = -1000455000,
+    XR_ERROR_TRACKABLE_TYPE_NOT_SUPPORTED_ANDROID = -1000455001,
+    XR_ERROR_ANCHOR_ID_NOT_FOUND_ANDROID = -1000457000,
+    XR_ERROR_ANCHOR_ALREADY_PERSISTED_ANDROID = -1000457001,
+    XR_ERROR_ANCHOR_NOT_TRACKING_ANDROID = -1000457002,
+    XR_ERROR_PERSISTED_DATA_NOT_READY_ANDROID = -1000457003,
     XR_ERROR_FUTURE_PENDING_EXT = -1000469001,
     XR_ERROR_FUTURE_INVALID_EXT = -1000469002,
     XR_ERROR_SYSTEM_NOTIFICATION_PERMISSION_DENIED_ML = -1000473000,
@@ -287,6 +300,7 @@ typedef enum XrResult {
     XR_COLOCATION_DISCOVERY_ALREADY_ADVERTISING_META = 1000571003,
     XR_COLOCATION_DISCOVERY_ALREADY_DISCOVERING_META = 1000571004,
     XR_ERROR_SPACE_GROUP_NOT_FOUND_META = -1000572002,
+    XR_ERROR_ANCHOR_NOT_OWNED_BY_CALLER_ANDROID = -1000701000,
     XR_ERROR_SPATIAL_CAPABILITY_UNSUPPORTED_EXT = -1000740001,
     XR_ERROR_SPATIAL_ENTITY_ID_INVALID_EXT = -1000740002,
     XR_ERROR_SPATIAL_BUFFER_ID_INVALID_EXT = -1000740003,
@@ -627,8 +641,21 @@ typedef enum XrStructureType {
     XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB = 1000238001,
     XR_TYPE_SPACE_USER_CREATE_INFO_FB = 1000241001,
     XR_TYPE_SYSTEM_HEADSET_ID_PROPERTIES_META = 1000245000,
+    XR_TYPE_SYSTEM_SPACE_DISCOVERY_PROPERTIES_META = 1000247000,
+    XR_TYPE_SPACE_DISCOVERY_INFO_META = 1000247001,
+    XR_TYPE_SPACE_FILTER_UUID_META = 1000247003,
+    XR_TYPE_SPACE_FILTER_COMPONENT_META = 1000247004,
+    XR_TYPE_SPACE_DISCOVERY_RESULT_META = 1000247005,
+    XR_TYPE_SPACE_DISCOVERY_RESULTS_META = 1000247006,
+    XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_RESULTS_AVAILABLE_META = 1000247007,
+    XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_COMPLETE_META = 1000247008,
     XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_META = 1000254000,
     XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_GET_INFO_META = 1000254001,
+    XR_TYPE_SYSTEM_SPACE_PERSISTENCE_PROPERTIES_META = 1000259000,
+    XR_TYPE_SPACES_SAVE_INFO_META = 1000259001,
+    XR_TYPE_EVENT_DATA_SPACES_SAVE_RESULT_META = 1000259002,
+    XR_TYPE_SPACES_ERASE_INFO_META = 1000259003,
+    XR_TYPE_EVENT_DATA_SPACES_ERASE_RESULT_META = 1000259004,
     XR_TYPE_SYSTEM_PASSTHROUGH_COLOR_LUT_PROPERTIES_META = 1000266000,
     XR_TYPE_PASSTHROUGH_COLOR_LUT_CREATE_INFO_META = 1000266001,
     XR_TYPE_PASSTHROUGH_COLOR_LUT_UPDATE_INFO_META = 1000266002,
@@ -638,6 +665,9 @@ typedef enum XrStructureType {
     XR_TYPE_SPACE_TRIANGLE_MESH_META = 1000269002,
     XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META = 1000274000,
     XR_TYPE_EVENT_DATA_PASSTHROUGH_LAYER_RESUMED_META = 1000282000,
+    XR_TYPE_BODY_TRACKING_CALIBRATION_INFO_META = 1000283002,
+    XR_TYPE_BODY_TRACKING_CALIBRATION_STATUS_META = 1000283003,
+    XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META = 1000283004,
     XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES2_FB = 1000287013,
     XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB = 1000287014,
     XR_TYPE_FACE_EXPRESSION_INFO2_FB = 1000287015,
@@ -736,6 +766,21 @@ typedef enum XrStructureType {
     XR_TYPE_PLANE_DETECTOR_LOCATION_EXT = 1000429005,
     XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT = 1000429006,
     XR_TYPE_SYSTEM_PLANE_DETECTION_PROPERTIES_EXT = 1000429007,
+    XR_TYPE_TRACKABLE_GET_INFO_ANDROID = 1000455000,
+    XR_TYPE_ANCHOR_SPACE_CREATE_INFO_ANDROID = 1000455001,
+    XR_TYPE_TRACKABLE_PLANE_ANDROID = 1000455003,
+    XR_TYPE_TRACKABLE_TRACKER_CREATE_INFO_ANDROID = 1000455004,
+    XR_TYPE_SYSTEM_TRACKABLES_PROPERTIES_ANDROID = 1000455005,
+    XR_TYPE_PERSISTED_ANCHOR_SPACE_CREATE_INFO_ANDROID = 1000457001,
+    XR_TYPE_PERSISTED_ANCHOR_SPACE_INFO_ANDROID = 1000457002,
+    XR_TYPE_DEVICE_ANCHOR_PERSISTENCE_CREATE_INFO_ANDROID = 1000457003,
+    XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID = 1000457004,
+    XR_TYPE_PASSTHROUGH_CAMERA_STATE_GET_INFO_ANDROID = 1000460000,
+    XR_TYPE_SYSTEM_PASSTHROUGH_CAMERA_STATE_PROPERTIES_ANDROID = 1000460001,
+    XR_TYPE_RAYCAST_INFO_ANDROID = 1000463000,
+    XR_TYPE_RAYCAST_HIT_RESULTS_ANDROID = 1000463001,
+    XR_TYPE_TRACKABLE_OBJECT_ANDROID = 1000466000,
+    XR_TYPE_TRACKABLE_OBJECT_CONFIGURATION_ANDROID = 1000466001,
     XR_TYPE_FUTURE_CANCEL_INFO_EXT = 1000469000,
     XR_TYPE_FUTURE_POLL_INFO_EXT = 1000469001,
     XR_TYPE_FUTURE_COMPLETION_EXT = 1000469002,
@@ -777,6 +822,12 @@ typedef enum XrStructureType {
     XR_TYPE_SHARE_SPACES_RECIPIENT_GROUPS_META = 1000572000,
     XR_TYPE_SPACE_GROUP_UUID_FILTER_INFO_META = 1000572001,
     XR_TYPE_SYSTEM_SPATIAL_ENTITY_GROUP_SHARING_PROPERTIES_META = 1000572100,
+    XR_TYPE_ANCHOR_SHARING_INFO_ANDROID = 1000701000,
+    XR_TYPE_ANCHOR_SHARING_TOKEN_ANDROID = 1000701001,
+    XR_TYPE_SYSTEM_ANCHOR_SHARING_EXPORT_PROPERTIES_ANDROID = 1000701002,
+    XR_TYPE_SYSTEM_MARKER_TRACKING_PROPERTIES_ANDROID = 1000707000,
+    XR_TYPE_TRACKABLE_MARKER_CONFIGURATION_ANDROID = 1000707001,
+    XR_TYPE_TRACKABLE_MARKER_ANDROID = 1000707002,
     XR_TYPE_SPATIAL_CAPABILITY_COMPONENT_TYPES_EXT = 1000740000,
     XR_TYPE_SPATIAL_CONTEXT_CREATE_INFO_EXT = 1000740001,
     XR_TYPE_CREATE_SPATIAL_CONTEXT_COMPLETION_EXT = 1000740002,
@@ -818,6 +869,7 @@ typedef enum XrStructureType {
     XR_TYPE_PERSIST_SPATIAL_ENTITY_COMPLETION_EXT = 1000781001,
     XR_TYPE_SPATIAL_ENTITY_UNPERSIST_INFO_EXT = 1000781002,
     XR_TYPE_UNPERSIST_SPATIAL_ENTITY_COMPLETION_EXT = 1000781003,
+    XR_TYPE_LOADER_INIT_INFO_PROPERTIES_EXT = 1000838000,
     XR_TYPE_GRAPHICS_BINDING_VULKAN2_KHR = XR_TYPE_GRAPHICS_BINDING_VULKAN_KHR,
     XR_TYPE_SWAPCHAIN_IMAGE_VULKAN2_KHR = XR_TYPE_SWAPCHAIN_IMAGE_VULKAN_KHR,
     XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN2_KHR = XR_TYPE_GRAPHICS_REQUIREMENTS_VULKAN_KHR,
@@ -933,6 +985,8 @@ typedef enum XrObjectType {
     XR_OBJECT_TYPE_SENSE_DATA_SNAPSHOT_BD = 1000389001,
     XR_OBJECT_TYPE_ANCHOR_BD = 1000389002,
     XR_OBJECT_TYPE_PLANE_DETECTOR_EXT = 1000429000,
+    XR_OBJECT_TYPE_TRACKABLE_TRACKER_ANDROID = 1000455001,
+    XR_OBJECT_TYPE_DEVICE_ANCHOR_PERSISTENCE_ANDROID = 1000457000,
     XR_OBJECT_TYPE_WORLD_MESH_DETECTOR_ML = 1000474000,
     XR_OBJECT_TYPE_FACIAL_EXPRESSION_CLIENT_ML = 1000482000,
     XR_OBJECT_TYPE_SPATIAL_ENTITY_EXT = 1000740000,
@@ -2186,6 +2240,12 @@ typedef XrBoxf XrBoxfKHR;
 
 typedef XrFrustumf XrFrustumfKHR;
 
+
+
+// XR_KHR_generic_controller is a preprocessor guard. Do not pass it to API calls.
+#define XR_KHR_generic_controller 1
+#define XR_KHR_generic_controller_SPEC_VERSION 1
+#define XR_KHR_GENERIC_CONTROLLER_EXTENSION_NAME "XR_KHR_generic_controller"
 
 
 // XR_EXT_performance_settings is a preprocessor guard. Do not pass it to API calls.
@@ -6927,6 +6987,86 @@ typedef struct XrSystemHeadsetIdPropertiesMETA {
 
 
 
+// XR_META_spatial_entity_discovery is a preprocessor guard. Do not pass it to API calls.
+#define XR_META_spatial_entity_discovery 1
+#define XR_META_spatial_entity_discovery_SPEC_VERSION 1
+#define XR_META_SPATIAL_ENTITY_DISCOVERY_EXTENSION_NAME "XR_META_spatial_entity_discovery"
+// XrSystemSpaceDiscoveryPropertiesMETA extends XrSystemProperties
+typedef struct XrSystemSpaceDiscoveryPropertiesMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrBool32                    supportsSpaceDiscovery;
+} XrSystemSpaceDiscoveryPropertiesMETA;
+
+typedef struct XR_MAY_ALIAS XrSpaceFilterBaseHeaderMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+} XrSpaceFilterBaseHeaderMETA;
+
+typedef struct XrSpaceDiscoveryInfoMETA {
+    XrStructureType                               type;
+    const void* XR_MAY_ALIAS                      next;
+    uint32_t                                      filterCount;
+    const XrSpaceFilterBaseHeaderMETA* const *    filters;
+} XrSpaceDiscoveryInfoMETA;
+
+typedef struct XrSpaceFilterUuidMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    uint32_t                    uuidCount;
+    const XrUuidEXT*            uuids;
+} XrSpaceFilterUuidMETA;
+
+typedef struct XrSpaceFilterComponentMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrSpaceComponentTypeFB      componentType;
+} XrSpaceFilterComponentMETA;
+
+typedef struct XrSpaceDiscoveryResultMETA {
+    XrSpace      space;
+    XrUuidEXT    uuid;
+} XrSpaceDiscoveryResultMETA;
+
+typedef struct XrSpaceDiscoveryResultsMETA {
+    XrStructureType                type;
+    const void* XR_MAY_ALIAS       next;
+    uint32_t                       resultCapacityInput;
+    uint32_t                       resultCountOutput;
+    XrSpaceDiscoveryResultMETA*    results;
+} XrSpaceDiscoveryResultsMETA;
+
+typedef struct XrEventDataSpaceDiscoveryResultsAvailableMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrAsyncRequestIdFB          requestId;
+} XrEventDataSpaceDiscoveryResultsAvailableMETA;
+
+typedef struct XrEventDataSpaceDiscoveryCompleteMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrAsyncRequestIdFB          requestId;
+    XrResult                    result;
+} XrEventDataSpaceDiscoveryCompleteMETA;
+
+typedef XrResult (XRAPI_PTR *PFN_xrDiscoverSpacesMETA)(XrSession session, const XrSpaceDiscoveryInfoMETA* info, XrAsyncRequestIdFB* requestId);
+typedef XrResult (XRAPI_PTR *PFN_xrRetrieveSpaceDiscoveryResultsMETA)(XrSession session, XrAsyncRequestIdFB requestId, XrSpaceDiscoveryResultsMETA* results);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrDiscoverSpacesMETA(
+    XrSession                                   session,
+    const XrSpaceDiscoveryInfoMETA*             info,
+    XrAsyncRequestIdFB*                         requestId);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrRetrieveSpaceDiscoveryResultsMETA(
+    XrSession                                   session,
+    XrAsyncRequestIdFB                          requestId,
+    XrSpaceDiscoveryResultsMETA*                results);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
 // XR_META_hand_tracking_microgestures is a preprocessor guard. Do not pass it to API calls.
 #define XR_META_hand_tracking_microgestures 1
 #define XR_META_hand_tracking_microgestures_SPEC_VERSION 1
@@ -6959,6 +7099,65 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetRecommendedLayerResolutionMETA(
     XrSession                                   session,
     const XrRecommendedLayerResolutionGetInfoMETA* info,
     XrRecommendedLayerResolutionMETA*           resolution);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_META_spatial_entity_persistence is a preprocessor guard. Do not pass it to API calls.
+#define XR_META_spatial_entity_persistence 1
+#define XR_META_spatial_entity_persistence_SPEC_VERSION 1
+#define XR_META_SPATIAL_ENTITY_PERSISTENCE_EXTENSION_NAME "XR_META_spatial_entity_persistence"
+// XrSystemSpacePersistencePropertiesMETA extends XrSystemProperties
+typedef struct XrSystemSpacePersistencePropertiesMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrBool32                    supportsSpacePersistence;
+} XrSystemSpacePersistencePropertiesMETA;
+
+typedef struct XrSpacesSaveInfoMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    uint32_t                    spaceCount;
+    XrSpace*                    spaces;
+} XrSpacesSaveInfoMETA;
+
+typedef struct XrEventDataSpacesSaveResultMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrAsyncRequestIdFB          requestId;
+    XrResult                    result;
+} XrEventDataSpacesSaveResultMETA;
+
+typedef struct XrSpacesEraseInfoMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    uint32_t                    spaceCount;
+    XrSpace*                    spaces;
+    uint32_t                    uuidCount;
+    XrUuidEXT*                  uuids;
+} XrSpacesEraseInfoMETA;
+
+typedef struct XrEventDataSpacesEraseResultMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrAsyncRequestIdFB          requestId;
+    XrResult                    result;
+} XrEventDataSpacesEraseResultMETA;
+
+typedef XrResult (XRAPI_PTR *PFN_xrSaveSpacesMETA)(XrSession session, const XrSpacesSaveInfoMETA* info, XrAsyncRequestIdFB* requestId);
+typedef XrResult (XRAPI_PTR *PFN_xrEraseSpacesMETA)(XrSession session, const XrSpacesEraseInfoMETA* info, XrAsyncRequestIdFB* requestId);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSaveSpacesMETA(
+    XrSession                                   session,
+    const XrSpacesSaveInfoMETA*                 info,
+    XrAsyncRequestIdFB*                         requestId);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrEraseSpacesMETA(
+    XrSession                                   session,
+    const XrSpacesEraseInfoMETA*                info,
+    XrAsyncRequestIdFB*                         requestId);
 #endif /* XR_EXTENSION_PROTOTYPES */
 #endif /* !XR_NO_PROTOTYPES */
 
@@ -7195,6 +7394,52 @@ typedef struct XrEventDataPassthroughLayerResumedMETA {
     XrPassthroughLayerFB        layer;
 } XrEventDataPassthroughLayerResumedMETA;
 
+
+
+// XR_META_body_tracking_calibration is a preprocessor guard. Do not pass it to API calls.
+#define XR_META_body_tracking_calibration 1
+#define XR_META_body_tracking_calibration_SPEC_VERSION 1
+#define XR_META_BODY_TRACKING_CALIBRATION_EXTENSION_NAME "XR_META_body_tracking_calibration"
+
+typedef enum XrBodyTrackingCalibrationStateMETA {
+    XR_BODY_TRACKING_CALIBRATION_STATE_VALID_META = 1,
+    XR_BODY_TRACKING_CALIBRATION_STATE_CALIBRATING_META = 2,
+    XR_BODY_TRACKING_CALIBRATION_STATE_INVALID_META = 3,
+    XR_BODY_TRACKING_CALIBRATION_STATE_MAX_ENUM_META = 0x7FFFFFFF
+} XrBodyTrackingCalibrationStateMETA;
+// XrBodyTrackingCalibrationStatusMETA extends XrBodyJointLocationsFB
+typedef struct XrBodyTrackingCalibrationStatusMETA {
+    XrStructureType                       type;
+    void* XR_MAY_ALIAS                    next;
+    XrBodyTrackingCalibrationStateMETA    status;
+} XrBodyTrackingCalibrationStatusMETA;
+
+typedef struct XrBodyTrackingCalibrationInfoMETA {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    float                       bodyHeight;
+} XrBodyTrackingCalibrationInfoMETA;
+
+// XrSystemPropertiesBodyTrackingCalibrationMETA extends XrSystemProperties
+typedef struct XrSystemPropertiesBodyTrackingCalibrationMETA {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsHeightOverride;
+} XrSystemPropertiesBodyTrackingCalibrationMETA;
+
+typedef XrResult (XRAPI_PTR *PFN_xrSuggestBodyTrackingCalibrationOverrideMETA)(XrBodyTrackerFB bodyTracker, const XrBodyTrackingCalibrationInfoMETA* calibrationInfo);
+typedef XrResult (XRAPI_PTR *PFN_xrResetBodyTrackingCalibrationMETA)(XrBodyTrackerFB bodyTracker);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrSuggestBodyTrackingCalibrationOverrideMETA(
+    XrBodyTrackerFB                             bodyTracker,
+    const XrBodyTrackingCalibrationInfoMETA*    calibrationInfo);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrResetBodyTrackingCalibrationMETA(
+    XrBodyTrackerFB                             bodyTracker);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
 
 
 // XR_FB_face_tracking2 is a preprocessor guard. Do not pass it to API calls.
@@ -7730,7 +7975,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetRenderModelPoseTopLevelUserPathEXT(
 
 // XR_EXT_hand_interaction is a preprocessor guard. Do not pass it to API calls.
 #define XR_EXT_hand_interaction 1
-#define XR_EXT_hand_interaction_SPEC_VERSION 1
+#define XR_EXT_hand_interaction_SPEC_VERSION 2
 #define XR_EXT_HAND_INTERACTION_EXTENSION_NAME "XR_EXT_hand_interaction"
 
 
@@ -8561,7 +8806,7 @@ XRAPI_ATTR XrResult XRAPI_CALL xrCreateAnchorSpaceBD(
 
 // XR_BD_spatial_anchor is a preprocessor guard. Do not pass it to API calls.
 #define XR_BD_spatial_anchor 1
-#define XR_BD_spatial_anchor_SPEC_VERSION 1
+#define XR_BD_spatial_anchor_SPEC_VERSION 2
 #define XR_BD_SPATIAL_ANCHOR_EXTENSION_NAME "XR_BD_spatial_anchor"
 
 typedef enum XrPersistenceLocationBD {
@@ -8587,8 +8832,8 @@ typedef struct XrSpatialAnchorCreateCompletionBD {
     XrStructureType       type;
     void* XR_MAY_ALIAS    next;
     XrResult              futureResult;
-    XrAnchorBD            anchor;
     XrUuidEXT             uuid;
+    XrAnchorBD            anchor;
 } XrSpatialAnchorCreateCompletionBD;
 
 typedef struct XrSpatialAnchorPersistInfoBD {
@@ -8673,7 +8918,7 @@ typedef struct XrSharedSpatialAnchorDownloadInfoBD {
 typedef XrResult (XRAPI_PTR *PFN_xrShareSpatialAnchorAsyncBD)(XrSenseDataProviderBD provider, const XrSpatialAnchorShareInfoBD* info, XrFutureEXT* future);
 typedef XrResult (XRAPI_PTR *PFN_xrShareSpatialAnchorCompleteBD)(XrSenseDataProviderBD provider, XrFutureEXT future, XrFutureCompletionEXT* completion);
 typedef XrResult (XRAPI_PTR *PFN_xrDownloadSharedSpatialAnchorAsyncBD)(XrSenseDataProviderBD provider, const XrSharedSpatialAnchorDownloadInfoBD* info, XrFutureEXT* future);
-typedef XrResult (XRAPI_PTR *PFN_xrDownloadSharedSpatialAnchorCompleteBD)(XrSenseDataProviderBD provider, XrFutureEXT future, XrFutureCompletionEXT*  completion);
+typedef XrResult (XRAPI_PTR *PFN_xrDownloadSharedSpatialAnchorCompleteBD)(XrSenseDataProviderBD provider, XrFutureEXT future, XrFutureCompletionEXT* completion);
 
 #ifndef XR_NO_PROTOTYPES
 #ifdef XR_EXTENSION_PROTOTYPES
@@ -8964,7 +9209,7 @@ typedef struct XrPlaneDetectorPolygonBufferEXT {
     XrVector2f*           vertices;
 } XrPlaneDetectorPolygonBufferEXT;
 
-typedef XrResult (XRAPI_PTR *PFN_xrCreatePlaneDetectorEXT)(XrSession session, const XrPlaneDetectorCreateInfoEXT*  createInfo, XrPlaneDetectorEXT* planeDetector);
+typedef XrResult (XRAPI_PTR *PFN_xrCreatePlaneDetectorEXT)(XrSession session, const XrPlaneDetectorCreateInfoEXT* createInfo, XrPlaneDetectorEXT* planeDetector);
 typedef XrResult (XRAPI_PTR *PFN_xrDestroyPlaneDetectorEXT)(XrPlaneDetectorEXT planeDetector);
 typedef XrResult (XRAPI_PTR *PFN_xrBeginPlaneDetectionEXT)(XrPlaneDetectorEXT planeDetector, const XrPlaneDetectorBeginInfoEXT* beginInfo);
 typedef XrResult (XRAPI_PTR *PFN_xrGetPlaneDetectionStateEXT)(XrPlaneDetectorEXT planeDetector, XrPlaneDetectionStateEXT* state);
@@ -9007,6 +9252,363 @@ XRAPI_ATTR XrResult XRAPI_CALL xrGetPlanePolygonBufferEXT(
 #define XR_OPPO_controller_interaction 1
 #define XR_OPPO_controller_interaction_SPEC_VERSION 1
 #define XR_OPPO_CONTROLLER_INTERACTION_EXTENSION_NAME "XR_OPPO_controller_interaction"
+
+
+// XR_ANDROID_trackables is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_trackables 1
+
+#define XR_NULL_TRACKABLE_ANDROID 0
+
+XR_DEFINE_ATOM(XrTrackableANDROID)
+XR_DEFINE_HANDLE(XrTrackableTrackerANDROID)
+#define XR_ANDROID_trackables_SPEC_VERSION 2
+#define XR_ANDROID_TRACKABLES_EXTENSION_NAME "XR_ANDROID_trackables"
+
+typedef enum XrTrackingStateANDROID {
+    XR_TRACKING_STATE_PAUSED_ANDROID = 0,
+    XR_TRACKING_STATE_STOPPED_ANDROID = 1,
+    XR_TRACKING_STATE_TRACKING_ANDROID = 2,
+    XR_TRACKING_STATE_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrTrackingStateANDROID;
+
+typedef enum XrTrackableTypeANDROID {
+    XR_TRACKABLE_TYPE_NOT_VALID_ANDROID = 0,
+    XR_TRACKABLE_TYPE_PLANE_ANDROID = 1,
+    XR_TRACKABLE_TYPE_DEPTH_ANDROID = 1000463000,
+    XR_TRACKABLE_TYPE_OBJECT_ANDROID = 1000466000,
+    XR_TRACKABLE_TYPE_MARKER_ANDROID = 1000707000,
+    XR_TRACKABLE_TYPE_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrTrackableTypeANDROID;
+
+typedef enum XrPlaneTypeANDROID {
+    XR_PLANE_TYPE_HORIZONTAL_DOWNWARD_FACING_ANDROID = 0,
+    XR_PLANE_TYPE_HORIZONTAL_UPWARD_FACING_ANDROID = 1,
+    XR_PLANE_TYPE_VERTICAL_ANDROID = 2,
+    XR_PLANE_TYPE_ARBITRARY_ANDROID = 3,
+    XR_PLANE_TYPE_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrPlaneTypeANDROID;
+
+typedef enum XrPlaneLabelANDROID {
+    XR_PLANE_LABEL_UNKNOWN_ANDROID = 0,
+    XR_PLANE_LABEL_WALL_ANDROID = 1,
+    XR_PLANE_LABEL_FLOOR_ANDROID = 2,
+    XR_PLANE_LABEL_CEILING_ANDROID = 3,
+    XR_PLANE_LABEL_TABLE_ANDROID = 4,
+    XR_PLANE_LABEL_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrPlaneLabelANDROID;
+typedef struct XrTrackableTrackerCreateInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrTrackableTypeANDROID      trackableType;
+} XrTrackableTrackerCreateInfoANDROID;
+
+typedef struct XrTrackableGetInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrTrackableANDROID          trackable;
+    XrSpace                     baseSpace;
+    XrTime                      time;
+} XrTrackableGetInfoANDROID;
+
+typedef struct XrTrackablePlaneANDROID {
+    XrStructureType           type;
+    void* XR_MAY_ALIAS        next;
+    XrTrackingStateANDROID    trackingState;
+    XrPosef                   centerPose;
+    XrExtent2Df               extents;
+    XrPlaneTypeANDROID        planeType;
+    XrPlaneLabelANDROID       planeLabel;
+    XrTrackableANDROID        subsumedByPlane;
+    XrTime                    lastUpdatedTime;
+    uint32_t                  vertexCapacityInput;
+    uint32_t*                 vertexCountOutput;
+    XrVector2f*               vertices;
+} XrTrackablePlaneANDROID;
+
+typedef struct XrAnchorSpaceCreateInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrSpace                     space;
+    XrTime                      time;
+    XrPosef                     pose;
+    XrTrackableANDROID          trackable;
+} XrAnchorSpaceCreateInfoANDROID;
+
+// XrSystemTrackablesPropertiesANDROID extends XrSystemProperties
+typedef struct XrSystemTrackablesPropertiesANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrBool32                    supportsAnchor;
+    uint32_t                    maxAnchors;
+} XrSystemTrackablesPropertiesANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateSupportedTrackableTypesANDROID)(XrInstance instance, XrSystemId systemId, uint32_t trackableTypeCapacityInput, uint32_t* trackableTypeCountOutput, XrTrackableTypeANDROID* trackableTypes);
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateSupportedAnchorTrackableTypesANDROID)(XrInstance instance, XrSystemId systemId, uint32_t trackableTypeCapacityInput, uint32_t* trackableTypeCountOutput, XrTrackableTypeANDROID* trackableTypes);
+typedef XrResult (XRAPI_PTR *PFN_xrCreateTrackableTrackerANDROID)(XrSession session, const XrTrackableTrackerCreateInfoANDROID* createInfo, XrTrackableTrackerANDROID* trackableTracker);
+typedef XrResult (XRAPI_PTR *PFN_xrDestroyTrackableTrackerANDROID)(XrTrackableTrackerANDROID trackableTracker);
+typedef XrResult (XRAPI_PTR *PFN_xrGetAllTrackablesANDROID)(XrTrackableTrackerANDROID trackableTracker, uint32_t trackableCapacityInput, uint32_t* trackableCountOutput, XrTrackableANDROID* trackables);
+typedef XrResult (XRAPI_PTR *PFN_xrGetTrackablePlaneANDROID)(XrTrackableTrackerANDROID trackableTracker, const XrTrackableGetInfoANDROID* getInfo, XrTrackablePlaneANDROID* planeOutput);
+typedef XrResult (XRAPI_PTR *PFN_xrCreateAnchorSpaceANDROID)(XrSession session, const XrAnchorSpaceCreateInfoANDROID* createInfo, XrSpace* anchorOutput);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateSupportedTrackableTypesANDROID(
+    XrInstance                                  instance,
+    XrSystemId                                  systemId,
+    uint32_t                                    trackableTypeCapacityInput,
+    uint32_t*                                   trackableTypeCountOutput,
+    XrTrackableTypeANDROID*                     trackableTypes);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateSupportedAnchorTrackableTypesANDROID(
+    XrInstance                                  instance,
+    XrSystemId                                  systemId,
+    uint32_t                                    trackableTypeCapacityInput,
+    uint32_t*                                   trackableTypeCountOutput,
+    XrTrackableTypeANDROID*                     trackableTypes);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateTrackableTrackerANDROID(
+    XrSession                                   session,
+    const XrTrackableTrackerCreateInfoANDROID*  createInfo,
+    XrTrackableTrackerANDROID*                  trackableTracker);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrDestroyTrackableTrackerANDROID(
+    XrTrackableTrackerANDROID                   trackableTracker);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrGetAllTrackablesANDROID(
+    XrTrackableTrackerANDROID                   trackableTracker,
+    uint32_t                                    trackableCapacityInput,
+    uint32_t*                                   trackableCountOutput,
+    XrTrackableANDROID*                         trackables);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrGetTrackablePlaneANDROID(
+    XrTrackableTrackerANDROID                   trackableTracker,
+    const XrTrackableGetInfoANDROID*            getInfo,
+    XrTrackablePlaneANDROID*                    planeOutput);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateAnchorSpaceANDROID(
+    XrSession                                   session,
+    const XrAnchorSpaceCreateInfoANDROID*       createInfo,
+    XrSpace*                                    anchorOutput);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_ANDROID_device_anchor_persistence is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_device_anchor_persistence 1
+XR_DEFINE_HANDLE(XrDeviceAnchorPersistenceANDROID)
+#define XR_ANDROID_device_anchor_persistence_SPEC_VERSION 1
+#define XR_ANDROID_DEVICE_ANCHOR_PERSISTENCE_EXTENSION_NAME "XR_ANDROID_device_anchor_persistence"
+
+typedef enum XrAnchorPersistStateANDROID {
+    XR_ANCHOR_PERSIST_STATE_PERSIST_NOT_REQUESTED_ANDROID = 0,
+    XR_ANCHOR_PERSIST_STATE_PERSIST_PENDING_ANDROID = 1,
+    XR_ANCHOR_PERSIST_STATE_PERSISTED_ANDROID = 2,
+    XR_ANCHOR_PERSIST_STATE_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrAnchorPersistStateANDROID;
+typedef struct XrDeviceAnchorPersistenceCreateInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+} XrDeviceAnchorPersistenceCreateInfoANDROID;
+
+typedef struct XrPersistedAnchorSpaceCreateInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrUuidEXT                   anchorId;
+} XrPersistedAnchorSpaceCreateInfoANDROID;
+
+typedef struct XrPersistedAnchorSpaceInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrSpace                     anchor;
+} XrPersistedAnchorSpaceInfoANDROID;
+
+// XrSystemDeviceAnchorPersistencePropertiesANDROID extends XrSystemProperties
+typedef struct XrSystemDeviceAnchorPersistencePropertiesANDROID {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsAnchorPersistence;
+} XrSystemDeviceAnchorPersistencePropertiesANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateSupportedPersistenceAnchorTypesANDROID)(XrInstance instance, XrSystemId systemId, uint32_t trackableTypeCapacityInput, uint32_t* trackableTypeCountOutput, XrTrackableTypeANDROID* trackableTypes);
+typedef XrResult (XRAPI_PTR *PFN_xrCreateDeviceAnchorPersistenceANDROID)(XrSession session, const XrDeviceAnchorPersistenceCreateInfoANDROID* createInfo, XrDeviceAnchorPersistenceANDROID* outHandle);
+typedef XrResult (XRAPI_PTR *PFN_xrDestroyDeviceAnchorPersistenceANDROID)(XrDeviceAnchorPersistenceANDROID handle);
+typedef XrResult (XRAPI_PTR *PFN_xrPersistAnchorANDROID)(XrDeviceAnchorPersistenceANDROID handle, const XrPersistedAnchorSpaceInfoANDROID* persistedInfo, XrUuidEXT* anchorIdOutput);
+typedef XrResult (XRAPI_PTR *PFN_xrGetAnchorPersistStateANDROID)(XrDeviceAnchorPersistenceANDROID handle, const XrUuidEXT* anchorId, XrAnchorPersistStateANDROID* persistState);
+typedef XrResult (XRAPI_PTR *PFN_xrCreatePersistedAnchorSpaceANDROID)(XrDeviceAnchorPersistenceANDROID handle, const XrPersistedAnchorSpaceCreateInfoANDROID* createInfo, XrSpace* anchorOutput);
+typedef XrResult (XRAPI_PTR *PFN_xrEnumeratePersistedAnchorsANDROID)(XrDeviceAnchorPersistenceANDROID handle, uint32_t anchorIdCapacityInput, uint32_t* anchorIdCountOutput, XrUuidEXT* anchorIds);
+typedef XrResult (XRAPI_PTR *PFN_xrUnpersistAnchorANDROID)(XrDeviceAnchorPersistenceANDROID handle, const XrUuidEXT* anchorId);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateSupportedPersistenceAnchorTypesANDROID(
+    XrInstance                                  instance,
+    XrSystemId                                  systemId,
+    uint32_t                                    trackableTypeCapacityInput,
+    uint32_t*                                   trackableTypeCountOutput,
+    XrTrackableTypeANDROID*                     trackableTypes);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreateDeviceAnchorPersistenceANDROID(
+    XrSession                                   session,
+    const XrDeviceAnchorPersistenceCreateInfoANDROID* createInfo,
+    XrDeviceAnchorPersistenceANDROID*           outHandle);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrDestroyDeviceAnchorPersistenceANDROID(
+    XrDeviceAnchorPersistenceANDROID            handle);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrPersistAnchorANDROID(
+    XrDeviceAnchorPersistenceANDROID            handle,
+    const XrPersistedAnchorSpaceInfoANDROID*    persistedInfo,
+    XrUuidEXT*                                  anchorIdOutput);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrGetAnchorPersistStateANDROID(
+    XrDeviceAnchorPersistenceANDROID            handle,
+    const XrUuidEXT*                            anchorId,
+    XrAnchorPersistStateANDROID*                persistState);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrCreatePersistedAnchorSpaceANDROID(
+    XrDeviceAnchorPersistenceANDROID            handle,
+    const XrPersistedAnchorSpaceCreateInfoANDROID* createInfo,
+    XrSpace*                                    anchorOutput);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumeratePersistedAnchorsANDROID(
+    XrDeviceAnchorPersistenceANDROID            handle,
+    uint32_t                                    anchorIdCapacityInput,
+    uint32_t*                                   anchorIdCountOutput,
+    XrUuidEXT*                                  anchorIds);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrUnpersistAnchorANDROID(
+    XrDeviceAnchorPersistenceANDROID            handle,
+    const XrUuidEXT*                            anchorId);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_ANDROID_passthrough_camera_state is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_passthrough_camera_state 1
+#define XR_ANDROID_passthrough_camera_state_SPEC_VERSION 1
+#define XR_ANDROID_PASSTHROUGH_CAMERA_STATE_EXTENSION_NAME "XR_ANDROID_passthrough_camera_state"
+
+typedef enum XrPassthroughCameraStateANDROID {
+    XR_PASSTHROUGH_CAMERA_STATE_DISABLED_ANDROID = 0,
+    XR_PASSTHROUGH_CAMERA_STATE_INITIALIZING_ANDROID = 1,
+    XR_PASSTHROUGH_CAMERA_STATE_READY_ANDROID = 2,
+    XR_PASSTHROUGH_CAMERA_STATE_ERROR_ANDROID = 3,
+    XR_PASSTHROUGH_CAMERA_STATE_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrPassthroughCameraStateANDROID;
+// XrSystemPassthroughCameraStatePropertiesANDROID extends XrSystemProperties
+typedef struct XrSystemPassthroughCameraStatePropertiesANDROID {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsPassthroughCameraState;
+} XrSystemPassthroughCameraStatePropertiesANDROID;
+
+typedef struct XrPassthroughCameraStateGetInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+} XrPassthroughCameraStateGetInfoANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrGetPassthroughCameraStateANDROID)(XrSession session, const XrPassthroughCameraStateGetInfoANDROID* getInfo, XrPassthroughCameraStateANDROID* cameraStateOutput);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetPassthroughCameraStateANDROID(
+    XrSession                                   session,
+    const XrPassthroughCameraStateGetInfoANDROID* getInfo,
+    XrPassthroughCameraStateANDROID*            cameraStateOutput);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_ANDROID_raycast is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_raycast 1
+#define XR_ANDROID_raycast_SPEC_VERSION   1
+#define XR_ANDROID_RAYCAST_EXTENSION_NAME "XR_ANDROID_raycast"
+typedef struct XrRaycastInfoANDROID {
+    XrStructureType                     type;
+    const void* XR_MAY_ALIAS            next;
+    uint32_t                            maxResults;
+    uint32_t                            trackerCount;
+    const XrTrackableTrackerANDROID*    trackers;
+    XrVector3f                          origin;
+    XrVector3f                          trajectory;
+    XrSpace                             space;
+    XrTime                              time;
+} XrRaycastInfoANDROID;
+
+typedef struct XrRaycastHitResultANDROID {
+    XrTrackableTypeANDROID    type;
+    XrTrackableANDROID        trackable;
+    XrPosef                   pose;
+} XrRaycastHitResultANDROID;
+
+typedef struct XrRaycastHitResultsANDROID {
+    XrStructureType               type;
+    void* XR_MAY_ALIAS            next;
+    uint32_t                      resultsCapacityInput;
+    uint32_t                      resultsCountOutput;
+    XrRaycastHitResultANDROID*    results;
+} XrRaycastHitResultsANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrEnumerateRaycastSupportedTrackableTypesANDROID)(XrInstance instance, XrSystemId systemId, uint32_t trackableTypeCapacityInput, uint32_t* trackableTypeCountOutput, XrTrackableTypeANDROID* trackableTypes);
+typedef XrResult (XRAPI_PTR *PFN_xrRaycastANDROID)(XrSession session, const XrRaycastInfoANDROID* rayInfo, XrRaycastHitResultsANDROID* results);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrEnumerateRaycastSupportedTrackableTypesANDROID(
+    XrInstance                                  instance,
+    XrSystemId                                  systemId,
+    uint32_t                                    trackableTypeCapacityInput,
+    uint32_t*                                   trackableTypeCountOutput,
+    XrTrackableTypeANDROID*                     trackableTypes);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrRaycastANDROID(
+    XrSession                                   session,
+    const XrRaycastInfoANDROID*                 rayInfo,
+    XrRaycastHitResultsANDROID*                 results);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_ANDROID_trackables_object is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_trackables_object 1
+#define XR_ANDROID_trackables_object_SPEC_VERSION 1
+#define XR_ANDROID_TRACKABLES_OBJECT_EXTENSION_NAME "XR_ANDROID_trackables_object"
+
+typedef enum XrObjectLabelANDROID {
+    XR_OBJECT_LABEL_UNKNOWN_ANDROID = 0,
+    XR_OBJECT_LABEL_KEYBOARD_ANDROID = 1,
+    XR_OBJECT_LABEL_MOUSE_ANDROID = 2,
+    XR_OBJECT_LABEL_LAPTOP_ANDROID = 3,
+    XR_OBJECT_LABEL_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrObjectLabelANDROID;
+typedef struct XrTrackableObjectANDROID {
+    XrStructureType           type;
+    void* XR_MAY_ALIAS        next;
+    XrTrackingStateANDROID    trackingState;
+    XrPosef                   centerPose;
+    XrExtent3DfEXT            extents;
+    XrObjectLabelANDROID      objectLabel;
+    XrTime                    lastUpdatedTime;
+} XrTrackableObjectANDROID;
+
+// XrTrackableObjectConfigurationANDROID extends XrTrackableTrackerCreateInfoANDROID
+typedef struct XrTrackableObjectConfigurationANDROID {
+    XrStructureType                type;
+    void* XR_MAY_ALIAS             next;
+    uint32_t                       labelCount;
+    const XrObjectLabelANDROID*    activeLabels;
+} XrTrackableObjectConfigurationANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrGetTrackableObjectANDROID)(XrTrackableTrackerANDROID tracker, const XrTrackableGetInfoANDROID* getInfo, XrTrackableObjectANDROID* objectOutput);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetTrackableObjectANDROID(
+    XrTrackableTrackerANDROID                   tracker,
+    const XrTrackableGetInfoANDROID*            getInfo,
+    XrTrackableObjectANDROID*                   objectOutput);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
 
 
 // XR_EXT_future is a preprocessor guard. Do not pass it to API calls.
@@ -9658,6 +10260,92 @@ typedef struct XrSpaceGroupUuidFilterInfoMETA {
     XrUuid                      groupUuid;
 } XrSpaceGroupUuidFilterInfoMETA;
 
+
+
+// XR_ANDROID_trackables_marker is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_trackables_marker 1
+#define XR_ANDROID_trackables_marker_SPEC_VERSION 1
+#define XR_ANDROID_TRACKABLES_MARKER_EXTENSION_NAME "XR_ANDROID_trackables_marker"
+
+typedef enum XrTrackableMarkerTrackingModeANDROID {
+    XR_TRACKABLE_MARKER_TRACKING_MODE_DYNAMIC_ANDROID = 0,
+    XR_TRACKABLE_MARKER_TRACKING_MODE_STATIC_ANDROID = 1,
+    XR_TRACKABLE_MARKER_TRACKING_MODE_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrTrackableMarkerTrackingModeANDROID;
+
+typedef enum XrTrackableMarkerDictionaryANDROID {
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_50_ANDROID = 0,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_100_ANDROID = 1,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_250_ANDROID = 2,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_1000_ANDROID = 3,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_50_ANDROID = 4,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_100_ANDROID = 5,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_250_ANDROID = 6,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_1000_ANDROID = 7,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_50_ANDROID = 8,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_100_ANDROID = 9,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_250_ANDROID = 10,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_1000_ANDROID = 11,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_50_ANDROID = 12,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_100_ANDROID = 13,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_250_ANDROID = 14,
+    XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_1000_ANDROID = 15,
+    XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_16H5_ANDROID = 16,
+    XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_25H9_ANDROID = 17,
+    XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_36H10_ANDROID = 18,
+    XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_36H11_ANDROID = 19,
+    XR_TRACKABLE_MARKER_DICTIONARY_MAX_ENUM_ANDROID = 0x7FFFFFFF
+} XrTrackableMarkerDictionaryANDROID;
+// XrSystemMarkerTrackingPropertiesANDROID extends XrSystemProperties
+typedef struct XrSystemMarkerTrackingPropertiesANDROID {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsMarkerTracking;
+    XrBool32              supportsMarkerSizeEstimation;
+    uint16_t              maxMarkerCount;
+} XrSystemMarkerTrackingPropertiesANDROID;
+
+typedef struct XrTrackableMarkerDatabaseEntryANDROID {
+    int32_t    id;
+    float      edgeSize;
+} XrTrackableMarkerDatabaseEntryANDROID;
+
+typedef struct XrTrackableMarkerDatabaseANDROID {
+    XrTrackableMarkerDictionaryANDROID              dictionary;
+    uint32_t                                        entryCount;
+    const XrTrackableMarkerDatabaseEntryANDROID*    entries;
+} XrTrackableMarkerDatabaseANDROID;
+
+// XrTrackableMarkerConfigurationANDROID extends XrTrackableTrackerCreateInfoANDROID
+typedef struct XrTrackableMarkerConfigurationANDROID {
+    XrStructureType                            type;
+    void* XR_MAY_ALIAS                         next;
+    XrTrackableMarkerTrackingModeANDROID       trackingMode;
+    uint32_t                                   databaseCount;
+    const XrTrackableMarkerDatabaseANDROID*    databases;
+} XrTrackableMarkerConfigurationANDROID;
+
+typedef struct XrTrackableMarkerANDROID {
+    XrStructureType                       type;
+    void* XR_MAY_ALIAS                    next;
+    XrTrackingStateANDROID                trackingState;
+    XrTime                                lastUpdatedTime;
+    XrTrackableMarkerDictionaryANDROID    dictionary;
+    int32_t                               markerId;
+    XrPosef                               centerPose;
+    XrExtent2Df                           extents;
+} XrTrackableMarkerANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrGetTrackableMarkerANDROID)(XrTrackableTrackerANDROID tracker, const XrTrackableGetInfoANDROID* getInfo, XrTrackableMarkerANDROID* markerOutput);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrGetTrackableMarkerANDROID(
+    XrTrackableTrackerANDROID                   tracker,
+    const XrTrackableGetInfoANDROID*            getInfo,
+    XrTrackableMarkerANDROID*                   markerOutput);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
 
 
 // XR_EXT_spatial_entity is a preprocessor guard. Do not pass it to API calls.
@@ -10387,6 +11075,25 @@ XRAPI_ATTR XrResult XRAPI_CALL xrUnpersistSpatialEntityCompleteEXT(
     XrUnpersistSpatialEntityCompletionEXT*      completion);
 #endif /* XR_EXTENSION_PROTOTYPES */
 #endif /* !XR_NO_PROTOTYPES */
+
+
+// XR_EXT_loader_init_properties is a preprocessor guard. Do not pass it to API calls.
+#define XR_EXT_loader_init_properties 1
+#define XR_EXT_loader_init_properties_SPEC_VERSION 1
+#define XR_EXT_LOADER_INIT_PROPERTIES_EXTENSION_NAME "XR_EXT_loader_init_properties"
+typedef struct XrLoaderInitPropertyValueEXT {
+    const char*    name;
+    const char*    value;
+} XrLoaderInitPropertyValueEXT;
+
+// XrLoaderInitInfoPropertiesEXT extends XrLoaderInitInfoBaseHeaderKHR
+typedef struct XrLoaderInitInfoPropertiesEXT {
+    XrStructureType                        type;
+    const void* XR_MAY_ALIAS               next;
+    uint32_t                               propertyValueCount;
+    const XrLoaderInitPropertyValueEXT*    propertyValues;
+} XrLoaderInitInfoPropertiesEXT;
+
 
 #ifdef __cplusplus
 }

--- a/thirdparty/openxr/include/openxr/openxr_platform.h
+++ b/thirdparty/openxr/include/openxr/openxr_platform.h
@@ -769,6 +769,48 @@ typedef struct XrVulkanSwapchainCreateInfoMETA {
 
 #endif /* XR_USE_GRAPHICS_API_VULKAN */
 
+#ifdef XR_USE_PLATFORM_ANDROID
+
+// XR_ANDROID_anchor_sharing_export is a preprocessor guard. Do not pass it to API calls.
+#define XR_ANDROID_anchor_sharing_export 1
+#define XR_ANDROID_anchor_sharing_export_SPEC_VERSION 1
+#define XR_ANDROID_ANCHOR_SHARING_EXPORT_EXTENSION_NAME "XR_ANDROID_anchor_sharing_export"
+typedef struct XrAnchorSharingInfoANDROID {
+    XrStructureType             type;
+    const void* XR_MAY_ALIAS    next;
+    XrSpace                     anchor;
+} XrAnchorSharingInfoANDROID;
+
+typedef struct XrAnchorSharingTokenANDROID {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    struct AIBinder*      token;
+} XrAnchorSharingTokenANDROID;
+
+// XrSystemAnchorSharingExportPropertiesANDROID extends XrSystemProperties
+typedef struct XrSystemAnchorSharingExportPropertiesANDROID {
+    XrStructureType       type;
+    void* XR_MAY_ALIAS    next;
+    XrBool32              supportsAnchorSharingExport;
+} XrSystemAnchorSharingExportPropertiesANDROID;
+
+typedef XrResult (XRAPI_PTR *PFN_xrShareAnchorANDROID)(XrSession session, const XrAnchorSharingInfoANDROID* sharingInfo, XrAnchorSharingTokenANDROID* anchorToken);
+typedef XrResult (XRAPI_PTR *PFN_xrUnshareAnchorANDROID)(XrSession session, XrSpace anchor);
+
+#ifndef XR_NO_PROTOTYPES
+#ifdef XR_EXTENSION_PROTOTYPES
+XRAPI_ATTR XrResult XRAPI_CALL xrShareAnchorANDROID(
+    XrSession                                   session,
+    const XrAnchorSharingInfoANDROID*           sharingInfo,
+    XrAnchorSharingTokenANDROID*                anchorToken);
+
+XRAPI_ATTR XrResult XRAPI_CALL xrUnshareAnchorANDROID(
+    XrSession                                   session,
+    XrSpace                                     anchor);
+#endif /* XR_EXTENSION_PROTOTYPES */
+#endif /* !XR_NO_PROTOTYPES */
+#endif /* XR_USE_PLATFORM_ANDROID */
+
 #ifdef __cplusplus
 }
 #endif

--- a/thirdparty/openxr/include/openxr/openxr_reflection.h
+++ b/thirdparty/openxr/include/openxr/openxr_reflection.h
@@ -141,6 +141,13 @@ XR_ENUM_STR(XrResult);
     _(XR_ERROR_SPACE_NETWORK_TIMEOUT_FB, -1000169002) \
     _(XR_ERROR_SPACE_NETWORK_REQUEST_FAILED_FB, -1000169003) \
     _(XR_ERROR_SPACE_CLOUD_STORAGE_DISABLED_FB, -1000169004) \
+    _(XR_ERROR_SPACE_INSUFFICIENT_RESOURCES_META, -1000259000) \
+    _(XR_ERROR_SPACE_STORAGE_AT_CAPACITY_META, -1000259001) \
+    _(XR_ERROR_SPACE_INSUFFICIENT_VIEW_META, -1000259002) \
+    _(XR_ERROR_SPACE_PERMISSION_INSUFFICIENT_META, -1000259003) \
+    _(XR_ERROR_SPACE_RATE_LIMITED_META, -1000259004) \
+    _(XR_ERROR_SPACE_TOO_DARK_META, -1000259005) \
+    _(XR_ERROR_SPACE_TOO_BRIGHT_META, -1000259006) \
     _(XR_ERROR_PASSTHROUGH_COLOR_LUT_BUFFER_SIZE_MISMATCH_META, -1000266000) \
     _(XR_ENVIRONMENT_DEPTH_NOT_AVAILABLE_META, 1000291000) \
     _(XR_ERROR_RENDER_MODEL_ID_INVALID_EXT, -1000300000) \
@@ -161,6 +168,12 @@ XR_ENUM_STR(XrResult);
     _(XR_ERROR_SCENE_CAPTURE_FAILURE_BD, -1000392000) \
     _(XR_ERROR_SPACE_NOT_LOCATABLE_EXT, -1000429000) \
     _(XR_ERROR_PLANE_DETECTION_PERMISSION_DENIED_EXT, -1000429001) \
+    _(XR_ERROR_MISMATCHING_TRACKABLE_TYPE_ANDROID, -1000455000) \
+    _(XR_ERROR_TRACKABLE_TYPE_NOT_SUPPORTED_ANDROID, -1000455001) \
+    _(XR_ERROR_ANCHOR_ID_NOT_FOUND_ANDROID, -1000457000) \
+    _(XR_ERROR_ANCHOR_ALREADY_PERSISTED_ANDROID, -1000457001) \
+    _(XR_ERROR_ANCHOR_NOT_TRACKING_ANDROID, -1000457002) \
+    _(XR_ERROR_PERSISTED_DATA_NOT_READY_ANDROID, -1000457003) \
     _(XR_ERROR_FUTURE_PENDING_EXT, -1000469001) \
     _(XR_ERROR_FUTURE_INVALID_EXT, -1000469002) \
     _(XR_ERROR_SYSTEM_NOTIFICATION_PERMISSION_DENIED_ML, -1000473000) \
@@ -173,6 +186,7 @@ XR_ENUM_STR(XrResult);
     _(XR_COLOCATION_DISCOVERY_ALREADY_ADVERTISING_META, 1000571003) \
     _(XR_COLOCATION_DISCOVERY_ALREADY_DISCOVERING_META, 1000571004) \
     _(XR_ERROR_SPACE_GROUP_NOT_FOUND_META, -1000572002) \
+    _(XR_ERROR_ANCHOR_NOT_OWNED_BY_CALLER_ANDROID, -1000701000) \
     _(XR_ERROR_SPATIAL_CAPABILITY_UNSUPPORTED_EXT, -1000740001) \
     _(XR_ERROR_SPATIAL_ENTITY_ID_INVALID_EXT, -1000740002) \
     _(XR_ERROR_SPATIAL_BUFFER_ID_INVALID_EXT, -1000740003) \
@@ -510,8 +524,21 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB, 1000238001) \
     _(XR_TYPE_SPACE_USER_CREATE_INFO_FB, 1000241001) \
     _(XR_TYPE_SYSTEM_HEADSET_ID_PROPERTIES_META, 1000245000) \
+    _(XR_TYPE_SYSTEM_SPACE_DISCOVERY_PROPERTIES_META, 1000247000) \
+    _(XR_TYPE_SPACE_DISCOVERY_INFO_META, 1000247001) \
+    _(XR_TYPE_SPACE_FILTER_UUID_META, 1000247003) \
+    _(XR_TYPE_SPACE_FILTER_COMPONENT_META, 1000247004) \
+    _(XR_TYPE_SPACE_DISCOVERY_RESULT_META, 1000247005) \
+    _(XR_TYPE_SPACE_DISCOVERY_RESULTS_META, 1000247006) \
+    _(XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_RESULTS_AVAILABLE_META, 1000247007) \
+    _(XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_COMPLETE_META, 1000247008) \
     _(XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_META, 1000254000) \
     _(XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_GET_INFO_META, 1000254001) \
+    _(XR_TYPE_SYSTEM_SPACE_PERSISTENCE_PROPERTIES_META, 1000259000) \
+    _(XR_TYPE_SPACES_SAVE_INFO_META, 1000259001) \
+    _(XR_TYPE_EVENT_DATA_SPACES_SAVE_RESULT_META, 1000259002) \
+    _(XR_TYPE_SPACES_ERASE_INFO_META, 1000259003) \
+    _(XR_TYPE_EVENT_DATA_SPACES_ERASE_RESULT_META, 1000259004) \
     _(XR_TYPE_SYSTEM_PASSTHROUGH_COLOR_LUT_PROPERTIES_META, 1000266000) \
     _(XR_TYPE_PASSTHROUGH_COLOR_LUT_CREATE_INFO_META, 1000266001) \
     _(XR_TYPE_PASSTHROUGH_COLOR_LUT_UPDATE_INFO_META, 1000266002) \
@@ -521,6 +548,9 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_SPACE_TRIANGLE_MESH_META, 1000269002) \
     _(XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META, 1000274000) \
     _(XR_TYPE_EVENT_DATA_PASSTHROUGH_LAYER_RESUMED_META, 1000282000) \
+    _(XR_TYPE_BODY_TRACKING_CALIBRATION_INFO_META, 1000283002) \
+    _(XR_TYPE_BODY_TRACKING_CALIBRATION_STATUS_META, 1000283003) \
+    _(XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META, 1000283004) \
     _(XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES2_FB, 1000287013) \
     _(XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB, 1000287014) \
     _(XR_TYPE_FACE_EXPRESSION_INFO2_FB, 1000287015) \
@@ -619,6 +649,21 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_PLANE_DETECTOR_LOCATION_EXT, 1000429005) \
     _(XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT, 1000429006) \
     _(XR_TYPE_SYSTEM_PLANE_DETECTION_PROPERTIES_EXT, 1000429007) \
+    _(XR_TYPE_TRACKABLE_GET_INFO_ANDROID, 1000455000) \
+    _(XR_TYPE_ANCHOR_SPACE_CREATE_INFO_ANDROID, 1000455001) \
+    _(XR_TYPE_TRACKABLE_PLANE_ANDROID, 1000455003) \
+    _(XR_TYPE_TRACKABLE_TRACKER_CREATE_INFO_ANDROID, 1000455004) \
+    _(XR_TYPE_SYSTEM_TRACKABLES_PROPERTIES_ANDROID, 1000455005) \
+    _(XR_TYPE_PERSISTED_ANCHOR_SPACE_CREATE_INFO_ANDROID, 1000457001) \
+    _(XR_TYPE_PERSISTED_ANCHOR_SPACE_INFO_ANDROID, 1000457002) \
+    _(XR_TYPE_DEVICE_ANCHOR_PERSISTENCE_CREATE_INFO_ANDROID, 1000457003) \
+    _(XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID, 1000457004) \
+    _(XR_TYPE_PASSTHROUGH_CAMERA_STATE_GET_INFO_ANDROID, 1000460000) \
+    _(XR_TYPE_SYSTEM_PASSTHROUGH_CAMERA_STATE_PROPERTIES_ANDROID, 1000460001) \
+    _(XR_TYPE_RAYCAST_INFO_ANDROID, 1000463000) \
+    _(XR_TYPE_RAYCAST_HIT_RESULTS_ANDROID, 1000463001) \
+    _(XR_TYPE_TRACKABLE_OBJECT_ANDROID, 1000466000) \
+    _(XR_TYPE_TRACKABLE_OBJECT_CONFIGURATION_ANDROID, 1000466001) \
     _(XR_TYPE_FUTURE_CANCEL_INFO_EXT, 1000469000) \
     _(XR_TYPE_FUTURE_POLL_INFO_EXT, 1000469001) \
     _(XR_TYPE_FUTURE_COMPLETION_EXT, 1000469002) \
@@ -660,6 +705,12 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_SHARE_SPACES_RECIPIENT_GROUPS_META, 1000572000) \
     _(XR_TYPE_SPACE_GROUP_UUID_FILTER_INFO_META, 1000572001) \
     _(XR_TYPE_SYSTEM_SPATIAL_ENTITY_GROUP_SHARING_PROPERTIES_META, 1000572100) \
+    _(XR_TYPE_ANCHOR_SHARING_INFO_ANDROID, 1000701000) \
+    _(XR_TYPE_ANCHOR_SHARING_TOKEN_ANDROID, 1000701001) \
+    _(XR_TYPE_SYSTEM_ANCHOR_SHARING_EXPORT_PROPERTIES_ANDROID, 1000701002) \
+    _(XR_TYPE_SYSTEM_MARKER_TRACKING_PROPERTIES_ANDROID, 1000707000) \
+    _(XR_TYPE_TRACKABLE_MARKER_CONFIGURATION_ANDROID, 1000707001) \
+    _(XR_TYPE_TRACKABLE_MARKER_ANDROID, 1000707002) \
     _(XR_TYPE_SPATIAL_CAPABILITY_COMPONENT_TYPES_EXT, 1000740000) \
     _(XR_TYPE_SPATIAL_CONTEXT_CREATE_INFO_EXT, 1000740001) \
     _(XR_TYPE_CREATE_SPATIAL_CONTEXT_COMPLETION_EXT, 1000740002) \
@@ -701,6 +752,7 @@ XR_ENUM_STR(XrResult);
     _(XR_TYPE_PERSIST_SPATIAL_ENTITY_COMPLETION_EXT, 1000781001) \
     _(XR_TYPE_SPATIAL_ENTITY_UNPERSIST_INFO_EXT, 1000781002) \
     _(XR_TYPE_UNPERSIST_SPATIAL_ENTITY_COMPLETION_EXT, 1000781003) \
+    _(XR_TYPE_LOADER_INIT_INFO_PROPERTIES_EXT, 1000838000) \
     _(XR_STRUCTURE_TYPE_MAX_ENUM, 0x7FFFFFFF)
 
 #define XR_LIST_ENUM_XrFormFactor(_) \
@@ -799,6 +851,8 @@ XR_ENUM_STR(XrResult);
     _(XR_OBJECT_TYPE_SENSE_DATA_SNAPSHOT_BD, 1000389001) \
     _(XR_OBJECT_TYPE_ANCHOR_BD, 1000389002) \
     _(XR_OBJECT_TYPE_PLANE_DETECTOR_EXT, 1000429000) \
+    _(XR_OBJECT_TYPE_TRACKABLE_TRACKER_ANDROID, 1000455001) \
+    _(XR_OBJECT_TYPE_DEVICE_ANCHOR_PERSISTENCE_ANDROID, 1000457000) \
     _(XR_OBJECT_TYPE_WORLD_MESH_DETECTOR_ML, 1000474000) \
     _(XR_OBJECT_TYPE_FACIAL_EXPRESSION_CLIENT_ML, 1000482000) \
     _(XR_OBJECT_TYPE_SPATIAL_ENTITY_EXT, 1000740000) \
@@ -1554,6 +1608,12 @@ XR_ENUM_STR(XrResult);
     _(XR_FULL_BODY_JOINT_NONE_META, 85) \
     _(XR_FULL_BODY_JOINT_MAX_ENUM_META, 0x7FFFFFFF)
 
+#define XR_LIST_ENUM_XrBodyTrackingCalibrationStateMETA(_) \
+    _(XR_BODY_TRACKING_CALIBRATION_STATE_VALID_META, 1) \
+    _(XR_BODY_TRACKING_CALIBRATION_STATE_CALIBRATING_META, 2) \
+    _(XR_BODY_TRACKING_CALIBRATION_STATE_INVALID_META, 3) \
+    _(XR_BODY_TRACKING_CALIBRATION_STATE_MAX_ENUM_META, 0x7FFFFFFF)
+
 #define XR_LIST_ENUM_XrFaceExpression2FB(_) \
     _(XR_FACE_EXPRESSION2_BROW_LOWERER_L_FB, 0) \
     _(XR_FACE_EXPRESSION2_BROW_LOWERER_R_FB, 1) \
@@ -1849,6 +1909,55 @@ XR_ENUM_STR(XrResult);
     _(XR_PLANE_DETECTION_STATE_FATAL_EXT, 4) \
     _(XR_PLANE_DETECTION_STATE_MAX_ENUM_EXT, 0x7FFFFFFF)
 
+#define XR_LIST_ENUM_XrTrackingStateANDROID(_) \
+    _(XR_TRACKING_STATE_PAUSED_ANDROID, 0) \
+    _(XR_TRACKING_STATE_STOPPED_ANDROID, 1) \
+    _(XR_TRACKING_STATE_TRACKING_ANDROID, 2) \
+    _(XR_TRACKING_STATE_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrTrackableTypeANDROID(_) \
+    _(XR_TRACKABLE_TYPE_NOT_VALID_ANDROID, 0) \
+    _(XR_TRACKABLE_TYPE_PLANE_ANDROID, 1) \
+    _(XR_TRACKABLE_TYPE_DEPTH_ANDROID, 1000463000) \
+    _(XR_TRACKABLE_TYPE_OBJECT_ANDROID, 1000466000) \
+    _(XR_TRACKABLE_TYPE_MARKER_ANDROID, 1000707000) \
+    _(XR_TRACKABLE_TYPE_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrPlaneTypeANDROID(_) \
+    _(XR_PLANE_TYPE_HORIZONTAL_DOWNWARD_FACING_ANDROID, 0) \
+    _(XR_PLANE_TYPE_HORIZONTAL_UPWARD_FACING_ANDROID, 1) \
+    _(XR_PLANE_TYPE_VERTICAL_ANDROID, 2) \
+    _(XR_PLANE_TYPE_ARBITRARY_ANDROID, 3) \
+    _(XR_PLANE_TYPE_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrPlaneLabelANDROID(_) \
+    _(XR_PLANE_LABEL_UNKNOWN_ANDROID, 0) \
+    _(XR_PLANE_LABEL_WALL_ANDROID, 1) \
+    _(XR_PLANE_LABEL_FLOOR_ANDROID, 2) \
+    _(XR_PLANE_LABEL_CEILING_ANDROID, 3) \
+    _(XR_PLANE_LABEL_TABLE_ANDROID, 4) \
+    _(XR_PLANE_LABEL_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrAnchorPersistStateANDROID(_) \
+    _(XR_ANCHOR_PERSIST_STATE_PERSIST_NOT_REQUESTED_ANDROID, 0) \
+    _(XR_ANCHOR_PERSIST_STATE_PERSIST_PENDING_ANDROID, 1) \
+    _(XR_ANCHOR_PERSIST_STATE_PERSISTED_ANDROID, 2) \
+    _(XR_ANCHOR_PERSIST_STATE_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrPassthroughCameraStateANDROID(_) \
+    _(XR_PASSTHROUGH_CAMERA_STATE_DISABLED_ANDROID, 0) \
+    _(XR_PASSTHROUGH_CAMERA_STATE_INITIALIZING_ANDROID, 1) \
+    _(XR_PASSTHROUGH_CAMERA_STATE_READY_ANDROID, 2) \
+    _(XR_PASSTHROUGH_CAMERA_STATE_ERROR_ANDROID, 3) \
+    _(XR_PASSTHROUGH_CAMERA_STATE_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrObjectLabelANDROID(_) \
+    _(XR_OBJECT_LABEL_UNKNOWN_ANDROID, 0) \
+    _(XR_OBJECT_LABEL_KEYBOARD_ANDROID, 1) \
+    _(XR_OBJECT_LABEL_MOUSE_ANDROID, 2) \
+    _(XR_OBJECT_LABEL_LAPTOP_ANDROID, 3) \
+    _(XR_OBJECT_LABEL_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
 #define XR_LIST_ENUM_XrFutureStateEXT(_) \
     _(XR_FUTURE_STATE_PENDING_EXT, 1) \
     _(XR_FUTURE_STATE_READY_EXT, 2) \
@@ -1936,6 +2045,34 @@ XR_ENUM_STR(XrResult);
     _(XR_FACIAL_BLEND_SHAPE_UPPER_LIP_RAISER_R_ML, 44) \
     _(XR_FACIAL_BLEND_SHAPE_TONGUE_OUT_ML, 45) \
     _(XR_FACIAL_BLEND_SHAPE_MAX_ENUM_ML, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrTrackableMarkerTrackingModeANDROID(_) \
+    _(XR_TRACKABLE_MARKER_TRACKING_MODE_DYNAMIC_ANDROID, 0) \
+    _(XR_TRACKABLE_MARKER_TRACKING_MODE_STATIC_ANDROID, 1) \
+    _(XR_TRACKABLE_MARKER_TRACKING_MODE_MAX_ENUM_ANDROID, 0x7FFFFFFF)
+
+#define XR_LIST_ENUM_XrTrackableMarkerDictionaryANDROID(_) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_50_ANDROID, 0) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_100_ANDROID, 1) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_250_ANDROID, 2) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_4X4_1000_ANDROID, 3) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_50_ANDROID, 4) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_100_ANDROID, 5) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_250_ANDROID, 6) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_5X5_1000_ANDROID, 7) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_50_ANDROID, 8) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_100_ANDROID, 9) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_250_ANDROID, 10) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_6X6_1000_ANDROID, 11) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_50_ANDROID, 12) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_100_ANDROID, 13) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_250_ANDROID, 14) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_ARUCO_7X7_1000_ANDROID, 15) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_16H5_ANDROID, 16) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_25H9_ANDROID, 17) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_36H10_ANDROID, 18) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_APRILTAG_36H11_ANDROID, 19) \
+    _(XR_TRACKABLE_MARKER_DICTIONARY_MAX_ENUM_ANDROID, 0x7FFFFFFF)
 
 #define XR_LIST_ENUM_XrSpatialCapabilityEXT(_) \
     _(XR_SPATIAL_CAPABILITY_PLANE_TRACKING_EXT, 1000741000) \
@@ -5146,6 +5283,63 @@ XR_ENUM_STR(XrResult);
     _(next) \
     _(id) \
 
+/// Calls your macro with the name of each member of XrSystemSpaceDiscoveryPropertiesMETA, in order.
+#define XR_LIST_STRUCT_XrSystemSpaceDiscoveryPropertiesMETA(_) \
+    _(type) \
+    _(next) \
+    _(supportsSpaceDiscovery) \
+
+/// Calls your macro with the name of each member of XrSpaceFilterBaseHeaderMETA, in order.
+#define XR_LIST_STRUCT_XrSpaceFilterBaseHeaderMETA(_) \
+    _(type) \
+    _(next) \
+
+/// Calls your macro with the name of each member of XrSpaceDiscoveryInfoMETA, in order.
+#define XR_LIST_STRUCT_XrSpaceDiscoveryInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(filterCount) \
+    _(filters) \
+
+/// Calls your macro with the name of each member of XrSpaceFilterUuidMETA, in order.
+#define XR_LIST_STRUCT_XrSpaceFilterUuidMETA(_) \
+    _(type) \
+    _(next) \
+    _(uuidCount) \
+    _(uuids) \
+
+/// Calls your macro with the name of each member of XrSpaceFilterComponentMETA, in order.
+#define XR_LIST_STRUCT_XrSpaceFilterComponentMETA(_) \
+    _(type) \
+    _(next) \
+    _(componentType) \
+
+/// Calls your macro with the name of each member of XrSpaceDiscoveryResultMETA, in order.
+#define XR_LIST_STRUCT_XrSpaceDiscoveryResultMETA(_) \
+    _(space) \
+    _(uuid) \
+
+/// Calls your macro with the name of each member of XrSpaceDiscoveryResultsMETA, in order.
+#define XR_LIST_STRUCT_XrSpaceDiscoveryResultsMETA(_) \
+    _(type) \
+    _(next) \
+    _(resultCapacityInput) \
+    _(resultCountOutput) \
+    _(results) \
+
+/// Calls your macro with the name of each member of XrEventDataSpaceDiscoveryResultsAvailableMETA, in order.
+#define XR_LIST_STRUCT_XrEventDataSpaceDiscoveryResultsAvailableMETA(_) \
+    _(type) \
+    _(next) \
+    _(requestId) \
+
+/// Calls your macro with the name of each member of XrEventDataSpaceDiscoveryCompleteMETA, in order.
+#define XR_LIST_STRUCT_XrEventDataSpaceDiscoveryCompleteMETA(_) \
+    _(type) \
+    _(next) \
+    _(requestId) \
+    _(result) \
+
 /// Calls your macro with the name of each member of XrRecommendedLayerResolutionMETA, in order.
 #define XR_LIST_STRUCT_XrRecommendedLayerResolutionMETA(_) \
     _(type) \
@@ -5159,6 +5353,42 @@ XR_ENUM_STR(XrResult);
     _(next) \
     _(layer) \
     _(predictedDisplayTime) \
+
+/// Calls your macro with the name of each member of XrSystemSpacePersistencePropertiesMETA, in order.
+#define XR_LIST_STRUCT_XrSystemSpacePersistencePropertiesMETA(_) \
+    _(type) \
+    _(next) \
+    _(supportsSpacePersistence) \
+
+/// Calls your macro with the name of each member of XrSpacesSaveInfoMETA, in order.
+#define XR_LIST_STRUCT_XrSpacesSaveInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(spaceCount) \
+    _(spaces) \
+
+/// Calls your macro with the name of each member of XrEventDataSpacesSaveResultMETA, in order.
+#define XR_LIST_STRUCT_XrEventDataSpacesSaveResultMETA(_) \
+    _(type) \
+    _(next) \
+    _(requestId) \
+    _(result) \
+
+/// Calls your macro with the name of each member of XrSpacesEraseInfoMETA, in order.
+#define XR_LIST_STRUCT_XrSpacesEraseInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(spaceCount) \
+    _(spaces) \
+    _(uuidCount) \
+    _(uuids) \
+
+/// Calls your macro with the name of each member of XrEventDataSpacesEraseResultMETA, in order.
+#define XR_LIST_STRUCT_XrEventDataSpacesEraseResultMETA(_) \
+    _(type) \
+    _(next) \
+    _(requestId) \
+    _(result) \
 
 /// Calls your macro with the name of each member of XrPassthroughColorLutDataMETA, in order.
 #define XR_LIST_STRUCT_XrPassthroughColorLutDataMETA(_) \
@@ -5227,6 +5457,24 @@ XR_ENUM_STR(XrResult);
     _(type) \
     _(next) \
     _(layer) \
+
+/// Calls your macro with the name of each member of XrBodyTrackingCalibrationStatusMETA, in order.
+#define XR_LIST_STRUCT_XrBodyTrackingCalibrationStatusMETA(_) \
+    _(type) \
+    _(next) \
+    _(status) \
+
+/// Calls your macro with the name of each member of XrBodyTrackingCalibrationInfoMETA, in order.
+#define XR_LIST_STRUCT_XrBodyTrackingCalibrationInfoMETA(_) \
+    _(type) \
+    _(next) \
+    _(bodyHeight) \
+
+/// Calls your macro with the name of each member of XrSystemPropertiesBodyTrackingCalibrationMETA, in order.
+#define XR_LIST_STRUCT_XrSystemPropertiesBodyTrackingCalibrationMETA(_) \
+    _(type) \
+    _(next) \
+    _(supportsHeightOverride) \
 
 /// Calls your macro with the name of each member of XrSystemFaceTrackingProperties2FB, in order.
 #define XR_LIST_STRUCT_XrSystemFaceTrackingProperties2FB(_) \
@@ -5809,8 +6057,8 @@ XR_ENUM_STR(XrResult);
     _(type) \
     _(next) \
     _(futureResult) \
-    _(anchor) \
     _(uuid) \
+    _(anchor) \
 
 /// Calls your macro with the name of each member of XrSpatialAnchorPersistInfoBD, in order.
 #define XR_LIST_STRUCT_XrSpatialAnchorPersistInfoBD(_) \
@@ -5969,6 +6217,128 @@ XR_ENUM_STR(XrResult);
     _(vertexCapacityInput) \
     _(vertexCountOutput) \
     _(vertices) \
+
+/// Calls your macro with the name of each member of XrTrackableTrackerCreateInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableTrackerCreateInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(trackableType) \
+
+/// Calls your macro with the name of each member of XrTrackableGetInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableGetInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(trackable) \
+    _(baseSpace) \
+    _(time) \
+
+/// Calls your macro with the name of each member of XrTrackablePlaneANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackablePlaneANDROID(_) \
+    _(type) \
+    _(next) \
+    _(trackingState) \
+    _(centerPose) \
+    _(extents) \
+    _(planeType) \
+    _(planeLabel) \
+    _(subsumedByPlane) \
+    _(lastUpdatedTime) \
+    _(vertexCapacityInput) \
+    _(vertexCountOutput) \
+    _(vertices) \
+
+/// Calls your macro with the name of each member of XrAnchorSpaceCreateInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrAnchorSpaceCreateInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(space) \
+    _(time) \
+    _(pose) \
+    _(trackable) \
+
+/// Calls your macro with the name of each member of XrSystemTrackablesPropertiesANDROID, in order.
+#define XR_LIST_STRUCT_XrSystemTrackablesPropertiesANDROID(_) \
+    _(type) \
+    _(next) \
+    _(supportsAnchor) \
+    _(maxAnchors) \
+
+/// Calls your macro with the name of each member of XrDeviceAnchorPersistenceCreateInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrDeviceAnchorPersistenceCreateInfoANDROID(_) \
+    _(type) \
+    _(next) \
+
+/// Calls your macro with the name of each member of XrPersistedAnchorSpaceCreateInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrPersistedAnchorSpaceCreateInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(anchorId) \
+
+/// Calls your macro with the name of each member of XrPersistedAnchorSpaceInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrPersistedAnchorSpaceInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(anchor) \
+
+/// Calls your macro with the name of each member of XrSystemDeviceAnchorPersistencePropertiesANDROID, in order.
+#define XR_LIST_STRUCT_XrSystemDeviceAnchorPersistencePropertiesANDROID(_) \
+    _(type) \
+    _(next) \
+    _(supportsAnchorPersistence) \
+
+/// Calls your macro with the name of each member of XrSystemPassthroughCameraStatePropertiesANDROID, in order.
+#define XR_LIST_STRUCT_XrSystemPassthroughCameraStatePropertiesANDROID(_) \
+    _(type) \
+    _(next) \
+    _(supportsPassthroughCameraState) \
+
+/// Calls your macro with the name of each member of XrPassthroughCameraStateGetInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrPassthroughCameraStateGetInfoANDROID(_) \
+    _(type) \
+    _(next) \
+
+/// Calls your macro with the name of each member of XrRaycastInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrRaycastInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(maxResults) \
+    _(trackerCount) \
+    _(trackers) \
+    _(origin) \
+    _(trajectory) \
+    _(space) \
+    _(time) \
+
+/// Calls your macro with the name of each member of XrRaycastHitResultANDROID, in order.
+#define XR_LIST_STRUCT_XrRaycastHitResultANDROID(_) \
+    _(type) \
+    _(trackable) \
+    _(pose) \
+
+/// Calls your macro with the name of each member of XrRaycastHitResultsANDROID, in order.
+#define XR_LIST_STRUCT_XrRaycastHitResultsANDROID(_) \
+    _(type) \
+    _(next) \
+    _(resultsCapacityInput) \
+    _(resultsCountOutput) \
+    _(results) \
+
+/// Calls your macro with the name of each member of XrTrackableObjectANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableObjectANDROID(_) \
+    _(type) \
+    _(next) \
+    _(trackingState) \
+    _(centerPose) \
+    _(extents) \
+    _(objectLabel) \
+    _(lastUpdatedTime) \
+
+/// Calls your macro with the name of each member of XrTrackableObjectConfigurationANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableObjectConfigurationANDROID(_) \
+    _(type) \
+    _(next) \
+    _(labelCount) \
+    _(activeLabels) \
 
 /// Calls your macro with the name of each member of XrFutureCancelInfoEXT, in order.
 #define XR_LIST_STRUCT_XrFutureCancelInfoEXT(_) \
@@ -6275,6 +6645,62 @@ XR_ENUM_STR(XrResult);
     _(type) \
     _(next) \
     _(groupUuid) \
+
+/// Calls your macro with the name of each member of XrAnchorSharingInfoANDROID, in order.
+#define XR_LIST_STRUCT_XrAnchorSharingInfoANDROID(_) \
+    _(type) \
+    _(next) \
+    _(anchor) \
+
+/// Calls your macro with the name of each member of XrAnchorSharingTokenANDROID, in order.
+#define XR_LIST_STRUCT_XrAnchorSharingTokenANDROID(_) \
+    _(type) \
+    _(next) \
+    _(token) \
+
+/// Calls your macro with the name of each member of XrSystemAnchorSharingExportPropertiesANDROID, in order.
+#define XR_LIST_STRUCT_XrSystemAnchorSharingExportPropertiesANDROID(_) \
+    _(type) \
+    _(next) \
+    _(supportsAnchorSharingExport) \
+
+/// Calls your macro with the name of each member of XrSystemMarkerTrackingPropertiesANDROID, in order.
+#define XR_LIST_STRUCT_XrSystemMarkerTrackingPropertiesANDROID(_) \
+    _(type) \
+    _(next) \
+    _(supportsMarkerTracking) \
+    _(supportsMarkerSizeEstimation) \
+    _(maxMarkerCount) \
+
+/// Calls your macro with the name of each member of XrTrackableMarkerDatabaseEntryANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableMarkerDatabaseEntryANDROID(_) \
+    _(id) \
+    _(edgeSize) \
+
+/// Calls your macro with the name of each member of XrTrackableMarkerDatabaseANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableMarkerDatabaseANDROID(_) \
+    _(dictionary) \
+    _(entryCount) \
+    _(entries) \
+
+/// Calls your macro with the name of each member of XrTrackableMarkerConfigurationANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableMarkerConfigurationANDROID(_) \
+    _(type) \
+    _(next) \
+    _(trackingMode) \
+    _(databaseCount) \
+    _(databases) \
+
+/// Calls your macro with the name of each member of XrTrackableMarkerANDROID, in order.
+#define XR_LIST_STRUCT_XrTrackableMarkerANDROID(_) \
+    _(type) \
+    _(next) \
+    _(trackingState) \
+    _(lastUpdatedTime) \
+    _(dictionary) \
+    _(markerId) \
+    _(centerPose) \
+    _(extents) \
 
 /// Calls your macro with the name of each member of XrSpatialCapabilityComponentTypesEXT, in order.
 #define XR_LIST_STRUCT_XrSpatialCapabilityComponentTypesEXT(_) \
@@ -6616,6 +7042,18 @@ XR_ENUM_STR(XrResult);
     _(futureResult) \
     _(unpersistResult) \
 
+/// Calls your macro with the name of each member of XrLoaderInitPropertyValueEXT, in order.
+#define XR_LIST_STRUCT_XrLoaderInitPropertyValueEXT(_) \
+    _(name) \
+    _(value) \
+
+/// Calls your macro with the name of each member of XrLoaderInitInfoPropertiesEXT, in order.
+#define XR_LIST_STRUCT_XrLoaderInitInfoPropertiesEXT(_) \
+    _(type) \
+    _(next) \
+    _(propertyValueCount) \
+    _(propertyValues) \
+
 
 
 /// Calls your macro with the structure type name and the XrStructureType constant for
@@ -6927,8 +7365,20 @@ XR_ENUM_STR(XrResult);
     _(XrEventDataSpaceListSaveCompleteFB, XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB) \
     _(XrSpaceUserCreateInfoFB, XR_TYPE_SPACE_USER_CREATE_INFO_FB) \
     _(XrSystemHeadsetIdPropertiesMETA, XR_TYPE_SYSTEM_HEADSET_ID_PROPERTIES_META) \
+    _(XrSystemSpaceDiscoveryPropertiesMETA, XR_TYPE_SYSTEM_SPACE_DISCOVERY_PROPERTIES_META) \
+    _(XrSpaceDiscoveryInfoMETA, XR_TYPE_SPACE_DISCOVERY_INFO_META) \
+    _(XrSpaceFilterUuidMETA, XR_TYPE_SPACE_FILTER_UUID_META) \
+    _(XrSpaceFilterComponentMETA, XR_TYPE_SPACE_FILTER_COMPONENT_META) \
+    _(XrSpaceDiscoveryResultsMETA, XR_TYPE_SPACE_DISCOVERY_RESULTS_META) \
+    _(XrEventDataSpaceDiscoveryResultsAvailableMETA, XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_RESULTS_AVAILABLE_META) \
+    _(XrEventDataSpaceDiscoveryCompleteMETA, XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_COMPLETE_META) \
     _(XrRecommendedLayerResolutionMETA, XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_META) \
     _(XrRecommendedLayerResolutionGetInfoMETA, XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_GET_INFO_META) \
+    _(XrSystemSpacePersistencePropertiesMETA, XR_TYPE_SYSTEM_SPACE_PERSISTENCE_PROPERTIES_META) \
+    _(XrSpacesSaveInfoMETA, XR_TYPE_SPACES_SAVE_INFO_META) \
+    _(XrEventDataSpacesSaveResultMETA, XR_TYPE_EVENT_DATA_SPACES_SAVE_RESULT_META) \
+    _(XrSpacesEraseInfoMETA, XR_TYPE_SPACES_ERASE_INFO_META) \
+    _(XrEventDataSpacesEraseResultMETA, XR_TYPE_EVENT_DATA_SPACES_ERASE_RESULT_META) \
     _(XrPassthroughColorLutCreateInfoMETA, XR_TYPE_PASSTHROUGH_COLOR_LUT_CREATE_INFO_META) \
     _(XrPassthroughColorLutUpdateInfoMETA, XR_TYPE_PASSTHROUGH_COLOR_LUT_UPDATE_INFO_META) \
     _(XrPassthroughColorMapLutMETA, XR_TYPE_PASSTHROUGH_COLOR_MAP_LUT_META) \
@@ -6938,6 +7388,9 @@ XR_ENUM_STR(XrResult);
     _(XrSpaceTriangleMeshMETA, XR_TYPE_SPACE_TRIANGLE_MESH_META) \
     _(XrSystemPropertiesBodyTrackingFullBodyMETA, XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META) \
     _(XrEventDataPassthroughLayerResumedMETA, XR_TYPE_EVENT_DATA_PASSTHROUGH_LAYER_RESUMED_META) \
+    _(XrBodyTrackingCalibrationStatusMETA, XR_TYPE_BODY_TRACKING_CALIBRATION_STATUS_META) \
+    _(XrBodyTrackingCalibrationInfoMETA, XR_TYPE_BODY_TRACKING_CALIBRATION_INFO_META) \
+    _(XrSystemPropertiesBodyTrackingCalibrationMETA, XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META) \
     _(XrSystemFaceTrackingProperties2FB, XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES2_FB) \
     _(XrFaceTrackerCreateInfo2FB, XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB) \
     _(XrFaceExpressionInfo2FB, XR_TYPE_FACE_EXPRESSION_INFO2_FB) \
@@ -7037,6 +7490,21 @@ XR_ENUM_STR(XrResult);
     _(XrPlaneDetectorLocationEXT, XR_TYPE_PLANE_DETECTOR_LOCATION_EXT) \
     _(XrPlaneDetectorLocationsEXT, XR_TYPE_PLANE_DETECTOR_LOCATIONS_EXT) \
     _(XrPlaneDetectorPolygonBufferEXT, XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT) \
+    _(XrTrackableTrackerCreateInfoANDROID, XR_TYPE_TRACKABLE_TRACKER_CREATE_INFO_ANDROID) \
+    _(XrTrackableGetInfoANDROID, XR_TYPE_TRACKABLE_GET_INFO_ANDROID) \
+    _(XrTrackablePlaneANDROID, XR_TYPE_TRACKABLE_PLANE_ANDROID) \
+    _(XrAnchorSpaceCreateInfoANDROID, XR_TYPE_ANCHOR_SPACE_CREATE_INFO_ANDROID) \
+    _(XrSystemTrackablesPropertiesANDROID, XR_TYPE_SYSTEM_TRACKABLES_PROPERTIES_ANDROID) \
+    _(XrDeviceAnchorPersistenceCreateInfoANDROID, XR_TYPE_DEVICE_ANCHOR_PERSISTENCE_CREATE_INFO_ANDROID) \
+    _(XrPersistedAnchorSpaceCreateInfoANDROID, XR_TYPE_PERSISTED_ANCHOR_SPACE_CREATE_INFO_ANDROID) \
+    _(XrPersistedAnchorSpaceInfoANDROID, XR_TYPE_PERSISTED_ANCHOR_SPACE_INFO_ANDROID) \
+    _(XrSystemDeviceAnchorPersistencePropertiesANDROID, XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID) \
+    _(XrSystemPassthroughCameraStatePropertiesANDROID, XR_TYPE_SYSTEM_PASSTHROUGH_CAMERA_STATE_PROPERTIES_ANDROID) \
+    _(XrPassthroughCameraStateGetInfoANDROID, XR_TYPE_PASSTHROUGH_CAMERA_STATE_GET_INFO_ANDROID) \
+    _(XrRaycastInfoANDROID, XR_TYPE_RAYCAST_INFO_ANDROID) \
+    _(XrRaycastHitResultsANDROID, XR_TYPE_RAYCAST_HIT_RESULTS_ANDROID) \
+    _(XrTrackableObjectANDROID, XR_TYPE_TRACKABLE_OBJECT_ANDROID) \
+    _(XrTrackableObjectConfigurationANDROID, XR_TYPE_TRACKABLE_OBJECT_CONFIGURATION_ANDROID) \
     _(XrFutureCancelInfoEXT, XR_TYPE_FUTURE_CANCEL_INFO_EXT) \
     _(XrFuturePollInfoEXT, XR_TYPE_FUTURE_POLL_INFO_EXT) \
     _(XrFuturePollResultEXT, XR_TYPE_FUTURE_POLL_RESULT_EXT) \
@@ -7080,6 +7548,9 @@ XR_ENUM_STR(XrResult);
     _(XrSystemSpatialEntityGroupSharingPropertiesMETA, XR_TYPE_SYSTEM_SPATIAL_ENTITY_GROUP_SHARING_PROPERTIES_META) \
     _(XrShareSpacesRecipientGroupsMETA, XR_TYPE_SHARE_SPACES_RECIPIENT_GROUPS_META) \
     _(XrSpaceGroupUuidFilterInfoMETA, XR_TYPE_SPACE_GROUP_UUID_FILTER_INFO_META) \
+    _(XrSystemMarkerTrackingPropertiesANDROID, XR_TYPE_SYSTEM_MARKER_TRACKING_PROPERTIES_ANDROID) \
+    _(XrTrackableMarkerConfigurationANDROID, XR_TYPE_TRACKABLE_MARKER_CONFIGURATION_ANDROID) \
+    _(XrTrackableMarkerANDROID, XR_TYPE_TRACKABLE_MARKER_ANDROID) \
     _(XrSpatialCapabilityComponentTypesEXT, XR_TYPE_SPATIAL_CAPABILITY_COMPONENT_TYPES_EXT) \
     _(XrSpatialContextCreateInfoEXT, XR_TYPE_SPATIAL_CONTEXT_CREATE_INFO_EXT) \
     _(XrCreateSpatialContextCompletionEXT, XR_TYPE_CREATE_SPATIAL_CONTEXT_COMPLETION_EXT) \
@@ -7121,6 +7592,7 @@ XR_ENUM_STR(XrResult);
     _(XrPersistSpatialEntityCompletionEXT, XR_TYPE_PERSIST_SPATIAL_ENTITY_COMPLETION_EXT) \
     _(XrSpatialEntityUnpersistInfoEXT, XR_TYPE_SPATIAL_ENTITY_UNPERSIST_INFO_EXT) \
     _(XrUnpersistSpatialEntityCompletionEXT, XR_TYPE_UNPERSIST_SPATIAL_ENTITY_COMPLETION_EXT) \
+    _(XrLoaderInitInfoPropertiesEXT, XR_TYPE_LOADER_INIT_INFO_PROPERTIES_EXT) \
 
 
 #if defined(XR_USE_GRAPHICS_API_D3D11)
@@ -7259,6 +7731,9 @@ XR_ENUM_STR(XrResult);
     _(XrLoaderInitInfoAndroidKHR, XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR) \
     _(XrAndroidSurfaceSwapchainCreateInfoFB, XR_TYPE_ANDROID_SURFACE_SWAPCHAIN_CREATE_INFO_FB) \
     _(XrSwapchainStateAndroidSurfaceDimensionsFB, XR_TYPE_SWAPCHAIN_STATE_ANDROID_SURFACE_DIMENSIONS_FB) \
+    _(XrAnchorSharingInfoANDROID, XR_TYPE_ANCHOR_SHARING_INFO_ANDROID) \
+    _(XrAnchorSharingTokenANDROID, XR_TYPE_ANCHOR_SHARING_TOKEN_ANDROID) \
+    _(XrSystemAnchorSharingExportPropertiesANDROID, XR_TYPE_SYSTEM_ANCHOR_SHARING_EXPORT_PROPERTIES_ANDROID) \
 
 #else
 #define XR_LIST_STRUCTURE_TYPES_XR_USE_PLATFORM_ANDROID(_)
@@ -7434,14 +7909,17 @@ XR_ENUM_STR(XrResult);
     _(XR_META_detached_controllers, 241) \
     _(XR_FB_spatial_entity_user, 242) \
     _(XR_META_headset_id, 246) \
+    _(XR_META_spatial_entity_discovery, 248) \
     _(XR_META_hand_tracking_microgestures, 253) \
     _(XR_META_recommended_layer_resolution, 255) \
+    _(XR_META_spatial_entity_persistence, 260) \
     _(XR_META_passthrough_color_lut, 267) \
     _(XR_META_spatial_entity_mesh, 270) \
     _(XR_META_automatic_layer_filter, 272) \
     _(XR_META_body_tracking_full_body, 275) \
     _(XR_META_touch_controller_plus, 280) \
     _(XR_META_passthrough_layer_resumed_event, 283) \
+    _(XR_META_body_tracking_calibration, 284) \
     _(XR_FB_face_tracking2, 288) \
     _(XR_META_spatial_entity_sharing, 291) \
     _(XR_META_environment_depth, 292) \
@@ -7469,6 +7947,11 @@ XR_ENUM_STR(XrResult);
     _(XR_EXT_hand_tracking_data_source, 429) \
     _(XR_EXT_plane_detection, 430) \
     _(XR_OPPO_controller_interaction, 454) \
+    _(XR_ANDROID_trackables, 456) \
+    _(XR_ANDROID_device_anchor_persistence, 458) \
+    _(XR_ANDROID_passthrough_camera_state, 461) \
+    _(XR_ANDROID_raycast, 464) \
+    _(XR_ANDROID_trackables_object, 467) \
     _(XR_EXT_future, 470) \
     _(XR_EXT_user_presence, 471) \
     _(XR_KHR_locate_spaces, 472) \
@@ -7482,7 +7965,10 @@ XR_ENUM_STR(XrResult);
     _(XR_EXT_composition_layer_inverted_alpha, 555) \
     _(XR_META_colocation_discovery, 572) \
     _(XR_META_spatial_entity_group_sharing, 573) \
+    _(XR_ANDROID_anchor_sharing_export, 702) \
+    _(XR_ANDROID_trackables_marker, 708) \
     _(XR_KHR_maintenance1, 711) \
+    _(XR_KHR_generic_controller, 712) \
     _(XR_EXT_spatial_entity, 741) \
     _(XR_EXT_spatial_plane_tracking, 742) \
     _(XR_EXT_spatial_marker_tracking, 744) \
@@ -7490,6 +7976,7 @@ XR_ENUM_STR(XrResult);
     _(XR_EXT_spatial_anchor, 763) \
     _(XR_EXT_spatial_persistence, 764) \
     _(XR_EXT_spatial_persistence_operations, 782) \
+    _(XR_EXT_loader_init_properties, 839) \
 
 
 
@@ -7682,6 +8169,7 @@ XR_ENUM_STR(XrResult);
     _(CreateVulkanInstanceKHR, KHR_vulkan_enable2) \
     _(CreateVulkanDeviceKHR, KHR_vulkan_enable2) \
     _(GetVulkanGraphicsDevice2KHR, KHR_vulkan_enable2) \
+    _(GetVulkanGraphicsRequirements2KHR, KHR_vulkan_enable2) \
 
 
 /// For every function defined by XR_KHR_extended_struct_name_lengths in this version of the spec,
@@ -7690,6 +8178,14 @@ XR_ENUM_STR(XrResult);
 /// because it is easy to add back but impossible to remove with the preprocessor.
 #define XR_LIST_FUNCTIONS_XR_KHR_extended_struct_name_lengths(_) \
     _(StructureTypeToString2KHR, KHR_extended_struct_name_lengths) \
+
+
+/// For every function defined by XR_KHR_locate_spaces in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_KHR_locate_spaces(_) \
+    _(LocateSpacesKHR, KHR_locate_spaces) \
 
 
 /// For every function defined by XR_EXT_performance_settings in this version of the spec,
@@ -8262,12 +8758,30 @@ XR_ENUM_STR(XrResult);
     _(DestroySpaceUserFB, FB_spatial_entity_user) \
 
 
+/// For every function defined by XR_META_spatial_entity_discovery in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_META_spatial_entity_discovery(_) \
+    _(DiscoverSpacesMETA, META_spatial_entity_discovery) \
+    _(RetrieveSpaceDiscoveryResultsMETA, META_spatial_entity_discovery) \
+
+
 /// For every function defined by XR_META_recommended_layer_resolution in this version of the spec,
 /// calls your macro with the function name and extension name.
 /// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
 /// because it is easy to add back but impossible to remove with the preprocessor.
 #define XR_LIST_FUNCTIONS_XR_META_recommended_layer_resolution(_) \
     _(GetRecommendedLayerResolutionMETA, META_recommended_layer_resolution) \
+
+
+/// For every function defined by XR_META_spatial_entity_persistence in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_META_spatial_entity_persistence(_) \
+    _(SaveSpacesMETA, META_spatial_entity_persistence) \
+    _(EraseSpacesMETA, META_spatial_entity_persistence) \
 
 
 /// For every function defined by XR_META_passthrough_color_lut in this version of the spec,
@@ -8286,6 +8800,15 @@ XR_ENUM_STR(XrResult);
 /// because it is easy to add back but impossible to remove with the preprocessor.
 #define XR_LIST_FUNCTIONS_XR_META_spatial_entity_mesh(_) \
     _(GetSpaceTriangleMeshMETA, META_spatial_entity_mesh) \
+
+
+/// For every function defined by XR_META_body_tracking_calibration in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_META_body_tracking_calibration(_) \
+    _(SuggestBodyTrackingCalibrationOverrideMETA, META_body_tracking_calibration) \
+    _(ResetBodyTrackingCalibrationMETA, META_body_tracking_calibration) \
 
 
 /// For every function defined by XR_FB_face_tracking2 in this version of the spec,
@@ -8482,6 +9005,60 @@ XR_ENUM_STR(XrResult);
     _(GetPlanePolygonBufferEXT, EXT_plane_detection) \
 
 
+/// For every function defined by XR_ANDROID_trackables in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_trackables(_) \
+    _(EnumerateSupportedTrackableTypesANDROID, ANDROID_trackables) \
+    _(EnumerateSupportedAnchorTrackableTypesANDROID, ANDROID_trackables) \
+    _(CreateTrackableTrackerANDROID, ANDROID_trackables) \
+    _(DestroyTrackableTrackerANDROID, ANDROID_trackables) \
+    _(GetAllTrackablesANDROID, ANDROID_trackables) \
+    _(GetTrackablePlaneANDROID, ANDROID_trackables) \
+    _(CreateAnchorSpaceANDROID, ANDROID_trackables) \
+
+
+/// For every function defined by XR_ANDROID_device_anchor_persistence in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_device_anchor_persistence(_) \
+    _(EnumerateSupportedPersistenceAnchorTypesANDROID, ANDROID_device_anchor_persistence) \
+    _(CreateDeviceAnchorPersistenceANDROID, ANDROID_device_anchor_persistence) \
+    _(DestroyDeviceAnchorPersistenceANDROID, ANDROID_device_anchor_persistence) \
+    _(PersistAnchorANDROID, ANDROID_device_anchor_persistence) \
+    _(GetAnchorPersistStateANDROID, ANDROID_device_anchor_persistence) \
+    _(CreatePersistedAnchorSpaceANDROID, ANDROID_device_anchor_persistence) \
+    _(EnumeratePersistedAnchorsANDROID, ANDROID_device_anchor_persistence) \
+    _(UnpersistAnchorANDROID, ANDROID_device_anchor_persistence) \
+
+
+/// For every function defined by XR_ANDROID_passthrough_camera_state in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_passthrough_camera_state(_) \
+    _(GetPassthroughCameraStateANDROID, ANDROID_passthrough_camera_state) \
+
+
+/// For every function defined by XR_ANDROID_raycast in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_raycast(_) \
+    _(EnumerateRaycastSupportedTrackableTypesANDROID, ANDROID_raycast) \
+    _(RaycastANDROID, ANDROID_raycast) \
+
+
+/// For every function defined by XR_ANDROID_trackables_object in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_trackables_object(_) \
+    _(GetTrackableObjectANDROID, ANDROID_trackables_object) \
+
+
 /// For every function defined by XR_EXT_future in this version of the spec,
 /// calls your macro with the function name and extension name.
 /// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
@@ -8551,6 +9128,23 @@ XR_ENUM_STR(XrResult);
     _(StopColocationDiscoveryMETA, META_colocation_discovery) \
     _(StartColocationAdvertisementMETA, META_colocation_discovery) \
     _(StopColocationAdvertisementMETA, META_colocation_discovery) \
+
+
+/// For every function defined by XR_ANDROID_anchor_sharing_export in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_anchor_sharing_export(_) \
+    _(ShareAnchorANDROID, ANDROID_anchor_sharing_export) \
+    _(UnshareAnchorANDROID, ANDROID_anchor_sharing_export) \
+
+
+/// For every function defined by XR_ANDROID_trackables_marker in this version of the spec,
+/// calls your macro with the function name and extension name.
+/// Trims the leading `xr` from the function name and the leading `XR_` from the feature name,
+/// because it is easy to add back but impossible to remove with the preprocessor.
+#define XR_LIST_FUNCTIONS_XR_ANDROID_trackables_marker(_) \
+    _(GetTrackableMarkerANDROID, ANDROID_trackables_marker) \
 
 
 /// For every function defined by XR_EXT_spatial_entity in this version of the spec,

--- a/thirdparty/openxr/include/openxr/openxr_reflection_parent_structs.h
+++ b/thirdparty/openxr/include/openxr/openxr_reflection_parent_structs.h
@@ -58,6 +58,7 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
     _avail(XrEventDataViveTrackerConnectedHTCX, XR_TYPE_EVENT_DATA_VIVE_TRACKER_CONNECTED_HTCX) \
     _avail(XrEventDataSpatialAnchorCreateCompleteFB, XR_TYPE_EVENT_DATA_SPATIAL_ANCHOR_CREATE_COMPLETE_FB) \
     _avail(XrEventDataSpaceSetStatusCompleteFB, XR_TYPE_EVENT_DATA_SPACE_SET_STATUS_COMPLETE_FB) \
+    _avail(XrEventDataPassthroughStateChangedFB, XR_TYPE_EVENT_DATA_PASSTHROUGH_STATE_CHANGED_FB) \
     _avail(XrEventDataMarkerTrackingUpdateVARJO, XR_TYPE_EVENT_DATA_MARKER_TRACKING_UPDATE_VARJO) \
     _avail(XrEventDataLocalizationChangedML, XR_TYPE_EVENT_DATA_LOCALIZATION_CHANGED_ML) \
     _avail(XrEventDataSpaceQueryResultsAvailableFB, XR_TYPE_EVENT_DATA_SPACE_QUERY_RESULTS_AVAILABLE_FB) \
@@ -65,12 +66,32 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
     _avail(XrEventDataSpaceSaveCompleteFB, XR_TYPE_EVENT_DATA_SPACE_SAVE_COMPLETE_FB) \
     _avail(XrEventDataSpaceEraseCompleteFB, XR_TYPE_EVENT_DATA_SPACE_ERASE_COMPLETE_FB) \
     _avail(XrEventDataSpaceShareCompleteFB, XR_TYPE_EVENT_DATA_SPACE_SHARE_COMPLETE_FB) \
+    _avail(XrEventDataSceneCaptureCompleteFB, XR_TYPE_EVENT_DATA_SCENE_CAPTURE_COMPLETE_FB) \
+    _avail(XrEventDataVirtualKeyboardCommitTextMETA, XR_TYPE_EVENT_DATA_VIRTUAL_KEYBOARD_COMMIT_TEXT_META) \
+    _avail(XrEventDataVirtualKeyboardBackspaceMETA, XR_TYPE_EVENT_DATA_VIRTUAL_KEYBOARD_BACKSPACE_META) \
+    _avail(XrEventDataVirtualKeyboardEnterMETA, XR_TYPE_EVENT_DATA_VIRTUAL_KEYBOARD_ENTER_META) \
+    _avail(XrEventDataVirtualKeyboardShownMETA, XR_TYPE_EVENT_DATA_VIRTUAL_KEYBOARD_SHOWN_META) \
+    _avail(XrEventDataVirtualKeyboardHiddenMETA, XR_TYPE_EVENT_DATA_VIRTUAL_KEYBOARD_HIDDEN_META) \
     _avail(XrEventDataSpaceListSaveCompleteFB, XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB) \
+    _avail(XrEventDataSpaceDiscoveryResultsAvailableMETA, XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_RESULTS_AVAILABLE_META) \
+    _avail(XrEventDataSpaceDiscoveryCompleteMETA, XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_COMPLETE_META) \
+    _avail(XrEventDataSpacesSaveResultMETA, XR_TYPE_EVENT_DATA_SPACES_SAVE_RESULT_META) \
+    _avail(XrEventDataSpacesEraseResultMETA, XR_TYPE_EVENT_DATA_SPACES_ERASE_RESULT_META) \
     _avail(XrEventDataPassthroughLayerResumedMETA, XR_TYPE_EVENT_DATA_PASSTHROUGH_LAYER_RESUMED_META) \
+    _avail(XrEventDataShareSpacesCompleteMETA, XR_TYPE_EVENT_DATA_SHARE_SPACES_COMPLETE_META) \
+    _avail(XrEventDataInteractionRenderModelsChangedEXT, XR_TYPE_EVENT_DATA_INTERACTION_RENDER_MODELS_CHANGED_EXT) \
     _avail(XrEventDataSenseDataProviderStateChangedBD, XR_TYPE_EVENT_DATA_SENSE_DATA_PROVIDER_STATE_CHANGED_BD) \
     _avail(XrEventDataSenseDataUpdatedBD, XR_TYPE_EVENT_DATA_SENSE_DATA_UPDATED_BD) \
+    _avail(XrEventDataUserPresenceChangedEXT, XR_TYPE_EVENT_DATA_USER_PRESENCE_CHANGED_EXT) \
     _avail(XrEventDataHeadsetFitChangedML, XR_TYPE_EVENT_DATA_HEADSET_FIT_CHANGED_ML) \
     _avail(XrEventDataEyeCalibrationChangedML, XR_TYPE_EVENT_DATA_EYE_CALIBRATION_CHANGED_ML) \
+    _avail(XrEventDataStartColocationAdvertisementCompleteMETA, XR_TYPE_EVENT_DATA_START_COLOCATION_ADVERTISEMENT_COMPLETE_META) \
+    _avail(XrEventDataStopColocationAdvertisementCompleteMETA, XR_TYPE_EVENT_DATA_STOP_COLOCATION_ADVERTISEMENT_COMPLETE_META) \
+    _avail(XrEventDataColocationAdvertisementCompleteMETA, XR_TYPE_EVENT_DATA_COLOCATION_ADVERTISEMENT_COMPLETE_META) \
+    _avail(XrEventDataStartColocationDiscoveryCompleteMETA, XR_TYPE_EVENT_DATA_START_COLOCATION_DISCOVERY_COMPLETE_META) \
+    _avail(XrEventDataColocationDiscoveryResultMETA, XR_TYPE_EVENT_DATA_COLOCATION_DISCOVERY_RESULT_META) \
+    _avail(XrEventDataColocationDiscoveryCompleteMETA, XR_TYPE_EVENT_DATA_COLOCATION_DISCOVERY_COMPLETE_META) \
+    _avail(XrEventDataStopColocationDiscoveryCompleteMETA, XR_TYPE_EVENT_DATA_STOP_COLOCATION_DISCOVERY_COMPLETE_META) \
     _avail(XrEventDataSpatialDiscoveryRecommendedEXT, XR_TYPE_EVENT_DATA_SPATIAL_DISCOVERY_RECOMMENDED_EXT) \
 
 
@@ -167,6 +188,7 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
 
 // Implementation detail of XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrLoaderInitInfoBaseHeaderKHR()
 #define _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrLoaderInitInfoBaseHeaderKHR_CORE(_avail, _unavail) \
+    _avail(XrLoaderInitInfoPropertiesEXT, XR_TYPE_LOADER_INIT_INFO_PROPERTIES_EXT) \
 
 
 #if defined(XR_USE_PLATFORM_ANDROID)
@@ -323,6 +345,20 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
 
 
 
+/// Like XR_LIST_ALL_STRUCTURE_TYPES, but only includes types whose parent struct type is XrSpaceFilterBaseHeaderMETA
+#define XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrSpaceFilterBaseHeaderMETA(_avail, _unavail) \
+    _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrSpaceFilterBaseHeaderMETA_CORE(_avail, _unavail) \
+
+
+// Implementation detail of XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrSpaceFilterBaseHeaderMETA()
+#define _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrSpaceFilterBaseHeaderMETA_CORE(_avail, _unavail) \
+    _avail(XrSpaceFilterUuidMETA, XR_TYPE_SPACE_FILTER_UUID_META) \
+    _avail(XrSpaceFilterComponentMETA, XR_TYPE_SPACE_FILTER_COMPONENT_META) \
+
+
+
+
+
 /// Like XR_LIST_ALL_STRUCTURE_TYPES, but only includes types whose parent struct type is XrShareSpacesRecipientBaseHeaderMETA
 #define XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrShareSpacesRecipientBaseHeaderMETA(_avail, _unavail) \
     _impl_XR_LIST_ALL_CHILD_STRUCTURE_TYPES_XrShareSpacesRecipientBaseHeaderMETA_CORE(_avail, _unavail) \
@@ -348,6 +384,7 @@ This file contains expansion macros (X Macros) for OpenXR structures that have a
     _avail(XrSpatialCapabilityConfigurationMicroQrCodeEXT, XR_TYPE_SPATIAL_CAPABILITY_CONFIGURATION_MICRO_QR_CODE_EXT) \
     _avail(XrSpatialCapabilityConfigurationArucoMarkerEXT, XR_TYPE_SPATIAL_CAPABILITY_CONFIGURATION_ARUCO_MARKER_EXT) \
     _avail(XrSpatialCapabilityConfigurationAprilTagEXT, XR_TYPE_SPATIAL_CAPABILITY_CONFIGURATION_APRIL_TAG_EXT) \
+    _avail(XrSpatialCapabilityConfigurationAnchorEXT, XR_TYPE_SPATIAL_CAPABILITY_CONFIGURATION_ANCHOR_EXT) \
 
 
 

--- a/thirdparty/openxr/include/openxr/openxr_reflection_structs.h
+++ b/thirdparty/openxr/include/openxr/openxr_reflection_structs.h
@@ -330,8 +330,20 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrEventDataSpaceListSaveCompleteFB, XR_TYPE_EVENT_DATA_SPACE_LIST_SAVE_COMPLETE_FB) \
     _avail(XrSpaceUserCreateInfoFB, XR_TYPE_SPACE_USER_CREATE_INFO_FB) \
     _avail(XrSystemHeadsetIdPropertiesMETA, XR_TYPE_SYSTEM_HEADSET_ID_PROPERTIES_META) \
+    _avail(XrSystemSpaceDiscoveryPropertiesMETA, XR_TYPE_SYSTEM_SPACE_DISCOVERY_PROPERTIES_META) \
+    _avail(XrSpaceDiscoveryInfoMETA, XR_TYPE_SPACE_DISCOVERY_INFO_META) \
+    _avail(XrSpaceFilterUuidMETA, XR_TYPE_SPACE_FILTER_UUID_META) \
+    _avail(XrSpaceFilterComponentMETA, XR_TYPE_SPACE_FILTER_COMPONENT_META) \
+    _avail(XrSpaceDiscoveryResultsMETA, XR_TYPE_SPACE_DISCOVERY_RESULTS_META) \
+    _avail(XrEventDataSpaceDiscoveryResultsAvailableMETA, XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_RESULTS_AVAILABLE_META) \
+    _avail(XrEventDataSpaceDiscoveryCompleteMETA, XR_TYPE_EVENT_DATA_SPACE_DISCOVERY_COMPLETE_META) \
     _avail(XrRecommendedLayerResolutionMETA, XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_META) \
     _avail(XrRecommendedLayerResolutionGetInfoMETA, XR_TYPE_RECOMMENDED_LAYER_RESOLUTION_GET_INFO_META) \
+    _avail(XrSystemSpacePersistencePropertiesMETA, XR_TYPE_SYSTEM_SPACE_PERSISTENCE_PROPERTIES_META) \
+    _avail(XrSpacesSaveInfoMETA, XR_TYPE_SPACES_SAVE_INFO_META) \
+    _avail(XrEventDataSpacesSaveResultMETA, XR_TYPE_EVENT_DATA_SPACES_SAVE_RESULT_META) \
+    _avail(XrSpacesEraseInfoMETA, XR_TYPE_SPACES_ERASE_INFO_META) \
+    _avail(XrEventDataSpacesEraseResultMETA, XR_TYPE_EVENT_DATA_SPACES_ERASE_RESULT_META) \
     _avail(XrPassthroughColorLutCreateInfoMETA, XR_TYPE_PASSTHROUGH_COLOR_LUT_CREATE_INFO_META) \
     _avail(XrPassthroughColorLutUpdateInfoMETA, XR_TYPE_PASSTHROUGH_COLOR_LUT_UPDATE_INFO_META) \
     _avail(XrPassthroughColorMapLutMETA, XR_TYPE_PASSTHROUGH_COLOR_MAP_LUT_META) \
@@ -341,6 +353,9 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrSpaceTriangleMeshMETA, XR_TYPE_SPACE_TRIANGLE_MESH_META) \
     _avail(XrSystemPropertiesBodyTrackingFullBodyMETA, XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_FULL_BODY_META) \
     _avail(XrEventDataPassthroughLayerResumedMETA, XR_TYPE_EVENT_DATA_PASSTHROUGH_LAYER_RESUMED_META) \
+    _avail(XrBodyTrackingCalibrationStatusMETA, XR_TYPE_BODY_TRACKING_CALIBRATION_STATUS_META) \
+    _avail(XrBodyTrackingCalibrationInfoMETA, XR_TYPE_BODY_TRACKING_CALIBRATION_INFO_META) \
+    _avail(XrSystemPropertiesBodyTrackingCalibrationMETA, XR_TYPE_SYSTEM_PROPERTIES_BODY_TRACKING_CALIBRATION_META) \
     _avail(XrSystemFaceTrackingProperties2FB, XR_TYPE_SYSTEM_FACE_TRACKING_PROPERTIES2_FB) \
     _avail(XrFaceTrackerCreateInfo2FB, XR_TYPE_FACE_TRACKER_CREATE_INFO2_FB) \
     _avail(XrFaceExpressionInfo2FB, XR_TYPE_FACE_EXPRESSION_INFO2_FB) \
@@ -440,6 +455,21 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrPlaneDetectorLocationEXT, XR_TYPE_PLANE_DETECTOR_LOCATION_EXT) \
     _avail(XrPlaneDetectorLocationsEXT, XR_TYPE_PLANE_DETECTOR_LOCATIONS_EXT) \
     _avail(XrPlaneDetectorPolygonBufferEXT, XR_TYPE_PLANE_DETECTOR_POLYGON_BUFFER_EXT) \
+    _avail(XrTrackableTrackerCreateInfoANDROID, XR_TYPE_TRACKABLE_TRACKER_CREATE_INFO_ANDROID) \
+    _avail(XrTrackableGetInfoANDROID, XR_TYPE_TRACKABLE_GET_INFO_ANDROID) \
+    _avail(XrTrackablePlaneANDROID, XR_TYPE_TRACKABLE_PLANE_ANDROID) \
+    _avail(XrAnchorSpaceCreateInfoANDROID, XR_TYPE_ANCHOR_SPACE_CREATE_INFO_ANDROID) \
+    _avail(XrSystemTrackablesPropertiesANDROID, XR_TYPE_SYSTEM_TRACKABLES_PROPERTIES_ANDROID) \
+    _avail(XrDeviceAnchorPersistenceCreateInfoANDROID, XR_TYPE_DEVICE_ANCHOR_PERSISTENCE_CREATE_INFO_ANDROID) \
+    _avail(XrPersistedAnchorSpaceCreateInfoANDROID, XR_TYPE_PERSISTED_ANCHOR_SPACE_CREATE_INFO_ANDROID) \
+    _avail(XrPersistedAnchorSpaceInfoANDROID, XR_TYPE_PERSISTED_ANCHOR_SPACE_INFO_ANDROID) \
+    _avail(XrSystemDeviceAnchorPersistencePropertiesANDROID, XR_TYPE_SYSTEM_DEVICE_ANCHOR_PERSISTENCE_PROPERTIES_ANDROID) \
+    _avail(XrSystemPassthroughCameraStatePropertiesANDROID, XR_TYPE_SYSTEM_PASSTHROUGH_CAMERA_STATE_PROPERTIES_ANDROID) \
+    _avail(XrPassthroughCameraStateGetInfoANDROID, XR_TYPE_PASSTHROUGH_CAMERA_STATE_GET_INFO_ANDROID) \
+    _avail(XrRaycastInfoANDROID, XR_TYPE_RAYCAST_INFO_ANDROID) \
+    _avail(XrRaycastHitResultsANDROID, XR_TYPE_RAYCAST_HIT_RESULTS_ANDROID) \
+    _avail(XrTrackableObjectANDROID, XR_TYPE_TRACKABLE_OBJECT_ANDROID) \
+    _avail(XrTrackableObjectConfigurationANDROID, XR_TYPE_TRACKABLE_OBJECT_CONFIGURATION_ANDROID) \
     _avail(XrFutureCancelInfoEXT, XR_TYPE_FUTURE_CANCEL_INFO_EXT) \
     _avail(XrFuturePollInfoEXT, XR_TYPE_FUTURE_POLL_INFO_EXT) \
     _avail(XrFuturePollResultEXT, XR_TYPE_FUTURE_POLL_RESULT_EXT) \
@@ -483,6 +513,9 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrSystemSpatialEntityGroupSharingPropertiesMETA, XR_TYPE_SYSTEM_SPATIAL_ENTITY_GROUP_SHARING_PROPERTIES_META) \
     _avail(XrShareSpacesRecipientGroupsMETA, XR_TYPE_SHARE_SPACES_RECIPIENT_GROUPS_META) \
     _avail(XrSpaceGroupUuidFilterInfoMETA, XR_TYPE_SPACE_GROUP_UUID_FILTER_INFO_META) \
+    _avail(XrSystemMarkerTrackingPropertiesANDROID, XR_TYPE_SYSTEM_MARKER_TRACKING_PROPERTIES_ANDROID) \
+    _avail(XrTrackableMarkerConfigurationANDROID, XR_TYPE_TRACKABLE_MARKER_CONFIGURATION_ANDROID) \
+    _avail(XrTrackableMarkerANDROID, XR_TYPE_TRACKABLE_MARKER_ANDROID) \
     _avail(XrSpatialCapabilityComponentTypesEXT, XR_TYPE_SPATIAL_CAPABILITY_COMPONENT_TYPES_EXT) \
     _avail(XrSpatialContextCreateInfoEXT, XR_TYPE_SPATIAL_CONTEXT_CREATE_INFO_EXT) \
     _avail(XrCreateSpatialContextCompletionEXT, XR_TYPE_CREATE_SPATIAL_CONTEXT_COMPLETION_EXT) \
@@ -524,6 +557,7 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrPersistSpatialEntityCompletionEXT, XR_TYPE_PERSIST_SPATIAL_ENTITY_COMPLETION_EXT) \
     _avail(XrSpatialEntityUnpersistInfoEXT, XR_TYPE_SPATIAL_ENTITY_UNPERSIST_INFO_EXT) \
     _avail(XrUnpersistSpatialEntityCompletionEXT, XR_TYPE_UNPERSIST_SPATIAL_ENTITY_COMPLETION_EXT) \
+    _avail(XrLoaderInitInfoPropertiesEXT, XR_TYPE_LOADER_INIT_INFO_PROPERTIES_EXT) \
 
 
 #if defined(XR_USE_GRAPHICS_API_D3D11)
@@ -678,6 +712,9 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _avail(XrLoaderInitInfoAndroidKHR, XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR) \
     _avail(XrAndroidSurfaceSwapchainCreateInfoFB, XR_TYPE_ANDROID_SURFACE_SWAPCHAIN_CREATE_INFO_FB) \
     _avail(XrSwapchainStateAndroidSurfaceDimensionsFB, XR_TYPE_SWAPCHAIN_STATE_ANDROID_SURFACE_DIMENSIONS_FB) \
+    _avail(XrAnchorSharingInfoANDROID, XR_TYPE_ANCHOR_SHARING_INFO_ANDROID) \
+    _avail(XrAnchorSharingTokenANDROID, XR_TYPE_ANCHOR_SHARING_TOKEN_ANDROID) \
+    _avail(XrSystemAnchorSharingExportPropertiesANDROID, XR_TYPE_SYSTEM_ANCHOR_SHARING_EXPORT_PROPERTIES_ANDROID) \
 
 #else
 #define _impl_XR_LIST_ALL_STRUCTURE_TYPES_XR_USE_PLATFORM_ANDROID(_avail, _unavail) \
@@ -685,6 +722,9 @@ This file contains expansion macros (X Macros) for OpenXR structures.
     _unavail(XrLoaderInitInfoAndroidKHR, XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR) \
     _unavail(XrAndroidSurfaceSwapchainCreateInfoFB, XR_TYPE_ANDROID_SURFACE_SWAPCHAIN_CREATE_INFO_FB) \
     _unavail(XrSwapchainStateAndroidSurfaceDimensionsFB, XR_TYPE_SWAPCHAIN_STATE_ANDROID_SURFACE_DIMENSIONS_FB) \
+    _unavail(XrAnchorSharingInfoANDROID, XR_TYPE_ANCHOR_SHARING_INFO_ANDROID) \
+    _unavail(XrAnchorSharingTokenANDROID, XR_TYPE_ANCHOR_SHARING_TOKEN_ANDROID) \
+    _unavail(XrSystemAnchorSharingExportPropertiesANDROID, XR_TYPE_SYSTEM_ANCHOR_SHARING_EXPORT_PROPERTIES_ANDROID) \
 
 #endif
 

--- a/thirdparty/openxr/src/common/hex_and_handles.h
+++ b/thirdparty/openxr/src/common/hex_and_handles.h
@@ -37,7 +37,12 @@ inline std::string to_hex(const uint8_t* const data, size_t bytes) {
 
 template <typename T>
 inline std::string to_hex(const T& data) {
-    return to_hex(reinterpret_cast<const uint8_t* const>(&data), sizeof(data));
+    return to_hex(reinterpret_cast<const uint8_t* const>(&data), sizeof(T));
+}
+
+template <typename T>
+inline std::string to_hex(T* const data) {
+    return to_hex(reinterpret_cast<const uint8_t* const>(&data), sizeof(T*));
 }
 
 #if XR_PTR_SIZE == 8

--- a/thirdparty/openxr/src/common/platform_utils.hpp
+++ b/thirdparty/openxr/src/common/platform_utils.hpp
@@ -361,7 +361,7 @@ static inline bool PlatformGetGlobalRuntimeFileName(uint16_t major_version, std:
     return false;
 }
 
-// Android system properties are sufficiently different from environment variables that we are not re-using
+// Android system properties are sufficiently different from environment variables that we are not reusing
 // PlatformUtilsGetEnv for this purpose
 static inline std::string PlatformUtilsGetAndroidSystemProperty(const char* name) {
     std::string result;

--- a/thirdparty/openxr/src/loader/loader_core.cpp
+++ b/thirdparty/openxr/src/loader/loader_core.cpp
@@ -75,13 +75,14 @@ inline bool IsMissingNullTerminator(const char (&str)[max_length]) {
 }
 
 // ---- Core 1.0 manual loader trampoline functions
-#ifdef XR_KHR_LOADER_INIT_SUPPORT  // platforms that support XR_KHR_loader_init.
-XRAPI_ATTR XrResult XRAPI_CALL LoaderXrInitializeLoaderKHR(const XrLoaderInitInfoBaseHeaderKHR *loaderInitInfo) XRLOADER_ABI_TRY {
+static XRAPI_ATTR XrResult XRAPI_CALL LoaderXrInitializeLoaderKHR(const XrLoaderInitInfoBaseHeaderKHR *);
+
+static XRAPI_ATTR XrResult XRAPI_CALL LoaderXrInitializeLoaderKHR(const XrLoaderInitInfoBaseHeaderKHR *loaderInitInfo)
+    XRLOADER_ABI_TRY {
     LoaderLogger::LogVerboseMessage("xrInitializeLoaderKHR", "Entering loader trampoline");
     return InitializeLoaderInitData(loaderInitInfo);
 }
 XRLOADER_ABI_CATCH_FALLBACK
-#endif
 
 static XRAPI_ATTR XrResult XRAPI_CALL LoaderXrEnumerateApiLayerProperties(uint32_t propertyCapacityInput,
                                                                           uint32_t *propertyCountOutput,
@@ -758,12 +759,8 @@ XRAPI_ATTR XrResult XRAPI_CALL LoaderXrGetInstanceProcAddr(XrInstance instance, 
         *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrGetInstanceProcAddr);
         return XR_SUCCESS;
     } else if (strcmp(name, "xrInitializeLoaderKHR") == 0) {
-#ifdef XR_KHR_LOADER_INIT_SUPPORT
         *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrInitializeLoaderKHR);
         return XR_SUCCESS;
-#else
-        return XR_ERROR_FUNCTION_UNSUPPORTED;
-#endif
     } else if (strcmp(name, "xrEnumerateApiLayerProperties") == 0) {
         *function = reinterpret_cast<PFN_xrVoidFunction>(LoaderXrEnumerateApiLayerProperties);
         return XR_SUCCESS;
@@ -843,8 +840,6 @@ LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrGetInstanceProcAddr(XrInstance in
     return LoaderXrGetInstanceProcAddr(instance, name, function);
 }
 
-#ifdef XR_KHR_LOADER_INIT_SUPPORT
 LOADER_EXPORT XRAPI_ATTR XrResult XRAPI_CALL xrInitializeLoaderKHR(const XrLoaderInitInfoBaseHeaderKHR *loaderInitInfo) {
     return LoaderXrInitializeLoaderKHR(loaderInitInfo);
 }
-#endif

--- a/thirdparty/openxr/src/loader/loader_init_data.cpp
+++ b/thirdparty/openxr/src/loader/loader_init_data.cpp
@@ -7,55 +7,127 @@
 // Initial Author: Mark Young <marky@lunarg.com>
 //
 
+#include "loader_logger.hpp"
+#include "runtime_interface.hpp"
+#include "loader_instance.hpp"
 #include "loader_init_data.hpp"
+#include "loader_properties.hpp"
 
-#ifdef XR_KHR_LOADER_INIT_SUPPORT
-
-// Check and copy the Android-specific init data.
 XrResult LoaderInitData::initialize(const XrLoaderInitInfoBaseHeaderKHR* info) {
-#if defined(XR_USE_PLATFORM_ANDROID)
-    if (info->type != XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR) {
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
-    auto cast_info = reinterpret_cast<XrLoaderInitInfoAndroidKHR const*>(info);
+    // We iterate the chain per struct type, so we only pick the first of each type in the chain.
 
-    if (cast_info->applicationVM == nullptr) {
-        return XR_ERROR_VALIDATION_FAILURE;
-    }
-    if (cast_info->applicationContext == nullptr) {
-        return XR_ERROR_VALIDATION_FAILURE;
+    XrResult result = initializeProperties(info);
+    if (result != XR_SUCCESS) {
+        return result;
     }
 
-    // Copy and store the JVM pointer and Android Context, ensuring the JVM is initialised.
-    _data = *cast_info;
-    _data.next = nullptr;
-    jni::init(static_cast<jni::JavaVM*>(_data.applicationVM));
-    const jni::Object context = jni::Object{static_cast<jni::jobject>(_data.applicationContext)};
-
-    // Retrieve a reference to the Android AssetManager.
-    const auto assetManager = context.call<jni::Object>("getAssets()Landroid/content/res/AssetManager;");
-    _android_asset_manager = AAssetManager_fromJava(jni::env(), assetManager.getHandle());
-
-    // Retrieve the path to the native libraries.
-    const auto applicationContext = context.call<jni::Object>("getApplicationContext()Landroid/content/Context;");
-    const auto applicationInfo = context.call<jni::Object>("getApplicationInfo()Landroid/content/pm/ApplicationInfo;");
-    _native_library_path = applicationInfo.get<std::string>("nativeLibraryDir");
-#else
-#error "Platform specific XR_KHR_loader_init structure is not defined for this platform."
-#endif  // XR_USE_PLATFORM_ANDROID
+#if defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+    result = initializePlatform(info);
+    if (result != XR_SUCCESS) {
+        return result;
+    }
+#endif  // defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 
     _initialized = true;
     return XR_SUCCESS;
 }
 
+XrResult LoaderInitData::initializeProperties(const XrLoaderInitInfoBaseHeaderKHR* info) {
+    while (info != nullptr) {
+        if (info->type == XR_TYPE_LOADER_INIT_INFO_PROPERTIES_EXT) {
+            const auto* propertyInfo = reinterpret_cast<XrLoaderInitInfoPropertiesEXT const*>(info);
+
+            // Validate the inputs first.
+            for (uint32_t i = 0; i < propertyInfo->propertyValueCount; i++) {
+                if (propertyInfo->propertyValues[i].name == nullptr) {
+                    return XR_ERROR_VALIDATION_FAILURE;
+                }
+                if (propertyInfo->propertyValues[i].value == nullptr) {
+                    return XR_ERROR_VALIDATION_FAILURE;
+                }
+                std::string view{propertyInfo->propertyValues[i].name};
+                if (view.size() == 0) {
+                    return XR_ERROR_VALIDATION_FAILURE;
+                }
+            }
+
+            // Inject provided properties into the loader property store.
+            LoaderProperty::ClearOverrides();
+            for (uint32_t i = 0; i < propertyInfo->propertyValueCount; i++) {
+                LoaderProperty::SetOverride(propertyInfo->propertyValues[i].name, propertyInfo->propertyValues[i].value);
+            }
+            // Take only the first such struct.
+            return XR_SUCCESS;
+        }
+        info = reinterpret_cast<const XrLoaderInitInfoBaseHeaderKHR*>(info->next);
+    }
+
+    // fine if we don't find this.
+    return XR_SUCCESS;
+}
+
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+XrResult LoaderInitData::initializePlatform(const XrLoaderInitInfoBaseHeaderKHR* info) {
+    // Check and copy the Android-specific init data.
+    while (info != nullptr) {
+        if (info->type == XR_TYPE_LOADER_INIT_INFO_ANDROID_KHR) {
+            auto cast_info = reinterpret_cast<XrLoaderInitInfoAndroidKHR const*>(info);
+
+            if (cast_info->applicationVM == nullptr) {
+                return XR_ERROR_VALIDATION_FAILURE;
+            }
+            if (cast_info->applicationContext == nullptr) {
+                return XR_ERROR_VALIDATION_FAILURE;
+            }
+
+            // Copy and store the JVM pointer and Android Context, ensuring the JVM is initialised.
+            _platform_info = *cast_info;
+            _platform_info.next = nullptr;  // Not safe to store next pointer since the memory may not exist later.
+
+            if (_platform_info.applicationVM == nullptr) {
+                return XR_ERROR_VALIDATION_FAILURE;
+            }
+            if (_platform_info.applicationContext == nullptr) {
+                return XR_ERROR_VALIDATION_FAILURE;
+            }
+            jni::init(static_cast<jni::JavaVM*>(_platform_info.applicationVM));
+            const jni::Object context = jni::Object{static_cast<jni::jobject>(_platform_info.applicationContext)};
+
+            // Retrieve a reference to the Android AssetManager.
+            const auto assetManager = context.call<jni::Object>("getAssets()Landroid/content/res/AssetManager;");
+            _android_asset_manager = AAssetManager_fromJava(jni::env(), assetManager.getHandle());
+
+            // Retrieve the path to the native libraries.
+            const auto applicationContext = context.call<jni::Object>("getApplicationContext()Landroid/content/Context;");
+            const auto applicationInfo = context.call<jni::Object>("getApplicationInfo()Landroid/content/pm/ApplicationInfo;");
+            _android_native_library_path = applicationInfo.get<std::string>("nativeLibraryDir");
+
+            // Take only the first such struct.
+            return XR_SUCCESS;
+        }
+        info = reinterpret_cast<const XrLoaderInitInfoBaseHeaderKHR*>(info->next);
+    }
+
+    // We didn't find one.
+    return XR_ERROR_VALIDATION_FAILURE;
+}
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+
 XrResult InitializeLoaderInitData(const XrLoaderInitInfoBaseHeaderKHR* loaderInitInfo) {
+    if (!ActiveLoaderInstance::IsAvailable()) {
+        LoaderLogger::LogVerboseMessage("InitializeLoaderInitData", "Unloading any previously loaded runtime");
+        // This will not shutdown the runtime, only unload the library.
+        RuntimeInterface::UnloadRuntime("InitializeLoaderInitData");
+    } else {
+        LoaderLogger::LogErrorMessage("InitializeLoaderInitData",
+                                      "An active instance currently exists while trying to reinitialize the loader");
+        return XR_ERROR_INITIALIZATION_FAILED;
+    }
     return LoaderInitData::instance().initialize(loaderInitInfo);
 }
 
-#ifdef XR_USE_PLATFORM_ANDROID
-std::string GetAndroidNativeLibraryDir() { return LoaderInitData::instance()._native_library_path; }
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+std::string GetAndroidNativeLibraryDir() { return LoaderInitData::instance()._android_native_library_path; }
 
-void* Android_Get_Asset_Manager() { return LoaderInitData::instance()._android_asset_manager; }
-#endif  // XR_USE_PLATFORM_ANDROID
-
-#endif  // XR_KHR_LOADER_INIT_SUPPORT
+void* GetAndroidAssetManager() { return LoaderInitData::instance()._android_asset_manager; }
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)

--- a/thirdparty/openxr/src/loader/loader_init_data.hpp
+++ b/thirdparty/openxr/src/loader/loader_init_data.hpp
@@ -12,13 +12,21 @@
 #include <xr_dependencies.h>
 #include <openxr/openxr_platform.h>
 
-#ifdef XR_USE_PLATFORM_ANDROID
+#if defined(XR_USE_PLATFORM_ANDROID)
 #include <json/value.h>
 #include <android/asset_manager_jni.h>
 #include "android_utilities.h"
-#endif  // XR_USE_PLATFORM_ANDROID
 
-#ifdef XR_KHR_LOADER_INIT_SUPPORT
+// Warning: For system software use only. Enabling this define in regular applications
+// will make it incompatible with many conformant runtimes.
+#if !defined(XR_DISABLE_LOADER_INIT_ANDROID_LOADER_KHR)
+/*!
+ * Later code will assume that if this is defined then a platform-specific struct
+ * must be provided for successful initialization.
+ */
+#define XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT
+#endif  // !defined(XR_DISABLE_LOADER_INIT_ANDROID_LOADER_KHR)
+#endif  // defined(XR_USE_PLATFORM_ANDROID)
 
 /*!
  * Stores a copy of the data passed to the xrInitializeLoaderKHR function in a singleton.
@@ -33,32 +41,42 @@ class LoaderInitData {
         return obj;
     }
 
-#if defined(XR_USE_PLATFORM_ANDROID)
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
     /*!
      * Type alias for the platform-specific structure type.
      */
-    using StructType = XrLoaderInitInfoAndroidKHR;
+    using PlatformStructType = XrLoaderInitInfoAndroidKHR;
+
     /*!
      * Native library path.
      */
-    std::string _native_library_path;
+    std::string _android_native_library_path;
     /*!
      * Android asset manager.
      */
     AAssetManager* _android_asset_manager;
-#else
-#error "Platform specific XR_KHR_loader_init structure is not defined for this platform."
 #endif
 
     /*!
      * Get our copy of the data, casted to pass to the runtime's matching method.
+     * Only some platforms have platform-specific loader init info.
      */
-    const XrLoaderInitInfoBaseHeaderKHR* getParam() const { return reinterpret_cast<const XrLoaderInitInfoBaseHeaderKHR*>(&_data); }
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    const XrLoaderInitInfoBaseHeaderKHR* getPlatformParam() {
+#if defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+        return reinterpret_cast<const XrLoaderInitInfoBaseHeaderKHR*>(&_platform_info);
+#else
+        return nullptr;
+#endif
+    }
+
+#if defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 
     /*!
      * Get the data via its real structure type.
      */
-    const StructType& getData() const { return _data; }
+    const PlatformStructType& getPlatformData() const { return _platform_info; }
+#endif
 
     /*!
      * Has this been correctly initialized?
@@ -67,26 +85,42 @@ class LoaderInitData {
 
     /*!
      * Initialize loader data - called by InitializeLoaderInitData() and thus ultimately by the loader's xrInitializeLoaderKHR
-     * implementation. Each platform that needs this extension will provide an implementation of this.
+     * implementation.
      */
     XrResult initialize(const XrLoaderInitInfoBaseHeaderKHR* info);
 
    private:
     //! Private constructor, forces use of singleton accessor.
     LoaderInitData() = default;
-    //! Platform-specific init data
-    StructType _data = {};
-    //! Flag for indicating whether _data is valid.
+
+    /*!
+     * Initialize non-platform-specific loader data.
+     */
+    // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+    XrResult initializeProperties(const XrLoaderInitInfoBaseHeaderKHR* info);
+
+    /*!
+     * Initialize platform-specific loader data - called ultimately by the loader's xrInitializeLoaderKHR
+     * implementation. Each platform that needs this extension will provide an implementation of this.
+     */
+    XrResult initializePlatform(const XrLoaderInitInfoBaseHeaderKHR* info);
+
+#if defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+    /*!
+     * Only some platforms have platform-specific loader init info.
+     */
+    PlatformStructType _platform_info;
+#endif  // defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+
+    //! Flag for indicating whether _platform_info is valid.
     bool _initialized = false;
 };
 
 //! Initialize loader init data, where required.
 XrResult InitializeLoaderInitData(const XrLoaderInitInfoBaseHeaderKHR* loaderInitInfo);
 
-#ifdef XR_USE_PLATFORM_ANDROID
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 XrResult GetPlatformRuntimeVirtualManifest(Json::Value& out_manifest);
 std::string GetAndroidNativeLibraryDir();
-void* Android_Get_Asset_Manager();
-#endif  // XR_USE_PLATFORM_ANDROID
-
-#endif  // XR_KHR_LOADER_INIT_SUPPORT
+void* GetAndroidAssetManager();
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)

--- a/thirdparty/openxr/src/loader/loader_logger.cpp
+++ b/thirdparty/openxr/src/loader/loader_logger.cpp
@@ -12,6 +12,7 @@
 #include "extra_algorithms.h"
 #include "hex_and_handles.h"
 #include "loader_logger_recorders.hpp"
+#include "loader_properties.hpp"
 #include "platform_utils.hpp"
 
 #include <openxr/openxr.h>
@@ -102,7 +103,7 @@ XrDebugUtilsMessageTypeFlagsEXT LoaderLogMessageTypesToDebugUtilsMessageTypes(Xr
 }
 
 LoaderLogger::LoaderLogger() {
-    std::string debug_string = PlatformUtilsGetEnv("XR_LOADER_DEBUG");
+    std::string debug_string = LoaderProperty::Get("XR_LOADER_DEBUG");
 
     // Add an error logger by default so that we at least get errors out to std::cerr.
     // Normally we enable stderr output. But if the XR_LOADER_DEBUG environment variable is

--- a/thirdparty/openxr/src/loader/loader_properties.cpp
+++ b/thirdparty/openxr/src/loader/loader_properties.cpp
@@ -1,0 +1,80 @@
+// Copyright (c) 2017-2025 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+#include "loader_properties.hpp"
+#include <platform_utils.hpp>
+
+#include <string>
+#include <unordered_map>
+#include <mutex>
+
+namespace {
+
+std::mutex& GetOverridePropertiesMutex() {
+    static std::mutex override_properties_mutex;
+    return override_properties_mutex;
+}
+
+std::unordered_map<std::string, std::string>& GetOverrideProperties() {
+    static std::unordered_map<std::string, std::string> override_properties;
+    return override_properties;
+}
+
+const std::string* TryGetPropertyOverride(const std::string& name) {
+    const auto& overrideProperties = GetOverrideProperties();
+    const auto& overrideProperty = overrideProperties.find(name);
+    if (overrideProperty != overrideProperties.end()) {
+        return &overrideProperty->second;
+    }
+    return nullptr;
+}
+
+}  // namespace
+
+// Loader property overrides take precedence over system environment variables because environment variables are not always
+// safe to use (and thus would be ignored). For example, override properties may be the only way to redirect XR_RUNTIME_JSON
+// from an elevated process on Windows.
+
+namespace LoaderProperty {
+
+std::string Get(const std::string& name) {
+    std::lock_guard<std::mutex> lock(GetOverridePropertiesMutex());
+    const std::string* propertyOverride = TryGetPropertyOverride(name);
+    if (propertyOverride != nullptr) {
+        return *propertyOverride;
+    } else {
+        return PlatformUtilsGetEnv(name.c_str());
+    }
+}
+
+std::string GetSecure(const std::string& name) {
+    std::lock_guard<std::mutex> lock(GetOverridePropertiesMutex());
+    const std::string* propertyOverride = TryGetPropertyOverride(name);
+    if (propertyOverride != nullptr) {
+        return *propertyOverride;
+    } else {
+        return PlatformUtilsGetSecureEnv(name.c_str());
+    }
+}
+
+bool IsSet(const std::string& name) {
+    std::lock_guard<std::mutex> lock(GetOverridePropertiesMutex());
+    const std::string* propertyOverride = TryGetPropertyOverride(name);
+    return propertyOverride != nullptr || PlatformUtilsGetEnvSet(name.c_str());
+}
+
+void SetOverride(std::string name, std::string value) {
+    std::lock_guard<std::mutex> lock(GetOverridePropertiesMutex());
+    auto& overrideProperties = GetOverrideProperties();
+    overrideProperties.insert(std::make_pair(std::move(name), std::move(value)));
+}
+
+void ClearOverrides() {
+    std::lock_guard<std::mutex> lock(GetOverridePropertiesMutex());
+    auto& overrideProperties = GetOverrideProperties();
+    overrideProperties.clear();
+}
+
+}  // namespace LoaderProperty

--- a/thirdparty/openxr/src/loader/loader_properties.hpp
+++ b/thirdparty/openxr/src/loader/loader_properties.hpp
@@ -1,0 +1,18 @@
+// Copyright (c) 2017-2025 The Khronos Group Inc.
+//
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+//
+
+#pragma once
+
+#include <string>
+
+// Exposes a centralized way to read properties which may be passed to the loader through xrInitializeLoaderKHR or available through
+// environment variables.
+namespace LoaderProperty {
+std::string Get(const std::string& name);
+std::string GetSecure(const std::string& name);
+bool IsSet(const std::string& name);
+void SetOverride(std::string name, std::string value);
+void ClearOverrides();
+}  // namespace LoaderProperty

--- a/thirdparty/openxr/src/loader/manifest_file.cpp
+++ b/thirdparty/openxr/src/loader/manifest_file.cpp
@@ -20,6 +20,7 @@
 #include "filesystem_utils.hpp"
 #include "loader_init_data.hpp"
 #include "loader_platform.hpp"
+#include "loader_properties.hpp"
 #include "platform_utils.hpp"
 #include "loader_logger.hpp"
 #include "unique_asset.h"
@@ -52,7 +53,7 @@
 #define SYSCONFDIR "/etc"
 #endif  // !SYSCONFDIR
 
-#ifdef XR_USE_PLATFORM_ANDROID
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 #include <android/asset_manager.h>
 #endif
 
@@ -192,7 +193,7 @@ static void ReadDataFilesInSearchPaths(const std::string &override_env_var, cons
         }
 #endif
         if (permit_override) {
-            override_path = PlatformUtilsGetSecureEnv(override_env_var.c_str());
+            override_path = LoaderProperty::GetSecure(override_env_var);
         }
     }
 
@@ -206,10 +207,10 @@ static void ReadDataFilesInSearchPaths(const std::string &override_env_var, cons
 
         // Determine how much space is needed to generate the full search path
         // for the current manifest files.
-        std::string xdg_conf_dirs = PlatformUtilsGetSecureEnv("XDG_CONFIG_DIRS");
-        std::string xdg_data_dirs = PlatformUtilsGetSecureEnv("XDG_DATA_DIRS");
-        std::string xdg_data_home = PlatformUtilsGetSecureEnv("XDG_DATA_HOME");
-        std::string home = PlatformUtilsGetSecureEnv("HOME");
+        std::string xdg_conf_dirs = LoaderProperty::GetSecure("XDG_CONFIG_DIRS");
+        std::string xdg_data_dirs = LoaderProperty::GetSecure("XDG_DATA_DIRS");
+        std::string xdg_data_home = LoaderProperty::GetSecure("XDG_DATA_HOME");
+        std::string home = LoaderProperty::GetSecure("HOME");
 
         if (xdg_conf_dirs.empty()) {
             CopyIncludedPaths(true, FALLBACK_CONFIG_DIRS, relative_path, search_path);
@@ -254,11 +255,11 @@ static void ReadDataFilesInSearchPaths(const std::string &override_env_var, cons
 
 // Get an XDG environment variable with a $HOME-relative default
 static std::string GetXDGEnvHome(const char *name, const char *fallback_path) {
-    std::string result = PlatformUtilsGetSecureEnv(name);
+    std::string result = LoaderProperty::GetSecure(name);
     if (!result.empty()) {
         return result;
     }
-    result = PlatformUtilsGetSecureEnv("HOME");
+    result = LoaderProperty::GetSecure("HOME");
     if (result.empty()) {
         return result;
     }
@@ -269,7 +270,7 @@ static std::string GetXDGEnvHome(const char *name, const char *fallback_path) {
 
 // Get an XDG environment variable with absolute defaults
 static std::string GetXDGEnvAbsolute(const char *name, const char *fallback_paths) {
-    std::string result = PlatformUtilsGetSecureEnv(name);
+    std::string result = LoaderProperty::GetSecure(name);
     if (!result.empty()) {
         return result;
     }
@@ -310,6 +311,7 @@ static bool FindEitherActiveRuntimeFilename(const char *prefix_desc, const std::
 // precedence order.
 static bool FindXDGConfigFile(const char *relative_dir, uint16_t major_version, std::string &out) {
     const std::string message{"Looking for active_runtime." XR_ARCH_ABI ".json or active_runtime.json"};
+    LoaderLogger::LogInfoMessage("", message);
     std::string dir_prefix = GetXDGEnvHome("XDG_CONFIG_HOME", ".config");
     if (!dir_prefix.empty()) {
         dir_prefix += "/";
@@ -512,7 +514,7 @@ void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionPropert
     GetExtensionProperties(_instance_extensions, props);
 }
 
-const std::string &ManifestFile::GetFunctionName(const std::string &func_name) const {
+std::string ManifestFile::GetFunctionName(const std::string &func_name) const {
     if (!_functions_renamed.empty()) {
         auto found = _functions_renamed.find(func_name);
         if (found != _functions_renamed.end()) {
@@ -649,7 +651,7 @@ void RuntimeManifestFile::CreateIfValid(const Json::Value &root_node, const std:
 XrResult RuntimeManifestFile::FindManifestFiles(const std::string &openxr_command,
                                                 std::vector<std::unique_ptr<RuntimeManifestFile>> &manifest_files) {
     XrResult result = XR_SUCCESS;
-    std::string filename = PlatformUtilsGetSecureEnv(OPENXR_RUNTIME_JSON_ENV_VAR);
+    std::string filename = LoaderProperty::GetSecure(OPENXR_RUNTIME_JSON_ENV_VAR);
     if (!filename.empty()) {
         LoaderLogger::LogInfoMessage(
             openxr_command,
@@ -680,14 +682,15 @@ XrResult RuntimeManifestFile::FindManifestFiles(const std::string &openxr_comman
         }
 #else  // !defined(XR_OS_WINDOWS) && !defined(XR_OS_LINUX)
 
-#if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
         Json::Value virtualManifest;
         result = GetPlatformRuntimeVirtualManifest(virtualManifest);
         if (XR_SUCCESS == result) {
             RuntimeManifestFile::CreateIfValid(virtualManifest, "", manifest_files);
             return result;
         }
-#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+
         if (!PlatformGetGlobalRuntimeFileName(XR_VERSION_MAJOR(XR_CURRENT_API_VERSION), filename)) {
             LoaderLogger::LogErrorMessage(
                 openxr_command,
@@ -713,7 +716,7 @@ ApiLayerManifestFile::ApiLayerManifestFile(ManifestFileType type, const std::str
       _description(description),
       _implementation_version(implementation_version) {}
 
-#if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 void ApiLayerManifestFile::AddManifestFilesAndroid(const std::string &openxr_command, ManifestFileType type,
                                                    std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
     if (!LoaderInitData::instance().initialized()) {
@@ -724,7 +727,7 @@ void ApiLayerManifestFile::AddManifestFilesAndroid(const std::string &openxr_com
         return;
     }
 
-    AAssetManager *assetManager = (AAssetManager *)Android_Get_Asset_Manager();
+    AAssetManager *assetManager = (AAssetManager *)GetAndroidAssetManager();
     std::vector<std::string> filenames;
     {
         std::string search_path = "";
@@ -776,7 +779,7 @@ void ApiLayerManifestFile::AddManifestFilesAndroid(const std::string &openxr_com
         CreateIfValid(type, filename, json_stream, &ApiLayerManifestFile::LocateLibraryInAssets, manifest_files);
     }
 }
-#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 
 void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, const std::string &filename, std::istream &json_stream,
                                          LibraryLocator locate_library,
@@ -825,14 +828,14 @@ void ApiLayerManifestFile::CreateIfValid(ManifestFileType type, const std::strin
         if (!layer_root_node["enable_environment"].isNull() && layer_root_node["enable_environment"].isString()) {
             std::string env_var = layer_root_node["enable_environment"].asString();
             // If it's not set in the environment, disable the layer
-            if (!PlatformUtilsGetEnvSet(env_var.c_str())) {
+            if (!LoaderProperty::IsSet(env_var)) {
                 enabled = false;
             }
         }
         // Check for the disable environment variable, which must be provided in the JSON
         std::string env_var = layer_root_node["disable_environment"].asString();
         // If the env var is set, disable the layer. Disable env var overrides enable above
-        if (PlatformUtilsGetEnvSet(env_var.c_str())) {
+        if (LoaderProperty::IsSet(env_var)) {
             enabled = false;
         }
 
@@ -920,7 +923,7 @@ bool ApiLayerManifestFile::LocateLibraryRelativeToJson(
     return true;
 }
 
-#if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 bool ApiLayerManifestFile::LocateLibraryInAssets(const std::string & /* json_filename */, const std::string &library_path,
                                                  std::string &out_combined_path) {
     std::string combined_path;
@@ -932,7 +935,7 @@ bool ApiLayerManifestFile::LocateLibraryInAssets(const std::string & /* json_fil
     out_combined_path = combined_path;
     return true;
 }
-#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 
 void ApiLayerManifestFile::PopulateApiLayerProperties(XrApiLayerProperties &props) const {
     props.layerVersion = _implementation_version;
@@ -952,7 +955,9 @@ XrResult ApiLayerManifestFile::FindManifestFiles(const std::string &openxr_comma
                                                  std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files) {
     std::string relative_path;
     std::string override_env_var;
+#ifdef XR_OS_WINDOWS
     std::string registry_location;
+#endif
 
     // Add the appropriate top-level folders for the relative path.  These should be
     // the string "openxr/" followed by the API major version as a string.
@@ -995,9 +1000,9 @@ XrResult ApiLayerManifestFile::FindManifestFiles(const std::string &openxr_comma
         ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
     }
 
-#if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
+#if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
     ApiLayerManifestFile::AddManifestFilesAndroid(openxr_command, type, manifest_files);
-#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)
+#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
 
     return XR_SUCCESS;
 }

--- a/thirdparty/openxr/src/loader/manifest_file.hpp
+++ b/thirdparty/openxr/src/loader/manifest_file.hpp
@@ -51,7 +51,7 @@ class ManifestFile {
     const std::string &Filename() const { return _filename; }
     const std::string &LibraryPath() const { return _library_path; }
     void GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props);
-    const std::string &GetFunctionName(const std::string &func_name) const;
+    std::string GetFunctionName(const std::string &func_name) const;
 
    protected:
     ManifestFile(ManifestFileType type, const std::string &filename, const std::string &library_path);
@@ -107,12 +107,13 @@ class ApiLayerManifestFile : public ManifestFile {
     static bool LocateLibraryRelativeToJson(const std::string &json_filename, const std::string &library_path,
                                             std::string &out_combined_path);
 
-#if defined(XR_KHR_LOADER_INIT_SUPPORT) && defined(XR_USE_PLATFORM_ANDROID)
+    // actually only implemented if defined(XR_USE_PLATFORM_ANDROID) && defined(XR_HAS_REQUIRED_PLATFORM_LOADER_INIT_STRUCT)
+#if defined(XR_USE_PLATFORM_ANDROID)
     static bool LocateLibraryInAssets(const std::string &json_filename, const std::string &library_path,
                                       std::string &out_combined_path);
     static void AddManifestFilesAndroid(const std::string &openxr_command, ManifestFileType type,
                                         std::vector<std::unique_ptr<ApiLayerManifestFile>> &manifest_files);
-#endif  // defined(XR_USE_PLATFORM_ANDROID) && defined(XR_KHR_LOADER_INIT_SUPPORT)
+#endif  // defined(XR_USE_PLATFORM_ANDROID)
 
     JsonVersion _api_version;
     std::string _layer_name;


### PR DESCRIPTION
Just updating the thirdparty library to OpenXR 1.1.52 which came out a few days ago.

There are some new core APIs we're eager to add support for.