### PR TITLE
Wayland: Inhibit idle in `DisplayServerWayland::screen_set_keep_on`

### DIFF
--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -679,6 +679,8 @@ void DisplayServerWayland::screen_set_keep_on(bool p_enable) {
 		return;
 	}
 
+	wayland_thread.window_set_idle_inhibition(MAIN_WINDOW_ID, p_enable);
+
 #ifdef DBUS_ENABLED
 	if (screensaver) {
 		if (p_enable) {


### PR DESCRIPTION
Without this, the screen does go into idle after a few minutes on a RPi5 with default install (wayland w/ labwc), even though `screen_keep_on` is set. DBUS is enabled but apparently, the screensaver call is not enough.