### PR TITLE
Use an array instead of `TightLocalVector` in `RasterizerSceneGLES3::_render_uv2`, to avoid allocation.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3839,12 +3839,13 @@ void RasterizerSceneGLES3::_render_uv2(const PagedArray<RenderGeometryInstance *
 		scene_state.enable_gl_depth_draw(true);
 		scene_state.set_gl_depth_func(GL_GREATER);
 
-		TightLocalVector<GLenum> draw_buffers;
-		draw_buffers.push_back(GL_COLOR_ATTACHMENT0);
-		draw_buffers.push_back(GL_COLOR_ATTACHMENT1);
-		draw_buffers.push_back(GL_COLOR_ATTACHMENT2);
-		draw_buffers.push_back(GL_COLOR_ATTACHMENT3);
-		glDrawBuffers(draw_buffers.size(), draw_buffers.ptr());
+		constexpr GLenum draw_buffers[]{
+			GL_COLOR_ATTACHMENT0,
+			GL_COLOR_ATTACHMENT1,
+			GL_COLOR_ATTACHMENT2,
+			GL_COLOR_ATTACHMENT3
+		};
+		glDrawBuffers(std::size(draw_buffers), draw_buffers);
 
 		glClearColor(0.0, 0.0, 0.0, 0.0);
 		RasterizerGLES3::clear_depth(0.0);


### PR DESCRIPTION
Just something small I randomly came across.
Due to misuse of `TightLocalVector`, this actually avoids 4 allocations.