### PR TITLE
Remove compilation of unused Freetype / BZip2

### DIFF
--- a/modules/freetype/SCsub
+++ b/modules/freetype/SCsub
@@ -35,7 +35,6 @@ if env["builtin_freetype"]:
         "src/base/fttype1.c",
         "src/base/ftwinfnt.c",
         "src/bdf/bdf.c",
-        "src/bzip2/ftbzip2.c",
         "src/cache/ftcache.c",
         "src/cff/cff.c",
         "src/cid/type1cid.c",


### PR DESCRIPTION
I encountered a weird bug while building Godot, in which the macro `FT_CONFIG_OPTION_USE_BZIP2` was somehow defined (the build system must have been mistaken about `ftoption.h` picking the system library instead of the builtin...).

Anyway, it resulted in a compilation error since Godot never links against the BZip2 library...

Since this feature is not used, would there be any objection to exclude the file `ftbzip2.c` from being built at all?