### PR TITLE
Add comments to `String::size` to lead people to `length()` and explain the difference.

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -179,7 +179,10 @@ public:
 	_FORCE_INLINE_ const T *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ const T *get_data() const { return size() ? ptr() : &_null; }
 
+	// Returns the number of characters in the buffer, including the terminating NUL character.
+	// In most cases, length() should be used instead.
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	// Returns the number of characters in the string (excluding terminating NUL character).
 	_FORCE_INLINE_ int length() const { return size() ? size() - 1 : 0; }
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 
@@ -299,7 +302,10 @@ public:
 	_FORCE_INLINE_ const char32_t *ptr() const { return _cowdata.ptr(); }
 	_FORCE_INLINE_ const char32_t *get_data() const { return size() ? ptr() : &_null; }
 
+	// Returns the number of characters in the buffer, including the terminating NUL character.
+	// In most cases, length() should be used instead.
 	_FORCE_INLINE_ int size() const { return _cowdata.size(); }
+	// Returns the number of characters in the string (excluding terminating NUL character).
 	_FORCE_INLINE_ int length() const { return size() ? size() - 1 : 0; }
 	_FORCE_INLINE_ bool is_empty() const { return length() == 0; }
 


### PR DESCRIPTION
We regularly have confusions between `String` `size()` and `length()`.
I had opened https://github.com/godotengine/godot/pull/105753 to fix this, but it wasn't reviewed in time and has been stagnant since.

Since it might take a while longer to rename it, this PR adds a comment to `size` to at least explain the difference between the two methods.