### PR TITLE
Make Alt skip GUI tooltips and Shift show tooltips instantly

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2128,11 +2128,19 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 						if (gui.tooltip_timer.is_valid()) {
 							gui.tooltip_timer->release_connections();
 						}
-						gui.tooltip_control = over;
-						gui.tooltip_pos = new_tooltip_pos;
-						gui.tooltip_timer = get_tree()->create_timer(gui.tooltip_delay);
-						gui.tooltip_timer->set_ignore_time_scale(true);
-						gui.tooltip_timer->connect("timeout", callable_mp(this, &Viewport::_gui_show_tooltip));
+						if (!Input::get_singleton()->is_key_pressed(Key::ALT)) {
+							// Skip tooltip when Alt is pressed.
+							float tooltip_delay = gui.tooltip_delay;
+							if (Input::get_singleton()->is_key_pressed(Key::SHIFT)) {
+								// Show tooltip immediately when Shift is pressed.
+								tooltip_delay = 0.0;
+							}
+							gui.tooltip_control = over;
+							gui.tooltip_pos = new_tooltip_pos;
+							gui.tooltip_timer = get_tree()->create_timer(tooltip_delay);
+							gui.tooltip_timer->set_ignore_time_scale(true);
+							gui.tooltip_timer->connect("timeout", callable_mp(this, &Viewport::_gui_show_tooltip));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
Holding <kbd>Alt</kbd> skips GUI tooltips when hovering UI elements with the mouse, which is useful for large tooltips that can be intrusive.

Holding <kbd>Shift</kbd> makes tooltips show instantly instead of waiting for the usual tooltip delay (which defaults to 0.5 seconds). This is particularly useful on the Scene, FileSystem and Inspector docks.

I chose to use <kbd>Alt</kbd> instead of <kbd>Ctrl</kbd> as <kbd>Ctrl</kbd> is often used for multiple selection, so it's probably better not to interfere with tooltip behavior for that one.

Help is welcome on the TODO items listed below :slightly_smiling_face: 

- This closes https://github.com/godotengine/godot-proposals/issues/13267.

## Preview

*Not holding any modifier at first, then holding <kbd>Alt</kbd>, then holding <kbd>Shift</kbd>.*

https://github.com/user-attachments/assets/2bdb7b1d-b277-4dac-9092-493e8259309e

## TODO

- [ ] Implement in the inspector for property names. Right now, it only works on property values.
  - The code is [here](https://github.com/godotengine/godot/blob/1f7630f1bfd9a7c65a5c144f85be38b4b64e3717/editor/doc/editor_help.cpp#L4608-L4609) and [here](https://github.com/godotengine/godot/blob/1f7630f1bfd9a7c65a5c144f85be38b4b64e3717/editor/doc/editor_help.cpp#L4630-L4632), but I couldn't get it working without removing *both* `is_anything_pressed()` checks, which is probably not the right idea.
- [ ] Implement in the script editor's symbol hover tooltips.
  - The code is [here](https://github.com/godotengine/godot/blob/1f7630f1bfd9a7c65a5c144f85be38b4b64e3717/scene/gui/code_edit.cpp#L462-L466), but I couldn't get it working (even though the branches were being reached when holding <kbd>Alt</kbd> or <kbd>Shift</kbd>). Something else is causing tooltips not to appear at all when *any* modifiers are pressed.
