### PR TITLE
Add `--user-test` command line argument to facilitate microtests, microbenchmarks, and more

### DIFF
--- a/main/SCsub
+++ b/main/SCsub
@@ -9,6 +9,16 @@ env.main_sources = []
 
 env_main = env.Clone()
 
+opts = Variables([], ARGUMENTS)
+opts.Add(
+    BoolVariable(
+        "user_test",
+        "Include the --user-test option. This option does nothing by default, so you can ignore this flag unless you plan to edit main/usertest/usertest.cpp.",
+        False,
+    )
+)
+opts.Update(env_main)
+
 env_main.add_source_files(env.main_sources, "*.cpp")
 
 if env["steamapi"] and env.editor_build:
@@ -16,6 +26,10 @@ if env["steamapi"] and env.editor_build:
 
 if env["tests"]:
     env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
+
+if env_main["user_test"]:
+    env_main.Append(CPPDEFINES=["GODOT_USER_TEST_ENABLED"])
+    env_main.add_source_files(env.main_sources, "usertest/*.cpp")
 
 env_main.CommandNoCache(
     "#main/splash.gen.h",

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -147,6 +147,10 @@
 #endif // TOOLS_ENABLED && !GDSCRIPT_NO_LSP
 #endif // MODULE_GDSCRIPT_ENABLED
 
+#ifdef GODOT_USER_TEST_ENABLED
+#include "main/usertest/usertest.h"
+#endif
+
 /* Static members */
 
 // Singletons
@@ -284,6 +288,9 @@ static bool validate_extension_api = false;
 static String validate_extension_api_file;
 #endif
 bool profile_gpu = false;
+#ifdef GODOT_USER_TEST_ENABLED
+static bool will_run_usertest = false;
+#endif
 
 // Constants.
 
@@ -701,6 +708,7 @@ void Main::print_help(const char *p_binary) {
 #ifdef TESTS_ENABLED
 	print_help_option("--test [--help]", "Run unit tests. Use --test --help for more information.\n");
 #endif // TESTS_ENABLED
+	print_help_option("--user-test", "Run the user test. Note: This is a development tool. By default, the user test does nothing.\n");
 	OS::get_singleton()->print("\n");
 }
 
@@ -1554,6 +1562,18 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing file to load argument after --validate-extension-api, aborting.");
 				goto error;
 			}
+#ifdef GODOT_USER_TEST_ENABLED
+		} else if (arg == "--user-test") {
+			// Register as an editor instance to use low-end fallback if relevant.
+			editor = true;
+			cmdline_tool = true;
+			will_run_usertest = true;
+			print_line("Running user test");
+			// Hack. Not needed but otherwise we end up detecting that this should
+			// run the project instead of a cmdline tool.
+			// Needs full refactoring to fix properly.
+			main_args.push_back(arg);
+#endif
 		} else if (arg == "--import") {
 			editor = true;
 			cmdline_tool = true;
@@ -4130,6 +4150,18 @@ int Main::start() {
 			return valid ? EXIT_SUCCESS : EXIT_FAILURE;
 		}
 	}
+
+#ifdef GODOT_USER_TEST_ENABLED
+	if (will_run_usertest) {
+		bool valid = run_usertest();
+		if (valid) {
+			print_line("User test succeeded.");
+		} else {
+			ERR_PRINT("User test failed.");
+		}
+		return valid ? EXIT_SUCCESS : EXIT_FAILURE;
+	}
+#endif
 
 #ifndef DISABLE_DEPRECATED
 	if (converting_project) {

--- a/main/usertest/usertest.cpp
+++ b/main/usertest/usertest.cpp
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  usertest.cpp                                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "usertest.h"
+
+#include "core/string/print_string.h"
+#include "core/variant/variant.h"
+
+// Note: This file is intended for local development only, for example for quick tests or benchmarks.
+//       If changes end up in a PR by accident, please revert them.
+
+// You can run this function by launching Godot with the --user-test argument.
+bool run_usertest() {
+	print_line("No user test configured. User tests are a tool for engine developers. To add one, edit main/usertest/usertest.cpp and recompile the engine.");
+
+	// Return true to indicate success, false to indicate failure.
+	return true;
+}

--- a/main/usertest/usertest.h
+++ b/main/usertest/usertest.h
@@ -1,0 +1,34 @@
+/**************************************************************************/
+/*  usertest.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+/// Returns true on success, false on failure.
+bool run_usertest();


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot-proposals/issues/12319

This adds the necessary code to make custom code tests and benchmarks easier to set up.
This will not be used by many (only those that are both aware of it and in need of running many micro tests and benchmarks). However, it's minimal code, and it will help those that do need these tests to do them more efficiently.

In addition, this file could be used to give users clear instructions for how to run benchmarks and quick tests in the [contributing docs](https://contributing.godotengine.org/).
