### PR TITLE
Fix SpinBox stepper grabbing focus state on mouse input

### DIFF
--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -257,7 +257,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 		switch (mb->get_button_index()) {
 			case MouseButton::LEFT: {
 				accepted = true;
-				line_edit->grab_focus();
+				line_edit->grab_focus(true);
 
 				if (mouse_on_up_button || mouse_on_down_button) {
 					// Arrow button is being pressed. Snap the value to next step.
@@ -281,7 +281,7 @@ void SpinBox::gui_input(const Ref<InputEvent> &p_event) {
 				drag.capture_pos = mb->get_position();
 			} break;
 			case MouseButton::RIGHT: {
-				line_edit->grab_focus();
+				line_edit->grab_focus(true);
 				if (mouse_on_up_button || mouse_on_down_button) {
 					set_value(mouse_on_up_button ? get_max() : get_min());
 				}


### PR DESCRIPTION
https://github.com/godotengine/godot/pull/110250 changed focus behavior for mouse input.

SpinBox is still showing focus when stepper is clicked with the mouse:

[Screencast_20250924_164720.webm](https://github.com/user-attachments/assets/8fdcb96f-eea6-4aaf-b92f-884b02dd9437)

After:

[Screencast_20250924_164553.webm](https://github.com/user-attachments/assets/eb1b8a42-4ca0-4bc0-a7a6-68347a36099f)

