### PR TITLE
Fix ancestry constructors

### DIFF
--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -713,6 +713,7 @@ CollisionObject3D::CollisionObject3D(RID p_rid, bool p_area) {
 	rid = p_rid;
 	area = p_area;
 	set_notify_transform(true);
+	_define_ancestry(AncestralClass::COLLISION_OBJECT_3D);
 
 	if (p_area) {
 		PhysicsServer3D::get_singleton()->area_attach_object_instance_id(rid, get_instance_id());
@@ -755,8 +756,6 @@ CollisionObject3D::CollisionObject3D() {
 }
 
 CollisionObject3D::~CollisionObject3D() {
-	_define_ancestry(AncestralClass::COLLISION_OBJECT_3D);
-
 	ERR_FAIL_NULL(PhysicsServer3D::get_singleton());
 	PhysicsServer3D::get_singleton()->free(rid);
 }

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -53,6 +53,7 @@ void PhysicsBody3D::_bind_methods() {
 
 PhysicsBody3D::PhysicsBody3D(PhysicsServer3D::BodyMode p_mode) :
 		CollisionObject3D(PhysicsServer3D::get_singleton()->body_create(), false) {
+	_define_ancestry(AncestralClass::PHYSICS_BODY_3D);
 	set_body_mode(p_mode);
 }
 
@@ -218,10 +219,6 @@ PackedStringArray PhysicsBody3D::get_configuration_warnings() const {
 	}
 
 	return warnings;
-}
-
-PhysicsBody3D::PhysicsBody3D() {
-	_define_ancestry(AncestralClass::PHYSICS_BODY_3D);
 }
 
 ///////////////////////////////////////

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -67,6 +67,4 @@ public:
 	TypedArray<PhysicsBody3D> get_collision_exceptions();
 	void add_collision_exception_with(Node *p_node); //must be physicsbody
 	void remove_collision_exception_with(Node *p_node);
-
-	PhysicsBody3D();
 };


### PR DESCRIPTION
Some object constructors in 4.x were not initializing ancestry correctly for some types, this was producing casting failures.

Fixes regression introduced in #107868 and #110763.

## Notes
* The report mentions a 2D regression but I'm not seeing (immediately) how that can be occurring, it would be nice to have an MRP, I don't have many 4.x test projects. Either way this should fix 3D problems.
* This is one gotcha for ancestry, if new constructors are added for these core node types that don't set the ancestry, the system will break. I'll see if there's a way we can make this more idiot - proof (me being the idiot in this case :grin: ).
* These were probably late night copy-pasta bugs when forward porting that didn't show up until #110763.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
