### PR TITLE
Transparently ungzip compressed files on the web

### DIFF
--- a/platform/web/js/engine/preloader.js
+++ b/platform/web/js/engine/preloader.js
@@ -6,6 +6,27 @@ const Preloader = /** @constructor */ function () { // eslint-disable-line no-un
 					return Promise.resolve();
 				}
 				if (result.value) {
+					if (load_status.loaded == 0) {
+						if (result.value[0] == 31 && result.value[1] == 139) {
+							const decompressor = new DecompressionStream('gzip');
+							const writer = decompressor.writable.getWriter();
+							writer.write(result.value);
+							function pump() {
+								reader.read().then(function (data) {
+									if (data.value) {
+										writer.write(data.value);
+									}
+									if (data.done) {
+										writer.close();
+									} else {
+										pump();
+									}
+								});
+							}
+							pump();
+							return onloadprogress(decompressor.readable.getReader(), controller);
+						}
+					}
 					controller.enqueue(result.value);
 					load_status.loaded += result.value.length;
 				}


### PR DESCRIPTION
If a wasm or pck file is delivered gziped by the server without the correct headers to cause the browser to decompress it, detect this and decompress it using DecompressionStream.

This is an alternative approach to #105227 that would also close https://github.com/godotengine/godot-proposals/issues/12208 .  Here instead of looking at the file extension, we simply look at the first few bytes of the stream thats being loaded to detect if its gzipped by looking for the gzip headers. The two file types normally loaded by this function should either have the "GDP" header for a pck file, or the "\0asm" header for a WASM file.

This change makes it possible to host web games on cloudflare pages.