### PR TITLE
Fix glow intensity not showing in compatibility renderer

### DIFF
--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1120,7 +1120,7 @@ void Environment::_validate_property(PropertyInfo &p_property) const {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 
-	if (p_property.name == "glow_intensity" && glow_blend_mode == GLOW_BLEND_MODE_MIX) {
+	if (p_property.name == "glow_intensity" && glow_blend_mode == GLOW_BLEND_MODE_MIX && OS::get_singleton()->get_current_rendering_method() != "gl_compatibility") {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 


### PR DESCRIPTION
- Fixes #110842

It appears that the logic that hides the glow intensity when blend mode is set to Mix was not disabled when glow was added to Compatibility. Compatibility ignores the blend mode, so it must always show glow intensity, even when the blend mode is set to mix.