### PR TITLE
FoldableContainer: Only expand or fold on mouse release

### DIFF
--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -243,9 +243,16 @@ void FoldableContainer::gui_input(const Ref<InputEvent> &p_event) {
 	if (b.is_valid()) {
 		Rect2 title_rect = Rect2(0, (title_position == POSITION_TOP) ? 0 : get_size().height - title_minimum_size.height, get_size().width, title_minimum_size.height);
 		if (b->get_button_index() == MouseButton::LEFT && b->is_pressed() && title_rect.has_point(b->get_position())) {
-			set_folded(!folded);
-			emit_signal(SNAME("folding_changed"), folded);
+			is_click_held = true;
 			accept_event();
+		}
+		if (b->get_button_index() == MouseButton::LEFT && b->is_released()) {
+			if (is_click_held && title_rect.has_point(b->get_position())) {
+				set_folded(!folded);
+				emit_signal(SNAME("folding_changed"), folded);
+				accept_event();
+			}
+			is_click_held = false;
 		}
 	}
 }

--- a/scene/gui/foldable_container.h
+++ b/scene/gui/foldable_container.h
@@ -58,6 +58,7 @@ private:
 	Ref<TextLine> text_buf;
 	bool changing_group = false;
 	bool is_hovering = false;
+	bool is_click_held = false;
 	mutable Vector2 title_minimum_size;
 
 	LocalVector<Control *> title_controls;


### PR DESCRIPTION
https://github.com/godotengine/godot-proposals/issues/13256
https://github.com/godotengine/godot-proposals/issues/8974

Untested changes, but i think it's simple enough that the risk of something wrong is very low. If someone else would like to spruce up this PR, an additional visual signifier for when the mouse is held down would be nice.

*Bugsquad edit:* Closes https://github.com/godotengine/godot-proposals/issues/13256