### PR TITLE
Fix 2D and 3D editors mouse focus drawing

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -467,7 +467,7 @@ void ViewportRotationControl::gui_input(const Ref<InputEvent> &p_event) {
 			if (mb->is_pressed()) {
 				gizmo_activated = true;
 				original_mouse_pos = get_local_mouse_position();
-				grab_focus();
+				grab_focus(true);
 			}
 		} else if (mb->get_button_index() == MouseButton::RIGHT) {
 			if (Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
@@ -1572,7 +1572,7 @@ void Node3DEditorViewport::_surface_mouse_enter() {
 	}
 
 	if (!surface->has_focus() && (!get_viewport()->gui_get_focus_owner() || !get_viewport()->gui_get_focus_owner()->is_text_field())) {
-		surface->grab_focus();
+		surface->grab_focus(true);
 	}
 }
 
@@ -3504,7 +3504,7 @@ void Node3DEditorViewport::_draw() {
 		force_over_plugin_list->forward_3d_force_draw_over_viewport(surface);
 	}
 
-	if (surface->has_focus() || rotation_control->has_focus()) {
+	if (surface->has_focus(true) || rotation_control->has_focus(true)) {
 		Size2 size = surface->get_size();
 		Rect2 r = Rect2(Point2(), size);
 		get_theme_stylebox(SNAME("FocusViewport"), EditorStringName(EditorStyles))->draw(surface->get_canvas_item(), r);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -2800,7 +2800,8 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 
 	// Grab focus
 	if (!viewport->has_focus() && (!get_viewport()->gui_get_focus_owner() || !get_viewport()->gui_get_focus_owner()->is_text_field())) {
-		callable_mp((Control *)viewport, &Control::grab_focus).call_deferred(false);
+		Ref<InputEventMouse> mouse_event = p_event;
+		callable_mp((Control *)viewport, &Control::grab_focus).call_deferred(mouse_event.is_valid());
 	}
 }
 
@@ -2988,7 +2989,7 @@ void CanvasItemEditor::_draw_percentage_at_position(real_t p_value, Point2 p_pos
 
 void CanvasItemEditor::_draw_focus() {
 	// Draw the focus around the base viewport
-	if (viewport->has_focus()) {
+	if (viewport->has_focus(true)) {
 		get_theme_stylebox(SNAME("FocusViewport"), EditorStringName(EditorStyles))->draw(viewport->get_canvas_item(), Rect2(Point2(), viewport->get_size()));
 	}
 }


### PR DESCRIPTION
After #110250 most editor controls don't draw focus on mouse events. This fixes the 2D and 3D editor which still do because of custom logic.


https://github.com/user-attachments/assets/0680f023-6b68-4aea-accf-528a398e06fa

