### PR TITLE
Use const ref parameters in the OpenXR module

### DIFF
--- a/modules/openxr/action_map/openxr_action.cpp
+++ b/modules/openxr/action_map/openxr_action.cpp
@@ -74,7 +74,7 @@ String OpenXRAction::get_name_with_set() const {
 	return action_name;
 }
 
-void OpenXRAction::set_localized_name(const String p_localized_name) {
+void OpenXRAction::set_localized_name(const String &p_localized_name) {
 	localized_name = p_localized_name;
 	emit_changed();
 }
@@ -101,21 +101,21 @@ PackedStringArray OpenXRAction::get_toplevel_paths() const {
 	return toplevel_paths;
 }
 
-void OpenXRAction::add_toplevel_path(const String p_toplevel_path) {
+void OpenXRAction::add_toplevel_path(const String &p_toplevel_path) {
 	if (!toplevel_paths.has(p_toplevel_path)) {
 		toplevel_paths.push_back(p_toplevel_path);
 		emit_changed();
 	}
 }
 
-void OpenXRAction::rem_toplevel_path(const String p_toplevel_path) {
+void OpenXRAction::rem_toplevel_path(const String &p_toplevel_path) {
 	if (toplevel_paths.has(p_toplevel_path)) {
 		toplevel_paths.erase(p_toplevel_path);
 		emit_changed();
 	}
 }
 
-void OpenXRAction::parse_toplevel_paths(const String p_toplevel_paths) {
+void OpenXRAction::parse_toplevel_paths(const String &p_toplevel_paths) {
 	toplevel_paths = p_toplevel_paths.split(",", false);
 	emit_changed();
 }

--- a/modules/openxr/action_map/openxr_action.h
+++ b/modules/openxr/action_map/openxr_action.h
@@ -66,7 +66,7 @@ public:
 
 	String get_name_with_set() const; // Retrieve the name of this action as <action_set>/<action>
 
-	void set_localized_name(const String p_localized_name); // Set the localized name of this action
+	void set_localized_name(const String &p_localized_name); // Set the localized name of this action
 	String get_localized_name() const; // Get the localized name of this action
 
 	void set_action_type(const ActionType p_action_type); // Set the type of this action
@@ -75,10 +75,10 @@ public:
 	void set_toplevel_paths(const PackedStringArray p_toplevel_paths); // Set the toplevel paths of this action
 	PackedStringArray get_toplevel_paths() const; // Get the toplevel paths of this action
 
-	void add_toplevel_path(const String p_toplevel_path); // Add a top level path to this action
-	void rem_toplevel_path(const String p_toplevel_path); // Remove a toplevel path from this action
+	void add_toplevel_path(const String &p_toplevel_path); // Add a top level path to this action
+	void rem_toplevel_path(const String &p_toplevel_path); // Remove a toplevel path from this action
 
-	void parse_toplevel_paths(const String p_toplevel_paths); // Parse and set the top level paths from a comma separated string
+	void parse_toplevel_paths(const String &p_toplevel_paths); // Parse and set the top level paths from a comma separated string
 };
 
 VARIANT_ENUM_CAST(OpenXRAction::ActionType);

--- a/modules/openxr/action_map/openxr_action_map.cpp
+++ b/modules/openxr/action_map/openxr_action_map.cpp
@@ -54,7 +54,7 @@ void OpenXRActionMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_default_action_sets"), &OpenXRActionMap::create_default_action_sets);
 }
 
-void OpenXRActionMap::set_action_sets(Array p_action_sets) {
+void OpenXRActionMap::set_action_sets(const Array &p_action_sets) {
 	action_sets.clear();
 
 	for (int i = 0; i < p_action_sets.size(); i++) {
@@ -73,7 +73,7 @@ int OpenXRActionMap::get_action_set_count() const {
 	return action_sets.size();
 }
 
-Ref<OpenXRActionSet> OpenXRActionMap::find_action_set(String p_name) const {
+Ref<OpenXRActionSet> OpenXRActionMap::find_action_set(const String &p_name) const {
 	for (int i = 0; i < action_sets.size(); i++) {
 		Ref<OpenXRActionSet> action_set = action_sets[i];
 		if (action_set->get_name() == p_name) {
@@ -90,7 +90,7 @@ Ref<OpenXRActionSet> OpenXRActionMap::get_action_set(int p_idx) const {
 	return action_sets[p_idx];
 }
 
-void OpenXRActionMap::add_action_set(Ref<OpenXRActionSet> p_action_set) {
+void OpenXRActionMap::add_action_set(const Ref<OpenXRActionSet> &p_action_set) {
 	ERR_FAIL_COND(p_action_set.is_null());
 
 	if (!action_sets.has(p_action_set)) {
@@ -99,7 +99,7 @@ void OpenXRActionMap::add_action_set(Ref<OpenXRActionSet> p_action_set) {
 	}
 }
 
-void OpenXRActionMap::remove_action_set(Ref<OpenXRActionSet> p_action_set) {
+void OpenXRActionMap::remove_action_set(const Ref<OpenXRActionSet> &p_action_set) {
 	int idx = action_sets.find(p_action_set);
 	if (idx != -1) {
 		action_sets.remove_at(idx);
@@ -120,7 +120,7 @@ void OpenXRActionMap::clear_interaction_profiles() {
 	emit_changed();
 }
 
-void OpenXRActionMap::set_interaction_profiles(Array p_interaction_profiles) {
+void OpenXRActionMap::set_interaction_profiles(const Array &p_interaction_profiles) {
 	clear_interaction_profiles();
 
 	for (const Variant &interaction_profile : p_interaction_profiles) {
@@ -137,7 +137,7 @@ int OpenXRActionMap::get_interaction_profile_count() const {
 	return interaction_profiles.size();
 }
 
-Ref<OpenXRInteractionProfile> OpenXRActionMap::find_interaction_profile(String p_path) const {
+Ref<OpenXRInteractionProfile> OpenXRActionMap::find_interaction_profile(const String &p_path) const {
 	for (Ref<OpenXRInteractionProfile> interaction_profile : interaction_profiles) {
 		if (interaction_profile->get_interaction_profile_path() == p_path) {
 			return interaction_profile;
@@ -153,7 +153,7 @@ Ref<OpenXRInteractionProfile> OpenXRActionMap::get_interaction_profile(int p_idx
 	return interaction_profiles[p_idx];
 }
 
-void OpenXRActionMap::add_interaction_profile(Ref<OpenXRInteractionProfile> p_interaction_profile) {
+void OpenXRActionMap::add_interaction_profile(const Ref<OpenXRInteractionProfile> &p_interaction_profile) {
 	ERR_FAIL_COND(p_interaction_profile.is_null());
 
 	if (!interaction_profiles.has(p_interaction_profile)) {
@@ -169,7 +169,7 @@ void OpenXRActionMap::add_interaction_profile(Ref<OpenXRInteractionProfile> p_in
 	}
 }
 
-void OpenXRActionMap::remove_interaction_profile(Ref<OpenXRInteractionProfile> p_interaction_profile) {
+void OpenXRActionMap::remove_interaction_profile(const Ref<OpenXRInteractionProfile> &p_interaction_profile) {
 	int idx = interaction_profiles.find(p_interaction_profile);
 	if (idx != -1) {
 		interaction_profiles.remove_at(idx);
@@ -571,7 +571,7 @@ void OpenXRActionMap::create_editor_action_sets() {
 	// TODO implement
 }
 
-Ref<OpenXRAction> OpenXRActionMap::get_action(const String p_path) const {
+Ref<OpenXRAction> OpenXRActionMap::get_action(const String &p_path) const {
 	PackedStringArray paths = p_path.split("/", false);
 	ERR_FAIL_COND_V(paths.size() != 2, Ref<OpenXRAction>());
 
@@ -583,7 +583,7 @@ Ref<OpenXRAction> OpenXRActionMap::get_action(const String p_path) const {
 	return Ref<OpenXRAction>();
 }
 
-void OpenXRActionMap::remove_action(const String p_path, bool p_remove_interaction_profiles) {
+void OpenXRActionMap::remove_action(const String &p_path, bool p_remove_interaction_profiles) {
 	Ref<OpenXRAction> action = get_action(p_path);
 	if (action.is_valid()) {
 		for (Ref<OpenXRInteractionProfile> interaction_profile : interaction_profiles) {
@@ -603,7 +603,7 @@ void OpenXRActionMap::remove_action(const String p_path, bool p_remove_interacti
 	}
 }
 
-PackedStringArray OpenXRActionMap::get_top_level_paths(const Ref<OpenXRAction> p_action) {
+PackedStringArray OpenXRActionMap::get_top_level_paths(const Ref<OpenXRAction> &p_action) {
 	PackedStringArray arr;
 
 	for (Ref<OpenXRInteractionProfile> ip : interaction_profiles) {

--- a/modules/openxr/action_map/openxr_action_map.h
+++ b/modules/openxr/action_map/openxr_action_map.h
@@ -47,32 +47,32 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_action_sets(Array p_action_sets); // Set our actions sets by providing an array with action sets (for loading from resource)
+	void set_action_sets(const Array &p_action_sets); // Set our actions sets by providing an array with action sets (for loading from resource)
 	Array get_action_sets() const; // Get our action sets as an array (for saving to resource)
 
 	int get_action_set_count() const; // Retrieve the number of action sets we have
-	Ref<OpenXRActionSet> find_action_set(String p_name) const; // Find an action set by name
+	Ref<OpenXRActionSet> find_action_set(const String &p_name) const; // Find an action set by name
 	Ref<OpenXRActionSet> get_action_set(int p_idx) const; // Retrieve an action set by index
-	void add_action_set(Ref<OpenXRActionSet> p_action_set); // Add an action set to our action map
-	void remove_action_set(Ref<OpenXRActionSet> p_action_set); // Remove an action set from our action map
+	void add_action_set(const Ref<OpenXRActionSet> &p_action_set); // Add an action set to our action map
+	void remove_action_set(const Ref<OpenXRActionSet> &p_action_set); // Remove an action set from our action map
 
 	void clear_interaction_profiles(); // Remove all our interaction profiles
-	void set_interaction_profiles(Array p_interaction_profiles); // Set our interaction profiles by providing an array (for loading from resource)
+	void set_interaction_profiles(const Array &p_interaction_profiles); // Set our interaction profiles by providing an array (for loading from resource)
 	Array get_interaction_profiles() const; // Get our interaction profiles as an array (for saving to resource)
 
 	int get_interaction_profile_count() const; // Retrieve the number of interaction profiles we have
-	Ref<OpenXRInteractionProfile> find_interaction_profile(String p_path) const; // Find an interaction profile by path
+	Ref<OpenXRInteractionProfile> find_interaction_profile(const String &p_path) const; // Find an interaction profile by path
 	Ref<OpenXRInteractionProfile> get_interaction_profile(int p_idx) const; // Retrieve an interaction profile by index
-	void add_interaction_profile(Ref<OpenXRInteractionProfile> p_interaction_profile); // Add an interaction profile to our action map
-	void remove_interaction_profile(Ref<OpenXRInteractionProfile> p_interaction_profile); // remove an interaction profile from our action map
+	void add_interaction_profile(const Ref<OpenXRInteractionProfile> &p_interaction_profile); // Add an interaction profile to our action map
+	void remove_interaction_profile(const Ref<OpenXRInteractionProfile> &p_interaction_profile); // remove an interaction profile from our action map
 
 	void create_default_action_sets(); // Create our default action set for runtime
 	void create_editor_action_sets(); // Create our action set for the editor
 
 	// Helper functions for editor
-	Ref<OpenXRAction> get_action(const String p_path) const; // Retrieve an action using <action name>/<action> as our parameter
-	void remove_action(const String p_path, bool p_remove_interaction_profiles = false); // Remove action from action set, also removes it from interaction profiles
-	PackedStringArray get_top_level_paths(const Ref<OpenXRAction> p_action); // Determines the top level paths based on where an action is bound in interaction profiles
+	Ref<OpenXRAction> get_action(const String &p_path) const; // Retrieve an action using <action name>/<action> as our parameter
+	void remove_action(const String &p_path, bool p_remove_interaction_profiles = false); // Remove action from action set, also removes it from interaction profiles
+	PackedStringArray get_top_level_paths(const Ref<OpenXRAction> &p_action); // Determines the top level paths based on where an action is bound in interaction profiles
 
 	// TODO add validation to display in the interface that checks if we have action sets with the same name or if we have interaction profiles for the same path
 

--- a/modules/openxr/action_map/openxr_action_set.cpp
+++ b/modules/openxr/action_map/openxr_action_set.cpp
@@ -60,7 +60,7 @@ Ref<OpenXRActionSet> OpenXRActionSet::new_action_set(const char *p_name, const c
 	return action_set;
 }
 
-void OpenXRActionSet::set_localized_name(const String p_localized_name) {
+void OpenXRActionSet::set_localized_name(const String &p_localized_name) {
 	localized_name = p_localized_name;
 	emit_changed();
 }
@@ -96,7 +96,7 @@ void OpenXRActionSet::clear_actions() {
 	emit_changed();
 }
 
-void OpenXRActionSet::set_actions(Array p_actions) {
+void OpenXRActionSet::set_actions(const Array &p_actions) {
 	// Any actions not retained in p_actions should be freed automatically, those held within our Array will have be relinked to our action set.
 	clear_actions();
 
@@ -110,7 +110,7 @@ Array OpenXRActionSet::get_actions() const {
 	return actions;
 }
 
-Ref<OpenXRAction> OpenXRActionSet::get_action(const String p_name) const {
+Ref<OpenXRAction> OpenXRActionSet::get_action(const String &p_name) const {
 	for (int i = 0; i < actions.size(); i++) {
 		Ref<OpenXRAction> action = actions[i];
 		if (action->get_name() == p_name) {
@@ -121,7 +121,7 @@ Ref<OpenXRAction> OpenXRActionSet::get_action(const String p_name) const {
 	return Ref<OpenXRAction>();
 }
 
-void OpenXRActionSet::add_action(Ref<OpenXRAction> p_action) {
+void OpenXRActionSet::add_action(const Ref<OpenXRAction> &p_action) {
 	ERR_FAIL_COND(p_action.is_null());
 
 	if (!actions.has(p_action)) {
@@ -136,7 +136,7 @@ void OpenXRActionSet::add_action(Ref<OpenXRAction> p_action) {
 	}
 }
 
-void OpenXRActionSet::remove_action(Ref<OpenXRAction> p_action) {
+void OpenXRActionSet::remove_action(const Ref<OpenXRAction> &p_action) {
 	int idx = actions.find(p_action);
 	if (idx != -1) {
 		actions.remove_at(idx);

--- a/modules/openxr/action_map/openxr_action_set.h
+++ b/modules/openxr/action_map/openxr_action_set.h
@@ -50,19 +50,19 @@ protected:
 public:
 	static Ref<OpenXRActionSet> new_action_set(const char *p_name, const char *p_localized_name, const int p_priority = 0); // Helper function for adding and setting up an action set
 
-	void set_localized_name(const String p_localized_name); // Set the localized name of this action set
+	void set_localized_name(const String &p_localized_name); // Set the localized name of this action set
 	String get_localized_name() const; // Get the localized name of this action set
 
 	void set_priority(const int p_priority); // Set the priority of this action set
 	int get_priority() const; // Get the priority of this action set
 
 	int get_action_count() const; // Retrieve the number of actions in our action set
-	void set_actions(Array p_actions); // Set our actions using an array of actions (for loading a resource)
+	void set_actions(const Array &p_actions); // Set our actions using an array of actions (for loading a resource)
 	Array get_actions() const; // Get our actions as an array (for saving a resource)
 
-	Ref<OpenXRAction> get_action(const String p_name) const; // Retrieve an action by name
-	void add_action(Ref<OpenXRAction> p_action); // Add a new action to our action set
-	void remove_action(Ref<OpenXRAction> p_action); // remove a action from our action set
+	Ref<OpenXRAction> get_action(const String &p_name) const; // Retrieve an action by name
+	void add_action(const Ref<OpenXRAction> &p_action); // Add a new action to our action set
+	void remove_action(const Ref<OpenXRAction> &p_action); // remove a action from our action set
 
 	Ref<OpenXRAction> add_new_action(const char *p_name, const char *p_localized_name, const OpenXRAction::ActionType p_action_type, const char *p_toplevel_paths); // Helper function for adding and setting up an action
 

--- a/modules/openxr/action_map/openxr_interaction_profile.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile.cpp
@@ -58,7 +58,7 @@ void OpenXRIPBinding::_bind_methods() {
 #endif // DISABLE_DEPRECATED
 }
 
-Ref<OpenXRIPBinding> OpenXRIPBinding::new_binding(const Ref<OpenXRAction> p_action, const String &p_binding_path) {
+Ref<OpenXRIPBinding> OpenXRIPBinding::new_binding(const Ref<OpenXRAction> &p_action, const String &p_binding_path) {
 	// This is a helper function to help build our default action sets
 
 	Ref<OpenXRIPBinding> binding;
@@ -78,8 +78,8 @@ Ref<OpenXRAction> OpenXRIPBinding::get_action() const {
 	return action;
 }
 
-void OpenXRIPBinding::set_binding_path(const String &path) {
-	binding_path = path;
+void OpenXRIPBinding::set_binding_path(const String &p_path) {
+	binding_path = p_path;
 	emit_changed();
 }
 
@@ -158,7 +158,7 @@ void OpenXRIPBinding::remove_binding_modifier(const Ref<OpenXRActionBindingModif
 
 #ifndef DISABLE_DEPRECATED
 
-void OpenXRIPBinding::set_paths(const PackedStringArray p_paths) { // Deprecated, but needed for loading old action maps.
+void OpenXRIPBinding::set_paths(const PackedStringArray &p_paths) { // Deprecated, but needed for loading old action maps.
 	// Fallback logic, this should ONLY be called when loading older action maps.
 	// We'll parse this momentarily and extract individual bindings.
 	binding_path = "";
@@ -184,12 +184,12 @@ int OpenXRIPBinding::get_path_count() const { // Deprecated.
 	return binding_path.is_empty() ? 0 : 1;
 }
 
-bool OpenXRIPBinding::has_path(const String p_path) const { // Deprecated.
+bool OpenXRIPBinding::has_path(const String &p_path) const { // Deprecated.
 	// Fallback logic, return true if this is our path.
 	return binding_path == p_path;
 }
 
-void OpenXRIPBinding::add_path(const String p_path) { // Deprecated.
+void OpenXRIPBinding::add_path(const String &p_path) { // Deprecated.
 	// Fallback logic, only assign first time this is called.
 	if (binding_path != p_path) {
 		ERR_FAIL_COND_MSG(!binding_path.is_empty(), "Method add_path has been deprecated. A binding path was already set, create separate binding resources for each path and use set_binding_path instead.");
@@ -199,7 +199,7 @@ void OpenXRIPBinding::add_path(const String p_path) { // Deprecated.
 	}
 }
 
-void OpenXRIPBinding::remove_path(const String p_path) { // Deprecated.
+void OpenXRIPBinding::remove_path(const String &p_path) { // Deprecated.
 	ERR_FAIL_COND_MSG(binding_path != p_path, "Method remove_path has been deprecated. Attempt at removing a different binding path, remove the correct binding record from the interaction profile instead.");
 
 	// Fallback logic, clear if this is our path.
@@ -239,7 +239,7 @@ Ref<OpenXRInteractionProfile> OpenXRInteractionProfile::new_profile(const char *
 	return profile;
 }
 
-void OpenXRInteractionProfile::set_interaction_profile_path(const String p_input_profile_path) {
+void OpenXRInteractionProfile::set_interaction_profile_path(const String &p_input_profile_path) {
 	OpenXRInteractionProfileMetadata *pmd = OpenXRInteractionProfileMetadata::get_singleton();
 	if (pmd) {
 		interaction_profile_path = pmd->check_profile_name(p_input_profile_path);

--- a/modules/openxr/action_map/openxr_interaction_profile.h
+++ b/modules/openxr/action_map/openxr_interaction_profile.h
@@ -54,14 +54,14 @@ protected:
 	static void _bind_methods();
 
 public:
-	static Ref<OpenXRIPBinding> new_binding(const Ref<OpenXRAction> p_action, const String &p_binding_path); // Helper function for adding a new binding.
+	static Ref<OpenXRIPBinding> new_binding(const Ref<OpenXRAction> &p_action, const String &p_binding_path); // Helper function for adding a new binding.
 
 	OpenXRActionMap *get_action_map() { return action_map; } // Return the action map we're a part of.
 
 	void set_action(const Ref<OpenXRAction> &p_action); // Set the action for this binding.
 	Ref<OpenXRAction> get_action() const; // Get the action for this binding.
 
-	void set_binding_path(const String &path);
+	void set_binding_path(const String &p_path);
 	String get_binding_path() const;
 
 	int get_binding_modifier_count() const; // Retrieve the number of binding modifiers in this profile path
@@ -75,12 +75,12 @@ public:
 
 	// Deprecated.
 #ifndef DISABLE_DEPRECATED
-	void set_paths(const PackedStringArray p_paths); // Set our paths (for loading from resource), needed for loading old action maps.
+	void set_paths(const PackedStringArray &p_paths); // Set our paths (for loading from resource), needed for loading old action maps.
 	PackedStringArray get_paths() const; // Get our paths (for saving to resource), needed for converted old action maps.
 	int get_path_count() const; // Get the number of io paths.
-	bool has_path(const String p_path) const; // Has this io path.
-	void add_path(const String p_path); // Add an io path.
-	void remove_path(const String p_path); // Remove an io path.
+	bool has_path(const String &p_path) const; // Has this io path.
+	void add_path(const String &p_path); // Add an io path.
+	void remove_path(const String &p_path); // Remove an io path.
 #endif // DISABLE_DEPRECATED
 
 	// TODO add validation that we can display in the interface that checks if no two paths belong to the same top level path
@@ -108,7 +108,7 @@ public:
 
 	OpenXRActionMap *get_action_map() { return action_map; }
 
-	void set_interaction_profile_path(const String p_input_profile_path); // Set our input profile path
+	void set_interaction_profile_path(const String &p_input_profile_path); // Set our input profile path
 	String get_interaction_profile_path() const; // get our input profile path
 
 	int get_binding_count() const; // Retrieve the number of bindings in this profile path

--- a/modules/openxr/action_map/openxr_interaction_profile_metadata.cpp
+++ b/modules/openxr/action_map/openxr_interaction_profile_metadata.cpp
@@ -110,7 +110,7 @@ void OpenXRInteractionProfileMetadata::register_io_path(const String &p_interact
 	}
 }
 
-bool OpenXRInteractionProfileMetadata::has_top_level_path(const String p_openxr_path) const {
+bool OpenXRInteractionProfileMetadata::has_top_level_path(const String &p_openxr_path) const {
 	for (int i = 0; i < top_level_paths.size(); i++) {
 		if (top_level_paths[i].openxr_path == p_openxr_path) {
 			return true;
@@ -120,7 +120,7 @@ bool OpenXRInteractionProfileMetadata::has_top_level_path(const String p_openxr_
 	return false;
 }
 
-String OpenXRInteractionProfileMetadata::get_top_level_name(const String p_openxr_path) const {
+String OpenXRInteractionProfileMetadata::get_top_level_name(const String &p_openxr_path) const {
 	for (int i = 0; i < top_level_paths.size(); i++) {
 		if (top_level_paths[i].openxr_path == p_openxr_path) {
 			return top_level_paths[i].display_name;
@@ -130,7 +130,7 @@ String OpenXRInteractionProfileMetadata::get_top_level_name(const String p_openx
 	return String();
 }
 
-String OpenXRInteractionProfileMetadata::get_top_level_extension(const String p_openxr_path) const {
+String OpenXRInteractionProfileMetadata::get_top_level_extension(const String &p_openxr_path) const {
 	for (int i = 0; i < top_level_paths.size(); i++) {
 		if (top_level_paths[i].openxr_path == p_openxr_path) {
 			return top_level_paths[i].openxr_extension_name;
@@ -140,7 +140,7 @@ String OpenXRInteractionProfileMetadata::get_top_level_extension(const String p_
 	return XR_PATH_UNSUPPORTED_NAME;
 }
 
-bool OpenXRInteractionProfileMetadata::has_interaction_profile(const String p_openxr_path) const {
+bool OpenXRInteractionProfileMetadata::has_interaction_profile(const String &p_openxr_path) const {
 	for (const InteractionProfile &interaction_profile : interaction_profiles) {
 		if (interaction_profile.openxr_path == p_openxr_path) {
 			return true;
@@ -150,7 +150,7 @@ bool OpenXRInteractionProfileMetadata::has_interaction_profile(const String p_op
 	return false;
 }
 
-String OpenXRInteractionProfileMetadata::get_interaction_profile_extension(const String p_openxr_path) const {
+String OpenXRInteractionProfileMetadata::get_interaction_profile_extension(const String &p_openxr_path) const {
 	for (const InteractionProfile &interaction_profile : interaction_profiles) {
 		if (interaction_profile.openxr_path == p_openxr_path) {
 			return interaction_profile.openxr_extension_name;
@@ -160,7 +160,7 @@ String OpenXRInteractionProfileMetadata::get_interaction_profile_extension(const
 	return XR_PATH_UNSUPPORTED_NAME;
 }
 
-const OpenXRInteractionProfileMetadata::InteractionProfile *OpenXRInteractionProfileMetadata::get_profile(const String p_openxr_path) const {
+const OpenXRInteractionProfileMetadata::InteractionProfile *OpenXRInteractionProfileMetadata::get_profile(const String &p_openxr_path) const {
 	for (const InteractionProfile &interaction_profile : interaction_profiles) {
 		if (interaction_profile.openxr_path == p_openxr_path) {
 			return &interaction_profile;
@@ -170,7 +170,7 @@ const OpenXRInteractionProfileMetadata::InteractionProfile *OpenXRInteractionPro
 	return nullptr;
 }
 
-bool OpenXRInteractionProfileMetadata::InteractionProfile::has_io_path(const String p_io_path) const {
+bool OpenXRInteractionProfileMetadata::InteractionProfile::has_io_path(const String &p_io_path) const {
 	for (int i = 0; i < io_paths.size(); i++) {
 		if (io_paths[i].openxr_path == p_io_path) {
 			return true;
@@ -180,7 +180,7 @@ bool OpenXRInteractionProfileMetadata::InteractionProfile::has_io_path(const Str
 	return false;
 }
 
-const OpenXRInteractionProfileMetadata::IOPath *OpenXRInteractionProfileMetadata::InteractionProfile::get_io_path(const String p_io_path) const {
+const OpenXRInteractionProfileMetadata::IOPath *OpenXRInteractionProfileMetadata::InteractionProfile::get_io_path(const String &p_io_path) const {
 	for (int i = 0; i < io_paths.size(); i++) {
 		if (io_paths[i].openxr_path == p_io_path) {
 			return &io_paths[i];
@@ -190,7 +190,7 @@ const OpenXRInteractionProfileMetadata::IOPath *OpenXRInteractionProfileMetadata
 	return nullptr;
 }
 
-const OpenXRInteractionProfileMetadata::IOPath *OpenXRInteractionProfileMetadata::get_io_path(const String p_interaction_profile, const String p_io_path) const {
+const OpenXRInteractionProfileMetadata::IOPath *OpenXRInteractionProfileMetadata::get_io_path(const String &p_interaction_profile, const String &p_io_path) const {
 	const OpenXRInteractionProfileMetadata::InteractionProfile *profile = get_profile(p_interaction_profile);
 	if (profile != nullptr) {
 		return profile->get_io_path(p_io_path);

--- a/modules/openxr/action_map/openxr_interaction_profile_metadata.h
+++ b/modules/openxr/action_map/openxr_interaction_profile_metadata.h
@@ -81,8 +81,8 @@ public:
 		String openxr_extension_name; // If set, only available if extension is enabled (i.e. XR_HTCX_vive_tracker_interaction)
 		Vector<IOPath> io_paths; // Inputs and outputs for this device
 
-		bool has_io_path(const String p_io_path) const;
-		const IOPath *get_io_path(const String p_io_path) const;
+		bool has_io_path(const String &p_io_path) const;
+		const IOPath *get_io_path(const String &p_io_path) const;
 	};
 
 private:
@@ -107,16 +107,16 @@ public:
 	String check_profile_name(const String &p_name) const;
 
 	void register_top_level_path(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_name);
-	bool has_top_level_path(const String p_openxr_path) const;
-	String get_top_level_name(const String p_openxr_path) const;
-	String get_top_level_extension(const String p_openxr_path) const;
+	bool has_top_level_path(const String &p_openxr_path) const;
+	String get_top_level_name(const String &p_openxr_path) const;
+	String get_top_level_extension(const String &p_openxr_path) const;
 
 	void register_interaction_profile(const String &p_display_name, const String &p_openxr_path, const String &p_openxr_extension_name);
-	bool has_interaction_profile(const String p_openxr_path) const;
-	String get_interaction_profile_extension(const String p_openxr_path) const;
-	const InteractionProfile *get_profile(const String p_openxr_path) const;
+	bool has_interaction_profile(const String &p_openxr_path) const;
+	String get_interaction_profile_extension(const String &p_openxr_path) const;
+	const InteractionProfile *get_profile(const String &p_openxr_path) const;
 	PackedStringArray get_interaction_profile_paths() const;
 
 	void register_io_path(const String &p_interaction_profile, const String &p_display_name, const String &p_toplevel_path, const String &p_openxr_path, const String &p_openxr_extension_name, OpenXRAction::ActionType p_action_type);
-	const IOPath *get_io_path(const String p_interaction_profile, const String p_io_path) const;
+	const IOPath *get_io_path(const String &p_interaction_profile, const String &p_io_path) const;
 };

--- a/modules/openxr/editor/openxr_action_editor.cpp
+++ b/modules/openxr/editor/openxr_action_editor.cpp
@@ -53,7 +53,7 @@ void OpenXRActionEditor::_notification(int p_what) {
 	}
 }
 
-void OpenXRActionEditor::_on_action_name_changed(const String p_new_text) {
+void OpenXRActionEditor::_on_action_name_changed(const String &p_new_text) {
 	if (action->get_name() != p_new_text) {
 		undo_redo->create_action(TTR("Rename Action"));
 		undo_redo->add_do_method(this, "_do_set_name", p_new_text);
@@ -75,13 +75,13 @@ void OpenXRActionEditor::_on_action_name_changed(const String p_new_text) {
 	}
 }
 
-void OpenXRActionEditor::_do_set_name(const String p_new_text) {
+void OpenXRActionEditor::_do_set_name(const String &p_new_text) {
 	action->set_name(p_new_text);
 	action->set_edited(true);
 	action_name->set_text(p_new_text);
 }
 
-void OpenXRActionEditor::_on_action_localized_name_changed(const String p_new_text) {
+void OpenXRActionEditor::_on_action_localized_name_changed(const String &p_new_text) {
 	if (action->get_localized_name() != p_new_text) {
 		undo_redo->create_action(TTR("Rename Actions Localized name"));
 		undo_redo->add_do_method(this, "_do_set_localized_name", p_new_text);
@@ -93,7 +93,7 @@ void OpenXRActionEditor::_on_action_localized_name_changed(const String p_new_te
 	}
 }
 
-void OpenXRActionEditor::_do_set_localized_name(const String p_new_text) {
+void OpenXRActionEditor::_do_set_localized_name(const String &p_new_text) {
 	action->set_localized_name(p_new_text);
 	action->set_edited(true);
 	action_localized_name->set_text(p_new_text);
@@ -125,7 +125,7 @@ void OpenXRActionEditor::_on_remove_action() {
 	emit_signal("remove", this);
 }
 
-OpenXRActionEditor::OpenXRActionEditor(Ref<OpenXRAction> p_action) {
+OpenXRActionEditor::OpenXRActionEditor(const Ref<OpenXRAction> &p_action) {
 	undo_redo = EditorUndoRedoManager::get_singleton();
 	action = p_action;
 

--- a/modules/openxr/editor/openxr_action_editor.h
+++ b/modules/openxr/editor/openxr_action_editor.h
@@ -52,8 +52,8 @@ private:
 	Button *rem_action = nullptr;
 
 	void _theme_changed();
-	void _on_action_name_changed(const String p_new_text);
-	void _on_action_localized_name_changed(const String p_new_text);
+	void _on_action_name_changed(const String &p_new_text);
+	void _on_action_localized_name_changed(const String &p_new_text);
 	void _on_item_selected(int p_idx);
 	void _on_remove_action();
 
@@ -62,11 +62,11 @@ protected:
 	void _notification(int p_what);
 
 	// used for undo/redo
-	void _do_set_name(const String p_new_text);
-	void _do_set_localized_name(const String p_new_text);
+	void _do_set_name(const String &p_new_text);
+	void _do_set_localized_name(const String &p_new_text);
 	void _do_set_action_type(OpenXRAction::ActionType p_action_type);
 
 public:
 	Ref<OpenXRAction> get_action() { return action; }
-	OpenXRActionEditor(Ref<OpenXRAction> p_action);
+	OpenXRActionEditor(const Ref<OpenXRAction> &p_action);
 };

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -73,7 +73,7 @@ void OpenXRActionMapEditor::_notification(int p_what) {
 	}
 }
 
-OpenXRActionSetEditor *OpenXRActionMapEditor::_add_action_set_editor(Ref<OpenXRActionSet> p_action_set) {
+OpenXRActionSetEditor *OpenXRActionMapEditor::_add_action_set_editor(const Ref<OpenXRActionSet> &p_action_set) {
 	ERR_FAIL_COND_V(p_action_set.is_null(), nullptr);
 
 	OpenXRActionSetEditor *action_set_editor = memnew(OpenXRActionSetEditor(action_map, p_action_set));
@@ -95,7 +95,7 @@ void OpenXRActionMapEditor::_create_action_sets() {
 	}
 }
 
-OpenXRInteractionProfileEditorBase *OpenXRActionMapEditor::_add_interaction_profile_editor(Ref<OpenXRInteractionProfile> p_interaction_profile) {
+OpenXRInteractionProfileEditorBase *OpenXRActionMapEditor::_add_interaction_profile_editor(const Ref<OpenXRInteractionProfile> &p_interaction_profile) {
 	ERR_FAIL_COND_V(p_interaction_profile.is_null(), nullptr);
 
 	String profile_path = p_interaction_profile->get_interaction_profile_path();
@@ -141,7 +141,7 @@ void OpenXRActionMapEditor::_create_interaction_profiles() {
 	}
 }
 
-OpenXRActionSetEditor *OpenXRActionMapEditor::_add_action_set(String p_name) {
+OpenXRActionSetEditor *OpenXRActionMapEditor::_add_action_set(const String &p_name) {
 	ERR_FAIL_COND_V(action_map.is_null(), nullptr);
 	Ref<OpenXRActionSet> new_action_set;
 
@@ -163,7 +163,7 @@ OpenXRActionSetEditor *OpenXRActionMapEditor::_add_action_set(String p_name) {
 	return action_set_editor;
 }
 
-void OpenXRActionMapEditor::_remove_action_set(String p_name) {
+void OpenXRActionMapEditor::_remove_action_set(const String &p_name) {
 	ERR_FAIL_COND(action_map.is_null());
 	Ref<OpenXRActionSet> action_set = action_map->find_action_set(p_name);
 	ERR_FAIL_COND(action_set.is_null());
@@ -231,7 +231,7 @@ void OpenXRActionMapEditor::_on_remove_action_set(Object *p_action_set_editor) {
 	action_map->set_edited(true);
 }
 
-void OpenXRActionMapEditor::_on_action_removed(Ref<OpenXRAction> p_action) {
+void OpenXRActionMapEditor::_on_action_removed(const Ref<OpenXRAction> &p_action) {
 	for (int i = 0; i < tabs->get_tab_count(); i++) {
 		// First tab won't be an interaction profile editor, but being thorough..
 		OpenXRInteractionProfileEditorBase *interaction_profile_editor = Object::cast_to<OpenXRInteractionProfileEditorBase>(tabs->get_tab_control(i));
@@ -253,7 +253,7 @@ void OpenXRActionMapEditor::_on_add_interaction_profile() {
 	select_interaction_profile_dialog->open(already_selected);
 }
 
-void OpenXRActionMapEditor::_on_interaction_profile_selected(const String p_path) {
+void OpenXRActionMapEditor::_on_interaction_profile_selected(const String &p_path) {
 	ERR_FAIL_COND(action_map.is_null());
 
 	Ref<OpenXRInteractionProfile> new_profile;
@@ -272,7 +272,7 @@ void OpenXRActionMapEditor::_on_interaction_profile_selected(const String p_path
 	tabs->set_current_tab(tabs->get_tab_count() - 1);
 }
 
-void OpenXRActionMapEditor::_load_action_map(const String p_path, bool p_create_new_if_missing) {
+void OpenXRActionMapEditor::_load_action_map(const String &p_path, bool p_create_new_if_missing) {
 	Error err = OK;
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (da->file_exists(p_path)) {
@@ -382,7 +382,7 @@ void OpenXRActionMapEditor::_do_remove_interaction_profile_editor(OpenXRInteract
 	action_map->remove_interaction_profile(interaction_profile);
 }
 
-void OpenXRActionMapEditor::open_action_map(String p_path) {
+void OpenXRActionMapEditor::open_action_map(const String &p_path) {
 	EditorNode::get_bottom_panel()->make_item_visible(this);
 
 	// out with the old...

--- a/modules/openxr/editor/openxr_action_map_editor.h
+++ b/modules/openxr/editor/openxr_action_map_editor.h
@@ -67,23 +67,23 @@ private:
 	VBoxContainer *actionsets_vb = nullptr;
 	OpenXRSelectInteractionProfileDialog *select_interaction_profile_dialog = nullptr;
 
-	OpenXRActionSetEditor *_add_action_set_editor(Ref<OpenXRActionSet> p_action_set);
+	OpenXRActionSetEditor *_add_action_set_editor(const Ref<OpenXRActionSet> &p_action_set);
 	void _create_action_sets();
-	OpenXRInteractionProfileEditorBase *_add_interaction_profile_editor(Ref<OpenXRInteractionProfile> p_interaction_profile);
+	OpenXRInteractionProfileEditorBase *_add_interaction_profile_editor(const Ref<OpenXRInteractionProfile> &p_interaction_profile);
 	void _create_interaction_profiles();
 
-	OpenXRActionSetEditor *_add_action_set(String p_name);
-	void _remove_action_set(String p_name);
+	OpenXRActionSetEditor *_add_action_set(const String &p_name);
+	void _remove_action_set(const String &p_name);
 
 	void _on_add_action_set();
 	void _set_focus_on_action_set(OpenXRActionSetEditor *p_action_set_editor);
 	void _on_remove_action_set(Object *p_action_set_editor);
-	void _on_action_removed(Ref<OpenXRAction> p_action);
+	void _on_action_removed(const Ref<OpenXRAction> &p_action);
 
 	void _on_add_interaction_profile();
-	void _on_interaction_profile_selected(const String p_path);
+	void _on_interaction_profile_selected(const String &p_path);
 
-	void _load_action_map(const String p_path, bool p_create_new_if_missing = false);
+	void _load_action_map(const String &p_path, bool p_create_new_if_missing = false);
 	void _on_save_action_map();
 	void _on_reset_to_default_layout();
 
@@ -107,7 +107,7 @@ public:
 	static void register_binding_modifier_editor(const String &p_binding_modifier_class, const String &p_editor_class);
 	static String get_binding_modifier_editor_class(const String &p_binding_modifier_class);
 
-	void open_action_map(String p_path);
+	void open_action_map(const String &p_path);
 
 	OpenXRActionMapEditor();
 };

--- a/modules/openxr/editor/openxr_action_set_editor.cpp
+++ b/modules/openxr/editor/openxr_action_set_editor.cpp
@@ -74,7 +74,7 @@ void OpenXRActionSetEditor::_notification(int p_what) {
 	}
 }
 
-OpenXRActionEditor *OpenXRActionSetEditor::_add_action_editor(Ref<OpenXRAction> p_action) {
+OpenXRActionEditor *OpenXRActionSetEditor::_add_action_editor(const Ref<OpenXRAction> &p_action) {
 	OpenXRActionEditor *action_editor = memnew(OpenXRActionEditor(p_action));
 	action_editor->connect("remove", callable_mp(this, &OpenXRActionSetEditor::_on_remove_action));
 	actions_vb->add_child(action_editor);
@@ -88,7 +88,7 @@ void OpenXRActionSetEditor::_on_toggle_expand() {
 	_set_fold_icon();
 }
 
-void OpenXRActionSetEditor::_on_action_set_name_changed(const String p_new_text) {
+void OpenXRActionSetEditor::_on_action_set_name_changed(const String &p_new_text) {
 	if (action_set->get_name() != p_new_text) {
 		undo_redo->create_action(TTR("Rename Action Set"));
 		undo_redo->add_do_method(this, "_do_set_name", p_new_text);
@@ -110,12 +110,12 @@ void OpenXRActionSetEditor::_on_action_set_name_changed(const String p_new_text)
 	}
 }
 
-void OpenXRActionSetEditor::_do_set_name(const String p_new_text) {
+void OpenXRActionSetEditor::_do_set_name(const String &p_new_text) {
 	action_set->set_name(p_new_text);
 	action_set_name->set_text(p_new_text);
 }
 
-void OpenXRActionSetEditor::_on_action_set_localized_name_changed(const String p_new_text) {
+void OpenXRActionSetEditor::_on_action_set_localized_name_changed(const String &p_new_text) {
 	if (action_set->get_localized_name() != p_new_text) {
 		undo_redo->create_action(TTR("Rename Action Sets Localized name"));
 		undo_redo->add_do_method(this, "_do_set_localized_name", p_new_text);
@@ -127,7 +127,7 @@ void OpenXRActionSetEditor::_on_action_set_localized_name_changed(const String p
 	}
 }
 
-void OpenXRActionSetEditor::_do_set_localized_name(const String p_new_text) {
+void OpenXRActionSetEditor::_do_set_localized_name(const String &p_new_text) {
 	action_set->set_localized_name(p_new_text);
 	action_set_localized_name->set_text(p_new_text);
 }
@@ -218,7 +218,7 @@ void OpenXRActionSetEditor::set_focus_on_entry() {
 	action_set_name->grab_focus();
 }
 
-OpenXRActionSetEditor::OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRActionSet> p_action_set) {
+OpenXRActionSetEditor::OpenXRActionSetEditor(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRActionSet> &p_action_set) {
 	undo_redo = EditorUndoRedoManager::get_singleton();
 	action_map = p_action_map;
 	action_set = p_action_set;

--- a/modules/openxr/editor/openxr_action_set_editor.h
+++ b/modules/openxr/editor/openxr_action_set_editor.h
@@ -64,11 +64,11 @@ private:
 
 	void _set_fold_icon();
 	void _theme_changed();
-	OpenXRActionEditor *_add_action_editor(Ref<OpenXRAction> p_action);
+	OpenXRActionEditor *_add_action_editor(const Ref<OpenXRAction> &p_action);
 
 	void _on_toggle_expand();
-	void _on_action_set_name_changed(const String p_new_text);
-	void _on_action_set_localized_name_changed(const String p_new_text);
+	void _on_action_set_name_changed(const String &p_new_text);
+	void _on_action_set_localized_name_changed(const String &p_new_text);
 	void _on_action_set_priority_changed(const double p_new_value);
 	void _on_add_action();
 	void _on_remove_action_set();
@@ -80,8 +80,8 @@ protected:
 	void _notification(int p_what);
 
 	// used for undo/redo
-	void _do_set_name(const String p_new_text);
-	void _do_set_localized_name(const String p_new_text);
+	void _do_set_name(const String &p_new_text);
+	void _do_set_localized_name(const String &p_new_text);
 	void _do_set_priority(int64_t value);
 	void _do_add_action_editor(OpenXRActionEditor *p_action_editor);
 	void _do_remove_action_editor(OpenXRActionEditor *p_action_editor);
@@ -92,5 +92,5 @@ public:
 
 	void remove_all_actions();
 
-	OpenXRActionSetEditor(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRActionSet> p_action_set);
+	OpenXRActionSetEditor(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRActionSet> &p_action_set);
 };

--- a/modules/openxr/editor/openxr_binding_modifier_editor.cpp
+++ b/modules/openxr/editor/openxr_binding_modifier_editor.cpp
@@ -273,7 +273,7 @@ OpenXRBindingModifierEditor::OpenXRBindingModifierEditor() {
 	main_vb->add_child(editor_inspector);
 }
 
-void OpenXRBindingModifierEditor::setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRBindingModifier> p_binding_modifier) {
+void OpenXRBindingModifierEditor::setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRBindingModifier> &p_binding_modifier) {
 	ERR_FAIL_NULL(binding_modifier_title);
 	ERR_FAIL_NULL(editor_inspector);
 

--- a/modules/openxr/editor/openxr_binding_modifier_editor.h
+++ b/modules/openxr/editor/openxr_binding_modifier_editor.h
@@ -104,7 +104,7 @@ protected:
 public:
 	Ref<OpenXRBindingModifier> get_binding_modifier() const { return binding_modifier; }
 
-	virtual void setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRBindingModifier> p_binding_modifier);
+	virtual void setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRBindingModifier> &p_binding_modifier);
 
 	OpenXRBindingModifierEditor();
 };

--- a/modules/openxr/editor/openxr_binding_modifiers_dialog.cpp
+++ b/modules/openxr/editor/openxr_binding_modifiers_dialog.cpp
@@ -53,7 +53,7 @@ void OpenXRBindingModifiersDialog::_notification(int p_what) {
 	}
 }
 
-OpenXRBindingModifierEditor *OpenXRBindingModifiersDialog::_add_binding_modifier_editor(Ref<OpenXRBindingModifier> p_binding_modifier) {
+OpenXRBindingModifierEditor *OpenXRBindingModifiersDialog::_add_binding_modifier_editor(const Ref<OpenXRBindingModifier> &p_binding_modifier) {
 	ERR_FAIL_COND_V(p_binding_modifier.is_null(), nullptr);
 
 	String class_name = p_binding_modifier->get_class();
@@ -222,7 +222,7 @@ OpenXRBindingModifiersDialog::OpenXRBindingModifiersDialog() {
 	add_child(create_dialog);
 }
 
-void OpenXRBindingModifiersDialog::setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile, Ref<OpenXRIPBinding> p_ip_binding) {
+void OpenXRBindingModifiersDialog::setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRInteractionProfile> &p_interaction_profile, const Ref<OpenXRIPBinding> &p_ip_binding) {
 	OpenXRInteractionProfileMetadata *meta_data = OpenXRInteractionProfileMetadata::get_singleton();
 	action_map = p_action_map;
 	interaction_profile = p_interaction_profile;

--- a/modules/openxr/editor/openxr_binding_modifiers_dialog.h
+++ b/modules/openxr/editor/openxr_binding_modifiers_dialog.h
@@ -51,7 +51,7 @@ private:
 	Button *add_binding_modifier_btn = nullptr;
 	CreateDialog *create_dialog = nullptr;
 
-	OpenXRBindingModifierEditor *_add_binding_modifier_editor(Ref<OpenXRBindingModifier> p_binding_modifier);
+	OpenXRBindingModifierEditor *_add_binding_modifier_editor(const Ref<OpenXRBindingModifier> &p_binding_modifier);
 	void _create_binding_modifiers();
 
 	void _on_add_binding_modifier();
@@ -74,5 +74,5 @@ protected:
 public:
 	OpenXRBindingModifiersDialog();
 
-	void setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile, Ref<OpenXRIPBinding> p_ip_binding = Ref<OpenXRIPBinding>());
+	void setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRInteractionProfile> &p_interaction_profile, const Ref<OpenXRIPBinding> &p_ip_binding = Ref<OpenXRIPBinding>());
 };

--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -61,7 +61,7 @@ void OpenXRInteractionProfileEditorBase::_do_update_interaction_profile() {
 	}
 }
 
-void OpenXRInteractionProfileEditorBase::_add_binding(const String p_action, const String p_path) {
+void OpenXRInteractionProfileEditorBase::_add_binding(const String &p_action, const String &p_path) {
 	ERR_FAIL_COND(action_map.is_null());
 	ERR_FAIL_COND(interaction_profile.is_null());
 
@@ -88,7 +88,7 @@ void OpenXRInteractionProfileEditorBase::_add_binding(const String p_action, con
 	_do_update_interaction_profile();
 }
 
-void OpenXRInteractionProfileEditorBase::_remove_binding(const String p_action, const String p_path) {
+void OpenXRInteractionProfileEditorBase::_remove_binding(const String &p_action, const String &p_path) {
 	ERR_FAIL_COND(action_map.is_null());
 	ERR_FAIL_COND(interaction_profile.is_null());
 
@@ -125,13 +125,13 @@ void OpenXRInteractionProfileEditorBase::_theme_changed() {
 	}
 }
 
-void OpenXRInteractionProfileEditorBase::remove_all_for_action_set(Ref<OpenXRActionSet> p_action_set) {
+void OpenXRInteractionProfileEditorBase::remove_all_for_action_set(const Ref<OpenXRActionSet> &p_action_set) {
 	// Note, don't need to remove bindings themselves as remove_all_for_action will be called for each before this is called.
 
 	// TODO update binding modifiers
 }
 
-void OpenXRInteractionProfileEditorBase::remove_all_for_action(Ref<OpenXRAction> p_action) {
+void OpenXRInteractionProfileEditorBase::remove_all_for_action(const Ref<OpenXRAction> &p_action) {
 	Vector<Ref<OpenXRIPBinding>> bindings = interaction_profile->get_bindings_for_action(p_action);
 	if (bindings.size() > 0) {
 		String action_name = p_action->get_name_with_set();
@@ -185,7 +185,7 @@ OpenXRInteractionProfileEditorBase::OpenXRInteractionProfileEditorBase() {
 	toolbar_vb->add_child(binding_modifiers_btn);
 }
 
-void OpenXRInteractionProfileEditorBase::setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile) {
+void OpenXRInteractionProfileEditorBase::setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRInteractionProfile> &p_interaction_profile) {
 	ERR_FAIL_NULL(binding_modifiers_dialog);
 	binding_modifiers_dialog->setup(p_action_map, p_interaction_profile);
 
@@ -214,12 +214,12 @@ void OpenXRInteractionProfileEditorBase::setup(Ref<OpenXRActionMap> p_action_map
 ///////////////////////////////////////////////////////////////////////////
 // Default interaction profile editor
 
-void OpenXRInteractionProfileEditor::select_action_for(const String p_io_path) {
+void OpenXRInteractionProfileEditor::select_action_for(const String &p_io_path) {
 	selecting_for_io_path = p_io_path;
 	select_action_dialog->open();
 }
 
-void OpenXRInteractionProfileEditor::_on_action_selected(const String p_action) {
+void OpenXRInteractionProfileEditor::_on_action_selected(const String &p_action) {
 	undo_redo->create_action(TTR("Add binding"));
 	undo_redo->add_do_method(this, "_add_binding", p_action, selecting_for_io_path);
 	undo_redo->add_undo_method(this, "_remove_binding", p_action, selecting_for_io_path);
@@ -228,7 +228,7 @@ void OpenXRInteractionProfileEditor::_on_action_selected(const String p_action) 
 	selecting_for_io_path = "";
 }
 
-void OpenXRInteractionProfileEditor::_on_remove_pressed(const String p_action, const String p_for_io_path) {
+void OpenXRInteractionProfileEditor::_on_remove_pressed(const String &p_action, const String &p_for_io_path) {
 	undo_redo->create_action(TTR("Remove binding"));
 	undo_redo->add_do_method(this, "_remove_binding", p_action, p_for_io_path);
 	undo_redo->add_undo_method(this, "_add_binding", p_action, p_for_io_path);
@@ -396,7 +396,7 @@ OpenXRInteractionProfileEditor::OpenXRInteractionProfileEditor() {
 	interaction_profile_sc->add_child(interaction_profile_hb);
 }
 
-void OpenXRInteractionProfileEditor::setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile) {
+void OpenXRInteractionProfileEditor::setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRInteractionProfile> &p_interaction_profile) {
 	OpenXRInteractionProfileEditorBase::setup(p_action_map, p_interaction_profile);
 
 	select_action_dialog = memnew(OpenXRSelectActionDialog(p_action_map));

--- a/modules/openxr/editor/openxr_interaction_profile_editor.h
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.h
@@ -72,13 +72,13 @@ public:
 	virtual void _theme_changed();
 
 	void _do_update_interaction_profile();
-	void _add_binding(const String p_action, const String p_path);
-	void _remove_binding(const String p_action, const String p_path);
+	void _add_binding(const String &p_action, const String &p_path);
+	void _remove_binding(const String &p_action, const String &p_path);
 
-	void remove_all_for_action_set(Ref<OpenXRActionSet> p_action_set);
-	void remove_all_for_action(Ref<OpenXRAction> p_action);
+	void remove_all_for_action_set(const Ref<OpenXRActionSet> &p_action_set);
+	void remove_all_for_action(const Ref<OpenXRAction> &p_action);
 
-	virtual void setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile);
+	virtual void setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRInteractionProfile> &p_interaction_profile);
 
 	OpenXRInteractionProfileEditorBase();
 };
@@ -95,13 +95,13 @@ private:
 	void _add_io_path(VBoxContainer *p_container, const OpenXRInteractionProfileMetadata::IOPath *p_io_path);
 
 public:
-	void select_action_for(const String p_io_path);
-	void _on_action_selected(const String p_action);
-	void _on_remove_pressed(const String p_action, const String p_for_io_path);
+	void select_action_for(const String &p_io_path);
+	void _on_action_selected(const String &p_action);
+	void _on_remove_pressed(const String &p_action, const String &p_for_io_path);
 
 	virtual void _update_interaction_profile() override;
 	virtual void _theme_changed() override;
-	virtual void setup(Ref<OpenXRActionMap> p_action_map, Ref<OpenXRInteractionProfile> p_interaction_profile) override;
+	virtual void setup(const Ref<OpenXRActionMap> &p_action_map, const Ref<OpenXRInteractionProfile> &p_interaction_profile) override;
 
 	OpenXRInteractionProfileEditor();
 };

--- a/modules/openxr/editor/openxr_select_action_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_action_dialog.cpp
@@ -44,7 +44,7 @@ void OpenXRSelectActionDialog::_notification(int p_what) {
 	}
 }
 
-void OpenXRSelectActionDialog::_on_select_action(const String p_action) {
+void OpenXRSelectActionDialog::_on_select_action(const String &p_action) {
 	if (selected_action != "") {
 		NodePath button_path = action_buttons[selected_action];
 		Button *button = Object::cast_to<Button>(get_node(button_path));
@@ -120,7 +120,7 @@ void OpenXRSelectActionDialog::ok_pressed() {
 	hide();
 }
 
-OpenXRSelectActionDialog::OpenXRSelectActionDialog(Ref<OpenXRActionMap> p_action_map) {
+OpenXRSelectActionDialog::OpenXRSelectActionDialog(const Ref<OpenXRActionMap> &p_action_map) {
 	action_map = p_action_map;
 
 	set_title(TTR("Select an action"));

--- a/modules/openxr/editor/openxr_select_action_dialog.h
+++ b/modules/openxr/editor/openxr_select_action_dialog.h
@@ -57,9 +57,9 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void _on_select_action(const String p_action);
+	void _on_select_action(const String &p_action);
 	void open();
 	virtual void ok_pressed() override;
 
-	OpenXRSelectActionDialog(Ref<OpenXRActionMap> p_action_map);
+	OpenXRSelectActionDialog(const Ref<OpenXRActionMap> &p_action_map);
 };

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.cpp
@@ -47,7 +47,7 @@ void OpenXRSelectInteractionProfileDialog::_notification(int p_what) {
 	}
 }
 
-void OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile(const String p_interaction_profile) {
+void OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile(const String &p_interaction_profile) {
 	if (selected_interaction_profile != "") {
 		NodePath button_path = ip_buttons[selected_interaction_profile];
 		Button *button = Object::cast_to<Button>(get_node(button_path));
@@ -67,7 +67,7 @@ void OpenXRSelectInteractionProfileDialog::_on_select_interaction_profile(const 
 	}
 }
 
-void OpenXRSelectInteractionProfileDialog::open(PackedStringArray p_do_not_include) {
+void OpenXRSelectInteractionProfileDialog::open(const PackedStringArray &p_do_not_include) {
 	int available_count = 0;
 
 	OpenXRInteractionProfileMetadata *meta_data = OpenXRInteractionProfileMetadata::get_singleton();

--- a/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
+++ b/modules/openxr/editor/openxr_select_interaction_profile_dialog.h
@@ -51,8 +51,8 @@ protected:
 	void _notification(int p_what);
 
 public:
-	void _on_select_interaction_profile(const String p_interaction_profile);
-	void open(PackedStringArray p_do_not_include);
+	void _on_select_interaction_profile(const String &p_interaction_profile);
+	void open(const PackedStringArray &p_do_not_include);
 	virtual void ok_pressed() override;
 
 	OpenXRSelectInteractionProfileDialog();

--- a/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
+++ b/modules/openxr/extensions/openxr_dpad_binding_extension.cpp
@@ -121,7 +121,7 @@ OpenXRDpadBindingModifier::OpenXRDpadBindingModifier() {
 	dpad_bindings->isSticky = false;
 }
 
-void OpenXRDpadBindingModifier::set_action_set(const Ref<OpenXRActionSet> p_action_set) {
+void OpenXRDpadBindingModifier::set_action_set(const Ref<OpenXRActionSet> &p_action_set) {
 	action_set = p_action_set;
 }
 

--- a/modules/openxr/extensions/openxr_dpad_binding_extension.h
+++ b/modules/openxr/extensions/openxr_dpad_binding_extension.h
@@ -76,7 +76,7 @@ protected:
 public:
 	OpenXRDpadBindingModifier();
 
-	void set_action_set(const Ref<OpenXRActionSet> p_action_set);
+	void set_action_set(const Ref<OpenXRActionSet> &p_action_set);
 	Ref<OpenXRActionSet> get_action_set() const;
 
 	void set_input_path(const String &p_input_path);

--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -516,7 +516,7 @@ bool OpenXRAPI::interaction_profile_supports_io_path(const String &p_ip_path, co
 	return true;
 }
 
-void OpenXRAPI::copy_string_to_char_buffer(const String p_string, char *p_buffer, int p_buffer_len) {
+void OpenXRAPI::copy_string_to_char_buffer(const String &p_string, char *p_buffer, int p_buffer_len) {
 	CharString char_string = p_string.utf8();
 	int len = char_string.length();
 	if (len < p_buffer_len - 1) {
@@ -1230,7 +1230,7 @@ bool OpenXRAPI::obtain_swapchain_formats() {
 	return true;
 }
 
-bool OpenXRAPI::create_main_swapchains(Size2i p_size) {
+bool OpenXRAPI::create_main_swapchains(const Size2i &p_size) {
 	ERR_NOT_ON_RENDER_THREAD_V(false);
 	ERR_FAIL_NULL_V(graphics_extension, false);
 	ERR_FAIL_COND_V(session == XR_NULL_HANDLE, false);
@@ -2896,15 +2896,15 @@ void OpenXRAPI::parse_velocities(const XrSpaceVelocity &p_velocity, Vector3 &r_l
 	}
 }
 
-bool OpenXRAPI::xr_result(XrResult result, const char *format, Array args) const {
-	if (XR_SUCCEEDED(result)) {
+bool OpenXRAPI::xr_result(XrResult p_result, const char *p_format, const Array &p_args) const {
+	if (XR_SUCCEEDED(p_result)) {
 		return true;
 	}
 
 	char resultString[XR_MAX_RESULT_STRING_SIZE];
-	xrResultToString(instance, result, resultString);
+	xrResultToString(instance, p_result, resultString);
 
-	print_error(String("OpenXR ") + String(format).format(args) + String(" [") + String(resultString) + String("]"));
+	print_error(String("OpenXR ") + String(p_format).format(p_args) + String(" [") + String(resultString) + String("]"));
 
 	return false;
 }
@@ -2964,7 +2964,7 @@ RID OpenXRAPI::find_tracker(const String &p_name) {
 	return RID();
 }
 
-RID OpenXRAPI::tracker_create(const String p_name) {
+RID OpenXRAPI::tracker_create(const String &p_name) {
 	ERR_FAIL_COND_V(instance == XR_NULL_HANDLE, RID());
 
 	Tracker new_tracker;
@@ -3034,7 +3034,7 @@ void OpenXRAPI::tracker_free(RID p_tracker) {
 	tracker_owner.free(p_tracker);
 }
 
-RID OpenXRAPI::action_set_create(const String p_name, const String p_localized_name, const int p_priority) {
+RID OpenXRAPI::action_set_create(const String &p_name, const String &p_localized_name, const int p_priority) {
 	ERR_FAIL_COND_V(instance == XR_NULL_HANDLE, RID());
 	ActionSet action_set;
 
@@ -3064,7 +3064,7 @@ RID OpenXRAPI::action_set_create(const String p_name, const String p_localized_n
 	return action_set_owner.make_rid(action_set);
 }
 
-RID OpenXRAPI::find_action_set(const String p_name) {
+RID OpenXRAPI::find_action_set(const String &p_name) {
 	for (const RID &action_set_rid : action_set_owner.get_owned_list()) {
 		ActionSet *action_set = action_set_owner.get_or_null(action_set_rid);
 		if (action_set && action_set->name == p_name) {
@@ -3188,7 +3188,7 @@ RID OpenXRAPI::find_action(const String &p_name, const RID &p_action_set) {
 	return RID();
 }
 
-RID OpenXRAPI::action_create(RID p_action_set, const String p_name, const String p_localized_name, OpenXRAction::ActionType p_action_type, const Vector<RID> &p_trackers) {
+RID OpenXRAPI::action_create(RID p_action_set, const String &p_name, const String &p_localized_name, OpenXRAction::ActionType p_action_type, const Vector<RID> &p_trackers) {
 	ERR_FAIL_COND_V(instance == XR_NULL_HANDLE, RID());
 
 	Action action;
@@ -3314,7 +3314,7 @@ XrPath OpenXRAPI::get_interaction_profile_path(RID p_interaction_profile) {
 	return ip->path;
 }
 
-RID OpenXRAPI::interaction_profile_create(const String p_name) {
+RID OpenXRAPI::interaction_profile_create(const String &p_name) {
 	if (!is_interaction_profile_supported(p_name)) {
 		// The extension enabling this path must not be active, we will silently skip this interaction profile
 		return RID();
@@ -3355,7 +3355,7 @@ void OpenXRAPI::interaction_profile_clear_bindings(RID p_interaction_profile) {
 	ip->bindings.clear();
 }
 
-int OpenXRAPI::interaction_profile_add_binding(RID p_interaction_profile, RID p_action, const String p_path) {
+int OpenXRAPI::interaction_profile_add_binding(RID p_interaction_profile, RID p_action, const String &p_path) {
 	InteractionProfile *ip = interaction_profile_owner.get_or_null(p_interaction_profile);
 	ERR_FAIL_NULL_V(ip, -1);
 
@@ -3463,7 +3463,7 @@ void OpenXRAPI::interaction_profile_free(RID p_interaction_profile) {
 	interaction_profile_owner.free(p_interaction_profile);
 }
 
-bool OpenXRAPI::sync_action_sets(const Vector<RID> p_active_sets) {
+bool OpenXRAPI::sync_action_sets(const Vector<RID> &p_active_sets) {
 	ERR_FAIL_COND_V(session == XR_NULL_HANDLE, false);
 
 	if (!running) {

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -260,7 +260,7 @@ private:
 	bool load_supported_swapchain_formats();
 	bool is_swapchain_format_supported(int64_t p_swapchain_format);
 	bool obtain_swapchain_formats();
-	bool create_main_swapchains(Size2i p_size);
+	bool create_main_swapchains(const Size2i &p_size);
 	void free_main_swapchains();
 	void destroy_session();
 
@@ -328,7 +328,7 @@ private:
 	bool on_state_exiting();
 
 	// convenience
-	void copy_string_to_char_buffer(const String p_string, char *p_buffer, int p_buffer_len);
+	void copy_string_to_char_buffer(const String &p_string, char *p_buffer, int p_buffer_len);
 
 	// Render state, Only accessible in rendering thread
 	struct RenderState {
@@ -435,7 +435,7 @@ public:
 	XRPose::TrackingConfidence transform_from_location(const XrSpaceLocation &p_location, Transform3D &r_transform);
 	XRPose::TrackingConfidence transform_from_location(const XrHandJointLocationEXT &p_location, Transform3D &r_transform);
 	void parse_velocities(const XrSpaceVelocity &p_velocity, Vector3 &r_linear_velocity, Vector3 &r_angular_velocity);
-	bool xr_result(XrResult result, const char *format, Array args = Array()) const;
+	bool xr_result(XrResult p_result, const char *p_format, const Array &p_args = Array()) const;
 	XrPath get_xr_path(const String &p_path);
 	String get_xr_path_name(const XrPath &p_path);
 	bool is_top_level_path_supported(const String &p_toplevel_path);
@@ -551,35 +551,35 @@ public:
 	// action map
 	String get_default_action_map_resource_name();
 
-	RID tracker_create(const String p_name);
+	RID tracker_create(const String &p_name);
 	String tracker_get_name(RID p_tracker);
 	void tracker_check_profile(RID p_tracker, XrSession p_session = XR_NULL_HANDLE);
 	void tracker_free(RID p_tracker);
 
-	RID action_set_create(const String p_name, const String p_localized_name, const int p_priority);
+	RID action_set_create(const String &p_name, const String &p_localized_name, const int p_priority);
 	String action_set_get_name(RID p_action_set);
 	XrActionSet action_set_get_handle(RID p_action_set);
 	bool attach_action_sets(const Vector<RID> &p_action_sets);
 	void action_set_free(RID p_action_set);
 
-	RID action_create(RID p_action_set, const String p_name, const String p_localized_name, OpenXRAction::ActionType p_action_type, const Vector<RID> &p_trackers);
+	RID action_create(RID p_action_set, const String &p_name, const String &p_localized_name, OpenXRAction::ActionType p_action_type, const Vector<RID> &p_trackers);
 	String action_get_name(RID p_action);
 	XrAction action_get_handle(RID p_action);
 	void action_free(RID p_action);
 
-	RID interaction_profile_create(const String p_name);
+	RID interaction_profile_create(const String &p_name);
 	String interaction_profile_get_name(RID p_interaction_profile);
 	void interaction_profile_clear_bindings(RID p_interaction_profile);
-	int interaction_profile_add_binding(RID p_interaction_profile, RID p_action, const String p_path);
+	int interaction_profile_add_binding(RID p_interaction_profile, RID p_action, const String &p_path);
 	bool interaction_profile_add_modifier(RID p_interaction_profile, const PackedByteArray &p_modifier);
 	bool interaction_profile_suggest_bindings(RID p_interaction_profile);
 	void interaction_profile_free(RID p_interaction_profile);
 
 	RID find_tracker(const String &p_name);
-	RID find_action_set(const String p_name);
+	RID find_action_set(const String &p_name);
 	RID find_action(const String &p_name, const RID &p_action_set = RID());
 
-	bool sync_action_sets(const Vector<RID> p_active_sets);
+	bool sync_action_sets(const Vector<RID> &p_active_sets);
 	bool get_action_bool(RID p_action, RID p_tracker);
 	float get_action_float(RID p_action, RID p_tracker);
 	Vector2 get_action_vector2(RID p_action, RID p_tracker);

--- a/modules/openxr/openxr_api_extension.cpp
+++ b/modules/openxr/openxr_api_extension.cpp
@@ -120,9 +120,9 @@ Transform3D OpenXRAPIExtension::transform_from_pose(GDExtensionConstPtr<const vo
 	return OpenXRAPI::get_singleton()->transform_from_pose(*(XrPosef *)p_pose.data);
 }
 
-bool OpenXRAPIExtension::xr_result(uint64_t result, String format, Array args) {
+bool OpenXRAPIExtension::xr_result(uint64_t p_result, const String &p_format, const Array &p_args) {
 	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), false);
-	return OpenXRAPI::get_singleton()->xr_result((XrResult)result, format.utf8().get_data(), args);
+	return OpenXRAPI::get_singleton()->xr_result((XrResult)p_result, p_format.utf8().get_data(), p_args);
 }
 
 bool OpenXRAPIExtension::openxr_is_enabled(bool p_check_run_in_editor) {
@@ -130,7 +130,7 @@ bool OpenXRAPIExtension::openxr_is_enabled(bool p_check_run_in_editor) {
 	return OpenXRAPI::openxr_is_enabled(p_check_run_in_editor);
 }
 
-uint64_t OpenXRAPIExtension::get_instance_proc_addr(String p_name) {
+uint64_t OpenXRAPIExtension::get_instance_proc_addr(const String &p_name) {
 	ERR_FAIL_NULL_V(OpenXRAPI::get_singleton(), 0);
 	CharString str = p_name.utf8();
 	PFN_xrVoidFunction addr = nullptr;

--- a/modules/openxr/openxr_api_extension.h
+++ b/modules/openxr/openxr_api_extension.h
@@ -63,12 +63,12 @@ public:
 	// Helper method to convert an XrPosef to a Transform3D.
 	Transform3D transform_from_pose(GDExtensionConstPtr<const void> p_pose);
 
-	bool xr_result(uint64_t result, String format, Array args = Array());
+	bool xr_result(uint64_t p_result, const String &p_format, const Array &p_args = Array());
 
 	static bool openxr_is_enabled(bool p_check_run_in_editor = true);
 
 	//TODO workaround as GDExtensionPtr<void> return type results in build error in godot-cpp
-	uint64_t get_instance_proc_addr(String p_name);
+	uint64_t get_instance_proc_addr(const String &p_name);
 	String get_error_string(uint64_t result);
 	String get_swapchain_format_name(int64_t p_swapchain_format);
 	void set_object_name(int64_t p_object_type, uint64_t p_object_handle, const String &p_object_name);

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -1028,17 +1028,17 @@ uint32_t OpenXRInterface::get_view_count() {
 	return 2;
 }
 
-void OpenXRInterface::_set_default_pos(Transform3D &p_transform, double p_world_scale, uint64_t p_eye) {
-	p_transform = Transform3D();
+void OpenXRInterface::_set_default_pos(Transform3D &r_transform, double p_world_scale, uint64_t p_eye) {
+	r_transform = Transform3D();
 
 	// if we're not tracking, don't put our head on the floor...
-	p_transform.origin.y = 1.5 * p_world_scale;
+	r_transform.origin.y = 1.5 * p_world_scale;
 
 	// overkill but..
 	if (p_eye == 1) {
-		p_transform.origin.x = 0.03 * p_world_scale;
+		r_transform.origin.x = 0.03 * p_world_scale;
 	} else if (p_eye == 2) {
-		p_transform.origin.x = -0.03 * p_world_scale;
+		r_transform.origin.x = -0.03 * p_world_scale;
 	}
 }
 
@@ -1307,11 +1307,10 @@ void OpenXRInterface::stop_passthrough() {
 }
 
 Array OpenXRInterface::get_supported_environment_blend_modes() {
-	Array modes;
-
 	if (!openxr_api) {
-		return modes;
+		return Array();
 	}
+	Array modes;
 
 	const Vector<XrEnvironmentBlendMode> env_blend_modes = openxr_api->get_supported_environment_blend_modes();
 

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -120,7 +120,7 @@ private:
 
 	void free_interaction_profiles();
 
-	void _set_default_pos(Transform3D &p_transform, double p_world_scale, uint64_t p_eye);
+	void _set_default_pos(Transform3D &r_transform, double p_world_scale, uint64_t p_eye);
 
 	void handle_hand_tracking(const String &p_path, OpenXRHandTrackingExtension::HandTrackedHands p_hand);
 

--- a/modules/openxr/scene/openxr_render_model_manager.cpp
+++ b/modules/openxr/scene/openxr_render_model_manager.cpp
@@ -63,7 +63,7 @@ void OpenXRRenderModelManager::_update_models() {
 	ERR_FAIL_NULL(render_model_extension);
 
 	// Make a copy of our current models.
-	HashMap<RID, Node3D *> org_render_models = render_models;
+	HashMap<RID, Node3D *> org_render_models = HashMap<RID, Node3D *>(render_models);
 
 	// Loop through our interaction data so we add new entries.
 	TypedArray<RID> render_model_rids = render_model_extension->render_model_get_all();

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -223,6 +223,5 @@ void XRInterface::trigger_haptic_pulse(const String &p_action_name, const String
 }
 
 Array XRInterface::get_supported_environment_blend_modes() {
-	Array default_blend_modes = { XR_ENV_BLEND_MODE_OPAQUE };
-	return default_blend_modes;
+	return Array{ XR_ENV_BLEND_MODE_OPAQUE };
 }


### PR DESCRIPTION
This PR changes parameters in the OpenXR module to const refs: `const Type &`. This change prevents making unnecessary copies of parameters when calling functions, including when the bindings call the functions.

Motivation: I tried changing the copy constructors of container types like Array to explicit, but this creates a problem for non-const-ref parameters of container types in the bindings. Right now, the bindings are implicitly making copies of this data, and the bindings do not compile anymore if this is changed to explicit. See the discussions in PR #107377 and PR #110912 for more information.

Only doing this for container types would be sufficient for that purpose, but that would be a massive change throughout the entire codebase. I think it would be better for reviewability if I open multiple PRs targeting specific parts of the codebase, so for example, this PR can be reviewed by the OpenXR team. And, while I'm at it, I also made this change for types such as `String` and `Ref<>` to fix up those too.

This PR also contains a small number of other changes to parameters, such as using `p_` and `r_` consistently.