### PR TITLE
Make navmesh rasterization errors more lenient

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1733,6 +1733,14 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("navigation/baking/thread_model/baking_use_multiple_threads", true);
 	GLOBAL_DEF("navigation/baking/thread_model/baking_use_high_priority_threads", true);
 #endif // !defined(NAVIGATION_2D_DISABLED) || !defined(NAVIGATION_3D_DISABLED)
+#ifndef NAVIGATION_2D_DISABLED
+	GLOBAL_DEF("navigation/2d/warnings/navmesh_edge_merge_errors", true);
+	GLOBAL_DEF("navigation/2d/warnings/navmesh_cell_size_mismatch", true);
+#endif // NAVIGATION_2D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
+	GLOBAL_DEF("navigation/3d/warnings/navmesh_edge_merge_errors", true);
+	GLOBAL_DEF("navigation/3d/warnings/navmesh_cell_size_mismatch", true);
+#endif // NAVIGATION_3D_DISABLED
 
 	ProjectSettings::get_singleton()->add_hidden_prefix("input/");
 }

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -2314,6 +2314,12 @@
 		<member name="navigation/2d/use_edge_connections" type="bool" setter="" getter="" default="true">
 			If enabled 2D navigation regions will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin. This setting only affects World2D default navigation maps.
 		</member>
+		<member name="navigation/2d/warnings/navmesh_cell_size_mismatch" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the navigation system will print warnings when a navigation mesh with a small cell size is used on a navigation map with a larger size as this commonly causes rasterization errors.
+		</member>
+		<member name="navigation/2d/warnings/navmesh_edge_merge_errors" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the navigation system will print warnings about navigation mesh edge merge errors occurring in navigation regions or maps.
+		</member>
 		<member name="navigation/3d/default_cell_height" type="float" setter="" getter="" default="0.25">
 			Default cell height for 3D navigation maps. See [method NavigationServer3D.map_set_cell_height].
 		</member>
@@ -2334,6 +2340,12 @@
 		</member>
 		<member name="navigation/3d/use_edge_connections" type="bool" setter="" getter="" default="true">
 			If enabled 3D navigation regions will use edge connections to connect with other navigation regions within proximity of the navigation map edge connection margin. This setting only affects World3D default navigation maps.
+		</member>
+		<member name="navigation/3d/warnings/navmesh_cell_size_mismatch" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the navigation system will print warnings when a navigation mesh with a small cell size (or in 3D height) is used on a navigation map with a larger size as this commonly causes rasterization errors.
+		</member>
+		<member name="navigation/3d/warnings/navmesh_edge_merge_errors" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], the navigation system will print warnings about navigation mesh edge merge errors occurring in navigation regions or maps.
 		</member>
 		<member name="navigation/avoidance/thread_model/avoidance_use_high_priority_threads" type="bool" setter="" getter="" default="true">
 			If enabled and avoidance calculations use multiple threads the threads run with high priority.

--- a/modules/navigation_2d/nav_map_2d.cpp
+++ b/modules/navigation_2d/nav_map_2d.cpp
@@ -80,7 +80,7 @@ void NavMap2D::set_merge_rasterizer_cell_scale(float p_value) {
 	if (merge_rasterizer_cell_scale == p_value) {
 		return;
 	}
-	merge_rasterizer_cell_scale = MAX(p_value, NavigationDefaults2D::NAV_MESH_CELL_SIZE_MIN);
+	merge_rasterizer_cell_scale = MAX(MIN(p_value, 0.1), NavigationDefaults2D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }

--- a/modules/navigation_2d/nav_map_2d.h
+++ b/modules/navigation_2d/nav_map_2d.h
@@ -56,7 +56,7 @@ class NavMap2D : public NavRid2D {
 	Vector2 merge_rasterizer_cell_size = Vector2(cell_size, cell_size);
 
 	// This value is used to control sensitivity of internal rasterizer.
-	float merge_rasterizer_cell_scale = 1.0;
+	float merge_rasterizer_cell_scale = 0.1;
 
 	bool use_edge_connections = true;
 	/// This value is used to detect the near edges to connect.

--- a/modules/navigation_2d/nav_region_2d.cpp
+++ b/modules/navigation_2d/nav_region_2d.cpp
@@ -94,8 +94,13 @@ void NavRegion2D::set_transform(Transform2D p_transform) {
 
 void NavRegion2D::set_navigation_mesh(Ref<NavigationPolygon> p_navigation_mesh) {
 #ifdef DEBUG_ENABLED
-	if (map && p_navigation_mesh.is_valid() && !Math::is_equal_approx(double(map->get_cell_size()), double(p_navigation_mesh->get_cell_size()))) {
-		ERR_PRINT_ONCE(vformat("Attempted to update a navigation region with a navigation mesh that uses a `cell_size` of %s while assigned to a navigation map set to a `cell_size` of %s. The cell size for navigation maps can be changed by using the NavigationServer map_set_cell_size() function. The cell size for default navigation maps can also be changed in the ProjectSettings.", double(p_navigation_mesh->get_cell_size()), double(map->get_cell_size())));
+	if (map && p_navigation_mesh.is_valid() && GLOBAL_GET_CACHED(bool, "navigation/2d/warnings/navmesh_cell_size_mismatch")) {
+		const double map_cell_size = double(map->get_cell_size());
+		const double navmesh_cell_size = double(p_navigation_mesh->get_cell_size());
+
+		if (map_cell_size > navmesh_cell_size) {
+			WARN_PRINT(vformat("A navigation mesh that uses a `cell_size` of %s was assigned to a navigation map set to a larger `cell_size` of %s.\nThis mismatch in cell size can cause rasterization errors with navigation mesh edges on the navigation map.\nThe cell size for navigation maps can be changed by using the NavigationServer map_set_cell_size() function.\nThe cell size for default navigation maps can also be changed in the project settings.\nThis warning can be toggled under 'navigation/2d/warnings/navmesh_cell_size_mismatch' in the project settings.", navmesh_cell_size, map_cell_size));
+		}
 	}
 #endif // DEBUG_ENABLED
 

--- a/modules/navigation_3d/3d/nav_map_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_map_builder_3d.cpp
@@ -36,6 +36,8 @@
 #include "nav_map_iteration_3d.h"
 #include "nav_region_iteration_3d.h"
 
+#include "core/config/project_settings.h"
+
 using namespace Nav3D;
 
 PointKey NavMapBuilder3D::get_point_key(const Vector3 &p_pos, const Vector3 &p_cell_size) {
@@ -111,6 +113,7 @@ void NavMapBuilder3D::_build_step_find_edge_connection_pairs(NavMapIterationBuil
 	connection_pairs_map.clear();
 	connection_pairs_map.reserve(polygon_count);
 	int free_edges_count = 0; // How many ConnectionPairs have only one Connection.
+	int edge_merge_error_count = 0;
 
 	for (const Ref<NavRegionIteration3D> &region : map_iteration->region_iterations) {
 		for (const ConnectableEdge &connectable_edge : region->get_external_edges()) {
@@ -139,9 +142,13 @@ void NavMapBuilder3D::_build_step_find_edge_connection_pairs(NavMapIterationBuil
 
 			} else {
 				// The edge is already connected with another edge, skip.
-				ERR_PRINT_ONCE("Navigation map synchronization error. Attempted to merge a navigation mesh polygon edge with another already-merged edge. This is usually caused by crossing edges, overlapping polygons, or a mismatch of the NavigationMesh / NavigationPolygon baked 'cell_size' and navigation map 'cell_size'. If you're certain none of above is the case, change 'navigation/3d/merge_rasterizer_cell_scale' to 0.001.");
+				edge_merge_error_count++;
 			}
 		}
+	}
+
+	if (edge_merge_error_count > 0 && GLOBAL_GET_CACHED(bool, "navigation/3d/warnings/navmesh_edge_merge_errors")) {
+		WARN_PRINT("Navigation map synchronization had " + itos(edge_merge_error_count) + " edge error(s).\nMore than 2 edges tried to occupy the same map rasterization space.\nThis causes a logical error in the navigation mesh geometry and is commonly caused by overlap or too densely placed edges.\nConsider baking with a higher 'cell_size', greater geometry margin, and less detailed bake objects to cause fewer edges.\nConsider lowering the 'navigation/3d/merge_rasterizer_cell_scale' in the project settings.\nThis warning can be toggled under 'navigation/3d/warnings/navmesh_edge_merge_errors' in the project settings.");
 	}
 
 	r_build.free_edge_count = free_edges_count;

--- a/modules/navigation_3d/3d/nav_region_builder_3d.cpp
+++ b/modules/navigation_3d/3d/nav_region_builder_3d.cpp
@@ -34,6 +34,8 @@
 #include "../nav_region_3d.h"
 #include "nav_region_iteration_3d.h"
 
+#include "core/config/project_settings.h"
+
 using namespace Nav3D;
 
 void NavRegionBuilder3D::build_iteration(NavRegionIterationBuild3D &r_build) {
@@ -180,6 +182,7 @@ void NavRegionBuilder3D::_build_step_find_edge_connection_pairs(NavRegionIterati
 	region_iteration->external_edges.clear();
 
 	int free_edges_count = 0;
+	int edge_merge_error_count = 0;
 
 	for (Polygon &poly : region_iteration->navmesh_polygons) {
 		for (uint32_t p = 0; p < poly.vertices.size(); p++) {
@@ -209,9 +212,13 @@ void NavRegionBuilder3D::_build_step_find_edge_connection_pairs(NavRegionIterati
 
 			} else {
 				// The edge is already connected with another edge, skip.
-				ERR_FAIL_COND_MSG(pair.size >= 2, "Navigation region synchronization error. More than 2 edges tried to occupy the same map rasterization space. This is a logical error in the navigation mesh caused by overlap or too densely placed edges.");
+				edge_merge_error_count++;
 			}
 		}
+	}
+
+	if (edge_merge_error_count > 0 && GLOBAL_GET_CACHED(bool, "navigation/3d/warnings/navmesh_edge_merge_errors")) {
+		WARN_PRINT("Navigation region synchronization had " + itos(edge_merge_error_count) + " edge error(s).\nMore than 2 edges tried to occupy the same map rasterization space.\nThis causes a logical error in the navigation mesh geometry and is commonly caused by overlap or too densely placed edges.\nConsider baking with a higher 'cell_size', greater geometry margin, and less detailed bake objects to cause fewer edges.\nConsider lowering the 'navigation/3d/merge_rasterizer_cell_scale' in the project settings.\nThis warning can be toggled under 'navigation/3d/warnings/navmesh_edge_merge_errors' in the project settings.");
 	}
 
 	performance_data.pm_edge_free_count = free_edges_count;

--- a/modules/navigation_3d/nav_map_3d.cpp
+++ b/modules/navigation_3d/nav_map_3d.cpp
@@ -97,7 +97,7 @@ void NavMap3D::set_merge_rasterizer_cell_scale(float p_value) {
 	if (merge_rasterizer_cell_scale == p_value) {
 		return;
 	}
-	merge_rasterizer_cell_scale = MAX(p_value, NavigationDefaults3D::NAV_MESH_CELL_SIZE_MIN);
+	merge_rasterizer_cell_scale = MAX(MIN(p_value, 0.1), NavigationDefaults3D::NAV_MESH_CELL_SIZE_MIN);
 	_update_merge_rasterizer_cell_dimensions();
 	map_settings_dirty = true;
 }

--- a/modules/navigation_3d/nav_map_3d.h
+++ b/modules/navigation_3d/nav_map_3d.h
@@ -62,7 +62,7 @@ class NavMap3D : public NavRid3D {
 	Vector3 merge_rasterizer_cell_size = Vector3(cell_size, cell_height, cell_size);
 
 	// This value is used to control sensitivity of internal rasterizer.
-	float merge_rasterizer_cell_scale = 1.0;
+	float merge_rasterizer_cell_scale = 0.1;
 
 	bool use_edge_connections = true;
 	/// This value is used to detect the near edges to connect.

--- a/modules/navigation_3d/nav_region_3d.cpp
+++ b/modules/navigation_3d/nav_region_3d.cpp
@@ -100,12 +100,18 @@ void NavRegion3D::set_transform(Transform3D p_transform) {
 
 void NavRegion3D::set_navigation_mesh(Ref<NavigationMesh> p_navigation_mesh) {
 #ifdef DEBUG_ENABLED
-	if (map && p_navigation_mesh.is_valid() && !Math::is_equal_approx(double(map->get_cell_size()), double(p_navigation_mesh->get_cell_size()))) {
-		ERR_PRINT_ONCE(vformat("Attempted to update a navigation region with a navigation mesh that uses a `cell_size` of %s while assigned to a navigation map set to a `cell_size` of %s. The cell size for navigation maps can be changed by using the NavigationServer map_set_cell_size() function. The cell size for default navigation maps can also be changed in the ProjectSettings.", double(p_navigation_mesh->get_cell_size()), double(map->get_cell_size())));
-	}
+	if (map && p_navigation_mesh.is_valid() && GLOBAL_GET_CACHED(bool, "navigation/3d/warnings/navmesh_cell_size_mismatch")) {
+		const double map_cell_size = double(map->get_cell_size());
+		const double map_cell_height = double(map->get_cell_height());
+		const double navmesh_cell_size = double(p_navigation_mesh->get_cell_size());
+		const double navmesh_cell_height = double(p_navigation_mesh->get_cell_height());
 
-	if (map && p_navigation_mesh.is_valid() && !Math::is_equal_approx(double(map->get_cell_height()), double(p_navigation_mesh->get_cell_height()))) {
-		ERR_PRINT_ONCE(vformat("Attempted to update a navigation region with a navigation mesh that uses a `cell_height` of %s while assigned to a navigation map set to a `cell_height` of %s. The cell height for navigation maps can be changed by using the NavigationServer map_set_cell_height() function. The cell height for default navigation maps can also be changed in the ProjectSettings.", double(p_navigation_mesh->get_cell_height()), double(map->get_cell_height())));
+		if (map_cell_size > navmesh_cell_size) {
+			WARN_PRINT(vformat("A navigation mesh that uses a `cell_size` of %s was assigned to a navigation map set to a larger `cell_size` of %s.\nThis mismatch in cell size can cause rasterization errors with navigation mesh edges on the navigation map.\nThe cell size for navigation maps can be changed by using the NavigationServer map_set_cell_size() function.\nThe cell size for default navigation maps can also be changed in the project settings.\nThis warning can be toggled under 'navigation/3d/warnings/navmesh_cell_size_mismatch' in the project settings.", navmesh_cell_size, map_cell_size));
+		}
+		if (map_cell_height > navmesh_cell_height) {
+			WARN_PRINT(vformat("A navigation mesh that uses a `cell_height` of %s was assigned to a navigation map set to a larger `cell_height` of %s.\nThis mismatch in cell height can cause rasterization errors with navigation mesh edges on the navigation map.\nThe cell height for navigation maps can be changed by using the NavigationServer map_set_cell_height() function.\nThe cell height for default navigation maps can also be changed in the project settings.\nThis warning can be toggled under 'navigation/3d/warnings/navmesh_cell_size_mismatch' in the project settings.", navmesh_cell_height, map_cell_height));
+		}
 	}
 #endif // DEBUG_ENABLED
 


### PR DESCRIPTION
Make navmesh rasterization on the navigation regions and map more lenient by starting out with a lower internal cell scale by default and changing the merge error to just warning that can be toggled.

Closes https://github.com/godotengine/godot/issues/110686
Closes https://github.com/godotengine/godot/issues/109311
Closes https://github.com/godotengine/godot/issues/110831
Closes https://github.com/godotengine/godot/issues/108263

Many projects in Godot have navmesh rasterization problems one way or another and this PR mitigates some of those problems.

### Changes:

- Adds project settings toggles to disable the warnings for projects that just want to live with them.
- Changes the default internal cell scale to a lower start value to avoid problems with (too late) physics step syncs.
- Makes sure that the internal cell scale stays at a value <= 0.1 as so many projects have no margins of their own.
- Changes the only-print-once per engine start errors to warnings that always print per navmesh build.
- Tells the number of edge errors and how to solve / mitigate their causes or suppress the msg.
- Continue to try to merge as much edges as possible even after an error with a navmesh geometry occurred.
- Make navigation map cell size and navmesh cell size warnings only trigger when map has a larger cell size (as the other way around is less likely to cause problems).


To be clear, this PR is not truly a bug fix even if it might feel like one for some projects.
This is a "be more lenient and make users have the final decision if they want to live with bugs and unknowns or not".

### Context:

In Godot navmesh on the NavigationServer gets merged by rasterizing the navmesh edges per edge key into a grid the size of the navigation map cell size / height.

If the input navigation mesh has geometry created and place in a way that it can not rasterize into that grid without causing edge overlaps in cells (only a pair is allowed) it creates errors, because the unique pairs of connections between navmesh edges can not be build. Aka the pathfinding on that edge will inevitable be broken, sometimes just subtle, sometimes very noticeable, depending on how important that edge was for the overall navmesh layout.

We can not avoid this rasterization step because everything in Godot about navmesh is flexible, in user hand, and can be added, removed and transformed, and even geometry modified all the time. Figuring such a geometry mess out does not work without rasterization and we can't do it super detailed and time consuming because it needs to run fast. We also can not set everything to a super tiny cell size by default as that will give other projects float precision problems early and for actual navmesh baking a small cell size is a major performance problem. We also can not just merge by mesh index because that just pushes the edge errors to a point later when they still do not fit the cell size of whatever navigation map they are used. There are proposals for having a less flexible but in turn more automated workflow https://github.com/godotengine/godot-proposals/issues/12707

### Changes from Godot 4.4.1 to 4.5:

While the actual rasterization has not changed between Godot 4.4.1 and 4.5 (it still uses the same cell size logic) some other things have that caused problems for some user projects.

- The Godot 4.5 release changed the order of how navmesh edges are merged by regions and the navigation map with regions merging their internal navmesh first. This actually helped in cases of multiple regions overlapping navmesh which is why users rarely see a merge error from the map in 4.5 as the map only (re)merges the external edges of regions. The problem this causes is that all projects that already had errors might now have the errors on different polygons due to the order change. Where before it might be an edge broken that they could ignore it now came back haunting on an edge where they could no longer ignore the error.

- In Godot 4.5 what also changed is that navigation regions are now cached until they need to change, e.g. navmesh or transform changes. In Godot 4.4.1 the navigation map and all regions would always update with every change. Due to the caching if a region was build with errors, without triggering an update for the actual region, the error and broken internal region edges would now persist. In old Godot it might have fixed itself at some point due to all the full updates, e.g. when users move geometry around to move the error causing geometry out of the way.

- In Godot 4.5 the edge errors were treated as actual errors, because they are. It can break an entire projects pathfinding not fixing them and way too many users ignored the errors in the past. That could also be seen by all the issues that now show up, most of them being faulty rasterization settings or broken geometry related. So having this treated as actual hard errors might have created hard to solve problems for their upgrade to Godot 4.5.  Having an actual error means that after an error occurred the edge loop would no longer continue trying to merge the rest of the (half) broken geometry. Some projects seem to have been very dependent on the fact that they could just ignore the errors while still getting whatever leftover navmesh managed to merge somehow.

- Physics continues to mess everything it touches up.

Tbh at least I completely underestimated how many projects are totally willing to run with unsolved errors up to releasing games with them. For most projects ignoring the errors and not fixing settings or geometry is a path to (later) project damnation with pathfinding being constantly broken in places. In some cases it might be fine to ignore the errors and just run with them. The problem is I or the engine can not make that decision because we do not know what master plan the user is cooking in their project (sometimes the user does not know as well but that is a different issue). So lets change it in a way so users have more options how to run things, even if they might be dangerous or sub-optimal at their own responsibility.