### PR TITLE
Add PCK loading from memory

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -582,6 +582,9 @@ bool ProjectSettings::load_resource_pack(const String &p_pack, bool p_replace_fi
 	return ProjectSettings::_load_resource_pack(p_pack, p_replace_files, p_offset, false);
 }
 
+bool ProjectSettings::load_resource_pack_from_buffer(const PackedByteArray &p_pack, bool p_replace_files, int p_offset) {
+	return ProjectSettings::_load_resource_pack_from_buffer(p_pack, p_replace_files, p_offset, false);
+}
 bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset, bool p_main_pack) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
@@ -592,6 +595,32 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 		return false;
 	}
 
+	_generate_resource_dir(p_main_pack);
+	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset) == OK;
+	if (!ok) {
+		return false;
+	}
+	_post_load_resource_pack();
+
+	return true;
+}
+
+bool ProjectSettings::_load_resource_pack_from_buffer(const PackedByteArray &p_pack, bool p_replace_files, int p_offset, bool p_main_pack) {
+	if (PackedData::get_singleton()->is_disabled()) {
+		return false;
+	}
+
+	_generate_resource_dir(p_main_pack);
+	bool ok = PackedData::get_singleton()->add_pack_from_buffer(p_pack, p_replace_files, p_offset) == OK;
+	if (!ok) {
+		return false;
+	}
+	_post_load_resource_pack();
+
+	return true;
+}
+
+void ProjectSettings::_generate_resource_dir(bool p_main_pack) {
 	if (!p_main_pack && !using_datapack && !OS::get_singleton()->get_resource_dir().is_empty()) {
 		// Add the project's resource file system to PackedData so directory access keeps working when
 		// the game is running without a main pack, like in the editor or on Android.
@@ -600,12 +629,9 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 		DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
 		using_datapack = true;
 	}
+}
 
-	bool ok = PackedData::get_singleton()->add_pack(p_pack, p_replace_files, p_offset) == OK;
-	if (!ok) {
-		return false;
-	}
-
+void ProjectSettings::_post_load_resource_pack() {
 	if (project_loaded) {
 		// This pack may have declared new global classes (make sure they are picked up).
 		refresh_global_class_list();
@@ -619,8 +645,6 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 		DirAccess::make_default<DirAccessPack>(DirAccess::ACCESS_RESOURCES);
 		using_datapack = true;
 	}
-
-	return true;
 }
 
 void ProjectSettings::_convert_to_last_version(int p_from_version) {
@@ -1636,6 +1660,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("load_resource_pack_from_buffer", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack_from_buffer, DEFVAL(true), DEFVAL(0));
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -146,7 +146,12 @@ protected:
 	void _convert_to_last_version(int p_from_version);
 
 	bool load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset);
+	bool load_resource_pack_from_buffer(const PackedByteArray &p_pack, bool p_replace_files, int p_offset);
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
+	bool _load_resource_pack_from_buffer(const PackedByteArray &p_pack, bool p_replace_files, int p_offset, bool p_main_pack);
+
+	void _generate_resource_dir(bool p_main_pack);
+	void _post_load_resource_pack();
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -30,7 +30,9 @@
 
 #include "file_access_pack.h"
 
+#include "core/crypto/crypto_core.h"
 #include "core/io/file_access_encrypted.h"
+#include "core/io/file_access_memory.h"
 #include "core/io/file_access_patched.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
@@ -39,6 +41,16 @@
 Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
 	for (int i = 0; i < sources.size(); i++) {
 		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset, p_decryption_key)) {
+			return OK;
+		}
+	}
+
+	return ERR_FILE_UNRECOGNIZED;
+}
+
+Error PackedData::add_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
+	for (int i = 0; i < sources.size(); i++) {
+		if (sources[i]->try_open_pack_from_buffer(p_bytes, p_replace_files, p_offset, p_decryption_key)) {
 			return OK;
 		}
 	}
@@ -220,6 +232,26 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	if (f.is_null()) {
 		return false;
 	}
+	return _try_open_pack(f, p_path, p_replace_files, p_offset, p_decryption_key);
+}
+
+bool PackedSourcePCK::try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
+	uint8_t md5_hash[16];
+	if (CryptoCore::md5(p_bytes.ptr(), p_bytes.size(), md5_hash) != OK) {
+		return false;
+	}
+	String internal_path = "mem://" + String::hex_encode_buffer((const uint8_t *)md5_hash, 16);
+
+	FileAccessMemory::register_file(internal_path, p_bytes);
+
+	Ref<FileAccessMemory> f;
+	f.instantiate();
+	f->open_internal(internal_path, FileAccess::READ);
+	return _try_open_pack(f, internal_path, p_replace_files, p_offset, p_decryption_key);
+}
+
+bool PackedSourcePCK::_try_open_pack(Ref<FileAccess> p_file, const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
+	Ref<FileAccess> &f = p_file;
 
 	bool pck_header_found = false;
 
@@ -400,6 +432,10 @@ bool PackedSourceDirectory::try_open_pack(const String &p_path, bool p_replace_f
 	return true;
 }
 
+bool PackedSourceDirectory::try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
+	return false; // Not implementable. Needed for add_pack_from_buffer.
+}
+
 Ref<FileAccess> PackedSourceDirectory::get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key) {
 	Ref<FileAccess> ret = FileAccess::create_for_path(p_path);
 	ret->reopen(p_path, FileAccess::READ);
@@ -544,6 +580,13 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 		f = FileAccess::open(path_to_load, FileAccess::READ | FileAccess::SKIP_PACK, &err);
 		ERR_FAIL_COND_MSG(err != OK, vformat(R"(Can't open pack-referenced file "%s" from sparse pack "%s" due to error "%s".)", simplified_path, pf.pack, error_names[err]));
 		off = 0; // For the sparse pack offset is always zero.
+	} else if (pf.pack.begins_with("mem://")) {
+		Ref<FileAccessMemory> f_mem;
+		f_mem.instantiate();
+		f_mem->open_internal(pf.pack, FileAccess::READ);
+		f_mem->seek(pf.offset);
+		off = pf.offset;
+		f = f_mem;
 	} else {
 		Error err = OK;
 		f = FileAccess::open(pf.pack, FileAccess::READ, &err);

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -143,6 +143,7 @@ public:
 
 	static PackedData *get_singleton() { return singleton; }
 	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>());
+	Error add_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>());
 
 	void clear();
 
@@ -161,13 +162,18 @@ public:
 class PackSource {
 public:
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) = 0;
+	virtual bool try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) = 0;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) = 0;
 	virtual ~PackSource() {}
 };
 
 class PackedSourcePCK : public PackSource {
+private:
+	bool _try_open_pack(Ref<FileAccess> p_file, const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>());
+
 public:
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
+	virtual bool try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 };
 
@@ -176,6 +182,7 @@ class PackedSourceDirectory : public PackSource {
 
 public:
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
+	virtual bool try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 	virtual Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 };
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -205,6 +205,10 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 	return true;
 }
 
+bool ZipArchive::try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
+	return false; // loading from memory only supported for PCK files
+}
+
 bool ZipArchive::file_exists(const String &p_name) const {
 	return files.has(p_name);
 }

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -62,6 +62,7 @@ public:
 	bool file_exists(const String &p_name) const;
 
 	virtual bool try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
+	virtual bool try_open_pack_from_buffer(const PackedByteArray &p_bytes, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 	Ref<FileAccess> get_file(const String &p_path, PackedData::PackedFile *p_file, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>()) override;
 
 	static ZipArchive *get_singleton();

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -178,6 +178,18 @@
 				[b]Note:[/b] [DirAccess] will not show changes made to the contents of [code]res://[/code] after calling this function.
 			</description>
 		</method>
+		<method name="load_resource_pack_from_buffer">
+			<return type="bool" />
+			<param index="0" name="pack" type="PackedByteArray" />
+			<param index="1" name="replace_files" type="bool" default="true" />
+			<param index="2" name="offset" type="int" default="0" />
+			<description>
+				Loads the contents of the .pck or .zip file from a preloaded buffer specified by [param pack] into the resource filesystem ([code]res://[/code]). Returns [code]true[/code] on success.
+				[b]Note:[/b] If a file from [param pack] shares the same path as a file already in the resource filesystem, any attempts to load that file will use the file from [param pack] unless [param replace_files] is set to [code]false[/code].
+				[b]Note:[/b] The optional [param offset] parameter can be used to specify the offset in bytes to the start of the resource pack. This is only supported for .pck files.
+				[b]Note:[/b] [DirAccess] will not show changes made to the contents of [code]res://[/code] after calling this function.
+			</description>
+		</method>
 		<method name="localize_path" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="path" type="String" />


### PR DESCRIPTION
Adds `load_resource_pack_from_buffer` as an in-memory alternative to `load_resource_pack`.

Closes godotengine/godot-proposals#5389.

I made several implementation decisions that I would like feedback on and am open to modifying if desired: 
- This code was written with the goal of not breaking backwards-compatibility for public functions. If it is acceptable to change `PackedData::add_pack` to accept a `Ref<FileAccess>` instead of a path, that would greatly simplify this code and remove some mostly-duplicated functions.
- The struct `PackedFile` was also left as-is for backwards-compatibility. This necessitated creating internal file paths (chosen to start with `mem://`) for downstream functions to read from, which also slightly slows performance for the new `from_buffer` function by requiring an additional hash of the buffer array. If it is acceptable to change `PackedFile` by replacing the pack path, then it would lead to a simpler and more efficient implementation.
- The function `FileAccessMemory::register_file` is used for storing buffers long-term. Although it seems to work for this purpose, I could not find any other use or documentation of this function in the repository. Is it deprecated? Alternatives to `register_file` include storing the `Ref<FileAccess>` inside `PackedFile` (could be a problem for disk files if the file handle is closed and needs to be reopened), or creating a static local variable inside `FileAccessPack` that holds all buffers loaded.
- `try_open_pack_from_buffer` was added as a purely virtual function to `PackSource`. There are lots of alternatives, but this would only really be a compatibility issue if users are inheriting from `PackSource` in their own classes (which I am not aware of).
- Loading `ZipArchive` from buffer is still not supported. A different API would have to be used for this (`inflate` instead of `unzOpen2`?) and it was not mentioned in the original proposal.