### PR TITLE
Use Window instead of Control for grab preview

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -365,6 +365,12 @@
 				Centers a native window on the current screen and an embedded window on its embedder [Viewport].
 			</description>
 		</method>
+		<method name="move_to_mouse">
+			<return type="void" />
+			<description>
+				Moves the window to the current mouse position.
+			</description>
+		</method>
 		<method name="move_to_foreground" deprecated="Use [method Window.grab_focus] instead.">
 			<return type="void" />
 			<description>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -365,16 +365,16 @@
 				Centers a native window on the current screen and an embedded window on its embedder [Viewport].
 			</description>
 		</method>
-		<method name="move_to_mouse">
-			<return type="void" />
-			<description>
-				Moves the window to the current mouse position.
-			</description>
-		</method>
 		<method name="move_to_foreground" deprecated="Use [method Window.grab_focus] instead.">
 			<return type="void" />
 			<description>
 				Causes the window to grab focus, allowing it to receive user input.
+			</description>
+		</method>
+		<method name="move_to_mouse">
+			<return type="void" />
+			<description>
+				Moves the window to the current mouse position.
 			</description>
 		</method>
 		<method name="popup">

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -374,7 +374,7 @@
 		<method name="move_to_mouse">
 			<return type="void" />
 			<description>
-				Moves the window to the current mouse position.
+				Moves the top left corner of the window to the current mouse position.
 			</description>
 		</method>
 		<method name="popup">

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1854,8 +1854,8 @@ Control *Viewport::_gui_find_control_at_pos(CanvasItem *p_node, const Point2 &p_
 		return nullptr;
 	}
 
-	Control *drag_preview = _gui_get_drag_preview();
-	if (!drag_preview || (c != drag_preview && !drag_preview->is_ancestor_of(c))) {
+	Window *drag_preview = _gui_get_drag_preview();
+	if (!drag_preview || !drag_preview->is_ancestor_of(c)) {
 		return c;
 	}
 
@@ -2029,7 +2029,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 								gui.dragging = true;
 								break;
 							} else {
-								Control *drag_preview = _gui_get_drag_preview();
+								Window *drag_preview = _gui_get_drag_preview();
 								if (drag_preview) {
 									ERR_PRINT("Don't set a drag preview and return null data. Preview was deleted and drag request ignored.");
 									memdelete(drag_preview);
@@ -2150,10 +2150,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (gui.dragging) {
 			// Handle drag & drop. This happens in the viewport where dragging started.
 
-			Control *drag_preview = _gui_get_drag_preview();
+			Window *drag_preview = _gui_get_drag_preview();
 			if (drag_preview) {
-				Vector2 pos = drag_preview->get_canvas_transform().affine_inverse().xform(mpos);
-				drag_preview->set_position(pos);
+				drag_preview->move_to_mouse();
 			}
 
 			gui.drag_mouse_over = section_root->gui.target_control;
@@ -2390,7 +2389,7 @@ void Viewport::gui_perform_drop_at(const Point2 &p_pos, Control *p_control) {
 		gui.drag_successful = false;
 	}
 
-	Control *drag_preview = _gui_get_drag_preview();
+	Window *drag_preview = _gui_get_drag_preview();
 	if (drag_preview) {
 		memdelete(drag_preview);
 		gui.drag_preview_id = ObjectID();
@@ -2460,23 +2459,35 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 	ERR_FAIL_COND(p_control->is_inside_tree());
 	ERR_FAIL_COND(p_control->get_parent() != nullptr);
 
-	Control *drag_preview = _gui_get_drag_preview();
+	Window *drag_preview = _gui_get_drag_preview();
 	if (drag_preview) {
 		memdelete(drag_preview);
 	}
-	p_control->set_as_top_level(true);
-	p_control->set_position(gui.last_mouse_pos);
-	p_base->get_root_parent_control()->add_child(p_control); // Add as child of viewport.
-	p_control->move_to_front();
 
-	gui.drag_preview_id = p_control->get_instance_id();
+	Window *window = memnew(Window);
+	
+	window->wrap_controls = true;
+	window->set_flag(Window::FLAG_BORDERLESS, true);
+	window->set_flag(Window::FLAG_ALWAYS_ON_TOP, true);
+	window->set_flag(Window::FLAG_MOUSE_PASSTHROUGH, true);
+	window->set_flag(Window::FLAG_NO_FOCUS, true);
+	window->set_flag(Window::FLAG_TRANSPARENT, true);
+	window->wrap_controls = true;
+	window->set_size(Size2i(0, 0));
+	p_base->get_root_parent_control()->add_child(window);
+
+	p_control->set_as_top_level(true);
+	p_control->move_to_front();
+	window->add_child(p_control);
+	window->visible = true;
+	gui.drag_preview_id = window->get_instance_id();
 }
 
-Control *Viewport::_gui_get_drag_preview() {
+Window *Viewport::_gui_get_drag_preview() {
 	if (gui.drag_preview_id.is_null()) {
 		return nullptr;
 	} else {
-		Control *drag_preview = ObjectDB::get_instance<Control>(gui.drag_preview_id);
+		Window *drag_preview = ObjectDB::get_instance<Window>(gui.drag_preview_id);
 		if (!drag_preview) {
 			ERR_PRINT("Don't free the control set as drag preview.");
 			gui.drag_preview_id = ObjectID();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2472,7 +2472,6 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 	window->set_flag(Window::FLAG_MOUSE_PASSTHROUGH, true);
 	window->set_flag(Window::FLAG_NO_FOCUS, true);
 	window->set_flag(Window::FLAG_TRANSPARENT, true);
-	window->wrap_controls = true;
 	window->set_size(Size2i(0, 0));
 	p_base->get_root_parent_control()->add_child(window);
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2465,7 +2465,7 @@ void Viewport::_gui_set_drag_preview(Control *p_base, Control *p_control) {
 	}
 
 	Window *window = memnew(Window);
-	
+
 	window->wrap_controls = true;
 	window->set_flag(Window::FLAG_BORDERLESS, true);
 	window->set_flag(Window::FLAG_ALWAYS_ON_TOP, true);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -455,7 +455,7 @@ private:
 	void _gui_force_drag_cancel();
 	void _gui_force_drag(Control *p_base, const Variant &p_data, Control *p_control);
 	void _gui_set_drag_preview(Control *p_base, Control *p_control);
-	Control *_gui_get_drag_preview();
+	Window *_gui_get_drag_preview();
 
 	void _gui_remove_focus_for_window(Node *p_window);
 	void _gui_unfocus_control(Control *p_control);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -387,7 +387,7 @@ void Window::move_to_mouse() {
 	Point2i mouse_pos;
 	int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
 	Point2i screen_pos = DisplayServer::get_singleton()->screen_get_position(parent_screen);
-	if (is_embedded()) {
+	if (is_embedded() && !force_native) {
 		mouse_pos = get_embedder()->get_mouse_position();
 		set_position(mouse_pos + Point2i(10, 10));
 	} else {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -380,6 +380,22 @@ Point2i Window::get_position() const {
 	return position;
 }
 
+void Window::move_to_mouse() {
+	ERR_MAIN_THREAD_GUARD;
+	ERR_FAIL_COND(!is_inside_tree());
+	
+	Point2i mouse_pos;
+	int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
+	Point2i screen_pos = DisplayServer::get_singleton()->screen_get_position(parent_screen);
+	if (is_embedded()) {
+		mouse_pos = get_embedder()->get_mouse_position();
+		set_position(mouse_pos + Point2i(10, 10));
+	} else {
+		mouse_pos = DisplayServer::get_singleton()->mouse_get_position();
+		set_position(mouse_pos + Point2i(10, 10));
+	}
+}
+
 void Window::move_to_center() {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
@@ -3153,6 +3169,7 @@ void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position"), &Window::set_position);
 	ClassDB::bind_method(D_METHOD("get_position"), &Window::get_position);
 	ClassDB::bind_method(D_METHOD("move_to_center"), &Window::move_to_center);
+	ClassDB::bind_method(D_METHOD("move_to_mouse"), &Window::move_to_mouse);
 
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &Window::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &Window::get_size);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -383,7 +383,7 @@ Point2i Window::get_position() const {
 void Window::move_to_mouse() {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
-	
+
 	Point2i mouse_pos;
 	int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
 	Point2i screen_pos = DisplayServer::get_singleton()->screen_get_position(parent_screen);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -385,8 +385,6 @@ void Window::move_to_mouse() {
 	ERR_FAIL_COND(!is_inside_tree());
 
 	Point2i mouse_pos;
-	int parent_screen = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
-	Point2i screen_pos = DisplayServer::get_singleton()->screen_get_position(parent_screen);
 	if (is_embedded() && !force_native) {
 		mouse_pos = get_embedder()->get_mouse_position();
 		set_position(mouse_pos + Point2i(10, 10));

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -312,6 +312,7 @@ public:
 	void set_position(const Point2i &p_position);
 	Point2i get_position() const;
 	void move_to_center();
+	void move_to_mouse();
 
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;

--- a/tests/scene/test_text_edit.h
+++ b/tests/scene/test_text_edit.h
@@ -2402,7 +2402,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == 4);
 			CHECK(text_edit->get_selection_origin_line() == 0);
 			CHECK(text_edit->get_selection_origin_column() == 0);
-			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(2, 0), MouseButtonMask::LEFT, Key::NONE);
+			// Increased offset to ensure drag preview window moves before dropping, otherwise drop data would be consumed by drag preview window
+			SEND_GUI_MOUSE_MOTION_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(20, 20), MouseButtonMask::LEFT, Key::NONE);
 			SEND_GUI_MOUSE_BUTTON_RELEASED_EVENT(text_edit->get_rect_at_line_column(1, 11).get_center() + Point2i(2, 0), MouseButton::LEFT, MouseButtonMask::NONE, Key::NONE);
 			CHECK_FALSE(text_edit->get_viewport()->gui_is_dragging());
 			CHECK(text_edit->get_text() == " test\ndrop here 'drag'");


### PR DESCRIPTION
Changed drag preview from control to window which fixes viewport clipping issues.

**Changelog:**
- Changed drag preview type from `Control` to `Window`.
- Added new method in `Window` which changes window's position to mouse's in order to track mouse position.

**Relations:**
- fix #67186 
- alternative to #64949 
- related to #67531 

**Known issues:**
- When the global project setting `embedded subwindows` is enabled it is not possible to drag and drop data from the main window into an external window.

https://github.com/user-attachments/assets/b00ea0e9-9294-44e2-a7f3-1d453fb5b46e

https://github.com/user-attachments/assets/4aeb81ba-2db4-41a1-8dec-0296f189d3cf