### PR TITLE
Allow generating POT when only Add Built-in Strings is enabled

### DIFF
--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -398,6 +398,11 @@ void LocalizationEditor::_pot_generate_open() {
 void LocalizationEditor::_pot_add_builtin_toggled() {
 	ProjectSettings::get_singleton()->set_setting("internationalization/locale/translation_add_builtin_strings_to_pot", translation_pot_add_builtin->is_pressed());
 	ProjectSettings::get_singleton()->save();
+
+	PackedStringArray pot_translations = GLOBAL_GET("internationalization/locale/translations_pot_files");
+	if (pot_translations.is_empty()) {
+		pot_generate_button->set_disabled(!translation_pot_add_builtin->is_pressed());
+	}
 }
 
 void LocalizationEditor::_pot_generate(const String &p_file) {
@@ -611,7 +616,7 @@ void LocalizationEditor::update_translations() {
 	// New translation parser plugin might extend possible file extensions in POT generation.
 	_update_pot_file_extensions();
 
-	pot_generate_button->set_disabled(pot_translations.is_empty());
+	pot_generate_button->set_disabled(pot_translations.is_empty() && !translation_pot_add_builtin->is_pressed());
 
 	updating_translations = false;
 }

--- a/editor/translations/pot_generator.cpp
+++ b/editor/translations/pot_generator.cpp
@@ -55,21 +55,15 @@ void POTGenerator::_print_all_translation_strings() {
 #endif
 
 void POTGenerator::generate_pot(const String &p_file) {
-	Vector<String> files = GLOBAL_GET("internationalization/locale/translations_pot_files");
-
-	if (files.is_empty()) {
-		WARN_PRINT("No files selected for POT generation.");
-		return;
-	}
-
 	// Clear all_translation_strings of the previous round.
 	all_translation_strings.clear();
 
+	Vector<String> files = GLOBAL_GET("internationalization/locale/translations_pot_files");
+
 	// Collect all translatable strings according to files order in "POT Generation" setting.
-	for (int i = 0; i < files.size(); i++) {
+	for (const String &file_path : files) {
 		Vector<Vector<String>> translations;
 
-		const String &file_path = files[i];
 		String file_extension = file_path.get_extension();
 
 		if (EditorTranslationParser::get_singleton()->can_parse(file_extension)) {
@@ -92,6 +86,11 @@ void POTGenerator::generate_pot(const String &p_file) {
 		for (const Vector<String> &extractable_msgids : get_extractable_message_list()) {
 			_add_new_msgid(extractable_msgids[0], extractable_msgids[1], extractable_msgids[2], "", "");
 		}
+	}
+
+	if (all_translation_strings.is_empty()) {
+		WARN_PRINT("No translatable strings found.");
+		return;
 	}
 
 	_write_to_pot(p_file);


### PR DESCRIPTION
Currently, the "Generate POT" button is disabled when the list of files for extraction is empty.

Not using strings in the project except for those that come with built-in controls is a valid use case.

This PR always allows generating a POT when the "Add Built-in Strings to POT" option is enabled.