### PR TITLE
Fix and improve `Node2D.move_local_{x,y}()` description

### DIFF
--- a/doc/classes/Node2D.xml
+++ b/doc/classes/Node2D.xml
@@ -49,20 +49,20 @@
 				[param point] should not be the same as the node's position, otherwise the node always looks to the right.
 			</description>
 		</method>
-		<method name="move_local_x">
+		<method name="move_local_x" keywords="translate_object_local">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="scaled" type="bool" default="false" />
 			<description>
-				Applies a local translation on the node's X axis based on the [method Node._process]'s [param delta]. If [param scaled] is [code]false[/code], normalizes the movement.
+				Applies a local translation on the node's X axis with the amount specified in [param delta]. If [param scaled] is [code]false[/code], normalizes the movement to occur independently of the node's [member scale].
 			</description>
 		</method>
-		<method name="move_local_y">
+		<method name="move_local_y" keywords="translate_object_local">
 			<return type="void" />
 			<param index="0" name="delta" type="float" />
 			<param index="1" name="scaled" type="bool" default="false" />
 			<description>
-				Applies a local translation on the node's Y axis based on the [method Node._process]'s [param delta]. If [param scaled] is [code]false[/code], normalizes the movement.
+				Applies a local translation on the node's Y axis with the amount specified in [param delta]. If [param scaled] is [code]false[/code], normalizes the movement to occur independently of the node's [member scale].
 			</description>
 		</method>
 		<method name="rotate">

--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -275,7 +275,7 @@
 				[b]Note:[/b] Despite the naming convention, this operation is [b]not[/b] calculated in parent space for compatibility reasons. To translate in parent space, add [param offset] to the [member position] ([code]node_3d.position += offset[/code]).
 			</description>
 		</method>
-		<method name="translate_object_local">
+		<method name="translate_object_local" keywords="move_local">
 			<return type="void" />
 			<param index="0" name="offset" type="Vector3" />
 			<description>


### PR DESCRIPTION
The `delta` parameter name refers to a generic distance parameter here, rather than the process or physics process time.

- This closes https://github.com/godotengine/godot-docs/issues/11320.
