### PR TITLE
Clear intermediate buffers when not in use in Compatibility

### DIFF
--- a/drivers/gles3/storage/render_scene_buffers_gles3.cpp
+++ b/drivers/gles3/storage/render_scene_buffers_gles3.cpp
@@ -200,6 +200,10 @@ void RenderSceneBuffersGLES3::_check_render_buffers() {
 	uint32_t depth_format_size = 4;
 	bool use_multiview = view_count > 1;
 
+	if (!use_internal_buffer && internal3d.color != 0) {
+		_clear_intermediate_buffers();
+	}
+
 	if ((!use_internal_buffer || internal3d.color != 0) && (msaa3d.mode == RS::VIEWPORT_MSAA_DISABLED || msaa3d.color != 0)) {
 		// already setup!
 		return;


### PR DESCRIPTION
After setting up the intermediate buffers for the first time, they don't get cleared after disabling glow / adjustments. When the buffers are present,
https://github.com/godotengine/godot/blob/1f7630f1bfd9a7c65a5c144f85be38b4b64e3717/drivers/gles3/rasterizer_scene_gles3.cpp#L2778 will not be 0.

Some post processing logic is dependent on if it is 0:
https://github.com/godotengine/godot/blob/1f7630f1bfd9a7c65a5c144f85be38b4b64e3717/drivers/gles3/rasterizer_scene_gles3.cpp#L2845 https://github.com/godotengine/godot/blob/1f7630f1bfd9a7c65a5c144f85be38b4b64e3717/drivers/gles3/rasterizer_scene_gles3.cpp#L2864

Fixes https://github.com/godotengine/godot/issues/100391