### PR TITLE
[Navigation 2D] Fix sign of cross product

### DIFF
--- a/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
+++ b/modules/navigation_2d/2d/nav_mesh_queries_2d.cpp
@@ -40,7 +40,7 @@
 
 using namespace Nav2D;
 
-#define THREE_POINTS_CROSS_PRODUCT(m_a, m_b, m_c) (((m_c) - (m_a)).cross((m_b) - (m_a)))
+#define THREE_POINTS_CROSS_PRODUCT(m_a, m_b, m_c) (-((m_c) - (m_a)).cross((m_b) - (m_a)))
 
 bool NavMeshQueries2D::emit_callback(const Callable &p_callback) {
 	ERR_FAIL_COND_V(!p_callback.is_valid(), false);
@@ -897,7 +897,7 @@ ClosestPointQueryResult NavMeshQueries2D::map_iteration_get_closest_point_info(c
 	const LocalVector<Ref<NavRegionIteration2D>> &regions = p_map_iteration.region_iterations;
 	for (const Ref<NavRegionIteration2D> &region : regions) {
 		for (const Polygon &polygon : region->get_navmesh_polygons()) {
-			real_t cross = (polygon.vertices[1] - polygon.vertices[0]).cross(polygon.vertices[2] - polygon.vertices[0]);
+			real_t cross = -(polygon.vertices[1] - polygon.vertices[0]).cross(polygon.vertices[2] - polygon.vertices[0]);
 			Vector2 closest_on_polygon;
 			real_t closest = FLT_MAX;
 			bool inside = true;
@@ -905,7 +905,7 @@ ClosestPointQueryResult NavMeshQueries2D::map_iteration_get_closest_point_info(c
 			for (uint32_t point_id = 0; point_id < polygon.vertices.size(); ++point_id) {
 				Vector2 edge = polygon.vertices[point_id] - previous;
 				Vector2 to_point = p_point - previous;
-				real_t edge_to_point_cross = edge.cross(to_point);
+				real_t edge_to_point_cross = -edge.cross(to_point);
 				bool clockwise = (edge_to_point_cross * cross) > 0;
 				// If we are not clockwise, the point will never be inside the polygon and so the closest point will be on an edge.
 				if (!clockwise) {
@@ -1029,7 +1029,7 @@ ClosestPointQueryResult NavMeshQueries2D::polygons_get_closest_point_info(const 
 	// TODO: Check for further 2D improvements.
 
 	for (const Polygon &polygon : p_polygons) {
-		real_t cross = (polygon.vertices[1] - polygon.vertices[0]).cross(polygon.vertices[2] - polygon.vertices[0]);
+		real_t cross = -(polygon.vertices[1] - polygon.vertices[0]).cross(polygon.vertices[2] - polygon.vertices[0]);
 		Vector2 closest_on_polygon;
 		real_t closest = FLT_MAX;
 		bool inside = true;
@@ -1037,7 +1037,7 @@ ClosestPointQueryResult NavMeshQueries2D::polygons_get_closest_point_info(const 
 		for (uint32_t point_id = 0; point_id < polygon.vertices.size(); ++point_id) {
 			Vector2 edge = polygon.vertices[point_id] - previous;
 			Vector2 to_point = p_point - previous;
-			real_t edge_to_point_cross = edge.cross(to_point);
+			real_t edge_to_point_cross = -edge.cross(to_point);
 			bool clockwise = (edge_to_point_cross * cross) > 0;
 			// If we are not clockwise, the point will never be inside the polygon and so the closest point will be on an edge.
 			if (!clockwise) {

--- a/tests/servers/test_triangle2.h
+++ b/tests/servers/test_triangle2.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  triangle2.h                                                           */
+/*  test_triangle2.h                                                      */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,23 +30,41 @@
 
 #pragma once
 
-#include "core/math/vector2.h"
+#include "modules/navigation_2d/triangle2.h"
 
-struct Triangle2 {
-	Vector2 vertex[3];
+#include "tests/test_macros.h"
 
-	real_t get_area() const {
-		return Math::abs((vertex[0] - vertex[1]).cross(vertex[0] - vertex[2])) * 0.5f;
+namespace TestTriangle2 {
+TEST_SUITE("[Triangle2]") {
+	TEST_CASE("[Triangle2] Test get_area") {
+		const Vector2 p0(5.0, 5.0);
+		const Vector2 p1(6.0, 7.0);
+		const Vector2 p2(7.0, 6.0);
+
+		CHECK_EQ(Triangle2(p0, p1, p2).get_area(), doctest::Approx(1.5));
+		CHECK_EQ(Triangle2(p0, p2, p1).get_area(), doctest::Approx(1.5));
+
+		CHECK_EQ(Triangle2(p0, p2, p2).get_area(), doctest::Approx(0.0));
+		CHECK_EQ(Triangle2(p0, p1, p1).get_area(), doctest::Approx(0.0));
 	}
 
-	Vector2 get_random_point_inside() const;
+	TEST_CASE("[Triangle2] Test get_closest_point_to") {
+		const Vector2 p0(5.0, 5.0);
+		const Vector2 p1(6.0, 7.0);
+		const Vector2 p2(7.0, 6.0);
 
-	Vector2 get_closest_point_to(const Vector2 &p_point) const;
+		const Vector2 p3(0.0, 0.0);
+		const Vector2 p4(6.0, 6.5);
 
-	Triangle2() {}
-	Triangle2(const Vector2 &p_v1, const Vector2 &p_v2, const Vector2 &p_v3) {
-		vertex[0] = p_v1;
-		vertex[1] = p_v2;
-		vertex[2] = p_v3;
+		const Triangle2 t(p0, p1, p2);
+
+		CHECK(t.get_closest_point_to(p0).is_equal_approx(p0));
+		CHECK(t.get_closest_point_to(p1).is_equal_approx(p1));
+		CHECK(t.get_closest_point_to(p2).is_equal_approx(p2));
+
+		CHECK(t.get_closest_point_to(p3).is_equal_approx(p0));
+
+		CHECK(t.get_closest_point_to(p4).is_equal_approx(p4));
 	}
-};
+}
+} // namespace TestTriangle2

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -190,6 +190,7 @@
 #include "tests/scene/test_navigation_obstacle_2d.h"
 #include "tests/scene/test_navigation_region_2d.h"
 #include "tests/servers/test_navigation_server_2d.h"
+#include "tests/servers/test_triangle2.h"
 #endif // MODULE_NAVIGATION_2D_ENABLED
 
 #ifdef MODULE_NAVIGATION_3D_ENABLED


### PR DESCRIPTION
Regression from splitting the servers. The original code effectively took the cross product using `Vector3(v0.x, 0, v0.y).cross(Vector3(v1.x, 0, v1.y)).y`, but this is not equivalent to the 2D cross product which is equivalent to `Vector3(v0.x, v0.y, 0).cross(v1.x, v1.y, 0).z`.

The former gives `v1.x * v0.y - v0.x * v1.y`, but the latter gives `v0.x * v1.y - v1.x * v0.y`.

Fixed by negating the result in all places, verified against that the original 3D code is the plain cross product.

Also replaced the area formula, using `abs` instead which was an oversight in the original code.


Added minimal tests for the area formula and also for the closest point method, the latter can be removed if not necessary but wanted to make sure the area formula is correct, verified the area with conventional methods.

Minimal project from smix8 (note that due to https://github.com/godotengine/godot/issues/110807 you will need to open the main scene manually, as saving the main scene currently breaks things):
[godot-4.5-path-corridorfunnel-bug.zip](https://github.com/user-attachments/files/22496855/godot-4.5-path-corridorfunnel-bug.zip)

Click in the red circle to confirm that the path no longer goes the wrong way

Related (but does not fix the entire issue):
* https://github.com/godotengine/godot/issues/110686

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
