### PR TITLE
Fix Script editor state types

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1466,23 +1466,23 @@ void CodeTextEditor::set_edit_state(const Variant &p_state) {
 	}
 
 	if (state.has("folded_lines")) {
-		Vector<int> folded_lines = state["folded_lines"];
-		for (int i = 0; i < folded_lines.size(); i++) {
-			text_editor->fold_line(folded_lines[i]);
+		const PackedInt32Array folded_lines = state["folded_lines"];
+		for (const int &line : folded_lines) {
+			text_editor->fold_line(line);
 		}
 	}
 
 	if (state.has("breakpoints")) {
-		Array breakpoints = state["breakpoints"];
-		for (int i = 0; i < breakpoints.size(); i++) {
-			text_editor->set_line_as_breakpoint(breakpoints[i], true);
+		const PackedInt32Array breakpoints = state["breakpoints"];
+		for (const int &line : breakpoints) {
+			text_editor->set_line_as_breakpoint(line, true);
 		}
 	}
 
 	if (state.has("bookmarks")) {
-		Array bookmarks = state["bookmarks"];
-		for (int i = 0; i < bookmarks.size(); i++) {
-			text_editor->set_line_as_bookmarked(bookmarks[i], true);
+		const PackedInt32Array bookmarks = state["bookmarks"];
+		for (const int &line : bookmarks) {
+			text_editor->set_line_as_bookmarked(line, true);
 		}
 	}
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1868,8 +1868,18 @@ bool CodeEdit::is_line_folded(int p_line) const {
 	return p_line + 1 < get_line_count() && !_is_line_hidden(p_line) && _is_line_hidden(p_line + 1);
 }
 
-TypedArray<int> CodeEdit::get_folded_lines() const {
+TypedArray<int> CodeEdit::get_folded_lines_bind() const {
 	TypedArray<int> folded_lines;
+	for (int i = 0; i < get_line_count(); i++) {
+		if (is_line_folded(i)) {
+			folded_lines.push_back(i);
+		}
+	}
+	return folded_lines;
+}
+
+PackedInt32Array CodeEdit::get_folded_lines() const {
+	PackedInt32Array folded_lines;
 	for (int i = 0; i < get_line_count(); i++) {
 		if (is_line_folded(i)) {
 			folded_lines.push_back(i);
@@ -2805,7 +2815,7 @@ void CodeEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("toggle_foldable_lines_at_carets"), &CodeEdit::toggle_foldable_lines_at_carets);
 
 	ClassDB::bind_method(D_METHOD("is_line_folded", "line"), &CodeEdit::is_line_folded);
-	ClassDB::bind_method(D_METHOD("get_folded_lines"), &CodeEdit::get_folded_lines);
+	ClassDB::bind_method(D_METHOD("get_folded_lines"), &CodeEdit::get_folded_lines_bind);
 
 	/* Code region */
 	ClassDB::bind_method(D_METHOD("create_code_region"), &CodeEdit::create_code_region);

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -432,7 +432,8 @@ public:
 
 	int get_folded_line_header(int p_line) const;
 	bool is_line_folded(int p_line) const;
-	TypedArray<int> get_folded_lines() const;
+	TypedArray<int> get_folded_lines_bind() const;
+	PackedInt32Array get_folded_lines() const;
 
 	/* Code region */
 	void create_code_region();

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2974,7 +2974,9 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 
 		// Check metadata.
 		CHECK(code_edit->get_folded_lines().size() == 1);
+		CHECK(code_edit->get_folded_lines_bind().size() == 1);
 		CHECK((int)code_edit->get_folded_lines()[0] == 0);
+		CHECK((int)code_edit->get_folded_lines_bind()[0] == 0);
 
 		// Cannot unfold nested.
 		code_edit->unfold_line(1);
@@ -2990,6 +2992,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 
 		// Check metadata.
 		CHECK(code_edit->get_folded_lines().size() == 0);
+		CHECK(code_edit->get_folded_lines_bind().size() == 0);
 
 		code_edit->fold_all_lines();
 		CHECK(code_edit->is_line_folded(0));


### PR DESCRIPTION
A _really funny_ inconsistency I found in code editor. Script's folded lines are stored as `Array[int]`, but they are loaded as `PackedInt32Array`. This is implicit conversion:
https://github.com/godotengine/godot/blob/9283328fe70d27f148c403943a283d93a9785beb/editor/gui/code_editor.cpp#L1469
No idea why CodeEdit returns folded lines as Array, while it returns breakpoints and bookmarks as PackedInt32Array. But guess what, the latter are loaded as Array 😂
https://github.com/godotengine/godot/blob/9283328fe70d27f148c403943a283d93a9785beb/editor/gui/code_editor.cpp#L1476
https://github.com/godotengine/godot/blob/9283328fe70d27f148c403943a283d93a9785beb/editor/gui/code_editor.cpp#L1483
wtf 💀

This PR makes `get_folded_lines()` return PackedInt32Array and ensures that all state arrays are loaded in their stored type. To preserve compatibility, I added a copy of `get_folded_lines()` with old type, for binding purposes.