### PR TITLE
Fix CCD bodies adding multiple contact manifolds when using Jolt

### DIFF
--- a/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_contact_listener_3d.cpp
@@ -193,6 +193,12 @@ bool JoltContactListener3D::_try_add_contacts(const JPH::Body &p_jolt_body1, con
 		return manifolds_by_shape_pair[shape_pair];
 	}();
 
+	if (unlikely(!manifold.contacts1.is_empty())) {
+		// CCD collisions can result in two contact callbacks for the same shape pair, one in the earlier discrete stage and one in the later CCD stage.
+		// We want the manifolds from the discrete stage, as the bodies still have their original velocities at that point, so we early-out if we've already stored something.
+		return false;
+	}
+
 	const JPH::uint contact_count = p_manifold.mRelativeContactPointsOn1.size();
 
 	manifold.contacts1.reserve((uint32_t)contact_count);


### PR DESCRIPTION
Fixes #110757.

The code in `JoltContactListener3D::_try_add_contacts`, as called by Jolt through its `JPH::ContactListener` callback interface, does not currently take into account that CCD collisions can cause it to be called multiple times in a single physics step for the same shape pair. This means that a `RigidBody3D` with `continuous_cd` enabled, as well as a non-zero `max_contacts_reported`, can end up with a list of contacts that actually make up two different contact manifolds, which is bad.

In 4.5-stable this also resulted in an error about `reserve() called with a capacity smaller than the current size`, but which has since been relegated to a `--verbose` warning as of #110826.

This PR fixes all that by simply doing an early-out from `JoltContactListener3D::_try_add_contacts` if the shape pair in question already has a set of contacts.