### PR TITLE
Add helper function in project setting to register global shader parameter

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -44,10 +44,42 @@
 #include "core/variant/variant_parser.h"
 #include "core/version.h"
 #include "servers/rendering/rendering_server.h"
+#include "servers/rendering/shader_language.h"
 
 #ifdef TOOLS_ENABLED
 #include "modules/modules_enabled.gen.h" // For mono.
 #endif // TOOLS_ENABLED
+
+static const char *global_shader_var_type_names[RS::GLOBAL_VAR_TYPE_MAX] = {
+	"bool",
+	"bvec2",
+	"bvec3",
+	"bvec4",
+	"int",
+	"ivec2",
+	"ivec3",
+	"ivec4",
+	"rect2i",
+	"uint",
+	"uvec2",
+	"uvec3",
+	"uvec4",
+	"float",
+	"vec2",
+	"vec3",
+	"vec4",
+	"color",
+	"rect2",
+	"mat2",
+	"mat3",
+	"mat4",
+	"transform_2d",
+	"transform",
+	"sampler2D",
+	"sampler2DArray",
+	"sampler3D",
+	"samplerCube",
+};
 
 ProjectSettings *ProjectSettings::get_singleton() {
 	return singleton;
@@ -1524,6 +1556,43 @@ bool ProjectSettings::has_global_group(const StringName &p_name) const {
 	return global_groups.has(p_name);
 }
 
+void ProjectSettings::add_shader_global_parameter(const StringName &p_name, RS::GlobalShaderParameterType p_type, const Variant &p_value) {
+	if (RenderingServer::get_singleton()->global_shader_parameter_get(p_name).get_type() != Variant::NIL) {
+		ERR_FAIL_MSG(vformat("Global shader parameter '%s' already exists.", p_name));
+	}
+
+	List<String> keywords;
+	ShaderLanguage::get_keyword_list(&keywords);
+
+	if (keywords.find(p_name) != nullptr || p_name == "script") {
+		ERR_FAIL_MSG(vformat("Name '%s' is a reserved shader language keyword.", p_name));
+	}
+
+	RS::get_singleton()->global_shader_parameter_add(p_name, p_type, p_value);
+
+	Dictionary gv;
+	gv["type"] = global_shader_var_type_names[p_type];
+	gv["value"] = p_value;
+
+	ProjectSettings::get_singleton()->set_setting("shader_globals/" + p_name, gv);
+	ProjectSettings::get_singleton()->save();
+}
+
+void ProjectSettings::remove_shader_global_parameter(const StringName &p_name) {
+	RS::get_singleton()->global_shader_parameter_remove(p_name);
+	ProjectSettings::get_singleton()->set_setting("shader_globals/" + p_name, Variant());
+	ProjectSettings::get_singleton()->save();
+}
+
+void ProjectSettings::set_shader_global_parameter(const StringName &p_name, const Variant &p_value) {
+	RS::get_singleton()->global_shader_parameter_set(p_name, p_value);
+
+	Dictionary gv = ProjectSettings::get_singleton()->get_setting("shader_globals/" + p_name);
+	gv["value"] = p_value;
+	ProjectSettings::get_singleton()->set_setting("shader_globals/" + p_name, gv);
+	ProjectSettings::get_singleton()->save();
+}
+
 void ProjectSettings::remove_scene_groups_cache(const StringName &p_path) {
 	scene_groups_cache.erase(p_path);
 }
@@ -1629,6 +1698,10 @@ void ProjectSettings::_bind_methods() {
 	// Change tracking methods
 	ClassDB::bind_method(D_METHOD("get_changed_settings"), &ProjectSettings::get_changed_settings);
 	ClassDB::bind_method(D_METHOD("check_changed_settings_in_group", "setting_prefix"), &ProjectSettings::check_changed_settings_in_group);
+	ClassDB::bind_method(D_METHOD("add_shader_global_parameter", "name", "type", "value"), &ProjectSettings::add_shader_global_parameter);
+	ClassDB::bind_method(D_METHOD("set_shader_global_parameter", "name", "value"), &ProjectSettings::set_shader_global_parameter);
+	ClassDB::bind_method(D_METHOD("remove_shader_global_parameter", "name"), &ProjectSettings::remove_shader_global_parameter);
+
 	ADD_SIGNAL(MethodInfo("settings_changed"));
 }
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -30,6 +30,12 @@
 
 #pragma once
 
+#include "core/object/class_db.h"
+#include "core/os/thread_safe.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/local_vector.h"
+#include "core/templates/rb_set.h"
+#include "servers/rendering_server.h"
 #include "core/object/object.h"
 #include "core/templates/rb_map.h"
 
@@ -228,6 +234,10 @@ public:
 	void add_global_group(const StringName &p_name, const String &p_description);
 	void remove_global_group(const StringName &p_name);
 	bool has_global_group(const StringName &p_name) const;
+
+	void add_shader_global_parameter(const StringName &p_name, RS::GlobalShaderParameterType p_type, const Variant &p_value);
+	void set_shader_global_parameter(const StringName &p_name, const Variant &p_value);
+	void remove_shader_global_parameter(const StringName &p_name);
 
 	const HashMap<StringName, HashSet<StringName>> &get_scene_groups_cache() const;
 	void add_scene_groups_cache(const StringName &p_path, const HashSet<StringName> &p_cache);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -54,6 +54,13 @@
 				[b]Note:[/b] Setting [code]"usage"[/code] for the property is not supported. Use [method set_as_basic], [method set_restart_if_changed], and [method set_as_internal] to modify usage flags.
 			</description>
 		</method>
+		<method name="add_shader_global_parameter">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="type" type="int" enum="RenderingServer.GlobalShaderParameterType" />
+			<param index="2" name="value" type="Variant" />
+			<description>
+				Add a new global shader uniform to project settings. [param name] must not be a shader language keyword or the word [code]"script"[/code]. Note that shader parameter names are case-sensitive.
 		<method name="check_changed_settings_in_group" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="setting_prefix" type="String" />
@@ -185,6 +192,13 @@
 				Returns the localized path (starting with [code]res://[/code]) corresponding to the absolute, native OS [param path]. See also [method globalize_path].
 			</description>
 		</method>
+		<method name="remove_shader_global_parameter">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<description>
+				Removes the global shader uniform specified by [param name]. Prints an error if the parameter specifgied by [param name] doesn't exist.
+			</description>
+		</method>
 		<method name="save">
 			<return type="int" enum="Error" />
 			<description>
@@ -268,6 +282,14 @@
 				[/csharp]
 				[/codeblocks]
 				This can also be used to erase custom project settings. To do this change the setting value to [code]null[/code].
+			</description>
+		</method>
+		<method name="set_shader_global_parameter">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="value" type="Variant" />
+			<description>
+				Sets the value of the global shader parameter specified by [param name]. Prints an error if the parameter specified by [param name] doesn't exist. See also [method add_shader_global_parameter].
 			</description>
 		</method>
 	</methods>

--- a/editor/shader/shader_globals_editor.cpp
+++ b/editor/shader/shader_globals_editor.cpp
@@ -444,6 +444,7 @@ void ShaderGlobalsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible_in_tree()) {
+				_changed();
 				inspector->edit(interface);
 			}
 		} break;


### PR DESCRIPTION
Supersedes https://github.com/godotengine/godot/pull/87727
Based on https://github.com/godotengine/godot/issues/77988#issuecomment-1912716370
Fixes https://github.com/godotengine/godot/issues/77988

Test project with an addon:
[global-shader-parameters-helper-functions.zip](https://github.com/user-attachments/files/22643918/global-shader-parameters-helper-functions.zip)

