### PR TITLE
Revert "Replace many uses of `is_class` with `derives_from`."

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -2220,7 +2220,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 #ifdef REAL_T_IS_DOUBLE
 		format_flags |= FORMAT_FLAG_REAL_T_IS_DOUBLE;
 #endif
-		if (!p_resource->derives_from<PackedScene>()) {
+		if (!p_resource->is_class("PackedScene")) {
 			Ref<Script> s = p_resource->get_script();
 			if (s.is_valid()) {
 				script_class = s->get_global_name();

--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -1439,7 +1439,7 @@ bool ResourceLoader::add_custom_resource_format_loader(const String &script_path
 
 	Ref<Resource> res = ResourceLoader::load(script_path);
 	ERR_FAIL_COND_V(res.is_null(), false);
-	ERR_FAIL_COND_V(!res->derives_from<Script>(), false);
+	ERR_FAIL_COND_V(!res->is_class("Script"), false);
 
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -233,7 +233,7 @@ bool ResourceSaver::add_custom_resource_format_saver(const String &script_path) 
 
 	Ref<Resource> res = ResourceLoader::load(script_path);
 	ERR_FAIL_COND_V(res.is_null(), false);
-	ERR_FAIL_COND_V(!res->derives_from<Script>(), false);
+	ERR_FAIL_COND_V(!res->is_class("Script"), false);
 
 	Ref<Script> s = res;
 	StringName ibt = s->get_instance_base_type();

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -562,7 +562,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 
 	_get_property_listv(p_list, p_reversed);
 
-	if (!derives_from<Script>()) { // can still be set, but this is for user-friendliness
+	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NEVER_DUPLICATE));
 	}
 

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -73,7 +73,7 @@ Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img) 
 }
 
 bool ResourceSaverPNG::recognize(const Ref<Resource> &p_resource) const {
-	return (p_resource.is_valid() && p_resource->derives_from<ImageTexture>());
+	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
 }
 
 void ResourceSaverPNG::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {

--- a/editor/animation/animation_player_editor_plugin.cpp
+++ b/editor/animation/animation_player_editor_plugin.cpp
@@ -1936,7 +1936,7 @@ AnimationMixer *AnimationPlayerEditor::fetch_mixer_for_library() const {
 		return nullptr;
 	}
 	// Does AnimationTree have AnimationPlayer?
-	if (original_node->derives_from<AnimationTree>()) {
+	if (original_node->is_class("AnimationTree")) {
 		AnimationTree *src_tree = Object::cast_to<AnimationTree>(original_node);
 		Node *src_player = src_tree->get_node_or_null(src_tree->get_animation_player());
 		if (src_player) {
@@ -2339,7 +2339,7 @@ void AnimationPlayerEditorPlugin::edit(Object *p_object) {
 
 	AnimationMixer *src_node = Object::cast_to<AnimationMixer>(p_object);
 	bool is_dummy = false;
-	if (!p_object->derives_from<AnimationPlayer>()) {
+	if (!p_object->is_class("AnimationPlayer")) {
 		// If it needs dummy AnimationPlayer, assign original AnimationMixer to LibraryEditor.
 		_update_dummy_player(src_node);
 
@@ -2409,7 +2409,7 @@ void AnimationPlayerEditorPlugin::_update_dummy_player(AnimationMixer *p_mixer) 
 }
 
 bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<AnimationPlayer>() || p_object->derives_from<AnimationTree>() || p_object->derives_from<AnimationMixer>();
+	return p_object->is_class("AnimationPlayer") || p_object->is_class("AnimationTree") || p_object->is_class("AnimationMixer");
 }
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
@@ -2455,7 +2455,7 @@ AnimationTrackKeyEditEditorPlugin::AnimationTrackKeyEditEditorPlugin() {
 }
 
 bool AnimationTrackKeyEditEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<AnimationTrackKeyEdit>();
+	return p_object->is_class("AnimationTrackKeyEdit");
 }
 
 bool EditorInspectorPluginAnimationMarkerKeyEdit::can_handle(Object *p_object) {
@@ -2476,5 +2476,5 @@ AnimationMarkerKeyEditEditorPlugin::AnimationMarkerKeyEditEditorPlugin() {
 }
 
 bool AnimationMarkerKeyEditEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<AnimationMarkerKeyEdit>();
+	return p_object->is_class("AnimationMarkerKeyEdit");
 }

--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -916,7 +916,7 @@ void AnimationNodeStateMachineEditor::_clip_dst_line_to_rect(const Vector2 &p_fr
 
 Ref<StyleBox> AnimationNodeStateMachineEditor::_adjust_stylebox_opacity(Ref<StyleBox> p_style, float p_opacity) {
 	Ref<StyleBox> style = p_style->duplicate();
-	if (style->derives_from<StyleBoxFlat>()) {
+	if (style->is_class("StyleBoxFlat")) {
 		Ref<StyleBoxFlat> flat_style = style;
 		Color bg_color = flat_style->get_bg_color();
 		Color border_color = flat_style->get_border_color();

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -5445,12 +5445,12 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 	ERR_FAIL_NULL(node);
 	NodePath path_to = root->get_path_to(node, true);
 
-	if (adding_track_type == Animation::TYPE_BLEND_SHAPE && !node->derives_from<MeshInstance3D>()) {
+	if (adding_track_type == Animation::TYPE_BLEND_SHAPE && !node->is_class("MeshInstance3D")) {
 		EditorNode::get_singleton()->show_warning(TTR("Blend Shape tracks only apply to MeshInstance3D nodes."));
 		return;
 	}
 
-	if ((adding_track_type == Animation::TYPE_POSITION_3D || adding_track_type == Animation::TYPE_ROTATION_3D || adding_track_type == Animation::TYPE_SCALE_3D) && !node->derives_from<Node3D>()) {
+	if ((adding_track_type == Animation::TYPE_POSITION_3D || adding_track_type == Animation::TYPE_ROTATION_3D || adding_track_type == Animation::TYPE_SCALE_3D) && !node->is_class("Node3D")) {
 		EditorNode::get_singleton()->show_warning(TTR("Position/Rotation/Scale 3D tracks only apply to 3D-based nodes."));
 		return;
 	}
@@ -5509,7 +5509,7 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 
 		} break;
 		case Animation::TYPE_ANIMATION: {
-			if (!node->derives_from<AnimationPlayer>()) {
+			if (!node->is_class("AnimationPlayer")) {
 				EditorNode::get_singleton()->show_warning(TTR("Animation tracks can only point to AnimationPlayer nodes."));
 				return;
 			}

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -1330,20 +1330,20 @@ AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_value_track_edit(Obj
 		return audio;
 	}
 
-	if (p_property == "frame" && (p_object->derives_from<Sprite2D>() || p_object->derives_from<Sprite3D>() || p_object->derives_from<AnimatedSprite2D>() || p_object->derives_from<AnimatedSprite3D>())) {
+	if (p_property == "frame" && (p_object->is_class("Sprite2D") || p_object->is_class("Sprite3D") || p_object->is_class("AnimatedSprite2D") || p_object->is_class("AnimatedSprite3D"))) {
 		AnimationTrackEditSpriteFrame *sprite = memnew(AnimationTrackEditSpriteFrame);
 		sprite->set_node(p_object);
 		return sprite;
 	}
 
-	if (p_property == "frame_coords" && (p_object->derives_from<Sprite2D>() || p_object->derives_from<Sprite3D>())) {
+	if (p_property == "frame_coords" && (p_object->is_class("Sprite2D") || p_object->is_class("Sprite3D"))) {
 		AnimationTrackEditSpriteFrame *sprite = memnew(AnimationTrackEditSpriteFrame);
 		sprite->set_as_coords();
 		sprite->set_node(p_object);
 		return sprite;
 	}
 
-	if (p_property == "current_animation" && (p_object->derives_from<AnimationPlayer>())) {
+	if (p_property == "current_animation" && (p_object->is_class("AnimationPlayer"))) {
 		AnimationTrackEditSubAnim *player = memnew(AnimationTrackEditSubAnim);
 		player->set_node(p_object);
 		return player;

--- a/editor/animation/animation_tree_editor_plugin.cpp
+++ b/editor/animation/animation_tree_editor_plugin.cpp
@@ -282,7 +282,7 @@ void AnimationTreeEditorPlugin::edit(Object *p_object) {
 }
 
 bool AnimationTreeEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<AnimationTree>();
+	return p_object->is_class("AnimationTree");
 }
 
 void AnimationTreeEditorPlugin::make_visible(bool p_visible) {

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -353,7 +353,7 @@ void InspectorDock::_prepare_history() {
 			}
 		} else if (Object::cast_to<Node>(obj)) {
 			text = Object::cast_to<Node>(obj)->get_name();
-		} else if (obj->derives_from<EditorDebuggerRemoteObjects>()) {
+		} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
 			text = obj->call("get_title");
 		} else {
 			text = obj->get_class();
@@ -551,9 +551,9 @@ void InspectorDock::update(Object *p_object) {
 	current = p_object;
 
 	const bool is_object = p_object != nullptr;
-	const bool is_resource = is_object && p_object->derives_from<Resource>();
-	const bool is_text_file = is_object && p_object->derives_from<TextFile>();
-	const bool is_node = is_object && p_object->derives_from<Node>();
+	const bool is_resource = is_object && p_object->is_class("Resource");
+	const bool is_text_file = is_object && p_object->is_class("TextFile");
+	const bool is_node = is_object && p_object->is_class("Node");
 
 	object_menu->set_disabled(!is_object || is_text_file);
 	search->set_editable(is_object && !is_text_file);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4125,7 +4125,7 @@ void SceneTreeDock::_focus_node() {
 	Node *node = scene_tree->get_selected();
 	ERR_FAIL_NULL(node);
 
-	if (node->derives_from<CanvasItem>()) {
+	if (node->is_class("CanvasItem")) {
 		CanvasItemEditorPlugin *editor = Object::cast_to<CanvasItemEditorPlugin>(editor_data->get_editor_by_name("2D"));
 		editor->get_canvas_item_editor()->focus_selection();
 	} else {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1665,7 +1665,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 
 	List<String> preferred;
 	for (const String &E : extensions) {
-		if (p_resource->derives_from<Script>() && (E == "tres" || E == "res")) {
+		if (p_resource->is_class("Script") && (E == "tres" || E == "res")) {
 			// This serves no purpose and confused people.
 			continue;
 		}
@@ -1902,13 +1902,13 @@ void EditorNode::_save_edited_subresources(Node *scene, HashMap<Ref<Resource>, b
 }
 
 void EditorNode::_find_node_types(Node *p_node, int &count_2d, int &count_3d) {
-	if (p_node->derives_from<Viewport>() || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
+	if (p_node->is_class("Viewport") || (p_node != editor_data.get_edited_scene_root() && p_node->get_owner() != editor_data.get_edited_scene_root())) {
 		return;
 	}
 
-	if (p_node->derives_from<CanvasItem>()) {
+	if (p_node->is_class("CanvasItem")) {
 		count_2d++;
-	} else if (p_node->derives_from<Node3D>()) {
+	} else if (p_node->is_class("Node3D")) {
 		count_3d++;
 	}
 
@@ -2781,13 +2781,13 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 	}
 
 	// Update the use folding setting and state.
-	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->derives_from<EditorDebuggerRemoteObjects>();
+	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding")) || current_obj->is_class("EditorDebuggerRemoteObjects");
 	if (InspectorDock::get_inspector_singleton()->is_using_folding() == disable_folding) {
 		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding, false);
 	}
 
-	bool is_resource = current_obj->derives_from<Resource>();
-	bool is_node = current_obj->derives_from<Node>();
+	bool is_resource = current_obj->is_class("Resource");
+	bool is_node = current_obj->is_class("Node");
 	bool stay_in_script_editor_on_node_selected = bool(EDITOR_GET("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected"));
 	bool skip_main_plugin = false;
 
@@ -2866,7 +2866,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		Node *selected_node = nullptr;
 
 		Vector<Node *> multi_nodes;
-		if (current_obj->derives_from<MultiNodeEdit>()) {
+		if (current_obj->is_class("MultiNodeEdit")) {
 			Node *scene = get_edited_scene();
 			if (scene) {
 				MultiNodeEdit *multi_node_edit = Object::cast_to<MultiNodeEdit>(current_obj);
@@ -2892,7 +2892,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			}
 		}
 
-		if (!current_obj->derives_from<EditorDebuggerRemoteObjects>()) {
+		if (!current_obj->is_class("EditorDebuggerRemoteObjects")) {
 			EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		}
 
@@ -2908,8 +2908,8 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			editable_info,
 			info_is_warning);
 
-	Object *editor_owner = (is_node || current_obj->derives_from<MultiNodeEdit>()) ? (Object *)SceneTreeDock::get_singleton() : is_resource ? (Object *)InspectorDock::get_inspector_singleton()
-																																			: (Object *)this;
+	Object *editor_owner = (is_node || current_obj->is_class("MultiNodeEdit")) ? (Object *)SceneTreeDock::get_singleton() : is_resource ? (Object *)InspectorDock::get_inspector_singleton()
+																																		: (Object *)this;
 
 	// Take care of the main editor plugin.
 
@@ -5309,7 +5309,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 		return get_class_icon(class_name, p_fallback);
 	}
 
-	if (scr.is_null() && p_object->derives_from<Script>()) {
+	if (scr.is_null() && p_object->is_class("Script")) {
 		scr = p_object;
 	}
 

--- a/editor/scene/2d/camera_2d_editor_plugin.cpp
+++ b/editor/scene/2d/camera_2d_editor_plugin.cpp
@@ -316,7 +316,7 @@ void Camera2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Camera2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Camera2D>();
+	return p_object->is_class("Camera2D");
 }
 
 void Camera2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/2d/path_2d_editor_plugin.cpp
+++ b/editor/scene/2d/path_2d_editor_plugin.cpp
@@ -987,7 +987,7 @@ void Path2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Path2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Path2D>();
+	return p_object->is_class("Path2D");
 }
 
 void Path2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
+++ b/editor/scene/2d/physics/collision_shape_2d_editor_plugin.cpp
@@ -652,7 +652,7 @@ void CollisionShape2DEditorPlugin::edit(Object *p_obj) {
 }
 
 bool CollisionShape2DEditorPlugin::handles(Object *p_obj) const {
-	return p_obj->derives_from<CollisionShape2D>();
+	return p_obj->is_class("CollisionShape2D");
 }
 
 void CollisionShape2DEditorPlugin::make_visible(bool visible) {

--- a/editor/scene/2d/skeleton_2d_editor_plugin.cpp
+++ b/editor/scene/2d/skeleton_2d_editor_plugin.cpp
@@ -116,7 +116,7 @@ void Skeleton2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Skeleton2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Skeleton2D>();
+	return p_object->is_class("Skeleton2D");
 }
 
 void Skeleton2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -718,7 +718,7 @@ void Sprite2DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Sprite2DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Sprite2D>();
+	return p_object->is_class("Sprite2D");
 }
 
 void Sprite2DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/camera_3d_editor_plugin.cpp
+++ b/editor/scene/3d/camera_3d_editor_plugin.cpp
@@ -112,7 +112,7 @@ void Camera3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Camera3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Camera3D>();
+	return p_object->is_class("Camera3D");
 }
 
 void Camera3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/scene/3d/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -64,7 +64,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool GPUParticlesCollisionSDF3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<GPUParticlesCollisionSDF3D>();
+	return p_object->is_class("GPUParticlesCollisionSDF3D");
 }
 
 void GPUParticlesCollisionSDF3DEditorPlugin::_notification(int p_what) {

--- a/editor/scene/3d/lightmap_gi_editor_plugin.cpp
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.cpp
@@ -139,7 +139,7 @@ void LightmapGIEditorPlugin::edit(Object *p_object) {
 }
 
 bool LightmapGIEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<LightmapGI>();
+	return p_object->is_class("LightmapGI");
 }
 
 void LightmapGIEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/mesh_library_editor_plugin.cpp
+++ b/editor/scene/3d/mesh_library_editor_plugin.cpp
@@ -311,7 +311,7 @@ void MeshLibraryEditorPlugin::edit(Object *p_node) {
 }
 
 bool MeshLibraryEditorPlugin::handles(Object *p_node) const {
-	return p_node->derives_from<MeshLibrary>();
+	return p_node->is_class("MeshLibrary");
 }
 
 void MeshLibraryEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/multimesh_editor_plugin.cpp
+++ b/editor/scene/3d/multimesh_editor_plugin.cpp
@@ -380,7 +380,7 @@ void MultiMeshEditorPlugin::edit(Object *p_object) {
 }
 
 bool MultiMeshEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<MultiMeshInstance3D>();
+	return p_object->is_class("MultiMeshInstance3D");
 }
 
 void MultiMeshEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -1113,7 +1113,7 @@ void Node3DEditorViewport::_select_region() {
 		}
 
 		// Replace the node by the group if grouped
-		if (node->derives_from<Node3D>()) {
+		if (node->is_class("Node3D")) {
 			Node3D *sel = Object::cast_to<Node3D>(node);
 			while (node && node != EditorNode::get_singleton()->get_edited_scene()->get_parent()) {
 				Node3D *selected_tmp = Object::cast_to<Node3D>(node);
@@ -10011,7 +10011,7 @@ void Node3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Node3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Node3D>();
+	return p_object->is_class("Node3D");
 }
 
 Dictionary Node3DEditorPlugin::get_state() const {

--- a/editor/scene/3d/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/scene/3d/occluder_instance_3d_editor_plugin.cpp
@@ -87,7 +87,7 @@ void OccluderInstance3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool OccluderInstance3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<OccluderInstance3D>();
+	return p_object->is_class("OccluderInstance3D");
 }
 
 void OccluderInstance3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/particles_3d_editor_plugin.cpp
+++ b/editor/scene/3d/particles_3d_editor_plugin.cpp
@@ -90,7 +90,7 @@ void Particles3DEditorPlugin::_node_selected(const NodePath &p_path) {
 		return;
 	}
 
-	if (!sel->derives_from<Node3D>()) {
+	if (!sel->is_class("Node3D")) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("\"%s\" doesn't inherit from Node3D."), sel->get_name()));
 		return;
 	}

--- a/editor/scene/3d/path_3d_editor_plugin.cpp
+++ b/editor/scene/3d/path_3d_editor_plugin.cpp
@@ -751,7 +751,7 @@ void Path3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Path3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Path3D>();
+	return p_object->is_class("Path3D");
 }
 
 void Path3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/root_motion_editor_plugin.cpp
+++ b/editor/scene/3d/root_motion_editor_plugin.cpp
@@ -227,7 +227,7 @@ bool EditorInspectorRootMotionPlugin::can_handle(Object *p_object) {
 }
 
 bool EditorInspectorRootMotionPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
-	if (p_path == "root_motion_track" && p_object->derives_from<AnimationMixer>() && p_type == Variant::NODE_PATH) {
+	if (p_path == "root_motion_track" && p_object->is_class("AnimationMixer") && p_type == Variant::NODE_PATH) {
 		EditorPropertyRootMotion *editor = memnew(EditorPropertyRootMotion);
 		add_property_editor(p_path, editor);
 		return true;

--- a/editor/scene/3d/skeleton_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_3d_editor_plugin.cpp
@@ -1423,7 +1423,7 @@ EditorPlugin::AfterGUIInput Skeleton3DEditorPlugin::forward_3d_gui_input(Camera3
 }
 
 bool Skeleton3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<Skeleton3D>();
+	return p_object->is_class("Skeleton3D");
 }
 
 void Skeleton3DEditor::_bone_enabled_changed(const int p_bone_id) {

--- a/editor/scene/3d/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/scene/3d/skeleton_ik_3d_editor_plugin.cpp
@@ -62,7 +62,7 @@ void SkeletonIK3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool SkeletonIK3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<SkeletonIK3D>();
+	return p_object->is_class("SkeletonIK3D");
 }
 
 void SkeletonIK3DEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/3d/voxel_gi_editor_plugin.cpp
+++ b/editor/scene/3d/voxel_gi_editor_plugin.cpp
@@ -90,7 +90,7 @@ void VoxelGIEditorPlugin::edit(Object *p_object) {
 }
 
 bool VoxelGIEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<VoxelGI>();
+	return p_object->is_class("VoxelGI");
 }
 
 void VoxelGIEditorPlugin::_notification(int p_what) {

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5822,7 +5822,7 @@ void CanvasItemEditorPlugin::edit(Object *p_object) {
 }
 
 bool CanvasItemEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<CanvasItem>();
+	return p_object->is_class("CanvasItem");
 }
 
 void CanvasItemEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -898,7 +898,7 @@ void FontPreview::_notification(int p_what) {
 					} else {
 						name = vformat("%s (%s)", prev_font->get_font_name(), prev_font->get_font_style_name());
 					}
-					if (prev_font->derives_from<FontVariation>()) {
+					if (prev_font->is_class("FontVariation")) {
 						// TRANSLATORS: This refers to variable font config, appended to the font name.
 						name += " - " + TTR("Variation");
 					}

--- a/editor/scene/resource_preloader_editor_plugin.cpp
+++ b/editor/scene/resource_preloader_editor_plugin.cpp
@@ -400,7 +400,7 @@ void ResourcePreloaderEditorPlugin::edit(Object *p_object) {
 }
 
 bool ResourcePreloaderEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<ResourcePreloader>();
+	return p_object->is_class("ResourcePreloader");
 }
 
 void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -139,7 +139,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 		undo_redo->add_undo_method(CanvasItemEditor::get_singleton(), "emit_signal", "item_lock_status_changed");
 		undo_redo->commit_action();
 	} else if (p_id == BUTTON_PIN) {
-		if (n->derives_from<AnimationMixer>()) {
+		if (n->is_class("AnimationMixer")) {
 			AnimationPlayerEditor::get_singleton()->unpin();
 			_update_tree();
 		}
@@ -147,7 +147,7 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 	} else if (p_id == BUTTON_GROUP) {
 		undo_redo->create_action(TTR("Ungroup Children"));
 
-		if (n->derives_from<CanvasItem>() || n->derives_from<Node3D>()) {
+		if (n->is_class("CanvasItem") || n->is_class("Node3D")) {
 			undo_redo->add_do_method(n, "remove_meta", "_edit_group_");
 			undo_redo->add_undo_method(n, "set_meta", "_edit_group_", true);
 			undo_redo->add_do_method(this, "emit_signal", "node_changed");
@@ -618,7 +618,7 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			_update_visibility_color(p_node, p_item);
 		}
 
-		if (p_node->derives_from<AnimationMixer>()) {
+		if (p_node->is_class("AnimationMixer")) {
 			bool is_pinned = AnimationPlayerEditor::get_singleton()->get_editing_node() == p_node && AnimationPlayerEditor::get_singleton()->is_pinned();
 
 			if (is_pinned) {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -4651,7 +4651,7 @@ bool ScriptEditorPlugin::handles(Object *p_object) const {
 		return true;
 	}
 
-	return p_object->derives_from<Script>();
+	return p_object->is_class("Script");
 }
 
 void ScriptEditorPlugin::make_visible(bool p_visible) {

--- a/editor/shader/visual_shader_editor_plugin.cpp
+++ b/editor/shader/visual_shader_editor_plugin.cpp
@@ -2167,7 +2167,7 @@ void VisualShaderEditor::_update_nodes() {
 				String script_path = ScriptServer::get_global_class_path(E);
 				Ref<Resource> res = ResourceLoader::load(script_path);
 				ERR_CONTINUE(res.is_null());
-				ERR_CONTINUE(!res->derives_from<Script>());
+				ERR_CONTINUE(!res->is_class("Script"));
 				Ref<Script> scr = Ref<Script>(res);
 
 				Ref<VisualShaderNodeCustom> ref;
@@ -8126,19 +8126,19 @@ public:
 Control *VisualShaderNodePluginDefault::create_editor(const Ref<Resource> &p_parent_resource, const Ref<VisualShaderNode> &p_node) {
 	Ref<VisualShader> p_shader = Ref<VisualShader>(p_parent_resource.ptr());
 
-	if (p_shader.is_valid() && (p_node->derives_from<VisualShaderNodeVaryingGetter>() || p_node->derives_from<VisualShaderNodeVaryingSetter>())) {
+	if (p_shader.is_valid() && (p_node->is_class("VisualShaderNodeVaryingGetter") || p_node->is_class("VisualShaderNodeVaryingSetter"))) {
 		VisualShaderNodePluginVaryingEditor *editor = memnew(VisualShaderNodePluginVaryingEditor);
 		editor->setup(vseditor, p_node, vseditor->get_current_shader_type());
 		return editor;
 	}
 
-	if (p_node->derives_from<VisualShaderNodeParameterRef>()) {
+	if (p_node->is_class("VisualShaderNodeParameterRef")) {
 		VisualShaderNodePluginParameterRefEditor *editor = memnew(VisualShaderNodePluginParameterRefEditor);
 		editor->setup(vseditor, p_node);
 		return editor;
 	}
 
-	if (p_node->derives_from<VisualShaderNodeInput>()) {
+	if (p_node->is_class("VisualShaderNodeInput")) {
 		VisualShaderNodePluginInputEditor *editor = memnew(VisualShaderNodePluginInputEditor);
 		editor->setup(vseditor, p_node);
 		return editor;
@@ -8316,7 +8316,7 @@ bool EditorInspectorVisualShaderModePlugin::can_handle(Object *p_object) {
 }
 
 bool EditorInspectorVisualShaderModePlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
-	if (p_path == "mode" && p_object->derives_from<VisualShader>() && p_type == Variant::INT) {
+	if (p_path == "mode" && p_object->is_class("VisualShader") && p_type == Variant::INT) {
 		EditorPropertyVisualShaderMode *mode_editor = memnew(EditorPropertyVisualShaderMode);
 		Vector<String> options = p_hint_text.split(",");
 		mode_editor->setup(options);

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1789,7 +1789,7 @@ void GridMapEditorPlugin::edit(Object *p_object) {
 }
 
 bool GridMapEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<GridMap>();
+	return p_object->is_class("GridMap");
 }
 
 void GridMapEditorPlugin::make_visible(bool p_visible) {

--- a/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
+++ b/modules/multiplayer/editor/multiplayer_editor_plugin.cpp
@@ -164,7 +164,7 @@ void MultiplayerEditorPlugin::edit(Object *p_object) {
 }
 
 bool MultiplayerEditorPlugin::handles(Object *p_object) const {
-	return p_object->derives_from<MultiplayerSynchronizer>();
+	return p_object->is_class("MultiplayerSynchronizer");
 }
 
 void MultiplayerEditorPlugin::make_visible(bool p_visible) {

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -76,7 +76,7 @@ Vector<uint8_t> ResourceSaverWebP::save_image_to_buffer(const Ref<Image> &p_img,
 }
 
 bool ResourceSaverWebP::recognize(const Ref<Resource> &p_resource) const {
-	return (p_resource.is_valid() && p_resource->derives_from<ImageTexture>());
+	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
 }
 
 void ResourceSaverWebP::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -148,13 +148,13 @@ void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 		return;
 	}
 
-	if (process_material.is_valid() && process_material->derives_from<ParticleProcessMaterial>()) {
+	if (process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
 		process_material->disconnect("emission_shape_changed", callable_mp((CanvasItem *)this, &GPUParticles2D::queue_redraw));
 	}
 
 	process_material = p_material;
 
-	if (process_material.is_valid() && process_material->derives_from<ParticleProcessMaterial>()) {
+	if (process_material.is_valid() && process_material->is_class("ParticleProcessMaterial")) {
 		process_material->connect("emission_shape_changed", callable_mp((CanvasItem *)this, &GPUParticles2D::queue_redraw));
 	}
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -891,7 +891,7 @@ void SceneDebuggerObject::deserialize(const Array &p_arr) {
 			if (var.is_zero()) {
 				var = Ref<Resource>();
 			} else if (var.get_type() == Variant::OBJECT) {
-				if (((Object *)var)->derives_from<EncodedObjectAsID>()) {
+				if (((Object *)var)->is_class("EncodedObjectAsID")) {
 					var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();
 					pinfo.type = var.get_type();
 					pinfo.hint = PROPERTY_HINT_OBJECT_ID;
@@ -1046,9 +1046,9 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 		Variant orig_tf;
 
 		if (keep_transform) {
-			if (n2->derives_from<Node3D>()) {
+			if (n2->is_class("Node3D")) {
 				orig_tf = n2->call("get_transform");
-			} else if (n2->derives_from<CanvasItem>()) {
+			} else if (n2->is_class("CanvasItem")) {
 				orig_tf = n2->call("_edit_get_state");
 			}
 		}
@@ -1056,12 +1056,12 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 		n2->set(p_prop, p_value);
 
 		if (keep_transform) {
-			if (n2->derives_from<Node3D>()) {
+			if (n2->is_class("Node3D")) {
 				Variant new_tf = n2->call("get_transform");
 				if (new_tf != orig_tf) {
 					n2->call("set_transform", orig_tf);
 				}
-			} else if (n2->derives_from<CanvasItem>()) {
+			} else if (n2->is_class("CanvasItem")) {
 				Variant new_tf = n2->call("_edit_get_state");
 				if (new_tf != orig_tf) {
 					n2->call("_edit_set_state", orig_tf);
@@ -1117,9 +1117,9 @@ void LiveEditor::_node_call_func(int p_id, const StringName &p_method, const Var
 		Variant orig_tf;
 
 		if (keep_transform) {
-			if (n2->derives_from<Node3D>()) {
+			if (n2->is_class("Node3D")) {
 				orig_tf = n2->call("get_transform");
-			} else if (n2->derives_from<CanvasItem>()) {
+			} else if (n2->is_class("CanvasItem")) {
 				orig_tf = n2->call("_edit_get_state");
 			}
 		}
@@ -1128,12 +1128,12 @@ void LiveEditor::_node_call_func(int p_id, const StringName &p_method, const Var
 		n2->callp(p_method, p_args, p_argcount, ce);
 
 		if (keep_transform) {
-			if (n2->derives_from<Node3D>()) {
+			if (n2->is_class("Node3D")) {
 				Variant new_tf = n2->call("get_transform");
 				if (new_tf != orig_tf) {
 					n2->call("set_transform", orig_tf);
 				}
-			} else if (n2->derives_from<CanvasItem>()) {
+			} else if (n2->is_class("CanvasItem")) {
 				Variant new_tf = n2->call("_edit_get_state");
 				if (new_tf != orig_tf) {
 					n2->call("_edit_set_state", orig_tf);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1464,7 +1464,7 @@ void VisualShader::set_mode(Mode p_mode) {
 				keep = false;
 			} else {
 				Ref<VisualShaderNode> from_node = graph[i].nodes[from].node;
-				if (from_node->derives_from<VisualShaderNodeOutput>() || from_node->derives_from<VisualShaderNodeInput>()) {
+				if (from_node->is_class("VisualShaderNodeOutput") || from_node->is_class("VisualShaderNodeInput")) {
 					keep = false;
 				}
 			}
@@ -1473,7 +1473,7 @@ void VisualShader::set_mode(Mode p_mode) {
 				keep = false;
 			} else {
 				Ref<VisualShaderNode> to_node = graph[i].nodes[to].node;
-				if (to_node->derives_from<VisualShaderNodeOutput>() || to_node->derives_from<VisualShaderNodeInput>()) {
+				if (to_node->is_class("VisualShaderNodeOutput") || to_node->is_class("VisualShaderNodeInput")) {
 					keep = false;
 				}
 			}


### PR DESCRIPTION
This reverts commit 78b743cf4a67973d477378286c47cba66c66a580.

* Reverts: https://github.com/godotengine/godot/pull/110832

The issue is that this materializes types, requiring them to be concrete. The more detailed solution would be to add guards like `#ifndef _3D_DISABLED` but needs detailed checking for each case

* Fixes: https://github.com/godotengine/godot/issues/110889

<!--
Please target the `master` branch in priority.

Relevant fixes are cherry-picked for stable branches as needed by maintainers.

To speed up the contribution process and avoid CI errors, please set up pre-commit hooks locally:
https://contributing.godotengine.org/en/latest/engine/guidelines/code_style.html
-->
