### PR TITLE
Add custom projection matrix support for rendering 

### DIFF
--- a/core/math/projection.cpp
+++ b/core/math/projection.cpp
@@ -876,6 +876,13 @@ bool Projection::is_orthogonal() const {
 	return columns[2][3] == 0.0;
 }
 
+bool Projection::is_frustum_symmetric() const {
+	return (columns[0][1] == 0.0f && columns[0][2] == 0.0f && columns[0][3] == 0.0f &&
+			columns[1][0] == 0.0f && columns[1][2] == 0.0f && columns[1][3] == 0.0f &&
+			columns[2][0] == 0.0f && columns[2][1] == 0.0f &&
+			columns[3][0] == 0.0f && columns[3][1] == 0.0f);
+}
+
 real_t Projection::get_fov() const {
 	// NOTE: This assumes a rectangular projection plane, i.e. that :
 	// - the matrix is a projection across z-axis (i.e. is invertible and columns[0][1], [0][3], [1][0] and [1][3] == 0)

--- a/core/math/projection.h
+++ b/core/math/projection.h
@@ -109,6 +109,7 @@ struct [[nodiscard]] Projection {
 	real_t get_aspect() const;
 	real_t get_fov() const;
 	bool is_orthogonal() const;
+	bool is_frustum_symmetric() const;
 
 	Vector<Plane> get_projection_planes(const Transform3D &p_transform) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2442,6 +2442,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Projection, get_aspect, sarray(), varray());
 	bind_method(Projection, get_fov, sarray(), varray());
 	bind_method(Projection, is_orthogonal, sarray(), varray());
+	bind_method(Projection, is_frustum_symmetric, sarray(), varray());
 
 	bind_method(Projection, get_viewport_half_extents, sarray(), varray());
 	bind_method(Projection, get_far_plane_half_extents, sarray(), varray());

--- a/doc/classes/Projection.xml
+++ b/doc/classes/Projection.xml
@@ -242,6 +242,12 @@
 				Returns a [Projection] that performs the inverse of this [Projection]'s projective transformation.
 			</description>
 		</method>
+		<method name="is_frustum_symmetric" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if this [Projection] conforms to standard orthographic or perspective.
+			</description>
+		</method>
 		<method name="is_orthogonal" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -173,6 +173,14 @@
 				Sets camera to use perspective projection. Objects on the screen becomes smaller when they are far away.
 			</description>
 		</method>
+		<method name="camera_set_projection">
+			<return type="void" />
+			<param index="0" name="camera" type="RID" />
+			<param index="1" name="projection" type="Projection" />
+			<description>
+				Sets a custom projection matrix.
+			</description>
+		</method>
 		<method name="camera_set_transform">
 			<return type="void" />
 			<param index="0" name="camera" type="RID" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -803,6 +803,11 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 		spec_constants |= SkyShaderGLES3::APPLY_TONEMAPPING;
 	}
 
+	const bool use_asymmetric_projection = (!p_use_multiview && !p_projection.is_frustum_symmetric());
+	if (use_asymmetric_projection) {
+		spec_constants |= SkyShaderGLES3::USE_ASYMMETRIC_PROJECTION;
+	}
+
 	RS::EnvironmentBG background = environment_get_background(p_env);
 
 	if (sky) {
@@ -872,6 +877,10 @@ void RasterizerSceneGLES3::_draw_sky(RID p_env, const Projection &p_projection, 
 	material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_DENSITY, environment_get_fog_density(p_env), shader_data->version, SkyShaderGLES3::MODE_BACKGROUND, spec_constants);
 	material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::FOG_SKY_AFFECT, environment_get_fog_sky_affect(p_env), shader_data->version, SkyShaderGLES3::MODE_BACKGROUND, spec_constants);
 	material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::DIRECTIONAL_LIGHT_COUNT, sky_globals.directional_light_count, shader_data->version, SkyShaderGLES3::MODE_BACKGROUND, spec_constants);
+
+	if (use_asymmetric_projection) {
+		material_storage->shaders.sky_shader.version_set_uniform(SkyShaderGLES3::INV_PROJECTION_MATRIX, camera.inverse(), shader_data->version, SkyShaderGLES3::MODE_BACKGROUND, spec_constants);
+	}
 
 	if (p_use_multiview) {
 		glBindBufferBase(GL_UNIFORM_BUFFER, SKY_MULTIVIEW_UNIFORM_LOCATION, scene_state.multiview_buffer);

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -7,6 +7,7 @@ mode_cubemap = #define USE_CUBEMAP_PASS
 #[specializations]
 
 USE_MULTIVIEW = false
+USE_ASYMMETRIC_PROJECTION = false
 USE_INVERTED_Y = true
 APPLY_TONEMAPPING = true
 USE_QUARTER_RES_PASS = false
@@ -120,6 +121,8 @@ layout(std140) uniform MultiviewData { // ubo:11
 	highp vec4 eye_offset[MAX_VIEWS];
 }
 multiview_data;
+#elif defined(USE_ASYMMETRIC_PROJECTION)
+uniform mat4 inv_projection_matrix;
 #endif
 
 layout(location = 0) out vec4 frag_color;
@@ -187,6 +190,10 @@ void main() {
 
 	// Unproject will give us the position between the eyes, need to re-offset.
 	cube_normal += multiview_data.eye_offset[ViewIndex].xyz;
+#elif defined(USE_ASYMMETRIC_PROJECTION)
+	vec4 unproject = vec4(uv_interp.x, -uv_interp.y, -1.0, 1.0);
+	vec4 unprojected = inv_projection_matrix * unproject;
+	cube_normal = unprojected.xyz / unprojected.w;
 #else
 	cube_normal.z = -1.0;
 	cube_normal.x = (uv_interp.x + projection.x) / projection.y;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1213,6 +1213,8 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 			// This is unused so just reset to identity.
 			Projection ident;
 			RendererRD::MaterialStorage::store_camera(ident, sky_scene_state.ubo.combined_reprojection[i]);
+
+			sky_scene_state.ubo.full_projection = !view_inv_projection.is_frustum_symmetric();
 		}
 
 		RendererRD::MaterialStorage::store_camera(view_inv_projection, sky_scene_state.ubo.view_inv_projections[i]);

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -158,7 +158,7 @@ public:
 
 			float z_far; // 4 - 340
 			uint32_t directional_light_count; // 4 - 344
-			uint32_t pad1; // 4 - 348
+			uint32_t full_projection; // 4 - 348
 			uint32_t pad2; // 4 - 352
 		};
 

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -76,7 +76,7 @@ layout(set = 0, binding = 2, std140) uniform SkySceneData {
 
 	float z_far; // 4 - 52
 	uint directional_light_count; // 4 - 56
-	uint pad1; // 4 - 60
+	bool full_projection; // 4 - 60
 	uint pad2; // 4 - 64
 }
 sky_scene_data;
@@ -209,9 +209,15 @@ void main() {
 	// Unproject will give us the position between the eyes, need to re-offset
 	cube_normal += sky_scene_data.view_eye_offsets[ViewIndex].xyz;
 #else
-	cube_normal.z = -1.0;
-	cube_normal.x = (cube_normal.z * (-uv_interp.x - params.projection.x)) / params.projection.y;
-	cube_normal.y = -(cube_normal.z * (uv_interp.y - params.projection.z)) / params.projection.w;
+	if (sky_scene_data.full_projection) {
+		vec4 unproject = vec4(uv_interp, 0.0, 1.0);
+		vec4 unprojected = sky_scene_data.view_inv_projections[0] * unproject;
+		cube_normal = unprojected.xyz / unprojected.w;
+	} else {
+		cube_normal.z = -1.0;
+		cube_normal.x = (cube_normal.z * (-uv_interp.x - params.projection.x)) / params.projection.y;
+		cube_normal.y = -(cube_normal.z * (uv_interp.y - params.projection.z)) / params.projection.w;
+	}
 #endif
 	cube_normal = mat3(params.orientation) * cube_normal;
 	cube_normal = normalize(cube_normal);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -74,7 +74,8 @@ public:
 		enum Type {
 			PERSPECTIVE,
 			ORTHOGONAL,
-			FRUSTUM
+			FRUSTUM,
+			CUSTOM,
 		};
 		Type type;
 		float fov;
@@ -87,6 +88,7 @@ public:
 		RID attributes;
 		RID compositor;
 
+		Projection projection;
 		Transform3D transform;
 
 		Camera() {
@@ -109,6 +111,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
+	virtual void camera_set_projection(RID p_camera, const Projection &p_projection);
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform);
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers);
 	virtual void camera_set_environment(RID p_camera, RID p_env);

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -49,6 +49,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_projection(RID p_camera, const Projection &p_projection) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2811,6 +2811,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &RenderingServer::camera_set_perspective);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &RenderingServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &RenderingServer::camera_set_frustum);
+	ClassDB::bind_method(D_METHOD("camera_set_projection", "camera", "projection"), &RenderingServer::camera_set_projection);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &RenderingServer::camera_set_transform);
 	ClassDB::bind_method(D_METHOD("camera_set_cull_mask", "camera", "layers"), &RenderingServer::camera_set_cull_mask);
 	ClassDB::bind_method(D_METHOD("camera_set_environment", "camera", "env"), &RenderingServer::camera_set_environment);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -913,6 +913,7 @@ public:
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_projection(RID p_camera, const Projection &p_projection) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform3D &p_transform) = 0;
 	virtual void camera_set_cull_mask(RID p_camera, uint32_t p_layers) = 0;
 	virtual void camera_set_environment(RID p_camera, RID p_env) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -672,6 +672,7 @@ public:
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
+	FUNC2(camera_set_projection, RID, const Projection &)
 	FUNC2(camera_set_transform, RID, const Transform3D &)
 	FUNC2(camera_set_cull_mask, RID, uint32_t)
 	FUNC2(camera_set_environment, RID, RID)


### PR DESCRIPTION
Starting point for https://github.com/godotengine/godot-proposals/issues/11436
Adds `RenderingServer.camera_set_projection`.

oblique projection example (camera should be orthographic and rotated -45 degrees x axis):
```gdscript
extends Camera3D

func _ready() -> void:
	var p := get_camera_projection()
	p[1][1] *= sqrt(2.0)
	RenderingServer.camera_set_projection(get_camera_rid(), p)
```
