### PR TITLE
Add inline resource picker

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1253,6 +1253,9 @@
 		<member name="text_editor/appearance/enable_inline_color_picker" type="bool" setter="" getter="">
 			If [code]true[/code], displays a colored button before any [Color] constructor in the script editor. Clicking on them allows the color to be modified through a color picker.
 		</member>
+		<member name="text_editor/appearance/enable_inline_path_display" type="bool" setter="" getter="">
+			If [code]true[/code], displays an inline hint for [code]uid://[/code] paths that converts them to [code]res://[/code] paths.
+		</member>
 		<member name="text_editor/appearance/guidelines/line_length_guideline_hard_column" type="int" setter="" getter="">
 			The column at which to display a subtle line as a line length guideline for scripts. This should generally be greater than [member text_editor/appearance/guidelines/line_length_guideline_soft_column].
 		</member>
@@ -1288,6 +1291,10 @@
 		</member>
 		<member name="text_editor/appearance/minimap/show_minimap" type="bool" setter="" getter="">
 			If [code]true[/code], draws an overview of the script near the scroll bar. The minimap can be left-clicked to scroll directly to a location in an "absolute" manner.
+		</member>
+		<member name="text_editor/appearance/path_picker_mode" type="int" setter="" getter="">
+			If set to a value other than [b]Off[/b], displays a quick load button before any [code]"res://"[/code] or [code]"uid://"[/code] path.
+			[b]Preserve Existing[/b] preserves the current path type, whereas [b]Only File Paths[/b] will convert UID paths to [code]res://[/code] paths, and [b]Only UID Paths[/b] will convert [code]res://[/code] paths to UID paths.
 		</member>
 		<member name="text_editor/appearance/whitespace/draw_spaces" type="bool" setter="" getter="">
 			If [code]true[/code], draws space characters as centered points.

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -92,6 +92,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	ColorPicker *inline_color_picker = nullptr;
 	OptionButton *inline_color_options = nullptr;
 	Ref<Texture2D> color_alpha_texture;
+	Ref<Texture2D> quick_load_texture;
 
 	GotoLinePopup *goto_line_popup = nullptr;
 	ScriptEditorQuickOpen *quick_open = nullptr;
@@ -114,6 +115,22 @@ class ScriptTextEditor : public ScriptEditorBase {
 	ColorPicker *color_picker = nullptr;
 	Vector3i color_position;
 	String color_args;
+
+	enum PathPickerMode {
+		PATH_PICKER_OFF,
+		PATH_PICKER_ONLY_UID,
+		PATH_PICKER_ONLY_RES,
+		PATH_PICKER_PRESERVE,
+	};
+
+	bool enable_inline_color_picker = true;
+	bool enable_inline_path_display = true;
+	PathPickerMode path_picker_mode = PATH_PICKER_OFF;
+
+	Ref<Font> code_editor_font;
+	int code_editor_font_size = 0;
+	real_t font_height = 0.0;
+	Color comment_color;
 
 	bool theme_loaded = false;
 
@@ -216,14 +233,28 @@ protected:
 	void _warning_clicked(const Variant &p_line);
 
 	bool _is_valid_color_info(const Dictionary &p_info);
-	Array _inline_object_parse(const String &p_text);
-	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
-	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
+	Array _inline_object_color_parse(const String &p_text);
+	void _inline_object_color_draw(const Dictionary &p_info, const Rect2 &p_rect);
+	void _inline_object_color_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
 	String _picker_color_stringify(const Color &p_color, COLOR_MODE p_mode);
 	void _picker_color_changed(const Color &p_color);
 	void _update_color_constructor_options();
 	void _update_background_color();
 	void _update_color_text();
+
+	Array _inline_object_path_parse(const String &p_text);
+	void _inline_object_path_draw(const Dictionary &p_info, const Rect2 &p_rect);
+	void _inline_object_path_file_picked(const String &p_path, const Dictionary &p_info);
+	void _inline_object_path_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
+
+	Array _inline_object_parse(const String &p_text);
+	void _inline_object_draw(const Dictionary &p_info, const Rect2 &p_rect);
+	void _inline_object_handle_click(const Dictionary &p_info, const Rect2 &p_rect);
+
+	void _update_inline_object_handlers();
+
+	void _update_font();
+	void _update_font_from_zoom(float p_zoom_factor);
 
 	void _notification(int p_what);
 

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -741,6 +741,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 
 	// Appearance
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/enable_inline_color_picker", true, "");
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "text_editor/appearance/enable_inline_path_display", true, "");
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/path_picker_mode", 1, "Off,Only UID Paths,Only File Paths,Preserve Existing");
 
 	// Appearance: Caret
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/caret/type", 0, "Line,Block")

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -3646,6 +3646,10 @@ Control::CursorShape TextEdit::get_cursor_shape(const Point2 &p_pos) const {
 			if (!is_inline_info_valid(k)) {
 				continue;
 			}
+			Dictionary info = k;
+			if (!info.get("clickable", false)) {
+				continue;
+			}
 			Rect2 obj_rect = ldata->get_line_object_rect(wrap_i, k);
 			obj_rect.position.x += xmargin_beg + wrap_indent - first_visible_col;
 			if (p_pos.x > obj_rect.position.x && p_pos.x < obj_rect.get_end().x) {


### PR DESCRIPTION
This adds an inline quick load button to the script editor, like the color picker. This works for all ((triple-) single-quoted, (triple-) double-quoted) strings that start with `res://` or `uid://`. It's different from what was suggested in the discussion (only have it on `load`/`preload` calls), but I think this way it works for more use-cases like a custom load method.

It has four modes:
* Off
* Only uid - only creates `uid://` paths
* Only res - only creates `res://` paths
* Preserve - respects whatever it is currently

[Screencast_20250925_235258.webm](https://github.com/user-attachments/assets/37c3832d-ef3f-4b2d-8bf9-15986773c065)

This also adds inline hints for UID paths:

<img width="617" height="290" alt="image" src="https://github.com/user-attachments/assets/ff7c29b5-c3d6-4daf-8e32-492902fbe9b8" />

While this isn't exactly like the chip mockup, I think it's more readable since you can see both the `res://` path and the original UID path.

I refactored the inline object handlers from just being for the color picker to merge results from multiple sources, so maybe adding new inline objects will be easier in the future. I used a RegEx to locate the strings for easier development, I'm not sure if it's fine but I'm not sure it's easily possible to do it the same way the color picker does it.

Resolves godotengine/godot-proposals/discussions/13192