### PR TITLE
Add optional second argument to `XMLParser.get_named_attribute_value_safe()` for default value

### DIFF
--- a/core/io/xml_parser.compat.inc
+++ b/core/io/xml_parser.compat.inc
@@ -1,0 +1,43 @@
+/**************************************************************************/
+/*  xml_parser.compat.inc                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "core/object/class_db.h"
+
+String XMLParser::_get_named_attribute_value_safe_bind_compat_110940(const String &p_name) const {
+	return get_named_attribute_value_safe(p_name, "");
+}
+
+void XMLParser::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("get_named_attribute_value_safe", "name"), &XMLParser::_get_named_attribute_value_safe_bind_compat_110940);
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "xml_parser.h"
+#include "xml_parser.compat.inc"
 
 #include "core/io/file_access.h"
 #include "core/object/class_db.h"
@@ -357,7 +358,7 @@ void XMLParser::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_attribute_value", "idx"), &XMLParser::get_attribute_value);
 	ClassDB::bind_method(D_METHOD("has_attribute", "name"), &XMLParser::has_attribute);
 	ClassDB::bind_method(D_METHOD("get_named_attribute_value", "name"), &XMLParser::get_named_attribute_value);
-	ClassDB::bind_method(D_METHOD("get_named_attribute_value_safe", "name"), &XMLParser::get_named_attribute_value_safe);
+	ClassDB::bind_method(D_METHOD("get_named_attribute_value_safe", "name", "default"), &XMLParser::get_named_attribute_value_safe, DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("is_empty"), &XMLParser::is_empty);
 	ClassDB::bind_method(D_METHOD("get_current_line"), &XMLParser::get_current_line);
 	ClassDB::bind_method(D_METHOD("skip_section"), &XMLParser::skip_section);
@@ -436,7 +437,7 @@ String XMLParser::get_named_attribute_value(const String &p_name) const {
 	return attributes[idx].value;
 }
 
-String XMLParser::get_named_attribute_value_safe(const String &p_name) const {
+String XMLParser::get_named_attribute_value_safe(const String &p_name, const String &p_default) const {
 	int idx = -1;
 	for (int i = 0; i < attributes.size(); i++) {
 		if (attributes[i].name == p_name) {
@@ -446,7 +447,7 @@ String XMLParser::get_named_attribute_value_safe(const String &p_name) const {
 	}
 
 	if (idx < 0) {
-		return "";
+		return p_default;
 	}
 	return attributes[idx].value;
 }

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -98,6 +98,12 @@ private:
 
 	static void _bind_methods();
 
+protected:
+#ifndef DISABLE_DEPRECATED
+	String _get_named_attribute_value_safe_bind_compat_110940(const String &p_name) const;
+	static void _bind_compatibility_methods();
+#endif
+
 public:
 	Error read();
 	NodeType get_node_type();
@@ -109,7 +115,7 @@ public:
 	String get_attribute_value(int p_idx) const;
 	bool has_attribute(const String &p_name) const;
 	String get_named_attribute_value(const String &p_name) const;
-	String get_named_attribute_value_safe(const String &p_name) const; // do not print error if doesn't exist
+	String get_named_attribute_value_safe(const String &p_name, const String &p_default = "") const; // do not print error if doesn't exist
 	bool is_empty() const;
 	int get_current_line() const;
 

--- a/doc/classes/XMLParser.xml
+++ b/doc/classes/XMLParser.xml
@@ -78,8 +78,9 @@
 		<method name="get_named_attribute_value_safe" qualifiers="const">
 			<return type="String" />
 			<param index="0" name="name" type="String" />
+			<param index="1" name="default" type="String" default="&quot;&quot;" />
 			<description>
-				Returns the value of an attribute of the currently parsed element, specified by its [param name]. This method will return an empty string if the element has no such attribute.
+				Returns the value of an attribute of the currently parsed element, specified by its [param name]. This method will return the string [param default] if the element has no such attribute.
 			</description>
 		</method>
 		<method name="get_node_data" qualifiers="const">

--- a/misc/extension_api_validation/4.6-stable/GH-110940.txt
+++ b/misc/extension_api_validation/4.6-stable/GH-110940.txt
@@ -1,0 +1,5 @@
+GH-110940
+---------
+Validate extension JSON: Error: Field 'classes/XMLParser/methods/get_named_attribute_value_safe/arguments': size changed value in new API, from 1 to 2.
+
+Added optional "default" argument to get_named_attribute_value_safe method. Compatibility method registered.


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/13281 .

This allows the user to specify the default value returned from `XMLParser.get_named_attribute_value_safe()` if the attribute name they specify is not found on the current element.

```gdscript
var xml = "<elem val=\"notTheDefault\" /> <elem />"

var p = XMLParser.new()
p.open_buffer(xml.to_utf8_buffer())

while p.read() != ERR_FILE_EOF:
    assert(p.get_node_type() == XMLParser.NODE_ELEMENT)
    print("Found element with name \"%s\" and val \"%s\"" % [
        p.get_node_name(),
        p.get_named_attribute_value_safe("val", "defaultValue")
    ])
```

Returns:
```
Found element with name "elem" and val "notTheDefault"
Found element with name "elem" and val "defaultValue"
```