### PR TITLE
Show centiseconds in LightmapGI bake time printout in the editor

### DIFF
--- a/editor/scene/3d/lightmap_gi_editor_plugin.cpp
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.cpp
@@ -166,8 +166,8 @@ void LightmapGIEditorPlugin::bake_func_end(uint64_t p_time_started) {
 		tmp_progress = nullptr;
 	}
 
-	const int time_taken = (OS::get_singleton()->get_ticks_msec() - p_time_started) * 0.001;
-	print_line(vformat("Done baking lightmaps in %02d:%02d:%02d.", time_taken / 3600, (time_taken % 3600) / 60, time_taken % 60));
+	const int time_taken = OS::get_singleton()->get_ticks_msec() - p_time_started;
+	print_line(vformat("Done baking lightmaps in %02d:%02d:%02d.%02d.", time_taken / 3'600'000, (time_taken % 3'600'000) / 60'000, (time_taken % 60'000) / 1000, (time_taken % 1000) / 10));
 	// Request attention in case the user was doing something else.
 	// Baking lightmaps is likely the editor task that can take the most time,
 	// so only request the attention for baking lightmaps.


### PR DESCRIPTION
On modern high-end GPUs, bake times are regularly under 15 seconds, especially with preview-quality settings.

In this case, sub-second differences can be significant for benchmarking PRs like https://github.com/godotengine/godot/pull/107400, so it's worth showing them. (We already show centiseconds in SCons build times, which are typically longer.)

In a future PR, we could add more information on where the time was spent (direct light, indirect light, denoising, probe generation, probe rendering, …), but this requires integration into the actual lightmapper while the current approach is lightmapper-agnostic.

## Preview

Various bakes (and rebakes) with different quality settings:

```
Done baking lightmaps in 00:00:00.85.
Done baking lightmaps in 00:00:00.84.
Done baking lightmaps in 00:00:00.94.
Done baking lightmaps in 00:00:21.18.
Done baking lightmaps in 00:00:00.62.
Done baking lightmaps in 00:00:00.59.
Done baking lightmaps in 00:00:01.51.
Done baking lightmaps in 00:00:01.48.
Done baking lightmaps in 00:00:01.48.
Done baking lightmaps in 00:00:01.54.
Done baking lightmaps in 00:00:10.09.
Done baking lightmaps in 00:00:01.41.
Done baking lightmaps in 00:00:01.40.
```