### PR TITLE
[3.x] Fix build on macOS 26 by removing AGL framework link

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -197,8 +197,6 @@ def configure(env):
             "-framework",
             "OpenGL",
             "-framework",
-            "AGL",
-            "-framework",
             "AudioUnit",
             "-framework",
             "CoreAudio",


### PR DESCRIPTION
Previously, a link error occurred as we'd be trying to link against a nonexistent framework. AGL was removed in macOS Tahoe since the first beta.

Please test on older macOS versions as well as Intel Macs, as I've only tested this on macOS 26 on Apple Silicon.

This fix isn't necessary in 4.x.

- See https://github.com/musescore/MuseScore/issues/28917.
