### PR TITLE
FoldableContainer: Override `has_point` to use title rect when folded

### DIFF
--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -255,6 +255,13 @@ String FoldableContainer::get_tooltip(const Point2 &p_pos) const {
 	return String();
 }
 
+bool FoldableContainer::has_point(const Point2 &p_point) const {
+	if (folded) {
+		return _get_title_rect().has_point(p_point);
+	}
+	return Control::has_point(p_point);
+}
+
 void FoldableContainer::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_DRAW: {

--- a/scene/gui/foldable_container.h
+++ b/scene/gui/foldable_container.h
@@ -102,6 +102,7 @@ private:
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
+	virtual bool has_point(const Point2 &p_point) const override;
 	void _notification(int p_what);
 	static void _bind_methods();
 


### PR DESCRIPTION
An attempt to fix https://github.com/godotengine/godot/issues/110834

Issue:
- Mouse pointer still changes appearance when hovering over the invisible (folded) part of a `FoldableContainer`

Solution:
- Override `Control::has_point` so that when folded, only the title rect is considered interactive. When unfloded, the default `Control` logic is used.

Notes:
- I copied the title rect logic from `FoldableContainer::gui_input`. This rect is being created 4 times (including my addition) across `_notification`, `gui_input` and now `has_point`. It might be useful to cache this and update on some size change event, or at the very least refactor the logic into a helper function.

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
