### PR TITLE
Change the visibility flag to optional for Blender compatibility.

### DIFF
--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -74,7 +74,7 @@ private:
 	float _fallback_image_quality = 0.25f;
 	Ref<GLTFDocumentExtension> _image_save_extension;
 	RootNodeMode _root_node_mode = RootNodeMode::ROOT_NODE_MODE_SINGLE_ROOT;
-	VisibilityMode _visibility_mode = VisibilityMode::VISIBILITY_MODE_INCLUDE_REQUIRED;
+	VisibilityMode _visibility_mode = VisibilityMode::VISIBILITY_MODE_INCLUDE_OPTIONAL;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
This fixed bug #110854

Blender refuses to load the glTF files that Godot saves when the visibility flag is set to "required".