### PR TITLE
FileSystemDock: Add "Rescan Filesystem" option to context menu

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2141,6 +2141,12 @@ void FileSystemDock::_tree_rmb_option(int p_option) {
 			selected_strings = _tree_get_selected(false, true);
 			[[fallthrough]];
 		}
+		case FILE_MENU_RESCAN: {
+			Vector<String> selected = _tree_get_selected(false);
+			if (!selected.is_empty()) {
+				EditorFileSystem::get_singleton()->scan_changes();
+			}
+		} break;
 		default: {
 			_file_option(p_option, selected_strings);
 		} break;
@@ -3381,6 +3387,8 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 				folder_colors_menu->set_item_icon_modulate(-1, editor_is_dark_theme ? E.value : E.value * 2);
 				folder_colors_menu->set_item_metadata(-1, E.key);
 			}
+		} else {
+			p_popup->add_icon_item(get_editor_theme_icon(SNAME("Reload")), TTRC("Rescan Filesystem"), FILE_MENU_RESCAN);
 		}
 	}
 

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -130,6 +130,7 @@ private:
 		FILE_MENU_NEW_SCRIPT,
 		FILE_MENU_NEW_SCENE,
 		FILE_MENU_RUN_SCRIPT,
+		FILE_MENU_RESCAN,
 		FILE_MENU_MAX,
 		// Extra shortcuts that don't exist in the menu.
 		EXTRA_FOCUS_PATH,


### PR DESCRIPTION
This adds a new "Rescan Filesystem" button when right-clicking the `res://` folder in the filesystem dock in order to give the ability to trigger this manually, which as far as I know cannot be done as of now.

Oftentimes when switching between workspaces in my display manager the filesystem scan fails to run or detect any changes in the project filesystem. The only way I've been able to remedy this is to either reload the project entirely or keep switching in/out of focus for the window and hope it triggers the filesystem rescan. 

Although this PR seems to mostly fix the issues for me, I’d like to know whether this option should also be given a shortcut like some of the other menu actions, and if there are any other implementation details I missed or should consider

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/12940