### PR TITLE
Fix region folding not loading properly

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -184,6 +184,11 @@ void ScriptTextEditor::enable_editor(Control *p_shortcut_context) {
 
 	_validate_script();
 
+	if (pending_state != Variant()) {
+		code_editor->set_edit_state(pending_state);
+		pending_state = Variant();
+	}
+
 	if (p_shortcut_context) {
 		for (int i = 0; i < edit_hb->get_child_count(); ++i) {
 			Control *c = cast_to<Control>(edit_hb->get_child(i));
@@ -704,11 +709,19 @@ bool ScriptTextEditor::is_unsaved() {
 }
 
 Variant ScriptTextEditor::get_edit_state() {
+	if (pending_state != Variant()) {
+		return pending_state;
+	}
 	return code_editor->get_edit_state();
 }
 
 void ScriptTextEditor::set_edit_state(const Variant &p_state) {
-	code_editor->set_edit_state(p_state);
+	if (editor_enabled) {
+		code_editor->set_edit_state(p_state);
+	} else {
+		// The editor is not fully initialized, so the state can't be loaded properly.
+		pending_state = p_state;
+	}
 
 	Dictionary state = p_state;
 	if (state.has("syntax_highlighter")) {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -62,6 +62,7 @@ class ScriptTextEditor : public ScriptEditorBase {
 	RichTextLabel *errors_panel = nullptr;
 
 	Ref<Script> script;
+	Variant pending_state;
 	bool script_is_valid = false;
 	bool editor_enabled = false;
 


### PR DESCRIPTION
Fixes #96370
Fixes #85780

ScriptTextEditor has a nice optimization™ that makes the script instances not fully loaded on startup. It loads the script, but does not initialize the CodeEdit until you switch tab, which makes it faster to restore scripts (similar to #110183).

The problem is that the editor also tried to restore script's state before it was enabled (i.e. initialized). So it went over folded lines and tried to fold them, but thanks to the aforementioned nice optimization™, it did not recognize that the folded lines are code regions (the language features were not fully loaded yet) and failed to fold them. Then the editor for whatever reason will immediately overwrite its stored state, so the folding is gone forever. It did work "sometimes", because the first script tab is initialized earlier for whatever reason.

This PR introduces `pending_state`. If editor tries to restore CodeEditor's state while it's not yet initialized, the state is stored in a variable and applied once the editor is fully initialized.