### PR TITLE
Fix regression with min size on nested inspectors

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -320,7 +320,6 @@ void EditorProperty::_notification(int p_what) {
 					height = MAX(height, minsize.height);
 					no_children = false;
 				}
-				child_room = MAX(child_room, get_minimum_size().width);
 
 				if (no_children) {
 					text_size = size.width;


### PR DESCRIPTION
Regression from #110434, causing properties to expand too much when they have nested inspectors. This fix means that the key button can be overlapped again if the inspector is too compressed, but that's more preferable than the alternative.