### PR TITLE
Clarify Callable ==, != operators and Callable.bind()

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -93,7 +93,7 @@
 			<return type="Callable" />
 			<description>
 				Returns a copy of this [Callable] with one or more arguments bound. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call]. See also [method unbind].
-				[b]Note:[/b] When this method is chained with other similar methods, the order in which the argument list is modified is read from right to left. Also, keep in mind that the returned [Callable] is not considered strictly unique, see [operator ==].
+				[b]Note:[/b] When this method is chained with other similar methods, the order in which the argument list is modified is read from right to left. Also, keep in mind that the returned [Callable] is not considered strictly unique, see [operator operator ==].
 			</description>
 		</method>
 		<method name="bindv">

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -269,7 +269,7 @@
 				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments and not the arguments themselves; thus, keep in mind the following:
 				[codeblock]
 				print.bind("banana") != print.bind("apple") // false
-				[/codeblock]				
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -280,7 +280,7 @@
 				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments and not the arguments themselves; thus, keep in mind the following:
 				[codeblock]
 				print.bind("banana") == print.bind("apple") // true
-				[/codeblock]				
+				[/codeblock]
 			</description>
 		</operator>
 	</operators>

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -277,7 +277,7 @@
 			<param index="0" name="right" type="Callable" />
 			<description>
 				Returns [code]true[/code] if both [Callable]s invoke the same custom target.
-				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments; thus, keep in mind the following:
+				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments and not the arguments themselves; thus, keep in mind the following:
 				[codeblock]
 				print.bind("banana") == print.bind("apple") // true
 				[/codeblock]				

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -266,7 +266,7 @@
 			<param index="0" name="right" type="Callable" />
 			<description>
 				Returns [code]true[/code] if both [Callable]s invoke different targets.
-				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments; thus, keep in mind the following:
+				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments and not the arguments themselves; thus, keep in mind the following:
 				[codeblock]
 				print.bind("banana") != print.bind("apple") // false
 				[/codeblock]				

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -93,7 +93,7 @@
 			<return type="Callable" />
 			<description>
 				Returns a copy of this [Callable] with one or more arguments bound. When called, the bound arguments are passed [i]after[/i] the arguments supplied by [method call]. See also [method unbind].
-				[b]Note:[/b] When this method is chained with other similar methods, the order in which the argument list is modified is read from right to left.
+				[b]Note:[/b] When this method is chained with other similar methods, the order in which the argument list is modified is read from right to left. Also, keep in mind that the returned [Callable] is not considered strictly unique, see [operator ==].
 			</description>
 		</method>
 		<method name="bindv">
@@ -266,6 +266,10 @@
 			<param index="0" name="right" type="Callable" />
 			<description>
 				Returns [code]true[/code] if both [Callable]s invoke different targets.
+				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments; thus, keep in mind the following:
+				[codeblock]
+				print.bind("banana") != print.bind("apple") // false
+				[/codeblock]				
 			</description>
 		</operator>
 		<operator name="operator ==">
@@ -273,6 +277,10 @@
 			<param index="0" name="right" type="Callable" />
 			<description>
 				Returns [code]true[/code] if both [Callable]s invoke the same custom target.
+				[b]Note:[/b] Beware that when comparing the same [Callable] with arguments bound via [method bind], the comparison only compares the number of bound arguments; thus, keep in mind the following:
+				[codeblock]
+				print.bind("banana") == print.bind("apple") // true
+				[/codeblock]				
 			</description>
 		</operator>
 	</operators>


### PR DESCRIPTION
<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
This PR addresses https://github.com/godotengine/godot-docs/issues/11295 

As far as I could see, this clarification concerns all Godot versions since the implementation of `Callable.bind()` and `Callable.unbind()`. 

**Note**: I do consider this behavior incorrect and something that should be changed. I don't think the `==` and `!=` operators should even attempt to compare the bound arguments and should automatically judge the Callables unequal if they aren't the same instance. 
Obviously, this would be a breaking change for past Godot versions, so it's not something that should be done, but maybe for Godot 4.6? thoughts? 