### PR TITLE
Fix missing `return_type` for abstract methods 

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2516,8 +2516,8 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	}
 
 	if (p_func) {
-		// If no `return` statement, then return type is `void`, not `Variant`.
-		if (p_func->body->has_return) {
+		// If no `return` statement and no explicitly `return` declaration, then return type is `void`, not `Variant`.
+		if (p_func->body->has_return || p_func->return_type) {
 			gd_function->return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
 			method_info.return_val = p_func->get_datatype().to_property_info(String());
 		} else {

--- a/modules/gdscript/tests/scripts/runtime/features/member_info.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info.gd
@@ -67,6 +67,15 @@ signal test_signal_7(a: TestMemberInfo, b: Array[TestMemberInfo], c: Dictionary[
 signal test_signal_8(a: MyClass, b: Array[MyClass], c: Dictionary[MyClass, MyClass])
 @warning_ignore_restore("unused_signal")
 
+@abstract
+class TestAbstractMyClass:
+	@abstract
+	func test_abstract_method_with_return_type() -> Node
+	@abstract
+	func test_abstract_method_return_type_void() -> void
+	@abstract
+	func test_abstract_method_without_return_type()
+
 func test():
 	var script: Script = get_script()
 	for property in script.get_property_list():

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.gd
@@ -5,6 +5,8 @@
 @abstract class A:
 	@abstract func test_abstract_func_1()
 	@abstract func test_abstract_func_2()
+	@abstract func test_abstract_func_with_return() -> Node
+	@abstract func test_abstract_func_with_return_void() -> void
 	func test_override_func_1(): pass
 	func test_override_func_2(): pass
 
@@ -17,6 +19,8 @@ class B extends A:
 	static func test_static_func_b2(): pass
 	func test_abstract_func_1(): pass
 	func test_abstract_func_2(): pass
+	func test_abstract_func_with_return() -> Node: return null
+	func test_abstract_func_with_return_void(): pass
 	func test_override_func_1(): pass
 	func test_override_func_2(): pass
 	func test_func_b1(): pass

--- a/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.out
+++ b/modules/gdscript/tests/scripts/runtime/features/member_info_inheritance.out
@@ -28,12 +28,16 @@ static func test_static_func_b1() -> void
 static func test_static_func_b2() -> void
 func test_abstract_func_1() -> void
 func test_abstract_func_2() -> void
+func test_abstract_func_with_return() -> Node
+func test_abstract_func_with_return_void() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 func test_func_b1() -> void
 func test_func_b2() -> void
 @abstract func test_abstract_func_1() -> void
 @abstract func test_abstract_func_2() -> void
+@abstract func test_abstract_func_with_return() -> Node
+@abstract func test_abstract_func_with_return_void() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 --- C ---
@@ -49,12 +53,16 @@ static func test_static_func_b1() -> void
 static func test_static_func_b2() -> void
 func test_abstract_func_1() -> void
 func test_abstract_func_2() -> void
+func test_abstract_func_with_return() -> Node
+func test_abstract_func_with_return_void() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 func test_func_b1() -> void
 func test_func_b2() -> void
 @abstract func test_abstract_func_1() -> void
 @abstract func test_abstract_func_2() -> void
+@abstract func test_abstract_func_with_return() -> Node
+@abstract func test_abstract_func_with_return_void() -> void
 func test_override_func_1() -> void
 func test_override_func_2() -> void
 === Signals ===


### PR DESCRIPTION
## Fixed Issue: 

https://github.com/godotengine/godot/issues/110818

## Issue description

Abstract method return type is always NIL.

When there is no return in the function body, the return_type always be NIL, where the abstract method has no body, so the return type of abstract method is always NIL.

So I just add a condition `is_abstract` to let abstract method can get return_type by declaration of func.

## Etc

But get return type by script body is wired, could we just get return_type by the declaration of func?

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/110818*
