### PR TITLE
Add `Tween.get_step_count()` method

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -137,6 +137,13 @@
 				Returns the number of remaining loops for this [Tween] (see [method set_loops]). A return value of [code]-1[/code] indicates an infinitely looping [Tween], and a return value of [code]0[/code] indicates that the [Tween] has already finished.
 			</description>
 		</method>
+		<method name="get_step_count" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total number of steps in this [Tween]. One step is either a single [Tweener] or a group of [Tweener]s running in parallel.
+				[b]Note:[/b] A [SubtweenTweener] added to a [Tween] using [method tween_subtween] counts as one step, regardless of the number of steps within the subtween.
+			</description>
+		</method>
 		<method name="get_total_elapsed_time" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -555,7 +562,7 @@
 		<signal name="step_finished">
 			<param index="0" name="idx" type="int" />
 			<description>
-				Emitted when one step of the [Tween] is complete, providing the step index. One step is either a single [Tweener] or a group of [Tweener]s running in parallel.
+				Emitted when one step of the [Tween] is complete, providing the step index. One step is either a single [Tweener] or a group of [Tweener]s running in parallel. Use [method get_step_count] to determine how many steps there are in total in the [Tween].
 			</description>
 		</signal>
 	</signals>

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -454,6 +454,10 @@ double Tween::get_total_time() const {
 	return total_time;
 }
 
+int Tween::get_step_count() const {
+	return (int)tweeners.size();
+}
+
 real_t Tween::run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t p_time, real_t p_initial, real_t p_delta, real_t p_duration) {
 	if (p_duration == 0) {
 		// Special case to avoid dividing by 0 in equations.
@@ -496,6 +500,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("play"), &Tween::play);
 	ClassDB::bind_method(D_METHOD("kill"), &Tween::kill);
 	ClassDB::bind_method(D_METHOD("get_total_elapsed_time"), &Tween::get_total_time);
+	ClassDB::bind_method(D_METHOD("get_step_count"), &Tween::get_step_count);
 
 	ClassDB::bind_method(D_METHOD("has_tweeners"), &Tween::has_tweeners);
 	ClassDB::bind_method(D_METHOD("is_running"), &Tween::is_running);

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -191,6 +191,7 @@ public:
 	bool can_process(bool p_tree_paused) const;
 	Node *get_bound_node() const;
 	double get_total_time() const;
+	int get_step_count() const;
 
 	Tween();
 	Tween(SceneTree *p_parent_tree);


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/14439 .

This adds the `Tween.get_step_count()` method, which returns the number of steps in the tween.

```gdscript
var tw1 = create_tween()
print("Has %s steps" % tw1.get_step_count())
tw1.tween_interval(1.0)
tw1.tween_interval(2.0)
print("Now has %s steps" % tw1.get_step_count())
tw1.tween_interval(1.0)
print("Now has %s steps" % tw1.get_step_count())
```
prints
```
Has 0 tweeners
Now has 2 tweeners
Now has 3 tweeners
```

