### PR TITLE
Remove the influence of precision for right side `is_on_wall()`

### DIFF
--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -410,7 +410,7 @@ static void _rest_cbk_result(const Vector2 &p_point_A, const Vector2 &p_point_B,
 	Vector2 contact_rel = p_point_B - p_point_A;
 	real_t len = contact_rel.length();
 
-	if (len < rd->min_allowed_depth) {
+	if (len < rd->min_allowed_depth - CMP_EPSILON) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/76756

**Godot version**

4.5 stable

**System information**

Ubuntu 24.04, Intel® Core™ i5-4690S, Intel HD Graphics (Unknown)

**Issue Description**

When a CharactorBody2D jumps to the right and collides with a wall, the result of is_on_wall() is not stable.

- When pressed ui_right and give a positive velocity.x, is_on_wall() returns true.
- When velocity.x is zero, is_on_wall() always returns false, sometimes return true. In my case, if object move to the corner of wall and press jump, is_on_wall() returns true on the top of the jump height, in other case, is_on_wall() returns false. 
- When jumps to the left and collides with a wall, the behavior is as expected, is_on_walls() returns true without exception.

**Re-Produce**

Here is the relevant issue and re-produce case. Thanks @SpicoTheSpiritGuy for the re-produce project.

https://github.com/godotengine/godot/issues/76756

**Cause Of Issue**

This issue is caused by the precision of number calculation.

In the re-produce project, when CharactorBody2D jumps to right and collides.

- The position of CharactorBody2D is (230.004, 202.924)
- The position of Wall is (230, 202.924)
- But the contact_rel result is (-0.0039978, 0), we can see the result we want is 0.004, but the real result is -0.0039978.
- When there is a gravity force, it causes min_allowed_depth to default value which is 0.04.

When CharactorBody2D jumps to left and collides.

- The position of CharactorBody2D is (22.996, 202.924)
- The position of Wall is (23, 202.924)
- But the contact_rel result is (0.00400734, 0) which is larger than default min_allowed_depth 0.04.

I don't know the reason, but when we jump left, the un-precision value always larger then jump-right.

**Solution**

> I add an precision factor after calculating contact length: `len += 0.0001;`.
> 
> But that caused another problems. When we landed, at that moment, CharactorBody2D collides both wall and floor. The result we expected is the length of wall and floor is equals. But the precision problems causes the two results are different. After landed, both is_on_floor() and is_on_wall() are true. That is not compatible with previous behavior.
> 
> So I add a priority on the contact_length, when velocity.y is not equals. `len += 0.0002`. Now the behavior is same as before.

After change to `CMP_EPSILON`, the above problem dismissed.

It is graceful for any suggestions.

Thank you very much.

---

UPDATE: After investigating, there is already a constants for compare precision issue. So just replace the `0.0001` to `CMP_EPSILON`. I think this is much better.

