### PR TITLE
Change "reserve called with a capacity smaller than the current size" error message to a verbose message.

### DIFF
--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -30,9 +30,10 @@
 
 #pragma once
 
-#include "core/string/ustring.h"
+#include "core/templates/span.h"
 
 class Variant;
+class String;
 
 extern void (*_print_func)(String);
 

--- a/core/string/string_buffer.h
+++ b/core/string/string_buffer.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/string/print_string.h"
 #include "core/string/ustring.h"
 
 template <int SHORT_BUFFER_SIZE = 64>
@@ -117,8 +118,10 @@ StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::append(const c
 
 template <int SHORT_BUFFER_SIZE>
 StringBuffer<SHORT_BUFFER_SIZE> &StringBuffer<SHORT_BUFFER_SIZE>::reserve(int p_size) {
-	ERR_FAIL_COND_V_MSG(p_size < length(), *this, "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 	if (p_size <= SHORT_BUFFER_SIZE || p_size <= buffer.size()) {
+		if (p_size < length()) {
+			WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
+		}
 		return *this;
 	}
 

--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -402,13 +402,15 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
-		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		if (_elements == nullptr) {
 			_capacity_mask = MAX(4u, p_new_capacity);
 			_capacity_mask = next_power_of_2(_capacity_mask) - 1;
 			return; // Unallocated yet.
 		}
 		if (p_new_capacity <= get_capacity()) {
+			if (p_new_capacity < size()) {
+				WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
+			}
 			return;
 		}
 		_resize_and_rehash(p_new_capacity);

--- a/core/templates/hash_map.h
+++ b/core/templates/hash_map.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/os/memory.h"
+#include "core/string/print_string.h"
 #include "core/templates/hashfuncs.h"
 #include "core/templates/pair.h"
 #include "core/templates/sort_list.h"
@@ -398,7 +399,6 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
-		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		uint32_t new_idx = _capacity_idx;
 
 		while (hash_table_size_primes[new_idx] < p_new_capacity) {
@@ -407,6 +407,9 @@ public:
 		}
 
 		if (new_idx == _capacity_idx) {
+			if (p_new_capacity < _size) {
+				WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
+			}
 			return;
 		}
 

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/os/memory.h"
+#include "core/string/print_string.h"
 #include "core/templates/hashfuncs.h"
 
 /**
@@ -298,7 +299,6 @@ public:
 	// Reserves space for a number of elements, useful to avoid many resizes and rehashes.
 	// If adding a known (possibly large) number of elements at once, must be larger than old capacity.
 	void reserve(uint32_t p_new_capacity) {
-		ERR_FAIL_COND_MSG(p_new_capacity < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		uint32_t new_capacity_idx = _capacity_idx;
 
 		while (hash_table_size_primes[new_capacity_idx] < p_new_capacity) {
@@ -307,6 +307,9 @@ public:
 		}
 
 		if (new_capacity_idx == _capacity_idx) {
+			if (p_new_capacity < _size) {
+				WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
+			}
 			return;
 		}
 

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/os/memory.h"
+#include "core/string/print_string.h"
 #include "core/templates/sort_array.h"
 #include "core/templates/vector.h"
 
@@ -161,7 +162,6 @@ public:
 	_FORCE_INLINE_ bool is_empty() const { return count == 0; }
 	_FORCE_INLINE_ U get_capacity() const { return capacity; }
 	void reserve(U p_size) {
-		ERR_FAIL_COND_MSG(p_size < size(), "reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		if (p_size > capacity) {
 			if (tight) {
 				capacity = p_size;
@@ -173,6 +173,8 @@ public:
 			}
 			data = (T *)memrealloc(data, capacity * sizeof(T));
 			CRASH_COND_MSG(!data, "Out of memory");
+		} else if (p_size < count) {
+			WARN_VERBOSE("reserve() called with a capacity smaller than the current size. This is likely a mistake.");
 		}
 	}
 


### PR DESCRIPTION
- Follow-up of https://github.com/godotengine/godot/pull/105278

We've been getting complaints from users about this message being unhelpful / spamming their console:

```
reserve() called with a capacity smaller than the current size. This is likely a mistake.
```

While the message _does_ indicate a bug, it's usually non-critical and shouldn't prevent them from working on their projects in peace.

This PR rectifies this by 'degrading' it to a verbose message.