### PR TITLE
Clean up ReparentDialog

### DIFF
--- a/editor/scene/reparent_dialog.h
+++ b/editor/scene/reparent_dialog.h
@@ -41,11 +41,13 @@ class ReparentDialog : public ConfirmationDialog {
 	SceneTreeEditor *tree = nullptr;
 	CheckBox *keep_transform = nullptr;
 
+	void _node_selected();
 	void _reparent();
-	void _cancel();
 
 protected:
-	void _notification(int p_what);
+	virtual void _pre_popup() override;
+	virtual void ok_pressed() override;
+
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
I was going to make a small clean up, but it turned out into a half-rework 😅
(the ReparentDialog is the dialog that appears when you use Reparent... option in Scene dock)

- Removed useless signal disconnection (it predates `NOTIFICATION_READY` being sent one time)
  - And actually replaced `confirmed` signal usage with `ok_pressed()` callback
- Opening the dialog now deselects all nodes (previously it would keep fake selection)
  - Fixes a bug where pressing Reparent may do nothing
    - (although it still may do nothing if you try to reparent to the same node)
- OK button is now disabled when no node is selected
- The condition where Tree might not have selected nodes is now considered an error
- Fixed auto-translation