### PR TITLE
Fix copy code button overflow to right side of the dialog

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -2764,7 +2764,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, const C
 
 			p_rt->push_cell();
 			p_rt->set_cell_row_background_color(code_bg_color, Color(code_bg_color, 0.99));
-			p_rt->set_cell_padding(Rect2(10 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE, 10 * EDSCALE));
+			p_rt->set_cell_padding(Rect2(1 * EDSCALE, 10 * EDSCALE, 1 * EDSCALE, 10 * EDSCALE));
 			p_rt->push_color(code_dark_color);
 
 			bool codeblock_printed = false;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/110890

**Issue Description**

There is a table with two columns for code block. Both code content and copy code button have 10px padding size.

Currently, I don't know why the table doesn't keep 100% width, but push copy code button out of the dialog. Just set padding size of first cell to `1 * EDSCALE`, then the copy code button appeared.

I guess there first and third parameter point to the x and width, or left and right.

Do anyone have a better solution?

**Re-produce Project**
[copy_code_mvp.zip](https://github.com/user-attachments/files/22552273/copy_code_mvp.zip)
<img width="1920" height="1080" alt="Screenshot from 2025-09-26 11-50-54" src="https://github.com/user-attachments/assets/663fc7f3-fce9-46d9-b67a-5dd5a00d4c3f" />


