### PR TITLE
Fix late destruction access violation with OpenXRAPIExtension object

### DIFF
--- a/modules/openxr/extensions/openxr_extension_wrapper.cpp
+++ b/modules/openxr/extensions/openxr_extension_wrapper.cpp
@@ -360,13 +360,16 @@ void *OpenXRExtensionWrapper::set_android_surface_swapchain_create_info_and_get_
 }
 
 Ref<OpenXRAPIExtension> OpenXRExtensionWrapper::_gdextension_get_openxr_api() {
-	static Ref<OpenXRAPIExtension> openxr_api_extension;
-	if (unlikely(openxr_api_extension.is_null())) {
-		openxr_api_extension.instantiate();
-	}
 	return openxr_api_extension;
 }
 
 void OpenXRExtensionWrapper::_gdextension_register_extension_wrapper() {
 	OpenXRAPI::register_extension_wrapper(this);
+}
+
+OpenXRExtensionWrapper::OpenXRExtensionWrapper() {
+	openxr_api_extension.instantiate();
+}
+
+OpenXRExtensionWrapper::~OpenXRExtensionWrapper() {
 }

--- a/modules/openxr/extensions/openxr_extension_wrapper.h
+++ b/modules/openxr/extensions/openxr_extension_wrapper.h
@@ -56,6 +56,8 @@ class OpenXRExtensionWrapper : public Object {
 protected:
 	static void _bind_methods();
 
+	Ref<OpenXRAPIExtension> openxr_api_extension;
+
 public:
 	// `get_requested_extensions` should return a list of OpenXR extensions related to this extension.
 	// If the bool * is a nullptr this extension is mandatory
@@ -180,8 +182,8 @@ public:
 
 	GDVIRTUAL1R(bool, _on_event_polled, GDExtensionConstPtr<void>);
 
-	OpenXRExtensionWrapper() = default;
-	virtual ~OpenXRExtensionWrapper() = default;
+	OpenXRExtensionWrapper();
+	virtual ~OpenXRExtensionWrapper() override;
 };
 
 // `OpenXRGraphicsExtensionWrapper` implements specific logic for each supported graphics API.


### PR DESCRIPTION
I have a game using a GDExtension with an `OpenXRExtensionWrapper` class, and once I added code to call `get_openxr_api()` I started observing crashes when the exported game process would exit. Just to make sure it's not something I am doing wrong, I exported and ran the "godot-xr-template" demo project and saw the same thing.

What I found was a change to refactor this class moved the `Ref<OpenXRAPIExtension>` from a member variable to a static delay-initialized variable instead. I can see why this was done because then you don't pay for it if you don't need it, and if you do need it, you only pay for it once. But the problem is that this static variable holds the last reference to this object and so the cleanup will happen at the very end, after the `WinMain()` function has returned and the C runtime code runs to clean up global variables. At this point it seems like there is some "instance binding" with pointers that are no longer valid (perhaps pointers into the GDExtension DLL?).

I am not familiar with this system to know what the best fix is, so I opted to revert this back to the prior behavior. The object that it creates looks light weight (no initialization code, no member variables) so I think having separate copies per `OpenXRExtensionWrapper` and initializing them immediately is not bad. As I said, I don't know enough about this area to say whether something different or better is needed. See https://github.com/godotengine/godot/pull/104087 "OpenXR: Clean-up OpenXRExtensionWrapper by removing multiple inheritance and deprecating OpenXRExtensionWrapperExtension" for more details on the commit that changed this from member variable to static.

Stack and crash details below:
```
 	00007ffc33720eb0()	Unknown
>	OpenXR Demo.exe!Object::_instance_binding_reference(bool p_reference) Line 711	C++
 	OpenXR Demo.exe!RefCounted::unreference() Line 89	C++
 	OpenXR Demo.exe!Ref<OpenXRAPIExtension>::unref() Line 207	C++
 	OpenXR Demo.exe!Ref<OpenXRAPIExtension>::~Ref<OpenXRAPIExtension>() Line 223	C++
 	OpenXR Demo.exe!`OpenXRExtensionWrapper::_gdextension_get_openxr_api'::`2'::`dynamic atexit destructor for 'openxr_api_extension''()	C++
 	OpenXR Demo.exe!_execute_onexit_table::__l2::<lambda>() Line 206	C++
 	OpenXR Demo.exe!__crt_seh_guarded_call<int>::operator()<void <lambda>(void),int <lambda>(void) &,void <lambda>(void)>(__acrt_lock_and_call::__l2::void <lambda>(void) && setup, _execute_onexit_table::__l2::int <lambda>(void) & action, __acrt_lock_and_call::__l2::void <lambda>(void) && cleanup) Line 204	C++
 	[Inline Frame] OpenXR Demo.exe!__acrt_lock_and_call(const __acrt_lock_id) Line 983	C++
 	OpenXR Demo.exe!_execute_onexit_table(_onexit_table_t * table) Line 160	C++
 	OpenXR Demo.exe!common_exit::__l2::<lambda>() Line 230	C++
 	OpenXR Demo.exe!__crt_seh_guarded_call<void>::operator()<void <lambda>(void),void <lambda>(void) &,void <lambda>(void)>(__acrt_lock_and_call::__l2::void <lambda>(void) && setup, common_exit::__l2::void <lambda>(void) & action, __acrt_lock_and_call::__l2::void <lambda>(void) && cleanup) Line 224	C++
 	[Inline Frame] OpenXR Demo.exe!__acrt_lock_and_call(const __acrt_lock_id) Line 983	C++
 	OpenXR Demo.exe!common_exit(const int return_code, const _crt_exit_cleanup_mode cleanup_mode, const _crt_exit_return_mode return_mode) Line 199	C++
 	OpenXR Demo.exe!__scrt_common_main_seh() Line 295	C++
 	OpenXR Demo.exe!ShimMainCRTStartup(...) Line 74	C
 	kernel32.dll!00007ffd8787e8d7()	Unknown
 	ntdll.dll!RtlUserThreadStart(long(*)(void *) StartAddress, void * Argument) Line 1184	C
```

<img width="1113" height="405" alt="instance_binding_crash" src="https://github.com/user-attachments/assets/4b75f945-1fc5-4da6-a395-678cf10ee1d5" />
<img width="581" height="177" alt="instance_binding_crash_locals" src="https://github.com/user-attachments/assets/eaf9af17-f41e-46b8-84d1-0afcab0d216f" />