### PR TITLE
Update SpinBox arrows on constrain change

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -497,6 +497,10 @@ void SpinBox::_notification(int p_what) {
 			_update_buttons_state_for_current_value();
 		} break;
 
+		case NOTIFICATION_READY: {
+			connect(CoreStringName(changed), callable_mp(this, &SpinBox::_update_buttons_state_for_current_value));
+		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED:
 			drag.allowed = false;
 			[[fallthrough]];


### PR DESCRIPTION
I encountered a bug where setting min and max value of SpinBox to the same value would make up arrow still clickable and do nothing. After further investigation, it turned out SpinBox is not updating buttons when min/max has changed.