### PR TITLE
Make `RD::texture_create` take a `Span<Span<uint8_t>>` to avoid needless allocations.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2364,6 +2364,10 @@ Vector<uint8_t> Image::get_data() const {
 	return data;
 }
 
+Span<uint8_t> Image::get_data_span() const {
+	return data.span();
+}
+
 Ref<Image> Image::create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
 	Ref<Image> image;
 	image.instantiate();

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -350,6 +350,7 @@ public:
 	bool is_empty() const;
 
 	Vector<uint8_t> get_data() const;
+	Span<uint8_t> get_data_span() const;
 
 	Error load(const String &p_path);
 	static Ref<Image> load_from_file(const String &p_path);

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -279,6 +279,13 @@ public:
 		}
 	}
 
+	void append_array(Span<T> p_span) {
+		reserve(size() + p_span.size());
+		for (U i = 0; i < p_span.size(); i++) {
+			memnew_placement(&data[count++], T(p_span[i]));
+		}
+	}
+
 	int64_t find(const T &p_val, int64_t p_from = 0) const {
 		if (p_from < 0) {
 			p_from = size() + p_from;
@@ -330,16 +337,6 @@ public:
 					w[i] = data[i];
 				}
 			}
-		}
-		return ret;
-	}
-
-	Vector<uint8_t> to_byte_array() const { //useful to pass stuff to gpu or variant
-		Vector<uint8_t> ret;
-		ret.resize(count * sizeof(T));
-		uint8_t *w = ret.ptrw();
-		if (w) {
-			memcpy(w, data, sizeof(T) * count);
 		}
 		return ret;
 	}

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -189,6 +189,10 @@ public:
 	void operator=(const Vector &p_from) { _cowdata = p_from._cowdata; }
 	void operator=(Vector &&p_from) { _cowdata = std::move(p_from._cowdata); }
 
+	// Caution: This function exists mostly for the bindings / backwards compatibility.
+	//  In almost all cases, it was used to pass the data to some API in byte form.
+	//  In this case, use `span().reinterpret<uint8_t>()` instead, which won't create a copy
+	//  of the data, and is thus a lot faster.
 	Vector<uint8_t> to_byte_array() const {
 		Vector<uint8_t> ret;
 		if (is_empty()) {

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -677,12 +677,10 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 		tf.texture_type = RD::TEXTURE_TYPE_3D;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
 
-		Vector<Vector<uint8_t>> texdata;
-		texdata.resize(1);
-		//grid and indices
+		// Grid and indices
 		tf.format = RD::DATA_FORMAT_R32G32_UINT;
-		texdata.write[0] = grid_indices.to_byte_array();
-		grid_texture = rd->texture_create(tf, RD::TextureView(), texdata);
+		Span<uint8_t> grid_indices_span = grid_indices.span().reinterpret<uint8_t>();
+		grid_texture = rd->texture_create(tf, RD::TextureView(), Span(&grid_indices_span, 1));
 	}
 }
 
@@ -1184,11 +1182,13 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	{ // create all textures
 
-		Vector<Vector<uint8_t>> albedo_data;
-		Vector<Vector<uint8_t>> emission_data;
+		LocalVector<Span<uint8_t>> albedo_data;
+		albedo_data.reserve(atlas_slices);
+		LocalVector<Span<uint8_t>> emission_data;
+		emission_data.reserve(atlas_slices);
 		for (int i = 0; i < atlas_slices; i++) {
-			albedo_data.push_back(albedo_images[i]->get_data());
-			emission_data.push_back(emission_images[i]->get_data());
+			albedo_data.push_back(albedo_images[i]->get_data_span());
+			emission_data.push_back(emission_images[i]->get_data_span());
 		}
 
 		RD::TextureFormat tf;
@@ -1258,9 +1258,8 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			tfp.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
 			tfp.format = RD::DATA_FORMAT_R32G32B32A32_SFLOAT;
 
-			Vector<Vector<uint8_t>> tdata;
-			tdata.push_back(panorama_tex->get_data());
-			light_environment_tex = rd->texture_create(tfp, RD::TextureView(), tdata);
+			Span<uint8_t> panorama_tex_span = panorama_tex->get_data_span();
+			light_environment_tex = rd->texture_create(tfp, RD::TextureView(), Span(&panorama_tex_span, 1));
 
 #ifdef DEBUG_TEXTURES
 			panorama_tex->save_exr("res://0_panorama.exr", false);

--- a/servers/rendering/renderer_rd/effects/fsr2.cpp
+++ b/servers/rendering/renderer_rd/effects/fsr2.cpp
@@ -30,6 +30,8 @@
 
 #include "fsr2.h"
 
+#include "core/templates/fixed_vector.h"
+
 #include "../storage_rd/material_storage.h"
 #include "../uniform_set_cache_rd.h"
 
@@ -219,12 +221,12 @@ static FfxErrorCode create_resource_rd(FfxFsr2Interface *p_backend_interface, co
 		res_desc.mipCount = uint32_t(1 + std::floor(std::log2(MAX(MAX(res_desc.width, res_desc.height), res_desc.depth))));
 	}
 
-	Vector<PackedByteArray> initial_data;
+	Vector<uint8_t> initial_data_vector;
+	FixedVector<Span<uint8_t>, 1> initial_data;
 	if (p_create_resource_description->initDataSize) {
-		PackedByteArray byte_array;
-		byte_array.resize(p_create_resource_description->initDataSize);
-		memcpy(byte_array.ptrw(), p_create_resource_description->initData, p_create_resource_description->initDataSize);
-		initial_data.push_back(byte_array);
+		initial_data_vector.resize(p_create_resource_description->initDataSize);
+		memcpy(initial_data_vector.ptrw(), p_create_resource_description->initData, p_create_resource_description->initDataSize);
+		initial_data.push_back(initial_data_vector.span());
 	}
 
 	RD::TextureFormat texture_format;

--- a/servers/rendering/renderer_rd/effects/smaa.cpp
+++ b/servers/rendering/renderer_rd/effects/smaa.cpp
@@ -111,7 +111,9 @@ SMAA::SMAA() {
 		tf.height = SEARCHTEX_HEIGHT;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;
 
-		smaa.search_tex = RD::get_singleton()->texture_create(tf, RD::TextureView(), Vector<Vector<unsigned char>>{ Image(search_tex_png).get_data() });
+		Image search_tex_img(search_tex_png);
+		Span<uint8_t> search_tex_imgs[1] = { search_tex_img.get_data_span() };
+		smaa.search_tex = RD::get_singleton()->texture_create(tf, RD::TextureView(), search_tex_imgs);
 	}
 
 	{
@@ -122,7 +124,9 @@ SMAA::SMAA() {
 		tf.height = AREATEX_HEIGHT;
 		tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT;
 
-		smaa.area_tex = RD::get_singleton()->texture_create(tf, RD::TextureView(), Vector<Vector<unsigned char>>{ Image(area_tex_png).get_data() });
+		Image area_tex_img(area_tex_png);
+		Span<uint8_t> area_tex_imgs[1] = { area_tex_img.get_data_span() };
+		smaa.area_tex = RD::get_singleton()->texture_create(tf, RD::TextureView(), area_tex_imgs);
 	}
 
 	{

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -107,8 +107,7 @@ void GI::voxel_gi_allocate_data(RID p_voxel_gi, const Transform3D &p_to_cell_xfo
 			tf.depth = voxel_gi->octree_size.z;
 			tf.texture_type = RD::TEXTURE_TYPE_3D;
 			tf.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
-			Vector<Vector<uint8_t>> s;
-			s.push_back(p_distance_field);
+			const Span<uint8_t> s[1] = { p_distance_field.span() };
 			voxel_gi->sdf_texture = RD::get_singleton()->texture_create(tf, RD::TextureView(), s);
 			RD::get_singleton()->set_resource_name(voxel_gi->sdf_texture, "VoxelGI SDF Texture");
 		}

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -102,8 +102,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 
@@ -116,8 +115,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_BLACK] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 
@@ -130,8 +128,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_TRANSPARENT] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 
@@ -144,8 +141,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_NORMAL] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 
@@ -158,8 +154,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_ANISO] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 
@@ -189,8 +184,7 @@ TextureStorage::TextureStorage() {
 		//memset(pv.ptrw(), 0, 16 * 4);
 		{
 			tformat.format = RD::DATA_FORMAT_R8G8B8A8_UINT;
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_2D_UINT] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -215,10 +209,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			for (int i = 0; i < 6; i++) {
-				vpv.push_back(pv);
-			}
+			Span<uint8_t> vpv[6]{ pv.span(), pv.span(), pv.span(), pv.span(), pv.span(), pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_BLACK] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -243,10 +234,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			for (int i = 0; i < 6; i++) {
-				vpv.push_back(pv);
-			}
+			Span<uint8_t> vpv[6]{ pv.span(), pv.span(), pv.span(), pv.span(), pv.span(), pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -271,10 +259,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			for (int i = 0; i < 6; i++) {
-				vpv.push_back(pv);
-			}
+			Span<uint8_t> vpv[6]{ pv.span(), pv.span(), pv.span(), pv.span(), pv.span(), pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_CUBEMAP_ARRAY_TRANSPARENT] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -299,10 +284,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			for (int i = 0; i < 6; i++) {
-				vpv.push_back(pv);
-			}
+			Span<uint8_t> vpv[6]{ pv.span(), pv.span(), pv.span(), pv.span(), pv.span(), pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_CUBEMAP_BLACK] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -327,10 +309,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			for (int i = 0; i < 6; i++) {
-				vpv.push_back(pv);
-			}
+			Span<uint8_t> vpv[6]{ pv.span(), pv.span(), pv.span(), pv.span(), pv.span(), pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_CUBEMAP_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -355,10 +334,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			for (int i = 0; i < 6; i++) {
-				vpv.push_back(pv);
-			}
+			Span<uint8_t> vpv[6]{ pv.span(), pv.span(), pv.span(), pv.span(), pv.span(), pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_CUBEMAP_TRANSPARENT] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -384,8 +360,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_3D_BLACK] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 		for (int i = 0; i < 64; i++) {
@@ -397,8 +372,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_3D_TRANSPARENT] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 		for (int i = 0; i < 64; i++) {
@@ -409,8 +383,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_3D_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -435,8 +408,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_2D_ARRAY_WHITE] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -461,8 +433,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_2D_ARRAY_BLACK] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -487,8 +458,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_2D_ARRAY_NORMAL] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -534,8 +504,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			decal_atlas.texture = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 			decal_atlas.texture_srgb = decal_atlas.texture;
 		}
@@ -559,8 +528,7 @@ TextureStorage::TextureStorage() {
 		}
 
 		{
-			Vector<Vector<uint8_t>> vpv;
-			vpv.push_back(pv);
+			Span<uint8_t> vpv[1]{ pv.span() };
 			default_rd_textures[DEFAULT_RD_TEXTURE_VRS] = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 		}
 	}
@@ -887,10 +855,8 @@ void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_im
 		rd_view.swizzle_b = ret_format.swizzle_b;
 		rd_view.swizzle_a = ret_format.swizzle_a;
 	}
-	Vector<uint8_t> data = image->get_data(); //use image data
-	Vector<Vector<uint8_t>> data_slices;
-	data_slices.push_back(data);
-	texture.rd_texture = RD::get_singleton()->texture_create(rd_format, rd_view, data_slices);
+	Span<uint8_t> img_data_spans[1] = { image->get_data_span() };
+	texture.rd_texture = RD::get_singleton()->texture_create(rd_format, rd_view, img_data_spans);
 	ERR_FAIL_COND(texture.rd_texture.is_null());
 	if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
 		rd_view.format_override = texture.rd_format_srgb;
@@ -997,10 +963,10 @@ void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<R
 		rd_view.swizzle_b = ret_format.swizzle_b;
 		rd_view.swizzle_a = ret_format.swizzle_a;
 	}
-	Vector<Vector<uint8_t>> data_slices;
+	LocalVector<Span<uint8_t>> data_slices;
+	data_slices.reserve(images.size());
 	for (int i = 0; i < images.size(); i++) {
-		Vector<uint8_t> data = images[i]->get_data(); //use image data
-		data_slices.push_back(data);
+		data_slices.push_back(images[i]->get_data_span());
 	}
 	texture.rd_texture = RD::get_singleton()->texture_create(rd_format, rd_view, data_slices);
 	ERR_FAIL_COND(texture.rd_texture.is_null());
@@ -1116,9 +1082,7 @@ void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format p_format
 		rd_view.swizzle_b = ret_format.swizzle_b;
 		rd_view.swizzle_a = ret_format.swizzle_a;
 	}
-	Vector<Vector<uint8_t>> data_slices;
-	data_slices.push_back(all_data); //one slice
-
+	Span<uint8_t> data_slices[1] = { all_data.span() };
 	texture.rd_texture = RD::get_singleton()->texture_create(rd_format, rd_view, data_slices);
 	ERR_FAIL_COND(texture.rd_texture.is_null());
 	if (texture.rd_format_srgb != RD::DATA_FORMAT_MAX) {
@@ -1753,7 +1717,7 @@ void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_textur
 	_texture_format_from_rd(tf.format, imfmt);
 	ERR_FAIL_COND(imfmt.image_format == Image::FORMAT_MAX);
 
-	Texture texture;
+	Texture texture{};
 
 	switch (tf.texture_type) {
 		case RD::TEXTURE_TYPE_2D: {
@@ -4129,8 +4093,7 @@ RID TextureStorage::render_target_get_sdf_texture(RID p_render_target) {
 		Vector<uint8_t> pv;
 		pv.resize(16 * 4);
 		memset(pv.ptrw(), 0, 16 * 4);
-		Vector<Vector<uint8_t>> vpv;
-		vpv.push_back(pv);
+		Span<uint8_t> vpv[1] = { pv.span() };
 		rt->sdf_buffer_read = RD::get_singleton()->texture_create(tformat, RD::TextureView(), vpv);
 	}
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -350,7 +350,7 @@ public:
 	Vector<uint8_t> _texture_get_data(Texture *tex, uint32_t p_layer, bool p_2d = false);
 	uint32_t _texture_layer_count(Texture *p_texture) const;
 	uint32_t _texture_alignment(Texture *p_texture) const;
-	Error _texture_initialize(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data, RDD::TextureLayout p_dst_layout, bool p_immediate_flush);
+	Error _texture_initialize(RID p_texture, uint32_t p_layer, const Span<uint8_t> p_data, RDD::TextureLayout p_dst_layout, bool p_immediate_flush);
 	void _texture_check_shared_fallback(Texture *p_texture);
 	void _texture_update_shared_fallback(RID p_texture_rid, Texture *p_texture, bool p_for_writing);
 	void _texture_free_shared_fallback(Texture *p_texture);
@@ -394,7 +394,7 @@ public:
 		}
 	};
 
-	RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data = Vector<Vector<uint8_t>>());
+	RID texture_create(const TextureFormat &p_format, const TextureView &p_view, const Span<Span<uint8_t>> &p_data = Span<Span<uint8_t>>());
 	RID texture_create_shared(const TextureView &p_view, RID p_with_texture);
 	RID texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers, uint64_t p_mipmaps = 1);
 	RID texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, uint32_t p_mipmaps = 1, TextureSliceType p_slice_type = TEXTURE_SLICE_2D, uint32_t p_layers = 0);


### PR DESCRIPTION
The API `RD::texture_create` currently necessitates allocation (often multiple) for calls.
However, it only reads from the given arguments, so most of the time, no allocation should be necessary. This PR avoids allocation by using `Span` for the arguments instead.

In the end, `to_byte_array` was a code smell, and all of its users ended up copying data unnecessarily. To avoid this pattern in the future, I delete it from `LocalVector`, and discourage its use internally in `Vector`.

Note: This is the first use of `FixedVector`, which is pending a fix: https://github.com/godotengine/godot/pull/106997

## Caveats

The proposed API is just a bit weird when you think about it. We should discuss if it should be merged in the current state.

For one, some callers currently call `Image::get_data()` to gather each image's data into some list. If we simply used `get_data().span()`, the callee would be allowed to copy their data before return, the data would be deallocated after the call, and the `Span` created from it would be invalid. While this is not currently the case, the current API allows for it. To avoid this situation, I introduce `get_data_span()` to `Image`, to force it to return a `Span` to its own owned data. The new API could be used in other situations where a quick view into the data is needed.

Another weird point is that the new API can potentially _cause_ situations where additional allocations are needed:
If you have a `Vector<Vector<uint8_t>>` already, for whatever reason, this change will create the need to allocate for a `Vector<Span<uint8_t>>` instead.
However, this does not happen in the codebase. There are basically just two situations:

- The caller passes a known number of images (1 to 6), and this can be statically allocated.
- The caller passes an unknown number of images as e.g. `TypedArray<PackedByteArray>` (aka `Vector<Variant>`), and conversions are needed anyway. The conversion to `LocalVector<Span<uint8_t>>` is cheaper than the previous one to `Vector<Vector<uint8_t>>`.

For both of these situations, no allocations are needed.

## Notes

`RenderingDevice::texture_create` sometimes adds more textures to the given ones. While it would be possible to implement this without many additional allocations, I just do it the same way the current implementation handles it and copy the given data if need be. It looks a little more complicated, but it's more performant than the previous implementation.