### PR TITLE
Add `GDSOFTCLASS` to deeper inheritors of `Object`

### DIFF
--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -149,6 +149,8 @@ public:
 };
 
 class ResourceFormatLoaderCrypto : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderCrypto, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -161,6 +163,8 @@ public:
 };
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverCrypto, ResourceFormatSaver);
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -48,9 +48,9 @@ class RemoteDebugger::PerformanceProfiler : public EngineProfiler {
 	uint64_t last_monitor_modification_time = 0;
 
 public:
-	void toggle(bool p_enable, const Array &p_opts) {}
-	void add(const Array &p_data) {}
-	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
+	void toggle(bool p_enable, const Array &p_opts) override {}
+	void add(const Array &p_data) override {}
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) override {
 		if (!performance) {
 			return;
 		}

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -37,6 +37,8 @@
 #include "core/string/ustring.h"
 
 class RemoteDebuggerPeer : public RefCounted {
+	GDSOFTCLASS(RemoteDebuggerPeer, RefCounted);
+
 protected:
 	int max_queued_messages = 4096;
 
@@ -54,6 +56,8 @@ public:
 };
 
 class RemoteDebuggerPeerTCP : public RemoteDebuggerPeer {
+	GDSOFTCLASS(RemoteDebuggerPeerTCP, RemoteDebuggerPeer);
+
 private:
 	Ref<StreamPeerTCP> tcp_client;
 	Mutex mutex;

--- a/core/extension/gdextension.h
+++ b/core/extension/gdextension.h
@@ -183,6 +183,8 @@ public:
 VARIANT_ENUM_CAST(GDExtension::InitializationLevel)
 
 class GDExtensionResourceLoader : public ResourceFormatLoader {
+	GDSOFTCLASS(GDExtensionResourceLoader, ResourceFormatLoader);
+
 public:
 	static Error load_gdextension_resource(const String &p_path, Ref<GDExtension> &p_extension);
 

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -35,6 +35,8 @@
 #include "core/crypto/crypto.h"
 
 class HTTPClientTCP : public HTTPClient {
+	GDSOFTCLASS(HTTPClientTCP, HTTPClient);
+
 private:
 	Status status = STATUS_DISCONNECTED;
 	IP::ResolverID resolving = IP::RESOLVER_INVALID_ID;

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -101,6 +101,8 @@ public:
 };
 
 class ResourceFormatLoaderImage : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderImage, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -107,6 +107,8 @@ public:
 };
 
 class ResourceFormatLoaderJSON : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderJSON, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -119,6 +121,8 @@ public:
 };
 
 class ResourceFormatSaverJSON : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverJSON, ResourceFormatSaver);
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/core/io/plist.h
+++ b/core/io/plist.h
@@ -37,6 +37,8 @@
 class PListNode;
 
 class PList : public RefCounted {
+	GDSOFTCLASS(PList, RefCounted);
+
 	friend class PListNode;
 
 public:

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -108,6 +108,8 @@ public:
 };
 
 class ResourceFormatLoaderBinary : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderBinary, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const override;
@@ -179,6 +181,8 @@ public:
 };
 
 class ResourceFormatSaverBinary : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverBinary, ResourceFormatSaver);
+
 public:
 	static inline ResourceFormatSaverBinary *singleton = nullptr;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -39,6 +39,8 @@ class ResourceFormatImporter;
 typedef Ref<Resource> (*ResourceFormatImporterLoadOnStartup)(ResourceFormatImporter *p_importer, const String &p_path, Error *r_error, bool p_use_sub_threads, float *r_progress, ResourceFormatLoader::CacheMode p_cache_mode);
 
 class ResourceFormatImporter : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatImporter, ResourceFormatLoader);
+
 	struct PathAndType {
 		String path;
 		String type;

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -35,6 +35,8 @@
 #include "core/string/translation.h"
 
 class TranslationLoaderPO : public ResourceFormatLoader {
+	GDSOFTCLASS(TranslationLoaderPO, ResourceFormatLoader);
+
 public:
 	static Ref<Resource> load_translation(Ref<FileAccess> f, Error *r_error = nullptr);
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;

--- a/core/string/translation_po.h
+++ b/core/string/translation_po.h
@@ -50,6 +50,8 @@ class TranslationPO : public Translation {
 
 	// Cache temporary variables related to _get_plural_index() to make it faster
 	class EQNode : public RefCounted {
+		GDSOFTCLASS(EQNode, RefCounted);
+
 	public:
 		String regex;
 		Ref<EQNode> left;

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -34,6 +34,8 @@
 #include "core/io/resource_saver.h"
 
 class ResourceSaverPNG : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceSaverPNG, ResourceFormatSaver);
+
 public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);

--- a/drivers/unix/net_socket_unix.h
+++ b/drivers/unix/net_socket_unix.h
@@ -37,6 +37,8 @@
 #include <sys/socket.h>
 
 class NetSocketUnix : public NetSocket {
+	GDSOFTCLASS(NetSocketUnix, NetSocket);
+
 private:
 	int _sock = -1;
 	IP::Type _ip_type = IP::TYPE_NONE;

--- a/drivers/windows/net_socket_winsock.h
+++ b/drivers/windows/net_socket_winsock.h
@@ -38,6 +38,8 @@
 #include <ws2tcpip.h>
 
 class NetSocketWinSock : public NetSocket {
+	GDSOFTCLASS(NetSocketWinSock, NetSocket);
+
 private:
 	SOCKET _sock = INVALID_SOCKET;
 	IP::Type _ip_type = IP::TYPE_NONE;

--- a/editor/debugger/editor_debugger_server.cpp
+++ b/editor/debugger/editor_debugger_server.cpp
@@ -37,6 +37,8 @@
 #include "editor/settings/editor_settings.h"
 
 class EditorDebuggerServerTCP : public EditorDebuggerServer {
+	GDSOFTCLASS(EditorDebuggerServerTCP, EditorDebuggerServer);
+
 private:
 	Ref<TCPServer> server;
 	String endpoint;

--- a/editor/debugger/editor_debugger_server.h
+++ b/editor/debugger/editor_debugger_server.h
@@ -34,6 +34,8 @@
 #include "core/object/ref_counted.h"
 
 class EditorDebuggerServer : public RefCounted {
+	GDSOFTCLASS(EditorDebuggerServer, RefCounted);
+
 public:
 	typedef EditorDebuggerServer *(*CreateServerFunc)(const String &p_uri);
 

--- a/editor/export/codesign.h
+++ b/editor/export/codesign.h
@@ -132,6 +132,8 @@ public:
 // Note: Proper code generator is not implemented (any we probably won't ever need it), just a hardcoded bytecode for the limited set of cases.
 
 class CodeSignRequirements : public CodeSignBlob {
+	GDSOFTCLASS(CodeSignRequirements, CodeSignBlob);
+
 	PackedByteArray blob;
 
 	static inline size_t PAD(size_t s, size_t a) {
@@ -168,6 +170,8 @@ public:
 // PList formatted entitlements.
 
 class CodeSignEntitlementsText : public CodeSignBlob {
+	GDSOFTCLASS(CodeSignEntitlementsText, CodeSignBlob);
+
 	PackedByteArray blob;
 
 public:
@@ -190,6 +194,8 @@ public:
 // ASN.1 serialized entitlements.
 
 class CodeSignEntitlementsBinary : public CodeSignBlob {
+	GDSOFTCLASS(CodeSignEntitlementsBinary, CodeSignBlob);
+
 	PackedByteArray blob;
 
 public:
@@ -212,6 +218,8 @@ public:
 // Code Directory, runtime options, code segment and special structure hashes.
 
 class CodeSignCodeDirectory : public CodeSignBlob {
+	GDSOFTCLASS(CodeSignCodeDirectory, CodeSignBlob);
+
 public:
 	enum Slot {
 		SLOT_INFO_PLIST = -1,
@@ -312,6 +320,8 @@ public:
 /*************************************************************************/
 
 class CodeSignSignature : public CodeSignBlob {
+	GDSOFTCLASS(CodeSignSignature, CodeSignBlob);
+
 	PackedByteArray blob;
 
 public:

--- a/editor/export/dedicated_server_export_plugin.h
+++ b/editor/export/dedicated_server_export_plugin.h
@@ -33,6 +33,8 @@
 #include "editor/export/editor_export_plugin.h"
 
 class DedicatedServerExportPlugin : public EditorExportPlugin {
+	GDSOFTCLASS(DedicatedServerExportPlugin, EditorExportPlugin);
+
 private:
 	EditorExportPreset::FileExportMode current_export_mode;
 

--- a/editor/export/gdextension_export_plugin.h
+++ b/editor/export/gdextension_export_plugin.h
@@ -34,9 +34,11 @@
 #include "editor/export/editor_export.h"
 
 class GDExtensionExportPlugin : public EditorExportPlugin {
+	GDSOFTCLASS(GDExtensionExportPlugin, EditorExportPlugin);
+
 protected:
-	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features);
-	virtual String get_name() const { return "GDExtension"; }
+	virtual void _export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) override;
+	virtual String get_name() const override { return "GDExtension"; }
 };
 
 void GDExtensionExportPlugin::_export_file(const String &p_path, const String &p_type, const HashSet<String> &p_features) {

--- a/editor/export/lipo.h
+++ b/editor/export/lipo.h
@@ -36,6 +36,8 @@
 #include "core/object/ref_counted.h"
 
 class LipO : public RefCounted {
+	GDSOFTCLASS(LipO, RefCounted);
+
 	struct FatArch {
 		uint32_t cputype;
 		uint32_t cpusubtype;

--- a/editor/export/macho.h
+++ b/editor/export/macho.h
@@ -36,6 +36,8 @@
 #include "core/object/ref_counted.h"
 
 class MachO : public RefCounted {
+	GDSOFTCLASS(MachO, RefCounted);
+
 public:
 	struct MachHeader {
 		uint32_t cputype;

--- a/editor/export/shader_baker_export_plugin.h
+++ b/editor/export/shader_baker_export_plugin.h
@@ -44,6 +44,8 @@ public:
 };
 
 class ShaderBakerExportPlugin : public EditorExportPlugin {
+	GDSOFTCLASS(ShaderBakerExportPlugin, EditorExportPlugin);
+
 protected:
 	struct WorkItem {
 		String cache_path;

--- a/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.h
+++ b/editor/shader/shader_baker/shader_baker_export_plugin_platform_metal.h
@@ -33,6 +33,8 @@
 #include "editor/export/shader_baker_export_plugin.h"
 
 class ShaderBakerExportPluginPlatformMetal : public ShaderBakerExportPluginPlatform {
+	GDSOFTCLASS(ShaderBakerExportPluginPlatformMetal, ShaderBakerExportPluginPlatform);
+
 public:
 	virtual RenderingShaderContainerFormat *create_shader_container_format(const Ref<EditorExportPlatform> &p_platform, const Ref<EditorExportPreset> &p_preset) override;
 	virtual bool matches_driver(const String &p_driver) override;

--- a/modules/betsy/image_compress_betsy.h
+++ b/modules/betsy/image_compress_betsy.h
@@ -91,6 +91,8 @@ Error _betsy_compress_bptc(Image *r_img, Image::UsedChannels p_channels);
 Error _betsy_compress_s3tc(Image *r_img, Image::UsedChannels p_channels);
 
 class BetsyCompressor : public Object {
+	GDSOFTCLASS(BetsyCompressor, Object);
+
 	mutable CommandQueueMT command_queue;
 	bool exit = false;
 	WorkerThreadPool::TaskID task_id = WorkerThreadPool::INVALID_TASK_ID;

--- a/modules/dds/texture_loader_dds.h
+++ b/modules/dds/texture_loader_dds.h
@@ -33,6 +33,8 @@
 #include "core/io/resource_loader.h"
 
 class ResourceFormatDDS : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatDDS, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -677,6 +677,8 @@ public:
 };
 
 class ResourceFormatLoaderGDScript : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderGDScript, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -687,6 +689,8 @@ public:
 };
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverGDScript, ResourceFormatSaver);
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/modules/ktx/texture_loader_ktx.h
+++ b/modules/ktx/texture_loader_ktx.h
@@ -34,6 +34,8 @@
 #include "scene/resources/texture.h"
 
 class ResourceFormatKTX : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatKTX, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/modules/mbedtls/tls_context_mbedtls.h
+++ b/modules/mbedtls/tls_context_mbedtls.h
@@ -43,6 +43,8 @@
 class TLSContextMbedTLS;
 
 class CookieContextMbedTLS : public RefCounted {
+	GDSOFTCLASS(CookieContextMbedTLS, RefCounted);
+
 	friend class TLSContextMbedTLS;
 
 protected:
@@ -60,6 +62,8 @@ public:
 };
 
 class TLSContextMbedTLS : public RefCounted {
+	GDSOFTCLASS(TLSContextMbedTLS, RefCounted);
+
 protected:
 	bool inited = false;
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -589,6 +589,8 @@ public:
 };
 
 class ResourceFormatLoaderCSharpScript : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderCSharpScript, ResourceFormatLoader);
+
 public:
 	Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -597,6 +599,8 @@ public:
 };
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverCSharpScript, ResourceFormatSaver);
+
 public:
 	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/modules/multiplayer/multiplayer_debugger.h
+++ b/modules/multiplayer/multiplayer_debugger.h
@@ -77,6 +77,8 @@ public:
 
 private:
 	class BandwidthProfiler : public EngineProfiler {
+		GDSOFTCLASS(BandwidthProfiler, EngineProfiler);
+
 	protected:
 		struct BandwidthFrame {
 			uint32_t timestamp;
@@ -92,12 +94,14 @@ private:
 		int bandwidth_usage(const Vector<BandwidthFrame> &p_buffer, int p_pointer);
 
 	public:
-		void toggle(bool p_enable, const Array &p_opts);
-		void add(const Array &p_data);
-		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
+		void toggle(bool p_enable, const Array &p_opts) override;
+		void add(const Array &p_data) override;
+		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) override;
 	};
 
 	class RPCProfiler : public EngineProfiler {
+		GDSOFTCLASS(RPCProfiler, EngineProfiler);
+
 	private:
 		HashMap<ObjectID, RPCNodeInfo> rpc_node_data;
 		uint64_t last_profile_time = 0;
@@ -105,20 +109,22 @@ private:
 		void init_node(const ObjectID p_node);
 
 	public:
-		void toggle(bool p_enable, const Array &p_opts);
-		void add(const Array &p_data);
-		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
+		void toggle(bool p_enable, const Array &p_opts) override;
+		void add(const Array &p_data) override;
+		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) override;
 	};
 
 	class ReplicationProfiler : public EngineProfiler {
+		GDSOFTCLASS(ReplicationProfiler, EngineProfiler);
+
 	private:
 		HashMap<ObjectID, SyncInfo> sync_data;
 		uint64_t last_profile_time = 0;
 
 	public:
-		void toggle(bool p_enable, const Array &p_opts);
-		void add(const Array &p_data);
-		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
+		void toggle(bool p_enable, const Array &p_opts) override;
+		void add(const Array &p_data) override;
+		void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) override;
 	};
 
 	static Error _capture(void *p_user, const String &p_msg, const Array &p_args, bool &r_captured);

--- a/modules/navigation_2d/2d/nav_mesh_generator_2d.h
+++ b/modules/navigation_2d/2d/nav_mesh_generator_2d.h
@@ -42,6 +42,8 @@ class NavigationPolygon;
 class NavigationMeshSourceGeometryData2D;
 
 class NavMeshGenerator2D : public Object {
+	GDSOFTCLASS(NavMeshGenerator2D, Object);
+
 	static NavMeshGenerator2D *singleton;
 
 	static Mutex baking_navmesh_mutex;

--- a/modules/navigation_3d/3d/nav_mesh_generator_3d.h
+++ b/modules/navigation_3d/3d/nav_mesh_generator_3d.h
@@ -40,6 +40,8 @@ class NavigationMesh;
 class NavigationMeshSourceGeometryData3D;
 
 class NavMeshGenerator3D : public Object {
+	GDSOFTCLASS(NavMeshGenerator3D, Object);
+
 	static NavMeshGenerator3D *singleton;
 
 	static Mutex baking_navmesh_mutex;

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -173,6 +173,8 @@ public:
 };
 
 class ResourceFormatLoaderTheora : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderTheora, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/modules/webp/resource_saver_webp.h
+++ b/modules/webp/resource_saver_webp.h
@@ -34,6 +34,8 @@
 #include "core/io/resource_saver.h"
 
 class ResourceSaverWebP : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceSaverWebP, ResourceFormatSaver);
+
 public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -35,6 +35,8 @@
 #include "core/debugger/remote_debugger_peer.h"
 
 class RemoteDebuggerPeerWebSocket : public RemoteDebuggerPeer {
+	GDSOFTCLASS(RemoteDebuggerPeerWebSocket, RemoteDebuggerPeer);
+
 	Ref<WebSocketPeer> ws_peer;
 	List<Array> in_queue;
 	List<Array> out_queue;

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -44,6 +44,8 @@
  * joins/leaves a multicast group.
  */
 class NetSocketAndroid : public NetSocketUnix {
+	GDSOFTCLASS(NetSocketAndroid, NetSocketUnix);
+
 private:
 	static jobject net_utils;
 	static jclass cls;
@@ -64,11 +66,11 @@ public:
 	static void setup(jobject p_net_utils);
 	static void terminate();
 
-	virtual void close();
+	virtual void close() override;
 
-	virtual Error set_broadcasting_enabled(bool p_enabled);
-	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name);
-	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name);
+	virtual Error set_broadcasting_enabled(bool p_enabled) override;
+	virtual Error join_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
+	virtual Error leave_multicast_group(const IPAddress &p_multi_address, const String &p_if_name) override;
 
 	NetSocketAndroid() {}
 	~NetSocketAndroid();

--- a/platform/web/export/editor_http_server.h
+++ b/platform/web/export/editor_http_server.h
@@ -37,6 +37,8 @@
 #include "editor/file_system/editor_paths.h"
 
 class EditorHTTPServer : public RefCounted {
+	GDSOFTCLASS(EditorHTTPServer, RefCounted);
+
 private:
 	Ref<TCPServer> server;
 	HashMap<String, String> mimes;

--- a/platform/web/http_client_web.h
+++ b/platform/web/http_client_web.h
@@ -56,6 +56,8 @@ extern int godot_js_fetch_is_chunked(int p_id);
 #endif
 
 class HTTPClientWeb : public HTTPClient {
+	GDSOFTCLASS(HTTPClientWeb, HTTPClient);
+
 private:
 	int js_id = 0;
 	Status status = STATUS_DISCONNECTED;

--- a/platform/web/net_socket_web.h
+++ b/platform/web/net_socket_web.h
@@ -35,6 +35,8 @@
 #include <sys/socket.h>
 
 class NetSocketWeb : public NetSocket {
+	GDSOFTCLASS(NetSocketWeb, NetSocket);
+
 protected:
 	static NetSocket *_create_func();
 

--- a/scene/3d/velocity_tracker_3d.h
+++ b/scene/3d/velocity_tracker_3d.h
@@ -33,6 +33,8 @@
 #include "core/object/ref_counted.h"
 
 class VelocityTracker3D : public RefCounted {
+	GDSOFTCLASS(VelocityTracker3D, RefCounted);
+
 	struct PositionHistory {
 		uint64_t frame = 0;
 		Vector3 position;

--- a/scene/gui/graph_edit_arranger.h
+++ b/scene/gui/graph_edit_arranger.h
@@ -37,6 +37,8 @@
 class GraphEdit;
 
 class GraphEditArranger : public RefCounted {
+	GDSOFTCLASS(GraphEditArranger, RefCounted);
+
 	enum SET_OPERATIONS {
 		IS_EQUAL,
 		IS_SUBSET,

--- a/scene/resources/compressed_texture.h
+++ b/scene/resources/compressed_texture.h
@@ -110,6 +110,8 @@ public:
 };
 
 class ResourceFormatLoaderCompressedTexture2D : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderCompressedTexture2D, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -174,6 +176,8 @@ public:
 };
 
 class ResourceFormatLoaderCompressedTextureLayered : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderCompressedTextureLayered, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -258,6 +262,8 @@ public:
 };
 
 class ResourceFormatLoaderCompressedTexture3D : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderCompressedTexture3D, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -143,6 +143,8 @@ public:
 };
 
 class ResourceFormatLoaderText : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderText, ResourceFormatLoader);
+
 public:
 	static ResourceFormatLoaderText *singleton;
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
@@ -203,6 +205,8 @@ public:
 };
 
 class ResourceFormatSaverText : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverText, ResourceFormatSaver);
+
 public:
 	static ResourceFormatSaverText *singleton;
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -106,6 +106,8 @@ public:
 VARIANT_ENUM_CAST(Shader::Mode);
 
 class ResourceFormatLoaderShader : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderShader, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -114,6 +116,8 @@ public:
 };
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverShader, ResourceFormatSaver);
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -56,6 +56,8 @@ public:
 };
 
 class ResourceFormatLoaderShaderInclude : public ResourceFormatLoader {
+	GDSOFTCLASS(ResourceFormatLoaderShaderInclude, ResourceFormatLoader);
+
 public:
 	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
@@ -64,6 +66,8 @@ public:
 };
 
 class ResourceFormatSaverShaderInclude : public ResourceFormatSaver {
+	GDSOFTCLASS(ResourceFormatSaverShaderInclude, ResourceFormatSaver);
+
 public:
 	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -54,6 +54,8 @@
 #endif
 
 class PhysicsServer2DWrapMT : public PhysicsServer2D {
+	GDSOFTCLASS(PhysicsServer2DWrapMT, PhysicsServer2D);
+
 	mutable PhysicsServer2D *physics_server_2d = nullptr;
 
 	mutable CommandQueueMT command_queue;

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -55,6 +55,8 @@
 #endif
 
 class PhysicsServer3DWrapMT : public PhysicsServer3D {
+	GDSOFTCLASS(PhysicsServer3DWrapMT, PhysicsServer3D);
+
 	mutable PhysicsServer3D *physics_server_3d = nullptr;
 
 	mutable CommandQueueMT command_queue;

--- a/servers/rendering/rendering_device_driver.h
+++ b/servers/rendering/rendering_device_driver.h
@@ -86,6 +86,8 @@ struct VersatileResourceTemplate {
 };
 
 class RenderingDeviceDriver : public RenderingDeviceCommons {
+	GDSOFTCLASS(RenderingDeviceDriver, RenderingDeviceCommons);
+
 public:
 	struct ID {
 		uint64_t id = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -42,6 +42,8 @@
 #include "servers/server_wrap_mt_common.h"
 
 class RenderingServerDefault : public RenderingServer {
+	GDSOFTCLASS(RenderingServerDefault, RenderingServer);
+
 	enum {
 		MAX_INSTANCE_CULL = 8192,
 		MAX_INSTANCE_LIGHTS = 4,

--- a/servers/rendering/rendering_shader_container.h
+++ b/servers/rendering/rendering_shader_container.h
@@ -150,6 +150,8 @@ public:
 };
 
 class RenderingShaderContainerFormat : public RenderingDeviceCommons {
+	GDSOFTCLASS(RenderingShaderContainerFormat, RenderingDeviceCommons);
+
 public:
 	virtual Ref<RenderingShaderContainer> create_container() const = 0;
 	virtual ShaderLanguageVersion get_shader_language_version() const = 0;


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->

Hi all 👋 (cc. @Ivorforce )

Further to bug report #110693, which was prematurely closed, and in which it was discovered that static casting errors occur when:

1. inheriting from `Object`  - directly or otherwise
2. but not defining an appropriate `GDCLASS` or `GDSOFTCLASS` at each child class

And notwithstanding that my previous PR's (#110694 and #110752) fixed part of the problem, by fixing direct children of `Object`. Please note that this is not - however - sufficient, since there can be children deeper in the inheritance tree that will still exhibit this bug.

This PR seeks to locate all those remaining - deeper in the inheritance tree from `Object` - and fix them by adding an appropriate `GDSOFTCLASS`.


## Changes

- `GDSOFTCLASS` added to _many_ classes
- `override` keywords added to public methods in:
    - `editor/export/gdextension_export_plugin.h`
    - `modules/multiplayer/multiplayer_debugger.h`
    - `platform/android/net_socket_android.h`

## How to validate

1. install `ripgrep`
2. Use (check first!) this script

```bash
#!/bin/bash

# List of parent classes (derived from the PR)
classes=(
    Object
	ResourceFormatLoader
	ResourceFormatSaver
	EngineProfiler
	RefCounted
	RemoteDebuggerPeer
	HTTPClient
	NetSocket
	EditorDebuggerServer
	CodeSignBlob
	EditorExportPlugin
	ShaderBakerExportPluginPlatform
	NetSocketUnix
	PhysicsServer2D
	PhysicsServer3D
	RenderingDeviceCommons
	RenderingServer
    NavMeshGenerator2D
    NavMeshGenerator3D
    BetsyCompressor
)

for cls in "${classes[@]}"; do
	echo "Searching for classes derived from $cls..."
	rg --pcre2 -n -H -o --multiline --multiline-dotall \
	  "^(class\s+(\w+)\s*:\s*public\s+$cls\s*\{(?:(?!GDCLASS|GDSOFTCLASS).)*?\})" \
	  --glob '*.h' --glob '*.cpp' \
	  --glob '!*.gen.h' --glob '!test*.h' \
	  --glob '!thirdparty/**' \
	  --replace '$2'
done
```

Thanks! 😄 

## Methodology 

They were initially found with [this script and output](https://gist.github.com/wheatear-dev/4f8b07613cfa8932cfd3ff8508b7f505), and then manually refined and expanded. Please note that:

- the script has problems with duplicates (similarly named classes in different files), and can't distinguish them, due to not actually interpreting C++ source code.
- some classes were manually marked with `SKIP` in the output, since they were either a duplicate - of a similarly named class that does descend from `Object` - or a descendant of such a duplicate.
