### PR TITLE
Add UID support in global class cache

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1431,10 +1431,10 @@ void ProjectSettings::refresh_global_class_list() {
 	Array script_classes = get_global_class_list();
 	for (int i = 0; i < script_classes.size(); i++) {
 		Dictionary c = script_classes[i];
-		if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+		if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 			continue;
 		}
-		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 	}
 }
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -287,10 +287,10 @@ void ScriptServer::init_languages() {
 
 			for (const Variant &script_class : script_classes) {
 				Dictionary c = script_class;
-				if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+				if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 					continue;
 				}
-				add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+				add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 			}
 			ProjectSettings::get_singleton()->clear("_global_script_classes");
 		}
@@ -299,10 +299,10 @@ void ScriptServer::init_languages() {
 		Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
 		for (const Variant &script_class : script_classes) {
 			Dictionary c = script_class;
-			if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+			if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 				continue;
 			}
-			add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+			add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 		}
 	}
 
@@ -411,23 +411,25 @@ void ScriptServer::global_classes_clear() {
 	inheriters_cache.clear();
 }
 
-void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool) {
+void ScriptServer::add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool, const ResourceUID::ID &p_uid) {
 	ERR_FAIL_COND_MSG(p_class == p_base || (global_classes.has(p_base) && get_global_class_native_base(p_base) == p_class), "Cyclic inheritance in script class.");
 	GlobalScriptClass *existing = global_classes.getptr(p_class);
 	if (existing) {
 		// Update an existing class (only set dirty if something changed).
-		if (existing->base != p_base || existing->path != p_path || existing->language != p_language) {
+		if (existing->base != p_base || existing->path != p_path || existing->language != p_language || existing->uid != p_uid) {
 			existing->base = p_base;
+			existing->uid = p_uid;
 			existing->path = p_path;
 			existing->language = p_language;
-			existing->is_abstract = p_is_abstract;
-			existing->is_tool = p_is_tool;
 			inheriters_cache_dirty = true;
 		}
+		existing->is_abstract = p_is_abstract;
+		existing->is_tool = p_is_tool;
 	} else {
 		// Add new class.
 		GlobalScriptClass g;
 		g.language = p_language;
+		g.uid = p_uid;
 		g.path = p_path;
 		g.base = p_base;
 		g.is_abstract = p_is_abstract;
@@ -495,6 +497,11 @@ StringName ScriptServer::get_global_class_language(const StringName &p_class) {
 	return global_classes[p_class].language;
 }
 
+ResourceUID::ID ScriptServer::get_global_class_uid(const String &p_class) {
+	ERR_FAIL_COND_V(!global_classes.has(p_class), ResourceUID::INVALID_ID);
+	return global_classes[p_class].uid;
+}
+
 String ScriptServer::get_global_class_path(const String &p_class) {
 	ERR_FAIL_COND_V(!global_classes.has(p_class), String());
 	return global_classes[p_class].path;
@@ -538,16 +545,19 @@ void ScriptServer::get_global_class_list(LocalVector<StringName> &r_global_class
 	sorter.sort(&r_global_classes[r_global_classes.size() - global_classes.size()], global_classes.size());
 }
 
-void ScriptServer::save_global_classes() {
-	Dictionary class_icons;
-
-	Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
-	for (const Variant &script_class : script_classes) {
-		Dictionary d = script_class;
-		if (!d.has("name") || !d.has("icon")) {
-			continue;
+void ScriptServer::save_global_classes(const HashMap<StringName, String> &p_script_class_icon_paths) {
+	HashMap<StringName, String> script_class_icon_paths;
+	if (p_script_class_icon_paths.is_empty()) {
+		Array script_classes = ProjectSettings::get_singleton()->get_global_class_list();
+		for (const Variant &script_class : script_classes) {
+			Dictionary d = script_class;
+			if (!d.has("name") || !d.has("icon")) {
+				continue;
+			}
+			script_class_icon_paths[d["name"]] = d["icon"];
 		}
-		class_icons[d["name"]] = d["icon"];
+	} else {
+		script_class_icon_paths = p_script_class_icon_paths;
 	}
 
 	LocalVector<StringName> gc;
@@ -555,12 +565,14 @@ void ScriptServer::save_global_classes() {
 	Array gcarr;
 	for (const StringName &class_name : gc) {
 		const GlobalScriptClass &global_class = global_classes[class_name];
+		String *icon = script_class_icon_paths.getptr(class_name);
 		Dictionary d;
 		d["class"] = class_name;
 		d["language"] = global_class.language;
+		d["uid"] = ResourceUID::get_singleton()->id_to_text(global_class.uid);
 		d["path"] = global_class.path;
 		d["base"] = global_class.base;
-		d["icon"] = class_icons.get(class_name, "");
+		d["icon"] = icon ? *icon : String();
 		d["is_abstract"] = global_class.is_abstract;
 		d["is_tool"] = global_class.is_tool;
 		gcarr.push_back(d);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -59,6 +59,7 @@ class ScriptServer {
 
 	struct GlobalScriptClass {
 		StringName language;
+		ResourceUID::ID uid = ResourceUID::INVALID_ID;
 		String path;
 		StringName base;
 		bool is_abstract = false;
@@ -85,11 +86,12 @@ public:
 	static void thread_exit();
 
 	static void global_classes_clear();
-	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool);
+	static void add_global_class(const StringName &p_class, const StringName &p_base, const StringName &p_language, const String &p_path, bool p_is_abstract, bool p_is_tool, const ResourceUID::ID &p_uid = ResourceUID::INVALID_ID);
 	static void remove_global_class(const StringName &p_class);
 	static void remove_global_class_by_path(const String &p_path);
 	static bool is_global_class(const StringName &p_class);
 	static StringName get_global_class_language(const StringName &p_class);
+	static ResourceUID::ID get_global_class_uid(const String &p_class);
 	static String get_global_class_path(const String &p_class);
 	static StringName get_global_class_base(const String &p_class);
 	static StringName get_global_class_native_base(const String &p_class);
@@ -98,7 +100,7 @@ public:
 	static void get_global_class_list(LocalVector<StringName> &r_global_classes);
 	static void get_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
 	static void get_indirect_inheriters_list(const StringName &p_base_type, List<StringName> *r_classes);
-	static void save_global_classes();
+	static void save_global_classes(const HashMap<StringName, String> &p_script_class_icon_paths = {});
 
 	static Vector<Ref<ScriptBacktrace>> capture_script_backtraces(bool p_include_variables = false);
 

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1070,22 +1070,7 @@ void EditorData::script_class_set_name(const String &p_path, const StringName &p
 }
 
 void EditorData::script_class_save_global_classes() {
-	LocalVector<StringName> global_classes;
-	ScriptServer::get_global_class_list(global_classes);
-	Array array_classes;
-	for (const StringName &class_name : global_classes) {
-		Dictionary d;
-		String *icon = _script_class_icon_paths.getptr(class_name);
-		d["class"] = class_name;
-		d["language"] = ScriptServer::get_global_class_language(class_name);
-		d["path"] = ScriptServer::get_global_class_path(class_name);
-		d["base"] = ScriptServer::get_global_class_base(class_name);
-		d["icon"] = icon ? *icon : String();
-		d["is_abstract"] = ScriptServer::is_global_class_abstract(class_name);
-		d["is_tool"] = ScriptServer::is_global_class_tool(class_name);
-		array_classes.push_back(d);
-	}
-	ProjectSettings::get_singleton()->store_global_class_list(array_classes);
+	ScriptServer::save_global_classes(_script_class_icon_paths);
 }
 
 void EditorData::script_class_load_icon_paths() {

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -2141,7 +2141,7 @@ void EditorFileSystem::_update_script_classes() {
 	if (update_script_paths.is_empty()) {
 		// Ensure the global class file is always present; it's essential for exports to work.
 		if (!FileAccess::exists(ProjectSettings::get_singleton()->get_global_class_list_path())) {
-			ScriptServer::save_global_classes();
+			EditorNode::get_editor_data().script_class_save_global_classes();
 		}
 		return;
 	}
@@ -2565,8 +2565,8 @@ void EditorFileSystem::_register_global_class_script(const String &p_search_path
 	if (lang.is_empty()) {
 		return; // No lang found that can handle this global class
 	}
-
-	ScriptServer::add_global_class(p_script_update.name, p_script_update.extends, lang, p_target_path, p_script_update.is_abstract, p_script_update.is_tool);
+	ResourceUID::ID uid = first_scan && !scanning ? ResourceLoader::get_resource_uid(p_target_path) : get_file_uid(p_target_path);
+	ScriptServer::add_global_class(p_script_update.name, p_script_update.extends, lang, p_target_path, p_script_update.is_abstract, p_script_update.is_tool, uid);
 	EditorNode::get_editor_data().script_class_set_icon_path(p_script_update.name, p_script_update.icon_path);
 	EditorNode::get_editor_data().script_class_set_name(p_target_path, p_script_update.name);
 }

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -382,8 +382,8 @@ static bool generate_class_index_recursive(const String &p_dir) {
 			}
 			ERR_FAIL_COND_V_MSG(ScriptServer::is_global_class(class_name), false,
 					"Class name '" + class_name + "' from " + source_file + " is already used in " + ScriptServer::get_global_class_path(class_name));
-
-			ScriptServer::add_global_class(class_name, base_type, gdscript_name, source_file, is_abstract, is_tool);
+			ResourceUID::ID uid = ResourceLoader::get_resource_uid(source_file);
+			ScriptServer::add_global_class(class_name, base_type, gdscript_name, source_file, is_abstract, is_tool, uid);
 		}
 
 		next = dir->get_next();

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -252,8 +252,8 @@ static void setup_global_classes(const String &p_dir) {
 			}
 			ERR_FAIL_COND_MSG(ScriptServer::is_global_class(class_name),
 					"Class name \"" + class_name + "\" from \"" + source_file + "\" is already used in \"" + ScriptServer::get_global_class_path(class_name) + "\".");
-
-			ScriptServer::add_global_class(class_name, base_type, GDScriptLanguage::get_singleton()->get_name(), source_file, is_abstract, is_tool);
+			ResourceUID::ID uid = ResourceLoader::get_resource_uid(source_file);
+			ScriptServer::add_global_class(class_name, base_type, GDScriptLanguage::get_singleton()->get_name(), source_file, is_abstract, is_tool, uid);
 		}
 		next = dir->get_next();
 	}

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -317,10 +317,10 @@ void test(TestType p_type) {
 	TypedArray<Dictionary> script_classes = ProjectSettings::get_singleton()->get_global_class_list();
 	for (int i = 0; i < script_classes.size(); i++) {
 		Dictionary c = script_classes[i];
-		if (!c.has("class") || !c.has("language") || !c.has("path") || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
+		if (!c.has("class") || !c.has("language") || (!c.has("uid") && !c.has("path")) || !c.has("base") || !c.has("is_abstract") || !c.has("is_tool")) {
 			continue;
 		}
-		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"]);
+		ScriptServer::add_global_class(c["class"], c["base"], c["language"], c["path"], c["is_abstract"], c["is_tool"], ResourceUID::get_singleton()->text_to_id(c["uid"]));
 	}
 
 	Vector<uint8_t> buf;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

UID makes it possible to track file movements outside the editor.
At the same time, the saving logic of the global script class is unified. 

This is also a step in preparation for godotengine/godot-proposals#13196, because we require global script class names to be unique. However, we accept that global script class files with the same name already exist (perhaps due to duplication). Therefore, we may need to check the file path of the activated global script class, and UID has an advantage over file path.