### PR TITLE
Remove unused `create_script` method from `ScriptLanguage`

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -273,7 +273,6 @@ public:
 	virtual bool is_using_templates() { return false; }
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptError> *r_errors = nullptr, List<Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const = 0;
 	virtual String validate_path(const String &p_path) const { return ""; }
-	virtual Script *create_script() const = 0;
 	virtual bool supports_builtin_mode() const = 0;
 	virtual bool supports_documentation() const { return false; }
 	virtual bool can_inherit_from_file() const { return false; }

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -361,13 +361,8 @@ public:
 	}
 
 	EXBIND1RC(String, validate_path, const String &)
-	GDVIRTUAL0RC_REQUIRED(Object *, _create_script)
-	Script *create_script() const override {
-		Object *ret = nullptr;
-		GDVIRTUAL_CALL(_create_script, ret);
-		return Object::cast_to<Script>(ret);
-	}
 #ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC(Object *, _create_script)
 	GDVIRTUAL0RC(bool, _has_named_classes)
 #endif
 	EXBIND0RC(bool, supports_builtin_mode)

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -47,7 +47,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_create_script" qualifiers="virtual required const">
+		<method name="_create_script" qualifiers="virtual const" deprecated="This method is not called by the engine.">
 			<return type="Object" />
 			<description>
 			</description>

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -608,7 +608,6 @@ public:
 	virtual Ref<Script> make_template(const String &p_template, const String &p_class_name, const String &p_base_class_name) const override;
 	virtual Vector<ScriptTemplate> get_built_in_templates(const StringName &p_object) override;
 	virtual bool validate(const String &p_script, const String &p_path = "", List<String> *r_functions = nullptr, List<ScriptLanguage::ScriptError> *r_errors = nullptr, List<ScriptLanguage::Warning> *r_warnings = nullptr, HashSet<int> *r_safe_lines = nullptr) const override;
-	virtual Script *create_script() const override;
 	virtual bool supports_builtin_mode() const override;
 	virtual bool supports_documentation() const override;
 	virtual bool can_inherit_from_file() const override { return true; }

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -246,10 +246,6 @@ int GDScriptLanguage::find_function(const String &p_function, const String &p_co
 	return -1;
 }
 
-Script *GDScriptLanguage::create_script() const {
-	return memnew(GDScript);
-}
-
 /* DEBUGGER FUNCTIONS */
 
 thread_local int GDScriptLanguage::_debug_parse_err_line = -1;

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -400,10 +400,6 @@ String CSharpLanguage::validate_path(const String &p_path) const {
 	return "";
 }
 
-Script *CSharpLanguage::create_script() const {
-	return memnew(CSharpScript);
-}
-
 bool CSharpLanguage::supports_builtin_mode() const {
 	return false;
 }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -518,7 +518,6 @@ public:
 		return true;
 	}
 	String validate_path(const String &p_path) const override;
-	Script *create_script() const override;
 	bool supports_builtin_mode() const override;
 	/* TODO? */ int find_function(const String &p_function, const String &p_code) const override {
 		return -1;


### PR DESCRIPTION
> **Note:** `ScriptLanguage` contains a lot of stuff. This method in particular is from the editor block of functionality. It is not related to core functionality.

The method is not exposed (only the virtual override is) and the engine does not use it anymore. No need to keep it around.